### PR TITLE
feat(filters): nested AND/OR filter expressions for events — backend + search bar (LFE-10421)

### DIFF
--- a/.agents/skills/seed-test-data/SKILL.md
+++ b/.agents/skills/seed-test-data/SKILL.md
@@ -29,19 +29,18 @@ this.
 
 ## Need → command
 
-| I need...                                                                               | Command                                                                                                                                                                                                                              |
-| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| A very complex observation tree (v3)                                                    | `pnpm run seed -- trace-tree --observations 5000 --depth 12 --breadth 500`                                                                                                                                                           |
-| The same tree readable in the v4 events UI                                              | add `--v4` (writes `events_full`; `events_core` fills via MV)                                                                                                                                                                        |
-| Async parents whose subtree outlives their own span (subtree wall-clock duration badge) | add `--async-parents` to `trace-tree` (root + hub end immediately while children keep running)                                                                                                                                       |
-| A super tough session (v3 legacy session view)                                          | `pnpm run seed -- long-session --traces 300 --observations-per-trace 8`                                                                                                                                                              |
-| Many traces for list/filter performance                                                 | `pnpm run seed -- many-traces --count 100000 --days 14`                                                                                                                                                                              |
-| Scores with spaces in the name (filter/grammar testing)                                 | `pnpm run seed -- scored-traces --traces 24 --v4`                                                                                                                                                                                    |
-| Varied human-annotation queues (annotate UI / keyboard testing)                         | `pnpm run seed -- annotation-queue --core-items 12` (creates a "core types" queue covering every score-field render path + an "edge cases" queue with archived/stale/partial scores and observation/session/deleted/completed items) |
-| Huge/malformed/unicode payloads                                                         | `pnpm run seed -- trace-tree --payload-bytes 1000000 --payload-style malformed` (styles: json, text, malformed, unicode, bignum)                                                                                                     |
-| Big integers beyond 2^53-1 (number-precision testing)                                   | `pnpm run seed -- trace-tree --observations 1 --payload-style bignum`                                                                                                                                                                |
-| See all scenarios and flags                                                             | `pnpm run seed -- list --json`                                                                                                                                                                                                       |
-| Predict without writing                                                                 | add `--dry-run`                                                                                                                                                                                                                      |
+| I need... | Command |
+| --- | --- |
+| A very complex observation tree (v3) | `pnpm run seed -- trace-tree --observations 5000 --depth 12 --breadth 500` |
+| The same tree readable in the v4 events UI | add `--v4` (writes `events_full`; `events_core` fills via MV) |
+| A super tough session (v3 legacy session view) | `pnpm run seed -- long-session --traces 300 --observations-per-trace 8` |
+| Many traces for list/filter performance | `pnpm run seed -- many-traces --count 100000 --days 14` |
+| Scores with spaces in the name (filter/grammar testing) | `pnpm run seed -- scored-traces --traces 24 --v4` |
+| Broad variety on every filter facet (search-bar / Ask-AI testing) | `pnpm run seed -- filter-variety --traces 120 --v4` |
+| Huge/malformed/unicode payloads | `pnpm run seed -- trace-tree --payload-bytes 1000000 --payload-style malformed` (styles: json, text, malformed, unicode, bignum) |
+| Big integers beyond 2^53-1 (number-precision testing) | `pnpm run seed -- trace-tree --observations 1 --payload-style bignum` |
+| See all scenarios and flags | `pnpm run seed -- list --json` |
+| Predict without writing | add `--dry-run` |
 
 ## Contract
 

--- a/packages/shared/scripts/seeder/AGENTS.md
+++ b/packages/shared/scripts/seeder/AGENTS.md
@@ -12,6 +12,7 @@ pnpm run seed -- trace-tree --observations 5000 --breadth 500 --v4
 pnpm run seed -- long-session --traces 300 --observations-per-trace 8
 pnpm run seed -- many-traces --count 100000 --days 14
 pnpm run seed -- scored-traces --traces 24 --v4   # scores w/ spaces in the name
