### PR TITLE
feat(web): reflect Parquet export-tuning override in blob-storage settings (LFE-10463)

### DIFF
--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -117,10 +117,25 @@ const legacyDescriptionForGroup = (
     : "Not included in the legacy observations export";
 };
 
+// The Parquet export path (ClickHouse-native FORMAT Parquet) runs no JS
+// enrichment, so the model-price columns (MODEL_ENRICHMENT_FIELDS) are absent.
+// Drop them from the model group description; all other groups are unchanged.
+const parquetDescriptionForGroup = (
+  group: ObservationFieldGroupFull,
+): string => {
+  const base = EXPORT_FIELD_GROUP_LABELS[group].description;
+  if (group !== "model") return base;
+  return base
+    .split(", ")
+    .filter((field) => !MODEL_ENRICHMENT_FIELDS.includes(field))
+    .join(", ");
+};
+
 export const EXPORT_FIELD_GROUP_OPTIONS = OBSERVATION_FIELD_GROUPS_FULL.map(
   (value) => ({
     value,
     ...EXPORT_FIELD_GROUP_LABELS[value],
     legacyDescription: legacyDescriptionForGroup(value),
+    parquetDescription: parquetDescriptionForGroup(value),
   }),
 );

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import {
   type BlobStorageIntegrationFormSchema,
   blobStorageIntegrationFormSchema,
+  parquetEnabledFromTuning,
 } from "@/src/features/blobstorage-integration/types";
 import {
   AnalyticsIntegrationExportSource,
@@ -11,6 +12,7 @@ import {
   BlobStorageExportMode,
   BlobStorageIntegrationFileType,
   BlobStorageIntegrationType,
+  EXPORT_FIELD_GROUP_OPTIONS,
 } from "@langfuse/shared";
 
 const VALID_BASE: BlobStorageIntegrationFormSchema = {
@@ -84,5 +86,45 @@ describe("blob storage form — exportFieldGroups validation", () => {
     });
 
     expect(onSubmit).toHaveBeenCalledOnce();
+  });
+});
+
+describe("parquetEnabledFromTuning", () => {
+  it.each([
+    [{ parquet: true }, true],
+    [{ parquet: true, gzipLevel: 1 }, true],
+    [{ parquet: false }, false],
+    [{ gzipLevel: 1 }, false],
+    [{}, false],
+    [null, false],
+    [undefined, false],
+    ["parquet", false],
+    [["parquet"], false],
+  ])("returns %s for %o", (input, expected) => {
+    expect(parquetEnabledFromTuning(input)).toBe(expected);
+  });
+});
+
+describe("EXPORT_FIELD_GROUP_OPTIONS — parquet description", () => {
+  const PRICE_FIELDS = ["input_price", "output_price", "total_price"];
+  const model = EXPORT_FIELD_GROUP_OPTIONS.find((o) => o.value === "model")!;
+
+  it("model group lists price columns in the standard description", () => {
+    expect(PRICE_FIELDS.every((f) => model.description.includes(f))).toBe(true);
+  });
+
+  it("model group drops price columns in the parquet description", () => {
+    expect(PRICE_FIELDS.some((f) => model.parquetDescription.includes(f))).toBe(
+      false,
+    );
+    // Non-price model columns are preserved.
+    expect(model.parquetDescription).toContain("provided_model_name");
+  });
+
+  it("non-model groups have identical standard and parquet descriptions", () => {
+    for (const option of EXPORT_FIELD_GROUP_OPTIONS) {
+      if (option.value === "model") continue;
+      expect(option.parquetDescription).toBe(option.description);
+    }
   });
 });

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -52,6 +52,22 @@ export const blobStorageIntegrationFormSchemaBase = z.object({
   compressed: z.boolean().default(true),
 });
 
