### PR TITLE
chore: enforce release safety-gate parity with release:cloud

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "playwright:install": "pnpm --filter web exec playwright install chromium",
     "storybook": "pnpm --filter web run storybook",
     "test": "turbo run test",
-    "release": "dotenv -e ../.env -- release-it",
+    "release": "bash ./scripts/release-preflight.sh && dotenv -e ../.env -- release-it",
     "release:cloud": "bash ./scripts/release-cloud.sh",
     "prepare": "husky"
   },

--- a/scripts/release-cloud.sh
+++ b/scripts/release-cloud.sh
@@ -2,96 +2,15 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Run the same safety gates as the `release` target before promoting to cloud.
+# release-preflight.sh exposes log/fail/require_command and run_release_preflight.
+LOG_PREFIX="release:cloud"
+# shellcheck source=scripts/release-preflight.sh
+source "${SCRIPT_DIR}/release-preflight.sh"
+
 PROMOTION_WORKFLOW_FILE="promote-main-to-production.yml"
-MIGRATION_CONFIRMATION_TOKEN="applied"
-
-log() {
-  echo "[release:cloud] $*"
-}
-
-fail() {
-  log "ERROR: $*"
-  exit 1
-}
-
-require_command() {
-  local command_name="$1"
-  if ! command -v "$command_name" >/dev/null 2>&1; then
-    fail "Required command '$command_name' is not installed."
-  fi
-}
-
-ensure_on_main_branch() {
-  local current_branch
-  current_branch="$(git rev-parse --abbrev-ref HEAD)"
-  if [[ "$current_branch" != "main" ]]; then
-    fail "Current branch is '$current_branch'. Switch to 'main' before running this command."
-  fi
-}
-
-ensure_main_matches_origin() {
-  git fetch origin main
-
-  local local_main_sha
-  local origin_main_sha
-  local_main_sha="$(git rev-parse HEAD)"
-  origin_main_sha="$(git rev-parse origin/main)"
-
-  if [[ "$local_main_sha" != "$origin_main_sha" ]]; then
-    fail "Local main ($local_main_sha) is not in sync with origin/main ($origin_main_sha)."
-  fi
-
-  log "Local main is in sync with origin/main ($local_main_sha)."
-}
-
-fetch_production_branch() {
-  git fetch origin production
-
-  if ! git show-ref --verify --quiet refs/remotes/origin/production; then
-    fail "Could not find remote branch origin/production."
-  fi
-}
-
-collect_prisma_migrations_not_in_production() {
-  git diff --name-only origin/production..HEAD -- packages/shared/prisma/migrations \
-    | awk -F/ 'NF >= 5 {print $5}' \
-    | sort -u
-}
-
-collect_clickhouse_migrations_not_in_production() {
-  git diff --name-only origin/production..HEAD -- packages/shared/clickhouse/migrations \
-    | sed -E 's#.*/([0-9]+_[^.]+)\.(up|down)\.sql#\1#' \
-    | sort -u
-}
-
-confirm_migrations_are_applied() {
-  local prisma_migrations="$1"
-  local clickhouse_migrations="$2"
-
-  log "Detected migrations in main that are not yet on production."
-
-  if [[ -n "$prisma_migrations" ]]; then
-    log "Postgres (Prisma) migrations not yet promoted:"
-    while IFS= read -r migration; do
-      [[ -n "$migration" ]] && echo "  - $migration"
-    done <<< "$prisma_migrations"
-  fi
-
-  if [[ -n "$clickhouse_migrations" ]]; then
-    log "ClickHouse migrations not yet promoted:"
-    while IFS= read -r migration; do
-      [[ -n "$migration" ]] && echo "  - $migration"
-    done <<< "$clickhouse_migrations"
-  fi
-
-  echo
-  log "Confirm you have reviewed these migrations and applied them to the production Postgres and ClickHouse databases."
-  read -r -p "Type '${MIGRATION_CONFIRMATION_TOKEN}' to continue: " confirmation
-
-  if [[ "$confirmation" != "$MIGRATION_CONFIRMATION_TOKEN" ]]; then
-    fail "Confirmation failed. Aborting cloud release."
-  fi
-}
 
 trigger_cloud_promotion() {
   require_command gh
@@ -106,21 +25,7 @@ trigger_cloud_promotion() {
 }
 
 main() {
-  ensure_on_main_branch
-  ensure_main_matches_origin
-  fetch_production_branch
-
-  local prisma_migrations
-  local clickhouse_migrations
-  prisma_migrations="$(collect_prisma_migrations_not_in_production)"
-  clickhouse_migrations="$(collect_clickhouse_migrations_not_in_production)"
-
-  if [[ -n "$prisma_migrations" || -n "$clickhouse_migrations" ]]; then
-    confirm_migrations_are_applied "$prisma_migrations" "$clickhouse_migrations"
-  else
-    log "No Prisma or ClickHouse migration differences detected between main and production."
-  fi
-
+  run_release_preflight
   trigger_cloud_promotion
 }
 

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# Shared safety gates run before any path that promotes main to production.
+# Sourced by release-cloud.sh and invoked standalone by the `release` script so
+# both entry points enforce the same preconditions:
+#   - the release is cut from `main`
+#   - local `main` matches `origin/main`
+#   - any migrations on main but not yet on production are confirmed as applied
+# Helpers (log/fail/require_command) are exposed for sourcing callers to reuse.
+
+set -euo pipefail
+
+LOG_PREFIX="${LOG_PREFIX:-release}"
+MIGRATION_CONFIRMATION_TOKEN="applied"
+
+log() {
+  echo "[${LOG_PREFIX}] $*"
+}
+
+fail() {
+  log "ERROR: $*"
+  exit 1
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    fail "Required command '$command_name' is not installed."
+  fi
+}
+
+ensure_on_main_branch() {
+  local current_branch
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+  if [[ "$current_branch" != "main" ]]; then
+    fail "Current branch is '$current_branch'. Switch to 'main' before running this command."
+  fi
+}
+
+ensure_main_matches_origin() {
+  git fetch origin main
+
+  local local_main_sha
+  local origin_main_sha
+  local_main_sha="$(git rev-parse HEAD)"
+  origin_main_sha="$(git rev-parse origin/main)"
+
+  if [[ "$local_main_sha" != "$origin_main_sha" ]]; then
+    fail "Local main ($local_main_sha) is not in sync with origin/main ($origin_main_sha)."
+  fi
+
+  log "Local main is in sync with origin/main ($local_main_sha)."
+}
+
+fetch_production_branch() {
+  git fetch origin production
+
+  if ! git show-ref --verify --quiet refs/remotes/origin/production; then
+    fail "Could not find remote branch origin/production."
+  fi
+}
+
+collect_prisma_migrations_not_in_production() {
+  git diff --name-only origin/production..HEAD -- packages/shared/prisma/migrations \
+    | awk -F/ 'NF >= 5 {print $5}' \
+    | sort -u
+}
+
+collect_clickhouse_migrations_not_in_production() {
+  git diff --name-only origin/production..HEAD -- packages/shared/clickhouse/migrations \
+    | sed -E 's#.*/([0-9]+_[^.]+)\.(up|down)\.sql#\1#' \
+    | sort -u
+}
+
+confirm_migrations_are_applied() {
+  local prisma_migrations="$1"
+  local clickhouse_migrations="$2"
+
+  log "Detected migrations in main that are not yet on production."
+
+  if [[ -n "$prisma_migrations" ]]; then
+    log "Postgres (Prisma) migrations not yet promoted:"
+    while IFS= read -r migration; do
+      [[ -n "$migration" ]] && echo "  - $migration"
+    done <<< "$prisma_migrations"
+  fi
+
+  if [[ -n "$clickhouse_migrations" ]]; then
+    log "ClickHouse migrations not yet promoted:"
+    while IFS= read -r migration; do
+      [[ -n "$migration" ]] && echo "  - $migration"
+    done <<< "$clickhouse_migrations"
+  fi
+
+  echo
+  log "Confirm you have reviewed these migrations and applied them to the production Postgres and ClickHouse databases."
+  read -r -p "Type '${MIGRATION_CONFIRMATION_TOKEN}' to continue: " confirmation
+
+  if [[ "$confirmation" != "$MIGRATION_CONFIRMATION_TOKEN" ]]; then
+    fail "Confirmation failed. Aborting release."
+  fi
+}
+
+run_release_preflight() {
+  ensure_on_main_branch
+  ensure_main_matches_origin
+  fetch_production_branch
+
+  local prisma_migrations
+  local clickhouse_migrations
+  prisma_migrations="$(collect_prisma_migrations_not_in_production)"
+  clickhouse_migrations="$(collect_clickhouse_migrations_not_in_production)"
+
+  if [[ -n "$prisma_migrations" || -n "$clickhouse_migrations" ]]; then
+    confirm_migrations_are_applied "$prisma_migrations" "$clickhouse_migrations"
+  else
+    log "No Prisma or ClickHouse migration differences detected between main and production."
+  fi
+}
+
+# Run the gates when executed directly; do nothing extra when sourced.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_release_preflight
+fi


### PR DESCRIPTION
## What does this PR do?

`pnpm run release` enforced fewer safety gates than `pnpm run release:cloud`, even though both ultimately promote `main` to production (the `release` path does so via the `v3.x.x` tag → `release.yml`, which force-pushes `main` to `production`). In particular, `release` could cut a versioned release without confirming that pending Postgres/ClickHouse migrations had been applied to production.

This PR gives both entry points the same safety gates without changing either deployment mechanism:

- Extracts the shared gates into `scripts/release-preflight.sh`:
  - must be on `main`
  - local `main` must match `origin/main`
  - any migrations on `main` but not yet on `production` must be confirmed as applied (typed `applied` confirmation)
- `release:cloud` now sources the preflight (dropping ~100 lines of duplicated logic) and keeps its cloud-specific promotion dispatch.
- `release` now runs the preflight before `release-it`.

Deployment models are intentionally left divergent (`release` = versioned release via release-it/tag; `release:cloud` = `promote-main-to-production.yml` dispatch); only the safety gates are unified.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] Shell scripts syntax-checked (`bash -n`) and the gate verified to abort when not on `main`.
- [x] `prettier --check` and `turbo run lint` pass (pre-commit hook).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts the shared safety-gate logic from `scripts/release-cloud.sh` into a new `scripts/release-preflight.sh` script, then wires that same preflight into the `release` npm script so both release paths enforce identical preconditions before promoting to production.

