### PR TITLE
fix(table): make experiments metadata column resizable

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -352,7 +352,12 @@ export function DataTable<TData extends object, TValue>({
         )}
       >
         <div
-          className="relative min-h-full w-full overflow-auto border-t"
+          // pr-2 + scrollbar-gutter:stable reserve a small gutter on the right so the
+          // last column's resize handle is never flush against the scrollbar/edge and
+          // always has some cursor room. Partial mitigation for LFE-10460: a maximized
+          // browser still clamps the cursor at the screen edge, so this guarantees room
+          // to the right, not a complete fix.
+          className="relative min-h-full w-full overflow-auto border-t pr-2 [scrollbar-gutter:stable]"
           style={{ ...columnSizeVars }}
         >
           <Table>

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -38,6 +38,13 @@ interface UseTableStateProps {
     filterColumnDefinition?: ColumnDefinition[];
     expandableFilterColumns?: string[];
     migrateFilterState?: FilterStateMigration;
+    /**
+     * Runs on a persisted saved-view `columnOrder` before it is applied, so a
+     * table whose default column position changed can reposition a stale column
+     * in pre-PR view payloads (mirrors `migrateFilterState`). Must be a pure
+     * transform; return the input unchanged to leave the order untouched.
+     */
+    migrateColumnOrder?: (columnOrder: string[]) => string[];
   };
   currentFilterState?: FilterState;
   currentExpandedFilters?: string[];
@@ -311,8 +318,18 @@ export function useTableViewManager({
         setSearchQueryRef.current(viewData.searchQuery || null);
       }
 
-      // Apply column order and visibility without validation since UI will handle gracefully
-      if (viewData.columnOrder) setColumnOrder(viewData.columnOrder);
+      // Apply column order and visibility without validation since UI will handle gracefully.
+      // A saved view persists its own columnOrder snapshot, so a pre-PR view can
+      // re-introduce a stale column position even after the localStorage migration
+      // has run (the migration is one-shot and this is a separate persistence path).
+      // Run the table's opt-in columnOrder migration on the payload first so the
+      // same "only reposition a stale default" rule applies here too.
+      if (viewData.columnOrder) {
+        const migratedColumnOrder = validationContext.migrateColumnOrder
+          ? validationContext.migrateColumnOrder(viewData.columnOrder)
+          : viewData.columnOrder;
+        setColumnOrder(migratedColumnOrder);
+      }
       if (viewData.columnVisibility)
         setColumnVisibility(viewData.columnVisibility);
 

--- a/web/src/features/column-visibility/hooks/useColumnOrder.ts
+++ b/web/src/features/column-visibility/hooks/useColumnOrder.ts
@@ -16,9 +16,59 @@ const readStoredColumnOrder = (localStorageKey: string): string[] => {
   }
 };
 
