### PR TITLE
fix(mcp): Enable filtering observations by metadata

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -596,6 +596,12 @@ describe("MCP Read Tools", () => {
       expect(result.resource).toBe("observation");
       expect(result.columns.providedModelName.type).toBe("stringOptions");
       expect(result.columns.tags.type).toBe("arrayOptions");
+      expect(result.columns.metadata).toEqual(
+        expect.objectContaining({
+          type: "stringObject",
+          requiresKey: true,
+        }),
+      );
       expect(result.columns.traceTags).toBeUndefined();
       expect(result.columns.comments).toBeUndefined();
       expect(result.columns.scores).toBeUndefined();
@@ -704,8 +710,63 @@ describe("MCP Read Tools", () => {
           operator: expect.objectContaining({ type: "string" }),
           value: expect.any(Object),
           type: expect.objectContaining({ type: "string" }),
+          key: expect.objectContaining({ type: "string" }),
         }),
       );
+    });
+
+    it("should filter by metadata advanced filters", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const traceId = randomUUID();
+      const matchingObservation = createObservationEvent({
+        projectId,
+        traceId,
+        name: `mcp-filter-metadata-match-${nanoid()}`,
+        metadata: { region: "us-east", tenant: "acme" },
+      });
+      const nonMatchingObservation = createObservationEvent({
+        projectId,
+        traceId,
+        name: `mcp-filter-metadata-miss-${nanoid()}`,
+        metadata: { region: "eu-west", tenant: "acme" },
+      });
+
+      await createEventsCh([matchingObservation, nonMatchingObservation]);
+
+      const result = (await handleListObservations(
+        {
+          filter: [
+            {
+              type: "stringOptions",
+              column: "id",
+              operator: "any of",
+              value: [matchingObservation.id, nonMatchingObservation.id],
+            },
+            {
+              type: "stringObject",
+              column: "metadata",
+              key: "region",
+              operator: "contains",
+              value: "us-",
+            },
+          ],
+          fields: ["id", "name"],
+          limit: 100,
+        },
+        context,
+      )) as { data: Array<{ id: string; name: string; url: string }> };
+
+      expect(result.data).toEqual([
+        {
+          id: matchingObservation.id,
+          name: matchingObservation.name,
+          url: buildObservationUrl({
+            projectId,
+            traceId,
+            observationId: matchingObservation.id,
+          }),
+        },
+      ]);
     });
 
     it("should list observations with compact default projection", async () => {

--- a/web/src/features/mcp/features/observations/tools/listObservations.ts
+++ b/web/src/features/mcp/features/observations/tools/listObservations.ts
@@ -144,6 +144,12 @@ const ObservationMcpFilterBaseSchema = z
     operator: z.string(),
     value: z.any(),
     type: z.string().optional(),
+    key: z
+      .string()
+      .optional()
+      .describe(
+        "Metadata/object key to filter on. Required when column is metadata.",
+      ),
   })
   .describe(
     `Advanced observation filter object. Example: ${OBSERVATION_MCP_FILTER_EXAMPLE_JSON}. The explicit form ${OBSERVATION_MCP_FILTER_EXAMPLE_WITH_TYPE_JSON} is also accepted.`,
@@ -226,7 +232,7 @@ const ListObservationsBaseSchema = z.object({
     .array(ObservationMcpFilterBaseSchema)
     .optional()
     .describe(
-      "Advanced filters. Each item must be an object with column, operator, value, and optional type. Type is inferred from getObservationFilterSchema columns when omitted.",
+      "Advanced filters. Each item must be an object with column, operator, value, optional type, and optional key. Type is inferred from getObservationFilterSchema columns when omitted. Use key for metadata filters.",
     ),
 });
 
@@ -235,7 +241,7 @@ const ListObservationsInputSchema = ListObservationsBaseSchema.extend({
     .array(ObservationMcpFilterSchema)
     .optional()
     .describe(
-      "Advanced filters. Each item must be an object with column, operator, value, and optional type. Type is inferred from getObservationFilterSchema columns when omitted.",
+      "Advanced filters. Each item must be an object with column, operator, value, optional type, and optional key. Type is inferred from getObservationFilterSchema columns when omitted. Use key for metadata filters.",
     ),
 });
 
@@ -300,6 +306,7 @@ export const [listObservationsTool, handleListObservations] = defineTool({
   description: [
     "Find and review observations in the current Langfuse project, such as generations, spans, events, agent steps, and tool calls.",
     "Use filters to narrow results by trace, name, type, level, environment, time range, or advanced filter conditions. Results are paginated with an opaque cursor.",
+    "For metadata filters, first call getObservationFilterMetadataKeys with observationIds, traceId, or a bounded time range, then set the relevant key field in the filter.",
     "",
     'By default this returns compact summary fields. Use fields: ["*"] for the full observation, or pass specific field names to limit the response size.',
     'Important: if you request metadata explicitly, for example fields: ["id", "metadata"], metadata values are truncated to 200 UTF-8 characters per key unless you also pass expandMetadataKeys with the keys that may need full values.',


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exposes the existing `stringObject` metadata filter capability in `listObservations` to LLM clients by adding the `key` field to `ObservationMcpFilterBaseSchema` (the tool's JSON schema) and updating tool descriptions to guide the recommended workflow.

- The `key` field was already required internally by `stringObjectFilter` and passed through the `.loose()` schema transform; it simply wasn't documented in the LLM-facing base schema, so clients didn't know to send it.
- Tests cover the new `metadata` column assertion in `getObservationFilterSchema`, the `key` field in the filter base schema, and an end-to-end filter-by-metadata integration scenario.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive and correctly bridges the gap between the already-functional internal stringObject filter pipeline and the LLM-facing schema that lacked the key field.

The metadata filter path was already wired end-to-end through the loose schema and singleFilter transform; this PR only adds key to the base schema so LLM clients know to supply it. Scope-guard and validation logic are unchanged, and the new integration test exercises the full metadata filter flow with matching and non-matching observations.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant LLM as LLM Client
    participant GOS as getObservationFilterSchema
    participant GOMK as getObservationFilterMetadataKeys
    participant LO as listObservations

    LLM->>GOS: (no args)
    GOS-->>LLM: "{ columns: { metadata: { type: "stringObject", requiresKey: true } } }"

    LLM->>GOMK: "{ traceId / observationIds / time range }"
    GOMK-->>LLM: "{ keys: ["region", "tenant", ...] }"

    LLM->>LO: "{ filter: [{ column: "metadata", type: "stringObject", key: "region", operator: "contains", value: "us-" }] }"
    Note over LO: ObservationMcpFilterBaseSchema accepts key (optional)
    Note over LO: ObservationMcpFilterSchema validates via stringObjectFilter (key required)
    Note over LO: assertAllowedExpensiveObservationAccess checks scope
    LO-->>LLM: "{ data: [...filtered observations] }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant LLM as LLM Client
    participant GOS as getObservationFilterSchema
    participant GOMK as getObservationFilterMetadataKeys
    participant LO as listObservations

    LLM->>GOS: (no args)
    GOS-->>LLM: "{ columns: { metadata: { type: "stringObject", requiresKey: true } } }"

    LLM->>GOMK: "{ traceId / observationIds / time range }"
    GOMK-->>LLM: "{ keys: ["region", "tenant", ...] }"

    LLM->>LO: "{ filter: [{ column: "metadata", type: "stringObject", key: "region", operator: "contains", value: "us-" }] }"
    Note over LO: ObservationMcpFilterBaseSchema accepts key (optional)
    Note over LO: ObservationMcpFilterSchema validates via stringObjectFilter (key required)
    Note over LO: assertAllowedExpensiveObservationAccess checks scope
    LO-->>LLM: "{ data: [...filtered observations] }"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(mcp): Enable filtering observations ..."](https://github.com/langfuse/langfuse/commit/4d5cc71cc9a9025a429bd1604994447bfc318fa7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40548936)</sub>

<!-- /greptile_comment -->