### PR TITLE
refactor: Enable & fix eslint `no-unneeded-ternary`

### DIFF
--- a/packages/config-eslint/base.js
+++ b/packages/config-eslint/base.js
@@ -46,6 +46,7 @@ export default tseslint.config(
     rules: {
       "no-void": "warn",
       "no-else-return": "warn",
+      "no-unneeded-ternary": "warn",
       "no-redeclare": "off",
       "import/order": "off",
     },

--- a/packages/config-eslint/next.js
+++ b/packages/config-eslint/next.js
@@ -84,6 +84,7 @@ export default [
     rules: {
       "no-void": "warn",
       "no-else-return": "warn",
+      "no-unneeded-ternary": "warn",
       "no-unused-vars": "off", // Use @typescript-eslint/no-unused-vars instead
       "@repo/no-tailwind-overflow-scroll": "warn",
       // Custom rules from old config

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -271,7 +271,7 @@ export const getScoresForSessions = async <
     clickhouseConfigs,
   });
 
-  const includeMetadataPayload = excludeMetadata ? false : true;
+  const includeMetadataPayload = !excludeMetadata;
   return rows.map((row) =>
     convertClickhouseScoreToDomain(row, includeMetadataPayload),
   );
@@ -320,7 +320,7 @@ export const getScoresForExperiments = async <
     clickhouseConfigs,
   });
 
-  const includeMetadataPayload = excludeMetadata ? false : true;
+  const includeMetadataPayload = !excludeMetadata;
   return rows.map((row) =>
     convertClickhouseScoreToDomain<ExcludeMetadata, AggregatableScoreDataType>(
       row,
@@ -551,7 +551,7 @@ const getScoresForTracesInternal = async <
     preferredClickhouseService,
   });
 
