### PR TITLE
refactor(web): Remove undesired in-source vitest test

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -26,6 +26,8 @@ evaluating, and debugging AI applications.
   cross-view extension playbook — the bar is intended to become the primary
   filter interface for every filterable view, so new filtering work extends it
   through that contract rather than forking it.
+- Do not add or widen ESLint disable comments or config overrides
+  without explicit user approval for the exact rule and scope.
 - Never commit secrets or credentials. Keep `.env*.example` files in
   sync with required env vars.
 

--- a/web/src/utils/api.clienttest.ts
+++ b/web/src/utils/api.clienttest.ts
@@ -1,0 +1,56 @@
+import { TRPCClientError } from "@trpc/client";
+import { isNetworkConnectivityError } from "@/src/utils/api";
+
+describe("isNetworkConnectivityError", () => {
+  it("detects the reported failed fetch error without a response", () => {
+    const error = TRPCClientError.from(new TypeError("Failed to fetch"));
+
+    expect(isNetworkConnectivityError(error)).toBe(true);
+  });
+
+  it("detects the reported failed fetch error with a hostname suffix", () => {
+    const error = TRPCClientError.from(
+      new TypeError("Failed to fetch (cloud.langfuse.com)"),
+    );
+
+    expect(isNetworkConnectivityError(error)).toBe(true);
+  });
+
+  it("does not treat other network failures as connectivity errors", () => {
+    const error = TRPCClientError.from(new TypeError("Load failed"));
+
+    expect(isNetworkConnectivityError(error)).toBe(false);
+  });
+
+  it("does not treat tRPC server errors as connectivity errors", () => {
+    const error = TRPCClientError.from({
+      error: {
+        code: -32603,
+        message: "Internal server error",
+        data: {
+          code: "INTERNAL_SERVER_ERROR",
+          httpStatus: 500,
+          path: "events.all",
+        },
+      },
+    });
+
+    expect(isNetworkConnectivityError(error)).toBe(false);
+  });
+
+  it("does not treat response parsing errors as connectivity errors", () => {
+    const error = TRPCClientError.from(new SyntaxError("Unexpected token <"), {
+      meta: {
+        response: new Response("<html></html>", { status: 502 }),
+      },
+    });
+
+    expect(isNetworkConnectivityError(error)).toBe(false);
+  });
+
+  it("does not treat non-tRPC errors as connectivity errors", () => {
+    expect(isNetworkConnectivityError(new TypeError("Failed to fetch"))).toBe(
+      false,
+    );
+  });
+});

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -75,7 +75,7 @@ const hasReportedFailedFetchMessage = (error: unknown): boolean => {
   return REPORTED_FAILED_FETCH_MESSAGE.test(error.message);
 };
 
-const isNetworkConnectivityError = (error: unknown): boolean => {
+export const isNetworkConnectivityError = (error: unknown): boolean => {
   if (!(error instanceof TRPCClientError)) return false;
 
   // tRPC server errors and infrastructure responses have response metadata.
@@ -88,71 +88,6 @@ const isNetworkConnectivityError = (error: unknown): boolean => {
     hasReportedFailedFetchMessage(error)
   );
 };
-
-/* eslint-disable @repo/no-in-source-vitest */
-const vitest = import.meta.vitest;
-
-if (vitest && typeof vitest === "object") {
-  const { describe, expect, it } = vitest;
-
-  describe("isNetworkConnectivityError", () => {
-    it("detects the reported failed fetch error without a response", () => {
-      const error = TRPCClientError.from(new TypeError("Failed to fetch"));
-
-      expect(isNetworkConnectivityError(error)).toBe(true);
-    });
-
-    it("detects the reported failed fetch error with a hostname suffix", () => {
-      const error = TRPCClientError.from(
-        new TypeError("Failed to fetch (cloud.langfuse.com)"),
-      );
-
-      expect(isNetworkConnectivityError(error)).toBe(true);
-    });
-
-    it("does not treat other network failures as connectivity errors", () => {
-      const error = TRPCClientError.from(new TypeError("Load failed"));
-
-      expect(isNetworkConnectivityError(error)).toBe(false);
-    });
-
-    it("does not treat tRPC server errors as connectivity errors", () => {
-      const error = TRPCClientError.from({
-        error: {
-          code: -32603,
-          message: "Internal server error",
-          data: {
-            code: "INTERNAL_SERVER_ERROR",
-            httpStatus: 500,
-            path: "events.all",
-          },
-        },
-      });
-
-      expect(isNetworkConnectivityError(error)).toBe(false);
-    });
-
-    it("does not treat response parsing errors as connectivity errors", () => {
-      const error = TRPCClientError.from(
-        new SyntaxError("Unexpected token <"),
-        {
-          meta: {
-            response: new Response("<html></html>", { status: 502 }),
-          },
-        },
-      );
-
-      expect(isNetworkConnectivityError(error)).toBe(false);
-    });
-
-    it("does not treat non-tRPC errors as connectivity errors", () => {
-      expect(isNetworkConnectivityError(new TypeError("Failed to fetch"))).toBe(
-        false,
-      );
-    });
-  });
-}
-/* eslint-enable @repo/no-in-source-vitest */
 
 /**
  * tRPC serializes query input into the GET URL. For reads whose input scales with


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves in-source vitest tests for `isNetworkConnectivityError` out of `api.ts` and into a proper `api.clienttest.ts` file, removing the need for the `/* eslint-disable @repo/no-in-source-vitest */` override. The `isNetworkConnectivityError` function is exported so the test file can import it directly.

- The new test file runs under the existing `client` vitest project (jsdom environment, `src/**/*.clienttest.{ts,tsx}` glob), and the `in-source` project already excludes `.clienttest.*` files, so there is no double-execution risk.
- The `AGENTS.md` codifies a new agent rule to prevent ESLint disable comments from being added without explicit approval, consistent with the removal of the override here.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a pure structural refactor of test location with no behavior changes to production code.

The only production-code change is adding `export` to `isNetworkConnectivityError`. All test logic is preserved verbatim. The `.clienttest.ts` naming convention is already wired up in `web/vitest.config.mts` under the `client` project (jsdom, `globals: true`), so the tests will be discovered and globals like `describe`/`expect`/`it` will be available without explicit imports. No logic, types, or interfaces were altered.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["api.ts\n(source module)"] -->|exports| B["isNetworkConnectivityError"]
    B --> C["api.clienttest.ts\n(test file)"]
    C --> D["vitest 'client' project\njsdom · *.clienttest.{ts,tsx}"]
    A -.->|previously contained| E["in-source tests\nimport.meta.vitest block\n(REMOVED)"]
    E -.->|ran under| F["vitest 'in-source' project\nincludeSource · node env"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["api.ts\n(source module)"] -->|exports| B["isNetworkConnectivityError"]
    B --> C["api.clienttest.ts\n(test file)"]
    C --> D["vitest 'client' project\njsdom · *.clienttest.{ts,tsx}"]
    A -.->|previously contained| E["in-source tests\nimport.meta.vitest block\n(REMOVED)"]
    E -.->|ran under| F["vitest 'in-source' project\nincludeSource · node env"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Remove undesired in-sourc..."](https://github.com/langfuse/langfuse/commit/ba2033c99d2785c7248b3a9fa5b6e947fece5da1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40068466)</sub>

<!-- /greptile_comment -->