### PR TITLE
fix(worker): propagate ClickHouse route tags

### DIFF
--- a/worker/src/__tests__/workerManager.test.ts
+++ b/worker/src/__tests__/workerManager.test.ts
@@ -14,7 +14,7 @@ const resolveMetricInfo = (queueName: QueueName) =>
   (
     WorkerManager as unknown as {
       resolveMetricInfo(queueName: QueueName): {
-        clickHouseRoute: string;
+        baseMetric: string;
       };
     }
   ).resolveMetricInfo(queueName);
@@ -61,17 +61,17 @@ describe("WorkerManager", () => {
   });
 
   describe("resolveMetricInfo", () => {
-    it("uses the queue name as the worker ClickHouse route", () => {
-      expect(resolveMetricInfo(QueueName.TraceDelete).clickHouseRoute).toBe(
-        QueueName.TraceDelete,
+    it("uses the base metric as the worker ClickHouse route", () => {
+      expect(resolveMetricInfo(QueueName.TraceDelete).baseMetric).toBe(
+        "langfuse.queue.trace_delete",
       );
     });
 
-    it("uses the base queue name as the worker ClickHouse route for sharded queues", () => {
+    it("uses the base metric as the worker ClickHouse route for sharded queues", () => {
       expect(
         resolveMetricInfo(`${QueueName.IngestionQueue}-1` as QueueName)
-          .clickHouseRoute,
-      ).toBe(QueueName.IngestionQueue);
+          .baseMetric,
+      ).toBe("langfuse.queue.ingestion");
     });
   });
 });

--- a/worker/src/__tests__/workerManager.test.ts
+++ b/worker/src/__tests__/workerManager.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { QueueName } from "@langfuse/shared/src/server";
 import { WorkerManager } from "../queues/workerManager";
 
 const extractProjectId = (data: unknown): string | undefined =>
@@ -8,6 +9,15 @@ const extractProjectId = (data: unknown): string | undefined =>
       extractProjectId(job: { data: unknown }): string | undefined;
     }
   ).extractProjectId({ data });
