### PR TITLE
ci: Remove noisy test output

### DIFF
--- a/web/vitest.config.mts
+++ b/web/vitest.config.mts
@@ -55,6 +55,7 @@ export default defineConfig({
     reporters: process.env.CI
       ? ["default", new VitestCiReporter()]
       : ["default"],
+    silent: process.env.CI ? "passed-only" : false,
     globals: true,
     retry: process.env.CI ? 3 : 0,
     testTimeout: 30_000,

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     reporters: process.env.CI
       ? ["default", new VitestCiReporter()]
       : ["default"],
+    silent: process.env.CI ? "passed-only" : false,
     retry: process.env.CI ? 3 : 0,
     dir: "./src",
     pool: "forks",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `silent: process.env.CI ? "passed-only" : false` at the top-level `test` config in both `web/vitest.config.mts` and `worker/vitest.config.ts`, suppressing console output from passing tests in CI to reduce log noise.

- Correctly places `silent` as a top-level `test` option (not inside a reporter tuple), matching the Vitest documented API where the valid type is `boolean | 'passed-only'`.
- No behavior change outside of CI environments; local runs retain full console output.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a minimal config-only change with no risk to application code or test correctness.

Both config files receive an identical, correctly-placed top-level test.silent option that maps directly to the documented Vitest API. The change only affects CI log verbosity; it does not alter test selection, retry behavior, or any other execution parameter.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: Remove noisy test output"](https://github.com/langfuse/langfuse/commit/0456a23724b7abd67f232b439db738cc095fa9f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39538634)</sub>

<!-- /greptile_comment -->