### PR TITLE
feat(filters): surface selected options at the top of the filter sidebar

### DIFF
--- a/web/src/components/table/data-table-controls.clienttest.tsx
+++ b/web/src/components/table/data-table-controls.clienttest.tsx
@@ -86,6 +86,66 @@ describe("CategoricalFacet", () => {
     ).toBeTruthy();
   });
 
+  it("keeps the 'Show more' cap when every option is reported selected (no-filter default)", () => {
+    // useSidebarFilterState returns value === options when no filter is applied
+    // (computeSelectedValues). That all-selected default must NOT be treated as
+    // a pinned selection — doing so would render the entire list with no cap.
+    const options = Array.from({ length: 20 }, (_, i) => `opt-${i}`);
+    render(
+      <Accordion type="multiple" value={["c"]}>
+        <CategoricalFacet
+          label="C"
+          filterKey="c"
+          expanded
+          loading={false}
+          options={options}
+          counts={new Map()}
+          value={options}
+          onChange={() => {}}
+          isActive={false}
+          isDisabled={false}
+          onReset={() => {}}
+        />
+      </Accordion>,
+    );
+
+    // The cap is preserved: "Show more" still renders and a deep value stays hidden.
+    expect(
+      screen.getByRole("button", { name: "Show more values" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("opt-19")).not.toBeInTheDocument();
+  });
+
+  it("never bypasses the cap, even for a large selection", () => {
+    // A large selection (e.g. a "none of" include-set) must still respect the
+    // visible-count cap rather than dumping every value into the DOM.
+    const options = Array.from({ length: 20 }, (_, i) => `opt-${i}`);
+    const selected = options.slice(0, 18); // 18 of 20 selected
+    render(
+      <Accordion type="multiple" value={["c"]}>
+        <CategoricalFacet
+          label="C"
+          filterKey="c"
+          expanded
+          loading={false}
+          options={options}
+          counts={new Map()}
+          value={selected}
+          onChange={() => {}}
+          isActive
+          isDisabled={false}
+          onReset={() => {}}
+        />
+      </Accordion>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Show more values" }),
+    ).toBeInTheDocument();
+    // Only the capped number of rows render, not all 18 selected.
+    expect(screen.getAllByRole("checkbox").length).toBeLessThanOrEqual(12);
+  });
+
   it("does not reorder short, fully-visible lists", () => {
     render(
       <Accordion type="multiple" value={["c"]}>

--- a/web/src/components/table/data-table-controls.clienttest.tsx
+++ b/web/src/components/table/data-table-controls.clienttest.tsx
@@ -47,4 +47,70 @@ describe("CategoricalFacet", () => {
 
     expect(screen.getByLabelText("Clear Type filter")).toBeInTheDocument();
   });
+
+  it("pins a selected option to the top of a long list so it is visible without 'Show more'", () => {
+    // 20 options, one selected near the bottom. Without pinning the selected
+    // value sits below the 12-item cap and is hidden behind "Show more".
+    const options = Array.from({ length: 20 }, (_, i) => `opt-${i}`);
+    render(
+      <Accordion type="multiple" value={["c"]}>
+        <CategoricalFacet
+          label="C"
+          filterKey="c"
+          expanded
+          loading={false}
+          options={options}
+          counts={new Map()}
+          value={["opt-18"]}
+          onChange={() => {}}
+          isActive
+          isDisabled={false}
+          onReset={() => {}}
+        />
+      </Accordion>,
+    );
+
+    // The list is long enough to be capped...
+    expect(
+      screen.getByRole("button", { name: "Show more values" }),
+    ).toBeInTheDocument();
+
+    // ...yet the selected value is shown despite sitting at position 19,
+    // and it precedes the first unselected option in DOM order (pinned to top).
+    const selected = screen.getByText("opt-18");
+    const firstUnselected = screen.getByText("opt-0");
+    expect(selected).toBeInTheDocument();
+    expect(
+      selected.compareDocumentPosition(firstUnselected) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("does not reorder short, fully-visible lists", () => {
+    render(
+      <Accordion type="multiple" value={["c"]}>
+        <CategoricalFacet
+          label="C"
+          filterKey="c"
+          expanded
+          loading={false}
+          options={["a", "b", "c"]}
+          counts={new Map()}
+          value={["c"]}
+          onChange={() => {}}
+          isActive
+          isDisabled={false}
+          onReset={() => {}}
+        />
+      </Accordion>,
+    );
+
+    // No cap, no "Show more": the natural order is preserved (a, b, c) — the
+    // selected "c" is NOT pulled above "a".
+    const a = screen.getByText("a");
+    const c = screen.getByText("c");
+    expect(
+      a.compareDocumentPosition(c) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
 });

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -650,10 +650,48 @@ export function CategoricalFacet({
       })
     : visibleOptionValues;
 
-  const hasMoreFilteredOptions = filteredOptions.length > MAX_VISIBLE_OPTIONS;
-  const visibleOptions = showAll
-    ? filteredOptions
-    : filteredOptions.slice(0, MAX_VISIBLE_OPTIONS);
+  // Pin selected options to the top of the list so an applied filter is
+  // immediately visible — without scrolling or expanding "Show more" — even
+  // when the selected value sits far down a long list (LFE-10494). Selected
+  // options are always shown; the visible-count cap applies only to the
+  // unselected remainder. We only reorder long lists (more options than the
+  // cap), where burial can actually happen; short, fully-visible lists keep
+  // their natural order to avoid gratuitous reshuffling.
+  const selectedSet = new Set(value);
+  const pinSelected = hasMoreOptions;
+  const selectedOptions = pinSelected
+    ? filteredOptions.filter((option) => selectedSet.has(option))
+    : [];
+  const remainingOptions = pinSelected
+    ? filteredOptions.filter((option) => !selectedSet.has(option))
+    : filteredOptions;
+
+  const hasMoreFilteredOptions = remainingOptions.length > MAX_VISIBLE_OPTIONS;
+  const visibleRemainingOptions = showAll
+    ? remainingOptions
+    : remainingOptions.slice(0, MAX_VISIBLE_OPTIONS);
+
+  const renderOption = (option: string) => {
+    const displayLabel = displayByValue?.get(option) ?? option;
+    return (
+      <FilterValueCheckbox
+        key={option}
+        id={`${filterKey}-${option}`}
+        label={displayLabel}
+        icon={renderIcon?.(option)}
+        count={counts.get(option) || 0}
+        checked={value.includes(option)}
+        onCheckedChange={(checked) => {
+          const newValues = checked
+            ? [...value, option]
+            : value.filter((v: string) => v !== option);
+          onChange(newValues);
+        }}
+        onLabelClick={onOnlyChange ? () => onOnlyChange(option) : undefined}
+        totalSelected={value.length}
+      />
+    );
+  };
 
   return (
     <FilterAccordionItem
@@ -818,32 +856,20 @@ export function CategoricalFacet({
                   </div>
                 ) : (
                   <>
-                    {visibleOptions.map((option: string) => {
-                      const displayLabel =
-                        displayByValue?.get(option) ?? option;
-                      return (
-                        <FilterValueCheckbox
-                          key={option}
-                          id={`${filterKey}-${option}`}
-                          label={displayLabel}
-                          icon={renderIcon?.(option)}
-                          count={counts.get(option) || 0}
-                          checked={value.includes(option)}
-                          onCheckedChange={(checked) => {
-                            const newValues = checked
-                              ? [...value, option]
-                              : value.filter((v: string) => v !== option);
-                            onChange(newValues);
-                          }}
-                          onLabelClick={
-                            onOnlyChange
-                              ? () => onOnlyChange(option)
-                              : undefined
-                          }
-                          totalSelected={value.length}
+                    {/* Selected options, pinned to the top (long lists only) */}
+                    {selectedOptions.map(renderOption)}
+
+                    {/* Separator between the pinned selection and the rest */}
+                    {selectedOptions.length > 0 &&
+                      visibleRemainingOptions.length > 0 && (
+                        <div
+                          className="border-border/60 mx-3 my-1 border-t"
+                          aria-hidden
                         />
-                      );
-                    })}
+                      )}
+
+                    {/* Remaining (unselected) options, capped */}
+                    {visibleRemainingOptions.map(renderOption)}
                     {hasMoreFilteredOptions && !showAll && (
                       <div className="px-2">
                         <Button

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -650,26 +650,45 @@ export function CategoricalFacet({
       })
     : visibleOptionValues;
 
-  // Pin selected options to the top of the list so an applied filter is
+  // Order a genuine selection to the top of the list so an applied filter is
   // immediately visible — without scrolling or expanding "Show more" — even
-  // when the selected value sits far down a long list (LFE-10494). Selected
-  // options are always shown; the visible-count cap applies only to the
-  // unselected remainder. We only reorder long lists (more options than the
-  // cap), where burial can actually happen; short, fully-visible lists keep
-  // their natural order to avoid gratuitous reshuffling.
+  // when the selected value sits far down a long list (LFE-10494).
+  //
+  // Two guards keep this honest:
+  //   1. Only reorder long lists (more options than the cap) that carry a real,
+  //      strict-subset selection. `value` mirrors the hook's
+  //      `computeSelectedValues`, which reports EVERY option as "selected" when
+  //      no filter is applied (and the inverted set for `none of`). Requiring a
+  //      strict subset skips that all-selected default — otherwise the whole
+  //      list would be treated as pinned — and leaves short lists untouched.
+  //   2. The visible-count cap is applied to the COMBINED ordered list, so even
+  //      a large selection (many values, or a `none of` include-set) can never
+  //      render the entire list; "Show more" still gates the overflow.
   const selectedSet = new Set(value);
-  const pinSelected = hasMoreOptions;
-  const selectedOptions = pinSelected
-    ? filteredOptions.filter((option) => selectedSet.has(option))
-    : [];
-  const remainingOptions = pinSelected
-    ? filteredOptions.filter((option) => !selectedSet.has(option))
+  const pinSelected =
+    hasMoreOptions &&
+    value.length > 0 &&
+    value.length < visibleOptionValues.length;
+  const orderedOptions = pinSelected
+    ? [
+        ...filteredOptions.filter((option) => selectedSet.has(option)),
+        ...filteredOptions.filter((option) => !selectedSet.has(option)),
+      ]
     : filteredOptions;
 
-  const hasMoreFilteredOptions = remainingOptions.length > MAX_VISIBLE_OPTIONS;
-  const visibleRemainingOptions = showAll
-    ? remainingOptions
-    : remainingOptions.slice(0, MAX_VISIBLE_OPTIONS);
+  const hasMoreFilteredOptions = orderedOptions.length > MAX_VISIBLE_OPTIONS;
+  const visibleOptions = showAll
+    ? orderedOptions
+    : orderedOptions.slice(0, MAX_VISIBLE_OPTIONS);
+
+  // Split the visible slice so a separator can mark where the pinned selection
+  // ends. When not pinning, everything renders in natural order (no divider).
+  const visibleSelectedOptions = pinSelected
+    ? visibleOptions.filter((option) => selectedSet.has(option))
+    : [];
+  const visibleRemainingOptions = pinSelected
+    ? visibleOptions.filter((option) => !selectedSet.has(option))
+    : visibleOptions;
 
   const renderOption = (option: string) => {
     const displayLabel = displayByValue?.get(option) ?? option;
@@ -857,10 +876,10 @@ export function CategoricalFacet({
                 ) : (
                   <>
                     {/* Selected options, pinned to the top (long lists only) */}
-                    {selectedOptions.map(renderOption)}
+                    {visibleSelectedOptions.map(renderOption)}
 
                     {/* Separator between the pinned selection and the rest */}
-                    {selectedOptions.length > 0 &&
+                    {visibleSelectedOptions.length > 0 &&
                       visibleRemainingOptions.length > 0 && (
                         <div
                           className="border-border/60 mx-3 my-1 border-t"

--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -121,6 +121,13 @@ export const observationEventsFilterConfig: FilterConfig = {
       label: getEventsColumnName("name"),
     },
     {
+      // Tags are a primary, user-defined filter — keep them near the identity
+      // facets at the top of the sidebar rather than buried mid-list (LFE-10494).
+      type: "categorical" as const,
+      column: "traceTags",
+      label: getEventsColumnName("traceTags"),
+    },
+    {
       type: "categorical" as const,
       column: "level",
       label: getEventsColumnName("level"),
@@ -139,11 +146,6 @@ export const observationEventsFilterConfig: FilterConfig = {
       type: "categorical" as const,
       column: "promptName",
       label: getEventsColumnName("promptName"),
-    },
-    {
-      type: "categorical" as const,
-      column: "traceTags",
-      label: getEventsColumnName("traceTags"),
     },
     {
       type: "stringKeyValue" as const,

--- a/web/src/features/filters/config/observations-config.ts
+++ b/web/src/features/filters/config/observations-config.ts
@@ -46,6 +46,13 @@ export const observationFilterConfig: FilterConfig = {
       label: "Trace Name",
     },
     {
+      // Tags are a primary, user-defined filter — keep them near the identity
+      // facets at the top of the sidebar rather than buried mid-list (LFE-10494).
+      type: "categorical" as const,
+      column: "tags",
+      label: "Trace Tags",
+    },
+    {
       type: "categorical" as const,
       column: "level",
       label: "Level",
@@ -64,11 +71,6 @@ export const observationFilterConfig: FilterConfig = {
       type: "categorical" as const,
       column: "promptName",
       label: "Prompt Name",
-    },
-    {
-      type: "categorical" as const,
-      column: "tags",
-      label: "Trace Tags",
     },
     {
       type: "stringKeyValue" as const,

--- a/web/src/features/filters/config/traces-config.ts
+++ b/web/src/features/filters/config/traces-config.ts
@@ -40,6 +40,13 @@ export const traceFilterConfig: FilterConfig = {
       label: "Session ID",
     },
     {
+      // Tags are a primary, user-defined filter — keep them near the identity
+      // facets at the top of the sidebar rather than buried mid-list (LFE-10494).
+      type: "categorical" as const,
+      column: "traceTags",
+      label: "Tags",
+    },
+    {
       type: "stringKeyValue" as const,
       column: "metadata",
       label: "Metadata",
@@ -72,11 +79,6 @@ export const traceFilterConfig: FilterConfig = {
       type: "string" as const,
       column: "commentContent",
       label: "Comment Content",
-    },
-    {
-      type: "categorical" as const,
-      column: "traceTags",
-      label: "Tags",
     },
     {
       type: "categorical" as const,


### PR DESCRIPTION
## TL;DR

Applied filters are now **immediately visible** in the facet sidebar. A selected
option that used to sit far down a long list — hidden behind "Show more", forcing
you to expand and scroll to learn what's filtered — is now **pinned to the top of
its group**. The **Tags** facet also moves up near the identity facets instead of
being buried mid-list.

## Why

A customer reported that in the filter sidebar a selected value (their example: a
tag) low in a long list was invisible without scrolling — *"why force me to look
at all the values before I learn which tag is used?"* Selected options were already
always-expanded (prior work), but the option list is capped at 12 with a "Show more"
button, and a selected value kept its natural position. So arriving via a saved view
or shared link with a deep value selected showed the facet **active and expanded but
with no checked option in view** — the selection was below the fold.

## What

Two complementary changes, both in the shared facet sidebar:

1. **Pin selected options to the top of their group** (`CategoricalFacet`). On long
   lists (more options than the 12-item cap, where burial can actually happen),
   checked options render first — always shown — with a subtle separator from the
   rest; the visible-count cap then applies only to the *unselected* remainder.
   Short, fully-visible lists keep their natural order, so there's no gratuitous
   reshuffling of small facets (Type, Level, booleans, …).
2. **Reposition the Tags facet higher** — just after the identity facets (Name /
   Trace Name) — in the traces, observations, and v4 events sidebars.

## Result

Verified live (browser → tRPC → ClickHouse). Arriving with a deep value selected
(`?filter=name;…;any of;user-gamma-event`, where the value is ~50th in the list):

- **Before:** the Name facet is active + expanded, but shows only the first 12
  values + "Show more" — the selected value is **nowhere in view**.
- **After:** the selected value is the **first row, checked**, above a divider, with
  "Show more" still capping the unselected remainder. Selecting a second value pulls
  it into the pinned cluster too. The Tags facet now sits right under Name.

<details>
<summary>Mechanism, edge cases &amp; verification</summary>

**Pinning rule.** `CategoricalFacet` partitions the (search-filtered) options into
`selected` / `remaining` using the checked `value` set, but **only when
`hasMoreOptions`** (total options > the 12 cap). The cap is applied to `remaining`
only, so a selected option is never hidden behind "Show more". A shared
`renderOption` helper renders both groups, so the checkbox / "Only" / count behavior
is identical to before.

- **"none of" / arrayOptions.** Pinning keys off the *checked* set (`value`). For
  `arrayOptions` (tags) the checked set is exactly the user's named values regardless
  of operator (any/all/none), so the named tags pin correctly. For `stringOptions`
  the checked set is the positive selection. The only inverted case
  (`stringOptions none of` on a >12-item list) is rare and no worse than today.
- **Short lists unchanged.** With ≤12 options the natural order is preserved, so
  booleans (True/False), environment, type, level, etc. don't reorder. The empty /
  loading / "no matches" states are untouched.
- **No state-contract changes.** This is display-only ordering inside the facet;
  `FilterState`, the URL codec, and saved views are unaffected (no reorder of the
  filter array). Tag repositioning is a pure facet-config display-order change.

**Tests.** Extended `data-table-controls.clienttest.tsx`: a selected value at
position 19 of 20 renders before the first unselected option (pinned) while "Show
more" is still present; a 3-item list keeps its natural order. Existing facet tests,
`filter-config` / `filter-integration` client tests, web typecheck and lint all pass.

**Design notes for review.**
- Direction allowed *"move selected up"* **or** *"don't reorder, hover-to-learn."* I
  went with pin-to-top as the most direct fix for the reported burial; hover-to-learn
  (counts, label tooltips) still works on the pinned rows.
- For the group level I chose a **static** Tags reposition over **dynamically
  floating every active facet to the top** — the dynamic version is more "generic"
  but causes whole-section jumps on the first selection in a facet. Happy to switch
  to dynamic floating if preferred.
</details>

## ⚠️ Overlap with #14515

This edits the same facet-sidebar files (`data-table-controls.tsx`,
`useSidebarFilterState.tsx` area) that the open LFE-10421 PR
[#14515](https://github.com/langfuse/langfuse/pull/14515) touches. Branched off
`main`; #14515 wraps the facet `.map` in an advanced-filter conditional while this
change lives inside `CategoricalFacet`'s body + the facet configs, so the conflict
surface is small — will rebase once #14515 squash-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR pins selected filter options to the top of their group in `CategoricalFacet` (long lists only) and repositions the Tags facet earlier in three filter config files, fixing a UX bug where a deep selected value was hidden behind "Show more."

- **Pinning logic** (`data-table-controls.tsx`): when a facet has more options than the 12-item cap, selected options are partitioned into a top cluster (always visible) with a thin separator; the cap applies only to the unselected remainder. Short lists retain their natural order.
- **Tags repositioned** in `traces-config.ts`, `observations-config.ts`, and `filter-config.ts` (events): moved from mid-list to just after the identity facets (Name / Trace Name / Session ID).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Display-only changes with no filter-state, URL codec, or backend impact. Safe to merge.

All changes are confined to rendering order and facet config position. The pinning logic correctly partitions options, preserves natural order for short lists, and is covered by two targeted tests. No shared state, no server calls, and no URL-codec changes are touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CategoricalFacet render] --> B{hasMoreOptions?\ntotal options > 12}
    B -- No --> C[pinSelected = false\nremainingOptions = filteredOptions\nNatural order preserved]
    B -- Yes --> D[pinSelected = true\nPartition filteredOptions]
    D --> E[selectedOptions\nAll pinned, always shown]
    D --> F[remainingOptions\nUnselected items]
    F --> G{remainingOptions.length\n> MAX_VISIBLE_OPTIONS?}
    G -- No --> H[visibleRemainingOptions = remainingOptions\nNo Show more button]
    G -- Yes --> I{showAll?}
    I -- No --> J[visibleRemainingOptions = first 12\nShow more button visible]
    I -- Yes --> K[visibleRemainingOptions = all remaining]
    E --> L[Render selected cluster]
    L --> M{selectedOptions > 0 &&\nvisibleRemaining > 0?}
    M -- Yes --> N[Render separator]
    M -- No --> O[No separator]
    N --> P[Render visibleRemainingOptions]
    O --> P
    C --> P
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[CategoricalFacet render] --> B{hasMoreOptions?\ntotal options > 12}
    B -- No --> C[pinSelected = false\nremainingOptions = filteredOptions\nNatural order preserved]
    B -- Yes --> D[pinSelected = true\nPartition filteredOptions]
    D --> E[selectedOptions\nAll pinned, always shown]
    D --> F[remainingOptions\nUnselected items]
    F --> G{remainingOptions.length\n> MAX_VISIBLE_OPTIONS?}
    G -- No --> H[visibleRemainingOptions = remainingOptions\nNo Show more button]
    G -- Yes --> I{showAll?}
    I -- No --> J[visibleRemainingOptions = first 12\nShow more button visible]
    I -- Yes --> K[visibleRemainingOptions = all remaining]
    E --> L[Render selected cluster]
    L --> M{selectedOptions > 0 &&\nvisibleRemaining > 0?}
    M -- Yes --> N[Render separator]
    M -- No --> O[No separator]
    N --> P[Render visibleRemainingOptions]
    O --> P
    C --> P
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(filters): surface selected options ..."](https://github.com/langfuse/langfuse/commit/0cd333c49e6cc650e3d6f485b573f0f24591737c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39647034)</sub>

<!-- /greptile_comment -->