### PR TITLE
fix(ingestion): report sampled-out events as warnings

### DIFF
--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -106,6 +106,36 @@ service:
                   status: 201
               errors: []
 
+        - request:
+            batch:
+              - id: keep-0001
+                timestamp: "2022-01-01T00:00:00.000Z"
+                type: "trace-create"
+                body:
+                  id: trace-keep
+                  timestamp: "2022-01-01T00:00:00.000Z"
+                  environment: "production"
+                  name: "Sampled-in trace"
+              - id: drop-0002
+                timestamp: "2022-01-01T00:00:01.000Z"
+                type: "trace-create"
+                body:
+                  id: trace-drop
+                  timestamp: "2022-01-01T00:00:01.000Z"
+                  environment: "production"
+                  name: "Sampled-out trace"
+          response:
+            body:
+              successes:
+                - id: keep-0001
+                  status: 201
+              errors: []
+              warnings:
+                - id: drop-0002
+                  status: 200
+                  message: "Event dropped by sampling"
+                  warning: "This event was not processed because it was excluded by project-level trace sampling configuration."
+
 types:
   IngestionEvent:
     discriminant: "type"
@@ -416,10 +446,33 @@ types:
       message: optional<string>
       error: optional<unknown>
 
+  IngestionWarning:
+    docs: |
+      A warning for an event that was accepted by the API but not processed by the
+      ingestion pipeline. Currently used for events dropped by project-level
+      trace sampling: the event is acknowledged (so clients do not retry it)
+      and uploaded to blob storage, but excluded from downstream processing
+      and reported with status 200 instead of 201 because no resource was
+      materialized.
+    properties:
+      id:
+        type: string
+        docs: The event id from the request envelope.
+      status:
+        type: integer
+        docs: HTTP-like status. 200 indicates the event was acknowledged but not processed by the ingestion pipeline.
+      message:
+        type: string
+        docs: Short, machine-readable summary of the warning.
+      warning:
+        type: string
+        docs: Human-readable explanation of why the event was not processed by the ingestion pipeline.
+
   IngestionResponse:
     properties:
       successes: list<IngestionSuccess>
       errors: list<IngestionError>
+      warnings: optional<list<IngestionWarning>>
 
   OpenAICompletionUsageSchema:
     docs: OpenAI Usage schema from (Chat-)Completion APIs

