### PR TITLE
chore(storybook): Fix prisma dependency issues

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -37,6 +37,10 @@ const config: StorybookConfig = {
       dirname(fileURLToPath(import.meta.url)),
       "../../packages/shared/src",
     );
+    const prismaBrowserStub = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "./prisma-browser-stub.cjs",
+    );
     viteConfig.resolve = viteConfig.resolve ?? {};
     // Use the array form with regex `find`s for *exact* matching. The object
     // form is treated by Vite/Rollup as a literal prefix replacement, so an
@@ -54,6 +58,10 @@ const config: StorybookConfig = {
           replacement: replacement as string,
         }));
     viteConfig.resolve.alias = [
+      {
+        find: /^\.prisma\/client\/index-browser$/,
+        replacement: prismaBrowserStub,
+      },
       {
         find: /^@langfuse\/shared\/src\/(.*)$/,
         replacement: `${sharedSrc}/$1`,

--- a/web/.storybook/prisma-browser-stub.cjs
+++ b/web/.storybook/prisma-browser-stub.cjs
@@ -1,0 +1,37 @@
+const fail = () => {
+  throw new Error(
+    "Prisma is server-only and must not be used in Storybook browser stories.",
+  );
+};
+
+const enumLike = new Proxy(
+  {},
+  {
+    get: (_target, prop) => (typeof prop === "symbol" ? undefined : String(prop)),
+    getOwnPropertyDescriptor: (_target, prop) => ({
+      configurable: true,
+      enumerable: true,
+      value: String(prop),
+    }),
+    ownKeys: () => ["PLACEHOLDER"],
+  },
+);
+
+const PrismaClient = new Proxy(function PrismaClient() {}, {
+  apply: fail,
+  construct: fail,
+});
+
+module.exports = new Proxy(
+  {},
+  {
+    get: (_target, prop) => {
+      if (prop === "__esModule") return false;
+      if (prop === "default") return undefined;
+      if (prop === "PrismaClient") return PrismaClient;
+      if (typeof prop === "symbol") return undefined;
+
+      return enumLike;
+    },
+  },
+);


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Prisma-related build errors in Storybook by adding two Vite resolve aliases in `viteFinal` that redirect `@prisma/client` and the internal `.prisma/client/index-browser` specifier to a new browser-safe stub file. The stub throws loudly if `PrismaClient` or server-only model objects are used in a story, while safely re-exporting enum values that may be pulled in transitively through `@langfuse/shared` barrel exports.

- `web/.storybook/main.ts` — adds two alias entries at the top of the alias list to intercept both the public and internal Prisma browser specifiers before the `@langfuse/shared` alias is evaluated.
- `web/.storybook/prisma-browser-stub.ts` — new shim that replaces `@prisma/client`; enums are returned as plain string objects, while `PrismaClient`, the `Prisma` namespace, and known model objects (`Action`, `BatchExport`, etc.) all throw on any use.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is scoped entirely to Storybook's dev-only build config and introduces no runtime production risk. Both alias paths are well-placed before the shared-package alias, and the stub correctly fails loudly for server-only Prisma objects.

The stub hard-codes the current list of Prisma enums and model objects. As the schema evolves, any newly added enum that is transitively imported through `@langfuse/shared` in a story will silently be `undefined` rather than throwing, which could cause confusing Storybook failures that are hard to trace back to this stub.

web/.storybook/prisma-browser-stub.ts — the enum and model export list needs to stay in sync with the Prisma schema as it grows.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    S[Storybook Story] -->|import '@prisma/client'| VA[Vite Alias Resolver]
    S -->|import '.prisma/client/index-browser'| VA
    VA -->|matches /@prisma\/client$/| STUB[prisma-browser-stub.ts]
    VA -->|matches /\.prisma\/client\/index-browser$/| STUB
    VA -->|no match| NORMAL[Normal Resolution]
    STUB -->|PrismaClient constructor| ERR[throws Error]
    STUB -->|Prisma.xxx namespace access| ERR
    STUB -->|Action / BatchExport / etc.| ERR
    STUB -->|Enum named export e.g. Role| OK[returns string-keyed object]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    S[Storybook Story] -->|import '@prisma/client'| VA[Vite Alias Resolver]
    S -->|import '.prisma/client/index-browser'| VA
    VA -->|matches /@prisma\/client$/| STUB[prisma-browser-stub.ts]
    VA -->|matches /\.prisma\/client\/index-browser$/| STUB
    VA -->|no match| NORMAL[Normal Resolution]
    STUB -->|PrismaClient constructor| ERR[throws Error]
    STUB -->|Prisma.xxx namespace access| ERR
    STUB -->|Action / BatchExport / etc.| ERR
    STUB -->|Enum named export e.g. Role| OK[returns string-keyed object]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/.storybook/prisma-browser-stub.ts:125-140
**Stub coverage will silently drift as the schema grows**

Named imports from `@prisma/client` that are not explicitly exported from this stub will resolve to `undefined` at runtime in Storybook rather than throwing. Because `@langfuse/shared` barrel-re-exports Prisma symbols, any new enum or model object added to the schema and transitively pulled into a story will silently be `undefined` rather than triggering the loud error this stub is designed to produce. The `Prisma` namespace Proxy will throw correctly for namespace-form access (`Prisma.SomeThing`), but named-export form (`import { SomeThing }`) will not.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(storybook): Fix prisma dependency ..."](https://github.com/langfuse/langfuse/commit/fd9835a5296565ff7e8953b2d14672705293c53c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40074084)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->