### PR TITLE
chore: allow trpc events-filterOptions to specify columns list

### DIFF
--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -14,6 +14,8 @@ import {
   getTracesIdentifierForSessionFromEvents,
   getEventsFilterOptionsForColumns,
   getEventsFilterOptionValuesPage,
+  createScoresCh,
+  createTraceScore,
   type EventFilterOptionColumn,
 } from "@langfuse/shared/src/server";
 import {
@@ -611,6 +613,65 @@ describe("Clickhouse Events Repository Test", () => {
 
         expect(explicitLevels).toContain(recentLevel);
         expect(explicitLevels).toContain(oldLevel);
+      });
+    });
+
+    it("only loads requested filter option columns", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+      const now = Date.now();
+
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "unrequested-filter-option-name",
+          level: "WARNING",
+          tags: ["unrequested-filter-option-tag"],
+          start_time: now * 1000,
+        }),
+      ]);
+      await createScoresCh([
+        createTraceScore({
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          name: "unrequested-filter-option-score",
+          data_type: "NUMERIC",
+          timestamp: now,
+          event_ts: now,
+          created_at: now,
+          updated_at: now,
+        }),
+        createTraceScore({
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          name: "unrequested-filter-option-category",
+          data_type: "CATEGORICAL",
+          string_value: "unrequested-category-value",
+          value: 1,
+          timestamp: now,
+          event_ts: now,
+          created_at: now,
+          updated_at: now,
+        }),
+      ]);
+
+      await waitForExpect(async () => {
+        const options = await getEventFilterOptions({
+          projectId: uniqueProjectId,
+          columns: ["level"],
+        });
+
+        expect(options.level.map((level) => level.value)).toContain("WARNING");
+        expect(options.name).toEqual([]);
+        expect(options.traceTags).toEqual([]);
+        expect(options.scores_avg).toEqual([]);
+        expect(options.score_categories).toEqual([]);
+        expect(options.trace_scores_avg).toEqual([]);
+        expect(options.trace_score_categories).toEqual([]);
       });
     });
 

--- a/web/src/features/events/hooks/useEventsFilterOptions.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.ts
@@ -1,17 +1,22 @@
-import { api } from "@/src/utils/api";
+import { api, type RouterInputs } from "@/src/utils/api";
 import { useMemo } from "react";
 import { type FilterState, type TimeFilter } from "@langfuse/shared";
