### PR TITLE
fix(trace): peek star a11y + delete-after-nav guard (LFE-10535)

### DIFF
--- a/web/src/components/star-toggle.clienttest.tsx
+++ b/web/src/components/star-toggle.clienttest.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+
+import { TooltipProvider } from "@/src/components/ui/tooltip";
+import { StarToggle } from "@/src/components/star-toggle";
+
+/**
+ * LFE-10535 (#1/#2): the star button's accessible name, its labeled-menu text,
+ * and its tooltip are all derived from `value`, so a screen reader always hears
+ * the real bookmark state and every text surface stays in sync with the
+ * (optimistic) icon. A stable `data-bookmark-toggle` hook lets the table keep
+ * "click the star without closing the peek" decoupled from the human label.
+ */
+const noop = () => Promise.resolve();
+
+describe("StarToggle accessible name (LFE-10535)", () => {
+  it("announces the bookmark state on the icon button", () => {
+    const { rerender } = render(
+      <StarToggle value={false} isLoading={false} onClick={noop} />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Bookmark" }),
+    ).toBeInTheDocument();
+
+    rerender(<StarToggle value={true} isLoading={false} onClick={noop} />);
+    expect(
+      screen.getByRole("button", { name: "Remove bookmark" }),
+    ).toBeInTheDocument();
+  });
+
+  it("announces the state in the labeled menu item and shows matching text", () => {
+    const { rerender } = render(
+      <StarToggle value={false} isLoading={false} onClick={noop} showLabel />,
+    );
+    expect(screen.getByRole("button", { name: "Bookmark" })).toHaveTextContent(
+      "Bookmark",
+    );
+
+    rerender(
+      <StarToggle value={true} isLoading={false} onClick={noop} showLabel />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Remove bookmark" }),
+    ).toHaveTextContent("Remove bookmark");
+  });
+
+  it("wires the tooltip onto the real focusable button with a stable behaviour hook", () => {
+    render(
+      <TooltipProvider>
+        <StarToggle value={true} isLoading={false} onClick={noop} tooltip />
+      </TooltipProvider>,
+    );
+    // The accessible name lives on the button itself (TooltipTrigger asChild),
+    // not on a wrapping <span> — so SR users hear the tooltip.
+    const button = screen.getByRole("button", { name: "Remove bookmark" });
+    expect(button).toHaveAttribute("data-bookmark-toggle");
+  });
+});

--- a/web/src/components/star-toggle.tsx
+++ b/web/src/components/star-toggle.tsx
@@ -1,6 +1,11 @@
 import { StarIcon } from "lucide-react";
 
 import { Button } from "@/src/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 import { api } from "@/src/utils/api";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { type RouterInput } from "@/src/utils/types";
