### PR TITLE
fix(worker): measure Parquet upload-wait via byte-counter backpressure (LFE-10463)

### DIFF
--- a/worker/src/features/blobstorage/byteCounters.test.ts
+++ b/worker/src/features/blobstorage/byteCounters.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { pipeline, Readable, Writable } from "stream";
+import { promisify } from "util";
+import {
+  ByteCounter,
+  TimedByteCounter,
+  type TimedByteCounterStats,
+} from "./byteCounters";
+
+const pipelineAsync = promisify(pipeline);
+
+const collect = (chunks: Buffer[], perChunkDelayMs = 0): Writable =>
+  new Writable({
+    // highWaterMark 1 keeps the readable buffer shallow so a slow sink reliably
+    // backpressures the counter (push() returns false), exercising the timer.
+    highWaterMark: 1,
+    write(chunk: Buffer, _enc, cb) {
+      chunks.push(Buffer.from(chunk));
+      if (perChunkDelayMs > 0) setTimeout(cb, perChunkDelayMs);
+      else cb();
+    },
+  });
+
+// Emits `count` chunks `gapMs` apart, simulating ClickHouse delivering row
+// groups with a wait between each.
+function spacedSource(
+  count: number,
+  gapMs: number,
+  bytesPerChunk = 64 * 1024,
+): Readable {
+  async function* gen() {
+    for (let i = 0; i < count; i++) {
+      if (gapMs > 0) await new Promise((r) => setTimeout(r, gapMs));
+      yield Buffer.alloc(bytesPerChunk, i % 256);
+    }
+  }
+  return Readable.from(gen());
+}
+
+describe("ByteCounter", () => {
+  it("forwards bytes unchanged and tallies the total", async () => {
+    const input = [Buffer.from("hello "), Buffer.from("world")];
+    const out: Buffer[] = [];
+    const counter = new ByteCounter();
+    await pipelineAsync(Readable.from(input), counter, collect(out));
+    expect(Buffer.concat(out).toString()).toBe("hello world");
+    expect(counter.bytes).toBe(11);
+  });
+});
+
+describe("TimedByteCounter", () => {
+  it("forwards every byte unchanged", async () => {
+    const chunks = Array.from({ length: 20 }, (_, i) =>
+      Buffer.from(`row-${i};`),
+    );
+    const expected = Buffer.concat(chunks);
+    const stats: TimedByteCounterStats = { sourceWaitMs: 0, backpressureMs: 0 };
+    const out: Buffer[] = [];
+    const counter = new TimedByteCounter(stats);
+    await pipelineAsync(Readable.from(chunks), counter, collect(out));
+    expect(Buffer.concat(out).equals(expected)).toBe(true);
+    expect(counter.bytes).toBe(expected.length);
+  });
+
+  it("attributes wait to ClickHouse when the source is the bottleneck", async () => {
+    // Slow source (30ms between chunks), instant sink: the gap is pure CH read.
+    const stats: TimedByteCounterStats = { sourceWaitMs: 0, backpressureMs: 0 };
+    const counter = new TimedByteCounter(stats);
+    await pipelineAsync(spacedSource(6, 30), counter, collect([]));
+
+    const chReadMs = stats.sourceWaitMs - stats.backpressureMs;
+    // ~6 * 30ms of source wait, almost none of it backpressure.
+    expect(stats.sourceWaitMs).toBeGreaterThan(100);
+    expect(stats.backpressureMs).toBeLessThan(stats.sourceWaitMs / 2);
+    expect(chReadMs).toBeGreaterThan(50);
+  });
+
+  it("attributes wait to upload backpressure when the sink is the bottleneck", async () => {
+    // Instant source, slow sink (40ms/chunk): the wait is S3 backpressure, and
+    // chReadMs (sourceWaitMs - backpressureMs) must not absorb it.
+    const stats: TimedByteCounterStats = { sourceWaitMs: 0, backpressureMs: 0 };
+    const counter = new TimedByteCounter(stats);
+    await pipelineAsync(spacedSource(6, 0), counter, collect([], 40));
+
+    const chReadMs = Math.max(0, stats.sourceWaitMs - stats.backpressureMs);
+    expect(stats.backpressureMs).toBeGreaterThan(100);
+    // The dominant wait is upload, not ClickHouse — the bug this guards against
+    // (uploadWaitMs collapsing to ~0) would instead show all time as chRead.
+    expect(stats.backpressureMs).toBeGreaterThan(chReadMs);
+  });
+
+  it("propagates upstream errors so the pipeline aborts", async () => {
+    const boom = new Error("upstream failed");
+    const source = new Readable({
+      read() {
+        this.destroy(boom);
+      },
+    });
+    const stats: TimedByteCounterStats = { sourceWaitMs: 0, backpressureMs: 0 };
+    await expect(
+      pipelineAsync(source, new TimedByteCounter(stats), collect([])),
+    ).rejects.toThrow("upstream failed");
+  });
+});

