### PR TITLE
chore(worker): unify export volume into one egress-cost metric (LFE-10508)

### DIFF
--- a/worker/src/__tests__/exportVolumeMetric.test.ts
+++ b/worker/src/__tests__/exportVolumeMetric.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const recordIncrement = vi.fn();
+vi.mock("@langfuse/shared/src/server", () => ({
+  recordIncrement: (...args: unknown[]) => recordIncrement(...args),
+}));
+
+import {
+  recordExportVolume,
+  EXPORT_VOLUME_METRIC,
+} from "../services/exportVolumeMetric";
+
+describe("recordExportVolume", () => {
+  beforeEach(() => recordIncrement.mockClear());
+
+  it("emits the unified metric with the byte value", () => {
+    recordExportVolume({
+      integration: "mixpanel",
+      bytes: 1234,
+      projectId: "p1",
+    });
+    expect(recordIncrement).toHaveBeenCalledWith(EXPORT_VOLUME_METRIC, 1234, {
+      integration: "mixpanel",
+      projectId: "p1",
+    });
+  });
+
+  it("includes blob dimensions and omits undefined tags", () => {
+    recordExportVolume({
+      integration: "blob_storage",
+      bytes: 42,
+      projectId: "p2",
+      destinationType: "S3",
+      source: "json-gzip",
+      table: "traces",
+      path: "standard",
+    });
+    expect(recordIncrement).toHaveBeenCalledWith(EXPORT_VOLUME_METRIC, 42, {
+      integration: "blob_storage",
+      projectId: "p2",
+      destination_type: "S3",
+      source: "json-gzip",
+      table: "traces",
+      path: "standard",
+    });
+  });
+
+  it("omits API-integration tags that are not provided", () => {
+    recordExportVolume({
+      integration: "posthog",
+      bytes: 7,
+      projectId: "p3",
+    });
+    const tags = recordIncrement.mock.calls[0][2];
+    expect(tags).not.toHaveProperty("destination_type");
+    expect(tags).not.toHaveProperty("source");
+    expect(tags).not.toHaveProperty("table");
+  });
+});

--- a/worker/src/__tests__/mixpanelExportVolume.test.ts
+++ b/worker/src/__tests__/mixpanelExportVolume.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { gzipSync } from "zlib";
+import { MixpanelClient } from "../features/mixpanel/mixpanelClient";
+import type { MixpanelEvent } from "../features/mixpanel/transformers";
+
+describe("MixpanelClient export volume", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("accumulates gzipped on-wire bytes across sendBatch chunks", async () => {
+    const client = new MixpanelClient({ projectToken: "t", region: "api" });
+
+    // > batchSize (1000) so flush() splits into two sendBatch chunks.
+    const total = 1500;
+    const events: MixpanelEvent[] = Array.from(
+      { length: total },
+      (_, i) =>
+        ({
+          event: "trace",
+          properties: { token: "t", distinct_id: String(i), $insert_id: i },
+        }) as unknown as MixpanelEvent,
+    );
+    events.forEach((e) => client.addEvent(e));
+
+    await client.flush();
+
+    const expected =
+      gzipSync(JSON.stringify(events.slice(0, 1000))).length +
+      gzipSync(JSON.stringify(events.slice(1000))).length;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(client.getSerializedBytes()).toBe(expected);
+  });
+});

