### PR TITLE
fix(agent): Improve message copy-paste behavior

### DIFF
--- a/web/src/ee/features/in-app-agent/components/InAppAgentMessage.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentMessage.stories.tsx
@@ -6,6 +6,25 @@ const meta = preview.meta({
   component: InAppAgentMessage,
 });
 
+function copySelectedNode(node: Node, document: Document) {
+  const range = document.createRange();
+  range.selectNodeContents(node);
+
+  const selection = document.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+
+  const clipboardData = new DataTransfer();
+  const copyEvent = new ClipboardEvent("copy", {
+    bubbles: true,
+    cancelable: true,
+    clipboardData,
+  });
+  node.dispatchEvent(copyEvent);
+
+  return { clipboardData, copyEvent };
+}
+
 export const AssistantText = meta.story({
   args: {
     role: "assistant",
@@ -157,6 +176,100 @@ export const AssistantMarkdown = meta.story({
         '  "next": "content still arriving"',
       ].join("\n"),
     },
+  },
+});
+
+export const CopyMarkdownSelectionInteraction = meta.story({
+  name: "(Test) Copy Markdown Selection",
+  args: {
+    role: "assistant",
+    content: {
+      type: "text",
+      text: [
+        "You can use **[Langfuse](https://langfuse.com)** to inspect _production traces_ and compare `input` values.",
+        "",
+        "Repeated text appears here.",
+        "",
+        "# Repeated text appears here.",
+        "",
+        "* Inspect [Wiki](https://en.wikipedia.org/wiki/Foo_(bar)) links.",
+        "",
+        "```ts",
+        "const value = `**```x```**`;",
+        "```",
+      ].join("\n"),
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const document = canvasElement.ownerDocument;
+    const message = canvasElement.querySelector("[data-compact]");
+    await expect(message).not.toBeNull();
+    if (!message) {
+      return;
+    }
+
+    const firstParagraph = message.querySelector("p");
+    await expect(firstParagraph).not.toBeNull();
+    if (!firstParagraph) {
+      return;
+    }
+
+    const { clipboardData, copyEvent } = copySelectedNode(
+      firstParagraph,
+      document,
+    );
+
+    expect(copyEvent.defaultPrevented).toBe(true);
+    expect(clipboardData.getData("text/plain")).toBe(
+      "You can use **[Langfuse](https://langfuse.com)** to inspect _production traces_ and compare `input` values.",
+    );
+    expect(clipboardData.getData("text/html")).toBe(
+      'You can use <strong><a href="https://langfuse.com/" target="_blank" rel="noopener noreferrer">Langfuse</a></strong> to inspect <em>production traces</em> and compare <code>input</code> values.',
+    );
+
+    const heading = message.querySelector("h1");
+    await expect(heading).not.toBeNull();
+    if (!heading?.firstChild) {
+      return;
+    }
+
+    const { clipboardData: headingClipboardData, copyEvent: headingCopyEvent } =
+      copySelectedNode(heading, document);
+
+    expect(headingCopyEvent.defaultPrevented).toBe(true);
+    expect(headingClipboardData.getData("text/plain")).toBe(
+      "# Repeated text appears here.",
+    );
+
+    const listItem = message.querySelector("li");
+    await expect(listItem).not.toBeNull();
+    if (!listItem) {
+      return;
+    }
+
+    const { clipboardData: listClipboardData, copyEvent: listCopyEvent } =
+      copySelectedNode(listItem, document);
+
+    expect(listCopyEvent.defaultPrevented).toBe(true);
+    expect(listClipboardData.getData("text/plain")).toBe(
+      "* Inspect [Wiki](https://en.wikipedia.org/wiki/Foo_(bar)) links.",
+    );
+
+    const codeBlock = message.querySelector("pre");
+    await expect(codeBlock).not.toBeNull();
+    if (!codeBlock) {
+      return;
+    }
+
+    const { clipboardData: codeClipboardData, copyEvent: codeCopyEvent } =
+      copySelectedNode(codeBlock, document);
+
+    expect(codeCopyEvent.defaultPrevented).toBe(true);
+    expect(codeClipboardData.getData("text/plain")).toBe(
+      "const value = `**```x```**`;",
+    );
+    expect(codeClipboardData.getData("text/html")).not.toContain("Copy code");
+    expect(codeClipboardData.getData("text/html")).not.toContain("button");
   },
 });
 

--- a/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import {
   ArrowRight,
   Check,
@@ -40,6 +39,11 @@ import { useElementSize } from "@/src/hooks/useElementSize";
 import { useCopyToClipboard } from "@/src/hooks/useCopyToClipboard";
 import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
+import {
+  expandMarkdownSelection,
+  getMarkdownSourceRangeFromRenderedOffsets,
+  projectMarkdownToRenderedText,
+} from "./utils/markdown";
 import styles from "./InAppAgentMessage.module.css";
 
 export type InAppAgentMessageRole = "assistant" | "user";
@@ -729,6 +733,24 @@ function MessageText({
   return (
     <div
       data-compact={isCompact}
+      onCopy={(event) => {
+        const browserSelection =
+          event.currentTarget.ownerDocument.getSelection();
+
+        const result = getSelectedMarkdownFromSource(
+          event.currentTarget,
+          browserSelection,
+          text,
+        );
+
+        if (!result) {
+          return;
+        }
+
+        event.preventDefault();
+        event.clipboardData.setData("text/plain", result.markdown);
+        event.clipboardData.setData("text/html", result.html);
+      }}
       className={cn(styles.Streamdown, isCompact && styles.compact)}
     >
       <Streamdown
@@ -773,6 +795,111 @@ function MessageText({
   );
 }
 
+function getSelectedMarkdownFromSource(
+  root: HTMLElement,
+  selection: Selection | null,
+  markdown: string,
+): { markdown: string; html: string } | null {
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return null;
+  }
+
+  const range = selection.getRangeAt(0);
+  if (
+    !(range.startContainer === root || root.contains(range.startContainer)) ||
+    !(range.endContainer === root || root.contains(range.endContainer))
+  ) {
+    return null;
+  }
+
+  const selectedText = selection.toString();
+  if (!selectedText.trim()) {
+    return null;
+  }
+
+  const projection = projectMarkdownToRenderedText(markdown);
+
+  const renderedStart = (() => {
+    const prefixRange = root.ownerDocument.createRange();
+    prefixRange.selectNodeContents(root);
+    prefixRange.setEnd(range.startContainer, range.startOffset);
+    return prefixRange.toString().length;
+  })();
+
+  const renderedEnd = (() => {
+    const prefixRange = root.ownerDocument.createRange();
+    prefixRange.selectNodeContents(root);
+    prefixRange.setEnd(range.endContainer, range.endOffset);
+    return prefixRange.toString().length;
+  })();
+
+  const fallbackStart = projection.plain.indexOf(selectedText, renderedStart);
+  const exactTextSelection =
+    fallbackStart === -1
+      ? null
+      : getMarkdownSourceRangeFromRenderedOffsets(
+          projection,
+          fallbackStart,
+          fallbackStart + selectedText.length,
+        );
+  const offsetSelection = getMarkdownSourceRangeFromRenderedOffsets(
+    projection,
+    renderedStart,
+    renderedEnd,
+  );
+
+  const sourceRange = exactTextSelection ?? offsetSelection;
+
+  if (!sourceRange) {
+    return null;
+  }
+
+  const { start, end } = expandMarkdownSelection(
+    markdown,
+    sourceRange.start,
+    sourceRange.end,
+  );
+  const selectedMarkdown = trimTrailingFenceNewline(markdown, start, end);
+
+  const htmlContainer = root.ownerDocument.createElement("div");
+  htmlContainer.append(range.cloneContents());
+  htmlContainer
+    .querySelectorAll("[data-in-app-agent-code-copy-button]")
+    .forEach((node) => node.remove());
+
+  return {
+    markdown: selectedMarkdown,
+    html: htmlContainer.innerHTML,
+  };
+}
+
+function trimTrailingFenceNewline(
+  markdown: string,
+  start: number,
+  end: number,
+) {
+  const selectedMarkdown = markdown.slice(start, end);
+
+  if (
+    !selectedMarkdown.endsWith("\n") ||
+    !markdown.slice(end).startsWith("```")
+  ) {
+    return selectedMarkdown;
+  }
+
+  const openingFenceIndex = markdown.lastIndexOf("```", start);
+  if (openingFenceIndex === -1) {
+    return selectedMarkdown;
+  }
+
+  const previousClosingFenceIndex = markdown.lastIndexOf("\n```", start);
+  if (previousClosingFenceIndex > openingFenceIndex) {
+    return selectedMarkdown;
+  }
+
+  return selectedMarkdown.slice(0, -1);
+}
+
 function CodeBlock({ children }: { children: ReactNode }) {
   const { copy, isCopied } = useCopyToClipboard({ successDuration: 1_500 });
 
@@ -795,13 +922,15 @@ function CodeBlock({ children }: { children: ReactNode }) {
     <pre className="group/code-block relative pr-10">
       <button
         type="button"
+        data-in-app-agent-code-copy-button="true"
         aria-label={isCopied ? "Copied code" : "Copy code"}
         title={isCopied ? "Copied" : "Copy code"}
+        contentEditable={false}
         disabled={!code}
         onClick={() => {
           copy(code).catch(() => undefined);
         }}
-        className="bg-background/90 text-muted-foreground hover:text-foreground focus-visible:ring-ring absolute top-1.5 right-1.5 z-10 inline-flex size-6 items-center justify-center rounded-md border opacity-80 shadow-sm transition hover:opacity-100 focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+        className="bg-background/90 text-muted-foreground hover:text-foreground focus-visible:ring-ring absolute top-1.5 right-1.5 z-10 inline-flex size-6 items-center justify-center rounded-md border opacity-80 shadow-sm transition select-none hover:opacity-100 focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
       >
         {isCopied ? (
           <Check className="size-3.5" />

--- a/web/src/ee/features/in-app-agent/components/utils/markdown.ts
+++ b/web/src/ee/features/in-app-agent/components/utils/markdown.ts
@@ -1,0 +1,216 @@
+export type ProjectedMarkdownText = ReturnType<
+  typeof projectMarkdownToRenderedText
+>;
+
+export function getMarkdownSourceRangeFromRenderedOffsets(
+  projection: ProjectedMarkdownText,
+  plainStart: number,
+  plainEnd: number,
+) {
+  if (plainStart < 0 || plainEnd <= plainStart) {
+    return null;
+  }
+
+  const sourceStart = projection.sourceByPlainIndex[plainStart];
+  const sourceEnd = projection.sourceByPlainIndex[plainEnd - 1];
+  if (sourceStart === undefined || sourceEnd === undefined) {
+    return null;
+  }
+
+  return { start: sourceStart, end: sourceEnd + 1 };
+}
+
+function getMarkdownBlockPrefixLength(markdown: string) {
+  return (
+    markdown.match(
+      /^(?: {0,3}(?:#{1,6}[ \t]+|[-+*][ \t]+|\d{1,9}[.)][ \t]+|>[ \t]?))/,
+    )?.[0].length ?? 0
+  );
+}
+
+function getMarkdownLinkAtStart(markdown: string, start: number) {
+  if (markdown[start] !== "[") {
+    return null;
+  }
+
+  const closeBracket = markdown.indexOf("]", start + 1);
+  if (closeBracket === -1 || closeBracket === start + 1) {
+    return null;
+  }
+
+  const destinationStart = closeBracket + 2;
+  if (markdown[closeBracket + 1] !== "(") {
+    return null;
+  }
+
+  const destinationEnd = findClosingMarkdownLinkDestination(
+    markdown,
+    destinationStart,
+  );
+  if (destinationEnd === -1) {
+    return null;
+  }
+
+  return {
+    labelStart: start + 1,
+    labelEnd: closeBracket,
+    end: destinationEnd + 1,
+  };
+}
+
+function findClosingMarkdownLinkDestination(markdown: string, start: number) {
+  let depth = 1;
+
+  for (let index = start; index < markdown.length; index++) {
+    const character = markdown[index];
+
+    if (character === "(") {
+      depth += 1;
+      continue;
+    }
+
+    if (character !== ")") {
+      continue;
+    }
+
+    depth -= 1;
+    if (depth === 0) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+export function projectMarkdownToRenderedText(markdown: string) {
+  let plain = "";
+  const sourceByPlainIndex: number[] = [];
+  let index = 0;
+  let isAtLineStart = true;
+  let isInFence = false;
+
+  const append = (character: string, sourceIndex: number) => {
+    plain += character;
+    sourceByPlainIndex.push(sourceIndex);
+    isAtLineStart = character === "\n";
+  };
+
+  while (index < markdown.length) {
+    const remaining = markdown.slice(index);
+
+    if (isAtLineStart) {
+      const fenceMatch = remaining.match(/^```[^\n]*(?:\n|$)/);
+      if (fenceMatch) {
+        if (
+          !isInFence &&
+          !hasClosingMarkdownFence(markdown, index + fenceMatch[0].length)
+        ) {
+          index += fenceMatch[0].length;
+          isAtLineStart = true;
+          continue;
+        }
+
+        isInFence = !isInFence;
+        index += fenceMatch[0].length;
+        continue;
+      }
+    }
+
+    if (isInFence) {
+      append(markdown[index] ?? "", index);
+      index += 1;
+      continue;
+    }
+
+    if (isAtLineStart) {
+      const blockPrefixLength = getMarkdownBlockPrefixLength(remaining);
+      if (blockPrefixLength > 0) {
+        index += blockPrefixLength;
+        isAtLineStart = false;
+        continue;
+      }
+    }
+
+    const link = getMarkdownLinkAtStart(markdown, index);
+
+    if (link) {
+      for (
+        let labelIndex = link.labelStart;
+        labelIndex < link.labelEnd;
+        labelIndex++
+      ) {
+        append(markdown[labelIndex] ?? "", labelIndex);
+      }
+      index = link.end;
+      isAtLineStart = false;
+      continue;
+    }
+
+    const markerMatch = remaining.match(/^(?:\*\*|__|~~|`|\*|_)/);
+    if (markerMatch) {
+      index += markerMatch[0].length;
+      isAtLineStart = false;
+      continue;
+    }
+
+    append(markdown[index] ?? "", index);
+    index += 1;
+  }
+
+  return { plain, sourceByPlainIndex };
+}
+
+function hasClosingMarkdownFence(markdown: string, start: number) {
+  return /(?:^|\n)```[^\n]*(?:\n|$)/.test(markdown.slice(start));
+}
+
+export function expandMarkdownSelection(
+  markdown: string,
+  initialStart: number,
+  initialEnd: number,
+) {
+  return (
+    expandLinkSelection(markdown, initialStart, initialEnd) ??
+    expandBlockPrefixSelection(markdown, initialStart, initialEnd) ?? {
+      start: initialStart,
+      end: initialEnd,
+    }
+  );
+}
+
+function expandLinkSelection(markdown: string, start: number, end: number) {
+  const openBracket = markdown.lastIndexOf("[", start);
+  if (openBracket === -1 || openBracket + 1 !== start) {
+    return null;
+  }
+
+  const closeBracket = markdown.indexOf("]", end);
+  if (closeBracket !== end || markdown[closeBracket + 1] !== "(") {
+    return null;
+  }
+
+  const closeParen = findClosingMarkdownLinkDestination(
+    markdown,
+    closeBracket + 2,
+  );
+  if (closeParen === -1) {
+    return null;
+  }
+
+  return { start: openBracket, end: closeParen + 1 };
+}
+
+function expandBlockPrefixSelection(
+  markdown: string,
+  start: number,
+  end: number,
+) {
+  const lineStart = markdown.lastIndexOf("\n", start - 1) + 1;
+  const prefixLength = getMarkdownBlockPrefixLength(markdown.slice(lineStart));
+
+  if (prefixLength === 0 || lineStart + prefixLength !== start) {
+    return null;
+  }
+
+  return { start: lineStart, end };
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR intercepts copy events on the assistant message `div` and replaces the default clipboard content with the source markdown (for `text/plain`) and a sanitized HTML fragment (for `text/html`), removing the "Copy code" button from copied code blocks.

- Adds `onCopy` handler to `MessageText` that calls a new `getSelectedMarkdownFromSource` function, which projects markdown to rendered text via `projectMarkdownToRenderedText`, maps the DOM selection back to source offsets, and expands the range to include block prefixes and full link syntax.
- Adds `contentEditable={false}` and `select-none` to the code-block copy button so the button text is excluded from programmatic and user selections; marks buttons with `data-in-app-agent-code-copy-button` so they are scrubbed from the `text/html` clipboard payload.
- Adds Storybook interaction tests covering full-message copy, single-paragraph copy, heading copy, list-item copy with nested link and nested parens in URL, and fenced-code-block copy.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is isolated to the copy-paste path of the agent message component and does not touch data persistence, auth, or shared state.

The new projection and offset-mapping logic is well-reasoned, handles the markdown constructs the agent actually emits (headings, blockquotes, bullet lists, inline formatting, fenced code), and is covered by Storybook interaction tests for each major scenario.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User presses Ctrl+C]) --> B[onCopy fires on MessageText div]
    B --> C[getSelectedMarkdownFromSource]
    C --> D{selection exists\nand not collapsed?}
    D -- no --> E[return null\ndefault copy applies]
    D -- yes --> F{start/end containers\ninside root?}
    F -- no --> E
    F -- yes --> G[projectMarkdownToRenderedText\nbuild plain + sourceByPlainIndex map]
    G --> H[getRenderedSelectionStartOffset\ngetRenderedSelectionEndOffset]
    H --> I[plain.indexOf selectedText\nfrom renderedStart]
    I --> J{exact match\nfound?}
    J -- yes --> K[exactTextSelection via\ngetMarkdownSourceRangeFromRenderedOffsets]
    J -- no --> L[offsetSelection via\ngetMarkdownSourceRangeFromRenderedOffsets]
    K --> M[sourceRange = exactTextSelection]
    L --> N[sourceRange = offsetSelection]
    M --> O[expandMarkdownSelection\ntry expandLinkSelection\nthen expandBlockPrefixSelection]
    N --> O
    O --> P[clone DOM range\nremove copy buttons\nget innerHTML]
    P --> Q[event.preventDefault\nclipboard text/plain = markdown slice\nclipboard text/html = sanitized HTML]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([User presses Ctrl+C]) --> B[onCopy fires on MessageText div]
    B --> C[getSelectedMarkdownFromSource]
    C --> D{selection exists\nand not collapsed?}
    D -- no --> E[return null\ndefault copy applies]
    D -- yes --> F{start/end containers\ninside root?}
    F -- no --> E
    F -- yes --> G[projectMarkdownToRenderedText\nbuild plain + sourceByPlainIndex map]
    G --> H[getRenderedSelectionStartOffset\ngetRenderedSelectionEndOffset]
    H --> I[plain.indexOf selectedText\nfrom renderedStart]
    I --> J{exact match\nfound?}
    J -- yes --> K[exactTextSelection via\ngetMarkdownSourceRangeFromRenderedOffsets]
    J -- no --> L[offsetSelection via\ngetMarkdownSourceRangeFromRenderedOffsets]
    K --> M[sourceRange = exactTextSelection]
    L --> N[sourceRange = offsetSelection]
    M --> O[expandMarkdownSelection\ntry expandLinkSelection\nthen expandBlockPrefixSelection]
    N --> O
    O --> P[clone DOM range\nremove copy buttons\nget innerHTML]
    P --> Q[event.preventDefault\nclipboard text/plain = markdown slice\nclipboard text/html = sanitized HTML]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agent): Improve copy-paste behavior"](https://github.com/langfuse/langfuse/commit/04eecf7ce9c561083d91a2e8425f3859b36e0c10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40069000)</sub>

<!-- /greptile_comment -->