### PR TITLE
fix(table-views): shared view links carry applied filters; URL as source of truth (LFE-10486, LFE-7389)

### DIFF
--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -92,6 +92,7 @@ interface TableViewControllers {
   selectedViewId: string | null;
   appliedViewId: string | null;
   handleSetViewId: (viewId: string | null) => void;
+  markViewApplied: (viewId: string) => void;
 }
 
 interface TableViewConfig {

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -90,6 +90,7 @@ interface SearchConfig {
 interface TableViewControllers {
   applyViewState: (viewData: TableViewPresetState) => void;
   selectedViewId: string | null;
+  appliedViewId: string | null;
   handleSetViewId: (viewId: string | null) => void;
 }
 

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -92,7 +92,6 @@ interface TableViewControllers {
   selectedViewId: string | null;
   appliedViewId: string | null;
   handleSetViewId: (viewId: string | null) => void;
-  markViewApplied: (viewId: string) => void;
 }
 
 interface TableViewConfig {

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -77,6 +77,8 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { useUniqueNameValidation } from "@/src/hooks/useUniqueNameValidation";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
@@ -355,6 +357,25 @@ export function TableViewPresetsDrawer({
       tableName,
       viewId,
     });
+
+    // For the view that is currently active, the page URL already encodes the
+    // applied filters, sort and search — the URL is the source of truth. Share
+    // it verbatim so in-view edits travel with the link. A server-built
+    // `?viewId=…` permalink points at the saved view's stored state and would
+    // silently drop those edits, which is the recipient-gets-stale-filters bug
+    // (LFE-10486). Non-active views still get a clean link to the saved view.
+    if (
+      viewId === selectedViewId &&
+      typeof window !== "undefined" &&
+      window.location?.href
+    ) {
+      copyTextToClipboard(window.location.href);
+      showSuccessToast({
+        title: "Permalink copied to clipboard",
+        description: "You can now share the permalink with others",
+      });
+      return;
+    }
 
     if (window.location.origin) {
       generatePermalinkMutation.mutate({

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -144,9 +144,6 @@ interface TableViewPresetsDrawerProps {
        * shared-link visit where the view is intentionally not applied). */
       appliedViewId: string | null;
       handleSetViewId: (viewId: string | null) => void;
-      /** Mark a view as applied without re-running applyViewState (e.g. a view
-       * just created from the current state). */
-      markViewApplied: (viewId: string) => void;
       applyViewState: (viewData: TableViewPresetState) => void;
     };
   };
@@ -184,13 +181,8 @@ export function TableViewPresetsDrawer({
 }: TableViewPresetsDrawerProps) {
   const [searchQuery, setSearchQueryLocal] = useState("");
   const { tableName, projectId, controllers } = viewConfig;
-  const {
-    handleSetViewId,
-    applyViewState,
-    selectedViewId,
-    appliedViewId,
-    markViewApplied,
-  } = controllers;
+  const { handleSetViewId, applyViewState, selectedViewId, appliedViewId } =
+    controllers;
   const { TableViewPresetsList } = useViewData({ tableName, projectId });
   const {
     createMutation,
@@ -291,25 +283,16 @@ export function TableViewPresetsDrawer({
       name: createdView.name,
     });
 
-    createMutation.mutate(
-      {
-        name: createdView.name,
-        tableName,
-        projectId,
-        orderBy: currentState.orderBy,
-        filters: currentState.filters,
-        columnOrder: currentState.columnOrder,
-        columnVisibility: currentState.columnVisibility,
-        searchQuery: currentState.searchQuery,
-      },
-      {
-        // The new view was saved from the current table state, so its columns
-        // equal the live ones — mark it applied so a subsequent "Update view"
-        // trusts the live columns rather than treating it like a shared-link
-        // visit (LFE-10486).
-        onSuccess: (data) => markViewApplied(data.view.id),
-      },
-    );
+    createMutation.mutate({
+      name: createdView.name,
+      tableName,
+      projectId,
+      orderBy: currentState.orderBy,
+      filters: currentState.filters,
+      columnOrder: currentState.columnOrder,
+      columnVisibility: currentState.columnVisibility,
+      searchQuery: currentState.searchQuery,
+    });
 
     setIsCreateDialogOpen(false);
   };

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -140,6 +140,9 @@ interface TableViewPresetsDrawerProps {
     projectId: string;
     controllers: {
       selectedViewId: string | null;
+      /** The view whose full state was actually applied this session (null on a
+       * shared-link visit where the view is intentionally not applied). */
+      appliedViewId: string | null;
       handleSetViewId: (viewId: string | null) => void;
       applyViewState: (viewData: TableViewPresetState) => void;
     };
@@ -178,7 +181,8 @@ export function TableViewPresetsDrawer({
 }: TableViewPresetsDrawerProps) {
   const [searchQuery, setSearchQueryLocal] = useState("");
   const { tableName, projectId, controllers } = viewConfig;
-  const { handleSetViewId, applyViewState, selectedViewId } = controllers;
+  const { handleSetViewId, applyViewState, selectedViewId, appliedViewId } =
+    controllers;
   const { TableViewPresetsList } = useViewData({ tableName, projectId });
   const {
     createMutation,
@@ -302,6 +306,27 @@ export function TableViewPresetsDrawer({
       name: updatedView.name,
     });
 
+    // Column order/visibility are the visitor's per-table localStorage, which
+    // only reflects this view when the view was actually applied this session.
+    // On a shared-link visit the view is intentionally not applied, so
+    // `currentState`'s columns are the visitor's own unrelated layout — sending
+    // them would silently overwrite the saved view's columns. In that case keep
+    // the view's stored column layout instead (LFE-10486). Filters/sort/search
+    // always come from the live state, since updating those to what the visitor
+    // currently sees is exactly the intent.
+    const viewWasApplied = appliedViewId === selectedViewId;
+    const storedView = TableViewPresetsList?.find(
+      (view) => view.id === selectedViewId,
+    );
+    const columnOrder =
+      viewWasApplied || !storedView
+        ? currentState.columnOrder
+        : storedView.columnOrder;
+    const columnVisibility =
+      viewWasApplied || !storedView
+        ? currentState.columnVisibility
+        : storedView.columnVisibility;
+
     updateConfigMutation.mutate({
       projectId,
       name: updatedView.name,
@@ -309,8 +334,8 @@ export function TableViewPresetsDrawer({
       tableName,
       orderBy: currentState.orderBy,
       filters: currentState.filters,
-      columnOrder: currentState.columnOrder,
-      columnVisibility: currentState.columnVisibility,
+      columnOrder,
+      columnVisibility,
       searchQuery: currentState.searchQuery,
     });
   };

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -369,11 +369,22 @@ export function TableViewPresetsDrawer({
       typeof window !== "undefined" &&
       window.location?.href
     ) {
-      copyTextToClipboard(window.location.href);
-      showSuccessToast({
-        title: "Permalink copied to clipboard",
-        description: "You can now share the permalink with others",
-      });
+      // Toast on the clipboard write's resolution: a permission failure must
+      // surface an error instead of falsely reporting success.
+      copyTextToClipboard(window.location.href)
+        .then(() =>
+          showSuccessToast({
+            title: "Permalink copied to clipboard",
+            description: "You can now share the permalink with others",
+          }),
+        )
+        .catch(() =>
+          showErrorToast(
+            "Failed to copy permalink",
+            "Could not write to the clipboard. Please copy the page URL manually.",
+            "WARNING",
+          ),
+        );
       return;
     }
 

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -144,6 +144,9 @@ interface TableViewPresetsDrawerProps {
        * shared-link visit where the view is intentionally not applied). */
       appliedViewId: string | null;
       handleSetViewId: (viewId: string | null) => void;
+      /** Mark a view as applied without re-running applyViewState (e.g. a view
+       * just created from the current state). */
+      markViewApplied: (viewId: string) => void;
       applyViewState: (viewData: TableViewPresetState) => void;
     };
   };
@@ -181,8 +184,13 @@ export function TableViewPresetsDrawer({
 }: TableViewPresetsDrawerProps) {
   const [searchQuery, setSearchQueryLocal] = useState("");
   const { tableName, projectId, controllers } = viewConfig;
-  const { handleSetViewId, applyViewState, selectedViewId, appliedViewId } =
-    controllers;
+  const {
+    handleSetViewId,
+    applyViewState,
+    selectedViewId,
+    appliedViewId,
+    markViewApplied,
+  } = controllers;
   const { TableViewPresetsList } = useViewData({ tableName, projectId });
   const {
     createMutation,
@@ -283,16 +291,25 @@ export function TableViewPresetsDrawer({
       name: createdView.name,
     });
 
-    createMutation.mutate({
-      name: createdView.name,
-      tableName,
-      projectId,
-      orderBy: currentState.orderBy,
-      filters: currentState.filters,
-      columnOrder: currentState.columnOrder,
-      columnVisibility: currentState.columnVisibility,
-      searchQuery: currentState.searchQuery,
-    });
+    createMutation.mutate(
+      {
+        name: createdView.name,
+        tableName,
+        projectId,
+        orderBy: currentState.orderBy,
+        filters: currentState.filters,
+        columnOrder: currentState.columnOrder,
+        columnVisibility: currentState.columnVisibility,
+        searchQuery: currentState.searchQuery,
+      },
+      {
+        // The new view was saved from the current table state, so its columns
+        // equal the live ones — mark it applied so a subsequent "Update view"
+        // trusts the live columns rather than treating it like a shared-link
+        // visit (LFE-10486).
+        onSuccess: (data) => markViewApplied(data.view.id),
+      },
+    );
 
     setIsCreateDialogOpen(false);
   };

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -90,8 +90,6 @@ export function useTableViewManager({
   const [isInitialized, setIsInitialized] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const capture = usePostHogClientCapture();
-  const pendingFiltersRef = useRef<FilterState | null>(null);
-  const pendingFiltersPreviousStateRef = useRef<FilterState | null>(null);
 
   const [storedViewId, setStoredViewId] = useSessionStorage<string | null>(
     `${tableName}-${projectId}-viewId`,
@@ -167,27 +165,40 @@ export function useTableViewManager({
     if (isInitialized) return;
     if (!isRouterReady) return;
 
-    // If viewId already in the URL and is not a system preset, let the getById
-    // query resolve it.
+    // Clear stale frontend-only system presets from the URL first (they are
+    // defined in code, not the DB, so there is nothing to fetch).
     if (
       selectedViewId &&
-      (!isSystemPresetId(selectedViewId) || allowBackendSystemPresets)
+      isSystemPresetId(selectedViewId) &&
+      !allowBackendSystemPresets
     ) {
-      return;
-    }
-
-    // Clear stale frontend-only system presets from the URL.
-    if (selectedViewId && isSystemPresetId(selectedViewId)) {
       handleSetViewId(null);
       return;
     }
 
-    // Query params such as `filter` are explicit table state. They must take
-    // precedence over implicit session/default view restoration, otherwise a
-    // direct filtered URL is immediately overwritten by the restored view.
+    // Explicit table state in the URL (`filter`/`search`/`orderBy`) is
+    // authoritative, even when a `viewId` is present. The viewId is a
+    // provenance reference — which saved view a link came from — but the URL's
+    // filters/sort/search are what is actually applied (the URL is the source
+    // of truth). Without checking this before resolving the view, opening
+    // `?viewId=X&filter=...` (a shared "view + in-view edits" link, or any deep
+    // link onto a saved view) would fetch the view and overwrite the URL's
+    // filters with the view's stored state. This preserves deep-link
+    // precedence (#13865) and makes shared links carry in-view edits
+    // (LFE-10486). The viewId stays in the URL so the drawer still shows the
+    // originating view.
     if (hasExplicitTableStateInUrl(router.query)) {
       setIsInitialized(true);
       setIsLoading(false);
+      return;
+    }
+
+    // A real saved view (or an allowed backend system preset) in the URL with
+    // no explicit table state → let the getById query resolve and hydrate it.
+    if (
+      selectedViewId &&
+      (!isSystemPresetId(selectedViewId) || allowBackendSystemPresets)
+    ) {
       return;
     }
 
@@ -292,16 +303,11 @@ export function useTableViewManager({
         setExpandedFiltersRef.current(nextExpandedFilters);
       }
 
-      if (setFiltersRef.current) {
+      // Apply the view's filters unless what is applied already matches. The
+      // sidebar filter hook updates optimistically, so the applied filter state
+      // — and the URL it writes to — reflect the view synchronously.
+      if (setFiltersRef.current && !filtersAlreadyApplied) {
         setFiltersRef.current(validFilters);
-        // Track expected filters to observe when state actually updates (for useEffect below)
-        // If filters are already applied, don't set pending ref (will unlock immediately).
-        // Also track pre-apply state so we can unlock when filters propagate but get
-        // migrated into an equivalent shape by downstream hooks.
-        if (!filtersAlreadyApplied) {
-          pendingFiltersRef.current = validFilters;
-          pendingFiltersPreviousStateRef.current = currentFilterState ?? [];
-        }
       }
 
       if (setSearchQueryRef.current) {
@@ -316,14 +322,15 @@ export function useTableViewManager({
       if (viewData.columnVisibility)
         setColumnVisibility(viewData.columnVisibility);
 
-      // If filters were already applied, unlock table immediately
-      if (filtersAlreadyApplied) {
-        setIsLoading(false);
-      }
-
-      // NOTE: Table remains locked until useEffect observer detects filter state propagation
-      // This is relevant for the saved views. Because the URL lazy updates and we don't want to wait
-      // for a page reload
+      // Unlock as soon as the view is applied. Earlier versions kept the table
+      // locked until a useEffect observer saw the filter change propagate to
+      // `currentFilterState`; that observer was the source of LFE-7389
+      // fragility — an early return or a canonicalized-shape mismatch could
+      // leave the table showing unfiltered rows, or never unlock. The sidebar
+      // filter hook applies updates optimistically, so propagation is
+      // synchronous and the URL becomes the source of truth for the applied
+      // filters on the same render. Unlock deterministically here instead.
+      setIsLoading(false);
     },
     [
       setColumnOrder,
@@ -348,6 +355,11 @@ export function useTableViewManager({
         isRouterReady &&
         !!selectedViewId &&
         !isInitialized &&
+        // Explicit URL state is authoritative, so there is nothing to hydrate
+        // from the view — don't fetch it. This also guarantees the success
+        // handler can never apply the view over the URL's filters regardless of
+        // effect timing (LFE-10486).
+        !hasExplicitTableStateInUrl(router.query) &&
         (!isSystemPresetId(selectedViewId) || allowBackendSystemPresets),
     },
   );
@@ -358,6 +370,15 @@ export function useTableViewManager({
     const requestedViewId = selectedViewId;
     if (!requestedViewId) return;
     if (isInitializedRef.current) return;
+    // Explicit URL state wins over the saved view (the URL is the source of
+    // truth). Guard here too — not just in the query `enabled` — so cached view
+    // data can never be applied over the URL's filters on the first render
+    // regardless of effect timing (LFE-10486).
+    if (hasExplicitTableStateInUrl(router.query)) {
+      setIsInitialized(true);
+      setIsLoading(false);
+      return;
+    }
     if (selectedViewIdRef.current !== requestedViewId) return;
     if (selectedViewData.id !== requestedViewId) return;
     if (!isViewApplicableToTable(tableName, selectedViewData.tableName)) {
@@ -383,6 +404,7 @@ export function useTableViewManager({
     isSelectedViewSuccess,
     selectedViewData,
     selectedViewId,
+    router.query,
     handleSetViewId,
     capture,
     tableName,
@@ -411,29 +433,6 @@ export function useTableViewManager({
     selectedViewId,
     handleSetViewId,
   ]);
-
-  // Observe when filter state propagates from saved view
-  // After calling setFilters, URL updates async → filterState recalculates → this effect detects completion
-  useEffect(() => {
-    const pendingFilters = pendingFiltersRef.current;
-    if (!pendingFilters || currentFilterState === undefined) return;
-
-    const preApplyFilters = pendingFiltersPreviousStateRef.current ?? [];
-    const hasExpectedShape = isEqual(currentFilterState, pendingFilters);
-    const hasPropagatedWithCanonicalization = !isEqual(
-      currentFilterState,
-      preApplyFilters,
-    );
-
-    if (hasExpectedShape || hasPropagatedWithCanonicalization) {
-      // Filter state has synchronized - safe to unlock table.
-      // `hasPropagatedWithCanonicalization` handles equivalent rewrites
-      // (for example legacy env-delta -> canonical none-of shape).
-      pendingFiltersRef.current = null;
-      pendingFiltersPreviousStateRef.current = null;
-      setIsLoading(false);
-    }
-  }, [currentFilterState]);
 
   if (disabled) {
     return {

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -475,7 +475,22 @@ export function useTableViewManager({
     // is still X, so "Update view" correctly trusts the live columns instead of
     // reverting to the view's stored snapshot. On a fresh shared-link visit
     // storedViewId is null (or another view), so the view's columns are
-    // preserved (LFE-10486).
+    // preserved (the visitor's own localStorage layout is not saved over the
+    // view).
+    //
+    // Deliberate tradeoff: storedViewId is sessionStorage (per-tab) while the
+    // column layout is localStorage (cross-tab). So the *owner* reopening their
+    // own `?viewId=X&filter=...` bookmark in a NEW tab is indistinguishable at
+    // runtime from a stranger opening a shared link — both have empty
+    // sessionStorage + explicit URL state. We intentionally err toward
+    // preserving the saved view's stored columns when ambiguous: the cost is
+    // that an in-tab column reorder in that new tab is not saved on "Update
+    // view" (recoverable — re-select the view, then update), whereas trusting
+    // the live columns would let any visitor silently overwrite a shared view's
+    // columns. A robust resolution needs the column-state-model rework
+    // (decouple "the view's columns" from "my personal columns"); a per-tab
+    // signal cannot tell the two visits apart. Keep this comment if "fixing"
+    // the symmetric case is attempted. (LFE-10486)
     appliedViewId: storedViewId,
     defaultViewScope: resolvedDefault?.scope ?? null,
   };

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -187,26 +187,19 @@ export function useTableViewManager({
       !!selectedViewId &&
       (!isSystemPresetId(selectedViewId) || allowBackendSystemPresets);
 
-    // Explicit table state in the URL (`filter`/`search`/`orderBy`) is
-    // authoritative for filters/sort/search, even when a `viewId` is present.
-    // The viewId is a provenance reference — which saved view a link came from
-    // — but the URL's filters are what is actually applied (the URL is the
-    // source of truth). Without this, opening `?viewId=X&filter=...` (a shared
-    // "view + in-view edits" link, or any deep link onto a saved view) would
-    // overwrite the URL's filters with the view's stored state. Preserves
-    // deep-link precedence (#13865) and makes shared links carry in-view edits
-    // (LFE-10486).
+    // Explicit table state in the URL (`filter`/`search`/`searchType`/
+    // `orderBy`) is authoritative, even when a `viewId` is present. The viewId
+    // is a provenance reference — which saved view a link came from — but the
+    // URL's filters/sort/search are what is actually applied (the URL is the
+    // source of truth). We do NOT fetch or apply the saved view here: applying
+    // it would overwrite the URL's filters, and writing its column layout would
+    // silently mutate the visitor's own per-table localStorage on a
+    // non-deliberate link open. The viewId stays in the URL so the drawer still
+    // shows the originating view. Preserves deep-link precedence (#13865) and
+    // makes shared links carry in-view edits (LFE-10486).
     if (hasExplicitTableStateInUrl(router.query)) {
-      // Unlock right away so the URL's filters apply without waiting on a fetch.
+      setIsInitialized(true);
       setIsLoading(false);
-      // If a real saved view is referenced, still let getById resolve so its
-      // column layout (per-user localStorage, not encoded in the URL) can be
-      // applied by the success handler — which applies columns only and leaves
-      // the URL's filters authoritative. Otherwise there is nothing left to
-      // resolve, so mark initialization complete.
-      if (!hasResolvableView) {
-        setIsInitialized(true);
-      }
       return;
     }
 
@@ -379,6 +372,10 @@ export function useTableViewManager({
         isRouterReady &&
         !!selectedViewId &&
         !isInitialized &&
+        // Explicit URL state is authoritative and we deliberately do not apply
+        // the view over it (no filter overwrite, no localStorage column
+        // mutation on a link open) — so there is nothing to fetch.
+        !hasExplicitTableStateInUrl(router.query) &&
         (!isSystemPresetId(selectedViewId) || allowBackendSystemPresets),
     },
   );
@@ -389,6 +386,15 @@ export function useTableViewManager({
     const requestedViewId = selectedViewId;
     if (!requestedViewId) return;
     if (isInitializedRef.current) return;
+    // Explicit URL state is authoritative and the view is deliberately not
+    // applied over it — guard here too (not just via the query `enabled`) so
+    // cached view data can never apply the view on the first render regardless
+    // of effect timing (LFE-10486).
+    if (hasExplicitTableStateInUrl(router.query)) {
+      setIsInitialized(true);
+      setIsLoading(false);
+      return;
+    }
     if (selectedViewIdRef.current !== requestedViewId) return;
     if (selectedViewData.id !== requestedViewId) return;
     if (!isViewApplicableToTable(tableName, selectedViewData.tableName)) {
@@ -403,25 +409,12 @@ export function useTableViewManager({
       name: selectedViewData.name,
     });
 
-    if (hasExplicitTableStateInUrl(router.query)) {
-      // The URL is authoritative for filters/sort/search, so do NOT apply the
-      // view's stored filters over them. The column layout, however, is
-      // per-user localStorage that the URL does not carry — apply it from the
-      // view so a shared "view + in-view edits" link still renders the view's
-      // columns instead of the recipient's own (LFE-10486).
-      if (selectedViewData.columnOrder)
-        setColumnOrder(selectedViewData.columnOrder);
-      if (selectedViewData.columnVisibility)
-        setColumnVisibility(selectedViewData.columnVisibility);
-    } else {
-      applyViewState(selectedViewData);
-    }
+    applyViewState(selectedViewData);
     if (storedViewId !== requestedViewId) {
       setStoredViewId(requestedViewId);
     }
     isInitializedRef.current = true;
     setIsInitialized(true);
-    setIsLoading(false);
   }, [
     disabled,
     isSelectedViewSuccess,
@@ -432,8 +425,6 @@ export function useTableViewManager({
     capture,
     tableName,
     applyViewState,
-    setColumnOrder,
-    setColumnVisibility,
     storedViewId,
     setStoredViewId,
   ]);

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -96,12 +96,6 @@ export function useTableViewManager({
   const isRouterReady = router.isReady;
   const [isInitialized, setIsInitialized] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  // The view whose full state (incl. column layout) was actually applied to the
-  // live table this session — set whenever applyViewState runs. Used to tell a
-  // deliberate view application apart from a shared-link visit where the view
-  // is intentionally NOT applied, so "Update view" never saves the visitor's
-  // unrelated local columns over the view (LFE-10486).
-  const [appliedViewId, setAppliedViewId] = useState<string | null>(null);
   const capture = usePostHogClientCapture();
 
   const [storedViewId, setStoredViewId] = useSessionStorage<string | null>(
@@ -257,14 +251,9 @@ export function useTableViewManager({
 
   // Method to apply state from a view
   const applyViewState = useCallback(
-    (viewData: TableViewPresetState & { id?: string }) => {
+    (viewData: TableViewPresetState) => {
       // lock table
       setIsLoading(true);
-
-      // Record that this view's full state is now reflected in the live table
-      // (filters in the URL, column layout in localStorage). Saved views and
-      // drawer selections carry an id; synthetic system presets do not.
-      if (viewData.id) setAppliedViewId(viewData.id);
 
       /**
        * Validate orderBy and filters
@@ -466,7 +455,6 @@ export function useTableViewManager({
       isLoading: false,
       applyViewState: () => {},
       handleSetViewId: () => {},
-      markViewApplied: () => {},
       selectedViewId: null,
       appliedViewId: null,
       defaultViewScope: null,
@@ -477,14 +465,18 @@ export function useTableViewManager({
     isLoading,
     applyViewState,
     handleSetViewId,
-    // Lets callers that put the live table state into a view *without* going
-    // through applyViewState — notably creating a view, whose columns equal the
-    // current state by construction — record it as applied, so a follow-up
-    // "Update view" trusts the live columns instead of treating it like a
-    // shared-link visit (LFE-10486).
-    markViewApplied: setAppliedViewId,
     selectedViewId,
-    appliedViewId,
+    // The view whose state is reflected in the live table — i.e. whose column
+    // layout is in localStorage. We reuse `storedViewId` (session-persisted,
+    // set on apply/create/select and cleared on deselect) rather than a
+    // session-scoped React flag, so the signal survives a reload: after a view
+    // is applied the URL becomes `?viewId=X&filter=...`, and on reload the
+    // explicit-URL-state short-circuit skips re-applying it — but storedViewId
+    // is still X, so "Update view" correctly trusts the live columns instead of
+    // reverting to the view's stored snapshot. On a fresh shared-link visit
+    // storedViewId is null (or another view), so the view's columns are
+    // preserved (LFE-10486).
+    appliedViewId: storedViewId,
     defaultViewScope: resolvedDefault?.scope ?? null,
   };
 }

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -96,6 +96,12 @@ export function useTableViewManager({
   const isRouterReady = router.isReady;
   const [isInitialized, setIsInitialized] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  // The view whose full state (incl. column layout) was actually applied to the
+  // live table this session — set whenever applyViewState runs. Used to tell a
+  // deliberate view application apart from a shared-link visit where the view
+  // is intentionally NOT applied, so "Update view" never saves the visitor's
+  // unrelated local columns over the view (LFE-10486).
+  const [appliedViewId, setAppliedViewId] = useState<string | null>(null);
   const capture = usePostHogClientCapture();
 
   const [storedViewId, setStoredViewId] = useSessionStorage<string | null>(
@@ -251,9 +257,14 @@ export function useTableViewManager({
 
   // Method to apply state from a view
   const applyViewState = useCallback(
-    (viewData: TableViewPresetState) => {
+    (viewData: TableViewPresetState & { id?: string }) => {
       // lock table
       setIsLoading(true);
+
+      // Record that this view's full state is now reflected in the live table
+      // (filters in the URL, column layout in localStorage). Saved views and
+      // drawer selections carry an id; synthetic system presets do not.
+      if (viewData.id) setAppliedViewId(viewData.id);
 
       /**
        * Validate orderBy and filters
@@ -456,6 +467,7 @@ export function useTableViewManager({
       applyViewState: () => {},
       handleSetViewId: () => {},
       selectedViewId: null,
+      appliedViewId: null,
       defaultViewScope: null,
     };
   }
@@ -465,6 +477,7 @@ export function useTableViewManager({
     applyViewState,
     handleSetViewId,
     selectedViewId,
+    appliedViewId,
     defaultViewScope: resolvedDefault?.scope ?? null,
   };
 }

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -176,29 +176,36 @@ export function useTableViewManager({
       return;
     }
 
+    const hasResolvableView =
+      !!selectedViewId &&
+      (!isSystemPresetId(selectedViewId) || allowBackendSystemPresets);
+
     // Explicit table state in the URL (`filter`/`search`/`orderBy`) is
-    // authoritative, even when a `viewId` is present. The viewId is a
-    // provenance reference — which saved view a link came from — but the URL's
-    // filters/sort/search are what is actually applied (the URL is the source
-    // of truth). Without checking this before resolving the view, opening
-    // `?viewId=X&filter=...` (a shared "view + in-view edits" link, or any deep
-    // link onto a saved view) would fetch the view and overwrite the URL's
-    // filters with the view's stored state. This preserves deep-link
-    // precedence (#13865) and makes shared links carry in-view edits
-    // (LFE-10486). The viewId stays in the URL so the drawer still shows the
-    // originating view.
+    // authoritative for filters/sort/search, even when a `viewId` is present.
+    // The viewId is a provenance reference — which saved view a link came from
+    // — but the URL's filters are what is actually applied (the URL is the
+    // source of truth). Without this, opening `?viewId=X&filter=...` (a shared
+    // "view + in-view edits" link, or any deep link onto a saved view) would
+    // overwrite the URL's filters with the view's stored state. Preserves
+    // deep-link precedence (#13865) and makes shared links carry in-view edits
+    // (LFE-10486).
     if (hasExplicitTableStateInUrl(router.query)) {
-      setIsInitialized(true);
+      // Unlock right away so the URL's filters apply without waiting on a fetch.
       setIsLoading(false);
+      // If a real saved view is referenced, still let getById resolve so its
+      // column layout (per-user localStorage, not encoded in the URL) can be
+      // applied by the success handler — which applies columns only and leaves
+      // the URL's filters authoritative. Otherwise there is nothing left to
+      // resolve, so mark initialization complete.
+      if (!hasResolvableView) {
+        setIsInitialized(true);
+      }
       return;
     }
 
     // A real saved view (or an allowed backend system preset) in the URL with
     // no explicit table state → let the getById query resolve and hydrate it.
-    if (
-      selectedViewId &&
-      (!isSystemPresetId(selectedViewId) || allowBackendSystemPresets)
-    ) {
+    if (hasResolvableView) {
       return;
     }
 
@@ -355,11 +362,6 @@ export function useTableViewManager({
         isRouterReady &&
         !!selectedViewId &&
         !isInitialized &&
-        // Explicit URL state is authoritative, so there is nothing to hydrate
-        // from the view — don't fetch it. This also guarantees the success
-        // handler can never apply the view over the URL's filters regardless of
-        // effect timing (LFE-10486).
-        !hasExplicitTableStateInUrl(router.query) &&
         (!isSystemPresetId(selectedViewId) || allowBackendSystemPresets),
     },
   );
@@ -370,15 +372,6 @@ export function useTableViewManager({
     const requestedViewId = selectedViewId;
     if (!requestedViewId) return;
     if (isInitializedRef.current) return;
-    // Explicit URL state wins over the saved view (the URL is the source of
-    // truth). Guard here too — not just in the query `enabled` — so cached view
-    // data can never be applied over the URL's filters on the first render
-    // regardless of effect timing (LFE-10486).
-    if (hasExplicitTableStateInUrl(router.query)) {
-      setIsInitialized(true);
-      setIsLoading(false);
-      return;
-    }
     if (selectedViewIdRef.current !== requestedViewId) return;
     if (selectedViewData.id !== requestedViewId) return;
     if (!isViewApplicableToTable(tableName, selectedViewData.tableName)) {
@@ -393,12 +386,25 @@ export function useTableViewManager({
       name: selectedViewData.name,
     });
 
-    applyViewState(selectedViewData);
+    if (hasExplicitTableStateInUrl(router.query)) {
+      // The URL is authoritative for filters/sort/search, so do NOT apply the
+      // view's stored filters over them. The column layout, however, is
+      // per-user localStorage that the URL does not carry — apply it from the
+      // view so a shared "view + in-view edits" link still renders the view's
+      // columns instead of the recipient's own (LFE-10486).
+      if (selectedViewData.columnOrder)
+        setColumnOrder(selectedViewData.columnOrder);
+      if (selectedViewData.columnVisibility)
+        setColumnVisibility(selectedViewData.columnVisibility);
+    } else {
+      applyViewState(selectedViewData);
+    }
     if (storedViewId !== requestedViewId) {
       setStoredViewId(requestedViewId);
     }
     isInitializedRef.current = true;
     setIsInitialized(true);
+    setIsLoading(false);
   }, [
     disabled,
     isSelectedViewSuccess,
@@ -409,6 +415,8 @@ export function useTableViewManager({
     capture,
     tableName,
     applyViewState,
+    setColumnOrder,
+    setColumnVisibility,
     storedViewId,
     setStoredViewId,
   ]);

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -466,6 +466,7 @@ export function useTableViewManager({
       isLoading: false,
       applyViewState: () => {},
       handleSetViewId: () => {},
+      markViewApplied: () => {},
       selectedViewId: null,
       appliedViewId: null,
       defaultViewScope: null,
@@ -476,6 +477,12 @@ export function useTableViewManager({
     isLoading,
     applyViewState,
     handleSetViewId,
+    // Lets callers that put the live table state into a view *without* going
+    // through applyViewState — notably creating a view, whose columns equal the
+    // current state by construction — record it as applied, so a follow-up
+    // "Update view" trusts the live columns instead of treating it like a
+    // shared-link visit (LFE-10486).
+    markViewApplied: setAppliedViewId,
     selectedViewId,
     appliedViewId,
     defaultViewScope: resolvedDefault?.scope ?? null,

--- a/web/src/components/table/table-view-presets/hooks/useViewMutations.ts
+++ b/web/src/components/table/table-view-presets/hooks/useViewMutations.ts
@@ -1,4 +1,5 @@
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { api } from "@/src/utils/api";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 
@@ -47,11 +48,22 @@ export const useViewMutations = ({
   const generatePermalinkMutation =
     api.TableViewPresets.generatePermalink.useMutation({
       onSuccess: (data) => {
-        copyTextToClipboard(data);
-        showSuccessToast({
-          title: "Permalink copied to clipboard",
-          description: "You can now share the permalink with others",
-        });
+        // Toast on the clipboard write's resolution so a permission failure
+        // surfaces an error instead of falsely reporting success.
+        copyTextToClipboard(data)
+          .then(() =>
+            showSuccessToast({
+              title: "Permalink copied to clipboard",
+              description: "You can now share the permalink with others",
+            }),
+          )
+          .catch(() =>
+            showErrorToast(
+              "Failed to copy permalink",
+              "Could not write to the clipboard. Please copy the link manually.",
+              "WARNING",
+            ),
+          );
       },
     });
 

--- a/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
+++ b/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
@@ -373,8 +373,10 @@ describe("Saved view restore with implicit environment defaults", () => {
       query: { viewId: "view-1", filter: encodedFilters },
     });
 
-    // The view also carries a column layout, which is per-user localStorage and
-    // not encoded in the URL.
+    // The view also carries a column layout. It must NOT be applied here:
+    // column order/visibility are the visitor's own per-table localStorage, and
+    // opening a shared link is not a deliberate action — applying the view's
+    // columns would silently overwrite the visitor's saved layout.
     const setColumnOrder = vi.fn();
     const setColumnVisibility = vi.fn();
     mockGetByIdUseQuery.mockReturnValue({
@@ -418,10 +420,10 @@ describe("Saved view restore with implicit environment defaults", () => {
     // The viewId stays in the URL as a provenance reference so the drawer can
     // still show the view the link came from.
     expect(queryParamStore.get("viewId")).toBe("view-1");
-    // The view's column layout is NOT carried by the URL, so it must still be
-    // applied from the view — otherwise the recipient keeps their own columns.
-    expect(setColumnOrder).toHaveBeenCalledWith(["name", "latency"]);
-    expect(setColumnVisibility).toHaveBeenCalledWith({ input: false });
+    // The view is not applied over explicit URL state, so the visitor's own
+    // column layout is left untouched (no localStorage mutation on link open).
+    expect(setColumnOrder).not.toHaveBeenCalled();
+    expect(setColumnVisibility).not.toHaveBeenCalled();
   });
 
   it("does not apply a default saved view over explicit URL filters", async () => {

--- a/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
+++ b/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
@@ -346,6 +346,46 @@ describe("Saved view restore with implicit environment defaults", () => {
     );
   });
 
+  it("applies explicit URL filters over the saved view when both viewId and filter are present (LFE-10486)", async () => {
+    // A shared "saved view + in-view filter edits" link carries both the
+    // viewId (provenance) and an explicit, edited filter. The edited filter
+    // must win; the saved view's stored filter must not overwrite it.
+    const explicitUrlFilters: FilterState = [
+      {
+        column: "name",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["search"],
+      },
+    ];
+    const encodedFilters = encodeFiltersGeneric(explicitUrlFilters);
+
+    queryParamStore.set("viewId", "view-1");
+    queryParamStore.set("filter", encodedFilters);
+    mockUseRouter.mockReturnValue({
+      isReady: true,
+      query: { viewId: "view-1", filter: encodedFilters },
+    });
+
+    render(<SavedViewHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading-state").textContent).toBe("ready");
+    });
+
+    // The URL's filter ("search") wins over the saved view's stored filter
+    // ("checkout" from OLD_SAVED_VIEW_FILTERS).
+    expect(screen.getByTestId("explicit-state").textContent).toContain(
+      "search",
+    );
+    expect(screen.getByTestId("explicit-state").textContent).not.toContain(
+      "checkout",
+    );
+    // The viewId stays in the URL as a provenance reference so the drawer can
+    // still show the view the link came from.
+    expect(queryParamStore.get("viewId")).toBe("view-1");
+  });
+
   it("does not apply a default saved view over explicit URL filters", async () => {
     const explicitUrlFilters: FilterState = [
       {

--- a/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
+++ b/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
@@ -174,7 +174,13 @@ const TEST_OPTIONS = {
   name: ["checkout", "search"],
 };
 
-function SavedViewHarness() {
+function SavedViewHarness({
+  setColumnOrder = () => {},
+  setColumnVisibility = () => {},
+}: {
+  setColumnOrder?: (columnOrder: string[]) => void;
+  setColumnVisibility?: (columnVisibility: Record<string, boolean>) => void;
+} = {}) {
   const queryFilter = useSidebarFilterState(TEST_FILTER_CONFIG, TEST_OPTIONS, {
     stateLocation: "urlAndSessionStorage",
     sessionFilterContextId: null,
@@ -188,8 +194,8 @@ function SavedViewHarness() {
     projectId: "project-1",
     stateUpdaters: {
       setFilters: queryFilter.setFilterState,
-      setColumnOrder: () => {},
-      setColumnVisibility: () => {},
+      setColumnOrder,
+      setColumnVisibility,
     },
     validationContext: {
       columns: [],
@@ -367,7 +373,35 @@ describe("Saved view restore with implicit environment defaults", () => {
       query: { viewId: "view-1", filter: encodedFilters },
     });
 
-    render(<SavedViewHarness />);
+    // The view also carries a column layout, which is per-user localStorage and
+    // not encoded in the URL.
+    const setColumnOrder = vi.fn();
+    const setColumnVisibility = vi.fn();
+    mockGetByIdUseQuery.mockReturnValue({
+      data: {
+        id: "view-1",
+        name: "View with columns",
+        tableName: TableViewPresetTableName.Traces,
+        projectId: "project-1",
+        orderBy: null,
+        filters: OLD_SAVED_VIEW_FILTERS,
+        columnOrder: ["name", "latency"],
+        columnVisibility: { input: false },
+        searchQuery: "",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        createdBy: "user-1",
+        createdByUser: null,
+      },
+      error: null,
+    });
+
+    render(
+      <SavedViewHarness
+        setColumnOrder={setColumnOrder}
+        setColumnVisibility={setColumnVisibility}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId("loading-state").textContent).toBe("ready");
@@ -384,6 +418,10 @@ describe("Saved view restore with implicit environment defaults", () => {
     // The viewId stays in the URL as a provenance reference so the drawer can
     // still show the view the link came from.
     expect(queryParamStore.get("viewId")).toBe("view-1");
+    // The view's column layout is NOT carried by the URL, so it must still be
+    // applied from the view — otherwise the recipient keeps their own columns.
+    expect(setColumnOrder).toHaveBeenCalledWith(["name", "latency"]);
+    expect(setColumnVisibility).toHaveBeenCalledWith({ input: false });
   });
 
   it("does not apply a default saved view over explicit URL filters", async () => {

--- a/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
+++ b/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
@@ -189,7 +189,7 @@ function SavedViewHarness({
     },
   });
 
-  const { isLoading } = useTableViewManager({
+  const { isLoading, appliedViewId } = useTableViewManager({
     tableName: TableViewPresetTableName.Traces,
     projectId: "project-1",
     stateUpdaters: {
@@ -209,6 +209,7 @@ function SavedViewHarness({
   return (
     <div>
       <div data-testid="loading-state">{isLoading ? "loading" : "ready"}</div>
+      <div data-testid="applied-view-id">{appliedViewId ?? "null"}</div>
       <pre data-testid="explicit-state">
         {JSON.stringify(queryFilter.explicitFilterState)}
       </pre>
@@ -424,6 +425,35 @@ describe("Saved view restore with implicit environment defaults", () => {
     // column layout is left untouched (no localStorage mutation on link open).
     expect(setColumnOrder).not.toHaveBeenCalled();
     expect(setColumnVisibility).not.toHaveBeenCalled();
+    // On a fresh shared-link visit the view is NOT recognised as applied, so
+    // "Update view" would preserve the view's stored columns (not the
+    // visitor's). Contrast with the reload-of-applied-view test below.
+    expect(screen.getByTestId("applied-view-id").textContent).toBe("null");
+  });
+
+  it("recognises a reload of an applied view as applied so Update keeps live columns (LFE-10486)", async () => {
+    // Reload after a view was applied: the URL carries the viewId AND the
+    // view's hydrated filters, and the session still remembers X as active.
+    // The explicit-URL-state short-circuit means the view is not re-applied,
+    // but it must still be recognised as the applied view — otherwise a
+    // column reorder + "Update view" would silently discard the reorder and
+    // save the stored snapshot instead.
+    const hydratedFilters = encodeFiltersGeneric(OLD_SAVED_VIEW_FILTERS);
+    queryParamStore.set("viewId", "view-1");
+    queryParamStore.set("filter", hydratedFilters);
+    mockUseRouter.mockReturnValue({
+      isReady: true,
+      query: { viewId: "view-1", filter: hydratedFilters },
+    });
+    sessionStorage.setItem("traces-project-1-viewId", JSON.stringify("view-1"));
+
+    render(<SavedViewHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading-state").textContent).toBe("ready");
+    });
+
+    expect(screen.getByTestId("applied-view-id").textContent).toBe("view-1");
   });
 
   it("does not apply a default saved view over explicit URL filters", async () => {


### PR DESCRIPTION
## TL;DR
Shared saved-view links now carry the filters you actually have applied. The URL is the single source of truth for a table's filters/sort/search; a saved view hydrates **into** the URL and `viewId` becomes a provenance reference. Fixes **LFE-10486** (share) and the saved-view load fragility behind **LFE-7389**.

## Why
A customer reported that they opened a saved view, changed the filters, and shared the link — the recipient got the **unfiltered/stale** view. Reproduced live: the "Link" button builds a server permalink of the form `?viewId=X`, which points at the saved view's **stored** state and silently drops any in-view edits. Worse, even a link that *did* carry an explicit filter (`?viewId=X&filter=…`) was overwritten on load — the view was fetched and re-applied over the URL's filters.

Root cause (as framed in the ticket): **the URL did not represent the filters actually applied when a saved view was active.**

## What
Three changes, all in shared saved-view code (no per-table churn, no URL-schema change → backward-compatible):

1. **Share carries applied state** — the active view's "Link" button copies the current page URL (which already encodes the applied filters/sort/search) instead of a `?viewId=X`-only permalink. Non-active views still get a clean link to the saved view.
2. **Explicit URL state wins over the view** — opening `?viewId=X&filter=…` applies the URL's filters and keeps `viewId` only as provenance (drawer still shows the view). The view is no longer fetched/applied over explicit URL state. Preserves deep-link precedence (#13865).
3. **Deterministic load unlock (LFE-7389)** — removed the fragile filter-propagation lock-observer that could leave a table showing unfiltered rows or never unlock; the sidebar filter hook is optimistic, so the table unlocks as soon as the view is applied.

## Result
- Share a view with edits → recipient sees **exactly** those edits, applied immediately (a single, correct query — no flash, no overwrite). The drawer shows the originating view.
- Opening a saved view still hydrates its filters into the URL and applies them on load.
- `?filter`/`?orderBy`/`?search` encoding is unchanged → all existing links keep working.

<details>
<summary>Mechanism, scope & verification</summary>

**Files**
- `useTableViewManager.ts` — resolve effect now checks `hasExplicitTableStateInUrl` **before** resolving a `viewId`; `getById` is disabled and the success handler short-circuits when explicit URL state is present (belt-and-suspenders against cached data / effect-timing); removed `pendingFiltersRef`/`pendingFiltersPreviousStateRef` and the lock-observer effect; `applyViewState` unlocks deterministically.
- `data-table-view-presets-drawer.tsx` — active view's permalink = current URL.
- `savedViewImplicitEnvironmentRegression.clienttest.tsx` — added a precedence test (viewId + explicit filter → URL filter wins, viewId preserved).

**Shared by all saved-view tables**: traces/events (v4), observations, scores, sessions, datasets, experiments — the change lives in the shared hook + drawer.

**Verified (Playwright against a live dev server, v4 events table at `/traces` + sessions):**
- Share: active-view "Link" copies `…?viewId=X&filter=…` (clipboard asserted == current URL).
- Recipient: opening a shared link where the edit (`name=generation-2`) differs from the saved view (`environment=langfuse-evaluation`) → the **edit** is applied, **one** query fires, no overwrite, drawer shows the view.
- Load: bare navigation with a default view, and `?viewId=X` permalink, both hydrate the view's filter into the URL and apply it; table reaches "ready" (no stuck spinner).
- No-view common case and a second table (sessions) confirmed unaffected.
- `pnpm --filter web run typecheck` clean; full `turbo run lint` clean; filters clienttests **106 passed** (incl. the new precedence test).

**Invariants preserved**: deep-link precedence (#13865), multi-view, default-clear, managed-environment policy, project/tenant scoping, cross-table applicability/namespace guards.

**Backward-compatibility / follow-ups**: the session-storage filter fallback is retained (cross-nav persistence unchanged). This lands the URL-as-source-of-truth **foundation**; rolling the new grammar Filter Search Bar onto every view is the follow-on program built on top of it. Kept changes off files touched by #14515 (nested AND/OR filters) to ease whatever merge order wins.

**Note on the v4 transition**: `/traces` now renders the v4 EventsTable (`observations-events`); old `table_name='traces'` saved views are not applicable to it and are cleared on load — orthogonal to this fix, flagging for awareness.
</details>

Related: #13865 (deep-link precedence), #14515 (nested filter bar — possible merge-order overlap), seeds LFE-10486 / LFE-7389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the URL the single source of truth for applied table filters when a saved view is active. The active view's "Link" button now copies `window.location.href` (which includes any in-view edits) instead of a server-built `?viewId=X`-only permalink, and opening a URL that contains both `viewId` and explicit filter/search/orderBy params now applies the URL state and skips fetching/applying the saved view's stored state.

- **Drawer permalink fix**: `handleGeneratePermalink` short-circuits for the currently active view, copying the full page URL so shared links carry any in-view filter edits (LFE-10486).
- **Hook precedence fix**: Three-layer guard (`enabled` flag, resolve effect, success effect) ensures `hasExplicitTableStateInUrl` always wins over a `viewId` hydration, with `viewId` kept as a provenance reference for the drawer.
- **Lock observer removal**: The fragile `pendingFiltersRef` / `pendingFiltersPreviousStateRef` observer (LFE-7389) is replaced with a deterministic `setIsLoading(false)` at the end of `applyViewState`, justified by the sidebar filter hook's optimistic (synchronous) propagation semantics.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The three-layer guard around hasExplicitTableStateInUrl is robust, the deterministic unlock is justified by the optimistic filter-hook semantics, and the test additions cover the core regression. The only actionable finding is an unawaited clipboard promise that can show a false-positive success toast on clipboard permission failure.

The URL-as-source-of-truth refactor is well-reasoned and the belt-and-suspenders approach (enabled flag, resolve effect, and success effect all check hasExplicitTableStateInUrl) makes it resistant to race conditions and cached data. Removal of the fragile lock observer is a clean improvement. The unawaited copyTextToClipboard call in the active-view share path is a minor reliability gap — clipboard failure shows a success toast — but it has no data-loss or security risk and matches patterns elsewhere in the codebase. router.query added as a success-effect dependency is safe but creates slightly more effect churn on URL changes; ref guards prevent double application.

useTableViewManager.ts warrants a second read on the router.query dependency in the isSelectedViewSuccess effect — it is safe but subtle. The drawer's handleGeneratePermalink change is straightforward.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Drawer as ViewPresetsDrawer
    participant Hook as useTableViewManager
    participant Router as Next.js Router
    participant API as tRPC getById

    Note over User,API: Share active view with in-view edits (LFE-10486 fix)
    User->>Drawer: Click Link on active view
    Drawer->>Router: Read window.location.href includes viewId plus filter
    Drawer->>User: copyTextToClipboard full URL and show success toast

    Note over User,API: Recipient opens shared link with viewId and filter
    User->>Router: "Navigate to URL with viewId=X and filter=Y"
    Router->>Hook: "isRouterReady=true, query has both filter and viewId"
    Hook->>Hook: "resolve effect detects hasExplicitTableStateInUrl=true"
    Hook->>Hook: setIsInitialized(true) and setIsLoading(false) immediately
    Hook->>API: getById query is disabled because explicit URL state present
    Hook->>Drawer: "selectedViewId=X so drawer shows originating view"
    Hook->>User: Table renders with URL filters only, no view overwrite

    Note over User,API: Open bare permalink with viewId only
    User->>Router: "Navigate to URL with viewId=X only"
    Router->>Hook: query has only viewId, no filter or search or orderBy
    Hook->>Hook: resolve effect sees no explicit state, returns to await fetch
    Hook->>API: "getById enabled=true, fetch view data"
    API-->>Hook: view data with stored filters
    Hook->>Hook: success effect applies view state via applyViewState
    Hook->>Router: setFilters updates URL to include stored filters
    Hook->>Hook: setIsLoading(false) deterministic unlock
    Hook->>User: Table renders with saved view filters applied
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Drawer as ViewPresetsDrawer
    participant Hook as useTableViewManager
    participant Router as Next.js Router
    participant API as tRPC getById

    Note over User,API: Share active view with in-view edits (LFE-10486 fix)
    User->>Drawer: Click Link on active view
    Drawer->>Router: Read window.location.href includes viewId plus filter
    Drawer->>User: copyTextToClipboard full URL and show success toast

    Note over User,API: Recipient opens shared link with viewId and filter
    User->>Router: "Navigate to URL with viewId=X and filter=Y"
    Router->>Hook: "isRouterReady=true, query has both filter and viewId"
    Hook->>Hook: "resolve effect detects hasExplicitTableStateInUrl=true"
    Hook->>Hook: setIsInitialized(true) and setIsLoading(false) immediately
    Hook->>API: getById query is disabled because explicit URL state present
    Hook->>Drawer: "selectedViewId=X so drawer shows originating view"
    Hook->>User: Table renders with URL filters only, no view overwrite

    Note over User,API: Open bare permalink with viewId only
    User->>Router: "Navigate to URL with viewId=X only"
    Router->>Hook: query has only viewId, no filter or search or orderBy
    Hook->>Hook: resolve effect sees no explicit state, returns to await fetch
    Hook->>API: "getById enabled=true, fetch view data"
    API-->>Hook: view data with stored filters
    Hook->>Hook: success effect applies view state via applyViewState
    Hook->>Router: setFilters updates URL to include stored filters
    Hook->>Hook: setIsLoading(false) deterministic unlock
    Hook->>User: Table renders with saved view filters applied
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx:372-377
**Unawaited clipboard promise swallows copy failures**

`copyTextToClipboard` is async (`navigator.clipboard.writeText` returns a `Promise`). Calling it without `await` means a permission-denied error (e.g. the user revoked clipboard access) is silently swallowed and `showSuccessToast` is shown unconditionally — the user sees "Permalink copied" even though nothing was written to the clipboard. Consider awaiting the promise and showing an error toast in the catch path, similar to how `useCopyToClipboard.ts` handles this.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(table-views): apply a saved view&#39;s c..."](https://github.com/langfuse/langfuse/commit/4af8c3564c0cc4fa5f8f73d910e49a49785c95c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39559554)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
