### PR TITLE
fix(trace): make Log View JSON (classic) pane scroll to the bottom

### DIFF
--- a/web/src/components/trace/components/TraceLogView/LogViewJsonMode.tsx
+++ b/web/src/components/trace/components/TraceLogView/LogViewJsonMode.tsx
@@ -70,6 +70,13 @@ export const LogViewJsonMode = memo(function LogViewJsonMode({
       )}
 
       {/* JSON view */}
+      {/*
+        The `flex-1 overflow-y-auto` wrapper is the single owner of the bounded
+        vertical scroll. JSONView must therefore render at its natural content
+        height — passing `h-full`/`min-h-full` would clamp it to the wrapper's
+        visible height (JSONView's root carries `max-h-full min-h-0`), leaving
+        no overflow and making tall JSON unscrollable (LFE-10513).
+      */}
       {data && !isLoading && (
         <div className="flex-1 overflow-y-auto">
           <JSONView
@@ -77,8 +84,7 @@ export const LogViewJsonMode = memo(function LogViewJsonMode({
             scrollable={false}
             externalJsonCollapsed={isCollapsed}
             onToggleCollapse={onToggleCollapse}
-            className="h-full [&_.io-message-content]:border-none"
-            codeClassName="min-h-full"
+            className="[&_.io-message-content]:border-none"
           />
         </div>
       )}


### PR DESCRIPTION
## TL;DR
The classic **JSON** mode of the trace **Log View** couldn't scroll — the top of a large JSON rendered, but the lower content was unreachable. This makes the pane scroll all the way to the bottom, with a one-line layout fix. The **Formatted** view (the user workaround) is untouched.

## Why
In a trace's detail/peek view, **Log View → JSON** (with Beta OFF) renders all observations as one JSON object. For any JSON tall enough to overflow the pane, you'd see the start and be stuck — the rest was permanently below the fold. A developer tool's JSON viewer that can't scroll is a rough edge. The Formatted view scrolled fine, so the surrounding container's height chain was healthy; the bug was local to the JSON-classic DOM. (These files hadn't changed in months — this was a longstanding bug, not a regression.)

## What
The JSON pane had **two competing scroll owners**: an outer `flex-1 overflow-y-auto` wrapper *and* a `JSONView` that was told `className="h-full"` + `codeClassName="min-h-full"`. Combined with `JSONView`'s own `max-h-full min-h-0`, the content got clamped to exactly the wrapper's visible height — so the scroll container had no overflow and there was nothing to scroll.

The fix makes the `flex-1 overflow-y-auto` wrapper the **single** owner of the bounded vertical scroll, and lets `JSONView` render at its natural content height by dropping the two height-locking classes. Minimal, layout-ownership only — no refactor.

## Result
Verified live in the browser against a trace with a large JSON:
- **JSON-classic pane:** scroll container now has real overflow (content `~9400px` in a `~600px` pane) and scrolls all the way to the bottom.
- **Formatted view:** still scrolls, unchanged.
- Before the fix, the same trace produced **no** scroll container with overflow (reproduced the bug); after, it scrolls to the bottom.

<details>
<summary>Mechanism & verification detail</summary>

**Render path:** `TraceDetailView` → `TraceLogView` (renders `LogViewJsonMode` when `currentView === "json"` and the trace is non-virtualized) → `LogViewJsonMode` → `JSONView` (`CodeJsonViewer.tsx`).

**Root cause:** `JSONView`'s root carries `flex max-h-full min-h-0 flex-col`. Passing it `className="h-full"` added `h-full`, and `codeClassName="min-h-full"` forced the body to fill — together clamping the rendered JSON to the parent's visible height. With the content height-locked to the viewport, the outer `flex-1 overflow-y-auto` had zero overflow, so scrolling was impossible.

**Fix:** remove `h-full` from `className` and drop `codeClassName="min-h-full"`. The content now grows to its natural height; the existing `flex-1 overflow-y-auto` wrapper does the scrolling.

**Verification:** drove a real headless Chromium against a local dev server — signed in, opened the trace's Log View, toggled to JSON (Beta OFF), then measured the nearest scrollable ancestor of the rendered JSON body. Fixed: `scrollHeight 9397 / clientHeight 606`, scrolled `0 → 8791`, reached bottom. Reverting the change on the same trace: no scroll container with overflow (bug reproduced). Formatted view scrolls in both. Lint + typecheck + existing Log View client tests pass.

**Follow-up (separate, noted for triage):** in the Log View, the JSON **Beta** toggle renders the expandable table view and virtualizes by *observation count*, not by JSON size — so a trace with few observations but one very large JSON isn't virtualized there. That's the current intended design of the Log View Beta path (the advanced I/O viewer lives in expandable rows); making the single-JSON Beta path virtualize large payloads is a larger change and out of scope for this scroll fix.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes the non-scrollable JSON pane in the classic Log View by removing two classes (`h-full` on `className`, `min-h-full` on `codeClassName`) that conflicted with `JSONView`'s own `max-h-full min-h-0` root, clamping content to the visible viewport and defeating the outer scroll container.

- **Root cause resolved**: with the `h-full` + `max-h-full` combination removed, `JSONView` now renders at its natural content height, giving the `flex-1 overflow-y-auto` wrapper real overflow to scroll.
- **Scope**: one component, two class removals, one explanatory comment — no logic or API surface changed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — two class removals in one component, no logic changes, scroll behavior now works as intended.

The change is a minimal, well-understood CSS layout fix. Removing h-full and min-h-full from JSONView eliminates the conflict with the component's own max-h-full min-h-0 root and correctly delegates vertical scroll ownership to the single overflow-y-auto wrapper. The Formatted view path is untouched. The inline comment clearly documents the invariant for future maintainers.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): make Log View JSON (classic)..."](https://github.com/langfuse/langfuse/commit/3c2cd3da3ca7604b7b4f7776a0ca7dd78613cd19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39827933)</sub>

<!-- /greptile_comment -->