+pnpm run seed -- filter-variety --traces 120 --v4 # broad variety on every filter facet
 ```
 
 The last stdout line of a run is a JSON summary with `traceIds`,

--- a/packages/shared/scripts/seeder/scenarios/filter-variety.ts
+++ b/packages/shared/scripts/seeder/scenarios/filter-variety.ts
@@ -1,0 +1,525 @@
+import {
+  createTrace,
+  createObservation,
+  createTraceScore,
+  createTracesCh,
+  createObservationsCh,
+  createScoresCh,
+  createEventsCh,
+  EventRecordInsertType,
+  ObservationRecordInsertType,
+  ScoreRecordInsertType,
+  TraceRecordInsertType,
+} from "../../../src/server";
+import { ObservationType } from "../../../src/domain";
+import { observationToEvent, traceToEvent } from "./event-mirror";
+import { jitter, Rng, utcDayStartMs } from "./rng";
+import {
+  chunk,
+  ScenarioContext,
+  ScenarioDefinition,
+  SeedError,
+  SeedSummary,
+} from "./types";
+import { countRows, traceLink, tracesListLink } from "./verify";
+
+// High-cardinality pools so every filterable facet has many distinct values —
+// the point of this scenario is breadth, not a specific tree shape. Values land
+// in non-ORDER-BY columns (tags, metadata, name, level, model, scores), so they
+// can come from the rng stream; only `type` (a v3 ORDER BY key) and per-row time
+// offsets are kept stateless.
+const ENVIRONMENTS = ["production", "staging", "development", "qa"] as const;
+
+// obs[0] is always a GENERATION (carries model + usage + cost so those filters
+// have data on every trace); obs[1] cycles the remaining types so the `type`
+// facet covers the full v4 enum across the dataset.
+const NON_GENERATION_TYPES: ObservationType[] = [
+  "AGENT",
+  "CHAIN",
+  "RETRIEVER",
+  "EMBEDDING",
+  "TOOL",
+  "EVALUATOR",
+  "GUARDRAIL",
+  "SPAN",
+  "EVENT",
+];
+
+const TRACE_NAMES = [
+  "checkout-flow",
+  "rag-answer",
+  "summarize-doc",
+  "classify-intent",
+  "agent-planner",
+  "tool-router",
+  "chat-completion",
+  "moderation-check",
+  "translate-text",
+  "recommend-products",
+] as const;
+
+const MODELS = [
+  "gpt-4o",
+  "gpt-4o-mini",
+  "gpt-4-turbo",
+  "claude-3-5-sonnet",
+  "claude-3-haiku",
+  "llama-3.1-70b",
+  "gemini-1.5-pro",
+] as const;
+
+// Domain-ish tags drawn as a small random subset per trace, so `traceTags`
+// any-of / all-of / none-of all have something to bite on.
+const TAG_POOL = [
+  "billing",
+  "urgent",
+  "customer-facing",
+  "internal",
+  "experimental",
+  "beta",
+  "canary",
+  "regression",
+  "high-priority",
+  "rag",
+  "tool-use",
+  "streaming",
+  "cached",
+  "pii",
+] as const;
+
+// Custom metadata keys — the attributes that live in metadata, not a top-level
+// column (exactly what the AI prompt is told to reach into). Keep values as
+// strings: the v4 events metadata column is Map(String, String).
+const REGIONS = [
+  "us-east-1",
+  "us-west-2",
+  "eu-west-1",
+  "eu-central-1",
+  "ap-southeast-1",
+] as const;
+const TENANTS = [
+  "acme-corp",
+  "globex",
+  "initech",
+  "umbrella",
+  "stark-industries",
+] as const;
+const TIERS = ["free", "pro", "enterprise", "trial"] as const;
+const QUEUES = [
+  "membership-support",
+  "billing-support",
+  "technical-support",
+  "sales",
+  "escalations",
+] as const;
+const FLAGS = [
+  "new-checkout",
+  "beta-rag",
+  "fast-path",
+  "legacy-router",
+  "none",
+] as const;
+const STEPS = [
+  "retrieve",
+  "rerank",
+  "generate",
+  "validate",
+  "finalize",
+] as const;
+const AB_BUCKETS = ["A", "B", "control"] as const;
+
+// Input/output phrasings carrying searchable keywords (refund, cancel, password,
+// upgrade, …) so input:/output: content search returns real rows.
+const CONTENT = [
+  {
+    in: "How do I get a refund for my last order?",
+    out: "Your refund has been initiated and will arrive in 5 days.",
+  },
+  {
+    in: "Please cancel my subscription",
+    out: "Your subscription has been cancelled effective today.",
+  },
+  {
+    in: "I forgot my password and cannot log in",
+    out: "Here is how to reset your password securely.",
+  },
+  {
+    in: "Upgrade me to the enterprise plan",
+    out: "You have been upgraded to the enterprise plan.",
+  },
+  {
+    in: "Why was my card declined at checkout?",
+    out: "The card was declined due to insufficient funds.",
+  },
+  {
+    in: "Translate this contract into German",
+    out: "Hier ist die deutsche Uebersetzung des Vertrags.",
+  },
+  {
+    in: "Summarize the quarterly earnings report",
+    out: "Revenue grew 12% QoQ, driven by enterprise demand.",
+  },
+  {
+    in: "Find products similar to the blue running shoes",
+    out: "Here are three similar running shoes in blue.",
+  },
+] as const;
+
+/** Pick `k` distinct tags deterministically from the seeded rng stream. */
+const pickTags = (rng: Rng): string[] => {
+  const k = rng.int(1, 4);
+  const chosen = new Set<string>();
+  let guard = 0;
+  while (chosen.size < k && guard++ < 20) chosen.add(rng.pick(TAG_POOL));
+  return ["seed", "filter-variety", ...chosen];
+};
+
+const run = async (
+  ctx: ScenarioContext,
+  params: Record<string, string | number | boolean>,
+): Promise<SeedSummary> => {
+  const startedAt = Date.now();
+  const traceCount = Math.max(1, Number(params.traces ?? 120));
+  const withV4 = params.v4 === true;
+
+  // Spread across the last 3 days (anchored on utcDayStartMs, not wall clock,
+  // so re-runs overwrite in place — see scored-traces for the rationale) so
+  // relative time filters ("last 24h", "last 3 days") have rows on both sides.
+  const windowMs = 3 * 24 * 60 * 60 * 1000;
+  const endMs = utcDayStartMs();
+  const startMs = endMs - windowMs;
+  const stepMs = windowMs / traceCount;
+  const firstTraceTimestamp = startMs + jitter(ctx.seed, 0, 1000);
+
+  if (ctx.dryRun) {
+    return {
+      scenario: "filter-variety",
+      target: "clickhouse",
+      params,
+      projectId: ctx.projectId,
+      environment: ctx.environment,
+      traceIds: [`${ctx.idPrefix}-t0`],
+      sessionIds: [],
+      counts: {
+        traces: traceCount,
+        observations: traceCount * 2,
+        scores: traceCount * 3,
+        events: withV4 ? traceCount * 3 : 0,
+      },
+      verified: {},
+      links: [
+        tracesListLink(ctx),
+        traceLink(ctx, `${ctx.idPrefix}-t0`, firstTraceTimestamp),
+      ],
+      dryRun: true,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  const rng = new Rng(ctx.seed);
+  const traces: TraceRecordInsertType[] = [];
+  const observations: ObservationRecordInsertType[] = [];
+  const scores: ScoreRecordInsertType[] = [];
+  const events: EventRecordInsertType[] = [];
+
+  for (let t = 0; t < traceCount; t++) {
+    const traceId = `${ctx.idPrefix}-t${t}`;
+    const timestamp =
+      startMs + Math.floor(t * stepMs) + jitter(ctx.seed, t, 1000);
+    // Stateless (index-derived), never the rng stream: environment for an even
+    // spread, level for a controlled error/warning rate.
+    const environment = ENVIRONMENTS[t % ENVIRONMENTS.length];
+    const content = CONTENT[t % CONTENT.length];
+
+    const trace = createTrace({
+      id: traceId,
+      project_id: ctx.projectId,
+      environment,
+      session_id: null,
+      timestamp,
+      name: rng.pick(TRACE_NAMES),
+      user_id: `user-${rng.int(1, 50)}`,
+      release: "seed-1.0.0",
+      version: `v${rng.int(1, 4)}`,
+      tags: pickTags(rng),
+      public: false,
+      bookmarked: t % 17 === 0,
+      metadata: {
+        scenario: "filter-variety",
+        region: rng.pick(REGIONS),
+        tenant: rng.pick(TENANTS),
+        "customer.tier": rng.pick(TIERS),
+        "routing.queue": rng.pick(QUEUES),
+        "feature.flag": rng.pick(FLAGS),
+        "experiment.step": rng.pick(STEPS),
+        "ab.bucket": rng.pick(AB_BUCKETS),
+        "deployment.version": `v${rng.int(1, 5)}.${rng.int(0, 9)}.${rng.int(0, 9)}`,
+      },
+      input: JSON.stringify({ message: content.in }),
+      output: content.out,
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      event_ts: Date.now(),
+    });
+    traces.push(trace);
+
+    const level =
+      t % 8 === 0
+        ? "ERROR"
+        : t % 8 === 3
+          ? "WARNING"
+          : t % 8 === 6
+            ? "DEBUG"
+            : "DEFAULT";
+    const usageInput = rng.int(50, 4000);
+    const usageOutput = rng.int(20, 2000);
+    const genStart = timestamp;
+    const genEnd = genStart + 400 + jitter(ctx.seed, t * 2, 6000);
+
+    // obs[0]: GENERATION — carries model/usage/cost so those facets are populated
+    // on every trace (and `latency` via the duration).
+    const genId = `${traceId}-o0`;
+    const generation = createObservation({
+      id: genId,
+      trace_id: traceId,
+      project_id: ctx.projectId,
+      environment,
+      type: "GENERATION",
+      parent_observation_id: null,
+      name: "answer-generation",
+      start_time: genStart,
+      end_time: genEnd,
+      completion_start_time: genStart + rng.int(80, 400),
+      level,
+      status_message:
+        level === "ERROR"
+          ? "Execution failed: upstream timeout after 30s"
+          : null,
+      version: null,
+      input: JSON.stringify({ prompt: content.in }),
+      output: content.out,
+      metadata: { scenario: "filter-variety", "node.kind": "generation" },
+      provided_model_name: rng.pick(MODELS),
+      internal_model_id: null,
+      model_parameters: JSON.stringify({ temperature: 0.2, max_tokens: 1024 }),
+      provided_usage_details: {
+        input: usageInput,
+        output: usageOutput,
+        total: usageInput + usageOutput,
+      },
+      usage_details: {
+        input: usageInput,
+        output: usageOutput,
+        total: usageInput + usageOutput,
+      },
+      provided_cost_details: {
+        input: usageInput * 2e-6,
+        output: usageOutput * 6e-6,
+      },
+      cost_details: {
+        input: usageInput * 2e-6,
+        output: usageOutput * 6e-6,
+        total: usageInput * 2e-6 + usageOutput * 6e-6,
+      },
+      total_cost: usageInput * 2e-6 + usageOutput * 6e-6,
+      prompt_id: null,
+      prompt_name: null,
+      prompt_version: null,
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      event_ts: Date.now(),
+    });
+    observations.push(generation);
+
+    // obs[1]: a non-generation child whose type cycles the rest of the v4 enum
+    // (stateless), so the `type` facet covers every kind across the dataset.
+    const childType = NON_GENERATION_TYPES[t % NON_GENERATION_TYPES.length];
+    const childId = `${traceId}-o1`;
+    const childStart = genStart + 10 + jitter(ctx.seed, t * 2 + 1, 200);
+    const child = createObservation({
+      id: childId,
+      trace_id: traceId,
+      project_id: ctx.projectId,
+      environment,
+      type: childType,
+      parent_observation_id: genId,
+      name: `${childType.toLowerCase()}-step`,
+      start_time: childStart,
+      end_time: childStart + 5 + jitter(ctx.seed, t * 2 + 2, 800),
+      completion_start_time: null,
+      level: "DEFAULT",
+      status_message: null,
+      version: null,
+      input: rng.bool(0.5) ? JSON.stringify({ query: content.in }) : null,
+      output: rng.bool(0.5) ? content.out : null,
+      metadata: {
+        scenario: "filter-variety",
+        "node.kind": childType.toLowerCase(),
+      },
+      provided_model_name: null,
+      internal_model_id: null,
+      model_parameters: "{}",
+      provided_usage_details: {},
+      usage_details: {},
+      provided_cost_details: {},
+      cost_details: {},
+      total_cost: null,
+      prompt_id: null,
+      prompt_name: null,
+      prompt_version: null,
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      event_ts: Date.now(),
+    });
+    observations.push(child);
+
+    // Scores: one observation-level numeric (-> scores.accuracy), one trace-level
+    // numeric (-> traceScores.helpfulness), one trace-level categorical sentiment.
+    scores.push(
+      createTraceScore({
+        id: `${genId}-score-accuracy`,
+        project_id: ctx.projectId,
+        trace_id: traceId,
+        observation_id: genId,
+        environment,
+        name: "accuracy",
+        value: Math.round(rng.next() * 100) / 100,
+        data_type: "NUMERIC",
+        source: "EVAL",
+        comment: null,
+        metadata: {},
+        timestamp,
+      }),
+      createTraceScore({
+        id: `${traceId}-score-helpfulness`,
+        project_id: ctx.projectId,
+        trace_id: traceId,
+        environment,
+        name: "helpfulness",
+        value: Math.round(rng.next() * 500) / 100,
+        data_type: "NUMERIC",
+        source: "EVAL",
+        comment: null,
+        metadata: {},
+        timestamp,
+      }),
+      createTraceScore({
+        id: `${traceId}-score-sentiment`,
+        project_id: ctx.projectId,
+        trace_id: traceId,
+        environment,
+        name: "sentiment",
+        value: 0,
+        string_value: rng.pick(["positive", "neutral", "negative"]),
+        data_type: "CATEGORICAL",
+        source: "EVAL",
+        comment: null,
+        metadata: {},
+        timestamp,
+      }),
+    );
+
+    if (withV4) {
+      events.push(traceToEvent(trace));
+      events.push(observationToEvent(generation, trace));
+      events.push(observationToEvent(child, trace));
+    }
+  }
+
+  const counts: Record<string, number> = {
+    traces: traces.length,
+    observations: observations.length,
+    scores: scores.length,
+    events: events.length,
+  };
+
+  ctx.log(
+    `writing ${traces.length} traces, ${observations.length} observations, ${scores.length} scores${withV4 ? `, ${events.length} events` : ""}`,
+  );
+  for (const batch of chunk(traces, 1000)) await createTracesCh(batch);
+  for (const batch of chunk(observations, 1000))
+    await createObservationsCh(batch);
+  for (const batch of chunk(scores, 1000)) await createScoresCh(batch);
+  for (const batch of chunk(events, 500)) await createEventsCh(batch);
+
+  const traceIds = traces.map((tr) => tr.id);
+  const verified: Record<string, number> = {
+    traces: await countRows(
+      "traces",
+      `project_id = {projectId: String} AND id IN {traceIds: Array(String)}`,
+      { projectId: ctx.projectId, traceIds },
+      "uniqExact(id)",
+    ),
+    scores: await countRows(
+      "scores",
+      `project_id = {projectId: String} AND trace_id IN {traceIds: Array(String)}`,
+      { projectId: ctx.projectId, traceIds },
+      "uniqExact(id)",
+    ),
+  };
+  if (withV4) {
+    verified.events = await countRows(
+      "events_full",
+      `project_id = {projectId: String} AND trace_id IN {traceIds: Array(String)}`,
+      { projectId: ctx.projectId, traceIds },
+      "uniqExact(span_id)",
+    );
+  }
+
+  if (verified.traces < traces.length) {
+    throw new SeedError(
+      `Readback mismatch: expected ${traces.length} traces, found ${verified.traces}`,
+    );
+  }
+  if (verified.scores < scores.length) {
+    throw new SeedError(
+      `Readback mismatch: expected ${scores.length} scores, found ${verified.scores}`,
+    );
+  }
+  if (withV4 && verified.events < events.length) {
+    throw new SeedError(
+      `Readback mismatch: expected ${events.length} events_full rows, found ${verified.events}`,
+    );
+  }
+
+  return {
+    scenario: "filter-variety",
+    target: "clickhouse",
+    params,
+    projectId: ctx.projectId,
+    environment: ctx.environment,
+    traceIds: traceIds.slice(0, 5),
+    sessionIds: [],
+    counts,
+    verified,
+    links: [
+      tracesListLink(ctx),
+      traceLink(ctx, traces[0].id, firstTraceTimestamp),
+    ],
+    dryRun: false,
+    durationMs: Date.now() - startedAt,
+  };
+};
+
+export const filterVarietyScenario: ScenarioDefinition = {
+  name: "filter-variety",
+  description:
+    "Many standalone traces spread over 3 days with broad variety on EVERY filter facet — multiple environments, all observation types, weighted error/warning levels, a varied model + tag pool, domain metadata keys (region, tenant, customer.tier, routing.queue, feature.flag, …), numeric + categorical scores, and searchable input/output. For exercising the search bar / filter sidebar (and the Ask-AI OR/grouped filters) against rich data.",
+  supportsV4: true,
+  flags: [
+    {
+      flag: "traces",
+      type: "number",
+      default: 120,
+      description: "number of standalone traces to create",
+    },
+    {
+      flag: "v4",
+      type: "boolean",
+      default: false,
+      description:
+        "also mirror traces/observations into v4 events_full/events_core",
+    },
+  ],
+  run,
+};

--- a/packages/shared/scripts/seeder/scenarios/index.ts
+++ b/packages/shared/scripts/seeder/scenarios/index.ts
@@ -1,4 +1,4 @@
-import { annotationQueueScenario } from "./annotation-queue";
+import { filterVarietyScenario } from "./filter-variety";
 import { longSessionScenario } from "./long-session";
 import { manyTracesScenario } from "./many-traces";
 import { scoredTracesScenario } from "./scored-traces";
@@ -13,7 +13,7 @@ export const scenarios: Record<string, ScenarioDefinition> = {
   "long-session": longSessionScenario,
   "many-traces": manyTracesScenario,
   "scored-traces": scoredTracesScenario,
-  "annotation-queue": annotationQueueScenario,
+  "filter-variety": filterVarietyScenario,
 };
 
 export * from "./types";

--- a/web/src/__tests__/server/unit/parseFilterCompletion.servertest.ts
+++ b/web/src/__tests__/server/unit/parseFilterCompletion.servertest.ts
@@ -1,8 +1,29 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  type FilterExpression,
+  type FilterInput,
+  type FilterState,
+  MAX_FILTER_EXPRESSION_DEPTH,
+} from "@langfuse/shared";
 import { parseGeneratedFilters } from "@/src/features/search-bar/server/parseFilterCompletion";
 
-describe("parseGeneratedFilters", () => {
+/** Assert the parser took the flat path and narrow for indexing. */
+function asFlat(input: FilterInput): FilterState {
+  if (!Array.isArray(input)) throw new Error("expected a flat filter array");
+  return input;
+}
+
+/** Assert the parser took the tree path and narrow for structural checks. */
+function asGroup(
+  input: FilterInput,
+): Extract<FilterExpression, { type: "group" }> {
+  if (Array.isArray(input) || input.type !== "group")
+    throw new Error("expected a nested group");
+  return input;
+}
+
+describe("parseGeneratedFilters — flat array (implicit AND)", () => {
   it("parses a plain JSON array of v4 filters and derives query text", () => {
     const completion = JSON.stringify([
       {
@@ -13,9 +34,9 @@ describe("parseGeneratedFilters", () => {
       },
       { type: "number", column: "latency", operator: ">", value: 2 },
     ]);
-    const { filters, queryText, droppedCount } =
+    const { filterInput, queryText, droppedCount } =
       parseGeneratedFilters(completion);
-    expect(filters).toHaveLength(2);
+    expect(asFlat(filterInput)).toHaveLength(2);
     expect(droppedCount).toBe(0);
     expect(queryText).toContain("level");
     expect(queryText).toContain("latency");
@@ -32,7 +53,8 @@ describe("parseGeneratedFilters", () => {
         },
       ],
     });
-    const { filters, droppedCount } = parseGeneratedFilters(completion);
+    const { filterInput, droppedCount } = parseGeneratedFilters(completion);
+    const filters = asFlat(filterInput);
     expect(filters).toHaveLength(1);
     expect(filters[0]?.column).toBe("environment");
     expect(droppedCount).toBe(0);
@@ -44,7 +66,8 @@ describe("parseGeneratedFilters", () => {
       '[{"type":"number","column":"totalCost","operator":">","value":0.5}]',
       "Hope that helps!",
     ].join("\n");
-    const { filters } = parseGeneratedFilters(completion);
+    const { filterInput } = parseGeneratedFilters(completion);
+    const filters = asFlat(filterInput);
     expect(filters).toHaveLength(1);
     expect(filters[0]?.column).toBe("totalCost");
   });
@@ -67,7 +90,8 @@ describe("parseGeneratedFilters", () => {
         value: ["ERROR"],
       },
     ]);
-    const { filters, droppedCount } = parseGeneratedFilters(completion);
+    const { filterInput, droppedCount } = parseGeneratedFilters(completion);
+    const filters = asFlat(filterInput);
     expect(filters).toHaveLength(1);
     expect(filters[0]?.column).toBe("level");
     expect(droppedCount).toBe(2);
@@ -90,8 +114,8 @@ describe("parseGeneratedFilters", () => {
         value: 0.8,
       },
     ]);
-    const { filters, droppedCount } = parseGeneratedFilters(completion);
-    expect(filters).toHaveLength(2);
+    const { filterInput, droppedCount } = parseGeneratedFilters(completion);
+    expect(asFlat(filterInput)).toHaveLength(2);
     expect(droppedCount).toBe(0);
   });
 
@@ -108,7 +132,8 @@ describe("parseGeneratedFilters", () => {
         value: ["ERROR"],
       },
     ]);
-    const { filters, droppedCount } = parseGeneratedFilters(completion);
+    const { filterInput, droppedCount } = parseGeneratedFilters(completion);
+    const filters = asFlat(filterInput);
     expect(filters).toHaveLength(1);
     expect(filters[0]?.column).toBe("level");
     expect(droppedCount).toBe(1);
@@ -133,24 +158,156 @@ describe("parseGeneratedFilters", () => {
         value: "production",
       },
     ]);
-    const { filters, droppedCount } = parseGeneratedFilters(completion);
+    const { filterInput, droppedCount } = parseGeneratedFilters(completion);
+    const filters = asFlat(filterInput);
     expect(filters).toHaveLength(1);
     expect(filters[0]?.column).toBe("level");
     expect(droppedCount).toBe(1);
   });
 
   it("returns no filters for non-JSON / refusal output", () => {
-    const { filters, queryText, droppedCount } = parseGeneratedFilters(
+    const { filterInput, queryText, droppedCount } = parseGeneratedFilters(
       "I'm sorry, I can't help with that.",
     );
-    expect(filters).toHaveLength(0);
+    expect(asFlat(filterInput)).toHaveLength(0);
     expect(queryText).toBe("");
     expect(droppedCount).toBe(0);
   });
 
   it("returns no filters for an empty array", () => {
-    const { filters, droppedCount } = parseGeneratedFilters("[]");
-    expect(filters).toHaveLength(0);
+    const { filterInput, droppedCount } = parseGeneratedFilters("[]");
+    expect(asFlat(filterInput)).toHaveLength(0);
     expect(droppedCount).toBe(0);
+  });
+});
+
+describe("parseGeneratedFilters — nested groups (OR / brackets)", () => {
+  it("parses a cross-field OR group into a tree and derives `OR` query text", () => {
+    const completion = JSON.stringify({
+      type: "group",
+      operator: "OR",
+      conditions: [
+        {
+          type: "stringOptions",
+          column: "level",
+          operator: "any of",
+          value: ["ERROR"],
+        },
+        { type: "number", column: "latency", operator: ">", value: 5 },
+      ],
+    });
+    const { filterInput, queryText, droppedCount } =
+      parseGeneratedFilters(completion);
+    const group = asGroup(filterInput);
+    expect(group.operator).toBe("OR");
+    expect(group.conditions).toHaveLength(2);
+    expect(droppedCount).toBe(0);
+    expect(queryText).toContain(" OR ");
+  });
+
+  it("preserves bracketing for a mixed AND-of-OR tree", () => {
+    const completion = JSON.stringify({
+      type: "group",
+      operator: "AND",
+      conditions: [
+        {
+          type: "stringOptions",
+          column: "environment",
+          operator: "any of",
+          value: ["production"],
+        },
+        {
+          type: "group",
+          operator: "OR",
+          conditions: [
+            {
+              type: "stringOptions",
+              column: "level",
+              operator: "any of",
+              value: ["ERROR"],
+            },
+            { type: "number", column: "totalCost", operator: ">", value: 1 },
+          ],
+        },
+      ],
+    });
+    const { filterInput, queryText, droppedCount } =
+      parseGeneratedFilters(completion);
+    const group = asGroup(filterInput);
+    expect(group.operator).toBe("AND");
+    expect(droppedCount).toBe(0);
+    // OR is parenthesized inside the AND, so the derived text brackets it.
+    expect(queryText).toContain(" OR ");
+    expect(queryText).toContain("(");
+  });
+
+  it("tolerates a { filterInput: {group} } wrapper", () => {
+    const completion = JSON.stringify({
+      filterInput: {
+        type: "group",
+        operator: "OR",
+        conditions: [
+          {
+            type: "stringOptions",
+            column: "level",
+            operator: "any of",
+            value: ["ERROR"],
+          },
+          {
+            type: "stringOptions",
+            column: "level",
+            operator: "any of",
+            value: ["WARNING"],
+          },
+        ],
+      },
+    });
+    const { filterInput } = parseGeneratedFilters(completion);
+    expect(asGroup(filterInput).operator).toBe("OR");
+  });
+
+  it("rejects the WHOLE tree when any leaf is non-representable (all-or-nothing)", () => {
+    // A bare `number` on the score column 500s the events query. Dropping just
+    // that leaf would change the OR's meaning, so the whole tree is rejected.
+    const completion = JSON.stringify({
+      type: "group",
+      operator: "OR",
+      conditions: [
+        {
+          type: "stringOptions",
+          column: "level",
+          operator: "any of",
+          value: ["ERROR"],
+        },
+        { type: "number", column: "scores_avg", operator: ">", value: 90 },
+      ],
+    });
+    const { filterInput, droppedCount } = parseGeneratedFilters(completion);
+    expect(asFlat(filterInput)).toHaveLength(0);
+    expect(droppedCount).toBe(2);
+  });
+
+  it("rejects a tree nested beyond the depth bound", () => {
+    let node: unknown = {
+      type: "string",
+      column: "name",
+      operator: "=",
+      value: "x",
+    };
+    for (let i = 0; i < MAX_FILTER_EXPRESSION_DEPTH + 1; i++) {
+      node = { type: "group", operator: "AND", conditions: [node] };
+    }
+    const { filterInput } = parseGeneratedFilters(JSON.stringify(node));
+    expect(asFlat(filterInput)).toHaveLength(0);
+  });
+
+  it("rejects a structurally-invalid group (empty conditions)", () => {
+    const completion = JSON.stringify({
+      type: "group",
+      operator: "AND",
+      conditions: [],
+    });
+    const { filterInput } = parseGeneratedFilters(completion);
+    expect(asFlat(filterInput)).toHaveLength(0);
   });
 });

--- a/web/src/__tests__/server/unit/searchBarFilterPrompt.servertest.ts
+++ b/web/src/__tests__/server/unit/searchBarFilterPrompt.servertest.ts
@@ -73,6 +73,14 @@ describe("buildFilterSystemPrompt", () => {
     expect(prompt).toContain(SCORE_COLUMNS.trace.categorical);
   });
 
+  it("documents the nested group output shape for OR / bracketing", () => {
+    expect(prompt).toContain("Boolean logic");
+    expect(prompt).toContain(`"type":"group"`);
+    expect(prompt).toContain(`"operator":"AND"|"OR"`);
+    // a worked cross-field OR example the model can pattern-match
+    expect(prompt).toContain(`"operator":"OR"`);
+  });
+
   it("omits the refine section without a current query", () => {
     expect(prompt).not.toContain("Current filters");
   });

--- a/web/src/components/BatchExportTableButton.tsx
+++ b/web/src/components/BatchExportTableButton.tsx
@@ -29,6 +29,10 @@ export type BatchExportTableButtonProps = {
   filterState: any;
   searchQuery?: any;
   searchType?: any;
+  /** Disable export (e.g. the active filter can't be expressed for export). */
+  disabled?: boolean;
+  /** Tooltip shown on the disabled trigger. */
+  disabledReason?: string;
 };
 
 export const BatchExportTableButton: React.FC<BatchExportTableButtonProps> = (
@@ -96,8 +100,13 @@ export const BatchExportTableButton: React.FC<BatchExportTableButtonProps> = (
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon" title="Export">
+      <DropdownMenuTrigger asChild disabled={props.disabled}>
+        <Button
+          variant="outline"
+          size="icon"
+          disabled={props.disabled}
+          title={props.disabled ? props.disabledReason : "Export"}
+        >
           {isExporting ? (
             <Spinner size="sm" />
           ) : (

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -106,6 +106,14 @@ export interface QueryFilter {
   clearAll: () => void;
   isFiltered: boolean;
   setFilterState: (filters: FilterState) => void;
+  /**
+   * The active filter is a nested expression (cross-field OR / bracket group)
+   * the flat facet sidebar cannot represent (Search/Filter v2). When true the
+   * facets render READ-ONLY (value lists still shown, controls disabled) under a
+   * hint banner — the search bar is the editor for that filter; "Clear all"
+   * returns to editing facets here.
+   */
+  isAdvancedFilter?: boolean;
 }
 
 interface DataTableControlsProps {
@@ -188,6 +196,14 @@ export function DataTableControls({
         </div>
       </div>
       <div className="pb-10">
+        {queryFilter.isAdvancedFilter && (
+          <div className="text-muted-foreground border-b px-3 py-2.5 text-xs leading-relaxed">
+            An advanced filter (OR / grouped conditions) is active — facets are
+            read-only. Edit it in the search bar above, or use
+            <span className="font-medium"> Clear all</span> to return to editing
+            facets here.
+          </div>
+        )}
         <Accordion
           type="multiple"
           className="w-full"

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -26,8 +26,10 @@ import {
 } from "@/src/components/table/loading-cells";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import {
+  combineFilterInputsWithAnd,
   type ObservationLevelType,
   type FilterState,
+  type FilterInput,
   BatchExportTableName,
   type ObservationType,
   TableViewPresetTableName,
@@ -435,8 +437,9 @@ export default function ObservationsEventsTable({
   const queryFilterRef = useRef(queryFilter);
   queryFilterRef.current = queryFilter;
 
-  const setFiltersWrapper = useCallback(
-    (filters: FilterState) => queryFilterRef.current?.setFilterState(filters),
+  const setFilterExpressionWrapper = useCallback(
+    (filterInput: FilterInput) =>
+      queryFilterRef.current?.setFilterExpression(filterInput),
     [],
   );
 
@@ -452,11 +455,11 @@ export default function ObservationsEventsTable({
   } = useEventsSearchBar({
     projectId,
     enabled: searchBarMode,
-    filterState: queryFilter.explicitFilterState,
+    filterExpression: queryFilter.explicitFilterExpression,
     searchQuery,
     searchType,
     observed: observedOptions,
-    setFilterState: setFiltersWrapper,
+    setFilterExpression: setFilterExpressionWrapper,
     setSearchQuery,
     setSearchType,
   });
@@ -497,15 +500,34 @@ export default function ObservationsEventsTable({
       ]
     : [];
 
-  // The sidebar's effective filter state is the single source of truth in both
-  // modes — the search bar syncs into it rather than replacing it.
-  const combinedFilterState = queryFilter.effectiveFilterState
-    .concat(dateRangeFilter)
+  // The sidebar's effective filter is the single source of truth in both modes
+  // — the search bar syncs into it rather than replacing it. It may be a nested
+  // tree (v2), so the page-scope filters (time range, userId, sessionId) are
+  // AND-conjoined as an OUTER AND wrapping it, never spliced inside (which would
+  // widen a user OR). combineFilterInputsWithAnd flattens AND-of-AND (so the
+  // depth budget isn't wasted) and stays a flat array for a flat filter.
+  const pageScopeFilters: FilterState = dateRangeFilter
     .concat(userIdFilter)
     .concat(sessionIdFilter);
+  const combinedFilterState: FilterInput =
+    combineFilterInputsWithAnd(
+      queryFilter.effectiveFilterExpression,
+      pageScopeFilters,
+    ) ?? [];
 
   // Use external filter state if provided, otherwise use combined filter state
-  const filterState = externalFilterState || combinedFilterState;
+  const filterState: FilterInput = externalFilterState || combinedFilterState;
+
+  // Bulk "select all matching" actions consume a flat FilterState; they cannot
+  // express a nested tree (cross-field OR / group). When an advanced filter is
+  // active we DISABLE those actions (see isAdvancedFilterActive) rather than
+  // ship an empty filter that would silently widen scope to every row.
+  // Selection-based actions over explicitly-checked rows stay enabled.
+  const isAdvancedFilterActive =
+    !externalFilterState && queryFilter.isAdvancedFilter === true;
+  const batchActionFilterState: FilterState = Array.isArray(filterState)
+    ? filterState
+    : [];
 
   // Use the custom hook for observations data fetching
   const {
@@ -651,6 +673,13 @@ export default function ObservationsEventsTable({
     : isTotalCountError
       ? "Could not count selected observations. Clear selection and try again."
       : undefined;
+  // "Select all matching" ships the filter to the backend, which can't yet
+  // express a nested tree — so block it when an advanced filter is active to
+  // avoid silently widening scope to every row. Explicit row selection (which
+  // ships ids, not the filter) stays enabled.
+  const selectAllBlockedByAdvancedFilter = selectAll && isAdvancedFilterActive;
+  const advancedFilterSelectAllReason =
+    "Select-all isn't available with an advanced (OR / grouped) filter yet — select specific rows, or switch to flat filters.";
   const tableActions: TableAction[] = [
     ...(hasTraceDeletionEntitlement
       ? [
@@ -679,6 +708,10 @@ export default function ObservationsEventsTable({
       description: "Add selected observations to an annotation queue.",
       targetLabel: "Annotation Queue",
       execute: handleAddToAnnotationQueue,
+      disabled: selectAllBlockedByAdvancedFilter,
+      disabledReason: selectAllBlockedByAdvancedFilter
+        ? advancedFilterSelectAllReason
+        : undefined,
       accessCheck: {
         scope: "annotationQueues:CUD",
       },
@@ -689,8 +722,10 @@ export default function ObservationsEventsTable({
       label: "Add to Dataset",
       description: "Add selected observations to a dataset",
       customDialog: true,
-      disabled: isSelectAllCountUnavailable,
-      disabledReason: selectAllCountUnavailableReason,
+      disabled: isSelectAllCountUnavailable || selectAllBlockedByAdvancedFilter,
+      disabledReason: selectAllBlockedByAdvancedFilter
+        ? advancedFilterSelectAllReason
+        : selectAllCountUnavailableReason,
       accessCheck: {
         scope: "datasets:CUD",
       },
@@ -702,8 +737,10 @@ export default function ObservationsEventsTable({
       description: "Run evaluations on selected observations.",
       customDialog: true,
       icon: <LightbulbIcon className="h-4 w-4 sm:mr-2" />,
-      disabled: isSelectAllCountUnavailable,
-      disabledReason: selectAllCountUnavailableReason,
+      disabled: isSelectAllCountUnavailable || selectAllBlockedByAdvancedFilter,
+      disabledReason: selectAllBlockedByAdvancedFilter
+        ? advancedFilterSelectAllReason
+        : selectAllCountUnavailableReason,
       accessCheck: {
         scope: "evalJob:CUD",
       },
@@ -1351,7 +1388,7 @@ export default function ObservationsEventsTable({
     projectId,
     stateUpdaters: {
       setOrderBy: setOrderByState,
-      setFilters: setFiltersWrapper,
+      setFilters: setFilterExpressionWrapper,
       setExpandedFilters: queryFilter.onExpandedChange,
       setColumnOrder: setColumnOrder,
       setColumnVisibility: setColumnVisibilityState,
@@ -1569,12 +1606,14 @@ export default function ObservationsEventsTable({
                 <BatchExportTableButton
                   {...{
                     projectId,
-                    filterState,
+                    filterState: batchActionFilterState,
                     orderByState,
                     searchQuery,
                     searchType,
                   }}
                   tableName={BatchExportTableName.Events}
+                  disabled={isAdvancedFilterActive}
+                  disabledReason="Export can't yet apply an advanced (OR / grouped) filter. Switch to flat filters to export."
                   key="batchExport"
                 />,
                 selectedObservationIds.length > 0 || selectAll ? (
@@ -1744,7 +1783,7 @@ export default function ObservationsEventsTable({
           projectId={projectId}
           selectedObservationIds={selectedObservationIds}
           query={{
-            filter: filterState,
+            filter: batchActionFilterState,
             orderBy: orderByState,
             searchQuery: searchQuery ?? undefined,
             searchType,
@@ -1765,7 +1804,7 @@ export default function ObservationsEventsTable({
           projectId={projectId}
           selectedObservationIds={selectedObservationIds}
           query={{
-            filter: filterState,
+            filter: batchActionFilterState,
             orderBy: orderByState,
             searchQuery: searchQuery ?? undefined,
             searchType,

--- a/web/src/features/events/hooks/useEventsTableData.ts
+++ b/web/src/features/events/hooks/useEventsTableData.ts
@@ -1,7 +1,7 @@
 import { api, sendAsPostOption } from "@/src/utils/api";
 import { useMemo } from "react";
 import {
-  type FilterState,
+  type FilterInput,
   AnnotationQueueObjectType,
   type TracingSearchType,
   type ScoreAggregate,
@@ -18,7 +18,8 @@ type FullEventsObservation = FullEventsObservations[number] & {
 
 type UseEventsTableDataParams = {
   projectId: string;
-  filterState: FilterState;
+  /** Flat FilterState OR a nested FilterExpression tree (Search/Filter v2). */
+  filterState: FilterInput;
   paginationState: {
     page: number;
     limit: number;
@@ -222,7 +223,11 @@ export function useEventsTableData({
       queueId: targetId,
       isBatchAction: selectAll,
       query: {
-        filter: filterState,
+        // Bulk "select all matching" actions consume a flat FilterState; a
+        // nested tree (cross-field OR) is not yet supported on this path, so it
+        // falls back to no user filter. Selection-based actions (specific rows)
+        // are unaffected. TODO(LFE-10421 follow-up): widen batch actions to FilterInput.
+        filter: Array.isArray(filterState) ? filterState : [],
         orderBy: orderByState,
       },
     });

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -2,7 +2,11 @@ import type React from "react";
 import { useCallback, useMemo, useEffect, useState } from "react";
 import { StringParam, useQueryParam } from "use-query-params";
 import {
+  combineFilterInputsWithAnd,
+  type FilterExpression,
+  type FilterInput,
   type FilterState,
+  getMandatoryFilterExpressionLeafFilters,
   singleFilter,
   type SingleValueOption,
   type ColumnDefinition,
@@ -11,6 +15,8 @@ import {
   computeSelectedValues,
   encodeFiltersGeneric,
   decodeFiltersGeneric,
+  decodeFilterInput,
+  encodeFilterInput,
 } from "../lib/filter-query-encoding";
 import {
   buildSidebarFilterQueryStorageKey,
@@ -510,47 +516,60 @@ export function useSidebarFilterState(
   );
   const [memoryFilterState, setMemoryFilterState] = useState<FilterState>([]);
 
-  const urlFilterState: FilterState = useMemo(() => {
-    if (
-      stateLocationType !== "url" &&
-      stateLocationType !== "urlAndSessionStorage"
-    ) {
-      return [];
-    }
+  const usesUrlState =
+    stateLocationType === "url" || stateLocationType === "urlAndSessionStorage";
 
-    const rawQuery = (() => {
-      if (pendingFiltersQuery !== null) {
-        return pendingFiltersQuery;
-      }
-
-      if (typeof urlFiltersQuery === "string") {
-        return urlFiltersQuery;
-      }
-
-      if (stateLocationType === "urlAndSessionStorage") {
-        return storedFiltersQuery;
-      }
-
-      return "";
-    })();
-
-    return decodeAndNormalizeFilters(
-      rawQuery,
-      config.columnDefinitions,
-      config.migrateFilterState,
-    );
+  const rawFilterQuery = useMemo(() => {
+    if (!usesUrlState) return "";
+    if (pendingFiltersQuery !== null) return pendingFiltersQuery;
+    if (typeof urlFiltersQuery === "string") return urlFiltersQuery;
+    if (stateLocationType === "urlAndSessionStorage") return storedFiltersQuery;
+    return "";
   }, [
-    config.columnDefinitions,
-    config.migrateFilterState,
+    usesUrlState,
     stateLocationType,
     pendingFiltersQuery,
     urlFiltersQuery,
     storedFiltersQuery,
   ]);
 
+  // Search/Filter v2: the URL `filter` param may hold a nested FilterExpression
+  // tree (cross-field OR / brackets) the flat facet sidebar cannot represent.
+  // Decode it once; a tree puts the sidebar into the read-only "advanced filter"
+  // state (isAdvancedFilter) while the flat fields below stay empty — so every
+  // other table that never produces a tree is byte-for-byte unaffected.
+  const decodedFilterInput: FilterInput = useMemo(
+    () => (usesUrlState ? decodeFilterInput(rawFilterQuery) : []),
+    [usesUrlState, rawFilterQuery],
+  );
+  const isAdvancedFilter = !Array.isArray(decodedFilterInput);
+
+  const urlFilterState: FilterState = useMemo(() => {
+    if (!usesUrlState || isAdvancedFilter) {
+      return [];
+    }
+
+    return decodeAndNormalizeFilters(
+      rawFilterQuery,
+      config.columnDefinitions,
+      config.migrateFilterState,
+    );
+  }, [
+    config.columnDefinitions,
+    config.migrateFilterState,
+    usesUrlState,
+    isAdvancedFilter,
+    rawFilterQuery,
+  ]);
+
   const canonicalFiltersQuery = useMemo(
-    () => encodeFiltersGeneric(urlFilterState),
-    [urlFilterState],
+    // A tree is its own canonical form (re-encode the decoded value); the flat
+    // delimited canonicalization below must never run on it (it would wipe it).
+    () =>
+      isAdvancedFilter
+        ? encodeFilterInput(decodedFilterInput)
+        : encodeFiltersGeneric(urlFilterState),
+    [isAdvancedFilter, decodedFilterInput, urlFilterState],
   );
 
   const explicitFilterState: FilterState =
@@ -657,6 +676,37 @@ export function useSidebarFilterState(
     ],
   );
 
+  // The user's full filter, flat array OR nested tree (v2). Flat case is just
+  // the array; tree case is the decoded expression.
+  const explicitFilterExpression: FilterInput = isAdvancedFilter
+    ? (decodedFilterInput as FilterExpression)
+    : explicitFilterState;
+
+  // Effective filter for the query: managed-environment default applied. For a
+  // tree, the implicit hidden-env default wraps the user tree as an OUTER AND
+  // (never inside it) — unless the user already authored an env filter anywhere
+  // in the tree, in which case their selection stands.
+  const effectiveFilterExpression: FilterInput = useMemo(() => {
+    if (!isAdvancedFilter) return filterState;
+    const tree = decodedFilterInput as FilterExpression;
+    // Only an AND-reachable (mandatory) env filter is a guaranteed constraint.
+    // An env filter that holds only inside an OR branch must NOT suppress the
+    // implicit hidden-env default, or hidden environments leak.
+    const userAuthoredEnv = getMandatoryFilterExpressionLeafFilters(tree).some(
+      (leaf) => leaf.column === managedEnvironmentColumn,
+    );
+    const envDefaults = userAuthoredEnv ? [] : effectiveEnvironmentFilterState;
+    if (envDefaults.length === 0) return tree;
+    // Outer AND, flattened so an already-AND tree doesn't nest (depth budget).
+    return combineFilterInputsWithAnd(tree, envDefaults) ?? tree;
+  }, [
+    isAdvancedFilter,
+    decodedFilterInput,
+    filterState,
+    effectiveEnvironmentFilterState,
+    managedEnvironmentColumn,
+  ]);
+
   const setFilterState = useCallback(
     (newFilters: FilterState) => {
       const explicitFilters = stripImplicitEnvironmentFilterFromExplicitState({
@@ -693,6 +743,31 @@ export function useSidebarFilterState(
     ],
   );
 
+  // Write a FilterInput (flat array OR nested tree). A flat array routes through
+  // setFilterState (managed-env strip, delimited encoding) so the sidebar path is
+  // unchanged; a tree is JSON-encoded into the same `filter` param. Only the
+  // events search bar calls this; the facet sidebar still uses setFilterState.
+  const setFilterExpression = useCallback(
+    (input: FilterInput) => {
+      if (Array.isArray(input)) {
+        setFilterState(input);
+        return;
+      }
+      const encoded = encodeFilterInput(input);
+      setPendingFiltersQuery(encoded);
+      setUrlFiltersQuery(encoded || null);
+      if (stateLocationType === "urlAndSessionStorage") {
+        setStoredFiltersQuery(encoded);
+      }
+    },
+    [
+      setFilterState,
+      stateLocationType,
+      setUrlFiltersQuery,
+      setStoredFiltersQuery,
+    ],
+  );
+
   // Drop optimistic override once URL catches up to the requested value.
   useEffect(() => {
     if (
@@ -725,6 +800,10 @@ export function useSidebarFilterState(
 
     if (pendingFiltersQuery !== null) return;
 
+    // The flat delimited canonicalization does not apply to a JSON tree — it
+    // would re-encode it to "" and wipe it. The tree is already canonical.
+    if (isAdvancedFilter) return;
+
     if (typeof urlFiltersQuery === "string") {
       if (urlFiltersQuery !== canonicalFiltersQuery) {
         setPendingFiltersQuery(canonicalFiltersQuery);
@@ -754,6 +833,7 @@ export function useSidebarFilterState(
     canonicalFiltersQuery,
     setStoredFiltersQuery,
     setUrlFiltersQuery,
+    isAdvancedFilter,
   ]);
 
   // Mirror explicit URL filter state into session fallback storage.
@@ -1168,6 +1248,18 @@ export function useSidebarFilterState(
     const getFacetDisabledState = (
       facet: FilterConfig["facets"][number],
     ): { isDisabled: boolean; reason?: string } => {
+      // A nested tree (cross-field OR / brackets) can't be expressed as flat
+      // facets, so the sidebar is read-only while one is active — the search bar
+      // is the editor. We still render the facet value lists rather than hiding
+      // them behind a notice, just with their controls disabled.
+      if (isAdvancedFilter) {
+        return {
+          isDisabled: true,
+          reason:
+            "Editing happens in the search bar while an advanced (OR / grouped) filter is active.",
+        };
+      }
+
       const staticDisabled = facet.isDisabled ?? false;
 
       if (staticDisabled) {
@@ -1790,6 +1882,7 @@ export function useSidebarFilterState(
     loading,
     filterState,
     explicitFilterState,
+    isAdvancedFilter,
     updateFilter,
     updateFilterOnly,
     updateOperator,
@@ -1808,11 +1901,19 @@ export function useSidebarFilterState(
     effectiveFilterState: filterState,
     explicitFilterState,
     setFilterState,
+    // Search/Filter v2 (nested tree). For every flat query these mirror the flat
+    // fields above (explicitFilterExpression === explicitFilterState, etc.), so
+    // consumers that ignore them are unaffected. Only the events search bar +
+    // its sidebar opt in.
+    explicitFilterExpression,
+    effectiveFilterExpression,
+    isAdvancedFilter,
+    setFilterExpression,
     updateFilter,
     updateFilterOnly,
     updateOperator,
     clearAll,
-    isFiltered: explicitFilterState.length > 0,
+    isFiltered: isAdvancedFilter || explicitFilterState.length > 0,
     filters,
     expanded: expandedState,
     onExpandedChange,

--- a/web/src/features/filters/lib/filter-query-encoding.ts
+++ b/web/src/features/filters/lib/filter-query-encoding.ts
@@ -1,5 +1,8 @@
 import {
+  type FilterExpression,
+  type FilterInput,
   type FilterState,
+  filterExpression,
   singleFilter,
   type SingleValueOption,
 } from "@langfuse/shared";
@@ -215,4 +218,52 @@ export function decodeFiltersGeneric(query: string): FilterState {
   }
 
   return filters;
+}
+
+// Search/Filter v2: the URL `filter` param can hold either the legacy flat
+// delimited FilterState (above) OR a nested FilterExpression tree. A tree is
+// encoded as JSON, which always begins with `{` — a character the delimited
+// format (which starts with a column name) never produces — so the two are
+// unambiguously distinguishable on decode. Flat arrays keep using the compact
+// delimited encoding, so every existing URL and saved view is unchanged.
+
+function isFilterTree(input: FilterInput): input is FilterExpression {
+  return !Array.isArray(input);
+}
+
+/**
+ * Encode a {@link FilterInput} for the URL `filter` param. Flat arrays use the
+ * legacy delimited format; a nested tree uses JSON (Date values serialize to
+ * ISO strings and re-coerce on decode via the timeFilter schema).
+ */
+export function encodeFilterInput(
+  input: FilterInput | null | undefined,
+): string {
+  if (input == null) return "";
+  if (isFilterTree(input)) {
+    return JSON.stringify(input);
+  }
+  return encodeFiltersGeneric(input);
+}
+
+/**
+ * Decode the URL `filter` param to a {@link FilterInput}. A leading `{` marks a
+ * JSON-encoded tree (validated structurally via the filterExpression schema);
+ * anything else is the legacy delimited flat format.
+ */
+export function decodeFilterInput(query: string): FilterInput {
+  if (!query.trim()) return [];
+
+  if (query.trimStart().startsWith("{")) {
+    try {
+      const parsed = filterExpression.safeParse(JSON.parse(query));
+      if (parsed.success) return parsed.data;
+      console.warn("Invalid filter expression skipped:", parsed.error);
+    } catch (error) {
+      console.warn("Error decoding filter expression:", error);
+    }
+    return [];
+  }
+
+  return decodeFiltersGeneric(query);
 }

--- a/web/src/features/search-bar/README.md
+++ b/web/src/features/search-bar/README.md
@@ -53,9 +53,22 @@ Generally available on the v4 events tables (no opt-in). Based on the
 - `has:endTime` / `-has:endTime` null checks
 - full-text search (see below): bare text, or `input:`/`output:`/`name:`/`id:`
 
-Cross-field OR, negated groups, and other shapes the flat contract cannot
-represent are commit-blocking diagnostics, not silent drops. There is no
+Cross-field `OR` and bracket grouping are supported (Search/Filter v2): they
+lower to a nested `FilterExpression` tree (`astToFilterInput`) instead of the
+flat `FilterState`, and the events tRPC `filter` input accepts both via
+`filterInput`. A query that is a pure AND of leaves still lowers to a flat
+`FilterState` (so the facet sidebar owns it); only a cross-field OR / bracket
+group produces a tree, which puts the facet sidebar into a read-only "advanced
+filter" state (the bar is the editor). Negated groups (`NOT (...)`) and free
+text inside an OR remain commit-blocking diagnostics, not silent drops — the
+backend has no general NOT, and free text is a global AND term. There is no
 FTS `*` operator: the events tRPC filter contract has none.
+
+`OR`/`AND` are **case-insensitive** operators — a user typing `or` means the
+operator, and the bar canonicalizes it to uppercase on commit (`canonicalizeKeywords`)
+so the operator is visible. To search the literal word, quote it (`"or"`). `NOT`
+stays uppercase-only; lowercase `not` and `!` are reserved and point the user at
+the `-field:value` exclusion form.
 
 **Full-text search.** It matches as a **contiguous substring** server-side
 (`clickhouse-sql/search.ts`, `ILIKE %query%`) and is expressed field-style:
@@ -97,12 +110,13 @@ two remaining multi-scope states still drop their id channel on the next commit:
 two without a real per-column "all fields" scope — deferred past beta. Trigger is
 narrow (a legacy URL from the old dropdown + the bar enabled + a commit).
 
-Operator-looking tokens that aren't supported yet are **reserved** — they emit
-an explicit "not supported yet" diagnostic instead of silently becoming free
-text: `!`, lowercase `not`/`or`/`and` (use `-field:value` to exclude;
-`field:(A OR B)` for one field's values). Quote a reserved word (`"or"`) to
-search for it as literal text. (Top-level grouping with `(` `)` is tracked as a
-follow-up.)
+`or`/`and` are case-insensitive operators (lowercase is canonicalized to uppercase
+on commit — see Query language above). The remaining operator-looking tokens that
+aren't supported are **reserved** — they emit an explicit "not supported"
+diagnostic instead of silently becoming free text: `!` and lowercase `not` (both
+point at `-field:value` to exclude). Quote a word (`"or"`, `"not"`) to search for
+it as literal text. Top-level grouping with `( )` and cross-field `OR` lower to a
+nested expression tree (see Query language above).
 
 ## Data flow (one source of truth, one direction)
 
@@ -267,21 +281,27 @@ the wand only survives on non-bar/embedded surfaces and the v3 traces table).
 - **The endpoint.** `server/router.ts` (`searchBar.generateFilter`), NOT the
   legacy `naturalLanguageFilters.createCompletion`. Its prompt is built from
   THIS registry (`server/buildFilterPrompt.ts`, derived from `FIELDS` +
-  `SCORE_COLUMNS`), so the model's vocabulary IS the grammar. It asks for a flat
-  `FilterState` (an array of `singleFilter`), then **round-trips it through
-  `filterStateToQueryText` server-side and returns only the filters that lower
-  to bar pills** — a hallucinated/non-v4 column lands in `skippedFilters` and is
-  dropped before it reaches the client. A unit test
+  `SCORE_COLUMNS`), so the model's vocabulary IS the grammar. It returns a
+  `FilterInput`: a flat `FilterState` (plain AND — the default) OR a nested
+  `{type:"group",operator,conditions}` tree when the request needs cross-field OR
+  or bracketing. `parseGeneratedFilters` **round-trips the output through the
+  reverse adapter server-side and returns only what lowers to bar pills.** Flat
+  arrays are filtered per element (one bad filter never discards the valid
+  siblings); a tree is **all-or-nothing** (dropping a leaf would change the OR's
+  meaning) and is also rejected if it exceeds the depth/node bounds. A unit test
   (`__tests__/server/unit/searchBarFilterPrompt.servertest.ts`) asserts every
   field's prompt-recommended `type` round-trips, so the prompt can't drift from
-  the reverse adapter.
+  the reverse adapter; `parseFilterCompletion.servertest.ts` covers both paths.
 - **Apply-immediately.** The result is applied via `useEventsSearchBar`'s
   `applyFilters` (it preserves grammar-less `skippedFilters` like a commit, then
-  writes `setFilterState`), so on returning to grammar mode `resetTo` re-derives
-  the generated filters as editable pills. There is no separate AI→bar sync path.
+  writes `setFilterExpression`), so on returning to grammar mode `resetTo`
+  re-derives the generated filters as editable pills (a tree renders as
+  parenthesized OR text). `applyFilters` and `commit` share one merge helper:
+  it ANDs the preserved skipped leaves onto the result (`combineFilterInputsWithAnd`),
+  so they never widen a user OR. There is no separate AI→bar sync path.
 - **Refine clears the free-text lane.** When opened with filters present, the
   bar's full committed text (free text rendered inline) is the refine context
-  sent to the model, which returns the COMPLETE updated `FilterState`. So
+  sent to the model, which returns the COMPLETE updated filter (flat or tree). So
   `applyFilters` also clears `searchQuery` and resets `searchType` to
   `DEFAULT_SEARCH_TYPE` — anything the model didn't re-emit is dropped, including
   free text the user asked to remove. Without this, a stale `searchQuery` would

--- a/web/src/features/search-bar/components/EventsSearchBarRow.tsx
+++ b/web/src/features/search-bar/components/EventsSearchBarRow.tsx
@@ -15,7 +15,7 @@
 
 import * as React from "react";
 
-import { type FilterState } from "@langfuse/shared";
+import { type FilterInput } from "@langfuse/shared";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProject } from "@/src/features/projects/hooks";
 import type { ObservedOptions } from "@/src/features/search-bar/lib/observed-options";
@@ -37,11 +37,12 @@ export function EventsSearchBarRow({
   commit: () => string | null;
   observed: ObservedOptions | undefined;
   /**
-   * Applies AI-generated filters (apply-immediately); the bar re-derives them.
-   * Preserves filters the grammar can't represent (no-silent-drop contract) —
-   * comes from `useEventsSearchBar.applyFilters`, not a raw `setFilterState`.
+   * Applies an AI-generated filter — flat list or nested OR/grouped tree —
+   * (apply-immediately); the bar re-derives it. Preserves filters the grammar
+   * can't represent (no-silent-drop contract) — comes from
+   * `useEventsSearchBar.applyFilters`, not a raw `setFilterState`.
    */
-  onApplyFilters: (filters: FilterState) => void;
+  onApplyFilters: (filterInput: FilterInput) => void;
   /** Project data context (observed values + metadata keys + result count) for
    *  the AI prompt — built by EventsTable from filterOptions + visible rows. */
   aiDataContext?: string;

--- a/web/src/features/search-bar/components/SearchBarAiPrompt.tsx
+++ b/web/src/features/search-bar/components/SearchBarAiPrompt.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 import { ArrowLeft, ArrowRight, Loader2 } from "lucide-react";
 import { useStore } from "zustand";
 
-import { type FilterState } from "@langfuse/shared";
+import { type FilterInput } from "@langfuse/shared";
 import { KeyboardShortcut } from "@/src/components/ui/keyboard-shortcut";
 import type { SearchBarStore } from "@/src/features/search-bar/store/searchBarStore";
 import { api } from "@/src/utils/api";
@@ -37,8 +37,9 @@ export function SearchBarAiPrompt({
   /** Observed values + metadata keys + result count, so the model maps to the
    *  project's real columns/values instead of guessing. */
   dataContext?: string;
-  /** Apply generated filters via the bar's setFilterState (apply-immediately). */
-  onApply: (filters: FilterState) => void;
+  /** Apply the generated filter — a flat list or a nested OR/grouped tree — via
+   *  the bar's setFilterState (apply-immediately). */
+  onApply: (filterInput: FilterInput) => void;
   /** Leave AI mode and restore the grammar composer. */
   onExit: () => void;
 }) {
@@ -109,11 +110,16 @@ export function SearchBarAiPrompt({
         setError("Filters changed while generating — try again.");
         return;
       }
-      if (result.filters.length === 0) {
+      // Empty = nothing applicable. A tree is never empty (the server returns a
+      // flat [] when it can't build one), so an empty array is the only "nothing".
+      if (
+        Array.isArray(result.filterInput) &&
+        result.filterInput.length === 0
+      ) {
         setError("Couldn't build filters from that — try rephrasing.");
         return;
       }
-      onApply(result.filters as FilterState);
+      onApply(result.filterInput);
       onExit();
     } catch {
       if (cancelledRef.current) return;

--- a/web/src/features/search-bar/components/SearchComposer.tsx
+++ b/web/src/features/search-bar/components/SearchComposer.tsx
@@ -25,7 +25,11 @@ import {
   deriveComposerSegments,
   type ComposerSegment,
 } from "@/src/features/search-bar/lib/composer-segments";
-import { serializeValue, termAt } from "@/src/features/search-bar/lib/langQ";
+import {
+  canonicalizeKeywords,
+  serializeValue,
+  termAt,
+} from "@/src/features/search-bar/lib/langQ";
 import {
   scoreTypeContextFromObserved,
   type ObservedOptions,
@@ -671,7 +675,10 @@ export function SearchComposer({
       // and rely on zustand's synchronous set so the commit reads the new value.
       let caretAtEnd = false;
       if (root !== null) {
-        const text = textFromRoot(root);
+        // Canonicalize bare or/and to uppercase OR/AND as we sync the DOM into
+        // the store, so a committed query VISIBLY shows the operator the user
+        // typed lowercase. Length-preserving, so the caret math below is intact.
+        const text = canonicalizeKeywords(textFromRoot(root));
         const sel = selectionOffsets(root);
         caretAtEnd =
           sel.start === sel.end && sel.end === text.length && text.length > 0;

--- a/web/src/features/search-bar/hooks/useEventsSearchBar.clienttest.tsx
+++ b/web/src/features/search-bar/hooks/useEventsSearchBar.clienttest.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import type { FilterState } from "@langfuse/shared";
+import type { FilterInput, FilterState } from "@langfuse/shared";
 
 import { DEFAULT_SEARCH_TYPE } from "@/src/features/search-bar/lib/commit";
 import { useEventsSearchBar } from "@/src/features/search-bar/hooks/useEventsSearchBar";
@@ -10,27 +10,42 @@ const NEW_FILTERS: FilterState = [
   { type: "string", column: "name", operator: "contains", value: "checkout" },
 ];
 
+// A cross-field OR tree, as the AI generator now produces it.
+const OR_TREE: FilterInput = {
+  type: "group",
+  operator: "OR",
+  conditions: [
+    {
+      type: "stringOptions",
+      column: "level",
+      operator: "any of",
+      value: ["ERROR"],
+    },
+    { type: "number", column: "latency", operator: ">", value: 5 },
+  ],
+};
+
 function setup(
   overrides: Partial<Parameters<typeof useEventsSearchBar>[0]> = {},
 ) {
-  const setFilterState = vi.fn();
+  const setFilterExpression = vi.fn();
   const setSearchQuery = vi.fn();
   const setSearchType = vi.fn();
   const { result } = renderHook(() =>
     useEventsSearchBar({
       projectId: "p",
       enabled: true,
-      filterState: [],
+      filterExpression: [],
       searchQuery: "refund",
       searchType: DEFAULT_SEARCH_TYPE,
       observed: undefined,
-      setFilterState,
+      setFilterExpression,
       setSearchQuery,
       setSearchType,
       ...overrides,
     }),
   );
-  return { result, setFilterState, setSearchQuery, setSearchType };
+  return { result, setFilterExpression, setSearchQuery, setSearchType };
 }
 
 describe("useEventsSearchBar.applyFilters", () => {
@@ -38,9 +53,18 @@ describe("useEventsSearchBar.applyFilters", () => {
     // The model gets the full bar text (with `refund` rendered inline) as
     // refine context and returns the COMPLETE updated FilterState. Applying it
     // must clear searchQuery, else the dropped free text re-derives back in.
-    const { result, setFilterState, setSearchQuery } = setup();
+    const { result, setFilterExpression, setSearchQuery } = setup();
     act(() => result.current.applyFilters(NEW_FILTERS));
-    expect(setFilterState).toHaveBeenCalledWith(NEW_FILTERS);
+    expect(setFilterExpression).toHaveBeenCalledWith(NEW_FILTERS);
+    expect(setSearchQuery).toHaveBeenCalledWith(null);
+  });
+
+  it("applies a nested OR tree unchanged when there are no skipped filters", () => {
+    // The AI generator can now return a tree (cross-field OR / brackets). With
+    // no grammar-less filters to preserve, applyFilters writes it through as-is.
+    const { result, setFilterExpression, setSearchQuery } = setup();
+    act(() => result.current.applyFilters(OR_TREE));
+    expect(setFilterExpression).toHaveBeenCalledWith(OR_TREE);
     expect(setSearchQuery).toHaveBeenCalledWith(null);
   });
 

--- a/web/src/features/search-bar/hooks/useEventsSearchBar.ts
+++ b/web/src/features/search-bar/hooks/useEventsSearchBar.ts
@@ -15,13 +15,19 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { FilterState, TracingSearchType } from "@langfuse/shared";
+import {
+  combineFilterInputsWithAnd,
+  type FilterInput,
+  type FilterState,
+  getFilterExpressionLeafFilters,
+  type TracingSearchType,
+} from "@langfuse/shared";
 
 import {
   DEFAULT_SEARCH_TYPE,
   planCommit,
 } from "@/src/features/search-bar/lib/commit";
-import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
+import { filterInputToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
 import {
   type ObservedOptions,
   scoreTypeContextFromObserved,
@@ -62,29 +68,30 @@ function filterIdentity(f: FilterState[number]): string {
 export function useEventsSearchBar({
   projectId,
   enabled,
-  filterState,
+  filterExpression,
   searchQuery,
   searchType,
   observed,
-  setFilterState,
+  setFilterExpression,
   setSearchQuery,
   setSearchType,
 }: {
   projectId: string;
   enabled: boolean;
-  /** The user's explicit facet filters (sidebar `explicitFilterState`). */
-  filterState: FilterState;
+  /** The user's explicit filter — flat array OR a nested tree (v2)
+   *  (sidebar `explicitFilterExpression`). */
+  filterExpression: FilterInput;
   searchQuery: string | null;
   searchType: TracingSearchType[];
   /** Observed filter options — used to route `scores.<name>` by score type. */
   observed: ObservedOptions | undefined;
-  setFilterState: (filters: FilterState) => void;
+  setFilterExpression: (filterInput: FilterInput) => void;
   setSearchQuery: (query: string | null) => void;
   setSearchType: (type: TracingSearchType[]) => void;
 }): {
   store: SearchBarStore;
   commit: () => string | null;
-  applyFilters: (filters: FilterState) => void;
+  applyFilters: (filterInput: FilterInput) => void;
 } {
   // Latest observed options, read inside commit and by the store's draft
   // validation so both route `scores.<name>` by the same observed score type.
@@ -101,8 +108,8 @@ export function useEventsSearchBar({
   // are filters that have no grammar form — the bar can't show them, so they
   // must be preserved across a commit instead of being silently wiped.
   const derived = useMemo(
-    () => filterStateToQueryText(filterState, { searchQuery, searchType }),
-    [filterState, searchQuery, searchType],
+    () => filterInputToQueryText(filterExpression, { searchQuery, searchType }),
+    [filterExpression, searchQuery, searchType],
   );
   const committedText = restingDraft(derived.text);
   const skippedFiltersRef = useRef(derived.skippedFilters);
@@ -130,8 +137,12 @@ export function useEventsSearchBar({
   }, [enabled, observed, store]);
 
   // Latest applied-state setters, read inside commit without rebuilding it.
-  const applyRef = useRef({ setFilterState, setSearchQuery, setSearchType });
-  applyRef.current = { setFilterState, setSearchQuery, setSearchType };
+  const applyRef = useRef({
+    setFilterExpression,
+    setSearchQuery,
+    setSearchType,
+  });
+  applyRef.current = { setFilterExpression, setSearchQuery, setSearchType };
 
   // Latest searchType, so commit can skip writing an unchanged value.
   const searchTypeRef = useRef(searchType);
@@ -139,30 +150,45 @@ export function useEventsSearchBar({
 
   // Re-attach the filters the grammar can't represent so neither a grammar
   // commit nor an AI apply ever drops them (no-silent-drop contract) — but drop
-  // any skipped filter whose (column, key) the new set just produced, so an
+  // any skipped filter whose (column, key) the new input just produced, so an
   // explicit edit replaces it instead of duplicating the column in URL state.
-  const mergeWithSkipped = useCallback((filters: FilterState): FilterState => {
-    const producedKeys = new Set(filters.map((f) => filterIdentity(f)));
-    const preserved = skippedFiltersRef.current.filter(
-      (f) => !producedKeys.has(filterIdentity(f)),
-    );
-    return preserved.length > 0 ? [...filters, ...preserved] : filters;
-  }, []);
+  // Works for a flat array OR a tree: the input's leaves are the produced set,
+  // and combineFilterInputsWithAnd ANDs the preserved leaves on as a single outer
+  // AND (never inside a user OR) and flattens AND-of-AND to spare the depth budget.
+  const mergeWithSkipped = useCallback(
+    (filterInput: FilterInput | null | undefined): FilterInput => {
+      const producedLeaves =
+        filterInput == null
+          ? []
+          : Array.isArray(filterInput)
+            ? filterInput
+            : getFilterExpressionLeafFilters(filterInput);
+      const producedKeys = new Set(
+        producedLeaves.map((f) => filterIdentity(f)),
+      );
+      const preserved = skippedFiltersRef.current.filter(
+        (f) => !producedKeys.has(filterIdentity(f)),
+      );
+      return (
+        combineFilterInputsWithAnd(filterInput ?? undefined, preserved) ?? []
+      );
+    },
+    [],
+  );
 
-  // Apply an externally-produced filter set (the AI filter generator) the same
-  // way a commit does — preserving skipped filters — instead of a raw replace
-  // that would silently drop them. The model receives the bar's full committed
-  // text as refine context (free text rendered inline) and returns the COMPLETE
-  // updated FilterState, so applying it must write all three URL lanes like a
-  // grammar commit does: anything the model didn't re-emit is dropped, including
-  // the free text. Clearing searchQuery / resetting searchType to the default is
-  // what makes "drop the free text" actually stick — otherwise the stale
-  // searchQuery survives and resetTo re-derives it back into the bar.
+  // Apply an externally-produced filter (the AI filter generator) the same way a
+  // commit does — preserving skipped filters — instead of a raw replace that
+  // would silently drop them. The model returns the COMPLETE updated filter (a
+  // flat list OR a nested OR/grouped tree), so applying it writes all three URL
+  // lanes like a grammar commit: anything the model didn't re-emit is dropped,
+  // including the free text. Clearing searchQuery / resetting searchType to the
+  // default is what makes "drop the free text" actually stick — otherwise the
+  // stale searchQuery survives and resetTo re-derives it back into the bar.
   const applyFilters = useCallback(
-    (filters: FilterState) => {
-      const { setFilterState, setSearchQuery, setSearchType } =
+    (filterInput: FilterInput) => {
+      const { setFilterExpression, setSearchQuery, setSearchType } =
         applyRef.current;
-      setFilterState(mergeWithSkipped(filters));
+      setFilterExpression(mergeWithSkipped(filterInput));
       setSearchQuery(null);
       if (!sameScopes(DEFAULT_SEARCH_TYPE, searchTypeRef.current)) {
         setSearchType(DEFAULT_SEARCH_TYPE);
@@ -180,11 +206,14 @@ export function useEventsSearchBar({
       store.getState().actions.revealInvalid();
       return null;
     }
-    const { setFilterState, setSearchQuery, setSearchType } = applyRef.current;
-    // Re-attach the filters the grammar can't represent so the commit never
-    // drops them (no-silent-drop contract; shared with the AI apply path).
-    const committedFilters = mergeWithSkipped(result.filters);
-    setFilterState(committedFilters);
+    const { setFilterExpression, setSearchQuery, setSearchType } =
+      applyRef.current;
+    // Re-attach the grammar-less (skipped) filters, dropping any whose column the
+    // bar just re-produced — the same no-silent-drop merge the AI apply uses. It
+    // ANDs the preserved leaves on as an outer AND (never inside a user OR) and
+    // stays a flat array when everything is a leaf.
+    const committedFilterInput = mergeWithSkipped(result.filterInput);
+    setFilterExpression(committedFilterInput);
     setSearchQuery(result.searchQuery);
     // Only write searchType when it actually changed. planCommit coerces a
     // draft with no scope token to the default (`["id","content"]` — ids+names
@@ -203,7 +232,7 @@ export function useEventsSearchBar({
     // so the echo string-compares equal and the space survives even when the
     // commit reorders the query (e.g. `refund level:ERROR` → `level:ERROR refund`).
     return restingDraft(
-      filterStateToQueryText(committedFilters, {
+      filterInputToQueryText(committedFilterInput, {
         searchQuery: result.searchQuery,
         searchType: result.searchType,
       }).text,

--- a/web/src/features/search-bar/lib/adapter.ts
+++ b/web/src/features/search-bar/lib/adapter.ts
@@ -20,7 +20,12 @@
 // - NOT lowers at this boundary (none-of / does-not-contain / inverted
 //   comparisons / inverted booleans); gaps error via fields.negationIssue.
 
-import { type FilterState, type TracingSearchType } from "@langfuse/shared";
+import {
+  type FilterExpression,
+  type FilterInput,
+  type FilterState,
+  type TracingSearchType,
+} from "@langfuse/shared";
 
 import type { ASTNode, FilterNode } from "./ast";
 import {
@@ -134,6 +139,173 @@ export function astToFilterState(
     filters: ctx.filters,
     searchQuery: ctx.searchTerms.length > 0 ? ctx.searchTerms.join(" ") : null,
     // The bar has no scope tokens; the caller (commit.ts) applies the default.
+    searchType: null,
+    errors: ctx.errors,
+  };
+}
+
+// ---- Nested boolean lowering (Search/Filter v2) ----
+//
+// The flat astToFilterState above rejects cross-field OR and bracket groups.
+// astToFilterInput lowers the SAME AST into a `FilterInput`: a flat
+// `FilterState` array when the query is a pure AND of leaves (so the facet
+// sidebar still owns it), or a nested `FilterExpression` tree when it contains
+// a cross-field OR or a bracket group. The per-leaf lowering is shared with
+// astToFilterState (both call `lowerFilter`), so they cannot drift; only the
+// combiner differs (implicit-AND array vs. recursive tree). This is the commit
+// gate's lowering — validate.ts runs the same function for parity.
+//
+// Free text stays GLOBAL (searchQuery, AND-ed with the whole tree by the
+// backend): it is only valid at the top-level AND context, never inside an OR
+// or under a NOT. NOT-of-a-group still errors (the backend has no general NOT;
+// negation is De-Morgan'd to inverse leaf operators).
+
+export type AstToFilterInputResult = {
+  filterInput: FilterInput | null;
+  searchQuery: string | null;
+  searchType: TracingSearchType[] | null;
+  errors: string[];
+};
+
+type ExpressionContext = {
+  searchTerms: string[];
+  errors: string[];
+  scoreTypes?: ScoreTypeContext;
+};
+
+function leavesToExpression(
+  leaves: SingleEventsFilter[],
+): FilterExpression | null {
+  if (leaves.length === 0) return null;
+  if (leaves.length === 1) return leaves[0]!;
+  return { type: "group", operator: "AND", conditions: leaves };
+}
+
+// Build an AND/OR group, flattening same-operator children and collapsing the
+// 0/1-child degenerate cases (a single child needs no group wrapper).
+function combineExpressions(
+  operator: "AND" | "OR",
+  parts: FilterExpression[],
+): FilterExpression | null {
+  const flat = parts.flatMap((part) =>
+    part.type === "group" && part.operator === operator
+      ? part.conditions
+      : [part],
+  );
+  if (flat.length === 0) return null;
+  if (flat.length === 1) return flat[0]!;
+  return { type: "group", operator, conditions: flat };
+}
+
+function lowerFilterToExpression(
+  node: FilterNode,
+  negated: boolean,
+  ctx: ExpressionContext,
+): FilterExpression | null {
+  const out: SingleEventsFilter[] = [];
+  lowerFilter(node, negated, out, ctx.errors, ctx.scoreTypes);
+  return leavesToExpression(out);
+}
+
+function lowerToExpression(
+  node: ASTNode,
+  negated: boolean,
+  ctx: ExpressionContext,
+  allowFreeText: boolean,
+): FilterExpression | null {
+  switch (node.kind) {
+    case "text":
+      if (negated) {
+        ctx.errors.push(
+          `Free text "${node.value}" cannot be negated — search text is global`,
+        );
+        return null;
+      }
+      if (!allowFreeText) {
+        ctx.errors.push(
+          `Free text "${node.value}" cannot be combined with OR — search applies to the whole query`,
+        );
+        return null;
+      }
+      if (!node.quoted && isDanglingDotPrefix(node.value)) {
+        ctx.errors.push(
+          `Incomplete field "${node.value}" — add a key after the dot (e.g. metadata.region:eu)`,
+        );
+        return null;
+      }
+      ctx.searchTerms.push(node.value);
+      return null;
+    case "not":
+      return lowerToExpression(node.child, !negated, ctx, allowFreeText);
+    case "and": {
+      if (negated) {
+        // NOT(a AND b) would need OR-of-negations — no general NOT downstream.
+        ctx.errors.push(
+          "Negated groups are not supported — negate individual filters instead (e.g. -env:dev)",
+        );
+        return null;
+      }
+      const parts: FilterExpression[] = [];
+      for (const child of node.children) {
+        const lowered = lowerToExpression(child, false, ctx, allowFreeText);
+        if (lowered !== null) parts.push(lowered);
+      }
+      return combineExpressions("AND", parts);
+    }
+    case "or": {
+      // Same-field single-value OR collapses to one any-of / none-of leaf, the
+      // same way astToFilterState routes it — so `level:ERROR OR level:WARNING`
+      // stays a single leaf rather than an OR group.
+      const collapsed = collapseSameFieldOr(node);
+      if (collapsed !== null) {
+        return lowerFilterToExpression(collapsed, negated, ctx);
+      }
+      if (negated) {
+        ctx.errors.push(
+          "Negated groups are not supported — negate individual filters instead (e.g. -env:dev)",
+        );
+        return null;
+      }
+      const parts: FilterExpression[] = [];
+      for (const child of node.children) {
+        // Free text cannot live inside an OR branch — it is a global AND term.
+        const lowered = lowerToExpression(child, false, ctx, false);
+        if (lowered !== null) parts.push(lowered);
+      }
+      return combineExpressions("OR", parts);
+    }
+    case "filter":
+      return lowerFilterToExpression(node, negated, ctx);
+  }
+}
+
+// A pure-AND tree of leaves flattens to a flat FilterState array (the facet
+// sidebar can own it); anything with an OR or a nested group stays a tree.
+function expressionToFilterInput(
+  expression: FilterExpression | null,
+): FilterInput | null {
+  if (expression === null) return null;
+  if (expression.type !== "group") return [expression];
+  if (expression.operator === "AND") {
+    const leaves = expression.conditions.filter(
+      (condition): condition is SingleEventsFilter =>
+        condition.type !== "group",
+    );
+    if (leaves.length === expression.conditions.length) return leaves;
+  }
+  return expression;
+}
+
+export function astToFilterInput(
+  ast: ASTNode | null,
+  scoreTypes?: ScoreTypeContext,
+): AstToFilterInputResult {
+  const ctx: ExpressionContext = { searchTerms: [], errors: [], scoreTypes };
+  const expression =
+    ast === null ? null : lowerToExpression(ast, false, ctx, true);
+  return {
+    filterInput: expressionToFilterInput(expression),
+    searchQuery: ctx.searchTerms.length > 0 ? ctx.searchTerms.join(" ") : null,
     searchType: null,
     errors: ctx.errors,
   };

--- a/web/src/features/search-bar/lib/commit.clienttest.ts
+++ b/web/src/features/search-bar/lib/commit.clienttest.ts
@@ -5,7 +5,7 @@ describe("planCommit", () => {
     const r = planCommit("  level:ERROR timeout  ");
     expect(r.status).toBe("committed");
     if (r.status !== "committed") return;
-    expect(r.filters).toEqual([
+    expect(r.filterInput).toEqual([
       {
         type: "stringOptions",
         column: "level",
@@ -32,13 +32,38 @@ describe("planCommit", () => {
     const r = planCommit("   ");
     expect(r.status).toBe("committed");
     if (r.status !== "committed") return;
-    expect(r.filters).toEqual([]);
+    expect(r.filterInput).toBeNull();
     expect(r.searchQuery).toBeNull();
     expect(r.canonical).toBe("");
   });
 
-  it("returns invalid with diagnostics for unrepresentable queries", () => {
+  it("commits a cross-field OR to a nested expression tree", () => {
     const r = planCommit("level:ERROR OR env:dev");
+    expect(r.status).toBe("committed");
+    if (r.status !== "committed") return;
+    expect(r.filterInput).toEqual({
+      type: "group",
+      operator: "OR",
+      conditions: [
+        {
+          type: "stringOptions",
+          column: "level",
+          operator: "any of",
+          value: ["ERROR"],
+        },
+        {
+          type: "stringOptions",
+          column: "environment",
+          operator: "any of",
+          value: ["dev"],
+        },
+      ],
+    });
+  });
+
+  it("returns invalid with diagnostics for unrepresentable queries", () => {
+    // A negated group has no flat or tree form (the backend has no general NOT).
+    const r = planCommit("NOT (level:ERROR env:dev)");
     expect(r.status).toBe("invalid");
     if (r.status !== "invalid") return;
     expect(r.diagnostics.length).toBeGreaterThan(0);

--- a/web/src/features/search-bar/lib/commit.ts
+++ b/web/src/features/search-bar/lib/commit.ts
@@ -7,9 +7,9 @@
 // one source of truth). Keeping it pure makes the commit semantics unit-
 // testable without rendering anything.
 
-import type { FilterState, TracingSearchType } from "@langfuse/shared";
+import type { FilterInput, TracingSearchType } from "@langfuse/shared";
 
-import { astToFilterState, type ScoreTypeContext } from "./adapter";
+import { astToFilterInput, type ScoreTypeContext } from "./adapter";
 import { serialize, type Diagnostic } from "./langQ";
 import { validateQuery } from "./validate";
 
@@ -23,7 +23,9 @@ export const DEFAULT_SEARCH_TYPE: TracingSearchType[] = ["id", "content"];
 export type CommitResult =
   | {
       status: "committed";
-      filters: FilterState;
+      /** Flat FilterState array, or a nested FilterExpression tree when the
+       *  query has a cross-field OR / bracket group (Search/Filter v2). */
+      filterInput: FilterInput | null;
       searchQuery: string | null;
       searchType: TracingSearchType[];
       /** Canonical serialization of the committed query (for recent searches). */
@@ -34,7 +36,7 @@ export type CommitResult =
 /**
  * Validate and lower `draftText`. `committed` carries everything the table
  * needs; `invalid` carries the span-tagged diagnostics for the editor to show.
- * `validateQuery` and `astToFilterState` agree by construction, so a valid
+ * `validateQuery` and `astToFilterInput` agree by construction, so a valid
  * draft always lowers without errors. `scoreTypes` (observed score names by
  * type) lets `scores.<name>:<value>` lower to the right column.
  */
@@ -46,7 +48,7 @@ export function planCommit(
   if (!res.valid) {
     return { status: "invalid", diagnostics: res.diagnostics };
   }
-  const { filters, searchQuery, searchType, errors } = astToFilterState(
+  const { filterInput, searchQuery, searchType, errors } = astToFilterInput(
     res.ast,
     scoreTypes,
   );
@@ -67,7 +69,7 @@ export function planCommit(
   }
   return {
     status: "committed",
-    filters,
+    filterInput,
     searchQuery,
     searchType: searchType ?? DEFAULT_SEARCH_TYPE,
     canonical: serialize(res.ast),

--- a/web/src/features/search-bar/lib/filter-input.clienttest.ts
+++ b/web/src/features/search-bar/lib/filter-input.clienttest.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { astToFilterInput } from "@/src/features/search-bar/lib/adapter";
+import { filterInputToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
+import { parse } from "@/src/features/search-bar/lib/langQ";
+import { validateQuery } from "@/src/features/search-bar/lib/validate";
+
+const lower = (text: string) => astToFilterInput(parse(text).ast);
+
+describe("astToFilterInput — flat vs tree", () => {
+  it("keeps a pure AND query flat (sidebar-owned)", () => {
+    const { filterInput, errors } = lower("level:ERROR name:checkout");
+    expect(errors).toEqual([]);
+    expect(Array.isArray(filterInput)).toBe(true);
+    expect(filterInput).toEqual([
+      {
+        type: "stringOptions",
+        column: "level",
+        operator: "any of",
+        value: ["ERROR"],
+      },
+      {
+        type: "string",
+        column: "name",
+        operator: "contains",
+        value: "checkout",
+      },
+    ]);
+  });
+
+  it("lowers cross-field OR to a nested OR tree", () => {
+    const { filterInput, errors } = lower("level:ERROR OR name:checkout");
+    expect(errors).toEqual([]);
+    expect(filterInput).toEqual({
+      type: "group",
+      operator: "OR",
+      conditions: [
+        {
+          type: "stringOptions",
+          column: "level",
+          operator: "any of",
+          value: ["ERROR"],
+        },
+        {
+          type: "string",
+          column: "name",
+          operator: "contains",
+          value: "checkout",
+        },
+      ],
+    });
+  });
+
+  it("collapses same-field OR to a single flat any-of (not a tree)", () => {
+    const { filterInput, errors } = lower("level:ERROR OR level:WARNING");
+    expect(errors).toEqual([]);
+    expect(filterInput).toEqual([
+      {
+        type: "stringOptions",
+        column: "level",
+        operator: "any of",
+        value: ["ERROR", "WARNING"],
+      },
+    ]);
+  });
+
+  it("lowers a grouped cross-field OR AND'd with other leaves to a tree", () => {
+    const { filterInput, errors } = lower(
+      "(level:ERROR OR name:checkout) -environment:prod",
+    );
+    expect(errors).toEqual([]);
+    // Outer AND: the cross-field OR group + the negated env leaf.
+    expect(filterInput).toMatchObject({
+      type: "group",
+      operator: "AND",
+      conditions: [
+        { type: "group", operator: "OR" },
+        { type: "stringOptions", column: "environment", operator: "none of" },
+      ],
+    });
+  });
+});
+
+describe("astToFilterInput — gates", () => {
+  it("rejects free text inside an OR", () => {
+    const { errors } = lower("hello OR level:ERROR");
+    expect(errors.join(" ")).toMatch(/cannot be combined with OR/);
+  });
+
+  it("rejects a negated group", () => {
+    const { errors } = lower("NOT (level:ERROR name:checkout)");
+    expect(errors.join(" ")).toMatch(/Negated groups are not supported/);
+  });
+
+  it("validateQuery now accepts cross-field OR + brackets", () => {
+    expect(validateQuery("level:ERROR OR name:checkout").valid).toBe(true);
+    expect(
+      validateQuery("(level:ERROR OR level:WARNING) -environment:prod").valid,
+    ).toBe(true);
+  });
+});
+
+describe("filterInputToQueryText — reverse round-trip", () => {
+  const roundTrips = (text: string) => {
+    const forward = lower(text);
+    const back = filterInputToQueryText(forward.filterInput, {});
+    const reForward = astToFilterInput(parse(back.text).ast);
+    expect(validateQuery(back.text).valid).toBe(true);
+    expect(reForward.filterInput).toEqual(forward.filterInput);
+  };
+
+  it("round-trips a cross-field OR tree", () => {
+    roundTrips("level:ERROR OR name:checkout");
+  });
+
+  it("round-trips a nested (OR) AND chain", () => {
+    roundTrips("(level:ERROR OR level:WARNING) -environment:prod");
+  });
+
+  it("round-trips a flat AND query", () => {
+    roundTrips("level:ERROR name:checkout latency:>2");
+  });
+});

--- a/web/src/features/search-bar/lib/filter-state-to-query.ts
+++ b/web/src/features/search-bar/lib/filter-state-to-query.ts
@@ -11,6 +11,8 @@
 
 import {
   eventsTableCols,
+  type FilterExpression,
+  type FilterInput,
   type FilterState,
   type TracingSearchType,
 } from "@langfuse/shared";
@@ -299,6 +301,85 @@ export function filterStateToQueryText(
   // misleadingly read as independent AND terms, disagree with the scope-rewrite
   // suggestions (which serialize the whole phrase), and strip a user's own
   // quotes on every derive.
+  const searchQuery = options.searchQuery?.trim() ?? "";
+  if (searchQuery.length > 0) {
+    const scopeField = scopedSearchField(options.searchType);
+    if (scopeField !== null) {
+      nodes.push({
+        kind: "filter",
+        key: scopeField,
+        op: "=",
+        values: [searchQuery],
+      });
+    } else {
+      nodes.push({ kind: "text", value: searchQuery });
+    }
+  }
+
+  const ast: ASTNode | null =
+    nodes.length === 0
+      ? null
+      : nodes.length === 1
+        ? nodes[0]!
+        : { kind: "and", children: nodes };
+  return { text: serialize(ast), skipped, skippedFilters };
+}
+
+// Build an editor AST from a nested FilterExpression (Search/Filter v2). Leaves
+// reuse `lowerSingle`; AND/OR groups become and/or nodes. The serializer is
+// precedence-aware (parenthesizes OR inside AND), so the produced text reparses
+// to an equivalent tree. A leaf with no grammar form is reported in `skipped`
+// (bar-produced trees never contain one — this is defensive for hand-authored
+// or saved-view trees).
+function expressionToAst(
+  expression: FilterExpression,
+  skipped: string[],
+  skippedFilters: FilterState,
+): ASTNode | null {
+  if (expression.type !== "group") {
+    const node = lowerSingle(expression);
+    if (node === null) {
+      skipped.push(
+        `${expression.column} (${expression.type} ${expression.operator})`,
+      );
+      skippedFilters.push(expression);
+      return null;
+    }
+    return node;
+  }
+
+  const children = expression.conditions
+    .map((condition) => expressionToAst(condition, skipped, skippedFilters))
+    .filter((node): node is ASTNode => node !== null);
+
+  if (children.length === 0) return null;
+  if (children.length === 1) return children[0]!;
+  return {
+    kind: expression.operator === "OR" ? "or" : "and",
+    children,
+  };
+}
+
+/**
+ * Reverse adapter for the v2 contract: a `FilterInput` (flat array OR a nested
+ * `FilterExpression`) plus full-text search → query text. Flat arrays delegate
+ * to {@link filterStateToQueryText}; trees render via {@link expressionToAst}
+ * + the precedence-aware serializer. Free text stays a global top-level AND
+ * term, exactly as in the flat path.
+ */
+export function filterInputToQueryText(
+  filterInput: FilterInput | null | undefined,
+  options: FilterStateToQueryOptions = {},
+): FilterStateToQueryResult {
+  if (filterInput == null || Array.isArray(filterInput)) {
+    return filterStateToQueryText(filterInput ?? [], options);
+  }
+
+  const skipped: string[] = [];
+  const skippedFilters: FilterState = [];
+  const treeNode = expressionToAst(filterInput, skipped, skippedFilters);
+  const nodes: ASTNode[] = treeNode === null ? [] : [treeNode];
+
   const searchQuery = options.searchQuery?.trim() ?? "";
   if (searchQuery.length > 0) {
     const scopeField = scopedSearchField(options.searchType);

--- a/web/src/features/search-bar/lib/grammar-url-codec.clienttest.ts
+++ b/web/src/features/search-bar/lib/grammar-url-codec.clienttest.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { encodeFilterInput } from "@/src/features/filters/lib/filter-query-encoding";
+import {
+  decodeGrammarFilter,
+  encodeGrammarFilter,
+  GRAMMAR_VERSION,
+} from "@/src/features/search-bar/lib/grammar-url-codec";
+
+describe("grammar-url-codec — round-trip", () => {
+  it("round-trips a flat AND query (stable encode∘decode∘encode)", () => {
+    const v = `${GRAMMAR_VERSION}:level:ERROR latency:>5`;
+    const decoded = decodeGrammarFilter(v);
+    expect(decoded).not.toBeNull();
+    expect(Array.isArray(decoded!.filterInput)).toBe(true); // flat
+    const re = encodeGrammarFilter(decoded!.filterInput, {
+      searchQuery: decoded!.searchQuery,
+      searchType: decoded!.searchType,
+    });
+    expect(re).toBe(v);
+  });
+
+  it("round-trips a cross-field OR tree", () => {
+    const v = `${GRAMMAR_VERSION}:level:ERROR OR latency:>5`;
+    const decoded = decodeGrammarFilter(v);
+    expect(decoded).not.toBeNull();
+    expect(Array.isArray(decoded!.filterInput)).toBe(false); // tree
+    const re = encodeGrammarFilter(decoded!.filterInput);
+    expect(re).toBe(v);
+  });
+
+  it("preserves free text as searchQuery through the codec", () => {
+    const decoded = decodeGrammarFilter(
+      `${GRAMMAR_VERSION}:level:ERROR refund`,
+    );
+    expect(decoded).not.toBeNull();
+    expect(decoded!.searchQuery).toBe("refund");
+  });
+
+  it("prefixes the current grammar version on encode", () => {
+    const v = decodeGrammarFilter(`${GRAMMAR_VERSION}:level:ERROR`);
+    const re = encodeGrammarFilter(v!.filterInput);
+    expect(re?.startsWith(`${GRAMMAR_VERSION}:`)).toBe(true);
+  });
+});
+
+describe("grammar-url-codec — compactness vs legacy JSON", () => {
+  it("is dramatically smaller than the JSON tree for a genuine nested tree", () => {
+    // Cross-field AND-groups ORed together stay a TREE (they don't collapse to a
+    // flat any-of like same-field OR does), so the legacy encoding is verbose
+    // JSON — the exact case grammar text wins. (For same-field multi-value the
+    // input collapses to a flat filter and the legacy `|`-delimited form is
+    // already compact, so this win is specifically about nested/cross-field.)
+    const branches = Array.from(
+      { length: 30 },
+      (_, i) => `(name:n${i} latency:>${i})`,
+    );
+    const v = `${GRAMMAR_VERSION}:${branches.join(" OR ")}`;
+    const decoded = decodeGrammarFilter(v);
+    expect(decoded).not.toBeNull();
+    expect(Array.isArray(decoded!.filterInput)).toBe(false); // a real tree
+    const grammar = encodeGrammarFilter(decoded!.filterInput)!;
+    const json = encodeFilterInput(decoded!.filterInput); // legacy JSON-tree encoding
+    expect(grammar.length).toBeLessThan(json.length / 2);
+  });
+});
+
+describe("grammar-url-codec — graceful fallback (returns null, never throws)", () => {
+  it("rejects an unversioned value", () => {
+    // No leading "<int>:" — the first ":" belongs to a field token.
+    expect(decodeGrammarFilter("level:ERROR")).toBeNull();
+  });
+
+  it("rejects empty / colon-less input", () => {
+    expect(decodeGrammarFilter("")).toBeNull();
+    expect(decodeGrammarFilter(null)).toBeNull();
+    expect(decodeGrammarFilter("noseparator")).toBeNull();
+  });
+
+  it("rejects a version newer than this client (un-migratable forward)", () => {
+    expect(
+      decodeGrammarFilter(`${GRAMMAR_VERSION + 1}:level:ERROR`),
+    ).toBeNull();
+  });
+
+  it("rejects version 0 / non-integer versions", () => {
+    expect(decodeGrammarFilter("0:level:ERROR")).toBeNull();
+    expect(decodeGrammarFilter("x:level:ERROR")).toBeNull();
+  });
+
+  it("rejects grammar text that doesn't validate", () => {
+    expect(decodeGrammarFilter(`${GRAMMAR_VERSION}:level:`)).toBeNull();
+    expect(
+      decodeGrammarFilter(`${GRAMMAR_VERSION}:totallyUnknownField:x`),
+    ).toBeNull();
+  });
+
+  it("encodes null/empty input as null (caller keeps the legacy param)", () => {
+    expect(encodeGrammarFilter([])).toBeNull();
+    expect(encodeGrammarFilter(null)).toBeNull();
+    expect(encodeGrammarFilter(undefined)).toBeNull();
+  });
+});

--- a/web/src/features/search-bar/lib/grammar-url-codec.ts
+++ b/web/src/features/search-bar/lib/grammar-url-codec.ts
@@ -1,0 +1,126 @@
+// Compact, versioned grammar-text codec for the events search bar's own URL
+// param (`fq`) — Search/Filter v2.
+//
+// The legacy `filter` param encodes a FilterInput as delimited-flat OR JSON-tree
+// (filters/lib/filter-query-encoding.ts). That stays the canonical, cross-table,
+// saved-view contract and is UNTOUCHED here. This codec is the alternative the
+// events bar uses for `fq`: the canonical grammar TEXT, which expresses flat AND
+// trees uniformly and is ~3–6× smaller than the JSON tree (a 600-term OR is
+// ~7KB of text vs ~45KB of JSON). Read precedence is the caller's job: prefer
+// `fq` when it decodes for the current version, else fall back to `filter`.
+//
+// VERSIONING. The grammar text is now a persisted contract, so it is versioned.
+// `GRAMMAR_VERSION` bumps ONLY on a breaking grammar change — a renamed canonical
+// column id or a changed operator meaning. Additive changes (new fields/operators)
+// still parse old URLs unchanged and need no migration. A value whose stored
+// version is below current runs through the migration chain before parsing; a
+// value that is too new, unmigratable, or unparseable decodes to null so the
+// caller falls back to the legacy param instead of crashing or mis-filtering.
+
+import { type FilterInput, type TracingSearchType } from "@langfuse/shared";
+
+import { astToFilterInput, type ScoreTypeContext } from "./adapter";
+import { filterInputToQueryText } from "./filter-state-to-query";
+import { validateQuery } from "./validate";
+
+/** Bump ONLY on a breaking grammar change (rename a canonical column id, change
+ *  an operator's meaning). Additive changes don't need a bump. */
+export const GRAMMAR_VERSION = 1;
+
+// `fq` value shape: "<version>:<grammar text>", e.g.
+//   "1:level:ERROR OR name:checkout"
+// The version prefix is split on the FIRST ":"; everything after is the verbatim
+// grammar text (which itself contains ":" in every `field:value`).
+const VERSION_SEP = ":";
+
+type GrammarTextOptions = {
+  searchQuery?: string | null;
+  searchType?: TracingSearchType[] | null;
+};
+
+/**
+ * Migration chain: `MIGRATIONS[v]` rewrites grammar text from version `v` to
+ * `v+1`. Pure string→string transforms, applied in sequence. Empty today — v1 is
+ * the first persisted version, with no breaking change behind it. Example for a
+ * future breaking rename (`latency` → `durationMs`):
+ *
+ *   const MIGRATIONS = {
+ *     1: (text) => text.replace(/(^|\s)latency:/g, "$1durationMs:"),
+ *   };
+ */
+const MIGRATIONS: Record<number, (text: string) => string> = {};
+
+/** Apply the migration chain from `fromVersion` up to current. Returns null when
+ *  a step is missing (no path) so the caller falls back to the legacy param. */
+function migrate(text: string, fromVersion: number): string | null {
+  let migrated = text;
+  for (let v = fromVersion; v < GRAMMAR_VERSION; v++) {
+    const step = MIGRATIONS[v];
+    if (!step) return null;
+    migrated = step(migrated);
+  }
+  return migrated;
+}
+
+/**
+ * Encode a {@link FilterInput} (+ optional free text / scope) as a versioned
+ * `fq` value. Returns null when the input has NO lossless grammar form — a leaf
+ * the bar can't serialize lands in `skippedFilters`, and an empty result has
+ * nothing to store — so the caller keeps using the legacy `filter` param for
+ * those (no silent drop).
+ */
+export function encodeGrammarFilter(
+  input: FilterInput | null | undefined,
+  options: GrammarTextOptions = {},
+): string | null {
+  if (input == null) return null;
+  const { text, skippedFilters } = filterInputToQueryText(input, options);
+  if (skippedFilters.length > 0) return null;
+  if (text.trim().length === 0) return null;
+  return `${GRAMMAR_VERSION}${VERSION_SEP}${text}`;
+}
+
+export type DecodedGrammarFilter = {
+  filterInput: FilterInput;
+  searchQuery: string | null;
+  searchType: TracingSearchType[] | null;
+};
+
+/**
+ * Decode a versioned `fq` value back to a {@link FilterInput} (+ free text).
+ * Returns null on ANY failure — missing/too-new version, no migration path, a
+ * parse/validation error, or a leaf the adapter rejects — so the caller falls
+ * back to the legacy `filter` param. Never throws.
+ */
+export function decodeGrammarFilter(
+  value: string | null | undefined,
+  scoreTypes?: ScoreTypeContext,
+): DecodedGrammarFilter | null {
+  if (!value) return null;
+  const sepIndex = value.indexOf(VERSION_SEP);
+  if (sepIndex <= 0) return null;
+
+  const version = Number(value.slice(0, sepIndex));
+  // A version we don't recognize (NaN, negative, or newer than this client) is
+  // un-migratable here — fall back rather than mis-parse a future format.
+  if (!Number.isInteger(version) || version < 1 || version > GRAMMAR_VERSION) {
+    return null;
+  }
+
+  const rawText = value.slice(sepIndex + 1);
+  const text = version < GRAMMAR_VERSION ? migrate(rawText, version) : rawText;
+  if (text == null) return null;
+
+  const result = validateQuery(text, scoreTypes);
+  if (!result.valid) return null;
+
+  const { filterInput, searchQuery, searchType, errors } = astToFilterInput(
+    result.ast,
+    scoreTypes,
+  );
+  if (errors.length > 0) return null;
+
+  // A pure free-text query (e.g. `refund`) lowers to no filters — represent it
+  // as an empty flat array so the result is always a FilterInput, never null.
+  return { filterInput: filterInput ?? [], searchQuery, searchType };
+}

--- a/web/src/features/search-bar/lib/langQ.clienttest.ts
+++ b/web/src/features/search-bar/lib/langQ.clienttest.ts
@@ -1,5 +1,10 @@
 import type { ASTNode } from "@/src/features/search-bar/lib/ast";
-import { parse, serialize, termAt } from "@/src/features/search-bar/lib/langQ";
+import {
+  canonicalizeKeywords,
+  parse,
+  serialize,
+  termAt,
+} from "@/src/features/search-bar/lib/langQ";
 import {
   removeToken,
   tidyQueryText,
@@ -390,6 +395,8 @@ describe("validateQuery", () => {
       "isRootObservation:true",
       "-isRootObservation:true",
       "level:ERROR OR level:WARNING",
+      "level:ERROR OR env:dev", // cross-field OR (lowers to a nested expression)
+      "(level:ERROR OR name:checkout) -environment:prod", // grouped cross-field OR
     ]) {
       const r = validateQuery(text);
       expect(r.valid, `expected valid: ${text}`).toBe(true);
@@ -398,7 +405,6 @@ describe("validateQuery", () => {
 
   it("rejects forms the flat filter contract cannot represent", () => {
     for (const text of [
-      "level:ERROR OR env:dev", // cross-field OR
       "NOT (level:ERROR env:dev)", // negated group
       "-latency:2", // negated numeric equality
       "-input:prefix*", // negated starts-with
@@ -418,8 +424,6 @@ describe("validateQuery", () => {
       "level:(ERROR,WARNING)", // same, on an option field
       "not level:ERROR", // lowercase `not` reserved (use -field:value)
       "!level:ERROR", // `!` reserved (use -field:value)
-      "level:ERROR or env:dev", // lowercase `or` reserved
-      "level:ERROR and env:dev", // lowercase `and` reserved
     ]) {
       const r = validateQuery(text);
       expect(r.valid, `expected invalid: ${text}`).toBe(false);
@@ -453,7 +457,7 @@ describe("validateQuery", () => {
       (d) => d.severity === "error",
     );
     expect(errors).toHaveLength(1);
-    expect(errors[0]!.message).toMatch(/uppercase OR or AND/);
+    expect(errors[0]!.message).toMatch(/OR or AND/);
   });
 
   it("emits a single Unclosed-paren diagnostic for `level:(`", () => {
@@ -470,8 +474,34 @@ describe("validateQuery", () => {
         .join(" | ");
     expect(msgOf("not level:ERROR")).toMatch(/not.*not supported yet/i);
     expect(msgOf("!level:ERROR")).toMatch(/not supported yet/i);
-    expect(msgOf("level:ERROR or env:dev")).toMatch(/not supported yet/i);
     // quoting escapes the reserved word back into free text
     expect(validateQuery('"not" level:ERROR').valid).toBe(true);
+  });
+
+  it("accepts lowercase or/and as the OR/AND operator (case-insensitive)", () => {
+    // Cross-field OR / AND between filters — a user typing the obvious lowercase
+    // form lands on the working operator, not the old 'not supported yet' wall.
+    expect(validateQuery("level:ERROR or env:dev").valid).toBe(true);
+    expect(validateQuery("level:ERROR and env:dev").valid).toBe(true);
+    expect(validateQuery("level:ERROR Or env:dev").valid).toBe(true);
+    // inside a value group too
+    expect(validateQuery("level:(ERROR or WARNING)").valid).toBe(true);
+    // quoting still escapes the word back into free text search
+    expect(validateQuery('name:checkout "or" refund').valid).toBe(true);
+  });
+
+  it("canonicalizes bare or/and keyword tokens to uppercase, leaving text alone", () => {
+    expect(canonicalizeKeywords("level:ERROR or env:dev")).toBe(
+      "level:ERROR OR env:dev",
+    );
+    expect(canonicalizeKeywords("a and b or c")).toBe("a AND b OR c");
+    // a value/field word that merely contains a keyword is untouched
+    expect(canonicalizeKeywords("name:corner")).toBe("name:corner");
+    expect(canonicalizeKeywords("name:or")).toBe("name:or");
+    // a quoted keyword is literal text, not an operator
+    expect(canonicalizeKeywords('"or" "and"')).toBe('"or" "and"');
+    // length-preserving (caret-safe): same width before/after
+    const q = "level:ERROR or env:dev";
+    expect(canonicalizeKeywords(q).length).toBe(q.length);
   });
 });

--- a/web/src/features/search-bar/lib/langQ.ts
+++ b/web/src/features/search-bar/lib/langQ.ts
@@ -202,11 +202,37 @@ export function indexOfOutsideQuotes(s: string, ch: string): number {
 
 // ---- term classification ----
 
+// AND / OR are case-insensitive: a user typing `or` between filters means the
+// operator (we canonicalize it to uppercase on commit — see canonicalizeKeywords).
+// To search the literal word, quote it (`"or"`). NOT stays uppercase-only —
+// lowercase `not` is guided to the `-field:value` form by reservedTokenIssue.
 function isKeyword(raw: string): "and" | "or" | "not" | null {
-  if (raw === "AND") return "and";
-  if (raw === "OR") return "or";
+  const upper = raw.toUpperCase();
+  if (upper === "AND") return "and";
+  if (upper === "OR") return "or";
   if (raw === "NOT") return "not";
   return null;
+}
+
+/**
+ * Uppercase standalone AND/OR keyword tokens so a committed query shows the
+ * canonical operator (`level:A or level:B` → `level:A OR level:B`) — the visible
+ * half of "accept lowercase and convert it to the operator". Only BARE keyword
+ * tokens are touched: a quoted word (`"or"`) or field/value text (`name:or`) lexes
+ * as a non-keyword term and is left alone. Length-preserving (`or`→`OR` is the
+ * same width), so a caret resting at the draft's end stays put across the rewrite.
+ */
+export function canonicalizeKeywords(text: string): string {
+  const tokens = lex(text, []);
+  let result = "";
+  let cursor = 0;
+  for (const token of tokens) {
+    if (token.type === "term" && isKeyword(token.raw) !== null) {
+      result += text.slice(cursor, token.span.from) + token.raw.toUpperCase();
+      cursor = token.span.to;
+    }
+  }
+  return result + text.slice(cursor);
 }
 
 // Operator prefixes between ':' and the value. Longest first so '>=' wins
@@ -239,20 +265,16 @@ export function parseGlob(
   return { op, core };
 }
 
-// Operator-looking tokens we don't support yet. Rather than silently treat
-// them as free text (lowercase `not`/`or`/`and`) or as a cryptic "unknown
-// field" (`!foo:bar`), surface an explicit "not supported yet" error. Quoting
-// (`"or"`) escapes the word back into free text.
+// Operator-looking tokens we don't support yet. `or`/`and` ARE operators now
+// (case-insensitive, see isKeyword) and never reach here. `not`/`!` stay
+// unsupported as prefixes — rather than treat them as free text or a cryptic
+// "unknown field", point the user at the `-field:value` exclusion form.
 function reservedTokenIssue(raw: string): string | null {
   if (raw.startsWith("!")) {
     return '"!" is not supported yet — use -field:value to exclude (e.g. -env:dev)';
   }
-  const lower = raw.toLowerCase();
-  if (lower === "not") {
+  if (raw.toLowerCase() === "not") {
     return '"not" is not supported yet — use -field:value to exclude (e.g. -env:dev)';
-  }
-  if (lower === "or" || lower === "and") {
-    return `"${raw}" between filters is not supported yet — combine one field's values with field:(A OR B), or quote "${raw}" to search text`;
   }
   return null;
 }
@@ -476,14 +498,15 @@ function parseGroupedValues(
       continue;
     }
 
-    if (token.raw === "OR" || token.raw === "AND") {
-      const sep = token.raw === "OR" ? "or" : "and";
+    const sepKw = isKeyword(token.raw);
+    if (sepKw === "or" || sepKw === "and") {
+      const sep = sepKw;
       if (expectValue) {
         diagnostics.push({
           from: span.from,
           to: span.to,
           severity: "error",
-          message: `${token.raw} is missing a left-hand value`,
+          message: `${token.raw.toUpperCase()} is missing a left-hand value`,
         });
       }
       if (sawSeparator !== null && sawSeparator !== sep) {
@@ -497,7 +520,7 @@ function parseGroupedValues(
       sawSeparator = sep;
       valueOp = sep;
       expectValue = true;
-      lastSeparator = { span, raw: token.raw };
+      lastSeparator = { span, raw: token.raw.toUpperCase() };
       continue;
     }
 
@@ -506,8 +529,7 @@ function parseGroupedValues(
         from: span.from,
         to: span.to,
         severity: "error",
-        message:
-          "Expected uppercase OR (any of) or AND (all of) between grouped values",
+        message: "Expected OR (any of) or AND (all of) between grouped values",
       });
     }
 
@@ -524,16 +546,15 @@ function parseGroupedValues(
     } else {
       // A bare comma inside a group (`tags:(a,b)`) lexes as one token, so it
       // would otherwise become the literal value "a,b" with no diagnostic.
-      // Grouped values separate with uppercase OR/AND — flag it, but still push
-      // the value so parseTermNode doesn't stack a misleading "missing grouped
-      // value" on top of the comma error.
+      // Grouped values separate with OR/AND — flag it, but still push the value
+      // so parseTermNode doesn't stack a misleading "missing grouped value" on
+      // top of the comma error.
       if (indexOfOutsideQuotes(token.raw, ",") !== -1) {
         diagnostics.push({
           from: span.from,
           to: span.to,
           severity: "error",
-          message:
-            "Separate grouped values with uppercase OR or AND, not commas",
+          message: "Separate grouped values with OR or AND, not commas",
         });
       }
       values.push(value);

--- a/web/src/features/search-bar/lib/validate.ts
+++ b/web/src/features/search-bar/lib/validate.ts
@@ -7,11 +7,11 @@
 //
 // Parity with the adapter is by construction: each top-level node is lowered
 // through the real adapter and its errors become diagnostics at that node's
-// span. `valid === true` therefore guarantees astToFilterState() lowers the
+// span. `valid === true` therefore guarantees astToFilterInput() lowers the
 // whole query without errors.
 
 import type { ASTNode, Span } from "./ast";
-import { astToFilterState, type ScoreTypeContext } from "./adapter";
+import { astToFilterInput, type ScoreTypeContext } from "./adapter";
 import { nullableFields, resolveField } from "./fields";
 import { parse, type Diagnostic, type ParseResult } from "./langQ";
 
@@ -98,7 +98,7 @@ export function semanticDiagnostics(
   // routing and a clean validation hides an error the commit then drops.
   const topLevel: ASTNode[] = ast.kind === "and" ? ast.children : [ast];
   for (const node of topLevel) {
-    const { errors } = astToFilterState(node, scoreTypes);
+    const { errors } = astToFilterInput(node, scoreTypes);
     const span = nodeSpan(node, textLength);
     for (const message of errors) {
       out.push({ from: span.from, to: span.to, severity: "error", message });

--- a/web/src/features/search-bar/server/buildFilterPrompt.ts
+++ b/web/src/features/search-bar/server/buildFilterPrompt.ts
@@ -11,9 +11,11 @@
 // render as pills. This is why a v4-native endpoint beats the legacy
 // trace-column prompt: there is no separate column list to drift out of sync.
 //
-// The model is asked for a flat Langfuse `FilterState` (an array of
-// `singleFilter` objects). Each field's allowed `type`/operators/value shape is
-// DERIVED from its `kind`/`syncMode` here, mirroring `lowerSingle` in
+// The model answers with a Langfuse `FilterInput`: a flat array of `singleFilter`
+// objects (implicit AND — the default) OR a nested `{type:"group",operator,
+// conditions}` tree when the request needs cross-field OR or bracketed logic.
+// Each field's allowed `type`/operators/value shape is DERIVED from its
+// `kind`/`syncMode` here, mirroring `lowerSingle` in
 // `../lib/filter-state-to-query.ts` (the reverse direction), so the two cannot
 // diverge.
 
@@ -110,7 +112,7 @@ The new request is an EDIT to this set, not a fresh start. Rules:
 - ADD a filter for whatever the request narrows down to.
 - Only modify or drop a filter the request actually targets.
 
-A phrase like "only X" / "just X" / "show me X" / "narrow to X" means ADD an X filter ON TOP OF the current ones — it does NOT mean discard the rest. Return the COMPLETE resulting array (existing filters that remain PLUS any new ones), never just the new delta.
+A phrase like "only X" / "just X" / "show me X" / "narrow to X" means ADD an X filter ON TOP OF the current ones — it does NOT mean discard the rest. Return the COMPLETE resulting filter (existing filters that remain PLUS any new ones), never just the new delta. If the existing filters are a group, or the edit introduces OR/branching, return the complete group.
 
 Worked example — current filters \`level:ERROR\`, request "only in production":
 you return BOTH filters, not just environment:
@@ -121,9 +123,9 @@ you return BOTH filters, not just environment:
   return `## Role
 
 You are the Langfuse filter generator for the observability (v4 events) table.
-Turn a natural-language request about LLM traces/observations into a flat
-Langfuse filter array in JSON, using the FULL filter surface — not just simple
-column matches. You can filter on:
+Turn a natural-language request about LLM traces/observations into a Langfuse
+filter in JSON, using the FULL filter surface — not just simple column matches.
+You can filter on:
 - catalog columns (below) with their operators,
 - custom **metadata** by key — BE WILLING to reach into metadata; many
   domain-specific attributes (queue, tenant, customer tier, feature flag, region,
@@ -131,7 +133,9 @@ column matches. You can filter on:
 - evaluation **scores** by name (numeric comparisons or categorical values),
 - **content search**: substring match on the input / output payload,
 - **null checks** (has / missing), tag groups (any / all / none of), and
-  **negation / exclusion**.
+  **negation / exclusion**,
+- **boolean logic**: combine conditions with AND (the default), OR, and bracketed
+  grouping when the request branches (see "Boolean logic" below).
 
 Prefer values, metadata keys, and score names that appear in the observed
 project data below (when provided) over inventing your own. Use real catalog
@@ -145,16 +149,22 @@ score names, thresholds, or values to satisfy it.
 
 ## Output format
 
-Respond with ONLY a JSON array of filter objects — no prose, no markdown fences.
-Each object has "type", "column", "operator", "value" (and "key" for metadata
-and score filters). If the request implies no filter, return [].
+Respond with ONLY JSON — no prose, no markdown fences. Two shapes:
 
-Example shape:
+1. **Flat array** (the DEFAULT — use it whenever every condition must hold, i.e.
+   plain AND). A JSON array of filter objects, each with "type", "column",
+   "operator", "value" (and "key" for metadata/score filters):
 
 [
   {"type": "stringOptions", "column": "level", "operator": "any of", "value": ["ERROR"]},
   {"type": "number", "column": "latency", "operator": ">", "value": 2}
 ]
+
+2. **Group** (ONLY when the request needs OR or bracketing — see "Boolean logic").
+   A single object \`{"type":"group","operator":"AND"|"OR","conditions":[…]}\`
+   whose conditions are filter objects or nested groups.
+
+If the request implies no filter, return [].
 
 ## Column catalog
 
@@ -210,6 +220,25 @@ contains X.
   / "with an X" → null "is not null".
 - Negated numbers use the inverse comparison ("not slower than 2s" → latency <= 2).
 
+## Boolean logic (AND / OR / grouping)
+
+A flat array is implicit AND — every filter must hold. Use a GROUP only when the
+request can't be expressed that way:
+
+- **OR across conditions** ("X or Y", "either … or …", "A, otherwise B"):
+  {"type":"group","operator":"OR","conditions":[<cond>, <cond>, …]}
+- **Bracketing / mixed AND+OR** ("A and (B or C)"): an outer AND group whose
+  conditions include an inner OR group (and vice-versa). Nest groups to mirror the
+  user's parentheses.
+
+Each entry in "conditions" is either a leaf filter object (same shape as the flat
+array) or another group. Within ONE field, prefer that field's multi-value
+operator over an OR of leaves: "level ERROR or WARNING" is one
+{"type":"stringOptions","column":"level","operator":"any of","value":["ERROR","WARNING"]},
+NOT an OR group. Reserve OR groups for branching ACROSS different
+fields/operators. Keep it shallow — nest at most a few levels and well under ~60
+leaf conditions. If only one condition results, return the flat one-element array.
+
 ## Tag groups
 
 traceTags is an array. "tagged a or b" → any of [a, b]; "tagged BOTH a and b" →
@@ -232,8 +261,9 @@ ${refineSection}${dataSection}
 ## Examples
 
 These span the full surface — comparisons, scores, metadata, content search,
-null checks, tag groups, and negation. Match the user's intent to the closest
-capability; don't reduce everything to a name/type guess.
+null checks, tag groups, negation, and boolean grouping. Match the user's intent
+to the closest capability; don't reduce everything to a name/type guess. Most
+requests are a flat array — only branch into a group when there's a real OR.
 
 Input: "slow production traces from the last 24 hours"
 Output: [{"type":"stringOptions","column":"environment","operator":"any of","value":["production"]},{"type":"number","column":"latency","operator":">","value":5},{"type":"datetime","column":"startTime","operator":">","value":"<24h before current datetime, ISO 8601>"}]
@@ -257,5 +287,14 @@ Input: "tagged both urgent and billing, not in dev"
 Output: [{"type":"arrayOptions","column":"traceTags","operator":"all of","value":["urgent","billing"]},{"type":"stringOptions","column":"environment","operator":"none of","value":["dev"]}]
 
 Input: "gpt-4 generations costing more than $0.50 that aren't errors"
-Output: [{"type":"stringOptions","column":"providedModelName","operator":"any of","value":["gpt-4"]},{"type":"stringOptions","column":"type","operator":"any of","value":["GENERATION"]},{"type":"number","column":"totalCost","operator":">","value":0.5},{"type":"stringOptions","column":"level","operator":"none of","value":["ERROR"]}]`;
+Output: [{"type":"stringOptions","column":"providedModelName","operator":"any of","value":["gpt-4"]},{"type":"stringOptions","column":"type","operator":"any of","value":["GENERATION"]},{"type":"number","column":"totalCost","operator":">","value":0.5},{"type":"stringOptions","column":"level","operator":"none of","value":["ERROR"]}]
+
+Input: "errors, or anything slower than 5 seconds" (cross-field OR → group)
+Output: {"type":"group","operator":"OR","conditions":[{"type":"stringOptions","column":"level","operator":"any of","value":["ERROR"]},{"type":"number","column":"latency","operator":">","value":5}]}
+
+Input: "production traces that either errored or cost more than a dollar" (AND of an OR → bracketing)
+Output: {"type":"group","operator":"AND","conditions":[{"type":"stringOptions","column":"environment","operator":"any of","value":["production"]},{"type":"group","operator":"OR","conditions":[{"type":"stringOptions","column":"level","operator":"any of","value":["ERROR"]},{"type":"number","column":"totalCost","operator":">","value":1}]}]}
+
+Input: "output mentions refund, or it's tagged billing" (cross-field OR → group)
+Output: {"type":"group","operator":"OR","conditions":[{"type":"string","column":"output","operator":"contains","value":"refund"},{"type":"arrayOptions","column":"traceTags","operator":"any of","value":["billing"]}]}`;
 }

--- a/web/src/features/search-bar/server/parseFilterCompletion.ts
+++ b/web/src/features/search-bar/server/parseFilterCompletion.ts
@@ -1,16 +1,25 @@
 // Pure post-processing for the v4 AI filter endpoint: turn a raw LLM completion
-// string into the `FilterState` the bar can apply. Kept separate from the tRPC
-// procedure (which owns auth, gating, telemetry, and the LLM call) so this — the
-// part with real branching logic — is unit-testable without a live model. This
-// mirrors the search-bar feature's own lib/ (pure) vs I/O split.
+// string into the `FilterInput` the bar can apply — a flat `FilterState` (plain
+// AND) or a nested AND/OR tree (cross-field OR / brackets). Kept separate from
+// the tRPC procedure (which owns auth, gating, telemetry, and the LLM call) so
+// this — the part with real branching logic — is unit-testable without a live
+// model. This mirrors the search-bar feature's own lib/ (pure) vs I/O split.
 
 import {
   eventsTableCols,
+  filterExpression,
+  type FilterExpression,
+  type FilterInput,
   type FilterState,
+  getFilterExpressionBoundsIssue,
+  getFilterExpressionLeafFilters,
   singleFilter,
 } from "@langfuse/shared";
 
-import { filterStateToQueryText } from "../lib/filter-state-to-query";
+import {
+  filterInputToQueryText,
+  filterStateToQueryText,
+} from "../lib/filter-state-to-query";
 
 // Mirrors COMPATIBLE_FILTER_TYPES in
 // packages/shared/src/server/queries/clickhouse-sql/filterTypeCompatibility.ts —
@@ -48,49 +57,55 @@ function isEventsContractCompatible(f: FilterState[number]): boolean {
 }
 
 /**
- * Extract a `FilterState` from the model's completion. Tries the whole string,
- * then the widest bracketed array (greedy, so it survives nested objects), and
- * tolerates a `{ "filters": [...] }` wrapper. Returns the structurally-valid
- * filters plus `rawCount` (how many elements the model actually emitted), so
- * the caller can count the malformed ones as dropped. `rawCount` is 0 when
- * nothing parses.
+ * Pull the first JSON value out of the model completion. Tries the whole string,
+ * then the widest bracketed array (a flat `FilterState`), then the widest brace
+ * object (a `{type:"group",…}` tree or a `{filters:[…]}` wrapper). Greedy so it
+ * survives nested objects/groups. Returns the parsed value, or null if nothing
+ * parses.
  */
-function parseFilterArray(completion: string): {
-  filters: FilterState;
-  rawCount: number;
-} {
-  const arrayMatch = completion.match(/\[[\s\S]*\]/)?.[0];
-  const candidates = [completion, arrayMatch].filter((c): c is string =>
-    Boolean(c),
-  );
+function extractJsonValue(completion: string): unknown {
+  const candidates = [
+    completion,
+    completion.match(/\[[\s\S]*\]/)?.[0],
+    completion.match(/\{[\s\S]*\}/)?.[0],
+  ].filter((c): c is string => Boolean(c));
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(candidate);
-      const raw = Array.isArray(parsed) ? parsed : parsed.filters;
-      if (!Array.isArray(raw)) continue;
-      // Parse PER ELEMENT, not the whole array: `z.array(singleFilter).parse`
-      // is all-or-nothing, so one off-spec element (wrong operator, missing
-      // key, value-as-string, unknown type — common on weaker models) would
-      // discard the valid siblings and surface a misleading "couldn't build
-      // filters". Keep the structurally-valid ones; the rejects show up in the
-      // dropped count below, mirroring the per-element keep/drop the two
-      // downstream guardrails already use.
-      const kept: FilterState = [];
-      for (const item of raw) {
-        const result = singleFilter.safeParse(item);
-        if (result.success) kept.push(result.data);
-      }
-      return { filters: kept, rawCount: raw.length };
+      return JSON.parse(candidate);
     } catch {
       // try the next candidate
     }
   }
-  return { filters: [], rawCount: 0 };
+  return null;
+}
+
+/** A `{type:"group",…}` node — the shape the model emits for OR / bracketed logic. */
+function isGroupShape(value: unknown): value is { conditions?: unknown[] } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (value as { type?: unknown }).type === "group"
+  );
+}
+
+/** Best-effort count of the leaf (non-group) conditions the model emitted, used
+ *  only for the dropped-count telemetry when a tree is rejected wholesale. */
+function countRawLeaves(value: unknown): number {
+  if (Array.isArray(value))
+    return value.reduce<number>((n, v) => n + countRawLeaves(v), 0);
+  if (isGroupShape(value))
+    return (value.conditions ?? []).reduce<number>(
+      (n, c) => n + countRawLeaves(c),
+      0,
+    );
+  return value != null ? 1 : 0;
 }
 
 export type GeneratedFilters = {
-  /** Filters that round-trip to bar grammar — safe to apply and show as pills. */
-  filters: FilterState;
+  /** Filter input that round-trips to bar grammar — a flat `FilterState` or a
+   *  nested AND/OR tree — safe to apply and re-render in the bar. */
+  filterInput: FilterInput;
   /** The derived bar query text (for display / telemetry). */
   queryText: string;
   /** How many model filters were dropped — malformed shape, hallucinated, or
@@ -98,26 +113,83 @@ export type GeneratedFilters = {
   droppedCount: number;
 };
 
+const EMPTY: GeneratedFilters = {
+  filterInput: [],
+  queryText: "",
+  droppedCount: 0,
+};
+
 /**
- * Parse the model completion and keep only the filters that round-trip to bar
- * grammar. A hallucinated or non-v4 column lands in `skippedFilters` and is
- * dropped here, so a caller can never apply a filter the bar can't show as an
- * editable pill.
+ * Flat-array path (the default, and what every model emits for plain AND
+ * filters): parse PER ELEMENT, not the whole array. `z.array(singleFilter)` is
+ * all-or-nothing, so one off-spec element (wrong operator, missing key,
+ * value-as-string — common on weaker models) would discard the valid siblings
+ * and surface a misleading "couldn't build filters". Keep the structurally-valid
+ * ones; the rejects show up in the dropped count.
  */
-export function parseGeneratedFilters(completion: string): GeneratedFilters {
-  // `rawCount` is what the model emitted; `parsed` already excludes elements
-  // that failed `singleFilter`, so the drop count is measured against rawCount.
-  const { filters: parsed, rawCount } = parseFilterArray(completion);
+function parseFlat(raw: unknown[]): GeneratedFilters {
+  const kept: FilterState = [];
+  for (const item of raw) {
+    const result = singleFilter.safeParse(item);
+    if (result.success) kept.push(result.data);
+  }
   // Guardrail 1: drop filters whose type the events contract would reject.
-  const compatible = parsed.filter(isEventsContractCompatible);
+  const compatible = kept.filter(isEventsContractCompatible);
   // Guardrail 2: drop anything that doesn't round-trip to bar grammar (unknown /
   // non-representable columns land in skippedFilters).
   const { text, skippedFilters } = filterStateToQueryText(compatible);
   const skipped = new Set(skippedFilters);
   const filters = compatible.filter((f) => !skipped.has(f));
   return {
-    filters,
+    filterInput: filters,
     queryText: text,
-    droppedCount: rawCount - filters.length,
+    droppedCount: raw.length - filters.length,
   };
+}
+
+/**
+ * Tree path (cross-field OR / bracketed logic). Unlike the flat path, tolerance
+ * is ALL-OR-NOTHING: dropping one leaf from an OR changes the boolean meaning of
+ * the whole expression, so a tree is applied only if it parses, fits the depth/
+ * node bounds, and EVERY leaf is contract-compatible and round-trips to grammar.
+ * Otherwise the whole tree is rejected (and the caller shows "couldn't build").
+ */
+function parseTree(value: unknown): GeneratedFilters {
+  const result = filterExpression.safeParse(value);
+  if (!result.success) return { ...EMPTY, droppedCount: countRawLeaves(value) };
+  const tree: FilterExpression = result.data;
+  // Mirror the tRPC boundary's depth/node caps here so an oversized AI tree is
+  // rejected as "couldn't build" rather than 400ing when the table applies it.
+  if (getFilterExpressionBoundsIssue(tree) !== null)
+    return { ...EMPTY, droppedCount: countRawLeaves(value) };
+  const leaves = getFilterExpressionLeafFilters(tree);
+  const allCompatible = leaves.every(isEventsContractCompatible);
+  const { text, skippedFilters } = filterInputToQueryText(tree);
+  if (!allCompatible || skippedFilters.length > 0)
+    return { ...EMPTY, droppedCount: leaves.length };
+  return { filterInput: tree, queryText: text, droppedCount: 0 };
+}
+
+/**
+ * Parse the model completion into a `FilterInput` and keep only what round-trips
+ * to bar grammar, so a caller can never apply a filter the bar can't show as an
+ * editable pill. A flat array (plain AND) is filtered per element; a
+ * `{type:"group"}` tree (OR / brackets) is accepted all-or-nothing.
+ */
+export function parseGeneratedFilters(completion: string): GeneratedFilters {
+  const parsed = extractJsonValue(completion);
+  if (parsed == null) return EMPTY;
+  // Unwrap a `{filters:[…]}` / `{filterInput:…}` envelope (some models add one),
+  // but never a real group node (which carries `type:"group"`, not these keys).
+  const value =
+    !isGroupShape(parsed) &&
+    typeof parsed === "object" &&
+    !Array.isArray(parsed) &&
+    ("filters" in parsed || "filterInput" in parsed)
+      ? ((parsed as Record<string, unknown>).filters ??
+        (parsed as Record<string, unknown>).filterInput)
+      : parsed;
+
+  if (isGroupShape(value)) return parseTree(value);
+  return parseFlat(Array.isArray(value) ? value : []);
 }

--- a/web/src/features/search-bar/server/router.ts
+++ b/web/src/features/search-bar/server/router.ts
@@ -3,11 +3,12 @@
 // Unlike the legacy `naturalLanguageFilters.createCompletion` (whose remotely
 // managed prompt targets the OLD trace columns), this procedure builds its
 // prompt from the search-bar field registry (`buildFilterSystemPrompt`), so the
-// model's vocabulary is exactly the v4 events grammar. It then ROUND-TRIPS the
-// model output through `filterStateToQueryText` and returns only the filters
-// that lower to bar pills — a hallucinated/unknown column can never reach the
-// client. The frontend applies the result via the bar's existing setFilterState
-// path (apply-immediately), and the bar re-derives the editable pills.
+// model's vocabulary is exactly the v4 events grammar. The model may answer with
+// a flat AND list OR a nested AND/OR group (cross-field OR + brackets). It then
+// ROUND-TRIPS the model output through the reverse adapter and returns only a
+// `filterInput` that lowers to bar pills — a hallucinated/unknown column can
+// never reach the client. The frontend applies the result via the bar's existing
+// apply-immediately path, and the bar re-derives the editable pills.
 
 import {
   createTRPCRouter,
@@ -175,9 +176,10 @@ export const searchBarRouter = createTRPCRouter({
           throw new Error("Expected LLM completion to be a string");
         }
 
-        // Parse the model output and keep only the filters that round-trip to
-        // bar grammar — a hallucinated/non-v4 column is dropped, never applied.
-        const { filters, queryText, droppedCount } =
+        // Parse the model output and keep only what round-trips to bar grammar —
+        // a hallucinated/non-v4 column is dropped, never applied. A flat list is
+        // filtered per element; a nested OR/grouped tree is all-or-nothing.
+        const { filterInput, queryText, droppedCount } =
           parseGeneratedFilters(llmCompletion);
 
         if (droppedCount > 0) {
@@ -190,7 +192,7 @@ export const searchBarRouter = createTRPCRouter({
           );
         }
 
-        return { filters, queryText };
+        return { filterInput, queryText };
       } catch (error) {
         // Already-shaped rejections (auth / precondition / not-found) are
         // expected control flow, not backend faults — rethrow them without

--- a/web/src/features/search-bar/store/searchBarStore.clienttest.ts
+++ b/web/src/features/search-bar/store/searchBarStore.clienttest.ts
@@ -7,7 +7,12 @@ describe("searchBarStore (draft-only)", () => {
     expect(store.getState().draft).toBe("level:ERROR");
     expect(store.getState().draftValid).toBe(true);
 
+    // A cross-field OR is now representable (lowers to a nested expression).
     store.getState().actions.setDraft("level:ERROR OR env:dev");
+    expect(store.getState().draftValid).toBe(true);
+
+    // A negated group still has no representable form.
+    store.getState().actions.setDraft("NOT (level:ERROR env:dev)");
     expect(store.getState().draftValid).toBe(false);
     expect(store.getState().draftDiagnostics.length).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## TL;DR

`(level:ERROR OR level:WARNING) AND -environment:prod AND name:*checkout*` now
works **end-to-end** — typed in the search bar, carried through the URL, run on
ClickHouse. The backend filter contract understands a nested boolean tree
(cross-field `OR`, bracket grouping) instead of only a flat implicit-`AND`
`FilterCondition[]`, and the GA search bar produces and consumes it.

Verified live (browser → tRPC → real ClickHouse): typing `level:ERROR OR type:SPAN`
writes an OR tree to the URL and returns the correct union (`55,275` =
`max(1316, 54592) ≤ … ≤ sum`); a tree URL re-derives the bar text; a depth-9 tree
is rejected `400`. Flat filters are byte-for-byte unchanged.

## Why

The grammar search bar (GA on the v4 events tables) already parses a full boolean
AST, but the backend contract was flat (`FilterState`, implicit AND) and the bar's
adapter *rejected* cross-field OR / groups at lowering. So those queries — and
bracket grouping — were commit-blocking diagnostics. v2 makes the whole stack
understand a **tree**.

## What

Decision 1C (hybrid) + Decision 2 Option A (extend the DTOs into a tree, recursive
parenthesizing emitter over the existing `Filter` classes), per the RFC. Ports the
already-prototyped backend (#12814) onto current `main`, adds the bounds it lacked,
and wires the FE through the **shared** filter stack.

**Backend contract**
- Recursive `filterExpression` / `filterGroup` (`z.lazy`); `filterInput =
  union(flatArray, expression)`; `normalizeFilterExpressionInput` (flat → top-level
  AND). Leaf `Filter` classes (randomized typed params, value never interpolated)
  are **unchanged** — only the combiner (`applyCompiledFilterNode` / `FilterTree`)
  became recursive.
- **Tenant isolation stays structural**: projectId/env/time wrap the user tree as
  an outer AND; `findMandatory` (AND-only leaves) gates optimizations (trace-id
  hash prune, start-time bound) so they never fire on a leaf under an OR.
- **Bounds**: depth ≤ 8, ≤ 64 leaf conditions, rejected at the tRPC boundary.
- events list/count + router accept `filterInput`; comment filters resolve
  recursively; positionInTrace must be AND-reachable.

**Frontend (full integration)**
- `astToFilterInput` lowers the AST to a flat array (pure AND — sidebar-owned) or a
  nested tree (cross-field OR / group). Per-leaf lowering is **shared** with the
  flat `astToFilterState` (no parity drift); `filterInputToQueryText` renders a tree
  back via the precedence-aware serializer.
- The URL `filter` param codec carries a tree as JSON (leading `{`); flat stays the
  legacy delimited format, so **every existing URL + saved view is unchanged**.
- `useSidebarFilterState` gains `explicitFilterExpression` / `effectiveFilterExpression`
  / `isAdvancedFilter` / `setFilterExpression`; the flat fields stay **byte-identical**,
  so the ~11 other tables that reuse the hook are untouched.
- Facet sidebar shows a read-only "advanced filter — edit in the search bar" state
  when a tree is active (the bar is the editor; "Clear all" returns to facets).

## Result

- Unit + integration tests: contract/emitter, depth/condition bounds, tenant-guard
  (project filter stays outside a user OR; trace-hash prune only on AND-reachable
  traceId), flat↔tree lowering parity, reverse round-trip, ClickHouse nested AND/OR
  list+count. Existing 179 search-bar client tests updated + green.
- Browser-verified the full round-trip + correctness + bounds + sidebar state.
- Addressed two review rounds: bounds off-by-one, singleton-OR mandatory-leaf
  sync, positionInTrace message, comment-filter cleanup, plus a hidden-env leak
  (env filter under an OR no longer suppresses the managed-env default) and the
  bulk-action gating below.
- Rebased onto current `main` (post #14521 table-views URL-as-source-of-truth);
  reconciled the new search-bar AI apply path with the tree-aware commit.

## ⚠️ Scoped follow-ups (flat path has no regression)

1. **Saved views of a tree.** Storing/restoring a nested filter needs widening the
   **9-table-shared** `useTableViewManager` (its `setFilters`/`currentFilterState`
   are flat-typed; widening breaks the other 8 under strict function variance) +
   the `TableViewPreset` schema + create/update tRPC. Saving a view *while a tree is
   active* currently captures the flat state only — a clean next PR.
2. **Bulk actions on a tree** (export / run-eval / add-to-dataset / annotation
   queue) consume a flat `FilterState`. When a tree filter is active these
   "select-all-matching" actions are **disabled** (with a reason) rather than
   silently widening to every row; explicit row selection stays enabled. Widening
   their backends to accept a tree is a follow-up.
3. **ClickHouse execution caps** (§3.5 `max_execution_time` / `max_rows_to_read`
   for OR queries) intentionally **not set blindly**: a per-query value could relax
   a stricter server-side limit, so it needs a prod-informed value (Nikita/Mark).
   The depth (≤8) / condition (≤64) bounds are the deterministic structural blast
   protection that ships here.

NOT-of-a-group stays the prototype's De-Morgan-to-leaves (the backend has no general
NOT); an explicit NOT node is a noted follow-up.

<details>
<summary>Files & mechanism</summary>

Backend: `interfaces/filters.ts`, `clickhouse-filter.ts` (`FilterTree`,
`CompiledFilterCollection`), `factory.ts` (`createFilterTreeFromFilter{Expression,Input}`),
`event-query-builder.ts` (`findMandatory`), `repositories/events.ts`,
`services/commentFilterService.ts`, events `{types,eventsRouter,eventsService}.ts`.

Frontend: `search-bar/lib/{adapter,filter-state-to-query,validate,commit}.ts`,
`search-bar/hooks/useEventsSearchBar.ts`, `filters/lib/filter-query-encoding.ts`
(`encode/decodeFilterInput`), `filters/hooks/useSidebarFilterState.tsx`,
`events/components/EventsTable.tsx`, `events/hooks/useEventsTableData.ts`,
`table/data-table-controls.tsx` (read-only state). README updated.

Seed/related: #12814 (the Phase-1 backend ported), #12845 (lucene FE prototype),
#14283 (v4 subquery-IN rewrite). Linear: LFE-10421.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

