### PR TITLE
feat(filters): nested AND/OR filter expression contract for events (LFE-10522)

### DIFF
--- a/packages/shared/src/interfaces/filters.ts
+++ b/packages/shared/src/interfaces/filters.ts
@@ -131,6 +131,236 @@ export const singleFilter = z.discriminatedUnion("type", [
   positionInTraceFilter,
 ]);
 
+/**
+ * Nested boolean filter contract (Search/Filter v2).
+ *
+ * The legacy `FilterState` is a flat `FilterCondition[]` with an implicit AND.
+ * A `filterExpression` is a tree: a leaf (`singleFilter`) or a `group` whose
+ * children are themselves expressions, combined by `AND`/`OR`. This lets the
+ * backend express cross-field OR, bracket grouping, and NOT-of-a-group that the
+ * flat contract cannot represent.
+ *
+ * `filterInput` is the wire union accepted by consumers: either a flat
+ * `FilterCondition[]` (back-compat) or a `filterExpression`. Flat arrays are
+ * normalized to a top-level AND group via {@link normalizeFilterExpressionInput}
+ * so there is a single representation downstream.
+ *
+ * Tenant isolation is NOT enforced here — it is structural: callers inject the
+ * mandatory project/env/time predicates as an outer AND wrapping the user
+ * expression (never inside it). {@link getMandatoryFilterExpressionLeafFilters}
+ * returns the leaves reachable through AND only, so optimizations that depend on
+ * a guaranteed predicate (e.g. trace-id hash pruning) never fire on a leaf that
+ * sits under an OR and could be widened away.
+ */
+export const filterGroupOperator = z.enum(["AND", "OR"]);
+
+type FilterConditionSchema = z.infer<typeof singleFilter>;
+type FilterGroupSchema = {
+  type: "group";
+  operator: z.infer<typeof filterGroupOperator>;
+  conditions: FilterExpressionSchema[];
+};
+type FilterExpressionSchema = FilterConditionSchema | FilterGroupSchema;
+type FilterInputSchema =
+  | FilterConditionSchema[]
+  | FilterExpressionSchema
+  | null
+  | undefined;
+
+export const filterExpression: z.ZodType<FilterExpressionSchema> = z.lazy(() =>
+  z.union([singleFilter, filterGroup]),
+);
+
+export const filterGroup: z.ZodType<FilterGroupSchema> = z.lazy(() =>
+  z.object({
+    type: z.literal("group"),
+    operator: filterGroupOperator,
+    conditions: z.array(filterExpression).min(1),
+  }),
+);
+
+/**
+ * Bounds on a `filterExpression` tree ("bound the blast"). Depth counts nested
+ * groups (a single AND/OR group is depth 1); the condition cap counts LEAF
+ * conditions only (group containers don't count), so a flat array of N filters
+ * — which normalizes to one wrapping AND group — caps at exactly N. These
+ * protect ClickHouse and the recursive emitter/parser from pathological input.
+ * They are enforced on {@link filterInput} (the v2 wire contract), so existing
+ * flat `z.array(singleFilter)` consumers are unaffected.
+ */
+export const MAX_FILTER_EXPRESSION_DEPTH = 8;
+export const MAX_FILTER_EXPRESSION_NODES = 64;
+
+function measureFilterExpression(expression: FilterExpressionSchema): {
+  leaves: number;
+  depth: number;
+} {
+  if (expression.type !== "group") {
+    return { leaves: 1, depth: 0 };
+  }
+
+  const childMeasures = expression.conditions.map(measureFilterExpression);
+  return {
+    leaves: childMeasures.reduce((sum, child) => sum + child.leaves, 0),
+    depth:
+      1 + childMeasures.reduce((max, child) => Math.max(max, child.depth), 0),
+  };
+}
+
+/**
+ * Returns a human-readable diagnostic when an expression exceeds the depth or
+ * condition bounds, or `null` when it is within bounds. Pure — reused by both
+ * the zod refinement on {@link filterInput} and the server-side compiler.
+ */
+export function getFilterExpressionBoundsIssue(
+  expression?: FilterExpressionSchema,
+): string | null {
+  if (!expression) {
+    return null;
+  }
+
+  const { leaves, depth } = measureFilterExpression(expression);
+
+  if (depth > MAX_FILTER_EXPRESSION_DEPTH) {
+    return `Filter is nested too deeply (max depth ${MAX_FILTER_EXPRESSION_DEPTH}).`;
+  }
+
+  if (leaves > MAX_FILTER_EXPRESSION_NODES) {
+    return `Filter has too many conditions (max ${MAX_FILTER_EXPRESSION_NODES}).`;
+  }
+
+  return null;
+}
+
+export const filterInput = z
+  .union([z.array(singleFilter), filterExpression])
+  .superRefine((value, ctx) => {
+    const issue = getFilterExpressionBoundsIssue(
+      normalizeFilterExpressionInput(value),
+    );
+    if (issue) {
+      ctx.addIssue({ code: "custom", message: issue });
+    }
+  });
+
+export function normalizeFilterExpressionInput(
+  filterInputValue?: FilterInputSchema,
+): FilterExpressionSchema | undefined {
+  if (!filterInputValue) {
+    return undefined;
+  }
+
+  if (Array.isArray(filterInputValue)) {
+    if (filterInputValue.length === 0) {
+      return undefined;
+    }
+
+    return {
+      type: "group",
+      operator: "AND",
+      conditions: filterInputValue,
+    };
+  }
+
+  return filterInputValue;
+}
+
+export function isFilterGroup(
+  filterValue: FilterExpressionSchema,
+): filterValue is FilterGroupSchema {
+  return filterValue.type === "group";
+}
+
+/**
+ * All leaf conditions in the tree, regardless of operator. Use for metadata
+ * (span attributes, "does this query touch scores?") — never for security
+ * decisions, since a leaf may sit under an OR.
+ */
+export function getFilterExpressionLeafFilters(
+  filterValue?: FilterExpressionSchema,
+): FilterConditionSchema[] {
+  if (!filterValue) {
+    return [];
+  }
+
+  if (!isFilterGroup(filterValue)) {
+    return [filterValue];
+  }
+
+  return filterValue.conditions.flatMap((condition) =>
+    getFilterExpressionLeafFilters(condition),
+  );
+}
+
+/**
+ * Leaf conditions reachable through AND groups only. As soon as an OR group is
+ * encountered, its subtree contributes nothing — an OR branch is not a
+ * guaranteed predicate. This is the safe set for query optimizations and for
+ * deriving values that must hold for every returned row (e.g. the start-time
+ * window, trace-id hash pruning).
+ */
+export function getMandatoryFilterExpressionLeafFilters(
+  filterValue?: FilterExpressionSchema,
+): FilterConditionSchema[] {
+  if (!filterValue) {
+    return [];
+  }
+
+  if (!isFilterGroup(filterValue)) {
+    return [filterValue];
+  }
+
+  // A multi-branch OR contributes no guaranteed predicate. A single-branch OR is
+  // semantically just its child (and the SQL emitter unwraps it), so it stays
+  // mandatory — keeping this in sync with applyCompiledFilterNode's collapse.
+  if (filterValue.operator === "OR" && filterValue.conditions.length !== 1) {
+    return [];
+  }
+
+  return filterValue.conditions.flatMap((condition) =>
+    getMandatoryFilterExpressionLeafFilters(condition),
+  );
+}
+
+/**
+ * Combine multiple {@link FilterInput}s into a single AND, flattening nested
+ * top-level AND groups (and flat arrays) so redundant `AND(AND(...))` wrappers
+ * never waste the depth budget. Returns a flat `FilterState` when every combined
+ * condition is a leaf (so the facet sidebar can still own it), a nested
+ * `FilterExpression` when any branch is a group, or `undefined` when nothing
+ * remains. Use this anywhere a user filter is AND-conjoined with mandatory
+ * predicates (managed-env default, page-scope filters, preserved leaves).
+ */
+export function combineFilterInputsWithAnd(
+  ...inputs: (FilterInputSchema | undefined)[]
+):
+  | FilterConditionSchema[]
+  | FilterGroupSchema
+  | FilterConditionSchema
+  | undefined {
+  const conditions: FilterExpressionSchema[] = [];
+  for (const input of inputs) {
+    const expression = normalizeFilterExpressionInput(input);
+    if (!expression) continue;
+    if (expression.type === "group" && expression.operator === "AND") {
+      conditions.push(...expression.conditions);
+    } else {
+      conditions.push(expression);
+    }
+  }
+
+  if (conditions.length === 0) return undefined;
+
+  // All leaves → a flat FilterState array (sidebar-owned, codec stays delimited).
+  if (conditions.every((condition) => condition.type !== "group")) {
+    return conditions as FilterConditionSchema[];
+  }
+
+  if (conditions.length === 1) return conditions[0];
+
+  return { type: "group", operator: "AND", conditions };
+}
+
 const eventsTableStringOperator = z.union([
   z.enum(filterOperators.string),
   z.literal(FTS_MATCH_OPERATOR),

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -29,6 +29,168 @@ type ClickhouseFilter = {
   params: { [x: string]: any } | {};
 };
 
+/**
+ * A compiled, ready-to-apply collection of leaf filters. Both the legacy flat
+ * {@link FilterList} and the nested {@link FilterTree} implement this so query
+ * builders can consume either without caring about shape.
+ *
+ * `find` searches ALL leaves; `findMandatory` searches only leaves reachable
+ * through AND groups. Query optimizations that assume a predicate always holds
+ * (e.g. trace-id hash pruning) MUST use `findMandatory`, so they never fire on
+ * a leaf that sits under an OR (where the predicate may not constrain a row).
+ */
+export interface CompiledFilterCollection {
+  apply(): ClickhouseFilter;
+  find(predicate: (filter: Filter) => boolean): Filter | undefined;
+  findMandatory(predicate: (filter: Filter) => boolean): Filter | undefined;
+  some(predicate: (filter: Filter) => boolean): boolean;
+  forEach(callback: (filter: Filter) => void): void;
+  length(): number;
+}
+
+type CompiledFilterNode = Filter | FilterGroupNode;
+
+function isFilterGroupNode(node: CompiledFilterNode): node is FilterGroupNode {
+  return node instanceof FilterGroupNode;
+}
+
+function flattenCompiledFilterNode(node: CompiledFilterNode): Filter[] {
+  if (!isFilterGroupNode(node)) {
+    return [node];
+  }
+
+  return node.children.flatMap((child) => flattenCompiledFilterNode(child));
+}
+
+function collectMandatoryCompiledFilters(node: CompiledFilterNode): Filter[] {
+  if (!isFilterGroupNode(node)) {
+    return [node];
+  }
+
+  // A multi-branch OR has no guaranteed predicate. A single-branch OR collapses
+  // to its unwrapped child in applyCompiledFilterNode, so it stays mandatory —
+  // keeping the optimization set in sync with the emitted SQL.
+  if (node.operator === "OR" && node.children.length !== 1) {
+    return [];
+  }
+
+  return node.children.flatMap((child) =>
+    collectMandatoryCompiledFilters(child),
+  );
+}
+
+/**
+ * Recursive parenthesizing emitter. Each child is wrapped in `( … )` and joined
+ * by the group operator, so precedence is explicit in SQL and never depends on
+ * ClickHouse's operator precedence. Empty children (a child that compiled to no
+ * SQL) are dropped; a group of 0 → `""`, a group of 1 → the unwrapped child.
+ */
+function applyCompiledFilterNode(node: CompiledFilterNode): ClickhouseFilter {
+  if (!isFilterGroupNode(node)) {
+    return node.apply();
+  }
+
+  const compiledChildren = node.children
+    .map((child) => applyCompiledFilterNode(child))
+    .filter((child) => child.query.trim().length > 0);
+
+  if (compiledChildren.length === 0) {
+    return {
+      query: "",
+      params: {},
+    };
+  }
+
+  if (compiledChildren.length === 1) {
+    return compiledChildren[0];
+  }
+
+  return {
+    query: compiledChildren
+      .map((child) => `(${child.query})`)
+      .join(` ${node.operator} `),
+    params: compiledChildren.reduce(
+      (acc, child) => ({ ...acc, ...child.params }),
+      {} as Record<string, any>,
+    ),
+  };
+}
+
+class FilterGroupNode {
+  constructor(
+    public operator: "AND" | "OR",
+    public children: CompiledFilterNode[],
+  ) {}
+}
+
+/**
+ * A compiled nested filter tree. The leaf {@link Filter}s are the SAME classes
+ * the flat path uses (so per-leaf injection safety — randomized named/typed
+ * params, value never interpolated — is unchanged); only the combiner is
+ * recursive. `apply()` emits the parenthesized SQL; `find`/`some`/`forEach`
+ * operate over all leaves, `findMandatory` over AND-only leaves.
+ */
+export class FilterTree implements CompiledFilterCollection {
+  private leaves: Filter[];
+  private mandatoryLeaves: Filter[];
+
+  constructor(private root: CompiledFilterNode | null = null) {
+    this.leaves = this.root ? flattenCompiledFilterNode(this.root) : [];
+    this.mandatoryLeaves = this.root
+      ? collectMandatoryCompiledFilters(this.root)
+      : [];
+  }
+
+  find(predicate: (filter: Filter) => boolean) {
+    return this.leaves.find(predicate);
+  }
+
+  findMandatory(predicate: (filter: Filter) => boolean) {
+    return this.mandatoryLeaves.find(predicate);
+  }
+
+  some(predicate: (filter: Filter) => boolean) {
+    return this.leaves.some(predicate);
+  }
+
+  forEach(callback: (filter: Filter) => void) {
+    this.leaves.forEach(callback);
+  }
+
+  length() {
+    return this.leaves.length;
+  }
+
+  apply(): ClickhouseFilter {
+    if (!this.root) {
+      return {
+        query: "",
+        params: {},
+      };
+    }
+
+    return applyCompiledFilterNode(this.root);
+  }
+
+  static fromFilter(filter: Filter): FilterTree {
+    return new FilterTree(filter);
+  }
+
+  static fromGroup(
+    operator: "AND" | "OR",
+    children: Array<Filter | FilterTree>,
+  ): FilterTree {
+    return new FilterTree(
+      new FilterGroupNode(
+        operator,
+        children
+          .map((child) => (child instanceof FilterTree ? child.root : child))
+          .filter((child): child is CompiledFilterNode => child !== null),
+      ),
+    );
+  }
+}
+
 const NGRAM_ACCELERATED_METADATA_OPERATORS = new Set<
   (typeof filterOperators)["stringObject"][number]
 >(["contains", "starts with", "ends with"]);
@@ -611,7 +773,7 @@ export class BooleanFilter implements Filter {
   }
 }
 
-export class FilterList {
+export class FilterList implements CompiledFilterCollection {
   private filters: Filter[];
 
   constructor(filters: Filter[] = []) {
@@ -624,6 +786,11 @@ export class FilterList {
 
   find(predicate: (filter: Filter) => boolean) {
     return this.filters.find(predicate);
+  }
+
+  // A flat list is an implicit top-level AND, so every leaf is mandatory.
+  findMandatory(predicate: (filter: Filter) => boolean) {
+    return this.find(predicate);
   }
 
   filter(predicate: (filter: Filter) => boolean) {

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -3,7 +3,10 @@ import {
   ObservationFieldGroupPublicApi,
 } from "../../../domain/observation-field-groups";
 import { OBSERVATIONS_TO_TRACE_INTERVAL } from "../../repositories/constants";
-import { FilterList, StringFilter } from "./clickhouse-filter";
+import {
+  type CompiledFilterCollection,
+  StringFilter,
+} from "./clickhouse-filter";
 
 /**
  * Extract the output column alias from a field expression (unquoted).
@@ -544,10 +547,11 @@ abstract class AbstractQueryBuilder {
   }
 
   /**
-   * Apply filters from a FilterList.
-   * Subclasses can override to add optimizations (e.g., partition pruning).
+   * Apply filters from a compiled filter collection (flat FilterList or nested
+   * FilterTree). Subclasses can override to add optimizations (e.g., partition
+   * pruning).
    */
-  applyFilters(filterList: FilterList): this {
+  applyFilters(filterList: CompiledFilterCollection): this {
     this.where(filterList.apply());
     return this;
   }
@@ -818,8 +822,10 @@ abstract class BaseEventsQueryBuilder<
    * Apply filters with automatic query optimizations.
    * Adds xxHash32 optimization for trace_id equality filters.
    */
-  override applyFilters(filterList: FilterList): this {
-    const traceIdFilter = filterList.find(
+  override applyFilters(filterList: CompiledFilterCollection): this {
+    // findMandatory (AND-only leaves) so the xxHash32 prune never fires on a
+    // trace_id leaf that sits under an OR, where it would not constrain rows.
+    const traceIdFilter = filterList.findMandatory(
       (f) =>
         f.clickhouseTable.startsWith("events") &&
         f.field === 'e."trace_id"' &&

--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -1,5 +1,13 @@
-import { FTS_MATCH_OPERATOR } from "../../../interfaces/filters";
-import { type EventsTableFilterState } from "../../../types";
+import {
+  FTS_MATCH_OPERATOR,
+  getFilterExpressionBoundsIssue,
+  normalizeFilterExpressionInput,
+} from "../../../interfaces/filters";
+import {
+  type EventsTableFilterState,
+  type FilterExpression,
+  type FilterInput,
+} from "../../../types";
 import { InvalidRequestError } from "../../../errors";
 import { isValidTableName } from "../../clickhouse/schemaUtils";
 import { logger } from "../../logger";
@@ -15,6 +23,8 @@ import {
   StringOptionsFilter,
   CategoryOptionsFilter,
   FilterList,
+  FilterTree,
+  type Filter,
   NumberFilter,
   ArrayOptionsFilter,
   BooleanFilter,
@@ -34,6 +44,127 @@ export class QueryBuilderError extends Error {
 // This function ensures that the user only selects valid columns from the clickhouse schema.
 // The filter property in this column needs to be zod verified.
 // User input for values (e.g. project_id = <value>) are sent to Clickhouse as parameters to prevent SQL injection
+const createFilterFromCondition = (
+  frontEndFilter: EventsTableFilterState[number],
+  columnMapping: UiColumnMappings,
+  columnDefinitions?: ColumnDefinition[],
+): Filter => {
+  // checks if the column exists in the clickhouse schema
+  const column = matchAndVerifyTracesUiColumn(frontEndFilter, columnMapping);
+
+  if (columnDefinitions && frontEndFilter.type !== "null") {
+    const colDef = columnDefinitions.find((c) => c.id === column.uiTableId);
+    if (colDef) {
+      const compatible = COMPATIBLE_FILTER_TYPES[colDef.type];
+      if (compatible && !compatible.includes(frontEndFilter.type)) {
+        throw new InvalidRequestError(
+          `Invalid filter type '${frontEndFilter.type}' for column '${frontEndFilter.column}'. Expected filter type '${colDef.type}'.`,
+        );
+      }
+    }
+  }
+
+  validateEventsTableMatchesFilter(frontEndFilter, column);
+
+  switch (frontEndFilter.type) {
+    case "string":
+      return new StringFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        value: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+        emptyEqualsNull: column.emptyEqualsNull,
+      });
+    case "datetime":
+      return new DateTimeFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        value: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+      });
+    case "stringOptions":
+      return new StringOptionsFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        values: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+        emptyEqualsNull: column.emptyEqualsNull,
+      });
+    case "categoryOptions":
+      return new CategoryOptionsFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        key: frontEndFilter.key,
+        values: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+      });
+    case "number":
+      return new NumberFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        value: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+        clickhouseTypeOverwrite: column.clickhouseTypeOverwrite,
+      });
+    case "arrayOptions":
+      return new ArrayOptionsFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        values: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+      });
+    case "boolean":
+      return new BooleanFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        value: frontEndFilter.value,
+        operator: frontEndFilter.operator,
+        tablePrefix: column.queryPrefix,
+      });
+    case "numberObject":
+      return new NumberObjectFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        key: frontEndFilter.key,
+        operator: frontEndFilter.operator,
+        value: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+      });
+    case "stringObject":
+      return new StringObjectFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        key: frontEndFilter.key,
+        value: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+      });
+    case "null":
+      return new NullFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        tablePrefix: column.queryPrefix,
+        emptyEqualsNull: column.emptyEqualsNull,
+      });
+    case "positionInTrace":
+      throw new QueryBuilderError(
+        "positionInTrace filters must be handled before ClickHouse filter compilation",
+      );
+    default:
+      // eslint-disable-next-line no-case-declarations
+      const exhaustiveCheck: never = frontEndFilter;
+      logger.error(`Invalid filter type: ${JSON.stringify(exhaustiveCheck)}`);
+      throw new QueryBuilderError(`Invalid filter type`);
+  }
+};
+
 export const createFilterFromFilterState = (
   filter: EventsTableFilterState,
   columnMapping: UiColumnMappings,
@@ -43,118 +174,75 @@ export const createFilterFromFilterState = (
     (frontEndFilter) => frontEndFilter.type !== "positionInTrace",
   );
 
-  return applicableFilters.map((frontEndFilter) => {
-    // checks if the column exists in the clickhouse schema
-    const column = matchAndVerifyTracesUiColumn(frontEndFilter, columnMapping);
+  return applicableFilters.map((frontEndFilter) =>
+    createFilterFromCondition(frontEndFilter, columnMapping, columnDefinitions),
+  );
+};
 
-    if (columnDefinitions && frontEndFilter.type !== "null") {
-      const colDef = columnDefinitions.find((c) => c.id === column.uiTableId);
-      if (colDef) {
-        const compatible = COMPATIBLE_FILTER_TYPES[colDef.type];
-        if (compatible && !compatible.includes(frontEndFilter.type)) {
-          throw new InvalidRequestError(
-            `Invalid filter type '${frontEndFilter.type}' for column '${frontEndFilter.column}'. Expected filter type '${colDef.type}'.`,
-          );
-        }
-      }
-    }
+const buildFilterTree = (
+  expression: FilterExpression | undefined,
+  columnMapping: UiColumnMappings,
+  columnDefinitions?: ColumnDefinition[],
+): FilterTree => {
+  if (!expression) {
+    return new FilterTree();
+  }
 
-    validateEventsTableMatchesFilter(frontEndFilter, column);
+  if (expression.type === "group") {
+    return FilterTree.fromGroup(
+      expression.operator,
+      expression.conditions.map((condition) =>
+        buildFilterTree(condition, columnMapping, columnDefinitions),
+      ),
+    );
+  }
 
-    switch (frontEndFilter.type) {
-      case "string":
-        return new StringFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          value: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-          emptyEqualsNull: column.emptyEqualsNull,
-        });
-      case "datetime":
-        return new DateTimeFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          value: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-        });
-      case "stringOptions":
-        return new StringOptionsFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          values: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-          emptyEqualsNull: column.emptyEqualsNull,
-        });
-      case "categoryOptions":
-        return new CategoryOptionsFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          key: frontEndFilter.key,
-          values: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-        });
-      case "number":
-        return new NumberFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          value: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-          clickhouseTypeOverwrite: column.clickhouseTypeOverwrite,
-        });
-      case "arrayOptions":
-        return new ArrayOptionsFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          values: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-        });
-      case "boolean":
-        return new BooleanFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          value: frontEndFilter.value,
-          operator: frontEndFilter.operator,
-          tablePrefix: column.queryPrefix,
-        });
-      case "numberObject":
-        return new NumberObjectFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          key: frontEndFilter.key,
-          operator: frontEndFilter.operator,
-          value: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-        });
-      case "stringObject":
-        return new StringObjectFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          key: frontEndFilter.key,
-          value: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-        });
-      case "null":
-        return new NullFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          tablePrefix: column.queryPrefix,
-          emptyEqualsNull: column.emptyEqualsNull,
-        });
-      default:
-        // eslint-disable-next-line no-case-declarations
-        const exhaustiveCheck: never = frontEndFilter;
-        logger.error(`Invalid filter type: ${JSON.stringify(exhaustiveCheck)}`);
-        throw new QueryBuilderError(`Invalid filter type`);
-    }
-  });
+  // positionInTrace is resolved by the repository (CTE rewrite) before
+  // compilation; it contributes no ClickHouse predicate here.
+  if (expression.type === "positionInTrace") {
+    return new FilterTree();
+  }
+
+  return FilterTree.fromFilter(
+    createFilterFromCondition(expression, columnMapping, columnDefinitions),
+  );
+};
+
+/**
+ * Compile a nested {@link FilterExpression} into a {@link FilterTree} that emits
+ * parenthesized ClickHouse SQL. Rejects expressions that exceed the depth/node
+ * bounds with an {@link InvalidRequestError} (defense in depth — the wire
+ * contract `filterInput` enforces the same bounds at the tRPC boundary).
+ */
+export const createFilterTreeFromFilterExpression = (
+  expression: FilterExpression | undefined,
+  columnMapping: UiColumnMappings,
+  columnDefinitions?: ColumnDefinition[],
+): FilterTree => {
+  const boundsIssue = getFilterExpressionBoundsIssue(expression);
+  if (boundsIssue) {
+    throw new InvalidRequestError(boundsIssue);
+  }
+
+  return buildFilterTree(expression, columnMapping, columnDefinitions);
+};
+
+/**
+ * Compile a {@link FilterInput} (flat array OR nested expression) into a
+ * {@link FilterTree}. Flat arrays normalize to a top-level AND group, so legacy
+ * callers get exactly the same SQL as the flat {@link createFilterFromFilterState}
+ * path (one AND group with N children collapses to N AND-joined predicates).
+ */
+export const createFilterTreeFromFilterInput = (
+  filterInputValue: FilterInput | undefined,
+  columnMapping: UiColumnMappings,
+  columnDefinitions?: ColumnDefinition[],
+): FilterTree => {
+  return createFilterTreeFromFilterExpression(
+    normalizeFilterExpressionInput(filterInputValue),
+    columnMapping,
+    columnDefinitions,
+  );
 };
 
 const validateEventsTableMatchesFilter = (

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -6,7 +6,9 @@ export {
 } from "./createGenerationsQuery";
 export {
   type Filter,
+  type CompiledFilterCollection,
   FilterList,
+  FilterTree,
   StringFilter,
   DateTimeFilter,
   StringOptionsFilter,
@@ -23,7 +25,11 @@ export {
   orderByToClickhouseSql,
   orderByToEntries,
 } from "./clickhouse-sql/orderby-factory";
-export { createFilterFromFilterState } from "./clickhouse-sql/factory";
+export {
+  createFilterFromFilterState,
+  createFilterTreeFromFilterExpression,
+  createFilterTreeFromFilterInput,
+} from "./clickhouse-sql/factory";
 export {
   clickhouseSearchCondition,
   type ClickhouseSearchConditionOptions,

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -30,6 +30,7 @@ import {
 import {
   DateTimeFilter,
   type Filter,
+  type CompiledFilterCollection,
   FilterList,
   FullEventsObservations,
   orderByToClickhouseSql,
@@ -44,10 +45,19 @@ import {
   type ApiColumnMapping,
   ObservationPriceFields,
 } from "../queries";
-import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
+import {
+  createFilterFromFilterState,
+  createFilterTreeFromFilterExpression,
+} from "../queries/clickhouse-sql/factory";
+import {
+  getFilterExpressionLeafFilters,
+  getMandatoryFilterExpressionLeafFilters,
+  normalizeFilterExpressionInput,
+} from "../../interfaces/filters";
 import type {
   EventsTableFilterState,
   FilterCondition,
+  FilterExpression,
   FilterState,
 } from "../../types";
 import type { TracingSearchType } from "../../interfaces/search";
@@ -154,6 +164,16 @@ type ObservationsTableQueryResultWitouhtTraceFields = Omit<
   ObservationsTableQueryResult,
   "trace_tags" | "trace_name" | "trace_user_id"
 >;
+
+/**
+ * Events-table variant of {@link ObservationTableQuery}: the `filter` accepts a
+ * nested {@link FilterExpression} in addition to the flat {@link FilterState}
+ * (Search/Filter v2). Flat arrays are normalized to a top-level AND group
+ * before compilation, so legacy callers are unaffected.
+ */
+type EventsObservationTableQuery = Omit<ObservationTableQuery, "filter"> & {
+  filter?: FilterState | FilterExpression;
+};
 
 const EVENT_SEARCH_COLUMNS = [
   "span_id",
@@ -309,16 +329,19 @@ async function enrichObservationsWithTraceFields(
 }
 
 /**
- * Internal helper: extract and convert time filter from FilterList
- * Common pattern: find time filter and convert to ClickHouse DateTime format
+ * Internal helper: extract and convert time filter from a compiled filter
+ * collection. Common pattern: find time filter and convert to ClickHouse
+ * DateTime format. Uses `findMandatory` so a start-time lower bound that only
+ * holds inside an OR branch is NOT used as a partition-pruning bound (it does
+ * not constrain every returned row).
  */
 export function extractTimeFilter(
-  filter: FilterList,
+  filter: CompiledFilterCollection,
   tableName: "events_proto" | "traces" = "events_proto",
   fieldName: "start_time" | "timestamp" = "start_time",
   prefix?: "e" | "t",
 ): string | null {
-  const timeFilter = filter.find(
+  const timeFilter = filter.findMandatory(
     (f) =>
       // For events tables, match any events_* prefix (events_proto, events_core, events_full)
       (tableName === "events_proto"
@@ -331,6 +354,45 @@ export function extractTimeFilter(
   return timeFilter
     ? convertDateToClickhouseDateTime((timeFilter as DateTimeFilter).value)
     : null;
+}
+
+/**
+ * Drops positionInTrace leaves from an expression (they are resolved by a CTE
+ * rewrite, not a ClickHouse predicate). Returns undefined when nothing remains,
+ * collapses single-child groups, and preserves the group operators otherwise.
+ */
+function removePositionInTraceFilters(
+  filter?: FilterExpression,
+): FilterExpression | undefined {
+  if (!filter) {
+    return undefined;
+  }
+
+  if (filter.type === "positionInTrace") {
+    return undefined;
+  }
+
+  if (filter.type !== "group") {
+    return filter;
+  }
+
+  const conditions = filter.conditions
+    .map((condition) => removePositionInTraceFilters(condition))
+    .filter((condition): condition is FilterExpression => Boolean(condition));
+
+  if (conditions.length === 0) {
+    return undefined;
+  }
+
+  if (conditions.length === 1) {
+    return conditions[0];
+  }
+
+  return {
+    type: "group",
+    operator: filter.operator,
+    conditions,
+  };
 }
 
 /**
@@ -463,7 +525,7 @@ export const getObservationsForTraceFromEventsTable = async (params: {
 };
 
 export const getObservationsCountFromEventsTable = async (
-  opts: ObservationTableQuery,
+  opts: EventsObservationTableQuery,
 ) => {
   const count = await getObservationsFromEventsTableInternal<{
     count: string;
@@ -476,7 +538,7 @@ export const getObservationsCountFromEventsTable = async (
 };
 
 export const getObservationsWithModelDataFromEventsTable = async (
-  opts: ObservationTableQuery,
+  opts: EventsObservationTableQuery,
 ): Promise<FullEventsObservations> => {
   const observationRecords =
     await getObservationsFromEventsTableInternal<ObservationsTableQueryResultWitouhtTraceFields>(
@@ -498,7 +560,7 @@ export const getObservationsWithModelDataFromEventsTable = async (
 };
 
 async function getObservationsFromEventsTableInternal<T>(
-  opts: ObservationTableQuery & {
+  opts: EventsObservationTableQuery & {
     select: "count" | "rows";
     selectToolData?: boolean;
   },
@@ -515,24 +577,55 @@ async function getObservationsFromEventsTableInternal<T>(
     clickhouseConfigs,
   } = opts;
 
-  // Extract positionInTrace filter and build baseFilter without it
-  const positionFilter = filter.find((f) => f.type === "positionInTrace");
-  const baseFilter: typeof filter = [
-    ...filter.filter((f) => f.type !== "positionInTrace"),
-  ];
+  // Normalize the (possibly nested) filter into a single expression tree.
+  const normalizedFilter = normalizeFilterExpressionInput(filter);
+  const allLeafFilters = getFilterExpressionLeafFilters(normalizedFilter);
+  const mandatoryLeafFilters =
+    getMandatoryFilterExpressionLeafFilters(normalizedFilter);
 
-  // Build filter list from baseFilter (without positionInTrace)
-  const observationsFilter = new FilterList(
-    createFilterFromFilterState(
-      baseFilter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
+  // positionInTrace is resolved by a CTE rewrite (not a ClickHouse predicate),
+  // and that rewrite assumes exactly one conjunctive position filter. Reject
+  // any positionInTrace that is duplicated or sits under an OR branch.
+  const allPositionFilters = allLeafFilters.filter(
+    (
+      leafFilter,
+    ): leafFilter is Extract<
+      FilterState[number],
+      { type: "positionInTrace" }
+    > => leafFilter.type === "positionInTrace",
+  );
+  const mandatoryPositionFilters = mandatoryLeafFilters.filter(
+    (
+      leafFilter,
+    ): leafFilter is Extract<
+      FilterState[number],
+      { type: "positionInTrace" }
+    > => leafFilter.type === "positionInTrace",
+  );
+
+  // position-in-trace is resolved by a single CTE rewrite that can only express
+  // an AND-reachable (mandatory) filter. A position filter sitting under an OR
+  // cannot be expressed, so reject it. Duplicates within a conjunctive AND are
+  // allowed and fall back to the first (matching the legacy `.find()` path).
+  if (allPositionFilters.length !== mandatoryPositionFilters.length) {
+    throw new InvalidRequestError(
+      "position-in-trace filters cannot appear inside an OR group.",
+    );
+  }
+
+  const positionFilter = mandatoryPositionFilters[0];
+  const baseFilter = removePositionInTraceFilters(normalizedFilter);
+
+  // Build the filter tree from baseFilter (without positionInTrace)
+  const observationsFilter = createFilterTreeFromFilterExpression(
+    baseFilter,
+    eventsTableUiColumnDefinitions,
+    eventsTableCols,
   );
 
   const startTimeFrom = extractTimeFilter(observationsFilter);
-  const hasObservationScoresFilter = baseFilter.some((f) => {
-    const column = f.column.toLowerCase();
+  const hasObservationScoresFilter = allLeafFilters.some((leafFilter) => {
+    const column = leafFilter.column.toLowerCase();
     return (
       column === "scores" ||
       column === "scores_avg" ||
@@ -541,8 +634,8 @@ async function getObservationsFromEventsTableInternal<T>(
       column === "scores (categorical)"
     );
   });
-  const hasTraceScoresFilter = baseFilter.some((f) => {
-    const column = f.column.toLowerCase();
+  const hasTraceScoresFilter = allLeafFilters.some((leafFilter) => {
+    const column = leafFilter.column.toLowerCase();
     return (
       column === "trace_scores_avg" ||
       column === "trace_score_categories" ||
@@ -597,11 +690,9 @@ async function getObservationsFromEventsTableInternal<T>(
           : 1;
 
     // Build observation-only filter for CTE (no s.* or t.* references)
-    const nativeFilter = new FilterList(
-      createFilterFromFilterState(
-        baseFilter,
-        eventsTableNativeUiColumnDefinitions,
-      ),
+    const nativeFilter = createFilterTreeFromFilterExpression(
+      baseFilter,
+      eventsTableNativeUiColumnDefinitions,
     );
     const appliedNativeFilter = nativeFilter.apply();
     const qualifyingObsBuilder = new EventsQueryBuilder({ projectId })

--- a/packages/shared/src/server/services/commentFilterService.test.ts
+++ b/packages/shared/src/server/services/commentFilterService.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { filterRangeIncludesZero } from "./commentFilterService";
+
+// `commentCount` filters AND together, so zero comments are in the matched range
+// only when a count of 0 satisfies EVERY condition. When zero is included we use
+// exclusion logic (items with 0 comments aren't in the comments table); when it
+// is excluded we narrow to the entities that actually have matching comments.
+//
+// Regression: an `=`/`<`/`<=` filter has no `>=`/`>` lower bound, and the old
+// implementation treated "no lower bound" as "includes zero" → match-everything.
+// Under the new OR rewriter that amplified `OR(commentCount=N, …)` into "the whole
+// tree matches everything", returning every event in the project.
+const num = (operator: string, value: number) => ({
+  type: "number",
+  operator,
+  value,
+});
+
+describe("filterRangeIncludesZero", () => {
+  it("excludes zero for `= N` where N != 0 (the OR-collapse regression)", () => {
+    expect(filterRangeIncludesZero([num("=", 5)])).toBe(false);
+  });
+
+  it("includes zero for `= 0`", () => {
+    expect(filterRangeIncludesZero([num("=", 0)])).toBe(true);
+  });
+
+  it("handles lower bounds", () => {
+    expect(filterRangeIncludesZero([num(">=", 1)])).toBe(false);
+    expect(filterRangeIncludesZero([num(">=", 0)])).toBe(true);
+    expect(filterRangeIncludesZero([num(">", 0)])).toBe(false);
+    expect(filterRangeIncludesZero([num(">", -1)])).toBe(true);
+  });
+
+  it("handles upper bounds", () => {
+    expect(filterRangeIncludesZero([num("<=", 0)])).toBe(true);
+    expect(filterRangeIncludesZero([num("<=", 5)])).toBe(true);
+    expect(filterRangeIncludesZero([num("<", 5)])).toBe(true);
+    expect(filterRangeIncludesZero([num("<", 0)])).toBe(false);
+  });
+
+  it("requires EVERY condition to admit zero (AND semantics)", () => {
+    // a range that excludes zero
+    expect(filterRangeIncludesZero([num(">=", 1), num("<=", 5)])).toBe(false);
+    // both admit zero
+    expect(filterRangeIncludesZero([num(">=", 0), num("<=", 5)])).toBe(true);
+    // one admits, one doesn't → excluded
+    expect(filterRangeIncludesZero([num("<=", 5), num("=", 5)])).toBe(false);
+  });
+
+  it("treats no count filters as including zero", () => {
+    expect(filterRangeIncludesZero([])).toBe(true);
+  });
+
+  it("does not assume zero for an unknown operator (narrows instead)", () => {
+    expect(filterRangeIncludesZero([num("<>", 0)])).toBe(false);
+  });
+});

--- a/packages/shared/src/server/services/commentFilterService.ts
+++ b/packages/shared/src/server/services/commentFilterService.ts
@@ -1,5 +1,9 @@
 import type { PrismaClient } from "../../db";
-import { type singleFilter } from "../../interfaces/filters";
+import {
+  normalizeFilterExpressionInput,
+  type singleFilter,
+} from "../../interfaces/filters";
+import { type FilterExpression, type FilterInput } from "../../types";
 import {
   type CommentObjectType,
   type CommentCountOperator,
@@ -34,31 +38,39 @@ export function validateObjectIdCount(
 
 /**
  * Checks if the comment count filters include items with zero comments.
- * This is true when:
- * - There's no lower bound filter (defaults to >= 0)
- * - The lower bound allows 0 (>= 0, >= negative, or > negative)
  *
- * When true, we need to use exclusion logic instead of inclusion logic,
- * since items with 0 comments don't exist in the comments table.
+ * The count filters AND together, so zero is in the matched range iff a count of
+ * 0 satisfies EVERY condition. This must cover every operator, not just lower
+ * bounds: `commentCount = 5` excludes zero (so we narrow), while `< 5` / `<= 0`
+ * include it. Treating an `=`/`<`/`<=` filter as "no lower bound = includes 0"
+ * was the bug behind `OR(commentCount=N, …)` collapsing to match-everything.
+ *
+ * When true, we use exclusion logic instead of inclusion logic, since items with
+ * 0 comments don't exist in the comments table.
  */
-function filterRangeIncludesZero(
+export function filterRangeIncludesZero(
   filters: Array<{ type: string; operator: string; value: number }>,
 ): boolean {
-  const lowerBoundFilters = filters.filter(
-    (f) => f.type === "number" && (f.operator === ">=" || f.operator === ">"),
-  );
-
-  // No lower bound = includes 0
-  if (lowerBoundFilters.length === 0) {
-    return true;
-  }
-
-  // Check if any lower bound allows 0
-  return lowerBoundFilters.some(
-    (f) =>
-      (f.operator === ">=" && f.value <= 0) ||
-      (f.operator === ">" && f.value < 0),
-  );
+  return filters
+    .filter((f) => f.type === "number")
+    .every((f) => {
+      switch (f.operator) {
+        case ">=":
+          return 0 >= f.value;
+        case ">":
+          return 0 > f.value;
+        case "<=":
+          return 0 <= f.value;
+        case "<":
+          return 0 < f.value;
+        case "=":
+          return f.value === 0;
+        // Unknown operator: don't assume zero is in range — fall back to
+        // inclusion logic (narrow) rather than match-everything.
+        default:
+          return false;
+      }
+    });
 }
 
 /**
@@ -105,9 +117,9 @@ export async function applyCommentFilters({
 }> {
   // Extract comment filters from filterState
   const commentCountFilters = filterState.filter(
-    (f) =>
-      (f.type === "number" || f.type === "datetime") &&
-      f.column === "commentCount",
+    // commentCount is always a number column; the inner loop only handles
+    // `number`, so match number-only (a datetime variant can't reach the wire).
+    (f) => f.type === "number" && f.column === "commentCount",
   );
   const commentContentFilter = filterState.find(
     (f) => f.type === "string" && f.column === "commentContent",
@@ -129,8 +141,7 @@ export async function applyCommentFilters({
   const updatedFilterState = filterState.filter(
     (f) =>
       !(
-        ((f.type === "number" || f.type === "datetime") &&
-          f.column === "commentCount") ||
+        (f.type === "number" && f.column === "commentCount") ||
         (f.type === "string" && f.column === "commentContent")
       ),
   );
@@ -322,5 +333,207 @@ export async function applyCommentFilters({
     ],
     hasNoMatches: false,
     matchingIds: objectIdsFromComments,
+  };
+}
+
+type CommentFilterRewriteResult = {
+  expression?: FilterExpression;
+  hasNoMatches: boolean;
+  matchingIds: string[] | null;
+};
+
+function isCommentFilter(filter: z.infer<typeof singleFilter>): boolean {
+  return (
+    (filter.type === "number" && filter.column === "commentCount") ||
+    (filter.type === "string" && filter.column === "commentContent")
+  );
+}
+
+/**
+ * Resolve comment pseudo-filters (`commentCount`/`commentContent`) anywhere in a
+ * nested {@link FilterExpression}. Each comment leaf is resolved to a set of
+ * matching object IDs via Postgres and rewritten to an `id any of [...]`
+ * condition; the surrounding tree structure (AND/OR groups) is preserved.
+ *
+ * Semantics of an empty match within a group:
+ * - inside AND: the whole group has no matches (AND with an impossible term);
+ * - inside OR: that branch drops, the rest of the OR still applies.
+ */
+async function rewriteCommentFiltersInExpression({
+  filterExpression,
+  prisma,
+  projectId,
+  objectType,
+  idColumn,
+}: {
+  filterExpression?: FilterExpression;
+  prisma: PrismaClient;
+  projectId: string;
+  objectType: CommentObjectType;
+  idColumn: string;
+}): Promise<CommentFilterRewriteResult> {
+  if (!filterExpression) {
+    return {
+      expression: undefined,
+      hasNoMatches: false,
+      matchingIds: null,
+    };
+  }
+
+  if (filterExpression.type !== "group") {
+    if (!isCommentFilter(filterExpression)) {
+      return {
+        expression: filterExpression,
+        hasNoMatches: false,
+        matchingIds: null,
+      };
+    }
+
+    const result = await applyCommentFilters({
+      filterState: [filterExpression],
+      prisma,
+      projectId,
+      objectType,
+      idColumn,
+    });
+
+    return {
+      expression: normalizeFilterExpressionInput(result.filterState),
+      hasNoMatches: result.hasNoMatches,
+      matchingIds: result.matchingIds,
+    };
+  }
+
+  const rewrittenChildren = await Promise.all(
+    filterExpression.conditions.map((condition) =>
+      rewriteCommentFiltersInExpression({
+        filterExpression: condition,
+        prisma,
+        projectId,
+        objectType,
+        idColumn,
+      }),
+    ),
+  );
+
+  if (filterExpression.operator === "AND") {
+    if (rewrittenChildren.some((child) => child.hasNoMatches)) {
+      return {
+        expression: undefined,
+        hasNoMatches: true,
+        matchingIds: [],
+      };
+    }
+
+    const expressions = rewrittenChildren.flatMap((child) =>
+      child.expression ? [child.expression] : [],
+    );
+
+    if (expressions.length === 0) {
+      return {
+        expression: undefined,
+        hasNoMatches: false,
+        matchingIds: null,
+      };
+    }
+
+    if (expressions.length === 1) {
+      return {
+        expression: expressions[0],
+        hasNoMatches: false,
+        matchingIds: null,
+      };
+    }
+
+    return {
+      expression: {
+        type: "group",
+        operator: "AND",
+        conditions: expressions,
+      },
+      hasNoMatches: false,
+      matchingIds: null,
+    };
+  }
+
+  // OR group: a non-comment child with no expression would match everything, so
+  // the whole OR matches everything — drop the comment-derived narrowing.
+  if (
+    rewrittenChildren.some((child) => !child.hasNoMatches && !child.expression)
+  ) {
+    return {
+      expression: undefined,
+      hasNoMatches: false,
+      matchingIds: null,
+    };
+  }
+
+  const expressions = rewrittenChildren.flatMap((child) =>
+    !child.hasNoMatches && child.expression ? [child.expression] : [],
+  );
+
+  if (expressions.length === 0) {
+    return {
+      expression: undefined,
+      hasNoMatches: true,
+      matchingIds: [],
+    };
+  }
+
+  if (expressions.length === 1) {
+    return {
+      expression: expressions[0],
+      hasNoMatches: false,
+      matchingIds: null,
+    };
+  }
+
+  return {
+    expression: {
+      type: "group",
+      operator: "OR",
+      conditions: expressions,
+    },
+    hasNoMatches: false,
+    matchingIds: null,
+  };
+}
+
+/**
+ * {@link applyCommentFilters} for the nested filter contract. Accepts a flat
+ * {@link FilterInput} array or a nested expression, resolves comment filters
+ * recursively, and returns the rewritten {@link FilterExpression}.
+ */
+export async function applyCommentFiltersToFilterInput({
+  filterState,
+  prisma,
+  projectId,
+  objectType,
+  idColumn = "id",
+}: {
+  filterState: FilterInput | undefined;
+  prisma: PrismaClient;
+  projectId: string;
+  objectType: CommentObjectType;
+  idColumn?: string;
+}): Promise<{
+  filterState: FilterExpression | undefined;
+  hasNoMatches: boolean;
+}> {
+  // matchingIds is intentionally not surfaced: a nested rewrite resolves comment
+  // filters into `id any of [...]` leaves anywhere in the tree, so there is no
+  // single matching-id set to return (the flat applyCommentFilters keeps it for
+  // its own intersection step; this tree variant has no such consumer).
+  const result = await rewriteCommentFiltersInExpression({
+    filterExpression: normalizeFilterExpressionInput(filterState),
+    prisma,
+    projectId,
+    objectType,
+    idColumn,
+  });
+
+  return {
+    filterState: result.expression,
+    hasNoMatches: result.hasNoMatches,
   };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2,6 +2,10 @@ import { type z } from "zod";
 import {
   eventsTableFilterState,
   eventsTableSingleFilter,
+  filterExpression,
+  filterGroup,
+  filterGroupOperator,
+  filterInput,
   singleFilter,
   timeFilter,
 } from "./interfaces/filters";
@@ -14,6 +18,12 @@ export type EventsTableFilterCondition = z.infer<
   typeof eventsTableSingleFilter
 >;
 export type EventsTableFilterState = z.infer<typeof eventsTableFilterState>;
+
+// Nested boolean filter contract (Search/Filter v2). See interfaces/filters.ts.
+export type FilterGroupOperator = z.infer<typeof filterGroupOperator>;
+export type FilterGroup = z.infer<typeof filterGroup>;
+export type FilterExpression = z.infer<typeof filterExpression>;
+export type FilterInput = z.infer<typeof filterInput>;
 
 // to be used in the client during editing
 export type MakeOptional<T> = {

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -4,7 +4,10 @@ import {
   CTEQueryBuilder,
   EventsAggregationQueryBuilder,
   EventsQueryBuilder,
+  createFilterTreeFromFilterExpression,
+  eventsTableUiColumnDefinitions,
 } from "@langfuse/shared/src/server";
+import { eventsTableCols, type FilterExpression } from "@langfuse/shared";
 
 describe("buildEventsFilterOptionsForColumnsQuery", () => {
   it("builds one events_core scan for multiple filter option columns", () => {
@@ -419,5 +422,102 @@ describe("EventsQueryBuilder", () => {
     expect(query).toContain(
       "mapFromArrays(e.experiment_item_metadata_names, e.experiment_item_metadata_values) as experiment_item_metadata",
     );
+  });
+});
+
+describe("EventsQueryBuilder nested filter expressions", () => {
+  it("adds trace hash pruning only for mandatory traceId filters", () => {
+    const filterExpression: FilterExpression = {
+      type: "group",
+      operator: "AND",
+      conditions: [
+        { type: "string", column: "traceId", operator: "=", value: "trace-1" },
+        {
+          type: "group",
+          operator: "OR",
+          conditions: [
+            { type: "string", column: "name", operator: "=", value: "alpha" },
+            { type: "string", column: "name", operator: "=", value: "beta" },
+          ],
+        },
+      ],
+    };
+
+    const { query, params } = new EventsQueryBuilder({
+      projectId: "test-project",
+    })
+      .selectFieldSet("count")
+      .applyFilters(
+        createFilterTreeFromFilterExpression(
+          filterExpression,
+          eventsTableUiColumnDefinitions,
+          eventsTableCols,
+        ),
+      )
+      .buildWithParams();
+
+    expect(query).toContain(
+      "xxHash32(trace_id) = xxHash32({traceIdXxHash: String})",
+    );
+    expect(params.traceIdXxHash).toBe("trace-1");
+  });
+
+  it("does not add trace hash pruning for OR-only traceId filters", () => {
+    const filterExpression: FilterExpression = {
+      type: "group",
+      operator: "OR",
+      conditions: [
+        { type: "string", column: "traceId", operator: "=", value: "trace-1" },
+        { type: "string", column: "name", operator: "=", value: "alpha" },
+      ],
+    };
+
+    const { query, params } = new EventsQueryBuilder({
+      projectId: "test-project",
+    })
+      .selectFieldSet("count")
+      .applyFilters(
+        createFilterTreeFromFilterExpression(
+          filterExpression,
+          eventsTableUiColumnDefinitions,
+          eventsTableCols,
+        ),
+      )
+      .buildWithParams();
+
+    expect(query).not.toContain("traceIdXxHash");
+    expect(params.traceIdXxHash).toBeUndefined();
+  });
+
+  it("keeps the authorized project filter outside nested OR expressions", () => {
+    const filterExpression: FilterExpression = {
+      type: "group",
+      operator: "OR",
+      conditions: [
+        { type: "string", column: "name", operator: "=", value: "alpha" },
+        { type: "string", column: "type", operator: "=", value: "SPAN" },
+      ],
+    };
+
+    const { query, params } = new EventsQueryBuilder({
+      projectId: "authorized-project",
+    })
+      .selectFieldSet("count")
+      .applyFilters(
+        createFilterTreeFromFilterExpression(
+          filterExpression,
+          eventsTableUiColumnDefinitions,
+          eventsTableCols,
+        ),
+      )
+      .buildWithParams();
+
+    // projectId is unshifted as a builder-level root-AND wrapping the user OR —
+    // structurally impossible to OR away.
+    expect(query).toContain("WHERE e.project_id = {projectId: String}");
+    expect(query).toMatch(
+      /WHERE e\.project_id = \{projectId: String\}[\s\S]*AND \(\(.+\) OR \(.+\)\)/,
+    );
+    expect(params.projectId).toBe("authorized-project");
   });
 });

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -26,7 +26,7 @@ import {
 import { prisma } from "@langfuse/shared/src/db";
 import { randomUUID } from "crypto";
 import { env } from "@/src/env.mjs";
-import { type FilterCondition } from "@langfuse/shared";
+import { type FilterCondition, type FilterExpression } from "@langfuse/shared";
 import waitForExpect from "wait-for-expect";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
@@ -463,6 +463,150 @@ describe("Clickhouse Events Repository Test", () => {
 
       expect(count).toBe(5);
       expect(observations.length).toBe(5);
+    });
+  });
+
+  maybe("Nested Filter Expression", () => {
+    const nestedOrAndFilter = (): FilterExpression => ({
+      type: "group",
+      operator: "OR",
+      conditions: [
+        {
+          type: "group",
+          operator: "AND",
+          conditions: [
+            { type: "string", column: "type", operator: "=", value: "SPAN" },
+            {
+              type: "string",
+              column: "environment",
+              operator: "=",
+              value: "prod",
+            },
+          ],
+        },
+        {
+          type: "group",
+          operator: "AND",
+          conditions: [
+            {
+              type: "string",
+              column: "type",
+              operator: "=",
+              value: "GENERATION",
+            },
+            {
+              type: "string",
+              column: "name",
+              operator: "=",
+              value: "beta-generation",
+            },
+          ],
+        },
+      ],
+    });
+
+    it("supports nested AND/OR filters for list and count queries", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+      const matchingSpanId = randomUUID();
+      const matchingGenerationId = randomUUID();
+      const nonMatchingId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: matchingSpanId,
+          span_id: matchingSpanId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "alpha-span",
+          environment: "prod",
+        }),
+        createEvent({
+          id: matchingGenerationId,
+          span_id: matchingGenerationId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "GENERATION",
+          name: "beta-generation",
+          environment: "staging",
+        }),
+        createEvent({
+          id: nonMatchingId,
+          span_id: nonMatchingId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "beta-generation",
+          environment: "staging",
+        }),
+      ]);
+
+      const filter = nestedOrAndFilter();
+
+      const [observations, count] = await Promise.all([
+        getObservationsWithModelDataFromEventsTable({
+          projectId: uniqueProjectId,
+          filter,
+          limit: 100,
+          offset: 0,
+        }),
+        getObservationsCountFromEventsTable({
+          projectId: uniqueProjectId,
+          filter,
+        }),
+      ]);
+
+      expect(count).toBe(2);
+      expect(observations).toHaveLength(2);
+      expect(observations.map((observation) => observation.id).sort()).toEqual(
+        [matchingGenerationId, matchingSpanId].sort(),
+      );
+    });
+
+    it("normalizes a flat filter array to the same result as a single-leaf query", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+      const matchingId = randomUUID();
+      const nonMatchingId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: matchingId,
+          span_id: matchingId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "alpha-span",
+          environment: "prod",
+        }),
+        createEvent({
+          id: nonMatchingId,
+          span_id: nonMatchingId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "alpha-span",
+          environment: "staging",
+        }),
+      ]);
+
+      // A flat FilterState array (implicit AND) flows through the same v2 path
+      // and matches only the row satisfying every condition.
+      const flatCount = await getObservationsCountFromEventsTable({
+        projectId: uniqueProjectId,
+        filter: [
+          { type: "string", column: "type", operator: "=", value: "SPAN" },
+          {
+            type: "string",
+            column: "environment",
+            operator: "=",
+            value: "prod",
+          },
+        ],
+      });
+
+      expect(flatCount).toBe(1);
     });
   });
 

--- a/web/src/__tests__/server/unit/events-router.servertest.ts
+++ b/web/src/__tests__/server/unit/events-router.servertest.ts
@@ -1,0 +1,51 @@
+import { addAttributesToSpan } from "@/src/features/events/server/eventsRouter";
+
+describe("eventsRouter addAttributesToSpan", () => {
+  it("handles a nested filter expression input without throwing", () => {
+    const setAttribute = vi.fn();
+    const span = { setAttribute } as any;
+
+    expect(() =>
+      addAttributesToSpan({
+        span,
+        input: {
+          projectId: "input-project-id",
+          filter: {
+            type: "group",
+            operator: "AND",
+            conditions: [
+              {
+                column: "type",
+                type: "stringOptions",
+                operator: "any of",
+                value: ["GENERATION"],
+              },
+              {
+                column: "startTime",
+                type: "datetime",
+                operator: ">=",
+                value: new Date("2026-03-25T22:15:17.734Z"),
+              },
+              {
+                column: "endTime",
+                type: "datetime",
+                operator: "<=",
+                value: new Date("2026-03-26T22:15:17.734Z"),
+              },
+            ],
+          },
+          page: 1,
+          limit: 1,
+          orderBy: null,
+          searchQuery: null,
+          searchType: [],
+        },
+        orderBy: undefined,
+      }),
+    ).not.toThrow();
+
+    // Leaves are flattened from the tree and recorded as span attributes.
+    expect(setAttribute).toHaveBeenCalledWith("type", "GENERATION");
+    expect(setAttribute).toHaveBeenCalledWith("duration_minutes", 24 * 60);
+  });
+});

--- a/web/src/__tests__/server/unit/filter-expression.servertest.ts
+++ b/web/src/__tests__/server/unit/filter-expression.servertest.ts
@@ -1,0 +1,332 @@
+import {
+  combineFilterInputsWithAnd,
+  filterExpression,
+  filterInput,
+  getFilterExpressionBoundsIssue,
+  getMandatoryFilterExpressionLeafFilters,
+  MAX_FILTER_EXPRESSION_DEPTH,
+  MAX_FILTER_EXPRESSION_NODES,
+  normalizeFilterExpressionInput,
+  type FilterCondition,
+  type FilterExpression,
+  type UiColumnMapping,
+} from "@langfuse/shared";
+import {
+  FilterList,
+  createFilterFromFilterState,
+  createFilterTreeFromFilterExpression,
+  createFilterTreeFromFilterInput,
+} from "@langfuse/shared/src/server";
+
+const testColumnMappings: UiColumnMapping[] = [
+  {
+    uiTableName: "Name",
+    uiTableId: "name",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "name",
+    queryPrefix: "t",
+  },
+  {
+    uiTableName: "Environment",
+    uiTableId: "environment",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "environment",
+    queryPrefix: "t",
+  },
+  {
+    uiTableName: "Type",
+    uiTableId: "type",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "type",
+    queryPrefix: "t",
+  },
+];
+
+// Strip parentheses and randomized param suffixes so two structurally
+// equivalent compilations compare equal.
+const normalizeSql = (query: string) =>
+  query
+    .replace(/[()]/g, "")
+    .replace(/stringFilter\w+/g, "stringFilter")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const leaf = (column: string, value: string): FilterCondition => ({
+  type: "string",
+  column,
+  operator: "=",
+  value,
+});
+
+describe("filter expression contract", () => {
+  it("normalizes flat filters into a top-level AND group", () => {
+    const flatFilters: FilterCondition[] = [
+      leaf("name", "alpha"),
+      leaf("environment", "prod"),
+    ];
+
+    expect(normalizeFilterExpressionInput(flatFilters)).toEqual({
+      type: "group",
+      operator: "AND",
+      conditions: flatFilters,
+    });
+  });
+
+  it("normalizes empty / nullish input to undefined", () => {
+    expect(normalizeFilterExpressionInput([])).toBeUndefined();
+    expect(normalizeFilterExpressionInput(undefined)).toBeUndefined();
+    expect(normalizeFilterExpressionInput(null)).toBeUndefined();
+  });
+
+  it("parses nested AND/OR groups", () => {
+    const nestedFilter = {
+      type: "group",
+      operator: "OR",
+      conditions: [
+        {
+          type: "group",
+          operator: "AND",
+          conditions: [leaf("name", "alpha"), leaf("environment", "prod")],
+        },
+        leaf("type", "SPAN"),
+      ],
+    } satisfies FilterExpression;
+
+    expect(filterExpression.parse(nestedFilter)).toEqual(nestedFilter);
+  });
+
+  it("rejects empty groups", () => {
+    const result = filterExpression.safeParse({
+      type: "group",
+      operator: "AND",
+      conditions: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("returns AND-only leaves as mandatory, none under an OR", () => {
+    const andOnly: FilterExpression = {
+      type: "group",
+      operator: "AND",
+      conditions: [
+        leaf("name", "alpha"),
+        {
+          type: "group",
+          operator: "AND",
+          conditions: [leaf("environment", "prod")],
+        },
+      ],
+    };
+    expect(
+      getMandatoryFilterExpressionLeafFilters(andOnly).map((f) => f.column),
+    ).toEqual(["name", "environment"]);
+
+    const withOr: FilterExpression = {
+      type: "group",
+      operator: "AND",
+      conditions: [
+        leaf("name", "alpha"),
+        {
+          type: "group",
+          operator: "OR",
+          conditions: [leaf("environment", "prod"), leaf("type", "SPAN")],
+        },
+      ],
+    };
+    // The OR subtree contributes nothing — only the AND-reachable leaf remains.
+    expect(
+      getMandatoryFilterExpressionLeafFilters(withOr).map((f) => f.column),
+    ).toEqual(["name"]);
+  });
+});
+
+describe("recursive ClickHouse filter compilation", () => {
+  it("compiles nested filters with explicit parentheses and unique params", () => {
+    const expression: FilterExpression = {
+      type: "group",
+      operator: "OR",
+      conditions: [
+        {
+          type: "group",
+          operator: "AND",
+          conditions: [leaf("name", "alpha"), leaf("environment", "prod")],
+        },
+        leaf("type", "SPAN"),
+      ],
+    };
+
+    const compiled = createFilterTreeFromFilterExpression(
+      expression,
+      testColumnMappings,
+    ).apply();
+
+    expect(compiled.query).toMatch(
+      /^\(\(t\.name = \{stringFilter\w+: String\}\) AND \(t\.environment = \{stringFilter\w+: String\}\)\) OR \(t\.type = \{stringFilter\w+: String\}\)$/,
+    );
+    expect(Object.keys(compiled.params)).toHaveLength(3);
+    expect(Object.values(compiled.params).sort()).toEqual([
+      "SPAN",
+      "alpha",
+      "prod",
+    ]);
+  });
+
+  it("keeps legacy flat filters equivalent after normalization", () => {
+    const flatFilters: FilterCondition[] = [
+      leaf("name", "alpha"),
+      leaf("environment", "prod"),
+    ];
+
+    const legacyCompiled = new FilterList(
+      createFilterFromFilterState(flatFilters, testColumnMappings),
+    ).apply();
+    const treeCompiled = createFilterTreeFromFilterInput(
+      flatFilters,
+      testColumnMappings,
+    ).apply();
+
+    expect(normalizeSql(treeCompiled.query)).toBe(
+      normalizeSql(legacyCompiled.query),
+    );
+    expect(Object.values(treeCompiled.params).sort()).toEqual(
+      Object.values(legacyCompiled.params).sort(),
+    );
+  });
+
+  it("collapses a single-child group to the unwrapped child", () => {
+    const compiled = createFilterTreeFromFilterExpression(
+      {
+        type: "group",
+        operator: "OR",
+        conditions: [leaf("name", "alpha")],
+      },
+      testColumnMappings,
+    ).apply();
+
+    // No OR / parentheses for a single condition.
+    expect(compiled.query).not.toContain(" OR ");
+    expect(compiled.query).toMatch(/^t\.name = \{stringFilter\w+: String\}$/);
+  });
+
+  it("emits nothing for an empty tree", () => {
+    expect(
+      createFilterTreeFromFilterExpression(
+        undefined,
+        testColumnMappings,
+      ).apply(),
+    ).toEqual({ query: "", params: {} });
+  });
+});
+
+describe("filter expression bounds", () => {
+  const nestToDepth = (depth: number): FilterExpression => {
+    let expression: FilterExpression = leaf("name", "alpha");
+    for (let i = 0; i < depth; i++) {
+      expression = { type: "group", operator: "AND", conditions: [expression] };
+    }
+    return expression;
+  };
+
+  it("accepts an expression within the depth and node bounds", () => {
+    expect(getFilterExpressionBoundsIssue(nestToDepth(3))).toBeNull();
+    expect(
+      filterInput.safeParse([leaf("name", "alpha"), leaf("type", "SPAN")])
+        .success,
+    ).toBe(true);
+  });
+
+  it("rejects an expression nested beyond the depth bound", () => {
+    const tooDeep = nestToDepth(MAX_FILTER_EXPRESSION_DEPTH + 1);
+    expect(getFilterExpressionBoundsIssue(tooDeep)).toMatch(
+      /nested too deeply/,
+    );
+    expect(filterInput.safeParse(tooDeep).success).toBe(false);
+  });
+
+  it("counts leaf conditions, not the wrapping group (no off-by-one)", () => {
+    // Exactly MAX flat conditions must be ALLOWED — the normalized wrapping AND
+    // group does not count toward the condition cap.
+    const exact: FilterCondition[] = Array.from(
+      { length: MAX_FILTER_EXPRESSION_NODES },
+      (_, i) => leaf("name", `value-${i}`),
+    );
+    expect(
+      getFilterExpressionBoundsIssue(normalizeFilterExpressionInput(exact)),
+    ).toBeNull();
+    expect(filterInput.safeParse(exact).success).toBe(true);
+  });
+
+  it("rejects an expression with too many conditions", () => {
+    const wide: FilterCondition[] = Array.from(
+      { length: MAX_FILTER_EXPRESSION_NODES + 1 },
+      (_, i) => leaf("name", `value-${i}`),
+    );
+    expect(
+      getFilterExpressionBoundsIssue(normalizeFilterExpressionInput(wide)),
+    ).toMatch(/too many conditions/);
+    expect(filterInput.safeParse(wide).success).toBe(false);
+  });
+
+  it("treats a single-branch OR as mandatory (stays in sync with SQL collapse)", () => {
+    const singletonOr: FilterExpression = {
+      type: "group",
+      operator: "OR",
+      conditions: [leaf("name", "alpha")],
+    };
+    expect(
+      getMandatoryFilterExpressionLeafFilters(singletonOr).map((f) => f.column),
+    ).toEqual(["name"]);
+  });
+
+  it("rejects oversized trees at the compiler boundary too", () => {
+    expect(() =>
+      createFilterTreeFromFilterExpression(
+        nestToDepth(MAX_FILTER_EXPRESSION_DEPTH + 1),
+        testColumnMappings,
+      ),
+    ).toThrow(/nested too deeply/);
+  });
+});
+
+describe("combineFilterInputsWithAnd", () => {
+  const leafA = leaf("name", "a");
+  const leafB = leaf("environment", "prod");
+  const orTree: FilterExpression = {
+    type: "group",
+    operator: "OR",
+    conditions: [leaf("level", "ERROR"), leaf("level", "WARNING")],
+  };
+
+  it("returns a flat array when every combined condition is a leaf", () => {
+    expect(combineFilterInputsWithAnd([leafA], [leafB])).toEqual([
+      leafA,
+      leafB,
+    ]);
+  });
+
+  it("flattens AND-of-AND so the depth budget is not wasted", () => {
+    const innerAnd: FilterExpression = {
+      type: "group",
+      operator: "AND",
+      conditions: [leafA, leafB],
+    };
+    // innerAnd + a leaf must yield a single flat AND, not AND(AND(...), leaf).
+    expect(
+      combineFilterInputsWithAnd(innerAnd, [leaf("type", "SPAN")]),
+    ).toEqual([leafA, leafB, leaf("type", "SPAN")]);
+  });
+
+  it("wraps an OR tree in an outer AND with extra leaves (never inside the OR)", () => {
+    expect(combineFilterInputsWithAnd(orTree, [leafB])).toEqual({
+      type: "group",
+      operator: "AND",
+      conditions: [orTree, leafB],
+    });
+  });
+
+  it("collapses to the single branch and ignores empty inputs", () => {
+    expect(combineFilterInputsWithAnd(orTree, [], undefined)).toEqual(orTree);
+    expect(combineFilterInputsWithAnd([], undefined)).toBeUndefined();
+  });
+});

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -5,6 +5,9 @@ import {
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
 import {
+  getFilterExpressionLeafFilters,
+  getMandatoryFilterExpressionLeafFilters,
+  normalizeFilterExpressionInput,
   type OrderByState,
   normalizeOrderByForTable,
   paginationZod,
@@ -31,7 +34,7 @@ import {
   getAgentGraphDataFromEventsTable,
   getObservationsForTraceFromEventsTable,
   MAX_OBSERVATIONS_PER_TRACE,
-  applyCommentFilters,
+  applyCommentFiltersToFilterInput,
   getLatestSdkVersionInfoFromEvents,
 } from "@langfuse/shared/src/server";
 
@@ -88,12 +91,13 @@ export const eventsRouter = createTRPCRouter({
   all: protectedProjectProcedure
     .input(GetAllEventsInput)
     .query(async ({ input, ctx }) => {
-      const { filterState, hasNoMatches } = await applyCommentFilters({
-        filterState: input.filter ?? [],
-        prisma: ctx.prisma,
-        projectId: ctx.session.projectId,
-        objectType: "OBSERVATION",
-      });
+      const { filterState, hasNoMatches } =
+        await applyCommentFiltersToFilterInput({
+          filterState: input.filter,
+          prisma: ctx.prisma,
+          projectId: ctx.session.projectId,
+          objectType: "OBSERVATION",
+        });
 
       if (hasNoMatches) {
         return { observations: [], hasMore: false };
@@ -125,12 +129,13 @@ export const eventsRouter = createTRPCRouter({
   countAll: protectedProjectProcedure
     .input(EventsTableOptions)
     .query(async ({ input, ctx }) => {
-      const { filterState, hasNoMatches } = await applyCommentFilters({
-        filterState: input.filter ?? [],
-        prisma: ctx.prisma,
-        projectId: ctx.session.projectId,
-        objectType: "OBSERVATION",
-      });
+      const { filterState, hasNoMatches } =
+        await applyCommentFiltersToFilterInput({
+          filterState: input.filter,
+          prisma: ctx.prisma,
+          projectId: ctx.session.projectId,
+          objectType: "OBSERVATION",
+        });
 
       if (hasNoMatches) {
         return { totalCount: 0 };
@@ -400,12 +405,20 @@ export const addAttributesToSpan = ({
 }) => {
   span.setAttribute("project_id", input.projectId);
 
-  // Only process filter if it exists (not present in GetEventFilterOptionsInput)
+  // Only process filter if it exists (not present in GetEventFilterOptionsInput).
+  // The filter may be a nested expression tree.
   if ("filter" in input && input.filter) {
-    const startTimeFilter = input.filter.find(
+    const normalized = normalizeFilterExpressionInput(input.filter);
+    const filterLeaves = getFilterExpressionLeafFilters(normalized);
+
+    // Duration is only meaningful when both bounds are AND-reachable: a
+    // startTime/endTime sitting under an OR doesn't bound every row. Use the
+    // mandatory leaves, matching extractTimeFilter.
+    const mandatoryLeaves = getMandatoryFilterExpressionLeafFilters(normalized);
+    const startTimeFilter = mandatoryLeaves.find(
       (f) => f.column === "startTime" && f.type === "datetime",
     );
-    const endTimeFilter = input.filter.find(
+    const endTimeFilter = mandatoryLeaves.find(
       (f) => f.column === "endTime" && f.type === "datetime",
     );
 
@@ -418,11 +431,19 @@ export const addAttributesToSpan = ({
       span.setAttribute("duration_minutes", durationMs / 60000);
     }
 
-    input.filter.forEach((f) => {
-      if (f.value !== undefined) {
-        span.setAttribute(f.column, String(f.value));
-      }
-    });
+    // Group values by column before setting attributes: a column repeated across
+    // an OR (e.g. type=GENERATION OR type=SPAN, now expressible) would otherwise
+    // have OTel overwrite down to the last value, losing the others.
+    const valuesByColumn = new Map<string, string[]>();
+    for (const f of filterLeaves) {
+      if (f.value === undefined) continue;
+      const values = valuesByColumn.get(f.column) ?? [];
+      values.push(String(f.value));
+      valuesByColumn.set(f.column, values);
+    }
+    for (const [column, values] of valuesByColumn) {
+      span.setAttribute(column, values.length === 1 ? values[0]! : values);
+    }
   }
 
   if (orderBy) {

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -1,6 +1,7 @@
 import { type z } from "zod";
 import {
   type FilterCondition,
+  type FilterExpression,
   LISTABLE_SCORE_TYPES,
   type NumericEventsTableColumnId,
   filterAndValidateDbScoreList,
@@ -48,7 +49,7 @@ const TRACE_SCORE_SCOPE_FILTER: FilterCondition[] = [
 
 interface GetObservationsListParams {
   projectId: string;
-  filter: any[];
+  filter?: FilterExpression;
   searchQuery?: string;
   searchType: any[];
   orderBy: any;
@@ -58,7 +59,7 @@ interface GetObservationsListParams {
 
 interface GetObservationsCountParams {
   projectId: string;
-  filter: any[];
+  filter?: FilterExpression;
   searchQuery?: string;
   searchType: any[];
   orderBy: any;

--- a/web/src/features/events/server/types.ts
+++ b/web/src/features/events/server/types.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
-import { singleFilter, TracingSearchType, orderBy } from "@langfuse/shared";
+import { filterInput, TracingSearchType, orderBy } from "@langfuse/shared";
 
 export const EventsTableOptions = z.object({
   projectId: z.string(), // Required for protectedProjectProcedure
-  filter: z.array(singleFilter),
+  // Accepts a flat FilterState array OR a nested FilterExpression tree
+  // (Search/Filter v2). Bounds (depth/node caps) are enforced by `filterInput`.
+  filter: filterInput,
   searchQuery: z.string().nullable(),
   searchType: z.array(TracingSearchType),
   orderBy: orderBy,


### PR DESCRIPTION
## TL;DR

We taught the events filter to be a **tree** without breaking the **list**.

A *leaf* is one condition (`level = ERROR`) — **leaves are untouched**, same classes, same typed params. All we added is a way to *combine* them with `AND` / `OR` / brackets, compiled to ClickHouse by one recursive **parenthesizing emitter**. The old flat list stays a first-class citizen, so every existing caller (saved views, the table, the public API) is byte-for-byte identical.

> **Scope:** backend sub-task of **LFE-10421**. This PR is the **contract + ClickHouse compiler** — runnable today by programmatic / saved-view / LLM-judge / test callers. The search-bar **frontend** (bar grammar, sidebar, Ask-AI) lands in a **separate, focused PR** on top of this one. Split out from #14515 so the contract reviews on its own.

---

## Why

The events filter was a flat `FilterCondition[]`, implicitly AND-ed. There was no way to express **cross-field OR** (`level:ERROR OR type:SPAN`) or **bracket grouping** (`(A OR B) AND C`) — the backend rejected them. This PR makes the contract a boolean tree so those queries compile and run on CH, while the flat path is unchanged.

## What — the shape (a union, not a rewrite)

```ts
// before — a flat list, implicitly AND-ed
type FilterState = FilterCondition[];

// now — EITHER the old list OR one tree; the LEAF type is the same FilterCondition
type FilterInput      = FilterCondition[] | FilterExpression;
type FilterExpression = FilterCondition                                  // a leaf
                      | { type: "group"; operator: "AND" | "OR";         // a group
                          conditions: FilterExpression[] };              // …of expressions (recursive)
```

A flat array is **normalized into a one-level AND tree on entry**, so the compiler only ever walks a tree — one code path, no special-casing. Backward compatibility is structural: *flat is just a degenerate tree.*

## How it runs — for the ClickHouse review

```mermaid
flowchart LR
  I["FilterInput"] --> A{"array?"}
  A -- "yes (legacy)" --> NW["normalize → group(AND, …)"]
  A -- "no (tree)" --> P["pass through"]
  NW --> T["FilterExpression"]
  P --> T
  T --> W["wrap project_id<br/>as OUTER AND (tenant)"]
  W --> E["recursive emitter →<br/>parenthesized SQL + typed params"]
```

Three things to look at:

1. **The emitter** (`applyCompiledFilterNode`, `clickhouse-filter.ts`) walks the tree, wraps each group in `( )`, and joins the children with the group's `AND` or `OR`. Precedence is written into the SQL, not inferred. The keyword comes from the enum, not from user input.
2. **Parameters are unchanged.** Each leaf still compiles through the existing `Filter` classes as a typed param with a randomized name. The tree path adds no string interpolation; only the join between leaves is new.
3. **Tenant scope is an outer `AND`.** `project_id` (and the env/time defaults) wrap the whole user tree (`factory.ts`), so a user `OR` can't widen scope past the project.

### find vs findMandatory

Two optimizations assume a filter is always applied: the trace-id `xxHash32` skip-index and the start-time partition bound. That only holds for leaves reachable through `AND`s. A leaf under an `OR` might not apply to a given row, so these have to skip it — otherwise they'd prune rows that actually match. That's the whole difference between `find` (all leaves) and `findMandatory` (AND-reachable only), and it's the main thing to check for correctness.

Trade-off: a `traceId` or time leaf under an `OR` loses its prune, so the query scans wider. The depth ≤ 8 / ≤ 64-leaf bounds (enforced at the tRPC boundary and again in the compiler) cap how large that can get. Fine as-is, or worth a guardrail?

### Examples (JSON → SQL)

**Flat stays flat.** `(level:ERROR OR level:WARNING) AND -environment:prod AND name:*checkout*` — same-field OR collapses to `any of` and negation folds, so this never becomes a tree and emits the same SQL as before:

```sql
WHERE (e.project_id = {sf_a1:String})
  AND ((e.level IN ({so_b2:Array(String)})) AND (e.environment NOT IN ({so_c3:Array(String)})) AND (position(e.name,{sf_d4:String})>0))
```

**Cross-field OR becomes a tree.** `level:ERROR OR type:SPAN`:

```sql
WHERE (e.project_id = {sf_a1:String})
  AND ((e.level IN ({so_b2:Array(String)})) OR (e.type IN ({so_c3:Array(String)})))
-- a union: max(1316, 54592) ≤ 55275 ≤ 1316 + 54592  (checked in the CH integration test)
```

**Brackets.** `(traceId:abc OR name:*login*) AND timestamp:>13:00` — only `project_id` and `start_time` are AND-reachable, so the partition bound runs and the trace-id skip-index doesn't:

| leaf | reachable via | mandatory? |
| --- | --- | --- |
| `project_id` | root AND | yes |
| `start_time > 13:00` | top-level AND | yes |
| `trace_id = abc` | under the OR | no |
| `name contains login` | under the OR | no |

```sql
WHERE (e.project_id = {sf_a1:String})
  AND (((e.trace_id = {sf_b2:String}) OR (position(e.name,{sf_c3:String})>0)))
  AND (e.start_time > {dt_d4:DateTime64(3)})
```

## Result

- Cross-field OR + bracket grouping compile and run on the v4 events tables.
- Flat filters are unchanged — same SQL, same params, no migration for saved views or existing callers.
- Tenant scope and the prune gating depend on where a node sits in the tree, so they hold without an extra runtime check.

## Verification

- **Unit:** contract + recursive emitter + bounds + tenant-guard (`filter-expression.servertest.ts`, `event-query-builder.servertest.ts`, `events-router.servertest.ts`) — incl. *"keeps the authorized project filter outside nested OR expressions"* and the depth/leaf bounds.
- **CH integration:** nested OR list + count (the verified `55,275` union) in `event-repository.servertest.ts`.
- `pnpm run lint`, web typecheck, shared build all green on this branch (off latest `main`).

<details>
<summary>Smallest useful read + file map</summary>

- `packages/shared/src/interfaces/filters.ts` — `filterInput` union, `normalizeFilterExpressionInput`, `getMandatoryFilterExpressionLeafFilters`, bounds (`MAX_FILTER_EXPRESSION_DEPTH` / `_NODES`), `combineFilterInputsWithAnd`.
- `packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts` — recursive emitter (`applyCompiledFilterNode`) + `find` vs `findMandatory`.
- `…/clickhouse-sql/factory.ts` — outer-AND project filter + `positionInTrace` CTE rewrite.
- `…/clickhouse-sql/event-query-builder.ts`, `repositories/events.ts` — wiring.
- `web/src/features/events/server/{eventsRouter,eventsService,types}.ts` — tRPC `filter` input widened to `filterInput`; bounds enforced at the boundary.

Deferred to the FE follow-up PR(s): search-bar grammar/adapter/validate/codec + bar components, the facet sidebar's advanced-filter state, Ask-AI tree generation, and the seed scenario.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the events filter contract from a flat `FilterCondition[]` (implicit AND) to a boolean tree (`FilterExpression`) supporting cross-field OR and bracket grouping, while preserving full backward compatibility with the flat format. The ClickHouse compiler is a new recursive parenthesizing emitter (`FilterTree`/`applyCompiledFilterNode`), and `findMandatory` ensures index-pruning optimizations (trace-id xxHash32, partition bounds) only fire on AND-reachable leaves.

- **New filter contract** (`filterInput` union) in `filters.ts`, with depth ≤ 8 and node ≤ 64 bounds enforced at the tRPC boundary and again at the compiler; tenant-scope `project_id` is injected as an outer AND by the query builder, never inside the user tree.
- **`FilterTree`** replaces `FilterList` as the return type of `createFilterTreeFromFilterExpression`/`createFilterTreeFromFilterInput`; `FilterList` is unchanged but now satisfies the shared `CompiledFilterCollection` interface.
- **Comment-filter rewrite** (`rewriteCommentFiltersInExpression`) correctly propagates `hasNoMatches` through AND/OR semantics and injects `id any of [...]` leaves back into the tree at the resolved position.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The flat-filter path is byte-for-byte unchanged, tenant isolation is structural, and the xxHash32/partition pruning guards are correctly wired to AND-only leaves.

The core logic is well-constructed and thoroughly tested. The only functional concern is that the comment-filter rewrite can add one extra depth level to a tree that was already at the limit, causing createFilterTreeFromFilterExpression to throw a spurious InvalidRequestError for that edge case. This requires a filter exactly at depth 8 with a comment-filter leaf at the deepest position — extremely unlikely in practice before the frontend for nested filters is built.

packages/shared/src/server/services/commentFilterService.ts — the normalizeFilterExpressionInput call on result.filterState at line 1199 adds an AND wrapper that can overflow the depth budget for filters at the limit. packages/shared/src/interfaces/filters.ts — the combineFilterInputsWithAnd return type includes an unreachable FilterConditionSchema branch.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as tRPC Client
    participant R as eventsRouter
    participant CS as commentFilterService
    participant S as eventsService
    participant Repo as events.ts repository
    participant QB as EventsQueryBuilder
    participant CH as ClickHouse

    C->>R: query(filter: FilterInput)
    Note over R: Zod validates filterInput<br/>(depth ≤ 8, nodes ≤ 64)
    R->>CS: applyCommentFiltersToFilterInput(filter)
    Note over CS: normalizeFilterExpressionInput()<br/>rewriteCommentFiltersInExpression()
    CS-->>R: "{ filterState: FilterExpression, hasNoMatches }"
    R->>S: "getEventList({ filter: FilterExpression })"
    S->>Repo: "getObservationsWithModelDataFromEventsTable({ filter })"
    Note over Repo: normalizeFilterExpressionInput()<br/>removePositionInTraceFilters()
    Repo->>Repo: createFilterTreeFromFilterExpression(baseFilter)
    Note over Repo: bounds check (defense-in-depth)<br/>buildFilterTree() → FilterTree
    Repo->>QB: applyFilters(FilterTree)
    Note over QB: findMandatory() for xxHash32 prune<br/>findMandatory() for partition prune<br/>applyCompiledFilterNode() → SQL
    QB->>CH: "WHERE project_id=? AND (user_tree_sql)"
    CH-->>QB: rows
    QB-->>Repo: results
    Repo-->>S: observations
    S-->>R: "{ observations, hasMore }"
    R-->>C: response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as tRPC Client
    participant R as eventsRouter
    participant CS as commentFilterService
    participant S as eventsService
    participant Repo as events.ts repository
    participant QB as EventsQueryBuilder
    participant CH as ClickHouse

    C->>R: query(filter: FilterInput)
    Note over R: Zod validates filterInput<br/>(depth ≤ 8, nodes ≤ 64)
    R->>CS: applyCommentFiltersToFilterInput(filter)
    Note over CS: normalizeFilterExpressionInput()<br/>rewriteCommentFiltersInExpression()
    CS-->>R: "{ filterState: FilterExpression, hasNoMatches }"
    R->>S: "getEventList({ filter: FilterExpression })"
    S->>Repo: "getObservationsWithModelDataFromEventsTable({ filter })"
    Note over Repo: normalizeFilterExpressionInput()<br/>removePositionInTraceFilters()
    Repo->>Repo: createFilterTreeFromFilterExpression(baseFilter)
    Note over Repo: bounds check (defense-in-depth)<br/>buildFilterTree() → FilterTree
    Repo->>QB: applyFilters(FilterTree)
    Note over QB: findMandatory() for xxHash32 prune<br/>findMandatory() for partition prune<br/>applyCompiledFilterNode() → SQL
    QB->>CH: "WHERE project_id=? AND (user_tree_sql)"
    CH-->>QB: rows
    QB-->>Repo: results
    Repo-->>S: observations
    S-->>R: "{ observations, hasMore }"
    R-->>C: response
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/services/commentFilterService.ts:1199
**Comment-filter rewrite can push depth past `MAX_FILTER_EXPRESSION_DEPTH`**

`applyCommentFilters` always returns a flat `filterState` array. When that array has at least one element, `normalizeFilterExpressionInput` wraps it in a new `{ type: "group", operator: "AND", conditions: [...] }` node. This replaces a leaf (depth contribution = 0) with a group (depth contribution = 1), increasing the resolved tree's depth by one.

If the incoming `filterInput` was at exactly `MAX_FILTER_EXPRESSION_DEPTH` (8) with a comment-filter leaf at the deepest position, the rewritten tree will have depth 9, and the subsequent `createFilterTreeFromFilterExpression` call in `getObservationsFromEventsTableInternal` will throw an `InvalidRequestError` — rejecting a structurally valid user request. The fix would be to either tolerate an off-by-one in the post-rewrite compiler check, or normalize the single-element array to a bare leaf before returning: `normalizeFilterExpressionInput(result.filterState.length === 1 ? result.filterState[0] : result.filterState)`.

### Issue 2 of 2
packages/shared/src/interfaces/filters.ts:337-340
The `FilterConditionSchema` branch in the return type is unreachable: when `conditions.length === 1`, the single element must be a group (a leaf would have been returned by the earlier `every` check as a flat array). Removing it keeps the type accurate.

```suggestion
  | FilterConditionSchema[]
  | FilterGroupSchema
  | undefined {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(filters): nested AND/OR filter expr..."](https://github.com/langfuse/langfuse/commit/5a7529d3dfeb78a1f765687375381ad5910af552) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39850329)</sub>

<!-- /greptile_comment -->