### PR TITLE
chore: Enable eslint `no-else-return`

### DIFF
--- a/packages/config-eslint/base.js
+++ b/packages/config-eslint/base.js
@@ -45,6 +45,7 @@ export default tseslint.config(
     },
     rules: {
       "no-void": "warn",
+      "no-else-return": "warn",
       "no-redeclare": "off",
       "import/order": "off",
     },

--- a/packages/config-eslint/next.js
+++ b/packages/config-eslint/next.js
@@ -83,6 +83,7 @@ export default [
     },
     rules: {
       "no-void": "warn",
+      "no-else-return": "warn",
       "no-unused-vars": "off", // Use @typescript-eslint/no-unused-vars instead
       "@repo/no-tailwind-overflow-scroll": "warn",
       // Custom rules from old config

--- a/packages/shared/scripts/seeder/seed-dataset-versions.ts
+++ b/packages/shared/scripts/seeder/seed-dataset-versions.ts
@@ -162,12 +162,12 @@ export async function seedDatasetVersions(
             validFrom: op.validFrom, // When this version became valid
             isDeleted: true, // Soft delete flag
           };
-        } else {
-          return {
-            ...baseRow,
-            validFrom: version.timestamp, // When this version became valid
-          };
         }
+
+        return {
+          ...baseRow,
+          validFrom: version.timestamp, // When this version became valid
+        };
       });
 
       // Insert in batches directly into dataset_items (versioned table)

--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -887,24 +887,24 @@ const createScoreTableRelations = (
         timeDimension: "start_time",
       },
     };
-  } else {
-    return {
-      events_traces: {
-        name: "events_core",
-        joinConditionSql:
-          "ON scores.trace_id = events_traces.trace_id AND scores.project_id = events_traces.project_id AND events_traces.parent_span_id = ''",
-        timeDimension: "start_time",
-        useFinal: false,
-      },
-      events_observations: {
-        name: "events_core",
-        joinConditionSql:
-          "ON scores.project_id = events_observations.project_id AND scores.trace_id = events_observations.trace_id AND scores.observation_id = events_observations.span_id",
-        timeDimension: "start_time",
-        useFinal: false,
-      },
-    };
   }
+
+  return {
+    events_traces: {
+      name: "events_core",
+      joinConditionSql:
+        "ON scores.trace_id = events_traces.trace_id AND scores.project_id = events_traces.project_id AND events_traces.parent_span_id = ''",
+      timeDimension: "start_time",
+      useFinal: false,
+    },
+    events_observations: {
+      name: "events_core",
+      joinConditionSql:
+        "ON scores.project_id = events_observations.project_id AND scores.trace_id = events_observations.trace_id AND scores.observation_id = events_observations.span_id",
+      timeDimension: "start_time",
+      useFinal: false,
+    },
+  };
 };
 
 function scoresNumericViewBase(version: "v1" | "v2"): ViewDeclarationType {

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -883,15 +883,18 @@ export class QueryBuilder {
     // Choose appropriate granularity based on date range to get ~50 buckets
     if (diffHours < 2) {
       return "minute"; // Less than a 2h, use minutes
-    } else if (diffHours < 72) {
-      return "hour"; // Less than 3 days, use hours
-    } else if (diffHours < 1440) {
-      return "day"; // Less than 60 days, use days
-    } else if (diffHours < 8760) {
-      return "week"; // Less than a year, use weeks
-    } else {
-      return "month"; // Over a year, use months
     }
+    if (diffHours < 72) {
+      return "hour"; // Less than 3 days, use hours
+    }
+    if (diffHours < 1440) {
+      return "day"; // Less than 60 days, use days
+    }
+    if (diffHours < 8760) {
+      return "week"; // Less than a year, use weeks
+    }
+
+    return "month"; // Over a year, use months
   }
 
   private getTimeDimensionSql(

--- a/packages/shared/src/server/datasets/executeWithDatasetServiceStrategy.ts
+++ b/packages/shared/src/server/datasets/executeWithDatasetServiceStrategy.ts
@@ -26,9 +26,9 @@ export async function executeWithDatasetServiceStrategy<T>(
       env.LANGFUSE_DATASET_SERVICE_WRITE_TO_VERSIONED_IMPLEMENTATION === "true"
     ) {
       return await implementations[Implementation.VERSIONED]();
-    } else {
-      return await implementations[Implementation.STATEFUL]();
     }
+
+    return await implementations[Implementation.STATEFUL]();
   }
 
   // READ operation - use configured source

--- a/packages/shared/src/server/llm/compileChatMessages.ts
+++ b/packages/shared/src/server/llm/compileChatMessages.ts
@@ -100,10 +100,10 @@ export function compileChatMessagesWithIds(
     if (isPlaceholder(message)) {
       const expandedMsgs = expandPlaceholder(message, placeholderValues);
       return expandedMsgs.map((msg) => ({ ...msg, id: uuidv4() }));
-    } else {
-      // Preserve message IDs for already non-placeholder messages
-      return [message as ChatMessageWithIdNoPlaceholders];
     }
+
+    // Preserve message IDs for already non-placeholder messages
+    return [message as ChatMessageWithIdNoPlaceholders];
   });
 
   // substitute text variables

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1405,18 +1405,18 @@ export class OtelIngestionProcessor {
         }
       }
       return result;
-    } else {
-      const result: Record<string, unknown> = Object.create(null);
-      for (const key of keys) {
-        const pathParts = key.split(".");
-        if (pathParts.length === 1) {
-          result[key] = input[`${prefix}.${key}`];
-        } else {
-          setNestedValue(result, pathParts, input[`${prefix}.${key}`]);
-        }
-      }
-      return result;
     }
+
+    const result: Record<string, unknown> = Object.create(null);
+    for (const key of keys) {
+      const pathParts = key.split(".");
+      if (pathParts.length === 1) {
+        result[key] = input[`${prefix}.${key}`];
+      } else {
+        setNestedValue(result, pathParts, input[`${prefix}.${key}`]);
+      }
+    }
+    return result;
   }
 
   private extractInputAndOutput(params: {

--- a/packages/shared/src/server/repositories/dataset-run-items-converters.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items-converters.ts
@@ -104,7 +104,7 @@ export function convertDatasetRunItemClickhouseToDomain<
         (row as any).dataset_item_metadata,
       ),
     } as DatasetRunItemDomain<WithIO>;
-  } else {
-    return baseConversion as DatasetRunItemDomain<WithIO>;
   }
+
+  return baseConversion as DatasetRunItemDomain<WithIO>;
 }

--- a/packages/shared/src/server/services/DatasetService/DatasetItemValidator.ts
+++ b/packages/shared/src/server/services/DatasetService/DatasetItemValidator.ts
@@ -137,9 +137,9 @@ export class DatasetItemValidator {
       if (opts?.sanitizeControlChars) {
         // Sanitize control characters from parsed value before sending to PostgreSQL
         return this.sanitizeJsonValue(parsed) as Prisma.InputJsonValue;
-      } else {
-        return parsed;
       }
+
+      return parsed;
     } catch (e) {
       logger.info(
         "[DatasetItemValidator.normalize] failed to parse dataset item data",

--- a/packages/shared/src/server/services/PromptService/index.ts
+++ b/packages/shared/src/server/services/PromptService/index.ts
@@ -376,11 +376,11 @@ export class PromptService {
           seen.delete(currentPrompt.id);
 
           return JSON.parse(resolvedPrompt);
-        } else {
-          seen.delete(currentPrompt.id);
-
-          return currentPrompt.prompt;
         }
+
+        seen.delete(currentPrompt.id);
+
+        return currentPrompt.prompt;
       };
 
       const resolvedPrompt = await resolve(parentPrompt, dependencies, 0);

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -1045,10 +1045,11 @@ class GoogleCloudStorageService implements StorageService {
             .on("finish", () => {
               resolve();
             });
+          return;
         });
