### PR TITLE
feat(worker): emit blob export keep-up ratio metric (LFE-10521)

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1202,6 +1202,10 @@ export const handleBlobStorageIntegrationProjectJob = async (
       );
     }
 
+    // Wall-clock spent exporting this one window's data, used to detect
+    // exporters that can't keep up (see metric emit below).
+    const exportStartedAt = Date.now();
+
     if (isTraceOnlyProject) {
       // Only process traces table for projects in the trace-only list (legacy behavior)
       logger.info(
@@ -1248,8 +1252,35 @@ export const handleBlobStorageIntegrationProjectJob = async (
       await Promise.all(processPromises);
     }
 
+    const exportDurationMs = Date.now() - exportStartedAt;
+
     // Determine if we've caught up with present-day data
     const caughtUp = maxTimestamp.getTime() >= uncappedMaxTimestamp.getTime();
+
+    // Falling-behind signal: how long it took to export one window's data
+    // relative to that window's scheduling cadence (the frequency interval).
+    // A ratio > 1 means a single run takes longer than the period it covers, so
+    // the exporter cannot keep up and lag grows over time. frequencyIntervalMs
+    // is the stable denominator the user reasons about ("exports every 20 min")
+    // — the actual data window collapses toward zero near the lag buffer in
+    // steady state and would make the ratio meaningless (LFE-10521). caughtUp
+    // is tagged so steady-state lag can be separated from expected back-to-back
+    // catch-up runs.
+    const durationTags = {
+      projectId,
+      exportFrequency: blobStorageIntegration.exportFrequency,
+      caughtUp: String(caughtUp),
+    };
+    recordHistogram(
+      "langfuse.blobstorage.window_export_duration_seconds",
+      exportDurationMs / 1000,
+      durationTags,
+    );
+    recordGauge(
+      "langfuse.blobstorage.window_export_duration_ratio",
+      exportDurationMs / frequencyIntervalMs,
+      durationTags,
+    );
 
     let nextSyncAt: Date;
     if (caughtUp) {

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1202,9 +1202,11 @@ export const handleBlobStorageIntegrationProjectJob = async (
       );
     }
 
-    // Wall-clock spent exporting this one window's data, used to detect
-    // exporters that can't keep up (see metric emit below).
-    const exportStartedAt = Date.now();
+    // Elapsed time spent exporting this one window's data, used to detect
+    // exporters that can't keep up (see metric emit below). Monotonic
+    // performance.now() — matches the file's other deltas and avoids a clock
+    // step (NTP/suspend) producing a negative duration.
+    const exportStartedAt = performance.now();
 
     if (isTraceOnlyProject) {
       // Only process traces table for projects in the trace-only list (legacy behavior)
@@ -1252,7 +1254,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
       await Promise.all(processPromises);
     }
 
-    const exportDurationMs = Date.now() - exportStartedAt;
+    const exportDurationMs = performance.now() - exportStartedAt;
 
     // Determine if we've caught up with present-day data
     const caughtUp = maxTimestamp.getTime() >= uncappedMaxTimestamp.getTime();


### PR DESCRIPTION
## What does this PR do?

Adds an actionable "can the blob exporter keep up?" signal. Follow-up to #14580, which removed the non-actionable `export_delay_seconds` frontier gauge.

What matters operationally is whether a project's exporter is **falling behind**: if a run exports every N minutes but the export itself takes longer than N minutes on average, lag grows unbounded.

**Added** (emitted on the successful export path, tagged `projectId`, `exportFrequency`, `caughtUp`)
- `langfuse.blobstorage.window_export_duration_ratio` (gauge) — wall-clock export time for one window ÷ the frequency interval. **> 1 means the exporter can't keep up.**
- `langfuse.blobstorage.window_export_duration_seconds` (histogram) — raw processing time per window, for diagnostics.

### Why the frequency interval as the denominator?

It's the cadence the operator reasons about ("exports every 20 minutes") and it's stable. The actual data window (`maxTimestamp − minTimestamp`) collapses toward zero near the lag buffer in steady state, which would make the ratio meaningless.

The `caughtUp` tag separates steady-state lag (the real alert: `caughtUp:true` and `ratio > 1`) from expected back-to-back catch-up runs.

## Type of change

- [x] New feature / instrumentation (no user-visible behavior change)

## Checklist

- [x] Lint and typecheck pass (`worker`)
- [x] Metrics emitted only on the successful export path; failures fall through to the existing error handling

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two new observability metrics to the blob storage exporter: a histogram (`langfuse.blobstorage.window_export_duration_seconds`) and a gauge (`langfuse.blobstorage.window_export_duration_ratio`) that together provide an actionable "can the exporter keep up?" signal.

- The `exportStartedAt` timer is correctly placed inside the `try` block after the preflight endpoint validation and config setup, so only the actual data-export work is measured.
- Both metrics are tagged with `projectId`, `exportFrequency`, and `caughtUp`; they are emitted only on the successful path, consistent with the PR description.
- `frequencyIntervalMs` is derived from `getFrequencyIntervalMs()`, which always returns a positive integer or throws, so no division-by-zero is possible in the ratio calculation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is additive instrumentation only — no logic is altered, and the metrics are emitted only after a successful export completes.

The timer placement is correct (after preflight, before export work), the denominator (`frequencyIntervalMs`) is always a positive integer, and no existing control flow is modified. The `projectId` tag follows the same cardinality pattern already used throughout the file.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as handleBlobStorageIntegrationProjectJob
    participant Export as processBlobStorageExport
    participant Metrics as recordHistogram / recordGauge

    Job->>Handler: invoke
    Handler->>Handler: validate endpoint (preflight)
    Handler->>Handler: "resolve exportTuning & executionConfig"
    note over Handler: exportStartedAt = Date.now()
    Handler->>Export: processBlobStorageExport (traces/observations/scores/events)
    Export-->>Handler: done
    note over Handler: exportDurationMs = Date.now() - exportStartedAt
    note over Handler: caughtUp = maxTimestamp >= uncappedMaxTimestamp
    Handler->>Metrics: recordHistogram(window_export_duration_seconds, durationMs/1000, tags)
    Handler->>Metrics: recordGauge(window_export_duration_ratio, durationMs/frequencyIntervalMs, tags)
    Handler->>Handler: compute nextSyncAt, update DB
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as handleBlobStorageIntegrationProjectJob
    participant Export as processBlobStorageExport
    participant Metrics as recordHistogram / recordGauge

    Job->>Handler: invoke
    Handler->>Handler: validate endpoint (preflight)
    Handler->>Handler: "resolve exportTuning & executionConfig"
    note over Handler: exportStartedAt = Date.now()
    Handler->>Export: processBlobStorageExport (traces/observations/scores/events)
    Export-->>Handler: done
    note over Handler: exportDurationMs = Date.now() - exportStartedAt
    note over Handler: caughtUp = maxTimestamp >= uncappedMaxTimestamp
    Handler->>Metrics: recordHistogram(window_export_duration_seconds, durationMs/1000, tags)
    Handler->>Metrics: recordGauge(window_export_duration_ratio, durationMs/frequencyIntervalMs, tags)
    Handler->>Handler: compute nextSyncAt, update DB
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): emit blob export keep-up r..."](https://github.com/langfuse/langfuse/commit/da870db86de4ab7b6f49690931843a32d2506a76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40042626)</sub>

<!-- /greptile_comment -->