### PR TITLE
feat(peek): unify the trace detail surface into one adaptive, resizable drawer

### DIFF
--- a/web/src/components/publish-object-switch.tsx
+++ b/web/src/components/publish-object-switch.tsx
@@ -5,11 +5,17 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/src/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api } from "@/src/utils/api";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
+import { cn } from "@/src/utils/tailwind";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 import { type RouterInput } from "@/src/utils/types";
 import { CheckIcon, Globe, Link, Share2 } from "lucide-react";
@@ -23,6 +29,8 @@ export const PublishTraceSwitch = (props: {
   size?: "icon" | "icon-xs";
   /** When set, render as a full-width labeled menu item instead of an icon. */
   label?: string;
+  /** Hover tooltip for the icon button (suppressed while the popover is open). */
+  tooltip?: string;
 }) => {
   const { isBetaEnabled } = useV4Beta();
   const capture = usePostHogClientCapture();
@@ -106,6 +114,7 @@ export const PublishTraceSwitch = (props: {
       isPublic={props.isPublic}
       size={props.size}
       label={props.label}
+      tooltip={props.tooltip}
       onChange={(val) => {
         capture("trace_detail:publish_button_click");
         return mut.mutateAsync({
@@ -168,6 +177,7 @@ const Base = (props: {
   disabled?: boolean;
   size?: "icon" | "icon-xs";
   label?: string;
+  tooltip?: string;
 }) => {
   const [isCopied, setIsCopied] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -185,42 +195,54 @@ const Base = (props: {
   };
 
   return (
-    <div className="flex items-center gap-1">
-      <div className="text-sm font-semibold">
+    <div className={cn("flex items-center gap-1", props.label && "w-full")}>
+      <div className={cn("text-sm font-semibold", props.label && "w-full")}>
         <Popover
           open={isOpen}
           onOpenChange={(open) => {
             if (!props.isLoading) setIsOpen(open);
           }}
         >
-          <PopoverTrigger asChild>
-            <Button
-              id="publish-trace"
-              variant="ghost"
-              size={props.label ? "sm" : props.size}
-              className={
-                props.label
-                  ? "w-full justify-start gap-2 font-normal"
-                  : undefined
-              }
-              loading={props.isLoading}
-              disabled={props.disabled}
-            >
-              {props.isPublic ? (
-                <Globe
-                  className="h-4 w-4"
-                  fill="#b3d9ff"
-                  stroke="#4d94ff"
-                  strokeWidth={2}
-                />
-              ) : (
-                <Share2 className="h-4 w-4" />
-              )}
-              {props.label ? (
-                <span className="text-sm">{props.label}</span>
-              ) : null}
-            </Button>
-          </PopoverTrigger>
+          {(() => {
+            const trigger = (
+              <PopoverTrigger asChild>
+                <Button
+                  id="publish-trace"
+                  variant="ghost"
+                  size={props.label ? "sm" : props.size}
+                  className={
+                    props.label
+                      ? "w-full justify-start gap-2 font-normal"
+                      : undefined
+                  }
+                  loading={props.isLoading}
+                  disabled={props.disabled}
+                >
+                  {props.isPublic ? (
+                    <Globe
+                      className="h-4 w-4"
+                      fill="#b3d9ff"
+                      stroke="#4d94ff"
+                      strokeWidth={2}
+                    />
+                  ) : (
+                    <Share2 className="h-4 w-4" />
+                  )}
+                  {props.label ? (
+                    <span className="text-sm">{props.label}</span>
+                  ) : null}
+                </Button>
+              </PopoverTrigger>
+            );
+            if (!props.tooltip) return trigger;
+            // Suppress the hover tooltip while the share popover is open.
+            return (
+              <Tooltip open={isOpen ? false : undefined}>
+                <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+                <TooltipContent>{props.tooltip}</TooltipContent>
+              </Tooltip>
+            );
+          })()}
           <PopoverContent className="flex flex-col gap-3">
             {props.isPublic ? (
               <>

--- a/web/src/components/publish-object-switch.tsx
+++ b/web/src/components/publish-object-switch.tsx
@@ -21,6 +21,8 @@ export const PublishTraceSwitch = (props: {
   timestamp?: Date;
   isPublic: boolean;
   size?: "icon" | "icon-xs";
+  /** When set, render as a full-width labeled menu item instead of an icon. */
+  label?: string;
 }) => {
   const { isBetaEnabled } = useV4Beta();
   const capture = usePostHogClientCapture();
@@ -103,6 +105,7 @@ export const PublishTraceSwitch = (props: {
       itemName="trace"
       isPublic={props.isPublic}
       size={props.size}
+      label={props.label}
       onChange={(val) => {
         capture("trace_detail:publish_button_click");
         return mut.mutateAsync({
@@ -164,6 +167,7 @@ const Base = (props: {
   isPublic: boolean;
   disabled?: boolean;
   size?: "icon" | "icon-xs";
+  label?: string;
 }) => {
   const [isCopied, setIsCopied] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -193,7 +197,12 @@ const Base = (props: {
             <Button
               id="publish-trace"
               variant="ghost"
-              size={props.size}
+              size={props.label ? "sm" : props.size}
+              className={
+                props.label
+                  ? "w-full justify-start gap-2 font-normal"
+                  : undefined
+              }
               loading={props.isLoading}
               disabled={props.disabled}
             >
@@ -207,6 +216,9 @@ const Base = (props: {
               ) : (
                 <Share2 className="h-4 w-4" />
               )}
+              {props.label ? (
+                <span className="text-sm">{props.label}</span>
+              ) : null}
             </Button>
           </PopoverTrigger>
           <PopoverContent className="flex flex-col gap-3">

--- a/web/src/components/star-toggle.tsx
+++ b/web/src/components/star-toggle.tsx
@@ -14,17 +14,21 @@ export function StarToggle({
   onClick,
   size = "icon",
   isLoading,
+  label,
 }: {
   value: boolean;
   disabled?: boolean;
   onClick: (value: boolean) => Promise<unknown>;
   size?: "icon" | "icon-xs";
   isLoading: boolean;
+  /** When set, render as a full-width labeled menu item instead of an icon. */
+  label?: string;
 }) {
   return (
     <Button
       variant="ghost"
-      size={size}
+      size={label ? "sm" : size}
+      className={label ? "w-full justify-start gap-2 font-normal" : undefined}
       onClick={(e) => {
         e.stopPropagation();
         onClick(!value);
@@ -39,6 +43,7 @@ export function StarToggle({
         stroke={value ? "#ca8a04" : "currentColor"}
         strokeWidth={2}
       />
+      {label ? <span className="text-sm">{label}</span> : null}
     </Button>
   );
 }
@@ -126,11 +131,13 @@ export function StarTraceDetailsToggle({
   traceId,
   value,
   size = "icon",
+  label,
 }: {
   projectId: string;
   traceId: string;
   value: boolean;
   size?: "icon" | "icon-xs";
+  label?: string;
 }) {
   const utils = api.useUtils();
   const hasAccess = useHasProjectAccess({
@@ -163,6 +170,7 @@ export function StarTraceDetailsToggle({
     <StarToggle
       value={optimisticValue}
       size={size}
+      label={label}
       disabled={!hasAccess}
       isLoading={isLoading}
       onClick={(nextValue) => {

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -63,9 +63,10 @@ type TablePeekViewProps = Pick<
   | "detailNavigationKey"
   | "resolveDetailNavigationPath"
   | "closePeek"
-  // Accepted for back-compat (table consumers still pass it via expandConfig);
-  // the in-place URL "Expand" replaces the old open-in-tab behavior, so it is
-  // no longer rendered. expandConfig cleanup is a follow-up.
+  // Drives the header's "Open in new tab" button (wired via expandConfig). The
+  // in-place "Expand" is a separate control; this opens the standalone page in
+  // a new tab. The old "open in current tab" variant (expandPeek(false)) is no
+  // longer rendered.
   | "expandPeek"
   | "peekEventOptions"
 > & {
@@ -182,6 +183,13 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
 
   const resolvedTitle = title ?? itemId;
 
+  // Distinct from Expand (which widens in place via the URL): this opens the
+  // standalone detail page in a NEW tab, leaving the peek untouched — handy for
+  // comparing against the full-page view. Only when the consumer wired
+  // expandConfig (so expandPeek exists).
+  const expandPeek = props.expandPeek;
+  const openInNewTab = expandPeek ? () => expandPeek(true) : undefined;
+
   const header = (
     <PeekHeader
       itemType={props.itemType}
@@ -198,6 +206,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
               onToggle: panel.toggleExpanded,
             }
       }
+      openInNewTab={openInNewTab}
       onClose={props.closePeek}
     />
   );

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -136,6 +136,11 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
   const setExpanded = useCallback(
     (expanded: boolean) => {
       const params = new URLSearchParams(window.location.search);
+      const currentlyExpanded =
+        params.get(PEEK_VIEW_PARAM) === PEEK_VIEW_EXPANDED;
+      // No-op when the flag already matches: skip the redundant shallow
+      // router.replace (and the re-render it would otherwise trigger).
+      if (expanded === currentlyExpanded) return;
       if (expanded) params.set(PEEK_VIEW_PARAM, PEEK_VIEW_EXPANDED);
       else params.delete(PEEK_VIEW_PARAM);
       router.replace(
@@ -197,104 +202,117 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
     />
   );
 
-  const body = (
-    <PeekTableStateProvider>
-      <div className="flex max-h-full min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="flex-1 overflow-auto" key={itemId}>
-          {children}
-        </div>
+  const content = (
+    <div className="flex max-h-full min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex-1 overflow-auto" key={itemId}>
+        {children}
       </div>
-    </PeekTableStateProvider>
+    </div>
   );
 
-  // Mobile: a vaul bottom drawer with native swipe-down dismissal.
-  if (isMobile) {
-    return (
-      <Drawer
-        open={!!itemId}
-        onOpenChange={handleOpenChange}
-        forceDirection="bottom"
-      >
-        <DrawerContent
-          size="full"
-          className="min-h-screen-with-banner top-[calc(var(--banner-offset)+10px)] bottom-0 gap-0 p-0"
-        >
-          <DrawerTitle className="sr-only">{resolvedTitle}</DrawerTitle>
-          <div className="flex w-full shrink-0 items-center justify-center pt-2 pb-1">
-            <div className="bg-muted h-1.5 w-12 rounded-full" />
-          </div>
-          {header}
-          {body}
-        </DrawerContent>
-      </Drawer>
-    );
-  }
-
-  // Desktop: a docked-right, resizable panel that stays on top of the table
-  // (non-modal, no overlay) so the table behind remains interactive.
+  // One PeekTableStateProvider wraps BOTH shells, above the mobile/desktop
+  // branch, so the nested-table state it holds (filters, sort, pagination,
+  // search) survives a breakpoint cross — without this, resizing across the
+  // mobile/desktop boundary swaps Drawer↔Sheet and would otherwise remount a
+  // fresh provider, dropping that state. It unmounts only on close (the early
+  // `return null` above), which is what resets the state (see README).
   return (
-    <Sheet open={!!itemId} onOpenChange={handleOpenChange} modal={false}>
-      <SheetPortal>
-        <SheetPrimitive.Content
-          aria-describedby={undefined}
-          data-peek-content=""
-          style={panel.panelStyle}
-          onPointerDownOutside={(e) => {
-            if (
-              shouldKeepPeekOpenOnOutsideInteraction(e.target, ignoredSelectors)
-            ) {
-              e.preventDefault();
-            }
-          }}
-          onInteractOutside={(e) => {
-            if (
-              shouldKeepPeekOpenOnOutsideInteraction(e.target, ignoredSelectors)
-            ) {
-              e.preventDefault();
-            }
-          }}
-          // Never close because focus moved out (e.g. into a portaled popover or
-          // another input); only pointer/Escape/close-button drive dismissal.
-          onFocusOutside={(e) => e.preventDefault()}
-          className={cn(
-            // No overflow-hidden here: the resize handle straddles the left edge
-            // (overhangs onto the table) so it's grabbable from either side. The
-            // body clips its own content instead.
-            "bg-background top-banner-offset h-screen-with-banner fixed right-0 bottom-0 flex max-h-full min-h-0 max-w-none flex-col gap-0 border-l",
-            // Soft shadow cast leftward (toward the table) to lift the peek off
-            // the content behind it.
-            "shadow-[-12px_0_32px_-16px_rgb(0_0_0_/_0.30)]",
-            "data-[state=open]:animate-in data-[state=open]:slide-in-from-right data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=closed]:duration-100 data-[state=open]:duration-100",
-            panel.isResizing && "select-none",
-          )}
+    <PeekTableStateProvider>
+      {isMobile ? (
+        // Mobile: a vaul bottom drawer with native swipe-down dismissal.
+        <Drawer
+          open={!!itemId}
+          onOpenChange={handleOpenChange}
+          forceDirection="bottom"
         >
-          <SheetPrimitive.Title className="sr-only">
-            {resolvedTitle}
-          </SheetPrimitive.Title>
-          {header}
-          {body}
-          {/* Rendered last so it is not the dialog's initial focus target. It
-              STRADDLES the left edge (−4px onto the table … +8px inside) so it's
-              an easy, grabbable target from either side; absolutely positioned,
-              so DOM order doesn't affect its placement. */}
-          <div
-            {...panel.resizeHandleProps}
-            className="group/resize absolute inset-y-0 -left-1 z-20 flex w-3 cursor-ew-resize touch-none justify-center focus-visible:outline-hidden"
+          <DrawerContent
+            size="full"
+            className="min-h-screen-with-banner top-[calc(var(--banner-offset)+10px)] bottom-0 gap-0 p-0"
           >
-            <div
-              aria-hidden="true"
+            <DrawerTitle className="sr-only">{resolvedTitle}</DrawerTitle>
+            <div className="flex w-full shrink-0 items-center justify-center pt-2 pb-1">
+              <div className="bg-muted h-1.5 w-12 rounded-full" />
+            </div>
+            {header}
+            {content}
+          </DrawerContent>
+        </Drawer>
+      ) : (
+        // Desktop: a docked-right, resizable panel that stays on top of the
+        // table (non-modal, no overlay) so the table behind stays interactive.
+        <Sheet open={!!itemId} onOpenChange={handleOpenChange} modal={false}>
+          <SheetPortal>
+            <SheetPrimitive.Content
+              aria-describedby={undefined}
+              data-peek-content=""
+              style={panel.panelStyle}
+              onPointerDownOutside={(e) => {
+                if (
+                  shouldKeepPeekOpenOnOutsideInteraction(
+                    e.target,
+                    ignoredSelectors,
+                  )
+                ) {
+                  e.preventDefault();
+                }
+              }}
+              onInteractOutside={(e) => {
+                if (
+                  shouldKeepPeekOpenOnOutsideInteraction(
+                    e.target,
+                    ignoredSelectors,
+                  )
+                ) {
+                  e.preventDefault();
+                }
+              }}
+              // Never close because focus moved out (e.g. into a portaled
+              // popover or another input); only pointer/Escape/close-button
+              // drive dismissal.
+              onFocusOutside={(e) => e.preventDefault()}
               className={cn(
-                // Sits on the panel's left edge; subtle at rest, clearer on
-                // hover/drag (neutral, no brand accent — the cursor signals it).
-                "h-full w-1 rounded-full transition-colors",
-                "group-hover/resize:bg-muted-foreground/40 group-focus-visible/resize:bg-muted-foreground/50",
-                panel.isResizing ? "bg-muted-foreground/60" : "bg-transparent",
+                // No overflow-hidden here: the resize handle straddles the left
+                // edge (overhangs onto the table) so it's grabbable from either
+                // side. The body clips its own content instead.
+                "bg-background top-banner-offset h-screen-with-banner fixed right-0 bottom-0 flex max-h-full min-h-0 max-w-none flex-col gap-0 border-l",
+                // Soft shadow cast leftward (toward the table) to lift the peek
+                // off the content behind it.
+                "shadow-[-12px_0_32px_-16px_rgb(0_0_0_/_0.30)]",
+                "data-[state=open]:animate-in data-[state=open]:slide-in-from-right data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=closed]:duration-100 data-[state=open]:duration-100",
+                panel.isResizing && "select-none",
               )}
-            />
-          </div>
-        </SheetPrimitive.Content>
-      </SheetPortal>
-    </Sheet>
+            >
+              <SheetPrimitive.Title className="sr-only">
+                {resolvedTitle}
+              </SheetPrimitive.Title>
+              {header}
+              {content}
+              {/* Rendered last so it is not the dialog's initial focus target.
+                  It STRADDLES the left edge (−4px onto the table … +8px inside)
+                  so it's an easy, grabbable target from either side; absolutely
+                  positioned, so DOM order doesn't affect its placement. */}
+              <div
+                {...panel.resizeHandleProps}
+                className="group/resize absolute inset-y-0 -left-1 z-20 flex w-3 cursor-ew-resize touch-none justify-center focus-visible:outline-hidden"
+              >
+                <div
+                  aria-hidden="true"
+                  className={cn(
+                    // Sits on the panel's left edge; subtle at rest, clearer on
+                    // hover/drag (neutral, no brand accent — cursor signals it).
+                    "h-full w-1 rounded-full transition-colors",
+                    "group-hover/resize:bg-muted-foreground/40 group-focus-visible/resize:bg-muted-foreground/50",
+                    panel.isResizing
+                      ? "bg-muted-foreground/60"
+                      : "bg-transparent",
+                  )}
+                />
+              </div>
+            </SheetPrimitive.Content>
+          </SheetPortal>
+        </Sheet>
+      )}
+    </PeekTableStateProvider>
   );
 }
 

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -199,7 +199,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
 
   const body = (
     <PeekTableStateProvider>
-      <div className="flex max-h-full min-h-0 flex-1 flex-col">
+      <div className="flex max-h-full min-h-0 flex-1 flex-col overflow-hidden">
         <div className="flex-1 overflow-auto" key={itemId}>
           {children}
         </div>
@@ -257,7 +257,10 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
           // another input); only pointer/Escape/close-button drive dismissal.
           onFocusOutside={(e) => e.preventDefault()}
           className={cn(
-            "bg-background top-banner-offset h-screen-with-banner fixed right-0 bottom-0 flex max-h-full min-h-0 max-w-none flex-col gap-0 overflow-hidden border-l",
+            // No overflow-hidden here: the resize handle straddles the left edge
+            // (overhangs onto the table) so it's grabbable from either side. The
+            // body clips its own content instead.
+            "bg-background top-banner-offset h-screen-with-banner fixed right-0 bottom-0 flex max-h-full min-h-0 max-w-none flex-col gap-0 border-l",
             // Soft shadow cast leftward (toward the table) to lift the peek off
             // the content behind it.
             "shadow-[-12px_0_32px_-16px_rgb(0_0_0_/_0.30)]",
@@ -270,21 +273,22 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
           </SheetPrimitive.Title>
           {header}
           {body}
-          {/* Rendered last so it is not the dialog's initial focus target; it
-              is absolutely positioned on the left edge regardless of DOM order. */}
+          {/* Rendered last so it is not the dialog's initial focus target. It
+              STRADDLES the left edge (−4px onto the table … +8px inside) so it's
+              an easy, grabbable target from either side; absolutely positioned,
+              so DOM order doesn't affect its placement. */}
           <div
             {...panel.resizeHandleProps}
-            className="group/resize absolute inset-y-0 left-0 z-10 flex w-2 cursor-ew-resize touch-none items-center justify-center focus-visible:outline-hidden"
+            className="group/resize absolute inset-y-0 -left-1 z-20 flex w-3 cursor-ew-resize touch-none justify-center focus-visible:outline-hidden"
           >
             <div
               aria-hidden="true"
               className={cn(
-                // Neutral, low-contrast affordance — the left border is the real
-                // edge; this only gently emphasizes it on hover/drag (no brand
-                // accent, in line with the cursor doing most of the signalling).
-                "h-full w-0.5 bg-transparent transition-colors",
-                "group-hover/resize:bg-muted-foreground/30 group-focus-visible/resize:bg-muted-foreground/40",
-                panel.isResizing && "bg-muted-foreground/50",
+                // Sits on the panel's left edge; subtle at rest, clearer on
+                // hover/drag (neutral, no brand accent — the cursor signals it).
+                "h-full w-1 rounded-full transition-colors",
+                "group-hover/resize:bg-muted-foreground/40 group-focus-visible/resize:bg-muted-foreground/50",
+                panel.isResizing ? "bg-muted-foreground/60" : "bg-transparent",
               )}
             />
           </div>

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -71,7 +71,7 @@ type TablePeekViewProps = Pick<
 // dismiss it — clicking a selection checkbox is a selection action, not a
 // dismiss. Row checkboxes are already covered by the `[data-row-index]` check
 // below; this also covers the header "select all". Applied to every peek so
-// tables don't each have to re-declare it (which is easy to forget).
+// tables don't each have to redeclare it (which is easy to forget).
 const ALWAYS_KEEP_PEEK_OPEN_SELECTORS = ['[role="checkbox"]'];
 
 /**

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -1,19 +1,15 @@
-import { Button } from "@/src/components/ui/button";
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@/src/components/ui/sheet";
-import { Expand, ExternalLink } from "lucide-react";
-import { Separator } from "@/src/components/ui/separator";
-import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
-import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { Sheet, SheetPortal } from "@/src/components/ui/sheet";
+import { Drawer, DrawerContent, DrawerTitle } from "@/src/components/ui/drawer";
+import { type LangfuseItemType } from "@/src/components/ItemBadge";
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { cn } from "@/src/utils/tailwind";
 import { memo } from "react";
 import { useRouter } from "next/router";
+import { useIsMobile } from "@/src/hooks/use-mobile";
 import { PeekTableStateProvider } from "@/src/components/table/peek/contexts/PeekTableStateContext";
+import { PeekHeader } from "@/src/components/table/peek/PeekHeader";
+import { usePeekPanelState } from "@/src/components/table/peek/usePeekPanelState";
 import { shouldIgnoreOutsideInteraction } from "@/src/utils/outside-interaction";
 
 type PeekViewItemType = Extract<
@@ -86,95 +82,159 @@ type TablePeekViewProps = Pick<
   children: React.ReactNode;
 };
 
+/**
+ * Decide whether an outside interaction should keep the peek open instead of
+ * closing it. The peek closes on a genuine click-outside, with two exceptions
+ * that preserve power-user behavior:
+ * - clicking another table row (`[data-row-index]`) switches the peeked item in
+ *   place rather than closing (handled by the row's own click handler), and
+ * - regions that opt out via `data-ignore-outside-interaction` (e.g. the in-app
+ *   assistant) or the table's configured `ignoredSelectors` (row checkboxes,
+ *   bookmark toggles) never trigger a close.
+ */
+const shouldKeepPeekOpenOnOutsideInteraction = (
+  target: EventTarget | null,
+  matchesIgnoredSelector: () => boolean,
+): boolean => {
+  if (matchesIgnoredSelector()) return true;
+  if (shouldIgnoreOutsideInteraction(target)) return true;
+  if (target instanceof Element && target.closest("[data-row-index]")) {
+    return true;
+  }
+  return false;
+};
+
 function TablePeekViewComponent(props: TablePeekViewProps) {
-  const peekView = props;
   const { title, children } = props;
   const router = useRouter();
-  const eventHandler = createPeekEventHandler(peekView.peekEventOptions);
+  const isMobile = useIsMobile();
+  const panel = usePeekPanelState();
+  const eventHandler = createPeekEventHandler(props.peekEventOptions);
   const itemId = router.query.peek as string | undefined;
 
+  // Hooks run unconditionally above this early return so ordering stays stable
+  // across open/close. Returning null on close unmounts PeekTableStateProvider,
+  // which is what resets nested-table state when the peek closes (see README).
   if (!itemId) return null;
 
   const handleOpenChange = (open: boolean) => {
-    // Note: Only handles close events as open events are handled by user clicking on a row in the table or navigating via detail page navigation
-    if (open || eventHandler()) return;
-    peekView.closePeek();
+    // Open is driven by row clicks / detail-page navigation; we only react to
+    // close requests (Escape, swipe-down, click-outside, the close button).
+    if (open) return;
+    props.closePeek();
   };
 
-  const canExpand = typeof peekView.expandPeek === "function";
+  const resolvedTitle = title ?? itemId;
 
+  const header = (
+    <PeekHeader
+      itemType={props.itemType}
+      title={resolvedTitle}
+      itemId={itemId}
+      detailNavigationKey={props.detailNavigationKey}
+      resolveDetailNavigationPath={props.resolveDetailNavigationPath}
+      onExpand={props.expandPeek}
+      fullscreen={
+        isMobile
+          ? undefined
+          : {
+              isFullscreen: panel.isFullscreen,
+              onToggle: panel.toggleFullscreen,
+            }
+      }
+      onClose={props.closePeek}
+    />
+  );
+
+  const body = (
+    <PeekTableStateProvider>
+      <div className="flex max-h-full min-h-0 flex-1 flex-col">
+        <div className="flex-1 overflow-auto" key={itemId}>
+          {children}
+        </div>
+      </div>
+    </PeekTableStateProvider>
+  );
+
+  // Mobile: a vaul bottom drawer with native swipe-down dismissal.
+  if (isMobile) {
+    return (
+      <Drawer
+        open={!!itemId}
+        onOpenChange={handleOpenChange}
+        forceDirection="bottom"
+      >
+        <DrawerContent
+          size="full"
+          className="min-h-screen-with-banner top-[calc(var(--banner-offset)+10px)] bottom-0 gap-0 p-0"
+        >
+          <DrawerTitle className="sr-only">{resolvedTitle}</DrawerTitle>
+          <div className="flex w-full shrink-0 items-center justify-center pt-2 pb-1">
+            <div className="bg-muted h-1.5 w-12 rounded-full" />
+          </div>
+          {header}
+          {body}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  // Desktop: a docked-right, resizable panel that stays on top of the table
+  // (non-modal, no overlay) so the table behind remains interactive.
   return (
     <Sheet open={!!itemId} onOpenChange={handleOpenChange} modal={false}>
-      <SheetContent
-        onPointerDownOutside={(e) => {
-          // Prevent the default behavior of closing when clicking outside when we set modal={false}
-          e.preventDefault();
-        }}
-        onInteractOutside={(e) => {
-          if (shouldIgnoreOutsideInteraction(e.target)) {
-            e.preventDefault();
-          }
-        }}
-        side="right"
-        className="flex max-h-full min-h-0 min-w-[60vw] flex-col gap-0 overflow-hidden p-0"
-      >
-        <SheetHeader className="bg-header flex min-h-11 flex-row flex-nowrap items-center justify-between px-2 py-1">
-          <SheetTitle className="flex min-w-0 flex-row items-center gap-2">
-            <ItemBadge type={peekView.itemType} showLabel />
-            <span
-              className="truncate text-sm font-medium focus:outline-hidden"
-              tabIndex={0}
-            >
-              {title ?? itemId}
-            </span>
-          </SheetTitle>
+      <SheetPortal>
+        <SheetPrimitive.Content
+          aria-describedby={undefined}
+          style={panel.panelStyle}
+          onPointerDownOutside={(e) => {
+            if (
+              shouldKeepPeekOpenOnOutsideInteraction(e.target, eventHandler)
+            ) {
+              e.preventDefault();
+            }
+          }}
+          onInteractOutside={(e) => {
+            if (
+              shouldKeepPeekOpenOnOutsideInteraction(e.target, eventHandler)
+            ) {
+              e.preventDefault();
+            }
+          }}
+          // Never close because focus moved out (e.g. into a portaled popover or
+          // another input); only pointer/Escape/close-button drive dismissal.
+          onFocusOutside={(e) => e.preventDefault()}
+          className={cn(
+            "bg-background top-banner-offset h-screen-with-banner fixed right-0 bottom-0 flex max-h-full min-h-0 max-w-none flex-col gap-0 overflow-hidden border-l shadow-lg",
+            "data-[state=open]:animate-in data-[state=open]:slide-in-from-right data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=closed]:duration-100 data-[state=open]:duration-100",
+            panel.isResizing && "select-none",
+          )}
+        >
+          <SheetPrimitive.Title className="sr-only">
+            {resolvedTitle}
+          </SheetPrimitive.Title>
+          {header}
+          {body}
+          {/* Rendered last so it is not the dialog's initial focus target; it
+              is absolutely positioned on the left edge regardless of DOM order. */}
           <div
-            className={cn(
-              "mt-0! flex shrink-0 flex-row items-center gap-2",
-              !canExpand && "mr-8",
-            )}
+            {...panel.resizeHandleProps}
+            className="group/resize absolute inset-y-0 left-0 z-10 flex w-2 cursor-ew-resize touch-none items-center justify-center focus-visible:outline-hidden"
           >
-            {itemId &&
-              peekView.detailNavigationKey &&
-              peekView.resolveDetailNavigationPath && (
-                <DetailPageNav
-                  currentId={itemId}
-                  path={peekView.resolveDetailNavigationPath}
-                  listKey={peekView.detailNavigationKey}
-                />
+            <div
+              aria-hidden="true"
+              className={cn(
+                // Neutral, low-contrast affordance — the left border is the real
+                // edge; this only gently emphasizes it on hover/drag (no brand
+                // accent, in line with the cursor doing most of the signalling).
+                "h-full w-0.5 bg-transparent transition-colors",
+                "group-hover/resize:bg-muted-foreground/30 group-focus-visible/resize:bg-muted-foreground/40",
+                panel.isResizing && "bg-muted-foreground/50",
               )}
-            {canExpand && (
-              <div className="mt-0! mr-8 flex h-full flex-row items-center gap-1 border-l">
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  title="Open in current tab"
-                  className="ml-2"
-                  onClick={() => peekView.expandPeek?.(false)}
-                >
-                  <Expand className="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  title="Open in new tab"
-                  onClick={() => peekView.expandPeek?.(true)}
-                >
-                  <ExternalLink className="h-4 w-4" />
-                </Button>
-              </div>
-            )}
+            />
           </div>
-        </SheetHeader>
-        <Separator />
-        <PeekTableStateProvider>
-          <div className="flex max-h-full min-h-0 flex-1 flex-col">
-            <div className="flex-1 overflow-auto" key={itemId}>
-              {children}
-            </div>
-          </div>
-        </PeekTableStateProvider>
-      </SheetContent>
+        </SheetPrimitive.Content>
+      </SheetPortal>
     </Sheet>
   );
 }

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -130,14 +130,15 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
   const isMobile = useIsMobile();
 
   // Expanded is view state, owned by the peek and reflected in the URL so it is
-  // shareable + survives back/forward. Managed here (not threaded through every
-  // table consumer); usePeekNavigation clears the param when the peek closes.
+  // shareable + survives reload. Managed here (not threaded through every table
+  // consumer); usePeekNavigation clears the param when the peek closes. Uses
+  // replace (not push) so toggling expand/collapse doesn't spam history.
   const setExpanded = useCallback(
     (expanded: boolean) => {
       const params = new URLSearchParams(window.location.search);
       if (expanded) params.set(PEEK_VIEW_PARAM, PEEK_VIEW_EXPANDED);
       else params.delete(PEEK_VIEW_PARAM);
-      router.push(
+      router.replace(
         {
           pathname: getPathnameWithoutBasePath(),
           query: urlSearchParamsToQuery(params),

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -4,13 +4,20 @@ import { Drawer, DrawerContent, DrawerTitle } from "@/src/components/ui/drawer";
 import { type LangfuseItemType } from "@/src/components/ItemBadge";
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { cn } from "@/src/utils/tailwind";
-import { memo, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { useIsMobile } from "@/src/hooks/use-mobile";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
+import { urlSearchParamsToQuery } from "@/src/utils/navigation";
 import { PeekTableStateProvider } from "@/src/components/table/peek/contexts/PeekTableStateContext";
 import { PeekHeader } from "@/src/components/table/peek/PeekHeader";
 import { usePeekPanelState } from "@/src/components/table/peek/usePeekPanelState";
 import { shouldIgnoreOutsideInteraction } from "@/src/utils/outside-interaction";
+
+// Peek view-mode URL param (also cleared by usePeekNavigation on close). When
+// `expanded`, the desktop peek widens to viewport − sidebar — shareable + back-able.
+const PEEK_VIEW_PARAM = "peekView";
+const PEEK_VIEW_EXPANDED = "expanded";
 
 type PeekViewItemType = Extract<
   LangfuseItemType,
@@ -56,10 +63,18 @@ type TablePeekViewProps = Pick<
   | "detailNavigationKey"
   | "resolveDetailNavigationPath"
   | "closePeek"
+  // Accepted for back-compat (table consumers still pass it via expandConfig);
+  // the in-place URL "Expand" replaces the old open-in-tab behavior, so it is
+  // no longer rendered. expandConfig cleanup is a follow-up.
   | "expandPeek"
   | "peekEventOptions"
 > & {
   title?: string;
+  /**
+   * Item-specific header actions (star / publish / delete …), shared with the
+   * full detail page so the peek and the page expose the same controls.
+   */
+  actions?: React.ReactNode;
   // Content
   /**
    * The content to display in the peek view.
@@ -111,8 +126,34 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
   const { title, children } = props;
   const router = useRouter();
   const itemId = router.query.peek as string | undefined;
+  const isExpanded = router.query[PEEK_VIEW_PARAM] === PEEK_VIEW_EXPANDED;
   const isMobile = useIsMobile();
-  const panel = usePeekPanelState({ isOpen: !!itemId });
+
+  // Expanded is view state, owned by the peek and reflected in the URL so it is
+  // shareable + survives back/forward. Managed here (not threaded through every
+  // table consumer); usePeekNavigation clears the param when the peek closes.
+  const setExpanded = useCallback(
+    (expanded: boolean) => {
+      const params = new URLSearchParams(window.location.search);
+      if (expanded) params.set(PEEK_VIEW_PARAM, PEEK_VIEW_EXPANDED);
+      else params.delete(PEEK_VIEW_PARAM);
+      router.push(
+        {
+          pathname: getPathnameWithoutBasePath(),
+          query: urlSearchParamsToQuery(params),
+        },
+        undefined,
+        { shallow: true },
+      );
+    },
+    [router],
+  );
+
+  const panel = usePeekPanelState({
+    isOpen: !!itemId,
+    isExpanded,
+    onExpandedChange: setExpanded,
+  });
   const ignoredSelectors = props.peekEventOptions?.ignoredSelectors ?? [];
 
   // Gate the first render on mount so we never paint the desktop sheet before
@@ -142,13 +183,13 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
       itemId={itemId}
       detailNavigationKey={props.detailNavigationKey}
       resolveDetailNavigationPath={props.resolveDetailNavigationPath}
-      onExpand={props.expandPeek}
-      fullscreen={
+      actions={props.actions}
+      expand={
         isMobile
           ? undefined
           : {
-              isFullscreen: panel.isFullscreen,
-              onToggle: panel.toggleFullscreen,
+              isExpanded: panel.isExpanded,
+              onToggle: panel.toggleExpanded,
             }
       }
       onClose={props.closePeek}
@@ -215,7 +256,10 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
           // another input); only pointer/Escape/close-button drive dismissal.
           onFocusOutside={(e) => e.preventDefault()}
           className={cn(
-            "bg-background top-banner-offset h-screen-with-banner fixed right-0 bottom-0 flex max-h-full min-h-0 max-w-none flex-col gap-0 overflow-hidden border-l shadow-lg",
+            "bg-background top-banner-offset h-screen-with-banner fixed right-0 bottom-0 flex max-h-full min-h-0 max-w-none flex-col gap-0 overflow-hidden border-l",
+            // Soft shadow cast leftward (toward the table) to lift the peek off
+            // the content behind it.
+            "shadow-[-12px_0_32px_-16px_rgb(0_0_0_/_0.30)]",
             "data-[state=open]:animate-in data-[state=open]:slide-in-from-right data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=closed]:duration-100 data-[state=open]:duration-100",
             panel.isResizing && "select-none",
           )}

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -76,6 +76,11 @@ type TablePeekViewProps = Pick<
    * full detail page so the peek and the page expose the same controls.
    */
   actions?: React.ReactNode;
+  /**
+   * The same actions rendered as labeled menu rows — shown in the header's
+   * overflow "…" menu when the peek is too narrow for the inline icon row.
+   */
+  actionsMenu?: React.ReactNode;
   // Content
   /**
    * The content to display in the peek view.
@@ -198,6 +203,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
       detailNavigationKey={props.detailNavigationKey}
       resolveDetailNavigationPath={props.resolveDetailNavigationPath}
       actions={props.actions}
+      actionsMenu={props.actionsMenu}
       expand={
         isMobile
           ? undefined

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -104,7 +104,7 @@ const ALWAYS_KEEP_PEEK_OPEN_SELECTORS = ['[role="checkbox"]'];
  * `document.activeElement` — `onPointerDownOutside` fires on pointer-down,
  * before focus has moved to the clicked element.
  */
-const shouldKeepPeekOpenOnOutsideInteraction = (
+export const shouldKeepPeekOpenOnOutsideInteraction = (
   target: EventTarget | null,
   ignoredSelectors: string[],
 ): boolean => {

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -50,21 +50,6 @@ export type DataTablePeekViewProps = {
   peekEventOptions?: PeekEventControlOptions;
 };
 
-export const createPeekEventHandler = (options?: PeekEventControlOptions) => {
-  if (!options) return () => false;
-  const { ignoredSelectors = [] } = options;
-
-  return (): boolean => {
-    for (const selector of ignoredSelectors) {
-      if (document.activeElement?.closest(selector)) {
-        return true;
-      }
-    }
-
-    return false;
-  };
-};
-
 type TablePeekViewProps = Pick<
   DataTablePeekViewProps,
   | "itemType"
@@ -82,14 +67,21 @@ type TablePeekViewProps = Pick<
   children: React.ReactNode;
 };
 
+// Shared DataTable selection controls live outside the peek but must never
+// dismiss it — clicking a selection checkbox is a selection action, not a
+// dismiss. Row checkboxes are already covered by the `[data-row-index]` check
+// below; this also covers the header "select all". Applied to every peek so
+// tables don't each have to re-declare it (which is easy to forget).
+const ALWAYS_KEEP_PEEK_OPEN_SELECTORS = ['[role="checkbox"]'];
+
 /**
  * Decide whether an outside interaction should keep the peek open instead of
  * closing it. The peek closes on a genuine click-outside, with exceptions that
  * preserve power-user behavior:
  * - clicking another table row (`[data-row-index]`) switches the peeked item in
  *   place rather than closing (handled by the row's own click handler),
- * - row-level controls the table opts out via `ignoredSelectors` (checkboxes,
- *   bookmark toggles) don't close it, and
+ * - shared selection controls and any table-specific `ignoredSelectors`
+ *   (bookmark toggles, etc.) don't close it, and
  * - regions that opt out via `data-ignore-outside-interaction` (e.g. the in-app
  *   assistant) never trigger a close.
  *
@@ -104,19 +96,18 @@ const shouldKeepPeekOpenOnOutsideInteraction = (
   if (!(target instanceof Element)) return false;
   if (shouldIgnoreOutsideInteraction(target)) return true;
   if (target.closest("[data-row-index]")) return true;
-  if (ignoredSelectors.some((selector) => target.closest(selector))) {
-    return true;
-  }
-  return false;
+  return [...ALWAYS_KEEP_PEEK_OPEN_SELECTORS, ...ignoredSelectors].some(
+    (selector) => target.closest(selector),
+  );
 };
 
 function TablePeekViewComponent(props: TablePeekViewProps) {
   const { title, children } = props;
   const router = useRouter();
-  const isMobile = useIsMobile();
-  const panel = usePeekPanelState();
-  const ignoredSelectors = props.peekEventOptions?.ignoredSelectors ?? [];
   const itemId = router.query.peek as string | undefined;
+  const isMobile = useIsMobile();
+  const panel = usePeekPanelState({ isOpen: !!itemId });
+  const ignoredSelectors = props.peekEventOptions?.ignoredSelectors ?? [];
 
   // Gate the first render on mount so we never paint the desktop sheet before
   // `useIsMobile` resolves (which would flash the wrong shell on a mobile

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -94,6 +94,12 @@ const shouldKeepPeekOpenOnOutsideInteraction = (
   ignoredSelectors: string[],
 ): boolean => {
   if (!(target instanceof Element)) return false;
+  // Never dismiss for a target actually inside the peek. Radix usually detects
+  // this, but primitives that capture the pointer natively (e.g. the inner
+  // react-resizable-panels split handle) can bypass its inside-detection and be
+  // misreported as outside — which would close the peek mid-drag and unmount
+  // the panel group. This guard keeps interactions within the peek safe.
+  if (target.closest("[data-peek-content]")) return true;
   if (shouldIgnoreOutsideInteraction(target)) return true;
   if (target.closest("[data-row-index]")) return true;
   return [...ALWAYS_KEEP_PEEK_OPEN_SELECTORS, ...ignoredSelectors].some(
@@ -189,6 +195,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
       <SheetPortal>
         <SheetPrimitive.Content
           aria-describedby={undefined}
+          data-peek-content=""
           style={panel.panelStyle}
           onPointerDownOutside={(e) => {
             if (

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -4,7 +4,7 @@ import { Drawer, DrawerContent, DrawerTitle } from "@/src/components/ui/drawer";
 import { type LangfuseItemType } from "@/src/components/ItemBadge";
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { cn } from "@/src/utils/tailwind";
-import { memo } from "react";
+import { memo, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { useIsMobile } from "@/src/hooks/use-mobile";
 import { PeekTableStateProvider } from "@/src/components/table/peek/contexts/PeekTableStateContext";
@@ -84,21 +84,27 @@ type TablePeekViewProps = Pick<
 
 /**
  * Decide whether an outside interaction should keep the peek open instead of
- * closing it. The peek closes on a genuine click-outside, with two exceptions
- * that preserve power-user behavior:
+ * closing it. The peek closes on a genuine click-outside, with exceptions that
+ * preserve power-user behavior:
  * - clicking another table row (`[data-row-index]`) switches the peeked item in
- *   place rather than closing (handled by the row's own click handler), and
+ *   place rather than closing (handled by the row's own click handler),
+ * - row-level controls the table opts out via `ignoredSelectors` (checkboxes,
+ *   bookmark toggles) don't close it, and
  * - regions that opt out via `data-ignore-outside-interaction` (e.g. the in-app
- *   assistant) or the table's configured `ignoredSelectors` (row checkboxes,
- *   bookmark toggles) never trigger a close.
+ *   assistant) never trigger a close.
+ *
+ * All checks run against the pointer event's `target`, not
+ * `document.activeElement` — `onPointerDownOutside` fires on pointer-down,
+ * before focus has moved to the clicked element.
  */
 const shouldKeepPeekOpenOnOutsideInteraction = (
   target: EventTarget | null,
-  matchesIgnoredSelector: () => boolean,
+  ignoredSelectors: string[],
 ): boolean => {
-  if (matchesIgnoredSelector()) return true;
+  if (!(target instanceof Element)) return false;
   if (shouldIgnoreOutsideInteraction(target)) return true;
-  if (target instanceof Element && target.closest("[data-row-index]")) {
+  if (target.closest("[data-row-index]")) return true;
+  if (ignoredSelectors.some((selector) => target.closest(selector))) {
     return true;
   }
   return false;
@@ -109,13 +115,19 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
   const router = useRouter();
   const isMobile = useIsMobile();
   const panel = usePeekPanelState();
-  const eventHandler = createPeekEventHandler(props.peekEventOptions);
+  const ignoredSelectors = props.peekEventOptions?.ignoredSelectors ?? [];
   const itemId = router.query.peek as string | undefined;
+
+  // Gate the first render on mount so we never paint the desktop sheet before
+  // `useIsMobile` resolves (which would flash the wrong shell on a mobile
+  // deep-link). Click-to-open is already post-mount, so it has no delay.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   // Hooks run unconditionally above this early return so ordering stays stable
   // across open/close. Returning null on close unmounts PeekTableStateProvider,
   // which is what resets nested-table state when the peek closes (see README).
-  if (!itemId) return null;
+  if (!itemId || !mounted) return null;
 
   const handleOpenChange = (open: boolean) => {
     // Open is driven by row clicks / detail-page navigation; we only react to
@@ -189,14 +201,14 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
           style={panel.panelStyle}
           onPointerDownOutside={(e) => {
             if (
-              shouldKeepPeekOpenOnOutsideInteraction(e.target, eventHandler)
+              shouldKeepPeekOpenOnOutsideInteraction(e.target, ignoredSelectors)
             ) {
               e.preventDefault();
             }
           }}
           onInteractOutside={(e) => {
             if (
-              shouldKeepPeekOpenOnOutsideInteraction(e.target, eventHandler)
+              shouldKeepPeekOpenOnOutsideInteraction(e.target, ignoredSelectors)
             ) {
               e.preventDefault();
             }

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -120,6 +120,10 @@ export function PeekHeader({
   onClose,
 }: PeekHeaderProps) {
   const [headerRef, headerSize] = useElementSize<HTMLDivElement>();
+  // The header width equals the peek width and so doesn't change when the
+  // controls settle (or data loads) after the first measurement — observe the
+  // control cluster too, whose width does change, to re-trigger the plan.
+  const [clusterRef, clusterSize] = useElementSize<HTMLDivElement>();
   const badgeRef = useRef<HTMLDivElement>(null);
   const actionsRef = useRef<HTMLDivElement>(null);
   const openInTabRef = useRef<HTMLDivElement>(null);
@@ -186,7 +190,15 @@ export function PeekHeader({
         : undefined,
     });
     setPlan((prev) => (samePlan(prev, next) ? prev : next));
-  }, [headerRef, headerSize?.width, hasActions, hasOpenInTab, hasNav, plan]);
+  }, [
+    headerRef,
+    headerSize?.width,
+    clusterSize?.width,
+    hasActions,
+    hasOpenInTab,
+    hasNav,
+    plan,
+  ]);
 
   const anyFolded = plan.foldActions || plan.foldOpenInTab;
 
@@ -209,7 +221,10 @@ export function PeekHeader({
             {title}
           </span>
         </div>
-        <div className="flex shrink-0 flex-row items-center gap-1">
+        <div
+          ref={clusterRef}
+          className="flex shrink-0 flex-row items-center gap-1"
+        >
           {/* Overflow: a labeled menu of whatever folded away. */}
           {anyFolded && (
             <Popover>

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/src/components/ui/button";
 import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
-import { Expand, ExternalLink, Maximize2, Minimize2, X } from "lucide-react";
+import { Maximize2, Minimize2, X } from "lucide-react";
 
 type PeekHeaderProps = {
   itemType: LangfuseItemType;
@@ -10,10 +10,10 @@ type PeekHeaderProps = {
   itemId: string;
   detailNavigationKey?: string;
   resolveDetailNavigationPath?: (entry: ListEntry) => string;
-  /** Open the full detail page (current tab / new tab). Hidden when absent. */
-  onExpand?: (openInNewTab: boolean) => void;
-  /** In-place fullscreen toggle. Desktop only; hidden on mobile. */
-  fullscreen?: { isFullscreen: boolean; onToggle: () => void };
+  /** Item-specific actions (star / publish / delete …), shared with the page. */
+  actions?: React.ReactNode;
+  /** Expand-to-max-width toggle. Desktop only; hidden on mobile. */
+  expand?: { isExpanded: boolean; onToggle: () => void };
   onClose: () => void;
 };
 
@@ -28,12 +28,10 @@ export function PeekHeader({
   itemId,
   detailNavigationKey,
   resolveDetailNavigationPath,
-  onExpand,
-  fullscreen,
+  actions,
+  expand,
   onClose,
 }: PeekHeaderProps) {
-  const canExpand = typeof onExpand === "function";
-
   return (
     <div className="bg-header flex min-h-11 shrink-0 flex-row flex-nowrap items-center justify-between gap-2 px-2 py-1">
       <div className="flex min-w-0 flex-row items-center gap-2">
@@ -47,6 +45,9 @@ export function PeekHeader({
         </span>
       </div>
       <div className="flex shrink-0 flex-row items-center gap-1">
+        {actions ? (
+          <div className="flex flex-row items-center gap-1">{actions}</div>
+        ) : null}
         {detailNavigationKey && resolveDetailNavigationPath && (
           <DetailPageNav
             currentId={itemId}
@@ -54,60 +55,32 @@ export function PeekHeader({
             listKey={detailNavigationKey}
           />
         )}
-        {(fullscreen || canExpand) && (
-          <div className="flex h-full flex-row items-center gap-1 border-l pl-1">
-            {fullscreen && (
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label={
-                  fullscreen.isFullscreen ? "Exit fullscreen" : "Fullscreen"
-                }
-                title={
-                  fullscreen.isFullscreen ? "Exit fullscreen" : "Fullscreen"
-                }
-                onClick={fullscreen.onToggle}
-              >
-                {fullscreen.isFullscreen ? (
-                  <Minimize2 className="h-4 w-4" />
-                ) : (
-                  <Maximize2 className="h-4 w-4" />
-                )}
-              </Button>
-            )}
-            {canExpand && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label="Open in current tab"
-                  title="Open in current tab"
-                  onClick={() => onExpand?.(false)}
-                >
-                  <Expand className="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label="Open in new tab"
-                  title="Open in new tab"
-                  onClick={() => onExpand?.(true)}
-                >
-                  <ExternalLink className="h-4 w-4" />
-                </Button>
-              </>
-            )}
-          </div>
-        )}
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          aria-label="Close"
-          title="Close"
-          onClick={onClose}
-        >
-          <X className="h-4 w-4" />
-        </Button>
+        <div className="flex h-full flex-row items-center gap-1 border-l pl-1">
+          {expand && (
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label={expand.isExpanded ? "Collapse peek" : "Expand peek"}
+              title={expand.isExpanded ? "Collapse" : "Expand"}
+              onClick={expand.onToggle}
+            >
+              {expand.isExpanded ? (
+                <Minimize2 className="h-4 w-4" />
+              ) : (
+                <Maximize2 className="h-4 w-4" />
+              )}
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Close"
+            title="Close"
+            onClick={onClose}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Button } from "@/src/components/ui/button";
 import {
   Popover,
@@ -15,6 +16,7 @@ import {
   MoreHorizontal,
   X,
 } from "lucide-react";
+import { cn } from "@/src/utils/tailwind";
 import { useElementSize } from "@/src/hooks/useElementSize";
 import {
   planToolbarOverflow,
@@ -60,6 +62,9 @@ const sameSet = (a: Set<OverflowUnit>, b: Set<OverflowUnit>) =>
  * The right control cluster is a priority-plus toolbar: it measures the header
  * and folds its lowest-priority controls into a "…" popover when space runs
  * out, so a narrow peek stays uncluttered and a wide one shows everything.
+ * `actions` is rendered once and portaled into either the inline slot or the
+ * popover, so folding moves its DOM without remounting it — an in-progress
+ * delete confirmation (or any action state) survives a width change.
  */
 export function PeekHeader({
   itemType,
@@ -73,11 +78,16 @@ export function PeekHeader({
   onClose,
 }: PeekHeaderProps) {
   const [headerRef, headerSize] = useElementSize<HTMLDivElement>();
-  const actionsRef = useRef<HTMLDivElement>(null);
+  // Host elements are tracked as state (ref callbacks) so the actions portal
+  // re-targets when a host mounts/unmounts (e.g. the popover opening).
+  const [inlineActionsHost, setInlineActionsHost] =
+    useState<HTMLDivElement | null>(null);
+  const [popoverActionsHost, setPopoverActionsHost] =
+    useState<HTMLDivElement | null>(null);
   const openInTabRef = useRef<HTMLDivElement>(null);
   const pinnedRef = useRef<HTMLDivElement>(null);
-  // Cached widths survive a unit being folded away (it is unmounted from the
-  // bar then, so it can't be re-measured until it returns inline).
+  // Cached widths survive a unit being folded away (it can't be re-measured
+  // while hidden / in the closed popover).
   const widthsRef = useRef<Partial<Record<OverflowUnit, number>>>({});
   const pinnedWidthRef = useRef(0);
   const [overflow, setOverflow] = useState<Set<OverflowUnit>>(new Set());
@@ -85,17 +95,21 @@ export function PeekHeader({
   const hasActions = Boolean(actions);
   const hasOpenInTab = Boolean(openInNewTab);
   const hasNav = Boolean(detailNavigationKey && resolveDetailNavigationPath);
+  const actionsFolded = hasActions && overflow.has("actions");
+  const openInTabFolded = hasOpenInTab && overflow.has("openInTab");
 
-  useEffect(() => {
-    const width = headerSize?.width;
+  // Measure + plan in a layout effect (before paint), reading the width from
+  // the ref directly — useElementSize's state lands post-paint, which would
+  // otherwise flash everything inline for a frame before folding.
+  useLayoutEffect(() => {
+    const width =
+      headerRef.current?.getBoundingClientRect().width ?? headerSize?.width;
     if (!width) return;
 
-    // Measure the units currently inline (folded ones keep their cached width)
-    // and the pinned block, then plan which units must fold.
-    if (hasActions && !overflow.has("actions") && actionsRef.current) {
-      widthsRef.current.actions = actionsRef.current.offsetWidth;
+    if (hasActions && !actionsFolded && inlineActionsHost) {
+      widthsRef.current.actions = inlineActionsHost.offsetWidth;
     }
-    if (hasOpenInTab && !overflow.has("openInTab") && openInTabRef.current) {
+    if (hasOpenInTab && !openInTabFolded && openInTabRef.current) {
       widthsRef.current.openInTab = openInTabRef.current.offsetWidth;
     }
     if (pinnedRef.current)
@@ -115,10 +129,16 @@ export function PeekHeader({
       moreWidth: MORE_BUTTON_PX,
     });
     setOverflow((prev) => (sameSet(prev, next) ? prev : next));
-  }, [headerSize?.width, hasActions, hasOpenInTab, hasNav, overflow]);
-
-  const actionsInline = hasActions && !overflow.has("actions");
-  const openInTabInline = hasOpenInTab && !overflow.has("openInTab");
+  }, [
+    headerRef,
+    headerSize?.width,
+    hasActions,
+    hasOpenInTab,
+    hasNav,
+    actionsFolded,
+    openInTabFolded,
+    inlineActionsHost,
+  ]);
 
   const openInTabButton = openInNewTab ? (
     <Button
@@ -131,6 +151,14 @@ export function PeekHeader({
       <ExternalLink className="h-4 w-4" />
     </Button>
   ) : null;
+
+  // Where the single actions instance lives: the popover when folded-and-open,
+  // otherwise the inline slot (which stays mounted — hidden — when folded, so
+  // the actions keep their state until the popover takes over).
+  const actionsHost =
+    actionsFolded && popoverActionsHost
+      ? popoverActionsHost
+      : inlineActionsHost;
 
   return (
     <div
@@ -165,19 +193,35 @@ export function PeekHeader({
               align="end"
               className="flex w-auto min-w-0 flex-row items-center gap-1 p-1"
             >
-              {overflow.has("actions") ? actions : null}
-              {overflow.has("openInTab") ? openInTabButton : null}
+              {actionsFolded && (
+                <div
+                  ref={setPopoverActionsHost}
+                  className="flex flex-row items-center gap-1"
+                />
+              )}
+              {openInTabFolded ? openInTabButton : null}
             </PopoverContent>
           </Popover>
         )}
 
-        {/* Overflowable units (rendered inline only when they fit). */}
-        {actionsInline ? (
-          <div ref={actionsRef} className="flex flex-row items-center gap-1">
-            {actions}
-          </div>
-        ) : null}
-        {openInTabInline ? (
+        {/* Inline actions slot: always mounted when actions exist; hidden (not
+            unmounted) when folded so the portaled actions keep their state. */}
+        {hasActions && (
+          <div
+            ref={setInlineActionsHost}
+            className={cn(
+              "flex flex-row items-center gap-1",
+              actionsFolded && "hidden",
+            )}
+          />
+        )}
+        {/* The single actions instance, projected into the active host. Keyed so
+            React keeps the same subtree across host changes (no remount). */}
+        {hasActions &&
+          actionsHost &&
+          createPortal(actions, actionsHost, "peek-actions")}
+
+        {hasOpenInTab && !openInTabFolded ? (
           <div ref={openInTabRef}>{openInTabButton}</div>
         ) : null}
 
@@ -191,6 +235,7 @@ export function PeekHeader({
               currentId={itemId}
               path={resolveDetailNavigationPath!}
               listKey={detailNavigationKey!}
+              size="sm"
             />
           )}
           {expand && (

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -1,8 +1,25 @@
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/src/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
 import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
-import { Maximize2, Minimize2, X } from "lucide-react";
+import {
+  ExternalLink,
+  Maximize2,
+  Minimize2,
+  MoreHorizontal,
+  X,
+} from "lucide-react";
+import { useElementSize } from "@/src/hooks/useElementSize";
+import {
+  planToolbarOverflow,
+  type PlanToolbarOverflowArgs,
+} from "@/src/components/table/peek/peekHeaderOverflow";
 
 type PeekHeaderProps = {
   itemType: LangfuseItemType;
@@ -14,13 +31,35 @@ type PeekHeaderProps = {
   actions?: React.ReactNode;
   /** Expand-to-max-width toggle. Desktop only; hidden on mobile. */
   expand?: { isExpanded: boolean; onToggle: () => void };
+  /** Open the standalone detail page in a new browser tab. Optional. */
+  openInNewTab?: () => void;
   onClose: () => void;
 };
+
+// Units (right→left clutter) that fold into the "…" popover when the header is
+// cramped, in collapse order: trace actions go first, then open-in-tab. Nav,
+// expand and close are pinned — nav especially, so its K/J shortcuts keep
+// working even when its buttons would be hidden.
+type OverflowUnit = "actions" | "openInTab";
+const DROP_ORDER: readonly OverflowUnit[] = ["actions", "openInTab"];
+
+// Space (px) the title + badge keep before controls start folding away, and the
+// width budgeted for the "…" trigger (an icon-xs button). Tuned by eye; the
+// planner's `safety` slack covers inter-control gaps.
+const RESERVED_TITLE_PX = 144;
+const MORE_BUTTON_PX = 32;
+
+const sameSet = (a: Set<OverflowUnit>, b: Set<OverflowUnit>) =>
+  a.size === b.size && [...a].every((u) => b.has(u));
 
 /**
  * Visible peek chrome shared by the desktop sheet and the mobile drawer. The
  * accessible dialog title is provided (visually hidden) by each shell, so this
  * stays a plain view component that works inside either primitive.
+ *
+ * The right control cluster is a priority-plus toolbar: it measures the header
+ * and folds its lowest-priority controls into a "…" popover when space runs
+ * out, so a narrow peek stays uncluttered and a wide one shows everything.
  */
 export function PeekHeader({
   itemType,
@@ -30,10 +69,74 @@ export function PeekHeader({
   resolveDetailNavigationPath,
   actions,
   expand,
+  openInNewTab,
   onClose,
 }: PeekHeaderProps) {
+  const [headerRef, headerSize] = useElementSize<HTMLDivElement>();
+  const actionsRef = useRef<HTMLDivElement>(null);
+  const openInTabRef = useRef<HTMLDivElement>(null);
+  const pinnedRef = useRef<HTMLDivElement>(null);
+  // Cached widths survive a unit being folded away (it is unmounted from the
+  // bar then, so it can't be re-measured until it returns inline).
+  const widthsRef = useRef<Partial<Record<OverflowUnit, number>>>({});
+  const pinnedWidthRef = useRef(0);
+  const [overflow, setOverflow] = useState<Set<OverflowUnit>>(new Set());
+
+  const hasActions = Boolean(actions);
+  const hasOpenInTab = Boolean(openInNewTab);
+  const hasNav = Boolean(detailNavigationKey && resolveDetailNavigationPath);
+
+  useEffect(() => {
+    const width = headerSize?.width;
+    if (!width) return;
+
+    // Measure the units currently inline (folded ones keep their cached width)
+    // and the pinned block, then plan which units must fold.
+    if (hasActions && !overflow.has("actions") && actionsRef.current) {
+      widthsRef.current.actions = actionsRef.current.offsetWidth;
+    }
+    if (hasOpenInTab && !overflow.has("openInTab") && openInTabRef.current) {
+      widthsRef.current.openInTab = openInTabRef.current.offsetWidth;
+    }
+    if (pinnedRef.current)
+      pinnedWidthRef.current = pinnedRef.current.offsetWidth;
+
+    const unitWidths: PlanToolbarOverflowArgs<OverflowUnit>["unitWidths"] = {};
+    if (hasActions && widthsRef.current.actions != null)
+      unitWidths.actions = widthsRef.current.actions;
+    if (hasOpenInTab && widthsRef.current.openInTab != null)
+      unitWidths.openInTab = widthsRef.current.openInTab;
+
+    const next = planToolbarOverflow<OverflowUnit>({
+      clusterWidth: width - RESERVED_TITLE_PX,
+      unitWidths,
+      dropOrder: DROP_ORDER,
+      pinnedWidth: pinnedWidthRef.current,
+      moreWidth: MORE_BUTTON_PX,
+    });
+    setOverflow((prev) => (sameSet(prev, next) ? prev : next));
+  }, [headerSize?.width, hasActions, hasOpenInTab, hasNav, overflow]);
+
+  const actionsInline = hasActions && !overflow.has("actions");
+  const openInTabInline = hasOpenInTab && !overflow.has("openInTab");
+
+  const openInTabButton = openInNewTab ? (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      aria-label="Open in new tab"
+      title="Open in new tab"
+      onClick={openInNewTab}
+    >
+      <ExternalLink className="h-4 w-4" />
+    </Button>
+  ) : null;
+
   return (
-    <div className="bg-header flex min-h-11 shrink-0 flex-row flex-nowrap items-center justify-between gap-2 px-2 py-1">
+    <div
+      ref={headerRef}
+      className="bg-header flex min-h-11 shrink-0 flex-row flex-nowrap items-center justify-between gap-2 overflow-hidden px-2 py-1"
+    >
       <div className="flex min-w-0 flex-row items-center gap-2">
         <ItemBadge type={itemType} showLabel />
         <span
@@ -45,17 +148,51 @@ export function PeekHeader({
         </span>
       </div>
       <div className="flex shrink-0 flex-row items-center gap-1">
-        {actions ? (
-          <div className="flex flex-row items-center gap-1">{actions}</div>
-        ) : null}
-        {detailNavigationKey && resolveDetailNavigationPath && (
-          <DetailPageNav
-            currentId={itemId}
-            path={resolveDetailNavigationPath}
-            listKey={detailNavigationKey}
-          />
+        {/* Overflow popover collects whatever folded away, in display order. */}
+        {overflow.size > 0 && (
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label="More actions"
+                title="More"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              className="flex w-auto min-w-0 flex-row items-center gap-1 p-1"
+            >
+              {overflow.has("actions") ? actions : null}
+              {overflow.has("openInTab") ? openInTabButton : null}
+            </PopoverContent>
+          </Popover>
         )}
-        <div className="flex h-full flex-row items-center gap-1 border-l pl-1">
+
+        {/* Overflowable units (rendered inline only when they fit). */}
+        {actionsInline ? (
+          <div ref={actionsRef} className="flex flex-row items-center gap-1">
+            {actions}
+          </div>
+        ) : null}
+        {openInTabInline ? (
+          <div ref={openInTabRef}>{openInTabButton}</div>
+        ) : null}
+
+        {/* Pinned block: nav (keeps K/J live), expand, close. */}
+        <div
+          ref={pinnedRef}
+          className="flex h-full flex-row items-center gap-1 border-l pl-1"
+        >
+          {hasNav && (
+            <DetailPageNav
+              currentId={itemId}
+              path={resolveDetailNavigationPath!}
+              listKey={detailNavigationKey!}
+            />
+          )}
           {expand && (
             <Button
               variant="ghost"

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -1,0 +1,114 @@
+import { Button } from "@/src/components/ui/button";
+import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
+import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
+import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
+import { Expand, ExternalLink, Maximize2, Minimize2, X } from "lucide-react";
+
+type PeekHeaderProps = {
+  itemType: LangfuseItemType;
+  title: React.ReactNode;
+  itemId: string;
+  detailNavigationKey?: string;
+  resolveDetailNavigationPath?: (entry: ListEntry) => string;
+  /** Open the full detail page (current tab / new tab). Hidden when absent. */
+  onExpand?: (openInNewTab: boolean) => void;
+  /** In-place fullscreen toggle. Desktop only; hidden on mobile. */
+  fullscreen?: { isFullscreen: boolean; onToggle: () => void };
+  onClose: () => void;
+};
+
+/**
+ * Visible peek chrome shared by the desktop sheet and the mobile drawer. The
+ * accessible dialog title is provided (visually hidden) by each shell, so this
+ * stays a plain view component that works inside either primitive.
+ */
+export function PeekHeader({
+  itemType,
+  title,
+  itemId,
+  detailNavigationKey,
+  resolveDetailNavigationPath,
+  onExpand,
+  fullscreen,
+  onClose,
+}: PeekHeaderProps) {
+  const canExpand = typeof onExpand === "function";
+
+  return (
+    <div className="bg-header flex min-h-11 shrink-0 flex-row flex-nowrap items-center justify-between gap-2 px-2 py-1">
+      <div className="flex min-w-0 flex-row items-center gap-2">
+        <ItemBadge type={itemType} showLabel />
+        <span
+          className="truncate text-sm font-medium focus:outline-hidden"
+          tabIndex={0}
+          title={typeof title === "string" ? title : undefined}
+        >
+          {title}
+        </span>
+      </div>
+      <div className="flex shrink-0 flex-row items-center gap-1">
+        {detailNavigationKey && resolveDetailNavigationPath && (
+          <DetailPageNav
+            currentId={itemId}
+            path={resolveDetailNavigationPath}
+            listKey={detailNavigationKey}
+          />
+        )}
+        {(fullscreen || canExpand) && (
+          <div className="flex h-full flex-row items-center gap-1 border-l pl-1">
+            {fullscreen && (
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label={
+                  fullscreen.isFullscreen ? "Exit fullscreen" : "Fullscreen"
+                }
+                title={
+                  fullscreen.isFullscreen ? "Exit fullscreen" : "Fullscreen"
+                }
+                onClick={fullscreen.onToggle}
+              >
+                {fullscreen.isFullscreen ? (
+                  <Minimize2 className="h-4 w-4" />
+                ) : (
+                  <Maximize2 className="h-4 w-4" />
+                )}
+              </Button>
+            )}
+            {canExpand && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label="Open in current tab"
+                  title="Open in current tab"
+                  onClick={() => onExpand?.(false)}
+                >
+                  <Expand className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label="Open in new tab"
+                  title="Open in new tab"
+                  onClick={() => onExpand?.(true)}
+                >
+                  <ExternalLink className="h-4 w-4" />
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Close"
+          title="Close"
+          onClick={onClose}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -1,5 +1,4 @@
 import { useLayoutEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { Button } from "@/src/components/ui/button";
 import {
   Popover,
@@ -16,7 +15,6 @@ import {
   MoreHorizontal,
   X,
 } from "lucide-react";
-import { cn } from "@/src/utils/tailwind";
 import { useElementSize } from "@/src/hooks/useElementSize";
 import {
   planPeekHeaderLayout,
@@ -29,8 +27,10 @@ type PeekHeaderProps = {
   itemId: string;
   detailNavigationKey?: string;
   resolveDetailNavigationPath?: (entry: ListEntry) => string;
-  /** Item-specific actions (star / publish / delete …), shared with the page. */
+  /** Item actions (star / publish / delete …) as the inline icon row. */
   actions?: React.ReactNode;
+  /** The same actions as labeled rows for the overflow "…" menu. */
+  actionsMenu?: React.ReactNode;
   /** Expand-to-max-width toggle. Desktop only; hidden on mobile. */
   expand?: { isExpanded: boolean; onToggle: () => void };
   /** Open the standalone detail page in a new browser tab. Optional. */
@@ -68,10 +68,8 @@ const FULL: PeekHeaderPlan = {
  *
  * The header adapts to the PEEK's own width (measured, not screen breakpoints):
  * it keeps the title readable and, as the peek narrows, folds the trace actions
- * into a "…" popover, shrinks the type badge to icon-only, then folds
- * open-in-tab — see {@link planPeekHeaderLayout}. `actions` are rendered once
- * and portaled into the inline slot or the popover, so folding moves their DOM
- * without remounting (an in-progress delete confirmation survives a resize).
+ * into a labeled "…" menu, shrinks the type badge to icon-only, compacts the
+ * prev/next nav, then folds open-in-tab — see {@link planPeekHeaderLayout}.
  */
 export function PeekHeader({
   itemType,
@@ -80,18 +78,14 @@ export function PeekHeader({
   detailNavigationKey,
   resolveDetailNavigationPath,
   actions,
+  actionsMenu,
   expand,
   openInNewTab,
   onClose,
 }: PeekHeaderProps) {
   const [headerRef, headerSize] = useElementSize<HTMLDivElement>();
   const badgeRef = useRef<HTMLDivElement>(null);
-  // Host elements as state (ref callbacks) so the actions portal re-targets
-  // when a host mounts/unmounts (e.g. the popover opening).
-  const [inlineActionsHost, setInlineActionsHost] =
-    useState<HTMLDivElement | null>(null);
-  const [popoverActionsHost, setPopoverActionsHost] =
-    useState<HTMLDivElement | null>(null);
+  const actionsRef = useRef<HTMLDivElement>(null);
   const openInTabRef = useRef<HTMLDivElement>(null);
   const navRef = useRef<HTMLDivElement>(null);
   const pinnedRef = useRef<HTMLDivElement>(null);
@@ -122,14 +116,12 @@ export function PeekHeader({
     if (plan.badgeShowLabel && badgeRef.current) {
       widthsRef.current.badgeLabel = badgeRef.current.offsetWidth;
     }
-    if (hasActions && !plan.foldActions && inlineActionsHost) {
-      widthsRef.current.actions = inlineActionsHost.offsetWidth;
+    if (hasActions && !plan.foldActions && actionsRef.current) {
+      widthsRef.current.actions = actionsRef.current.offsetWidth;
     }
     if (hasOpenInTab && !plan.foldOpenInTab && openInTabRef.current) {
       widthsRef.current.openInTab = openInTabRef.current.offsetWidth;
     }
-    // Nav width depends on its mode (cache per mode); otherPinned (expand +
-    // close + divider) is mode-independent = the pinned block minus the nav.
     if (pinnedRef.current) {
       const navW = hasNav && navRef.current ? navRef.current.offsetWidth : 0;
       if (hasNav) {
@@ -158,15 +150,7 @@ export function PeekHeader({
         : undefined,
     });
     setPlan((prev) => (samePlan(prev, next) ? prev : next));
-  }, [
-    headerRef,
-    headerSize?.width,
-    hasActions,
-    hasOpenInTab,
-    hasNav,
-    plan,
-    inlineActionsHost,
-  ]);
+  }, [headerRef, headerSize?.width, hasActions, hasOpenInTab, hasNav, plan]);
 
   const openInTabButton = openInNewTab ? (
     <Button
@@ -181,13 +165,6 @@ export function PeekHeader({
   ) : null;
 
   const anyFolded = plan.foldActions || plan.foldOpenInTab;
-  // The single actions instance lives in the popover when folded-and-open,
-  // otherwise the inline slot (kept mounted — hidden — when folded, so action
-  // state is preserved until the popover takes over).
-  const actionsHost =
-    plan.foldActions && popoverActionsHost
-      ? popoverActionsHost
-      : inlineActionsHost;
 
   return (
     <div
@@ -208,7 +185,7 @@ export function PeekHeader({
         </span>
       </div>
       <div className="flex shrink-0 flex-row items-center gap-1">
-        {/* Overflow popover collects whatever folded away, in display order. */}
+        {/* Overflow: a labeled menu of whatever folded away. */}
         {anyFolded && (
           <Popover>
             <PopoverTrigger asChild>
@@ -223,33 +200,28 @@ export function PeekHeader({
             </PopoverTrigger>
             <PopoverContent
               align="end"
-              className="flex w-auto min-w-0 flex-row items-center gap-1 p-1"
+              className="flex w-auto min-w-44 flex-col gap-0.5 p-1"
             >
-              {plan.foldActions && (
-                <div
-                  ref={setPopoverActionsHost}
-                  className="flex flex-row items-center gap-1"
-                />
-              )}
-              {plan.foldOpenInTab ? openInTabButton : null}
+              {plan.foldActions ? actionsMenu : null}
+              {plan.foldOpenInTab && openInNewTab ? (
+                <button
+                  type="button"
+                  onClick={openInNewTab}
+                  className="hover:bg-accent flex w-full items-center gap-2 rounded-sm py-1.5 pr-2 pl-1.5 text-sm"
+                >
+                  <ExternalLink className="h-4 w-4" />
+                  Open in new tab
+                </button>
+              ) : null}
             </PopoverContent>
           </Popover>
         )}
 
-        {/* Inline actions slot: always mounted when actions exist; hidden (not
-            unmounted) when folded so the portaled actions keep their state. */}
-        {hasActions && (
-          <div
-            ref={setInlineActionsHost}
-            className={cn(
-              "flex flex-row items-center gap-1",
-              plan.foldActions && "hidden",
-            )}
-          />
-        )}
-        {hasActions &&
-          actionsHost &&
-          createPortal(actions, actionsHost, "peek-actions")}
+        {hasActions && !plan.foldActions ? (
+          <div ref={actionsRef} className="flex flex-row items-center gap-1">
+            {actions}
+          </div>
+        ) : null}
 
         {hasOpenInTab && !plan.foldOpenInTab ? (
           <div ref={openInTabRef}>{openInTabButton}</div>
@@ -258,7 +230,7 @@ export function PeekHeader({
         {/* Pinned block: nav (keeps K/J live), expand, close. */}
         <div
           ref={pinnedRef}
-          className="flex h-full flex-row items-center gap-1 border-l pl-1"
+          className="flex h-full flex-row items-center gap-1"
         >
           {hasNav && (
             <div ref={navRef} className="flex flex-row items-center">

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -19,8 +19,8 @@ import {
 import { cn } from "@/src/utils/tailwind";
 import { useElementSize } from "@/src/hooks/useElementSize";
 import {
-  planToolbarOverflow,
-  type PlanToolbarOverflowArgs,
+  planPeekHeaderLayout,
+  type PeekHeaderPlan,
 } from "@/src/components/table/peek/peekHeaderOverflow";
 
 type PeekHeaderProps = {
@@ -38,33 +38,40 @@ type PeekHeaderProps = {
   onClose: () => void;
 };
 
-// Units (right→left clutter) that fold into the "…" popover when the header is
-// cramped, in collapse order: trace actions go first, then open-in-tab. Nav,
-// expand and close are pinned — nav especially, so its K/J shortcuts keep
-// working even when its buttons would be hidden.
-type OverflowUnit = "actions" | "openInTab";
-const DROP_ORDER: readonly OverflowUnit[] = ["actions", "openInTab"];
-
-// Space (px) the title + badge keep before controls start folding away, and the
-// width budgeted for the "…" trigger (an icon-xs button). Tuned by eye; the
-// planner's `safety` slack covers inter-control gaps.
-const RESERVED_TITLE_PX = 144;
+// The title keeps at least this much width before anything else collapses; the
+// type badge falls back to this width when icon-only; the "…" trigger is an
+// icon-xs button. Tuned by eye — planner `safety` covers inter-control gaps.
+const MIN_TITLE_PX = 240;
+const BADGE_ICON_PX = 32;
 const MORE_BUTTON_PX = 32;
+const BADGE_LABEL_FALLBACK_PX = 72;
+const NAV_FULL_FALLBACK_PX = 92;
+const NAV_COMPACT_FALLBACK_PX = 52;
 
-const sameSet = (a: Set<OverflowUnit>, b: Set<OverflowUnit>) =>
-  a.size === b.size && [...a].every((u) => b.has(u));
+const samePlan = (a: PeekHeaderPlan, b: PeekHeaderPlan) =>
+  a.foldActions === b.foldActions &&
+  a.foldOpenInTab === b.foldOpenInTab &&
+  a.badgeShowLabel === b.badgeShowLabel &&
+  a.navCompact === b.navCompact;
+
+const FULL: PeekHeaderPlan = {
+  foldActions: false,
+  foldOpenInTab: false,
+  badgeShowLabel: true,
+  navCompact: false,
+};
 
 /**
  * Visible peek chrome shared by the desktop sheet and the mobile drawer. The
  * accessible dialog title is provided (visually hidden) by each shell, so this
  * stays a plain view component that works inside either primitive.
  *
- * The right control cluster is a priority-plus toolbar: it measures the header
- * and folds its lowest-priority controls into a "…" popover when space runs
- * out, so a narrow peek stays uncluttered and a wide one shows everything.
- * `actions` is rendered once and portaled into either the inline slot or the
- * popover, so folding moves its DOM without remounting it — an in-progress
- * delete confirmation (or any action state) survives a width change.
+ * The header adapts to the PEEK's own width (measured, not screen breakpoints):
+ * it keeps the title readable and, as the peek narrows, folds the trace actions
+ * into a "…" popover, shrinks the type badge to icon-only, then folds
+ * open-in-tab — see {@link planPeekHeaderLayout}. `actions` are rendered once
+ * and portaled into the inline slot or the popover, so folding moves their DOM
+ * without remounting (an in-progress delete confirmation survives a resize).
  */
 export function PeekHeader({
   itemType,
@@ -78,65 +85,86 @@ export function PeekHeader({
   onClose,
 }: PeekHeaderProps) {
   const [headerRef, headerSize] = useElementSize<HTMLDivElement>();
-  // Host elements are tracked as state (ref callbacks) so the actions portal
-  // re-targets when a host mounts/unmounts (e.g. the popover opening).
+  const badgeRef = useRef<HTMLDivElement>(null);
+  // Host elements as state (ref callbacks) so the actions portal re-targets
+  // when a host mounts/unmounts (e.g. the popover opening).
   const [inlineActionsHost, setInlineActionsHost] =
     useState<HTMLDivElement | null>(null);
   const [popoverActionsHost, setPopoverActionsHost] =
     useState<HTMLDivElement | null>(null);
   const openInTabRef = useRef<HTMLDivElement>(null);
+  const navRef = useRef<HTMLDivElement>(null);
   const pinnedRef = useRef<HTMLDivElement>(null);
-  // Cached widths survive a unit being folded away (it can't be re-measured
-  // while hidden / in the closed popover).
-  const widthsRef = useRef<Partial<Record<OverflowUnit, number>>>({});
-  const pinnedWidthRef = useRef(0);
-  const [overflow, setOverflow] = useState<Set<OverflowUnit>>(new Set());
+  // Cached widths survive a part being folded / collapsed (it can't be
+  // re-measured while hidden, in the closed popover, or in the other nav mode).
+  const widthsRef = useRef<{
+    actions?: number;
+    openInTab?: number;
+    badgeLabel?: number;
+    navFull?: number;
+    navCompact?: number;
+    otherPinned?: number;
+  }>({});
+  const [plan, setPlan] = useState<PeekHeaderPlan>(FULL);
 
   const hasActions = Boolean(actions);
   const hasOpenInTab = Boolean(openInNewTab);
   const hasNav = Boolean(detailNavigationKey && resolveDetailNavigationPath);
-  const actionsFolded = hasActions && overflow.has("actions");
-  const openInTabFolded = hasOpenInTab && overflow.has("openInTab");
 
-  // Measure + plan in a layout effect (before paint), reading the width from
-  // the ref directly — useElementSize's state lands post-paint, which would
-  // otherwise flash everything inline for a frame before folding.
+  // Measure + plan in a layout effect (before paint), reading width from the
+  // ref directly — useElementSize's state lands post-paint, which would flash
+  // the un-adapted header for a frame.
   useLayoutEffect(() => {
     const width =
       headerRef.current?.getBoundingClientRect().width ?? headerSize?.width;
     if (!width) return;
 
-    if (hasActions && !actionsFolded && inlineActionsHost) {
+    if (plan.badgeShowLabel && badgeRef.current) {
+      widthsRef.current.badgeLabel = badgeRef.current.offsetWidth;
+    }
+    if (hasActions && !plan.foldActions && inlineActionsHost) {
       widthsRef.current.actions = inlineActionsHost.offsetWidth;
     }
-    if (hasOpenInTab && !openInTabFolded && openInTabRef.current) {
+    if (hasOpenInTab && !plan.foldOpenInTab && openInTabRef.current) {
       widthsRef.current.openInTab = openInTabRef.current.offsetWidth;
     }
-    if (pinnedRef.current)
-      pinnedWidthRef.current = pinnedRef.current.offsetWidth;
+    // Nav width depends on its mode (cache per mode); otherPinned (expand +
+    // close + divider) is mode-independent = the pinned block minus the nav.
+    if (pinnedRef.current) {
+      const navW = hasNav && navRef.current ? navRef.current.offsetWidth : 0;
+      if (hasNav) {
+        if (plan.navCompact) widthsRef.current.navCompact = navW;
+        else widthsRef.current.navFull = navW;
+      }
+      widthsRef.current.otherPinned = pinnedRef.current.offsetWidth - navW;
+    }
 
-    const unitWidths: PlanToolbarOverflowArgs<OverflowUnit>["unitWidths"] = {};
-    if (hasActions && widthsRef.current.actions != null)
-      unitWidths.actions = widthsRef.current.actions;
-    if (hasOpenInTab && widthsRef.current.openInTab != null)
-      unitWidths.openInTab = widthsRef.current.openInTab;
-
-    const next = planToolbarOverflow<OverflowUnit>({
-      clusterWidth: width - RESERVED_TITLE_PX,
-      unitWidths,
-      dropOrder: DROP_ORDER,
-      pinnedWidth: pinnedWidthRef.current,
+    const next = planPeekHeaderLayout({
+      headerWidth: width,
+      minTitle: MIN_TITLE_PX,
+      badgeLabelWidth: widthsRef.current.badgeLabel ?? BADGE_LABEL_FALLBACK_PX,
+      badgeIconWidth: BADGE_ICON_PX,
+      navFullWidth: hasNav
+        ? (widthsRef.current.navFull ?? NAV_FULL_FALLBACK_PX)
+        : 0,
+      navCompactWidth: hasNav
+        ? (widthsRef.current.navCompact ?? NAV_COMPACT_FALLBACK_PX)
+        : 0,
+      otherPinnedWidth: widthsRef.current.otherPinned ?? 0,
       moreWidth: MORE_BUTTON_PX,
+      actionsWidth: hasActions ? (widthsRef.current.actions ?? 0) : undefined,
+      openInTabWidth: hasOpenInTab
+        ? (widthsRef.current.openInTab ?? 0)
+        : undefined,
     });
-    setOverflow((prev) => (sameSet(prev, next) ? prev : next));
+    setPlan((prev) => (samePlan(prev, next) ? prev : next));
   }, [
     headerRef,
     headerSize?.width,
     hasActions,
     hasOpenInTab,
     hasNav,
-    actionsFolded,
-    openInTabFolded,
+    plan,
     inlineActionsHost,
   ]);
 
@@ -152,11 +180,12 @@ export function PeekHeader({
     </Button>
   ) : null;
 
-  // Where the single actions instance lives: the popover when folded-and-open,
-  // otherwise the inline slot (which stays mounted — hidden — when folded, so
-  // the actions keep their state until the popover takes over).
+  const anyFolded = plan.foldActions || plan.foldOpenInTab;
+  // The single actions instance lives in the popover when folded-and-open,
+  // otherwise the inline slot (kept mounted — hidden — when folded, so action
+  // state is preserved until the popover takes over).
   const actionsHost =
-    actionsFolded && popoverActionsHost
+    plan.foldActions && popoverActionsHost
       ? popoverActionsHost
       : inlineActionsHost;
 
@@ -166,7 +195,10 @@ export function PeekHeader({
       className="bg-header flex min-h-11 shrink-0 flex-row flex-nowrap items-center justify-between gap-2 overflow-hidden px-2 py-1"
     >
       <div className="flex min-w-0 flex-row items-center gap-2">
-        <ItemBadge type={itemType} showLabel />
+        {/* Badge never truncates: it shows the full label or just the icon. */}
+        <div ref={badgeRef} className="shrink-0">
+          <ItemBadge type={itemType} showLabel={plan.badgeShowLabel} />
+        </div>
         <span
           className="truncate text-sm font-medium focus:outline-hidden"
           tabIndex={0}
@@ -177,7 +209,7 @@ export function PeekHeader({
       </div>
       <div className="flex shrink-0 flex-row items-center gap-1">
         {/* Overflow popover collects whatever folded away, in display order. */}
-        {overflow.size > 0 && (
+        {anyFolded && (
           <Popover>
             <PopoverTrigger asChild>
               <Button
@@ -193,13 +225,13 @@ export function PeekHeader({
               align="end"
               className="flex w-auto min-w-0 flex-row items-center gap-1 p-1"
             >
-              {actionsFolded && (
+              {plan.foldActions && (
                 <div
                   ref={setPopoverActionsHost}
                   className="flex flex-row items-center gap-1"
                 />
               )}
-              {openInTabFolded ? openInTabButton : null}
+              {plan.foldOpenInTab ? openInTabButton : null}
             </PopoverContent>
           </Popover>
         )}
@@ -211,17 +243,15 @@ export function PeekHeader({
             ref={setInlineActionsHost}
             className={cn(
               "flex flex-row items-center gap-1",
-              actionsFolded && "hidden",
+              plan.foldActions && "hidden",
             )}
           />
         )}
-        {/* The single actions instance, projected into the active host. Keyed so
-            React keeps the same subtree across host changes (no remount). */}
         {hasActions &&
           actionsHost &&
           createPortal(actions, actionsHost, "peek-actions")}
 
-        {hasOpenInTab && !openInTabFolded ? (
+        {hasOpenInTab && !plan.foldOpenInTab ? (
           <div ref={openInTabRef}>{openInTabButton}</div>
         ) : null}
 
@@ -231,12 +261,14 @@ export function PeekHeader({
           className="flex h-full flex-row items-center gap-1 border-l pl-1"
         >
           {hasNav && (
-            <DetailPageNav
-              currentId={itemId}
-              path={resolveDetailNavigationPath!}
-              listKey={detailNavigationKey!}
-              size="sm"
-            />
+            <div ref={navRef} className="flex flex-row items-center">
+              <DetailPageNav
+                currentId={itemId}
+                path={resolveDetailNavigationPath!}
+                listKey={detailNavigationKey!}
+                compact={plan.navCompact}
+              />
+            </div>
           )}
           {expand && (
             <Button

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -5,6 +5,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/src/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
@@ -60,6 +66,36 @@ const FULL: PeekHeaderPlan = {
   badgeShowLabel: true,
   navCompact: false,
 };
+
+// Header tooltips appear quickly and share one style (Radix Tooltip, not the
+// slow/inconsistent native `title`).
+const TOOLTIP_DELAY_MS = 300;
+
+function HeaderIconButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label={label}
+          onClick={onClick}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 /**
  * Visible peek chrome shared by the desktop sheet and the mobile drawer. The
@@ -152,122 +188,111 @@ export function PeekHeader({
     setPlan((prev) => (samePlan(prev, next) ? prev : next));
   }, [headerRef, headerSize?.width, hasActions, hasOpenInTab, hasNav, plan]);
 
-  const openInTabButton = openInNewTab ? (
-    <Button
-      variant="ghost"
-      size="icon-xs"
-      aria-label="Open in new tab"
-      title="Open in new tab"
-      onClick={openInNewTab}
-    >
-      <ExternalLink className="h-4 w-4" />
-    </Button>
-  ) : null;
-
   const anyFolded = plan.foldActions || plan.foldOpenInTab;
 
   return (
-    <div
-      ref={headerRef}
-      className="bg-header flex min-h-11 shrink-0 flex-row flex-nowrap items-center justify-between gap-2 overflow-hidden px-2 py-1"
-    >
-      <div className="flex min-w-0 flex-row items-center gap-2">
-        {/* Badge never truncates: it shows the full label or just the icon. */}
-        <div ref={badgeRef} className="shrink-0">
-          <ItemBadge type={itemType} showLabel={plan.badgeShowLabel} />
-        </div>
-        <span
-          className="truncate text-sm font-medium focus:outline-hidden"
-          tabIndex={0}
-          title={typeof title === "string" ? title : undefined}
-        >
-          {title}
-        </span>
-      </div>
-      <div className="flex shrink-0 flex-row items-center gap-1">
-        {/* Overflow: a labeled menu of whatever folded away. */}
-        {anyFolded && (
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label="More actions"
-                title="More"
-              >
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent
-              align="end"
-              className="flex w-auto min-w-44 flex-col gap-0.5 p-1"
-            >
-              {plan.foldActions ? actionsMenu : null}
-              {plan.foldOpenInTab && openInNewTab ? (
-                <button
-                  type="button"
-                  onClick={openInNewTab}
-                  className="hover:bg-accent flex w-full items-center gap-2 rounded-sm py-1.5 pr-2 pl-1.5 text-sm"
-                >
-                  <ExternalLink className="h-4 w-4" />
-                  Open in new tab
-                </button>
-              ) : null}
-            </PopoverContent>
-          </Popover>
-        )}
-
-        {hasActions && !plan.foldActions ? (
-          <div ref={actionsRef} className="flex flex-row items-center gap-1">
-            {actions}
+    <TooltipProvider delayDuration={TOOLTIP_DELAY_MS}>
+      <div
+        ref={headerRef}
+        className="bg-header flex min-h-11 shrink-0 flex-row flex-nowrap items-center justify-between gap-2 overflow-hidden px-2 py-1"
+      >
+        <div className="flex min-w-0 flex-row items-center gap-2">
+          {/* Badge never truncates: it shows the full label or just the icon. */}
+          <div ref={badgeRef} className="shrink-0">
+            <ItemBadge type={itemType} showLabel={plan.badgeShowLabel} />
           </div>
-        ) : null}
-
-        {hasOpenInTab && !plan.foldOpenInTab ? (
-          <div ref={openInTabRef}>{openInTabButton}</div>
-        ) : null}
-
-        {/* Pinned block: nav (keeps K/J live), expand, close. */}
-        <div
-          ref={pinnedRef}
-          className="flex h-full flex-row items-center gap-1"
-        >
-          {hasNav && (
-            <div ref={navRef} className="flex flex-row items-center">
-              <DetailPageNav
-                currentId={itemId}
-                path={resolveDetailNavigationPath!}
-                listKey={detailNavigationKey!}
-                compact={plan.navCompact}
-              />
-            </div>
-          )}
-          {expand && (
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              aria-label={expand.isExpanded ? "Collapse peek" : "Expand peek"}
-              title={expand.isExpanded ? "Collapse" : "Expand"}
-              onClick={expand.onToggle}
-            >
-              {expand.isExpanded ? (
-                <Minimize2 className="h-4 w-4" />
-              ) : (
-                <Maximize2 className="h-4 w-4" />
-              )}
-            </Button>
-          )}
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            aria-label="Close"
-            title="Close"
-            onClick={onClose}
+          <span
+            className="truncate text-sm font-medium focus:outline-hidden"
+            tabIndex={0}
+            title={typeof title === "string" ? title : undefined}
           >
-            <X className="h-4 w-4" />
-          </Button>
+            {title}
+          </span>
+        </div>
+        <div className="flex shrink-0 flex-row items-center gap-1">
+          {/* Overflow: a labeled menu of whatever folded away. */}
+          {anyFolded && (
+            <Popover>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      aria-label="More actions"
+                    >
+                      <MoreHorizontal className="h-4 w-4" />
+                    </Button>
+                  </PopoverTrigger>
+                </TooltipTrigger>
+                <TooltipContent>More</TooltipContent>
+              </Tooltip>
+              <PopoverContent
+                align="end"
+                className="flex w-auto min-w-44 flex-col gap-0.5 p-1"
+              >
+                {plan.foldActions ? actionsMenu : null}
+                {plan.foldOpenInTab && openInNewTab ? (
+                  <button
+                    type="button"
+                    onClick={openInNewTab}
+                    className="hover:bg-accent flex w-full items-center gap-2 rounded-sm py-1.5 pr-2 pl-1.5 text-sm"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    Open in new tab
+                  </button>
+                ) : null}
+              </PopoverContent>
+            </Popover>
+          )}
+
+          {hasActions && !plan.foldActions ? (
+            <div ref={actionsRef} className="flex flex-row items-center gap-1">
+              {actions}
+            </div>
+          ) : null}
+
+          {hasOpenInTab && !plan.foldOpenInTab && openInNewTab ? (
+            <div ref={openInTabRef}>
+              <HeaderIconButton label="Open in new tab" onClick={openInNewTab}>
+                <ExternalLink className="h-4 w-4" />
+              </HeaderIconButton>
+            </div>
+          ) : null}
+
+          {/* Pinned block: nav (keeps K/J live), expand, close. */}
+          <div
+            ref={pinnedRef}
+            className="flex h-full flex-row items-center gap-1"
+          >
+            {hasNav && (
+              <div ref={navRef} className="flex flex-row items-center">
+                <DetailPageNav
+                  currentId={itemId}
+                  path={resolveDetailNavigationPath!}
+                  listKey={detailNavigationKey!}
+                  compact={plan.navCompact}
+                />
+              </div>
+            )}
+            {expand && (
+              <HeaderIconButton
+                label={expand.isExpanded ? "Collapse" : "Expand"}
+                onClick={expand.onToggle}
+              >
+                {expand.isExpanded ? (
+                  <Minimize2 className="h-4 w-4" />
+                ) : (
+                  <Maximize2 className="h-4 w-4" />
+                )}
+              </HeaderIconButton>
+            )}
+            <HeaderIconButton label="Close" onClick={onClose}>
+              <X className="h-4 w-4" />
+            </HeaderIconButton>
+          </div>
         </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }

--- a/web/src/components/table/peek/README.md
+++ b/web/src/components/table/peek/README.md
@@ -26,15 +26,28 @@ Dismissal:
   opened inside the peek do not close it (DismissableLayer stacking).
 - **Escape**, the close button, and (mobile) swipe-down also close.
 
-Panel state lives in [`usePeekPanelState`](./usePeekPanelState.ts), at the state
-altitudes from `frontend-large-feature-architecture`:
+Panel state follows the local-feature-state pattern from
+`frontend-large-feature-architecture`:
 
-| State       | Altitude                        | Where it lives                                                            |
-| ----------- | ------------------------------- | ------------------------------------------------------------------------- |
-| width       | cross-view persisted preference | `localStorage` (`peekViewWidthFraction`, a viewport fraction)             |
-| fullscreen  | ephemeral per open session      | React state — resets on close, so the peek never reopens stuck fullscreen |
-| resize drag | high-frequency transient        | local draft, committed to `localStorage` only on pointer-up               |
-| which item  | route                           | the `peek` URL param (see below)                                          |
+- [`store/peekPanelStore.ts`](./store/peekPanelStore.ts) — a per-mount vanilla
+  Zustand store (created once via lazy `useState`). All state lives here and is
+  mutated only through named `actions`. Selectors (`selectWidth`,
+  `selectIsFullscreen`, …) return primitives so subscriptions bail out cheaply.
+- [`actions/resizePeekPanel.ts`](./actions/resizePeekPanel.ts) — the drag
+  workflow (window pointer listeners → store actions; commits width on
+  pointer-up). It takes the store instance, not React hooks.
+- [`usePeekPanelState.ts`](./usePeekPanelState.ts) — the integration boundary:
+  owns the store, subscribes to slices, wires lifecycle effects, and exposes
+  thin callbacks that delegate to the actions.
+
+State altitudes:
+
+| State       | Altitude                        | Where it lives                                                                  |
+| ----------- | ------------------------------- | ------------------------------------------------------------------------------- |
+| width       | cross-view persisted preference | store `widthFraction`, mirrored to `localStorage` (`peekViewWidthFraction`)     |
+| fullscreen  | ephemeral per open session      | store `isFullscreen` — reset on close via `resetForVisibility`, never stuck     |
+| resize drag | high-frequency transient        | store `draftFraction` / `isResizing`, committed to `localStorage` on pointer-up |
+| which item  | route                           | the `peek` URL param (see below)                                                |
 
 ## Architecture
 

--- a/web/src/components/table/peek/README.md
+++ b/web/src/components/table/peek/README.md
@@ -6,6 +6,36 @@ This document describes how table state (filters, sorting, pagination, search) i
 
 Peek views allow users to quickly preview table items in a side panel. When navigating between items using K/J shortcuts, tables inside the peek view remount, which would normally reset their state. The peek state management system prevents this by storing table state in a context that persists across navigation.
 
+## Panel shell, resize, and fullscreen
+
+`TablePeekView` ([`../peek.tsx`](../peek.tsx)) is responsive and keeps the peek
+**on top of the table** (it does not split the layout):
+
+- **Desktop** — a docked-right, non-modal Radix dialog (no overlay), so the
+  table behind stays interactive. A left-edge handle resizes it; dragging to the
+  far edge engages fullscreen.
+- **Mobile** (`useIsMobile`, <768px) — a `vaul` bottom drawer with native
+  swipe-down dismissal.
+
+Dismissal:
+
+- **Click-outside closes**, with two exceptions: clicking another table row
+  (`[data-row-index]`) **switches** the peeked item in place, and regions that
+  opt out via `data-ignore-outside-interaction` (e.g. the in-app assistant) or
+  the table's `ignoredSelectors` never close it. Nested Radix popovers/menus
+  opened inside the peek do not close it (DismissableLayer stacking).
+- **Escape**, the close button, and (mobile) swipe-down also close.
+
+Panel state lives in [`usePeekPanelState`](./usePeekPanelState.ts), at the state
+altitudes from `frontend-large-feature-architecture`:
+
+| State       | Altitude                        | Where it lives                                                            |
+| ----------- | ------------------------------- | ------------------------------------------------------------------------- |
+| width       | cross-view persisted preference | `localStorage` (`peekViewWidthFraction`, a viewport fraction)             |
+| fullscreen  | ephemeral per open session      | React state — resets on close, so the peek never reopens stuck fullscreen |
+| resize drag | high-frequency transient        | local draft, committed to `localStorage` only on pointer-up               |
+| which item  | route                           | the `peek` URL param (see below)                                          |
+
 ## Architecture
 
 The peek state architecture separates the persisting context provider from the remounting content:

--- a/web/src/components/table/peek/README.md
+++ b/web/src/components/table/peek/README.md
@@ -53,11 +53,16 @@ State altitudes:
 | resize drag | high-frequency transient        | store `draftFraction` / `draftExpanded` / `isResizing`, committed on pointer-up                            |
 | which item  | route                           | the `peek` URL param (see below)                                                                           |
 
-The peek and the standalone trace page share trace-level actions via
-[`../../trace/TraceDetailActions.tsx`](../../trace/TraceDetailActions.tsx)
-(star / publish / delete). **Next slice:** a shared `TraceDetailSurface`
-(one trace-data hook + header + body) so the peek and `TracePage` stop forking
-title/nav/fetch and `<Trace context>` branching — see the PR discussion.
+The peek and the standalone trace page already share one beta-aware fetch
+([`../../trace/useTraceDetailData.ts`](../../trace/useTraceDetailData.ts)), one
+body + title
+([`../../trace/TraceDetailBody.tsx`](../../trace/TraceDetailBody.tsx) →
+`TraceDetailBody` / `traceDetailTitle`), and one action set
+([`../../trace/TraceDetailActions.tsx`](../../trace/TraceDetailActions.tsx) —
+star / publish / delete) — `usePeekData` is now a thin wrapper over the shared
+hook. **Next slice:** collapse the `<Trace context>` branching and fold these
+primitives into a single `TraceDetailSurface` wrapper so the peek and `TracePage`
+share one component, not four — see the PR discussion.
 
 ## Architecture
 

--- a/web/src/components/table/peek/README.md
+++ b/web/src/components/table/peek/README.md
@@ -6,48 +6,58 @@ This document describes how table state (filters, sorting, pagination, search) i
 
 Peek views allow users to quickly preview table items in a side panel. When navigating between items using K/J shortcuts, tables inside the peek view remount, which would normally reset their state. The peek state management system prevents this by storing table state in a context that persists across navigation.
 
-## Panel shell, resize, and fullscreen
+## Panel shell, resize, and expand
 
 `TablePeekView` ([`../peek.tsx`](../peek.tsx)) is responsive and keeps the peek
 **on top of the table** (it does not split the layout):
 
 - **Desktop** — a docked-right, non-modal Radix dialog (no overlay), so the
   table behind stays interactive. A left-edge handle resizes it; dragging to the
-  far edge engages fullscreen.
+  far edge (or the header Expand button) **expands** it to the max width
+  (viewport − sidebar; the sidebar stays visible).
 - **Mobile** (`useIsMobile`, <768px) — a `vaul` bottom drawer with native
-  swipe-down dismissal.
+  swipe-down dismissal (Expand is hidden).
 
 Dismissal:
 
-- **Click-outside closes**, with two exceptions: clicking another table row
-  (`[data-row-index]`) **switches** the peeked item in place, and regions that
-  opt out via `data-ignore-outside-interaction` (e.g. the in-app assistant) or
-  the table's `ignoredSelectors` never close it. Nested Radix popovers/menus
-  opened inside the peek do not close it (DismissableLayer stacking).
+- **Click-outside closes**, with exceptions: a target inside the peek
+  (`[data-peek-content]`) never closes it; clicking another table row
+  (`[data-row-index]`) **switches** the peeked item in place; and selection
+  checkboxes / `data-ignore-outside-interaction` regions / the table's
+  `ignoredSelectors` don't close it. Nested Radix popovers/menus opened inside
+  the peek don't close it (DismissableLayer stacking).
 - **Escape**, the close button, and (mobile) swipe-down also close.
 
 Panel state follows the local-feature-state pattern from
 `frontend-large-feature-architecture`:
 
 - [`store/peekPanelStore.ts`](./store/peekPanelStore.ts) — a per-mount vanilla
-  Zustand store (created once via lazy `useState`). All state lives here and is
-  mutated only through named `actions`. Selectors (`selectWidth`,
-  `selectIsFullscreen`, …) return primitives so subscriptions bail out cheaply.
+  Zustand store (lazy `useState`) owning ONLY the widget width + transient drag
+  state, mutated through named `actions`. Selectors (`selectWidgetWidth`,
+  `selectIsResizing`, `selectDraftExpanded`) return primitives so subscriptions
+  bail out cheaply.
 - [`actions/resizePeekPanel.ts`](./actions/resizePeekPanel.ts) — the drag
-  workflow (window pointer listeners → store actions; commits width on
-  pointer-up). It takes the store instance, not React hooks.
+  workflow (window pointer listeners → store actions; on pointer-up commits a
+  widget width or flips the expanded flag). Takes the store instance, not hooks.
 - [`usePeekPanelState.ts`](./usePeekPanelState.ts) — the integration boundary:
-  owns the store, subscribes to slices, wires lifecycle effects, and exposes
-  thin callbacks that delegate to the actions.
+  owns the store, derives the final width (widget vs expanded — measuring the
+  sidebar offset for the expanded case), and wires drag/keyboard to the store +
+  action. Takes `isExpanded` in / `onExpandedChange` out (the URL owns expanded).
 
 State altitudes:
 
-| State       | Altitude                        | Where it lives                                                                  |
-| ----------- | ------------------------------- | ------------------------------------------------------------------------------- |
-| width       | cross-view persisted preference | store `widthFraction`, mirrored to `localStorage` (`peekViewWidthFraction`)     |
-| fullscreen  | ephemeral per open session      | store `isFullscreen` — reset on close via `resetForVisibility`, never stuck     |
-| resize drag | high-frequency transient        | store `draftFraction` / `isResizing`, committed to `localStorage` on pointer-up |
-| which item  | route                           | the `peek` URL param (see below)                                                |
+| State       | Altitude                        | Where it lives                                                                                             |
+| ----------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| expanded    | route (shareable, reloadable)   | URL `peekView=expanded`, managed in `peek.tsx` (`router.replace`), cleared on close by `usePeekNavigation` |
+| width       | cross-view persisted preference | store `widthFraction`, mirrored to `localStorage` (`peekViewWidthFraction`)                                |
+| resize drag | high-frequency transient        | store `draftFraction` / `draftExpanded` / `isResizing`, committed on pointer-up                            |
+| which item  | route                           | the `peek` URL param (see below)                                                                           |
+
+The peek and the standalone trace page share trace-level actions via
+[`../../trace/TraceDetailActions.tsx`](../../trace/TraceDetailActions.tsx)
+(star / publish / delete). **Next slice:** a shared `TraceDetailSurface`
+(one trace-data hook + header + body) so the peek and `TracePage` stop forking
+title/nav/fetch and `<Trace context>` branching — see the PR discussion.
 
 ## Architecture
 

--- a/web/src/components/table/peek/actions/resizePeekPanel.clienttest.ts
+++ b/web/src/components/table/peek/actions/resizePeekPanel.clienttest.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { beginPeekResize } from "@/src/components/table/peek/actions/resizePeekPanel";
-import { createPeekPanelStore } from "@/src/components/table/peek/store/peekPanelStore";
+import {
+  createPeekPanelStore,
+  selectDraftExpanded,
+} from "@/src/components/table/peek/store/peekPanelStore";
 
 const STORAGE_KEY = "peekViewWidthFraction";
 
@@ -54,6 +57,17 @@ describe("beginPeekResize", () => {
     expect(commitExpanded).not.toHaveBeenCalled();
     expect(store.getState().draftFraction).toBeNull();
     expect(store.getState().isResizing).toBe(false);
+  });
+
+  it("flips to expanded at the sidebar-aligned threshold (not the static 0.95)", () => {
+    const store = createPeekPanelStore();
+    const commitExpanded = vi.fn();
+    // Sidebar edge at fraction 0.8 → dragging to 0.85 expands, no overshoot.
+    beginPeekResize(store, pointerDown(), commitExpanded, 0.8);
+    move(clientXForFraction(0.85));
+    expect(selectDraftExpanded(store.getState())).toBe(true);
+    window.dispatchEvent(new Event("pointerup"));
+    expect(commitExpanded).toHaveBeenLastCalledWith(true);
   });
 
   it("removes its window listeners after a cancelled drag", () => {

--- a/web/src/components/table/peek/actions/resizePeekPanel.clienttest.ts
+++ b/web/src/components/table/peek/actions/resizePeekPanel.clienttest.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { beginPeekResize } from "@/src/components/table/peek/actions/resizePeekPanel";
+import { createPeekPanelStore } from "@/src/components/table/peek/store/peekPanelStore";
+
+const STORAGE_KEY = "peekViewWidthFraction";
+
+// A primary-button pointerdown — the only kind that begins a drag.
+const pointerDown = () =>
+  ({ button: 0, preventDefault: () => {} }) as unknown as React.PointerEvent;
+
+// The panel is docked right, so its width fraction is `1 - clientX/innerWidth`.
+// Derive the clientX that yields a target fraction from the live viewport width.
+const clientXForFraction = (fraction: number) =>
+  Math.round((1 - fraction) * window.innerWidth);
+
+const move = (clientX: number) =>
+  window.dispatchEvent(new MouseEvent("pointermove", { clientX }));
+
+describe("beginPeekResize", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  it("commits the dragged widget width to localStorage on pointer-up", () => {
+    window.localStorage.setItem(STORAGE_KEY, "0.5");
+    const store = createPeekPanelStore();
+    const commitExpanded = vi.fn();
+
+    beginPeekResize(store, pointerDown(), commitExpanded);
+    move(clientXForFraction(0.7));
+    window.dispatchEvent(new Event("pointerup"));
+
+    expect(store.getState().widthFraction).toBeCloseTo(0.7);
+    expect(
+      parseFloat(window.localStorage.getItem(STORAGE_KEY) ?? ""),
+    ).toBeCloseTo(0.7);
+    expect(commitExpanded).toHaveBeenLastCalledWith(false);
+    expect(store.getState().isResizing).toBe(false);
+  });
+
+  it("aborts on pointercancel WITHOUT committing the width or expanding", () => {
+    // pointercancel is a system abort (palm rejection, gesture intercept, OS
+    // interrupt), not a release — the saved width must survive untouched.
+    window.localStorage.setItem(STORAGE_KEY, "0.5");
+    const store = createPeekPanelStore();
+    const commitExpanded = vi.fn();
+
+    beginPeekResize(store, pointerDown(), commitExpanded);
+    move(clientXForFraction(0.7)); // would persist 0.7 on a real pointer-up
+    window.dispatchEvent(new Event("pointercancel"));
+
+    expect(store.getState().widthFraction).toBeCloseTo(0.5);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("0.5");
+    expect(commitExpanded).not.toHaveBeenCalled();
+    expect(store.getState().draftFraction).toBeNull();
+    expect(store.getState().isResizing).toBe(false);
+  });
+
+  it("removes its window listeners after a cancelled drag", () => {
+    const store = createPeekPanelStore();
+    const commitExpanded = vi.fn();
+
+    beginPeekResize(store, pointerDown(), commitExpanded);
+    window.dispatchEvent(new Event("pointercancel"));
+    // A stray move after teardown must not revive draft state.
+    move(clientXForFraction(0.7));
+    expect(store.getState().draftFraction).toBeNull();
+  });
+});

--- a/web/src/components/table/peek/actions/resizePeekPanel.ts
+++ b/web/src/components/table/peek/actions/resizePeekPanel.ts
@@ -44,7 +44,7 @@ export function beginPeekResize(
   const teardown = () => {
     window.removeEventListener("pointermove", onPointerMove);
     window.removeEventListener("pointerup", onPointerUp);
-    window.removeEventListener("pointercancel", onPointerUp);
+    window.removeEventListener("pointercancel", onPointerCancel);
     document.body.style.removeProperty("user-select");
     document.body.style.removeProperty("cursor");
   };
@@ -65,9 +65,18 @@ export function beginPeekResize(
     actions.cancelResize();
   };
 
+  // pointercancel is an ABORT, not a release (system gesture intercept, palm
+  // rejection, accessibility tooling, pointer-capture transfer, OS interrupt).
+  // Tear down and drop the in-flight draft WITHOUT committing — a cancelled
+  // gesture must not overwrite the persisted width or flip the expanded flag.
+  const onPointerCancel = () => {
+    teardown();
+    store.getState().actions.cancelResize();
+  };
+
   window.addEventListener("pointermove", onPointerMove);
   window.addEventListener("pointerup", onPointerUp);
-  window.addEventListener("pointercancel", onPointerUp);
+  window.addEventListener("pointercancel", onPointerCancel);
   document.body.style.userSelect = "none";
   document.body.style.cursor = "ew-resize";
   store.getState().actions.setResizing(true);

--- a/web/src/components/table/peek/actions/resizePeekPanel.ts
+++ b/web/src/components/table/peek/actions/resizePeekPanel.ts
@@ -1,0 +1,66 @@
+import { type PointerEvent as ReactPointerEvent } from "react";
+import {
+  PEEK_FULLSCREEN_ENTER_FRACTION,
+  type PeekPanelStore,
+} from "@/src/components/table/peek/store/peekPanelStore";
+
+/** Viewport fraction to the RIGHT of the pointer (the panel is docked right). */
+function widthFractionFromClientX(clientX: number): number {
+  return 1 - clientX / window.innerWidth;
+}
+
+/**
+ * Drag workflow for the left-edge resize handle. Attaches window pointer
+ * listeners, drives the store through its `actions`, and commits the width on
+ * pointer-up. Dragging past {@link PEEK_FULLSCREEN_ENTER_FRACTION} enters
+ * fullscreen (without persisting a width).
+ *
+ * Not a hook — it takes the store instance directly (per the local-feature
+ * state pattern). Returns a teardown that ends an in-flight drag; the caller
+ * also runs it on unmount so a drag interrupted by the peek closing can't leak
+ * listeners or leave the body cursor/selection styles applied.
+ */
+export function beginPeekResize(
+  store: PeekPanelStore,
+  event: ReactPointerEvent,
+): () => void {
+  // Only primary-button drags; the keyboard path handles the rest.
+  if (event.button !== 0) return () => {};
+  event.preventDefault();
+
+  const onPointerMove = (move: PointerEvent) => {
+    const fraction = widthFractionFromClientX(move.clientX);
+    const { actions } = store.getState();
+    if (fraction >= PEEK_FULLSCREEN_ENTER_FRACTION) {
+      actions.enterFullscreenDraft();
+    } else {
+      actions.setDraftFraction(fraction);
+    }
+  };
+
+  const teardown = () => {
+    window.removeEventListener("pointermove", onPointerMove);
+    window.removeEventListener("pointerup", onPointerUp);
+    window.removeEventListener("pointercancel", onPointerUp);
+    document.body.style.removeProperty("user-select");
+    document.body.style.removeProperty("cursor");
+  };
+
+  const onPointerUp = () => {
+    teardown();
+    const { draftFraction, actions } = store.getState();
+    // A drag that ended on a widget width commits it; one that ended in
+    // fullscreen (draftFraction === null) leaves the persisted width untouched.
+    if (draftFraction !== null) actions.commitWidth(draftFraction);
+    actions.setResizing(false);
+  };
+
+  window.addEventListener("pointermove", onPointerMove);
+  window.addEventListener("pointerup", onPointerUp);
+  window.addEventListener("pointercancel", onPointerUp);
+  document.body.style.userSelect = "none";
+  document.body.style.cursor = "ew-resize";
+  store.getState().actions.setResizing(true);
+
+  return teardown;
+}

--- a/web/src/components/table/peek/actions/resizePeekPanel.ts
+++ b/web/src/components/table/peek/actions/resizePeekPanel.ts
@@ -12,8 +12,8 @@ function widthFractionFromClientX(clientX: number): number {
 /**
  * Drag workflow for the left-edge resize handle. Attaches window pointer
  * listeners, drives the store's transient drag state, and on pointer-up either
- * commits a widget width or flips the URL `expanded` flag via
- * `onExpandedChange`. Dragging past {@link PEEK_EXPAND_ENTER_FRACTION} previews
+ * commits a widget width or flips the expanded flag via `commitExpanded` (which
+ * writes the URL). Dragging past {@link PEEK_EXPAND_ENTER_FRACTION} previews
  * (and, on release, commits) the expanded max width — so the drag and the
  * header button are two triggers of the same expanded state.
  *
@@ -25,7 +25,7 @@ function widthFractionFromClientX(clientX: number): number {
 export function beginPeekResize(
   store: PeekPanelStore,
   event: ReactPointerEvent,
-  onExpandedChange: (expanded: boolean) => void,
+  commitExpanded: (expanded: boolean) => void,
 ): () => void {
   // Only primary-button drags; the keyboard path handles the rest.
   if (event.button !== 0) return () => {};
@@ -54,12 +54,14 @@ export function beginPeekResize(
     const { draftExpanded, draftFraction, actions } = store.getState();
     if (draftExpanded) {
       // Released past the threshold → expanded (reflected in the URL).
-      onExpandedChange(true);
+      commitExpanded(true);
     } else if (draftFraction !== null) {
       // Released on a widget width → persist it and ensure we're collapsed.
       actions.commitWidth(draftFraction);
-      onExpandedChange(false);
+      commitExpanded(false);
     }
+    // The hook holds the committed expanded value (pendingExpanded) until the
+    // URL catches up, so clearing the drag state here can't flash the old width.
     actions.cancelResize();
   };
 

--- a/web/src/components/table/peek/actions/resizePeekPanel.ts
+++ b/web/src/components/table/peek/actions/resizePeekPanel.ts
@@ -1,6 +1,6 @@
 import { type PointerEvent as ReactPointerEvent } from "react";
 import {
-  PEEK_FULLSCREEN_ENTER_FRACTION,
+  PEEK_EXPAND_ENTER_FRACTION,
   type PeekPanelStore,
 } from "@/src/components/table/peek/store/peekPanelStore";
 
@@ -11,18 +11,21 @@ function widthFractionFromClientX(clientX: number): number {
 
 /**
  * Drag workflow for the left-edge resize handle. Attaches window pointer
- * listeners, drives the store through its `actions`, and commits the width on
- * pointer-up. Dragging past {@link PEEK_FULLSCREEN_ENTER_FRACTION} enters
- * fullscreen (without persisting a width).
+ * listeners, drives the store's transient drag state, and on pointer-up either
+ * commits a widget width or flips the URL `expanded` flag via
+ * `onExpandedChange`. Dragging past {@link PEEK_EXPAND_ENTER_FRACTION} previews
+ * (and, on release, commits) the expanded max width — so the drag and the
+ * header button are two triggers of the same expanded state.
  *
  * Not a hook — it takes the store instance directly (per the local-feature
  * state pattern). Returns a teardown that ends an in-flight drag; the caller
- * also runs it on unmount so a drag interrupted by the peek closing can't leak
- * listeners or leave the body cursor/selection styles applied.
+ * also runs it on unmount / when the peek closes so a drag interrupted mid-flight
+ * can't leak listeners or leave the body cursor/selection styles applied.
  */
 export function beginPeekResize(
   store: PeekPanelStore,
   event: ReactPointerEvent,
+  onExpandedChange: (expanded: boolean) => void,
 ): () => void {
   // Only primary-button drags; the keyboard path handles the rest.
   if (event.button !== 0) return () => {};
@@ -31,8 +34,8 @@ export function beginPeekResize(
   const onPointerMove = (move: PointerEvent) => {
     const fraction = widthFractionFromClientX(move.clientX);
     const { actions } = store.getState();
-    if (fraction >= PEEK_FULLSCREEN_ENTER_FRACTION) {
-      actions.enterFullscreenDraft();
+    if (fraction >= PEEK_EXPAND_ENTER_FRACTION) {
+      actions.setDraftExpanded();
     } else {
       actions.setDraftFraction(fraction);
     }
@@ -48,11 +51,16 @@ export function beginPeekResize(
 
   const onPointerUp = () => {
     teardown();
-    const { draftFraction, actions } = store.getState();
-    // A drag that ended on a widget width commits it; one that ended in
-    // fullscreen (draftFraction === null) leaves the persisted width untouched.
-    if (draftFraction !== null) actions.commitWidth(draftFraction);
-    actions.setResizing(false);
+    const { draftExpanded, draftFraction, actions } = store.getState();
+    if (draftExpanded) {
+      // Released past the threshold → expanded (reflected in the URL).
+      onExpandedChange(true);
+    } else if (draftFraction !== null) {
+      // Released on a widget width → persist it and ensure we're collapsed.
+      actions.commitWidth(draftFraction);
+      onExpandedChange(false);
+    }
+    actions.cancelResize();
   };
 
   window.addEventListener("pointermove", onPointerMove);

--- a/web/src/components/table/peek/actions/resizePeekPanel.ts
+++ b/web/src/components/table/peek/actions/resizePeekPanel.ts
@@ -26,6 +26,16 @@ export function beginPeekResize(
   store: PeekPanelStore,
   event: ReactPointerEvent,
   commitExpanded: (expanded: boolean) => void,
+  // Fraction at which the drag flips to "expanded" — the sidebar edge
+  // (`viewport − sidebar`), passed live by the hook so the panel stops exactly
+  // at the sidebar instead of overshooting onto it and snapping back. Defaults
+  // to the static threshold when no sidebar offset is known.
+  expandAtFraction: number = PEEK_EXPAND_ENTER_FRACTION,
+  // Whether the panel is currently expanded. The drag seeds its draft from
+  // this so merely PRESSING the handle doesn't change the width — only moving
+  // does (otherwise starting a drag while expanded snaps to the widget width
+  // on pointer-down, a visible jump).
+  startExpanded = false,
 ): () => void {
   // Only primary-button drags; the keyboard path handles the rest.
   if (event.button !== 0) return () => {};
@@ -34,7 +44,9 @@ export function beginPeekResize(
   const onPointerMove = (move: PointerEvent) => {
     const fraction = widthFractionFromClientX(move.clientX);
     const { actions } = store.getState();
-    if (fraction >= PEEK_EXPAND_ENTER_FRACTION) {
+    // At/past the sidebar edge (incl. the pointer leaving the window) →
+    // expanded; never let the widget width overshoot onto the sidebar.
+    if (fraction >= expandAtFraction) {
       actions.setDraftExpanded();
     } else {
       actions.setDraftFraction(fraction);
@@ -80,6 +92,9 @@ export function beginPeekResize(
   document.body.style.userSelect = "none";
   document.body.style.cursor = "ew-resize";
   store.getState().actions.setResizing(true);
+  // Seed the draft to the current width so pressing the handle is a no-op until
+  // the pointer actually moves.
+  if (startExpanded) store.getState().actions.setDraftExpanded();
 
   return teardown;
 }

--- a/web/src/components/table/peek/hooks/usePeekData.ts
+++ b/web/src/components/table/peek/hooks/usePeekData.ts
@@ -1,6 +1,4 @@
-import { api } from "@/src/utils/api";
-import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
-import { useEventsTraceData } from "@/src/features/events/hooks/useEventsTraceData";
+import { useTraceDetailData } from "@/src/components/trace/useTraceDetailData";
 
 type UsePeekDataProps = {
   projectId: string;
@@ -8,49 +6,13 @@ type UsePeekDataProps = {
   timestamp?: Date;
 };
 
+/**
+ * Peek's trace-data hook — a thin wrapper over the shared
+ * {@link useTraceDetailData} so the peek and the standalone trace page fetch
+ * through one place. Callers read `data` / `isLoading`.
+ */
 export const usePeekData = ({
   projectId,
   traceId,
   timestamp,
-}: UsePeekDataProps) => {
-  const { isBetaEnabled } = useV4Beta();
-
-  // Old path: fetch from traces table (beta OFF)
-  const tracesQuery = api.traces.byIdWithObservationsAndScores.useQuery(
-    {
-      traceId: traceId as string,
-      projectId,
-      timestamp,
-    },
-    {
-      enabled: !!traceId && !isBetaEnabled,
-      retry(failureCount, error) {
-        if (error.data?.code === "UNAUTHORIZED") return false;
-        return failureCount < 3;
-      },
-      staleTime: 60 * 1000, // 1 minute
-    },
-  );
-
-  // New path: fetch from events table (beta ON)
-  const eventsData = useEventsTraceData({
-    projectId,
-    traceId: traceId ?? "",
-    timestamp,
-    enabled: !!traceId && isBetaEnabled,
-  });
-
-  // Return the appropriate data based on beta toggle
-  if (isBetaEnabled) {
-    return {
-      data: eventsData.data,
-      isLoading: eventsData.isLoading,
-      error: eventsData.error,
-      // Provide stub for other fields to match tracesQuery return type
-      isError: !!eventsData.error,
-      isFetching: eventsData.isLoading,
-    };
-  }
-
-  return tracesQuery;
-};
+}: UsePeekDataProps) => useTraceDetailData({ projectId, traceId, timestamp });

--- a/web/src/components/table/peek/hooks/usePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/usePeekNavigation.ts
@@ -5,6 +5,8 @@ import { useCallback } from "react";
 import { urlSearchParamsToQuery } from "@/src/utils/navigation";
 
 const PEEK_PARAM = "peek";
+// View-mode param shared with the peek component (cleared whenever the peek closes).
+const PEEK_VIEW_PARAM = "peekView";
 
 interface BasePeekConfig {
   /** Additional URL parameters to clear when closing peek view and persist when expanding peek view */
@@ -75,6 +77,7 @@ export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
       if (!id) {
         // Close peek view - clear all peek-related params
         params.delete(PEEK_PARAM);
+        params.delete(PEEK_VIEW_PARAM);
         config?.queryParams?.forEach((param) => params.delete(param));
       } else {
         // Clear all query params that are set in the config
@@ -116,6 +119,7 @@ export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
 
     // Close peek view - clear all peek-related params
     params.delete(PEEK_PARAM);
+    params.delete(PEEK_VIEW_PARAM);
     config?.queryParams?.forEach((param) => params.delete(param));
 
     router.push(

--- a/web/src/components/table/peek/outsideInteraction.clienttest.tsx
+++ b/web/src/components/table/peek/outsideInteraction.clienttest.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { shouldKeepPeekOpenOnOutsideInteraction } from "@/src/components/table/peek";
+
+// Build a detached element tree and return the deepest child as the event target.
+function targetWith(
+  attrs: Record<string, string>,
+  wrap?: Record<string, string>,
+) {
+  const el = document.createElement("span");
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  if (wrap) {
+    const parent = document.createElement("div");
+    for (const [k, v] of Object.entries(wrap)) parent.setAttribute(k, v);
+    parent.appendChild(el);
+    document.body.appendChild(parent);
+  } else {
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
+const IGNORED = ['[role="checkbox"]', '[aria-label="bookmark"]'];
+
+describe("shouldKeepPeekOpenOnOutsideInteraction", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("closes (returns false) for a plain outside target", () => {
+    expect(
+      shouldKeepPeekOpenOnOutsideInteraction(targetWith({}), IGNORED),
+    ).toBe(false);
+  });
+
+  it("keeps open for any target inside the peek content", () => {
+    const target = targetWith({}, { "data-peek-content": "" });
+    expect(shouldKeepPeekOpenOnOutsideInteraction(target, IGNORED)).toBe(true);
+  });
+
+  it("keeps open when clicking another table row (switch, not close)", () => {
+    const target = targetWith({}, { "data-row-index": "3" });
+    expect(shouldKeepPeekOpenOnOutsideInteraction(target, IGNORED)).toBe(true);
+  });
+
+  it("keeps open for an opt-out region", () => {
+    const target = targetWith({}, { "data-ignore-outside-interaction": "" });
+    expect(shouldKeepPeekOpenOnOutsideInteraction(target, IGNORED)).toBe(true);
+  });
+
+  it("keeps open for a selection checkbox even outside any row", () => {
+    expect(
+      shouldKeepPeekOpenOnOutsideInteraction(
+        targetWith({ role: "checkbox" }),
+        IGNORED,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps open for a table-configured ignoredSelector", () => {
+    expect(
+      shouldKeepPeekOpenOnOutsideInteraction(
+        targetWith({ "aria-label": "bookmark" }),
+        IGNORED,
+      ),
+    ).toBe(true);
+  });
+
+  it("closes for non-Element targets", () => {
+    expect(shouldKeepPeekOpenOnOutsideInteraction(null, IGNORED)).toBe(false);
+    expect(
+      shouldKeepPeekOpenOnOutsideInteraction(new EventTarget(), IGNORED),
+    ).toBe(false);
+  });
+});

--- a/web/src/components/table/peek/peek-experiment-item-detail.tsx
+++ b/web/src/components/table/peek/peek-experiment-item-detail.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from "next/router";
 import { usePeekData } from "@/src/components/table/peek/hooks/usePeekData";
-import { Trace } from "@/src/components/trace/Trace";
-import { Skeleton } from "@/src/components/ui/skeleton";
+import { TraceDetailBody } from "@/src/components/trace/TraceDetailBody";
 import { TablePeekView } from "@/src/components/table/peek";
 
 const PeekViewExperimentItemDetail = ({ projectId }: { projectId: string }) => {
@@ -23,20 +22,8 @@ const PeekViewExperimentItemDetail = ({ projectId }: { projectId: string }) => {
     timestamp,
   });
 
-  if (!peekId || !trace.data) {
-    return <Skeleton className="h-full w-full rounded-none" />;
-  }
-
   return (
-    <Trace
-      key={`${trace.data.id}-${peekId}`}
-      trace={trace.data}
-      scores={trace.data.scores}
-      corrections={trace.data.corrections}
-      projectId={trace.data.projectId}
-      observations={trace.data.observations}
-      context="peek"
-    />
+    <TraceDetailBody trace={trace.data} context="peek" keySuffix={peekId} />
   );
 };
 

--- a/web/src/components/table/peek/peek-observation-detail.tsx
+++ b/web/src/components/table/peek/peek-observation-detail.tsx
@@ -1,6 +1,7 @@
 import { TablePeekView } from "@/src/components/table/peek";
 import { usePeekData } from "@/src/components/table/peek/hooks/usePeekData";
 import { Trace } from "@/src/components/trace/Trace";
+import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { useRouter } from "next/router";
 
@@ -65,6 +66,19 @@ export const TablePeekViewObservationDetail = (
             ? `${trace.data.name}: ${trace.data.id}`
             : trace.data.id
           : traceId
+      }
+      actions={
+        trace.data ? (
+          <TraceDetailActions
+            traceId={trace.data.id}
+            projectId={trace.data.projectId}
+            bookmarked={trace.data.bookmarked}
+            isPublic={trace.data.public}
+            name={trace.data.name}
+            timestamp={timestamp}
+            onAfterDelete={props.closePeek}
+          />
+        ) : undefined
       }
     >
       <PeekViewObservationDetail trace={trace} peekId={peekId} />

--- a/web/src/components/table/peek/peek-observation-detail.tsx
+++ b/web/src/components/table/peek/peek-observation-detail.tsx
@@ -1,33 +1,11 @@
 import { TablePeekView } from "@/src/components/table/peek";
 import { usePeekData } from "@/src/components/table/peek/hooks/usePeekData";
-import { Trace } from "@/src/components/trace/Trace";
+import {
+  TraceDetailBody,
+  traceDetailTitle,
+} from "@/src/components/trace/TraceDetailBody";
 import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
-import { Skeleton } from "@/src/components/ui/skeleton";
 import { useRouter } from "next/router";
-
-const PeekViewObservationDetail = ({
-  peekId,
-  trace,
-}: {
-  peekId: string | undefined;
-  trace: ReturnType<typeof usePeekData>;
-}) => {
-  if (!peekId || !trace.data) {
-    return <Skeleton className="h-full w-full rounded-none" />;
-  }
-
-  return (
-    <Trace
-      key={`${trace.data.id}-${peekId}`}
-      trace={trace.data}
-      scores={trace.data.scores}
-      corrections={trace.data.corrections}
-      projectId={trace.data.projectId}
-      observations={trace.data.observations}
-      context="peek"
-    />
-  );
-};
 
 export const TablePeekViewObservationDetail = (
   props: Omit<
@@ -60,13 +38,7 @@ export const TablePeekViewObservationDetail = (
   return (
     <TablePeekView
       {...props}
-      title={
-        trace.data
-          ? trace.data.name
-            ? `${trace.data.name}: ${trace.data.id}`
-            : trace.data.id
-          : traceId
-      }
+      title={traceDetailTitle(trace.data, traceId)}
       actions={
         trace.data ? (
           <TraceDetailActions
@@ -81,7 +53,7 @@ export const TablePeekViewObservationDetail = (
         ) : undefined
       }
     >
-      <PeekViewObservationDetail trace={trace} peekId={peekId} />
+      <TraceDetailBody trace={trace.data} context="peek" keySuffix={peekId} />
     </TablePeekView>
   );
 };

--- a/web/src/components/table/peek/peek-observation-detail.tsx
+++ b/web/src/components/table/peek/peek-observation-detail.tsx
@@ -35,21 +35,28 @@ export const TablePeekViewObservationDetail = (
     timestamp,
   });
 
+  const actionProps = trace.data
+    ? {
+        traceId: trace.data.id,
+        projectId: trace.data.projectId,
+        bookmarked: trace.data.bookmarked,
+        isPublic: trace.data.public,
+        name: trace.data.name,
+        timestamp,
+        onAfterDelete: props.closePeek,
+      }
+    : null;
+
   return (
     <TablePeekView
       {...props}
       title={traceDetailTitle(trace.data, traceId)}
       actions={
-        trace.data ? (
-          <TraceDetailActions
-            traceId={trace.data.id}
-            projectId={trace.data.projectId}
-            bookmarked={trace.data.bookmarked}
-            isPublic={trace.data.public}
-            name={trace.data.name}
-            timestamp={timestamp}
-            onAfterDelete={props.closePeek}
-          />
+        actionProps ? <TraceDetailActions {...actionProps} /> : undefined
+      }
+      actionsMenu={
+        actionProps ? (
+          <TraceDetailActions {...actionProps} layout="menu" />
         ) : undefined
       }
     >

--- a/web/src/components/table/peek/peek-trace-detail.tsx
+++ b/web/src/components/table/peek/peek-trace-detail.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { Trace } from "@/src/components/trace/Trace";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { TablePeekView } from "@/src/components/table/peek";
+import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
 
 const PeekViewTraceDetail = ({
   trace,
@@ -59,6 +60,19 @@ export const TablePeekViewTraceDetail = (
             ? `${trace.data.name}: ${trace.data.id}`
             : trace.data.id
           : peekId
+      }
+      actions={
+        trace.data ? (
+          <TraceDetailActions
+            traceId={trace.data.id}
+            projectId={trace.data.projectId}
+            bookmarked={trace.data.bookmarked}
+            isPublic={trace.data.public}
+            name={trace.data.name}
+            timestamp={timestamp}
+            onAfterDelete={props.closePeek}
+          />
+        ) : undefined
       }
     >
       <PeekViewTraceDetail trace={trace} />

--- a/web/src/components/table/peek/peek-trace-detail.tsx
+++ b/web/src/components/table/peek/peek-trace-detail.tsx
@@ -1,29 +1,11 @@
 import { usePeekData } from "@/src/components/table/peek/hooks/usePeekData";
 import { useRouter } from "next/router";
-import { Trace } from "@/src/components/trace/Trace";
-import { Skeleton } from "@/src/components/ui/skeleton";
+import {
+  TraceDetailBody,
+  traceDetailTitle,
+} from "@/src/components/trace/TraceDetailBody";
 import { TablePeekView } from "@/src/components/table/peek";
 import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
-
-const PeekViewTraceDetail = ({
-  trace,
-}: {
-  trace: ReturnType<typeof usePeekData>;
-}) => {
-  return !trace.data ? (
-    <Skeleton className="h-full w-full rounded-none" />
-  ) : (
-    <Trace
-      key={trace.data.id}
-      trace={trace.data}
-      scores={trace.data.scores}
-      corrections={trace.data.corrections}
-      projectId={trace.data.projectId}
-      observations={trace.data.observations}
-      context="peek"
-    />
-  );
-};
 
 export const TablePeekViewTraceDetail = (
   props: Omit<
@@ -54,13 +36,7 @@ export const TablePeekViewTraceDetail = (
   return (
     <TablePeekView
       {...props}
-      title={
-        trace.data
-          ? trace.data.name
-            ? `${trace.data.name}: ${trace.data.id}`
-            : trace.data.id
-          : peekId
-      }
+      title={traceDetailTitle(trace.data, peekId)}
       actions={
         trace.data ? (
           <TraceDetailActions
@@ -75,7 +51,7 @@ export const TablePeekViewTraceDetail = (
         ) : undefined
       }
     >
-      <PeekViewTraceDetail trace={trace} />
+      <TraceDetailBody trace={trace.data} context="peek" />
     </TablePeekView>
   );
 };

--- a/web/src/components/table/peek/peek-trace-detail.tsx
+++ b/web/src/components/table/peek/peek-trace-detail.tsx
@@ -33,21 +33,28 @@ export const TablePeekViewTraceDetail = (
     timestamp,
   });
 
+  const actionProps = trace.data
+    ? {
+        traceId: trace.data.id,
+        projectId: trace.data.projectId,
+        bookmarked: trace.data.bookmarked,
+        isPublic: trace.data.public,
+        name: trace.data.name,
+        timestamp,
+        onAfterDelete: props.closePeek,
+      }
+    : null;
+
   return (
     <TablePeekView
       {...props}
       title={traceDetailTitle(trace.data, peekId)}
       actions={
-        trace.data ? (
-          <TraceDetailActions
-            traceId={trace.data.id}
-            projectId={trace.data.projectId}
-            bookmarked={trace.data.bookmarked}
-            isPublic={trace.data.public}
-            name={trace.data.name}
-            timestamp={timestamp}
-            onAfterDelete={props.closePeek}
-          />
+        actionProps ? <TraceDetailActions {...actionProps} /> : undefined
+      }
+      actionsMenu={
+        actionProps ? (
+          <TraceDetailActions {...actionProps} layout="menu" />
         ) : undefined
       }
     >

--- a/web/src/components/table/peek/peekHeaderOverflow.clienttest.ts
+++ b/web/src/components/table/peek/peekHeaderOverflow.clienttest.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { planToolbarOverflow } from "@/src/components/table/peek/peekHeaderOverflow";
+
+// actions is the first to fold, then openInTab; nav/expand/close are pinned.
+const DROP_ORDER = ["actions", "openInTab"] as const;
+const WIDTHS = { actions: 90, openInTab: 32 };
+const base = {
+  unitWidths: WIDTHS,
+  dropOrder: DROP_ORDER,
+  pinnedWidth: 120, // nav + expand + close
+  moreWidth: 32,
+  safety: 24,
+};
+
+describe("planToolbarOverflow", () => {
+  it("keeps everything inline when there is room", () => {
+    // 120 + (90+32) + 24 = 266 ≤ 400
+    expect(planToolbarOverflow({ ...base, clusterWidth: 400 }).size).toBe(0);
+  });
+
+  it("folds the lowest-priority unit (actions) first when tight", () => {
+    // inline needs 266 > 300? no — pick a width between the two thresholds.
+    // with "…": 120 + 32 + openInTab(32) + 24 = 208; keep openInTab, drop actions.
+    const overflow = planToolbarOverflow({ ...base, clusterWidth: 240 });
+    expect([...overflow]).toEqual(["actions"]);
+  });
+
+  it("folds both units when very tight", () => {
+    const overflow = planToolbarOverflow({ ...base, clusterWidth: 180 });
+    expect(overflow.has("actions")).toBe(true);
+    expect(overflow.has("openInTab")).toBe(true);
+  });
+
+  it("respects drop order: openInTab stays inline while actions collapse", () => {
+    // 240: drop actions → 120+32+32+24=208 ≤ 240 → openInTab kept inline.
+    const overflow = planToolbarOverflow({ ...base, clusterWidth: 240 });
+    expect(overflow.has("openInTab")).toBe(false);
+  });
+
+  it("ignores units that are not present (no measured width)", () => {
+    // Only actions present; openInTab absent → never in the overflow set.
+    const overflow = planToolbarOverflow({
+      ...base,
+      unitWidths: { actions: 90 },
+      clusterWidth: 150,
+    });
+    expect(overflow.has("openInTab")).toBe(false);
+    expect(overflow.has("actions")).toBe(true);
+  });
+
+  it("treats a zero/unmeasured cluster as fully collapsed", () => {
+    expect(planToolbarOverflow({ ...base, clusterWidth: 0 }).size).toBe(
+      DROP_ORDER.length,
+    );
+  });
+});

--- a/web/src/components/table/peek/peekHeaderOverflow.clienttest.ts
+++ b/web/src/components/table/peek/peekHeaderOverflow.clienttest.ts
@@ -1,57 +1,68 @@
 import { describe, expect, it } from "vitest";
 
-import { planToolbarOverflow } from "@/src/components/table/peek/peekHeaderOverflow";
+import { planPeekHeaderLayout } from "@/src/components/table/peek/peekHeaderOverflow";
 
-// actions is the first to fold, then openInTab; nav/expand/close are pinned.
-const DROP_ORDER = ["actions", "openInTab"] as const;
-const WIDTHS = { actions: 90, openInTab: 32 };
+// Representative measured widths (px).
 const base = {
-  unitWidths: WIDTHS,
-  dropOrder: DROP_ORDER,
-  pinnedWidth: 120, // nav + expand + close
+  minTitle: 240,
+  badgeLabelWidth: 64,
+  badgeIconWidth: 32,
+  navFullWidth: 92, // ↑K ↓J with chips
+  navCompactWidth: 52, // icon-only arrows
+  otherPinnedWidth: 68, // expand + close + divider
   moreWidth: 32,
-  safety: 24,
+  actionsWidth: 90,
+  openInTabWidth: 28,
+  safety: 16,
 };
 
-describe("planToolbarOverflow", () => {
-  it("keeps everything inline when there is room", () => {
-    // 120 + (90+32) + 24 = 266 ≤ 400
-    expect(planToolbarOverflow({ ...base, clusterWidth: 400 }).size).toBe(0);
+const FULL = {
+  foldActions: false,
+  foldOpenInTab: false,
+  badgeShowLabel: true,
+  navCompact: false,
+};
+
+describe("planPeekHeaderLayout", () => {
+  it("keeps everything when the title has room", () => {
+    expect(planPeekHeaderLayout({ ...base, headerWidth: 760 })).toEqual(FULL);
   });
 
-  it("folds the lowest-priority unit (actions) first when tight", () => {
-    // inline needs 266 > 300? no — pick a width between the two thresholds.
-    // with "…": 120 + 32 + openInTab(32) + 24 = 208; keep openInTab, drop actions.
-    const overflow = planToolbarOverflow({ ...base, clusterWidth: 240 });
-    expect([...overflow]).toEqual(["actions"]);
+  it("reduces in order as the peek narrows: actions, then badge, then nav", () => {
+    // Wide-ish: only the actions fold.
+    const a = planPeekHeaderLayout({ ...base, headerWidth: 560 });
+    expect(a.foldActions).toBe(true);
+    expect(a.badgeShowLabel).toBe(true);
+    expect(a.navCompact).toBe(false);
+
+    // Narrower: actions folded + badge icon-only.
+    const b = planPeekHeaderLayout({ ...base, headerWidth: 500 });
+    expect(b.foldActions).toBe(true);
+    expect(b.badgeShowLabel).toBe(false);
+
+    // Narrower still: nav goes compact too.
+    const c = planPeekHeaderLayout({ ...base, headerWidth: 430 });
+    expect(c.navCompact).toBe(true);
   });
 
-  it("folds both units when very tight", () => {
-    const overflow = planToolbarOverflow({ ...base, clusterWidth: 180 });
-    expect(overflow.has("actions")).toBe(true);
-    expect(overflow.has("openInTab")).toBe(true);
+  it("folds open-in-tab last, when very tight", () => {
+    const plan = planPeekHeaderLayout({ ...base, headerWidth: 320 });
+    expect(plan.foldActions).toBe(true);
+    expect(plan.badgeShowLabel).toBe(false);
+    expect(plan.navCompact).toBe(true);
+    expect(plan.foldOpenInTab).toBe(true);
   });
 
-  it("respects drop order: openInTab stays inline while actions collapse", () => {
-    // 240: drop actions → 120+32+32+24=208 ≤ 240 → openInTab kept inline.
-    const overflow = planToolbarOverflow({ ...base, clusterWidth: 240 });
-    expect(overflow.has("openInTab")).toBe(false);
-  });
-
-  it("ignores units that are not present (no measured width)", () => {
-    // Only actions present; openInTab absent → never in the overflow set.
-    const overflow = planToolbarOverflow({
+  it("never folds units that aren't present, but still adapts badge/nav", () => {
+    const plan = planPeekHeaderLayout({
       ...base,
-      unitWidths: { actions: 90 },
-      clusterWidth: 150,
+      actionsWidth: undefined,
+      openInTabWidth: undefined,
+      headerWidth: 300,
     });
-    expect(overflow.has("openInTab")).toBe(false);
-    expect(overflow.has("actions")).toBe(true);
-  });
-
-  it("treats a zero/unmeasured cluster as fully collapsed", () => {
-    expect(planToolbarOverflow({ ...base, clusterWidth: 0 }).size).toBe(
-      DROP_ORDER.length,
-    );
+    expect(plan.foldActions).toBe(false);
+    expect(plan.foldOpenInTab).toBe(false);
+    expect(plan.badgeShowLabel).toBe(false);
+    expect(plan.navCompact).toBe(true);
   });
 });

--- a/web/src/components/table/peek/peekHeaderOverflow.ts
+++ b/web/src/components/table/peek/peekHeaderOverflow.ts
@@ -1,59 +1,99 @@
 /**
- * Priority-plus overflow math for the peek header's right-aligned control
- * cluster. Pure + framework-free so the collapse behaviour can be unit-tested
- * without a DOM. The header measures its controls and calls this to decide
- * which low-priority units collapse into the "…" popover when space is tight.
+ * Layout planner for the peek header. Pure + framework-free so the adaptive
+ * behaviour can be unit-tested without a DOM. The header measures its parts and
+ * calls this to decide — from the PEEK's own width, not the screen's — how to
+ * stay uncluttered while keeping the title readable.
  *
- * Keeping it width-based (not breakpoint-based) lets the peek — which the user
- * resizes freely from ~40% to full width — show everything when there's room
- * and fold the least-important controls away when there isn't.
+ * The rule: the title always gets at least `minTitle` px. When it wouldn't, we
+ * apply reductions in least-painful order until it fits:
+ *   1. fold the trace actions into the "…" menu (still one click away),
+ *   2. shrink the type badge to icon-only (never truncate it to "Tr…"),
+ *   3. compact the prev/next nav (icon-only arrows, K/J in the tooltip),
+ *   4. fold open-in-tab into "…".
+ * Anything still over budget just lets the title truncate (its natural state).
  */
 
-export type PlanToolbarOverflowArgs<K extends string> = {
-  /** Width available to the whole right cluster (header width − reserved title), px. */
-  clusterWidth: number;
-  /** Measured widths (px) of each present overflowable unit; absent ⇒ not rendered. */
-  unitWidths: Partial<Record<K, number>>;
-  /** Units in collapse order: the first entry is the first to move into "…". */
-  dropOrder: readonly K[];
-  /** Combined width (px) of the pinned controls that never collapse. */
-  pinnedWidth: number;
-  /** Width (px) of the "…" trigger, counted only once something overflows. */
+export type PeekHeaderPlan = {
+  foldActions: boolean;
+  foldOpenInTab: boolean;
+  badgeShowLabel: boolean;
+  navCompact: boolean;
+};
+
+export type PlanPeekHeaderArgs = {
+  /** The peek header's measured width, px (= the peek's width). */
+  headerWidth: number;
+  /** Minimum width the title keeps before anything else collapses, px. */
+  minTitle: number;
+  badgeLabelWidth: number;
+  badgeIconWidth: number;
+  /** Prev/next nav width with K/J chips, px (0 when no nav). */
+  navFullWidth: number;
+  /** Prev/next nav width as compact icon arrows, px (0 when no nav). */
+  navCompactWidth: number;
+  /** Pinned controls other than nav (expand + close + divider), px. */
+  otherPinnedWidth: number;
+  /** Width of the "…" overflow trigger, counted once anything folds, px. */
   moreWidth: number;
-  /** Slack (px) absorbing inter-control gaps + sub-pixel rounding so we fold a touch early. */
+  /** Trace actions cluster width, px; omit when there are no actions. */
+  actionsWidth?: number;
+  /** Open-in-tab button width, px; omit when it isn't shown. */
+  openInTabWidth?: number;
+  /** Slack absorbing inter-control gaps + rounding, px. */
   safety?: number;
 };
 
-/**
- * Returns the set of units that should collapse into the overflow menu. Empty
- * when everything fits inline (and the "…" trigger isn't needed).
- */
-export function planToolbarOverflow<K extends string>({
-  clusterWidth,
-  unitWidths,
-  dropOrder,
-  pinnedWidth,
+export function planPeekHeaderLayout({
+  headerWidth,
+  minTitle,
+  badgeLabelWidth,
+  badgeIconWidth,
+  navFullWidth,
+  navCompactWidth,
+  otherPinnedWidth,
   moreWidth,
-  safety = 24,
-}: PlanToolbarOverflowArgs<K>): Set<K> {
-  const present = dropOrder.filter((u) => unitWidths[u] != null);
-  const widthOf = (u: K) => unitWidths[u] ?? 0;
-  const sum = (units: K[]) => units.reduce((acc, u) => acc + widthOf(u), 0);
+  actionsWidth,
+  openInTabWidth,
+  safety = 16,
+}: PlanPeekHeaderArgs): PeekHeaderPlan {
+  const hasActions = actionsWidth != null;
+  const hasOpenInTab = openInTabWidth != null;
 
-  // Everything fits inline → no overflow, no "…" trigger.
-  if (pinnedWidth + sum(present) + safety <= clusterWidth) {
-    return new Set<K>();
+  let foldActions = false;
+  let foldOpenInTab = false;
+  let badgeShowLabel = true;
+  let navCompact = false;
+
+  const pinnedWidth = () =>
+    (navCompact ? navCompactWidth : navFullWidth) + otherPinnedWidth;
+  const clusterWidth = () =>
+    pinnedWidth() +
+    (foldActions || foldOpenInTab ? moreWidth : 0) +
+    (hasActions && !foldActions ? (actionsWidth ?? 0) : 0) +
+    (hasOpenInTab && !foldOpenInTab ? (openInTabWidth ?? 0) : 0) +
+    safety;
+  const badgeWidth = () => (badgeShowLabel ? badgeLabelWidth : badgeIconWidth);
+  const titleAvailable = () => headerWidth - badgeWidth() - clusterWidth();
+
+  const reductions: Array<() => void> = [
+    () => {
+      if (hasActions) foldActions = true;
+    },
+    () => {
+      badgeShowLabel = false;
+    },
+    () => {
+      navCompact = true;
+    },
+    () => {
+      if (hasOpenInTab) foldOpenInTab = true;
+    },
+  ];
+
+  for (const reduce of reductions) {
+    if (titleAvailable() >= minTitle) break;
+    reduce();
   }
 
-  // Otherwise the "…" trigger is shown; drop the lowest-priority units (front
-  // of dropOrder) until the remaining inline controls + the trigger fit.
-  const overflow = new Set<K>();
-  let visible = [...present];
-  for (const unit of dropOrder) {
-    if (pinnedWidth + moreWidth + sum(visible) + safety <= clusterWidth) break;
-    if (!visible.includes(unit)) continue;
-    overflow.add(unit);
-    visible = visible.filter((u) => u !== unit);
-  }
-  return overflow;
+  return { foldActions, foldOpenInTab, badgeShowLabel, navCompact };
 }

--- a/web/src/components/table/peek/peekHeaderOverflow.ts
+++ b/web/src/components/table/peek/peekHeaderOverflow.ts
@@ -1,0 +1,59 @@
+/**
+ * Priority-plus overflow math for the peek header's right-aligned control
+ * cluster. Pure + framework-free so the collapse behaviour can be unit-tested
+ * without a DOM. The header measures its controls and calls this to decide
+ * which low-priority units collapse into the "…" popover when space is tight.
+ *
+ * Keeping it width-based (not breakpoint-based) lets the peek — which the user
+ * resizes freely from ~40% to full width — show everything when there's room
+ * and fold the least-important controls away when there isn't.
+ */
+
+export type PlanToolbarOverflowArgs<K extends string> = {
+  /** Width available to the whole right cluster (header width − reserved title), px. */
+  clusterWidth: number;
+  /** Measured widths (px) of each present overflowable unit; absent ⇒ not rendered. */
+  unitWidths: Partial<Record<K, number>>;
+  /** Units in collapse order: the first entry is the first to move into "…". */
+  dropOrder: readonly K[];
+  /** Combined width (px) of the pinned controls that never collapse. */
+  pinnedWidth: number;
+  /** Width (px) of the "…" trigger, counted only once something overflows. */
+  moreWidth: number;
+  /** Slack (px) absorbing inter-control gaps + sub-pixel rounding so we fold a touch early. */
+  safety?: number;
+};
+
+/**
+ * Returns the set of units that should collapse into the overflow menu. Empty
+ * when everything fits inline (and the "…" trigger isn't needed).
+ */
+export function planToolbarOverflow<K extends string>({
+  clusterWidth,
+  unitWidths,
+  dropOrder,
+  pinnedWidth,
+  moreWidth,
+  safety = 24,
+}: PlanToolbarOverflowArgs<K>): Set<K> {
+  const present = dropOrder.filter((u) => unitWidths[u] != null);
+  const widthOf = (u: K) => unitWidths[u] ?? 0;
+  const sum = (units: K[]) => units.reduce((acc, u) => acc + widthOf(u), 0);
+
+  // Everything fits inline → no overflow, no "…" trigger.
+  if (pinnedWidth + sum(present) + safety <= clusterWidth) {
+    return new Set<K>();
+  }
+
+  // Otherwise the "…" trigger is shown; drop the lowest-priority units (front
+  // of dropOrder) until the remaining inline controls + the trigger fit.
+  const overflow = new Set<K>();
+  let visible = [...present];
+  for (const unit of dropOrder) {
+    if (pinnedWidth + moreWidth + sum(visible) + safety <= clusterWidth) break;
+    if (!visible.includes(unit)) continue;
+    overflow.add(unit);
+    visible = visible.filter((u) => u !== unit);
+  }
+  return overflow;
+}

--- a/web/src/components/table/peek/store/peekPanelStore.clienttest.ts
+++ b/web/src/components/table/peek/store/peekPanelStore.clienttest.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createPeekPanelStore,
+  PEEK_DEFAULT_WIDTH_FRACTION,
+  PEEK_MAX_WIDGET_WIDTH_FRACTION,
+  PEEK_MIN_WIDTH_FRACTION,
+  selectWidth,
+} from "@/src/components/table/peek/store/peekPanelStore";
+
+const STORAGE_KEY = "peekViewWidthFraction";
+const pct = (fraction: number) => `${fraction * 100}vw`;
+
+describe("peekPanelStore", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  it("defaults to the widget width and is not fullscreen", () => {
+    const store = createPeekPanelStore();
+    const state = store.getState();
+    expect(state.isFullscreen).toBe(false);
+    expect(state.widthFraction).toBeCloseTo(PEEK_DEFAULT_WIDTH_FRACTION);
+    expect(selectWidth(state)).toBe(pct(PEEK_DEFAULT_WIDTH_FRACTION));
+  });
+
+  it("reads and clamps the persisted width on creation", () => {
+    window.localStorage.setItem(STORAGE_KEY, "0.7");
+    expect(createPeekPanelStore().getState().widthFraction).toBeCloseTo(0.7);
+
+    window.localStorage.setItem(STORAGE_KEY, "5");
+    expect(createPeekPanelStore().getState().widthFraction).toBeCloseTo(
+      PEEK_MAX_WIDGET_WIDTH_FRACTION,
+    );
+  });
+
+  it("commitWidth clamps, persists, and clears the draft + fullscreen", () => {
+    const store = createPeekPanelStore();
+    store.getState().actions.enterFullscreenDraft();
+    store.getState().actions.commitWidth(0.72);
+    const state = store.getState();
+    expect(state.widthFraction).toBeCloseTo(0.72);
+    expect(state.draftFraction).toBeNull();
+    expect(state.isFullscreen).toBe(false);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("0.72");
+  });
+
+  it("setDraftFraction drives the live width and leaves fullscreen", () => {
+    const store = createPeekPanelStore();
+    store.getState().actions.enterFullscreenDraft();
+    store.getState().actions.setDraftFraction(0.42);
+    const state = store.getState();
+    expect(state.isFullscreen).toBe(false);
+    expect(selectWidth(state)).toBe(pct(0.42));
+    // The committed width preference is untouched until pointer-up.
+    expect(state.widthFraction).toBeCloseTo(PEEK_DEFAULT_WIDTH_FRACTION);
+  });
+
+  it("enterFullscreenDraft renders 100vw without persisting a width", () => {
+    const store = createPeekPanelStore();
+    store.getState().actions.enterFullscreenDraft();
+    expect(selectWidth(store.getState())).toBe("100vw");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("toggleFullscreen flips and falls back to the persisted widget width", () => {
+    window.localStorage.setItem(STORAGE_KEY, "0.65");
+    const store = createPeekPanelStore();
+    store.getState().actions.toggleFullscreen();
+    expect(selectWidth(store.getState())).toBe("100vw");
+    store.getState().actions.toggleFullscreen();
+    expect(selectWidth(store.getState())).toBe(pct(0.65));
+  });
+
+  it("nudgeWidth bases off the persisted width (even from fullscreen) and clamps", () => {
+    window.localStorage.setItem(STORAGE_KEY, "0.5");
+    const store = createPeekPanelStore();
+    store.getState().actions.toggleFullscreen();
+
+    // Exits fullscreen relative to 0.5, not the fullscreen ceiling.
+    store.getState().actions.nudgeWidth("shrink");
+    expect(store.getState().isFullscreen).toBe(false);
+    expect(store.getState().widthFraction).toBeCloseTo(0.45);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("0.45");
+
+    store.getState().actions.nudgeWidth("grow");
+    expect(store.getState().widthFraction).toBeCloseTo(0.5);
+  });
+
+  it("nudgeWidth never shrinks below the minimum", () => {
+    window.localStorage.setItem(STORAGE_KEY, String(PEEK_MIN_WIDTH_FRACTION));
+    const store = createPeekPanelStore();
+    store.getState().actions.nudgeWidth("shrink");
+    expect(store.getState().widthFraction).toBeCloseTo(PEEK_MIN_WIDTH_FRACTION);
+  });
+
+  it("resetForVisibility clears fullscreen on close, no-ops while open", () => {
+    const store = createPeekPanelStore();
+    store.getState().actions.toggleFullscreen();
+
+    store.getState().actions.resetForVisibility(true);
+    expect(store.getState().isFullscreen).toBe(true);
+
+    store.getState().actions.resetForVisibility(false);
+    expect(store.getState().isFullscreen).toBe(false);
+  });
+});

--- a/web/src/components/table/peek/store/peekPanelStore.clienttest.ts
+++ b/web/src/components/table/peek/store/peekPanelStore.clienttest.ts
@@ -5,7 +5,8 @@ import {
   PEEK_DEFAULT_WIDTH_FRACTION,
   PEEK_MAX_WIDGET_WIDTH_FRACTION,
   PEEK_MIN_WIDTH_FRACTION,
-  selectWidth,
+  selectDraftExpanded,
+  selectWidgetWidth,
 } from "@/src/components/table/peek/store/peekPanelStore";
 
 const STORAGE_KEY = "peekViewWidthFraction";
@@ -15,12 +16,13 @@ describe("peekPanelStore", () => {
   beforeEach(() => window.localStorage.clear());
   afterEach(() => window.localStorage.clear());
 
-  it("defaults to the widget width and is not fullscreen", () => {
+  it("defaults to the widget width, not resizing or expanded", () => {
     const store = createPeekPanelStore();
     const state = store.getState();
-    expect(state.isFullscreen).toBe(false);
+    expect(state.isResizing).toBe(false);
+    expect(state.draftExpanded).toBe(false);
     expect(state.widthFraction).toBeCloseTo(PEEK_DEFAULT_WIDTH_FRACTION);
-    expect(selectWidth(state)).toBe(pct(PEEK_DEFAULT_WIDTH_FRACTION));
+    expect(selectWidgetWidth(state)).toBe(pct(PEEK_DEFAULT_WIDTH_FRACTION));
   });
 
   it("reads and clamps the persisted width on creation", () => {
@@ -33,56 +35,45 @@ describe("peekPanelStore", () => {
     );
   });
 
-  it("commitWidth clamps, persists, and clears the draft + fullscreen", () => {
+  it("commitWidth clamps, persists, and clears the draft", () => {
     const store = createPeekPanelStore();
-    store.getState().actions.enterFullscreenDraft();
+    store.getState().actions.setDraftExpanded();
     store.getState().actions.commitWidth(0.72);
     const state = store.getState();
     expect(state.widthFraction).toBeCloseTo(0.72);
     expect(state.draftFraction).toBeNull();
-    expect(state.isFullscreen).toBe(false);
+    expect(state.draftExpanded).toBe(false);
     expect(window.localStorage.getItem(STORAGE_KEY)).toBe("0.72");
   });
 
-  it("setDraftFraction drives the live width and leaves fullscreen", () => {
+  it("setDraftFraction drives the live widget width (and clears draftExpanded)", () => {
     const store = createPeekPanelStore();
-    store.getState().actions.enterFullscreenDraft();
+    store.getState().actions.setDraftExpanded();
     store.getState().actions.setDraftFraction(0.42);
     const state = store.getState();
-    expect(state.isFullscreen).toBe(false);
-    expect(selectWidth(state)).toBe(pct(0.42));
+    expect(state.draftExpanded).toBe(false);
+    expect(selectWidgetWidth(state)).toBe(pct(0.42));
     // The committed width preference is untouched until pointer-up.
     expect(state.widthFraction).toBeCloseTo(PEEK_DEFAULT_WIDTH_FRACTION);
   });
 
-  it("enterFullscreenDraft renders 100vw without persisting a width", () => {
+  it("setDraftExpanded previews expansion without persisting a width", () => {
     const store = createPeekPanelStore();
-    store.getState().actions.enterFullscreenDraft();
-    expect(selectWidth(store.getState())).toBe("100vw");
+    store.getState().actions.setDraftExpanded();
+    expect(selectDraftExpanded(store.getState())).toBe(true);
+    expect(store.getState().draftFraction).toBeNull();
     expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
-  it("toggleFullscreen flips and falls back to the persisted widget width", () => {
-    window.localStorage.setItem(STORAGE_KEY, "0.65");
-    const store = createPeekPanelStore();
-    store.getState().actions.toggleFullscreen();
-    expect(selectWidth(store.getState())).toBe("100vw");
-    store.getState().actions.toggleFullscreen();
-    expect(selectWidth(store.getState())).toBe(pct(0.65));
-  });
-
-  it("nudgeWidth bases off the persisted width (even from fullscreen) and clamps", () => {
+  it("nudgeWidth grows/shrinks within bounds and persists", () => {
     window.localStorage.setItem(STORAGE_KEY, "0.5");
     const store = createPeekPanelStore();
-    store.getState().actions.toggleFullscreen();
-
-    // Exits fullscreen relative to 0.5, not the fullscreen ceiling.
-    store.getState().actions.nudgeWidth("shrink");
-    expect(store.getState().isFullscreen).toBe(false);
-    expect(store.getState().widthFraction).toBeCloseTo(0.45);
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("0.45");
 
     store.getState().actions.nudgeWidth("grow");
+    expect(store.getState().widthFraction).toBeCloseTo(0.55);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("0.55");
+
+    store.getState().actions.nudgeWidth("shrink");
     expect(store.getState().widthFraction).toBeCloseTo(0.5);
   });
 
@@ -101,20 +92,9 @@ describe("peekPanelStore", () => {
     store.getState().actions.cancelResize();
     const state = store.getState();
     expect(state.draftFraction).toBeNull();
+    expect(state.draftExpanded).toBe(false);
     expect(state.isResizing).toBe(false);
-    // The persisted width is untouched by an abandoned drag.
     expect(state.widthFraction).toBeCloseTo(0.5);
     expect(window.localStorage.getItem(STORAGE_KEY)).toBe("0.5");
-  });
-
-  it("resetForVisibility clears fullscreen on close, no-ops while open", () => {
-    const store = createPeekPanelStore();
-    store.getState().actions.toggleFullscreen();
-
-    store.getState().actions.resetForVisibility(true);
-    expect(store.getState().isFullscreen).toBe(true);
-
-    store.getState().actions.resetForVisibility(false);
-    expect(store.getState().isFullscreen).toBe(false);
   });
 });

--- a/web/src/components/table/peek/store/peekPanelStore.clienttest.ts
+++ b/web/src/components/table/peek/store/peekPanelStore.clienttest.ts
@@ -93,6 +93,20 @@ describe("peekPanelStore", () => {
     expect(store.getState().widthFraction).toBeCloseTo(PEEK_MIN_WIDTH_FRACTION);
   });
 
+  it("cancelResize abandons the draft without committing a width", () => {
+    window.localStorage.setItem(STORAGE_KEY, "0.5");
+    const store = createPeekPanelStore();
+    store.getState().actions.setResizing(true);
+    store.getState().actions.setDraftFraction(0.8);
+    store.getState().actions.cancelResize();
+    const state = store.getState();
+    expect(state.draftFraction).toBeNull();
+    expect(state.isResizing).toBe(false);
+    // The persisted width is untouched by an abandoned drag.
+    expect(state.widthFraction).toBeCloseTo(0.5);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("0.5");
+  });
+
   it("resetForVisibility clears fullscreen on close, no-ops while open", () => {
     const store = createPeekPanelStore();
     store.getState().actions.toggleFullscreen();

--- a/web/src/components/table/peek/store/peekPanelStore.ts
+++ b/web/src/components/table/peek/store/peekPanelStore.ts
@@ -72,6 +72,8 @@ export interface PeekPanelStoreState {
   isResizing: boolean;
   actions: {
     setResizing: (isResizing: boolean) => void;
+    /** Abandon an in-flight drag without committing (e.g. peek closed mid-drag). */
+    cancelResize: () => void;
     /** Drag below the fullscreen threshold: live widget width. */
     setDraftFraction: (fraction: number) => void;
     /** Drag past the fullscreen threshold. */
@@ -97,6 +99,7 @@ export function createPeekPanelStore(): PeekPanelStore {
     isResizing: false,
     actions: {
       setResizing: (isResizing) => set({ isResizing }),
+      cancelResize: () => set({ draftFraction: null, isResizing: false }),
       setDraftFraction: (fraction) =>
         set({
           draftFraction: clampWidthFraction(fraction),

--- a/web/src/components/table/peek/store/peekPanelStore.ts
+++ b/web/src/components/table/peek/store/peekPanelStore.ts
@@ -1,0 +1,144 @@
+import { createStore, type StoreApi } from "zustand/vanilla";
+
+/**
+ * Per-mount store for the desktop peek panel: how wide it is and whether it is
+ * fullscreen. Follows the local-feature-state pattern from
+ * `frontend-large-feature-architecture` — one store instance per peek host,
+ * mutated only through named `actions`, the drag workflow lives in
+ * `../actions/resizePeekPanel.ts`.
+ *
+ * State altitudes:
+ * - **widthFraction** — cross-view persisted preference. Mirrored to
+ *   localStorage (resolution-independent fraction) so every peek shares it.
+ * - **isFullscreen** — ephemeral per open session; reset on close via
+ *   `resetForVisibility` (the host outlives open/close, so it is explicit).
+ * - **draftFraction / isResizing** — high-frequency transient drag state; the
+ *   draft is committed to `widthFraction` (and localStorage) only on pointer-up.
+ *
+ * Width and fullscreen are one continuum: dragging past
+ * `PEEK_FULLSCREEN_ENTER_FRACTION` enters fullscreen; dragging back returns to a
+ * widget width. The header button is just a shortcut for the same toggle.
+ */
+
+const STORAGE_KEY = "peekViewWidthFraction";
+
+// Widget width bounds, as a fraction of the viewport width.
+export const PEEK_MIN_WIDTH_FRACTION = 0.3;
+export const PEEK_MAX_WIDGET_WIDTH_FRACTION = 0.9;
+export const PEEK_DEFAULT_WIDTH_FRACTION = 0.5;
+// Dragging the handle beyond this fraction of the viewport snaps to fullscreen.
+export const PEEK_FULLSCREEN_ENTER_FRACTION = 0.95;
+const KEYBOARD_RESIZE_STEP = 0.05;
+
+export const clampWidthFraction = (fraction: number) =>
+  Math.min(
+    PEEK_MAX_WIDGET_WIDTH_FRACTION,
+    Math.max(PEEK_MIN_WIDTH_FRACTION, fraction),
+  );
+
+// Cross-view width preference, persisted as a raw fraction. SSR-safe: reads the
+// default on the server and the first client render, the real value after mount.
+function readStoredWidthFraction(): number {
+  if (typeof window === "undefined") return PEEK_DEFAULT_WIDTH_FRACTION;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return PEEK_DEFAULT_WIDTH_FRACTION;
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "number"
+      ? clampWidthFraction(parsed)
+      : PEEK_DEFAULT_WIDTH_FRACTION;
+  } catch {
+    return PEEK_DEFAULT_WIDTH_FRACTION;
+  }
+}
+
+function writeStoredWidthFraction(fraction: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(fraction));
+  } catch {
+    // Ignore write failures (private mode, quota) — width is a best-effort pref.
+  }
+}
+
+export interface PeekPanelStoreState {
+  /** Committed widget width (persisted), as a fraction of the viewport. */
+  widthFraction: number;
+  /** Live width during a drag; null when not dragging. */
+  draftFraction: number | null;
+  /** Whether the panel fills the viewport. */
+  isFullscreen: boolean;
+  /** True while the resize handle is being dragged. */
+  isResizing: boolean;
+  actions: {
+    setResizing: (isResizing: boolean) => void;
+    /** Drag below the fullscreen threshold: live widget width. */
+    setDraftFraction: (fraction: number) => void;
+    /** Drag past the fullscreen threshold. */
+    enterFullscreenDraft: () => void;
+    /** End a drag on a widget width: persist it and clear the draft. */
+    commitWidth: (fraction: number) => void;
+    /** Toggle fullscreen; off falls back to the persisted widget width. */
+    toggleFullscreen: () => void;
+    /** Keyboard resize from the persisted widget width (never the ceiling). */
+    nudgeWidth: (direction: "grow" | "shrink") => void;
+    /** Reset fullscreen when the peek closes (`isOpen` → false). */
+    resetForVisibility: (isOpen: boolean) => void;
+  };
+}
+
+export type PeekPanelStore = StoreApi<PeekPanelStoreState>;
+
+export function createPeekPanelStore(): PeekPanelStore {
+  return createStore<PeekPanelStoreState>((set, get) => ({
+    widthFraction: readStoredWidthFraction(),
+    draftFraction: null,
+    isFullscreen: false,
+    isResizing: false,
+    actions: {
+      setResizing: (isResizing) => set({ isResizing }),
+      setDraftFraction: (fraction) =>
+        set({
+          draftFraction: clampWidthFraction(fraction),
+          isFullscreen: false,
+        }),
+      enterFullscreenDraft: () =>
+        set({ isFullscreen: true, draftFraction: null }),
+      commitWidth: (fraction) => {
+        const clamped = clampWidthFraction(fraction);
+        writeStoredWidthFraction(clamped);
+        set({
+          widthFraction: clamped,
+          draftFraction: null,
+          isFullscreen: false,
+        });
+      },
+      toggleFullscreen: () =>
+        set((state) => ({ isFullscreen: !state.isFullscreen })),
+      nudgeWidth: (direction) => {
+        const delta =
+          direction === "grow" ? KEYBOARD_RESIZE_STEP : -KEYBOARD_RESIZE_STEP;
+        const next = clampWidthFraction(get().widthFraction + delta);
+        writeStoredWidthFraction(next);
+        set({ widthFraction: next, draftFraction: null, isFullscreen: false });
+      },
+      resetForVisibility: (isOpen) => {
+        if (!isOpen && get().isFullscreen) set({ isFullscreen: false });
+      },
+    },
+  }));
+}
+
+export const selectIsFullscreen = (state: PeekPanelStoreState) =>
+  state.isFullscreen;
+export const selectIsResizing = (state: PeekPanelStoreState) =>
+  state.isResizing;
+
+/**
+ * The panel's CSS width as a primitive string (`"50vw"` / `"100vw"`) so the
+ * subscription bails out unless the rendered width actually changes.
+ */
+export const selectWidth = (state: PeekPanelStoreState): string =>
+  state.isFullscreen
+    ? "100vw"
+    : `${clampWidthFraction(state.draftFraction ?? state.widthFraction) * 100}vw`;

--- a/web/src/components/table/peek/store/peekPanelStore.ts
+++ b/web/src/components/table/peek/store/peekPanelStore.ts
@@ -1,23 +1,24 @@
 import { createStore, type StoreApi } from "zustand/vanilla";
 
 /**
- * Per-mount store for the desktop peek panel: how wide it is and whether it is
- * fullscreen. Follows the local-feature-state pattern from
- * `frontend-large-feature-architecture` — one store instance per peek host,
- * mutated only through named `actions`, the drag workflow lives in
- * `../actions/resizePeekPanel.ts`.
+ * Per-mount store for the desktop peek panel's WIDTH. Follows the
+ * local-feature-state pattern from `frontend-large-feature-architecture` — one
+ * store instance per peek host, mutated only through named `actions`; the drag
+ * workflow lives in `../actions/resizePeekPanel.ts`.
  *
- * State altitudes:
- * - **widthFraction** — cross-view persisted preference. Mirrored to
- *   localStorage (resolution-independent fraction) so every peek shares it.
- * - **isFullscreen** — ephemeral per open session; reset on close via
- *   `resetForVisibility` (the host outlives open/close, so it is explicit).
- * - **draftFraction / isResizing** — high-frequency transient drag state; the
- *   draft is committed to `widthFraction` (and localStorage) only on pointer-up.
+ * Whether the peek is *expanded* (max width) is NOT stored here — it lives in
+ * the URL (`peekView=expanded`, owned by `usePeekNavigation`) so it is shareable
+ * and survives back/forward. This store only owns the widget width and the
+ * transient drag state:
+ * - **widthFraction** — cross-view persisted widget width (localStorage, a
+ *   resolution-independent viewport fraction).
+ * - **draftFraction / draftExpanded / isResizing** — high-frequency transient
+ *   drag state. On pointer-up the drag either commits a widget width or asks the
+ *   caller to flip the URL `expanded` flag (see the resize action).
  *
- * Width and fullscreen are one continuum: dragging past
- * `PEEK_FULLSCREEN_ENTER_FRACTION` enters fullscreen; dragging back returns to a
- * widget width. The header button is just a shortcut for the same toggle.
+ * Width and expanded are one continuum: dragging the handle past
+ * `PEEK_EXPAND_ENTER_FRACTION` previews the expanded width (`draftExpanded`);
+ * dragging back returns to a widget width.
  */
 
 const STORAGE_KEY = "peekViewWidthFraction";
@@ -26,8 +27,8 @@ const STORAGE_KEY = "peekViewWidthFraction";
 export const PEEK_MIN_WIDTH_FRACTION = 0.4;
 export const PEEK_MAX_WIDGET_WIDTH_FRACTION = 0.9;
 export const PEEK_DEFAULT_WIDTH_FRACTION = 0.5;
-// Dragging the handle beyond this fraction of the viewport snaps to fullscreen.
-export const PEEK_FULLSCREEN_ENTER_FRACTION = 0.95;
+// Dragging the handle beyond this fraction of the viewport previews "expanded".
+export const PEEK_EXPAND_ENTER_FRACTION = 0.95;
 const KEYBOARD_RESIZE_STEP = 0.05;
 
 export const clampWidthFraction = (fraction: number) =>
@@ -64,28 +65,24 @@ function writeStoredWidthFraction(fraction: number): void {
 export interface PeekPanelStoreState {
   /** Committed widget width (persisted), as a fraction of the viewport. */
   widthFraction: number;
-  /** Live width during a drag; null when not dragging. */
+  /** Live widget width during a drag; null when not dragging or expanded. */
   draftFraction: number | null;
-  /** Whether the panel fills the viewport. */
-  isFullscreen: boolean;
+  /** True while a drag is previewing the expanded (max) width. */
+  draftExpanded: boolean;
   /** True while the resize handle is being dragged. */
   isResizing: boolean;
   actions: {
     setResizing: (isResizing: boolean) => void;
     /** Abandon an in-flight drag without committing (e.g. peek closed mid-drag). */
     cancelResize: () => void;
-    /** Drag below the fullscreen threshold: live widget width. */
+    /** Drag below the expand threshold: live widget width. */
     setDraftFraction: (fraction: number) => void;
-    /** Drag past the fullscreen threshold. */
-    enterFullscreenDraft: () => void;
+    /** Drag past the expand threshold: preview the expanded (max) width. */
+    setDraftExpanded: () => void;
     /** End a drag on a widget width: persist it and clear the draft. */
     commitWidth: (fraction: number) => void;
-    /** Toggle fullscreen; off falls back to the persisted widget width. */
-    toggleFullscreen: () => void;
-    /** Keyboard resize from the persisted widget width (never the ceiling). */
+    /** Keyboard resize of the persisted widget width. */
     nudgeWidth: (direction: "grow" | "shrink") => void;
-    /** Reset fullscreen when the peek closes (`isOpen` → false). */
-    resetForVisibility: (isOpen: boolean) => void;
   };
 }
 
@@ -95,53 +92,47 @@ export function createPeekPanelStore(): PeekPanelStore {
   return createStore<PeekPanelStoreState>((set, get) => ({
     widthFraction: readStoredWidthFraction(),
     draftFraction: null,
-    isFullscreen: false,
+    draftExpanded: false,
     isResizing: false,
     actions: {
       setResizing: (isResizing) => set({ isResizing }),
-      cancelResize: () => set({ draftFraction: null, isResizing: false }),
+      cancelResize: () =>
+        set({ draftFraction: null, draftExpanded: false, isResizing: false }),
       setDraftFraction: (fraction) =>
         set({
           draftFraction: clampWidthFraction(fraction),
-          isFullscreen: false,
+          draftExpanded: false,
         }),
-      enterFullscreenDraft: () =>
-        set({ isFullscreen: true, draftFraction: null }),
+      setDraftExpanded: () => set({ draftExpanded: true, draftFraction: null }),
       commitWidth: (fraction) => {
         const clamped = clampWidthFraction(fraction);
         writeStoredWidthFraction(clamped);
         set({
           widthFraction: clamped,
           draftFraction: null,
-          isFullscreen: false,
+          draftExpanded: false,
         });
       },
-      toggleFullscreen: () =>
-        set((state) => ({ isFullscreen: !state.isFullscreen })),
       nudgeWidth: (direction) => {
         const delta =
           direction === "grow" ? KEYBOARD_RESIZE_STEP : -KEYBOARD_RESIZE_STEP;
         const next = clampWidthFraction(get().widthFraction + delta);
         writeStoredWidthFraction(next);
-        set({ widthFraction: next, draftFraction: null, isFullscreen: false });
-      },
-      resetForVisibility: (isOpen) => {
-        if (!isOpen && get().isFullscreen) set({ isFullscreen: false });
+        set({ widthFraction: next, draftFraction: null, draftExpanded: false });
       },
     },
   }));
 }
 
-export const selectIsFullscreen = (state: PeekPanelStoreState) =>
-  state.isFullscreen;
 export const selectIsResizing = (state: PeekPanelStoreState) =>
   state.isResizing;
+export const selectDraftExpanded = (state: PeekPanelStoreState) =>
+  state.draftExpanded;
 
 /**
- * The panel's CSS width as a primitive string (`"50vw"` / `"100vw"`) so the
- * subscription bails out unless the rendered width actually changes.
+ * The widget width as a primitive CSS string (`"50vw"`) so the subscription
+ * bails out unless the rendered width changes. The expanded (max) width is
+ * computed by the hook, since it depends on the live sidebar offset.
  */
-export const selectWidth = (state: PeekPanelStoreState): string =>
-  state.isFullscreen
-    ? "100vw"
-    : `${clampWidthFraction(state.draftFraction ?? state.widthFraction) * 100}vw`;
+export const selectWidgetWidth = (state: PeekPanelStoreState): string =>
+  `${clampWidthFraction(state.draftFraction ?? state.widthFraction) * 100}vw`;

--- a/web/src/components/table/peek/store/peekPanelStore.ts
+++ b/web/src/components/table/peek/store/peekPanelStore.ts
@@ -23,7 +23,7 @@ import { createStore, type StoreApi } from "zustand/vanilla";
 const STORAGE_KEY = "peekViewWidthFraction";
 
 // Widget width bounds, as a fraction of the viewport width.
-export const PEEK_MIN_WIDTH_FRACTION = 0.3;
+export const PEEK_MIN_WIDTH_FRACTION = 0.4;
 export const PEEK_MAX_WIDGET_WIDTH_FRACTION = 0.9;
 export const PEEK_DEFAULT_WIDTH_FRACTION = 0.5;
 // Dragging the handle beyond this fraction of the viewport snaps to fullscreen.

--- a/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
+++ b/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
@@ -1,17 +1,12 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import {
-  PEEK_DEFAULT_WIDTH_FRACTION,
-  PEEK_MAX_WIDGET_WIDTH_FRACTION,
-  PEEK_MIN_WIDTH_FRACTION,
-  usePeekPanelState,
-} from "@/src/components/table/peek/usePeekPanelState";
+import { usePeekPanelState } from "@/src/components/table/peek/usePeekPanelState";
+import { PEEK_DEFAULT_WIDTH_FRACTION } from "@/src/components/table/peek/store/peekPanelStore";
 
 const STORAGE_KEY = "peekViewWidthFraction";
-
-const widthFraction = (panelStyle: React.CSSProperties) =>
-  parseFloat(String(panelStyle.width)) / 100;
+const widthFraction = (style: React.CSSProperties) =>
+  parseFloat(String(style.width)) / 100;
 
 const renderPanel = (isOpen = true) =>
   renderHook(({ isOpen }) => usePeekPanelState({ isOpen }), {
@@ -31,103 +26,52 @@ function pressArrow(
 }
 
 describe("usePeekPanelState", () => {
-  beforeEach(() => {
-    window.localStorage.clear();
-  });
-  afterEach(() => {
-    window.localStorage.clear();
-  });
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
 
-  it("defaults to the widget width and is not fullscreen", () => {
+  it("exposes the widget width and a stable resize-handle contract", () => {
     const { result } = renderPanel();
     expect(result.current.isFullscreen).toBe(false);
     expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
       PEEK_DEFAULT_WIDTH_FRACTION,
     );
-  });
-
-  it("reads a persisted width from localStorage on mount", () => {
-    window.localStorage.setItem(STORAGE_KEY, "0.7");
-    const { result } = renderPanel();
-    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(0.7);
-  });
-
-  it("clamps an out-of-range persisted width into the widget bounds", () => {
-    window.localStorage.setItem(STORAGE_KEY, "5");
-    const { result } = renderPanel();
-    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
-      PEEK_MAX_WIDGET_WIDTH_FRACTION,
+    expect(result.current.resizeHandleProps.role).toBe("separator");
+    expect(result.current.resizeHandleProps["aria-label"]).toBe(
+      "Resize peek view",
     );
   });
 
-  it("keyboard resize grows/shrinks within bounds and persists", () => {
+  it("toggleFullscreen delegates to the store (100vw, then restore)", () => {
+    window.localStorage.setItem(STORAGE_KEY, "0.6");
     const { result } = renderPanel();
+    act(() => result.current.toggleFullscreen());
+    expect(result.current.isFullscreen).toBe(true);
+    expect(result.current.panelStyle.width).toBe("100vw");
+    act(() => result.current.toggleFullscreen());
+    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(0.6);
+  });
 
-    // ArrowLeft grows the docked-right panel.
+  it("keyboard resize delegates to the nudge action", () => {
+    const { result } = renderPanel();
     pressArrow(result, "ArrowLeft");
     expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
       PEEK_DEFAULT_WIDTH_FRACTION + 0.05,
     );
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBe(
-      String(PEEK_DEFAULT_WIDTH_FRACTION + 0.05),
-    );
-
-    // ArrowRight shrinks it back.
     pressArrow(result, "ArrowRight");
     expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
       PEEK_DEFAULT_WIDTH_FRACTION,
     );
   });
 
-  it("never shrinks below the minimum widget width", () => {
-    window.localStorage.setItem(STORAGE_KEY, String(PEEK_MIN_WIDTH_FRACTION));
-    const { result } = renderPanel();
-    pressArrow(result, "ArrowRight");
-    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
-      PEEK_MIN_WIDTH_FRACTION,
-    );
-  });
-
-  it("toggles fullscreen to 100vw and restores the persisted widget width", () => {
-    window.localStorage.setItem(STORAGE_KEY, "0.65");
-    const { result } = renderPanel();
-
-    act(() => result.current.toggleFullscreen());
-    expect(result.current.isFullscreen).toBe(true);
-    expect(result.current.panelStyle.width).toBe("100vw");
-
-    act(() => result.current.toggleFullscreen());
-    expect(result.current.isFullscreen).toBe(false);
-    // Width preference is untouched by the fullscreen round-trip.
-    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(0.65);
-  });
-
-  it("resets fullscreen when the peek closes (isOpen → false)", () => {
+  it("resets fullscreen when the peek closes and stays reset on reopen", () => {
     const { result, rerender } = renderPanel(true);
-
     act(() => result.current.toggleFullscreen());
     expect(result.current.isFullscreen).toBe(true);
 
-    // Close the peek: fullscreen must not survive into the next open.
     rerender({ isOpen: false });
     expect(result.current.isFullscreen).toBe(false);
 
-    // Reopen: still a widget, not stuck fullscreen.
     rerender({ isOpen: true });
     expect(result.current.isFullscreen).toBe(false);
-  });
-
-  it("keyboard resize while fullscreen does not clobber the saved width", () => {
-    window.localStorage.setItem(STORAGE_KEY, "0.5");
-    const { result } = renderPanel();
-
-    act(() => result.current.toggleFullscreen());
-    expect(result.current.isFullscreen).toBe(true);
-
-    // ArrowRight exits fullscreen relative to the saved 0.5, not the 0.9 ceiling.
-    pressArrow(result, "ArrowRight");
-    expect(result.current.isFullscreen).toBe(false);
-    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(0.45);
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("0.45");
   });
 });

--- a/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
+++ b/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
@@ -13,6 +13,11 @@ const STORAGE_KEY = "peekViewWidthFraction";
 const widthFraction = (panelStyle: React.CSSProperties) =>
   parseFloat(String(panelStyle.width)) / 100;
 
+const renderPanel = (isOpen = true) =>
+  renderHook(({ isOpen }) => usePeekPanelState({ isOpen }), {
+    initialProps: { isOpen },
+  });
+
 function pressArrow(
   result: { current: ReturnType<typeof usePeekPanelState> },
   key: "ArrowLeft" | "ArrowRight",
@@ -34,7 +39,7 @@ describe("usePeekPanelState", () => {
   });
 
   it("defaults to the widget width and is not fullscreen", () => {
-    const { result } = renderHook(() => usePeekPanelState());
+    const { result } = renderPanel();
     expect(result.current.isFullscreen).toBe(false);
     expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
       PEEK_DEFAULT_WIDTH_FRACTION,
@@ -43,20 +48,20 @@ describe("usePeekPanelState", () => {
 
   it("reads a persisted width from localStorage on mount", () => {
     window.localStorage.setItem(STORAGE_KEY, "0.7");
-    const { result } = renderHook(() => usePeekPanelState());
+    const { result } = renderPanel();
     expect(widthFraction(result.current.panelStyle)).toBeCloseTo(0.7);
   });
 
   it("clamps an out-of-range persisted width into the widget bounds", () => {
     window.localStorage.setItem(STORAGE_KEY, "5");
-    const { result } = renderHook(() => usePeekPanelState());
+    const { result } = renderPanel();
     expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
       PEEK_MAX_WIDGET_WIDTH_FRACTION,
     );
   });
 
   it("keyboard resize grows/shrinks within bounds and persists", () => {
-    const { result } = renderHook(() => usePeekPanelState());
+    const { result } = renderPanel();
 
     // ArrowLeft grows the docked-right panel.
     pressArrow(result, "ArrowLeft");
@@ -76,7 +81,7 @@ describe("usePeekPanelState", () => {
 
   it("never shrinks below the minimum widget width", () => {
     window.localStorage.setItem(STORAGE_KEY, String(PEEK_MIN_WIDTH_FRACTION));
-    const { result } = renderHook(() => usePeekPanelState());
+    const { result } = renderPanel();
     pressArrow(result, "ArrowRight");
     expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
       PEEK_MIN_WIDTH_FRACTION,
@@ -85,7 +90,7 @@ describe("usePeekPanelState", () => {
 
   it("toggles fullscreen to 100vw and restores the persisted widget width", () => {
     window.localStorage.setItem(STORAGE_KEY, "0.65");
-    const { result } = renderHook(() => usePeekPanelState());
+    const { result } = renderPanel();
 
     act(() => result.current.toggleFullscreen());
     expect(result.current.isFullscreen).toBe(true);
@@ -95,5 +100,34 @@ describe("usePeekPanelState", () => {
     expect(result.current.isFullscreen).toBe(false);
     // Width preference is untouched by the fullscreen round-trip.
     expect(widthFraction(result.current.panelStyle)).toBeCloseTo(0.65);
+  });
+
+  it("resets fullscreen when the peek closes (isOpen → false)", () => {
+    const { result, rerender } = renderPanel(true);
+
+    act(() => result.current.toggleFullscreen());
+    expect(result.current.isFullscreen).toBe(true);
+
+    // Close the peek: fullscreen must not survive into the next open.
+    rerender({ isOpen: false });
+    expect(result.current.isFullscreen).toBe(false);
+
+    // Reopen: still a widget, not stuck fullscreen.
+    rerender({ isOpen: true });
+    expect(result.current.isFullscreen).toBe(false);
+  });
+
+  it("keyboard resize while fullscreen does not clobber the saved width", () => {
+    window.localStorage.setItem(STORAGE_KEY, "0.5");
+    const { result } = renderPanel();
+
+    act(() => result.current.toggleFullscreen());
+    expect(result.current.isFullscreen).toBe(true);
+
+    // ArrowRight exits fullscreen relative to the saved 0.5, not the 0.9 ceiling.
+    pressArrow(result, "ArrowRight");
+    expect(result.current.isFullscreen).toBe(false);
+    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(0.45);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("0.45");
   });
 });

--- a/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
+++ b/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { usePeekPanelState } from "@/src/components/table/peek/usePeekPanelState";
 import { PEEK_DEFAULT_WIDTH_FRACTION } from "@/src/components/table/peek/store/peekPanelStore";
@@ -8,10 +8,15 @@ const STORAGE_KEY = "peekViewWidthFraction";
 const widthFraction = (style: React.CSSProperties) =>
   parseFloat(String(style.width)) / 100;
 
-const renderPanel = (isOpen = true) =>
-  renderHook(({ isOpen }) => usePeekPanelState({ isOpen }), {
-    initialProps: { isOpen },
-  });
+function setup(isExpanded = false) {
+  const onExpandedChange = vi.fn();
+  const { result, rerender } = renderHook(
+    ({ isExpanded }) =>
+      usePeekPanelState({ isOpen: true, isExpanded, onExpandedChange }),
+    { initialProps: { isExpanded } },
+  );
+  return { result, rerender, onExpandedChange };
+}
 
 function pressArrow(
   result: { current: ReturnType<typeof usePeekPanelState> },
@@ -29,9 +34,9 @@ describe("usePeekPanelState", () => {
   beforeEach(() => window.localStorage.clear());
   afterEach(() => window.localStorage.clear());
 
-  it("exposes the widget width and a stable resize-handle contract", () => {
-    const { result } = renderPanel();
-    expect(result.current.isFullscreen).toBe(false);
+  it("renders the widget width and a stable resize-handle contract", () => {
+    const { result } = setup();
+    expect(result.current.isExpanded).toBe(false);
     expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
       PEEK_DEFAULT_WIDTH_FRACTION,
     );
@@ -41,19 +46,23 @@ describe("usePeekPanelState", () => {
     );
   });
 
-  it("toggleFullscreen delegates to the store (100vw, then restore)", () => {
-    window.localStorage.setItem(STORAGE_KEY, "0.6");
-    const { result } = renderPanel();
-    act(() => result.current.toggleFullscreen());
-    expect(result.current.isFullscreen).toBe(true);
-    expect(result.current.panelStyle.width).toBe("100vw");
-    act(() => result.current.toggleFullscreen());
-    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(0.6);
+  it("renders the expanded (viewport − sidebar) width when expanded", () => {
+    const { result } = setup(true);
+    expect(result.current.isExpanded).toBe(true);
+    // No sidebar element in jsdom → offset 0 → full viewport calc.
+    expect(String(result.current.panelStyle.width)).toContain("calc(100vw");
   });
 
-  it("keyboard resize delegates to the nudge action", () => {
-    const { result } = renderPanel();
+  it("toggleExpanded writes the expanded flag (URL) via the callback", () => {
+    const { result, onExpandedChange } = setup(false);
+    act(() => result.current.toggleExpanded());
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("keyboard resize collapses expanded and nudges the widget width", () => {
+    const { result, onExpandedChange } = setup(false);
     pressArrow(result, "ArrowLeft");
+    expect(onExpandedChange).toHaveBeenCalledWith(false);
     expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
       PEEK_DEFAULT_WIDTH_FRACTION + 0.05,
     );
@@ -61,17 +70,8 @@ describe("usePeekPanelState", () => {
     expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
       PEEK_DEFAULT_WIDTH_FRACTION,
     );
-  });
-
-  it("resets fullscreen when the peek closes and stays reset on reopen", () => {
-    const { result, rerender } = renderPanel(true);
-    act(() => result.current.toggleFullscreen());
-    expect(result.current.isFullscreen).toBe(true);
-
-    rerender({ isOpen: false });
-    expect(result.current.isFullscreen).toBe(false);
-
-    rerender({ isOpen: true });
-    expect(result.current.isFullscreen).toBe(false);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe(
+      String(PEEK_DEFAULT_WIDTH_FRACTION),
+    );
   });
 });

--- a/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
+++ b/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
@@ -5,8 +5,12 @@ import { usePeekPanelState } from "@/src/components/table/peek/usePeekPanelState
 import { PEEK_DEFAULT_WIDTH_FRACTION } from "@/src/components/table/peek/store/peekPanelStore";
 
 const STORAGE_KEY = "peekViewWidthFraction";
-const widthFraction = (style: React.CSSProperties) =>
-  parseFloat(String(style.width)) / 100;
+// Widget width is `min(<n>vw, calc(100vw - <sidebar>px))` — pull the leading
+// vw fraction (the widget's own width) out of the min() wrapper.
+const widthFraction = (style: React.CSSProperties) => {
+  const match = String(style.width).match(/([\d.]+)vw/);
+  return match ? parseFloat(match[1]) / 100 : NaN;
+};
 
 function setup(isExpanded = false) {
   const onExpandedChange = vi.fn();

--- a/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
+++ b/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
@@ -1,0 +1,99 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  PEEK_DEFAULT_WIDTH_FRACTION,
+  PEEK_MAX_WIDGET_WIDTH_FRACTION,
+  PEEK_MIN_WIDTH_FRACTION,
+  usePeekPanelState,
+} from "@/src/components/table/peek/usePeekPanelState";
+
+const STORAGE_KEY = "peekViewWidthFraction";
+
+const widthFraction = (panelStyle: React.CSSProperties) =>
+  parseFloat(String(panelStyle.width)) / 100;
+
+function pressArrow(
+  result: { current: ReturnType<typeof usePeekPanelState> },
+  key: "ArrowLeft" | "ArrowRight",
+) {
+  act(() => {
+    result.current.resizeHandleProps.onKeyDown({
+      key,
+      preventDefault: () => {},
+    } as unknown as React.KeyboardEvent);
+  });
+}
+
+describe("usePeekPanelState", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("defaults to the widget width and is not fullscreen", () => {
+    const { result } = renderHook(() => usePeekPanelState());
+    expect(result.current.isFullscreen).toBe(false);
+    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
+      PEEK_DEFAULT_WIDTH_FRACTION,
+    );
+  });
+
+  it("reads a persisted width from localStorage on mount", () => {
+    window.localStorage.setItem(STORAGE_KEY, "0.7");
+    const { result } = renderHook(() => usePeekPanelState());
+    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(0.7);
+  });
+
+  it("clamps an out-of-range persisted width into the widget bounds", () => {
+    window.localStorage.setItem(STORAGE_KEY, "5");
+    const { result } = renderHook(() => usePeekPanelState());
+    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
+      PEEK_MAX_WIDGET_WIDTH_FRACTION,
+    );
+  });
+
+  it("keyboard resize grows/shrinks within bounds and persists", () => {
+    const { result } = renderHook(() => usePeekPanelState());
+
+    // ArrowLeft grows the docked-right panel.
+    pressArrow(result, "ArrowLeft");
+    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
+      PEEK_DEFAULT_WIDTH_FRACTION + 0.05,
+    );
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe(
+      String(PEEK_DEFAULT_WIDTH_FRACTION + 0.05),
+    );
+
+    // ArrowRight shrinks it back.
+    pressArrow(result, "ArrowRight");
+    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
+      PEEK_DEFAULT_WIDTH_FRACTION,
+    );
+  });
+
+  it("never shrinks below the minimum widget width", () => {
+    window.localStorage.setItem(STORAGE_KEY, String(PEEK_MIN_WIDTH_FRACTION));
+    const { result } = renderHook(() => usePeekPanelState());
+    pressArrow(result, "ArrowRight");
+    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(
+      PEEK_MIN_WIDTH_FRACTION,
+    );
+  });
+
+  it("toggles fullscreen to 100vw and restores the persisted widget width", () => {
+    window.localStorage.setItem(STORAGE_KEY, "0.65");
+    const { result } = renderHook(() => usePeekPanelState());
+
+    act(() => result.current.toggleFullscreen());
+    expect(result.current.isFullscreen).toBe(true);
+    expect(result.current.panelStyle.width).toBe("100vw");
+
+    act(() => result.current.toggleFullscreen());
+    expect(result.current.isFullscreen).toBe(false);
+    // Width preference is untouched by the fullscreen round-trip.
+    expect(widthFraction(result.current.panelStyle)).toBeCloseTo(0.65);
+  });
+});

--- a/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
+++ b/web/src/components/table/peek/usePeekPanelState.clienttest.tsx
@@ -59,6 +59,19 @@ describe("usePeekPanelState", () => {
     expect(onExpandedChange).toHaveBeenCalledWith(true);
   });
 
+  it("toggleExpanded toggles against the displayed (pending) state, not the stale URL prop", () => {
+    const { result, onExpandedChange } = setup(false);
+    // First click commits expanded; the hook holds it as `pending` until the
+    // URL (isExpanded prop) catches up — we deliberately do NOT rerender it.
+    act(() => result.current.toggleExpanded());
+    expect(onExpandedChange).toHaveBeenLastCalledWith(true);
+    expect(result.current.isExpanded).toBe(true); // button now shows Collapse
+    // A rapid second click in that pending window must collapse (match the
+    // button), not re-commit `true` against the stale prop (a no-op).
+    act(() => result.current.toggleExpanded());
+    expect(onExpandedChange).toHaveBeenLastCalledWith(false);
+  });
+
   it("keyboard resize collapses expanded and nudges the widget width", () => {
     const { result, onExpandedChange } = setup(false);
     pressArrow(result, "ArrowLeft");

--- a/web/src/components/table/peek/usePeekPanelState.ts
+++ b/web/src/components/table/peek/usePeekPanelState.ts
@@ -98,7 +98,13 @@ export function usePeekPanelState({
   // visible). The peek portals into the `modal` layer, outside the sidebar's
   // CSS-var scope, so the offset is measured live (re-measured on viewport /
   // sidebar resize, which also covers the collapse/expand transition).
-  const [sidebarOffset, setSidebarOffset] = useState(0);
+  // Lazy-measured on mount (SSR-safe via the guard in readSidebarOffsetPx) so
+  // the FIRST expanded paint already uses the real offset — initializing to 0
+  // would paint calc(100vw - 0px) = full width for one frame, covering the
+  // sidebar, before the effect below measures and corrects it.
+  const [sidebarOffset, setSidebarOffset] = useState(() =>
+    readSidebarOffsetPx(),
+  );
   useEffect(() => {
     if (!effectiveExpanded) return;
     const measure = () => setSidebarOffset(readSidebarOffsetPx());
@@ -156,9 +162,13 @@ export function usePeekPanelState({
     [store, commitExpanded],
   );
 
+  // Toggle relative to what the button currently SHOWS (effectiveExpanded),
+  // not the URL-derived isExpanded — during the pending window after a commit
+  // the two differ for a render, and reading isExpanded there would make a
+  // rapid second click re-commit the same value (a no-op) instead of toggling.
   const toggleExpanded = useCallback(
-    () => commitExpanded(!isExpanded),
-    [isExpanded, commitExpanded],
+    () => commitExpanded(!effectiveExpanded),
+    [effectiveExpanded, commitExpanded],
   );
 
   const widthPercent = effectiveExpanded

--- a/web/src/components/table/peek/usePeekPanelState.ts
+++ b/web/src/components/table/peek/usePeekPanelState.ts
@@ -16,8 +16,9 @@ import useLocalStorage from "@/src/components/useLocalStorage";
  * - **width** is a cross-view preference, so it persists in localStorage as a
  *   viewport fraction (resolution-independent) shared by every peek.
  * - **fullscreen** is ephemeral per open session: it lives in React state and
- *   resets when the peek unmounts (i.e. on close). The panel always reopens as
- *   the persisted widget width, never stuck fullscreen.
+ *   is reset whenever the peek closes (`isOpen` → false). The peek host stays
+ *   mounted across open/close, so this reset is explicit — the panel always
+ *   reopens as the persisted widget width, never stuck fullscreen.
  * - the **resize drag** is high-frequency transient state, held locally as a
  *   draft and only committed to localStorage on pointer-up — the store is not
  *   written on every move.
@@ -66,7 +67,11 @@ export type PeekPanelState = {
   };
 };
 
-export function usePeekPanelState(): PeekPanelState {
+export function usePeekPanelState({
+  isOpen,
+}: {
+  isOpen: boolean;
+}): PeekPanelState {
   const [storedFraction, setStoredFraction] = useLocalStorage<number>(
     STORAGE_KEY,
     PEEK_DEFAULT_WIDTH_FRACTION,
@@ -74,6 +79,13 @@ export function usePeekPanelState(): PeekPanelState {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [draftFraction, setDraftFraction] = useState<number | null>(null);
   const [isResizing, setIsResizing] = useState(false);
+
+  // Fullscreen is per open session. The peek host stays mounted across
+  // open/close, so reset it explicitly when the peek closes (not on item
+  // changes during K/J navigation, which keep `isOpen` true).
+  useEffect(() => {
+    if (!isOpen) setIsFullscreen(false);
+  }, [isOpen]);
 
   const committedFraction = clampFraction(storedFraction);
   const committedFractionRef = useRef(committedFraction);
@@ -144,21 +156,20 @@ export function usePeekPanelState(): PeekPanelState {
 
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent) => {
-      // Left grows the panel (it is docked right), Right shrinks it.
+      // Left grows the panel (it is docked right), Right shrinks it. Always base
+      // off the persisted widget width — even when exiting fullscreen — so a
+      // keypress never clobbers the saved preference with the fullscreen ceiling.
       if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
         event.preventDefault();
-        const base = isFullscreen
-          ? PEEK_MAX_WIDGET_WIDTH_FRACTION
-          : committedFractionRef.current;
         const delta =
           event.key === "ArrowLeft"
             ? KEYBOARD_RESIZE_STEP
             : -KEYBOARD_RESIZE_STEP;
         setIsFullscreen(false);
-        setStoredFraction(clampFraction(base + delta));
+        setStoredFraction(clampFraction(committedFractionRef.current + delta));
       }
     },
-    [isFullscreen, setStoredFraction],
+    [setStoredFraction],
   );
 
   const toggleFullscreen = useCallback(() => {

--- a/web/src/components/table/peek/usePeekPanelState.ts
+++ b/web/src/components/table/peek/usePeekPanelState.ts
@@ -94,19 +94,20 @@ export function usePeekPanelState({
     [onExpandedChange],
   );
 
-  // While expanded, keep the panel at viewport − sidebar (sidebar stays
-  // visible). The peek portals into the `modal` layer, outside the sidebar's
-  // CSS-var scope, so the offset is measured live (re-measured on viewport /
-  // sidebar resize, which also covers the collapse/expand transition).
-  // Lazy-measured on mount (SSR-safe via the guard in readSidebarOffsetPx) so
-  // the FIRST expanded paint already uses the real offset — initializing to 0
-  // would paint calc(100vw - 0px) = full width for one frame, covering the
-  // sidebar, before the effect below measures and corrects it.
+  // While expanded the panel width is `calc(100vw - sidebarOffset)` so the
+  // sidebar stays visible. The peek portals into the `modal` layer, outside the
+  // sidebar's CSS-var scope, so the offset is measured from the DOM. Seeded
+  // synchronously on mount (lazy initializer, SSR-safe via the guard in
+  // readSidebarOffsetPx) so the first expanded paint already uses the real
+  // offset rather than calc(100vw - 0px) = full width for one frame.
   const [sidebarOffset, setSidebarOffset] = useState(() =>
     readSidebarOffsetPx(),
   );
+  // Track the sidebar continuously — NOT only while expanded — so a sidebar
+  // toggle/resize that happens while the peek is collapsed is still reflected
+  // by the next expand (no stale-offset flash). The observer is idle unless the
+  // sidebar actually resizes, and setSidebarOffset bails on an unchanged value.
   useEffect(() => {
-    if (!effectiveExpanded) return;
     const measure = () => setSidebarOffset(readSidebarOffsetPx());
     measure();
     window.addEventListener("resize", measure);
@@ -120,7 +121,7 @@ export function usePeekPanelState({
       window.removeEventListener("resize", measure);
       observer?.disconnect();
     };
-  }, [effectiveExpanded]);
+  }, []);
 
   const panelStyle: CSSProperties = {
     width: effectiveExpanded ? `calc(100vw - ${sidebarOffset}px)` : widgetWidth,

--- a/web/src/components/table/peek/usePeekPanelState.ts
+++ b/web/src/components/table/peek/usePeekPanelState.ts
@@ -10,6 +10,7 @@ import {
 import { useStore } from "zustand";
 import {
   createPeekPanelStore,
+  PEEK_MIN_WIDTH_FRACTION,
   selectDraftExpanded,
   selectIsResizing,
   selectWidgetWidth,
@@ -30,6 +31,9 @@ export type PeekPanelView = {
     role: "separator";
     "aria-orientation": "vertical";
     "aria-label": string;
+    "aria-valuemin": number;
+    "aria-valuemax": number;
+    "aria-valuenow": number;
     tabIndex: 0;
     onPointerDown: (event: ReactPointerEvent) => void;
     onKeyDown: (event: ReactKeyboardEvent) => void;
@@ -42,14 +46,20 @@ function readSidebarOffsetPx(): number {
   const el = document.querySelector('[data-sidebar="sidebar"]');
   if (!el) return 0;
   const rect = el.getBoundingClientRect();
+  // Guard against the off-canvas mobile sidebar (rendered in a Sheet): only a
+  // left-docked, on-screen sidebar contributes an offset.
   return rect.left < 100 && rect.width > 0 ? Math.round(rect.right) : 0;
 }
 
 /**
  * Integration boundary for the peek panel width: owns the per-mount widget-width
- * store, derives the final width (widget vs expanded), and wires drag/keyboard to
- * the store + resize action. Whether the peek is *expanded* is owned by the URL
- * (`isExpanded` in, `onExpandedChange` out) so it is shareable and back-able.
+ * store, derives the final width (widget vs expanded), and wires drag/keyboard
+ * to the store + resize action. Whether the peek is *expanded* is owned by the
+ * URL (`isExpanded` in, `onExpandedChange` out) so it is shareable + reloadable.
+ *
+ * `pendingExpanded` bridges the async gap: when a drag/button commits a new
+ * expanded value we hold it locally until the URL (`isExpanded`) catches up, so
+ * the panel never flashes the old width for a frame on release.
  */
 export function usePeekPanelState({
   isOpen,
@@ -66,12 +76,28 @@ export function usePeekPanelState({
   const draftExpanded = useStore(store, selectDraftExpanded);
   const widgetWidth = useStore(store, selectWidgetWidth);
 
-  // During a drag the live draft wins; otherwise the URL flag does.
-  const effectiveExpanded = isResizing ? draftExpanded : isExpanded;
+  // Locally-committed expanded value, held until the URL reflects it.
+  const [pendingExpanded, setPendingExpanded] = useState<boolean | null>(null);
+  useEffect(() => setPendingExpanded(null), [isExpanded]);
 
-  // While expanded, keep the panel at viewport − sidebar (sidebar stays visible).
-  // The peek portals into the `modal` layer, outside the sidebar's CSS-var scope,
-  // so the offset is measured live (and re-measured on viewport / sidebar resize).
+  // During a drag the live draft wins; otherwise the just-committed value, then
+  // the URL flag.
+  const effectiveExpanded = isResizing
+    ? draftExpanded
+    : (pendingExpanded ?? isExpanded);
+
+  const commitExpanded = useCallback(
+    (expanded: boolean) => {
+      setPendingExpanded(expanded);
+      onExpandedChange(expanded);
+    },
+    [onExpandedChange],
+  );
+
+  // While expanded, keep the panel at viewport − sidebar (sidebar stays
+  // visible). The peek portals into the `modal` layer, outside the sidebar's
+  // CSS-var scope, so the offset is measured live (re-measured on viewport /
+  // sidebar resize, which also covers the collapse/expand transition).
   const [sidebarOffset, setSidebarOffset] = useState(0);
   useEffect(() => {
     if (!effectiveExpanded) return;
@@ -94,8 +120,9 @@ export function usePeekPanelState({
     width: effectiveExpanded ? `calc(100vw - ${sidebarOffset}px)` : widgetWidth,
   };
 
-  // End an in-flight drag (drop listeners, restore body styles, clear drag state)
-  // on unmount and whenever the peek closes — the host outlives open/close.
+  // End an in-flight drag (drop listeners, restore body styles, clear drag
+  // state) on unmount and whenever the peek closes — the host outlives
+  // open/close.
   const dragTeardownRef = useRef<(() => void) | null>(null);
   const endActiveDrag = useCallback(() => {
     dragTeardownRef.current?.();
@@ -109,9 +136,9 @@ export function usePeekPanelState({
 
   const onPointerDown = useCallback(
     (event: ReactPointerEvent) => {
-      dragTeardownRef.current = beginPeekResize(store, event, onExpandedChange);
+      dragTeardownRef.current = beginPeekResize(store, event, commitExpanded);
     },
-    [store, onExpandedChange],
+    [store, commitExpanded],
   );
 
   const onKeyDown = useCallback(
@@ -120,22 +147,26 @@ export function usePeekPanelState({
       // collapses out of the expanded view onto a widget width.
       if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
         event.preventDefault();
-        onExpandedChange(false);
+        commitExpanded(false);
         store
           .getState()
           .actions.nudgeWidth(event.key === "ArrowLeft" ? "grow" : "shrink");
       }
     },
-    [store, onExpandedChange],
+    [store, commitExpanded],
   );
 
   const toggleExpanded = useCallback(
-    () => onExpandedChange(!isExpanded),
-    [isExpanded, onExpandedChange],
+    () => commitExpanded(!isExpanded),
+    [isExpanded, commitExpanded],
   );
 
+  const widthPercent = effectiveExpanded
+    ? 100
+    : Math.round(parseFloat(widgetWidth));
+
   return {
-    isExpanded,
+    isExpanded: effectiveExpanded,
     isResizing,
     panelStyle,
     toggleExpanded,
@@ -143,6 +174,9 @@ export function usePeekPanelState({
       role: "separator",
       "aria-orientation": "vertical",
       "aria-label": "Resize peek view",
+      "aria-valuemin": Math.round(PEEK_MIN_WIDTH_FRACTION * 100),
+      "aria-valuemax": 100,
+      "aria-valuenow": widthPercent,
       tabIndex: 0,
       onPointerDown,
       onKeyDown,

--- a/web/src/components/table/peek/usePeekPanelState.ts
+++ b/web/src/components/table/peek/usePeekPanelState.ts
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useRef,
   useState,
   type CSSProperties,
@@ -79,6 +80,9 @@ export function usePeekPanelState(): PeekPanelState {
   committedFractionRef.current = committedFraction;
 
   const dragStateRef = useRef<DragState | null>(null);
+  // Tears down an in-flight drag (listeners + body styles); also run on unmount
+  // so a drag interrupted by the peek closing can't leak listeners/cursor.
+  const endDragRef = useRef<(() => void) | null>(null);
 
   const startResize = useCallback(
     (event: ReactPointerEvent) => {
@@ -103,13 +107,17 @@ export function usePeekPanelState(): PeekPanelState {
         }
       };
 
-      const onPointerUp = () => {
+      const teardown = () => {
         window.removeEventListener("pointermove", onPointerMove);
         window.removeEventListener("pointerup", onPointerUp);
         window.removeEventListener("pointercancel", onPointerUp);
         document.body.style.removeProperty("user-select");
         document.body.style.removeProperty("cursor");
+        endDragRef.current = null;
+      };
 
+      const onPointerUp = () => {
+        teardown();
         const final = dragStateRef.current;
         if (final && !final.fullscreen) {
           setStoredFraction(final.fraction);
@@ -119,6 +127,7 @@ export function usePeekPanelState(): PeekPanelState {
         setIsResizing(false);
       };
 
+      endDragRef.current = teardown;
       window.addEventListener("pointermove", onPointerMove);
       window.addEventListener("pointerup", onPointerUp);
       window.addEventListener("pointercancel", onPointerUp);
@@ -128,6 +137,10 @@ export function usePeekPanelState(): PeekPanelState {
     },
     [setStoredFraction],
   );
+
+  // Safety net: if the component unmounts mid-drag, drop the window listeners
+  // and restore the body cursor/selection styles.
+  useEffect(() => () => endDragRef.current?.(), []);
 
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent) => {

--- a/web/src/components/table/peek/usePeekPanelState.ts
+++ b/web/src/components/table/peek/usePeekPanelState.ts
@@ -58,16 +58,25 @@ export function usePeekPanelState({
     (state) => state.actions.toggleFullscreen,
   );
 
-  // Fullscreen is per open session; the host outlives open/close, so reset it
-  // explicitly when the peek closes (not on item changes during K/J nav).
-  useEffect(() => {
-    store.getState().actions.resetForVisibility(isOpen);
-  }, [store, isOpen]);
-
-  // End an in-flight drag if the component unmounts mid-drag (drops window
-  // listeners, restores body cursor/selection styles).
+  // Ends an in-flight drag: drops the window listeners + restores body styles
+  // (via the resize action's teardown) and clears the store's drag state.
   const dragTeardownRef = useRef<(() => void) | null>(null);
-  useEffect(() => () => dragTeardownRef.current?.(), []);
+  const endActiveDrag = useCallback(() => {
+    dragTeardownRef.current?.();
+    dragTeardownRef.current = null;
+    store.getState().actions.cancelResize();
+  }, [store]);
+
+  // The host stays mounted across open/close, so on close (not on K/J item
+  // changes) explicitly reset fullscreen and abandon any in-flight resize drag —
+  // otherwise an Escape mid-drag would leave window listeners + body styles set.
+  useEffect(() => {
+    if (!isOpen) endActiveDrag();
+    store.getState().actions.resetForVisibility(isOpen);
+  }, [store, isOpen, endActiveDrag]);
+
+  // Also tear down on a real unmount.
+  useEffect(() => endActiveDrag, [endActiveDrag]);
 
   const onPointerDown = useCallback(
     (event: ReactPointerEvent) => {

--- a/web/src/components/table/peek/usePeekPanelState.ts
+++ b/web/src/components/table/peek/usePeekPanelState.ts
@@ -10,21 +10,21 @@ import {
 import { useStore } from "zustand";
 import {
   createPeekPanelStore,
-  selectIsFullscreen,
+  selectDraftExpanded,
   selectIsResizing,
-  selectWidth,
+  selectWidgetWidth,
 } from "@/src/components/table/peek/store/peekPanelStore";
 import { beginPeekResize } from "@/src/components/table/peek/actions/resizePeekPanel";
 
 export type PeekPanelView = {
-  /** Whether the panel currently fills the viewport. */
-  isFullscreen: boolean;
+  /** Whether the panel is expanded to max width (viewport − sidebar). */
+  isExpanded: boolean;
   /** True while the user is dragging the resize handle. */
   isResizing: boolean;
   /** Inline style (width) for the docked panel. */
   panelStyle: CSSProperties;
-  /** Toggle fullscreen on/off; off restores the persisted widget width. */
-  toggleFullscreen: () => void;
+  /** Toggle the expanded view (writes the URL via `onExpandedChange`). */
+  toggleExpanded: () => void;
   /** Props to spread onto the left-edge resize handle. */
   resizeHandleProps: {
     role: "separator";
@@ -36,74 +36,109 @@ export type PeekPanelView = {
   };
 };
 
+/** Right edge of the (left-docked) sidebar = its current width, in px. */
+function readSidebarOffsetPx(): number {
+  if (typeof document === "undefined") return 0;
+  const el = document.querySelector('[data-sidebar="sidebar"]');
+  if (!el) return 0;
+  const rect = el.getBoundingClientRect();
+  return rect.left < 100 && rect.width > 0 ? Math.round(rect.right) : 0;
+}
+
 /**
- * Integration boundary for the peek panel: owns the per-mount store (created
- * once via lazy `useState`), subscribes to the slices the chrome needs, and
- * exposes thin callbacks that delegate to store actions / the resize workflow.
- * All state and logic live in the store and `actions/*` — this hook only wires
- * them to the view and to lifecycle effects.
+ * Integration boundary for the peek panel width: owns the per-mount widget-width
+ * store, derives the final width (widget vs expanded), and wires drag/keyboard to
+ * the store + resize action. Whether the peek is *expanded* is owned by the URL
+ * (`isExpanded` in, `onExpandedChange` out) so it is shareable and back-able.
  */
 export function usePeekPanelState({
   isOpen,
+  isExpanded,
+  onExpandedChange,
 }: {
   isOpen: boolean;
+  isExpanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
 }): PeekPanelView {
   const [store] = useState(() => createPeekPanelStore());
 
-  const isFullscreen = useStore(store, selectIsFullscreen);
   const isResizing = useStore(store, selectIsResizing);
-  const width = useStore(store, selectWidth);
-  const toggleFullscreen = useStore(
-    store,
-    (state) => state.actions.toggleFullscreen,
-  );
+  const draftExpanded = useStore(store, selectDraftExpanded);
+  const widgetWidth = useStore(store, selectWidgetWidth);
 
-  // Ends an in-flight drag: drops the window listeners + restores body styles
-  // (via the resize action's teardown) and clears the store's drag state.
+  // During a drag the live draft wins; otherwise the URL flag does.
+  const effectiveExpanded = isResizing ? draftExpanded : isExpanded;
+
+  // While expanded, keep the panel at viewport − sidebar (sidebar stays visible).
+  // The peek portals into the `modal` layer, outside the sidebar's CSS-var scope,
+  // so the offset is measured live (and re-measured on viewport / sidebar resize).
+  const [sidebarOffset, setSidebarOffset] = useState(0);
+  useEffect(() => {
+    if (!effectiveExpanded) return;
+    const measure = () => setSidebarOffset(readSidebarOffsetPx());
+    measure();
+    window.addEventListener("resize", measure);
+    const sidebar = document.querySelector('[data-sidebar="sidebar"]');
+    const observer =
+      sidebar && typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(measure)
+        : null;
+    if (sidebar) observer?.observe(sidebar);
+    return () => {
+      window.removeEventListener("resize", measure);
+      observer?.disconnect();
+    };
+  }, [effectiveExpanded]);
+
+  const panelStyle: CSSProperties = {
+    width: effectiveExpanded ? `calc(100vw - ${sidebarOffset}px)` : widgetWidth,
+  };
+
+  // End an in-flight drag (drop listeners, restore body styles, clear drag state)
+  // on unmount and whenever the peek closes — the host outlives open/close.
   const dragTeardownRef = useRef<(() => void) | null>(null);
   const endActiveDrag = useCallback(() => {
     dragTeardownRef.current?.();
     dragTeardownRef.current = null;
     store.getState().actions.cancelResize();
   }, [store]);
-
-  // The host stays mounted across open/close, so on close (not on K/J item
-  // changes) explicitly reset fullscreen and abandon any in-flight resize drag —
-  // otherwise an Escape mid-drag would leave window listeners + body styles set.
   useEffect(() => {
     if (!isOpen) endActiveDrag();
-    store.getState().actions.resetForVisibility(isOpen);
-  }, [store, isOpen, endActiveDrag]);
-
-  // Also tear down on a real unmount.
+  }, [isOpen, endActiveDrag]);
   useEffect(() => endActiveDrag, [endActiveDrag]);
 
   const onPointerDown = useCallback(
     (event: ReactPointerEvent) => {
-      dragTeardownRef.current = beginPeekResize(store, event);
+      dragTeardownRef.current = beginPeekResize(store, event, onExpandedChange);
     },
-    [store],
+    [store, onExpandedChange],
   );
 
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent) => {
-      // Left grows the panel (it is docked right), Right shrinks it.
-      if (event.key === "ArrowLeft") {
+      // Left grows the panel (it is docked right), Right shrinks it; either
+      // collapses out of the expanded view onto a widget width.
+      if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
         event.preventDefault();
-        store.getState().actions.nudgeWidth("grow");
-      } else if (event.key === "ArrowRight") {
-        event.preventDefault();
-        store.getState().actions.nudgeWidth("shrink");
+        onExpandedChange(false);
+        store
+          .getState()
+          .actions.nudgeWidth(event.key === "ArrowLeft" ? "grow" : "shrink");
       }
     },
-    [store],
+    [store, onExpandedChange],
+  );
+
+  const toggleExpanded = useCallback(
+    () => onExpandedChange(!isExpanded),
+    [isExpanded, onExpandedChange],
   );
 
   return {
-    isFullscreen,
+    isExpanded,
     isResizing,
-    panelStyle: { width },
-    toggleFullscreen,
+    panelStyle,
+    toggleExpanded,
     resizeHandleProps: {
       role: "separator",
       "aria-orientation": "vertical",

--- a/web/src/components/table/peek/usePeekPanelState.ts
+++ b/web/src/components/table/peek/usePeekPanelState.ts
@@ -7,47 +7,16 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import useLocalStorage from "@/src/components/useLocalStorage";
+import { useStore } from "zustand";
+import {
+  createPeekPanelStore,
+  selectIsFullscreen,
+  selectIsResizing,
+  selectWidth,
+} from "@/src/components/table/peek/store/peekPanelStore";
+import { beginPeekResize } from "@/src/components/table/peek/actions/resizePeekPanel";
 
-/**
- * State for the desktop peek panel: how wide it is and whether it is fullscreen.
- *
- * State altitudes follow `frontend-large-feature-architecture`:
- * - **width** is a cross-view preference, so it persists in localStorage as a
- *   viewport fraction (resolution-independent) shared by every peek.
- * - **fullscreen** is ephemeral per open session: it lives in React state and
- *   is reset whenever the peek closes (`isOpen` → false). The peek host stays
- *   mounted across open/close, so this reset is explicit — the panel always
- *   reopens as the persisted widget width, never stuck fullscreen.
- * - the **resize drag** is high-frequency transient state, held locally as a
- *   draft and only committed to localStorage on pointer-up — the store is not
- *   written on every move.
- *
- * Fullscreen and width are a single continuum: dragging the handle past
- * `FULLSCREEN_ENTER_FRACTION` toggles fullscreen on (drag to 100% → fullscreen),
- * and dragging back off it returns to a widget width. The header button is just
- * a shortcut for the same toggle; turning it off restores the persisted width.
- */
-
-const STORAGE_KEY = "peekViewWidthFraction";
-
-// Widget width bounds, as a fraction of the viewport width.
-export const PEEK_MIN_WIDTH_FRACTION = 0.3;
-export const PEEK_MAX_WIDGET_WIDTH_FRACTION = 0.9;
-export const PEEK_DEFAULT_WIDTH_FRACTION = 0.5;
-// Dragging the handle beyond this fraction of the viewport snaps to fullscreen.
-export const PEEK_FULLSCREEN_ENTER_FRACTION = 0.95;
-const KEYBOARD_RESIZE_STEP = 0.05;
-
-const clampFraction = (fraction: number) =>
-  Math.min(
-    PEEK_MAX_WIDGET_WIDTH_FRACTION,
-    Math.max(PEEK_MIN_WIDTH_FRACTION, fraction),
-  );
-
-type DragState = { fullscreen: boolean; fraction: number };
-
-export type PeekPanelState = {
+export type PeekPanelView = {
   /** Whether the panel currently fills the viewport. */
   isFullscreen: boolean;
   /** True while the user is dragging the resize handle. */
@@ -67,131 +36,71 @@ export type PeekPanelState = {
   };
 };
 
+/**
+ * Integration boundary for the peek panel: owns the per-mount store (created
+ * once via lazy `useState`), subscribes to the slices the chrome needs, and
+ * exposes thin callbacks that delegate to store actions / the resize workflow.
+ * All state and logic live in the store and `actions/*` — this hook only wires
+ * them to the view and to lifecycle effects.
+ */
 export function usePeekPanelState({
   isOpen,
 }: {
   isOpen: boolean;
-}): PeekPanelState {
-  const [storedFraction, setStoredFraction] = useLocalStorage<number>(
-    STORAGE_KEY,
-    PEEK_DEFAULT_WIDTH_FRACTION,
-  );
-  const [isFullscreen, setIsFullscreen] = useState(false);
-  const [draftFraction, setDraftFraction] = useState<number | null>(null);
-  const [isResizing, setIsResizing] = useState(false);
+}): PeekPanelView {
+  const [store] = useState(() => createPeekPanelStore());
 
-  // Fullscreen is per open session. The peek host stays mounted across
-  // open/close, so reset it explicitly when the peek closes (not on item
-  // changes during K/J navigation, which keep `isOpen` true).
+  const isFullscreen = useStore(store, selectIsFullscreen);
+  const isResizing = useStore(store, selectIsResizing);
+  const width = useStore(store, selectWidth);
+  const toggleFullscreen = useStore(
+    store,
+    (state) => state.actions.toggleFullscreen,
+  );
+
+  // Fullscreen is per open session; the host outlives open/close, so reset it
+  // explicitly when the peek closes (not on item changes during K/J nav).
   useEffect(() => {
-    if (!isOpen) setIsFullscreen(false);
-  }, [isOpen]);
+    store.getState().actions.resetForVisibility(isOpen);
+  }, [store, isOpen]);
 
-  const committedFraction = clampFraction(storedFraction);
-  const committedFractionRef = useRef(committedFraction);
-  committedFractionRef.current = committedFraction;
+  // End an in-flight drag if the component unmounts mid-drag (drops window
+  // listeners, restores body cursor/selection styles).
+  const dragTeardownRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => dragTeardownRef.current?.(), []);
 
-  const dragStateRef = useRef<DragState | null>(null);
-  // Tears down an in-flight drag (listeners + body styles); also run on unmount
-  // so a drag interrupted by the peek closing can't leak listeners/cursor.
-  const endDragRef = useRef<(() => void) | null>(null);
-
-  const startResize = useCallback(
+  const onPointerDown = useCallback(
     (event: ReactPointerEvent) => {
-      // Only primary button drags; let the keyboard path handle the rest.
-      if (event.button !== 0) return;
-      event.preventDefault();
-
-      const onPointerMove = (move: PointerEvent) => {
-        const fraction = 1 - move.clientX / window.innerWidth;
-        if (fraction >= PEEK_FULLSCREEN_ENTER_FRACTION) {
-          dragStateRef.current = {
-            fullscreen: true,
-            fraction: committedFractionRef.current,
-          };
-          setIsFullscreen(true);
-          setDraftFraction(null);
-        } else {
-          const clamped = clampFraction(fraction);
-          dragStateRef.current = { fullscreen: false, fraction: clamped };
-          setIsFullscreen(false);
-          setDraftFraction(clamped);
-        }
-      };
-
-      const teardown = () => {
-        window.removeEventListener("pointermove", onPointerMove);
-        window.removeEventListener("pointerup", onPointerUp);
-        window.removeEventListener("pointercancel", onPointerUp);
-        document.body.style.removeProperty("user-select");
-        document.body.style.removeProperty("cursor");
-        endDragRef.current = null;
-      };
-
-      const onPointerUp = () => {
-        teardown();
-        const final = dragStateRef.current;
-        if (final && !final.fullscreen) {
-          setStoredFraction(final.fraction);
-        }
-        dragStateRef.current = null;
-        setDraftFraction(null);
-        setIsResizing(false);
-      };
-
-      endDragRef.current = teardown;
-      window.addEventListener("pointermove", onPointerMove);
-      window.addEventListener("pointerup", onPointerUp);
-      window.addEventListener("pointercancel", onPointerUp);
-      document.body.style.userSelect = "none";
-      document.body.style.cursor = "ew-resize";
-      setIsResizing(true);
+      dragTeardownRef.current = beginPeekResize(store, event);
     },
-    [setStoredFraction],
+    [store],
   );
-
-  // Safety net: if the component unmounts mid-drag, drop the window listeners
-  // and restore the body cursor/selection styles.
-  useEffect(() => () => endDragRef.current?.(), []);
 
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent) => {
-      // Left grows the panel (it is docked right), Right shrinks it. Always base
-      // off the persisted widget width — even when exiting fullscreen — so a
-      // keypress never clobbers the saved preference with the fullscreen ceiling.
-      if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+      // Left grows the panel (it is docked right), Right shrinks it.
+      if (event.key === "ArrowLeft") {
         event.preventDefault();
-        const delta =
-          event.key === "ArrowLeft"
-            ? KEYBOARD_RESIZE_STEP
-            : -KEYBOARD_RESIZE_STEP;
-        setIsFullscreen(false);
-        setStoredFraction(clampFraction(committedFractionRef.current + delta));
+        store.getState().actions.nudgeWidth("grow");
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        store.getState().actions.nudgeWidth("shrink");
       }
     },
-    [setStoredFraction],
+    [store],
   );
-
-  const toggleFullscreen = useCallback(() => {
-    setIsFullscreen((value) => !value);
-  }, []);
-
-  const effectiveFraction = clampFraction(draftFraction ?? committedFraction);
-  const panelStyle: CSSProperties = {
-    width: isFullscreen ? "100vw" : `${effectiveFraction * 100}vw`,
-  };
 
   return {
     isFullscreen,
     isResizing,
-    panelStyle,
+    panelStyle: { width },
     toggleFullscreen,
     resizeHandleProps: {
       role: "separator",
       "aria-orientation": "vertical",
       "aria-label": "Resize peek view",
       tabIndex: 0,
-      onPointerDown: startResize,
+      onPointerDown,
       onKeyDown,
     },
   };

--- a/web/src/components/table/peek/usePeekPanelState.ts
+++ b/web/src/components/table/peek/usePeekPanelState.ts
@@ -10,6 +10,7 @@ import {
 import { useStore } from "zustand";
 import {
   createPeekPanelStore,
+  PEEK_EXPAND_ENTER_FRACTION,
   PEEK_MIN_WIDTH_FRACTION,
   selectDraftExpanded,
   selectIsResizing,
@@ -123,8 +124,13 @@ export function usePeekPanelState({
     };
   }, []);
 
+  // Both expanded and widget widths are capped at the sidebar edge
+  // (`viewport − sidebar`). Capping the widget too means dragging to the max
+  // lands on the exact same width as expanded — no snap-back jump — and the
+  // panel never paints over the sidebar even if a stored fraction is large.
+  const maxWidth = `calc(100vw - ${sidebarOffset}px)`;
   const panelStyle: CSSProperties = {
-    width: effectiveExpanded ? `calc(100vw - ${sidebarOffset}px)` : widgetWidth,
+    width: effectiveExpanded ? maxWidth : `min(${widgetWidth}, ${maxWidth})`,
   };
 
   // End an in-flight drag (drop listeners, restore body styles, clear drag
@@ -143,9 +149,25 @@ export function usePeekPanelState({
 
   const onPointerDown = useCallback(
     (event: ReactPointerEvent) => {
-      dragTeardownRef.current = beginPeekResize(store, event, commitExpanded);
+      // The drag flips to expanded at the sidebar edge (viewport − sidebar),
+      // clamped to the widget bounds, so it can't overshoot onto the sidebar.
+      const vw = typeof window === "undefined" ? 0 : window.innerWidth;
+      const expandAtFraction =
+        vw > 0
+          ? Math.min(
+              PEEK_EXPAND_ENTER_FRACTION,
+              Math.max(PEEK_MIN_WIDTH_FRACTION, (vw - sidebarOffset) / vw),
+            )
+          : PEEK_EXPAND_ENTER_FRACTION;
+      dragTeardownRef.current = beginPeekResize(
+        store,
+        event,
+        commitExpanded,
+        expandAtFraction,
+        effectiveExpanded,
+      );
     },
-    [store, commitExpanded],
+    [store, commitExpanded, sidebarOffset, effectiveExpanded],
   );
 
   const onKeyDown = useCallback(

--- a/web/src/components/table/peek/usePeekPanelState.ts
+++ b/web/src/components/table/peek/usePeekPanelState.ts
@@ -1,0 +1,174 @@
+import {
+  useCallback,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import useLocalStorage from "@/src/components/useLocalStorage";
+
+/**
+ * State for the desktop peek panel: how wide it is and whether it is fullscreen.
+ *
+ * State altitudes follow `frontend-large-feature-architecture`:
+ * - **width** is a cross-view preference, so it persists in localStorage as a
+ *   viewport fraction (resolution-independent) shared by every peek.
+ * - **fullscreen** is ephemeral per open session: it lives in React state and
+ *   resets when the peek unmounts (i.e. on close). The panel always reopens as
+ *   the persisted widget width, never stuck fullscreen.
+ * - the **resize drag** is high-frequency transient state, held locally as a
+ *   draft and only committed to localStorage on pointer-up — the store is not
+ *   written on every move.
+ *
+ * Fullscreen and width are a single continuum: dragging the handle past
+ * `FULLSCREEN_ENTER_FRACTION` toggles fullscreen on (drag to 100% → fullscreen),
+ * and dragging back off it returns to a widget width. The header button is just
+ * a shortcut for the same toggle; turning it off restores the persisted width.
+ */
+
+const STORAGE_KEY = "peekViewWidthFraction";
+
+// Widget width bounds, as a fraction of the viewport width.
+export const PEEK_MIN_WIDTH_FRACTION = 0.3;
+export const PEEK_MAX_WIDGET_WIDTH_FRACTION = 0.9;
+export const PEEK_DEFAULT_WIDTH_FRACTION = 0.5;
+// Dragging the handle beyond this fraction of the viewport snaps to fullscreen.
+export const PEEK_FULLSCREEN_ENTER_FRACTION = 0.95;
+const KEYBOARD_RESIZE_STEP = 0.05;
+
+const clampFraction = (fraction: number) =>
+  Math.min(
+    PEEK_MAX_WIDGET_WIDTH_FRACTION,
+    Math.max(PEEK_MIN_WIDTH_FRACTION, fraction),
+  );
+
+type DragState = { fullscreen: boolean; fraction: number };
+
+export type PeekPanelState = {
+  /** Whether the panel currently fills the viewport. */
+  isFullscreen: boolean;
+  /** True while the user is dragging the resize handle. */
+  isResizing: boolean;
+  /** Inline style (width) for the docked panel. */
+  panelStyle: CSSProperties;
+  /** Toggle fullscreen on/off; off restores the persisted widget width. */
+  toggleFullscreen: () => void;
+  /** Props to spread onto the left-edge resize handle. */
+  resizeHandleProps: {
+    role: "separator";
+    "aria-orientation": "vertical";
+    "aria-label": string;
+    tabIndex: 0;
+    onPointerDown: (event: ReactPointerEvent) => void;
+    onKeyDown: (event: ReactKeyboardEvent) => void;
+  };
+};
+
+export function usePeekPanelState(): PeekPanelState {
+  const [storedFraction, setStoredFraction] = useLocalStorage<number>(
+    STORAGE_KEY,
+    PEEK_DEFAULT_WIDTH_FRACTION,
+  );
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [draftFraction, setDraftFraction] = useState<number | null>(null);
+  const [isResizing, setIsResizing] = useState(false);
+
+  const committedFraction = clampFraction(storedFraction);
+  const committedFractionRef = useRef(committedFraction);
+  committedFractionRef.current = committedFraction;
+
+  const dragStateRef = useRef<DragState | null>(null);
+
+  const startResize = useCallback(
+    (event: ReactPointerEvent) => {
+      // Only primary button drags; let the keyboard path handle the rest.
+      if (event.button !== 0) return;
+      event.preventDefault();
+
+      const onPointerMove = (move: PointerEvent) => {
+        const fraction = 1 - move.clientX / window.innerWidth;
+        if (fraction >= PEEK_FULLSCREEN_ENTER_FRACTION) {
+          dragStateRef.current = {
+            fullscreen: true,
+            fraction: committedFractionRef.current,
+          };
+          setIsFullscreen(true);
+          setDraftFraction(null);
+        } else {
+          const clamped = clampFraction(fraction);
+          dragStateRef.current = { fullscreen: false, fraction: clamped };
+          setIsFullscreen(false);
+          setDraftFraction(clamped);
+        }
+      };
+
+      const onPointerUp = () => {
+        window.removeEventListener("pointermove", onPointerMove);
+        window.removeEventListener("pointerup", onPointerUp);
+        window.removeEventListener("pointercancel", onPointerUp);
+        document.body.style.removeProperty("user-select");
+        document.body.style.removeProperty("cursor");
+
+        const final = dragStateRef.current;
+        if (final && !final.fullscreen) {
+          setStoredFraction(final.fraction);
+        }
+        dragStateRef.current = null;
+        setDraftFraction(null);
+        setIsResizing(false);
+      };
+
+      window.addEventListener("pointermove", onPointerMove);
+      window.addEventListener("pointerup", onPointerUp);
+      window.addEventListener("pointercancel", onPointerUp);
+      document.body.style.userSelect = "none";
+      document.body.style.cursor = "ew-resize";
+      setIsResizing(true);
+    },
+    [setStoredFraction],
+  );
+
+  const onKeyDown = useCallback(
+    (event: ReactKeyboardEvent) => {
+      // Left grows the panel (it is docked right), Right shrinks it.
+      if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+        event.preventDefault();
+        const base = isFullscreen
+          ? PEEK_MAX_WIDGET_WIDTH_FRACTION
+          : committedFractionRef.current;
+        const delta =
+          event.key === "ArrowLeft"
+            ? KEYBOARD_RESIZE_STEP
+            : -KEYBOARD_RESIZE_STEP;
+        setIsFullscreen(false);
+        setStoredFraction(clampFraction(base + delta));
+      }
+    },
+    [isFullscreen, setStoredFraction],
+  );
+
+  const toggleFullscreen = useCallback(() => {
+    setIsFullscreen((value) => !value);
+  }, []);
+
+  const effectiveFraction = clampFraction(draftFraction ?? committedFraction);
+  const panelStyle: CSSProperties = {
+    width: isFullscreen ? "100vw" : `${effectiveFraction * 100}vw`,
+  };
+
+  return {
+    isFullscreen,
+    isResizing,
+    panelStyle,
+    toggleFullscreen,
+    resizeHandleProps: {
+      role: "separator",
+      "aria-orientation": "vertical",
+      "aria-label": "Resize peek view",
+      tabIndex: 0,
+      onPointerDown: startResize,
+      onKeyDown,
+    },
+  };
+}

--- a/web/src/components/trace/TraceDetailActions.tsx
+++ b/web/src/components/trace/TraceDetailActions.tsx
@@ -3,25 +3,6 @@ import { StarTraceDetailsToggle } from "@/src/components/star-toggle";
 import { PublishTraceSwitch } from "@/src/components/publish-object-switch";
 import { DeleteTraceButton } from "@/src/components/deleteButton";
 
-/** A labeled menu row wrapping one of the icon controls (used in the peek's
- *  overflow "…" menu so folded actions read as proper labeled items). The
- *  control keeps its own behavior — Share opens its URL popover, Delete its
- *  confirm — so nothing is reimplemented. */
-function ActionMenuRow({
-  control,
-  label,
-}: {
-  control: React.ReactNode;
-  label: string;
-}) {
-  return (
-    <div className="hover:bg-accent flex items-center gap-2 rounded-sm py-0.5 pr-2 pl-1">
-      {control}
-      <span className="text-sm">{label}</span>
-    </div>
-  );
-}
-
 /**
  * Trace-level header actions (star / publish / delete) shared by the peek and
  * the standalone trace page, so both surfaces expose the same controls. Each
@@ -29,7 +10,8 @@ function ActionMenuRow({
  * project scope, matching the page's long-standing behavior.
  *
  * `layout="toolbar"` (default) is the inline icon row; `layout="menu"` renders
- * the same controls as labeled rows for the peek's overflow popover.
+ * the same controls as full-width labeled rows for the peek's overflow popover
+ * (whole row clickable) — Share keeps its URL popover, Delete its confirm.
  *
  * Delete always targets the whole trace (same as the page, even when reached
  * from an observation/event row — the surface shows that trace). Behavior
@@ -64,64 +46,73 @@ export function TraceDetailActions({
   layout?: "toolbar" | "menu";
 }) {
   const utils = api.useUtils();
+  const isMenu = layout === "menu";
 
-  const star = (
-    <StarTraceDetailsToggle
-      projectId={projectId}
-      traceId={traceId}
-      value={bookmarked}
-      size={size}
-    />
-  );
-  const publish = (
-    <PublishTraceSwitch
-      projectId={projectId}
-      traceId={traceId}
-      timestamp={timestamp}
-      isPublic={isPublic}
-      size={size}
-    />
-  );
-  const del = (
-    <DeleteTraceButton
-      itemId={traceId}
-      projectId={projectId}
-      redirectUrl={deleteRedirectUrl}
-      invalidateFunc={() => {
-        // The page path navigates away (redirectUrl) and never calls this.
-        // The peek path is hosted over many different lists, so invalidate all
-        // queries to refresh whichever list is behind the peek, then close it.
-        utils.invalidate();
-        onAfterDelete?.();
-      }}
-      deleteConfirmation={name ?? ""}
-      icon
-      // Match Star/Publish so the three icons share one row height (the delete
-      // icon branch otherwise falls back to "icon" = 32px vs 24px) and one
-      // style — ghost, not the default boxed "outline-solid".
-      size={size}
-      variant="ghost"
-    />
-  );
+  // The page path navigates away (redirectUrl) and never calls this. The peek
+  // path is hosted over many different lists, so invalidate all queries to
+  // refresh whichever list is behind the peek, then close it.
+  const onDeleteInvalidate = () => {
+    utils.invalidate();
+    onAfterDelete?.();
+  };
 
-  if (layout === "menu") {
+  if (isMenu) {
     return (
-      <div className="flex flex-col gap-0.5">
-        <ActionMenuRow
-          control={star}
+      <div className="flex w-full flex-col gap-0.5">
+        <StarTraceDetailsToggle
+          projectId={projectId}
+          traceId={traceId}
+          value={bookmarked}
           label={bookmarked ? "Remove bookmark" : "Bookmark"}
         />
-        <ActionMenuRow control={publish} label="Share" />
-        <ActionMenuRow control={del} label="Delete" />
+        <PublishTraceSwitch
+          projectId={projectId}
+          traceId={traceId}
+          timestamp={timestamp}
+          isPublic={isPublic}
+          label="Share"
+        />
+        <DeleteTraceButton
+          itemId={traceId}
+          projectId={projectId}
+          redirectUrl={deleteRedirectUrl}
+          invalidateFunc={onDeleteInvalidate}
+          deleteConfirmation={name ?? ""}
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start font-normal"
+        />
       </div>
     );
   }
 
   return (
     <div className="flex flex-row items-center gap-1">
-      {star}
-      {publish}
-      {del}
+      <StarTraceDetailsToggle
+        projectId={projectId}
+        traceId={traceId}
+        value={bookmarked}
+        size={size}
+      />
+      <PublishTraceSwitch
+        projectId={projectId}
+        traceId={traceId}
+        timestamp={timestamp}
+        isPublic={isPublic}
+        size={size}
+      />
+      <DeleteTraceButton
+        itemId={traceId}
+        projectId={projectId}
+        redirectUrl={deleteRedirectUrl}
+        invalidateFunc={onDeleteInvalidate}
+        deleteConfirmation={name ?? ""}
+        icon
+        // Match Star/Publish so the three icons share one row height and a
+        // ghost (not boxed "outline-solid") style.
+        size={size}
+        variant="ghost"
+      />
     </div>
   );
 }

--- a/web/src/components/trace/TraceDetailActions.tsx
+++ b/web/src/components/trace/TraceDetailActions.tsx
@@ -70,6 +70,9 @@ export function TraceDetailActions({
         }}
         deleteConfirmation={name ?? ""}
         icon
+        // Match Star/Publish so the three icons share one row height (the
+        // delete icon branch otherwise falls back to "icon" = 32px vs 24px).
+        size={size}
       />
     </div>
   );

--- a/web/src/components/trace/TraceDetailActions.tsx
+++ b/web/src/components/trace/TraceDetailActions.tsx
@@ -1,0 +1,68 @@
+import { api } from "@/src/utils/api";
+import { StarTraceDetailsToggle } from "@/src/components/star-toggle";
+import { PublishTraceSwitch } from "@/src/components/publish-object-switch";
+import { DeleteTraceButton } from "@/src/components/deleteButton";
+
+/**
+ * Trace-level header actions (star / publish / delete) shared by the peek and
+ * the standalone trace page, so both surfaces expose the same controls. Each
+ * sub-component self-hides when the user lacks the relevant project scope (e.g.
+ * a public trace viewed by a non-member), so this is safe to render anywhere.
+ *
+ * Delete behavior differs only by surface:
+ * - **page**: pass `deleteRedirectUrl` → navigates to the list after delete.
+ * - **peek**: pass `onAfterDelete` (e.g. `closePeek`) → closes in place; the
+ *   list is invalidated so the deleted row disappears.
+ */
+export function TraceDetailActions({
+  traceId,
+  projectId,
+  bookmarked,
+  isPublic,
+  name,
+  timestamp,
+  deleteRedirectUrl,
+  onAfterDelete,
+  size = "icon-xs",
+}: {
+  traceId: string;
+  projectId: string;
+  bookmarked: boolean;
+  isPublic: boolean;
+  name?: string | null;
+  timestamp?: Date;
+  deleteRedirectUrl?: string;
+  onAfterDelete?: () => void;
+  size?: "icon" | "icon-xs";
+}) {
+  const utils = api.useUtils();
+
+  return (
+    <div className="flex flex-row items-center gap-1">
+      <StarTraceDetailsToggle
+        projectId={projectId}
+        traceId={traceId}
+        value={bookmarked}
+        size={size}
+      />
+      <PublishTraceSwitch
+        projectId={projectId}
+        traceId={traceId}
+        timestamp={timestamp}
+        isPublic={isPublic}
+        size={size}
+      />
+      <DeleteTraceButton
+        itemId={traceId}
+        projectId={projectId}
+        redirectUrl={deleteRedirectUrl}
+        invalidateFunc={() => {
+          utils.traces.all.invalidate();
+          onAfterDelete?.();
+        }}
+        deleteConfirmation={name ?? ""}
+        icon
+      />
+    </div>
+  );
+}

--- a/web/src/components/trace/TraceDetailActions.tsx
+++ b/web/src/components/trace/TraceDetailActions.tsx
@@ -2,6 +2,11 @@ import { api } from "@/src/utils/api";
 import { StarTraceDetailsToggle } from "@/src/components/star-toggle";
 import { PublishTraceSwitch } from "@/src/components/publish-object-switch";
 import { DeleteTraceButton } from "@/src/components/deleteButton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 
 /**
  * Trace-level header actions (star / publish / delete) shared by the peek and
@@ -88,18 +93,31 @@ export function TraceDetailActions({
 
   return (
     <div className="flex flex-row items-center gap-1">
-      <StarTraceDetailsToggle
-        projectId={projectId}
-        traceId={traceId}
-        value={bookmarked}
-        size={size}
-      />
+      {/* Star/Share are plain icon buttons without their own tooltip, so wrap
+          them (delete's IconOnlyButton already has one). The span is the
+          tooltip trigger; the control inside keeps its own click behavior. */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="flex">
+            <StarTraceDetailsToggle
+              projectId={projectId}
+              traceId={traceId}
+              value={bookmarked}
+              size={size}
+            />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          {bookmarked ? "Remove bookmark" : "Bookmark"}
+        </TooltipContent>
+      </Tooltip>
       <PublishTraceSwitch
         projectId={projectId}
         traceId={traceId}
         timestamp={timestamp}
         isPublic={isPublic}
         size={size}
+        tooltip={isPublic ? "Shared (public)" : "Share"}
       />
       <DeleteTraceButton
         itemId={traceId}

--- a/web/src/components/trace/TraceDetailActions.tsx
+++ b/web/src/components/trace/TraceDetailActions.tsx
@@ -3,11 +3,33 @@ import { StarTraceDetailsToggle } from "@/src/components/star-toggle";
 import { PublishTraceSwitch } from "@/src/components/publish-object-switch";
 import { DeleteTraceButton } from "@/src/components/deleteButton";
 
+/** A labeled menu row wrapping one of the icon controls (used in the peek's
+ *  overflow "…" menu so folded actions read as proper labeled items). The
+ *  control keeps its own behavior — Share opens its URL popover, Delete its
+ *  confirm — so nothing is reimplemented. */
+function ActionMenuRow({
+  control,
+  label,
+}: {
+  control: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <div className="hover:bg-accent flex items-center gap-2 rounded-sm py-0.5 pr-2 pl-1">
+      {control}
+      <span className="text-sm">{label}</span>
+    </div>
+  );
+}
+
 /**
  * Trace-level header actions (star / publish / delete) shared by the peek and
  * the standalone trace page, so both surfaces expose the same controls. Each
  * sub-component renders DISABLED (not hidden) when the user lacks the relevant
  * project scope, matching the page's long-standing behavior.
+ *
+ * `layout="toolbar"` (default) is the inline icon row; `layout="menu"` renders
+ * the same controls as labeled rows for the peek's overflow popover.
  *
  * Delete always targets the whole trace (same as the page, even when reached
  * from an observation/event row — the surface shows that trace). Behavior
@@ -28,6 +50,7 @@ export function TraceDetailActions({
   deleteRedirectUrl,
   onAfterDelete,
   size = "icon-xs",
+  layout = "toolbar",
 }: {
   traceId: string;
   projectId: string;
@@ -38,44 +61,67 @@ export function TraceDetailActions({
   deleteRedirectUrl?: string;
   onAfterDelete?: () => void;
   size?: "icon" | "icon-xs";
+  layout?: "toolbar" | "menu";
 }) {
   const utils = api.useUtils();
 
+  const star = (
+    <StarTraceDetailsToggle
+      projectId={projectId}
+      traceId={traceId}
+      value={bookmarked}
+      size={size}
+    />
+  );
+  const publish = (
+    <PublishTraceSwitch
+      projectId={projectId}
+      traceId={traceId}
+      timestamp={timestamp}
+      isPublic={isPublic}
+      size={size}
+    />
+  );
+  const del = (
+    <DeleteTraceButton
+      itemId={traceId}
+      projectId={projectId}
+      redirectUrl={deleteRedirectUrl}
+      invalidateFunc={() => {
+        // The page path navigates away (redirectUrl) and never calls this.
+        // The peek path is hosted over many different lists, so invalidate all
+        // queries to refresh whichever list is behind the peek, then close it.
+        utils.invalidate();
+        onAfterDelete?.();
+      }}
+      deleteConfirmation={name ?? ""}
+      icon
+      // Match Star/Publish so the three icons share one row height (the delete
+      // icon branch otherwise falls back to "icon" = 32px vs 24px) and one
+      // style — ghost, not the default boxed "outline-solid".
+      size={size}
+      variant="ghost"
+    />
+  );
+
+  if (layout === "menu") {
+    return (
+      <div className="flex flex-col gap-0.5">
+        <ActionMenuRow
+          control={star}
+          label={bookmarked ? "Remove bookmark" : "Bookmark"}
+        />
+        <ActionMenuRow control={publish} label="Share" />
+        <ActionMenuRow control={del} label="Delete" />
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-row items-center gap-1">
-      <StarTraceDetailsToggle
-        projectId={projectId}
-        traceId={traceId}
-        value={bookmarked}
-        size={size}
-      />
-      <PublishTraceSwitch
-        projectId={projectId}
-        traceId={traceId}
-        timestamp={timestamp}
-        isPublic={isPublic}
-        size={size}
-      />
-      <DeleteTraceButton
-        itemId={traceId}
-        projectId={projectId}
-        redirectUrl={deleteRedirectUrl}
-        invalidateFunc={() => {
-          // The page path navigates away (redirectUrl) and never calls this.
-          // The peek path is hosted over many different lists, so invalidate
-          // all queries to refresh whichever list is behind the peek, then
-          // close it.
-          utils.invalidate();
-          onAfterDelete?.();
-        }}
-        deleteConfirmation={name ?? ""}
-        icon
-        // Match Star/Publish so the three icons share one row height (the
-        // delete icon branch otherwise falls back to "icon" = 32px vs 24px) and
-        // one style — ghost, not the default boxed "outline-solid".
-        size={size}
-        variant="ghost"
-      />
+      {star}
+      {publish}
+      {del}
     </div>
   );
 }

--- a/web/src/components/trace/TraceDetailActions.tsx
+++ b/web/src/components/trace/TraceDetailActions.tsx
@@ -6,13 +6,17 @@ import { DeleteTraceButton } from "@/src/components/deleteButton";
 /**
  * Trace-level header actions (star / publish / delete) shared by the peek and
  * the standalone trace page, so both surfaces expose the same controls. Each
- * sub-component self-hides when the user lacks the relevant project scope (e.g.
- * a public trace viewed by a non-member), so this is safe to render anywhere.
+ * sub-component renders DISABLED (not hidden) when the user lacks the relevant
+ * project scope, matching the page's long-standing behavior.
  *
- * Delete behavior differs only by surface:
+ * Delete always targets the whole trace (same as the page, even when reached
+ * from an observation/event row — the surface shows that trace). Behavior
+ * differs only by surface:
  * - **page**: pass `deleteRedirectUrl` → navigates to the list after delete.
- * - **peek**: pass `onAfterDelete` (e.g. `closePeek`) → closes in place; the
- *   list is invalidated so the deleted row disappears.
+ * - **peek**: pass `onAfterDelete` (e.g. `closePeek`) → closes in place. We
+ *   invalidate broadly because the peek is hosted over many different lists
+ *   (traces, observations, events, sessions, experiments, datasets), each
+ *   backed by a different query — so the deleted row disappears everywhere.
  */
 export function TraceDetailActions({
   traceId,
@@ -57,7 +61,11 @@ export function TraceDetailActions({
         projectId={projectId}
         redirectUrl={deleteRedirectUrl}
         invalidateFunc={() => {
-          utils.traces.all.invalidate();
+          // The page path navigates away (redirectUrl) and never calls this.
+          // The peek path is hosted over many different lists, so invalidate
+          // all queries to refresh whichever list is behind the peek, then
+          // close it.
+          utils.invalidate();
           onAfterDelete?.();
         }}
         deleteConfirmation={name ?? ""}

--- a/web/src/components/trace/TraceDetailActions.tsx
+++ b/web/src/components/trace/TraceDetailActions.tsx
@@ -71,8 +71,10 @@ export function TraceDetailActions({
         deleteConfirmation={name ?? ""}
         icon
         // Match Star/Publish so the three icons share one row height (the
-        // delete icon branch otherwise falls back to "icon" = 32px vs 24px).
+        // delete icon branch otherwise falls back to "icon" = 32px vs 24px) and
+        // one style — ghost, not the default boxed "outline-solid".
         size={size}
+        variant="ghost"
       />
     </div>
   );

--- a/web/src/components/trace/TraceDetailBody.tsx
+++ b/web/src/components/trace/TraceDetailBody.tsx
@@ -1,0 +1,45 @@
+import { Trace } from "@/src/components/trace/Trace";
+import { Skeleton } from "@/src/components/ui/skeleton";
+import { type useTraceDetailData } from "@/src/components/trace/useTraceDetailData";
+
+type TraceDetailData = NonNullable<
+  ReturnType<typeof useTraceDetailData>["data"]
+>;
+
+/** Detail-view title (`name: id`, or just the id), shared by the peek + page. */
+export function traceDetailTitle(
+  trace: { name?: string | null; id: string } | undefined,
+  fallback?: string,
+): string | undefined {
+  if (!trace) return fallback;
+  return trace.name ? `${trace.name}: ${trace.id}` : trace.id;
+}
+
+/**
+ * The trace detail body (`<Trace>`), shared by the peek and the standalone
+ * page so the invocation isn't copy-pasted. Renders a skeleton until the data
+ * arrives. `keySuffix` lets a caller force a remount when the focused item
+ * changes (e.g. the observation peek keys on the observation id).
+ */
+export function TraceDetailBody({
+  trace,
+  context,
+  keySuffix,
+}: {
+  trace: TraceDetailData | undefined;
+  context: "peek" | "fullscreen" | "annotation";
+  keySuffix?: string;
+}) {
+  if (!trace) return <Skeleton className="h-full w-full rounded-none" />;
+  return (
+    <Trace
+      key={keySuffix ? `${trace.id}-${keySuffix}` : trace.id}
+      trace={trace}
+      scores={trace.scores}
+      corrections={trace.corrections}
+      projectId={trace.projectId}
+      observations={trace.observations}
+      context={context}
+    />
+  );
+}

--- a/web/src/components/trace/TracePage.tsx
+++ b/web/src/components/trace/TracePage.tsx
@@ -1,8 +1,8 @@
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { useRouter } from "next/router";
-import { api } from "@/src/utils/api";
 import { ErrorPage } from "@/src/components/error-page";
 import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
+import { useTraceDetailData } from "@/src/components/trace/useTraceDetailData";
 import Page from "@/src/components/layouts/page";
 import { Trace } from "@/src/components/trace/Trace";
 import { useSession } from "next-auth/react";
@@ -11,8 +11,6 @@ import { Button } from "@/src/components/ui/button";
 import Link from "next/link";
 import { stripBasePath } from "@/src/utils/redirect";
 import { Badge } from "@/src/components/ui/badge";
-import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
-import { useEventsTraceData } from "@/src/features/events/hooks/useEventsTraceData";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { useEffect } from "react";
 
@@ -26,44 +24,13 @@ export function TracePage({
   const router = useRouter();
   const session = useSession();
   const routeProjectId = (router.query.projectId as string) ?? "";
-  const { isBetaEnabled } = useV4Beta();
 
-  // Old path: fetch from traces table (beta OFF)
-  const tracesQuery = api.traces.byIdWithObservationsAndScores.useQuery(
-    {
-      traceId,
-      timestamp,
-      projectId: routeProjectId,
-    },
-    {
-      enabled: !isBetaEnabled,
-      retry(failureCount, error) {
-        if (
-          error.data?.code === "UNAUTHORIZED" ||
-          error.data?.code === "NOT_FOUND"
-        )
-          return false;
-        return failureCount < 3;
-      },
-    },
-  );
-
-  // New path: fetch from events table (beta ON)
-  const eventsData = useEventsTraceData({
+  // Shared, beta-aware fetch (same hook the peek uses).
+  const trace = useTraceDetailData({
     projectId: routeProjectId,
     traceId,
     timestamp,
-    enabled: isBetaEnabled,
   });
-
-  // Use the appropriate data source based on beta toggle
-  const trace = isBetaEnabled
-    ? {
-        data: eventsData.data,
-        isLoading: eventsData.isLoading,
-        error: eventsData.error as typeof tracesQuery.error,
-      }
-    : tracesQuery;
 
   const projectIdForAccessCheck = trace.data?.projectId ?? routeProjectId;
   const hasProjectAccess = useIsAuthenticatedAndProjectMember(
@@ -71,37 +38,23 @@ export function TracePage({
   );
 
   useEffect(() => {
-    if (isBetaEnabled && eventsData.cutoffObservationsAfterMaxCount) {
+    if (trace.cutoffObservationsAfterMaxCount) {
       showErrorToast(
         "Trace truncated",
         "This trace has too many observations for the detail view. Only a subset is shown.",
         "WARNING",
       );
     }
-  }, [isBetaEnabled, eventsData.cutoffObservationsAfterMaxCount]);
+  }, [trace.cutoffObservationsAfterMaxCount]);
 
-  // Handle errors - for events path, we check if there's no data after loading
-  if (!isBetaEnabled && tracesQuery.error?.data?.code === "UNAUTHORIZED")
+  if (trace.isUnauthorized)
     return <ErrorPage message="You do not have access to this trace." />;
 
-  if (!isBetaEnabled && tracesQuery.error?.data?.code === "NOT_FOUND")
+  if (trace.isNotFound)
     return (
       <ErrorPage
         title="Trace not found"
         message="The trace is either still being processed or has been deleted."
-        additionalButton={{
-          label: "Retry",
-          onClick: () => window.location.reload(),
-        }}
-      />
-    );
-
-  // For events path: show not found if no observations found after loading
-  if (isBetaEnabled && !eventsData.isLoading && !eventsData.data)
-    return (
-      <ErrorPage
-        title="Trace not found"
-        message="No observations found for this trace. The trace may still be processing or has been deleted."
         additionalButton={{
           label: "Retry",
           onClick: () => window.location.reload(),

--- a/web/src/components/trace/TracePage.tsx
+++ b/web/src/components/trace/TracePage.tsx
@@ -143,6 +143,7 @@ export function TracePage({
                 return `/project/${projectId as string}/traces/${entry.id}${finalQueryString}`;
               }}
               listKey="traces"
+              size="sm"
             />
             <TraceDetailActions
               traceId={trace.data.id}

--- a/web/src/components/trace/TracePage.tsx
+++ b/web/src/components/trace/TracePage.tsx
@@ -4,7 +4,10 @@ import { ErrorPage } from "@/src/components/error-page";
 import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
 import { useTraceDetailData } from "@/src/components/trace/useTraceDetailData";
 import Page from "@/src/components/layouts/page";
-import { Trace } from "@/src/components/trace/Trace";
+import {
+  TraceDetailBody,
+  traceDetailTitle,
+} from "@/src/components/trace/TraceDetailBody";
 import { useSession } from "next-auth/react";
 import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
 import { Button } from "@/src/components/ui/button";
@@ -103,9 +106,7 @@ export function TracePage({
   return (
     <Page
       headerProps={{
-        title: trace.data.name
-          ? `${trace.data.name}: ${trace.data.id}`
-          : trace.data.id,
+        title: traceDetailTitle(trace.data) ?? trace.data.id,
         itemType: "TRACE",
         breadcrumb: [
           {
@@ -157,12 +158,8 @@ export function TracePage({
       }}
     >
       <div className="flex max-h-full min-h-0 flex-1 overflow-hidden">
-        <Trace
+        <TraceDetailBody
           trace={trace.data}
-          scores={trace.data.scores}
-          corrections={trace.data.corrections}
-          projectId={trace.data.projectId}
-          observations={trace.data.observations}
           context={router.query.peek !== undefined ? "peek" : "fullscreen"}
         />
       </div>

--- a/web/src/components/trace/TracePage.tsx
+++ b/web/src/components/trace/TracePage.tsx
@@ -1,10 +1,8 @@
-import { PublishTraceSwitch } from "@/src/components/publish-object-switch";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { useRouter } from "next/router";
 import { api } from "@/src/utils/api";
-import { StarTraceDetailsToggle } from "@/src/components/star-toggle";
 import { ErrorPage } from "@/src/components/error-page";
-import { DeleteTraceButton } from "@/src/components/deleteButton";
+import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
 import Page from "@/src/components/layouts/page";
 import { Trace } from "@/src/components/trace/Trace";
 import { useSession } from "next-auth/react";
@@ -165,25 +163,6 @@ export function TracePage({
         showSidebarTrigger: !showPublicIndicators,
         leadingControl,
         breadcrumbBadges: sharedBadge,
-        actionButtonsLeft: (
-          <div className="ml-1 flex items-center gap-1">
-            <div className="flex items-center gap-0">
-              <StarTraceDetailsToggle
-                traceId={trace.data.id}
-                projectId={trace.data.projectId}
-                value={trace.data.bookmarked}
-                size="icon-xs"
-              />
-              <PublishTraceSwitch
-                traceId={trace.data.id}
-                projectId={trace.data.projectId}
-                timestamp={timestamp}
-                isPublic={trace.data.public}
-                size="icon-xs"
-              />
-            </div>
-          </div>
-        ),
         actionButtonsRight: (
           <>
             <DetailPageNav
@@ -211,12 +190,14 @@ export function TracePage({
               }}
               listKey="traces"
             />
-            <DeleteTraceButton
-              itemId={traceId}
+            <TraceDetailActions
+              traceId={trace.data.id}
               projectId={trace.data.projectId}
-              redirectUrl={`/project/${router.query.projectId as string}/traces`}
-              deleteConfirmation={trace.data.name ?? ""}
-              icon
+              bookmarked={trace.data.bookmarked}
+              isPublic={trace.data.public}
+              name={trace.data.name}
+              timestamp={timestamp}
+              deleteRedirectUrl={`/project/${router.query.projectId as string}/traces`}
             />
           </>
         ),

--- a/web/src/components/trace/useTraceDetailData.clienttest.tsx
+++ b/web/src/components/trace/useTraceDetailData.clienttest.tsx
@@ -57,6 +57,20 @@ describe("useTraceDetailData (beta / events path)", () => {
     expect(r.isNotFound).toBe(false);
   });
 
+  it("does NOT report a non-UNAUTHORIZED error (e.g. 500) as not-found", () => {
+    mockUseEventsTraceData.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: { data: { code: "INTERNAL_SERVER_ERROR" } },
+      cutoffObservationsAfterMaxCount: false,
+    });
+    const r = render();
+    // A transient server error is neither "not found" nor "unauthorized".
+    expect(r.isNotFound).toBe(false);
+    expect(r.isUnauthorized).toBe(false);
+    expect(r.isError).toBe(true);
+  });
+
   it("treats no-data-after-loading (no error) as a genuine not-found", () => {
     mockUseEventsTraceData.mockReturnValue({
       data: undefined,

--- a/web/src/components/trace/useTraceDetailData.clienttest.tsx
+++ b/web/src/components/trace/useTraceDetailData.clienttest.tsx
@@ -1,0 +1,71 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTraceDetailData } from "@/src/components/trace/useTraceDetailData";
+
+// Created via vi.hoisted so they exist before the hoisted vi.mock factories run.
+const { mockUseV4Beta, mockUseEventsTraceData, mockTracesQuery } = vi.hoisted(
+  () => ({
+    mockUseV4Beta: vi.fn(),
+    mockUseEventsTraceData: vi.fn(),
+    mockTracesQuery: vi.fn(),
+  }),
+);
+
+vi.mock("@/src/features/events/hooks/useV4Beta", () => ({
+  useV4Beta: () => mockUseV4Beta(),
+}));
+vi.mock("@/src/features/events/hooks/useEventsTraceData", () => ({
+  useEventsTraceData: (args: unknown) => mockUseEventsTraceData(args),
+}));
+// The traces-table query hook always runs (it's a hook; enabled:false on the
+// beta path), so it only needs to return a query-shaped object.
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    traces: {
+      byIdWithObservationsAndScores: { useQuery: () => mockTracesQuery() },
+    },
+  },
+}));
+
+const render = () =>
+  renderHook(() => useTraceDetailData({ projectId: "p", traceId: "t" })).result
+    .current;
+
+describe("useTraceDetailData (beta / events path)", () => {
+  beforeEach(() => {
+    mockUseV4Beta.mockReturnValue({ isBetaEnabled: true });
+    mockTracesQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+  });
+
+  it("surfaces an UNAUTHORIZED error as isUnauthorized, not isNotFound", () => {
+    mockUseEventsTraceData.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: { data: { code: "UNAUTHORIZED" } },
+      cutoffObservationsAfterMaxCount: false,
+    });
+    const r = render();
+    expect(r.isUnauthorized).toBe(true);
+    // The two flags must be mutually exclusive — an access error is not a
+    // missing trace (else the page shows "Trace not found" for a 403).
+    expect(r.isNotFound).toBe(false);
+  });
+
+  it("treats no-data-after-loading (no error) as a genuine not-found", () => {
+    mockUseEventsTraceData.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      cutoffObservationsAfterMaxCount: false,
+    });
+    const r = render();
+    expect(r.isNotFound).toBe(true);
+    expect(r.isUnauthorized).toBe(false);
+  });
+});

--- a/web/src/components/trace/useTraceDetailData.ts
+++ b/web/src/components/trace/useTraceDetailData.ts
@@ -65,10 +65,11 @@ export function useTraceDetailData({
       error: eventsData.error,
       isError: !!eventsData.error,
       // The events path surfaces "missing" as no-data after loading rather than
-      // a NOT_FOUND error code — but an UNAUTHORIZED failure also lands as no
-      // data, so exclude it here and report it via isUnauthorized instead (else
-      // the page mislabels an access error as "Trace not found").
-      isNotFound: !eventsData.isLoading && !eventsData.data && !isUnauthorized,
+      // a NOT_FOUND error code. Any error (UNAUTHORIZED, a 500, a network blip)
+      // also lands as no-data, so "not found" must mean no-data AND no-error —
+      // else a transient failure is mislabeled as a deleted/missing trace.
+      isNotFound:
+        !eventsData.isLoading && !eventsData.data && !eventsData.error,
       isUnauthorized,
       cutoffObservationsAfterMaxCount:
         eventsData.cutoffObservationsAfterMaxCount,

--- a/web/src/components/trace/useTraceDetailData.ts
+++ b/web/src/components/trace/useTraceDetailData.ts
@@ -52,15 +52,24 @@ export function useTraceDetailData({
   });
 
   if (isBetaEnabled) {
+    // useEventsTraceData types its error as `unknown`; narrow to the trpc shape
+    // to read the code (the non-beta branch gets this for free from the typed
+    // tracesQuery.error).
+    const eventsErrorCode = (
+      eventsData.error as { data?: { code?: string } } | null | undefined
+    )?.data?.code;
+    const isUnauthorized = eventsErrorCode === "UNAUTHORIZED";
     return {
       data: eventsData.data,
       isLoading: eventsData.isLoading,
       error: eventsData.error,
       isError: !!eventsData.error,
       // The events path surfaces "missing" as no-data after loading rather than
-      // a NOT_FOUND error code.
-      isNotFound: !eventsData.isLoading && !eventsData.data,
-      isUnauthorized: false,
+      // a NOT_FOUND error code — but an UNAUTHORIZED failure also lands as no
+      // data, so exclude it here and report it via isUnauthorized instead (else
+      // the page mislabels an access error as "Trace not found").
+      isNotFound: !eventsData.isLoading && !eventsData.data && !isUnauthorized,
+      isUnauthorized,
       cutoffObservationsAfterMaxCount:
         eventsData.cutoffObservationsAfterMaxCount,
     };

--- a/web/src/components/trace/useTraceDetailData.ts
+++ b/web/src/components/trace/useTraceDetailData.ts
@@ -1,0 +1,78 @@
+import { api } from "@/src/utils/api";
+import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
+import { useEventsTraceData } from "@/src/features/events/hooks/useEventsTraceData";
+
+/**
+ * Single source of truth for fetching a trace's detail data, beta-aware (events
+ * table when the v4 preview is on, the traces table otherwise). Both the peek
+ * and the standalone trace page use this so the fetch isn't forked — it exposes
+ * the union of what each surface needs (the page's not-found / unauthorized
+ * pages and the truncation flag; the peek just reads `data`/`isLoading`).
+ */
+export function useTraceDetailData({
+  projectId,
+  traceId,
+  timestamp,
+  enabled = true,
+}: {
+  projectId: string;
+  traceId?: string;
+  timestamp?: Date;
+  enabled?: boolean;
+}) {
+  const { isBetaEnabled } = useV4Beta();
+
+  // Old path: traces table (beta OFF).
+  const tracesQuery = api.traces.byIdWithObservationsAndScores.useQuery(
+    {
+      traceId: traceId ?? "",
+      projectId,
+      timestamp,
+    },
+    {
+      enabled: enabled && !!traceId && !isBetaEnabled,
+      retry(failureCount, error) {
+        if (
+          error.data?.code === "UNAUTHORIZED" ||
+          error.data?.code === "NOT_FOUND"
+        )
+          return false;
+        return failureCount < 3;
+      },
+      staleTime: 60 * 1000,
+    },
+  );
+
+  // New path: events table (beta ON).
+  const eventsData = useEventsTraceData({
+    projectId,
+    traceId: traceId ?? "",
+    timestamp,
+    enabled: enabled && !!traceId && isBetaEnabled,
+  });
+
+  if (isBetaEnabled) {
+    return {
+      data: eventsData.data,
+      isLoading: eventsData.isLoading,
+      error: eventsData.error,
+      isError: !!eventsData.error,
+      // The events path surfaces "missing" as no-data after loading rather than
+      // a NOT_FOUND error code.
+      isNotFound: !eventsData.isLoading && !eventsData.data,
+      isUnauthorized: false,
+      cutoffObservationsAfterMaxCount:
+        eventsData.cutoffObservationsAfterMaxCount,
+    };
+  }
+
+  return {
+    data: tracesQuery.data,
+    isLoading: tracesQuery.isLoading,
+    error: tracesQuery.error,
+    isError: tracesQuery.isError,
+    isNotFound: tracesQuery.error?.data?.code === "NOT_FOUND",
+    isUnauthorized: tracesQuery.error?.data?.code === "UNAUTHORIZED",
+    cutoffObservationsAfterMaxCount: false,
+  };
+}

--- a/web/src/features/navigate-detail-pages/DetailPageNav.tsx
+++ b/web/src/features/navigate-detail-pages/DetailPageNav.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/src/components/ui/button";
+import { Button, type ButtonProps } from "@/src/components/ui/button";
 import { InputCommandShortcut } from "@/src/components/ui/input-command";
 import { KeyboardShortcut } from "@/src/components/ui/keyboard-shortcut";
 import {
@@ -25,8 +25,10 @@ export const DetailPageNav = (props: {
   path: (entry: ListEntry) => string;
   listKey: string;
   onNavigate?: (entry: ListEntry) => void;
+  /** Button size; defaults to the cva default. Pass "sm" to match icon-xs rows. */
+  size?: ButtonProps["size"];
 }) => {
-  const { currentId, path, listKey, onNavigate } = props;
+  const { currentId, path, listKey, onNavigate, size } = props;
   const { detailPagelists } = useDetailPageLists();
   const entries = detailPagelists[listKey] ?? [];
   const [shortcutPulse, setShortcutPulse] = useState<ShortcutPulse>(null);
@@ -119,6 +121,7 @@ export const DetailPageNav = (props: {
             <Button
               variant="outline"
               type="button"
+              size={size}
               className={cn(
                 "gap-1.5 px-2 transition-[background-color,border-color,box-shadow,color] duration-150",
                 shortcutPulse === "previous" &&
@@ -147,6 +150,7 @@ export const DetailPageNav = (props: {
             <Button
               variant="outline"
               type="button"
+              size={size}
               className={cn(
                 "gap-1.5 px-2 transition-[background-color,border-color,box-shadow,color] duration-150",
                 shortcutPulse === "next" &&

--- a/web/src/features/navigate-detail-pages/DetailPageNav.tsx
+++ b/web/src/features/navigate-detail-pages/DetailPageNav.tsx
@@ -27,8 +27,14 @@ export const DetailPageNav = (props: {
   onNavigate?: (entry: ListEntry) => void;
   /** Button size; defaults to the cva default. Pass "sm" to match icon-xs rows. */
   size?: ButtonProps["size"];
+  /**
+   * Compact mode for dense toolbars (e.g. the peek header): icon-only ghost
+   * arrows with the K/J hint moved to the tooltip, so the buttons match a row
+   * of icon-xs controls instead of standing out. Shortcuts still work.
+   */
+  compact?: boolean;
 }) => {
-  const { currentId, path, listKey, onNavigate, size } = props;
+  const { currentId, path, listKey, onNavigate, size, compact } = props;
   const { detailPagelists } = useDetailPageLists();
   const entries = detailPagelists[listKey] ?? [];
   const [shortcutPulse, setShortcutPulse] = useState<ShortcutPulse>(null);
@@ -113,20 +119,22 @@ export const DetailPageNav = (props: {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [previousPageEntry, nextPageEntry, navigateToEntry, pulseShortcut]);
 
-  if (entries.length > 1)
+  if (entries.length > 1) {
+    const buttonClassName = (active: boolean) =>
+      cn(
+        "transition-[background-color,border-color,box-shadow,color] duration-150",
+        !compact && "gap-1.5 px-2",
+        active && "border-primary/60 bg-accent/60 ring-primary/20 ring-2",
+      );
     return (
       <div className="flex flex-row gap-1">
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              variant="outline"
+              variant={compact ? "ghost" : "outline"}
               type="button"
-              size={size}
-              className={cn(
-                "gap-1.5 px-2 transition-[background-color,border-color,box-shadow,color] duration-150",
-                shortcutPulse === "previous" &&
-                  "border-primary/60 bg-accent/60 ring-primary/20 ring-2",
-              )}
+              size={compact ? "icon-xs" : size}
+              className={buttonClassName(shortcutPulse === "previous")}
               disabled={!previousPageEntry}
               onClick={() => {
                 if (previousPageEntry) {
@@ -136,7 +144,7 @@ export const DetailPageNav = (props: {
               }}
             >
               <ArrowUp className="h-4 w-4" />
-              <KeyboardShortcut>K</KeyboardShortcut>
+              {!compact && <KeyboardShortcut>K</KeyboardShortcut>}
             </Button>
           </TooltipTrigger>
           <TooltipContent>
@@ -148,14 +156,10 @@ export const DetailPageNav = (props: {
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              variant="outline"
+              variant={compact ? "ghost" : "outline"}
               type="button"
-              size={size}
-              className={cn(
-                "gap-1.5 px-2 transition-[background-color,border-color,box-shadow,color] duration-150",
-                shortcutPulse === "next" &&
-                  "border-primary/60 bg-accent/60 ring-primary/20 ring-2",
-              )}
+              size={compact ? "icon-xs" : size}
+              className={buttonClassName(shortcutPulse === "next")}
               disabled={!nextPageEntry}
               onClick={() => {
                 if (nextPageEntry) {
@@ -165,7 +169,7 @@ export const DetailPageNav = (props: {
               }}
             >
               <ArrowDown className="h-4 w-4" />
-              <KeyboardShortcut>J</KeyboardShortcut>
+              {!compact && <KeyboardShortcut>J</KeyboardShortcut>}
             </Button>
           </TooltipTrigger>
           <TooltipContent>
@@ -175,5 +179,6 @@ export const DetailPageNav = (props: {
         </Tooltip>
       </div>
     );
+  }
   return null;
 };


### PR DESCRIPTION
## TL;DR
The table **peek** is now a **resizable, width-adaptive** drawer that **Expand**s in place (swipe-down on mobile, click-outside to close) — and the scope that grew underneath it: the peek and the standalone trace page now render **one shared trace-detail surface** instead of two diverging copies. As the peek narrows, its header adapts to **its own width** (not the screen), folding controls into a tidy menu rather than crowding. Closes **LFE-10118**, folds in **LFE-5877**.

## Why (the story)
There were **three** ways to look at the same trace, and they'd drifted apart:
- the **peek** (`?peek=`) — a fixed-width side panel, minimal chrome, no star/publish/delete;
- an **in-place fullscreen** toggle — same panel, wider, but un-shareable (no URL);
- **"open in current tab"** — which navigated to `/traces/<id>`, a *different component* with the delete button, a breadcrumb, and **no way back**.

So "expand" and "open the page" were a jarring UI swap, and the peek and the page were two implementations of the same thing. That fork was an early mistake that grew out of control — and it's exactly what blocks improving the peek: you can't make it faster or richer while every change has to be made twice.

## What
**One peek, one surface, that adapts to its size.**
- **One Expand control** — widens the peek to max width (**viewport − sidebar**, so the nav stays visible), reflected in the **URL** (`peekView=expanded`) so it's shareable and reload-safe. Dragging the handle to the edge does the same thing. Replaces the ephemeral fullscreen *and* both old open-in-tab buttons; the standalone-page view is still one click away via **Open in new tab**.
- **Responsive shell** — docked, resizable panel on desktop; a `vaul` **swipe-down drawer** on mobile. **Click-outside closes**; clicking another row still **switches** the peeked item in place (power-user behavior preserved).
- **Width-adaptive header** — measures the *peek's own width* and, as it narrows, reduces in least-painful order: the trace actions fold into a labeled **"…" menu**, the type badge drops to an **icon** (never truncates to "Tr…"), the prev/next nav goes **compact** (arrows only, K/J in the tooltip), then open-in-tab folds. Correct on first paint, not just after a nudge.
- **Unified detail surface** — the peek and the standalone `/traces/<id>` page now share one data fetch, one body, one title, and one action set (star/publish/delete). They're thin shells around the same core, so the peek finally has parity with the page and future work lands **once**.
- **Modernized state** per `frontend-large-feature-architecture` (the exemplar we're setting): a per-mount Zustand store for the widget width, the URL for the expanded view, localStorage for the persisted width preference.

## On breaking the "small PR" rule
Our big-frontend-feature skill says *don't bundle a large rewrite*. We deliberately broke that here, with eyes open: **the duplication was the bug**, and there's no incremental path that doesn't first remove the fork. We ran a multi-perspective review (a risk lens, an architecture lens, and a QA-edge-case lens) plus several follow-up reviewer rounds, and fixed every P0/P1 surfaced.

## Result
Verified live across both surfaces: resize (stops exactly at the **sidebar edge** — no overshoot/snap-back, and no jump when grabbing the handle while expanded), Expand ↔ URL, reload/back, mobile swipe, click-outside vs row-switch, nested split resize, the **width-adaptive header** (fold → menu, badge → icon, nav → compact across the drag range, and compact on refresh), shared star/publish/delete with delete-closes-peek, and unified fast tooltips. **31** focused unit tests; lint / typecheck / prettier green.

Also fixes a **pre-existing** v4 bug the unification surfaced: on the events path an access error rendered as *"Trace not found"* — now correctly *"you don't have access to this trace"*.

<details>
<summary>Engineering detail — state, adaptation, fixes, a11y, what's deferred</summary>

**State altitudes**
- `store/peekPanelStore.ts` — per-mount vanilla Zustand store (lazy `useState`), owns only the widget width + transient drag state, mutated through named `actions`; primitive selectors.
- `actions/resizePeekPanel.ts` — the drag workflow (window listeners → store actions; commits a width or flips the expanded flag on pointer-up). The expand threshold and width cap are **sidebar-aligned**, so a drag stops at `viewport − sidebar` instead of overshooting onto the sidebar and snapping back; a pointer leaving the window clamps cleanly; the drag seeds its draft from the current state so merely *pressing* the handle while expanded doesn't jump.
- `usePeekPanelState.ts` — integration boundary: derives width (widget vs expanded, capped at the sidebar edge via CSS `min()`), measures the sidebar offset live, wires drag/keyboard.
- **Expanded** lives in the URL (`peekView=expanded`, `router.replace` so toggling doesn't spam history), cleared on close by `usePeekNavigation`.

**Width-adaptive header** (`PeekHeader.tsx` + `peekHeaderOverflow.ts`)
- A pure, unit-tested planner keeps the title above a minimum width and applies reductions in order — fold actions → badge to icon → compact nav → fold open-in-tab — based on the measured peek width.
- The header width equals the peek width, so it doesn't change when controls settle; a second observer on the control cluster re-triggers the plan, so a refreshed narrow peek is correct on the **first paint**.
- The "…" overflow is a real labeled menu (full-width, whole-row clickable) reusing the existing controls — Share keeps its URL popover, Delete its confirm. All header controls share one fast Radix tooltip (no native `title`); Share suppresses its tooltip while its popover is open.

**Unified surface:** `useTraceDetailData` (beta-aware fetch), `TraceDetailBody`, `traceDetailTitle`, `TraceDetailActions` — all shared by `TracePage` and the peek wrappers. `isNotFound` now requires no-data **and** no-error, so a 500/UNAUTHORIZED on the v4 path is no longer mislabeled as a missing trace.

**Other notable fixes**
- Dismissal is target-based and never closes for a target inside the peek (`data-peek-content`) — fixes a crash where the inner trace split's pointer-capture was misread as an outside click and tore the panel group down mid-drag.
- Delete-from-peek invalidates broadly (the peek is hosted over many different lists) and closes in place; the page still navigates.
- Nested-table state (filters/sort/pagination) survives the desktop↔mobile breakpoint cross; the `actions` subtree is keyed so folding moves DOM without remounting (an in-progress delete confirmation survives a resize).
- star / publish / delete share one ghost icon style; resize handle straddles the left edge and exposes `aria-valuemin/max/now`; soft left-cast shadow lifts the panel.

**Deferred follow-ups (now cheap, since the core is shared):** collapse the `<Trace context>` branching; a `panelStyle`-only subscriber so a 60fps drag doesn't re-render the shell; retire the now-dead `expandConfig`/`expandPeek` plumbing; experiment-item peek actions.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
