### PR TITLE
docs(agents): document clickhouse query tags

### DIFF
--- a/.agents/skills/clickhouse-best-practices/SKILL.md
+++ b/.agents/skills/clickhouse-best-practices/SKILL.md
@@ -32,6 +32,20 @@ Comprehensive guidance for ClickHouse covering schema design, query optimization
   you first confirm the query builder cannot express the query.
 - Never use `FINAL` on the `events` table; it is designed so `FINAL` is not
   required and the keyword hurts performance.
+- ClickHouse query attribution is stored in `system.query_log.log_comment` as
+  JSON from `packages/shared/src/server/clickhouse/queryTags.ts`. Parse it with
+  `JSONExtractString(log_comment, 'surface')`,
+  `JSONExtractString(log_comment, 'route')`, and
+  `JSONExtractString(log_comment, 'projectId')`. Known `surface` values are
+  `trpc`, `publicapi`, `worker`, `mcp`, and `unknown`; ClickhouseWriter inserts
+  use `projectId = "MULTI_PROJECT"`.
+- Query attribution is propagated through OpenTelemetry baggage. Entry points
+  call `contextWithLangfuseProps(...)` from
+  `packages/shared/src/server/headerPropagation.ts`, setting ClickHouse
+  `surface`, optional `route`, and optional `projectId`. The ClickHouse
+  repository layer then reads baggage via `normalizeClickHouseQueryTags(...)`
+  and writes it to `log_comment`. Prefer setting attribution at entry points
+  rather than passing tags through every repository call.
 - Any migration in `packages/shared/clickhouse/migrations/clustered/**` with
   more than one `ALTER` on the same table must end every metadata `ALTER`
   (`ADD/DROP/MODIFY COLUMN`, `ADD/DROP INDEX`) with `SETTINGS alter_sync = 2`,


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two new Langfuse-specific rules to the ClickHouse best-practices agent skill, documenting how query attribution is stored in `system.query_log.log_comment` and how it is propagated through OpenTelemetry baggage.

- The first added rule describes parsing `log_comment` JSON with `JSONExtractString` and lists known `surface` values (`trpc`, `publicapi`, `worker`, `mcp`, `unknown`) and the `MULTI_PROJECT` sentinel used by `ClickhouseWriter`.
- The second rule documents the baggage propagation path, but references a source file (`packages/shared/src/server/clickhouse/queryTags.ts`) and a function (`normalizeClickHouseQueryTags`) that do not exist anywhere in the repository, and misattributes `surface`/`route` setup to `contextWithLangfuseProps`, which does not set those fields in the current implementation.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Documentation-only change to an agent skill file, but two of the added rules cite a non-existent source file and a non-existent function, and mischaracterize a real function's behavior.

The added rules point agents to `queryTags.ts` and `normalizeClickHouseQueryTags`, neither of which exists in the codebase. An agent acting on this guidance will look in the wrong place or attempt to call a function that doesn't exist. The description of `contextWithLangfuseProps` as setting `surface` and `route` also contradicts its actual implementation. These inaccuracies undermine the skill's reliability.

.agents/skills/clickhouse-best-practices/SKILL.md — the two newly added bullet points need to reference the correct file (`packages/shared/src/server/repositories/clickhouse.ts`) and the correct helper (`tagsWithTraceId`), and the description of `contextWithLangfuseProps` needs to match its actual baggage keys.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant EP as Entry Point (tRPC / Public API / Worker)
    participant HP as headerPropagation.ts contextWithLangfuseProps()
    participant OTel as OpenTelemetry Baggage
    participant CH as clickhouse.ts queryClickhouse / insertClickhouse
    participant QL as system.query_log

    EP->>HP: "contextWithLangfuseProps({ projectId, userId, ... })"
    HP->>OTel: setBaggage(langfuse.project.id, langfuse.user.id, ...)
    EP->>CH: "query / insert with tags ({ surface, route, ... })"
    CH->>CH: tagsWithTraceId(tags) merge OTel traceId
    CH->>QL: "log_comment = JSON.stringify(mergedTags)"
    Note over QL: Queryable via JSONExtractString(log_comment, 'surface')
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant EP as Entry Point (tRPC / Public API / Worker)
    participant HP as headerPropagation.ts contextWithLangfuseProps()
    participant OTel as OpenTelemetry Baggage
    participant CH as clickhouse.ts queryClickhouse / insertClickhouse
    participant QL as system.query_log

    EP->>HP: "contextWithLangfuseProps({ projectId, userId, ... })"
    HP->>OTel: setBaggage(langfuse.project.id, langfuse.user.id, ...)
    EP->>CH: "query / insert with tags ({ surface, route, ... })"
    CH->>CH: tagsWithTraceId(tags) merge OTel traceId
    CH->>QL: "log_comment = JSON.stringify(mergedTags)"
    Note over QL: Queryable via JSONExtractString(log_comment, 'surface')
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.agents/skills/clickhouse-best-practices/SKILL.md:35-36
**Referenced file does not exist in the repository**

The documentation points to `packages/shared/src/server/clickhouse/queryTags.ts` as the source for the `log_comment` JSON structure, but no such file exists anywhere in the repo. The actual `log_comment` serialization happens in `packages/shared/src/server/repositories/clickhouse.ts` via the `tagsWithTraceId` helper. An agent following this skill would fail to find the referenced file and get a misleading picture of where the logic lives.

### Issue 2 of 2
.agents/skills/clickhouse-best-practices/SKILL.md:44-48
**`normalizeClickHouseQueryTags` does not exist, and `contextWithLangfuseProps` does not set `surface` or `route`**

Two issues in this block:

1. `normalizeClickHouseQueryTags(...)` is referenced as the ClickHouse repository layer's entry point for reading baggage, but a repo-wide search finds no such function anywhere in the codebase.

2. The current `contextWithLangfuseProps` implementation in `headerPropagation.ts` sets `langfuse.project.id`, `langfuse.user.id`, and `langfuse.api_key.id` in OTel baggage. It does **not** set `surface` or `route`. Any agent told to call `contextWithLangfuseProps` to populate the `surface` tag will be working from incorrect guidance.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): document clickhouse query ..."](https://github.com/langfuse/langfuse/commit/4ed260698f52e36031ddaa8c99ba4a7a98bd815a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39815260)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->