--- a/worker/src/__tests__/mixpanelIntegrationProjectJob.test.ts
+++ b/worker/src/__tests__/mixpanelIntegrationProjectJob.test.ts
@@ -59,6 +59,7 @@ vi.mock("../features/mixpanel/mixpanelClient", () => ({
       h.timeline.push("flush");
     });
     getBatchSize = vi.fn().mockReturnValue(0);
+    getSerializedBytes = vi.fn().mockReturnValue(0);
     constructor() {
       h.constructed.push(this);
     }
@@ -102,6 +103,7 @@ vi.mock("@langfuse/shared/src/db", () => ({
 vi.mock("@langfuse/shared/src/server", () => ({
   QueueName: { MixpanelIntegrationProcessingQueue: "mixpanel" },
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  recordIncrement: vi.fn(),
   getCurrentSpan: vi.fn(() => undefined),
   getTracesForAnalyticsIntegrations: vi.fn(() => h.fakeStream("traces")),
   getGenerationsForAnalyticsIntegrations: vi.fn(() =>

--- a/worker/src/__tests__/posthogExportVolume.test.ts
+++ b/worker/src/__tests__/posthogExportVolume.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { countingFetch } from "../features/posthog/handlePostHogIntegrationProjectJob";
+
+describe("countingFetch (posthog export volume)", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("counts /batch/ string and Blob bodies, ignores /flags/, forwards all", async () => {
+    const volume = { bytes: 0 };
+    const wrapped = countingFetch(volume)!;
+
+    await wrapped("https://app.posthog.com/batch/", {
+      method: "POST",
+      headers: {},
+      body: "abcd",
+    });
+    expect(volume.bytes).toBe(4);
+
+    await wrapped("https://app.posthog.com/batch/", {
+      method: "POST",
+      headers: {},
+      body: new Blob([new Uint8Array(10)]),
+    });
+    expect(volume.bytes).toBe(14);
+
+    // Feature-flag traffic must not be counted as export egress.
+    await wrapped("https://app.posthog.com/flags/?v=2", {
+      method: "POST",
+      headers: {},
+      body: "ignored",
+    });
+    expect(volume.bytes).toBe(14);
+
+    // Every request is still forwarded to the underlying fetch.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -59,6 +59,7 @@ import { env as sharedEnv } from "@langfuse/shared/src/env";
 import { randomUUID } from "crypto";
 import { SpanKind } from "@opentelemetry/api";
 import { env, v4AllowPreviewOptIn } from "../../env";
+import { recordExportVolume } from "../../services/exportVolumeMetric";
 
 export const BlobExportFormat = {
   JSON_RAW: "json-raw",
@@ -556,7 +557,9 @@ const processBlobStorageExport = async (config: {
           );
           recordGauge(
             "langfuse.blobstorage.export_heartbeat.serialized_bytes",
-            serializedCounter.bytes,
+            compressedCounter
+              ? compressedCounter.bytes
+              : serializedCounter.bytes,
             heartbeatTags,
           );
         }, HEARTBEAT_INTERVAL_MS);
@@ -785,28 +788,21 @@ const processBlobStorageExport = async (config: {
           const exportFormat = parquetEligible
             ? BlobExportFormat.PARQUET
             : resolveBlobExportFormat(config.fileType, config.compressed);
-          const byteTags = {
-            table: config.table,
+          // Unified export-volume metric: the actual uploaded volume per
+          // source (post-gzip size for compressed formats, raw/parquet size
+          // otherwise). destination_type (S3 / S3_COMPATIBLE / AZURE_*) splits
+          // the egress by data-transfer cost in the Datadog dashboard.
+          recordExportVolume({
+            integration: "blob_storage",
+            bytes: compressedCounter
+              ? compressedCounter.bytes
+              : serializedCounter.bytes,
             projectId: config.projectId,
-            path: exportPath,
+            destinationType: config.type,
             source: exportFormat,
-            // Integration type (S3 / S3_COMPATIBLE / AZURE_BLOB_STORAGE) as the
-            // destination, so export volume can be split by data-transfer cost
-            // in the Datadog dashboard (native AWS S3 vs. external egress).
-            destination_type: config.type,
-          };
-          recordIncrement(
-            "langfuse.blob_export.serialized_bytes",
-            serializedCounter.bytes,
-            byteTags,
-          );
-          if (compressedCounter && gzipStats) {
-            recordIncrement(
-              "langfuse.blob_export.compressed_bytes",
-              compressedCounter.bytes,
-              { ...byteTags, gzipLevel: gzipStats.level },
-            );
-          }
+            table: config.table,
+            path: exportPath,
+          });
 
           const uploadDurationMs = uploadDurationMsFinal;
           const chReadMs = Math.round(

--- a/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
+++ b/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
@@ -12,6 +12,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { decrypt } from "@langfuse/shared/encryption";
 import { MixpanelClient } from "./mixpanelClient";
+import { recordExportVolume } from "../../services/exportVolumeMetric";
 import {
   transformTraceForMixpanel,
   transformGenerationForMixpanel,
@@ -283,6 +284,12 @@ export const handleMixpanelIntegrationProjectJob = async (
       data: {
         lastSyncAt: executionConfig.maxTimestamp,
       },
+    });
+    // Record gzipped on-wire export volume once the run has succeeded.
+    recordExportVolume({
+      integration: "mixpanel",
+      bytes: mixpanel.getSerializedBytes(),
+      projectId,
     });
     logger.info(
       `[MIXPANEL] Mixpanel integration processing complete for project ${projectId}`,

--- a/worker/src/features/mixpanel/mixpanelClient.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.ts
@@ -15,9 +15,18 @@ export class MixpanelClient {
   private config: MixpanelClientConfig;
   private batch: MixpanelEvent[] = [];
   private batchSize = 1000; // Similar to PostHog's flushAt setting
+  // Gzipped on-wire bytes sent so far, for the export-volume metric.
+  private serializedBytes = 0;
 
   constructor(config: MixpanelClientConfig) {
     this.config = config;
+  }
+
+  /**
+   * Total gzipped on-wire bytes sent to Mixpanel across all flushes.
+   */
+  public getSerializedBytes(): number {
+    return this.serializedBytes;
   }
 
   /**
@@ -58,6 +67,8 @@ export class MixpanelClient {
 
     // Compress the body with gzip
     const compressedBody = gzipSync(body);
+    // Count the gzipped payload as on-wire export volume (sent below).
+    this.serializedBytes += compressedBody.length;
 
     // Create Basic Auth header (token as username, empty password)
     const authHeader = `Basic ${Buffer.from(`${this.config.projectToken}:`).toString("base64")}`;

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -53,12 +53,18 @@ export const countingFetch =
   (url, options) => {
     if (url.endsWith("/batch/")) {
       const body = options.body;
-      volume.bytes +=
-        typeof body === "string"
-          ? Buffer.byteLength(body)
-          : body instanceof Blob
-            ? body.size
-            : 0;
+      if (typeof body === "string") {
+        volume.bytes += Buffer.byteLength(body);
+      } else if (body instanceof Blob) {
+        volume.bytes += body.size;
+      } else {
+        // The SDK sends gzipped Blob bodies today; warn (rather than silently
+        // counting 0) if a future SDK version uses another body type, so the
+        // export-volume under-reporting is observable.
+        logger.warn(
+          `[POSTHOG] Unexpected /batch/ body type "${typeof body}"; export volume under-reported`,
+        );
+      }
     }
     return globalThis.fetch(url, options as RequestInit);
   };

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -19,6 +19,7 @@ import {
 } from "./transformers";
 import { decrypt } from "@langfuse/shared/encryption";
 import { PostHog } from "posthog-node";
+import { recordExportVolume } from "../../services/exportVolumeMetric";
 
 type PostHogExecutionConfig = {
   projectId: string;
@@ -31,11 +32,36 @@ type PostHogExecutionConfig = {
   // `grace_hash` (slower, but spills to disk) on retries so an OOM on the first
   // attempt recovers without manual intervention while healthy syncs stay fast.
   useGraceHash: boolean;
+  // Shared accumulator for gzipped on-wire upload volume, written by the
+  // fetch wrapper on each client and read once the run succeeds.
+  volume: { bytes: number };
 };
 
 const postHogSettings = {
   flushAt: 1000,
 };
+
+type PostHogClientOptions = NonNullable<
+  ConstructorParameters<typeof PostHog>[1]
+>;
+
+// Wrap the SDK's fetch transport to count gzipped on-wire upload volume for
+// the export-volume metric. The SDK gzips the /batch/ body by default and also
+// calls /flags/, so only /batch/ request bodies are measured (LFE-10508).
+export const countingFetch =
+  (volume: { bytes: number }): PostHogClientOptions["fetch"] =>
+  (url, options) => {
+    if (url.endsWith("/batch/")) {
+      const body = options.body;
+      volume.bytes +=
+        typeof body === "string"
+          ? Buffer.byteLength(body)
+          : body instanceof Blob
+            ? body.size
+            : 0;
+    }
+    return globalThis.fetch(url, options as RequestInit);
+  };
 
 const processPostHogTraces = async (config: PostHogExecutionConfig) => {
   const traces = getTracesForAnalyticsIntegrations(
@@ -54,6 +80,7 @@ const processPostHogTraces = async (config: PostHogExecutionConfig) => {
   const posthog = new PostHog(config.decryptedPostHogApiKey, {
     host: config.postHogHost,
     ...postHogSettings,
+    fetch: countingFetch(config.volume),
   });
 
   let sendError: Error | undefined;
@@ -102,6 +129,7 @@ const processPostHogGenerations = async (config: PostHogExecutionConfig) => {
   const posthog = new PostHog(config.decryptedPostHogApiKey, {
     host: config.postHogHost,
     ...postHogSettings,
+    fetch: countingFetch(config.volume),
   });
 
   let sendError: Error | undefined;
@@ -150,6 +178,7 @@ const processPostHogScores = async (config: PostHogExecutionConfig) => {
   const posthog = new PostHog(config.decryptedPostHogApiKey, {
     host: config.postHogHost,
     ...postHogSettings,
+    fetch: countingFetch(config.volume),
   });
 
   let sendError: Error | undefined;
@@ -197,6 +226,7 @@ const processPostHogEvents = async (config: PostHogExecutionConfig) => {
   const posthog = new PostHog(config.decryptedPostHogApiKey, {
     host: config.postHogHost,
     ...postHogSettings,
+    fetch: countingFetch(config.volume),
   });
 
   let sendError: Error | undefined;
@@ -324,6 +354,7 @@ export const handlePostHogIntegrationProjectJob = async (
     decryptedPostHogApiKey: decrypt(postHogIntegration.encryptedPosthogApiKey),
     postHogHost: postHogIntegration.posthogHostName,
     useGraceHash: job.attemptsMade > 0,
+    volume: { bytes: 0 },
   };
 
   try {
@@ -361,6 +392,12 @@ export const handlePostHogIntegrationProjectJob = async (
       data: {
         lastSyncAt: executionConfig.maxTimestamp,
       },
+    });
+    // Record gzipped on-wire export volume once the run has succeeded.
+    recordExportVolume({
+      integration: "posthog",
+      bytes: executionConfig.volume.bytes,
+      projectId,
     });
     logger.info(
       `[POSTHOG] PostHog integration processing complete for project ${projectId}`,

--- a/worker/src/services/exportVolumeMetric.ts
+++ b/worker/src/services/exportVolumeMetric.ts
@@ -1,0 +1,41 @@
+import { recordIncrement } from "@langfuse/shared/src/server";
+
+export const EXPORT_VOLUME_METRIC = "langfuse.export.serialized_bytes";
+
+export type ExportIntegration = "blob_storage" | "posthog" | "mixpanel";
+
+type ExportVolume = {
+  integration: ExportIntegration;
+  // Gzipped on-wire bytes the integration shipped this run.
+  bytes: number;
+  projectId: string;
+  // Egress-cost classification; blob only (S3 / S3_COMPATIBLE / AZURE_*).
+  destinationType?: string;
+  // Blob-only dimensions: export format, table, and codepath.
+  source?: string;
+  table?: string;
+  path?: string;
+};
+
+/**
+ * Single metric for total outbound export volume, so egress can be summed
+ * across integrations and split by `integration` / `destination_type` for
+ * cost. Undefined tags are omitted so each integration sets only the
+ * dimensions it has.
+ */
+export const recordExportVolume = ({
+  integration,
+  bytes,
+  projectId,
+  destinationType,
+  source,
+  table,
+  path,
+}: ExportVolume): void => {
+  const tags: Record<string, string> = { integration, projectId };
+  if (destinationType !== undefined) tags.destination_type = destinationType;
+  if (source !== undefined) tags.source = source;
+  if (table !== undefined) tags.table = table;
+  if (path !== undefined) tags.path = path;
+  recordIncrement(EXPORT_VOLUME_METRIC, bytes, tags);
+};


### PR DESCRIPTION
## What does this PR do?

Introduces a single Datadog metric `langfuse.export.serialized_bytes`
(tagged by `integration`) for total outbound export volume, attributable
to egress cost. Each integration that ships data **directly to an external
destination** emits its gzipped on-wire byte count via a shared
`recordExportVolume` helper, so `sum:langfuse.export.serialized_bytes{*}`
is true total egress.

- **blob_storage** — emits via the helper; renamed from
  `langfuse.blob_export.serialized_bytes`, and
  `langfuse.blob_export.compressed_bytes` removed (on-wire volume folded in).
- **mixpanel** — accumulates the gzipped request body
  (`compressedBody.length`) in the client.
- **posthog** — wraps the `posthog-node` `fetch` transport to measure the
  gzipped `/batch/` request body (ignores `/flags/`); no re-serialization.

Commits are split per integration for review.

**Out of scope:** batch export (worker upload is internal S3 transfer; the
egress is the customer's unobservable signed-URL download), webhooks, core
data S3 export, browser downloads.

## Type of change

- [x] Chore / internal change (observability only; no user-facing or API change)

## How to test

Unit tests cover the helper tag mapping, the Mixpanel byte accumulation,
and the PostHog fetch wrapper (`/batch/` counted, `/flags/` ignored,
requests forwarded). Worker typecheck + lint pass.

## Checklist

- [x] Worker typecheck + lint pass
- [x] Unit tests added (helper, Mixpanel, PostHog)
- [ ] Follow-up (separate, not this PR): update Datadog dashboards that
      reference the old `langfuse.blob_export.serialized_bytes` /
      `compressed_bytes` metric names

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates two separate blob-export metrics (`langfuse.blob_export.serialized_bytes` and `langfuse.blob_export.compressed_bytes`) into a single unified metric `langfuse.export.serialized_bytes` shared across the blob-storage, Mixpanel, and PostHog integrations. It also updates the blob-storage heartbeat gauge to reflect on-wire (post-gzip) bytes instead of pre-gzip bytes.

- **Unified metric (`exportVolumeMetric.ts`)**: Introduces `recordExportVolume` with integration-specific optional tags (`destination_type`, `source`, `table`, `path`). Undefined tags are omitted so each integration emits only relevant dimensions.
- **Mixpanel byte counting (`mixpanelClient.ts`)**: Accumulates gzipped payload length in `serializedBytes` inside `sendBatch`; exposed via `getSerializedBytes()` and read once the job succeeds.
- **PostHog byte counting (`handlePostHogIntegrationProjectJob.ts`)**: Wraps the SDK's `fetch` transport with `countingFetch` which intercepts `/batch/` URLs, tallies `string` or `Blob` body sizes into a shared `volume` object, and ignores `/flags/` traffic.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the metric consolidation is additive and the old metric names simply stop being emitted — no data path or export behaviour is altered.

The core export logic is unchanged; the only new risk is that `countingFetch` silently records zero bytes if the PostHog SDK ever sends a body type other than `string` or `Blob`. That would cause the posthog entry in the unified metric to under-report without any observable error, but it does not affect correctness of the actual data export.

worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts — the body-type fallthrough in `countingFetch` is worth a second look.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant BlobJob as Blob Storage Job
    participant PostHogJob as PostHog Job
    participant MixpanelJob as Mixpanel Job
    participant countingFetch as countingFetch wrapper
    participant PostHogSDK as PostHog SDK
    participant MixpanelClient as MixpanelClient
    participant recordExportVolume as recordExportVolume()
    participant recordIncrement as recordIncrement (Datadog)

    BlobJob->>BlobJob: stream → compress → upload
    BlobJob->>recordExportVolume: "bytes = compressedCounter ?? serializedCounter"
    recordExportVolume->>recordIncrement: langfuse.export.serialized_bytes

    PostHogJob->>PostHogJob: "init volume = {bytes:0}"
    PostHogJob->>PostHogSDK: "new PostHog(..., fetch=countingFetch(volume))"
    PostHogSDK->>countingFetch: "fetch('/batch/', {body: Blob|string})"
    countingFetch->>countingFetch: "volume.bytes += body.size"
    countingFetch->>PostHogSDK: globalThis.fetch(url, options)
    PostHogJob->>recordExportVolume: "bytes = volume.bytes (on success only)"
    recordExportVolume->>recordIncrement: langfuse.export.serialized_bytes

    MixpanelJob->>MixpanelClient: "addEvent() * N then flush()"
    MixpanelClient->>MixpanelClient: "gzipSync(batch) → serializedBytes +="
    MixpanelClient->>MixpanelClient: HTTP POST /import
    MixpanelJob->>recordExportVolume: "bytes = mixpanel.getSerializedBytes()"
    recordExportVolume->>recordIncrement: langfuse.export.serialized_bytes
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant BlobJob as Blob Storage Job
    participant PostHogJob as PostHog Job
    participant MixpanelJob as Mixpanel Job
    participant countingFetch as countingFetch wrapper
    participant PostHogSDK as PostHog SDK
    participant MixpanelClient as MixpanelClient
    participant recordExportVolume as recordExportVolume()
    participant recordIncrement as recordIncrement (Datadog)

    BlobJob->>BlobJob: stream → compress → upload
    BlobJob->>recordExportVolume: "bytes = compressedCounter ?? serializedCounter"
    recordExportVolume->>recordIncrement: langfuse.export.serialized_bytes

    PostHogJob->>PostHogJob: "init volume = {bytes:0}"
    PostHogJob->>PostHogSDK: "new PostHog(..., fetch=countingFetch(volume))"
    PostHogSDK->>countingFetch: "fetch('/batch/', {body: Blob|string})"
    countingFetch->>countingFetch: "volume.bytes += body.size"
    countingFetch->>PostHogSDK: globalThis.fetch(url, options)
    PostHogJob->>recordExportVolume: "bytes = volume.bytes (on success only)"
    recordExportVolume->>recordIncrement: langfuse.export.serialized_bytes

    MixpanelJob->>MixpanelClient: "addEvent() * N then flush()"
    MixpanelClient->>MixpanelClient: "gzipSync(batch) → serializedBytes +="
    MixpanelClient->>MixpanelClient: HTTP POST /import
    MixpanelJob->>recordExportVolume: "bytes = mixpanel.getSerializedBytes()"
    recordExportVolume->>recordIncrement: langfuse.export.serialized_bytes
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts:56-65
**Silent zero-bytes fallthrough for unknown body types**

The byte-counting falls through to `0` if the PostHog SDK sends a body that is neither a `string` nor a `Blob` (e.g., `Buffer`, `ArrayBuffer`, `ReadableStream`). This would cause the export-volume metric to silently under-report without any log or error. Currently the posthog-node SDK uses `Blob` bodies for compressed payloads (covered by the test), but this is an internal implementation detail that could change across SDK upgrades. A warning or explicit assertion would make the gap observable.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): record PostHog export vol..."](https://github.com/langfuse/langfuse/commit/0727d1d36ffd881c97ef831ccf55a52b3a5c6e20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39816024)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->