### PR TITLE
chore(playground): deny playground execution to users of role VIEWER

### DIFF
--- a/web/src/features/playground/server/authorizeRequest.ts
+++ b/web/src/features/playground/server/authorizeRequest.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { getAuthOptions } from "@/src/server/auth";
 import { isProjectMemberOrAdmin } from "@/src/server/utils/checkProjectMembershipOrAdmin";
 import { ForbiddenError, UnauthorizedError } from "@langfuse/shared";
+import { hasProjectAccess } from "../../rbac/utils/checkProjectAccess";
 
 export type AuthorizeRequestResult = {
   userId: string;
@@ -17,6 +18,9 @@ export const authorizeRequestOrThrow = async (
 
   if (!isProjectMemberOrAdmin(session.user, projectId))
     throw new ForbiddenError("User is not a member of this project");
+
+  if (!hasProjectAccess({ session, projectId, scope: "playground:execute" }))
+    throw new ForbiddenError("Insufficient permissions to execute playground.");
 
   return { userId: session.user.id };
 };

--- a/web/src/features/rbac/constants/projectAccessRights.ts
+++ b/web/src/features/rbac/constants/projectAccessRights.ts
@@ -65,6 +65,8 @@ export const projectScopes = [
   "llmTools:CUD",
   "llmTools:read",
 
+  "playground:execute",
+
   "comments:CUD",
   "comments:read",
 
@@ -124,6 +126,7 @@ export const projectRoleAccessRights: Record<Role, ProjectScope[]> = {
     "llmSchemas:read",
     "llmTools:CUD",
     "llmTools:read",
+    "playground:execute",
     "batchExports:create",
     "batchExports:read",
     "comments:CUD",
@@ -180,6 +183,7 @@ export const projectRoleAccessRights: Record<Role, ProjectScope[]> = {
     "llmSchemas:read",
     "llmTools:CUD",
     "llmTools:read",
+    "playground:execute",
     "batchExports:create",
     "batchExports:read",
     "comments:CUD",
@@ -226,6 +230,7 @@ export const projectRoleAccessRights: Record<Role, ProjectScope[]> = {
     "llmSchemas:CUD",
     "llmTools:CUD",
     "llmTools:read",
+    "playground:execute",
     "batchExports:create",
     "batchExports:read",
     "comments:CUD",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds server-side RBAC enforcement to deny playground execution for users with the `VIEWER` role. It registers a new `"playground:execute"` scope and grants it to `OWNER`, `ADMIN`, and `MEMBER` roles while intentionally withholding it from `VIEWER` and `NONE`.

- **`projectAccessRights.ts`**: Adds `"playground:execute"` to the `projectScopes` list and grants it to OWNER, ADMIN, and MEMBER roles.
- **`authorizeRequest.ts`**: Adds a `hasProjectAccess` guard after the existing membership check so that VIEWERs receive a `ForbiddenError` when attempting to execute the playground.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the server-side execution gate is correctly implemented and consistent with the rest of the RBAC system.

The VIEWER denial is enforced on the server but there is no matching UI guard, so VIEWERs can still reach the playground page and click Run before receiving a generic forbidden error. The core security constraint is correctly enforced; the gap is purely a UX concern.

The playground UI component(s) that render the execute button — these are not touched in this PR and currently lack a useHasProjectAccess check for the playground:execute scope.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant authorizeRequestOrThrow
    participant isProjectMemberOrAdmin
    participant hasProjectAccess
    participant projectRoleAccessRights

    Client->>authorizeRequestOrThrow: POST /playground/execute (projectId)
    authorizeRequestOrThrow->>authorizeRequestOrThrow: getServerSession()
    alt No session / no user
        authorizeRequestOrThrow-->>Client: 401 UnauthorizedError
    end
    authorizeRequestOrThrow->>isProjectMemberOrAdmin: check(user, projectId)
    alt Not a project member
        authorizeRequestOrThrow-->>Client: 403 ForbiddenError (not a member)
    end
    authorizeRequestOrThrow->>hasProjectAccess: check(session, projectId, "playground:execute")
    hasProjectAccess->>projectRoleAccessRights: lookup role → scopes
    alt Role is VIEWER or NONE (scope absent)
        hasProjectAccess-->>authorizeRequestOrThrow: false
        authorizeRequestOrThrow-->>Client: 403 ForbiddenError (insufficient permissions)
    end
    hasProjectAccess-->>authorizeRequestOrThrow: true
    authorizeRequestOrThrow-->>Client: "{ userId }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant authorizeRequestOrThrow
    participant isProjectMemberOrAdmin
    participant hasProjectAccess
    participant projectRoleAccessRights

    Client->>authorizeRequestOrThrow: POST /playground/execute (projectId)
    authorizeRequestOrThrow->>authorizeRequestOrThrow: getServerSession()
    alt No session / no user
        authorizeRequestOrThrow-->>Client: 401 UnauthorizedError
    end
    authorizeRequestOrThrow->>isProjectMemberOrAdmin: check(user, projectId)
    alt Not a project member
        authorizeRequestOrThrow-->>Client: 403 ForbiddenError (not a member)
    end
    authorizeRequestOrThrow->>hasProjectAccess: check(session, projectId, "playground:execute")
    hasProjectAccess->>projectRoleAccessRights: lookup role → scopes
    alt Role is VIEWER or NONE (scope absent)
        hasProjectAccess-->>authorizeRequestOrThrow: false
        authorizeRequestOrThrow-->>Client: 403 ForbiddenError (insufficient permissions)
    end
    hasProjectAccess-->>authorizeRequestOrThrow: true
    authorizeRequestOrThrow-->>Client: "{ userId }"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/playground/server/authorizeRequest.ts:22-23
**No client-side guard for VIEWER role**

There is no `useHasProjectAccess` call guarding the playground UI for VIEWERs. VIEWERs can still navigate to the playground page and click "Run" — they will receive a `ForbiddenError` from the server, but there is no UI-level indication that the action is unavailable to them. Adding a `useHasProjectAccess({ projectId, scope: "playground:execute" })` check to the playground component to disable or hide the execute button for VIEWER users would give a cleaner experience and keep UI and server policy in sync.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(playground): deny playground execu..."](https://github.com/langfuse/langfuse/commit/a36efc125acd821ae6b1bbdde8bf943c4ebf6d40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39785783)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->