--- a/worker/src/features/blobstorage/byteCounters.ts
+++ b/worker/src/features/blobstorage/byteCounters.ts
@@ -1,14 +1,10 @@
 import { Transform } from "stream";
 
-// Subset of the export-pipeline source stats that TimedByteCounter writes into.
-// sourceWaitMs accumulates the total inter-chunk gap; backpressureMs isolates
-// the portion of that gap caused by the downstream (S3 upload) not draining.
 export type TimedByteCounterStats = {
   sourceWaitMs: number;
   backpressureMs: number;
 };
 
-// Counts bytes flowing through without altering them.
 export class ByteCounter extends Transform {
   bytes = 0;
   _transform(
@@ -21,36 +17,26 @@ export class ByteCounter extends Transform {
   }
 }
 
-// ByteCounter for the Parquet path (piped binary stream, no per-row generator),
-// sitting at the upload boundary. It tallies total inter-chunk gaps into
-// `stats.sourceWaitMs` and, separately, the downstream S3 backpressure into
-// `stats.backpressureMs` via the same push()/_read() gap that TimedGzip uses.
-// sourceWaitMs alone conflates CH delivery with S3 backpressure; subtracting
-// backpressureMs recovers the pure ClickHouse-read wait (chReadMs), and
-// backpressureMs itself is the upload wait (uploadWaitMs) — the gzip path's
-// derivation, reconstructed without a gzip stage.
+// Boundary byte counter for the Parquet path. sourceWaitMs is the total
+// inter-chunk gap; backpressureMs isolates the S3-upload share of it via the
+// push()/_read() gap (as TimedGzip does). chReadMs = sourceWaitMs -
+// backpressureMs; uploadWaitMs = backpressureMs.
 export class TimedByteCounter extends ByteCounter {
   private readonly stats: TimedByteCounterStats;
-  // Clock starts at construction (like countedStream, before its loop) so the
-  // first gap captures time-to-first-byte — the dominant CH wait, since Parquet
-  // composes a row group before any bytes. Guarding it would drop TTFB from chReadMs.
+  // From construction so the first gap captures Parquet's time-to-first-byte.
   private lastChunkDoneAt: number = performance.now();
-  // Start of the current downstream-backpressure interval (push() returned
-  // false), or null when not backpressured. Mirrors TimedGzip.bpStart.
   private bpStart: number | null = null;
   constructor(stats: TimedByteCounterStats) {
     super();
     this.stats = stats;
   }
-  // Close out a backpressure interval once the downstream consumer pulls again.
   private creditBackpressure() {
     if (this.bpStart !== null) {
       this.stats.backpressureMs += performance.now() - this.bpStart;
       this.bpStart = null;
     }
   }
-  // _read fires when the downstream (S3 uploader) wants more data, i.e. it has
-  // drained. The gap since push() last stalled is S3 upload backpressure.
+  // _read = downstream drained; closes the open backpressure interval.
   _read(size: number) {
     this.creditBackpressure();
     super._read(size);
@@ -62,16 +48,13 @@ export class TimedByteCounter extends ByteCounter {
   ) {
     this.stats.sourceWaitMs += performance.now() - this.lastChunkDoneAt;
     this.bytes += chunk.length;
-    // Push explicitly (not via callback(null, chunk)) so a false return — the
-    // readable buffer is full and the uploader hasn't drained it — opens a
-    // backpressure interval, credited on the next _read.
+    // Explicit push so a false return opens a backpressure interval.
     if (!this.push(chunk) && this.bpStart === null) {
       this.bpStart = performance.now();
     }
     this.lastChunkDoneAt = performance.now();
     callback(null);
   }
-  // Credit a trailing backpressure interval that never saw a final _read.
   _flush(callback: (error?: Error | null) => void) {
     this.creditBackpressure();
     callback();

--- a/worker/src/features/blobstorage/byteCounters.ts
+++ b/worker/src/features/blobstorage/byteCounters.ts
@@ -1,0 +1,79 @@
+import { Transform } from "stream";
+
+// Subset of the export-pipeline source stats that TimedByteCounter writes into.
+// sourceWaitMs accumulates the total inter-chunk gap; backpressureMs isolates
+// the portion of that gap caused by the downstream (S3 upload) not draining.
+export type TimedByteCounterStats = {
+  sourceWaitMs: number;
+  backpressureMs: number;
+};
+
+// Counts bytes flowing through without altering them.
+export class ByteCounter extends Transform {
+  bytes = 0;
+  _transform(
+    chunk: Buffer,
+    _encoding: string,
+    callback: (error: Error | null, data?: Buffer) => void,
+  ) {
+    this.bytes += chunk.length;
+    callback(null, chunk);
+  }
+}
+
+// ByteCounter for the Parquet path (piped binary stream, no per-row generator),
+// sitting at the upload boundary. It tallies total inter-chunk gaps into
+// `stats.sourceWaitMs` and, separately, the downstream S3 backpressure into
+// `stats.backpressureMs` via the same push()/_read() gap that TimedGzip uses.
+// sourceWaitMs alone conflates CH delivery with S3 backpressure; subtracting
+// backpressureMs recovers the pure ClickHouse-read wait (chReadMs), and
+// backpressureMs itself is the upload wait (uploadWaitMs) — the gzip path's
+// derivation, reconstructed without a gzip stage.
+export class TimedByteCounter extends ByteCounter {
+  private readonly stats: TimedByteCounterStats;
+  // Clock starts at construction (like countedStream, before its loop) so the
+  // first gap captures time-to-first-byte — the dominant CH wait, since Parquet
+  // composes a row group before any bytes. Guarding it would drop TTFB from chReadMs.
+  private lastChunkDoneAt: number = performance.now();
+  // Start of the current downstream-backpressure interval (push() returned
+  // false), or null when not backpressured. Mirrors TimedGzip.bpStart.
+  private bpStart: number | null = null;
+  constructor(stats: TimedByteCounterStats) {
+    super();
+    this.stats = stats;
+  }
+  // Close out a backpressure interval once the downstream consumer pulls again.
+  private creditBackpressure() {
+    if (this.bpStart !== null) {
+      this.stats.backpressureMs += performance.now() - this.bpStart;
+      this.bpStart = null;
+    }
+  }
+  // _read fires when the downstream (S3 uploader) wants more data, i.e. it has
+  // drained. The gap since push() last stalled is S3 upload backpressure.
+  _read(size: number) {
+    this.creditBackpressure();
+    super._read(size);
+  }
+  _transform(
+    chunk: Buffer,
+    _encoding: string,
+    callback: (error: Error | null, data?: Buffer) => void,
+  ) {
+    this.stats.sourceWaitMs += performance.now() - this.lastChunkDoneAt;
+    this.bytes += chunk.length;
+    // Push explicitly (not via callback(null, chunk)) so a false return — the
+    // readable buffer is full and the uploader hasn't drained it — opens a
+    // backpressure interval, credited on the next _read.
+    if (!this.push(chunk) && this.bpStart === null) {
+      this.bpStart = performance.now();
+    }
+    this.lastChunkDoneAt = performance.now();
+    callback(null);
+  }
+  // Credit a trailing backpressure interval that never saw a final _read.
+  _flush(callback: (error?: Error | null) => void) {
+    this.creditBackpressure();
+    callback();
+  }
+}

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -41,6 +41,7 @@ import {
   type BlobTableExportOutcome,
 } from "./inFlightExports";
 import { TimedGzip, ZLIB_DEFAULT_LEVEL, type GzipStats } from "./gzipStream";
+import { ByteCounter, TimedByteCounter } from "./byteCounters";
 import { WORKER_HOST_ID } from "../../utils/hostId";
 import {
   BlobStorageIntegrationType,
@@ -268,44 +269,6 @@ const getFileTypeProperties = (fileType: BlobStorageIntegrationFileType) => {
   }
 };
 
-class ByteCounter extends Transform {
-  bytes = 0;
-  _transform(
-    chunk: Buffer,
-    _encoding: string,
-    callback: (error: Error | null, data?: Buffer) => void,
-  ) {
-    this.bytes += chunk.length;
-    callback(null, chunk);
-  }
-}
-
-// ByteCounter that also tallies inter-chunk gaps into `stats.sourceWaitMs`, so
-// the Parquet path (piped binary stream, no per-row generator) reuses the
-// standard chReadMs/uploadWaitMs derivation. Coarse: source wait conflates CH
-// delivery with S3 backpressure (same as countedStream).
-class TimedByteCounter extends ByteCounter {
-  private readonly stats: { sourceWaitMs: number };
-  // Clock starts at construction (like countedStream, before its loop) so the
-  // first gap captures time-to-first-byte — the dominant CH wait, since Parquet
-  // composes a row group before any bytes. Guarding it would drop TTFB from chReadMs.
-  private lastChunkDoneAt: number = performance.now();
-  constructor(stats: { sourceWaitMs: number }) {
-    super();
-    this.stats = stats;
-  }
-  _transform(
-    chunk: Buffer,
-    _encoding: string,
-    callback: (error: Error | null, data?: Buffer) => void,
-  ) {
-    this.stats.sourceWaitMs += performance.now() - this.lastChunkDoneAt;
-    this.bytes += chunk.length;
-    this.lastChunkDoneAt = performance.now();
-    callback(null, chunk);
-  }
-}
-
 async function* countedStream<T>(
   source: AsyncGenerator<T>,
   stats: { rows: number; sourceWaitMs: number },
@@ -517,10 +480,12 @@ const processBlobStorageExport = async (config: {
           }
         };
 
-        // Tracks ClickHouse read wait. Declared before the counters so the
-        // parquet TimedByteCounter can write into it (the parquet path has no
-        // per-row generator, so countedStream does not run).
-        const sourceStats = { rows: 0, sourceWaitMs: 0 };
+        // Tracks ClickHouse read wait (and, on the parquet path, S3 backpressure
+        // in backpressureMs). Declared before the counters so the parquet
+        // TimedByteCounter can write into it (the parquet path has no per-row
+        // generator, so countedStream does not run and backpressureMs stays 0
+        // on every non-parquet path).
+        const sourceStats = { rows: 0, sourceWaitMs: 0, backpressureMs: 0 };
         // When enrichment is active, chStats isolates ClickHouse read wait from
         // enrichment CPU. enrichMs = sourceStats.sourceWaitMs - chStats.sourceWaitMs.
         let chStats: { rows: number; sourceWaitMs: number } | null = null;
@@ -809,8 +774,17 @@ const processBlobStorageExport = async (config: {
           }
 
           const uploadDurationMs = uploadDurationMsFinal;
+          // On the parquet path the source counter sits at the upload boundary,
+          // so its sourceWaitMs folds S3 backpressure into the CH-read wait;
+          // strip the measured backpressure to recover pure chReadMs. Other
+          // paths leave sourceStats.backpressureMs at 0, so this is a no-op
+          // (gzip isolates CH read upstream in chStats).
           const chReadMs = Math.round(
-            chStats ? chStats.sourceWaitMs : sourceStats.sourceWaitMs,
+            Math.max(
+              0,
+              (chStats ? chStats.sourceWaitMs : sourceStats.sourceWaitMs) -
+                (chStats ? 0 : sourceStats.backpressureMs),
+            ),
           );
           const enrichMs = chStats
             ? Math.max(
@@ -824,9 +798,14 @@ const processBlobStorageExport = async (config: {
                 Math.round(gzipStats.activeMs - gzipStats.backpressureMs),
               )
             : 0;
+          // Upload wait comes from a measured backpressure signal where one
+          // exists — gzip push/read on the standard path, the boundary counter
+          // on parquet — and falls back to the duration residual otherwise.
           const uploadWaitMs = gzipStats
             ? Math.round(gzipStats.backpressureMs)
-            : Math.max(0, uploadDurationMs - chReadMs - enrichMs);
+            : parquetEligible
+              ? Math.round(sourceStats.backpressureMs)
+              : Math.max(0, uploadDurationMs - chReadMs - enrichMs);
 
           logger.info(
             `[BLOB INTEGRATION] Successfully exported ${config.table} for project ${config.projectId}: ` +
@@ -848,8 +827,14 @@ const processBlobStorageExport = async (config: {
           );
         } finally {
           span.setAttribute("blob.rows", sourceStats.rows);
+          // See the success-path derivation: strip parquet boundary backpressure
+          // from sourceWaitMs to recover pure chReadMs (no-op on other paths).
           const finalChReadMs = Math.round(
-            chStats ? chStats.sourceWaitMs : sourceStats.sourceWaitMs,
+            Math.max(
+              0,
+              (chStats ? chStats.sourceWaitMs : sourceStats.sourceWaitMs) -
+                (chStats ? 0 : sourceStats.backpressureMs),
+            ),
           );
           const finalEnrichMs = chStats
             ? Math.max(
@@ -874,7 +859,9 @@ const processBlobStorageExport = async (config: {
                 : 0;
               const finalUploadWaitMs = gzipStats
                 ? Math.round(gzipStats.backpressureMs)
-                : Math.max(0, totalUploadMs - finalChReadMs - finalEnrichMs);
+                : parquetEligible
+                  ? Math.round(sourceStats.backpressureMs)
+                  : Math.max(0, totalUploadMs - finalChReadMs - finalEnrichMs);
               span.setAttribute("blob.gzipCpuMs", finalGzipCpuMs);
               span.setAttribute("blob.uploadWaitMs", finalUploadWaitMs);
               const finalExportFormat = parquetEligible

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -480,11 +480,8 @@ const processBlobStorageExport = async (config: {
           }
         };
 
-        // Tracks ClickHouse read wait (and, on the parquet path, S3 backpressure
-        // in backpressureMs). Declared before the counters so the parquet
-        // TimedByteCounter can write into it (the parquet path has no per-row
-        // generator, so countedStream does not run and backpressureMs stays 0
-        // on every non-parquet path).
+        // Source read wait; backpressureMs is set only by the parquet
+        // TimedByteCounter and stays 0 on every other path.
         const sourceStats = { rows: 0, sourceWaitMs: 0, backpressureMs: 0 };
         // When enrichment is active, chStats isolates ClickHouse read wait from
         // enrichment CPU. enrichMs = sourceStats.sourceWaitMs - chStats.sourceWaitMs.
@@ -774,11 +771,9 @@ const processBlobStorageExport = async (config: {
           }
 
           const uploadDurationMs = uploadDurationMsFinal;
-          // On the parquet path the source counter sits at the upload boundary,
-          // so its sourceWaitMs folds S3 backpressure into the CH-read wait;
-          // strip the measured backpressure to recover pure chReadMs. Other
-          // paths leave sourceStats.backpressureMs at 0, so this is a no-op
-          // (gzip isolates CH read upstream in chStats).
+          // Parquet's source counter sits at the upload boundary, so strip its
+          // backpressure to recover pure CH read (no-op elsewhere: gzip isolates
+          // CH read in chStats, and backpressureMs is 0 on every other path).
           const chReadMs = Math.round(
             Math.max(
               0,
@@ -798,9 +793,7 @@ const processBlobStorageExport = async (config: {
                 Math.round(gzipStats.activeMs - gzipStats.backpressureMs),
               )
             : 0;
-          // Upload wait comes from a measured backpressure signal where one
-          // exists — gzip push/read on the standard path, the boundary counter
-          // on parquet — and falls back to the duration residual otherwise.
+          // Measured backpressure (gzip / parquet boundary), else duration residual.
           const uploadWaitMs = gzipStats
             ? Math.round(gzipStats.backpressureMs)
             : parquetEligible
@@ -827,8 +820,7 @@ const processBlobStorageExport = async (config: {
           );
         } finally {
           span.setAttribute("blob.rows", sourceStats.rows);
-          // See the success-path derivation: strip parquet boundary backpressure
-          // from sourceWaitMs to recover pure chReadMs (no-op on other paths).
+          // Same chReadMs / uploadWaitMs derivation as the success path above.
           const finalChReadMs = Math.round(
             Math.max(
               0,


### PR DESCRIPTION
## What does this PR do?

Fixes per-stage timing on the **Parquet** blob-export path (LFE-10463). Since the Parquet format landed, `uploadWaitMs` collapsed to ~0 and `chReadMs` no longer meant "ClickHouse wait".

**Root cause:** the Parquet path has no per-row generator, so it relied on a single inline `TimedByteCounter` sitting at the upload boundary. Its `sourceWaitMs` therefore conflated ClickHouse-read time with S3 upload backpressure (the buffered uploader backpressures the stream). `chReadMs` absorbed everything, and `uploadWaitMs = max(0, uploadDurationMs − chReadMs)` came out ~0. (The gzip path was unaffected because it measures S3 backpressure separately in `TimedGzip`.)

**Fix:** reconstruct the gzip path's two-sided measurement without a gzip stage. `TimedByteCounter` now pushes explicitly and times the `push()`→`_read()` gap into `stats.backpressureMs` — the same signal `TimedGzip` uses. The derivation becomes:

- `chReadMs = max(0, sourceWaitMs − backpressureMs)` → pure ClickHouse wait
- `uploadWaitMs = backpressureMs` on Parquet (measured, not a residual)
- `gzipCpuMs = 0` stays correct (no worker-side gzip)

The backpressure subtraction is a **no-op on every non-Parquet path** (`backpressureMs` stays 0 there; gzip isolates CH-read upstream in `chStats`), so existing paths are byte-for-byte unchanged.

Also extracted `ByteCounter`/`TimedByteCounter` into `byteCounters.ts` (mirrors `gzipStream.ts`) so the boundary timer is unit-testable in isolation.

Fixes LFE-10463

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Tests

Added `byteCounters.test.ts` — byte integrity plus both regimes: CH-bound (wait lands in `chReadMs`) and upload-bound (wait lands in `backpressureMs`, guarding against the collapse) plus error propagation. Verified `pnpm turbo run typecheck/lint --filter=worker` and the blob-storage unit suites.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts `ByteCounter` and `TimedByteCounter` into their own module (`byteCounters.ts`) and extends `TimedByteCounter` with a proper downstream-backpressure measurement — mirroring the `TimedGzip` push/`_read` pattern — so the Parquet export path can correctly split `uploadWaitMs` from `chReadMs` in metrics.

- `TimedByteCounter` now records backpressure via explicit `this.push()` (returning `false` opens a `bpStart` interval; `_read` credits it), and `sourceStats.backpressureMs` is wired into both the success-path and `finally`-block metric derivations.
- `handleBlobStorageIntegrationProjectJob.ts` now uses `sourceStats.backpressureMs` (directly measured) for `uploadWaitMs` on the Parquet path, replacing the old residual formula that silently absorbed backpressure into `chReadMs`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is additive on the metrics plane and existing non-Parquet paths are unchanged.

The backpressure-measurement logic is correct and mirrors the established TimedGzip pattern. The two timing-based tests rely on real wall-clock delays, which could be flaky on slow CI runners — the only reason to pause before merging would be if CI is known to be resource-constrained.

byteCounters.test.ts — the wall-clock timing assertions are the only element that could cause a spurious failure in a congested environment.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CH as ClickHouse (parquetSource)
    participant TBC as TimedByteCounter
    participant S3 as S3 Uploader

    CH->>TBC: chunk (sourceWaitMs gap measured)
    TBC->>S3: push(chunk) → returns false (buffer full)
    Note over TBC: bpStart = now()
    TBC-->>CH: callback(null) — writable ready

    Note over S3: uploading to S3...
    S3->>TBC: _read() — downstream drained
    Note over TBC: backpressureMs += now()-bpStart
    TBC->>TBC: super._read() — resume transform pump

    CH->>TBC: next chunk
    Note over TBC: sourceWaitMs += now()-lastChunkDoneAt
    TBC->>S3: push(chunk) → true

    Note over TBC: _flush(): creditBackpressure()
    Note over TBC: chReadMs = sourceWaitMs - backpressureMs
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CH as ClickHouse (parquetSource)
    participant TBC as TimedByteCounter
    participant S3 as S3 Uploader

    CH->>TBC: chunk (sourceWaitMs gap measured)
    TBC->>S3: push(chunk) → returns false (buffer full)
    Note over TBC: bpStart = now()
    TBC-->>CH: callback(null) — writable ready

    Note over S3: uploading to S3...
    S3->>TBC: _read() — downstream drained
    Note over TBC: backpressureMs += now()-bpStart
    TBC->>TBC: super._read() — resume transform pump

    CH->>TBC: next chunk
    Note over TBC: sourceWaitMs += now()-lastChunkDoneAt
    TBC->>S3: push(chunk) → true

    Note over TBC: _flush(): creditBackpressure()
    Note over TBC: chReadMs = sourceWaitMs - backpressureMs
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/blobstorage/byteCounters.test.ts:65-90
**Timing assertions may be flaky on loaded CI runners**

Both backpressure-path tests rely on wall-clock thresholds (`toBeGreaterThan(100)` for ~6×30 ms or 6×40 ms). On a heavily loaded runner those delays can slip significantly in either direction, and on some environments `setTimeout` resolution can be coarser than 10 ms, which may cause the "source bottleneck" test to accumulate unexpected backpressure (making `stats.backpressureMs` exceed `stats.sourceWaitMs / 2`) or the "sink bottleneck" test to fall below 100 ms. The thresholds look generous, but it's worth noting they are environment-dependent. Consider adding `vi.setSystemTime` / fake timers, or at minimum document that these tests require real timers with adequate resolution.

### Issue 2 of 2
worker/src/features/blobstorage/byteCounters.ts:63-72
**Two consecutive `performance.now()` calls introduce a tiny negative bias in `chReadMs`**

When `push(chunk)` returns `false`, `bpStart` is stamped at T₁, then `lastChunkDoneAt` is stamped at T₂ (a few microseconds later). The next chunk's `sourceWaitMs` contribution starts from T₂, while `backpressureMs` starts from T₁. The resulting `chReadMs = sourceWaitMs - backpressureMs` is therefore slightly under-counted by T₂ − T₁. The `Math.max(0, …)` guard in the calling code prevents a negative result, so this is entirely harmless in practice, but stamping both at the same `now = performance.now()` value would eliminate the asymmetry.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): measure Parquet upload-wait..."](https://github.com/langfuse/langfuse/commit/7ae7d9cb07147daeb3c72fad66cfe45321fa99f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39848812)</sub>

<!-- /greptile_comment -->