### PR TITLE
fix(pricing): bill gemini-live-2.5-flash-native-audio audio tokens at the audio rate

### DIFF
--- a/worker/src/__tests__/pricing-tier-matcher.test.ts
+++ b/worker/src/__tests__/pricing-tier-matcher.test.ts
@@ -199,6 +199,32 @@ describe("default-model-prices.json", () => {
     }
   });
 
+  it("should expose canonical _tokens-suffixed audio price keys whenever bare audio keys are present", () => {
+    // The cost calculator does exact-match `find(p => p.usageType === key)` against
+    // parsed usage_details (see IngestionService.calculateUsageCosts). The canonical
+    // post-parse key for audio tokens is `input_audio_tokens` / `output_audio_tokens`
+    // (established by IngestionService integration tests and OTel mapping). A price
+    // entry that lists only the bare `input_audio` / `output_audio` key silently bills
+    // $0 for audio because no usage key matches.
+    const offenders: string[] = [];
+    for (const model of defaultModelPrices) {
+      for (const tier of model.pricingTiers) {
+        const keys = new Set(Object.keys(tier.prices));
+        if (keys.has("input_audio") && !keys.has("input_audio_tokens")) {
+          offenders.push(
+            `${model.modelName} (${tier.name}): has "input_audio" but missing canonical "input_audio_tokens"`,
+          );
+        }
+        if (keys.has("output_audio") && !keys.has("output_audio_tokens")) {
+          offenders.push(
+            `${model.modelName} (${tier.name}): has "output_audio" but missing canonical "output_audio_tokens"`,
+          );
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
   it("should have valid regex patterns in all conditions", () => {
     for (const model of defaultModelPrices) {
       for (const tier of model.pricingTiers) {

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -4249,9 +4249,11 @@
         "prices": {
           "input_text": 0.5e-6,
           "input_audio": 3e-6,
+          "input_audio_tokens": 3e-6,
           "input_image": 3e-6,
           "output_text": 2e-6,
-          "output_audio": 12e-6
+          "output_audio": 12e-6,
+          "output_audio_tokens": 12e-6
         }
       }
     ]


### PR DESCRIPTION
## What does this PR do?

`gemini-live-2.5-flash-native-audio` is the only model in `worker/src/constants/default-model-prices.json` whose audio price entries use only the bare `input_audio` / `output_audio` keys. The cost calculator does exact-match lookup against parsed `usage_details`, and the canonical post-parse key for audio tokens is `input_audio_tokens` / `output_audio_tokens` — established by the IngestionService integration tests (`worker/src/services/IngestionService/tests/IngestionService.integration.test.ts:344,346,399,401`) and the OTel mapping path.

Because the price keys and the usage keys never matched, audio prompt and completion tokens for that model silently billed at **$0** instead of their intended $3e-6 / $12e-6 — i.e. audio cost was being dropped entirely on every call.

### Fix

Add the canonical `_tokens`-suffixed keys alongside the existing bare keys (keeping the bare keys for backward compatibility with anything that already reads them):

```diff
   "prices": {
     "input_text": 0.5e-6,
     "input_audio": 3e-6,
+    "input_audio_tokens": 3e-6,
     "input_image": 3e-6,
     "output_text": 2e-6,
-    "output_audio": 12e-6
+    "output_audio": 12e-6,
+    "output_audio_tokens": 12e-6
   }
```

### Regression test

`worker/src/__tests__/pricing-tier-matcher.test.ts` — a parser-level guard that walks every model × tier and fails whenever a price entry exposes `input_audio` / `output_audio` without its canonical `_tokens`-suffixed sibling. This is the cheapest form the bug can be caught: it doesn't require any DB or queue setup, runs in the existing JSON-validation suite, and would have caught this entry the moment it was added.

**Mutation-tested:** with the JSON fix reverted, the new test fails and names the exact offender:

```
AssertionError: expected [ ... ] to deeply equal []
+ "gemini-live-2.5-flash-native-audio (Standard): has \"input_audio\" but missing canonical \"input_audio_tokens\""
+ "gemini-live-2.5-flash-native-audio (Standard): has \"output_audio\" but missing canonical \"output_audio_tokens\""
```

With the fix applied, all 52 tests in the file pass.

Fixes # (no issue filed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes silent $0 billing for audio tokens on `gemini-live-2.5-flash-native-audio` by adding the canonical `_tokens`-suffixed price keys (`input_audio_tokens`, `output_audio_tokens`) that the cost calculator looks up via exact-match against parsed `usage_details`. A regression test is also added to prevent the same class of mismatch from recurring.

- **JSON fix**: `input_audio_tokens: 3e-6` and `output_audio_tokens: 12e-6` are added to the model's pricing tier alongside the existing bare keys, matching how all other audio-capable models in the file are already structured.
- **Regression test**: The new test in `pricing-tier-matcher.test.ts` walks every model × tier and fails if a tier exposes `input_audio` / `output_audio` without the canonical `_tokens` sibling — confirmed mutation-tested in the PR description.
- **Missing `updatedAt` bump**: The `updatedAt` field for this model was not advanced; the upsert script's `isModelUpToDate` guard compares timestamps and will skip this model on all existing deployments where the row is already present, meaning the new keys will not reach the database without a forced re-run.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The JSON price-key fix is correct, but without bumping `updatedAt` the new keys will never be written to the database on already-deployed instances, leaving the audio billing bug in place for any environment that ran the upsert before this PR.

The cost calculator fix in the JSON is correct and the regression test is well-written. However, the upsert script's staleness guard compares `updatedAt` timestamps — since the model's `updatedAt` was not advanced and its tier structure is unchanged, `isModelUpToDate` returns `true` and the entire model is skipped on deployment. The new price keys will not reach the database on any instance where this model row already exists, so the original $0 audio billing remains active in practice.

worker/src/constants/default-model-prices.json — the `updatedAt` field for `gemini-live-2.5-flash-native-audio` needs to be advanced to a date after this change to trigger the database upsert.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant JS as default-model-prices.json
    participant US as upsertDefaultModelPrices
    participant DB as Database
    participant IS as IngestionService
    participant CC as calculateUsageCosts

    US->>DB: Query existing model updatedAt
    DB-->>US: "updatedAt = "2026-03-19""
    US->>JS: Read JSON updatedAt
    JS-->>US: "updatedAt = "2026-03-19" (unchanged ⚠️)"
    US->>US: isModelUpToDate() → true → SKIP

    Note over DB: input_audio_tokens/output_audio_tokens never written to DB

    IS->>CC: modelPrices from DB (missing _tokens keys)
    CC->>CC: "find(p => p.usageType === "input_audio_tokens") → undefined"
    CC-->>IS: "audio cost = $0 (bug persists)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant JS as default-model-prices.json
    participant US as upsertDefaultModelPrices
    participant DB as Database
    participant IS as IngestionService
    participant CC as calculateUsageCosts

    US->>DB: Query existing model updatedAt
    DB-->>US: "updatedAt = "2026-03-19""
    US->>JS: Read JSON updatedAt
    JS-->>US: "updatedAt = "2026-03-19" (unchanged ⚠️)"
    US->>US: isModelUpToDate() → true → SKIP

    Note over DB: input_audio_tokens/output_audio_tokens never written to DB

    IS->>CC: modelPrices from DB (missing _tokens keys)
    CC->>CC: "find(p => p.usageType === "input_audio_tokens") → undefined"
    CC-->>IS: "audio cost = $0 (bug persists)"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/constants/default-model-prices.json:4234-4239
The `updatedAt` timestamp was not bumped alongside the price-key additions. `upsertDefaultModelPrices` uses `isModelUpToDate` to decide whether to skip a model — that check compares the JSON `updatedAt` against the stored database value. Since this model was already deployed with `updatedAt = "2026-03-19T00:00:00.000Z"` and the tier structure is also unchanged, `isModelUpToDate` returns `true` and the upsert is **skipped**, leaving the database without `input_audio_tokens` / `output_audio_tokens` on any instance where the row already exists — unless the script is forced.

```suggestion
  {
    "id": "029e6695-ff24-47f0-b37b-7285fb2e5785",
    "modelName": "gemini-live-2.5-flash-native-audio",
    "matchPattern": "(?i)^(google\/)?(gemini-live-2.5-flash-native-audio)$",
    "createdAt": "2026-03-16T00:00:00.000Z",
    "updatedAt": "2026-06-25T00:00:00.000Z",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing): bill gemini-live-2.5-flash..."](https://github.com/langfuse/langfuse/commit/f2f8846f89e98f79fa279f49abc066ff99930c9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39798001)</sub>

<!-- /greptile_comment -->