### PR TITLE
fix(slack): paginate channel loading

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -409,14 +409,6 @@ const EnvSchema = z.object({
   SLACK_CLIENT_ID: z.string().optional(),
   SLACK_CLIENT_SECRET: z.string().optional(),
   SLACK_STATE_SECRET: z.string().optional(),
-  SLACK_FETCH_LIMIT: z.coerce
-    .number()
-    .positive()
-    .optional()
-    .default(5_000)
-    .describe(
-      "How many records should be fetched from Slack, before we give up",
-    ),
   SLACK_PAGE_SIZE: z.coerce
     .number()
     .positive()

--- a/packages/shared/src/server/services/SlackService.ts
+++ b/packages/shared/src/server/services/SlackService.ts
@@ -47,6 +47,7 @@ export interface SlackChannel {
 export interface GetChannelsResult {
   channels: SlackChannel[];
   hasPrivateChannelAccess: boolean;
+  nextCursor?: string;
 }
 
 /** SlackMessage is the Block Kit payload sent to Slack. */
@@ -339,15 +340,14 @@ export class SlackService {
   }
 
   /**
-   * Recursively fetch all channels accessible to the bot
-   * Uses cursor-based pagination defined by Slack API https://api.slack.com/apis/pagination
+   * Fetch one page of channels accessible to the bot.
+   * Uses cursor-based pagination defined by Slack API https://api.slack.com/apis/pagination.
    */
-  private async getChannelsRecursive(
+  private async getChannelsPage(
     client: WebClient,
     channelTypes = "public_channel,private_channel",
     cursor?: string,
-    fetchedRecords = 0,
-  ): Promise<SlackChannel[]> {
+  ): Promise<Omit<GetChannelsResult, "hasPrivateChannelAccess">> {
     try {
       const result = await client.conversations.list({
         exclude_archived: true,
@@ -370,28 +370,12 @@ export class SlackService {
       );
 
       const nextCursor = result.response_metadata?.next_cursor;
-      if (
-        nextCursor &&
-        fetchedRecords + channels.length < env.SLACK_FETCH_LIMIT
-      ) {
-        try {
-          const nextPageChannels = await this.getChannelsRecursive(
-            client,
-            channelTypes,
-            nextCursor,
-            fetchedRecords + channels.length,
-          );
-          return channels.concat(nextPageChannels);
-        } catch (error) {
-          logger.error(
-            `Failed to retrieve next page of channels, returning only already fetched`,
-            error,
-          );
-        }
-      }
-      return channels;
+      return {
+        channels,
+        nextCursor: nextCursor || undefined,
+      };
     } catch (error) {
-      logger.error("Failed to fetch channels recursively", { error, cursor });
+      logger.error("Failed to fetch Slack channels page", { error, cursor });
       throw error;
     }
   }
@@ -399,18 +383,23 @@ export class SlackService {
   /**
    * Get channels accessible to the bot.
    */
-  async getChannels(client: WebClient): Promise<GetChannelsResult> {
+  async getChannels(
+    client: WebClient,
+    cursor?: string,
+  ): Promise<GetChannelsResult> {
     try {
-      const channels = await this.getChannelsRecursive(
+      const { channels, nextCursor } = await this.getChannelsPage(
         client,
         "public_channel,private_channel",
+        cursor,
       );
 
       logger.debug("Retrieved channels from Slack", {
         channelCount: channels.length,
+        hasNextPage: Boolean(nextCursor),
       });
 
-      return { channels, hasPrivateChannelAccess: true };
+      return { channels, hasPrivateChannelAccess: true, nextCursor };
     } catch (error: any) {
       // we added `groups:read` scope after initial release, so older installations may not have it.
       // Detect this case and fall back to fetching only public channels instead of failing completely.
@@ -424,12 +413,13 @@ export class SlackService {
         );
 
         try {
-          const channels = await this.getChannelsRecursive(
+          const { channels, nextCursor } = await this.getChannelsPage(
             client,
             "public_channel",
+            cursor,
           );
 
-          return { channels, hasPrivateChannelAccess: false };
+          return { channels, hasPrivateChannelAccess: false, nextCursor };
         } catch (fallbackError) {
           logger.error("Failed to fetch public channels fallback", {
             error: fallbackError,

--- a/web/src/features/slack/components/ChannelSelector.tsx
+++ b/web/src/features/slack/components/ChannelSelector.tsx
@@ -46,6 +46,7 @@ interface ChannelSelectorProps {
 }
 
 const ITEM_HEIGHT = 32;
+const MAX_SLACK_CHANNEL_PAGES = 20;
 
 const useSlackChannels = (projectId: string) => {
   const {
@@ -61,7 +62,10 @@ const useSlackChannels = (projectId: string) => {
     { projectId },
     {
       enabled: !!projectId,
-      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      getNextPageParam: (lastPage, allPages) =>
+        allPages.length >= MAX_SLACK_CHANNEL_PAGES
+          ? undefined
+          : lastPage.nextCursor,
       staleTime: 5 * 60 * 1000,
     },
   );

--- a/web/src/features/slack/components/ChannelSelector.tsx
+++ b/web/src/features/slack/components/ChannelSelector.tsx
@@ -7,7 +7,6 @@ import {
   PopoverTrigger,
 } from "@/src/components/ui/popover";
 import { Alert, AlertDescription } from "@/src/components/ui/alert";
-import { Select, SelectTrigger, SelectValue } from "@/src/components/ui/select";
 import {
   Command,
   CommandEmpty,
@@ -47,6 +46,57 @@ interface ChannelSelectorProps {
 }
 
 const ITEM_HEIGHT = 32;
+
+const useSlackChannels = (projectId: string) => {
+  const {
+    data: channelsPages,
+    isLoading,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    error,
+    refetch: refetchChannels,
+  } = api.slack.getChannels.useInfiniteQuery(
+    { projectId },
+    {
+      enabled: !!projectId,
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      staleTime: 5 * 60 * 1000,
+    },
+  );
+
+  const channelsData = useMemo(() => {
+    const pages = channelsPages?.pages ?? [];
+    if (pages.length === 0) return null;
+
+    return {
+      channels: pages.flatMap((page) => page.channels),
+      hasPrivateChannelAccess: pages.every(
+        (page) => page.hasPrivateChannelAccess,
+      ),
+    };
+  }, [channelsPages?.pages]);
+
+  const isLoadingChannels =
+    isLoading || isFetchingNextPage || (isFetching && !channelsData);
+
+  // useInfiniteQuery stores page state, but next pages are only loaded when requested.
+  useEffect(() => {
+    if (error || !hasNextPage || isFetchingNextPage) return;
+
+    fetchNextPage().catch((error) => {
+      console.error("Failed to load next Slack channels page", error);
+    });
+  }, [error, fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  return {
+    channelsData,
+    isLoadingChannels,
+    error,
+    refetchChannels,
+  };
+};
 
 /**
  * A dropdown component for selecting Slack channels with search and filtering capabilities.
@@ -92,19 +142,8 @@ export const ChannelSelector: React.FC<ChannelSelectorProps> = ({
   const effectiveName = trimmedSearch.replace(/^#/, "");
 
   // Get available channels
-  const {
-    data: channelsData,
-    isLoading,
-    error,
-    refetch: refetchChannels,
-  } = api.slack.getChannels.useQuery(
-    { projectId },
-    {
-      enabled: !!projectId,
-      // Keep data fresh
-      staleTime: 5 * 60 * 1000, // 5 minutes
-    },
-  );
+  const { channelsData, isLoadingChannels, error, refetchChannels } =
+    useSlackChannels(projectId);
 
   // Handle refresh
   const handleRefresh = async () => {
@@ -203,52 +242,6 @@ export const ChannelSelector: React.FC<ChannelSelectorProps> = ({
     </div>
   );
 
-  // Handle loading state
-  if (isLoading) {
-    return (
-      <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <Select disabled>
-            <SelectTrigger>
-              <SelectValue placeholder="Loading channels..." />
-            </SelectTrigger>
-          </Select>
-          {showRefreshButton && (
-            <Button variant="outline" size="sm" disabled>
-              <RefreshCw className="h-4 w-4" />
-            </Button>
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  // Handle error state
-  if (error) {
-    return (
-      <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <Select disabled>
-            <SelectTrigger>
-              <SelectValue placeholder="Error loading channels" />
-            </SelectTrigger>
-          </Select>
-          {showRefreshButton && (
-            <Button variant="outline" size="sm" onClick={handleRefresh}>
-              <RefreshCw className="h-4 w-4" />
-            </Button>
-          )}
-        </div>
-        <Alert>
-          <AlertDescription>
-            Failed to load channels. Please check your Slack connection and try
-            again.
-          </AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
-
   const hasExactMatch = filteredChannels.some(
     (channel) => channel.name.toLowerCase() === effectiveName.toLowerCase(),
   );
@@ -304,9 +297,11 @@ export const ChannelSelector: React.FC<ChannelSelectorProps> = ({
                     </CommandItem>
                   </CommandGroup>
                 )}
-                {!canUseTypedName && filteredChannels.length === 0 && (
-                  <CommandEmpty>No channels available.</CommandEmpty>
-                )}
+                {!isLoadingChannels &&
+                  !canUseTypedName &&
+                  filteredChannels.length === 0 && (
+                    <CommandEmpty>No channels available.</CommandEmpty>
+                  )}
                 <CommandGroup
                   className="p-0"
                   style={{
@@ -335,6 +330,21 @@ export const ChannelSelector: React.FC<ChannelSelectorProps> = ({
                     );
                   })}
                 </CommandGroup>
+                {isLoadingChannels && (
+                  <CommandGroup className="p-0">
+                    <CommandItem
+                      value="loading-slack-channels"
+                      disabled
+                      className="text-muted-foreground"
+                    >
+                      <RefreshCw className="h-4 w-4 animate-spin" />
+                      <span className="flex-1 truncate">
+                        Loading Slack channels. This can take a while for large
+                        workspaces.
+                      </span>
+                    </CommandItem>
+                  </CommandGroup>
+                )}
               </CommandList>
             </Command>
           </PopoverContent>
@@ -345,21 +355,30 @@ export const ChannelSelector: React.FC<ChannelSelectorProps> = ({
             variant="outline"
             size="sm"
             onClick={handleRefresh}
-            disabled={disabled || isRefreshing}
+            disabled={disabled || isRefreshing || isLoadingChannels}
           >
             <RefreshCw
-              className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
+              className={`h-4 w-4 ${isRefreshing || isLoadingChannels ? "animate-spin" : ""}`}
             />
           </Button>
         )}
       </div>
 
       {/* Channel stats */}
-      {channelsData?.channels && (
+      {channelsData?.channels && !isLoadingChannels ? (
         <div className="text-muted-foreground text-xs">
           {filteredChannels.length} of {channelsData.channels.length} channels
           {memberOnly && " (member only)"}
         </div>
+      ) : null}
+
+      {error && (
+        <Alert>
+          <AlertDescription>
+            Failed to load channels. You can still enter a channel name
+            manually, or check your Slack connection and try again.
+          </AlertDescription>
+        </Alert>
       )}
 
       {/* Private channel scope warning */}

--- a/web/src/features/slack/server/router.ts
+++ b/web/src/features/slack/server/router.ts
@@ -88,7 +88,7 @@ export const slackRouter = createTRPCRouter({
    * Get channels for a project's Slack integration
    */
   getChannels: protectedProjectProcedure
-    .input(z.object({ projectId: z.string() }))
+    .input(z.object({ projectId: z.string(), cursor: z.string().optional() }))
     .query(async ({ ctx, input }) => {
       throwIfNoProjectAccess({
         session: ctx.session,
@@ -112,20 +112,25 @@ export const slackRouter = createTRPCRouter({
         const client = await slackService.getWebClientForProject(
           input.projectId,
         );
-        const { channels, hasPrivateChannelAccess } =
-          await slackService.getChannels(client);
+        const { channels, hasPrivateChannelAccess, nextCursor } =
+          await slackService.getChannels(client, input.cursor);
 
         await auditLog({
           session: ctx.session,
           resourceType: "slackIntegration",
           resourceId: integration.id,
           action: "read",
-          after: { action: "channels_fetched", channelCount: channels.length },
+          after: {
+            action: "channels_fetched",
+            channelCount: channels.length,
+            hasNextPage: Boolean(nextCursor),
+          },
         });
 
         return {
           channels,
           hasPrivateChannelAccess,
+          nextCursor,
           teamId: integration.teamId,
           teamName: integration.teamName,
         };

--- a/web/src/features/slack/server/router.ts
+++ b/web/src/features/slack/server/router.ts
@@ -115,17 +115,19 @@ export const slackRouter = createTRPCRouter({
         const { channels, hasPrivateChannelAccess, nextCursor } =
           await slackService.getChannels(client, input.cursor);
 
-        await auditLog({
-          session: ctx.session,
-          resourceType: "slackIntegration",
-          resourceId: integration.id,
-          action: "read",
-          after: {
-            action: "channels_fetched",
-            channelCount: channels.length,
-            hasNextPage: Boolean(nextCursor),
-          },
-        });
+        if (!input.cursor) {
+          await auditLog({
+            session: ctx.session,
+            resourceType: "slackIntegration",
+            resourceId: integration.id,
+            action: "read",
+            after: {
+              action: "channels_fetched",
+              channelCount: channels.length,
+              hasNextPage: Boolean(nextCursor),
+            },
+          });
+        }
 
         return {
           channels,


### PR DESCRIPTION
## Summary

- Changes Slack channel fetching from server-side recursive loading to one-page-at-a-time pagination so large workspaces no longer block a single request until all channels are loaded.
- Moves channel pagination orchestration into the client with `useInfiniteQuery`, while preserving the existing `SLACK_PAGE_SIZE=1000` default to reduce Slack API calls and rate-limit pressure.
- Keeps manual channel entry available while channels are loading, and shows the long-running loading state inside the dropdown instead of blocking the selector.

## Linear

- [LFE-10534](https://linear.app/langfuse/issue/LFE-10534/slack-connect-504-timeout-fetching-channels)

## Major Decisions

- The backend now returns `nextCursor` instead of recursively fetching every Slack page. This avoids 504s from large channel lists while keeping the API aligned with Slack cursor pagination.
- The client automatically fetches subsequent pages after the initial page. This keeps search over the full loaded set without requiring Slack-side search, which is not available for channels.

## Review Focus

- Slack channel pagination behavior in large workspaces.
- Selector UX while pages are still loading, especially manual channel entry and refresh behavior.

## Impacted Packages

- `web`
- `@langfuse/shared`

## Verification

- `pnpm --filter web run typecheck`
- `pnpm --filter web run lint`
- `pnpm run test src/__tests__/server/slack-integration.servertest.ts`
- `pnpm run test-client src/features/automations/components/automationForm.clienttest.tsx`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the server-side recursive Slack channel fetch (which caused 504 timeouts for large workspaces) with client-driven pagination: the backend now returns one page plus a `nextCursor`, and the frontend uses `useInfiniteQuery` with a `useEffect` chain to automatically load subsequent pages until exhausted.

- **Backend**: `getChannelsRecursive` is replaced by `getChannelsPage`, which fetches one Slack API page and returns `nextCursor`. `getChannels` now accepts a `cursor` argument; the tRPC `getChannels` procedure exposes it as an optional input field.
- **Frontend**: A new `useSlackChannels` hook wraps `useInfiniteQuery` and auto-fetches remaining pages via `useEffect`. The blocking \"Loading channels…\" disabled selector is replaced by an inline spinner inside the dropdown, allowing manual channel entry while pages are still arriving.
- **Removed limit**: The `SLACK_FETCH_LIMIT` server-side cap is gone; the env var remains in `env.ts` as dead code with no effect.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; the core pagination logic is straightforward and the tRPC infinite query integration is wired correctly. The main items to watch are audit log write volume on large workspaces and the now-unused SLACK_FETCH_LIMIT env var.

The pagination wiring (cursor passthrough, getNextPageParam, useEffect chain) is correct and React Query handles concurrent fetch deduplication safely. Three non-blocking concerns exist: dead SLACK_FETCH_LIMIT env var, per-page audit log entries that multiply with workspace size, and the channel count footer staying hidden throughout the entire multi-page load rather than updating incrementally.

packages/shared/src/env.ts — SLACK_FETCH_LIMIT should be removed; web/src/features/slack/server/router.ts — audit log call inside the loop
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as ChannelSelector
    participant Hook as useSlackChannels
    participant tRPC as tRPC Router
    participant Slack as Slack API

    UI->>Hook: mount (projectId)
    Hook->>tRPC: "getChannels({ projectId }) [page 1, no cursor]"
    tRPC->>Slack: "conversations.list(limit=1000)"
    Slack-->>tRPC: channels + nextCursor
    tRPC-->>Hook: "{ channels, nextCursor, hasPrivateChannelAccess }"
    Note over Hook: hasNextPage=true, useEffect fires
    Hook->>tRPC: "getChannels({ projectId, cursor }) [page 2]"
    tRPC->>Slack: "conversations.list(limit=1000, cursor=...)"
    Slack-->>tRPC: channels + nextCursor?
    tRPC-->>Hook: "{ channels, nextCursor? }"
    Note over Hook: Repeat until nextCursor is empty
    Hook-->>UI: channelsData (accumulated), isLoadingChannels
    UI->>UI: Show loading spinner in dropdown while fetching
    UI->>UI: Show full channel list when done
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as ChannelSelector
    participant Hook as useSlackChannels
    participant tRPC as tRPC Router
    participant Slack as Slack API

    UI->>Hook: mount (projectId)
    Hook->>tRPC: "getChannels({ projectId }) [page 1, no cursor]"
    tRPC->>Slack: "conversations.list(limit=1000)"
    Slack-->>tRPC: channels + nextCursor
    tRPC-->>Hook: "{ channels, nextCursor, hasPrivateChannelAccess }"
    Note over Hook: hasNextPage=true, useEffect fires
    Hook->>tRPC: "getChannels({ projectId, cursor }) [page 2]"
    tRPC->>Slack: "conversations.list(limit=1000, cursor=...)"
    Slack-->>tRPC: channels + nextCursor?
    tRPC-->>Hook: "{ channels, nextCursor? }"
    Note over Hook: Repeat until nextCursor is empty
    Hook-->>UI: channelsData (accumulated), isLoadingChannels
    UI->>UI: Show loading spinner in dropdown while fetching
    UI->>UI: Show full channel list when done
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/slack/server/router.ts:118-128
**Audit log written once per page fetch**

An audit entry tagged `channels_fetched` is recorded for every paginated request. Before this PR, loading all channels produced a single audit entry. Now, a workspace with 5 000 channels (5 pages at default `SLACK_PAGE_SIZE=1000`) writes 5 entries each time the selector mounts and again on each manual refresh. The entries accumulate silently in the background because page fetches are orchestrated automatically by the client `useEffect`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(slack): paginate channel loading"](https://github.com/langfuse/langfuse/commit/4acf69a9ca88a726cc8d3ef43db6a2b4cb08b43f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40055632)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->