### PR TITLE
fix(auth): `generateUserProjectRolesQuery` query

### DIFF
--- a/packages/shared/src/server/auth/userProjectRoleAuth.ts
+++ b/packages/shared/src/server/auth/userProjectRoleAuth.ts
@@ -73,6 +73,7 @@ function generateUserProjectRolesQuery({
         AND NOT EXISTS (
           SELECT 1 FROM project_memberships pm 
           WHERE pm.org_membership_id = om.id
+            AND pm.project_id = ${projectId}
         )
       ${sqlFilter}
       ${searchFilter}

--- a/web/src/__tests__/server/generateUserProjectRolesQuery.servertest.ts
+++ b/web/src/__tests__/server/generateUserProjectRolesQuery.servertest.ts
@@ -254,7 +254,7 @@ describe("find user project roles", () => {
       },
     });
 
-    const users = await getUserProjectRoles({
+    const usersOrg1 = await getUserProjectRoles({
       projectId: project.id,
       orgId: org.id,
       filterCondition: [],
@@ -262,13 +262,151 @@ describe("find user project roles", () => {
       orderBy: Prisma.empty,
     });
 
-    expect(users).toEqual([
+    expect(usersOrg1).toEqual([
       expect.objectContaining({
         id: user.id,
         name: user.name,
         email: user.email,
       }),
     ]);
+
+    const usersOrg2 = await getUserProjectRoles({
+      projectId: project2.id,
+      orgId: org2.id,
+      filterCondition: [],
+      searchFilter: Prisma.empty,
+      orderBy: Prisma.empty,
+    });
+
+    expect(usersOrg2).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: user3.id,
+          name: user3.name,
+          email: user3.email,
+        }),
+        expect.objectContaining({
+          id: user2.id,
+          name: user2.name,
+          email: user2.email,
+        }),
+      ]),
+    );
+
+    expect(usersOrg2).toHaveLength(2);
+    expect(usersOrg2).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: user.id,
+        }),
+      ]),
+    );
+  });
+
+  it("should inherit the org role when a user only has a project-specific override on a different project", async () => {
+    const { org, project: projectX } = await createOrgAndProject();
+
+    const projectY = await prisma.project.create({
+      data: {
+        id: v4(),
+        name: v4(),
+        orgId: org.id,
+      },
+    });
+
+    const userWithOrgRoleOnly = await prisma.user.create({
+      data: {
+        id: v4(),
+        email: v4(),
+        name: "User A",
+      },
+    });
+
+    const userB = await prisma.user.create({
+      data: {
+        id: v4(),
+        email: v4(),
+        name: "User B",
+      },
+    });
+
+    const userC = await prisma.user.create({
+      data: {
+        id: v4(),
+        email: v4(),
+        name: "User C",
+      },
+    });
+
+    await prisma.organizationMembership.create({
+      data: {
+        userId: userWithOrgRoleOnly.id,
+        orgId: org.id,
+        role: "MEMBER",
+      },
+    });
+
+    const orgMembershipOfUserB = await prisma.organizationMembership.create({
+      data: {
+        userId: userB.id,
+        orgId: org.id,
+        role: "MEMBER",
+      },
+    });
+
+    const orgMembershipOfUserC = await prisma.organizationMembership.create({
+      data: {
+        userId: userC.id,
+        orgId: org.id,
+        role: "MEMBER",
+      },
+    });
+
+    await prisma.projectMembership.create({
+      data: {
+        userId: userB.id,
+        projectId: projectX.id,
+        role: "VIEWER",
+        orgMembershipId: orgMembershipOfUserB.id,
+      },
+    });
+
+    await prisma.projectMembership.create({
+      data: {
+        userId: userC.id,
+        projectId: projectY.id,
+        role: "ADMIN",
+        orgMembershipId: orgMembershipOfUserC.id,
+      },
+    });
+
+    const users = await getUserProjectRoles({
+      projectId: projectX.id,
+      orgId: org.id,
+      filterCondition: [],
+      searchFilter: Prisma.empty,
+      orderBy: Prisma.empty,
+    });
+
+    expect(users).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: userWithOrgRoleOnly.id,
+          role: "MEMBER",
+        }),
+        expect.objectContaining({
+          id: userB.id,
+          role: "VIEWER",
+        }),
+        // User C has a project-specific override on a different project (projectY)
+        // so they should inherit their org role (MEMBER) for projectX
+        expect.objectContaining({
+          id: userC.id,
+          role: "MEMBER",
+        }),
+      ]),
+    );
+    expect(users).toHaveLength(3);
   });
 
   it("should return empty array for empty organization", async () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in `generateUserProjectRolesQuery` where the `NOT EXISTS` subquery in the first branch of the UNION was incorrectly excluding users from the "inherit org role" path whenever they had a project membership for **any** project, not just the queried project. Adding `AND pm.project_id = ${projectId}` scopes the exclusion to the current project only.

- **Bug fixed**: Users with explicit role overrides on a different project within the same org were invisible when listing members for the target project — they were excluded from the inheritance branch (because they had *some* project membership) and also excluded from the explicit-role branch (because they had no membership for the queried project), resulting in a silent omission.
- **Tests added**: A new test case ("should inherit the org role when a user only has a project-specific override on a different project") directly exercises the regression, and the existing cross-project isolation test is extended to also verify `org2` member results.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single predicate added to a parameterized SQL subquery that corrects a silent membership omission with no API or schema changes.

The one-line fix is precisely targeted: it adds the missing project_id filter to the NOT EXISTS subquery so users with role overrides on other projects are no longer silently dropped when listing members for the queried project. The new regression test directly exercises the failure scenario, and the existing test suite continues to cover cross-org isolation and NONE-role exclusion.

No files require special attention. Both changed files are clean and self-contained.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Query: getUserProjectRoles\nprojectId, orgId] --> B[CTE: all_eligible_users]
    B --> C[Part 1: Org-role inheritors\nFROM organization_memberships]
    B --> D[Part 2: Explicit project role\nFROM project_memberships]

    C --> E{org_id = orgId\nAND role != 'NONE'}
    E --> F{"NOT EXISTS\nproject_memberships\nWHERE org_membership_id = om.id\nAND project_id = projectId\n(FIXED: was missing project_id filter)"}
    F -->|true — no explicit role for this project| G[Use org role]
    F -->|false — has explicit role for this project| H[Excluded from Part 1\ngoes to Part 2]

    D --> I{project_id = projectId\nAND role != 'NONE'}
    I -->|match| J[Use project role]

    G --> K[UNION]
    J --> K
    K --> L[Final result with ORDER BY / LIMIT / OFFSET]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Query: getUserProjectRoles\nprojectId, orgId] --> B[CTE: all_eligible_users]
    B --> C[Part 1: Org-role inheritors\nFROM organization_memberships]
    B --> D[Part 2: Explicit project role\nFROM project_memberships]

    C --> E{org_id = orgId\nAND role != 'NONE'}
    E --> F{"NOT EXISTS\nproject_memberships\nWHERE org_membership_id = om.id\nAND project_id = projectId\n(FIXED: was missing project_id filter)"}
    F -->|true — no explicit role for this project| G[Use org role]
    F -->|false — has explicit role for this project| H[Excluded from Part 1\ngoes to Part 2]

    D --> I{project_id = projectId\nAND role != 'NONE'}
    I -->|match| J[Use project role]

    G --> K[UNION]
    J --> K
    K --> L[Final result with ORDER BY / LIMIT / OFFSET]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): \`generateUserProjectRolesQuer..."](https://github.com/langfuse/langfuse/commit/9978adc0734e860f045d8e9af2f1df3e4a0e4004) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39857242)</sub>

<!-- /greptile_comment -->