### PR TITLE
feat(web): reflect Parquet export-tuning override in blob-storage settings (LFE-10463)

### DIFF
--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -99,28 +99,50 @@ const EXPORT_FIELD_GROUP_LABELS = {
 // whenever the model group is selected — for both export paths.
 const MODEL_ENRICHMENT_FIELDS = ["input_price", "output_price", "total_price"];
 
-// The `description` of EXPORT_FIELD_GROUP_LABELS lists the enriched
-// observations fields of each group; the legacy observations table contains
-// fewer columns. Derive the legacy description from the export contract so it
-// stays in sync when the contract changes.
+const legacyFieldsForGroup = (group: ObservationFieldGroupFull): string[] =>
+  LEGACY_OBSERVATION_EXPORT_FIELDS.filter((f) => f.group === group).map(
+    (f) => f.field,
+  );
+
+const joinFields = (fields: string[]): string =>
+  fields.length > 0
+    ? fields.join(", ")
+    : "Not included in the legacy observations export";
+
+const withoutPrices = (csv: string): string =>
+  csv
+    .split(", ")
+    .filter((field) => !MODEL_ENRICHMENT_FIELDS.includes(field))
+    .join(", ");
+
+// EXPORT_FIELD_GROUP_LABELS describes the enriched schema; the legacy
+// observations table is narrower. Derive legacy from the export contract so it
+// stays in sync. The legacy standard export still enriches model prices, so
+// they're listed here.
 const legacyDescriptionForGroup = (
   group: ObservationFieldGroupFull,
 ): string => {
-  const fields = LEGACY_OBSERVATION_EXPORT_FIELDS.filter(
-    (f) => f.group === group,
-  ).map((f) => f.field);
-  if (group === "model") {
-    fields.push(...MODEL_ENRICHMENT_FIELDS);
-  }
-  return fields.length > 0
-    ? fields.join(", ")
-    : "Not included in the legacy observations export";
+  const fields = legacyFieldsForGroup(group);
+  if (group === "model") fields.push(...MODEL_ENRICHMENT_FIELDS);
+  return joinFields(fields);
 };
+
+// Parquet runs no JS enrichment, so model price columns are absent. The two
+// variants differ by source: enriched parquet uses the enriched schema, legacy
+// parquet the (already narrower) legacy schema.
+const parquetDescriptionForGroup = (group: ObservationFieldGroupFull): string =>
+  withoutPrices(EXPORT_FIELD_GROUP_LABELS[group].description);
+
+const legacyParquetDescriptionForGroup = (
+  group: ObservationFieldGroupFull,
+): string => joinFields(legacyFieldsForGroup(group));
 
 export const EXPORT_FIELD_GROUP_OPTIONS = OBSERVATION_FIELD_GROUPS_FULL.map(
   (value) => ({
     value,
     ...EXPORT_FIELD_GROUP_LABELS[value],
     legacyDescription: legacyDescriptionForGroup(value),
+    parquetDescription: parquetDescriptionForGroup(value),
+    legacyParquetDescription: legacyParquetDescriptionForGroup(value),
   }),
 );

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import {
   type BlobStorageIntegrationFormSchema,
   blobStorageIntegrationFormSchema,
+  parquetEnabledFromTuning,
 } from "@/src/features/blobstorage-integration/types";
 import {
   AnalyticsIntegrationExportSource,
@@ -11,6 +12,7 @@ import {
   BlobStorageExportMode,
   BlobStorageIntegrationFileType,
   BlobStorageIntegrationType,
+  EXPORT_FIELD_GROUP_OPTIONS,
 } from "@langfuse/shared";
 
 const VALID_BASE: BlobStorageIntegrationFormSchema = {
@@ -84,5 +86,68 @@ describe("blob storage form — exportFieldGroups validation", () => {
     });
 
     expect(onSubmit).toHaveBeenCalledOnce();
+  });
+});
+
+describe("parquetEnabledFromTuning", () => {
+  it.each([
+    [{ parquet: true }, true],
+    [{ parquet: true, gzipLevel: 1 }, true],
+    [{ parquet: false }, false],
+    [{ gzipLevel: 1 }, false],
+    [{}, false],
+    [null, false],
+    [undefined, false],
+    ["parquet", false],
+    [["parquet"], false],
+  ])("%o → %s", (input, expected) => {
+    expect(parquetEnabledFromTuning(input)).toBe(expected);
+  });
+});
+
+describe("EXPORT_FIELD_GROUP_OPTIONS — parquet description", () => {
+  const PRICE_FIELDS = ["input_price", "output_price", "total_price"];
+  const model = EXPORT_FIELD_GROUP_OPTIONS.find((o) => o.value === "model")!;
+
+  it("model group lists price columns in the standard description", () => {
+    expect(PRICE_FIELDS.every((f) => model.description.includes(f))).toBe(true);
+  });
+
+  it("model group drops price columns in the parquet description", () => {
+    expect(PRICE_FIELDS.some((f) => model.parquetDescription.includes(f))).toBe(
+      false,
+    );
+    // Non-price model columns are preserved.
+    expect(model.parquetDescription).toContain("provided_model_name");
+  });
+
+  it("non-model groups have identical standard and parquet descriptions", () => {
+    for (const option of EXPORT_FIELD_GROUP_OPTIONS) {
+      if (option.value === "model") continue;
+      expect(option.parquetDescription).toBe(option.description);
+    }
+  });
+
+  it("legacy parquet drops prices and uses the narrower legacy schema", () => {
+    const basic = EXPORT_FIELD_GROUP_OPTIONS.find((o) => o.value === "basic")!;
+    const traceContext = EXPORT_FIELD_GROUP_OPTIONS.find(
+      (o) => o.value === "trace_context",
+    )!;
+
+    // No price columns (parquet runs no enrichment) — unlike legacyDescription.
+    expect(
+      PRICE_FIELDS.some((f) => model.legacyParquetDescription.includes(f)),
+    ).toBe(false);
+    expect(PRICE_FIELDS.some((f) => model.legacyDescription.includes(f))).toBe(
+      true,
+    );
+
+    // Enriched-only columns are absent from the legacy schema.
+    expect(basic.parquetDescription).toContain("bookmarked");
+    expect(basic.legacyParquetDescription).not.toContain("bookmarked");
+    expect(traceContext.parquetDescription).toContain("trace_name");
+    expect(traceContext.legacyParquetDescription).toBe(
+      "Not included in the legacy observations export",
+    );
   });
 });

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -52,6 +52,17 @@ export const blobStorageIntegrationFormSchemaBase = z.object({
   compressed: z.boolean().default(true),
 });
 