+
+type EventFilterOptionColumnsInput =
+  RouterInputs["events"]["filterOptions"]["columns"];
 
 type UseEventsFilterOptionsParams = {
   projectId: string;
   oldFilterState: FilterState;
   isRootObservation?: boolean;
+  columns?: EventFilterOptionColumnsInput;
 };
 
 export function useEventsFilterOptions({
   projectId,
   oldFilterState,
   isRootObservation,
+  columns,
 }: UseEventsFilterOptionsParams) {
   // Extract start time filters for filter options query
   const startTimeFilters = useMemo(() => {
@@ -29,6 +34,7 @@ export function useEventsFilterOptions({
       startTimeFilter:
         startTimeFilters.length > 0 ? startTimeFilters : undefined,
       isRootObservation,
+      columns,
     },
     {
       trpc: {

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -22,6 +22,7 @@ import {
   getEventCount,
   getEventFilterOptions,
   getEventBatchIO,
+  EVENT_FILTER_OPTIONS_COLUMNS,
 } from "./eventsService";
 import {
   instrumentAsync,
@@ -56,6 +57,12 @@ export type GetAllEventsInput = z.infer<typeof GetAllEventsInput>;
 const GetEventFilterOptionsInput = zodSchema.object({
   projectId: zodSchema.string(),
   startTimeFilter: zodSchema.array(timeFilter).optional(),
+  monitorWindow: MonitorWindowSchema.optional(),
+  isRootObservation: zodSchema.boolean().optional(),
+  hasParentObservation: zodSchema.boolean().optional(),
+  columns: zodSchema
+    .array(zodSchema.enum(EVENT_FILTER_OPTIONS_COLUMNS))
+    .optional(),
 });
 
 export type GetEventFilterOptionsInput = z.infer<
@@ -150,15 +157,7 @@ export const eventsRouter = createTRPCRouter({
       );
     }),
   filterOptions: protectedProjectProcedure
-    .input(
-      zodSchema.object({
-        projectId: zodSchema.string(),
-        startTimeFilter: zodSchema.array(timeFilter).optional(),
-        monitorWindow: MonitorWindowSchema.optional(),
-        isRootObservation: zodSchema.boolean().optional(),
-        hasParentObservation: zodSchema.boolean().optional(),
-      }),
-    )
+    .input(GetEventFilterOptionsInput)
     .query(async ({ input }) => {
       return instrumentAsync(
         {
@@ -176,6 +175,7 @@ export const eventsRouter = createTRPCRouter({
               (input.hasParentObservation !== undefined
                 ? !input.hasParentObservation
                 : undefined), // backward compat for legacy hasParentObservation filterOption
+            columns: input.columns,
           });
         },
       );

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -71,6 +71,7 @@ interface GetObservationsFilterOptionsParams {
   isRootObservation?: boolean;
   hasParentObservation?: boolean;
   observationType?: string;
+  columns?: readonly EventFilterOptionsColumn[];
 }
 
 type EventFilterValueOption = {
@@ -99,6 +100,20 @@ const EVENT_FILTER_OPTION_COLUMNS = [
   "toolNames",
   "calledToolNames",
 ] as const satisfies readonly EventFilterOptionColumn[];
+
+const EVENT_SCORE_FILTER_OPTION_COLUMNS = [
+  "scores_avg",
+  "score_categories",
+  "trace_scores_avg",
+  "trace_score_categories",
+] as const;
+
+export const EVENT_FILTER_OPTIONS_COLUMNS = [
+  ...EVENT_FILTER_OPTION_COLUMNS,
+  ...EVENT_SCORE_FILTER_OPTION_COLUMNS,
+] as const;
+
+type EventFilterOptionsColumn = (typeof EVENT_FILTER_OPTIONS_COLUMNS)[number];
 
 const OBSERVATIONS_TO_TRACE_INTERVAL_MS = 2 * 24 * 60 * 60 * 1000;
 const SCORE_TO_TRACE_OBSERVATIONS_INTERVAL_MS = 60 * 60 * 1000;
@@ -527,9 +542,20 @@ export async function getEventFilterOptions(
   params: GetObservationsFilterOptionsParams,
 ) {
   const scopedParams = ensureStartTimeFilterForEventFilterOptions(params);
-  const { projectId } = scopedParams;
+  const { projectId, columns = EVENT_FILTER_OPTIONS_COLUMNS } = scopedParams;
   const { eventsFilter, traceTimestampFilters, traceScoreTimestampFilters } =
     getEventFilterOptionsScope(scopedParams);
+  const requestedColumns = new Set<EventFilterOptionsColumn>(columns);
+  const eventColumns = EVENT_FILTER_OPTION_COLUMNS.filter((column) =>
+    requestedColumns.has(column),
+  );
+  const shouldLoadScoresAvg = requestedColumns.has("scores_avg");
+  const shouldLoadScoreCategories =
+    requestedColumns.has("score_categories") ||
+    requestedColumns.has("trace_score_categories");
+  const shouldLoadTraceScores =
+    requestedColumns.has("trace_scores_avg") ||
+    requestedColumns.has("trace_score_categories");
 
   const [
     numericScoreNames,
@@ -537,17 +563,25 @@ export async function getEventFilterOptions(
     traceScoreColumns,
     eventFilterOptions,
   ] = await Promise.all([
-    getNumericScoresGroupedByName(projectId, traceTimestampFilters),
-    getCategoricalScoresGroupedByName(projectId, traceTimestampFilters),
-    getScoresGroupedByNameSourceType({
-      projectId,
-      filter: [...TRACE_SCORE_SCOPE_FILTER, ...traceScoreTimestampFilters],
-    }),
-    getEventsFilterOptionsForColumns({
-      projectId,
-      filter: eventsFilter,
-      columns: EVENT_FILTER_OPTION_COLUMNS,
-    }),
+    shouldLoadScoresAvg
+      ? getNumericScoresGroupedByName(projectId, traceTimestampFilters)
+      : Promise.resolve([]),
+    shouldLoadScoreCategories
+      ? getCategoricalScoresGroupedByName(projectId, traceTimestampFilters)
+      : Promise.resolve([]),
+    shouldLoadTraceScores
+      ? getScoresGroupedByNameSourceType({
+          projectId,
+          filter: [...TRACE_SCORE_SCOPE_FILTER, ...traceScoreTimestampFilters],
+        })
+      : Promise.resolve([]),
+    eventColumns.length > 0
+      ? getEventsFilterOptionsForColumns({
+          projectId,
+          filter: eventsFilter,
+          columns: eventColumns,
+        })
+      : Promise.resolve([]),
   ]);
   const traceNumericScoreNames = Array.from(
     new Set(
@@ -569,12 +603,20 @@ export async function getEventFilterOptions(
 
   return {
     ...eventFilterOptionsByColumn,
-    scores_avg: numericScoreNames.map((score) => score.name),
-    score_categories: categoricalScoreNames,
-    trace_scores_avg: traceNumericScoreNames,
-    trace_score_categories: categoricalScoreNames.filter((score) =>
-      traceCategoricalScoreNames.has(score.label),
-    ),
+    scores_avg: shouldLoadScoresAvg
+      ? numericScoreNames.map((score) => score.name)
+      : [],
+    score_categories: requestedColumns.has("score_categories")
+      ? categoricalScoreNames
+      : [],
+    trace_scores_avg: requestedColumns.has("trace_scores_avg")
+      ? traceNumericScoreNames
+      : [],
+    trace_score_categories: requestedColumns.has("trace_score_categories")
+      ? categoricalScoreNames.filter((score) =>
+          traceCategoricalScoreNames.has(score.label),
+        )
+      : [],
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional `columns` parameter to the `events/filterOptions` tRPC endpoint, allowing callers to specify which filter-option columns they actually need. When provided, only the requested queries are executed against ClickHouse, skipping score lookups and event-column queries that aren't needed.

- The schema is refactored from an inline definition into the top-level `GetEventFilterOptionsInput` (now exported), and the router passes the new `columns` field through to `getEventFilterOptions`.
- `getEventFilterOptions` now resolves early (`Promise.resolve([])`) for score and event-column fetches that are not covered by the requested columns list, and the return object always preserves the full shape (using `[]` for unrequested columns).
- A new server test validates that requesting only `["level"]` returns populated data for that column while all other columns — including score columns backed by seeded data — return empty arrays.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is additive — the new `columns` param is optional and defaults to the full column list, preserving existing behaviour for all current callers.

All existing callers omit `columns` and therefore receive the same result as before. The new filtering logic is internally consistent: `shouldLoadScoreCategories` is correctly set when either `score_categories` or `trace_score_categories` is requested, and the return object always has every key (with `[]` for unrequested ones), so callers don't need to guard for missing keys. The test seeds data for every skipped column and asserts they return empty, giving good coverage of the optimisation path.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["filterOptions tRPC call\n(columns?: string[])"] --> B["getEventFilterOptions(params)"]
    B --> C["ensureStartTimeFilterForEventFilterOptions"]
    C --> D["Compute requestedColumns Set\n(default: all columns)"]
    D --> E["eventColumns = EVENT_FILTER_OPTION_COLUMNS\n.filter(c => requestedColumns.has(c))"]
    D --> F{"shouldLoadScoresAvg?"}
    D --> G{"shouldLoadScoreCategories?"}
    D --> H{"shouldLoadTraceScores?"}
    E --> I{"eventColumns.length > 0?"}
    I -->|Yes| J["getEventsFilterOptionsForColumns(eventColumns)"]
    I -->|No| K["Resolve([])"]
    F -->|Yes| L["getNumericScoresGroupedByName"]
    F -->|No| M["Resolve([])"]
    G -->|Yes| N["getCategoricalScoresGroupedByName"]
    G -->|No| O["Resolve([])"]
    H -->|Yes| P["getScoresGroupedByNameSourceType"]
    H -->|No| Q["Resolve([])"]
    J --> R["Promise.all([...])"]
    K --> R
    L --> R
    M --> R
    N --> R
    O --> R
    P --> R
    Q --> R
    R --> S["toEventFilterOptionsByColumn(eventFilterOptions)\n(always returns all event columns, empty for unrequested)"]
    S --> T["Return merged result\n{...eventColumnData, scores_avg, score_categories,\n trace_scores_avg, trace_score_categories}"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["filterOptions tRPC call\n(columns?: string[])"] --> B["getEventFilterOptions(params)"]
    B --> C["ensureStartTimeFilterForEventFilterOptions"]
    C --> D["Compute requestedColumns Set\n(default: all columns)"]
    D --> E["eventColumns = EVENT_FILTER_OPTION_COLUMNS\n.filter(c => requestedColumns.has(c))"]
    D --> F{"shouldLoadScoresAvg?"}
    D --> G{"shouldLoadScoreCategories?"}
    D --> H{"shouldLoadTraceScores?"}
    E --> I{"eventColumns.length > 0?"}
    I -->|Yes| J["getEventsFilterOptionsForColumns(eventColumns)"]
    I -->|No| K["Resolve([])"]
    F -->|Yes| L["getNumericScoresGroupedByName"]
    F -->|No| M["Resolve([])"]
    G -->|Yes| N["getCategoricalScoresGroupedByName"]
    G -->|No| O["Resolve([])"]
    H -->|Yes| P["getScoresGroupedByNameSourceType"]
    H -->|No| Q["Resolve([])"]
    J --> R["Promise.all([...])"]
    K --> R
    L --> R
    M --> R
    N --> R
    O --> R
    P --> R
    Q --> R
    R --> S["toEventFilterOptionsByColumn(eventFilterOptions)\n(always returns all event columns, empty for unrequested)"]
    S --> T["Return merged result\n{...eventColumnData, scores_avg, score_categories,\n trace_scores_avg, trace_score_categories}"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: allow trpc events-filterOptions t..."](https://github.com/langfuse/langfuse/commit/4d6967e2e76346491aa8059f77d76561a794e7f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39835949)</sub>

<!-- /greptile_comment -->