### PR TITLE
ci: Setup storybook deployment for main branch

### DIFF
--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -2,6 +2,9 @@ name: Storybook Preview
 
 on:
   workflow_dispatch: {}
+  push:
+    branches:
+      - main
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
@@ -16,6 +19,7 @@ jobs:
     name: Deploy Storybook preview
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: >-
+      (github.event_name == 'push' && github.ref_name == 'main') ||
       github.event_name == 'workflow_dispatch' ||
       (contains(github.event.pull_request.labels.*.name, 'storybook') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -27,7 +31,7 @@ jobs:
     steps:
       - name: Resolve pull request number
         id: resolve-pr-number
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.ref_name != 'main'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -71,6 +75,7 @@ jobs:
         id: publish
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || steps.resolve-pr-number.outputs.pr_number }}
+          STABLE_DEPLOYMENT: ${{ github.ref_name == 'main' && github.event_name != 'pull_request' }}
           VERCEL_ORG_ID: ${{ secrets.STORYBOOK_VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.STORYBOOK_VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.STORYBOOK_VERCEL_TOKEN }}
@@ -98,13 +103,19 @@ jobs:
             exit 1
           fi
 
-          preview_alias="pr-${PR_NUMBER}-storybook.langfuse.vercel.app"
+          if [ "${STABLE_DEPLOYMENT}" = "true" ]; then
+            preview_alias="storybook.langfuse.vercel.app"
+          else
+            preview_alias="pr-${PR_NUMBER}-storybook.langfuse.vercel.app"
+          fi
+
           vercel alias set "${preview_url}" "${preview_alias}" --scope langfuse
           preview_url="https://${preview_alias}"
 
           echo "url=${preview_url}" >> "$GITHUB_OUTPUT"
 
       - name: Comment preview link
+        if: github.event_name == 'pull_request' || steps.resolve-pr-number.outputs.pr_number != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PREVIEW_URL: ${{ steps.publish.outputs.url }}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the Storybook preview workflow to also deploy on pushes to the `main` branch, creating a stable deployment at `storybook.langfuse.vercel.app` in addition to the per-PR preview aliases.

- The `STABLE_DEPLOYMENT` flag differentiates main-branch runs from PR/branch runs, routing the Vercel alias and skipping PR comment posting when deploying from `main`.
- The `resolve-pr-number` step condition is tightened to exclude `workflow_dispatch` runs on `main`, which previously would have tried (and failed) to find a PR for the main branch itself.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a CI-only workflow addition with no impact on application code; it adds a new deployment path to a stable Storybook URL on merge to main.

All event-path combinations (push to main, workflow_dispatch on main, workflow_dispatch on a branch, pull_request) lead to a coherent and correct alias and comment-posting decision. The STABLE_DEPLOYMENT boolean-to-string expression is correctly consumed by the shell check, and the tightened resolve-pr-number condition cleanly prevents the previous silent failure when dispatching manually on main.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: Setup storybook deployment for main ..."](https://github.com/langfuse/langfuse/commit/61d36be0cfd600f91348bf8ea0c79ef4a3edf18a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39816399)</sub>

<!-- /greptile_comment -->