### PR TITLE
fix(v4): use auto timeline granularity

### DIFF
--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -92,10 +92,7 @@ describe("v4TransitionRouter", () => {
       projectId,
       fromTimestamp: new Date("2026-06-24T00:00:00Z"),
       toTimestamp: new Date("2026-06-25T00:00:00Z"),
-      interval: {
-        count: 1,
-        unit: "day",
-      },
+      granularity: "auto",
     });
 
     expect(rows).toEqual([
@@ -112,7 +109,7 @@ describe("v4TransitionRouter", () => {
       "FROM clusterAllReplicas('test-cluster', 'system.query_log')",
     );
     expect(clickhouseQuery?.query).toContain(
-      "toStartOfInterval(event_time_microseconds, INTERVAL 1 DAY, 'UTC')",
+      "toStartOfInterval(event_time_microseconds, INTERVAL 1 HOUR, 'UTC') AS bucket_time",
     );
     expect(clickhouseQuery?.query).toContain(
       "splitByChar('?', JSONExtractString(log_comment, 'route'))[1]",

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -1,5 +1,4 @@
 import { z } from "zod/v4";
-import { type IntervalUnit } from "@/src/utils/date-range-utils";
 import {
   createTRPCRouter,
   protectedProjectProcedure,
@@ -10,22 +9,36 @@ import {
   systemTableRef,
 } from "@langfuse/shared/src/server";
 
-const intervalUnitSchema = z.enum([
-  "second",
-  "minute",
-  "hour",
-  "day",
-  "month",
-  "year",
-] satisfies [IntervalUnit, ...IntervalUnit[]]);
+const timelineGranularity = z.literal("auto");
+type ResolvedTimelineGranularity = "minute" | "hour" | "day" | "week" | "month";
 
-const intervalUnitSql: Record<IntervalUnit, string> = {
-  second: "SECOND",
-  minute: "MINUTE",
-  hour: "HOUR",
-  day: "DAY",
-  month: "MONTH",
-  year: "YEAR",
+const resolveTimelineGranularity = (
+  fromTimestamp: Date,
+  toTimestamp: Date,
+): ResolvedTimelineGranularity => {
+  const diffMs = toTimestamp.getTime() - fromTimestamp.getTime();
+  const diffHours = diffMs / (1000 * 60 * 60);
+
+  if (diffHours < 2) return "minute";
+  if (diffHours < 72) return "hour";
+  if (diffHours < 1440) return "day";
+  if (diffHours < 8760) return "week";
+  return "month";
+};
+
+const getTimelineBucketSql = (
+  sql: string,
+  granularity: ResolvedTimelineGranularity,
+): string => {
+  const intervalByGranularity: Record<ResolvedTimelineGranularity, string> = {
+    minute: "1 MINUTE",
+    hour: "1 HOUR",
+    day: "1 DAY",
+    week: "1 WEEK",
+    month: "1 MONTH",
+  };
+
+  return `toStartOfInterval(${sql}, INTERVAL ${intervalByGranularity[granularity]}, 'UTC')`;
 };
 
 type LegacyApiUsageRow = {
@@ -41,22 +54,24 @@ export const v4TransitionRouter = createTRPCRouter({
         projectId: z.string(),
         fromTimestamp: z.date(),
         toTimestamp: z.date(),
-        interval: z.object({
-          count: z.number().int().positive().max(10_000),
-          unit: intervalUnitSchema,
-        }),
+        granularity: timelineGranularity.default("auto"),
       }),
     )
     .query(async ({ input }) => {
-      const intervalSql = `${input.interval.count} ${
-        intervalUnitSql[input.interval.unit]
-      }`;
+      const granularity = resolveTimelineGranularity(
+        input.fromTimestamp,
+        input.toTimestamp,
+      );
+      const bucketTimeSql = getTimelineBucketSql(
+        "event_time_microseconds",
+        granularity,
+      );
 
       const rows = await queryClickhouse<LegacyApiUsageRow>({
         query: `
 WITH selected AS (
   SELECT
-    toStartOfInterval(event_time_microseconds, INTERVAL ${intervalSql}, 'UTC') AS bucket_time,
+    ${bucketTimeSql} AS bucket_time,
     splitByChar('?', JSONExtractString(log_comment, 'route'))[1] AS route_path
   FROM ${systemTableRef("system.query_log")}
   WHERE

--- a/web/src/pages/project/[projectId]/v4/index.tsx
+++ b/web/src/pages/project/[projectId]/v4/index.tsx
@@ -8,7 +8,6 @@ import { DashboardCard } from "@/src/features/dashboard/components/cards/Dashboa
 import { Chart } from "@/src/features/widgets/chart-library/Chart";
 import {
   DASHBOARD_AGGREGATION_OPTIONS,
-  getOptimalInterval,
   toAbsoluteTimeRange,
 } from "@/src/utils/date-range-utils";
 import { useDashboardDateRange } from "@/src/hooks/useDashboardDateRange";
@@ -43,17 +42,12 @@ export default function V4Page() {
     );
   }, [timeRange]);
 
-  const interval = useMemo(
-    () => getOptimalInterval(absoluteTimeRange.from, absoluteTimeRange.to),
-    [absoluteTimeRange.from, absoluteTimeRange.to],
-  );
-
   const legacyApiUsage = api.v4Transition.timeSeriesByEntrypoint.useQuery(
     {
       projectId: projectId ?? "",
       fromTimestamp: absoluteTimeRange.from,
       toTimestamp: absoluteTimeRange.to,
-      interval,
+      granularity: "auto",
     },
     {
       enabled: Boolean(projectId),


### PR DESCRIPTION
## Summary
- replace the v4 legacy usage timeline interval input with `granularity: "auto"`
- resolve auto timeline buckets with dashboard-style thresholds
- update the v4 page call site and router unit test

## Verification
- `pnpm --dir web exec vitest run --project server-unit src/__tests__/server/unit/v4TransitionRouter.servertest.ts`
- `pnpm --dir web exec eslint src/features/v4/server/v4TransitionRouter.ts src/__tests__/server/unit/v4TransitionRouter.servertest.ts 'src/pages/project/[projectId]/v4/index.tsx' --max-warnings 0`