--- a/packages/shared/src/server/ingestion/processEventBatch.test.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../env", () => ({
+  env: {
+    LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "test-bucket",
+    LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: "test-key",
+    LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: "test-secret",
+    LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: "http://localhost:9000",
+    LANGFUSE_S3_EVENT_UPLOAD_REGION: "us-east-1",
+    LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true",
+    LANGFUSE_S3_EVENT_UPLOAD_SSE: "",
+    LANGFUSE_S3_EVENT_UPLOAD_SSE_KMS_KEY_ID: "",
+    LANGFUSE_S3_EVENT_UPLOAD_PREFIX: "",
+    LANGFUSE_S3_EVENT_KEY_MAX_SEGMENT_BYTES: 1024,
+    LANGFUSE_INGESTION_QUEUE_DELAY_MS: 5000,
+    LANGFUSE_SKIP_S3_LIST_FOR_OBSERVATIONS_PROJECT_IDS: "",
+    LANGFUSE_INGESTION_PROCESSING_SAMPLED_PROJECTS: new Map<string, number>(),
+  },
+}));
+
+// vi.hoisted shares handles between the hoisted mock factories and the tests.
+const mocks = vi.hoisted(() => ({
+  uploadJson: vi.fn().mockResolvedValue(undefined),
+  queueAdd: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../redis/redis", () => ({
+  redis: {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue("OK"),
+    del: vi.fn().mockResolvedValue(1),
+    exists: vi.fn().mockResolvedValue(0),
+  },
+}));
+
+// IngestionQueue.getInstance is synchronous and returns a queue (or null),
+// not a Promise; only queue.add is async.
+vi.mock("../redis/ingestionQueue", () => ({
+  IngestionQueue: {
+    getInstance: vi.fn().mockReturnValue({
+      add: mocks.queueAdd,
+    }),
+  },
+}));
+
+vi.mock("../services/StorageService", () => ({
+  StorageService: class {},
+  StorageServiceFactory: {
+    getInstance: vi.fn().mockReturnValue({
+      uploadJson: mocks.uploadJson,
+    }),
+  },
+}));
+
+vi.mock("./sampling", () => ({
+  isTraceIdInSample: vi.fn(),
+}));
+
+vi.mock("../instrumentation", () => ({
+  getCurrentSpan: vi.fn(() => ({
+    setAttribute: vi.fn(),
+    addEvent: vi.fn(),
+    setStatus: vi.fn(),
+    end: vi.fn(),
+  })),
+  instrumentAsync: vi.fn((_name: string, fn: () => unknown) => fn()),
+  recordDistribution: vi.fn(),
+  recordIncrement: vi.fn(),
+  startActiveSpan: vi.fn((_name: string, fn: (span: unknown) => unknown) =>
+    fn({ setAttribute: vi.fn(), end: vi.fn() }),
+  ),
+}));
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../redis/s3SlowdownTracking", () => ({
+  isS3SlowDownError: vi.fn().mockReturnValue(false),
+  markProjectS3Slowdown: vi.fn(),
+}));
+
+vi.mock("../redis/ingestionFailureTracking", () => ({
+  markProjectIngestFailure: vi.fn(),
+}));
+
+import { processEventBatch, aggregateBatchResult } from "./processEventBatch";
+import { isTraceIdInSample } from "./sampling";
+import { IngestionQueue } from "../redis/ingestionQueue";
+
+const sampledMock = vi.mocked(isTraceIdInSample);
+
+const makeAuthCheck = () =>
+  ({
+    validKey: true as const,
+    scope: {
+      projectId: "proj_test",
+      accessLevel: "project" as const,
+    },
+  }) as unknown as Parameters<typeof processEventBatch>[1];
+
+const makeTraceEvent = (id: string, traceId: string) => ({
+  id,
+  timestamp: "2024-01-01T00:00:00.000Z",
+  type: "trace-create" as const,
+  body: {
+    id: traceId,
+    timestamp: "2024-01-01T00:00:00.000Z",
+    environment: "default",
+  },
+});
+
+const setSampling = (
+  impl: (p: {
+    projectId: string | null;
+    event: { type: string; body: { id?: string; traceId?: string } };
+  }) => { isSampled: boolean; isSamplingConfigured: boolean },
+) => {
+  sampledMock.mockImplementation(impl as never);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setSampling(() => ({ isSampled: true, isSamplingConfigured: false }));
+});
+
+describe("aggregateBatchResult", () => {
+  it("reports all results as successes when nothing is sampled out", () => {
+    const result = aggregateBatchResult(
+      [],
+      [
+        { id: "e1", result: {} },
+        { id: "e2", result: {} },
+      ],
+      "proj_test",
+      [],
+    );
+    expect(result.successes).toHaveLength(2);
+    expect(result.successes.every((s) => s.status === 201)).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("filters sampled-out events from successes and surfaces them as warnings", () => {
+    const result = aggregateBatchResult(
+      [],
+      [
+        { id: "e1", result: {} },
+        { id: "e2", result: {} },
+        { id: "e3", result: {} },
+      ],
+      "proj_test",
+      ["e2"],
+    );
+    expect(result.successes.map((s) => s.id)).toEqual(["e1", "e3"]);
+    expect(result.successes.every((s) => s.status === 201)).toBe(true);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatchObject({
+      id: "e2",
+      status: 200,
+      message: "Event dropped by sampling",
+    });
+    expect(result.warnings[0].warning).toContain("sampling");
+  });
+
+  it("handles a mixed batch: some sampled in, some sampled out", () => {
+    const result = aggregateBatchResult(
+      [],
+      [
+        { id: "in-1", result: {} },
+        { id: "out-1", result: {} },
+        { id: "in-2", result: {} },
+        { id: "out-2", result: {} },
+      ],
+      "proj_test",
+      ["out-1", "out-2"],
+    );
+    expect(result.successes.map((s) => s.id)).toEqual(["in-1", "in-2"]);
+    expect(result.warnings.map((w) => w.id)).toEqual(["out-1", "out-2"]);
+  });
+
+  it("returns empty successes when every event is sampled out", () => {
+    const result = aggregateBatchResult(
+      [],
+      [
+        { id: "e1", result: {} },
+        { id: "e2", result: {} },
+      ],
+      "proj_test",
+      ["e1", "e2"],
+    );
+    expect(result.successes).toEqual([]);
+    expect(result.warnings.map((w) => w.id)).toEqual(["e1", "e2"]);
+  });
+
+  it("preserves errors alongside warnings and successes", () => {
+    const result = aggregateBatchResult(
+      [{ id: "e-bad", error: new (class extends Error {})("bad") }],
+      [
+        { id: "e1", result: {} },
+        { id: "e2", result: {} },
+      ],
+      "proj_test",
+      ["e2"],
+    );
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].id).toBe("e-bad");
+    expect(result.errors[0].status).toBe(500);
+    expect(result.successes.map((s) => s.id)).toEqual(["e1"]);
+    expect(result.warnings.map((w) => w.id)).toEqual(["e2"]);
+  });
+
+  it("never leaks warnings into the errors array", () => {
+    const result = aggregateBatchResult([], [], "proj_test", ["w1"]);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.map((w) => w.id)).toEqual(["w1"]);
+  });
+
+  it("is backward compatible when called without sampledOutEventIds", () => {
+    const result = aggregateBatchResult(
+      [],
+      [
+        { id: "e1", result: {} },
+        { id: "e2", result: {} },
+      ],
+      "proj_test",
+    );
+    expect(result.successes).toHaveLength(2);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("defensively warns for sampled-out ids absent from results without filtering successes", () => {
+    const result = aggregateBatchResult(
+      [],
+      [{ id: "e1", result: {} }],
+      "proj_test",
+      ["nonexistent"],
+    );
+    expect(result.successes.map((s) => s.id)).toEqual(["e1"]);
+    expect(result.warnings.map((w) => w.id)).toEqual(["nonexistent"]);
+  });
+});
+
+describe("processEventBatch", () => {
+  it("returns empty successes, errors and warnings for empty input", async () => {
+    const result = await processEventBatch([], makeAuthCheck());
+    expect(result.successes).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("reports a validation error (400) for an invalid event", async () => {
+    const result = await processEventBatch(
+      [{ not: "valid" }],
+      makeAuthCheck(),
+      { delay: 0 },
+    );
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0].status).toBe(400);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("reports all events as successes when no sampling is configured", async () => {
+    setSampling(() => ({ isSampled: true, isSamplingConfigured: false }));
+    const result = await processEventBatch(
+      [makeTraceEvent("evt-1", "trace-1")],
+      makeAuthCheck(),
+      { delay: 0 },
+    );
+    expect(result.successes.map((s) => s.id)).toEqual(["evt-1"]);
+    expect(result.successes[0].status).toBe(201);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("reports all events as successes when sampling keeps everything", async () => {
+    setSampling(() => ({ isSampled: true, isSamplingConfigured: true }));
+    const result = await processEventBatch(
+      [makeTraceEvent("evt-1", "trace-1"), makeTraceEvent("evt-2", "trace-2")],
+      makeAuthCheck(),
+      { delay: 0 },
+    );
+    expect(result.successes.map((s) => s.id)).toEqual(["evt-1", "evt-2"]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("reports every event as a warning when all are sampled out", async () => {
+    setSampling(() => ({ isSampled: false, isSamplingConfigured: true }));
+    const result = await processEventBatch(
+      [makeTraceEvent("evt-1", "trace-1"), makeTraceEvent("evt-2", "trace-2")],
+      makeAuthCheck(),
+      { delay: 0 },
+    );
+    expect(result.successes).toEqual([]);
+    expect(result.warnings.map((w) => w.id)).toEqual(["evt-1", "evt-2"]);
+    expect(result.warnings.every((w) => w.status === 200)).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("keeps sampled-in events as successes and sampled-out events as warnings", async () => {
+    setSampling(({ event }) => {
+      const traceId = event.body.id;
+      return traceId === "trace-out"
+        ? { isSampled: false, isSamplingConfigured: true }
+        : { isSampled: true, isSamplingConfigured: true };
+    });
+    const result = await processEventBatch(
+      [
+        makeTraceEvent("in-1", "trace-in-1"),
+        makeTraceEvent("out-1", "trace-out"),
+        makeTraceEvent("in-2", "trace-in-2"),
+      ],
+      makeAuthCheck(),
+      { delay: 0 },
+    );
+    expect(result.successes.map((s) => s.id).sort()).toEqual(["in-1", "in-2"]);
+    expect(result.warnings.map((w) => w.id)).toEqual(["out-1"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("calls StorageServiceFactory.getInstance().uploadJson for the S3 path", async () => {
+    const result = await processEventBatch(
+      [makeTraceEvent("evt-1", "trace-1")],
+      makeAuthCheck(),
+      { delay: 0 },
+    );
+    expect(result.successes).toHaveLength(1);
+    expect(mocks.uploadJson).toHaveBeenCalled();
+  });
+
+  it("uses IngestionQueue.getInstance synchronously and enqueues via queue.add", async () => {
+    setSampling(() => ({ isSampled: true, isSamplingConfigured: true }));
+    await processEventBatch(
+      [makeTraceEvent("evt-1", "trace-1")],
+      makeAuthCheck(),
+      { delay: 0 },
+    );
+    expect(IngestionQueue.getInstance).toHaveBeenCalled();
+    expect(mocks.queueAdd).toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -122,9 +122,15 @@ export const processEventBatch = async (
     message?: string;
     error?: string;
   }[];
+  warnings: {
+    id: string;
+    status: number;
+    message: string;
+    warning: string;
+  }[];
 }> => {
   if (input.length === 0) {
-    return { successes: [], errors: [] };
+    return { successes: [], errors: [], warnings: [] };
   }
   const {
     delay = null,
@@ -201,11 +207,11 @@ export const processEventBatch = async (
   //
   // The dedup struct also caches `entityType` and `bucketPrefix` so the two
   // downstream loops (S3 upload + IngestionQueue enqueue) read a single
-  // source-of-truth per id instead of recomputing — that makes the
+  // source-of-truth per id instead of recomputing; that makes the
   // producer/consumer-must-agree invariant structural. The sanitization warn
   // log fires once at the time we resolve the prefix.
   //
-  // `String(...)` preserves the prior null → "null" coercion of
+  // `String(...)` preserves the prior null to "null" coercion of
   // `authCheck.scope.projectId`. The surrounding function legitimately treats
   // projectId as nullable elsewhere (metric labels, span attributes); we
   // don't narrow it in the type system, and a `null` projectId would land
@@ -334,6 +340,10 @@ export const processEventBatch = async (
   const projectIdsToSkipS3List =
     env.LANGFUSE_SKIP_S3_LIST_FOR_OBSERVATIONS_PROJECT_IDS?.split(",") ?? [];
 
+  // Collected here; aggregateBatchResult is the single authority that filters
+  // these out of `successes` and surfaces them as `warnings`.
+  const sampledOutEventIds: string[] = [];
+
   await Promise.all(
     Object.keys(sortedBatchByEventBodyId).map(async (id) => {
       const eventData = sortedBatchByEventBodyId[id];
@@ -357,6 +367,9 @@ export const processEventBatch = async (
       });
 
       if (!isSampled) {
+        for (const event of eventData.data) {
+          sampledOutEventIds.push(event.id);
+        }
         recordIncrement("langfuse.ingestion.sampling", eventData.data.length, {
           projectId: authCheck.scope.projectId ?? "<not set>",
           sampling_decision: "out",
@@ -407,6 +420,7 @@ export const processEventBatch = async (
     [...validationErrors, ...authenticationErrors],
     sortedBatch.map((event) => ({ id: event.id, result: event })),
     authCheck.scope.projectId,
+    sampledOutEventIds,
   );
 };
 
@@ -456,6 +470,7 @@ export const aggregateBatchResult = (
   errors: Array<{ id: string; error: unknown }>,
   results: Array<{ id: string; result: unknown }>,
   projectId?: string,
+  sampledOutEventIds: string[] = [],
 ) => {
   const returnedErrors: {
     id: string;
@@ -463,6 +478,21 @@ export const aggregateBatchResult = (
     message?: string;
     error?: string;
   }[] = [];
+
+  const sampledOutSet = new Set(sampledOutEventIds);
+
+  const warnings: {
+    id: string;
+    status: number;
+    message: string;
+    warning: string;
+  }[] = sampledOutEventIds.map((id) => ({
+    id,
+    status: 200,
+    message: "Event dropped by sampling",
+    warning:
+      "This event was not processed because it was excluded by project-level trace sampling configuration.",
+  }));
 
   const successes: {
     id: string;
@@ -508,11 +538,15 @@ export const aggregateBatchResult = (
   }
 
   results.forEach((result) => {
+    // Sampled-out events are excluded from successes and surfaced as warnings.
+    if (sampledOutSet.has(result.id)) {
+      return;
+    }
     successes.push({
       id: result.id,
       status: 201,
     });
   });
 
-  return { successes, errors: returnedErrors };
+  return { successes, errors: returnedErrors, warnings };
 };


### PR DESCRIPTION
## What does this PR do?

Fixes the ingestion batch response for events skipped by project-level trace sampling.

Previously, sampled-out events could still be included in `successes` with status 201, even though they were not enqueued for downstream ingestion processing. This change tracks sampled-out event ids, excludes them from `successes`, and returns them as `warnings` instead.

This keeps sampled-out events non-retryable for clients while avoiding reporting them as successfully materialized ingestion events.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have read the contributing guide.
- My code doesn't follow the style guidelines of this project (`pnpm run format`).
- I have commented my code, particularly in hard-to-understand areas.
- I have checked if my PR needs changes to the documentation.
- I have checked if my changes generate no new warnings (`pnpm run lint`).
- I have added tests that prove my fix is effective or that my feature works.
- I have checked if new and existing unit tests pass locally with my changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a correctness issue in the ingestion batch response: events skipped by project-level trace sampling were previously returned as `successes` with status 201, even though they were never enqueued for downstream ClickHouse processing. The fix tracks sampled-out event IDs during the IngestionQueue enqueue loop, then filters them out of `successes` and surfaces them as a new `warnings` array (status 200) in `aggregateBatchResult`.

- **Core logic change** (`processEventBatch.ts`): a `sampledOutEventIds` array is populated when `isSampled === false`, passed to `aggregateBatchResult`, which builds warnings from it and filters those IDs from successes using a `Set`.
- **API contract** (`ingestion.yml`): a new `IngestionWarning` type is defined and `IngestionResponse.warnings` is added as `optional<list<IngestionWarning>>` for backward-compatible SDK generation; S3 upload still occurs for all events (sampled-in and sampled-out) as intended.
- **Tests** (`processEventBatch.test.ts`): comprehensive new unit tests cover mixed batches, all-sampled-out, backward-compatibility (missing arg), and error/warning coexistence.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The change is well-scoped, backward-compatible, and thoroughly tested.

The sampling logic correctly collects event IDs in the enqueue loop before aggregateBatchResult runs, and the Set-based filter guarantees no sampled-out ID leaks into successes. The new warnings field is always present in the response (even as []), which is a contract change for all callers of processEventBatch — existing callers like the legacy span/trace endpoints simply ignore the new field, so nothing breaks. The only items worth a second look are the missing warnings assertion in the pre-existing worker test and a minor spec/docs clarification on the optionality of warnings.

worker/src/__tests__/processEventBatch.test.ts should assert res.warnings to keep parity with the new behavior.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant processEventBatch
    participant S3
    participant IngestionQueue
    participant aggregateBatchResult

    Client->>processEventBatch: batch of events
    processEventBatch->>processEventBatch: "validate & sort events"
    processEventBatch->>S3: upload ALL events (sampled-in + sampled-out)
    processEventBatch->>processEventBatch: for each eventBodyId group
    alt "isSampled == false"
        processEventBatch->>processEventBatch: push event IDs into sampledOutEventIds[]
        Note over processEventBatch: skip IngestionQueue enqueue
    else "isSampled == true"
        processEventBatch->>IngestionQueue: enqueue job for downstream processing
    end
    processEventBatch->>aggregateBatchResult: errors, sortedBatch results, sampledOutEventIds
    aggregateBatchResult->>aggregateBatchResult: build warnings[] from sampledOutEventIds
    aggregateBatchResult->>aggregateBatchResult: filter sampledOutSet from successes
    aggregateBatchResult-->>processEventBatch: successes, errors, warnings
    processEventBatch-->>Client: successes (201), errors, warnings (200)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant processEventBatch
    participant S3
    participant IngestionQueue
    participant aggregateBatchResult

    Client->>processEventBatch: batch of events
    processEventBatch->>processEventBatch: "validate & sort events"
    processEventBatch->>S3: upload ALL events (sampled-in + sampled-out)
    processEventBatch->>processEventBatch: for each eventBodyId group
    alt "isSampled == false"
        processEventBatch->>processEventBatch: push event IDs into sampledOutEventIds[]
        Note over processEventBatch: skip IngestionQueue enqueue
    else "isSampled == true"
        processEventBatch->>IngestionQueue: enqueue job for downstream processing
    end
    processEventBatch->>aggregateBatchResult: errors, sortedBatch results, sampledOutEventIds
    aggregateBatchResult->>aggregateBatchResult: build warnings[] from sampledOutEventIds
    aggregateBatchResult->>aggregateBatchResult: filter sampledOutSet from successes
    aggregateBatchResult-->>processEventBatch: successes, errors, warnings
    processEventBatch-->>Client: successes (201), errors, warnings (200)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/__tests__/processEventBatch.test.ts:22-23
**Missing `warnings` assertion in pre-existing test**

The existing test only asserts `res.successes` and `res.errors` but not `res.warnings`. Now that `warnings` is a first-class field on the response, the assertion should be extended to confirm the empty-input early-return path produces `warnings: []` as well — consistent with the new tests added in `packages/shared`.

### Issue 2 of 2
fern/apis/server/definition/ingestion.yml:471-475
The server always returns `warnings` (at minimum as `[]`) — it is never absent in the response. Keeping it as `optional` is valid for backward-compatible SDK generation, but the inline docs could be clearer about this. Consider clarifying that the field is always present in responses from this version onward, even though it is typed as optional for client SDK compatibility.

```suggestion
  IngestionResponse:
    properties:
      successes: list<IngestionSuccess>
      errors: list<IngestionError>
      warnings:
        type: optional<list<IngestionWarning>>
        docs: |
          Always present (at minimum as an empty list) in responses from servers
          that support sampling-aware ingestion. Typed as optional for backward
          compatibility with client SDKs generated before this field was introduced.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): report sampled-out event..."](https://github.com/langfuse/langfuse/commit/c4882078ed1cf6ae7e1b45755f709bb8aad3dd93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39891415)</sub>

<!-- /greptile_comment -->