### PR TITLE
feat(blobstorage): circuit-breaker disables export after repeated failures (LFE-10279)

### DIFF
--- a/packages/shared/prisma/migrations/20260624000000_add_blob_storage_consecutive_failures/migration.sql
+++ b/packages/shared/prisma/migrations/20260624000000_add_blob_storage_consecutive_failures/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "blob_storage_integrations" ADD COLUMN "consecutive_failures" INTEGER NOT NULL DEFAULT 0;

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1244,6 +1244,11 @@ model BlobStorageIntegration {
   lastError   String?   @map("last_error")
   lastErrorAt DateTime? @map("last_error_at")
 
+  // Circuit breaker: consecutive failed sync runs. Reset to 0 on success; once
+  // it reaches the configured threshold the integration is auto-disabled
+  // (enabled = false) so a wedged chunk stops retrying forever (LFE-10279).
+  consecutiveFailures Int @default(0) @map("consecutive_failures")
+
   // Notification tracking
   lastFailureNotificationSentAt DateTime? @map("last_failure_notification_sent_at")
 

--- a/packages/shared/src/server/services/email/blobStorageExportFailed/BlobStorageExportFailedEmailTemplate.tsx
+++ b/packages/shared/src/server/services/email/blobStorageExportFailed/BlobStorageExportFailedEmailTemplate.tsx
@@ -17,17 +17,23 @@ import {
 type BlobStorageExportFailedEmailTemplateProps = {
   projectName: string;
   settingsUrl: string;
+  // When true the export was auto-disabled after repeated failures and needs
+  // to be re-enabled by the customer once the underlying issue is resolved.
+  paused?: boolean;
 };
 
 export const BlobStorageExportFailedEmailTemplate = ({
   projectName,
   settingsUrl,
+  paused = false,
 }: BlobStorageExportFailedEmailTemplateProps) => {
   return (
     <Html>
       <Head />
       <Preview>
-        Blob storage export failed for project &quot;{projectName}&quot;
+        {paused
+          ? `Blob storage export paused for project "${projectName}"`
+          : `Blob storage export failed for project "${projectName}"`}
       </Preview>
       <Tailwind>
         <Body className="bg-background my-auto mx-auto font-sans">
@@ -44,12 +50,25 @@ export const BlobStorageExportFailedEmailTemplate = ({
 
             <Section>
               <Heading className="mx-0 my-[30px] p-0 text-center text-2xl font-normal text-black">
-                Blob Storage Export Failed
+                {paused
+                  ? "Blob Storage Export Paused"
+                  : "Blob Storage Export Failed"}
               </Heading>
               <Text className="text-gray-700 text-sm leading-6">
-                The scheduled blob storage export for project &quot;
-                {projectName}&quot; has failed. Review the integration settings
-                to see the error details and resolve the issue.
+                {paused ? (
+                  <>
+                    The scheduled blob storage export for project &quot;
+                    {projectName}&quot; has been paused after repeated failures.
+                    Review the integration settings to see the error details,
+                    resolve the issue, and re-enable the export.
+                  </>
+                ) : (
+                  <>
+                    The scheduled blob storage export for project &quot;
+                    {projectName}&quot; has failed. Review the integration
+                    settings to see the error details and resolve the issue.
+                  </>
+                )}
               </Text>
             </Section>
 

--- a/packages/shared/src/server/services/email/blobStorageExportFailed/BlobStorageExportFailedEmailTemplate.tsx
+++ b/packages/shared/src/server/services/email/blobStorageExportFailed/BlobStorageExportFailedEmailTemplate.tsx
@@ -85,8 +85,9 @@ export const BlobStorageExportFailedEmailTemplate = ({
 
             <Section>
               <Text className="text-[#666666] text-[12px] leading-[24px]">
-                This notification was sent to project admins regarding a failed
-                blob storage export for project &quot;{projectName}&quot;.
+                This notification was sent to project admins regarding a{" "}
+                {paused ? "paused" : "failed"} blob storage export for project
+                &quot;{projectName}&quot;.
               </Text>
             </Section>
           </Container>

--- a/packages/shared/src/server/services/email/blobStorageExportFailed/sendBlobStorageExportFailedEmail.ts
+++ b/packages/shared/src/server/services/email/blobStorageExportFailed/sendBlobStorageExportFailedEmail.ts
@@ -18,6 +18,9 @@ export type SendBlobStorageExportFailedEmailParams = {
   projectName: string;
   settingsUrl: string;
   receiverEmails: string[];
+  // When true the integration was auto-disabled by the circuit breaker after
+  // repeated failures (LFE-10279); the email tells owners it must be re-enabled.
+  paused?: boolean;
 };
 
 export const sendBlobStorageExportFailedEmail = async ({
@@ -25,6 +28,7 @@ export const sendBlobStorageExportFailedEmail = async ({
   projectName,
   settingsUrl,
   receiverEmails,
+  paused = false,
 }: SendBlobStorageExportFailedEmailParams) => {
   if (!env.EMAIL_FROM_ADDRESS || !env.SMTP_CONNECTION_URL) {
     logger.error(
@@ -40,11 +44,14 @@ export const sendBlobStorageExportFailedEmail = async ({
   try {
     const mailer = createMailTransport(env.SMTP_CONNECTION_URL);
     const safeProjectName = sanitizeEmailSubject(projectName);
-    const subject = `Blob storage export failed for "${safeProjectName}" – action required`;
+    const subject = paused
+      ? `Blob storage export paused for "${safeProjectName}" – action required`
+      : `Blob storage export failed for "${safeProjectName}" – action required`;
     const html = await render(
       BlobStorageExportFailedEmailTemplate({
         projectName: safeProjectName,
         settingsUrl,
+        paused,
       }),
     );
 

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -611,6 +611,57 @@ describe("Blob Storage Integration tRPC Router", () => {
     });
   });
 
+  // LFE-10279: re-enabling a circuit-breaker-disabled integration must grant a
+  // fresh failure budget, otherwise the next single failure re-trips the breaker.
+  describe("circuit breaker reset on re-enable", () => {
+    it("clears consecutiveFailures and lastError when a disabled integration is re-enabled", async () => {
+      const { caller, project } = await prepare();
+      await createIntegration({ projectId: project.id, enabled: false });
+      await prisma.blobStorageIntegration.update({
+        where: { projectId: project.id },
+        data: {
+          consecutiveFailures: 5,
+          lastError: "boom",
+          lastErrorAt: new Date(),
+        },
+      });
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        enabled: true,
+      });
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId: project.id },
+      });
+      expect(row.enabled).toBe(true);
+      expect(row.consecutiveFailures).toBe(0);
+      expect(row.lastError).toBeNull();
+      expect(row.lastErrorAt).toBeNull();
+    });
+
+    it("leaves an in-progress failure count intact when an already-enabled integration is edited", async () => {
+      const { caller, project } = await prepare();
+      await createIntegration({ projectId: project.id, enabled: true });
+      await prisma.blobStorageIntegration.update({
+        where: { projectId: project.id },
+        data: { consecutiveFailures: 2 },
+      });
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        enabled: true,
+      });
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId: project.id },
+      });
+      expect(row.consecutiveFailures).toBe(2);
+    });
+  });
+
   describe("legacy blob export source cutoff gate", () => {
     afterEach(() => {
       vi.restoreAllMocks();

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -117,6 +117,15 @@ export async function upsertBlobStorageIntegration(params: {
   };
 
   return prisma.$transaction(async (tx) => {
+    // Lock the row for the duration of the transaction so a concurrent worker
+    // circuit-breaker disable can't commit between this read and the upsert.
+    // Without it, `reactivated` is computed from a stale enabled=true and the
+    // breaker reset is skipped while the upsert re-enables the row, leaving a
+    // tripped counter that re-disables on the next failure and sends a second
+    // pause email (LFE-10279). No-op for a brand-new integration (no row to
+    // lock; the upsert INSERTs and ON CONFLICT handles concurrent creates).
+    await tx.$queryRaw`SELECT 1 FROM blob_storage_integrations WHERE project_id = ${projectId} FOR UPDATE`;
+
     const existing = await tx.blobStorageIntegration.findUnique({
       where: { projectId },
       select: {

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -119,7 +119,12 @@ export async function upsertBlobStorageIntegration(params: {
   return prisma.$transaction(async (tx) => {
     const existing = await tx.blobStorageIntegration.findUnique({
       where: { projectId },
-      select: { exportMode: true, lastError: true, runStartedAt: true },
+      select: {
+        exportMode: true,
+        enabled: true,
+        lastError: true,
+        runStartedAt: true,
+      },
     });
 
     // Require secret key for new integrations (unless using host credentials)
@@ -134,6 +139,12 @@ export async function upsertBlobStorageIntegration(params: {
     }
 
     const modeChanged = existing && existing.exportMode !== data.exportMode;
+    // Re-enabling a circuit-breaker-disabled integration grants a fresh failure
+    // budget: clear the consecutive-failure counter and last error so the next
+    // failure doesn't immediately re-trip the breaker (LFE-10279). Only on the
+    // false→true transition — an edit to an already-enabled integration leaves
+    // an in-progress failure count intact.
+    const reactivated = existing != null && !existing.enabled && data.enabled;
     const encryptedSecret = secretAccessKey ? encrypt(secretAccessKey) : null;
 
     // exportSource for the CREATE payload. The !existing guard was previously
@@ -174,6 +185,10 @@ export async function upsertBlobStorageIntegration(params: {
         // previous mode's lastSyncAt.
         ...(modeChanged ? { lastSyncAt: null, nextSyncAt: new Date() } : {}),
         runStartedAt: null,
+        // Reset the circuit breaker on re-enable (see `reactivated` above).
+        ...(reactivated
+          ? { consecutiveFailures: 0, lastError: null, lastErrorAt: null }
+          : {}),
       },
     });
 

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -186,8 +186,17 @@ export async function upsertBlobStorageIntegration(params: {
         ...(modeChanged ? { lastSyncAt: null, nextSyncAt: new Date() } : {}),
         runStartedAt: null,
         // Reset the circuit breaker on re-enable (see `reactivated` above).
+        // Clear lastFailureNotificationSentAt too: the auto-disable claim seeds
+        // it to dedupe the pause email, so leaving it set would suppress the
+        // first failure email after re-enable. Null matches a brand-new
+        // integration and restores the full cooldown grace (LFE-10279).
         ...(reactivated
-          ? { consecutiveFailures: 0, lastError: null, lastErrorAt: null }
+          ? {
+              consecutiveFailures: 0,
+              lastError: null,
+              lastErrorAt: null,
+              lastFailureNotificationSentAt: null,
+            }
           : {}),
       },
     });

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -285,6 +285,61 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       expect(row.consecutiveFailures).toBe(0);
       expect(row.enabled).toBe(true);
     });
+
+    it("only counts the final retry of a BullMQ job as one failed sync run", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      (env as any).LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES = 3;
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId,
+          secretAccessKey: encrypt(secretAccessKey),
+          region: region ? region : "auto",
+          endpoint: endpoint ? endpoint : null,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "daily",
+          // Enriched source + V4 preview off => the guard throws on every run.
+          exportSource: "EVENTS",
+          lastSyncAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+        },
+      });
+
+      // A job configured for 5 BullMQ attempts. attemptsMade is 0-based during
+      // processing, so the final allowed attempt is attemptsMade === 4.
+      const runAttempt = (attemptsMade: number) =>
+        handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+          attemptsMade,
+          opts: { attempts: 5 },
+        } as Job);
+
+      // Non-final retries record the error but do not advance the breaker.
+      for (const attempt of [0, 1, 2, 3]) {
+        await expect(runAttempt(attempt)).rejects.toThrow(/enriched/i);
+      }
+      let row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      expect(row.lastError).toMatch(/enriched/i);
+      expect(row.consecutiveFailures).toBe(0);
+      expect(row.enabled).toBe(true);
+
+      // The retry-exhausted attempt counts as exactly one failed sync run.
+      await expect(runAttempt(4)).rejects.toThrow(/enriched/i);
+      row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      expect(row.consecutiveFailures).toBe(1);
+      expect(row.enabled).toBe(true);
+    });
   });
 
   it("should not process when blob storage integration is disabled", async () => {

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -414,6 +414,66 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       expect(row.enabled).toBe(true);
       expect(row.consecutiveFailures).toBe(0);
     });
+
+    it("drives the breaker for failures before the export starts", async () => {
+      (env as any).LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES = 3;
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId,
+          secretAccessKey: encrypt(secretAccessKey),
+          region: region ? region : "auto",
+          endpoint: endpoint ? endpoint : null,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "daily",
+          exportSource: "TRACES_OBSERVATIONS",
+          lastSyncAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+        },
+      });
+
+      // Fail the runStartedAt lease update — a pre-export operation that used to
+      // run outside the try and so bypassed the circuit breaker entirely. The
+      // lease write is the only update carrying a Date runStartedAt; the catch's
+      // increment writes runStartedAt: null, so it passes through untouched.
+      const realUpdate = prisma.blobStorageIntegration.update.bind(
+        prisma.blobStorageIntegration,
+      );
+      const spy = vi
+        .spyOn(prisma.blobStorageIntegration, "update")
+        .mockImplementation(async (...callArgs) => {
+          const data = (callArgs[0] as any)?.data;
+          if (data?.runStartedAt instanceof Date) {
+            throw new Error("simulated lease-update failure before export");
+          }
+          return realUpdate(...callArgs);
+        });
+
+      try {
+        await expect(
+          handleBlobStorageIntegrationProjectJob({
+            data: { payload: { projectId } },
+          } as Job),
+        ).rejects.toThrow(/lease-update failure/i);
+      } finally {
+        spy.mockRestore();
+      }
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      // The pre-export failure now counts: without the relocated try the catch
+      // never ran and consecutiveFailures stayed at 0.
+      expect(row.consecutiveFailures).toBe(1);
+      expect(row.lastError).toMatch(/lease-update failure/i);
+    });
   });
 
   it("should not process when blob storage integration is disabled", async () => {

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -170,6 +170,123 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     });
   });
 