- **New `release-preflight.sh`**: Consolidates branch-sync, main-vs-origin parity, and migration-confirmation checks; exposes `log`/`fail`/`require_command`/`run_release_preflight` for reuse; runs automatically when executed directly and is a no-op when sourced (guarded by `BASH_SOURCE[0] == $0`).
- **Refactored `release-cloud.sh`**: Sources `release-preflight.sh` via an absolute `SCRIPT_DIR`-resolved path, sets `LOG_PREFIX="release:cloud"` before sourcing so log output is correctly namespaced, and delegates preflight to `run_release_preflight` before calling `trigger_cloud_promotion`.
- **`package.json`**: Prepends `bash ./scripts/release-preflight.sh &&` to the `release` script so the same gates fire for the `release-it`-based release path.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Clean refactoring — shared logic is correctly extracted and both release paths now run identical gates. No functional behavior is lost or altered.

The extraction is mechanically sound: BASH_SOURCE[0] == $0 correctly prevents double-invocation when sourced, LOG_PREFIX is set before sourcing so namespacing is preserved, SCRIPT_DIR ensures the source path is resolved absolutely regardless of the caller's working directory, and set -euo pipefail in the sourced script is harmless because the parent already sets those options. Both entry points end up running the same precondition checks in the same order.

No files require special attention. All three changed files are low-risk shell scripts and a one-line package.json change.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant NPM as pnpm release
    participant Cloud as pnpm release:cloud
    participant PF as release-preflight.sh
    participant RC as release-cloud.sh
    participant RI as release-it

    Dev->>NPM: pnpm run release
    NPM->>PF: bash ./scripts/release-preflight.sh
    PF->>PF: ensure_on_main_branch()
    PF->>PF: ensure_main_matches_origin()
    PF->>PF: fetch_production_branch()
    PF->>PF: collect_prisma/clickhouse_migrations()
    alt migrations detected
        PF-->>Dev: prompt: type 'applied' to continue
        Dev-->>PF: confirmation input
    end
    PF-->>NPM: exit 0 (preflight passed)
    NPM->>RI: dotenv -- release-it
    RI-->>Dev: version bump + changelog + tag

    Dev->>Cloud: pnpm run release:cloud
    Cloud->>RC: bash ./scripts/release-cloud.sh
    RC->>PF: "source release-preflight.sh (LOG_PREFIX=release:cloud)"
    RC->>PF: run_release_preflight()
    PF->>PF: ensure_on_main_branch()
    PF->>PF: ensure_main_matches_origin()
    PF->>PF: fetch_production_branch()
    PF->>PF: collect_prisma/clickhouse_migrations()
    alt migrations detected
        PF-->>Dev: prompt: type 'applied' to continue
        Dev-->>PF: confirmation input
    end
    RC->>RC: trigger_cloud_promotion()
    RC-->>Dev: gh workflow run to production
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant NPM as pnpm release
    participant Cloud as pnpm release:cloud
    participant PF as release-preflight.sh
    participant RC as release-cloud.sh
    participant RI as release-it

    Dev->>NPM: pnpm run release
    NPM->>PF: bash ./scripts/release-preflight.sh
    PF->>PF: ensure_on_main_branch()
    PF->>PF: ensure_main_matches_origin()
    PF->>PF: fetch_production_branch()
    PF->>PF: collect_prisma/clickhouse_migrations()
    alt migrations detected
        PF-->>Dev: prompt: type 'applied' to continue
        Dev-->>PF: confirmation input
    end
    PF-->>NPM: exit 0 (preflight passed)
    NPM->>RI: dotenv -- release-it
    RI-->>Dev: version bump + changelog + tag

    Dev->>Cloud: pnpm run release:cloud
    Cloud->>RC: bash ./scripts/release-cloud.sh
    RC->>PF: "source release-preflight.sh (LOG_PREFIX=release:cloud)"
    RC->>PF: run_release_preflight()
    PF->>PF: ensure_on_main_branch()
    PF->>PF: ensure_main_matches_origin()
    PF->>PF: fetch_production_branch()
    PF->>PF: collect_prisma/clickhouse_migrations()
    alt migrations detected
        PF-->>Dev: prompt: type 'applied' to continue
        Dev-->>PF: confirmation input
    end
    RC->>RC: trigger_cloud_promotion()
    RC-->>Dev: gh workflow run to production
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: enforce release safety-gate parit..."](https://github.com/langfuse/langfuse/commit/ab0c4565f01599e597aad2c08f004fcab28224bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39828891)</sub>

<!-- /greptile_comment -->