### PR TITLE
fix(datasets): send Azure x-ms-blob-type header on media upload

### DIFF
--- a/web/src/__tests__/server/unit/getRequiredUploadHeaders.servertest.ts
+++ b/web/src/__tests__/server/unit/getRequiredUploadHeaders.servertest.ts
@@ -1,0 +1,33 @@
+const mockEnv = vi.hoisted(() => ({
+  env: {
+    LANGFUSE_USE_AZURE_BLOB: undefined as string | undefined,
+  },
+}));
+
+vi.mock("@/src/env.mjs", () => mockEnv);
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getRequiredUploadHeaders } from "@/src/features/media/server/getRequiredUploadHeaders";
+
+afterEach(() => {
+  mockEnv.env.LANGFUSE_USE_AZURE_BLOB = undefined;
+});
+
+describe("getRequiredUploadHeaders", () => {
+  it("requires x-ms-blob-type when Azure Blob Storage is configured", () => {
+    mockEnv.env.LANGFUSE_USE_AZURE_BLOB = "true";
+    expect(getRequiredUploadHeaders()).toEqual({
+      "x-ms-blob-type": "BlockBlob",
+    });
+  });
+
+  it("returns no extra headers for S3-compatible storage (flag unset)", () => {
+    expect(getRequiredUploadHeaders()).toEqual({});
+  });
+
+  it("returns no extra headers when the Azure flag is not exactly 'true'", () => {
+    mockEnv.env.LANGFUSE_USE_AZURE_BLOB = "false";
+    expect(getRequiredUploadHeaders()).toEqual({});
+  });
+});