+/**
+ * A one-time, opt-in transform of the persisted column order. Use it when a
+ * table changes its *default* column position: the reconciliation in
+ * `useColumnOrder` only splices in column IDs that are new to the app, so it
+ * never repositions a column that already exists in a returning user's stored
+ * order. A migration lets a specific table reposition such a column exactly
+ * once, guarded by `versionKey` so it never re-fights a user who later moves
+ * the column themselves.
+ *
+ * Migrations are entirely opt-in (passed per-call): tables that omit them keep
+ * the previous behavior byte-for-byte.
+ */
+export type ColumnOrderMigration = {
+  /**
+   * localStorage key for the one-time guard flag. Should be unique per table +
+   * migration, e.g. `experimentsColumnOrder-metadataReorder-v1-${projectId}`.
+   */
+  versionKey: string;
+  /**
+   * Pure transform applied to the reconciled column order. Must not mutate its
+   * input. Return the input unchanged to skip (the flag is still set so it does
+   * not retry on every mount).
+   */
+  apply: (columnOrder: string[]) => string[];
+};
+
+const hasRunMigration = (versionKey: string): boolean => {
+  if (typeof window === "undefined") {
+    return true; // never run migrations server-side
+  }
+  try {
+    return localStorage.getItem(versionKey) !== null;
+  } catch (error) {
+    console.error("Error reading migration flag from local storage", error);
+    return true;
+  }
+};
+
+const markMigrationRun = (versionKey: string): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    localStorage.setItem(versionKey, "1");
+  } catch (error) {
+    console.error("Error writing migration flag to local storage", error);
+  }
+};
+
 function useColumnOrder<TData>(
   localStorageKey: string,
   columns: LangfuseColumnDef<TData>[],
+  migrations?: ColumnOrderMigration[],
 ) {
   const [columnOrder, setColumnOrder] = useLocalStorage<string[]>(
     localStorageKey,
@@ -29,7 +79,7 @@ function useColumnOrder<TData>(
     const appColumnIds = columns.map((c) => c.accessorKey);
     const storedColumnIds = readStoredColumnOrder(localStorageKey);
 
-    const finalColumnOrder: string[] = storedColumnIds.filter((id) =>
+    let finalColumnOrder: string[] = storedColumnIds.filter((id) =>
       appColumnIds.includes(id),
     );
 
@@ -39,11 +89,20 @@ function useColumnOrder<TData>(
       }
     });
 
+    // Apply any opt-in one-time migrations (e.g. repositioning a column whose
+    // default slot changed). Each runs at most once, guarded by its versionKey.
+    migrations?.forEach((migration) => {
+      if (!hasRunMigration(migration.versionKey)) {
+        finalColumnOrder = migration.apply(finalColumnOrder);
+        markMigrationRun(migration.versionKey);
+      }
+    });
+
     // Compare the new order with the current order to avoid unnecessary updates
     if (JSON.stringify(finalColumnOrder) !== JSON.stringify(columnOrder)) {
       setColumnOrder(finalColumnOrder);
     }
-  }, [columns, localStorageKey, columnOrder, setColumnOrder]);
+  }, [columns, localStorageKey, columnOrder, setColumnOrder, migrations]);
 
   return [columnOrder, setColumnOrder] as const;
 }

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -288,6 +288,21 @@ export default function ExperimentsTable({
       },
     },
     {
+      // Placed here (right after the identifying name/description columns) rather
+      // than last so it is never the trailing column. As the last column its right
+      // resize handle sat flush against the table edge and could not be dragged
+      // wider in a maximized browser (LFE-10460).
+      accessorKey: "metadata",
+      id: "metadata",
+      header: getExperimentsColumnName("metadata"),
+      size: 100,
+      enableHiding: true,
+      cell: ({ row }) => {
+        const value: Record<string, string> = row.getValue("metadata");
+        return <IOTableCell data={value} singleLine={rowHeight === "s"} />;
+      },
+    },
+    {
       accessorKey: "itemCount",
       id: "itemCount",
       header: getExperimentsColumnName("itemCount"),
@@ -459,17 +474,6 @@ export default function ExperimentsTable({
         ) : null;
       },
       columns: experimentScoreColumns,
-    },
-    {
-      accessorKey: "metadata",
-      id: "metadata",
-      header: getExperimentsColumnName("metadata"),
-      size: 100,
-      enableHiding: true,
-      cell: ({ row }) => {
-        const value: Record<string, string> = row.getValue("metadata");
-        return <IOTableCell data={value} singleLine={rowHeight === "s"} />;
-      },
     },
   ];
 

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -483,9 +483,42 @@ export default function ExperimentsTable({
       columns,
     );
 
+  // One-time migration for LFE-10460: the metadata column's default position
+  // moved from last to right after `description`, but useColumnOrder replays a
+  // returning user's stored order verbatim and never repositions an existing
+  // column. So for anyone who visited this page before, metadata would stay the
+  // trailing column and the resize bug would persist. This migration moves
+  // metadata to its new default slot ONLY when it is currently the last column
+  // (the stale pre-PR default); if the user has manually moved it anywhere else,
+  // we leave their layout untouched. Guarded by a version flag so it runs once.
+  const columnOrderMigrations = useMemo(
+    () => [
+      {
+        versionKey: `experimentsColumnOrder-metadataReorder-v1-${projectId}`,
+        apply: (order: string[]) => {
+          const lastIndex = order.length - 1;
+          // Only act on the stale default: metadata sitting as the last column.
+          if (order[lastIndex] !== "metadata") return order;
+          // New default slot: immediately after the `description` column,
+          // matching the JS column definition (select, name, description, metadata...).
+          const descriptionIndex = order.indexOf("description");
+          const targetIndex =
+            descriptionIndex === -1 ? 0 : descriptionIndex + 1;
+          if (targetIndex === lastIndex) return order; // already in place
+          const next = [...order];
+          next.splice(lastIndex, 1); // remove trailing metadata
+          next.splice(targetIndex, 0, "metadata"); // insert at new default slot
+          return next;
+        },
+      },
+    ],
+    [projectId],
+  );
+
   const [columnOrder, setColumnOrder] = useColumnOrder<ExperimentsTableRow>(
     `experimentsColumnOrder-${projectId}`,
     columns,
+    columnOrderMigrations,
   );
 
   const { isLoading: isViewLoading, ...viewControllers } = useTableViewManager({

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -62,6 +62,32 @@ import {
 import { ExperimentChartsGrid } from "../ExperimentChartsGrid";
 import { useExperimentChartsAccordion } from "../../hooks/useExperimentChartsAccordion";
 
+/**
+ * LFE-10460: the metadata column's default position moved from last to right
+ * after `description`. Both persistence paths (localStorage replay and saved
+ * table views) snapshot the pre-PR order with metadata trailing, so this pure
+ * transform repositions it to its new default slot ONLY when it is currently
+ * the last column (the stale pre-PR default). If a user has manually moved
+ * metadata anywhere else, their layout is left untouched.
+ *
+ * Reused as both the one-time `useColumnOrder` migration (localStorage path)
+ * and the `migrateColumnOrder` transform on saved-view payloads.
+ */
+const repositionTrailingMetadata = (order: string[]): string[] => {
+  const lastIndex = order.length - 1;
+  // Only act on the stale default: metadata sitting as the last column.
+  if (order[lastIndex] !== "metadata") return order;
+  // New default slot: immediately after the `description` column, matching the
+  // JS column definition (select, name, description, metadata...).
+  const descriptionIndex = order.indexOf("description");
+  const targetIndex = descriptionIndex === -1 ? 0 : descriptionIndex + 1;
+  if (targetIndex === lastIndex) return order; // already in place
+  const next = [...order];
+  next.splice(lastIndex, 1); // remove trailing metadata
+  next.splice(targetIndex, 0, "metadata"); // insert at new default slot
+  return next;
+};
+
 export default function ExperimentsTable({
   projectId,
   defaultFilter,
@@ -483,33 +509,19 @@ export default function ExperimentsTable({
       columns,
     );
 
-  // One-time migration for LFE-10460: the metadata column's default position
-  // moved from last to right after `description`, but useColumnOrder replays a
-  // returning user's stored order verbatim and never repositions an existing
-  // column. So for anyone who visited this page before, metadata would stay the
-  // trailing column and the resize bug would persist. This migration moves
-  // metadata to its new default slot ONLY when it is currently the last column
-  // (the stale pre-PR default); if the user has manually moved it anywhere else,
-  // we leave their layout untouched. Guarded by a version flag so it runs once.
+  // One-time migration for LFE-10460 on the localStorage replay path:
+  // useColumnOrder replays a returning user's stored order verbatim and never
+  // repositions an existing column, so without this metadata would stay the
+  // trailing column and the resize bug would persist. Guarded by a version flag
+  // so it runs once (won't re-fight a user who later moves metadata themselves).
+  // The saved-view persistence path is covered separately via
+  // `validationContext.migrateColumnOrder` below — both reuse
+  // `repositionTrailingMetadata`.
   const columnOrderMigrations = useMemo(
     () => [
       {
         versionKey: `experimentsColumnOrder-metadataReorder-v1-${projectId}`,
-        apply: (order: string[]) => {
-          const lastIndex = order.length - 1;
-          // Only act on the stale default: metadata sitting as the last column.
-          if (order[lastIndex] !== "metadata") return order;
-          // New default slot: immediately after the `description` column,
-          // matching the JS column definition (select, name, description, metadata...).
-          const descriptionIndex = order.indexOf("description");
-          const targetIndex =
-            descriptionIndex === -1 ? 0 : descriptionIndex + 1;
-          if (targetIndex === lastIndex) return order; // already in place
-          const next = [...order];
-          next.splice(lastIndex, 1); // remove trailing metadata
-          next.splice(targetIndex, 0, "metadata"); // insert at new default slot
-          return next;
-        },
+        apply: repositionTrailingMetadata,
       },
     ],
     [projectId],
@@ -535,6 +547,11 @@ export default function ExperimentsTable({
       columns,
       filterColumnDefinition: filterConfig.columnDefinitions,
       expandableFilterColumns: filterConfig.facets.map((facet) => facet.column),
+      // A pre-PR saved view persists its own metadata-last column order, which
+      // would otherwise re-introduce LFE-10460 after applying the view (the
+      // localStorage migration is one-shot and doesn't reach this path). Reuse
+      // the same "only reposition a stale default" transform here.
+      migrateColumnOrder: repositionTrailingMetadata,
     },
     currentFilterState: queryFilter.explicitFilterState,
     currentExpandedFilters: queryFilter.expanded,


### PR DESCRIPTION
## What does this PR do?

The **Metadata** column on the experiments table could not be resized because it was the **last** column. Its right-edge resize handle sat flush against the table's right boundary, so growing it required cursor travel past the edge — and a maximized browser clamps the cursor at the screen edge, making the drag impossible.

This applies the pragmatic, decided fix in two parts:

1. **Shared `DataTable` (all tables):** add `pr-2` + `scrollbar-gutter: stable` to the horizontal scroll container so the last column's resize handle always has a small gutter and never sits behind the scrollbar/edge.
   - This is a deliberate **partial mitigation**: a maximized browser still clamps the cursor at the screen edge, so it guarantees *room to the right*, not a complete fix. `scrollbar-gutter: stable` also stops content from sitting behind an overlay scrollbar.
2. **Experiments table:** move the `metadata` column from last to just **after the identifying `name`/`description` columns**, so it is no longer the trailing column and is comfortably resizable. The same `ExperimentsTable` backs both the project Experiments page and the dataset-level Experiments tab.

Fixes LFE-10460.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

Verified locally with Playwright on the experiments page:
- Metadata is now the 3rd data column (after Name, Description), no longer last.
- Metadata resizes both directions and stays put (100px → 220px grow → 140px shrink).
- The scroll container has `padding-right: 8px` + `scrollbar-gutter: stable`.

Regression-checked the Traces (16 cols) and Scores (15 cols) tables: horizontal scroll still works, pinned/sticky columns intact, header alignment unchanged.

`typecheck`, `eslint`, and `prettier` pass (pre-commit `turbo run lint` 8/8 green).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes the un-resizable `metadata` column in the Experiments table by (1) moving the column from last position to third (after `name`/`description`) so its resize handle is never flush against the table boundary, and (2) adding `pr-2` + `scrollbar-gutter: stable` to the shared `DataTable` scroll container to guarantee a small gutter for all last-column resize handles.

- **`ExperimentsTable.tsx`**: The `metadata` column definition is moved earlier in the `columns` array — only the order changes, not the definition itself. Users with a persisted column order in localStorage keep their existing layout; the new default applies to new users only.
- **`data-table.tsx`**: `pr-2` and `[scrollbar-gutter:stable]` are applied to the inner scroll container of every `DataTable` in the application. On overlay-scrollbar platforms (macOS), the gutter space will always be reserved, which could leave a small visual gap on the right side of tables that never overflow horizontally.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — both changes are small and well-tested by the author.

The column reorder in ExperimentsTable is a straightforward, low-risk change. The shared DataTable tweak is global in scope: `scrollbar-gutter: stable` will permanently reserve scrollbar gutter space on overlay-scrollbar platforms for every table in the app, which could produce a small visual gap on tables that never overflow horizontally. The author tested wide tables (Traces, Scores) but narrower tables may look slightly different.

web/src/components/table/data-table.tsx — the `scrollbar-gutter:stable` change affects all DataTable instances; worth a quick visual check on compact tables (e.g. settings pages or narrow data views) to confirm no unexpected whitespace appears.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ExperimentsTable renders columns array] --> B{Column position}
    B -->|Before PR| C["... name → description → itemCount → ... → metadata (LAST)"]
    B -->|After PR| D["... name → description → metadata (3rd) → itemCount → ..."]

    E[DataTable scroll container] --> F["pr-2 + scrollbar-gutter:stable added"]
    F --> G{Browser platform}
    G -->|Windows classic scrollbar| H[No visible change — gutter already occupied]
    G -->|macOS overlay scrollbar| I[~17px gutter always reserved on right edge]

    D --> J[Metadata resize handle no longer flush against table boundary]
    I --> J
    J --> K[Drag-to-resize works in both directions ✓]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ExperimentsTable renders columns array] --> B{Column position}
    B -->|Before PR| C["... name → description → itemCount → ... → metadata (LAST)"]
    B -->|After PR| D["... name → description → metadata (3rd) → itemCount → ..."]

    E[DataTable scroll container] --> F["pr-2 + scrollbar-gutter:stable added"]
    F --> G{Browser platform}
    G -->|Windows classic scrollbar| H[No visible change — gutter already occupied]
    G -->|macOS overlay scrollbar| I[~17px gutter always reserved on right edge]

    D --> J[Metadata resize handle no longer flush against table boundary]
    I --> J
    J --> K[Drag-to-resize works in both directions ✓]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/table/data-table.tsx:360
**Global gutter reservation on all DataTable instances**

`scrollbar-gutter: stable` is applied to every `DataTable` in the application, not only the experiments table. On macOS and other overlay-scrollbar environments, this permanently reserves the scrollbar gutter (~15-17 px) on the right of every table — even when the content does not overflow and no scrollbar ever appears. Combined with `pr-2` (8 px), the trailing whitespace on compact or narrow tables could be noticeable. The author noted this was tested on Traces and Scores (both wide tables that do overflow), but smaller tables that never scroll horizontally may present an unexpected visual gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(table): make experiments metadata co..."](https://github.com/langfuse/langfuse/commit/8ab64da2adc5f77645b122719b95aae751193991) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39526305)</sub>

<!-- /greptile_comment -->