### PR TITLE
feat(worker): replace blob export delay gauge with keep-up ratio (LFE-10521)

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1086,18 +1086,6 @@ export const handleBlobStorageIntegrationProjectJob = async (
     `[BLOB INTEGRATION] Calculated maxTimestamp for project ${projectId}: ${maxTimestamp}, isValid: ${!isNaN(maxTimestamp.getTime())}, getTime: ${maxTimestamp.getTime()}, frequencyIntervalMs: ${frequencyIntervalMs}`,
   );
 
-  // How far behind real-time this project's export frontier is. maxTimestamp is
-  // the end of the window this job advances to, so lag ≈ the export buffer when
-  // caught up and grows during historic catch-up. Per-job emit, so it goes stale
-  // if the exporter stops entirely for a project (see LFE-10521).
-  if (!isNaN(maxTimestamp.getTime())) {
-    recordGauge(
-      "langfuse.blobstorage.export_delay_seconds",
-      (now.getTime() - maxTimestamp.getTime()) / 1000,
-      { projectId },
-    );
-  }
-
   // Skip export if the time window is empty or invalid
   if (minTimestamp >= maxTimestamp) {
     logger.info(


### PR DESCRIPTION
## What does this PR do?

Replaces the `langfuse.blobstorage.export_delay_seconds` gauge (added in #14559) with an actionable "can the exporter keep up?" signal.

The old frontier-lag gauge wasn't actionable. What matters operationally is whether a project's blob exporter is **falling behind**: if a run exports every N minutes but the export itself takes longer than N minutes on average, lag grows unbounded.

**Removed**
- `langfuse.blobstorage.export_delay_seconds`

**Added** (emitted on the successful export path, tagged `projectId`, `exportFrequency`, `caughtUp`)
- `langfuse.blobstorage.window_export_duration_ratio` (gauge) — wall-clock export time for one window ÷ the frequency interval. **> 1 means the exporter can't keep up.**
- `langfuse.blobstorage.window_export_duration_seconds` (histogram) — raw processing time per window, for diagnostics.

### Why the frequency interval as the denominator?

It's the cadence the operator reasons about ("exports every 20 minutes") and it's stable. The actual data window (`maxTimestamp − minTimestamp`) collapses toward zero near the lag buffer in steady state, which would make the ratio meaningless.

The `caughtUp` tag separates steady-state lag (the real alert: `caughtUp:true` and `ratio > 1`) from expected back-to-back catch-up runs.

## Type of change

- [x] New feature / instrumentation (no user-visible behavior change)

## Checklist

- [x] Lint and typecheck pass (`worker`)
- [x] Metrics emitted only on the successful export path; failures fall through to the existing error handling