### PR TITLE
fix(v4): fill empty timeline buckets

### DIFF
--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -72,7 +72,7 @@ describe("v4TransitionRouter", () => {
   beforeEach(() => {
     mockedQueryClickhouse.mockResolvedValue([
       {
-        time: "2026-06-25T12:00:00Z",
+        time: "2026-06-24T12:00:00Z",
         entrypoint: "publicapi: GET /api/public/traces/{id}",
         count: "0.6666666666666666",
       },
@@ -95,13 +95,28 @@ describe("v4TransitionRouter", () => {
       granularity: "auto",
     });
 
-    expect(rows).toEqual([
-      {
-        time: "2026-06-25T12:00:00Z",
-        entrypoint: "publicapi: GET /api/public/traces/{id}",
-        count: 0.6666666666666666,
-      },
-    ]);
+    expect(rows).toHaveLength(25);
+    expect(new Set(rows.map((row) => row.time)).size).toBe(24);
+    expect(rows[0]).toEqual({
+      time: "2026-06-24T00:00:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+    expect(rows[12]).toEqual({
+      time: "2026-06-24T12:00:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+    expect(rows[13]).toEqual({
+      time: "2026-06-24T12:00:00Z",
+      entrypoint: "publicapi: GET /api/public/traces/{id}",
+      count: 0.6666666666666666,
+    });
+    expect(rows[24]).toEqual({
+      time: "2026-06-24T23:00:00Z",
+      entrypoint: "",
+      count: 0,
+    });
 
     expect(mockedQueryClickhouse).toHaveBeenCalledTimes(1);
     const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
@@ -160,5 +175,240 @@ describe("v4TransitionRouter", () => {
     expect(clickhouseQuery?.query).toContain(
       "match(route_path, '^GET /api/public/traces/[^/?#]+$'), 3",
     );
+  });
+
+  it("fills daily buckets for a 30 day timeline", async () => {
+    mockedQueryClickhouse.mockResolvedValueOnce([
+      {
+        time: "2026-06-10T00:00:00Z",
+        entrypoint: "publicapi: GET /api/public/traces",
+        count: "42",
+      },
+    ]);
+
+    const caller = v4TransitionRouter.createCaller(
+      createInnerTRPCContext({ session, headers: {} }),
+    );
+
+    const rows = await caller.timeSeriesByEntrypoint({
+      projectId,
+      fromTimestamp: new Date("2026-05-26T00:00:00Z"),
+      toTimestamp: new Date("2026-06-25T00:00:00Z"),
+      granularity: "auto",
+    });
+
+    expect(rows).toHaveLength(31);
+    expect(new Set(rows.map((row) => row.time)).size).toBe(30);
+    expect(rows[0]).toEqual({
+      time: "2026-05-26T00:00:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+    expect(rows[15]).toEqual({
+      time: "2026-06-10T00:00:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+    expect(rows[16]).toEqual({
+      time: "2026-06-10T00:00:00Z",
+      entrypoint: "publicapi: GET /api/public/traces",
+      count: 42,
+    });
+    expect(rows[30]).toEqual({
+      time: "2026-06-24T00:00:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+
+    const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
+    expect(clickhouseQuery?.query).toContain(
+      "toStartOfInterval(event_time_microseconds, INTERVAL 1 DAY, 'UTC') AS bucket_time",
+    );
+  });
+
+  it("fills 2 minute buckets for a 1 hour timeline", async () => {
+    mockedQueryClickhouse.mockResolvedValueOnce([
+      {
+        time: "2026-06-24T00:20:00Z",
+        entrypoint: "publicapi: GET /api/public/traces",
+        count: "8",
+      },
+    ]);
+
+    const caller = v4TransitionRouter.createCaller(
+      createInnerTRPCContext({ session, headers: {} }),
+    );
+
+    const rows = await caller.timeSeriesByEntrypoint({
+      projectId,
+      fromTimestamp: new Date("2026-06-24T00:00:00Z"),
+      toTimestamp: new Date("2026-06-24T01:00:00Z"),
+      granularity: "auto",
+    });
+
+    expect(rows).toHaveLength(31);
+    expect(new Set(rows.map((row) => row.time)).size).toBe(30);
+    expect(rows[0]).toEqual({
+      time: "2026-06-24T00:00:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+    expect(rows[10]).toEqual({
+      time: "2026-06-24T00:20:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+    expect(rows[11]).toEqual({
+      time: "2026-06-24T00:20:00Z",
+      entrypoint: "publicapi: GET /api/public/traces",
+      count: 8,
+    });
+    expect(rows[30]).toEqual({
+      time: "2026-06-24T00:58:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+
+    const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
+    expect(clickhouseQuery?.query).toContain(
+      "toStartOfInterval(event_time_microseconds, INTERVAL 2 MINUTE, 'UTC') AS bucket_time",
+    );
+  });
+
+  it("fills minute buckets for a non-special 45 minute timeline", async () => {
+    mockedQueryClickhouse.mockResolvedValueOnce([
+      {
+        time: "2026-06-24T00:15:00Z",
+        entrypoint: "publicapi: GET /api/public/traces",
+        count: "8",
+      },
+    ]);
+
+    const caller = v4TransitionRouter.createCaller(
+      createInnerTRPCContext({ session, headers: {} }),
+    );
+
+    const rows = await caller.timeSeriesByEntrypoint({
+      projectId,
+      fromTimestamp: new Date("2026-06-24T00:00:00Z"),
+      toTimestamp: new Date("2026-06-24T00:45:00Z"),
+      granularity: "auto",
+    });
+
+    expect(rows).toHaveLength(46);
+    expect(new Set(rows.map((row) => row.time)).size).toBe(45);
+    expect(rows[0]).toEqual({
+      time: "2026-06-24T00:00:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+    expect(rows[15]).toEqual({
+      time: "2026-06-24T00:15:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+    expect(rows[16]).toEqual({
+      time: "2026-06-24T00:15:00Z",
+      entrypoint: "publicapi: GET /api/public/traces",
+      count: 8,
+    });
+    expect(rows[45]).toEqual({
+      time: "2026-06-24T00:44:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+
+    const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
+    expect(clickhouseQuery?.query).toContain(
+      "toStartOfInterval(event_time_microseconds, INTERVAL 1 MINUTE, 'UTC') AS bucket_time",
+    );
+  });
+
+  it("fills 5 minute buckets for a 3 hour timeline", async () => {
+    mockedQueryClickhouse.mockResolvedValueOnce([
+      {
+        time: "2026-06-24T01:00:00Z",
+        entrypoint: "publicapi: GET /api/public/traces",
+        count: "12",
+      },
+    ]);
+
+    const caller = v4TransitionRouter.createCaller(
+      createInnerTRPCContext({ session, headers: {} }),
+    );
+
+    const rows = await caller.timeSeriesByEntrypoint({
+      projectId,
+      fromTimestamp: new Date("2026-06-24T00:00:00Z"),
+      toTimestamp: new Date("2026-06-24T03:00:00Z"),
+      granularity: "auto",
+    });
+
+    expect(rows).toHaveLength(37);
+    expect(new Set(rows.map((row) => row.time)).size).toBe(36);
+    expect(rows[0]).toEqual({
+      time: "2026-06-24T00:00:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+    expect(rows[12]).toEqual({
+      time: "2026-06-24T01:00:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+    expect(rows[13]).toEqual({
+      time: "2026-06-24T01:00:00Z",
+      entrypoint: "publicapi: GET /api/public/traces",
+      count: 12,
+    });
+    expect(rows[36]).toEqual({
+      time: "2026-06-24T02:55:00Z",
+      entrypoint: "",
+      count: 0,
+    });
+
+    const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
+    expect(clickhouseQuery?.query).toContain(
+      "toStartOfInterval(event_time_microseconds, INTERVAL 5 MINUTE, 'UTC') AS bucket_time",
+    );
+  });
+
+  it("uses minute buckets for a non-special 7 day timeline", async () => {
+    mockedQueryClickhouse.mockResolvedValueOnce([]);
+
+    const caller = v4TransitionRouter.createCaller(
+      createInnerTRPCContext({ session, headers: {} }),
+    );
+
+    const rows = await caller.timeSeriesByEntrypoint({
+      projectId,
+      fromTimestamp: new Date("2026-06-18T00:00:00Z"),
+      toTimestamp: new Date("2026-06-25T00:00:00Z"),
+      granularity: "auto",
+    });
+
+    expect(rows).toEqual([]);
+
+    const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
+    expect(clickhouseQuery?.query).toContain(
+      "toStartOfInterval(event_time_microseconds, INTERVAL 1 MINUTE, 'UTC') AS bucket_time",
+    );
+  });
+
+  it("rejects ranges over 30 days", async () => {
+    const caller = v4TransitionRouter.createCaller(
+      createInnerTRPCContext({ session, headers: {} }),
+    );
+
+    await expect(
+      caller.timeSeriesByEntrypoint({
+        projectId,
+        fromTimestamp: new Date("2026-05-25T00:00:00Z"),
+        toTimestamp: new Date("2026-06-25T00:00:00Z"),
+        granularity: "auto",
+      }),
+    ).rejects.toThrow("30 days");
+
+    expect(mockedQueryClickhouse).not.toHaveBeenCalled();
   });
 });

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -10,20 +10,26 @@ import {
 } from "@langfuse/shared/src/server";
 
 const timelineGranularity = z.literal("auto");
-type ResolvedTimelineGranularity = "minute" | "hour" | "day" | "week" | "month";
+type ResolvedTimelineGranularity = "minute" | "2m" | "5m" | "hour" | "day";
+const MINUTE_MS = 60 * 1000;
+const MAX_TIMELINE_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
+const TIMELINE_GRANULARITY_DURATION_TOLERANCE_MS = 1000;
+
+const isTimelineDuration = (actualMs: number, expectedMs: number): boolean =>
+  Math.abs(actualMs - expectedMs) <= TIMELINE_GRANULARITY_DURATION_TOLERANCE_MS;
 
 const resolveTimelineGranularity = (
   fromTimestamp: Date,
   toTimestamp: Date,
 ): ResolvedTimelineGranularity => {
   const diffMs = toTimestamp.getTime() - fromTimestamp.getTime();
-  const diffHours = diffMs / (1000 * 60 * 60);
 
-  if (diffHours < 2) return "minute";
-  if (diffHours < 72) return "hour";
-  if (diffHours < 1440) return "day";
-  if (diffHours < 8760) return "week";
-  return "month";
+  if (isTimelineDuration(diffMs, 60 * MINUTE_MS)) return "2m";
+  if (isTimelineDuration(diffMs, 3 * 60 * MINUTE_MS)) return "5m";
+  if (isTimelineDuration(diffMs, 24 * 60 * MINUTE_MS)) return "hour";
+  if (isTimelineDuration(diffMs, MAX_TIMELINE_RANGE_MS)) return "day";
+
+  return "minute";
 };
 
 const getTimelineBucketSql = (
@@ -32,10 +38,10 @@ const getTimelineBucketSql = (
 ): string => {
   const intervalByGranularity: Record<ResolvedTimelineGranularity, string> = {
     minute: "1 MINUTE",
+    "2m": "2 MINUTE",
+    "5m": "5 MINUTE",
     hour: "1 HOUR",
     day: "1 DAY",
-    week: "1 WEEK",
-    month: "1 MONTH",
   };
 
   return `toStartOfInterval(${sql}, INTERVAL ${intervalByGranularity[granularity]}, 'UTC')`;
@@ -47,15 +53,128 @@ type LegacyApiUsageRow = {
   count: string | number;
 };
 
+type LegacyApiUsageResultRow = {
+  time: string;
+  entrypoint: string;
+  count: number;
+};
+
+const floorTimelineBucket = (
+  timestamp: Date,
+  granularity: ResolvedTimelineGranularity,
+): Date => {
+  const bucket = new Date(timestamp);
+
+  switch (granularity) {
+    case "minute":
+      bucket.setUTCSeconds(0, 0);
+      return bucket;
+    case "2m":
+      bucket.setUTCMinutes(Math.floor(bucket.getUTCMinutes() / 2) * 2, 0, 0);
+      return bucket;
+    case "5m":
+      bucket.setUTCMinutes(Math.floor(bucket.getUTCMinutes() / 5) * 5, 0, 0);
+      return bucket;
+    case "hour":
+      bucket.setUTCMinutes(0, 0, 0);
+      return bucket;
+    case "day":
+      bucket.setUTCHours(0, 0, 0, 0);
+      return bucket;
+    default: {
+      const exhaustiveCheck: never = granularity;
+      throw new Error(`Invalid timeline granularity: ${exhaustiveCheck}`);
+    }
+  }
+};
+
+const addTimelineBucket = (
+  timestamp: Date,
+  granularity: ResolvedTimelineGranularity,
+): Date => {
+  const next = new Date(timestamp);
+
+  switch (granularity) {
+    case "minute":
+      next.setUTCMinutes(next.getUTCMinutes() + 1);
+      return next;
+    case "2m":
+      next.setUTCMinutes(next.getUTCMinutes() + 2);
+      return next;
+    case "5m":
+      next.setUTCMinutes(next.getUTCMinutes() + 5);
+      return next;
+    case "hour":
+      next.setUTCHours(next.getUTCHours() + 1);
+      return next;
+    case "day":
+      next.setUTCDate(next.getUTCDate() + 1);
+      return next;
+    default: {
+      const exhaustiveCheck: never = granularity;
+      throw new Error(`Invalid timeline granularity: ${exhaustiveCheck}`);
+    }
+  }
+};
+
+const formatTimelineBucket = (timestamp: Date): string =>
+  timestamp.toISOString().replace(/\.\d{3}Z$/, "Z");
+
+const getEmptyTimelineBuckets = (
+  fromTimestamp: Date,
+  toTimestamp: Date,
+  granularity: ResolvedTimelineGranularity,
+): LegacyApiUsageResultRow[] => {
+  const buckets: LegacyApiUsageResultRow[] = [];
+
+  for (
+    let bucket = floorTimelineBucket(fromTimestamp, granularity);
+    bucket.getTime() < toTimestamp.getTime();
+    bucket = addTimelineBucket(bucket, granularity)
+  ) {
+    buckets.push({
+      time: formatTimelineBucket(bucket),
+      entrypoint: "",
+      count: 0,
+    });
+  }
+
+  return buckets;
+};
+
+const compareTimelineRows = (
+  left: LegacyApiUsageResultRow,
+  right: LegacyApiUsageResultRow,
+): number => {
+  if (left.time < right.time) return -1;
+  if (left.time > right.time) return 1;
+  if (left.entrypoint === right.entrypoint) return 0;
+  if (left.entrypoint === "") return -1;
+  if (right.entrypoint === "") return 1;
+  return left.entrypoint.localeCompare(right.entrypoint);
+};
+
 export const v4TransitionRouter = createTRPCRouter({
   timeSeriesByEntrypoint: protectedProjectProcedure
     .input(
-      z.object({
-        projectId: z.string(),
-        fromTimestamp: z.date(),
-        toTimestamp: z.date(),
-        granularity: timelineGranularity.default("auto"),
-      }),
+      z
+        .object({
+          projectId: z.string(),
+          fromTimestamp: z.date(),
+          toTimestamp: z.date(),
+          granularity: timelineGranularity.default("auto"),
+        })
+        .refine(
+          ({ fromTimestamp, toTimestamp }) =>
+            toTimestamp.getTime() > fromTimestamp.getTime(),
+          { message: "fromTimestamp must be before toTimestamp" },
+        )
+        .refine(
+          ({ fromTimestamp, toTimestamp }) =>
+            toTimestamp.getTime() - fromTimestamp.getTime() <=
+            MAX_TIMELINE_RANGE_MS,
+          { message: "V4 legacy API usage ranges cannot exceed 30 days" },
+        ),
     )
     .query(async ({ input }) => {
       const granularity = resolveTimelineGranularity(
@@ -155,10 +274,20 @@ ORDER BY bucket_time ASC, legacy_route ASC
         },
       });
 
-      return rows.map((row) => ({
+      const dataRows = rows.map((row) => ({
         time: row.time,
         entrypoint: row.entrypoint,
         count: Number(row.count),
       }));
+
+      return dataRows.length === 0
+        ? dataRows
+        : getEmptyTimelineBuckets(
+            input.fromTimestamp,
+            input.toTimestamp,
+            granularity,
+          )
+            .concat(dataRows)
+            .sort(compareTimelineRows);
     }),
 });

--- a/web/src/pages/project/[projectId]/v4/index.tsx
+++ b/web/src/pages/project/[projectId]/v4/index.tsx
@@ -7,11 +7,48 @@ import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import { DashboardCard } from "@/src/features/dashboard/components/cards/DashboardCard";
 import { Chart } from "@/src/features/widgets/chart-library/Chart";
 import {
-  DASHBOARD_AGGREGATION_OPTIONS,
+  DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
   toAbsoluteTimeRange,
+  type AbsoluteTimeRange,
+  type TimeRange,
 } from "@/src/utils/date-range-utils";
-import { useDashboardDateRange } from "@/src/hooks/useDashboardDateRange";
+import { useGlobalDateRange } from "@/src/features/global-time-range/useGlobalDateRange";
 import { api } from "@/src/utils/api";
+
+const V4_TIME_RANGE_PRESETS = [
+  "last5Minutes",
+  "last30Minutes",
+  "last1Hour",
+  "last3Hours",
+  "last1Day",
+  "last7Days",
+  "last30Days",
+] as const;
+
+const MAX_V4_TIMELINE_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+const getCappedAbsoluteTimeRange = (
+  timeRange: TimeRange,
+): AbsoluteTimeRange => {
+  const absoluteRange =
+    toAbsoluteTimeRange(timeRange) ??
+    ({
+      from: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      to: new Date(),
+    } satisfies AbsoluteTimeRange);
+
+  if (
+    absoluteRange.to.getTime() - absoluteRange.from.getTime() <=
+    MAX_V4_TIMELINE_RANGE_MS
+  ) {
+    return absoluteRange;
+  }
+
+  return {
+    from: new Date(absoluteRange.to.getTime() - MAX_V4_TIMELINE_RANGE_MS),
+    to: absoluteRange.to,
+  };
+};
 
 const UPGRADE_DOCS = [
   {
@@ -31,16 +68,19 @@ const UPGRADE_DOCS = [
 export default function V4Page() {
   const router = useRouter();
   const projectId = router.query.projectId as string | undefined;
-  const { timeRange, setTimeRange } = useDashboardDateRange();
+  const { timeRange, setTimeRange } = useGlobalDateRange({
+    allowedRanges: V4_TIME_RANGE_PRESETS,
+    fallback: DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
+  });
 
   const absoluteTimeRange = useMemo(() => {
-    return (
-      toAbsoluteTimeRange(timeRange) ?? {
-        from: new Date(Date.now() - 24 * 60 * 60 * 1000),
-        to: new Date(),
-      }
-    );
+    return getCappedAbsoluteTimeRange(timeRange);
   }, [timeRange]);
+
+  const earliestSelectableDate = useMemo(
+    () => new Date(Date.now() - MAX_V4_TIMELINE_RANGE_MS),
+    [],
+  );
 
   const legacyApiUsage = api.v4Transition.timeSeriesByEntrypoint.useQuery(
     {
@@ -80,7 +120,8 @@ export default function V4Page() {
           <TimeRangePicker
             timeRange={timeRange}
             onTimeRangeChange={setTimeRange}
-            timeRangePresets={DASHBOARD_AGGREGATION_OPTIONS}
+            timeRangePresets={V4_TIME_RANGE_PRESETS}
+            disabled={{ before: earliestSelectableDate }}
             className="my-0 max-w-full overflow-x-auto"
           />
         ),


### PR DESCRIPTION
## Summary
- merge latest `main` after #14567 landed and keep the v4 upgrade status tiles
- fill empty timeline buckets for the v4 public API usage chart when real data exists, so the time axis stays continuous
- share the same exact-duration bucketing strategy across ClickHouse public API usage and Postgres trace-level eval execution timelines: 1h -> 2-minute, 3h -> 5-minute, 1d -> hourly, 30d -> daily, everything else -> 1-minute
- use Postgres `date_bin` for multi-minute eval execution buckets so the Postgres-backed chart matches the ClickHouse-backed chart
- cap both v4 timeline APIs and the picker to a maximum 30-day range

## Verification
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/langfuse_test' DIRECT_URL='postgresql://postgres:postgres@localhost:5432/langfuse_test' NEXTAUTH_URL='http://localhost:3000' NEXTAUTH_SECRET='test-nextauth-secret' CLICKHOUSE_URL='http://localhost:8123' CLICKHOUSE_USER='default' CLICKHOUSE_PASSWORD='password' SALT='0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' LANGFUSE_S3_EVENT_UPLOAD_BUCKET='test-bucket' pnpm --dir web exec vitest run --project server-unit src/__tests__/server/unit/v4TransitionRouter.servertest.ts`
- `pnpm --dir web exec eslint src/features/v4/server/v4TransitionRouter.ts src/__tests__/server/unit/v4TransitionRouter.servertest.ts 'src/pages/project/[projectId]/v4/index.tsx' --max-warnings 0`
- merge commit hook: Prettier check + `turbo run lint`

## Browser review
- Attempted locally at `http://localhost:3000/project/cmc9e35bz04e3ad077g5yhti4/v4`; the route exists but redirects to sign-in in the current local session. The affected charts also depend on ClickHouse `system.query_log` and Postgres job execution rows rather than seedable fixture data.