+// True when the internal, DB-set `exportTuning.parquet` override is on (no UI
+// write path). Mirrors the worker resolver: only `{ parquet: true }` counts.
+export function parquetEnabledFromTuning(exportTuning: unknown): boolean {
+  return (
+    typeof exportTuning === "object" &&
+    exportTuning !== null &&
+    !Array.isArray(exportTuning) &&
+    (exportTuning as Record<string, unknown>).parquet === true
+  );
+}
+
 export const blobStorageIntegrationFormSchema =
   blobStorageIntegrationFormSchemaBase
     .superRefine(validateAzureContainerName)

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -30,6 +30,7 @@ import {
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import {
   blobStorageIntegrationFormSchema,
+  parquetEnabledFromTuning,
   type BlobStorageIntegrationFormSchema,
   type BlobStorageSyncStatus,
 } from "@/src/features/blobstorage-integration/types";
@@ -373,6 +374,9 @@ const BlobStorageIntegrationSettingsForm = ({
 
   const watchedExportMode = blobStorageForm.watch("exportMode");
   const watchedExportSource = blobStorageForm.watch("exportSource");
+  // Internal `exportTuning.parquet` override (no write path); reflected read-only
+  // below since the worker forces Parquet over the persisted fileType + gzip.
+  const isParquetOverride = parquetEnabledFromTuning(state?.exportTuning);
   const exportSourceOptions = getExportSourceOptions(
     state?.exportSource,
     availability,
@@ -700,7 +704,12 @@ const BlobStorageIntegrationSettingsForm = ({
             <FormItem>
               <FormLabel>File Type</FormLabel>
               <FormControl>
-                <Select value={field.value} onValueChange={field.onChange}>
+                {/* "PARQUET" is display-only; the persisted fileType is kept but ignored. */}
+                <Select
+                  value={isParquetOverride ? "PARQUET" : field.value}
+                  onValueChange={field.onChange}
+                  disabled={isParquetOverride}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="Select file type" />
                   </SelectTrigger>
@@ -708,11 +717,16 @@ const BlobStorageIntegrationSettingsForm = ({
                     <SelectItem value="JSONL">JSONL</SelectItem>
                     <SelectItem value="CSV">CSV</SelectItem>
                     <SelectItem value="JSON">JSON</SelectItem>
+                    {isParquetOverride && (
+                      <SelectItem value="PARQUET">Parquet</SelectItem>
+                    )}
                   </SelectContent>
                 </Select>
               </FormControl>
               <FormDescription>
-                The file format for exported data.
+                {isParquetOverride
+                  ? "Exporting as Apache Parquet — a columnar binary format encoded and compressed by ClickHouse. This is configured for your project and overrides the file type; gzip compression is not applicable."
+                  : "The file format for exported data."}
               </FormDescription>
               <FormMessage />
             </FormItem>
@@ -899,9 +913,13 @@ const BlobStorageIntegrationSettingsForm = ({
                           )}
                         </div>
                         <div className="text-muted-foreground text-xs">
-                          {isLegacyOnlyExport
-                            ? option.legacyDescription
-                            : option.description}
+                          {isParquetOverride
+                            ? isLegacyOnlyExport
+                              ? option.legacyParquetDescription
+                              : option.parquetDescription
+                            : isLegacyOnlyExport
+                              ? option.legacyDescription
+                              : option.description}
                         </div>
                       </label>
                     </div>
@@ -952,26 +970,30 @@ const BlobStorageIntegrationSettingsForm = ({
           />
         )}
 
-        <FormField
-          control={blobStorageForm.control}
-          name="compressed"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Gzip Compression</FormLabel>
-              <FormControl>
-                <Switch
-                  checked={field.value}
-                  onCheckedChange={field.onChange}
-                  className="mt-1 ml-4"
-                />
-              </FormControl>
-              <FormDescription>
-                Compress exported files with gzip (.csv.gz, .json.gz, .jsonl.gz)
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        {/* Parquet compresses internally — gzip does not apply. */}
+        {!isParquetOverride && (
+          <FormField
+            control={blobStorageForm.control}
+            name="compressed"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Gzip Compression</FormLabel>
+                <FormControl>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    className="mt-1 ml-4"
+                  />
+                </FormControl>
+                <FormDescription>
+                  Compress exported files with gzip (.csv.gz, .json.gz,
+                  .jsonl.gz)
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
 
         <FormField
           control={blobStorageForm.control}


### PR DESCRIPTION
## What does this PR do?

Surfaces the ClickHouse-native **Parquet** blob-export format (added in #14509, LFE-10463) in the Blob Storage Integration settings page.

Parquet is an **internal, DB-set** `exportTuning.parquet` knob with no UI write path. When set, the worker already overrides the file format — it always produces a `.parquet` artifact and ignores `fileType`/`compressed`. This PR makes the settings form **reflect that override read-only** so the UI doesn't misrepresent what will be exported. It is a deliberately lightweight, removable interim surface — if Parquet later becomes a first-class `fileType` option, this reflection goes away.

When the override is active, the form:
- locks the **File Type** selector to "Parquet" with an explanatory description,
- hides the **Gzip Compression** toggle (Parquet compresses internally),
- drops the enrichment-only price columns (`input_price`, `output_price`, `total_price`) from the **Model** field group — they're absent from Parquet exports because the ClickHouse-native path runs no JS enrichment.

Implementation:
- **shared** (`analytics-integrations/index.ts`): derive a `parquetDescription` per export field group (only the model group differs), alongside the existing `legacyDescription`.
- **web** (`blobstorage-integration/types.ts`): `parquetEnabledFromTuning()` reads the persisted `exportTuning` column; the settings page keys the three UI changes off it.

No Postgres enum/schema migration, no public API change, no Fern change, no worker change.

Fixes # (LFE-10463)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Added client tests: `parquetEnabledFromTuning` truthiness + the Model-group parquet description (drops prices; other groups unchanged). 19 client tests pass.
- `pnpm turbo run typecheck lint --filter=web --filter=@langfuse/shared` pass.
- Browser review of the read-only reflection (requires an integration with `exportTuning.parquet=true` in the DB) is still recommended before merge — not run in this environment.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces the internal `exportTuning.parquet` flag (a DB-only knob, no UI write path) in the Blob Storage settings form so the UI doesn't misrepresent what the worker will actually export. When the flag is active the form locks the File Type selector to "Parquet", hides the Gzip Compression toggle, and strips the enrichment-only price columns from the Model field-group description.

- **`packages/shared`**: adds `parquetDescriptionForGroup` and `parquetDescription` field to `EXPORT_FIELD_GROUP_OPTIONS`; model group drops `input_price`, `output_price`, `total_price` via a string-split filter over the known comma-separated description format.
- **`web/types.ts`**: adds `parquetEnabledFromTuning()` with thorough runtime guards mirroring the worker resolver.
- **`web/blobstorage.tsx`**: gates the three UI overrides on `isParquetOverride`; the underlying form values (`fileType`, `compressed`) are preserved so saving doesn't rewrite DB state.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are read-only UI reflection with no write path or schema changes.

The change is deliberately lightweight: it reads a JSON column already written by the DB and adjusts three display elements. The parquetEnabledFromTuning guard is thorough and well-tested. The only comment is a minor wording issue in the description text that refers to a control that is hidden.

Only blobstorage.tsx warrants a second look for the description wording; all other files are clean.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx:727-729
The description says "overrides the file type and compression below", but the Gzip Compression control is hidden entirely when `isParquetOverride` is true — there is nothing "below" to refer to. A user reading this will scroll down looking for the compression field and not find it.

```suggestion
                {isParquetOverride
                  ? "Exporting as Apache Parquet — a columnar binary format encoded and compressed by ClickHouse. This is configured for your project and overrides the file type; gzip compression is not applicable."
                  : "The file format for exported data."}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): reflect Parquet export-tuning..."](https://github.com/langfuse/langfuse/commit/0121918bba86342ffbf17dc6202ebe9905eb00b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39773180)</sub>

<!-- /greptile_comment -->