### PR TITLE
fix(datasets): add azure media upload headers

### DIFF
--- a/web/src/__tests__/server/dataset-item-media-references.servertest.ts
+++ b/web/src/__tests__/server/dataset-item-media-references.servertest.ts
@@ -271,9 +271,12 @@ describe("Dataset item media tRPC procedures", () => {
 
     expect(result.mediaId).toBeDefined();
     expect(result.uploadUrl).toBeDefined();
-    expect(result.uploadHeaders).toEqual({
-      "x-amz-checksum-sha256": sha256Hash,
-    });
+    expect(result.uploadHeaders).toEqual(
+      getItemMediaUploadHeaders({
+        sha256Hash,
+        uploadUrl: result.uploadUrl,
+      }),
+    );
     // A pending (null validFrom) association is declared for the item.
     const pending = await prisma.datasetItemMedia.findFirst({
       where: { projectId, mediaId: result.mediaId, datasetItemValidFrom: null },

--- a/web/src/__tests__/server/dataset-item-media-references.servertest.ts
+++ b/web/src/__tests__/server/dataset-item-media-references.servertest.ts
@@ -6,6 +6,7 @@ import {
   getDatasetItemForApi,
   listDatasetItemsForApi,
 } from "@/src/features/datasets/server/publicDatasetService";
+import { getItemMediaUploadHeaders } from "@/src/features/datasets/server/dataset-router";
 import {
   GetDatasetV1Response,
   GetDatasetItemsV1Response,
@@ -237,6 +238,8 @@ describe("Dataset item media references (public API read path)", () => {
 });
 
 describe("Dataset item media tRPC procedures", () => {
+  const itIfAzureBlobStorage =
+    process.env.LANGFUSE_USE_AZURE_BLOB === "true" ? it : it.skip;
   const validSha256 = () =>
     crypto.createHash("sha256").update(v4()).digest("base64");
 
@@ -244,6 +247,7 @@ describe("Dataset item media tRPC procedures", () => {
     datasetId: string;
     datasetItemId?: string;
     contentLength?: number;
+    sha256Hash?: string;
   }) =>
     caller.datasets.getItemMediaUploadUrl({
       projectId,
@@ -252,19 +256,24 @@ describe("Dataset item media tRPC procedures", () => {
       field: "input",
       contentType: MediaContentType.PNG,
       contentLength: args.contentLength ?? 1234,
-      sha256Hash: validSha256(),
+      sha256Hash: args.sha256Hash ?? validSha256(),
     });
 
   it("issues an upload URL and declares a pending association", async () => {
     const dataset = await createDataset();
     const datasetItemId = v4();
+    const sha256Hash = validSha256();
     const result = await requestUploadUrl({
       datasetId: dataset.id,
       datasetItemId,
+      sha256Hash,
     });
 
     expect(result.mediaId).toBeDefined();
     expect(result.uploadUrl).toBeDefined();
+    expect(result.uploadHeaders).toEqual({
+      "x-amz-checksum-sha256": sha256Hash,
+    });
     // A pending (null validFrom) association is declared for the item.
     const pending = await prisma.datasetItemMedia.findFirst({
       where: { projectId, mediaId: result.mediaId, datasetItemValidFrom: null },
@@ -277,6 +286,93 @@ describe("Dataset item media tRPC procedures", () => {
       referenceString: null,
     });
   });
+
+  it("adds the Azure block blob header when Azure blob storage is enabled", () => {
+    const sha256Hash = validSha256();
+    const uploadUrl =
+      "https://account.blob.core.windows.net/container/blob?sv=2025-01-05&sig=signature";
+
+    expect(
+      getItemMediaUploadHeaders({
+        sha256Hash,
+        uploadUrl,
+        useAzureBlob: "true",
+      }),
+    ).toEqual({
+      "x-amz-checksum-sha256": sha256Hash,
+      "x-ms-blob-type": "BlockBlob",
+      "x-ms-version": "2025-01-05",
+    });
+  });
+
+  it("does not add S3 headers for GCS or OCI media storage", () => {
+    const sha256Hash = validSha256();
+
+    expect(
+      getItemMediaUploadHeaders({
+        sha256Hash,
+        useGoogleCloudStorage: "true",
+      }),
+    ).toEqual({});
+    expect(
+      getItemMediaUploadHeaders({
+        sha256Hash,
+        useOciNativeObjectStorage: "true",
+      }),
+    ).toEqual({});
+  });
+
+  itIfAzureBlobStorage(
+    "uploads dataset item media to Azure blob storage with returned tRPC headers",
+    async () => {
+      const dataset = await createDataset();
+      const datasetItemId = v4();
+      const fileBytes = Buffer.from("azure-media");
+      const sha256Hash = crypto
+        .createHash("sha256")
+        .update(fileBytes)
+        .digest("base64");
+      const result = await requestUploadUrl({
+        datasetId: dataset.id,
+        datasetItemId,
+        contentLength: fileBytes.length,
+        sha256Hash,
+      });
+
+      expect(result.uploadUrl).toBeDefined();
+      expect(result.uploadHeaders).toMatchObject({
+        "x-amz-checksum-sha256": sha256Hash,
+        "x-ms-blob-type": "BlockBlob",
+      });
+      expect(result.uploadHeaders["x-ms-version"]).toBeDefined();
+
+      const uploadResponse = await fetch(result.uploadUrl!, {
+        method: "PUT",
+        body: fileBytes,
+        headers: {
+          "Content-Type": MediaContentType.PNG,
+          ...result.uploadHeaders,
+        },
+      });
+
+      await caller.datasets.markItemMediaUploadComplete({
+        projectId,
+        mediaId: result.mediaId,
+        uploadedAt: new Date(),
+        uploadHttpStatus: uploadResponse.status,
+        uploadHttpError: uploadResponse.ok
+          ? undefined
+          : await uploadResponse.text(),
+      });
+
+      expect(uploadResponse.status).toBe(201);
+      const media = await prisma.media.findUnique({
+        where: { projectId_id: { projectId, id: result.mediaId } },
+      });
+      expect(media?.uploadHttpStatus).toBe(201);
+      expect(media?.uploadHttpError).toBeNull();
+    },
+  );
 
   it("rejects an upload for a dataset in another project", async () => {
     // datasetId is not a dataset in this project

--- a/web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts
+++ b/web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts
@@ -112,13 +112,15 @@ export function useDatasetItemMediaUpload({
         // uploadUrl is null when the content already exists (dedupe by hash)
         if (uploadUrl) {
           const uploadStart = Date.now();
+          const headers = new Headers({ "Content-Type": file.type });
+          Object.entries(uploadHeaders).forEach(([key, value]) => {
+            if (value) headers.set(key, value);
+          });
+
           const response = await fetch(uploadUrl, {
             method: "PUT",
             body: file,
-            headers: {
-              "Content-Type": file.type,
-              ...uploadHeaders,
-            },
+            headers,
           });
 
           await markUploadComplete.mutateAsync({

--- a/web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts
+++ b/web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts
@@ -98,15 +98,16 @@ export function useDatasetItemMediaUpload({
         const buffer = await file.arrayBuffer();
         const sha256Hash = await sha256Base64(buffer);
 
-        const { mediaId, uploadUrl } = await getUploadUrl.mutateAsync({
-          projectId,
-          datasetId,
-          datasetItemId,
-          field,
-          contentType: file.type as MediaContentType,
-          contentLength: file.size,
-          sha256Hash,
-        });
+        const { mediaId, uploadUrl, uploadHeaders } =
+          await getUploadUrl.mutateAsync({
+            projectId,
+            datasetId,
+            datasetItemId,
+            field,
+            contentType: file.type as MediaContentType,
+            contentLength: file.size,
+            sha256Hash,
+          });
 
         // uploadUrl is null when the content already exists (dedupe by hash)
         if (uploadUrl) {
@@ -116,7 +117,7 @@ export function useDatasetItemMediaUpload({
             body: file,
             headers: {
               "Content-Type": file.type,
-              "x-amz-checksum-sha256": sha256Hash,
+              ...uploadHeaders,
             },
           });
 

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -4,6 +4,7 @@ import {
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
 import { Prisma, type Dataset } from "@langfuse/shared/src/db";
+import { env as sharedEnv } from "@langfuse/shared/src/env";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { createMediaUploadUrl } from "@/src/features/media/server/mediaService";
@@ -101,6 +102,51 @@ import { createBatchActionJob } from "@/src/features/table/server/createBatchAct
 const DUPLICATE_DATASET_ITEMS_BATCH_SIZE = 100;
 const REMOTE_EXPERIMENT_TIMEOUT_MS = 20_000;
 const REMOTE_EXPERIMENT_MAX_REDIRECTS = 10;
+
+const getAzureStorageVersionFromUploadUrl = (uploadUrl?: string | null) => {
+  if (!uploadUrl) return null;
+
+  try {
+    return new URL(uploadUrl).searchParams.get("sv");
+  } catch {
+    return null;
+  }
+};
+
+export const getItemMediaUploadHeaders = ({
+  sha256Hash,
+  uploadUrl,
+  useAzureBlob = sharedEnv.LANGFUSE_USE_AZURE_BLOB,
+  useGoogleCloudStorage = sharedEnv.LANGFUSE_USE_GOOGLE_CLOUD_STORAGE,
+  useOciNativeObjectStorage = sharedEnv.LANGFUSE_USE_OCI_NATIVE_OBJECT_STORAGE,
+}: {
+  sha256Hash: string;
+  uploadUrl?: string | null;
+  useAzureBlob?: "true" | "false";
+  useGoogleCloudStorage?: "true" | "false";
+  useOciNativeObjectStorage?: "true" | "false";
+}) => {
+  if (
+    useGoogleCloudStorage === "true" ||
+    useOciNativeObjectStorage === "true"
+  ) {
+    return {};
+  }
+
+  if (useAzureBlob === "true") {
+    const azureStorageVersion = getAzureStorageVersionFromUploadUrl(uploadUrl);
+
+    return {
+      "x-amz-checksum-sha256": sha256Hash,
+      "x-ms-blob-type": "BlockBlob",
+      ...(azureStorageVersion ? { "x-ms-version": azureStorageVersion } : {}),
+    };
+  }
+
+  return {
+    "x-amz-checksum-sha256": sha256Hash,
+  };
+};
 
 /**
  * Adds a case-insensitive search condition to a query
@@ -856,7 +902,7 @@ export const datasetRouter = createTRPCRouter({
           `File size must be less than ${env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH} bytes`,
         );
 
-      return createMediaUploadUrl({
+      const result = await createMediaUploadUrl({
         projectId: input.projectId,
         body: {
           contentType: input.contentType,
@@ -867,6 +913,14 @@ export const datasetRouter = createTRPCRouter({
           field: input.field,
         },
       });
+
+      return {
+        ...result,
+        uploadHeaders: getItemMediaUploadHeaders({
+          sha256Hash: input.sha256Hash,
+          uploadUrl: result.uploadUrl,
+        }),
+      };
     }),
   markItemMediaUploadComplete: protectedProjectProcedure
     .input(


### PR DESCRIPTION
## What does this PR do?

Fixes #14569

Linear: [LFE-10526](https://linear.app/langfuse/issue/LFE-10526/bug-media-upload-in-dataset-items-failed-for-azure-storage-account)

- Returns storage-specific upload headers from the dataset item media tRPC route without changing the public media API.
- Adds Azure Blob Storage headers (`x-ms-blob-type` and SAS-derived `x-ms-version`) while preserving the checksum header used by the existing SDK upload path.
- Uses the returned headers in the dataset item media upload hook.
- Adds coverage for provider header selection and an Azure-mode Azurite upload smoke test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Review Focus

- Confirm the tRPC-only response extension is preferable to changing the public media API contract.
- Confirm the Azure header set matches the Python SDK workaround plus the explicit service-version header requested in the bug report.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Azure Blob Storage media uploads in dataset items by returning storage-provider-specific upload headers from the `getItemMediaUploadUrl` tRPC route and consuming them in the upload hook.

- A new `getItemMediaUploadHeaders` helper selects the correct header set per provider: `x-ms-blob-type` + SAS-derived `x-ms-version` for Azure, `x-amz-checksum-sha256` for S3 (default), and an empty object for GCS/OCI.
- The tRPC mutation response is extended with `uploadHeaders`, and `useDatasetItemMediaUpload` spreads them into the `fetch` call instead of the previously hardcoded S3 checksum header.
- New unit tests cover provider header selection, and a conditional Azurite smoke test validates an end-to-end Azure upload.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the dataset item media upload path and is backward-compatible for all existing storage providers.

The header selection logic is straightforward and fully covered by unit tests plus a conditional Azurite integration test. The tRPC response extension is additive and does not change the public media API. GCS/OCI behavior improves by dropping the previously-sent AWS checksum header. The sv extraction from the SAS URL is guarded with a try/catch and a null-conditional spread, so a missing or malformed URL degrades gracefully.

No files require special attention. dataset-router.ts carries the most logic, and the exported getItemMediaUploadHeaders is well-tested directly.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as useDatasetItemMediaUpload
    participant tRPC as datasets.getItemMediaUploadUrl
    participant Media as createMediaUploadUrl
    participant Env as sharedEnv
    participant Storage as Storage Provider (S3/Azure/GCS/OCI)

    Browser->>tRPC: "mutateAsync({ sha256Hash, ... })"
    tRPC->>Media: createMediaUploadUrl(...)
    Media-->>tRPC: "{ mediaId, uploadUrl }"
    tRPC->>Env: read LANGFUSE_USE_AZURE_BLOB / GCS / OCI flags
    Env-->>tRPC: provider flags
    tRPC->>tRPC: "getItemMediaUploadHeaders({ sha256Hash, uploadUrl })"
    Note over tRPC: Azure: x-ms-blob-type + x-ms-version + x-amz-checksum-sha256<br/>S3: x-amz-checksum-sha256<br/>GCS/OCI: {}
    tRPC-->>Browser: "{ mediaId, uploadUrl, uploadHeaders }"
    Browser->>Storage: PUT uploadUrl (Content-Type + ...uploadHeaders)
    Storage-->>Browser: 200/201
    Browser->>tRPC: markItemMediaUploadComplete(...)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as useDatasetItemMediaUpload
    participant tRPC as datasets.getItemMediaUploadUrl
    participant Media as createMediaUploadUrl
    participant Env as sharedEnv
    participant Storage as Storage Provider (S3/Azure/GCS/OCI)

    Browser->>tRPC: "mutateAsync({ sha256Hash, ... })"
    tRPC->>Media: createMediaUploadUrl(...)
    Media-->>tRPC: "{ mediaId, uploadUrl }"
    tRPC->>Env: read LANGFUSE_USE_AZURE_BLOB / GCS / OCI flags
    Env-->>tRPC: provider flags
    tRPC->>tRPC: "getItemMediaUploadHeaders({ sha256Hash, uploadUrl })"
    Note over tRPC: Azure: x-ms-blob-type + x-ms-version + x-amz-checksum-sha256<br/>S3: x-amz-checksum-sha256<br/>GCS/OCI: {}
    tRPC-->>Browser: "{ mediaId, uploadUrl, uploadHeaders }"
    Browser->>Storage: PUT uploadUrl (Content-Type + ...uploadHeaders)
    Storage-->>Browser: 200/201
    Browser->>tRPC: markItemMediaUploadComplete(...)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(datasets): add azure media upload he..."](https://github.com/langfuse/langfuse/commit/827df26cfd18fbb45219139fae8ce07b943a8df5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40060048)</sub>

<!-- /greptile_comment -->