-      } else {
-        throw new Error("Unsupported data type. Must be Readable or string.");
       }
+
+      throw new Error("Unsupported data type. Must be Readable or string.");
     } catch (err) {
       logger.error(
         `Failed to upload file to Google Cloud Storage ${fileName}`,

--- a/packages/shared/src/utils/chatml/adapters/aisdk.ts
+++ b/packages/shared/src/utils/chatml/adapters/aisdk.ts
@@ -263,10 +263,10 @@ function normalizeMessage(msg: unknown): Record<string, unknown> {
       // Rich object: spread for table rendering
       const { content, ...rest } = normalized;
       return { ...rest, ...content };
-    } else {
-      // Simple object: stringify for text rendering
-      normalized.content = stringifyToolResultContent(normalized.content);
     }
+
+    // Simple object: stringify for text rendering
+    normalized.content = stringifyToolResultContent(normalized.content);
   }
 
   return normalized;

--- a/packages/shared/src/utils/chatml/adapters/gemini.ts
+++ b/packages/shared/src/utils/chatml/adapters/gemini.ts
@@ -329,10 +329,10 @@ function normalizeGeminiMessage(msg: unknown): Record<string, unknown> {
       // Rich object: spread for table rendering
       const { content, ...rest } = normalized;
       return { ...rest, ...content };
-    } else {
-      // Simple object: stringify for text rendering
-      normalized.content = stringifyToolResultContent(normalized.content);
     }
+
+    // Simple object: stringify for text rendering
+    normalized.content = stringifyToolResultContent(normalized.content);
   }
 
   return normalized;

--- a/packages/shared/src/utils/chatml/adapters/langgraph.ts
+++ b/packages/shared/src/utils/chatml/adapters/langgraph.ts
@@ -202,10 +202,10 @@ function normalizeMessage(msg: unknown): Record<string, unknown> {
       // Rich object: spread for table rendering
       const { content, ...rest } = normalized;
       return { ...rest, ...content };
-    } else {
-      // Simple object: stringify for text rendering
-      normalized.content = stringifyToolResultContent(normalized.content);
     }
+
+    // Simple object: stringify for text rendering
+    normalized.content = stringifyToolResultContent(normalized.content);
   }
 
   return normalized;

--- a/packages/shared/src/utils/chatml/adapters/microsoft-agent.ts
+++ b/packages/shared/src/utils/chatml/adapters/microsoft-agent.ts
@@ -220,10 +220,10 @@ function normalizeMicrosoftAgentMessage(msg: unknown): Record<string, unknown> {
       // Rich object: spread for table rendering
       const { content, ...rest } = normalized;
       return { ...rest, ...content };
-    } else {
-      // Simple object: stringify for text rendering
-      normalized.content = stringifyToolResultContent(normalized.content);
     }
+
+    // Simple object: stringify for text rendering
+    normalized.content = stringifyToolResultContent(normalized.content);
   }
 
   return normalized;

--- a/packages/shared/src/utils/chatml/adapters/openai.ts
+++ b/packages/shared/src/utils/chatml/adapters/openai.ts
@@ -258,10 +258,10 @@ function normalizeMessage(msg: unknown): Record<string, unknown> {
       // Rich object: spread for table rendering
       const { content, ...rest } = normalized;
       return { ...rest, ...content };
-    } else {
-      // Simple object: stringify for text rendering
-      normalized.content = stringifyToolResultContent(normalized.content);
     }
+
+    // Simple object: stringify for text rendering
+    normalized.content = stringifyToolResultContent(normalized.content);
   }
 
   return normalized;

--- a/web/src/__tests__/server/observation-api.servertest.ts
+++ b/web/src/__tests__/server/observation-api.servertest.ts
@@ -54,15 +54,14 @@ const createObservationData = (
       end_time: data.end_time ? data.end_time : undefined,
       event_ts: data.event_ts ? data.event_ts : undefined,
     });
-  } else {
-    // Observations table: use milliseconds, requires internal_model_id
-    const { model_id, ...rest } = data;
-    return createObservation({
-      ...rest,
-      internal_model_id: model_id || data.internal_model_id,
-      // Timestamps already in milliseconds
-    });
   }
+  // Observations table: use milliseconds, requires internal_model_id
+  const { model_id, ...rest } = data;
+  return createObservation({
+    ...rest,
+    internal_model_id: model_id || data.internal_model_id,
+    // Timestamps already in milliseconds
+  });
 };
 
 // Helper to insert observations into the correct table

--- a/web/src/__tests__/server/observations-api.servertest.ts
+++ b/web/src/__tests__/server/observations-api.servertest.ts
@@ -69,25 +69,24 @@ const createObservationData = (
       user_id: trace?.user_id ?? null,
       tags: trace?.tags ?? [],
     });
-  } else {
-    // For observations table: milliseconds, simpler structure
-    return createObservation({
-      id,
-      trace_id: data.trace_id,
-      project_id: data.project_id,
-      name: data.name,
-      type: data.type,
-      level: data.level,
-      start_time: data.start_time,
-      end_time: data.end_time === null ? null : data.end_time,
-      input: data.input,
-      output: data.output,
-      metadata: data.metadata,
-      provided_model_name: data.provided_model_name,
-      provided_usage_details: data.provided_usage_details,
-      provided_cost_details: data.provided_cost_details,
-    });
   }
+  // For observations table: milliseconds, simpler structure
+  return createObservation({
+    id,
+    trace_id: data.trace_id,
+    project_id: data.project_id,
+    name: data.name,
+    type: data.type,
+    level: data.level,
+    start_time: data.start_time,
+    end_time: data.end_time === null ? null : data.end_time,
+    input: data.input,
+    output: data.output,
+    metadata: data.metadata,
+    provided_model_name: data.provided_model_name,
+    provided_usage_details: data.provided_usage_details,
+    provided_cost_details: data.provided_cost_details,
+  });
 };
 
 // Helper to create trace and observations in one go

--- a/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
+++ b/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
@@ -178,9 +178,8 @@ describe("ClickHouse Resource Error Handling", () => {
           const isResourceError = ((err: Error) => {
             if (err instanceof ClickHouseResourceError) {
               return true;
-            } else {
-              return false;
             }
+            return false;
           })(wrappedError);
 
           expect(isResourceError).toBe(shouldBeResourceError);

--- a/web/src/__tests__/server/traces-api.servertest.ts
+++ b/web/src/__tests__/server/traces-api.servertest.ts
@@ -78,26 +78,25 @@ const createObservationOrEvent = (
             ? data.end_time * timeMultiplier
             : null,
     });
-  } else {
-    // For observations table: milliseconds
-    return createObservation({
-      id,
-      trace_id: data.trace_id,
-      project_id: data.project_id,
-      name: data.name,
-      type: data.type ?? "SPAN",
-      level: data.level ?? "DEFAULT",
-      start_time: data.start_time,
-      end_time: data.end_time === null ? null : data.end_time,
-      input: data.input,
-      output: data.output,
-      metadata: data.metadata,
-      provided_model_name: data.provided_model_name,
-      provided_usage_details: data.provided_usage_details,
-      provided_cost_details: data.provided_cost_details,
-      total_cost: data.total_cost,
-    });
   }
