### PR TITLE
refactor(api): deduplicate comma-separated query parsing

### DIFF
--- a/packages/shared/src/features/scores/interfaces/api/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/api/shared.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { publicApiPaginationZod } from "../../../../utils/zod";
+import {
+  commaSeparatedEnumArray,
+  publicApiPaginationZod,
+} from "../../../../utils/zod";
 import { stringDateTime } from "../../../../utils/typeChecks";
 import { applyScoreValidation } from "../../../../utils/scores";
 import { PostScoreBodyFoundationSchema } from "../shared";
@@ -18,7 +21,6 @@ import { InvalidRequestError } from "../../../../errors";
 const operators = ["<", ">", "<=", ">=", "!=", "="] as const;
 
 export const SCORE_FIELD_GROUPS = ["score", "trace"] as const;
-export type ScoreFieldGroup = (typeof SCORE_FIELD_GROUPS)[number];
 
 /**
  * Endpoints
@@ -51,17 +53,9 @@ export const GetScoresQuery = z.object({
       message: "Each score ID must be a string",
     })
     .nullish(),
-  fields: z
-    .string()
-    .nullish()
-    .transform((v) => {
-      if (!v) return null;
-      return v
-        .split(",")
-        .map((f) => f.trim())
-        .filter((f) => SCORE_FIELD_GROUPS.includes(f as ScoreFieldGroup));
-    })
-    .pipe(z.array(z.enum(SCORE_FIELD_GROUPS)).nullable()),
+  fields: commaSeparatedEnumArray(SCORE_FIELD_GROUPS, null, {
+    unknownValues: "filter",
+  }),
   filter: z
     .string()
     .optional()

--- a/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
@@ -3,6 +3,11 @@ import {
   ScoreDataTypeArray,
   ScoreSourceArray,
 } from "../../../../../domain/scores";
+import {
+  commaSeparatedEnumArray,
+  optionalCommaSeparatedStringArray,
+  publicApiPaginationLimitZod,
+} from "../../../../../utils/zod";
 import { APIScoreSchemaV3 } from "./schemas";
 
 export const SCORE_FIELD_GROUPS_V3 = [
@@ -13,21 +18,7 @@ export const SCORE_FIELD_GROUPS_V3 = [
 ] as const;
 export type ScoreFieldGroupV3 = (typeof SCORE_FIELD_GROUPS_V3)[number];
 
-const fieldsParam = z
-  .string()
-  .optional()
-  .transform((val) => (val ? val.split(",").map((g) => g.trim()) : ["core"]))
-  .pipe(z.array(z.enum(SCORE_FIELD_GROUPS_V3)));
-
-const csvStringParam = z
-  .string()
-  .transform((val) =>
-    val
-      .split(",")
-      .map((v) => v.trim())
-      .filter((v) => v.length > 0),
-  )
-  .optional();
+const fieldsParam = commaSeparatedEnumArray(SCORE_FIELD_GROUPS_V3, ["core"]);
 
 // Accepts case-insensitive input for uppercase enum allowedValues (e.g. "api"
 // or "API" both parse to "API"). Downstream code only sees the canonical form.
@@ -62,19 +53,19 @@ const csvEnumParam = <T extends readonly string[]>(
 // cross-field superRefine validation lives in the handler.
 export const GetScoresQueryV3 = z
   .object({
-    limit: z.coerce.number().int().positive().max(100).default(50),
+    limit: publicApiPaginationLimitZod,
     fields: fieldsParam,
     // Identifier filters (multi-value, comma-separated)
-    id: csvStringParam,
-    name: csvStringParam,
+    id: optionalCommaSeparatedStringArray,
+    name: optionalCommaSeparatedStringArray,
     source: csvEnumParam(ScoreSourceArray, "source"),
     dataType: csvEnumParam(ScoreDataTypeArray, "dataType"),
-    environment: csvStringParam,
-    configId: csvStringParam,
-    queueId: csvStringParam,
-    authorUserId: csvStringParam,
+    environment: optionalCommaSeparatedStringArray,
+    configId: optionalCommaSeparatedStringArray,
+    queueId: optionalCommaSeparatedStringArray,
+    authorUserId: optionalCommaSeparatedStringArray,
     // Value filters
-    value: csvStringParam,
+    value: optionalCommaSeparatedStringArray,
     // Treat empty string as absent so `?valueMin=` doesn't silently coerce to 0
     // and narrow results to `value >= 0`. Zod 4 rejects ±Infinity / NaN out of
     // the box, so `.finite()` is not needed.
@@ -87,10 +78,10 @@ export const GetScoresQueryV3 = z
       z.coerce.number().optional(),
     ),
     // Entity-bounded filters
-    traceId: csvStringParam,
-    sessionId: csvStringParam,
-    observationId: csvStringParam,
-    experimentId: csvStringParam,
+    traceId: optionalCommaSeparatedStringArray,
+    sessionId: optionalCommaSeparatedStringArray,
+    observationId: optionalCommaSeparatedStringArray,
+    experimentId: optionalCommaSeparatedStringArray,
     // Timestamp filters — preprocess empty string to undefined so ?fromTimestamp=
     // from a templating system is treated as absent, consistent with valueMin/valueMax.
     fromTimestamp: z.preprocess(

--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -39,15 +39,19 @@ export const jsonSchema: z.ZodType<Json> = z.lazy(() =>
   ]),
 );
 
+export const paginationLimitZod = z.preprocess(
+  (x) => (x === "" ? undefined : x),
+  z.coerce.number().int().gte(1).lte(100).default(50),
+);
+
+export const publicApiPaginationLimitZod = paginationLimitZod;
+
 export const paginationZod = {
   page: z.preprocess(
     (x) => (x === "" ? undefined : x),
     z.coerce.number().nonnegative().default(1),
   ),
-  limit: z.preprocess(
-    (x) => (x === "" ? undefined : x),
-    z.coerce.number().gte(1).lte(100).default(50),
-  ),
+  limit: paginationLimitZod,
 };
 
 export const publicApiPaginationZod = {
@@ -55,11 +59,65 @@ export const publicApiPaginationZod = {
     (x) => (x === "" ? undefined : x),
     z.coerce.number().gt(0).default(1),
   ),
-  limit: z.preprocess(
-    (x) => (x === "" ? undefined : x),
-    z.coerce.number().gte(1).lte(100).default(50),
-  ),
+  limit: publicApiPaginationLimitZod,
 };
+
+const splitCommaSeparatedQueryParam = (value: string) =>
+  value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+export const optionalCommaSeparatedStringArray = z
+  .string()
+  .nullish()
+  .transform((value) => {
+    if (!value) return undefined;
+
+    const values = splitCommaSeparatedQueryParam(value);
+    return values.length > 0 ? values : undefined;
+  });
+
+type CommaSeparatedEnumArrayOptions = {
+  unknownValues?: "reject" | "filter";
+};
+
+type CommaSeparatedEnumArrayOutput<
+  TValues extends readonly [string, ...string[]],
+  TDefault extends Array<TValues[number]> | null,
+> = TDefault extends null
+  ? Array<TValues[number]> | null
+  : Array<TValues[number]>;
+
+export function commaSeparatedEnumArray<
+  const TValues extends readonly [string, ...string[]],
+  const TDefault extends Array<TValues[number]> | null,
+>(
+  values: TValues,
+  defaultValue: TDefault,
+  options?: CommaSeparatedEnumArrayOptions,
+): z.ZodType<CommaSeparatedEnumArrayOutput<TValues, TDefault>> {
+  const arraySchema = z.array(z.enum(values));
+  const schema =
+    defaultValue === null
+      ? arraySchema.nullable().default(null)
+      : arraySchema.default(defaultValue);
+
+  return z.preprocess((value) => {
+    if (value === null || value === undefined || value === "") return undefined;
+    if (typeof value !== "string") return value;
+
+    const items = splitCommaSeparatedQueryParam(value);
+
+    if (options?.unknownValues === "filter") {
+      return items.filter((item): item is TValues[number] =>
+        values.includes(item as TValues[number]),
+      );
+    }
+
+    return items;
+  }, schema) as z.ZodType<CommaSeparatedEnumArrayOutput<TValues, TDefault>>;
+}
 
 export const optionalPaginationZod = {
   page: z

--- a/web/src/__tests__/server/zod.servertest.ts
+++ b/web/src/__tests__/server/zod.servertest.ts
@@ -1,7 +1,10 @@
 import {
+  commaSeparatedEnumArray,
   isJsonNumberLiteral,
+  optionalCommaSeparatedStringArray,
   paginationZod,
   parseJsonPrioritised,
+  publicApiPaginationLimitZod,
 } from "@langfuse/shared";
 import { ZodError } from "zod";
 
@@ -27,6 +30,63 @@ describe("Pagination Zod Schema", () => {
     expect(() => paginationZod.page.parse("abc")).toThrow(ZodError);
     expect(() => paginationZod.limit.parse("abc")).toThrow(ZodError);
     expect(() => paginationZod.limit.parse("0")).toThrow(ZodError);
+    expect(() => paginationZod.limit.parse("1.5")).toThrow(ZodError);
+  });
+});
+
+describe("Public API pagination limit Zod Schema", () => {
+  it("validates integer limits with public API defaults", () => {
+    expect(publicApiPaginationLimitZod.parse("20")).toBe(20);
+    expect(publicApiPaginationLimitZod.parse("")).toBe(50);
+    expect(() => publicApiPaginationLimitZod.parse("1.5")).toThrow(ZodError);
+    expect(() => publicApiPaginationLimitZod.parse("101")).toThrow(ZodError);
+  });
+});
+
+describe("Comma-separated query parameter Zod schemas", () => {
+  it("parses optional comma-separated string arrays", () => {
+    expect(optionalCommaSeparatedStringArray.parse("a, b,,c ")).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+    expect(optionalCommaSeparatedStringArray.parse("")).toBeUndefined();
+    expect(optionalCommaSeparatedStringArray.parse(undefined)).toBeUndefined();
+  });
+
+  it("parses comma-separated enum arrays with defaults", () => {
+    const schema = commaSeparatedEnumArray(["core", "metadata"] as const, [
+      "core",
+    ]);
+
+    expect(schema.parse("core, metadata")).toEqual(["core", "metadata"]);
+    expect(schema.parse(undefined)).toEqual(["core"]);
+    expect(() => schema.parse("core,invalid")).toThrow(ZodError);
+  });
+
+  it("can filter unknown comma-separated enum values", () => {
+    const schema = commaSeparatedEnumArray(
+      ["core", "metadata"] as const,
+      ["core"],
+      { unknownValues: "filter" },
+    );
+
+    expect(schema.parse("core, invalid,metadata")).toEqual([
+      "core",
+      "metadata",
+    ]);
+    expect(schema.parse("invalid")).toEqual([]);
+  });
+
+  it("supports null defaults for omitted comma-separated enum values", () => {
+    const schema = commaSeparatedEnumArray(
+      ["core", "metadata"] as const,
+      null,
+      { unknownValues: "filter" },
+    );
+
+    expect(schema.parse(undefined)).toBeNull();
+    expect(schema.parse("invalid")).toEqual([]);
   });
 });
 

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -321,9 +321,9 @@ export const GetObservationsV2Query = z.object({
   }),
   // Metadata expansion keys (optional)
   // Comma-separated list of metadata keys to return non-truncated: expandMetadata=transcript,steps
-  expandMetadata: z
-    .union([optionalCommaSeparatedStringArray, z.null()])
-    .transform((keys) => keys ?? null),
+  expandMetadata: optionalCommaSeparatedStringArray.transform(
+    (keys) => keys ?? null,
+  ),
   // Pagination
   limit: z.coerce.number().nonnegative().lte(1000).default(50),
   cursor: EncodedObservationsCursorV2.optional(),

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -1,22 +1,22 @@
 import {
   type Observation,
+  commaSeparatedEnumArray,
   type EventsObservation,
+  OBSERVATION_FIELD_GROUPS_PUBLIC_API,
   ObservationLevel,
   eventsTableSingleFilter,
+  optionalCommaSeparatedStringArray,
   paginationMetaResponseZod,
   publicApiPaginationZod,
   singleFilter,
   InvalidRequestError,
+  type ObservationFieldGroupPublicApi,
 } from "@langfuse/shared";
 import {
   reduceUsageOrCostDetails,
   stringDateTime,
   type ObservationPriceFields,
 } from "@langfuse/shared/src/server";
-import {
-  OBSERVATION_FIELD_GROUPS_PUBLIC_API,
-  type ObservationFieldGroupPublicApi,
-} from "@langfuse/shared";
 import { z } from "zod";
 import { useEventsTableSchema } from "@langfuse/shared/query";
 
@@ -316,35 +316,14 @@ export const encodeCursor = (
 export const GetObservationsV2Query = z.object({
   // Field groups parameter (optional - defaults to all groups)
   // Comma-separated list of field groups: fields=basic,metadata,io
-  fields: z
-    .string()
-    .nullish()
-    .transform((v) => {
-      if (!v) return null;
-      return v
-        .split(",")
-        .map((f) => f.trim())
-        .filter((f): f is ObservationFieldGroupPublicApi =>
-          OBSERVATION_FIELD_GROUPS_PUBLIC_API.includes(
-            f as ObservationFieldGroupPublicApi,
-          ),
-        );
-    })
-    .pipe(z.array(z.enum(OBSERVATION_FIELD_GROUPS_PUBLIC_API)).nullable()),
+  fields: commaSeparatedEnumArray(OBSERVATION_FIELD_GROUPS_PUBLIC_API, null, {
+    unknownValues: "filter",
+  }),
   // Metadata expansion keys (optional)
   // Comma-separated list of metadata keys to return non-truncated: expandMetadata=transcript,steps
   expandMetadata: z
-    .string()
-    .nullish()
-    .transform((v) => {
-      if (!v) return null;
-      const keys = v
-        .split(",")
-        .map((k) => k.trim())
-        .filter((k) => k.length > 0);
-      return keys.length > 0 ? keys : null;
-    })
-    .pipe(z.array(z.string()).nullable()),
+    .union([optionalCommaSeparatedStringArray, z.null()])
+    .transform((keys) => keys ?? null),
   // Pagination
   limit: z.coerce.number().nonnegative().lte(1000).default(50),
   cursor: EncodedObservationsCursorV2.optional(),

--- a/web/src/features/public-api/types/traces.ts
+++ b/web/src/features/public-api/types/traces.ts
@@ -1,6 +1,7 @@
 import { APIObservation } from "@/src/features/public-api/types/observations";
 import {
   APIScoreSchemaV1,
+  commaSeparatedEnumArray,
   paginationMetaResponseZod,
   orderBy,
   publicApiPaginationZod,
@@ -11,7 +12,6 @@ import {
   stringDateTime,
   TraceBody,
   TRACE_FIELD_GROUPS,
-  type TraceFieldGroup,
 } from "@langfuse/shared/src/server";
 import { z } from "zod";
 import { useEventsTableSchema } from "@langfuse/shared/query";
@@ -80,18 +80,9 @@ export const GetTracesV1Query = z.object({
       return { column, order: order?.toUpperCase() };
     })
     .pipe(orderBy.nullable()),
-  fields: z
-    .string()
-    .nullish()
-    .transform((v) => {
-      if (!v) return null;
-      const parsed = v
-        .split(",")
-        .map((f) => f.trim())
-        .filter((f) => TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup));
-      return parsed.length > 0 ? parsed : null;
-    })
-    .pipe(z.array(z.enum(TRACE_FIELD_GROUPS)).nullable()),
+  fields: commaSeparatedEnumArray(TRACE_FIELD_GROUPS, null, {
+    unknownValues: "filter",
+  }).transform((fields) => (fields && fields.length > 0 ? fields : null)),
   useEventsTable: useEventsTableSchema,
   filter: z
     .string()
@@ -122,18 +113,9 @@ export const PostTracesV1Response = z.object({ id: z.string() });
 // GET /api/public/traces/{traceId}
 export const GetTraceV1Query = z.object({
   traceId: z.string(),
-  fields: z
-    .string()
-    .nullish()
-    .transform((v) => {
-      if (!v) return null;
-      const parsed = v
-        .split(",")
-        .map((f) => f.trim())
-        .filter((f) => TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup));
-      return parsed.length > 0 ? parsed : null;
-    })
-    .pipe(z.array(z.enum(TRACE_FIELD_GROUPS)).nullable()),
+  fields: commaSeparatedEnumArray(TRACE_FIELD_GROUPS, null, {
+    unknownValues: "filter",
+  }).transform((fields) => (fields && fields.length > 0 ? fields : null)),
 });
 export const GetTraceV1Response = APIExtendedTrace.extend({
   scores: z.array(APIScoreSchemaV1),


### PR DESCRIPTION
## Summary

- Add shared Zod helpers for public API pagination limits and comma-separated query parameters.
- Reuse the enum/string CSV helpers across traces, observations, and scores public API schemas.
- Cover the helper behavior for defaults, unknown-value filtering, rejection, and pagination limits.

## Verification

- pnpm --filter @langfuse/shared run typecheck
- pnpm --filter web run typecheck
- pnpm --filter @langfuse/shared run lint
- pnpm --filter web run lint
- pnpm --filter web exec vitest run --project server src/__tests__/server/zod.servertest.ts

## Impacted Packages

- packages/shared
- web

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts repeated inline comma-separated query-parameter parsing into three shared Zod helpers (`paginationLimitZod`/`publicApiPaginationLimitZod`, `optionalCommaSeparatedStringArray`, `commaSeparatedEnumArray`) and replaces duplicated logic across traces, observations, and scores schemas.

- **New helpers in `packages/shared/src/utils/zod.ts`**: `commaSeparatedEnumArray` is a generic factory supporting both "filter" and "reject" modes for unknown enum values; `optionalCommaSeparatedStringArray` normalises null/undefined/empty-string to `undefined`; `paginationLimitZod` is shared by both internal and public-API pagination and now additionally enforces `.int()`.
- **Behavioural deltas worth noting**: (1) `paginationZod.limit` silently gains the `.int()` constraint because it now delegates to `paginationLimitZod` — float strings like `"1.5"` that were previously accepted are now rejected (the new test explicitly covers this). (2) Empty-string `""` on nullable CSV fields in `GetScoresQueryV3` (e.g. `id`, `name`) now yields `undefined` instead of `[]`, though both are treated as "no filter" downstream.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a pure refactoring that preserves existing parse behaviour across all affected endpoints, with two small style-level observations flagged but no functional regressions.

All replaced inline schemas produce identical outputs for the inputs that matter at runtime. The one concrete behaviour gap — paginationZod.limit now rejecting floats — is intentional and covered by a new test. The z.null() dead-code branch in expandMetadata is harmless but avoidable.

web/src/features/public-api/types/observations.ts for the unreachable z.null() branch; packages/shared/src/utils/zod.ts for the alias direction between paginationLimitZod and publicApiPaginationLimitZod.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Query param input] --> B{null / undefined / empty string?}
    B -- yes --> C[return undefined]
    C --> D[Schema applies default]
    D --> E{defaultValue === null?}
    E -- yes --> F[Output: null]
    E -- no --> G[Output: defaultValue array]
    B -- no --> H{typeof value !== string?}
    H -- yes --> I[Pass value through unchanged]
    I --> J[z.array z.enum validation]
    H -- no --> K[splitCommaSeparatedQueryParam]
    K --> L{unknownValues: filter?}
    L -- yes --> M[Filter items not in enum values]
    L -- no --> N[Keep all items as-is]
    M --> O[z.array z.enum validation]
    N --> O
    O --> P[Output: TValues array]
    J --> P
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Query param input] --> B{null / undefined / empty string?}
    B -- yes --> C[return undefined]
    C --> D[Schema applies default]
    D --> E{defaultValue === null?}
    E -- yes --> F[Output: null]
    E -- no --> G[Output: defaultValue array]
    B -- no --> H{typeof value !== string?}
    H -- yes --> I[Pass value through unchanged]
    I --> J[z.array z.enum validation]
    H -- no --> K[splitCommaSeparatedQueryParam]
    K --> L{unknownValues: filter?}
    L -- yes --> M[Filter items not in enum values]
    L -- no --> N[Keep all items as-is]
    M --> O[z.array z.enum validation]
    N --> O
    O --> P[Output: TValues array]
    J --> P
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/public-api/types/observations.ts:324-326
The `z.null()` branch in this union is unreachable. `optionalCommaSeparatedStringArray` is built on `z.string().nullish()`, which already accepts `null` and returns `undefined` for it (via the `!value` check). Zod's `z.union` tries branches in order, so `z.null()` is never consulted. The simplest equivalent is to drop the union and transform directly.

```suggestion
  expandMetadata: optionalCommaSeparatedStringArray.transform(
    (keys) => keys ?? null,
  ),
```

### Issue 2 of 2
packages/shared/src/utils/zod.ts:42-47
`publicApiPaginationLimitZod` is a direct alias for `paginationLimitZod` rather than a separate definition, which means any future change to the internal pagination schema automatically changes the public API contract. The public API limit is typically a stable surface; keeping these as two independent definitions (or making `paginationLimitZod` delegate to `publicApiPaginationLimitZod`) makes the intended layering clearer and prevents unintended coupling.

```suggestion
export const publicApiPaginationLimitZod = z.preprocess(
  (x) => (x === "" ? undefined : x),
  z.coerce.number().int().gte(1).lte(100).default(50),
);

export const paginationLimitZod = publicApiPaginationLimitZod;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(api): deduplicate comma-separat..."](https://github.com/langfuse/langfuse/commit/8b737949859007cedf109827591357beaa5bcbc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39822739)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->