-  const includeMetadataPayload = excludeMetadata ? false : true;
+  const includeMetadataPayload = !excludeMetadata;
   return rows.map((row) => {
     const score = convertClickhouseScoreToDomain(
       {
@@ -684,7 +684,7 @@ export const getScoresForObservations = async <
     clickhouseConfigs,
   });
 
-  const includeMetadataPayload = excludeMetadata ? false : true;
+  const includeMetadataPayload = !excludeMetadata;
   return rows.map((row) => ({
     ...convertClickhouseScoreToDomain(
       {
@@ -1053,7 +1053,7 @@ export async function getScoresUiTable<
     ...rest,
   });
 
-  const includeMetadataPayload = excludeMetadata ? false : true;
+  const includeMetadataPayload = !excludeMetadata;
   return rows.map((row) => {
     const score = convertClickhouseScoreToDomain(
       {

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -639,7 +639,7 @@ export const createDatasetItemForApi = async ({
       sourceObservationId: input.sourceObservationId ?? undefined,
       status: input.status ?? undefined,
       normalizeOpts: { sanitizeControlChars: true },
-      validateOpts: { normalizeUndefinedToNull: !!input.id ? false : true },
+      validateOpts: { normalizeUndefinedToNull: !input.id },
     });
 
     if (auditScope) {

--- a/web/src/features/evals/components/code-eval-template-form-body.tsx
+++ b/web/src/features/evals/components/code-eval-template-form-body.tsx
@@ -157,7 +157,7 @@ const contractReadOnlyExtension = EditorState.changeFilter.of((tr) => {
     }
   }, true);
 
-  return touchesProtectedRange ? false : true;
+  return !touchesProtectedRange;
 });
 
 const contractReadOnlyExtensions = [contractReadOnlyExtension];

--- a/web/src/features/evals/components/template-form.tsx
+++ b/web/src/features/evals/components/template-form.tsx
@@ -215,7 +215,7 @@ export const InnerEvalTemplateForm = (props: {
   // If existing template has no provider, it was using default model
   const shouldUseDefaultModel =
     props.preFilledFormValues?.shouldUseDefaultModel ??
-    (props.preFilledFormValues?.selectedModel ? false : true);
+    !props.preFilledFormValues?.selectedModel;
 
   const { data: defaultModel } = api.defaultLlmModel.fetchDefaultModel.useQuery(
     { projectId: props.projectId },

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -811,7 +811,7 @@ export function useSidebarFilterState(
               column,
               type: "boolean" as const,
               operator: "=" as const,
-              value: invert ? false : true,
+              value: !invert,
             },
           ];
         }
@@ -822,7 +822,7 @@ export function useSidebarFilterState(
               column,
               type: "boolean" as const,
               operator: "=" as const,
-              value: invert ? true : false,
+              value: !!invert,
             },
           ];
         }


### PR DESCRIPTION
Resolves LFE-10516

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables the `no-unneeded-ternary` ESLint rule in both `base.js` and `next.js` configs and fixes all existing violations by replacing `x ? false : true` / `x ? true : false` patterns with their `!x` / `!!x` equivalents.

- **ESLint config**: Adds `"no-unneeded-ternary": "warn"` to both configs and introduces a `legacy-deprecated-suppressions` override block (with `reportUnusedDisableDirectives: "off"`) for files that have pre-existing `eslint-disable` comments that would become "unused" under the new rule.
- **Code fixes in 5 files**: All conversions are mechanical and semantically equivalent — `excludeMetadata ? false : true` → `!excludeMetadata`, `invert ? false : true` → `!invert`, etc., across `scores.ts`, `publicDatasetService.ts`, `code-eval-template-form-body.tsx`, `template-form.tsx`, and `useSidebarFilterState.tsx`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

All changes are mechanical boolean simplifications with no semantic difference; the ESLint config additions are additive and scoped.

Every ternary-to-negation replacement is semantically identical to its original: `x ? false : true` === `!x` and `x ? true : false` === `!!x` in all cases touched here. The legacy-suppressions override is a deliberate escape hatch for pre-existing disable comments in files not yet migrated — the comment explains the intent. No logic, data flow, or API contract is altered.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ESLint config change\n(base.js / next.js)"] --> B["Add no-unneeded-ternary: warn"]
    A --> C["Add legacy-deprecated-suppressions\noverride for files with\nexisting eslint-disable comments"]
    B --> D["Triggers violations in 5 files"]
    D --> E["scores.ts\nexcludeMetadata ? false : true\n→ !excludeMetadata"]
    D --> F["publicDatasetService.ts\n!!input.id ? false : true\n→ !input.id"]
    D --> G["code-eval-template-form-body.tsx\ntouchesProtectedRange ? false : true\n→ !touchesProtectedRange"]
    D --> H["template-form.tsx\nselectedModel ? false : true\n→ !selectedModel"]
    D --> I["useSidebarFilterState.tsx\ninvert ? false : true → !invert\ninvert ? true : false → !!invert"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["ESLint config change\n(base.js / next.js)"] --> B["Add no-unneeded-ternary: warn"]
    A --> C["Add legacy-deprecated-suppressions\noverride for files with\nexisting eslint-disable comments"]
    B --> D["Triggers violations in 5 files"]
    D --> E["scores.ts\nexcludeMetadata ? false : true\n→ !excludeMetadata"]
    D --> F["publicDatasetService.ts\n!!input.id ? false : true\n→ !input.id"]
    D --> G["code-eval-template-form-body.tsx\ntouchesProtectedRange ? false : true\n→ !touchesProtectedRange"]
    D --> H["template-form.tsx\nselectedModel ? false : true\n→ !selectedModel"]
    D --> I["useSidebarFilterState.tsx\ninvert ? false : true → !invert\ninvert ? true : false → !!invert"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: Fix \`no-unneeded-ternary\` issu..."](https://github.com/langfuse/langfuse/commit/efb1e240ac44d12e556363ac1f1ed1b9322ead53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39822092)</sub>

<!-- /greptile_comment -->