+  // For observations table: milliseconds
+  return createObservation({
+    id,
+    trace_id: data.trace_id,
+    project_id: data.project_id,
+    name: data.name,
+    type: data.type ?? "SPAN",
+    level: data.level ?? "DEFAULT",
+    start_time: data.start_time,
+    end_time: data.end_time === null ? null : data.end_time,
+    input: data.input,
+    output: data.output,
+    metadata: data.metadata,
+    provided_model_name: data.provided_model_name,
+    provided_usage_details: data.provided_usage_details,
+    provided_cost_details: data.provided_cost_details,
+    total_cost: data.total_cost,
+  });
 };
 
 const waitForEventsTable = async (useEventsTable: boolean) => {

--- a/web/src/components/date-picker.tsx
+++ b/web/src/components/date-picker.tsx
@@ -418,15 +418,14 @@ export function TimeRangePicker({
           <span>{setting?.label || namedRangeValue}</span>
         </div>
       );
-    } else {
-      // No time range selected
-      return (
-        <div className="flex items-center gap-2">
-          <CalendarIcon className="h-4 w-4" />
-          <span>Select time range</span>
-        </div>
-      );
     }
+    // No time range selected
+    return (
+      <div className="flex items-center gap-2">
+        <CalendarIcon className="h-4 w-4" />
+        <span>Select time range</span>
+      </div>
+    );
   };
 
   return (

--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -100,32 +100,30 @@ function renderArrayValue(arr: unknown[]): JSX.Element {
           if (keys.length <= OBJECT_PREVIEW_KEYS) {
             const keyPreview = keys.map((k) => `"${k}": ...`).join(", ");
             return `{${keyPreview}}`;
-          } else {
-            return `{"${keys[0]}": ...}`;
           }
+          return `{"${keys[0]}": ...}`;
         }
         if (itemType === "array") return "...";
         return String(item);
       })
       .join(", ");
     return <span className={PREVIEW_TEXT_CLASSES}>[{displayItems}]</span>;
-  } else {
-    // Show truncated values for large arrays
-    const preview = arr
-      .slice(0, ARRAY_PREVIEW_ITEMS)
-      .map((item) => {
-        const itemType = getValueType(item);
-        if (itemType === "string") return `"${String(item)}"`;
-        if (itemType === "object" || itemType === "array") return "...";
-        return String(item);
-      })
-      .join(", ");
-    return (
-      <span className={PREVIEW_TEXT_CLASSES}>
-        [{preview}, ...{arr.length - ARRAY_PREVIEW_ITEMS} more]
-      </span>
-    );
   }
+  // Show truncated values for large arrays
+  const preview = arr
+    .slice(0, ARRAY_PREVIEW_ITEMS)
+    .map((item) => {
+      const itemType = getValueType(item);
+      if (itemType === "string") return `"${String(item)}"`;
+      if (itemType === "object" || itemType === "array") return "...";
+      return String(item);
+    })
+    .join(", ");
+  return (
+    <span className={PREVIEW_TEXT_CLASSES}>
+      [{preview}, ...{arr.length - ARRAY_PREVIEW_ITEMS} more]
+    </span>
+  );
 }
 
 function renderObjectValue(obj: Record<string, unknown>): JSX.Element {

--- a/web/src/components/table/data-table-column-visibility-filter.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.tsx
@@ -503,18 +503,17 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
                           </div>
                         </GroupVisibilityHeader>
                       );
-                    } else {
-                      // Single columns
-                      return (
-                        <ColumnVisibilityListItem
-                          key={column.accessorKey}
-                          column={column}
-                          columnVisibility={columnVisibility}
-                          toggleColumn={toggleColumn}
-                          isOrderable={isColumnOrderingEnabled}
-                        />
-                      );
                     }
