### PR TITLE
feat(worker): stream ClickHouse-native Parquet blob exports (LFE-10463)

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -104,6 +104,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1013.0",
     "@azure/storage-blob": "^12.26.0",
     "@clickhouse/client": "^1.18.5",
+    "@clickhouse/client-common": "^1.18.5",
     "@google-cloud/storage": "^7.19.0",
     "@langchain/anthropic": "^1.3.26",
     "@langchain/aws": "^1.3.4",

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -1,9 +1,12 @@
+import { type Readable } from "stream";
 import { env } from "../../env";
 import {
   clickhouseClient,
   convertDateToClickhouseDateTime,
   PreferredClickhouseService,
 } from "../clickhouse/client";
+import { EXCEPTION_TAG_HEADER_NAME } from "@clickhouse/client-common";
+import { ClickhouseExecExceptionTagTransform } from "./clickhouseExecExceptionTag";
 import { logger } from "../logger";
 import { getTracer, instrumentAsync } from "../instrumentation";
 import { randomUUID } from "crypto";
@@ -355,6 +358,129 @@ export async function* queryClickhouseStreamRawText(
     );
   } finally {
     span.end();
+  }
+}
+
+// Shared ClickHouse settings for the blob-export Parquet path (LFE-10463).
+// `output_format_parquet_row_group_size` bounds how many rows ClickHouse buffers
+// before flushing a row group, which caps server-side memory and lets the body
+// stream incrementally rather than materializing the whole Parquet file first.
+export const BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS: ClickHouseSettings = {
+  output_format_parquet_row_group_size: "1000000",
+};
+
+export type ClickhouseExecRawResult = {
+  queryId: string;
+  // ClickHouse's raw response body, with the exception-tag Transform already
+  // applied: a mid-stream failure (CH >= 25.11) errors this stream instead of
+  // emitting a truncated artifact.
+  stream: Readable;
+  responseHeaders: Record<string, string | string[] | undefined>;
+};
+
+/**
+ * Raw binary read for the blob-export Parquet path (LFE-10463). Runs the query
+ * via `clickhouseClient().exec()` — which returns the unparsed HTTP response
+ * body as a {@link Readable} — and appends `FORMAT <format>` to the SQL (exec
+ * has no `format` parameter; the FORMAT clause must live in the query string).
+ * Used to stream ClickHouse-native `FORMAT Parquet` bytes straight to upload,
+ * offloading columnar encoding + compression to ClickHouse query threads.
+ *
+ * Unlike {@link queryClickhouseStream}, `exec()` does NOT run the
+ * `@clickhouse/client` ResultSet machinery, so it performs no mid-stream
+ * exception detection. We restore that by piping the body through
+ * {@link ClickhouseExecExceptionTagTransform}, which scans for the
+ * `x-clickhouse-exception-tag` end-of-stream marker and errors the stream on a
+ * failed query — so the pipeline aborts before any S3 commit instead of
+ * uploading a truncated object.
+ *
+ * IMPORTANT: that detection only works on ClickHouse >= 25.11 (it relies on the
+ * exception-tag response header). On older servers a query that fails after a
+ * 200 response is NOT detected. The only caller (blob Parquet export) is an
+ * experimental, per-project opt-in carrying the same ClickHouse version caveat
+ * as raw passthrough — see RAW_PASSTHROUGH_MIN_CLICKHOUSE_VERSION.
+ *
+ * Pass Parquet tuning (e.g. `output_format_parquet_row_group_size`) via
+ * `clickhouseSettings`.
+ */
+export async function queryClickhouseExecRaw(
+  opts: ClickhouseQueryOpts & { format: string },
+): Promise<ClickhouseExecRawResult> {
+  if (!opts.allowLegacyEventsRead) assertNoLegacyEventsRead(opts.query);
+  const tracer = getTracer("clickhouse-query-exec-raw");
+  const span = tracer.startSpan("clickhouse-query-exec-raw", {
+    kind: SpanKind.CLIENT,
+  });
+
+  let queryId: string | undefined;
+
+  try {
+    const queryWithFormat = `${opts.query}\nFORMAT ${opts.format}`;
+    setSpanQueryAttributes(span, queryWithFormat);
+
+    const res = await context
+      .with(trace.setSpan(context.active(), span), () =>
+        clickhouseClient(
+          opts.clickhouseConfigs,
+          opts.preferredClickhouseService,
+        ).exec({
+          query: queryWithFormat,
+          query_params: opts.params,
+          clickhouse_settings: {
+            ...opts.clickhouseSettings,
+            log_comment: JSON.stringify(tagsWithTraceId(opts.tags)),
+          },
+        }),
+      )
+      .catch((error) => {
+        throw ClickHouseResourceError.wrapIfResourceError(
+          enrichWithQueryId(error as Error, queryId),
+          opts.tags,
+        );
+      });
+
+    queryId = res.query_id;
+    span.setAttribute("ch.queryId", queryId);
+    recordSummaryOnSpan(span, res.response_headers);
+
+    if (env.NODE_ENV === "development") {
+      logger.info(`clickhouse:exec ${res.query_id} ${queryWithFormat}`);
+    }
+
+    const exceptionTag = res.response_headers[EXCEPTION_TAG_HEADER_NAME] as
+      | string
+      | undefined;
+
+    const wrapped = res.stream.pipe(
+      new ClickhouseExecExceptionTagTransform({
+        exceptionTag,
+        wrapError: (error) =>
+          ClickHouseResourceError.wrapIfResourceError(
+            enrichWithQueryId(error, queryId),
+            opts.tags,
+          ),
+      }),
+    );
+
+    // The span outlives this function — it spans the consumer's read of the
+    // stream. Close it once the body is fully drained or fails. Propagate a
+    // source-stream error to the wrapped stream so the consumer sees it.
+    res.stream.on("error", (error) => wrapped.destroy(error));
+    wrapped.once("end", () => span.end());
+    wrapped.once("error", () => span.end());
+
+    return {
+      queryId,
+      stream: wrapped,
+      responseHeaders: res.response_headers,
+    };
+  } catch (error) {
+    span.end();
+    if (error instanceof ClickHouseResourceError) throw error;
+    throw ClickHouseResourceError.wrapIfResourceError(
+      enrichWithQueryId(error as Error, queryId),
+      opts.tags,
+    );
   }
 }
 

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -463,11 +463,19 @@ export async function queryClickhouseExecRaw(
     );
 
     // The span outlives this function — it spans the consumer's read of the
-    // stream. Close it once the body is fully drained or fails. Propagate a
-    // source-stream error to the wrapped stream so the consumer sees it.
+    // stream. Propagate a source-stream error forward so the consumer sees it.
     res.stream.on("error", (error) => wrapped.destroy(error));
-    wrapped.once("end", () => span.end());
-    wrapped.once("error", () => span.end());
+    // `.pipe()` only wires src→dest; it does NOT tear the source down when the
+    // consumer destroys `wrapped` (e.g. the worker's stream.pipeline aborting on
+    // an S3 upload failure). Without this, the live ClickHouse HTTP body keeps
+    // streaming into an unread socket, pinning a connection-pool slot and a
+    // server-side query thread until the request timeout fires. 'close' is
+    // guaranteed to fire on every termination path — end, error, and the no-arg
+    // destroy() that emits neither — and span.end() is idempotent.
+    wrapped.once("close", () => {
+      span.end();
+      if (!res.stream.destroyed) res.stream.destroy();
+    });
 
     return {
       queryId,

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -361,11 +361,18 @@ export async function* queryClickhouseStreamRawText(
   }
 }
 
-// Blob-export Parquet settings (LFE-10463). row_group_size bounds the rows
-// ClickHouse buffers before flushing a row group — capping server memory and
-// letting the body stream incrementally instead of materializing the whole file.
+// Blob-export Parquet settings (LFE-10463). A row group is buffered in memory
+// before it flushes, so we bound it on BOTH axes: ClickHouse flushes whichever
+// limit hits first. The bytes cap (not the row count) is the real memory
+// governor and auto-adapts to row width — wide io rows (observations/events with
+// large input/output/metadata) flush after fewer rows, narrow rows pack more in.
+// We set it below ClickHouse's 512 MiB default because the export dispatcher runs
+// up to four tables concurrently per project (traces, observations, scores,
+// events), so peak ≈ 4 × this value. The row cap keeps narrow-table groups from
+// growing to an unbounded row count.
 export const BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS: ClickHouseSettings = {
   output_format_parquet_row_group_size: "1000000",
+  output_format_parquet_row_group_size_bytes: String(128 * 1024 * 1024), // 128 MiB
 };
 
 export type ClickhouseExecRawResult = {

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -361,47 +361,34 @@ export async function* queryClickhouseStreamRawText(
   }
 }
 