+// Reads the persisted `exportTuning` JSON column (client-safe, no server deps)
+// to reflect the Parquet override in the settings form. `exportTuning` is an
+// internal, DB-set knob with no UI write path; when `parquet` is true the worker
+// overrides `fileType` and `compressed` (Parquet compresses internally) — see
+// `blob-export-tuning.ts`. Mirrors the worker-side `resolveBlobExportTuning`
+// parquet semantics: anything that is not an object with `parquet === true` is
+// treated as off.
+export function parquetEnabledFromTuning(exportTuning: unknown): boolean {
+  return (
+    typeof exportTuning === "object" &&
+    exportTuning !== null &&
+    !Array.isArray(exportTuning) &&
+    (exportTuning as Record<string, unknown>).parquet === true
+  );
+}
+
 export const blobStorageIntegrationFormSchema =
   blobStorageIntegrationFormSchemaBase
     .superRefine(validateAzureContainerName)

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -30,6 +30,7 @@ import {
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import {
   blobStorageIntegrationFormSchema,
+  parquetEnabledFromTuning,
   type BlobStorageIntegrationFormSchema,
   type BlobStorageSyncStatus,
 } from "@/src/features/blobstorage-integration/types";
@@ -373,6 +374,11 @@ const BlobStorageIntegrationSettingsForm = ({
 
   const watchedExportMode = blobStorageForm.watch("exportMode");
   const watchedExportSource = blobStorageForm.watch("exportSource");
+  // Parquet is an internal, DB-set `exportTuning` override with no UI write path.
+  // The form reflects it read-only: when active it forces the format to Parquet
+  // (overriding the persisted fileType + gzip), so the selectors below are
+  // locked/hidden and the model group drops its enrichment-only price columns.
+  const isParquetOverride = parquetEnabledFromTuning(state?.exportTuning);
   const exportSourceOptions = getExportSourceOptions(
     state?.exportSource,
     availability,
@@ -700,7 +706,14 @@ const BlobStorageIntegrationSettingsForm = ({
             <FormItem>
               <FormLabel>File Type</FormLabel>
               <FormControl>
-                <Select value={field.value} onValueChange={field.onChange}>
+                {/* When the Parquet override is active the selector is locked to
+                    a synthetic "PARQUET" value (not a BlobStorageIntegrationFileType);
+                    the persisted fileType is preserved but ignored by the worker. */}
+                <Select
+                  value={isParquetOverride ? "PARQUET" : field.value}
+                  onValueChange={field.onChange}
+                  disabled={isParquetOverride}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="Select file type" />
                   </SelectTrigger>
@@ -708,11 +721,16 @@ const BlobStorageIntegrationSettingsForm = ({
                     <SelectItem value="JSONL">JSONL</SelectItem>
                     <SelectItem value="CSV">CSV</SelectItem>
                     <SelectItem value="JSON">JSON</SelectItem>
+                    {isParquetOverride && (
+                      <SelectItem value="PARQUET">Parquet</SelectItem>
+                    )}
                   </SelectContent>
                 </Select>
               </FormControl>
               <FormDescription>
-                The file format for exported data.
+                {isParquetOverride
+                  ? "Exporting as Apache Parquet — a columnar binary format encoded and compressed by ClickHouse. This is configured for your project and overrides the file type and compression below."
+                  : "The file format for exported data."}
               </FormDescription>
               <FormMessage />
             </FormItem>
@@ -899,9 +917,11 @@ const BlobStorageIntegrationSettingsForm = ({
                           )}
                         </div>
                         <div className="text-muted-foreground text-xs">
-                          {isLegacyOnlyExport
-                            ? option.legacyDescription
-                            : option.description}
+                          {isParquetOverride
+                            ? option.parquetDescription
+                            : isLegacyOnlyExport
+                              ? option.legacyDescription
+                              : option.description}
                         </div>
                       </label>
                     </div>
@@ -952,26 +972,31 @@ const BlobStorageIntegrationSettingsForm = ({
           />
         )}
 
-        <FormField
-          control={blobStorageForm.control}
-          name="compressed"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Gzip Compression</FormLabel>
-              <FormControl>
-                <Switch
-                  checked={field.value}
-                  onCheckedChange={field.onChange}
-                  className="mt-1 ml-4"
-                />
-              </FormControl>
-              <FormDescription>
-                Compress exported files with gzip (.csv.gz, .json.gz, .jsonl.gz)
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        {/* Gzip is meaningless for Parquet (ClickHouse compresses it
+            internally); the worker ignores `compressed` on that path. */}
+        {!isParquetOverride && (
+          <FormField
+            control={blobStorageForm.control}
+            name="compressed"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Gzip Compression</FormLabel>
+                <FormControl>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    className="mt-1 ml-4"
+                  />
+                </FormControl>
+                <FormDescription>
+                  Compress exported files with gzip (.csv.gz, .json.gz,
+                  .jsonl.gz)
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
 
         <FormField
           control={blobStorageForm.control}


### PR DESCRIPTION
## What does this PR do?

Surfaces the ClickHouse-native **Parquet** blob-export format (added in #14509, LFE-10463) in the Blob Storage Integration settings page.

Parquet is an **internal, DB-set** `exportTuning.parquet` knob with no UI write path. When set, the worker already overrides the file format — it always produces a `.parquet` artifact and ignores `fileType`/`compressed`. This PR makes the settings form **reflect that override read-only** so the UI doesn't misrepresent what will be exported. It is a deliberately lightweight, removable interim surface — if Parquet later becomes a first-class `fileType` option, this reflection goes away.

When the override is active, the form:
- locks the **File Type** selector to "Parquet" with an explanatory description,
- hides the **Gzip Compression** toggle (Parquet compresses internally),
- drops the enrichment-only price columns (`input_price`, `output_price`, `total_price`) from the **Model** field group — they're absent from Parquet exports because the ClickHouse-native path runs no JS enrichment.

Implementation:
- **shared** (`analytics-integrations/index.ts`): derive a `parquetDescription` per export field group (only the model group differs), alongside the existing `legacyDescription`.
- **web** (`blobstorage-integration/types.ts`): `parquetEnabledFromTuning()` reads the persisted `exportTuning` column; the settings page keys the three UI changes off it.

No Postgres enum/schema migration, no public API change, no Fern change, no worker change.

Fixes # (LFE-10463)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Added client tests: `parquetEnabledFromTuning` truthiness + the Model-group parquet description (drops prices; other groups unchanged). 19 client tests pass.
- `pnpm turbo run typecheck lint --filter=web --filter=@langfuse/shared` pass.
- Browser review of the read-only reflection (requires an integration with `exportTuning.parquet=true` in the DB) is still recommended before merge — not run in this environment.