+
+const resolveMetricInfo = (queueName: QueueName) =>
+  (
+    WorkerManager as unknown as {
+      resolveMetricInfo(queueName: QueueName): {
+        clickHouseRoute: string;
+      };
+    }
+  ).resolveMetricInfo(queueName);
 
 describe("WorkerManager", () => {
   describe("extractProjectId", () => {
@@ -47,6 +57,21 @@ describe("WorkerManager", () => {
           },
         }),
       ).toBeUndefined();
+    });
+  });
+
+  describe("resolveMetricInfo", () => {
+    it("uses the queue name as the worker ClickHouse route", () => {
+      expect(resolveMetricInfo(QueueName.TraceDelete).clickHouseRoute).toBe(
+        QueueName.TraceDelete,
+      );
+    });
+
+    it("uses the base queue name as the worker ClickHouse route for sharded queues", () => {
+      expect(
+        resolveMetricInfo(`${QueueName.IngestionQueue}-1` as QueueName)
+          .clickHouseRoute,
+      ).toBe(QueueName.IngestionQueue);
     });
   });
 });

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -42,18 +42,21 @@ export class WorkerManager {
 
   private static resolveMetricInfo(queueName: QueueName): {
     baseMetric: string;
+    clickHouseRoute: string;
     shardTag: { shard: string } | undefined;
   } {
     for (const base of SHARDED_QUEUE_BASE_NAMES) {
       if (queueName.startsWith(base)) {
         return {
           baseMetric: convertQueueNameToMetricName(base),
+          clickHouseRoute: base,
           shardTag: { shard: queueName },
         };
       }
     }
     return {
       baseMetric: convertQueueNameToMetricName(queueName),
+      clickHouseRoute: queueName,
       shardTag: undefined,
     };
   }
@@ -63,7 +66,8 @@ export class WorkerManager {
     queueName: QueueName,
   ): Processor {
     const oldMetric = convertQueueNameToMetricName(queueName);
-    const { baseMetric, shardTag } = WorkerManager.resolveMetricInfo(queueName);
+    const { baseMetric, clickHouseRoute, shardTag } =
+      WorkerManager.resolveMetricInfo(queueName);
 
     return async (job: Job) => {
       const startTime = Date.now();
@@ -88,6 +92,7 @@ export class WorkerManager {
         projectId: WorkerManager.extractProjectId(job),
         clickhouse: {
           surface: "worker",
+          route: clickHouseRoute,
         },
       });
       const result = await otelContext.with(clickHouseCtx, () =>

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -42,21 +42,18 @@ export class WorkerManager {
 
   private static resolveMetricInfo(queueName: QueueName): {
     baseMetric: string;
-    clickHouseRoute: string;
     shardTag: { shard: string } | undefined;
   } {
     for (const base of SHARDED_QUEUE_BASE_NAMES) {
       if (queueName.startsWith(base)) {
         return {
           baseMetric: convertQueueNameToMetricName(base),
-          clickHouseRoute: base,
           shardTag: { shard: queueName },
         };
       }
     }
     return {
       baseMetric: convertQueueNameToMetricName(queueName),
-      clickHouseRoute: queueName,
       shardTag: undefined,
     };
   }
@@ -66,8 +63,7 @@ export class WorkerManager {
     queueName: QueueName,
   ): Processor {
     const oldMetric = convertQueueNameToMetricName(queueName);
-    const { baseMetric, clickHouseRoute, shardTag } =
-      WorkerManager.resolveMetricInfo(queueName);
+    const { baseMetric, shardTag } = WorkerManager.resolveMetricInfo(queueName);
 
     return async (job: Job) => {
       const startTime = Date.now();
@@ -92,7 +88,7 @@ export class WorkerManager {
         projectId: WorkerManager.extractProjectId(job),
         clickhouse: {
           surface: "worker",
-          route: clickHouseRoute,
+          route: baseMetric,
         },
       });
       const result = await otelContext.with(clickHouseCtx, () =>

--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -138,6 +138,7 @@ describe("ClickhouseWriter", () => {
     );
     expect(logComment).toMatchObject({
       surface: "worker",
+      route: "clickhouse-writer",
       projectId: "MULTI_PROJECT",
     });
   });

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -581,6 +581,7 @@ export class ClickhouseWriter {
         clickhouse_settings: {
           log_comment: buildClickHouseLogComment({
             surface: "worker",
+            route: "clickhouse-writer",
             projectId: MULTI_PROJECT_LOG_COMMENT_PROJECT_ID,
           }),
         },


### PR DESCRIPTION
## Summary
- add worker queue entrypoints to ClickHouse query tags via `route`
- collapse sharded queues to their base queue name to avoid shard-level series cardinality
- tag direct ClickhouseWriter inserts as `clickhouse-writer`

## Verification
- `pnpm --filter worker test workerManager.test.ts ClickhouseWriter.unit.test.ts`

## Impacted packages
- `worker`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR propagates ClickHouse query route tags from worker entrypoints so that ClickHouse `log_comment` metadata correctly identifies which queue (or the `ClickhouseWriter` itself) initiated each query. Sharded queue names are collapsed to their base name before tagging to avoid per-shard cardinality explosion.

- **`workerManager.ts`**: `resolveMetricInfo` now returns a `clickHouseRoute` field alongside `baseMetric`/`shardTag`; sharded queues get the base queue name, non-sharded queues get their own name. The value is passed into `contextWithLangfuseProps` as `clickhouse.route`, stored in OTel baggage and read by `buildClickHouseLogComment` for every downstream ClickHouse query in the job's async scope.
- **`ClickhouseWriter/index.ts`**: Direct batch inserts via `writeToClickhouse` now hard-code `route: "clickhouse-writer"`, overriding any ambient baggage since the flush runs on an independent timer outside any individual job context.
- Tests cover both the shard-collapsing and the `clickhouse-writer` tag via unit-level assertions.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Changes are additive observability metadata only — no data path, persistence, or control flow is altered.

The PR adds a new clickHouseRoute field to resolveMetricInfo and threads it through contextWithLangfuseProps as OTel baggage. The shard-collapsing logic mirrors the identical startsWith check already used for metrics, and both new behaviors are covered by unit tests.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant BullMQ
    participant WorkerManager
    participant OTelBaggage
    participant Processor
    participant ClickhouseWriter
    participant ClickHouse

    BullMQ->>WorkerManager: job dispatched (queueName)
    WorkerManager->>WorkerManager: resolveMetricInfo(queueName)
    WorkerManager->>OTelBaggage: contextWithLangfuseProps clickhouse route
    Note over OTelBaggage: baggage: langfuse.clickhouse.route = clickHouseRoute
    WorkerManager->>Processor: otelContext.with(clickHouseCtx, processor)
    Processor->>ClickHouse: query with route tag from OTel baggage

    Note over ClickhouseWriter: Runs on independent flush timer
    ClickhouseWriter->>ClickHouse: insert with hardcoded route clickhouse-writer
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant BullMQ
    participant WorkerManager
    participant OTelBaggage
    participant Processor
    participant ClickhouseWriter
    participant ClickHouse

    BullMQ->>WorkerManager: job dispatched (queueName)
    WorkerManager->>WorkerManager: resolveMetricInfo(queueName)
    WorkerManager->>OTelBaggage: contextWithLangfuseProps clickhouse route
    Note over OTelBaggage: baggage: langfuse.clickhouse.route = clickHouseRoute
    WorkerManager->>Processor: otelContext.with(clickHouseCtx, processor)
    Processor->>ClickHouse: query with route tag from OTel baggage

    Note over ClickhouseWriter: Runs on independent flush timer
    ClickhouseWriter->>ClickHouse: insert with hardcoded route clickhouse-writer
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: propagate ClickHouse route tags in ..."](https://github.com/langfuse/langfuse/commit/c00ed0b5d2d304fa88491efd5e6acacc119f63e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39830763)</sub>

<!-- /greptile_comment -->