### PR TITLE
fix(queue): type monitor queue payload wrapper

### DIFF
--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -13,10 +13,11 @@ import { EvalTargetObjectSchema } from "../features/evals/types";
 import { JobConfigExecutionMode } from "../features/evals/evalConfigBlocking";
 import {
   type MonitorQueueEvent,
+  type MonitorQueueEventInput,
   MonitorWebhookQueueEventSchema,
 } from "../features/monitors/scheduler/types";
 
-export type { MonitorQueueEvent };
+export type { MonitorQueueEvent, MonitorQueueEventInput };
 
 export const IngestionEvent = z.object({
   data: z.object({
@@ -598,7 +599,7 @@ export type TQueueJobTypes = {
   [QueueName.MonitorQueue]: {
     timestamp: Date;
     id: string;
-    payload: MonitorQueueEvent;
+    payload: MonitorQueueEventInput;
     name: QueueJobs.MonitorJob;
   };
 };

--- a/packages/shared/src/server/redis/monitorQueue.ts
+++ b/packages/shared/src/server/redis/monitorQueue.ts
@@ -1,5 +1,5 @@
 import { Queue } from "bullmq";
-import { QueueName, type MonitorQueueEvent } from "../queues";
+import { QueueName, type TQueueJobTypes } from "../queues";
 import {
   createNewRedisInstance,
   redisQueueRetryOptions,
@@ -8,9 +8,13 @@ import {
 import { logger } from "../logger";
 
 export class MonitorQueue {
-  private static instance: Queue | null = null;
+  private static instance: Queue<
+    TQueueJobTypes[QueueName.MonitorQueue]
+  > | null = null;
 
-  public static getInstance(): Queue | null {
+  public static getInstance(): Queue<
+    TQueueJobTypes[QueueName.MonitorQueue]
+  > | null {
     if (MonitorQueue.instance) return MonitorQueue.instance;
 
     const newRedis = createNewRedisInstance({
@@ -19,15 +23,18 @@ export class MonitorQueue {
     });
 
     MonitorQueue.instance = newRedis
-      ? new Queue<MonitorQueueEvent>(QueueName.MonitorQueue, {
-          connection: newRedis,
-          prefix: getQueuePrefix(QueueName.MonitorQueue),
-          defaultJobOptions: {
-            removeOnComplete: true,
-            removeOnFail: 100,
-            attempts: 1,
+      ? new Queue<TQueueJobTypes[QueueName.MonitorQueue]>(
+          QueueName.MonitorQueue,
+          {
+            connection: newRedis,
+            prefix: getQueuePrefix(QueueName.MonitorQueue),
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 100,
+              attempts: 1,
+            },
           },
-        })
+        )
       : null;
 
     MonitorQueue.instance?.on("error", (err) => {


### PR DESCRIPTION
Summary
- Type MonitorQueue as the standard TQueueJobTypes wrapper used by its producer
- Keep runtime behavior unchanged

Verification
- pnpm --filter @langfuse/shared run db:generate
- pnpm --filter @langfuse/shared typecheck

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects the generic type parameter on `MonitorQueue` from the bare `MonitorQueueEvent` payload type to the standard `TQueueJobTypes[QueueName.MonitorQueue]` wrapper, bringing it in line with every other queue in the codebase. Runtime behaviour is unchanged; only the TypeScript type for the `Queue` instance and its factory method is affected.

- Replaces `Queue<MonitorQueueEvent>` with `Queue<TQueueJobTypes[QueueName.MonitorQueue]>` so the compile-time type of the queue instance now reflects the full job envelope (`timestamp`, `id`, `name`, `payload`) that the producer actually sends.
- Drops the now-unused `MonitorQueueEvent` import in favour of `TQueueJobTypes`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is type-only with no runtime impact.

The change touches a single file and only corrects the TypeScript generic on the queue instance. The actual job data written to and read from Redis is unaffected, and the new type matches what the producer already sends.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Scheduler as MonitorScheduler
    participant Queue as MonitorQueue BullMQ
    participant Worker as Monitor Worker

    Scheduler->>Queue: queue.add(MonitorJob, envelope)
    Note over Queue: Queue typed as TQueueJobTypes[MonitorQueue]
    Queue-->>Worker: Job dequeued
    Worker->>Worker: parse job.data.payload
    Worker->>Worker: Process monitor event
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Scheduler as MonitorScheduler
    participant Queue as MonitorQueue BullMQ
    participant Worker as Monitor Worker

    Scheduler->>Queue: queue.add(MonitorJob, envelope)
    Note over Queue: Queue typed as TQueueJobTypes[MonitorQueue]
    Queue-->>Worker: Job dequeued
    Worker->>Worker: parse job.data.payload
    Worker->>Worker: Process monitor event
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(queue): type monitor queue payload w..."](https://github.com/langfuse/langfuse/commit/24be8717bd57e4ead79940492297f7ec9cd6c100) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39805650)</sub>

<!-- /greptile_comment -->