+  // LFE-10279: after N consecutive failures of the same chunk the integration
+  // is auto-disabled so it stops retrying forever. We drive deterministic
+  // failures via the enriched-export-source guard (no ClickHouse/network).
+  describe("circuit breaker", () => {
+    const originalV4Preview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+    const originalThreshold =
+      env.LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES;
+
+    afterEach(() => {
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
+        originalV4Preview;
+      (env as any).LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES =
+        originalThreshold;
+    });
+
+    it("disables the integration after the configured number of consecutive failures", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      (env as any).LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES = 3;
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId,
+          secretAccessKey: encrypt(secretAccessKey),
+          region: region ? region : "auto",
+          endpoint: endpoint ? endpoint : null,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "daily",
+          // Enriched source + V4 preview off => the guard throws on every run.
+          exportSource: "EVENTS",
+          lastSyncAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+        },
+      });
+
+      const runJob = () =>
+        handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+        } as Job);
+
+      // First two failures: counter increments, integration stays enabled.
+      await expect(runJob()).rejects.toThrow(/enriched/i);
+      await expect(runJob()).rejects.toThrow(/enriched/i);
+
+      let row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      expect(row.consecutiveFailures).toBe(2);
+      expect(row.enabled).toBe(true);
+
+      // Third failure reaches the threshold and disables the integration.
+      await expect(runJob()).rejects.toThrow(/enriched/i);
+
+      row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      expect(row.consecutiveFailures).toBe(3);
+      expect(row.enabled).toBe(false);
+
+      // Once disabled the job short-circuits without throwing or counting.
+      await expect(runJob()).resolves.toBeUndefined();
+      row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      expect(row.consecutiveFailures).toBe(3);
+      expect(row.enabled).toBe(false);
+    });
+
+    it("resets the failure counter after a successful run", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      (env as any).LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES = 3;
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+      const now = new Date();
+      const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+
+      // Start with a stale failure count to prove success clears it. Use a
+      // non-enriched source so the run succeeds (empty export window is fine).
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId: minioAccessKeyId,
+          secretAccessKey: encrypt(minioAccessKeySecret),
+          region: region ? region : "auto",
+          endpoint: minioEndpoint,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "hourly",
+          exportSource: "TRACES_OBSERVATIONS",
+          lastSyncAt: oneHourAgo,
+          compressed: false,
+          consecutiveFailures: 2,
+        },
+      });
+
+      await handleBlobStorageIntegrationProjectJob({
+        data: { payload: { projectId } },
+      } as Job);
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      expect(row.consecutiveFailures).toBe(0);
+      expect(row.enabled).toBe(true);
+    });
+  });
+
   it("should not process when blob storage integration is disabled", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
     s3Prefix = projectId;

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -340,6 +340,80 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       expect(row.consecutiveFailures).toBe(1);
       expect(row.enabled).toBe(true);
     });
