### PR TITLE
fix(trace-timeline): anchor gantt origin to earliest start; stop truncating Timeline label (LFE-10496)

### DIFF
--- a/web/src/components/trace/components/TraceTimeline/index.tsx
+++ b/web/src/components/trace/components/TraceTimeline/index.tsx
@@ -10,7 +10,11 @@ import { useSelection } from "../../contexts/SelectionContext";
 import { useViewPreferences } from "../../contexts/ViewPreferencesContext";
 import { useHandlePrefetchObservation } from "../../hooks/useHandlePrefetchObservation";
 import { flattenTreeWithTimelineMetrics } from "./timeline-flattening";
-import { calculateStepSize, SCALE_WIDTH } from "./timeline-calculations";
+import {
+  calculateStepSize,
+  findEarliestStartTime,
+  SCALE_WIDTH,
+} from "./timeline-calculations";
 import { TimelineScale } from "./TimelineScale";
 import { TimelineRow } from "./TimelineRow";
 
@@ -30,18 +34,39 @@ export function TraceTimeline() {
   const timeIndexRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
 
-  // TODO: Extract aggregation logic to shared utility - duplicated in tree-building.ts and TraceTree.tsx
-  // Calculate trace duration from roots (max latency across all roots)
-  const traceDuration = useMemo(() => {
-    if (roots.length === 0) return 0;
-    return Math.max(...roots.map((r) => r.latency ?? 0));
+  // Timeline origin (the 0s mark): the earliest start time across the WHOLE
+  // tree, not just the roots. A child can start before its root (the TRACE
+  // wrapper's start is the trace timestamp, which may be later than the first
+  // observation), so anchoring to roots alone misplaces the origin past early
+  // children. See findEarliestStartTime.
+  const traceStartTime = useMemo(() => {
+    return findEarliestStartTime(roots) ?? new Date();
   }, [roots]);
 
-  const traceStartTime = useMemo(() => {
-    if (roots.length === 0) return new Date();
-    // Use earliest start time among roots
-    return new Date(Math.min(...roots.map((r) => r.startTime.getTime())));
-  }, [roots]);
+  // TODO: Extract aggregation logic to shared utility - duplicated in tree-building.ts and TraceTree.tsx
+  // Total span of the scale, in seconds. Measured from the timeline origin
+  // (earliest start) to the latest end across the tree, so every bar fits
+  // within the scale even when the origin sits before a root's start. Falls
+  // back to the largest root latency when end times are unavailable.
+  const traceDuration = useMemo(() => {
+    if (roots.length === 0) return 0;
+
+    const originMs = traceStartTime.getTime();
+    let latestEndMs = -Infinity;
+
+    const stack = [...roots];
+    while (stack.length > 0) {
+      const node = stack.pop()!;
+      const end = (node.endTime ?? node.startTime).getTime();
+      if (end > latestEndMs) latestEndMs = end;
+      for (const child of node.children) stack.push(child);
+    }
+
+    const spanFromEnds = (latestEndMs - originMs) / 1000;
+    const maxRootLatency = Math.max(...roots.map((r) => r.latency ?? 0));
+
+    return Math.max(spanFromEnds, maxRootLatency);
+  }, [roots, traceStartTime]);
 
   // Calculate step size for time axis
   const stepSize = useMemo(() => {

--- a/web/src/components/trace/components/TraceTimeline/index.tsx
+++ b/web/src/components/trace/components/TraceTimeline/index.tsx
@@ -12,6 +12,7 @@ import { useHandlePrefetchObservation } from "../../hooks/useHandlePrefetchObser
 import { flattenTreeWithTimelineMetrics } from "./timeline-flattening";
 import {
   calculateStepSize,
+  calculateTraceDuration,
   findEarliestStartTime,
   SCALE_WIDTH,
 } from "./timeline-calculations";
@@ -44,28 +45,14 @@ export function TraceTimeline() {
   }, [roots]);
 
   // TODO: Extract aggregation logic to shared utility - duplicated in tree-building.ts and TraceTree.tsx
-  // Total span of the scale, in seconds. Measured from the timeline origin
+  // Total span of the scale, in seconds, measured from the timeline origin
   // (earliest start) to the latest end across the tree, so every bar fits
-  // within the scale even when the origin sits before a root's start. Falls
-  // back to the largest root latency when end times are unavailable.
+  // within the scale even when the origin sits before a root's start. The
+  // latency fallback (for traces without end times) is anchored to the origin,
+  // so a root that starts after an earlier child still fits. See
+  // calculateTraceDuration.
   const traceDuration = useMemo(() => {
-    if (roots.length === 0) return 0;
-
-    const originMs = traceStartTime.getTime();
-    let latestEndMs = -Infinity;
-
-    const stack = [...roots];
-    while (stack.length > 0) {
-      const node = stack.pop()!;
-      const end = (node.endTime ?? node.startTime).getTime();
-      if (end > latestEndMs) latestEndMs = end;
-      for (const child of node.children) stack.push(child);
-    }
-
-    const spanFromEnds = (latestEndMs - originMs) / 1000;
-    const maxRootLatency = Math.max(...roots.map((r) => r.latency ?? 0));
-
-    return Math.max(spanFromEnds, maxRootLatency);
+    return calculateTraceDuration(roots, traceStartTime);
   }, [roots, traceStartTime]);
 
   // Calculate step size for time axis

--- a/web/src/components/trace/components/TraceTimeline/timeline-calculations.clienttest.ts
+++ b/web/src/components/trace/components/TraceTimeline/timeline-calculations.clienttest.ts
@@ -4,10 +4,32 @@ import {
   calculateTimelineOffset,
   calculateTimelineWidth,
   calculateStepSize,
+  findEarliestStartTime,
   getPredefinedStepSizes,
   SCALE_WIDTH,
   PREDEFINED_STEP_SIZES,
 } from "./timeline-calculations";
+import { type TreeNode } from "../../lib/types";
+
+// Minimal TreeNode factory for origin tests (only the fields the helper reads).
+function makeNode(
+  id: string,
+  startTime: string,
+  children: TreeNode[] = [],
+): TreeNode {
+  return {
+    id,
+    type: "SPAN",
+    name: id,
+    startTime: new Date(startTime),
+    endTime: null,
+    children,
+    startTimeSinceTrace: 0,
+    startTimeSinceParentStart: null,
+    depth: 0,
+    childrenDepth: 0,
+  } as TreeNode;
+}
 
 describe("timeline-calculations", () => {
   describe("calculateTimelineOffset", () => {
@@ -262,6 +284,66 @@ describe("timeline-calculations", () => {
       // This shouldn't happen in practice, but handle gracefully
       const width = calculateTimelineWidth(20, 10);
       expect(width).toBe(SCALE_WIDTH * 2); // Just calculates proportionally
+    });
+  });
+
+  describe("findEarliestStartTime (timeline origin)", () => {
+    it("returns null for an empty tree", () => {
+      expect(findEarliestStartTime([])).toBeNull();
+    });
+
+    it("returns the root start time when the root starts first", () => {
+      const root = makeNode("root", "2024-01-01T00:00:00Z", [
+        makeNode("child", "2024-01-01T00:00:02Z"),
+      ]);
+      expect(findEarliestStartTime([root])?.toISOString()).toBe(
+        "2024-01-01T00:00:00.000Z",
+      );
+    });
+
+    it("anchors to a child that starts BEFORE the root (the origin bug)", () => {
+      // The root (TRACE wrapper) starts at the trace timestamp, but an early
+      // observation began before it. The origin must be the child's start.
+      const root = makeNode("root", "2024-01-01T00:00:05Z", [
+        makeNode("early-child", "2024-01-01T00:00:01Z"),
+        makeNode("late-child", "2024-01-01T00:00:07Z"),
+      ]);
+
+      const origin = findEarliestStartTime([root]);
+      expect(origin?.toISOString()).toBe("2024-01-01T00:00:01.000Z");
+
+      // And the offset of that early child against the corrected origin is 0,
+      // not negative as it would be when anchoring to the root.
+      const offset = calculateTimelineOffset(
+        new Date("2024-01-01T00:00:01Z"),
+        origin!,
+        10,
+      );
+      expect(offset).toBe(0);
+    });
+
+    it("descends into deeply nested children to find the minimum", () => {
+      const root = makeNode("root", "2024-01-01T00:00:10Z", [
+        makeNode("a", "2024-01-01T00:00:08Z", [
+          makeNode("b", "2024-01-01T00:00:03Z", [
+            makeNode("c", "2024-01-01T00:00:02Z"),
+          ]),
+        ]),
+      ]);
+      expect(findEarliestStartTime([root])?.toISOString()).toBe(
+        "2024-01-01T00:00:02.000Z",
+      );
+    });
+
+    it("considers all roots when there are multiple", () => {
+      const roots = [
+        makeNode("r1", "2024-01-01T00:00:04Z"),
+        makeNode("r2", "2024-01-01T00:00:01Z"),
+        makeNode("r3", "2024-01-01T00:00:06Z"),
+      ];
+      expect(findEarliestStartTime(roots)?.toISOString()).toBe(
+        "2024-01-01T00:00:01.000Z",
+      );
     });
   });
 });

--- a/web/src/components/trace/components/TraceTimeline/timeline-calculations.clienttest.ts
+++ b/web/src/components/trace/components/TraceTimeline/timeline-calculations.clienttest.ts
@@ -4,6 +4,7 @@ import {
   calculateTimelineOffset,
   calculateTimelineWidth,
   calculateStepSize,
+  calculateTraceDuration,
   findEarliestStartTime,
   getPredefinedStepSizes,
   SCALE_WIDTH,
@@ -11,18 +12,25 @@ import {
 } from "./timeline-calculations";
 import { type TreeNode } from "../../lib/types";
 
-// Minimal TreeNode factory for origin tests (only the fields the helper reads).
+// Minimal TreeNode factory for origin/duration tests (only the fields the
+// helpers read). `opts` lets a test set endTime / latency / children.
 function makeNode(
   id: string,
   startTime: string,
-  children: TreeNode[] = [],
+  opts: {
+    children?: TreeNode[];
+    endTime?: string | null;
+    latency?: number;
+  } = {},
 ): TreeNode {
+  const { children = [], endTime = null, latency } = opts;
   return {
     id,
     type: "SPAN",
     name: id,
     startTime: new Date(startTime),
-    endTime: null,
+    endTime: endTime === null ? null : new Date(endTime),
+    latency,
     children,
     startTimeSinceTrace: 0,
     startTimeSinceParentStart: null,
@@ -293,9 +301,9 @@ describe("timeline-calculations", () => {
     });
 
     it("returns the root start time when the root starts first", () => {
-      const root = makeNode("root", "2024-01-01T00:00:00Z", [
-        makeNode("child", "2024-01-01T00:00:02Z"),
-      ]);
+      const root = makeNode("root", "2024-01-01T00:00:00Z", {
+        children: [makeNode("child", "2024-01-01T00:00:02Z")],
+      });
       expect(findEarliestStartTime([root])?.toISOString()).toBe(
         "2024-01-01T00:00:00.000Z",
       );
@@ -304,10 +312,12 @@ describe("timeline-calculations", () => {
     it("anchors to a child that starts BEFORE the root (the origin bug)", () => {
       // The root (TRACE wrapper) starts at the trace timestamp, but an early
       // observation began before it. The origin must be the child's start.
-      const root = makeNode("root", "2024-01-01T00:00:05Z", [
-        makeNode("early-child", "2024-01-01T00:00:01Z"),
-        makeNode("late-child", "2024-01-01T00:00:07Z"),
-      ]);
+      const root = makeNode("root", "2024-01-01T00:00:05Z", {
+        children: [
+          makeNode("early-child", "2024-01-01T00:00:01Z"),
+          makeNode("late-child", "2024-01-01T00:00:07Z"),
+        ],
+      });
 
       const origin = findEarliestStartTime([root]);
       expect(origin?.toISOString()).toBe("2024-01-01T00:00:01.000Z");
@@ -323,13 +333,17 @@ describe("timeline-calculations", () => {
     });
 
     it("descends into deeply nested children to find the minimum", () => {
-      const root = makeNode("root", "2024-01-01T00:00:10Z", [
-        makeNode("a", "2024-01-01T00:00:08Z", [
-          makeNode("b", "2024-01-01T00:00:03Z", [
-            makeNode("c", "2024-01-01T00:00:02Z"),
-          ]),
-        ]),
-      ]);
+      const root = makeNode("root", "2024-01-01T00:00:10Z", {
+        children: [
+          makeNode("a", "2024-01-01T00:00:08Z", {
+            children: [
+              makeNode("b", "2024-01-01T00:00:03Z", {
+                children: [makeNode("c", "2024-01-01T00:00:02Z")],
+              }),
+            ],
+          }),
+        ],
+      });
       expect(findEarliestStartTime([root])?.toISOString()).toBe(
         "2024-01-01T00:00:02.000Z",
       );
@@ -344,6 +358,79 @@ describe("timeline-calculations", () => {
       expect(findEarliestStartTime(roots)?.toISOString()).toBe(
         "2024-01-01T00:00:01.000Z",
       );
+    });
+  });
+
+  describe("calculateTraceDuration (timeline scale span)", () => {
+    it("returns 0 for an empty tree", () => {
+      expect(calculateTraceDuration([], new Date())).toBe(0);
+    });
+
+    it("spans from the origin to the latest end when end times exist", () => {
+      // Root T0..T+10, child T+2..T+12 → latest end is T+12.
+      const origin = new Date("2024-01-01T00:00:00Z");
+      const root = makeNode("root", "2024-01-01T00:00:00Z", {
+        endTime: "2024-01-01T00:00:10Z",
+        children: [
+          makeNode("child", "2024-01-01T00:00:02Z", {
+            endTime: "2024-01-01T00:00:12Z",
+          }),
+        ],
+      });
+      expect(calculateTraceDuration([root], origin)).toBe(12);
+    });
+
+    it("measures the latest end relative to an origin BEFORE the root start", () => {
+      // Early child anchors the origin at T+0; root runs T+5..T+9. The span
+      // must reach the child's end (T+11), not just the root's end.
+      const origin = new Date("2024-01-01T00:00:00Z");
+      const root = makeNode("root", "2024-01-01T00:00:05Z", {
+        endTime: "2024-01-01T00:00:09Z",
+        children: [
+          makeNode("early-child", "2024-01-01T00:00:00Z", {
+            endTime: "2024-01-01T00:00:11Z",
+          }),
+        ],
+      });
+      expect(calculateTraceDuration([root], origin)).toBe(11);
+    });
+
+    it("offset-aware latency fallback covers a root that starts after the origin (the P2 bug)", () => {
+      // No node has an end time, so `endTime ?? startTime` collapses
+      // spanFromEnds to the start gap only. An early child anchors the origin
+      // at T+0; the root starts at T+3 with latency 10. The root's bar reaches
+      // T+13, so the scale MUST be 13 — not the naive max(spanFromEnds=3,
+      // latency=10) = 10, which would let the bar overrun the axis.
+      const origin = new Date("2024-01-01T00:00:00Z");
+      const root = makeNode("root", "2024-01-01T00:00:03Z", {
+        latency: 10,
+        children: [makeNode("early-child", "2024-01-01T00:00:00Z")],
+      });
+
+      const span = calculateTraceDuration([root], origin);
+      expect(span).toBe(13);
+
+      // The root bar (offset from origin + width) fits exactly within the axis
+      // (modulo floating-point rounding). With the pre-fix scale of 10 it would
+      // have reached 1.3 * SCALE_WIDTH and overrun the last tick.
+      const offset = calculateTimelineOffset(root.startTime, origin, span);
+      const width = calculateTimelineWidth(root.latency!, span);
+      expect(offset + width).toBeCloseTo(SCALE_WIDTH, 6);
+    });
+
+    it("uses the larger of end-based span and offset-aware latency", () => {
+      // Root starts at the origin with latency 10 but a child ends at T+12 →
+      // the end-based span (12) wins over the latency span (10).
+      const origin = new Date("2024-01-01T00:00:00Z");
+      const root = makeNode("root", "2024-01-01T00:00:00Z", {
+        latency: 10,
+        children: [
+          makeNode("child", "2024-01-01T00:00:02Z", {
+            endTime: "2024-01-01T00:00:12Z",
+          }),
+        ],
+      });
+      expect(calculateTraceDuration([root], origin)).toBe(12);
     });
   });
 });

--- a/web/src/components/trace/components/TraceTimeline/timeline-calculations.ts
+++ b/web/src/components/trace/components/TraceTimeline/timeline-calculations.ts
@@ -3,9 +3,43 @@
  * These functions handle all timeline positioning and sizing logic
  */
 
+import { type TreeNode } from "../../lib/types";
+
 // Fixed widths for timeline styling
 export const SCALE_WIDTH = 900;
 export const STEP_SIZE = 100;
+
+/**
+ * Find the earliest start time across the whole tree (roots + all descendants).
+ *
+ * This is the timeline origin (the 0s mark). It must be the minimum start time
+ * over the entire tree, not just the roots: a child observation can start
+ * before its root (the TRACE wrapper's start time is the trace's own timestamp,
+ * which may be later than the first observation). Anchoring the origin to the
+ * roots alone pushes the 0s mark past such early children, giving them negative
+ * offsets and misaligning the whole gantt.
+ *
+ * @param roots - Root nodes of the trace tree
+ * @returns Earliest start time across the tree, or `null` when there are no nodes
+ */
+export function findEarliestStartTime(roots: TreeNode[]): Date | null {
+  if (roots.length === 0) return null;
+
+  let earliest = Infinity;
+
+  // Iterative DFS to avoid stack overflow on deep trees.
+  const stack: TreeNode[] = [...roots];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    const start = node.startTime.getTime();
+    if (start < earliest) earliest = start;
+    for (const child of node.children) {
+      stack.push(child);
+    }
+  }
+
+  return new Date(earliest);
+}
 
 // Predefined step sizes for time axis (in seconds)
 export const PREDEFINED_STEP_SIZES = [

--- a/web/src/components/trace/components/TraceTimeline/timeline-calculations.ts
+++ b/web/src/components/trace/components/TraceTimeline/timeline-calculations.ts
@@ -41,6 +41,56 @@ export function findEarliestStartTime(roots: TreeNode[]): Date | null {
   return new Date(earliest);
 }
 
+/**
+ * Total span of the timeline scale, in seconds.
+ *
+ * Measured from the timeline origin (the earliest start across the whole tree,
+ * see findEarliestStartTime) to the latest end across the tree, so every bar
+ * fits within the scale even when the origin sits before a root's start.
+ *
+ * When end times are unavailable, `endTime ?? startTime` collapses
+ * `spanFromEnds` to the earliest-to-latest start gap. We therefore also
+ * consider each root's latency-based span, but measured FROM THE ORIGIN: a
+ * root's bar spans `(root.startTime − origin) + latency`, not just `latency`.
+ * Anchoring the latency fallback to the origin keeps the root's bar inside the
+ * axis when it starts after an earlier child (otherwise the bar overruns the
+ * last tick by the dropped `(root.startTime − origin)` offset).
+ *
+ * @param roots - Root nodes of the trace tree
+ * @param origin - Timeline origin (earliest start across the tree)
+ * @returns Total scale span in seconds (0 when there are no roots)
+ */
+export function calculateTraceDuration(
+  roots: TreeNode[],
+  origin: Date,
+): number {
+  if (roots.length === 0) return 0;
+
+  const originMs = origin.getTime();
+  let latestEndMs = -Infinity;
+
+  // Iterative DFS to avoid stack overflow on deep trees.
+  const stack: TreeNode[] = [...roots];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    const end = (node.endTime ?? node.startTime).getTime();
+    if (end > latestEndMs) latestEndMs = end;
+    for (const child of node.children) stack.push(child);
+  }
+
+  const spanFromEnds = (latestEndMs - originMs) / 1000;
+
+  // Offset-aware latency fallback: each root's bar reaches
+  // (offset from origin, in seconds) + (its latency, in seconds).
+  const maxRootLatencySpan = Math.max(
+    ...roots.map(
+      (r) => (r.startTime.getTime() - originMs) / 1000 + (r.latency ?? 0),
+    ),
+  );
+
+  return Math.max(spanFromEnds, maxRootLatencySpan);
+}
+
 // Predefined step sizes for time axis (in seconds)
 export const PREDEFINED_STEP_SIZES = [
   0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25,

--- a/web/src/components/trace/components/_layout/TracePanelNavigationHeader.tsx
+++ b/web/src/components/trace/components/_layout/TracePanelNavigationHeader.tsx
@@ -157,7 +157,7 @@ function TracePanelNavigationHeaderExpanded({
             onKeyDown={handleSearchKeyDown}
           />
         </div>
-        <div className="flex flex-row items-center gap-0.5">
+        <div className="flex shrink-0 flex-row items-center gap-0.5">
           {/* Expand/Collapse All Button */}
           <Button
             onClick={handleToggleTreeNodes}
@@ -198,7 +198,7 @@ function TracePanelNavigationHeaderExpanded({
             size="sm"
             onClick={() => setViewMode(isTimelineView ? null : "timeline")}
             className={cn(
-              "h-7 px-2 text-xs",
+              "h-7 shrink-0 px-2 text-xs",
               isTimelineView && "bg-primary text-primary-foreground",
             )}
           >


### PR DESCRIPTION
## TL;DR
The trace **timeline (gantt)** sometimes started its `0s` mark *after* the root span — even after some child spans — and the **"Timeline"** view toggle could be clipped. This anchors the timeline origin to the earliest start across the whole tree and keeps the toggle fully legible. Two small, focused fixes; one PR.

## Why
1. **Wrong origin.** The `0s` mark was anchored to the *roots'* earliest start. But a child observation can begin **before** its root: the root is the `TRACE` wrapper whose start is the trace's own timestamp, which may be later than the first observation that arrived. So the origin landed past those early children, giving them **negative offsets** and shifting the entire gantt — exactly the "starts after the root / after other spans" report.
2. **Clipped label.** In the trace panel toolbar the search input grows (`flex-1`) while the control group could shrink, so the longest control — the **"Timeline"** label — got clipped on narrower panels.

## What
- New pure helper `findEarliestStartTime(roots)` walks the whole tree (iteratively, deep-tree safe) and returns the minimum start. The timeline origin uses it instead of the roots-only minimum.
- The total scale span is now measured from that origin to the **latest end across the tree** (fallback: largest root latency), so every bar still fits when the origin moves earlier.
- Toolbar: `shrink-0` on the control group and the Timeline toggle so the label never clips.

## Result
- Origin sits at the true earliest start; no negative offsets; bars ordered correctly.
- "Timeline" label always fully visible.

<details>
<summary>Mechanism & verification</summary>

**Files**
- `web/src/components/trace/components/TraceTimeline/timeline-calculations.ts` — `findEarliestStartTime` helper.
- `web/src/components/trace/components/TraceTimeline/index.tsx` — origin uses earliest-across-tree; scale span = origin→latest-end (fallback largest root latency).
- `web/src/components/trace/components/_layout/TracePanelNavigationHeader.tsx` — `shrink-0` on the toolbar control group + Timeline toggle.
- `web/src/components/trace/components/TraceTimeline/timeline-calculations.clienttest.ts` — origin-anchoring tests.

**Unit tests** — 32/32 pass, including new cases: empty tree, root-starts-first, **child-starts-before-root → origin is the child & that child's offset is 0**, deeply nested minimum, multi-root minimum.

**Live verification (Playwright, seeded local data)** — ingested a trace where a child starts 3s before the root, opened the timeline, and probed the DOM:
- `early-child-BEFORE-root` → `marginLeft: 0` (the origin), `root-span` → +3s, `late-child` → +5s. **No negative offsets**; ordering early(0) < root(3s) < late(5s).
- "Timeline" toggle: `scrollWidth === clientWidth` (not clipped) and within the viewport.

This is a UI-positioning fix only; no API/schema/query changes.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two distinct UI issues in the trace Gantt chart. A new `findEarliestStartTime` helper performs an iterative DFS over the full node tree to anchor the timeline origin (`0s` mark) at the true global minimum start time, replacing the previous root-only minimum that could miss child observations beginning before their parent TRACE wrapper. A matching traversal in `traceDuration` extends the scale to the latest end time across the tree, and two `shrink-0` Tailwind classes prevent the "Timeline" toggle label from being clipped in the toolbar.

- `findEarliestStartTime` in `timeline-calculations.ts` walks all nodes iteratively and the new tests cover empty trees, root-first, child-before-root, deep nesting, and multi-root cases.
- `traceDuration` now measures from the new origin to the latest `endTime` (falling back to `maxRootLatency`) so all bars remain within the scale.
- `TracePanelNavigationHeader.tsx` adds `shrink-0` to the control group and the Timeline button to prevent label clipping on narrow panels.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are UI-only and well-tested, with no API, schema, or data-layer impact.

The core logic is correct and the new test suite covers the key cases. The one subtle gap is in the traceDuration fallback path: when a child precedes its root and no endTime values are set, maxRootLatency is measured from the root's own start rather than from the new earlier origin, so the labeled axis can be shorter than the root bar in that specific combination of conditions. This is an uncommon scenario and does not affect the bug being fixed; the contentWidth calculation ensures the scrollable container still expands to fit all bars.

The traceDuration useMemo in index.tsx deserves a second look for the edge case where children precede the root and no end times are available on any node.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TraceTimeline mounts] --> B[findEarliestStartTime - DFS over all nodes]
    B --> C{roots empty?}
    C -- yes --> D[traceStartTime = new Date now]
    C -- no --> E[traceStartTime = min startTime across tree]
    E --> F[traceDuration useMemo - DFS over all nodes]
    D --> G[traceDuration = 0]
    F --> H[Collect latestEndMs - endTime ?? startTime per node]
    H --> I[spanFromEnds = latestEndMs - originMs / 1000]
    I --> J[maxRootLatency = max root.latency across roots]
    J --> K[traceDuration = max spanFromEnds, maxRootLatency]
    K --> L[calculateStepSize - axis ticks]
    K --> M[flattenTreeWithTimelineMetrics - per-row offsets + widths]
    E --> M
    L --> N[TimelineScale - labeled axis]
    M --> O[TimelineRow x N - virtualized rows]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[TraceTimeline mounts] --> B[findEarliestStartTime - DFS over all nodes]
    B --> C{roots empty?}
    C -- yes --> D[traceStartTime = new Date now]
    C -- no --> E[traceStartTime = min startTime across tree]
    E --> F[traceDuration useMemo - DFS over all nodes]
    D --> G[traceDuration = 0]
    F --> H[Collect latestEndMs - endTime ?? startTime per node]
    H --> I[spanFromEnds = latestEndMs - originMs / 1000]
    I --> J[maxRootLatency = max root.latency across roots]
    J --> K[traceDuration = max spanFromEnds, maxRootLatency]
    K --> L[calculateStepSize - axis ticks]
    K --> M[flattenTreeWithTimelineMetrics - per-row offsets + widths]
    E --> M
    L --> N[TimelineScale - labeled axis]
    M --> O[TimelineRow x N - virtualized rows]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/trace/components/TraceTimeline/index.tsx:65-68
**`maxRootLatency` fallback underestimates scale when origin precedes root start**

When a child starts before its root *and* end times are unavailable for all nodes, `latestEndMs` equals the maximum `startTime` across the tree (because `endTime ?? startTime` is used). In that case `spanFromEnds` covers only the earliest-to-latest *start* gap, and `maxRootLatency` is then the tiebreaker — but `latency` measures duration from the *root's* start, not from the new (earlier) origin. The effective scale therefore misses the `(root.startTime − origin)` offset, so the root's bar (offset + width) can extend past the last labeled tick on the axis. Concretely: origin = T0, root starts at T+3s with `latency = 10`, no `endTime` anywhere → `spanFromEnds = 3`, `maxRootLatency = 10`, `traceDuration = 10`, but the root bar ends at T+13s relative to origin. The labeled axis stops at 10s while the bar continues to 1.3× `SCALE_WIDTH`.

### Issue 2 of 2
web/src/components/trace/components/TraceTimeline/index.tsx:54-68
**Duplicate full-tree traversal on every render**

`traceStartTime` already performs a full DFS via `findEarliestStartTime`, and `traceDuration` runs an independent DFS over the same tree to find `latestEndMs`. For large traces with deep or wide trees this is two complete passes where one would suffice. Consider combining both into a single utility (e.g. `findTreeTimeRange`) that returns `{ earliest, latestEnd }` so both values are computed in one traversal.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace-timeline): anchor gantt origin..."](https://github.com/langfuse/langfuse/commit/5ae25efcbe33adbd418d543fe75d3e4e0211c33c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39782708)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->