--- a/web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts
+++ b/web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts
@@ -98,15 +98,16 @@ export function useDatasetItemMediaUpload({
         const buffer = await file.arrayBuffer();
         const sha256Hash = await sha256Base64(buffer);
 
-        const { mediaId, uploadUrl } = await getUploadUrl.mutateAsync({
-          projectId,
-          datasetId,
-          datasetItemId,
-          field,
-          contentType: file.type as MediaContentType,
-          contentLength: file.size,
-          sha256Hash,
-        });
+        const { mediaId, uploadUrl, uploadHeaders } =
+          await getUploadUrl.mutateAsync({
+            projectId,
+            datasetId,
+            datasetItemId,
+            field,
+            contentType: file.type as MediaContentType,
+            contentLength: file.size,
+            sha256Hash,
+          });
 
         // uploadUrl is null when the content already exists (dedupe by hash)
         if (uploadUrl) {
@@ -117,6 +118,9 @@ export function useDatasetItemMediaUpload({
             headers: {
               "Content-Type": file.type,
               "x-amz-checksum-sha256": sha256Hash,
+              // Storage-provider-specific headers (e.g. Azure's required
+              // x-ms-blob-type) the server tells us to send for this PUT.
+              ...uploadHeaders,
             },
           });
 

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -7,6 +7,7 @@ import { Prisma, type Dataset } from "@langfuse/shared/src/db";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { createMediaUploadUrl } from "@/src/features/media/server/mediaService";
+import { getRequiredUploadHeaders } from "@/src/features/media/server/getRequiredUploadHeaders";
 import {
   datasetItemMediaReferenceKey,
   resolveDatasetItemMediaReferences,
@@ -856,7 +857,7 @@ export const datasetRouter = createTRPCRouter({
           `File size must be less than ${env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH} bytes`,
         );
 
-      return createMediaUploadUrl({
+      const { mediaId, uploadUrl } = await createMediaUploadUrl({
         projectId: input.projectId,
         body: {
           contentType: input.contentType,
@@ -867,6 +868,11 @@ export const datasetRouter = createTRPCRouter({
           field: input.field,
         },
       });
+
+      // The client PUTs the file straight to blob storage, so it must send the
+      // headers that storage requires (Azure rejects a Put Blob without
+      // x-ms-blob-type). Surfacing them here keeps the client storage-agnostic.
+      return { mediaId, uploadUrl, uploadHeaders: getRequiredUploadHeaders() };
     }),
   markItemMediaUploadComplete: protectedProjectProcedure
     .input(

--- a/web/src/features/media/server/getRequiredUploadHeaders.ts
+++ b/web/src/features/media/server/getRequiredUploadHeaders.ts
@@ -1,0 +1,21 @@
+import { env } from "@/src/env.mjs";
+
+/**
+ * Returns the HTTP headers a client must send on the direct-to-storage PUT for a
+ * media upload, keyed by the configured media storage provider.
+ *
+ * Azure Blob Storage rejects a Put Blob request that omits `x-ms-blob-type`
+ * (`MissingRequiredHeader`), regardless of the SAS token. S3/MinIO, GCS and OCI
+ * accept the existing `Content-Type` + checksum headers the client already
+ * sends, so they need nothing extra here.
+ *
+ * The provider decision mirrors `getMediaStorageServiceClient`, which lets
+ * `StorageServiceFactory` fall back to `LANGFUSE_USE_AZURE_BLOB` for the media
+ * bucket. Keep these two in sync.
+ */
+export function getRequiredUploadHeaders(): Record<string, string> {
+  if (env.LANGFUSE_USE_AZURE_BLOB === "true") {
+    return { "x-ms-blob-type": "BlockBlob" };
+  }
+  return {};
+}


### PR DESCRIPTION
## What

The dataset-item media upload hook now sends the storage-provider-specific headers required for the direct-to-storage `PUT`. For Azure Blob Storage that means `x-ms-blob-type: BlockBlob`; for S3-compatible storage nothing extra is added.

Fixes #14569

## Why

`useDatasetItemMediaUpload` uploads the file straight to the signed URL with S3-only headers (`Content-Type`, `x-amz-checksum-sha256`). When `LANGFUSE_USE_AZURE_BLOB=true`, the server signs an Azure SAS PUT URL, but Azure's [Put Blob](https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob?tabs=microsoft-entra-id#request-headers-all-blob-types) API **requires** the `x-ms-blob-type` header regardless of the SAS token. Without it Azure responds:

```
<Error><Code>MissingRequiredHeader</Code>...<HeaderName>x-ms-blob-type</HeaderName></Error>
```

so media uploads to dataset items fail on every Azure-backed instance.

## How

- New `getRequiredUploadHeaders()` (`web/src/features/media/server/`) returns the headers the client must send, keyed off the configured media storage provider. It reads `LANGFUSE_USE_AZURE_BLOB` — the same signal `getMediaStorageServiceClient` lets `StorageServiceFactory` fall back to for the media bucket — so the header decision always matches the client that actually signs the URL.
- `getItemMediaUploadUrl` (tRPC) returns `uploadHeaders` alongside `uploadUrl`.
- The hook spreads `uploadHeaders` into the `PUT`.

This keeps the client storage-agnostic and is robust to custom external endpoints (URL-sniffing would miss a rewritten Azure host). It is scoped to the tRPC path and does **not** touch the public `/api/public/media` contract — the SDKs already set their own Azure headers.

`x-ms-blob-type: BlockBlob` is sufficient: the SAS URL generated by `@azure/storage-blob` embeds the signed version (`sv`), so `x-ms-version` is not needed on the request.

## Testing

- New unit test `getRequiredUploadHeaders.servertest.ts` covers the three meaningful env states: Azure (`"true"`) → `{ "x-ms-blob-type": "BlockBlob" }`, flag unset → `{}`, flag `"false"` → `{}`.
- `pnpm --filter web run typecheck` and `eslint` on the changed files pass clean.

Generated with Claude Code

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Azure Blob Storage media uploads in the dataset-item flow by adding the required `x-ms-blob-type: BlockBlob` header to the client's direct-to-storage PUT. Previously, the header was omitted entirely, causing Azure to reject every upload with `MissingRequiredHeader`.

- **New `getRequiredUploadHeaders()`**: reads `LANGFUSE_USE_AZURE_BLOB` (the same env flag used by `StorageServiceFactory`) and returns `{ \"x-ms-blob-type\": \"BlockBlob\" }` for Azure or an empty object otherwise, keeping the client storage-agnostic.
- **`getItemMediaUploadUrl` tRPC mutation**: now awaits `createMediaUploadUrl`, appends `uploadHeaders` to the response, and the hook spreads those headers into the `fetch` PUT request.
- Unit tests cover all three meaningful env states for the new helper.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for S3/MinIO environments; Azure deployments need CORS configuration verified before uploads will work end-to-end in the browser.

The logic change is small and correct — the new header is only added for Azure, Azure ignores the pre-existing `x-amz-checksum-sha256` header, and the env-flag alignment with `StorageServiceFactory` is exact. The one gap is that browser PUT requests to Azure now include `x-ms-blob-type`, a non-simple CORS header that requires the Azure container's CORS `AllowedHeaders` to include it (or the `x-ms-*` wildcard). Without that, the CORS preflight will be rejected and uploads will still fail, just with a different error.

Deployment docs or setup guide for Azure-backed instances should be updated to call out the required CORS `AllowedHeaders` change; no application code files require additional attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as Browser (hook)
    participant tRPC as tRPC: getItemMediaUploadUrl
    participant Helper as getRequiredUploadHeaders()
    participant Storage as Azure / S3 Blob Storage

    Browser->>tRPC: "mutate({ projectId, datasetId, field, contentType, sha256Hash, ... })"
    tRPC->>tRPC: "createMediaUploadUrl() → { mediaId, uploadUrl }"
    tRPC->>Helper: getRequiredUploadHeaders()
    Helper-->>tRPC: "{ "x-ms-blob-type": "BlockBlob" } (Azure) or {} (S3)"
    tRPC-->>Browser: "{ mediaId, uploadUrl, uploadHeaders }"

    Browser->>Storage: PUT uploadUrl
    Note over Browser,Storage: Content-Type, x-amz-checksum-sha256, [+ uploadHeaders]
    Storage-->>Browser: 200 OK

    Browser->>tRPC: "markItemMediaUploadComplete({ mediaId, uploadHttpStatus, ... })"
    tRPC-->>Browser: "{ success: true }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as Browser (hook)
    participant tRPC as tRPC: getItemMediaUploadUrl
    participant Helper as getRequiredUploadHeaders()
    participant Storage as Azure / S3 Blob Storage

    Browser->>tRPC: "mutate({ projectId, datasetId, field, contentType, sha256Hash, ... })"
    tRPC->>tRPC: "createMediaUploadUrl() → { mediaId, uploadUrl }"
    tRPC->>Helper: getRequiredUploadHeaders()
    Helper-->>tRPC: "{ "x-ms-blob-type": "BlockBlob" } (Azure) or {} (S3)"
    tRPC-->>Browser: "{ mediaId, uploadUrl, uploadHeaders }"

    Browser->>Storage: PUT uploadUrl
    Note over Browser,Storage: Content-Type, x-amz-checksum-sha256, [+ uploadHeaders]
    Storage-->>Browser: 200 OK

    Browser->>tRPC: "markItemMediaUploadComplete({ mediaId, uploadHttpStatus, ... })"
    tRPC-->>Browser: "{ success: true }"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts:118-124
**Azure CORS must allow `x-ms-blob-type`**

`x-ms-blob-type` is not a CORS simple header, so the browser will send an `OPTIONS` preflight before the `PUT`. If the Azure Blob container's CORS policy doesn't include `x-ms-blob-type` (or the `x-ms-*` wildcard) in `AllowedHeaders`, the preflight will be rejected and the upload will fail with a CORS error even though the SAS URL is valid. Previously the upload failed with a 400 from Azure, so the CORS path was never reached. Users enabling this fix will need their Azure container CORS configured with something like `x-ms-*` in allowed headers.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(datasets): send Azure x-ms-blob-type..."](https://github.com/langfuse/langfuse/commit/eb4371845ce9f566a5ecb8be0a22331adf037c82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39938603)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->