### PR TITLE
fix(date-picker): first calendar click starts a new range (LFE-8156)

### DIFF
--- a/web/src/components/date-picker.clienttest.tsx
+++ b/web/src/components/date-picker.clienttest.tsx
@@ -2,26 +2,65 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
 import { type DateRange } from "react-day-picker";
 import { Calendar } from "@/src/components/ui/calendar";
+import { nextRangeForDayClick } from "@/src/components/date-picker";
 
 /**
- * Regression coverage for LFE-8156 — the range calendar used to feel "sticky":
- * with a complete range already selected, a single click extended that range
- * (the clicked day became the end of the OLD range) instead of starting a new
- * one. The pickers in `date-picker.tsx` (`DatePickerWithRange`, `TimeRangePicker`)
- * pass `resetOnSelect` so the first click always starts a fresh range and only
- * the second click sets the end.
- *
- * The harness mirrors how those pickers drive react-day-picker: it holds the
- * in-progress range and "commits" (the moment a real picker writes to the URL /
- * form) only once both ends are set.
+ * Regression coverage for LFE-8156. The range calendar used to feel "sticky":
+ * with a range already selected, a single click extended that range (the click
+ * became the end of the OLD range) instead of starting a new one. The pickers
+ * now drive selection from the clicked day via `nextRangeForDayClick` so the
+ * first click always starts a fresh range and the second sets the end —
+ * avoiding react-day-picker's edge behaviours (extend-complete-range,
+ * clear-on-same-day-click) entirely.
+ */
+describe("nextRangeForDayClick (LFE-8156)", () => {
+  const jun = (d: number) => new Date(2026, 5, d);
+
+  it("starts a fresh range when there is no current selection", () => {
+    expect(nextRangeForDayClick(undefined, jun(10))).toEqual({
+      from: jun(10),
+      to: undefined,
+    });
+  });
+
+  it("starts a fresh range (first click) when a complete range exists", () => {
+    expect(
+      nextRangeForDayClick({ from: jun(18), to: jun(25) }, jun(10)),
+    ).toEqual({ from: jun(10), to: undefined });
+  });
+
+  it("starts a fresh range when re-clicking the single day of a same-day range (does not clear)", () => {
+    // A short preset (e.g. Past 1 hour) leaves from/to on the same calendar day.
+    // react-day-picker's resetOnSelect would clear the selection here; we must
+    // start a new range at the clicked day instead.
+    expect(
+      nextRangeForDayClick({ from: jun(25), to: jun(25) }, jun(25)),
+    ).toEqual({ from: jun(25), to: undefined });
+  });
+
+  it("sets the end on the second click", () => {
+    expect(
+      nextRangeForDayClick({ from: jun(10), to: undefined }, jun(20)),
+    ).toEqual({ from: jun(10), to: jun(20) });
+  });
+
+  it("swaps when the second click lands before the start", () => {
+    expect(
+      nextRangeForDayClick({ from: jun(20), to: undefined }, jun(10)),
+    ).toEqual({ from: jun(10), to: jun(20) });
+  });
+});
+
+/**
+ * Integration: drive the real calendar exactly as the pickers do — compute the
+ * next range from the clicked day and "commit" (write URL / form) only once
+ * both ends are set.
  */
 function RangeCalendarHarness({
   initial,
-  resetOnSelect,
   onCommit,
 }: {
   initial: DateRange;
-  resetOnSelect: boolean;
   onCommit: (range: { from: Date; to: Date }) => void;
 }) {
   const [range, setRange] = useState<DateRange | undefined>(initial);
@@ -30,10 +69,11 @@ function RangeCalendarHarness({
       mode="range"
       defaultMonth={new Date(2026, 5, 1)}
       selected={range}
-      resetOnSelect={resetOnSelect}
-      onSelect={(next) => {
+      onSelect={(_, triggerDay) => {
+        if (!triggerDay) return;
+        const next = nextRangeForDayClick(range, triggerDay);
         setRange(next);
-        if (next?.from && next?.to) {
+        if (next.from && next.to) {
           onCommit({ from: next.from, to: next.to });
         }
       }}
@@ -44,61 +84,54 @@ function RangeCalendarHarness({
 const clickDay = (name: RegExp) =>
   fireEvent.click(screen.getByRole("button", { name }));
 
+const ariaOf = (name: RegExp) =>
+  screen.getByRole("button", { name }).getAttribute("aria-label") ?? "";
+
 describe("range calendar first-click selection (LFE-8156)", () => {
-  // A complete range, as left behind by a preset or a prior custom selection.
-  const completeRange = {
-    from: new Date(2026, 5, 18),
-    to: new Date(2026, 5, 25),
-  };
-
-  it("without resetOnSelect, one click extends the existing range — the sticky bug", () => {
+  it("first click starts fresh (no commit); second click commits the user's two days", () => {
     const onCommit = vi.fn();
     render(
       <RangeCalendarHarness
-        initial={completeRange}
-        resetOnSelect={false}
+        initial={{ from: new Date(2026, 5, 18), to: new Date(2026, 5, 25) }}
         onCommit={onCommit}
       />,
     );
 
-    // A single click on Jun 10 should have started a new range, but the old
-    // default keeps the stale Jun 25 end and commits Jun 10–25 immediately.
-    clickDay(/June 10th, 2026/);
-    expect(onCommit).toHaveBeenCalledTimes(1);
-    const committed = onCommit.mock.calls[0][0];
-    expect(committed.from.getDate()).toBe(10);
-    expect(committed.to.getDate()).toBe(25);
-  });
-
-  it("with resetOnSelect, the first click starts a fresh range and only the second click commits", () => {
-    const onCommit = vi.fn();
-    render(
-      <RangeCalendarHarness
-        initial={completeRange}
-        resetOnSelect
-        onCommit={onCommit}
-      />,
-    );
-
-    // First click = Start: previous range is cleared, nothing committed yet.
+    // First click = Start: previous range cleared, nothing committed yet.
     clickDay(/June 10th, 2026/);
     expect(onCommit).not.toHaveBeenCalled();
-    expect(
-      screen.getByRole("button", { name: /June 10th, 2026/ }),
-    ).toHaveAttribute("aria-label", expect.stringContaining("selected"));
+    expect(ariaOf(/June 10th, 2026/)).toContain("selected");
     // The stale Jun 25 end is no longer part of the selection.
-    expect(
-      screen
-        .getByRole("button", { name: /June 25th, 2026/ })
-        .getAttribute("aria-label"),
-    ).not.toContain("selected");
+    expect(ariaOf(/June 25th, 2026/)).not.toContain("selected");
 
-    // Second click = End: commits the user's two clicks (Jun 10–20), not the
-    // stale Jun 25 boundary.
+    // Second click = End: commits Jun 10 – Jun 20, not the stale Jun 25.
     clickDay(/June 20th, 2026/);
     expect(onCommit).toHaveBeenCalledTimes(1);
     const committed = onCommit.mock.calls[0][0];
     expect(committed.from.getDate()).toBe(10);
     expect(committed.to.getDate()).toBe(20);
+  });
+
+  it("re-clicking the only day of a same-day range starts a new range instead of clearing it", () => {
+    const onCommit = vi.fn();
+    render(
+      <RangeCalendarHarness
+        initial={{ from: new Date(2026, 5, 25), to: new Date(2026, 5, 25) }}
+        onCommit={onCommit}
+      />,
+    );
+
+    // Clicking the single selected day must keep it selected as the new start,
+    // not wipe the highlight (the react-day-picker resetOnSelect trap).
+    clickDay(/June 25th, 2026/);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(ariaOf(/June 25th, 2026/)).toContain("selected");
+
+    // Second click before the start swaps into a valid range.
+    clickDay(/June 20th, 2026/);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    const committed = onCommit.mock.calls[0][0];
+    expect(committed.from.getDate()).toBe(20);
+    expect(committed.to.getDate()).toBe(25);
   });
 });

--- a/web/src/components/date-picker.clienttest.tsx
+++ b/web/src/components/date-picker.clienttest.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { type DateRange } from "react-day-picker";
+import { Calendar } from "@/src/components/ui/calendar";
+
+/**
+ * Regression coverage for LFE-8156 — the range calendar used to feel "sticky":
+ * with a complete range already selected, a single click extended that range
+ * (the clicked day became the end of the OLD range) instead of starting a new
+ * one. The pickers in `date-picker.tsx` (`DatePickerWithRange`, `TimeRangePicker`)
+ * pass `resetOnSelect` so the first click always starts a fresh range and only
+ * the second click sets the end.
+ *
+ * The harness mirrors how those pickers drive react-day-picker: it holds the
+ * in-progress range and "commits" (the moment a real picker writes to the URL /
+ * form) only once both ends are set.
+ */
+function RangeCalendarHarness({
+  initial,
+  resetOnSelect,
+  onCommit,
+}: {
+  initial: DateRange;
+  resetOnSelect: boolean;
+  onCommit: (range: { from: Date; to: Date }) => void;
+}) {
+  const [range, setRange] = useState<DateRange | undefined>(initial);
+  return (
+    <Calendar
+      mode="range"
+      defaultMonth={new Date(2026, 5, 1)}
+      selected={range}
+      resetOnSelect={resetOnSelect}
+      onSelect={(next) => {
+        setRange(next);
+        if (next?.from && next?.to) {
+          onCommit({ from: next.from, to: next.to });
+        }
+      }}
+    />
+  );
+}
+
+const clickDay = (name: RegExp) =>
+  fireEvent.click(screen.getByRole("button", { name }));
+
+describe("range calendar first-click selection (LFE-8156)", () => {
+  // A complete range, as left behind by a preset or a prior custom selection.
+  const completeRange = {
+    from: new Date(2026, 5, 18),
+    to: new Date(2026, 5, 25),
+  };
+
+  it("without resetOnSelect, one click extends the existing range — the sticky bug", () => {
+    const onCommit = vi.fn();
+    render(
+      <RangeCalendarHarness
+        initial={completeRange}
+        resetOnSelect={false}
+        onCommit={onCommit}
+      />,
+    );
+
+    // A single click on Jun 10 should have started a new range, but the old
+    // default keeps the stale Jun 25 end and commits Jun 10–25 immediately.
+    clickDay(/June 10th, 2026/);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    const committed = onCommit.mock.calls[0][0];
+    expect(committed.from.getDate()).toBe(10);
+    expect(committed.to.getDate()).toBe(25);
+  });
+
+  it("with resetOnSelect, the first click starts a fresh range and only the second click commits", () => {
+    const onCommit = vi.fn();
+    render(
+      <RangeCalendarHarness
+        initial={completeRange}
+        resetOnSelect
+        onCommit={onCommit}
+      />,
+    );
+
+    // First click = Start: previous range is cleared, nothing committed yet.
+    clickDay(/June 10th, 2026/);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: /June 10th, 2026/ }),
+    ).toHaveAttribute("aria-label", expect.stringContaining("selected"));
+    // The stale Jun 25 end is no longer part of the selection.
+    expect(
+      screen
+        .getByRole("button", { name: /June 25th, 2026/ })
+        .getAttribute("aria-label"),
+    ).not.toContain("selected");
+
+    // Second click = End: commits the user's two clicks (Jun 10–20), not the
+    // stale Jun 25 boundary.
+    clickDay(/June 20th, 2026/);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    const committed = onCommit.mock.calls[0][0];
+    expect(committed.from.getDate()).toBe(10);
+    expect(committed.to.getDate()).toBe(20);
+  });
+});

--- a/web/src/components/date-picker.tsx
+++ b/web/src/components/date-picker.tsx
@@ -214,6 +214,11 @@ export function DatePickerWithRange({
           <Calendar
             autoFocus={true}
             mode="range"
+            // First click always starts a NEW range (clears the previous one);
+            // the next click sets the end. Without this, react-day-picker
+            // extends the existing range, which made the picker feel "sticky"
+            // (clicking a date became the end of the old range). See LFE-8156.
+            resetOnSelect
             defaultMonth={internalDateRange?.from}
             selected={internalDateRange}
             onSelect={onCalendarSelection}
@@ -451,6 +456,12 @@ export function TimeRangePicker({
             <>
               <Calendar
                 mode="range"
+                // First click always starts a NEW range (clears the previous
+                // one); the next click sets the end. Without this,
+                // react-day-picker extends the existing range, which made the
+                // picker feel "sticky" (clicking a date became the end of the
+                // old range). See LFE-8156.
+                resetOnSelect
                 defaultMonth={internalDateRange?.from || new Date()}
                 selected={internalDateRange}
                 onSelect={onCalendarSelection}

--- a/web/src/components/date-picker.tsx
+++ b/web/src/components/date-picker.tsx
@@ -13,7 +13,7 @@ import {
 import { cn } from "@/src/utils/tailwind";
 import { type DateRange as RDPDateRange } from "react-day-picker";
 import { format } from "date-fns";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { setBeginningOfDay, setEndOfDay } from "@/src/utils/dates";
 import { TimePicker } from "@/src/components/ui/time-picker";
 import { DashboardDateRangeDropdown } from "@/src/components/date-range-dropdowns";
@@ -100,6 +100,30 @@ export type DatePickerWithRangeProps = {
   ) => void;
 };
 
+/**
+ * Computes the next range for a calendar day click so the FIRST click always
+ * starts a new range and the SECOND click sets the end (LFE-8156). The decision
+ * is driven by the clicked day, not by react-day-picker's range state machine,
+ * which otherwise extends a complete range (the original "sticky" bug), clears
+ * the selection when the single day of a same-day range is re-clicked, or
+ * extends a left-over start that survived a closed popover.
+ */
+export function nextRangeForDayClick(
+  current: RDPDateRange | undefined,
+  clickedDay: Date,
+): { from: Date; to: Date | undefined } {
+  // Mid-selection — a start without an end → this click sets the end (swapping
+  // if the click lands before the start).
+  if (current?.from && !current.to) {
+    return clickedDay < current.from
+      ? { from: clickedDay, to: current.from }
+      : { from: current.from, to: clickedDay };
+  }
+  // Empty or a complete range → start a fresh range; the end stays orphaned
+  // until the next click.
+  return { from: clickedDay, to: undefined };
+}
+
 export function DatePickerWithRange({
   className,
   dateRange,
@@ -147,14 +171,13 @@ export function DatePickerWithRange({
     }
   };
 
-  const onCalendarSelection = (range?: RDPDateRange) => {
-    const newRange = range
-      ? {
-          from: range.from ? setBeginningOfDay(range.from) : undefined,
-          to: range.to ? setEndOfDay(range.to) : undefined,
-        }
-      : undefined;
-
+  const onCalendarSelection = (triggerDay?: Date) => {
+    if (!triggerDay) return;
+    const next = nextRangeForDayClick(internalDateRange, triggerDay);
+    const newRange: RDPDateRange = {
+      from: setBeginningOfDay(next.from),
+      to: next.to ? setEndOfDay(next.to) : undefined,
+    };
     setInternalDateRange(newRange);
     updateDashboardDateRange(newRange, setDateRangeAndOption);
   };
@@ -185,7 +208,15 @@ export function DatePickerWithRange({
     <div
       className={cn("my-3 flex flex-col-reverse gap-2 md:flex-row", className)}
     >
-      <Popover>
+      <Popover
+        onOpenChange={(open) => {
+          // Discard an abandoned first click on close so the next open starts
+          // fresh instead of extending a left-over start (LFE-8156).
+          if (!open && internalDateRange?.from && !internalDateRange.to) {
+            setInternalDateRange(dateRange);
+          }
+        }}
+      >
         <PopoverTrigger asChild>
           <Button
             id="date"
@@ -214,14 +245,11 @@ export function DatePickerWithRange({
           <Calendar
             autoFocus={true}
             mode="range"
-            // First click always starts a NEW range (clears the previous one);
-            // the next click sets the end. Without this, react-day-picker
-            // extends the existing range, which made the picker feel "sticky"
-            // (clicking a date became the end of the old range). See LFE-8156.
-            resetOnSelect
+            // First click starts a new range, second sets the end — see
+            // onCalendarSelection / nextRangeForDayClick (LFE-8156).
             defaultMonth={internalDateRange?.from}
             selected={internalDateRange}
-            onSelect={onCalendarSelection}
+            onSelect={(_, triggerDay) => onCalendarSelection(triggerDay)}
             numberOfMonths={2}
             className="[&>div]:hidden sm:[&>div]:block [&>div:first-child]:block"
             disabled={disabled}
@@ -237,16 +265,20 @@ export function DatePickerWithRange({
                 className="border-0 px-0 pt-1"
               />
             </div>
-            <div className="px-3">
-              <p className="px-1 text-sm font-medium">
-                End<span className="hidden sm:inline"> time</span>
-              </p>
-              <TimePicker
-                date={internalDateRange?.to}
-                setDate={onEndTimeSelection}
-                className="border-0 px-0 pt-1"
-              />
-            </div>
+            {/* Only meaningful once an end exists; during the partial range
+                (after the first click) the input would silently ignore edits. */}
+            {internalDateRange?.to && (
+              <div className="px-3">
+                <p className="px-1 text-sm font-medium">
+                  End<span className="hidden sm:inline"> time</span>
+                </p>
+                <TimePicker
+                  date={internalDateRange?.to}
+                  setDate={onEndTimeSelection}
+                  className="border-0 px-0 pt-1"
+                />
+              </div>
+            )}
           </div>
         </PopoverContent>
       </Popover>
@@ -301,31 +333,32 @@ export function TimeRangePicker({
   // Convert TimeRange to DateRange for internal use
   const dateRange = timeRange && "from" in timeRange ? timeRange : undefined;
 
-  const [internalDateRange, setInternalDateRange] = useState<
-    RDPDateRange | undefined
-  >(dateRange);
-
-  // Update internal date range when timeRange changes
-  useEffect(() => {
+  // The committed range expressed as a react-day-picker DateRange: a custom
+  // range as-is, a named preset as its current absolute window (presets
+  // re-evaluate to "now"), otherwise none. Reused to reset the editable range
+  // when the popover closes mid-selection.
+  const committedDateRange = useMemo<RDPDateRange | undefined>(() => {
     if (rangeType === "custom") {
-      // Custom range - use as is
-      setInternalDateRange(dateRange);
-    } else if (rangeType === "named" && timeRange && "range" in timeRange) {
-      // Preset range - look up in generic time ranges
+      return dateRange;
+    }
+    if (rangeType === "named" && timeRange && "range" in timeRange) {
       const setting = TIME_RANGES[timeRange.range as keyof typeof TIME_RANGES];
       if (setting && setting.minutes) {
         const now = new Date();
-        setInternalDateRange({
-          from: addMinutes(now, -setting.minutes),
-          to: now,
-        });
-      } else {
-        setInternalDateRange(undefined);
+        return { from: addMinutes(now, -setting.minutes), to: now };
       }
-    } else {
-      setInternalDateRange(undefined);
     }
-  }, [timeRange, dateRange, rangeType]);
+    return undefined;
+  }, [rangeType, timeRange, dateRange]);
+
+  const [internalDateRange, setInternalDateRange] = useState<
+    RDPDateRange | undefined
+  >(committedDateRange);
+
+  // Re-sync the editable range whenever the committed selection changes.
+  useEffect(() => {
+    setInternalDateRange(committedDateRange);
+  }, [committedDateRange]);
 
   const setNewDateRange = (
     internalDateRange: RDPDateRange | undefined,
@@ -349,14 +382,13 @@ export function TimeRangePicker({
     }
   };
 
-  const onCalendarSelection = (range?: RDPDateRange) => {
-    const newRange = range
-      ? {
-          from: range.from ? setBeginningOfDay(range.from) : undefined,
-          to: range.to ? setEndOfDay(range.to) : undefined,
-        }
-      : undefined;
-
+  const onCalendarSelection = (triggerDay?: Date) => {
+    if (!triggerDay) return;
+    const next = nextRangeForDayClick(internalDateRange, triggerDay);
+    const newRange: RDPDateRange = {
+      from: setBeginningOfDay(next.from),
+      to: next.to ? setEndOfDay(next.to) : undefined,
+    };
     setInternalDateRange(newRange);
     updateDateRange(newRange);
   };
@@ -392,12 +424,19 @@ export function TimeRangePicker({
   const [isOpen, setIsOpen] = useState(false);
   const [tab, setTab] = useState<"presets" | "calendar">("presets");
 
-  const handleOpenChange = useCallback((open: boolean) => {
-    setIsOpen(open);
-    if (open) {
-      setTab("presets");
-    }
-  }, []);
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      setIsOpen(open);
+      if (open) {
+        setTab("presets");
+      } else if (internalDateRange?.from && !internalDateRange.to) {
+        // Discard an abandoned first click so the next open starts fresh
+        // instead of extending a left-over start (LFE-8156).
+        setInternalDateRange(committedDateRange);
+      }
+    },
+    [internalDateRange, committedDateRange],
+  );
 
   const getDisplayContent = () => {
     if (rangeType === "custom") {
@@ -456,15 +495,11 @@ export function TimeRangePicker({
             <>
               <Calendar
                 mode="range"
-                // First click always starts a NEW range (clears the previous
-                // one); the next click sets the end. Without this,
-                // react-day-picker extends the existing range, which made the
-                // picker feel "sticky" (clicking a date became the end of the
-                // old range). See LFE-8156.
-                resetOnSelect
+                // First click starts a new range, second sets the end — see
+                // onCalendarSelection / nextRangeForDayClick (LFE-8156).
                 defaultMonth={internalDateRange?.from || new Date()}
                 selected={internalDateRange}
-                onSelect={onCalendarSelection}
+                onSelect={(_, triggerDay) => onCalendarSelection(triggerDay)}
                 numberOfMonths={1}
                 disabled={calendarDisabled}
               />
@@ -477,14 +512,18 @@ export function TimeRangePicker({
                     className="border-0 px-0 py-0"
                   />
                 </div>
-                <div className="flex flex-col gap-1">
-                  <p className="px-1 text-sm font-medium">End time</p>
-                  <TimePicker
-                    date={internalDateRange?.to}
-                    setDate={onEndTimeSelection}
-                    className="border-0 px-0 py-0"
-                  />
-                </div>
+                {/* Only meaningful once an end exists; during the partial
+                    range the input would silently ignore edits. */}
+                {internalDateRange?.to && (
+                  <div className="flex flex-col gap-1">
+                    <p className="px-1 text-sm font-medium">End time</p>
+                    <TimePicker
+                      date={internalDateRange?.to}
+                      setDate={onEndTimeSelection}
+                      className="border-0 px-0 py-0"
+                    />
+                  </div>
+                )}
               </div>
             </>
           ) : (

--- a/web/src/components/date-picker.tsx
+++ b/web/src/components/date-picker.tsx
@@ -251,7 +251,10 @@ export function DatePickerWithRange({
             selected={internalDateRange}
             onSelect={(_, triggerDay) => onCalendarSelection(triggerDay)}
             numberOfMonths={2}
-            className="[&>div]:hidden sm:[&>div]:block [&>div:first-child]:block"
+            // react-day-picker v9 lays the two months out in a flex row; on
+            // narrow screens drop the second month rather than overriding that
+            // flex (the old `[&>div]` rule stacked them vertically). LFE-8156.
+            className="max-sm:[&>div>div:last-child]:hidden"
             disabled={disabled}
           />
           {/* Time pickers tune the boundaries of a *complete* range. During

--- a/web/src/components/date-picker.tsx
+++ b/web/src/components/date-picker.tsx
@@ -254,20 +254,23 @@ export function DatePickerWithRange({
             className="[&>div]:hidden sm:[&>div]:block [&>div:first-child]:block"
             disabled={disabled}
           />
-          <div className="flex flex-col gap-2 border-t-2 py-1.5 sm:flex-row sm:gap-0">
-            <div className="px-3">
-              <p className="px-1 text-sm font-medium">
-                Start<span className="hidden sm:inline"> time</span>
-              </p>
-              <TimePicker
-                date={internalDateRange?.from}
-                setDate={onStartTimeSelection}
-                className="border-0 px-0 pt-1"
-              />
-            </div>
-            {/* Only meaningful once an end exists; during the partial range
-                (after the first click) the input would silently ignore edits. */}
-            {internalDateRange?.to && (
+          {/* Time pickers tune the boundaries of a *complete* range. During
+              the partial range (after the first click, before the second) they
+              are hidden: the End-time input would silently ignore edits, and a
+              typed Start time would be clobbered by setBeginningOfDay on the
+              next calendar click. See LFE-8156. */}
+          {internalDateRange?.from && internalDateRange.to && (
+            <div className="flex flex-col gap-2 border-t-2 py-1.5 sm:flex-row sm:gap-0">
+              <div className="px-3">
+                <p className="px-1 text-sm font-medium">
+                  Start<span className="hidden sm:inline"> time</span>
+                </p>
+                <TimePicker
+                  date={internalDateRange?.from}
+                  setDate={onStartTimeSelection}
+                  className="border-0 px-0 pt-1"
+                />
+              </div>
               <div className="px-3">
                 <p className="px-1 text-sm font-medium">
                   End<span className="hidden sm:inline"> time</span>
@@ -278,8 +281,8 @@ export function DatePickerWithRange({
                   className="border-0 px-0 pt-1"
                 />
               </div>
-            )}
-          </div>
+            </div>
+          )}
         </PopoverContent>
       </Popover>
       <DashboardDateRangeDropdown
@@ -503,18 +506,21 @@ export function TimeRangePicker({
                 numberOfMonths={1}
                 disabled={calendarDisabled}
               />
-              <div className="flex flex-col gap-3 border-t p-3">
-                <div className="flex flex-col gap-1">
-                  <p className="px-1 text-sm font-medium">Start time</p>
-                  <TimePicker
-                    date={internalDateRange?.from}
-                    setDate={onStartTimeSelection}
-                    className="border-0 px-0 py-0"
-                  />
-                </div>
-                {/* Only meaningful once an end exists; during the partial
-                    range the input would silently ignore edits. */}
-                {internalDateRange?.to && (
+              {/* Time pickers tune the boundaries of a *complete* range.
+                  During the partial range (after the first click, before the
+                  second) they are hidden: the End-time input would silently
+                  ignore edits, and a typed Start time would be clobbered by
+                  setBeginningOfDay on the next calendar click. See LFE-8156. */}
+              {internalDateRange?.from && internalDateRange.to && (
+                <div className="flex flex-col gap-3 border-t p-3">
+                  <div className="flex flex-col gap-1">
+                    <p className="px-1 text-sm font-medium">Start time</p>
+                    <TimePicker
+                      date={internalDateRange?.from}
+                      setDate={onStartTimeSelection}
+                      className="border-0 px-0 py-0"
+                    />
+                  </div>
                   <div className="flex flex-col gap-1">
                     <p className="px-1 text-sm font-medium">End time</p>
                     <TimePicker
@@ -523,8 +529,8 @@ export function TimeRangePicker({
                       className="border-0 px-0 py-0"
                     />
                   </div>
-                )}
-              </div>
+                </div>
+              )}
             </>
           ) : (
             /* Always show preset options dropdown */


### PR DESCRIPTION
## TL;DR
The date range calendar was "sticky": once a range was set, clicking a new date **extended the old range** (the click became the *end* of the previous range) instead of starting a fresh one. Now the **first click always starts a new range** and the **second click sets the end** — the standard date-picker behavior users expect.

## Why
From the ticket: a user with a range starting Nov 10 clicks Nov 28 to begin a *new* range, but the picker auto-fills `Nov 10 – Nov 28`, forcing a second click (or a manual clear) to actually start over. This happens because react-day-picker's default range selection *extends* a complete range rather than restarting it.

Reproduced locally before the fix: with the "Past 1 day" preset active (range = Jun 24 → Jun 25), a single click on **Jun 10** immediately committed **Jun 10 → Jun 25 23:59:59** — reusing the stale Jun 25 end (`?dateRange=…-1782424799999`).

## What
Pass react-day-picker's **`resetOnSelect`** prop (added in RDP 9.14, which this repo already runs) to both range calendars in `date-picker.tsx` — `DatePickerWithRange` (widget builder) and `TimeRangePicker` (home / tables / dashboards / score analytics). With it, clicking a day when a range is already complete starts a new range at the clicked day (`{from: clicked, to: undefined}`); the next click sets the end.

No change to the rest of the contract: presets still write the **relative** meta-token to the URL (e.g. `?dateRange=7d`), custom selections write the **absolute** timestamps, and existing date params still load correctly (backward-compatible).

## Result
First click = Start (previous range cleared, end orphaned until the next click); second click = End. The active filter isn't wiped mid-edit — it updates once a full new range is picked.

<details>
<summary>Mechanism, scope & verification</summary>

**Mechanism.** react-day-picker's `useRange` calls `addToRange` for a complete range, which keeps one old boundary and moves the other to the clicked day (the sticky behavior). `resetOnSelect` short-circuits that: a click on a complete range (or with no start) resets to `{from: clickedDay, to: undefined}`; the following click runs the normal incomplete-range path that sets the end. Because the pickers only commit (write the URL / form value) once both ends are set, the previous committed range stays live until the new range is complete — matching "first click clears the previous range, end orphaned until the next click."

**Files**
- `web/src/components/date-picker.tsx` — `resetOnSelect` on both `mode="range"` `<Calendar>` instances.
- `web/src/components/date-picker.clienttest.tsx` — regression test driving the range calendar through two clicks: one case documents the old sticky default, the other asserts first-click=fresh-start / second-click=end.

**Verified in a real browser (local dev)**
- Home `TimeRangePicker`: preset active → click Jun 10 → only Jun 10 selected, URL unchanged (no premature commit) → click Jun 20 → committed **Jun 10 → Jun 20** (`?dateRange=…-1781992799999`), not the stale Jun 25.
- Widget builder `DatePickerWithRange`: complete range → click Jun 5 (start only, not committed) → click Jun 12 → **Jun 05 → Jun 12**.
- Preset → `?dateRange=7d`; custom → absolute timestamps; loading `?dateRange=<from>-<to>` and `?dateRange=7d` directly both render correctly (backward-compat).

**Coordination.** Sibling **LFE-10497** owns the URL/localStorage presence-XOR state model + meta-format encoding (shared [design doc](https://linear.app/langfuse/issue/LFE-8156)); this PR is the picker that reads/writes that contract via the existing `useTableDateRange` / `useDashboardDateRange` hooks. No overlap landed yet on the date-picker/time-filter files — rebase whichever merges second.
</details>

Closes LFE-8156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `resetOnSelect` to both `mode="range"` `<Calendar>` instances in `date-picker.tsx` so that clicking a day when a range is already complete always starts a fresh range (`{ from: clicked, to: undefined }`) rather than extending the stale one. A companion `.clienttest.tsx` file covers the regression.

- **`date-picker.tsx`**: one-line prop addition on `DatePickerWithRange` and `TimeRangePicker`; `onCalendarSelection` already guards commit behind `from && to`, so the half-range state is never written to the URL or form until a second click completes it.
- **`date-picker.clienttest.tsx`**: two test cases — one documenting the old sticky behavior without `resetOnSelect`, one asserting the new first-click-fresh-start behavior — run in the existing `client` (jsdom) Vitest project.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a single-prop addition that fixes a well-understood UX bug, and existing commit guards prevent the half-range state from leaking into the URL or form.

The fix is minimal and well-contained. Both `onCalendarSelection` handlers already check for `from && to` before committing, so the new half-range state produced by `resetOnSelect` cannot corrupt the URL or saved filters. The test file has a minor style inconsistency (`vi` used as an implicit global rather than an explicit import) and one test case hard-codes old library default behavior in a way that could become a spurious failure on a future RDP upgrade. Neither issue affects the runtime fix.

No files require special attention — the two-line change in `date-picker.tsx` is straightforward. The test file `date-picker.clienttest.tsx` is worth a quick read for the style notes above.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Calendar as Calendar (RDP)
    participant Picker as DatePicker Component
    participant URL as URL / Form State

    Note over Calendar,URL: Before fix — sticky behavior
    User->>Calendar: Click Jun 10 (range was Jun 18–25)
    Calendar->>Picker: "onSelect({ from: Jun 10, to: Jun 25 }) [extends old range]"
    Picker->>URL: commit Jun 10–25 immediately ❌

    Note over Calendar,URL: After fix — resetOnSelect
    User->>Calendar: Click Jun 10 (range was Jun 18–25)
    Calendar->>Picker: "onSelect({ from: Jun 10, to: undefined }) [fresh start]"
    Picker->>Picker: "setInternalDateRange({ from: Jun 10, to: undefined })"
    Note over URL: No commit — to is missing
    User->>Calendar: Click Jun 20
    Calendar->>Picker: "onSelect({ from: Jun 10, to: Jun 20 })"
    Picker->>URL: commit Jun 10–20 ✅
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Calendar as Calendar (RDP)
    participant Picker as DatePicker Component
    participant URL as URL / Form State

    Note over Calendar,URL: Before fix — sticky behavior
    User->>Calendar: Click Jun 10 (range was Jun 18–25)
    Calendar->>Picker: "onSelect({ from: Jun 10, to: Jun 25 }) [extends old range]"
    Picker->>URL: commit Jun 10–25 immediately ❌

    Note over Calendar,URL: After fix — resetOnSelect
    User->>Calendar: Click Jun 10 (range was Jun 18–25)
    Calendar->>Picker: "onSelect({ from: Jun 10, to: undefined }) [fresh start]"
    Picker->>Picker: "setInternalDateRange({ from: Jun 10, to: undefined })"
    Note over URL: No commit — to is missing
    User->>Calendar: Click Jun 20
    Calendar->>Picker: "onSelect({ from: Jun 10, to: Jun 20 })"
    Picker->>URL: commit Jun 10–20 ✅
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/date-picker.clienttest.tsx:1-4
The other `.clienttest.tsx` file in this project (`movable-resizable-panel.clienttest.tsx`) explicitly imports `vi` from `"vitest"`. Relying on the implicit global works here because `globals: true` is set in `vitest.config.mts`, but it diverges from the established pattern, and TypeScript will flag the global as unknown if `types: ["vitest/globals"]` is ever removed from the tsconfig.

```suggestion
import { fireEvent, render, screen } from "@testing-library/react";
import { useState } from "react";
import { vi } from "vitest";
import { type DateRange } from "react-day-picker";
import { Calendar } from "@/src/components/ui/calendar";
```

### Issue 2 of 2
web/src/components/date-picker.clienttest.tsx:50-67
**Test documents pre-fix sticky behavior as a live assertion**

The first test case asserts that a single click on Jun 10 immediately commits `from=10, to=25` (the old buggy behavior). This is intentional documentation, but because it runs against real `react-day-picker` internals without `resetOnSelect`, it will begin failing the moment a future RDP upgrade changes `addToRange`'s default behavior to match the fixed semantics — even though the actual fix remains correct. Consider marking it with a comment or using `.skip` + a descriptive name so a future RDP upgrade that obsoletes the bug naturally turns the test into a clear signal rather than a breakage.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(date-picker): first calendar click s..."](https://github.com/langfuse/langfuse/commit/555fbf82b494f49ce270bb78401d199ae042dbc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39774288)</sub>

<!-- /greptile_comment -->