### PR TITLE
feat(worker): emit per-project blob export lag gauge (LFE-10521)

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1090,6 +1090,18 @@ export const handleBlobStorageIntegrationProjectJob = async (
     `[BLOB INTEGRATION] Calculated maxTimestamp for project ${projectId}: ${maxTimestamp}, isValid: ${!isNaN(maxTimestamp.getTime())}, getTime: ${maxTimestamp.getTime()}, frequencyIntervalMs: ${frequencyIntervalMs}`,
   );
 
+  // How far behind real-time this project's export frontier is. maxTimestamp is
+  // the end of the window this job advances to, so lag ≈ the export buffer when
+  // caught up and grows during historic catch-up. Per-job emit, so it goes stale
+  // if the exporter stops entirely for a project (see LFE-10521).
+  if (!isNaN(maxTimestamp.getTime())) {
+    recordGauge(
+      "langfuse.blobstorage.export_lag_seconds",
+      (now.getTime() - maxTimestamp.getTime()) / 1000,
+      { projectId },
+    );
+  }
+
   // Skip export if the time window is empty or invalid
   if (minTimestamp >= maxTimestamp) {
     logger.info(

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1096,7 +1096,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
   // if the exporter stops entirely for a project (see LFE-10521).
   if (!isNaN(maxTimestamp.getTime())) {
     recordGauge(
-      "langfuse.blobstorage.export_lag_seconds",
+      "langfuse.blobstorage.export_delay_seconds",
       (now.getTime() - maxTimestamp.getTime()) / 1000,
       { projectId },
     );


### PR DESCRIPTION
## What does this PR do?

Emits a per-project gauge `langfuse.blobstorage.export_delay_seconds` so we can graph how far behind real-time each project's blob export frontier is. Datadog can't compute `now()`, and the export frontier was previously only available as a log value.

The gauge is recorded in `handleBlobStorageIntegrationProjectJob.ts` right after `maxTimestamp` (the end of the window the job advances to) is computed:

```
langfuse.blobstorage.export_delay_seconds = (Date.now() − maxTimestamp.getTime()) / 1000
```

tagged with `projectId`. It follows the existing `*_delay_seconds` convention (e.g. `event_propagation.processed_partition_delay_seconds`). When caught up, lag ≈ the export buffer; during historic catch-up it grows.

Per-job emit, so it goes stale if the exporter stops entirely for a project — noted in the code comment. A periodic live-while-idle reporter is left as a follow-up (LFE-10521 caveat).

Dashboard widget (Progress section, `second` unit → auto-scales to days) will be added once this deploys.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] `pnpm run lint` passes
- [x] `pnpm run typecheck` passes