+                    // Single columns
+                    return (
+                      <ColumnVisibilityListItem
+                        key={column.accessorKey}
+                        column={column}
+                        columnVisibility={columnVisibility}
+                        toggleColumn={toggleColumn}
+                        isOrderable={isColumnOrderingEnabled}
+                      />
+                    );
                   })}
                 </div>
               </SortableContext>

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -274,9 +274,8 @@ export function DataTable<TData extends object, TValue>({
     getRowId: (row, index) => {
       if ("id" in row && typeof row.id === "string") {
         return row.id;
-      } else {
-        return index.toString();
       }
+      return index.toString();
     },
     state: {
       columnFilters,
@@ -524,12 +523,11 @@ export function DataTable<TData extends object, TValue>({
 function renderOrderingIndicator(orderBy?: OrderByState) {
   if (!orderBy) return null;
   if (orderBy.order === "ASC") return <span className="ml-1">▲</span>;
-  else
-    return (
-      <span className="ml-1" title="Sort by this column">
-        ▼
-      </span>
-    );
+  return (
+    <span className="ml-1" title="Sort by this column">
+      ▼
+    </span>
+  );
 }
 
 interface TableBodyComponentProps<TData> {

--- a/web/src/components/trace/components/TraceTimeline/index.tsx
+++ b/web/src/components/trace/components/TraceTimeline/index.tsx
@@ -177,9 +177,8 @@ export function TraceTimeline() {
               // Match based on observation ID or trace ID
               if (item.node.type === "TRACE") {
                 return score.traceId === item.node.id;
-              } else {
-                return score.observationId === item.node.id;
               }
+              return score.observationId === item.node.id;
             });
 
             // Get comment count for this node

--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -95,10 +95,9 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
         setShouldPulseToggle(false);
       }, 12000); // Stop pulse after 12 seconds
       return () => clearTimeout(timeout);
-    } else {
-      // Reset pulse when leaving timeline view
-      setShouldPulseToggle(false);
     }
+    // Reset pulse when leaving timeline view
+    setShouldPulseToggle(false);
   }, [isTimelineView]);
 
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({

--- a/web/src/components/trace/components/_shared/tree-flattening.clienttest.ts
+++ b/web/src/components/trace/components/_shared/tree-flattening.clienttest.ts
@@ -683,49 +683,48 @@ describe("flattenTree", () => {
         }
 
         return nodes[0];
-      } else {
-        // Realistic: ~20% intermediate nodes, ~80% leaf nodes, max depth ~5
-        const intermediateNodeCount = Math.floor(count * 0.2);
-        const leafNodeCount = count - intermediateNodeCount;
-
-        const allNodes: TestNode[] = [];
-
-        // Create all nodes first
-        for (let i = 0; i < count; i++) {
-          allNodes.push({
-            id: `node-${i}`,
-            name: `Node ${i}`,
-            children: [],
-            startTime: new Date(`2024-01-01T00:00:${i % 60}.${i % 1000}Z`),
-          });
-        }
-
-        // Build realistic hierarchy
-        // Root nodes (10% of intermediate nodes)
-        const rootCount = Math.max(1, Math.floor(intermediateNodeCount * 0.1));
-        const roots: TestNode[] = allNodes.slice(0, rootCount);
-
-        // Remaining intermediate nodes attach to previous nodes
-        for (let i = rootCount; i < intermediateNodeCount; i++) {
-          const parentIndex = Math.floor(Math.random() * i);
-          allNodes[parentIndex].children.push(allNodes[i]);
-        }
-
-        // Leaf nodes attach to any intermediate node
-        for (let i = 0; i < leafNodeCount; i++) {
-          const nodeIndex = intermediateNodeCount + i;
-          const parentIndex = Math.floor(Math.random() * intermediateNodeCount);
-          allNodes[parentIndex].children.push(allNodes[nodeIndex]);
-        }
-
-        // Create root with all root-level nodes as children
-        return {
-          id: "root",
-          name: "Root",
-          children: roots,
-          startTime: new Date("2024-01-01T00:00:00.000Z"),
-        };
       }
+      // Realistic: ~20% intermediate nodes, ~80% leaf nodes, max depth ~5
+      const intermediateNodeCount = Math.floor(count * 0.2);
+      const leafNodeCount = count - intermediateNodeCount;
+
+      const allNodes: TestNode[] = [];
+
+      // Create all nodes first
+      for (let i = 0; i < count; i++) {
+        allNodes.push({
+          id: `node-${i}`,
+          name: `Node ${i}`,
+          children: [],
+          startTime: new Date(`2024-01-01T00:00:${i % 60}.${i % 1000}Z`),
+        });
+      }
+
+      // Build realistic hierarchy
+      // Root nodes (10% of intermediate nodes)
+      const rootCount = Math.max(1, Math.floor(intermediateNodeCount * 0.1));
+      const roots: TestNode[] = allNodes.slice(0, rootCount);
+
+      // Remaining intermediate nodes attach to previous nodes
+      for (let i = rootCount; i < intermediateNodeCount; i++) {
+        const parentIndex = Math.floor(Math.random() * i);
+        allNodes[parentIndex].children.push(allNodes[i]);
+      }
+
+      // Leaf nodes attach to any intermediate node
+      for (let i = 0; i < leafNodeCount; i++) {
+        const nodeIndex = intermediateNodeCount + i;
+        const parentIndex = Math.floor(Math.random() * intermediateNodeCount);
+        allNodes[parentIndex].children.push(allNodes[nodeIndex]);
+      }
+
+      // Create root with all root-level nodes as children
+      return {
+        id: "root",
+        name: "Root",
+        children: roots,
+        startTime: new Date("2024-01-01T00:00:00.000Z"),
+      };
     };
 
     const runPerformanceTest = (

--- a/web/src/components/ui/AdvancedJsonViewer/components/MediaButtonGroup.tsx
+++ b/web/src/components/ui/AdvancedJsonViewer/components/MediaButtonGroup.tsx
@@ -108,10 +108,9 @@ function MediaPreview({ mediaItem }: { mediaItem: MediaReturnType }) {
     return <AudioPlayer src={mediaUrl} />;
   } else if (contentType.startsWith("video")) {
     return <VideoPlayer src={mediaUrl} />;
-  } else {
-    // Documents: use file icon view
-    return <LangfuseMediaView mediaAPIReturnValue={mediaItem} variant="icon" />;
   }
+  // Documents: use file icon view
+  return <LangfuseMediaView mediaAPIReturnValue={mediaItem} variant="icon" />;
 }
 
 /**

--- a/web/src/components/ui/LangfuseMediaView.tsx
+++ b/web/src/components/ui/LangfuseMediaView.tsx
@@ -122,9 +122,8 @@ export const LangfuseMediaView = ({
     return <AudioPlayer src={mediaUrl} />;
   } else if (mediaData.type.startsWith("video")) {
     return <VideoPlayer src={mediaUrl} />;
-  } else {
-    return <FileViewer src={mediaUrl} contentType={mediaData.type} />;
   }
+  return <FileViewer src={mediaUrl} contentType={mediaData.type} />;
 };
 
 function FileViewer({

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -1139,9 +1139,8 @@ export function PrettyJsonView(props: {
     } else if (internalExpansionState === false) {
       // user collapsed all
       return false;
-    } else {
-      return finalState;
     }
+    return finalState;
   }, [finalExpansionState, internalExpansionState]);
 
   // table data with lazy-loaded children

--- a/web/src/components/ui/time-picker-utils.tsx
+++ b/web/src/components/ui/time-picker-utils.tsx
@@ -184,9 +184,8 @@ export function convert12HourTo24Hour(hour: number, period: Period) {
   if (period === "PM") {
     if (hour <= 11) {
       return hour + 12;
-    } else {
-      return hour;
     }
+    return hour;
   } else if (period === "AM") {
     if (hour === 12) return 0;
     return hour;

--- a/web/src/ee/features/multi-tenant-sso/utils.ts
+++ b/web/src/ee/features/multi-tenant-sso/utils.ts
@@ -346,20 +346,19 @@ const dbToNextAuthProvider = (provider: SsoProviderSchema): Provider | null => {
       },
       ...getClientConfig(provider.authConfig),
     });
-  else {
-    // Type check to ensure we handle all providers
 
-    const _: never = provider;
-    logger.error(
+  // Type check to ensure we handle all providers
+
+  const _: never = provider;
+  logger.error(
+    `Unrecognized SSO provider for domain ${(provider as any).domain}`,
+  );
+  traceException(
+    new Error(
       `Unrecognized SSO provider for domain ${(provider as any).domain}`,
-    );
-    traceException(
-      new Error(
-        `Unrecognized SSO provider for domain ${(provider as any).domain}`,
-      ),
-    );
-    return null;
-  }
+    ),
+  );
+  return null;
 };
 
 /**
@@ -397,7 +396,6 @@ export const findMultiTenantSsoConfig = async ({
 
   if (config) {
     return { isMultiTenantSsoProvider: true, domain: config.domain };
-  } else {
-    return { isMultiTenantSsoProvider: false, domain: null };
   }
+  return { isMultiTenantSsoProvider: false, domain: null };
 };

--- a/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
@@ -104,10 +104,9 @@ export const AnnotationQueueItemPage: React.FC<{
 
   const relevantItem = useMemo(() => {
     if (isSingleItem) return seenItemData.data;
-    else
-      return progressIndex < seenItemIds.length
-        ? seenItemData.data
-        : nextItemData;
+    return progressIndex < seenItemIds.length
+      ? seenItemData.data
+      : nextItemData;
   }, [
     progressIndex,
     seenItemIds.length,

--- a/web/src/features/automations/components/automationForm.tsx
+++ b/web/src/features/automations/components/automationForm.tsx
@@ -473,9 +473,8 @@ export const AutomationForm = ({
             githubDefaults.githubDispatch.displayGitHubToken || undefined,
         },
       };
-    } else {
-      throw new Error("Invalid action type");
     }
+    throw new Error("Invalid action type");
   };
 
   // Initialize form with default values or values from existing automation

--- a/web/src/features/comments/lib/mentionParser.ts
+++ b/web/src/features/comments/lib/mentionParser.ts
@@ -115,10 +115,9 @@ export function sanitizeMentions(
         }
 
         return `@[${canonicalName}](${MENTION_USER_PREFIX}${userId})`;
-      } else {
-        // Invalid user: Strip mention markdown, keep display name as plain text
-        return displayName;
       }
+      // Invalid user: Strip mention markdown, keep display name as plain text
+      return displayName;
     },
   );
 

--- a/web/src/features/dashboard/lib/dashboard-utils.ts
+++ b/web/src/features/dashboard/lib/dashboard-utils.ts
@@ -14,9 +14,8 @@ export const createTracesTimeFilter = (
         ...f,
         column: columnName,
       };
-    } else {
-      return f;
     }
+    return f;
   });
 };
 

--- a/web/src/features/dashboard/lib/score-analytics-utils.ts
+++ b/web/src/features/dashboard/lib/score-analytics-utils.ts
@@ -269,23 +269,22 @@ export function transformCategoricalScoresToChartData(
       chartData: [{ ...categoryCounts, binLabel: "Aggregation" }] as ChartBin[],
       chartLabels: uniqueAndSort(labels),
     };
-  } else {
-    const scoreDataByTimestamp = groupCategoricalScoreDataByTimestamp(
-      data,
-      scoreTimestampAccessor,
-    );
-
-    const chartData: ChartBin[] = [];
-    const chartLabels: string[] = [];
-
-    Object.entries(scoreDataByTimestamp).forEach(([timestamp, data]) => {
-      const { categoryCounts, labels } = aggregateCategoricalScoreData(data);
-      chartLabels.push(...labels);
-      chartData.push({ ...categoryCounts, binLabel: timestamp } as ChartBin);
-    });
-
-    return { chartData, chartLabels };
   }
+  const scoreDataByTimestamp = groupCategoricalScoreDataByTimestamp(
+    data,
+    scoreTimestampAccessor,
+  );
+
+  const chartData: ChartBin[] = [];
+  const chartLabels: string[] = [];
+
+  Object.entries(scoreDataByTimestamp).forEach(([timestamp, data]) => {
+    const { categoryCounts, labels } = aggregateCategoricalScoreData(data);
+    chartLabels.push(...labels);
+    chartData.push({ ...categoryCounts, binLabel: timestamp } as ChartBin);
+  });
+
+  return { chartData, chartLabels };
 }
 
 export function isEmptyChart({ data }: { data: ChartBin[] }) {

--- a/web/src/features/datasets/lib/csv/helpers.ts
+++ b/web/src/features/datasets/lib/csv/helpers.ts
@@ -227,18 +227,17 @@ export function buildSchemaObject(
       if (csvColumns.length === 1) {
         // Single column: use the raw value
         return [schemaKey, parseValue(row[headerMap.get(csvColumns[0]!)!])];
-      } else {
-        // Multiple columns: create an object
-        return [
-          schemaKey,
-          Object.fromEntries(
-            csvColumns.map((csvColumn) => [
-              csvColumn,
-              parseValue(row[headerMap.get(csvColumn)!]),
-            ]),
-          ),
-        ];
       }
+      // Multiple columns: create an object
+      return [
+        schemaKey,
+        Object.fromEntries(
+          csvColumns.map((csvColumn) => [
+            csvColumn,
+            parseValue(row[headerMap.get(csvColumn)!]),
+          ]),
+        ),
+      ];
     }),
   );
 }

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -242,12 +242,12 @@ const generateDatasetQuery = ({
     FROM combined d
     ${orderAndLimit}
     `;
-  } else {
-    const baseColumns = Prisma.sql`id, name, description, metadata, project_id, updated_at, created_at, input_schema, expected_output_schema`;
+  }
+  const baseColumns = Prisma.sql`id, name, description, metadata, project_id, updated_at, created_at, input_schema, expected_output_schema`;
 
-    // When we're at the root level, show all individual datasets that don't have folders
-    // and one representative per folder for datasets that do have folders
-    return Prisma.sql`
+  // When we're at the root level, show all individual datasets that don't have folders
+  // and one representative per folder for datasets that do have folders
+  return Prisma.sql`
     WITH ${datasetsCTE},
     individual_datasets AS (
       /* Individual datasets without folders */
@@ -284,7 +284,6 @@ const generateDatasetQuery = ({
     FROM combined d
     ${orderAndLimit}
     `;
-  }
 };
 
 export const datasetRouter = createTRPCRouter({
@@ -608,30 +607,29 @@ export const datasetRouter = createTRPCRouter({
           totalRuns,
           runs,
         };
-      } else {
-        const [runs, totalRuns] = await Promise.all([
-          getDatasetRunsTableRowsCh({
-            projectId: input.projectId,
-            datasetId: input.datasetId,
-            filter: input.filter ?? [],
-            limit: isPresent(input.limit) ? input.limit : undefined,
-            offset:
-              isPresent(input.page) && isPresent(input.limit)
-                ? input.page * input.limit
-                : undefined,
-          }),
-          getDatasetRunsTableCountCh({
-            projectId: input.projectId,
-            datasetId: input.datasetId,
-            filter: input.filter ?? [],
-          }),
-        ]);
-
-        return {
-          totalRuns,
-          runs,
-        };
       }
+      const [runs, totalRuns] = await Promise.all([
+        getDatasetRunsTableRowsCh({
+          projectId: input.projectId,
+          datasetId: input.datasetId,
+          filter: input.filter ?? [],
+          limit: isPresent(input.limit) ? input.limit : undefined,
+          offset:
+            isPresent(input.page) && isPresent(input.limit)
+              ? input.page * input.limit
+              : undefined,
+        }),
+        getDatasetRunsTableCountCh({
+          projectId: input.projectId,
+          datasetId: input.datasetId,
+          filter: input.filter ?? [],
+        }),
+      ]);
+
+      return {
+        totalRuns,
+        runs,
+      };
     }),
 
   runsByDatasetIdMetrics: protectedProjectProcedure

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -752,9 +752,8 @@ export const InnerEvaluatorForm = (props: {
         if ("message" in error && typeof error.message === "string") {
           setFormError(error.message as string);
           return;
-        } else {
-          setFormError(JSON.stringify(error));
         }
+        setFormError(JSON.stringify(error));
       });
   }
 
@@ -1193,12 +1192,11 @@ export const InnerEvaluatorForm = (props: {
                         return experimentEvalFilterColsWithOptions(
                           experimentEvalFilterOptions,
                         );
-                      } else {
-                        // dataset (legacy non-OTEL experiments)
-                        return datasetFormFilterColsWithOptions(
-                          datasetFilterOptions,
-                        );
                       }
+                      // dataset (legacy non-OTEL experiments)
+                      return datasetFormFilterColsWithOptions(
+                        datasetFilterOptions,
+                      );
                     };
 
                     const hasFilters = field.value && field.value.length > 0;

--- a/web/src/features/evals/components/maintainer-tooltip.tsx
+++ b/web/src/features/evals/components/maintainer-tooltip.tsx
@@ -12,9 +12,8 @@ function MaintainerIcon({ maintainer }: { maintainer: string }) {
     return <RagasLogoIcon />;
   } else if (maintainer.includes("Langfuse")) {
     return <LangfuseIcon size={16} />;
-  } else {
-    return <UserCircle2Icon className="h-4 w-4" />;
   }
+  return <UserCircle2Icon className="h-4 w-4" />;
 }
 
 export function MaintainerTooltip({ maintainer }: { maintainer: string }) {

--- a/web/src/features/evals/components/template-form.tsx
+++ b/web/src/features/evals/components/template-form.tsx
@@ -423,10 +423,9 @@ export const InnerEvalTemplateForm = (props: {
         if ("message" in error && typeof error.message === "string") {
           setFormError(error.message as string);
           return;
-        } else {
-          setFormError(JSON.stringify(error));
-          console.error(error);
         }
+        setFormError(JSON.stringify(error));
+        console.error(error);
       });
   }
 

--- a/web/src/features/models/components/UpsertModelFormDialog.tsx
+++ b/web/src/features/models/components/UpsertModelFormDialog.tsx
@@ -93,29 +93,28 @@ export const UpsertModelFormDialog = (({
         tokenizerConfig: JSON.stringify(props.modelData.tokenizerConfig ?? {}),
         pricingTiers: loadedTiers,
       };
-    } else {
-      // CREATE: Start with 1 default tier
-      return {
-        modelName: props.prefilledModelData?.modelName ?? "",
-        matchPattern: props.prefilledModelData?.modelName
-          ? `(?i)^(${props.prefilledModelData?.modelName})$`
-          : "",
-        tokenizerId: null,
-        tokenizerConfig: null,
-        pricingTiers: [
-          {
-            name: "Standard",
-            isDefault: true,
-            priority: 0,
-            conditions: [],
-            prices: props.prefilledModelData?.prices ?? {
-              input: 0.000001,
-              output: 0.000002,
-            },
-          },
-        ],
-      };
     }
+    // CREATE: Start with 1 default tier
+    return {
+      modelName: props.prefilledModelData?.modelName ?? "",
+      matchPattern: props.prefilledModelData?.modelName
+        ? `(?i)^(${props.prefilledModelData?.modelName})$`
+        : "",
+      tokenizerId: null,
+      tokenizerConfig: null,
+      pricingTiers: [
+        {
+          name: "Standard",
+          isDefault: true,
+          priority: 0,
+          conditions: [],
+          prices: props.prefilledModelData?.prices ?? {
+            input: 0.000001,
+            output: 0.000002,
+          },
+        },
+      ],
+    };
   }, [props]);
 
   const form = useForm({

--- a/web/src/features/navigate-detail-pages/DetailPageNav.tsx
+++ b/web/src/features/navigate-detail-pages/DetailPageNav.tsx
@@ -171,5 +171,5 @@ export const DetailPageNav = (props: {
         </Tooltip>
       </div>
     );
-  else return null;
+  return null;
 };

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -277,12 +277,11 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
         } as ChatMessageWithId;
         setMessages((prev) => [...prev, placeholderMessage]);
         return placeholderMessage;
-      } else {
-        const newMessage = createEmptyMessage(message);
-        setMessages((prev) => [...prev, newMessage]);
-
-        return newMessage;
       }
+      const newMessage = createEmptyMessage(message);
+      setMessages((prev) => [...prev, newMessage]);
+
+      return newMessage;
     },
     [],
   );

--- a/web/src/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/features/playground/server/chatCompletionHandler.ts
@@ -136,21 +136,19 @@ export default async function chatCompletionHandler(req: NextRequest) {
             "Content-Type": "text/plain; charset=utf-8",
           },
         });
-      } else {
-        const completion = await fetchLLMCompletion({
-          ...fetchLLMCompletionParams,
-          streaming,
-        });
-
-        if (typeof completion === "string") {
-          return NextResponse.json({ content: completion });
-        } else {
-          return NextResponse.json({
-            content: completion.text,
-            reasoning: completion.reasoning,
-          });
-        }
       }
+      const completion = await fetchLLMCompletion({
+        ...fetchLLMCompletionParams,
+        streaming,
+      });
+
+      if (typeof completion === "string") {
+        return NextResponse.json({ content: completion });
+      }
+      return NextResponse.json({
+        content: completion.text,
+        reasoning: completion.reasoning,
+      });
     });
   } catch (err) {
     logger.error("Failed to handle chat completion", err);

--- a/web/src/features/prompts/components/NewPromptForm/PromptChatMessages.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/PromptChatMessages.tsx
@@ -78,13 +78,12 @@ export const PromptChatMessages: React.FC<PromptChatMessagesProps> = ({
             id,
             type: ChatMessageType.Placeholder,
           } as ChatMessageWithId;
-        } else {
-          return {
-            ...message,
-            id,
-            type: ChatMessageType.PublicAPICreated,
-          } as ChatMessageWithId;
         }
+        return {
+          ...message,
+          id,
+          type: ChatMessageType.PublicAPICreated,
+        } as ChatMessageWithId;
       }),
     );
 

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -1617,12 +1617,12 @@ const generatePromptQuery = (
     FROM combined p
     ${orderAndLimit};
     `;
-  } else {
-    const baseColumns = Prisma.sql`id, name, version, project_id, prompt, type, updated_at, created_at, labels, tags, config, created_by`;
+  }
+  const baseColumns = Prisma.sql`id, name, version, project_id, prompt, type, updated_at, created_at, labels, tags, config, created_by`;
 
-    // When we're at the root level, show all individual prompts that don't have folders
-    // and one representative per folder for prompts that do have folders
-    return Prisma.sql`
+  // When we're at the root level, show all individual prompts that don't have folders
+  // and one representative per folder for prompts that do have folders
+  return Prisma.sql`
     WITH ${latestCTE},
     individual_prompts AS (
       /* Individual prompts without folders */
@@ -1662,5 +1662,4 @@ const generatePromptQuery = (
     FROM combined p
     ${orderAndLimit};
     `;
-  }
 };

--- a/web/src/features/rbac/server/membersRouter.ts
+++ b/web/src/features/rbac/server/membersRouter.ts
@@ -269,12 +269,11 @@ export const membersRouter = createTRPCRouter({
               after: newProjectMembership,
             });
             return;
-          } else {
-            throw new TRPCError({
-              code: "BAD_REQUEST",
-              message: "User is already a member of this organization",
-            });
           }
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "User is already a member of this organization",
+          });
         }
 
         // Check member limit before creating new membership

--- a/web/src/features/score-analytics/components/ScoreAnalyticsNoticeBanner.tsx
+++ b/web/src/features/score-analytics/components/ScoreAnalyticsNoticeBanner.tsx
@@ -16,10 +16,9 @@ export function ScoreAnalyticsNoticeBanner() {
       }, 1500);
 
       return () => clearTimeout(timer);
-    } else {
-      // Reset when loading completes
-      setShowLoadingBanner(false);
     }
+    // Reset when loading completes
+    setShowLoadingBanner(false);
   }, [isEstimating, estimate, isLoading]);
 
   // Don't show anything if we haven't started

--- a/web/src/features/score-analytics/components/charts/ScoreDistributionBooleanChart.tsx
+++ b/web/src/features/score-analytics/components/charts/ScoreDistributionBooleanChart.tsx
@@ -84,12 +84,11 @@ export function ScoreDistributionBooleanChart({
             pv: item.count,
             uv: dist2Map.get(item.binIndex) ?? 0,
           };
-        } else {
-          return {
-            name: label,
-            pv: item.count,
-          };
         }
+        return {
+          name: label,
+          pv: item.count,
+        };
       });
   }, [
     distribution1,

--- a/web/src/features/score-analytics/components/charts/ScoreDistributionNumericChart.tsx
+++ b/web/src/features/score-analytics/components/charts/ScoreDistributionNumericChart.tsx
@@ -53,13 +53,12 @@ export function ScoreDistributionNumericChart({
             pv: item.count,
             uv: dist2Map.get(item.binIndex) ?? 0,
           };
-        } else {
-          // Single score mode - also use 'pv' for consistency with Bar dataKey
-          return {
-            dimension: label,
-            pv: item.count,
-          };
         }
+        // Single score mode - also use 'pv' for consistency with Bar dataKey
+        return {
+          dimension: label,
+          pv: item.count,
+        };
       });
   }, [distribution1, distribution2, binLabels, isComparisonMode]);
 

--- a/web/src/features/score-configs/components/UpsertScoreConfigDialog.tsx
+++ b/web/src/features/score-configs/components/UpsertScoreConfigDialog.tsx
@@ -121,22 +121,21 @@ export function UpsertScoreConfigDialog({
           form.reset();
           onOpenChange(false);
         });
-    } else {
-      return createScoreConfig
-        .mutateAsync({
-          projectId,
-          ...values,
-          description: values.description ?? null,
-          categories: values.categories?.length ? values.categories : undefined,
-        })
-        .then(() => {
-          capture("score_configs:create_form_submit", {
-            dataType: values.dataType,
-          });
-          form.reset();
-          onOpenChange(false);
-        });
     }
+    return createScoreConfig
+      .mutateAsync({
+        projectId,
+        ...values,
+        description: values.description ?? null,
+        categories: values.categories?.length ? values.categories : undefined,
+      })
+      .then(() => {
+        capture("score_configs:create_form_submit", {
+          dataType: values.dataType,
+        });
+        form.reset();
+        onOpenChange(false);
+      });
   }
 
   return (

--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -952,15 +952,14 @@ export function AnnotationForm<Target extends ScoreTarget>({
     if (Array.isArray(serverScores)) {
       // Flat scores from trace/session detail
       return transformToAnnotationScores(serverScores, availableConfigs);
-    } else {
-      // Aggregates from compare view
-      return transformToAnnotationScores(
-        serverScores,
-        availableConfigs,
-        scoreTarget.type === "trace" ? scoreTarget.traceId : "",
-        scoreTarget.type === "trace" ? scoreTarget.observationId : undefined,
-      );
     }
+    // Aggregates from compare view
+    return transformToAnnotationScores(
+      serverScores,
+      availableConfigs,
+      scoreTarget.type === "trace" ? scoreTarget.traceId : "",
+      scoreTarget.type === "trace" ? scoreTarget.observationId : undefined,
+    );
   }, [serverScores, availableConfigs, scoreTarget]);
 
   // Step 2: Merge with cache

--- a/web/src/features/scores/hooks/useScoreConfigSelection.ts
+++ b/web/src/features/scores/hooks/useScoreConfigSelection.ts
@@ -107,13 +107,12 @@ export function useScoreConfigSelection({
         if (field?.id) {
           toast.error("Cannot deselect a populated score");
           return;
-        } else {
-          // No score -> remove row from form and empty selected config ids
-          remove(fieldIndex);
-          setEmptySelectedConfigIds?.(
-            emptySelectedConfigIds.filter((id) => id !== changedValueId),
-          );
         }
+        // No score -> remove row from form and empty selected config ids
+        remove(fieldIndex);
+        setEmptySelectedConfigIds?.(
+          emptySelectedConfigIds.filter((id) => id !== changedValueId),
+        );
       }
     },
     [

--- a/web/src/features/scores/hooks/useScoreConfigs.ts
+++ b/web/src/features/scores/hooks/useScoreConfigs.ts
@@ -48,11 +48,10 @@ export function useAnnotationScoreConfigs({
       selectedConfigIds: configSelection.configs.map((c) => c.id),
       availableConfigs: configSelection.configs,
     };
-  } else {
-    return {
-      isLoading: configs.isLoading,
-      selectedConfigIds: emptySelectedConfigIds,
-      availableConfigs: configs.data?.configs ?? [],
-    };
   }
+  return {
+    isLoading: configs.isLoading,
+    selectedConfigIds: emptySelectedConfigIds,
+    availableConfigs: configs.data?.configs ?? [],
+  };
 }

--- a/web/src/features/trace-graph-view/components/TraceGraphView.tsx
+++ b/web/src/features/trace-graph-view/components/TraceGraphView.tsx
@@ -50,17 +50,15 @@ export const TraceGraphView: React.FC<TraceGraphViewProps> = ({
     if (!hasStepData) {
       // has no steps → add timing-based steps
       return buildStepData(agentGraphData);
-    } else {
-      const isLangGraph = agentGraphData.some(
-        (o) => o.node && o.node.trim().length > 0,
-      );
-      if (isLangGraph) {
-        // TODO: make detection more robust based on metadata
-        return transformLanggraphToGeneralized(agentGraphData);
-      } else {
-        return agentGraphData; // Already normalized
-      }
     }
+    const isLangGraph = agentGraphData.some(
+      (o) => o.node && o.node.trim().length > 0,
+    );
+    if (isLangGraph) {
+      // TODO: make detection more robust based on metadata
+      return transformLanggraphToGeneralized(agentGraphData);
+    }
+    return agentGraphData; // Already normalized
   }, [agentGraphData]);
 
   const { graph, nodeToObservationsMap } = useMemo(() => {

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -1164,27 +1164,26 @@ export function WidgetForm({
             // Include all original query fields for pivot table processing
             ...item,
           };
-        } else {
-          // Regular chart processing
-          const metricField = `${selectedAggregation}_${selectedMeasure}`;
-          const metric = item[metricField];
-          const dimensionField = selectedDimension;
-          return {
-            dimension:
-              item[dimensionField] !== undefined && dimensionField !== "none"
-                ? (() => {
-                    const val = item[dimensionField];
-                    if (typeof val === "string") return val;
-                    if (val === null || val === undefined || val === "")
-                      return "n/a";
-                    if (Array.isArray(val)) return val.join(", ");
-                    return String(val);
-                  })()
-                : formatMetricName(metricField),
-            metric: Array.isArray(metric) ? metric : Number(metric || 0),
-            time_dimension: item["time_dimension"],
-          };
         }
+        // Regular chart processing
+        const metricField = `${selectedAggregation}_${selectedMeasure}`;
+        const metric = item[metricField];
+        const dimensionField = selectedDimension;
+        return {
+          dimension:
+            item[dimensionField] !== undefined && dimensionField !== "none"
+              ? (() => {
+                  const val = item[dimensionField];
+                  if (typeof val === "string") return val;
+                  if (val === null || val === undefined || val === "")
+                    return "n/a";
+                  if (Array.isArray(val)) return val.join(", ");
+                  return String(val);
+                })()
+              : formatMetricName(metricField),
+          metric: Array.isArray(metric) ? metric : Number(metric || 0),
+          time_dimension: item["time_dimension"],
+        };
       }) ?? [],
     [
       queryResult.data,

--- a/web/src/hooks/usePaginationState.ts
+++ b/web/src/hooks/usePaginationState.ts
@@ -56,20 +56,19 @@ export function usePaginationState(
         });
       };
       return [contextState, setState] as const;
-    } else {
-      // Return page/limit format
-      const contextState = { page: pageIndex + 1, limit: pageSize };
-      const setState = (newPagination: { page: number; limit: number }) => {
-        peekContext.setTableState({
-          ...peekContext.tableState,
-          pagination: {
-            pageIndex: newPagination.page - 1,
-            pageSize: newPagination.limit,
-          },
-        });
-      };
-      return [contextState, setState] as const;
     }
+    // Return page/limit format
+    const contextState = { page: pageIndex + 1, limit: pageSize };
+    const setState = (newPagination: { page: number; limit: number }) => {
+      peekContext.setTableState({
+        ...peekContext.tableState,
+        pagination: {
+          pageIndex: newPagination.page - 1,
+          pageSize: newPagination.limit,
+        },
+      });
+    };
+    return [contextState, setState] as const;
   }
 
   // Not in peek context
@@ -90,11 +89,10 @@ export function usePaginationState(
       });
     };
     return [urlState, setUrlState] as const;
-  } else {
-    // Return page/limit format as-is
-    return [
-      paginationState as { page: number; limit: number },
-      setPaginationState as (value: { page: number; limit: number }) => void,
-    ] as const;
   }
+  // Return page/limit format as-is
+  return [
+    paginationState as { page: number; limit: number },
+    setPaginationState as (value: { page: number; limit: number }) => void,
+  ] as const;
 }

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -1013,14 +1013,13 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             });
             if (user) {
               return true;
-            } else {
-              // Add random delay to prevent leaking if user exists as otherwise it would be instant compared to sending an email
-              await new Promise((resolve) =>
-                setTimeout(resolve, Math.random() * 2000 + 200),
-              );
-              // Prevents sign in with email link if user does not exist
-              return false;
             }
+            // Add random delay to prevent leaking if user exists as otherwise it would be instant compared to sending an email
+            await new Promise((resolve) =>
+              setTimeout(resolve, Math.random() * 2000 + 200),
+            );
+            // Prevents sign in with email link if user does not exist
+            return false;
           }
 
           // Optional configuration: validate authorised email domains for google provider

--- a/web/src/utils/date-range-utils.ts
+++ b/web/src/utils/date-range-utils.ts
@@ -335,12 +335,11 @@ export const formatDateRange = (from: Date, to: Date) => {
     const fromPattern = showFromYear ? "LLL dd, yyyy" : "LLL dd";
     const toPattern = showToYear ? "LLL dd, yyyy" : "LLL dd";
     return `${format(from, fromPattern)} - ${format(to, toPattern)}`;
-  } else {
-    // Show dates with times for partial day ranges
-    const fromPattern = showFromYear ? "LLL dd yyyy, HH:mm" : "LLL dd, HH:mm";
-    const toPattern = showToYear ? "LLL dd yyyy, HH:mm" : "LLL dd, HH:mm";
-    return `${format(from, fromPattern)} - ${format(to, toPattern)}`;
   }
+  // Show dates with times for partial day ranges
+  const fromPattern = showFromYear ? "LLL dd yyyy, HH:mm" : "LLL dd, HH:mm";
+  const toPattern = showToYear ? "LLL dd yyyy, HH:mm" : "LLL dd, HH:mm";
+  return `${format(from, fromPattern)} - ${format(to, toPattern)}`;
 };
 
 export type RelativeTimeRange = {
@@ -586,9 +585,8 @@ export function getScoreAnalyticsInterval(
     return "week";
   }
   // > 1 year → month (yields 12+ points)
-  else {
-    return "month";
-  }
+
+  return "month";
 }
 
 /**
@@ -599,9 +597,8 @@ export function getScoreAnalyticsInterval(
 export function rangeToString(range: TimeRange): string {
   if ("range" in range) {
     return getAbbreviatedTimeRange(range.range);
-  } else {
-    return `${range.from.getTime()}-${range.to.getTime()}`;
   }
+  return `${range.from.getTime()}-${range.to.getTime()}`;
 }
 
 /**
@@ -691,10 +688,9 @@ export function getChartAxisFormat(
       if (durationHours !== null && durationHours <= 24) {
         // Within 1 day: time only
         return "HH:mm";
-      } else {
-        // Multiple days: date + time
-        return "MMM dd, HH:mm";
       }
+      // Multiple days: date + time
+      return "MMM dd, HH:mm";
 
     case "day":
       // 7 days - 90 days: date without time

--- a/web/src/utils/dates.ts
+++ b/web/src/utils/dates.ts
@@ -71,11 +71,10 @@ export const getRelativeTimestampFromNow = (timestamp: Date): string => {
     return `${Math.floor(diffInHours)} hours ago`;
   } else if (diffInDays < 7) {
     return `${Math.floor(diffInDays)} days ago`;
-  } else {
-    return timestamp.toLocaleDateString("en-US", {
-      year: "2-digit",
-      month: "numeric",
-      day: "numeric",
-    });
   }
+  return timestamp.toLocaleDateString("en-US", {
+    year: "2-digit",
+    month: "numeric",
+    day: "numeric",
+  });
 };

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -88,9 +88,9 @@ export const getChunkWithFlattenedScores = <
           ...acc,
           [key]: value,
         };
-      } else {
-        return acc;
       }
+
+      return acc;
     }, emptyScoreColumns);
     return {
       ...data,

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -70,19 +70,19 @@ export const evalJobDatasetCreatorQueueProcessor = async (
       if (shouldRetry) {
         // Retry was scheduled, complete this job successfully
         return true;
-      } else {
-        // Max attempts reached, log warning and complete successfully
-        logger.warn(
-          `Observation not found after max retries. Completing job without creating eval.`,
-          {
-            projectId: job.data.payload.projectId,
-            datasetItemId: job.data.payload.datasetItemId,
-            observationId: job.data.payload.observationId,
-            traceId: job.data.payload.traceId,
-          },
-        );
-        return true;
       }
+
+      // Max attempts reached, log warning and complete successfully
+      logger.warn(
+        `Observation not found after max retries. Completing job without creating eval.`,
+        {
+          projectId: job.data.payload.projectId,
+          datasetItemId: job.data.payload.datasetItemId,
+          observationId: job.data.payload.observationId,
+          traceId: job.data.payload.traceId,
+        },
+      );
+      return true;
     }
 
     // All other errors should be logged and propagated for BullMQ retry

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -98,12 +98,12 @@ export const ingestionQueueProcessorBuilder = (
             `Skipping ingestion event ${job.data.payload.data.fileKey} for project ${job.data.payload.authCheck.scope.projectId}`,
           );
           return;
-        } else {
-          recordIncrement("langfuse.ingestion.recently_processed_cache", 1, {
-            type: job.data.payload.data.type,
-            skipped: "false",
-          });
         }
+
+        recordIncrement("langfuse.ingestion.recently_processed_cache", 1, {
+          type: job.data.payload.data.type,
+          skipped: "false",
+        });
       }
 
       // Check if project should be redirected to secondary queue

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -465,15 +465,15 @@ export class ClickhouseWriter {
                 truncated: true,
               });
               return true;
-            } else {
-              logger.error(
-                `ClickHouse query failed with non-retryable error: ${error.message}`,
-                {
-                  error: error.message,
-                },
-              );
-              return false;
             }
+
+            logger.error(
+              `ClickHouse query failed with non-retryable error: ${error.message}`,
+              {
+                error: error.message,
+              },
+            );
+            return false;
           },
           startingDelay: 100,
           timeMultiple: 1,

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -713,26 +713,26 @@ export class IngestionService {
         `Skipping TraceUpsert queue for project ${projectId} - no job configs cached`,
       );
       return;
-    } else {
-      // Job configs present, so we add to the TraceUpsert queue.
-      const shardingKey = `${projectId}-${entityId}`;
-      const traceUpsertQueue = TraceUpsertQueue.getInstance({ shardingKey });
-      if (!traceUpsertQueue) {
-        logger.error("TraceUpsertQueue is not initialized");
-        return;
-      }
-      await traceUpsertQueue.add(QueueJobs.TraceUpsert, {
-        payload: {
-          projectId,
-          traceId: entityId,
-          exactTimestamp: new Date(finalTraceRecord.timestamp),
-          traceEnvironment: finalTraceRecord.environment,
-        },
-        id: randomUUID(),
-        timestamp: new Date(),
-        name: QueueJobs.TraceUpsert as const,
-      });
     }
+
+    // Job configs present, so we add to the TraceUpsert queue.
+    const shardingKey = `${projectId}-${entityId}`;
+    const traceUpsertQueue = TraceUpsertQueue.getInstance({ shardingKey });
+    if (!traceUpsertQueue) {
+      logger.error("TraceUpsertQueue is not initialized");
+      return;
+    }
+    await traceUpsertQueue.add(QueueJobs.TraceUpsert, {
+      payload: {
+        projectId,
+        traceId: entityId,
+        exactTimestamp: new Date(finalTraceRecord.timestamp),
+        traceEnvironment: finalTraceRecord.environment,
+      },
+      id: randomUUID(),
+      timestamp: new Date(),
+      name: QueueJobs.TraceUpsert as const,
+    });
   }
 
   private async processObservationEventList(params: {

--- a/worker/src/services/IngestionService/utils.ts
+++ b/worker/src/services/IngestionService/utils.ts
@@ -75,9 +75,9 @@ export function overwriteObject(
         Object.keys(srcValue).length === 0) // empty object check for cost / usage details
     ) {
       return objValue;
-    } else {
-      return srcValue;
     }
+
+    return srcValue;
   });
 
   result.metadata =

--- a/worker/src/utils/RedisLock.ts
+++ b/worker/src/utils/RedisLock.ts
@@ -171,12 +171,12 @@ export class RedisLock {
       if (result === 1) {
         logger.debug(`[${this.name}] Released lock`);
         return true;
-      } else {
-        logger.warn(
-          `[${this.name}] Lock was not released (not owned or already expired)`,
-        );
-        return false;
       }
+
+      logger.warn(
+        `[${this.name}] Lock was not released (not owned or already expired)`,
+      );
+      return false;
     } catch (error) {
       // Log but don't throw - lock will expire via TTL anyway
       logger.error(`[${this.name}] Failed to release lock`, error);


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables the `no-else-return` ESLint rule in both `packages/config-eslint/base.js` and `packages/config-eslint/next.js`, and then applies the resulting auto-fixable refactors across ~70 files. Every change is a mechanical removal of an `else` clause following a guaranteed-exit branch (`return`, `throw`, or similar), leaving the semantics of each function identical.

- **ESLint config change**: `"no-else-return": "warn"` added to both the base and Next.js shared configs, ensuring the rule applies repo-wide going forward.
- **Code fixes**: ~70 files updated to hoist the `else` body one level up after an early-exit branch, with no behavioral changes — the transformations were verified to be logically equivalent in all reviewed files (`chatCompletionHandler.ts`, `IngestionService/index.ts`, `dataset-router.ts`, `auth.ts`, `RedisLock.ts`, etc.).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

All changes are mechanical no-else-return refactors with no behavioral impact; safe to merge.

Every modified file applies the same pattern — removing an else clause after a guaranteed early-exit branch — leaving all functions logically identical. Spot-checks across the most complex cases confirmed equivalence. The only additive change is the ESLint rule configuration itself, which is additive-only and non-breaking.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ESLint rule added
no-else-return: warn] --> B{Branch has
early exit?}
    B -- "return / throw
before else" --> C[Remove else clause
Hoist else-body up one level]
    B -- "No early exit" --> D[No change needed]
    C --> E[Semantically equivalent code
Flatter indentation]
    D --> F[Code unchanged]
    E --> G[~70 files updated
across web/, worker/, packages/]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ESLint rule added
no-else-return: warn] --> B{Branch has
early exit?}
    B -- "return / throw
before else" --> C[Remove else clause
Hoist else-body up one level]
    B -- "No early exit" --> D[No change needed]
    C --> E[Semantically equivalent code
Flatter indentation]
    D --> F[Code unchanged]
    E --> G[~70 files updated
across web/, worker/, packages/]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: Fix \`no-else-return\` issues"](https://github.com/langfuse/langfuse/commit/42cca79cabdb67fa5fa960c23ef106661da765bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39518709)</sub>

<!-- /greptile_comment -->