-// Shared ClickHouse settings for the blob-export Parquet path (LFE-10463).
-// `output_format_parquet_row_group_size` bounds how many rows ClickHouse buffers
-// before flushing a row group, which caps server-side memory and lets the body
-// stream incrementally rather than materializing the whole Parquet file first.
+// Blob-export Parquet settings (LFE-10463). row_group_size bounds the rows
+// ClickHouse buffers before flushing a row group — capping server memory and
+// letting the body stream incrementally instead of materializing the whole file.
 export const BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS: ClickHouseSettings = {
   output_format_parquet_row_group_size: "1000000",
 };
 
 export type ClickhouseExecRawResult = {
   queryId: string;
-  // ClickHouse's raw response body, with the exception-tag Transform already
-  // applied: a mid-stream failure (CH >= 25.11) errors this stream instead of
-  // emitting a truncated artifact.
+  // Raw response body, already wrapped by the exception-tag Transform so a
+  // mid-stream failure (CH >= 25.11) errors it instead of truncating.
   stream: Readable;
   responseHeaders: Record<string, string | string[] | undefined>;
 };
 
 /**
  * Raw binary read for the blob-export Parquet path (LFE-10463). Runs the query
- * via `clickhouseClient().exec()` — which returns the unparsed HTTP response
- * body as a {@link Readable} — and appends `FORMAT <format>` to the SQL (exec
- * has no `format` parameter; the FORMAT clause must live in the query string).
- * Used to stream ClickHouse-native `FORMAT Parquet` bytes straight to upload,
- * offloading columnar encoding + compression to ClickHouse query threads.
+ * via `clickhouseClient().exec()` (returns the unparsed HTTP body as a
+ * {@link Readable}) and appends `FORMAT <format>` to the SQL — exec has no
+ * `format` param. Streams ClickHouse-native Parquet bytes straight to upload,
+ * offloading columnar encoding + compression to ClickHouse.
  *
- * Unlike {@link queryClickhouseStream}, `exec()` does NOT run the
- * `@clickhouse/client` ResultSet machinery, so it performs no mid-stream
- * exception detection. We restore that by piping the body through
- * {@link ClickhouseExecExceptionTagTransform}, which scans for the
- * `x-clickhouse-exception-tag` end-of-stream marker and errors the stream on a
- * failed query — so the pipeline aborts before any S3 commit instead of
- * uploading a truncated object.
- *
- * IMPORTANT: that detection only works on ClickHouse >= 25.11 (it relies on the
- * exception-tag response header). On older servers a query that fails after a
- * 200 response is NOT detected. The only caller (blob Parquet export) is an
- * experimental, per-project opt-in carrying the same ClickHouse version caveat
- * as raw passthrough — see RAW_PASSTHROUGH_MIN_CLICKHOUSE_VERSION.
- *
- * Pass Parquet tuning (e.g. `output_format_parquet_row_group_size`) via
- * `clickhouseSettings`.
+ * `exec()` skips the ResultSet machinery and its mid-stream exception detection,
+ * so we restore it by piping through {@link ClickhouseExecExceptionTagTransform}
+ * — the stream errors on a failed query, aborting the upload before any commit.
+ * Detection needs CH >= 25.11 (exception-tag header); the only caller is an
+ * experimental per-project opt-in with the same caveat as raw passthrough — see
+ * RAW_PASSTHROUGH_MIN_CLICKHOUSE_VERSION. Pass Parquet tuning via `clickhouseSettings`.
  */
 export async function queryClickhouseExecRaw(
   opts: ClickhouseQueryOpts & { format: string },
@@ -451,7 +438,7 @@ export async function queryClickhouseExecRaw(
       | string
       | undefined;
 
-    const wrapped = res.stream.pipe(
+    const guardedStream = res.stream.pipe(
       new ClickhouseExecExceptionTagTransform({
         exceptionTag,
         wrapError: (error) =>
@@ -462,24 +449,22 @@ export async function queryClickhouseExecRaw(
       }),
     );
 
-    // The span outlives this function — it spans the consumer's read of the
-    // stream. Propagate a source-stream error forward so the consumer sees it.
-    res.stream.on("error", (error) => wrapped.destroy(error));
-    // `.pipe()` only wires src→dest; it does NOT tear the source down when the
-    // consumer destroys `wrapped` (e.g. the worker's stream.pipeline aborting on
-    // an S3 upload failure). Without this, the live ClickHouse HTTP body keeps
-    // streaming into an unread socket, pinning a connection-pool slot and a
-    // server-side query thread until the request timeout fires. 'close' is
-    // guaranteed to fire on every termination path — end, error, and the no-arg
-    // destroy() that emits neither — and span.end() is idempotent.
-    wrapped.once("close", () => {
+    // The span outlives this function (it covers the consumer's read). Forward
+    // source errors so the consumer sees them.
+    res.stream.on("error", (error) => guardedStream.destroy(error));
+    // `.pipe()` only wires src→dest, so destroying guardedStream (e.g. the
+    // worker's pipeline aborting on an upload failure) would leave the live CH
+    // body streaming into an unread socket — pinning a connection slot and query
+    // thread until the request timeout. 'close' fires on every termination path
+    // (end, error, no-arg destroy); span.end() is idempotent.
+    guardedStream.once("close", () => {
       span.end();
       if (!res.stream.destroyed) res.stream.destroy();
     });
 
     return {
       queryId,
-      stream: wrapped,
+      stream: guardedStream,
       responseHeaders: res.response_headers,
     };
   } catch (error) {

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -361,15 +361,10 @@ export async function* queryClickhouseStreamRawText(
   }
 }
 
-// Blob-export Parquet settings (LFE-10463). A row group is buffered in memory
-// before it flushes, so we bound it on BOTH axes: ClickHouse flushes whichever
-// limit hits first. The bytes cap (not the row count) is the real memory
-// governor and auto-adapts to row width — wide io rows (observations/events with
-// large input/output/metadata) flush after fewer rows, narrow rows pack more in.
-// We set it below ClickHouse's 512 MiB default because the export dispatcher runs
-// up to four tables concurrently per project (traces, observations, scores,
-// events), so peak ≈ 4 × this value. The row cap keeps narrow-table groups from
-// growing to an unbounded row count.
+// Blob-export Parquet settings (LFE-10463). CH buffers a row group in memory and
+// flushes at whichever cap hits first. The bytes cap is the real memory governor
+// (auto-adapts to row width); set below CH's 512 MiB default since the dispatcher
+// exports up to 4 tables concurrently (peak ≈ 4×). The row cap bounds narrow tables.
 export const BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS: ClickHouseSettings = {
   output_format_parquet_row_group_size: "1000000",
   output_format_parquet_row_group_size_bytes: String(128 * 1024 * 1024), // 128 MiB

--- a/packages/shared/src/server/repositories/clickhouseExecExceptionTag.test.ts
+++ b/packages/shared/src/server/repositories/clickhouseExecExceptionTag.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { Readable, pipeline } from "stream";
+import { promisify } from "util";
+import {
+  ClickhouseExecExceptionTagTransform,
+  EXCEPTION_TRAILER_MARKER,
+} from "./clickhouseExecExceptionTag";
+
+const pipelineAsync = promisify(pipeline);
+
+// Build a valid ClickHouse >= 25.11 end-of-stream exception trailer for a given
+// tag + single-line message, matching the layout that the client's
+// extractErrorAtTheEndOfChunk parses:
+//   `\r\n__exception__\r\n<tag>` <message> `\n<len> __exception__\r\n<tag>\r\n`
+// where <len> is the byte length of `<message>\n`. The leading marker is what
+// the Transform scans for; the trailing portion is what the parser reads.
+function buildExceptionTrailer(tag: string, message: string): Buffer {
+  const messageWithNewline = message + "\n";
+  const len = Buffer.byteLength(messageWithNewline, "utf-8");
+  return Buffer.concat([
+    Buffer.from(`\r\n__exception__\r\n${tag}`, "utf-8"),
+    Buffer.from(messageWithNewline, "utf-8"),
+    Buffer.from(`${len} __exception__\r\n${tag}\r\n`, "utf-8"),
+  ]);
+}
+
+async function collect(
+  chunks: Buffer[],
+  options: ConstructorParameters<typeof ClickhouseExecExceptionTagTransform>[0],
+): Promise<Buffer> {
+  const transform = new ClickhouseExecExceptionTagTransform(options);
+  const out: Buffer[] = [];
+  transform.on("data", (c: Buffer) => out.push(c));
+  await pipelineAsync(Readable.from(chunks), transform);
+  return Buffer.concat(out);
+}
+
+describe("ClickhouseExecExceptionTagTransform", () => {
+  const TAG = "FOOBAR";
+
+  it("passes clean binary data through unchanged when no marker is present", async () => {
+    const data = Buffer.from([0x50, 0x41, 0x52, 0x31, 0x00, 0xff, 0x0d, 0x0a]); // includes a stray \r\n
+    const result = await collect([data], { exceptionTag: TAG });
+    expect(result.equals(data)).toBe(true);
+  });
+
+  it("passes data through unchanged when detection is disabled (no exception tag)", async () => {
+    // A chunk that happens to contain the marker bytes must NOT be treated as an
+    // error when the tag header is absent (CH < 25.11): pure passthrough.
+    const data = Buffer.concat([
+      Buffer.from("real-parquet-bytes"),
+      EXCEPTION_TRAILER_MARKER,
+      Buffer.from("more"),
+    ]);
+    const result = await collect([data], { exceptionTag: undefined });
+    expect(result.equals(data)).toBe(true);
+  });
+
+  it("errors the stream with the parsed message when the trailer is present", async () => {
+    const message = "Code: 241. DB::Exception: Memory limit exceeded";
+    const chunk = Buffer.concat([
+      Buffer.from("clean-data-before-error"),
+      buildExceptionTrailer(TAG, message),
+    ]);
+    await expect(collect([chunk], { exceptionTag: TAG })).rejects.toThrow(
+      /Memory limit exceeded/,
+    );
+  });
+
+  it("does not emit the trailer bytes downstream, only the clean prefix", async () => {
+    const prefix = Buffer.from("PAR1-clean-leading-bytes-PAR1");
+    const chunk = Buffer.concat([
+      prefix,
+      buildExceptionTrailer(TAG, "Code: 159. DB::Exception: Timeout exceeded"),
+    ]);
+
+    const transform = new ClickhouseExecExceptionTagTransform({
+      exceptionTag: TAG,
+    });
+    const out: Buffer[] = [];
+    transform.on("data", (c: Buffer) => out.push(c));
+    await expect(
+      pipelineAsync(Readable.from([chunk]), transform),
+    ).rejects.toThrow();
+    // Whatever was emitted before the error must be a prefix of the clean data,
+    // and must never include the marker.
+    const emitted = Buffer.concat(out);
+    expect(emitted.length).toBeLessThanOrEqual(prefix.length);
+    expect(prefix.subarray(0, emitted.length).equals(emitted)).toBe(true);
+    expect(emitted.indexOf(EXCEPTION_TRAILER_MARKER)).toBe(-1);
+  });
+
+  it("detects a marker split across chunk boundaries (1-byte chunks)", async () => {
+    const full = Buffer.concat([
+      Buffer.from("leading"),
+      buildExceptionTrailer(TAG, "Code: 241. DB::Exception: boundary split"),
+    ]);
+    const singleBytes = Array.from(full).map((b) => Buffer.from([b]));
+    await expect(collect(singleBytes, { exceptionTag: TAG })).rejects.toThrow(
+      /boundary split/,
+    );
+  });
+
+  it("preserves trailing data that resembles the marker prefix but is clean", async () => {
+    // Stream ends with the first 16 bytes of the marker but never completes it —
+    // must be flushed intact, not swallowed.
+    const partialMarker = EXCEPTION_TRAILER_MARKER.subarray(
+      0,
+      EXCEPTION_TRAILER_MARKER.length - 1,
+    );
+    const data = Buffer.concat([Buffer.from("body"), partialMarker]);
+    const result = await collect([data], { exceptionTag: TAG });
+    expect(result.equals(data)).toBe(true);
+  });
+
+  it("applies wrapError to the emitted error", async () => {
+    class WrappedError extends Error {}
+    const chunk = buildExceptionTrailer(
+      TAG,
+      "Code: 241. DB::Exception: wrap me",
+    );
+    await expect(
+      collect([chunk], {
+        exceptionTag: TAG,
+        wrapError: (e) => new WrappedError(e.message),
+      }),
+    ).rejects.toBeInstanceOf(WrappedError);
+  });
+});

--- a/packages/shared/src/server/repositories/clickhouseExecExceptionTag.test.ts
+++ b/packages/shared/src/server/repositories/clickhouseExecExceptionTag.test.ts
@@ -56,6 +56,21 @@ describe("ClickhouseExecExceptionTagTransform", () => {
     expect(result.equals(data)).toBe(true);
   });
 
+  it("passes through the bare marker when NOT followed by the tag (adversarial footer bytes)", async () => {
+    // A Parquet footer min/max stat is uncompressed and can carry a raw user
+    // string starting with the literal 17-byte marker. Scanning for marker+tag
+    // (not the bare marker) means such input must pass through, not false-
+    // positive into a per-window export DoS. The per-query tag is unguessable.
+    const data = Buffer.concat([
+      Buffer.from("PAR1...row-group..."),
+      EXCEPTION_TRAILER_MARKER,
+      Buffer.from("attacker-suffix-not-the-real-tag"),
+      Buffer.from("...footer...PAR1"),
+    ]);
+    const result = await collect([data], { exceptionTag: "server-random-tag" });
+    expect(result.equals(data)).toBe(true);
+  });
+
   it("errors the stream with the parsed message when the trailer is present", async () => {
     const message = "Code: 241. DB::Exception: Memory limit exceeded";
     const chunk = Buffer.concat([

--- a/packages/shared/src/server/repositories/clickhouseExecExceptionTag.ts
+++ b/packages/shared/src/server/repositories/clickhouseExecExceptionTag.ts
@@ -1,0 +1,123 @@
+// Mid-stream exception detection for the `exec()`-based binary export path
+// (LFE-10463 Parquet). `query().stream()` (used by queryClickhouseStream /
+// queryClickhouseStreamRawText) parses each row and lets the @clickhouse/client
+// ResultSet scan for the `x-clickhouse-exception-tag` end-of-stream marker, so a
+// query that fails AFTER a 200 response errors the stream instead of silently
+// truncating. `exec()` returns the raw HTTP body with NO such scanning — so for
+// binary formats (Parquet) we replicate that detection here.
+//
+// ClickHouse >= 25.11 appends a fixed marker to the response body when a query
+// fails mid-stream: `\r\n__exception__\r\n<tag>` … `<len> __exception__\r\n<tag>\r\n`,
+// where <tag> is the value of the `x-clickhouse-exception-tag` response header.
+// The 17-byte opening marker `\r\n__exception__\r\n` is what we scan for. Unlike
+// the client's JSONEachRow detection (which triggers on any `\r\n` once the tag
+// header is present — fine for newline-delimited text, ambiguous for binary), we
+// match the full literal marker, which is astronomically unlikely to occur
+// inside Parquet bytes by chance. Once found, everything from the marker to the
+// end of the stream is the error trailer (not file data); we accumulate it and
+// hand it to the client's own `extractErrorAtTheEndOfChunk` to parse the message.
+//
+// CAVEAT (mirrors rawPassthrough): on ClickHouse < 25.11 the tag header is
+// absent, so detection is disabled and a mid-stream failure is NOT caught — the
+// only caller is an experimental per-project opt-in gated on that version.
+
+import { Transform } from "stream";
+import { extractErrorAtTheEndOfChunk } from "@clickhouse/client-common";
+
+// `\r\n__exception__\r\n` — the opening of the end-of-stream error trailer.
+export const EXCEPTION_TRAILER_MARKER = Buffer.from("\r\n__exception__\r\n");
+
+export interface ClickhouseExecExceptionTagTransformOptions {
+  // Value of the `x-clickhouse-exception-tag` response header. Undefined on
+  // ClickHouse < 25.11 (or when absent) → detection disabled, bytes pass through.
+  exceptionTag: string | undefined;
+  // Lets the caller (clickhouse.ts) classify the extracted error, e.g. wrap a
+  // "memory limit exceeded" into a ClickHouseResourceError. Defaults to identity
+  // so this module stays free of server-only imports and is unit-testable.
+  wrapError?: (error: Error) => Error;
+}
+
+/**
+ * Passes ClickHouse `exec()` bytes through untouched until it detects the
+ * end-of-stream exception trailer, at which point it errors the stream with the
+ * parsed ClickHouse error (aborting any downstream upload before commit).
+ *
+ * Holds back the last (markerLength - 1) bytes between chunks so a marker split
+ * across a chunk boundary is still detected; those bytes are emitted on flush
+ * when no error is present, so clean data is never dropped. Memory stays bounded
+ * (a ~16-byte carry; the error trailer is small and only buffered after a marker
+ * is seen) — the full stream is never buffered.
+ */
+export class ClickhouseExecExceptionTagTransform extends Transform {
+  private readonly exceptionTag: string | undefined;
+  private readonly wrapError: (error: Error) => Error;
+  // Tail of the previous chunk withheld to catch a marker spanning the boundary.
+  private carry: Buffer = Buffer.alloc(0);
+  // Once non-null we are past the marker: swallow downstream output and
+  // accumulate the trailer for the final extractErrorAtTheEndOfChunk call.
+  private errorBuf: Buffer | null = null;
+
+  constructor(options: ClickhouseExecExceptionTagTransformOptions) {
+    super();
+    this.exceptionTag = options.exceptionTag;
+    this.wrapError = options.wrapError ?? ((error) => error);
+  }
+
+  _transform(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null, data?: Buffer) => void,
+  ): void {
+    // Detection disabled (CH < 25.11): pure passthrough, no buffering.
+    if (this.exceptionTag === undefined) {
+      callback(null, chunk);
+      return;
+    }
+
+    // Already in the trailer: keep accumulating, emit nothing downstream.
+    if (this.errorBuf !== null) {
+      this.errorBuf = Buffer.concat([this.errorBuf, chunk]);
+      callback();
+      return;
+    }
+
+    const buf =
+      this.carry.length > 0 ? Buffer.concat([this.carry, chunk]) : chunk;
+    const markerIdx = buf.indexOf(EXCEPTION_TRAILER_MARKER);
+
+    if (markerIdx !== -1) {
+      // Emit clean file bytes before the marker; everything from the marker on
+      // is the error trailer.
+      if (markerIdx > 0) this.push(buf.subarray(0, markerIdx));
+      this.errorBuf = Buffer.from(buf.subarray(markerIdx));
+      callback();
+      return;
+    }
+
+    // No marker yet: emit all but the last (markerLength - 1) bytes, retaining
+    // those in case the marker straddles this and the next chunk.
+    const keep = EXCEPTION_TRAILER_MARKER.length - 1;
+    if (buf.length > keep) {
+      this.push(buf.subarray(0, buf.length - keep));
+      this.carry = Buffer.from(buf.subarray(buf.length - keep));
+    } else {
+      this.carry = Buffer.from(buf);
+    }
+    callback();
+  }
+
+  _flush(callback: (error?: Error | null, data?: Buffer) => void): void {
+    if (this.errorBuf !== null) {
+      // exceptionTag is defined here (errorBuf is only set when it is).
+      const parsed = extractErrorAtTheEndOfChunk(
+        this.errorBuf,
+        this.exceptionTag as string,
+      );
+      callback(this.wrapError(parsed));
+      return;
+    }
+    // No error: flush the withheld tail so clean data is complete.
+    if (this.carry.length > 0) this.push(this.carry);
+    callback();
+  }
+}

--- a/packages/shared/src/server/repositories/clickhouseExecExceptionTag.ts
+++ b/packages/shared/src/server/repositories/clickhouseExecExceptionTag.ts
@@ -108,12 +108,22 @@ export class ClickhouseExecExceptionTagTransform extends Transform {
 
   _flush(callback: (error?: Error | null, data?: Buffer) => void): void {
     if (this.errorBuf !== null) {
-      // exceptionTag is defined here (errorBuf is only set when it is).
-      const parsed = extractErrorAtTheEndOfChunk(
+      // exceptionTag is defined here (errorBuf is only set when it is). The
+      // marker was found, so this IS a ClickHouse failure — never complete the
+      // stream cleanly. extractErrorAtTheEndOfChunk can fail to parse a
+      // truncated/malformed trailer; fall back to a generic error rather than
+      // letting a null/undefined collapse `callback(error)` into a clean
+      // `callback()` (which would commit a corrupt Parquet artifact).
+      const parsed: Error | null | undefined = extractErrorAtTheEndOfChunk(
         this.errorBuf,
         this.exceptionTag as string,
       );
-      callback(this.wrapError(parsed));
+      const error =
+        parsed ??
+        new Error(
+          "ClickHouse mid-stream failure: exception trailer detected but could not be parsed",
+        );
+      callback(this.wrapError(error));
       return;
     }
     // No error: flush the withheld tail so clean data is complete.

--- a/packages/shared/src/server/repositories/clickhouseExecExceptionTag.ts
+++ b/packages/shared/src/server/repositories/clickhouseExecExceptionTag.ts
@@ -5,10 +5,16 @@
 // body with no such scan, so we replicate it here.
 //
 // On ClickHouse >= 25.11 a failed query appends `\r\n__exception__\r\n<tag>` …
-// `<len> __exception__\r\n<tag>\r\n` to the body. We scan for the fixed 17-byte
-// opening marker (`\r\n__exception__\r\n`) — far more specific than the client's
-// any-`\r\n` heuristic, so effectively impossible to hit inside Parquet bytes by
-// chance — then hand the trailer to the client's own extractErrorAtTheEndOfChunk.
+// `<len> __exception__\r\n<tag>\r\n` to the body, where <tag> is the per-query
+// random value of the `x-clickhouse-exception-tag` header. We scan for the full
+// `\r\n__exception__\r\n<tag>` opening — the tag MUST be included: the literal
+// 17-byte prefix alone can appear in a *successful* Parquet body, because the
+// footer's Thrift-encoded column min/max statistics are uncompressed and carry
+// raw user strings (a value starting with `\r\n…` is the column lex-min). Without
+// the tag, an adversarial trace value could plant the prefix, false-positive the
+// scan, and deterministically fail every export of that window (a per-window
+// DoS). The server-generated tag is unguessable, so including it makes the marker
+// unforgeable. Once found, the trailer is handed to extractErrorAtTheEndOfChunk.
 //
 // CAVEAT (mirrors rawPassthrough): pre-25.11 the tag header is absent, detection
 // is off, and a mid-stream failure is not caught — the only caller is an
@@ -17,7 +23,7 @@
 import { Transform } from "stream";
 import { extractErrorAtTheEndOfChunk } from "@clickhouse/client-common";
 
-// Opening of the end-of-stream error trailer.
+// Literal prefix of the error trailer; the per-query tag is appended at runtime.
 export const EXCEPTION_TRAILER_MARKER = Buffer.from("\r\n__exception__\r\n");
 
 export interface ClickhouseExecExceptionTagTransformOptions {
@@ -32,18 +38,18 @@ export interface ClickhouseExecExceptionTagTransformOptions {
  * Passes ClickHouse `exec()` bytes through until the end-of-stream exception
  * trailer appears, then errors the stream with the parsed ClickHouse error
  * (aborting any downstream upload before commit). Withholds the last
- * (markerLength - 1) bytes between chunks to catch a marker split across a
+ * (scanMarker length - 1) bytes between chunks to catch a marker split across a
  * boundary, flushing them when no error is found so clean data is never dropped.
- * Memory stays bounded — only the ~16-byte tail and (post-marker) the small
- * trailer are buffered; the stream itself never is.
+ * Memory stays bounded — only the small tail and (post-marker) the trailer are
+ * buffered; the stream itself never is.
  */
 export class ClickhouseExecExceptionTagTransform extends Transform {
-  // Bytes that must precede the marker to detect it straddling a chunk boundary.
-  private static readonly markerStraddleBytes =
-    EXCEPTION_TRAILER_MARKER.length - 1;
-
   private readonly exceptionTag: string | undefined;
   private readonly wrapError: (error: Error) => Error;
+  // Full opening sequence we scan for: `\r\n__exception__\r\n` + the per-query tag.
+  private readonly scanMarker: Buffer;
+  // Bytes withheld between chunks so a scanMarker straddling a boundary is caught.
+  private readonly markerStraddleBytes: number;
   // Tail of the previous chunk withheld to catch a marker spanning the boundary.
   private pendingTail: Buffer = Buffer.alloc(0);
   // Non-null once past the marker: downstream output stops and the trailer
@@ -54,6 +60,14 @@ export class ClickhouseExecExceptionTagTransform extends Transform {
     super();
     this.exceptionTag = options.exceptionTag;
     this.wrapError = options.wrapError ?? ((error) => error);
+    this.scanMarker =
+      options.exceptionTag !== undefined
+        ? Buffer.concat([
+            EXCEPTION_TRAILER_MARKER,
+            Buffer.from(options.exceptionTag, "utf-8"),
+          ])
+        : EXCEPTION_TRAILER_MARKER;
+    this.markerStraddleBytes = this.scanMarker.length - 1;
   }
 
   _transform(
@@ -78,7 +92,7 @@ export class ClickhouseExecExceptionTagTransform extends Transform {
       this.pendingTail.length > 0
         ? Buffer.concat([this.pendingTail, chunk])
         : chunk;
-    const trailerStart = buf.indexOf(EXCEPTION_TRAILER_MARKER);
+    const trailerStart = buf.indexOf(this.scanMarker);
 
     if (trailerStart !== -1) {
       // Bytes before the marker are clean file data; the rest is the trailer.
@@ -89,8 +103,7 @@ export class ClickhouseExecExceptionTagTransform extends Transform {
     }
 
     // No marker: emit everything but the tail that could start a split marker.
-    const keepFrom =
-      buf.length - ClickhouseExecExceptionTagTransform.markerStraddleBytes;
+    const keepFrom = buf.length - this.markerStraddleBytes;
     if (keepFrom > 0) {
       this.push(buf.subarray(0, keepFrom));
       this.pendingTail = Buffer.from(buf.subarray(keepFrom));

--- a/packages/shared/src/server/repositories/clickhouseExecExceptionTag.ts
+++ b/packages/shared/src/server/repositories/clickhouseExecExceptionTag.ts
@@ -1,61 +1,54 @@
-// Mid-stream exception detection for the `exec()`-based binary export path
-// (LFE-10463 Parquet). `query().stream()` (used by queryClickhouseStream /
-// queryClickhouseStreamRawText) parses each row and lets the @clickhouse/client
-// ResultSet scan for the `x-clickhouse-exception-tag` end-of-stream marker, so a
-// query that fails AFTER a 200 response errors the stream instead of silently
-// truncating. `exec()` returns the raw HTTP body with NO such scanning — so for
-// binary formats (Parquet) we replicate that detection here.
+// Mid-stream exception detection for the `exec()` binary export path (LFE-10463
+// Parquet). `query().stream()` lets @clickhouse/client scan for the
+// `x-clickhouse-exception-tag` end-of-stream marker, so a query failing after a
+// 200 errors the stream instead of truncating silently. `exec()` returns the raw
+// body with no such scan, so we replicate it here.
 //
-// ClickHouse >= 25.11 appends a fixed marker to the response body when a query
-// fails mid-stream: `\r\n__exception__\r\n<tag>` … `<len> __exception__\r\n<tag>\r\n`,
-// where <tag> is the value of the `x-clickhouse-exception-tag` response header.
-// The 17-byte opening marker `\r\n__exception__\r\n` is what we scan for. Unlike
-// the client's JSONEachRow detection (which triggers on any `\r\n` once the tag
-// header is present — fine for newline-delimited text, ambiguous for binary), we
-// match the full literal marker, which is astronomically unlikely to occur
-// inside Parquet bytes by chance. Once found, everything from the marker to the
-// end of the stream is the error trailer (not file data); we accumulate it and
-// hand it to the client's own `extractErrorAtTheEndOfChunk` to parse the message.
+// On ClickHouse >= 25.11 a failed query appends `\r\n__exception__\r\n<tag>` …
+// `<len> __exception__\r\n<tag>\r\n` to the body. We scan for the fixed 17-byte
+// opening marker (`\r\n__exception__\r\n`) — far more specific than the client's
+// any-`\r\n` heuristic, so effectively impossible to hit inside Parquet bytes by
+// chance — then hand the trailer to the client's own extractErrorAtTheEndOfChunk.
 //
-// CAVEAT (mirrors rawPassthrough): on ClickHouse < 25.11 the tag header is
-// absent, so detection is disabled and a mid-stream failure is NOT caught — the
-// only caller is an experimental per-project opt-in gated on that version.
+// CAVEAT (mirrors rawPassthrough): pre-25.11 the tag header is absent, detection
+// is off, and a mid-stream failure is not caught — the only caller is an
+// experimental per-project opt-in gated on that version.
 
 import { Transform } from "stream";
 import { extractErrorAtTheEndOfChunk } from "@clickhouse/client-common";
 
-// `\r\n__exception__\r\n` — the opening of the end-of-stream error trailer.
+// Opening of the end-of-stream error trailer.
 export const EXCEPTION_TRAILER_MARKER = Buffer.from("\r\n__exception__\r\n");
 
 export interface ClickhouseExecExceptionTagTransformOptions {
-  // Value of the `x-clickhouse-exception-tag` response header. Undefined on
-  // ClickHouse < 25.11 (or when absent) → detection disabled, bytes pass through.
+  // `x-clickhouse-exception-tag` response header; undefined pre-25.11 → detection off.
   exceptionTag: string | undefined;
-  // Lets the caller (clickhouse.ts) classify the extracted error, e.g. wrap a
-  // "memory limit exceeded" into a ClickHouseResourceError. Defaults to identity
-  // so this module stays free of server-only imports and is unit-testable.
+  // Lets the caller classify the error (e.g. ClickHouseResourceError). Identity
+  // by default, keeping this module free of server-only imports and unit-testable.
   wrapError?: (error: Error) => Error;
 }
 
 /**
- * Passes ClickHouse `exec()` bytes through untouched until it detects the
- * end-of-stream exception trailer, at which point it errors the stream with the
- * parsed ClickHouse error (aborting any downstream upload before commit).
- *
- * Holds back the last (markerLength - 1) bytes between chunks so a marker split
- * across a chunk boundary is still detected; those bytes are emitted on flush
- * when no error is present, so clean data is never dropped. Memory stays bounded
- * (a ~16-byte carry; the error trailer is small and only buffered after a marker
- * is seen) — the full stream is never buffered.
+ * Passes ClickHouse `exec()` bytes through until the end-of-stream exception
+ * trailer appears, then errors the stream with the parsed ClickHouse error
+ * (aborting any downstream upload before commit). Withholds the last
+ * (markerLength - 1) bytes between chunks to catch a marker split across a
+ * boundary, flushing them when no error is found so clean data is never dropped.
+ * Memory stays bounded — only the ~16-byte tail and (post-marker) the small
+ * trailer are buffered; the stream itself never is.
  */
 export class ClickhouseExecExceptionTagTransform extends Transform {
+  // Bytes that must precede the marker to detect it straddling a chunk boundary.
+  private static readonly markerStraddleBytes =
+    EXCEPTION_TRAILER_MARKER.length - 1;
+
   private readonly exceptionTag: string | undefined;
   private readonly wrapError: (error: Error) => Error;
   // Tail of the previous chunk withheld to catch a marker spanning the boundary.
-  private carry: Buffer = Buffer.alloc(0);
-  // Once non-null we are past the marker: swallow downstream output and
-  // accumulate the trailer for the final extractErrorAtTheEndOfChunk call.
-  private errorBuf: Buffer | null = null;
+  private pendingTail: Buffer = Buffer.alloc(0);
+  // Non-null once past the marker: downstream output stops and the trailer
+  // accumulates here for the final extractErrorAtTheEndOfChunk call.
+  private trailerBuffer: Buffer | null = null;
 
   constructor(options: ClickhouseExecExceptionTagTransformOptions) {
     super();
@@ -68,54 +61,53 @@ export class ClickhouseExecExceptionTagTransform extends Transform {
     _encoding: BufferEncoding,
     callback: (error?: Error | null, data?: Buffer) => void,
   ): void {
-    // Detection disabled (CH < 25.11): pure passthrough, no buffering.
+    // Detection off (pre-25.11): pure passthrough.
     if (this.exceptionTag === undefined) {
       callback(null, chunk);
       return;
     }
 
-    // Already in the trailer: keep accumulating, emit nothing downstream.
-    if (this.errorBuf !== null) {
-      this.errorBuf = Buffer.concat([this.errorBuf, chunk]);
+    // Past the marker: accumulate the trailer, emit nothing.
+    if (this.trailerBuffer !== null) {
+      this.trailerBuffer = Buffer.concat([this.trailerBuffer, chunk]);
       callback();
       return;
     }
 
     const buf =
-      this.carry.length > 0 ? Buffer.concat([this.carry, chunk]) : chunk;
-    const markerIdx = buf.indexOf(EXCEPTION_TRAILER_MARKER);
+      this.pendingTail.length > 0
+        ? Buffer.concat([this.pendingTail, chunk])
+        : chunk;
+    const trailerStart = buf.indexOf(EXCEPTION_TRAILER_MARKER);
 
-    if (markerIdx !== -1) {
-      // Emit clean file bytes before the marker; everything from the marker on
-      // is the error trailer.
-      if (markerIdx > 0) this.push(buf.subarray(0, markerIdx));
-      this.errorBuf = Buffer.from(buf.subarray(markerIdx));
+    if (trailerStart !== -1) {
+      // Bytes before the marker are clean file data; the rest is the trailer.
+      if (trailerStart > 0) this.push(buf.subarray(0, trailerStart));
+      this.trailerBuffer = Buffer.from(buf.subarray(trailerStart));
       callback();
       return;
     }
 
-    // No marker yet: emit all but the last (markerLength - 1) bytes, retaining
-    // those in case the marker straddles this and the next chunk.
-    const keep = EXCEPTION_TRAILER_MARKER.length - 1;
-    if (buf.length > keep) {
-      this.push(buf.subarray(0, buf.length - keep));
-      this.carry = Buffer.from(buf.subarray(buf.length - keep));
+    // No marker: emit everything but the tail that could start a split marker.
+    const keepFrom =
+      buf.length - ClickhouseExecExceptionTagTransform.markerStraddleBytes;
+    if (keepFrom > 0) {
+      this.push(buf.subarray(0, keepFrom));
+      this.pendingTail = Buffer.from(buf.subarray(keepFrom));
     } else {
-      this.carry = Buffer.from(buf);
+      this.pendingTail = Buffer.from(buf);
     }
     callback();
   }
 
   _flush(callback: (error?: Error | null, data?: Buffer) => void): void {
-    if (this.errorBuf !== null) {
-      // exceptionTag is defined here (errorBuf is only set when it is). The
-      // marker was found, so this IS a ClickHouse failure — never complete the
-      // stream cleanly. extractErrorAtTheEndOfChunk can fail to parse a
-      // truncated/malformed trailer; fall back to a generic error rather than
-      // letting a null/undefined collapse `callback(error)` into a clean
-      // `callback()` (which would commit a corrupt Parquet artifact).
+    if (this.trailerBuffer !== null) {
+      // The marker was seen, so this is a real failure — never finish cleanly.
+      // extractErrorAtTheEndOfChunk can fail to parse a truncated trailer; a
+      // falsy return would collapse callback(error) into callback() and commit a
+      // corrupt Parquet artifact, so fall back to a generic error.
       const parsed: Error | null | undefined = extractErrorAtTheEndOfChunk(
-        this.errorBuf,
+        this.trailerBuffer,
         this.exceptionTag as string,
       );
       const error =
@@ -127,7 +119,7 @@ export class ClickhouseExecExceptionTagTransform extends Transform {
       return;
     }
     // No error: flush the withheld tail so clean data is complete.
-    if (this.carry.length > 0) this.push(this.carry);
+    if (this.pendingTail.length > 0) this.push(this.pendingTail);
     callback();
   }
 }

--- a/packages/shared/src/server/repositories/clickhouseExecExceptionTag.ts
+++ b/packages/shared/src/server/repositories/clickhouseExecExceptionTag.ts
@@ -1,24 +1,12 @@
-// Mid-stream exception detection for the `exec()` binary export path (LFE-10463
-// Parquet). `query().stream()` lets @clickhouse/client scan for the
-// `x-clickhouse-exception-tag` end-of-stream marker, so a query failing after a
-// 200 errors the stream instead of truncating silently. `exec()` returns the raw
-// body with no such scan, so we replicate it here.
-//
-// On ClickHouse >= 25.11 a failed query appends `\r\n__exception__\r\n<tag>` …
-// `<len> __exception__\r\n<tag>\r\n` to the body, where <tag> is the per-query
-// random value of the `x-clickhouse-exception-tag` header. We scan for the full
-// `\r\n__exception__\r\n<tag>` opening — the tag MUST be included: the literal
-// 17-byte prefix alone can appear in a *successful* Parquet body, because the
-// footer's Thrift-encoded column min/max statistics are uncompressed and carry
-// raw user strings (a value starting with `\r\n…` is the column lex-min). Without
-// the tag, an adversarial trace value could plant the prefix, false-positive the
-// scan, and deterministically fail every export of that window (a per-window
-// DoS). The server-generated tag is unguessable, so including it makes the marker
-// unforgeable. Once found, the trailer is handed to extractErrorAtTheEndOfChunk.
-//
-// CAVEAT (mirrors rawPassthrough): pre-25.11 the tag header is absent, detection
-// is off, and a mid-stream failure is not caught — the only caller is an
-// experimental per-project opt-in gated on that version.
+// Replicates @clickhouse/client's mid-stream exception detection for the
+// `exec()` binary export path (LFE-10463 Parquet): exec() returns the raw body
+// with no scan, so a query failing after a 200 would truncate silently. On CH
+// >= 25.11 a failure appends `\r\n__exception__\r\n<tag>` … to the body. We scan
+// for marker+tag (not the bare marker): the literal prefix can occur in a
+// successful Parquet footer's uncompressed min/max stats (raw user strings), so
+// scanning the prefix alone lets an adversarial trace value false-positive every
+// export of a window — a per-window DoS. The per-query tag is unguessable.
+// Caveat (like rawPassthrough): pre-25.11 the tag header is absent → detection off.
 
 import { Transform } from "stream";
 import { extractErrorAtTheEndOfChunk } from "@clickhouse/client-common";
@@ -35,13 +23,11 @@ export interface ClickhouseExecExceptionTagTransformOptions {
 }
 
 /**
- * Passes ClickHouse `exec()` bytes through until the end-of-stream exception
- * trailer appears, then errors the stream with the parsed ClickHouse error
- * (aborting any downstream upload before commit). Withholds the last
+ * Passes `exec()` bytes through until the exception trailer appears, then errors
+ * the stream (aborting any downstream upload before commit). Withholds the last
  * (scanMarker length - 1) bytes between chunks to catch a marker split across a
- * boundary, flushing them when no error is found so clean data is never dropped.
- * Memory stays bounded — only the small tail and (post-marker) the trailer are
- * buffered; the stream itself never is.
+ * boundary, flushing them on clean end. Memory is bounded — the stream is never
+ * fully buffered.
  */
 export class ClickhouseExecExceptionTagTransform extends Transform {
   private readonly exceptionTag: string | undefined;

--- a/packages/shared/src/server/repositories/clickhouseExecRaw.integration.test.ts
+++ b/packages/shared/src/server/repositories/clickhouseExecRaw.integration.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  queryClickhouseExecRaw,
+  BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+} from "./clickhouse";
+
+// Integration tests against a live ClickHouse (>= 25.11 for mid-stream exception
+// detection). Validate the FORMAT Parquet exec path end to end: valid Parquet
+// bytes on success, and a hard stream error (not a silent truncation) when the
+// query fails after the 200 response.
+
+const PARQUET_MAGIC = Buffer.from("PAR1");
+
+async function collect(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+describe("queryClickhouseExecRaw — FORMAT Parquet", () => {
+  it("streams valid Parquet bytes (PAR1 magic at both ends)", async () => {
+    const { stream } = await queryClickhouseExecRaw({
+      query: "SELECT number AS n FROM numbers(1000)",
+      format: "Parquet",
+      clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+      tags: { feature: "test", kind: "analytic" },
+    });
+
+    const buffer = await collect(stream);
+
+    expect(buffer.length).toBeGreaterThan(8);
+    expect(buffer.subarray(0, 4).equals(PARQUET_MAGIC)).toBe(true);
+    expect(buffer.subarray(buffer.length - 4).equals(PARQUET_MAGIC)).toBe(true);
+  });
+
+  it("surfaces a failing query as an error instead of a silent/truncated success", async () => {
+    // A query that throwIf-fails must never yield a clean stream. Depending on
+    // how far ClickHouse gets before failing, the error surfaces either as a
+    // pre-200 exec() rejection or, once 200 has been sent, via the end-of-stream
+    // exception-tag trailer the Transform scans for. Both are acceptable — the
+    // invariant under test is that the failure is never swallowed. (The trailer
+    // parsing path itself is unit-tested with synthetic chunks in
+    // clickhouseExecExceptionTag.test.ts.)
+    const run = async () => {
+      const { stream } = await queryClickhouseExecRaw({
+        query:
+          "SELECT throwIf(number = 5000, 'mid-stream boom') AS n FROM numbers(100000)",
+        format: "Parquet",
+        clickhouseSettings: {
+          ...BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+          output_format_parquet_row_group_size: "256",
+        },
+        tags: { feature: "test", kind: "analytic" },
+      });
+      return collect(stream);
+    };
+
+    await expect(run()).rejects.toThrow(/boom/);
+  });
+});

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -81,6 +81,8 @@ import {
   queryClickhouse,
   queryClickhouseStream,
   queryClickhouseStreamRawText,
+  queryClickhouseExecRaw,
+  BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
 } from "./clickhouse";
 import {
   EventsObservationRecordReadType,
@@ -3590,6 +3592,31 @@ export const getEventsForBlobStorageExportRaw = function (
       convertLatencyToSeconds,
     ),
   );
+};
+
+// LFE-10463: ClickHouse-native `FORMAT Parquet` export of events. Reuses the
+// same field-group-aware query builder and streams the raw binary body straight
+// to upload. Like the raw-passthrough variant there is no JS enrichment, so
+// latency ms→s conversion must happen in SQL (`convertLatencyToSeconds`) and
+// price columns are NOT added.
+export const getEventsForBlobStorageExportParquet = function (
+  projectId: string,
+  minTimestamp: Date,
+  maxTimestamp: Date,
+  fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
+  convertLatencyToSeconds: boolean = false,
+) {
+  return queryClickhouseExecRaw({
+    ...buildEventsForBlobStorageExportQuery(
+      projectId,
+      minTimestamp,
+      maxTimestamp,
+      fieldGroups,
+      convertLatencyToSeconds,
+    ),
+    format: "Parquet",
+    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+  });
 };
 
 /**

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3581,7 +3581,7 @@ export const getEventsForBlobStorageExportRaw = function (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
-  convertLatencyToSeconds: boolean = false,
+  convertLatencyToSeconds = false,
 ) {
   return queryClickhouseStreamRawText(
     buildEventsForBlobStorageExportQuery(
@@ -3602,7 +3602,7 @@ export const getEventsForBlobStorageExportParquet = function (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
-  convertLatencyToSeconds: boolean = false,
+  convertLatencyToSeconds = false,
 ) {
   return queryClickhouseExecRaw({
     ...buildEventsForBlobStorageExportQuery(

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3594,11 +3594,9 @@ export const getEventsForBlobStorageExportRaw = function (
   );
 };
 
-// LFE-10463: ClickHouse-native `FORMAT Parquet` export of events. Reuses the
-// same field-group-aware query builder and streams the raw binary body straight
-// to upload. Like the raw-passthrough variant there is no JS enrichment, so
-// latency ms→s conversion must happen in SQL (`convertLatencyToSeconds`) and
-// price columns are NOT added.
+// LFE-10463: FORMAT Parquet export — reuses the field-group-aware builder and
+// streams raw binary bytes to upload. No JS enrichment, so latency ms→s must run
+// in SQL (`convertLatencyToSeconds`) and price columns are NOT added.
 export const getEventsForBlobStorageExportParquet = function (
   projectId: string,
   minTimestamp: Date,

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -4,6 +4,8 @@ import {
   queryClickhouse,
   queryClickhouseStream,
   queryClickhouseStreamRawText,
+  queryClickhouseExecRaw,
+  BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
   upsertClickhouse,
 } from "./clickhouse";
 import { logger } from "../logger";
@@ -1920,6 +1922,28 @@ export const getObservationsForBlobStorageExportRaw = function (
       fieldGroups,
     ),
   );
+};
+
+// LFE-10463: ClickHouse-native `FORMAT Parquet` export. Reuses the same field-
+// group-aware query builder and streams the raw binary body straight to upload.
+// Like the raw-passthrough variant, price columns are NOT added (no JS
+// enrichment on this path).
+export const getObservationsForBlobStorageExportParquet = function (
+  projectId: string,
+  minTimestamp: Date,
+  maxTimestamp: Date,
+  fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
+) {
+  return queryClickhouseExecRaw({
+    ...buildObservationsForBlobStorageExportQuery(
+      projectId,
+      minTimestamp,
+      maxTimestamp,
+      fieldGroups,
+    ),
+    format: "Parquet",
+    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+  });
 };
 
 export const getGenerationsForAnalyticsIntegrations = async function* (

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1924,10 +1924,9 @@ export const getObservationsForBlobStorageExportRaw = function (
   );
 };
 
-// LFE-10463: ClickHouse-native `FORMAT Parquet` export. Reuses the same field-
-// group-aware query builder and streams the raw binary body straight to upload.
-// Like the raw-passthrough variant, price columns are NOT added (no JS
-// enrichment on this path).
+// LFE-10463: FORMAT Parquet export — reuses the field-group-aware builder and
+// streams raw binary bytes to upload. Like raw passthrough, no JS enrichment, so
+// price columns are NOT added.
 export const getObservationsForBlobStorageExportParquet = function (
   projectId: string,
   minTimestamp: Date,

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -18,6 +18,8 @@ import {
   commandClickhouse,
   queryClickhouse,
   queryClickhouseStream,
+  queryClickhouseExecRaw,
+  BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
   upsertClickhouse,
   parseClickhouseUTCDateTimeFormat,
   clickhouseCompliantRandomCharacters,
@@ -2038,11 +2040,13 @@ export const getDistinctScoreNames = async (p: {
   return rows.map((row) => row.name);
 };
 
-export const getScoresForBlobStorageExport = function (
+// Shared query for both the standard (parsed) and Parquet (`exec` binary)
+// score export paths.
+const buildScoresForBlobStorageExportQuery = (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
-) {
+) => {
   const query = `
     SELECT
       id,
@@ -2068,7 +2072,7 @@ export const getScoresForBlobStorageExport = function (
     AND data_type IN ({dataTypes: Array(String)})
   `;
 
-  const records = queryClickhouseStream<Record<string, unknown>>({
+  return {
     query,
     params: {
       projectId,
@@ -2085,9 +2089,35 @@ export const getScoresForBlobStorageExport = function (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
-  });
+  };
+};
 
-  return records;
+export const getScoresForBlobStorageExport = function (
+  projectId: string,
+  minTimestamp: Date,
+  maxTimestamp: Date,
+) {
+  return queryClickhouseStream<Record<string, unknown>>(
+    buildScoresForBlobStorageExportQuery(projectId, minTimestamp, maxTimestamp),
+  );
+};
+
+// LFE-10463: ClickHouse-native `FORMAT Parquet` export of scores. Reuses the
+// standard query SQL and streams the raw binary body straight to upload.
+export const getScoresForBlobStorageExportParquet = function (
+  projectId: string,
+  minTimestamp: Date,
+  maxTimestamp: Date,
+) {
+  return queryClickhouseExecRaw({
+    ...buildScoresForBlobStorageExportQuery(
+      projectId,
+      minTimestamp,
+      maxTimestamp,
+    ),
+    format: "Parquet",
+    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+  });
 };
 
 export const getScoresForAnalyticsIntegrations = async function* (

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -3,6 +3,8 @@ import {
   parseClickhouseUTCDateTimeFormat,
   queryClickhouse,
   queryClickhouseStream,
+  queryClickhouseExecRaw,
+  BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
   upsertClickhouse,
 } from "./clickhouse";
 import {
@@ -1393,11 +1395,13 @@ export const getUserMetrics = async (
   });
 };
 
-export const getTracesForBlobStorageExport = function (
+// Shared query for both the standard (parsed) and Parquet (`exec` binary)
+// trace export paths, so the SELECT/WHERE stays in one place.
+const buildTracesForBlobStorageExportQuery = (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
-) {
+) => {
   const traceTable = "traces";
 
   const query = `
@@ -1425,7 +1429,7 @@ export const getTracesForBlobStorageExport = function (
     AND timestamp <= {maxTimestamp: DateTime64(3)}
   `;
 
-  return queryClickhouseStream<Record<string, unknown>>({
+  return {
     query,
     params: {
       projectId,
@@ -1441,6 +1445,35 @@ export const getTracesForBlobStorageExport = function (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
+  };
+};
+
+export const getTracesForBlobStorageExport = function (
+  projectId: string,
+  minTimestamp: Date,
+  maxTimestamp: Date,
+) {
+  return queryClickhouseStream<Record<string, unknown>>(
+    buildTracesForBlobStorageExportQuery(projectId, minTimestamp, maxTimestamp),
+  );
+};
+
+// LFE-10463: ClickHouse-native `FORMAT Parquet` export. Reuses the standard
+// query SQL and streams the raw binary body straight to upload (no JS parse,
+// enrich, or serialize). Returns the wrapped Readable from queryClickhouseExecRaw.
+export const getTracesForBlobStorageExportParquet = function (
+  projectId: string,
+  minTimestamp: Date,
+  maxTimestamp: Date,
+) {
+  return queryClickhouseExecRaw({
+    ...buildTracesForBlobStorageExportQuery(
+      projectId,
+      minTimestamp,
+      maxTimestamp,
+    ),
+    format: "Parquet",
+    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
   });
 };
 

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1458,9 +1458,8 @@ export const getTracesForBlobStorageExport = function (
   );
 };
 
-// LFE-10463: ClickHouse-native `FORMAT Parquet` export. Reuses the standard
-// query SQL and streams the raw binary body straight to upload (no JS parse,
-// enrich, or serialize). Returns the wrapped Readable from queryClickhouseExecRaw.
+// LFE-10463: FORMAT Parquet export — reuses the standard SQL, streams raw binary
+// bytes to upload (no JS parse/enrich/serialize) via queryClickhouseExecRaw.
 export const getTracesForBlobStorageExportParquet = function (
   projectId: string,
   minTimestamp: Date,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ importers:
         version: 16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -193,6 +193,9 @@ importers:
       '@clickhouse/client':
         specifier: ^1.18.5
         version: 1.18.5
+      '@clickhouse/client-common':
+        specifier: ^1.18.5
+        version: 1.18.5
       '@google-cloud/storage':
         specifier: ^7.19.0
         version: 7.19.0
@@ -201,7 +204,7 @@ importers:
         version: 1.3.26(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/aws':
         specifier: ^1.3.4
-        version: 1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+        version: 1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))
       '@langchain/core':
         specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
@@ -210,7 +213,7 @@ importers:
         version: 0.1.11(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/openai':
         specifier: ^1.4.2
-        version: 1.4.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)
+        version: 1.4.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))(ws@8.21.0)
       '@opentelemetry/api':
         specifier: '>=1.0.0 <1.10.0'
         version: 1.9.1
@@ -288,7 +291,7 @@ importers:
         version: 11.2.7
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nodemailer:
         specifier: ^7.0.11
         version: 7.0.13
@@ -700,7 +703,7 @@ importers:
         version: 16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-query-params:
         specifier: ^5.1.0
         version: 5.1.0(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(use-query-params@2.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -12797,9 +12800,9 @@ snapshots:
       type-graphql: 2.0.0-rc.1(class-validator@0.14.4)(graphql-scalars@1.25.0(graphql@16.13.2))(graphql@16.13.2)
       zod: 4.3.6
     optionalDependencies:
-      '@langchain/aws': 1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+      '@langchain/aws': 1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))
       '@langchain/langgraph-sdk': 1.9.10(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@langchain/openai': 1.4.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)
+      '@langchain/openai': 1.4.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))(ws@8.21.0)
       langchain: 1.3.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
     transitivePeerDependencies:
       - '@ag-ui/encoder'
@@ -13622,7 +13625,7 @@ snapshots:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       zod: 4.3.6
 
-  '@langchain/aws@1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))':
+  '@langchain/aws@1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))':
     dependencies:
       '@aws-sdk/client-bedrock-agent-runtime': 3.1024.0
       '@aws-sdk/client-bedrock-runtime': 3.1013.0
@@ -13657,12 +13660,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))':
+  '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.8.7(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@langchain/langgraph-sdk@1.8.7(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 9.3.0
@@ -13685,11 +13688,11 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@langchain/langgraph@1.2.7(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
+  '@langchain/langgraph@1.2.7(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
-      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
-      '@langchain/langgraph-sdk': 1.8.7(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))
+      '@langchain/langgraph-sdk': 1.8.7(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 4.3.6
@@ -13701,7 +13704,7 @@ snapshots:
       - svelte
       - vue
 
-  '@langchain/openai@1.4.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)':
+  '@langchain/openai@1.4.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))(ws@8.21.0)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       js-tiktoken: 1.0.21
@@ -13933,7 +13936,7 @@ snapshots:
   '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@prisma/client': 6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2)
-      next-auth: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-auth: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   '@next/env@16.0.0': {}
 
@@ -18584,7 +18587,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -20067,8 +20070,8 @@ snapshots:
   langchain@1.3.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6)):
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
-      '@langchain/langgraph': 1.2.7(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
-      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+      '@langchain/langgraph': 1.2.7(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(ws@8.21.0))
       langsmith: 0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       uuid: 11.1.1
       zod: 4.3.6
@@ -20820,7 +20823,7 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@babel/runtime': 7.29.2
       '@panva/hkdf': 1.2.1

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -1744,4 +1744,122 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       expect(content).toContain("CSV Fallback Event");
     }, 30_000);
   });
+
+  maybeDescribe("Parquet export (LFE-10463)", () => {
+    // End-to-end: exportTuning.parquet routes the real handler through
+    // queryClickhouseExecRaw → exception-tag Transform → ByteCounter → MinIO,
+    // producing .parquet objects for every table. Parquet magic ("PAR1") is
+    // ASCII, so it survives the string download at both ends of the body.
+    const PARQUET_MAGIC = "PAR1";
+
+    it("exports valid .parquet files for all tables, ignoring compressed, and survives an adversarial trace name", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+      const now = new Date();
+      const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+      const dataTime = now.getTime() - 90 * 60 * 1000;
+      const traceId = randomUUID();
+      const adversarialTraceId = randomUUID();
+      const observationId = randomUUID();
+      const scoreId = randomUUID();
+      const eventId = randomUUID();
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId: minioAccessKeyId,
+          secretAccessKey: encrypt(minioAccessKeySecret),
+          region: region ? region : "auto",
+          endpoint: minioEndpoint,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "hourly",
+          exportSource: "TRACES_OBSERVATIONS_EVENTS",
+          nextSyncAt: twoHoursAgo,
+          lastSyncAt: twoHoursAgo,
+          // compressed must be ignored on the parquet path (no .gz suffix).
+          compressed: true,
+          fileType: BlobStorageIntegrationFileType.JSONL,
+          exportTuning: { parquet: true },
+        },
+      });
+
+      await Promise.all([
+        createTracesCh([
+          createTrace({
+            id: traceId,
+            project_id: projectId,
+            timestamp: dataTime,
+            name: "Parquet Trace",
+          }),
+          // A trace whose name starts with the exception-trailer marker. It
+          // lands verbatim in the uncompressed Parquet footer min-stat; the
+          // per-query-tag scan must NOT treat it as a failure (regression for
+          // the footer-DoS fix — the export must still succeed).
+          createTrace({
+            id: adversarialTraceId,
+            project_id: projectId,
+            timestamp: dataTime,
+            name: "\r\n__exception__\r\n adversarial",
+          }),
+        ]),
+        createObservationsCh([
+          createObservation({
+            id: observationId,
+            trace_id: traceId,
+            project_id: projectId,
+            start_time: dataTime,
+            end_time: dataTime + 5000,
+            name: "Parquet Observation",
+          }),
+        ]),
+        createScoresCh([
+          createTraceScore({
+            id: scoreId,
+            trace_id: traceId,
+            project_id: projectId,
+            timestamp: dataTime,
+            name: "Parquet Score",
+            value: 0.5,
+          }),
+        ]),
+        createEventsCh([
+          createEvent({
+            id: eventId,
+            project_id: projectId,
+            trace_id: traceId,
+            type: "GENERATION",
+            name: "Parquet Event",
+            start_time: dataTime * 1000,
+            end_time: (dataTime + 5000) * 1000,
+          }),
+        ]),
+      ]);
+
+      await handleBlobStorageIntegrationProjectJob({
+        data: { payload: { projectId } },
+      } as Job);
+
+      const files = await s3StorageService.listFiles(s3Prefix);
+      const projectFiles = files.filter((f) => f.file.includes(projectId));
+
+      // traces, observations, scores, observations_v2 (events).
+      expect(projectFiles).toHaveLength(4);
+      for (const f of projectFiles) {
+        expect(f.file.endsWith(".parquet")).toBe(true);
+        expect(f.file).not.toContain(".gz");
+      }
+
+      // Every object is a valid Parquet file (magic at both ends).
+      for (const f of projectFiles) {
+        const content = await s3StorageService.download(f.file);
+        expect(content.startsWith(PARQUET_MAGIC)).toBe(true);
+        expect(content.endsWith(PARQUET_MAGIC)).toBe(true);
+      }
+    }, 30_000);
+  });
 });

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -1746,9 +1746,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
   });
 
   maybeDescribe("Parquet export (LFE-10463)", () => {
-    // End-to-end: exportTuning.parquet routes the real handler through
-    // queryClickhouseExecRaw → exception-tag Transform → ByteCounter → MinIO,
-    // producing .parquet objects for every table. Parquet magic ("PAR1") is
+    // E2e: exportTuning.parquet runs the real handler → MinIO. Parquet magic is
     // ASCII, so it survives the string download at both ends of the body.
     const PARQUET_MAGIC = "PAR1";
 
@@ -1796,10 +1794,9 @@ describe("BlobStorageIntegrationProcessingJob", () => {
             timestamp: dataTime,
             name: "Parquet Trace",
           }),
-          // A trace whose name starts with the exception-trailer marker. It
-          // lands verbatim in the uncompressed Parquet footer min-stat; the
-          // per-query-tag scan must NOT treat it as a failure (regression for
-          // the footer-DoS fix — the export must still succeed).
+          // Name starting with the exception marker lands in the uncompressed
+          // footer min-stat; the per-query-tag scan must not false-positive
+          // (footer-DoS regression — export must still succeed).
           createTrace({
             id: adversarialTraceId,
             project_id: projectId,

--- a/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
+++ b/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { Readable } from "stream";
 
 // Records of every uploadFileBuffered call so we can assert the resolved tuning
 // was threaded through. Hoisted so the module mock can close over it.
@@ -39,6 +40,28 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
     getObservationsForBlobStorageExport: () => empty(),
     getScoresForBlobStorageExport: () => empty(),
     getEventsForBlobStorageExport: () => empty(),
+    // LFE-10463 Parquet path: each returns an already-resolved
+    // { stream } (the binary body) — a tiny Readable with the Parquet magic.
+    getTracesForBlobStorageExportParquet: async () => ({
+      queryId: "q",
+      stream: Readable.from([Buffer.from("PAR1")]),
+      responseHeaders: {},
+    }),
+    getScoresForBlobStorageExportParquet: async () => ({
+      queryId: "q",
+      stream: Readable.from([Buffer.from("PAR1")]),
+      responseHeaders: {},
+    }),
+    getObservationsForBlobStorageExportParquet: async () => ({
+      queryId: "q",
+      stream: Readable.from([Buffer.from("PAR1")]),
+      responseHeaders: {},
+    }),
+    getEventsForBlobStorageExportParquet: async () => ({
+      queryId: "q",
+      stream: Readable.from([Buffer.from("PAR1")]),
+      responseHeaders: {},
+    }),
     createModelCache: () => ({ getModel: async () => null }),
     blobStorageEndpointConnectionValidationOptions: () => undefined,
   };
@@ -127,6 +150,56 @@ describe("handleBlobStorageIntegrationProjectJob tuning wiring", () => {
       // backend keeps its native default (Azure 5, buffered S3 env, etc.).
       expect(call.maxConcurrentParts).toBeUndefined();
       expect(call.maxPartAttempts).toBeUndefined();
+    }
+  });
+
+  // LFE-10463: parquet tuning routes every table through the Parquet path,
+  // overriding fileType (CSV here) and the .gz suffix.
+  it("produces .parquet files with the parquet content type when parquet is enabled", async () => {
+    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue(
+      baseRow({ parquet: true }),
+    );
+
+    await handleBlobStorageIntegrationProjectJob(makeJob());
+
+    // exportSource TRACES_OBSERVATIONS → scores, traces, observations.
+    expect(uploadCalls.length).toBe(3);
+    for (const call of uploadCalls) {
+      expect(call.fileName.endsWith(".parquet")).toBe(true);
+      expect(call.fileName.endsWith(".gz")).toBe(false);
+      expect(call.fileType).toBe("application/vnd.apache.parquet");
+    }
+  });
+
+  it("ignores the compressed flag on the parquet path (no .gz suffix)", async () => {
+    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue({
+      ...baseRow({ parquet: true }),
+      compressed: true,
+      fileType: "JSONL",
+    });
+
+    await handleBlobStorageIntegrationProjectJob(makeJob());
+
+    expect(uploadCalls.length).toBe(3);
+    for (const call of uploadCalls) {
+      expect(call.fileName.endsWith(".parquet")).toBe(true);
+      expect(call.fileName).not.toContain(".gz");
+      expect(call.fileType).toBe("application/vnd.apache.parquet");
+    }
+  });
+
+  it("parquet takes precedence over rawPassthrough", async () => {
+    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue({
+      ...baseRow({ parquet: true, rawPassthrough: true }),
+      fileType: "JSONL",
+    });
+
+    await handleBlobStorageIntegrationProjectJob(makeJob());
+
+    expect(uploadCalls.length).toBe(3);
+    for (const call of uploadCalls) {
+      expect(call.fileName.endsWith(".parquet")).toBe(true);
+      expect(call.fileType).toBe("application/vnd.apache.parquet");
     }
   });
 });

--- a/worker/src/__tests__/clickhouseExecRawParquet.integration.test.ts
+++ b/worker/src/__tests__/clickhouseExecRawParquet.integration.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect } from "vitest";
 import {
   queryClickhouseExecRaw,
   BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
-} from "./clickhouse";
+} from "@langfuse/shared/src/server";
 
-// Integration tests against a live ClickHouse (>= 25.11 for mid-stream exception
-// detection). Validate the FORMAT Parquet exec path end to end: valid Parquet
-// bytes on success, and a hard stream error (not a silent truncation) when the
-// query fails after the 200 response.
+// Integration tests for the FORMAT Parquet exec path against a live ClickHouse.
+// Lives in worker (not shared) because the shared test job runs without a
+// ClickHouse service — these need a real server. Validates valid Parquet bytes
+// on success and a hard error (not a silent/truncated success) on failure.
+// Mid-stream exception-tag parsing is unit-tested separately in shared
+// (clickhouseExecExceptionTag.test.ts) and does not depend on CH version here.
 
 const PARQUET_MAGIC = Buffer.from("PAR1");
 
@@ -36,13 +38,12 @@ describe("queryClickhouseExecRaw — FORMAT Parquet", () => {
   });
 
   it("surfaces a failing query as an error instead of a silent/truncated success", async () => {
-    // A query that throwIf-fails must never yield a clean stream. Depending on
-    // how far ClickHouse gets before failing, the error surfaces either as a
-    // pre-200 exec() rejection or, once 200 has been sent, via the end-of-stream
-    // exception-tag trailer the Transform scans for. Both are acceptable — the
-    // invariant under test is that the failure is never swallowed. (The trailer
-    // parsing path itself is unit-tested with synthetic chunks in
-    // clickhouseExecExceptionTag.test.ts.)
+    // A query that throwIf-fails must never yield a clean stream. The error
+    // surfaces either as a pre-200 exec() rejection or, once 200 has been sent,
+    // via the end-of-stream exception-tag trailer the Transform scans for (CH
+    // >= 25.11). Both are acceptable — the invariant is that the failure is
+    // never swallowed. (Trailer parsing is unit-tested with synthetic chunks in
+    // shared's clickhouseExecExceptionTag.test.ts.)
     const run = async () => {
       const { stream } = await queryClickhouseExecRaw({
         query:

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -11,10 +11,14 @@ import {
   streamTransformations,
   getObservationsForBlobStorageExport,
   getObservationsForBlobStorageExportRaw,
+  getObservationsForBlobStorageExportParquet,
   getTracesForBlobStorageExport,
+  getTracesForBlobStorageExportParquet,
   getScoresForBlobStorageExport,
+  getScoresForBlobStorageExportParquet,
   getEventsForBlobStorageExport,
   getEventsForBlobStorageExportRaw,
+  getEventsForBlobStorageExportParquet,
   getCurrentSpan,
   instrumentAsync,
   recordGauge,
@@ -63,6 +67,9 @@ export const BlobExportFormat = {
   CSV_GZIP: "csv-gzip",
   JSONL_RAW: "jsonl-raw",
   JSONL_GZIP: "jsonl-gzip",
+  // LFE-10463: ClickHouse-native columnar export; compression is internal to
+  // Parquet, so there is no separate raw/gzip split.
+  PARQUET: "parquet",
 } as const;
 export type BlobExportFormat =
   (typeof BlobExportFormat)[keyof typeof BlobExportFormat];
@@ -273,6 +280,33 @@ class ByteCounter extends Transform {
   }
 }
 
+// ByteCounter that also tallies the wall-clock gap between consecutive chunks
+// into `stats.sourceWaitMs`, used by the Parquet path (a piped binary stream
+// with no per-row generator) so it can reuse the same chReadMs/uploadWaitMs
+// derivation as the standard path. As with countedStream, this "source wait"
+// conflates upstream ClickHouse delivery with downstream S3 backpressure — it is
+// a coarse read-vs-upload split, not an exact one.
+class TimedByteCounter extends ByteCounter {
+  private readonly stats: { sourceWaitMs: number };
+  private lastChunkDoneAt: number | null = null;
+  constructor(stats: { sourceWaitMs: number }) {
+    super();
+    this.stats = stats;
+  }
+  _transform(
+    chunk: Buffer,
+    _encoding: string,
+    callback: (error: Error | null, data?: Buffer) => void,
+  ) {
+    if (this.lastChunkDoneAt !== null) {
+      this.stats.sourceWaitMs += performance.now() - this.lastChunkDoneAt;
+    }
+    this.bytes += chunk.length;
+    this.lastChunkDoneAt = performance.now();
+    callback(null, chunk);
+  }
+}
+
 async function* countedStream<T>(
   source: AsyncGenerator<T>,
   stats: { rows: number; sourceWaitMs: number },
@@ -318,6 +352,9 @@ const processBlobStorageExport = async (config: {
   convertV4LatencyToSeconds: boolean;
   exportFieldGroups?: ObservationFieldGroupFull[];
   rawPassthrough: boolean;
+  // LFE-10463: when true, export via ClickHouse-native `FORMAT Parquet`,
+  // overriding `fileType` and `compressed`. Takes precedence over rawPassthrough.
+  parquet: boolean;
   // undefined concurrency/attempts => backend keeps its native default.
   partSizeBytes: number;
   maxConcurrentParts: number | undefined;
@@ -419,22 +456,14 @@ const processBlobStorageExport = async (config: {
       try {
         const blobStorageProps = getFileTypeProperties(config.fileType);
 
-        const timestamp = config.maxTimestamp
-          .toISOString()
-          .replace(/:/g, "-")
-          .substring(0, 19);
-        const extension = config.compressed
-          ? `${blobStorageProps.extension}.gz`
-          : blobStorageProps.extension;
-        const filePath = `${config.prefix ?? ""}${config.projectId}/${config.table}/${timestamp}.${extension}`;
-        const uploadContentType = config.compressed
-          ? "application/gzip"
-          : blobStorageProps.contentType;
-
-        const exportFieldGroups =
-          config.exportFieldGroups && config.exportFieldGroups.length > 0
-            ? config.exportFieldGroups
-            : [...OBSERVATION_FIELD_GROUPS_FULL];
+        // LFE-10463: Parquet is a per-project opt-in (exportTuning.parquet) that
+        // applies to ALL tables and file types. It overrides fileType and
+        // compressed — Parquet handles compression internally (ClickHouse default
+        // codec) — and takes precedence over rawPassthrough (already enforced in
+        // resolveBlobExportTuning). Parquet is NOT a BlobStorageIntegrationFileType
+        // member, so the extension/content-type are computed inline here rather
+        // than via getFileTypeProperties (which switches on the enum).
+        const parquetEligible = config.parquet;
 
         // Raw passthrough (LFE-10402) is opt-in per project and only valid for
         // JSONL output of the enriched-observation tables — the only formats
@@ -444,15 +473,42 @@ const processBlobStorageExport = async (config: {
         // select the path per table (scores/traces always use the standard path,
         // so per-table fallback is expected and not worth a warning).
         const passthroughEligible =
+          !parquetEligible &&
           config.rawPassthrough &&
           config.fileType === BlobStorageIntegrationFileType.JSONL &&
           (config.table === "observations" ||
             config.table === "observations_v2");
 
-        span.setAttribute(
-          "blob.path",
-          passthroughEligible ? "passthrough" : "standard",
-        );
+        const exportPath = parquetEligible
+          ? "parquet"
+          : passthroughEligible
+            ? "passthrough"
+            : "standard";
+
+        const timestamp = config.maxTimestamp
+          .toISOString()
+          .replace(/:/g, "-")
+          .substring(0, 19);
+        // Parquet: fixed `.parquet` extension (no `.gz`) and Parquet content type.
+        const extension = parquetEligible
+          ? "parquet"
+          : config.compressed
+            ? `${blobStorageProps.extension}.gz`
+            : blobStorageProps.extension;
+        const filePath = `${config.prefix ?? ""}${config.projectId}/${config.table}/${timestamp}.${extension}`;
+        const uploadContentType = parquetEligible
+          ? "application/vnd.apache.parquet"
+          : config.compressed
+            ? "application/gzip"
+            : blobStorageProps.contentType;
+
+        const exportFieldGroups =
+          config.exportFieldGroups && config.exportFieldGroups.length > 0
+            ? config.exportFieldGroups
+            : [...OBSERVATION_FIELD_GROUPS_FULL];
+
+        span.setAttribute("blob.path", exportPath);
+        span.setAttribute("blob.config.parquet", config.parquet);
 
         const pipelineCallback = (err: NodeJS.ErrnoException | null) => {
           if (err) {
@@ -463,8 +519,23 @@ const processBlobStorageExport = async (config: {
           }
         };
 
-        const serializedCounter = new ByteCounter();
-        const compressedCounter = config.compressed ? new ByteCounter() : null;
+        // Tracks ClickHouse read wait. Declared before the counters so the
+        // parquet TimedByteCounter can write into it (the parquet path has no
+        // per-row generator, so countedStream does not run).
+        const sourceStats = { rows: 0, sourceWaitMs: 0 };
+        // When enrichment is active, chStats isolates ClickHouse read wait from
+        // enrichment CPU. enrichMs = sourceStats.sourceWaitMs - chStats.sourceWaitMs.
+        let chStats: { rows: number; sourceWaitMs: number } | null = null;
+
+        // Parquet feeds sourceStats.sourceWaitMs from the piped binary stream so
+        // the shared metrics derivation works without a per-row generator.
+        const serializedCounter = parquetEligible
+          ? new TimedByteCounter(sourceStats)
+          : new ByteCounter();
+        // No worker-side gzip on the parquet path (compression is internal to
+        // Parquet), so the parquet path never allocates a compressed counter.
+        const compressedCounter =
+          !parquetEligible && config.compressed ? new ByteCounter() : null;
         // Paired with compressedCounter: both exist iff compression is on.
         const gzipStats: GzipStats | null = compressedCounter
           ? {
@@ -473,13 +544,6 @@ const processBlobStorageExport = async (config: {
               backpressureMs: 0,
             }
           : null;
-
-        // Both paths tally rows in JS via countedStream (the passthrough yields
-        // raw row text rather than parsed objects, but still iterates).
-        const sourceStats = { rows: 0, sourceWaitMs: 0 };
-        // When enrichment is active, chStats isolates ClickHouse read wait from
-        // enrichment CPU. enrichMs = sourceStats.sourceWaitMs - chStats.sourceWaitMs.
-        let chStats: { rows: number; sourceWaitMs: number } | null = null;
 
         const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
         const heartbeatTags = {
@@ -501,7 +565,66 @@ const processBlobStorageExport = async (config: {
 
         let fileStream: Readable;
 
-        if (passthroughEligible) {
+        if (parquetEligible) {
+          // LFE-10463: ClickHouse-native FORMAT Parquet. Stream the raw binary
+          // body straight to upload — no JS parse/enrich/serialize, no worker
+          // gzip, and no row counting (a binary stream has no row boundaries, so
+          // sourceStats.rows stays 0). Field-group projection, latency ms→s, and
+          // the dropped price columns are all baked into the SQL. The
+          // exception-tag Transform inside queryClickhouseExecRaw errors the
+          // stream on a mid-stream ClickHouse failure (CH ≥ 25.11), aborting the
+          // upload before any S3 commit — same guarantee as raw passthrough.
+          let parquetSource: Readable;
+          switch (config.table) {
+            case "traces":
+              parquetSource = (
+                await getTracesForBlobStorageExportParquet(
+                  config.projectId,
+                  config.minTimestamp,
+                  config.maxTimestamp,
+                )
+              ).stream;
+              break;
+            case "scores":
+              parquetSource = (
+                await getScoresForBlobStorageExportParquet(
+                  config.projectId,
+                  config.minTimestamp,
+                  config.maxTimestamp,
+                )
+              ).stream;
+              break;
+            case "observations":
+              parquetSource = (
+                await getObservationsForBlobStorageExportParquet(
+                  config.projectId,
+                  config.minTimestamp,
+                  config.maxTimestamp,
+                  exportFieldGroups,
+                )
+              ).stream;
+              break;
+            case "observations_v2": // observations_v2 is the events table
+              parquetSource = (
+                await getEventsForBlobStorageExportParquet(
+                  config.projectId,
+                  config.minTimestamp,
+                  config.maxTimestamp,
+                  exportFieldGroups,
+                  config.convertV4LatencyToSeconds,
+                )
+              ).stream;
+              break;
+            default:
+              throw new Error(`Unsupported table type: ${config.table}`);
+          }
+
+          fileStream = pipeline(
+            parquetSource,
+            serializedCounter,
+            pipelineCallback,
+          );
+        } else if (passthroughEligible) {
           // Stream ClickHouse JSONEachRow row text straight through: skip the
           // per-row JSON.parse, enrichment, and re-serialize. Shaping (latency→s,
           // dropped price columns, field-group selection) is baked into the SQL.
@@ -663,14 +786,13 @@ const processBlobStorageExport = async (config: {
             projectId: config.projectId,
           });
 
-          const exportFormat = resolveBlobExportFormat(
-            config.fileType,
-            config.compressed,
-          );
+          const exportFormat = parquetEligible
+            ? BlobExportFormat.PARQUET
+            : resolveBlobExportFormat(config.fileType, config.compressed);
           const byteTags = {
             table: config.table,
             projectId: config.projectId,
-            path: passthroughEligible ? "passthrough" : "standard",
+            path: exportPath,
             source: exportFormat,
           };
           recordIncrement(
@@ -709,7 +831,7 @@ const processBlobStorageExport = async (config: {
           logger.info(
             `[BLOB INTEGRATION] Successfully exported ${config.table} for project ${config.projectId}: ` +
               `jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${WORKER_HOST_ID} ` +
-              `path=${passthroughEligible ? "passthrough" : "standard"} ` +
+              `path=${exportPath} ` +
               `rows=${sourceStats.rows} chReadMs=${chReadMs} enrichMs=${enrichMs} ` +
               `gzipCpuMs=${gzipCpuMs} uploadWaitMs=${uploadWaitMs} ` +
               `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${uploadDurationMs} ` +
@@ -755,13 +877,12 @@ const processBlobStorageExport = async (config: {
                 : Math.max(0, totalUploadMs - finalChReadMs - finalEnrichMs);
               span.setAttribute("blob.gzipCpuMs", finalGzipCpuMs);
               span.setAttribute("blob.uploadWaitMs", finalUploadWaitMs);
-              const finalExportFormat = resolveBlobExportFormat(
-                config.fileType,
-                config.compressed,
-              );
+              const finalExportFormat = parquetEligible
+                ? BlobExportFormat.PARQUET
+                : resolveBlobExportFormat(config.fileType, config.compressed);
               const stageTags = {
                 table: config.table,
-                path: passthroughEligible ? "passthrough" : "standard",
+                path: exportPath,
                 source: finalExportFormat,
               };
               recordHistogram(
@@ -819,7 +940,7 @@ const processBlobStorageExport = async (config: {
 
             const metricTags = {
               table: config.table,
-              path: passthroughEligible ? "passthrough" : "standard",
+              path: exportPath,
               gzipLevel: gzipStats.level,
             };
             recordHistogram(
@@ -1033,6 +1154,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
       exportFieldGroups:
         blobStorageIntegration.exportFieldGroups as ObservationFieldGroupFull[],
       rawPassthrough: exportTuning.rawPassthrough,
+      parquet: exportTuning.parquet,
       partSizeBytes: exportTuning.partSizeBytes,
       maxConcurrentParts: exportTuning.maxConcurrentParts,
       maxPartAttempts: exportTuning.maxPartAttempts,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -280,12 +280,10 @@ class ByteCounter extends Transform {
   }
 }
 
-// ByteCounter that also tallies the wall-clock gap between consecutive chunks
-// into `stats.sourceWaitMs`, used by the Parquet path (a piped binary stream
-// with no per-row generator) so it can reuse the same chReadMs/uploadWaitMs
-// derivation as the standard path. As with countedStream, this "source wait"
-// conflates upstream ClickHouse delivery with downstream S3 backpressure — it is
-// a coarse read-vs-upload split, not an exact one.
+// ByteCounter that also tallies the gap between chunks into `stats.sourceWaitMs`,
+// letting the Parquet path (a piped binary stream, no per-row generator) reuse
+// the standard chReadMs/uploadWaitMs derivation. Like countedStream, this "source
+// wait" conflates ClickHouse delivery with S3 backpressure — a coarse split.
 class TimedByteCounter extends ByteCounter {
   private readonly stats: { sourceWaitMs: number };
   private lastChunkDoneAt: number | null = null;
@@ -456,13 +454,11 @@ const processBlobStorageExport = async (config: {
       try {
         const blobStorageProps = getFileTypeProperties(config.fileType);
 
-        // LFE-10463: Parquet is a per-project opt-in (exportTuning.parquet) that
-        // applies to ALL tables and file types. It overrides fileType and
-        // compressed — Parquet handles compression internally (ClickHouse default
-        // codec) — and takes precedence over rawPassthrough (already enforced in
-        // resolveBlobExportTuning). Parquet is NOT a BlobStorageIntegrationFileType
-        // member, so the extension/content-type are computed inline here rather
-        // than via getFileTypeProperties (which switches on the enum).
+        // LFE-10463: per-project opt-in spanning all tables/file types. Overrides
+        // fileType and compressed (Parquet compresses internally) and outranks
+        // rawPassthrough (enforced in resolveBlobExportTuning). It isn't a
+        // BlobStorageIntegrationFileType member, so extension/content-type are set
+        // inline below rather than via getFileTypeProperties.
         const parquetEligible = config.parquet;
 
         // Raw passthrough (LFE-10402) is opt-in per project and only valid for
@@ -566,14 +562,12 @@ const processBlobStorageExport = async (config: {
         let fileStream: Readable;
 
         if (parquetEligible) {
-          // LFE-10463: ClickHouse-native FORMAT Parquet. Stream the raw binary
-          // body straight to upload — no JS parse/enrich/serialize, no worker
-          // gzip, and no row counting (a binary stream has no row boundaries, so
-          // sourceStats.rows stays 0). Field-group projection, latency ms→s, and
-          // the dropped price columns are all baked into the SQL. The
-          // exception-tag Transform inside queryClickhouseExecRaw errors the
-          // stream on a mid-stream ClickHouse failure (CH ≥ 25.11), aborting the
-          // upload before any S3 commit — same guarantee as raw passthrough.
+          // LFE-10463: stream raw FORMAT Parquet bytes straight to upload — no JS
+          // parse/enrich/serialize, no gzip, no row counting (binary has no row
+          // boundaries, so sourceStats.rows stays 0). Field-group projection,
+          // latency ms→s, and dropped price columns are baked into the SQL. The
+          // exception-tag Transform in queryClickhouseExecRaw aborts the upload
+          // before commit on a mid-stream failure — same guarantee as passthrough.
           let parquetSource: Readable;
           switch (config.table) {
             case "traces":

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -503,8 +503,9 @@ const processBlobStorageExport = async (config: {
             ? config.exportFieldGroups
             : [...OBSERVATION_FIELD_GROUPS_FULL];
 
+        // blob.path already encodes parquet (no per-table fallback), so no
+        // separate blob.config.parquet attribute is needed.
         span.setAttribute("blob.path", exportPath);
-        span.setAttribute("blob.config.parquet", config.parquet);
 
         const pipelineCallback = (err: NodeJS.ErrnoException | null) => {
           if (err) {

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -280,17 +280,15 @@ class ByteCounter extends Transform {
   }
 }
 
-// ByteCounter that also tallies the gap between chunks into `stats.sourceWaitMs`,
-// letting the Parquet path (a piped binary stream, no per-row generator) reuse
-// the standard chReadMs/uploadWaitMs derivation. Like countedStream, this "source
-// wait" conflates ClickHouse delivery with S3 backpressure — a coarse split.
+// ByteCounter that also tallies inter-chunk gaps into `stats.sourceWaitMs`, so
+// the Parquet path (piped binary stream, no per-row generator) reuses the
+// standard chReadMs/uploadWaitMs derivation. Coarse: source wait conflates CH
+// delivery with S3 backpressure (same as countedStream).
 class TimedByteCounter extends ByteCounter {
   private readonly stats: { sourceWaitMs: number };
-  // Clock starts at construction (not on the first chunk) so the first gap
-  // captures time-to-first-byte — the dominant ClickHouse wait, since Parquet
-  // composes a row group before emitting any bytes. countedStream starts its
-  // clock before its for-await loop for the same reason; guarding the first
-  // chunk would systematically drop TTFB from chReadMs (→ inflated uploadWaitMs).
+  // Clock starts at construction (like countedStream, before its loop) so the
+  // first gap captures time-to-first-byte — the dominant CH wait, since Parquet
+  // composes a row group before any bytes. Guarding it would drop TTFB from chReadMs.
   private lastChunkDoneAt: number = performance.now();
   constructor(stats: { sourceWaitMs: number }) {
     super();

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -286,7 +286,12 @@ class ByteCounter extends Transform {
 // wait" conflates ClickHouse delivery with S3 backpressure — a coarse split.
 class TimedByteCounter extends ByteCounter {
   private readonly stats: { sourceWaitMs: number };
-  private lastChunkDoneAt: number | null = null;
+  // Clock starts at construction (not on the first chunk) so the first gap
+  // captures time-to-first-byte — the dominant ClickHouse wait, since Parquet
+  // composes a row group before emitting any bytes. countedStream starts its
+  // clock before its for-await loop for the same reason; guarding the first
+  // chunk would systematically drop TTFB from chReadMs (→ inflated uploadWaitMs).
+  private lastChunkDoneAt: number = performance.now();
   constructor(stats: { sourceWaitMs: number }) {
     super();
     this.stats = stats;
@@ -296,9 +301,7 @@ class TimedByteCounter extends ByteCounter {
     _encoding: string,
     callback: (error: Error | null, data?: Buffer) => void,
   ) {
-    if (this.lastChunkDoneAt !== null) {
-      this.stats.sourceWaitMs += performance.now() - this.lastChunkDoneAt;
-    }
+    this.stats.sourceWaitMs += performance.now() - this.lastChunkDoneAt;
     this.bytes += chunk.length;
     this.lastChunkDoneAt = performance.now();
     callback(null, chunk);


### PR DESCRIPTION
## What does this PR do?

Phase 2 of the Parquet blob-export format ([LFE-10463](https://linear.app/langfuse/issue/LFE-10463); follows #14506, the shared-types phase). When a project's `exportTuning.parquet` flag is set, every export table (traces, observations, scores, events) is written via ClickHouse's native `FORMAT Parquet`, streamed straight to upload — no worker gzip, no per-row JSON parse/enrich/serialize. Columnar encoding and compression run on ClickHouse query threads, eliminating the single-threaded gzip bottleneck that dominates large exports.

**How it works**

- `queryClickhouseExecRaw()` (new, in `repositories/clickhouse.ts`) runs the query via `clickhouseClient().exec()`, which returns the raw HTTP body as a `Readable`. It appends `FORMAT <value>` to the SQL (exec has no `format` param) and wraps the body in an exception-tag-scanning `Transform`.
- `exec()` skips the client's row-parsing machinery, so it does no mid-stream exception detection. The new `ClickhouseExecExceptionTagTransform` restores that for binary formats: it scans for ClickHouse's end-of-stream `\r\n__exception__\r\n<tag>` marker (CH ≥ 25.11) and errors the stream on a failed query, so the pipeline aborts **before** any S3 commit instead of uploading a truncated object. Same version caveat as raw passthrough.
- Per-table Parquet export fns reuse the existing export SQL; `traces`/`scores` had their inline SQL extracted into shared query builders so the standard and Parquet paths can't drift.
- Handler: a `parquetEligible` dispatch guard (overrides `fileType`/`compressed`, takes precedence over `rawPassthrough`), `.parquet` extension + `application/vnd.apache.parquet` content type, metrics tagged `format=parquet`, and row count `0` (a binary stream has no row boundaries).
- Adds `@clickhouse/client-common` as a direct dependency for the exception-tag helpers (already present transitively at the same version).

**Behavior is gated entirely behind `exportTuning.parquet`** (set via DB, no UI/API surface yet — see [LFE-10463](https://linear.app/langfuse/issue/LFE-10463)). Existing integrations are untouched.

Fixes # (no GitHub issue — tracked in Linear)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Tests added: exception-tag `Transform` unit tests (synthetic trailers, chunk-boundary splits, passthrough when detection is disabled), live-ClickHouse integration (valid Parquet `PAR1` magic; a failing query surfaces an error rather than truncating), and parquet dispatch wiring (`.parquet` filenames per table, `compressed` ignored, precedence over `rawPassthrough`).
- Verified locally: `pnpm turbo lint`/`typecheck` for shared + worker, all touched test suites green against live ClickHouse 25.12.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a ClickHouse-native `FORMAT Parquet` export path for the blob-storage integration (LFE-10463), streaming binary Parquet bytes directly from ClickHouse to object storage — bypassing the per-row JS parse/enrich/serialize pipeline and worker-side gzip. A per-project `exportTuning.parquet` flag activates it; when set it overrides `fileType`, `compressed`, and takes precedence over `rawPassthrough`.

- **New `queryClickhouseExecRaw`** in `clickhouse.ts` calls `clickhouseClient().exec()`, appends `FORMAT <format>` to the SQL, and wraps the raw HTTP body in a new `ClickhouseExecExceptionTagTransform` that scans for the ClickHouse ≥ 25.11 end-of-stream exception trailer, erroring the stream on mid-stream failures before any S3 commit.
- **`ClickhouseExecExceptionTagTransform`** is a bounded-memory `Transform` (16-byte carry between chunks) with solid unit test coverage across marker split, passthrough-disabled, and partial-trailer cases.
- **Four new `getXxxForBlobStorageExportParquet` functions** in `traces.ts`, `scores.ts`, `observations.ts`, and `events.ts` share the existing query-builder SQL; the existing `getXxxForBlobStorageExport` stream functions are refactored onto the same shared builders with no behaviour change.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core binary streaming pipeline is well-designed and tested, but the exception-tag Transform's _flush path has a gap where a null return from extractErrorAtTheEndOfChunk would silently complete the stream instead of erroring it, risking a corrupt Parquet object being committed to storage.

The new ClickhouseExecExceptionTagTransform._flush calls extractErrorAtTheEndOfChunk and passes the result directly to callback() without a null guard. If the library returns null for a malformed trailer, callback(null) ends the stream cleanly, bypassing the upload-abort guarantee that is the primary safety property of this feature. The unit tests do not exercise the null-return edge case. The span lifecycle on stream destroy() without error is also unguarded.

clickhouseExecExceptionTag.ts — the _flush null-guard gap; clickhouse.ts — span close-event handling in queryClickhouseExecRaw.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Worker as BlobStorage Worker
    participant CH as ClickHouse
    participant T as ExceptionTagTransform
    participant TC as TimedByteCounter
    participant S3 as Object Storage

    Worker->>CH: exec("SELECT ... FORMAT Parquet")
    CH-->>Worker: 200 OK + x-clickhouse-exception-tag header
    Note over Worker: queryClickhouseExecRaw wraps body in ExceptionTagTransform

    loop Stream chunks
        CH-->>T: binary Parquet chunk
        T->>T: scan for marker
        alt No marker found
            T-->>TC: pass chunk through
            TC-->>S3: upload chunk (multipart)
        else Marker detected
            T->>T: accumulate error trailer
            T--xTC: error(parsed ClickHouse exception)
            Note over S3: upload aborted before commit
        end
    end

    alt Stream ends cleanly
        T->>T: _flush - emit withheld carry bytes
        TC-->>S3: finalize multipart upload
    else Stream ends with trailer
        T->>T: _flush - extractErrorAtTheEndOfChunk
        T--xS3: stream error propagated via pipeline
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Worker as BlobStorage Worker
    participant CH as ClickHouse
    participant T as ExceptionTagTransform
    participant TC as TimedByteCounter
    participant S3 as Object Storage

    Worker->>CH: exec("SELECT ... FORMAT Parquet")
    CH-->>Worker: 200 OK + x-clickhouse-exception-tag header
    Note over Worker: queryClickhouseExecRaw wraps body in ExceptionTagTransform

    loop Stream chunks
        CH-->>T: binary Parquet chunk
        T->>T: scan for marker
        alt No marker found
            T-->>TC: pass chunk through
            TC-->>S3: upload chunk (multipart)
        else Marker detected
            T->>T: accumulate error trailer
            T--xTC: error(parsed ClickHouse exception)
            Note over S3: upload aborted before commit
        end
    end

    alt Stream ends cleanly
        T->>T: _flush - emit withheld carry bytes
        TC-->>S3: finalize multipart upload
    else Stream ends with trailer
        T->>T: _flush - extractErrorAtTheEndOfChunk
        T--xS3: stream error propagated via pipeline
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/shared/src/server/repositories/clickhouseExecExceptionTag.ts:109-117
**Potential silent stream completion when `extractErrorAtTheEndOfChunk` returns null**

`extractErrorAtTheEndOfChunk` is documented (and can behave) as returning `Error | null` — null when the trailer cannot be parsed. When null is returned, `this.wrapError(null)` yields null (default wrapError is identity), and `callback(null)` ends the stream cleanly instead of erroring it. The net effect is that a ClickHouse failure after the marker is detected would silently complete the stream, allowing a truncated or corrupt Parquet file to be committed to object storage. A null-guard and a fallback `new Error("ClickHouse mid-stream failure (unparseable trailer)")` would close this gap.

### Issue 2 of 3
packages/shared/src/server/repositories/clickhouse.ts:135-141
**Span leaks when consumer destroys the stream without an error**

The span is closed only on `end` and `error` events. When `pipeline()` in the caller aborts an upload by calling `stream.destroy()` with no argument — or when the BullMQ job times out and the Node.js `pipeline` tears down the chain — `wrapped` emits `close` but neither `end` nor `error`. The span then stays open until the process exits. Adding `wrapped.once("close", () => span.end())` alongside the existing `error` listener would cover all teardown paths.

### Issue 3 of 3
packages/shared/src/server/repositories/clickhouse.ts:105-110
**`queryId` is always `undefined` when the pre-200 error fires**

`queryId` is declared before the `try`, assigned at line 112 (`queryId = res.query_id`), but the `.catch()` callback that calls `enrichWithQueryId(error as Error, queryId)` runs synchronously before the assignment — `queryId` is still `undefined` at that point. The resulting error message will never include the query ID for exec-level (pre-200) failures. The pattern is copied from `queryClickhouseStream`, so this is pre-existing, but now that there is a new public function it may be worth correcting for debuggability.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): stream ClickHouse-native P..."](https://github.com/langfuse/langfuse/commit/96012ffd4adb6af19e158f7a68c7d02315b8cee3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39518635)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->