### PR TITLE
refactor(server): Re-annotate deprecated barrelfile exports

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -1,3 +1,9 @@
+import {
+  getObservationById as getObservationByIdRoutingWrapper,
+  getTraceById as getTraceByIdRoutingWrapper,
+  getTracesIdentifierForSession as getTracesIdentifierForSessionRoutingWrapper,
+} from "./repositories/events";
+
 export * from "./services/StorageService";
 export * from "./services/safeBlobKeySegment";
 export * from "./ingestion/eventBucketPath";
@@ -156,3 +162,31 @@ export * from "./utils/formatAuthProvider";
 export * from "./traceDeletionProcessor";
 export * from "./deletionGuard";
 export * from "./analytics-integrations/types";
+
+// Re-annotate these deprecated routing wrappers at the public server barrel.
+// They are otherwise exposed through multiple `export *` hops, where consumers
+// and lint tooling can lose the original JSDoc deprecation metadata.
+/**
+ * @deprecated Please prefer `getTraceByIdFromEventsTable` for new use-cases.
+ * This should be exclusively used for backwards compatibility if the write mode
+ * is events_only.
+ */
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional public alias for the deprecated routing wrapper.
+export const getTraceById = getTraceByIdRoutingWrapper;
+
+/**
+ * @deprecated Please prefer `getObservationByIdFromEventsTable` for new
+ * use-cases. This should be exclusively used for backwards compatibility if the
+ * write mode is events_only.
+ */
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional public alias for the deprecated routing wrapper.
+export const getObservationById = getObservationByIdRoutingWrapper;
+
+/**
+ * @deprecated Please prefer `getTracesIdentifierForSessionFromEvents` for new
+ * use-cases. This should be exclusively used for backwards compatibility if the
+ * write mode is events_only.
+ */
+export const getTracesIdentifierForSession =
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional public alias for the deprecated routing wrapper.
+  getTracesIdentifierForSessionRoutingWrapper;


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR explicitly re-exports three deprecated routing-wrapper functions (`getTraceById`, `getObservationById`, `getTracesIdentifierForSession`) at the `packages/shared/src/server/index.ts` barrel, preserving their `@deprecated` JSDoc through what is otherwise a two-hop `export *` chain (`repositories/events.ts` → `repositories/index.ts` → `server/index.ts`).

- Three functions are imported with local aliases (`*RoutingWrapper`) and immediately re-exported with the same names and full `@deprecated` JSDoc, so TypeScript tooling and `@typescript-eslint/no-deprecated` can surface the annotation to downstream callers.
- The `eslint-disable-next-line @typescript-eslint/no-deprecated` directives correctly suppress the lint error that would otherwise fire on the right-hand-side reference to the deprecated symbols.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive re-annotation of already-exposed symbols; no logic is altered.

The three explicit named exports shadow the same names coming through the existing `export * from "./repositories"` wildcard chain (TypeScript lets explicit named exports win over wildcard re-exports without error), the deprecation JSDoc is identical to the source declarations, and the eslint-disable comments are correctly scoped. No behaviour changes, no new public API surface beyond what was already reachable.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["repositories/events.ts\n(getTraceById @deprecated\ngetObservationById @deprecated\ngetTracesIdentifierForSession @deprecated)"]
    B["repositories/index.ts\nexport * from './events'"]
    C["server/index.ts\nexport * from './repositories'\n(wildcard hop — loses JSDoc)"]
    D["server/index.ts\nimport { ... as *RoutingWrapper }\nexport const getTraceById = ...\n(explicit + @deprecated re-annotated)"]
    E["Consumer tooling\n@typescript-eslint/no-deprecated fires ✅"]

    A -->|"export *"| B
    B -->|"export *"| C
    A -->|"direct import alias"| D
    D -->|"named export with JSDoc"| E
    C -.->|"wildcard (overridden by explicit)"| E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["repositories/events.ts\n(getTraceById @deprecated\ngetObservationById @deprecated\ngetTracesIdentifierForSession @deprecated)"]
    B["repositories/index.ts\nexport * from './events'"]
    C["server/index.ts\nexport * from './repositories'\n(wildcard hop — loses JSDoc)"]
    D["server/index.ts\nimport { ... as *RoutingWrapper }\nexport const getTraceById = ...\n(explicit + @deprecated re-annotated)"]
    E["Consumer tooling\n@typescript-eslint/no-deprecated fires ✅"]

    A -->|"export *"| B
    B -->|"export *"| C
    A -->|"direct import alias"| D
    D -->|"named export with JSDoc"| E
    C -.->|"wildcard (overridden by explicit)"| E
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(server): Re-annotate deprecated..."](https://github.com/langfuse/langfuse/commit/735e76c1006ad45f1d5f04c623cae7cda9a895a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40072297)</sub>

<!-- /greptile_comment -->