@@ -14,7 +19,8 @@ export function StarToggle({
   onClick,
   size = "icon",
   isLoading,
-  label,
+  showLabel = false,
+  tooltip = false,
 }: {
   value: boolean;
   disabled?: boolean;
@@ -22,20 +28,34 @@ export function StarToggle({
   size?: "icon" | "icon-xs";
   isLoading: boolean;
   /** When set, render as a full-width labeled menu item instead of an icon. */
-  label?: string;
+  showLabel?: boolean;
+  /** When set, wrap the icon button in a hover tooltip announcing the state. */
+  tooltip?: boolean;
 }) {
-  return (
+  // Single source of truth for the accessible name, the menu label, AND the
+  // tooltip — all derived from `value`, so an optimistic flip updates the icon
+  // and every text surface together, and a screen reader always hears the real
+  // state in both the toolbar and the menu (LFE-10535).
+  const stateLabel = value ? "Remove bookmark" : "Bookmark";
+
+  const button = (
     <Button
       variant="ghost"
-      size={label ? "sm" : size}
-      className={label ? "w-full justify-start gap-2 font-normal" : undefined}
+      size={showLabel ? "sm" : size}
+      className={
+        showLabel ? "w-full justify-start gap-2 font-normal" : undefined
+      }
       onClick={(e) => {
         e.stopPropagation();
         onClick(!value);
       }}
       disabled={disabled}
       loading={isLoading}
-      aria-label="bookmark"
+      aria-label={stateLabel}
+      // Stable behaviour hook (decoupled from the human-facing label): the
+      // table marks this selector as "don't close the peek" so you can bookmark
+      // a row without dismissing the open peek.
+      data-bookmark-toggle="true"
     >
       <StarIcon
         className="h-4 w-4"
@@ -43,8 +63,19 @@ export function StarToggle({
         stroke={value ? "#ca8a04" : "currentColor"}
         strokeWidth={2}
       />
-      {label ? <span className="text-sm">{label}</span> : null}
+      {showLabel ? <span className="text-sm">{stateLabel}</span> : null}
     </Button>
+  );
+
+  if (!tooltip) return button;
+
+  // TooltipTrigger asChild wraps the real <Button> (not a <span>), so Radix puts
+  // aria-describedby on the focusable control and SR users hear the tooltip.
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent>{stateLabel}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -131,13 +162,17 @@ export function StarTraceDetailsToggle({
   traceId,
   value,
   size = "icon",
-  label,
+  showLabel = false,
+  tooltip = false,
 }: {
   projectId: string;
   traceId: string;
   value: boolean;
   size?: "icon" | "icon-xs";
-  label?: string;
+  /** Render as a full-width labeled menu item (label tracks the optimistic state). */
+  showLabel?: boolean;
+  /** Wrap the icon button in a hover tooltip announcing the optimistic state. */
+  tooltip?: boolean;
 }) {
   const utils = api.useUtils();
   const hasAccess = useHasProjectAccess({
@@ -170,7 +205,8 @@ export function StarTraceDetailsToggle({
     <StarToggle
       value={optimisticValue}
       size={size}
-      label={label}
+      showLabel={showLabel}
+      tooltip={tooltip}
       disabled={!hasAccess}
       isLoading={isLoading}
       onClick={(nextValue) => {

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -128,6 +128,17 @@ export const shouldKeepPeekOpenOnOutsideInteraction = (
   );
 };
 
+/**
+ * After an in-flight delete resolves, only close the peek if it STILL shows the
+ * trace that was deleted. Deleting trace A then K/J-navigating to trace B before
+ * the mutation settles must leave B's peek open — A's stale `closePeek` callback
+ * would otherwise clear the (now-B) peek param and dismiss it (LFE-10535).
+ */
+export const shouldClosePeekAfterDelete = (
+  currentPeekTraceId: string | undefined,
+  deletedTraceId: string,
+): boolean => currentPeekTraceId === deletedTraceId;
+
 function TablePeekViewComponent(props: TablePeekViewProps) {
   const { title, children } = props;
   const router = useRouter();

--- a/web/src/components/table/peek/outsideInteraction.clienttest.tsx
+++ b/web/src/components/table/peek/outsideInteraction.clienttest.tsx
@@ -20,7 +20,7 @@ function targetWith(
   return el;
 }
 
-const IGNORED = ['[role="checkbox"]', '[aria-label="bookmark"]'];
+const IGNORED = ['[role="checkbox"]', "[data-bookmark-toggle]"];
 
 describe("shouldKeepPeekOpenOnOutsideInteraction", () => {
   afterEach(() => {
@@ -60,7 +60,7 @@ describe("shouldKeepPeekOpenOnOutsideInteraction", () => {
   it("keeps open for a table-configured ignoredSelector", () => {
     expect(
       shouldKeepPeekOpenOnOutsideInteraction(
-        targetWith({ "aria-label": "bookmark" }),
+        targetWith({ "data-bookmark-toggle": "true" }),
         IGNORED,
       ),
     ).toBe(true);

--- a/web/src/components/table/peek/peek-observation-detail.tsx
+++ b/web/src/components/table/peek/peek-observation-detail.tsx
@@ -1,4 +1,7 @@
-import { TablePeekView } from "@/src/components/table/peek";
+import {
+  TablePeekView,
+  shouldClosePeekAfterDelete,
+} from "@/src/components/table/peek";
 import { usePeekData } from "@/src/components/table/peek/hooks/usePeekData";
 import {
   TraceDetailBody,
@@ -6,6 +9,7 @@ import {
 } from "@/src/components/trace/TraceDetailBody";
 import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
 import { useRouter } from "next/router";
+import { useRef } from "react";
 
 export const TablePeekViewObservationDetail = (
   props: Omit<
@@ -29,6 +33,12 @@ export const TablePeekViewObservationDetail = (
 
   const traceId = router.query.traceId as string | undefined;
 
+  // Live handle on the peeked observation's trace id: an in-flight delete that
+  // resolves after K/J-navigation reads the CURRENT trace here, so it only
+  // closes the peek when it still shows the trace that was deleted (LFE-10535).
+  const traceIdRef = useRef(traceId);
+  traceIdRef.current = traceId;
+
   const trace = usePeekData({
     projectId,
     traceId,
@@ -43,7 +53,11 @@ export const TablePeekViewObservationDetail = (
         isPublic: trace.data.public,
         name: trace.data.name,
         timestamp,
-        onAfterDelete: props.closePeek,
+        onAfterDelete: (deletedTraceId: string) => {
+          if (shouldClosePeekAfterDelete(traceIdRef.current, deletedTraceId)) {
+            props.closePeek();
+          }
+        },
       }
     : null;
 

--- a/web/src/components/table/peek/peek-trace-detail.tsx
+++ b/web/src/components/table/peek/peek-trace-detail.tsx
@@ -1,10 +1,14 @@
 import { usePeekData } from "@/src/components/table/peek/hooks/usePeekData";
 import { useRouter } from "next/router";
+import { useRef } from "react";
 import {
   TraceDetailBody,
   traceDetailTitle,
 } from "@/src/components/trace/TraceDetailBody";
-import { TablePeekView } from "@/src/components/table/peek";
+import {
+  TablePeekView,
+  shouldClosePeekAfterDelete,
+} from "@/src/components/table/peek";
 import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
 
 export const TablePeekViewTraceDetail = (
@@ -20,6 +24,12 @@ export const TablePeekViewTraceDetail = (
   const router = useRouter();
   const peekId = router.query.peek as string | undefined;
   const timestampParam = router.query.timestamp as string | undefined;
+
+  // Live handle on the peeked trace id: an in-flight delete that resolves after
+  // K/J-navigation reads the CURRENT peek here (not the stale value captured
+  // when the delete was fired), so it only closes the peek it actually deleted.
+  const peekIdRef = useRef(peekId);
+  peekIdRef.current = peekId;
 
   // Decode the timestamp parameter before parsing as Date
   // This handles cases where the timestamp might be URL-encoded
@@ -41,7 +51,11 @@ export const TablePeekViewTraceDetail = (
         isPublic: trace.data.public,
         name: trace.data.name,
         timestamp,
-        onAfterDelete: props.closePeek,
+        onAfterDelete: (deletedTraceId: string) => {
+          if (shouldClosePeekAfterDelete(peekIdRef.current, deletedTraceId)) {
+            props.closePeek();
+          }
+        },
       }
     : null;
 

--- a/web/src/components/table/peek/peekDeleteGuard.clienttest.tsx
+++ b/web/src/components/table/peek/peekDeleteGuard.clienttest.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldClosePeekAfterDelete } from "@/src/components/table/peek";
+
+/**
+ * LFE-10535 (#3): deleting trace A then K/J-navigating to trace B before the
+ * delete resolves must NOT close B's peek. The peek closes on a successful
+ * delete only while it still shows the trace that was deleted.
+ */
+describe("shouldClosePeekAfterDelete (LFE-10535)", () => {
+  it("closes when the peek still shows the deleted trace", () => {
+    expect(shouldClosePeekAfterDelete("trace-a", "trace-a")).toBe(true);
+  });
+
+  it("keeps the peek open when it moved on to another trace", () => {
+    expect(shouldClosePeekAfterDelete("trace-b", "trace-a")).toBe(false);
+  });
+
+  it("does not close when the peek is already gone", () => {
+    expect(shouldClosePeekAfterDelete(undefined, "trace-a")).toBe(false);
+  });
+});

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1307,7 +1307,9 @@ export default function TracesTable({
       itemType: "TRACE" as const,
       detailNavigationKey: detailPageListKeys.traces,
       peekEventOptions: {
-        ignoredSelectors: ['[role="checkbox"]', '[aria-label="bookmark"]'],
+        // Stable hook (decoupled from the star's state-aware aria-label) so
+        // clicking a row's bookmark toggles it without dismissing the peek.
+        ignoredSelectors: ['[role="checkbox"]', "[data-bookmark-toggle]"],
       },
       ...peekNavigationProps,
     };

--- a/web/src/components/trace/TraceDetailActions.tsx
+++ b/web/src/components/trace/TraceDetailActions.tsx
@@ -2,11 +2,6 @@ import { api } from "@/src/utils/api";
 import { StarTraceDetailsToggle } from "@/src/components/star-toggle";
 import { PublishTraceSwitch } from "@/src/components/publish-object-switch";
 import { DeleteTraceButton } from "@/src/components/deleteButton";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/src/components/ui/tooltip";
 
 /**
  * Trace-level header actions (star / publish / delete) shared by the peek and
@@ -22,10 +17,12 @@ import {
  * from an observation/event row — the surface shows that trace). Behavior
  * differs only by surface:
  * - **page**: pass `deleteRedirectUrl` → navigates to the list after delete.
- * - **peek**: pass `onAfterDelete` (e.g. `closePeek`) → closes in place. We
- *   invalidate broadly because the peek is hosted over many different lists
- *   (traces, observations, events, sessions, experiments, datasets), each
- *   backed by a different query — so the deleted row disappears everywhere.
+ * - **peek**: pass `onAfterDelete` (e.g. `closePeek`) → closes in place. It
+ *   receives the deleted trace id so the peek can stay open if K/J-navigation
+ *   already moved on to another trace (LFE-10535). We invalidate broadly
+ *   because the peek is hosted over many different lists (traces, observations,
+ *   events, sessions, experiments, datasets), each backed by a different query
+ *   — so the deleted row disappears everywhere.
  */
 export function TraceDetailActions({
   traceId,
@@ -46,7 +43,7 @@ export function TraceDetailActions({
   name?: string | null;
   timestamp?: Date;
   deleteRedirectUrl?: string;
-  onAfterDelete?: () => void;
+  onAfterDelete?: (deletedTraceId: string) => void;
   size?: "icon" | "icon-xs";
   layout?: "toolbar" | "menu";
 }) {
@@ -55,10 +52,12 @@ export function TraceDetailActions({
 
   // The page path navigates away (redirectUrl) and never calls this. The peek
   // path is hosted over many different lists, so invalidate all queries to
-  // refresh whichever list is behind the peek, then close it.
+  // refresh whichever list is behind the peek, then close it. We hand the
+  // deleted trace id to onAfterDelete so the peek can skip closing when it has
+  // already navigated to a different trace (LFE-10535).
   const onDeleteInvalidate = () => {
     utils.invalidate();
-    onAfterDelete?.();
+    onAfterDelete?.(traceId);
   };
 
   if (isMenu) {
@@ -68,7 +67,7 @@ export function TraceDetailActions({
           projectId={projectId}
           traceId={traceId}
           value={bookmarked}
-          label={bookmarked ? "Remove bookmark" : "Bookmark"}
+          showLabel
         />
         <PublishTraceSwitch
           projectId={projectId}
@@ -93,24 +92,16 @@ export function TraceDetailActions({
 
   return (
     <div className="flex flex-row items-center gap-1">
-      {/* Star/Share are plain icon buttons without their own tooltip, so wrap
-          them (delete's IconOnlyButton already has one). The span is the
-          tooltip trigger; the control inside keeps its own click behavior. */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="flex">
-            <StarTraceDetailsToggle
-              projectId={projectId}
-              traceId={traceId}
-              value={bookmarked}
-              size={size}
-            />
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>
-          {bookmarked ? "Remove bookmark" : "Bookmark"}
-        </TooltipContent>
-      </Tooltip>
+      {/* The star owns its tooltip (composed onto the real button, so the
+          aria-describedby lands on the focusable control) and drives its label
+          from the optimistic state — see StarToggle. */}
+      <StarTraceDetailsToggle
+        projectId={projectId}
+        traceId={traceId}
+        value={bookmarked}
+        size={size}
+        tooltip
+      />
       <PublishTraceSwitch
         projectId={projectId}
         traceId={traceId}


### PR DESCRIPTION
## TL;DR
Three small follow-up fixes to the trace **peek** action toolbar from #14530 (LFE-10535): the bookmark **star now announces its real state to screen readers**, its **tooltip/label stay in sync with the optimistic icon**, and an **in-flight trace delete no longer closes the peek** after you've `K`/`J`-navigated to a different trace.

## Why
Three nits surfaced after the unified trace-detail surface shipped (#14530):
1. `StarToggle` hard-coded `aria-label="bookmark"`, which overrode the visible menu label — a screen reader announced "bookmark" in both the bookmarked and un-bookmarked states, and never the actual state.
2. In the toolbar, the tooltip was attached to a wrapping `<span>` (via `TooltipTrigger asChild`), so `aria-describedby` landed on the span, not the focusable button — SR users never heard it. The tooltip text and the overflow-menu label also read the parent `bookmarked` prop, which lags the optimistic icon by a refetch (~100–500ms): yellow star, "Bookmark" label.
3. Deleting trace A and then `K`/`J`-navigating to trace B before the mutation settled closed B's peek — A's `closePeek` fired unconditionally once the delete resolved.

## What
- One **single source of truth** for the star's accessible name, menu label, and tooltip — all derived from `value` ("Bookmark" / "Remove bookmark") — so the optimistic flip updates the icon and every text surface together, and SR users hear the real state in both the toolbar and the overflow menu. The tooltip now composes onto the **real button** (`TooltipTrigger asChild` wrapping the `Button`).
- `onAfterDelete` now receives the **deleted trace id**; the peek closes only while it still shows that trace (`shouldClosePeekAfterDelete`). Applied to both the trace peek and the observation peek.
- The table's "click a row's star without dismissing the peek" behaviour now keys off a stable **`data-bookmark-toggle`** hook instead of the (now state-aware) `aria-label`.

## Result
SR announces the bookmark state in both the toolbar and the menu; the tooltip/label track the optimistic icon; deleting a trace only closes the peek if it still shows that trace. Verified live in the peek (menu + expanded toolbar): state-aware `aria-label`, tooltip on the real focusable button, and label+icon flipping together on click.

<details>
<summary>Mechanism, scope & verification</summary>

- **`star-toggle.tsx`** — `StarToggle`: `label?: string` → `showLabel?: boolean` (label text derived from `value`); new `tooltip?: boolean` wraps the button in a Radix tooltip; `aria-label` is state-aware; adds `data-bookmark-toggle`. `StarTraceDetailsToggle` threads `showLabel`/`tooltip` so the optimistic `value` drives all three surfaces. The table/session toggles inherit the state-aware name for free.
- **`TraceDetailActions.tsx`** — toolbar drops the manual `Tooltip`/`<span>` wrapper for `<StarTraceDetailsToggle … tooltip />`; menu uses `showLabel`; `onAfterDelete?.(traceId)`.
- **`peek.tsx`** — new pure helper `shouldClosePeekAfterDelete(currentPeekTraceId, deletedTraceId)`, alongside the existing `shouldKeepPeekOpenOnOutsideInteraction`.
- **`peek-trace-detail.tsx` / `peek-observation-detail.tsx`** — a live ref to the peeked trace id so the guard reads the current peek (not the value captured when delete was fired).
- **`traces.tsx`** — peek `ignoredSelectors` → `[data-bookmark-toggle]`.
- **Tests** — `star-toggle.clienttest.tsx` (accessible name in icon + menu modes, tooltip composed on the real button); `peekDeleteGuard.clienttest.tsx` (close-while-still-showing vs keep-open-after-nav); updated `outsideInteraction.clienttest.tsx`. Full `lint` + `typecheck` green.

Self-contained peek/`TraceDetailActions` work — no overlap with the timeline tickets.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR delivers three targeted follow-ups to the trace peek toolbar: state-aware accessible names on the bookmark star (derived from `value` so optimistic flips stay in sync), correct tooltip composition directly onto the focusable button, and a guard that prevents a settled delete from closing the peek when K/J-navigation has already moved to a different trace.

- `StarToggle` now derives its `aria-label`, label text, and tooltip from `value` via a single `stateLabel` variable; a stable `data-bookmark-toggle` data attribute replaces the now-state-aware `aria-label` as the hook for peek's `ignoredSelectors`.
- `shouldClosePeekAfterDelete` in `peek.tsx` gates `closePeek()` behind a live ref to the current peek param in both `peek-trace-detail.tsx` and `peek-observation-detail.tsx`, so a stale in-flight delete can no longer dismiss a newly-opened peek.
- `onAfterDelete` in `TraceDetailActions` is widened to `(deletedTraceId: string) => void` and threaded through `onDeleteInvalidate` so each peek component can compare against its own live ref.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. All three fixes are self-contained and well-tested; no data paths, auth flows, or query logic are affected.

The delete-guard logic, accessible name derivation, and tooltip rewiring are all correct and covered by new tests. The one flag is that when `tooltip=true` is passed to `StarToggle`, both the button's `aria-label` and the Radix `TooltipContent` render the identical `stateLabel` string, which some screen readers will announce twice as name + description. It's a minor accessibility roughness, not a functional regression.

web/src/components/star-toggle.tsx — the `aria-label` / tooltip text duplication when `tooltip=true`.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant DeleteButton
    participant TraceDetailActions
    participant PeekDetail
    participant shouldClosePeekAfterDelete

    User->>DeleteButton: Click delete (trace A)
    DeleteButton->>TraceDetailActions: "executeDeleteMutation(onDeleteSuccess[traceId=A])"
    Note over DeleteButton: mutation in-flight
    User->>PeekDetail: K/J navigate to trace B
    Note over PeekDetail: peekIdRef.current = "B"
    TraceDetailActions-->>DeleteButton: mutation resolves
    DeleteButton->>TraceDetailActions: onDeleteSuccess() → onDeleteInvalidate()
    TraceDetailActions->>PeekDetail: onAfterDelete("A")
    PeekDetail->>shouldClosePeekAfterDelete: ("B", "A")
    shouldClosePeekAfterDelete-->>PeekDetail: false → peek stays open ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant DeleteButton
    participant TraceDetailActions
    participant PeekDetail
    participant shouldClosePeekAfterDelete

    User->>DeleteButton: Click delete (trace A)
    DeleteButton->>TraceDetailActions: "executeDeleteMutation(onDeleteSuccess[traceId=A])"
    Note over DeleteButton: mutation in-flight
    User->>PeekDetail: K/J navigate to trace B
    Note over PeekDetail: peekIdRef.current = "B"
    TraceDetailActions-->>DeleteButton: mutation resolves
    DeleteButton->>TraceDetailActions: onDeleteSuccess() → onDeleteInvalidate()
    TraceDetailActions->>PeekDetail: onAfterDelete("A")
    PeekDetail->>shouldClosePeekAfterDelete: ("B", "A")
    shouldClosePeekAfterDelete-->>PeekDetail: false → peek stays open ✓
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/star-toggle.tsx:74-78
**Tooltip and aria-label announce identical text to screen readers**

When `tooltip=true`, both the button's `aria-label` and `TooltipContent` are set to the same `stateLabel` string. Radix wires the tooltip via `aria-describedby`, so some screen readers will announce the state twice — e.g., "Remove bookmark, Remove bookmark." The tooltip serves sighted users hovering; the `aria-label` already covers SR users. Consider omitting `aria-label` when the tooltip is present (since `TooltipTrigger asChild` means the button's accessible name can come from the tooltip via `aria-labelledby`), or leave it as-is if the duplication is acceptable in your target AT matrix.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): peek star a11y + delete-afte..."](https://github.com/langfuse/langfuse/commit/702d22506e1d84c53679f8b79098b285e5232206) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40082860)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->