+
+    it("does not disable when a concurrent success resets the counter mid-trip", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      (env as any).LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES = 3;
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId,
+          secretAccessKey: encrypt(secretAccessKey),
+          region: region ? region : "auto",
+          endpoint: endpoint ? endpoint : null,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "daily",
+          // Enriched source + V4 preview off => the guard throws on every run.
+          exportSource: "EVENTS",
+          lastSyncAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+          // One short of the threshold: this run's increment reaches it.
+          consecutiveFailures: 2,
+        },
+      });
+
+      // Simulate a concurrent successful run (Worker B) committing its reset
+      // between this worker's increment-read and its disable claim. We hook the
+      // increment update (the only one carrying consecutiveFailures in its
+      // data) and zero the counter right after it commits. The gte-gated
+      // disable claim must then no-op instead of disabling a healthy
+      // integration (LFE-10279).
+      const realUpdate = prisma.blobStorageIntegration.update.bind(
+        prisma.blobStorageIntegration,
+      );
+      const spy = vi
+        .spyOn(prisma.blobStorageIntegration, "update")
+        .mockImplementation(async (...callArgs) => {
+          const result = await (realUpdate as any)(...callArgs);
+          const data = (callArgs[0] as any)?.data;
+          if (data?.consecutiveFailures !== undefined) {
+            await prisma.blobStorageIntegration.updateMany({
+              where: { projectId },
+              data: {
+                consecutiveFailures: 0,
+                lastError: null,
+                lastErrorAt: null,
+              },
+            });
+          }
+          return result;
+        });
+
+      try {
+        await expect(
+          handleBlobStorageIntegrationProjectJob({
+            data: { payload: { projectId } },
+          } as Job),
+        ).rejects.toThrow(/enriched/i);
+      } finally {
+        spy.mockRestore();
+      }
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      // Stays enabled with the counter the concurrent success left behind:
+      // without the gte gate the stale increment-read would disable it here.
+      expect(row.enabled).toBe(true);
+      expect(row.consecutiveFailures).toBe(0);
+    });
   });
 
   it("should not process when blob storage integration is disabled", async () => {

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -189,6 +189,15 @@ const EnvSchema = z.object({
     .positive()
     .default(24),
 
+  // Circuit breaker: after this many consecutive failed sync runs the blob
+  // storage integration is auto-disabled (enabled = false) and the project
+  // owners are notified, so a wedged chunk stops retrying forever (LFE-10279).
+  LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(5),
+
   // Comma-separated list of project IDs that should only export traces table (skip observations and scores)
   LANGFUSE_BLOB_STORAGE_EXPORT_TRACE_ONLY_PROJECT_IDS: z
     .string()

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -192,11 +192,15 @@ const EnvSchema = z.object({
   // Circuit breaker: after this many consecutive failed sync runs the blob
   // storage integration is auto-disabled (enabled = false) and the project
   // owners are notified, so a wedged chunk stops retrying forever (LFE-10279).
+  // A "sync run" is a fully retry-exhausted BullMQ job: the queue already
+  // retries each job up to `attempts` times, so only the final retry counts
+  // here. The default is kept below the per-job retry count so transient blips
+  // absorbed by BullMQ never advance the counter on their own.
   LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES: z.coerce
     .number()
     .int()
     .positive()
-    .default(5),
+    .default(3),
 
   // Comma-separated list of project IDs that should only export traces table (skip observations and scores)
   LANGFUSE_BLOB_STORAGE_EXPORT_TRACE_ONLY_PROJECT_IDS: z

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1159,6 +1159,8 @@ export const handleBlobStorageIntegrationProjectJob = async (
         lastError: null,
         lastErrorAt: null,
         runStartedAt: null,
+        // Reset the circuit breaker: this chunk succeeded (LFE-10279).
+        consecutiveFailures: 0,
       },
     });
 
@@ -1188,16 +1190,47 @@ export const handleBlobStorageIntegrationProjectJob = async (
     );
   } catch (error) {
     const errorMessage = extractStorageErrorMessage(error);
+    const maxConsecutiveFailures =
+      env.LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES;
 
+    // Circuit breaker (LFE-10279): count consecutive failures and auto-disable
+    // the integration once the threshold is reached, so a wedged or
+    // misconfigured chunk stops retrying forever. lastSyncAt only advances on
+    // success, so every failure here is a retry of the same
+    // (projectId, lastSyncAt) chunk.
+    let paused = false;
     try {
-      await prisma.blobStorageIntegration.update({
-        where: { projectId },
-        data: {
-          lastError: errorMessage,
-          lastErrorAt: new Date(),
-          runStartedAt: null,
-        },
-      });
+      const { consecutiveFailures } =
+        await prisma.blobStorageIntegration.update({
+          where: { projectId },
+          data: {
+            lastError: errorMessage,
+            lastErrorAt: new Date(),
+            runStartedAt: null,
+            consecutiveFailures: { increment: 1 },
+          },
+          select: { consecutiveFailures: true },
+        });
+
+      if (consecutiveFailures >= maxConsecutiveFailures) {
+        // Atomic claim on the enabled true→false transition. The increment
+        // above is atomic, so two concurrent workers can both read a value at
+        // or past the threshold; gating the disable on actually flipping the
+        // flag means only one wins and sends the one-time pause email. The
+        // counter is reset on re-enable (upsertBlobStorageIntegration), not
+        // here, so a losing worker's stale increment can't shrink the next
+        // grace period.
+        const { count } = await prisma.blobStorageIntegration.updateMany({
+          where: { projectId, enabled: true },
+          data: { enabled: false },
+        });
+        if (count > 0) {
+          paused = true;
+          logger.warn(
+            `[BLOB INTEGRATION] Disabled blob storage integration for project ${projectId} after ${consecutiveFailures} consecutive failures (threshold ${maxConsecutiveFailures})`,
+          );
+        }
+      }
     } catch (persistError) {
       logger.error(
         `[BLOB INTEGRATION] Failed to persist blob storage error for project ${projectId}`,
@@ -1205,7 +1238,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
       );
     }
 
-    notifyBlobStorageExportFailedInBackground(projectId);
+    notifyBlobStorageExportFailedInBackground(projectId, paused);
 
     const chain = formatErrorChain(error);
     logger.error(
@@ -1222,7 +1255,10 @@ export const handleBlobStorageIntegrationProjectJob = async (
   }
 };
 
-function notifyBlobStorageExportFailedInBackground(projectId: string): void {
+function notifyBlobStorageExportFailedInBackground(
+  projectId: string,
+  paused: boolean = false,
+): void {
   (async () => {
     try {
       const cooldownMs =
@@ -1231,29 +1267,36 @@ function notifyBlobStorageExportFailedInBackground(projectId: string): void {
         60 *
         1000;
 
-      // Atomic claim: set timestamp before sending to prevent duplicate emails on concurrent retries.
-      // If the email send subsequently fails, the cooldown still applies — the next failure
-      // after cooldown expiry will retry the notification.
-      const claimed = await prisma.blobStorageIntegration.updateMany({
-        where: {
-          projectId,
-          OR: [
-            { lastFailureNotificationSentAt: null },
-            {
-              lastFailureNotificationSentAt: {
-                lt: new Date(Date.now() - cooldownMs),
+      // Cooldown gating prevents email spam on repeated failures. The circuit
+      // breaker pause is a one-time state change, so it bypasses the cooldown to
+      // guarantee owners learn the integration was disabled (LFE-10279).
+      // Dedup for the pause email is handled upstream: only the worker that wins
+      // the atomic enabled true→false claim calls this with paused = true.
+      if (!paused) {
+        // Atomic claim: set timestamp before sending to prevent duplicate emails on concurrent retries.
+        // If the email send subsequently fails, the cooldown still applies — the next failure
+        // after cooldown expiry will retry the notification.
+        const claimed = await prisma.blobStorageIntegration.updateMany({
+          where: {
+            projectId,
+            OR: [
+              { lastFailureNotificationSentAt: null },
+              {
+                lastFailureNotificationSentAt: {
+                  lt: new Date(Date.now() - cooldownMs),
+                },
               },
-            },
-          ],
-        },
-        data: { lastFailureNotificationSentAt: new Date() },
-      });
+            ],
+          },
+          data: { lastFailureNotificationSentAt: new Date() },
+        });
 
-      if (claimed.count === 0) {
-        logger.info(
-          `[BLOB INTEGRATION] Skipping failure notification for project ${projectId}, cooldown still active`,
-        );
-        return;
+        if (claimed.count === 0) {
+          logger.info(
+            `[BLOB INTEGRATION] Skipping failure notification for project ${projectId}, cooldown still active`,
+          );
+          return;
+        }
       }
 
       const emailEnv = {
@@ -1291,6 +1334,7 @@ function notifyBlobStorageExportFailedInBackground(projectId: string): void {
         projectName,
         settingsUrl,
         receiverEmails: adminEmails,
+        paused,
       });
     } catch (error) {
       logger.error(

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1238,8 +1238,17 @@ export const handleBlobStorageIntegrationProjectJob = async (
         // loser (paused=false) hits a fresh cooldown and is suppressed —
         // otherwise it could send a contradictory "failed" email alongside the
         // winner's "paused" email for the same trip.
+        // Re-check the counter in the where clause: the increment-read above and
+        // this claim are separate round-trips, so under READ COMMITTED a
+        // concurrent success can reset consecutiveFailures to 0 in between. The
+        // gte gate makes the claim a no-op in that case, avoiding a spurious
+        // disable + "paused" email for an integration that just succeeded.
         const { count } = await prisma.blobStorageIntegration.updateMany({
-          where: { projectId, enabled: true },
+          where: {
+            projectId,
+            enabled: true,
+            consecutiveFailures: { gte: maxConsecutiveFailures },
+          },
           data: { enabled: false, lastFailureNotificationSentAt: new Date() },
         });
         if (count > 0) {

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1193,11 +1193,23 @@ export const handleBlobStorageIntegrationProjectJob = async (
     const maxConsecutiveFailures =
       env.LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES;
 
-    // Circuit breaker (LFE-10279): count consecutive failures and auto-disable
-    // the integration once the threshold is reached, so a wedged or
-    // misconfigured chunk stops retrying forever. lastSyncAt only advances on
-    // success, so every failure here is a retry of the same
-    // (projectId, lastSyncAt) chunk.
+    // The queue retries each job up to `attempts` times with exponential
+    // backoff, so one scheduled run produces several catch passes. Only the
+    // final, retry-exhausted pass counts as one failed sync run for the circuit
+    // breaker; otherwise a transient blip absorbed by BullMQ would advance the
+    // counter multiple times within a single run and trip the breaker
+    // prematurely (LFE-10279). attemptsMade is 0-based during processing and is
+    // incremented after this handler returns, so the last allowed attempt has
+    // attemptsMade === attempts - 1.
+    const isFinalAttempt =
+      (job.attemptsMade ?? 0) >= (job.opts?.attempts ?? 1) - 1;
+
+    // Circuit breaker (LFE-10279): count consecutive failed sync runs and
+    // auto-disable the integration once the threshold is reached, so a wedged
+    // or misconfigured chunk stops retrying forever. lastSyncAt only advances on
+    // success, so every failed run here retries the same
+    // (projectId, lastSyncAt) chunk. lastError is recorded on every pass for
+    // live visibility, but the counter only advances once the run is exhausted.
     let paused = false;
     try {
       const { consecutiveFailures } =
@@ -1207,12 +1219,14 @@ export const handleBlobStorageIntegrationProjectJob = async (
             lastError: errorMessage,
             lastErrorAt: new Date(),
             runStartedAt: null,
-            consecutiveFailures: { increment: 1 },
+            ...(isFinalAttempt
+              ? { consecutiveFailures: { increment: 1 } }
+              : {}),
           },
           select: { consecutiveFailures: true },
         });
 
-      if (consecutiveFailures >= maxConsecutiveFailures) {
+      if (isFinalAttempt && consecutiveFailures >= maxConsecutiveFailures) {
         // Atomic claim on the enabled true→false transition. The increment
         // above is atomic, so two concurrent workers can both read a value at
         // or past the threshold; gating the disable on actually flipping the
@@ -1242,7 +1256,12 @@ export const handleBlobStorageIntegrationProjectJob = async (
       );
     }
 
-    notifyBlobStorageExportFailedInBackground(projectId, paused);
+    // Notify only once the run is exhausted: a failure that BullMQ still
+    // recovers on a later retry is not a failed sync run, so it should not
+    // alert owners.
+    if (isFinalAttempt) {
+      notifyBlobStorageExportFailedInBackground(projectId, paused);
+    }
 
     const chain = formatErrorChain(error);
     logger.error(

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -981,13 +981,17 @@ export const handleBlobStorageIntegrationProjectJob = async (
       logger.info(
         `[BLOB INTEGRATION] Skipping export for project ${projectId}: time window is empty (min: ${minTimestamp.toISOString()}, max: ${maxTimestamp.toISOString()})`,
       );
-      await prisma.blobStorageIntegration.update({
-        where: { projectId },
+      // An empty window is a successful no-op run, so clear the breaker too and
+      // gate on enabled: true — symmetric to the success commit below, so a
+      // concurrent disable claim isn't clobbered (LFE-10279).
+      await prisma.blobStorageIntegration.updateMany({
+        where: { projectId, enabled: true },
         data: {
           runStartedAt: null,
           nextSyncAt: new Date(now.getTime() + frequencyIntervalMs),
           lastError: null,
           lastErrorAt: null,
+          consecutiveFailures: 0,
         },
       });
       return;

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1220,9 +1220,13 @@ export const handleBlobStorageIntegrationProjectJob = async (
         // counter is reset on re-enable (upsertBlobStorageIntegration), not
         // here, so a losing worker's stale increment can't shrink the next
         // grace period.
+        // Seed lastFailureNotificationSentAt in the same claim so a concurrent
+        // loser (paused=false) hits a fresh cooldown and is suppressed —
+        // otherwise it could send a contradictory "failed" email alongside the
+        // winner's "paused" email for the same trip.
         const { count } = await prisma.blobStorageIntegration.updateMany({
           where: { projectId, enabled: true },
-          data: { enabled: false },
+          data: { enabled: false, lastFailureNotificationSentAt: new Date() },
         });
         if (count > 0) {
           paused = true;

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1261,7 +1261,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
 
 function notifyBlobStorageExportFailedInBackground(
   projectId: string,
-  paused: boolean = false,
+  paused = false,
 ): void {
   (async () => {
     try {

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -930,63 +930,69 @@ export const handleBlobStorageIntegrationProjectJob = async (
     return;
   }
 
-  await prisma.blobStorageIntegration.update({
-    where: { projectId },
-    data: { runStartedAt: new Date() },
-  });
-
-  // Sync between lastSyncAt and now - 30 minutes
-  // Cap the export to one frequency period to enable chunked historic exports
-  const minTimestamp = await getMinTimestampForExport(
-    projectId,
-    blobStorageIntegration.lastSyncAt,
-    blobStorageIntegration.exportMode,
-    blobStorageIntegration.exportStartDate,
-  );
-
-  logger.info(
-    `[BLOB INTEGRATION] Calculated minTimestamp for project ${projectId}: ${minTimestamp}, isValid: ${!isNaN(minTimestamp.getTime())}, getTime: ${minTimestamp.getTime()}, exportMode: ${blobStorageIntegration.exportMode}, lastSyncAt: ${blobStorageIntegration.lastSyncAt}, exportStartDate: ${blobStorageIntegration.exportStartDate}`,
-  );
-
-  const now = new Date();
-  const uncappedMaxTimestamp = new Date(
-    now.getTime() - BLOB_STORAGE_LAG_BUFFER_MS,
-  );
-  const frequencyIntervalMs = getFrequencyIntervalMs(
-    blobStorageIntegration.exportFrequency,
-  );
-
-  // Cap maxTimestamp to one frequency period ahead of minTimestamp
-  // This ensures large historic exports are broken into manageable chunks
-  const maxTimestamp = new Date(
-    Math.min(
-      minTimestamp.getTime() + frequencyIntervalMs,
-      uncappedMaxTimestamp.getTime(),
-    ),
-  );
-
-  logger.info(
-    `[BLOB INTEGRATION] Calculated maxTimestamp for project ${projectId}: ${maxTimestamp}, isValid: ${!isNaN(maxTimestamp.getTime())}, getTime: ${maxTimestamp.getTime()}, frequencyIntervalMs: ${frequencyIntervalMs}`,
-  );
-
-  // Skip export if the time window is empty or invalid
-  if (minTimestamp >= maxTimestamp) {
-    logger.info(
-      `[BLOB INTEGRATION] Skipping export for project ${projectId}: time window is empty (min: ${minTimestamp.toISOString()}, max: ${maxTimestamp.toISOString()})`,
-    );
+  try {
+    // The try starts here (not just around the export) so the circuit breaker
+    // also covers the lease update and export-window computation. A throw from
+    // getMinTimestampForExport — which queries ClickHouse on the first
+    // FULL_HISTORY sync — or from the runStartedAt update would otherwise skip
+    // the catch entirely, leaving a wedged project to retry forever without
+    // ever counting toward the breaker or notifying owners (LFE-10279).
     await prisma.blobStorageIntegration.update({
       where: { projectId },
-      data: {
-        runStartedAt: null,
-        nextSyncAt: new Date(now.getTime() + frequencyIntervalMs),
-        lastError: null,
-        lastErrorAt: null,
-      },
+      data: { runStartedAt: new Date() },
     });
-    return;
-  }
 
-  try {
+    // Sync between lastSyncAt and now - 30 minutes
+    // Cap the export to one frequency period to enable chunked historic exports
+    const minTimestamp = await getMinTimestampForExport(
+      projectId,
+      blobStorageIntegration.lastSyncAt,
+      blobStorageIntegration.exportMode,
+      blobStorageIntegration.exportStartDate,
+    );
+
+    logger.info(
+      `[BLOB INTEGRATION] Calculated minTimestamp for project ${projectId}: ${minTimestamp}, isValid: ${!isNaN(minTimestamp.getTime())}, getTime: ${minTimestamp.getTime()}, exportMode: ${blobStorageIntegration.exportMode}, lastSyncAt: ${blobStorageIntegration.lastSyncAt}, exportStartDate: ${blobStorageIntegration.exportStartDate}`,
+    );
+
+    const now = new Date();
+    const uncappedMaxTimestamp = new Date(
+      now.getTime() - BLOB_STORAGE_LAG_BUFFER_MS,
+    );
+    const frequencyIntervalMs = getFrequencyIntervalMs(
+      blobStorageIntegration.exportFrequency,
+    );
+
+    // Cap maxTimestamp to one frequency period ahead of minTimestamp
+    // This ensures large historic exports are broken into manageable chunks
+    const maxTimestamp = new Date(
+      Math.min(
+        minTimestamp.getTime() + frequencyIntervalMs,
+        uncappedMaxTimestamp.getTime(),
+      ),
+    );
+
+    logger.info(
+      `[BLOB INTEGRATION] Calculated maxTimestamp for project ${projectId}: ${maxTimestamp}, isValid: ${!isNaN(maxTimestamp.getTime())}, getTime: ${maxTimestamp.getTime()}, frequencyIntervalMs: ${frequencyIntervalMs}`,
+    );
+
+    // Skip export if the time window is empty or invalid
+    if (minTimestamp >= maxTimestamp) {
+      logger.info(
+        `[BLOB INTEGRATION] Skipping export for project ${projectId}: time window is empty (min: ${minTimestamp.toISOString()}, max: ${maxTimestamp.toISOString()})`,
+      );
+      await prisma.blobStorageIntegration.update({
+        where: { projectId },
+        data: {
+          runStartedAt: null,
+          nextSyncAt: new Date(now.getTime() + frequencyIntervalMs),
+          lastError: null,
+          lastErrorAt: null,
+        },
+      });
+      return;
+    }
+
     // Fail loudly rather than export from unpopulated tables when an enriched
     // source survives on a deployment without the enriched path, e.g. after a
     // V4-preview rollback. The catch persists lastError and notifies admins
@@ -1148,24 +1154,32 @@ export const handleBlobStorageIntegrationProjectJob = async (
       );
     }
 
-    // Update integration after successful processing
-    await prisma.blobStorageIntegration.update({
-      where: {
-        projectId,
-      },
-      data: {
-        lastSyncAt: maxTimestamp,
-        nextSyncAt,
-        lastError: null,
-        lastErrorAt: null,
-        runStartedAt: null,
-        // Reset the circuit breaker: this chunk succeeded (LFE-10279).
-        consecutiveFailures: 0,
-      },
-    });
+    // Update integration after successful processing. Gate on enabled: true so
+    // a concurrent worker that won the circuit-breaker disable claim isn't
+    // clobbered by this late-arriving success — otherwise we'd wipe the
+    // lastError/lastErrorAt it recorded and re-enable nothing, leaving admins a
+    // "paused" email pointing at an empty Review Settings page (LFE-10279).
+    const { count: successCount } =
+      await prisma.blobStorageIntegration.updateMany({
+        where: {
+          projectId,
+          enabled: true,
+        },
+        data: {
+          lastSyncAt: maxTimestamp,
+          nextSyncAt,
+          lastError: null,
+          lastErrorAt: null,
+          runStartedAt: null,
+          // Reset the circuit breaker: this chunk succeeded (LFE-10279).
+          consecutiveFailures: 0,
+        },
+      });
 
-    // If still catching up, immediately queue the next chunk job
-    if (!caughtUp) {
+    // If still catching up, immediately queue the next chunk job — but only if
+    // this success actually landed (the integration is still enabled), so we
+    // don't enqueue a successor for a just-disabled integration.
+    if (!caughtUp && successCount > 0) {
       const queue = BlobStorageIntegrationProcessingQueue.getInstance();
       if (queue) {
         const jobId = `${projectId}-${maxTimestamp.toISOString()}`;


### PR DESCRIPTION
## What does this PR do?

Adds a **circuit-breaker** to the blob storage export integration so a repeatedly-failing chunk stops retrying forever.

A failing export chunk was requeued indefinitely: on error `lastSyncAt` never advances, so the scheduler re-enqueues the same `(projectId, lastSyncAt)` chunk every cycle. BullMQ also retries each job (`attempts: 5`, exponential backoff) within a cycle, so the same failure recurs at both layers. A single wedged or misconfigured project could emit thousands of errors and keep the failure monitor firing with no path to resolution.

Now the integration tracks consecutive failed **sync runs**. A sync run is a fully retry-exhausted BullMQ job: BullMQ already absorbs transient errors within a run, so only the final retry counts toward the breaker — a blip it recovers from never advances the counter or emails owners. Once consecutive failed runs reach `LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES` (default 3, kept below the per-job retry count) the integration is auto-disabled (`enabled = false`) and project owners are emailed that it was paused. The counter resets on any successful run, and on manual re-enable. Once disabled, the scheduler no longer selects the project (it filters `enabled: true`), so both the retry loop and the monitor noise stop until an owner re-enables it.

The pause email reuses the existing `BlobStorageExportFailedEmail` path with a new "paused" variant and bypasses the failure-notification cooldown, so owners always learn the integration was disabled. The auto-disable runs as an atomic `enabled true→false` claim that also seeds the notification timestamp, so concurrent workers can't send duplicate or contradictory pause/failed emails for the same trip.

Fixes LFE-10279.

Scope note: the ticket also proposed splitting the failure metric by error class (customer-config vs. infra). That half was deliberately deferred to a follow-up; this PR is the circuit-breaker only.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] Added tests that prove the feature works (disable-after-N-failures, reset-on-success, and final-retry-only gating in `blobStorageIntegrationProcessing.test.ts`).
- [x] New and existing unit tests pass locally (targeted worker tests + repo lint + typecheck).
- [x] DB migration included (`consecutive_failures` column).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a circuit-breaker to the blob-storage export pipeline: after `LANGFUSE_BLOB_STORAGE_MAX_CONSECUTIVE_FAILURES` consecutive failures the integration is auto-disabled, project admins are emailed a "paused" notification, and the scheduler's `enabled: true` filter stops the retry loop. Re-enabling via the settings UI grants a fresh failure budget by resetting the counter.

- A new `consecutive_failures` column is added to `blob_storage_integrations` via migration; it increments atomically in Prisma on each error and resets to 0 on success.
- The disable claim uses an atomic `updateMany` (`enabled: true` filter) to ensure only one worker among concurrent processors sends the "paused" email; the existing cooldown timestamp is seeded in the same write to prevent a racing "failed" email from slipping through.
- Re-enabling a disabled integration in `upsertBlobStorageIntegration` resets `consecutiveFailures`, `lastError`, and `lastErrorAt` — but does not clear `lastFailureNotificationSentAt`, so the first post-re-enable failure can be silently swallowed by the notification cooldown.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the notification-cooldown fix applied — the circuit breaker logic and atomic disable claim are correct, but post-re-enable failures can be silently swallowed until the cooldown expires.

The reactivation path in upsertBlobStorageIntegration resets consecutiveFailures, lastError, and lastErrorAt but leaves lastFailureNotificationSentAt untouched. Because the circuit-breaker updateMany seeds that timestamp when it disables the integration, a user who re-enables and hits another failure within the cooldown window gets no email notification. The test for the re-enable path also never sets lastFailureNotificationSentAt in setup, so it cannot catch this gap. Everything else looks correct.

web/src/features/blobstorage-integration/service.ts — the reactivated spread needs lastFailureNotificationSentAt: null; the companion test should be updated to seed and assert that field.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(blobstorage): drop redundant boolean..."](https://github.com/langfuse/langfuse/commit/1e1d4d48b834d65e3c6d2e1de5f292bccc65c76a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39537117)</sub>

<!-- /greptile_comment -->
