### PR TITLE
feat(v4): polish migration readiness page

### DIFF
--- a/web/src/features/v4/components/V4MigrationProjectCards.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.tsx
@@ -1,12 +1,21 @@
 import { useMemo, type ReactNode } from "react";
 import Link from "next/link";
-import { ArrowRight, ExternalLink } from "lucide-react";
-import { Button } from "@/src/components/ui/button";
-import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
+import { format } from "date-fns";
+import { ChevronRight, ExternalLink } from "lucide-react";
+import { Bar, BarChart, XAxis, YAxis } from "recharts";
+import { Badge } from "@/src/components/ui/badge";
+import { Alert, AlertDescription } from "@/src/components/ui/alert";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/src/components/ui/chart";
 import { DashboardCard } from "@/src/features/dashboard/components/cards/DashboardCard";
-import { Chart } from "@/src/features/widgets/chart-library/Chart";
 import { encodeFiltersGeneric } from "@/src/features/filters/lib/filter-query-encoding";
-import { numberFormatter } from "@/src/utils/numbers";
+import { getV4MigrationStatus } from "@/src/features/v4/utils";
+import { compactNumberFormatter, numberFormatter } from "@/src/utils/numbers";
+import { cn } from "@/src/utils/tailwind";
 
 export type V4LegacyIntegrations = {
   posthog: boolean;
@@ -32,19 +41,34 @@ export type V4TraceLevelEvalExecutionPoint = {
   count: number;
 };
 
-export const PUBLIC_API_DOCS = [
-  {
-    label: "V4 upgrade guide",
-    href: "https://langfuse.com/docs/v4",
-  },
-  {
-    label: "Observations API v2",
-    href: "https://langfuse.com/docs/api-and-data-platform/features/observations-api#v2",
-  },
-  {
-    label: "Metrics API v2",
-    href: "https://langfuse.com/docs/metrics/features/metrics-api#v2",
-  },
+type ProductHref = string | { pathname: string; query: Record<string, string> };
+
+type UsageSeries = {
+  name: string;
+  total: number;
+  points: number[];
+  lastSeen?: string;
+};
+
+type StackedUsageChartSeries = UsageSeries & {
+  key: string;
+  color: string;
+};
+
+const V4_DOCS_LINK = {
+  label: "Docs",
+  href: "https://langfuse.com/docs/v4",
+} as const;
+
+const MAX_STACKED_CHART_SERIES = 6;
+const STACKED_CHART_COLORS = [
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-4))",
+  "hsl(var(--chart-5))",
+  "hsl(var(--chart-7))",
+  "hsl(var(--chart-8))",
+  "hsl(var(--chart-3))",
 ] as const;
 
 export const INTEGRATION_LINKS = [
@@ -83,44 +107,329 @@ export const getTraceLevelEvalsHref = (projectId: string) => ({
   },
 });
 
-const CardError = ({ children }: { children: string }) => (
-  <div className="border-destructive/30 bg-destructive/10 text-destructive flex min-h-28 items-center rounded-md border p-4 text-sm">
-    {children}
-  </div>
+const normalizeEntrypoint = (entrypoint: string) =>
+  entrypoint.replace(/^publicapi:\s*/, "");
+
+const getBucketTimes = (rows: Array<{ time: string }>): string[] =>
+  Array.from(new Set(rows.map((row) => row.time))).sort();
+
+const getBucketLabel = (time: string) => {
+  const date = new Date(time);
+  return Number.isNaN(date.getTime()) ? time : format(date, "MMM d, HH:mm");
+};
+
+const groupUsageSeries = <T extends { time: string; count: number }>({
+  rows,
+  getName,
+  bucketTimes,
+}: {
+  rows: T[] | undefined;
+  getName: (row: T) => string;
+  bucketTimes?: string[];
+}): UsageSeries[] => {
+  const times = bucketTimes ?? getBucketTimes(rows ?? []);
+  const groups = new Map<
+    string,
+    {
+      total: number;
+      countsByTime: Map<string, number>;
+      lastSeen?: string;
+    }
+  >();
+
+  for (const row of rows ?? []) {
+    const name = getName(row);
+    if (!name) continue;
+
+    const group =
+      groups.get(name) ??
+      ({
+        total: 0,
+        countsByTime: new Map<string, number>(),
+      } satisfies {
+        total: number;
+        countsByTime: Map<string, number>;
+        lastSeen?: string;
+      });
+    group.total += row.count;
+    group.countsByTime.set(
+      row.time,
+      (group.countsByTime.get(row.time) ?? 0) + row.count,
+    );
+
+    if (row.count > 0 && (!group.lastSeen || row.time > group.lastSeen)) {
+      group.lastSeen = row.time;
+    }
+
+    groups.set(name, group);
+  }
+
+  return Array.from(groups.entries())
+    .map(([name, group]) => ({
+      name,
+      total: group.total,
+      points: times.map((time) => group.countsByTime.get(time) ?? 0),
+      lastSeen: group.lastSeen,
+    }))
+    .filter((series) => series.total > 0)
+    .sort((left, right) => {
+      if (right.total !== left.total) return right.total - left.total;
+      return left.name.localeCompare(right.name);
+    });
+};
+
+const Notice = ({ children }: { children: ReactNode }) => (
+  <Alert>
+    <AlertDescription>{children}</AlertDescription>
+  </Alert>
 );
 
-export const ProductLinkButton = ({
+const InlineLink = ({
   href,
+  external,
   children,
 }: {
-  href: string | { pathname: string; query: Record<string, string> };
+  href: ProductHref | string;
+  external?: boolean;
   children: ReactNode;
-}) => (
-  <Button asChild variant="outline" size="sm">
-    <Link href={href}>
-      {children}
-      <ArrowRight className="ml-1 h-3.5 w-3.5" />
-    </Link>
-  </Button>
-);
+}) => {
+  const className =
+    "text-accent-dark-blue hover:text-primary-accent/60 inline-flex items-center gap-1 text-sm font-semibold whitespace-nowrap";
 
-const ExternalDocButton = ({
-  href,
-  children,
-}: {
-  href: string;
-  children: ReactNode;
-}) => (
-  <Button asChild variant="outline" size="sm">
-    <a href={href} target="_blank" rel="noopener noreferrer">
+  return external ? (
+    <a
+      href={href as string}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+    >
       {children}
-      <ExternalLink className="ml-1 h-3.5 w-3.5" />
+      <ExternalLink className="h-3 w-3 shrink-0" />
     </a>
-  </Button>
+  ) : (
+    <Link href={href as ProductHref} className={className}>
+      {children}
+      <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+    </Link>
+  );
+};
+
+const Section = ({
+  title,
+  count,
+  detailsHref,
+  children,
+}: {
+  title: string;
+  count: number;
+  detailsHref: ProductHref;
+  children: ReactNode;
+}) => (
+  <section>
+    <div className="flex items-center justify-between gap-3">
+      <h3 className="text-sm font-medium">{title}</h3>
+      <div className="flex items-center gap-2">
+        <Badge variant="outline-solid" size="sm">
+          {numberFormatter(count, 0)}
+        </Badge>
+        <InlineLink href={detailsHref}>Go to details</InlineLink>
+      </div>
+    </div>
+    <div className="mt-3 flex flex-col gap-2">{children}</div>
+  </section>
+);
+
+const getStackedChartSeries = (
+  series: UsageSeries[],
+): StackedUsageChartSeries[] => {
+  const visibleSeries = series.slice(0, MAX_STACKED_CHART_SERIES);
+  const hiddenSeries = series.slice(MAX_STACKED_CHART_SERIES);
+  const stackSeries =
+    hiddenSeries.length === 0
+      ? visibleSeries
+      : [
+          ...visibleSeries,
+          {
+            name: "Other",
+            total: hiddenSeries.reduce((total, item) => total + item.total, 0),
+            points: visibleSeries[0]?.points.map((_, index) =>
+              hiddenSeries.reduce(
+                (total, item) => total + (item.points[index] ?? 0),
+                0,
+              ),
+            ) ?? [0],
+          },
+        ];
+
+  return stackSeries.map((item, index) => ({
+    ...item,
+    key: `series_${index}`,
+    color: STACKED_CHART_COLORS[index % STACKED_CHART_COLORS.length],
+  }));
+};
+
+const UsageStackedBarOverview = ({
+  bucketTimes,
+  series,
+  valueLabel,
+}: {
+  bucketTimes: string[];
+  series: UsageSeries[];
+  valueLabel: string;
+}) => {
+  const chartSeries = useMemo(() => getStackedChartSeries(series), [series]);
+  const chartData = useMemo(
+    () =>
+      bucketTimes.map((time, bucketIndex) => {
+        const row: Record<string, string | number> = {
+          timeLabel: getBucketLabel(time),
+        };
+
+        for (const item of chartSeries) {
+          row[item.key] = item.points[bucketIndex] ?? 0;
+        }
+
+        return row;
+      }),
+    [bucketTimes, chartSeries],
+  );
+  const chartConfig = useMemo<ChartConfig>(
+    () =>
+      Object.fromEntries(
+        chartSeries.map((item) => [
+          item.key,
+          {
+            label: item.name,
+            color: item.color,
+          },
+        ]),
+      ),
+    [chartSeries],
+  );
+  const total = series.reduce((sum, item) => sum + item.total, 0);
+
+  if (chartSeries.length === 0 || chartData.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-md border p-3">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <span className="text-sm font-medium">Usage over time</span>
+        <span className="text-muted-foreground text-xs">
+          {numberFormatter(total, 0, 2)} {valueLabel}
+        </span>
+      </div>
+      <ChartContainer config={chartConfig} className="h-32">
+        <BarChart
+          accessibilityLayer
+          data={chartData}
+          margin={{ top: 4, right: 8, bottom: 0, left: -18 }}
+        >
+          <XAxis
+            dataKey="timeLabel"
+            tickLine={false}
+            axisLine={{ stroke: "hsl(var(--border) / 0.5)" }}
+            minTickGap={24}
+            fontSize={11}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            width={42}
+            fontSize={11}
+            tickFormatter={(value) => compactNumberFormatter(Number(value), 1)}
+          />
+          <ChartTooltip
+            cursor={false}
+            contentStyle={{ backgroundColor: "hsl(var(--background))" }}
+            content={({ active, payload, label }) => (
+              <ChartTooltipContent
+                active={active}
+                payload={payload}
+                label={label}
+                valueFormatter={(value) => numberFormatter(Number(value), 0, 2)}
+                sortPayloadByValue="desc"
+              />
+            )}
+          />
+          {chartSeries.map((item, index) => (
+            <Bar
+              key={item.key}
+              dataKey={item.key}
+              stackId="usage"
+              fill={item.color}
+              radius={
+                index === chartSeries.length - 1 ? [3, 3, 0, 0] : undefined
+              }
+            />
+          ))}
+        </BarChart>
+      </ChartContainer>
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 border-t pt-3">
+        {chartSeries.map((item) => (
+          <div
+            key={item.key}
+            className="flex max-w-full min-w-0 items-center gap-2 text-xs sm:max-w-80"
+            title={item.name}
+          >
+            <span
+              className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+              style={{ backgroundColor: item.color }}
+            />
+            <span className="truncate font-medium">{item.name}</span>
+            <span className="text-muted-foreground shrink-0">
+              {numberFormatter(item.total, 0, 2)} {valueLabel}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const ActionRow = ({
+  title,
+  titleClassName,
+  detail,
+  total,
+  usageLabel,
+}: {
+  title: string;
+  titleClassName?: string;
+  detail: string;
+  total?: number;
+  usageLabel?: string;
+}) => (
+  <div className="grid gap-3 rounded-md border px-3 py-2 md:grid-cols-[minmax(0,1fr)_8rem] md:items-center">
+    <div className="min-w-0">
+      <div className={cn("truncate text-sm font-medium", titleClassName)}>
+        {title}
+      </div>
+      <div className="text-muted-foreground mt-0.5 truncate text-xs">
+        {detail}
+      </div>
+    </div>
+    <div className="md:text-right">
+      {typeof total === "number" ? (
+        <>
+          <div className="text-sm font-medium">
+            {numberFormatter(total, 0, 2)}
+          </div>
+          <div className="text-muted-foreground text-xs">
+            {usageLabel ?? "uses"}
+          </div>
+        </>
+      ) : (
+        <span className="text-muted-foreground text-sm">Configuration</span>
+      )}
+    </div>
+  </div>
 );
 
 export const V4MigrationProjectCards = ({
   projectId,
+  projectName,
   summary,
   legacyApiUsage,
   traceLevelEvalExecutions,
@@ -132,6 +441,7 @@ export const V4MigrationProjectCards = ({
   hasTraceLevelEvalExecutionsError,
 }: {
   projectId: string;
+  projectName?: string;
   summary: V4MigrationSummary | undefined;
   legacyApiUsage: V4LegacyApiUsagePoint[] | undefined;
   traceLevelEvalExecutions: V4TraceLevelEvalExecutionPoint[] | undefined;
@@ -147,175 +457,149 @@ export const V4MigrationProjectCards = ({
     [projectId],
   );
 
+  const legacyApiBucketTimes = useMemo(
+    () => getBucketTimes(legacyApiUsage ?? []),
+    [legacyApiUsage],
+  );
+  const legacyApiSeries = useMemo(() => {
+    return groupUsageSeries({
+      rows: legacyApiUsage,
+      getName: (row) => normalizeEntrypoint(row.entrypoint),
+      bucketTimes: legacyApiBucketTimes,
+    });
+  }, [legacyApiBucketTimes, legacyApiUsage]);
+
+  const evalExecutionBucketTimes = useMemo(
+    () => getBucketTimes(traceLevelEvalExecutions ?? []),
+    [traceLevelEvalExecutions],
+  );
+  const evalExecutionSeries = useMemo(
+    () =>
+      groupUsageSeries({
+        rows: traceLevelEvalExecutions,
+        getName: (row) => row.scoreName,
+        bucketTimes: evalExecutionBucketTimes,
+      }),
+    [evalExecutionBucketTimes, traceLevelEvalExecutions],
+  );
+
   const legacyIntegrationLinks = useMemo(
     () =>
       INTEGRATION_LINKS.filter(
         (link) => summary?.legacyIntegrations[link.key] === true,
-      ).map((link) => ({
-        ...link,
-        href: `/project/${projectId}/settings/integrations/${link.path}`,
-      })),
-    [projectId, summary?.legacyIntegrations],
+      ),
+    [summary?.legacyIntegrations],
   );
 
-  const integrationsHref = `/project/${projectId}/settings/integrations`;
-
-  const chartData = useMemo(
-    () =>
-      legacyApiUsage?.map((row) => ({
-        time_dimension: row.time,
-        dimension: row.entrypoint,
-        metric: row.count,
-      })) ?? [],
-    [legacyApiUsage],
-  );
-
-  const evalExecutionChartData = useMemo(
-    () =>
-      traceLevelEvalExecutions?.map((row) => ({
-        time_dimension: row.time,
-        dimension: row.scoreName,
-        metric: row.count,
-      })) ?? [],
-    [traceLevelEvalExecutions],
-  );
+  const activeTaskCount =
+    legacyApiSeries.length +
+    (summary?.traceLevelEvalCount ?? 0) +
+    legacyIntegrationLinks.length;
+  const migrationStatus = getV4MigrationStatus(activeTaskCount);
+  const isLoading =
+    isSummaryLoading ||
+    isLegacyApiUsageLoading ||
+    isTraceLevelEvalExecutionsLoading;
 
   return (
-    <>
-      <div className="grid grid-cols-1 items-stretch gap-3 lg:grid-cols-[minmax(0,2fr)_minmax(20rem,1fr)]">
-        <DashboardCard
-          title="Trace-level evals"
-          description="Trace-targeting evaluator configs and non-cancelled execution jobs by generated score name."
-          isLoading={isSummaryLoading || isTraceLevelEvalExecutionsLoading}
-          cardContentClassName="min-h-[30rem]"
-          headerClassName="pr-12"
-          headerRight={
-            <ProductLinkButton href={traceLevelEvalsHref}>
-              View evals
-            </ProductLinkButton>
-          }
-        >
-          <div className="flex flex-col gap-4">
+    <DashboardCard
+      title="Required changes"
+      description={
+        isLoading
+          ? "Loading V4 migration data."
+          : `${projectName ? `${projectName} - ` : ""}${numberFormatter(
+              activeTaskCount,
+              0,
+            )} required ${
+              activeTaskCount === 1 ? "change" : "changes"
+            } in the selected time range`
+      }
+      isLoading={isLoading}
+      headerRight={
+        isLoading ? undefined : (
+          <div className="flex items-center gap-2">
+            <InlineLink href={V4_DOCS_LINK.href} external>
+              {V4_DOCS_LINK.label}
+            </InlineLink>
+            <Badge
+              variant={migrationStatus.badgeVariant}
+              className="whitespace-nowrap"
+            >
+              {migrationStatus.label}
+            </Badge>
+          </div>
+        )
+      }
+    >
+      {isLoading ? (
+        <div className="min-h-80" />
+      ) : (
+        <>
+          <Section
+            title="Legacy public APIs"
+            count={legacyApiSeries.length}
+            detailsHref={`/project/${projectId}/settings/api-keys`}
+          >
+            {hasLegacyApiUsageError ? (
+              <Notice>Failed to load public API usage.</Notice>
+            ) : legacyApiSeries.length ? (
+              <UsageStackedBarOverview
+                bucketTimes={legacyApiBucketTimes}
+                series={legacyApiSeries}
+                valueLabel="calls"
+              />
+            ) : (
+              <Notice>No legacy public API usage in this range.</Notice>
+            )}
+          </Section>
+
+          <Section
+            title="Trace-level evals"
+            count={summary?.traceLevelEvalCount ?? evalExecutionSeries.length}
+            detailsHref={traceLevelEvalsHref}
+          >
+            {hasSummaryError || hasTraceLevelEvalExecutionsError ? (
+              <Notice>Failed to load trace-level eval data.</Notice>
+            ) : evalExecutionSeries.length ? (
+              <UsageStackedBarOverview
+                bucketTimes={evalExecutionBucketTimes}
+                series={evalExecutionSeries}
+                valueLabel="executions"
+              />
+            ) : (summary?.traceLevelEvalCount ?? 0) > 0 ? (
+              <ActionRow
+                title={`${numberFormatter(
+                  summary?.traceLevelEvalCount ?? 0,
+                  0,
+                )} configured trace-level evals`}
+                detail="No executions found in the selected range."
+              />
+            ) : (
+              <Notice>No trace-level evals detected.</Notice>
+            )}
+          </Section>
+
+          <Section
+            title="Integrations"
+            count={legacyIntegrationLinks.length}
+            detailsHref={`/project/${projectId}/settings/integrations`}
+          >
             {hasSummaryError ? (
-              <CardError>Failed to load trace-level evals.</CardError>
-            ) : (
-              <div>
-                <p className="text-muted-foreground text-sm">
-                  Configured trace-level evals
-                </p>
-                <div className="text-4xl font-semibold">
-                  {numberFormatter(summary?.traceLevelEvalCount ?? 0, 0)}
-                </div>
-              </div>
-            )}
-
-            {hasTraceLevelEvalExecutionsError ? (
-              <CardError>Failed to load trace-level eval executions.</CardError>
-            ) : evalExecutionChartData.length > 0 ? (
-              <div className="h-[22rem] w-full">
-                <Chart
-                  chartType="BAR_TIME_SERIES"
-                  data={evalExecutionChartData}
-                  rowLimit={1_000}
-                  chartConfig={{
-                    type: "BAR_TIME_SERIES",
-                    unit: "short",
-                  }}
-                  overrideWarning
+              <Notice>Failed to load integration data.</Notice>
+            ) : legacyIntegrationLinks.length ? (
+              legacyIntegrationLinks.map((integration) => (
+                <ActionRow
+                  key={integration.key}
+                  title={integration.label}
+                  detail="Legacy traces and observations export is enabled."
                 />
-              </div>
+              ))
             ) : (
-              <NoDataOrLoading
-                isLoading={isTraceLevelEvalExecutionsLoading}
-                description="No trace-level eval executions were found for this project in the selected time range."
-                className="min-h-[22rem]"
-              />
+              <Notice>No legacy integration exports detected.</Notice>
             )}
-          </div>
-        </DashboardCard>
-
-        <DashboardCard
-          title="Integrations"
-          description="PostHog, Mixpanel, and Blob Storage exports that need review for V4."
-          isLoading={isSummaryLoading}
-        >
-          {hasSummaryError ? (
-            <CardError>Failed to load integrations.</CardError>
-          ) : (
-            <div className="flex min-h-32 flex-col gap-4">
-              <div>
-                <p className="text-muted-foreground text-sm">
-                  Configured integrations to review
-                </p>
-                <div className="text-4xl font-semibold">
-                  {numberFormatter(summary?.legacyIntegrationCount ?? 0, 0)}
-                </div>
-              </div>
-
-              <div className="flex flex-wrap gap-2">
-                <ProductLinkButton href={integrationsHref}>
-                  View integrations
-                </ProductLinkButton>
-                {legacyIntegrationLinks.length > 0
-                  ? legacyIntegrationLinks.map((link) => (
-                      <ProductLinkButton key={link.key} href={link.href}>
-                        {link.label}
-                      </ProductLinkButton>
-                    ))
-                  : null}
-              </div>
-            </div>
-          )}
-        </DashboardCard>
-      </div>
-
-      <DashboardCard
-        title="Public API calls to review"
-        description="ClickHouse-backed public API calls that may need changes for V4."
-        isLoading={isLegacyApiUsageLoading}
-        cardContentClassName="min-h-[32rem]"
-        headerClassName="pr-12"
-      >
-        {hasLegacyApiUsageError ? (
-          <div className="border-destructive/30 bg-destructive/10 text-destructive flex min-h-36 items-center rounded-md border p-4 text-sm">
-            Failed to load public API usage.
-          </div>
-        ) : (
-          <>
-            <div className="flex flex-wrap gap-2">
-              {PUBLIC_API_DOCS.map((doc) => (
-                <ExternalDocButton key={doc.href} href={doc.href}>
-                  {doc.label}
-                </ExternalDocButton>
-              ))}
-            </div>
-            <p className="text-muted-foreground text-sm">
-              We do not have query-log data for GET /api/public/sessions.
-            </p>
-
-            {chartData.length > 0 ? (
-              <div className="h-[30rem] w-full">
-                <Chart
-                  chartType="BAR_TIME_SERIES"
-                  data={chartData}
-                  rowLimit={1_000}
-                  chartConfig={{
-                    type: "BAR_TIME_SERIES",
-                    unit: "short",
-                  }}
-                  overrideWarning
-                />
-              </div>
-            ) : (
-              <NoDataOrLoading
-                isLoading={isLegacyApiUsageLoading}
-                description="No ClickHouse-backed public API usage was found for this project in the selected time range."
-                className="min-h-[30rem]"
-              />
-            )}
-          </>
-        )}
-      </DashboardCard>
-    </>
+          </Section>
+        </>
+      )}
+    </DashboardCard>
   );
 };

--- a/web/src/features/v4/components/V4MigrationProjectCards.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.tsx
@@ -491,9 +491,15 @@ export const V4MigrationProjectCards = ({
     [summary?.legacyIntegrations],
   );
 
+  const hasAnyError =
+    hasSummaryError ||
+    hasLegacyApiUsageError ||
+    hasTraceLevelEvalExecutionsError;
+  const traceLevelEvalCount =
+    summary?.traceLevelEvalCount ?? evalExecutionSeries.length;
   const activeTaskCount =
     legacyApiSeries.length +
-    (summary?.traceLevelEvalCount ?? 0) +
+    traceLevelEvalCount +
     legacyIntegrationLinks.length;
   const migrationStatus = getV4MigrationStatus(activeTaskCount);
   const isLoading =
@@ -507,12 +513,14 @@ export const V4MigrationProjectCards = ({
       description={
         isLoading
           ? "Loading V4 migration data."
-          : `${projectName ? `${projectName} - ` : ""}${numberFormatter(
-              activeTaskCount,
-              0,
-            )} required ${
-              activeTaskCount === 1 ? "change" : "changes"
-            } in the selected time range`
+          : hasAnyError
+            ? `${projectName ? `${projectName} - ` : ""}Some migration data could not be loaded.`
+            : `${projectName ? `${projectName} - ` : ""}${numberFormatter(
+                activeTaskCount,
+                0,
+              )} required ${
+                activeTaskCount === 1 ? "change" : "changes"
+              } in the selected time range`
       }
       isLoading={isLoading}
       headerRight={
@@ -522,10 +530,12 @@ export const V4MigrationProjectCards = ({
               {V4_DOCS_LINK.label}
             </InlineLink>
             <Badge
-              variant={migrationStatus.badgeVariant}
+              variant={
+                hasAnyError ? "outline-solid" : migrationStatus.badgeVariant
+              }
               className="whitespace-nowrap"
             >
-              {migrationStatus.label}
+              {hasAnyError ? "Unavailable" : migrationStatus.label}
             </Badge>
           </div>
         )
@@ -555,7 +565,7 @@ export const V4MigrationProjectCards = ({
 
           <Section
             title="Trace-level evals"
-            count={summary?.traceLevelEvalCount ?? evalExecutionSeries.length}
+            count={traceLevelEvalCount}
             detailsHref={traceLevelEvalsHref}
           >
             {hasSummaryError || hasTraceLevelEvalExecutionsError ? (
@@ -566,10 +576,10 @@ export const V4MigrationProjectCards = ({
                 series={evalExecutionSeries}
                 valueLabel="executions"
               />
-            ) : (summary?.traceLevelEvalCount ?? 0) > 0 ? (
+            ) : traceLevelEvalCount > 0 ? (
               <ActionRow
                 title={`${numberFormatter(
-                  summary?.traceLevelEvalCount ?? 0,
+                  traceLevelEvalCount,
                   0,
                 )} configured trace-level evals`}
                 detail="No executions found in the selected range."

--- a/web/src/features/v4/components/V4MigrationProjectCards.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.tsx
@@ -1,12 +1,24 @@
 import { useMemo, type ReactNode } from "react";
 import Link from "next/link";
-import { ArrowRight, ExternalLink } from "lucide-react";
-import { Button } from "@/src/components/ui/button";
-import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
+import { format } from "date-fns";
+import { ChevronRight, ExternalLink } from "lucide-react";
+import { Bar, BarChart, XAxis, YAxis } from "recharts";
+import { Badge } from "@/src/components/ui/badge";
+import { Alert, AlertDescription } from "@/src/components/ui/alert";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/src/components/ui/chart";
 import { DashboardCard } from "@/src/features/dashboard/components/cards/DashboardCard";
-import { Chart } from "@/src/features/widgets/chart-library/Chart";
 import { encodeFiltersGeneric } from "@/src/features/filters/lib/filter-query-encoding";
-import { numberFormatter } from "@/src/utils/numbers";
+import {
+  getV4MigrationStatus,
+  normalizeLegacyApiEntrypoint,
+} from "@/src/features/v4/utils";
+import { compactNumberFormatter, numberFormatter } from "@/src/utils/numbers";
+import { cn } from "@/src/utils/tailwind";
 
 export type V4LegacyIntegrations = {
   posthog: boolean;
@@ -32,19 +44,34 @@ export type V4TraceLevelEvalExecutionPoint = {
   count: number;
 };
 
-export const PUBLIC_API_DOCS = [
-  {
-    label: "V4 upgrade guide",
-    href: "https://langfuse.com/docs/v4",
-  },
-  {
-    label: "Observations API v2",
-    href: "https://langfuse.com/docs/api-and-data-platform/features/observations-api#v2",
-  },
-  {
-    label: "Metrics API v2",
-    href: "https://langfuse.com/docs/metrics/features/metrics-api#v2",
-  },
+type ProductHref = string | { pathname: string; query: Record<string, string> };
+
+type UsageSeries = {
+  name: string;
+  total: number;
+  points: number[];
+  lastSeen?: string;
+};
+
+type StackedUsageChartSeries = UsageSeries & {
+  key: string;
+  color: string;
+};
+
+const V4_DOCS_LINK = {
+  label: "Docs",
+  href: "https://langfuse.com/docs/v4",
+} as const;
+
+const MAX_STACKED_CHART_SERIES = 6;
+const STACKED_CHART_COLORS = [
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-4))",
+  "hsl(var(--chart-5))",
+  "hsl(var(--chart-7))",
+  "hsl(var(--chart-8))",
+  "hsl(var(--chart-3))",
 ] as const;
 
 export const INTEGRATION_LINKS = [
@@ -83,44 +110,326 @@ export const getTraceLevelEvalsHref = (projectId: string) => ({
   },
 });
 
-const CardError = ({ children }: { children: string }) => (
-  <div className="border-destructive/30 bg-destructive/10 text-destructive flex min-h-28 items-center rounded-md border p-4 text-sm">
-    {children}
-  </div>
+const getBucketTimes = (rows: Array<{ time: string }>): string[] =>
+  Array.from(new Set(rows.map((row) => row.time))).sort();
+
+const getBucketLabel = (time: string) => {
+  const date = new Date(time);
+  return Number.isNaN(date.getTime()) ? time : format(date, "MMM d, HH:mm");
+};
+
+const groupUsageSeries = <T extends { time: string; count: number }>({
+  rows,
+  getName,
+  bucketTimes,
+}: {
+  rows: T[] | undefined;
+  getName: (row: T) => string;
+  bucketTimes?: string[];
+}): UsageSeries[] => {
+  const times = bucketTimes ?? getBucketTimes(rows ?? []);
+  const groups = new Map<
+    string,
+    {
+      total: number;
+      countsByTime: Map<string, number>;
+      lastSeen?: string;
+    }
+  >();
+
+  for (const row of rows ?? []) {
+    const name = getName(row);
+    if (!name) continue;
+
+    const group =
+      groups.get(name) ??
+      ({
+        total: 0,
+        countsByTime: new Map<string, number>(),
+      } satisfies {
+        total: number;
+        countsByTime: Map<string, number>;
+        lastSeen?: string;
+      });
+    group.total += row.count;
+    group.countsByTime.set(
+      row.time,
+      (group.countsByTime.get(row.time) ?? 0) + row.count,
+    );
+
+    if (row.count > 0 && (!group.lastSeen || row.time > group.lastSeen)) {
+      group.lastSeen = row.time;
+    }
+
+    groups.set(name, group);
+  }
+
+  return Array.from(groups.entries())
+    .map(([name, group]) => ({
+      name,
+      total: group.total,
+      points: times.map((time) => group.countsByTime.get(time) ?? 0),
+      lastSeen: group.lastSeen,
+    }))
+    .filter((series) => series.total > 0)
+    .sort((left, right) => {
+      if (right.total !== left.total) return right.total - left.total;
+      return left.name.localeCompare(right.name);
+    });
+};
+
+const Notice = ({ children }: { children: ReactNode }) => (
+  <Alert>
+    <AlertDescription>{children}</AlertDescription>
+  </Alert>
 );
 
-export const ProductLinkButton = ({
+const InlineLink = ({
   href,
+  external,
   children,
 }: {
-  href: string | { pathname: string; query: Record<string, string> };
+  href: ProductHref | string;
+  external?: boolean;
   children: ReactNode;
-}) => (
-  <Button asChild variant="outline" size="sm">
-    <Link href={href}>
-      {children}
-      <ArrowRight className="ml-1 h-3.5 w-3.5" />
-    </Link>
-  </Button>
-);
+}) => {
+  const className =
+    "text-accent-dark-blue hover:text-primary-accent/60 inline-flex items-center gap-1 text-sm font-semibold whitespace-nowrap";
 
-const ExternalDocButton = ({
-  href,
-  children,
-}: {
-  href: string;
-  children: ReactNode;
-}) => (
-  <Button asChild variant="outline" size="sm">
-    <a href={href} target="_blank" rel="noopener noreferrer">
+  return external ? (
+    <a
+      href={href as string}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+    >
       {children}
-      <ExternalLink className="ml-1 h-3.5 w-3.5" />
+      <ExternalLink className="h-3 w-3 shrink-0" />
     </a>
-  </Button>
+  ) : (
+    <Link href={href as ProductHref} className={className}>
+      {children}
+      <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+    </Link>
+  );
+};
+
+const Section = ({
+  title,
+  count,
+  detailsHref,
+  children,
+}: {
+  title: string;
+  count: number;
+  detailsHref: ProductHref;
+  children: ReactNode;
+}) => (
+  <section>
+    <div className="flex items-center justify-between gap-3">
+      <h3 className="text-sm font-medium">{title}</h3>
+      <div className="flex items-center gap-2">
+        <Badge variant="outline-solid" size="sm">
+          {numberFormatter(count, 0)}
+        </Badge>
+        <InlineLink href={detailsHref}>Go to details</InlineLink>
+      </div>
+    </div>
+    <div className="mt-3 flex flex-col gap-2">{children}</div>
+  </section>
+);
+
+const getStackedChartSeries = (
+  series: UsageSeries[],
+): StackedUsageChartSeries[] => {
+  const visibleSeries = series.slice(0, MAX_STACKED_CHART_SERIES);
+  const hiddenSeries = series.slice(MAX_STACKED_CHART_SERIES);
+  const stackSeries =
+    hiddenSeries.length === 0
+      ? visibleSeries
+      : [
+          ...visibleSeries,
+          {
+            name: "Other",
+            total: hiddenSeries.reduce((total, item) => total + item.total, 0),
+            points: visibleSeries[0]?.points.map((_, index) =>
+              hiddenSeries.reduce(
+                (total, item) => total + (item.points[index] ?? 0),
+                0,
+              ),
+            ) ?? [0],
+          },
+        ];
+
+  return stackSeries.map((item, index) => ({
+    ...item,
+    key: `series_${index}`,
+    color: STACKED_CHART_COLORS[index % STACKED_CHART_COLORS.length],
+  }));
+};
+
+const UsageStackedBarOverview = ({
+  bucketTimes,
+  series,
+  valueLabel,
+}: {
+  bucketTimes: string[];
+  series: UsageSeries[];
+  valueLabel: string;
+}) => {
+  const chartSeries = useMemo(() => getStackedChartSeries(series), [series]);
+  const chartData = useMemo(
+    () =>
+      bucketTimes.map((time, bucketIndex) => {
+        const row: Record<string, string | number> = {
+          timeLabel: getBucketLabel(time),
+        };
+
+        for (const item of chartSeries) {
+          row[item.key] = item.points[bucketIndex] ?? 0;
+        }
+
+        return row;
+      }),
+    [bucketTimes, chartSeries],
+  );
+  const chartConfig = useMemo<ChartConfig>(
+    () =>
+      Object.fromEntries(
+        chartSeries.map((item) => [
+          item.key,
+          {
+            label: item.name,
+            color: item.color,
+          },
+        ]),
+      ),
+    [chartSeries],
+  );
+  const total = series.reduce((sum, item) => sum + item.total, 0);
+
+  if (chartSeries.length === 0 || chartData.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-md border p-3">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <span className="text-sm font-medium">Usage over time</span>
+        <span className="text-muted-foreground text-xs">
+          {numberFormatter(total, 0, 2)} {valueLabel}
+        </span>
+      </div>
+      <ChartContainer config={chartConfig} className="h-32">
+        <BarChart
+          accessibilityLayer
+          data={chartData}
+          margin={{ top: 4, right: 8, bottom: 0, left: -18 }}
+        >
+          <XAxis
+            dataKey="timeLabel"
+            tickLine={false}
+            axisLine={{ stroke: "hsl(var(--border) / 0.5)" }}
+            minTickGap={24}
+            fontSize={11}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            width={42}
+            fontSize={11}
+            tickFormatter={(value) => compactNumberFormatter(Number(value), 1)}
+          />
+          <ChartTooltip
+            cursor={false}
+            contentStyle={{ backgroundColor: "hsl(var(--background))" }}
+            content={({ active, payload, label }) => (
+              <ChartTooltipContent
+                active={active}
+                payload={payload}
+                label={label}
+                valueFormatter={(value) => numberFormatter(Number(value), 0, 2)}
+                sortPayloadByValue="desc"
+              />
+            )}
+          />
+          {chartSeries.map((item, index) => (
+            <Bar
+              key={item.key}
+              dataKey={item.key}
+              stackId="usage"
+              fill={item.color}
+              radius={
+                index === chartSeries.length - 1 ? [3, 3, 0, 0] : undefined
+              }
+            />
+          ))}
+        </BarChart>
+      </ChartContainer>
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 border-t pt-3">
+        {chartSeries.map((item) => (
+          <div
+            key={item.key}
+            className="flex max-w-full min-w-0 items-center gap-2 text-xs sm:max-w-80"
+            title={item.name}
+          >
+            <span
+              className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+              style={{ backgroundColor: item.color }}
+            />
+            <span className="truncate font-medium">{item.name}</span>
+            <span className="text-muted-foreground shrink-0">
+              {numberFormatter(item.total, 0, 2)} {valueLabel}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const ActionRow = ({
+  title,
+  titleClassName,
+  detail,
+  total,
+  usageLabel,
+}: {
+  title: string;
+  titleClassName?: string;
+  detail: string;
+  total?: number;
+  usageLabel?: string;
+}) => (
+  <div className="grid gap-3 rounded-md border px-3 py-2 md:grid-cols-[minmax(0,1fr)_8rem] md:items-center">
+    <div className="min-w-0">
+      <div className={cn("truncate text-sm font-medium", titleClassName)}>
+        {title}
+      </div>
+      <div className="text-muted-foreground mt-0.5 truncate text-xs">
+        {detail}
+      </div>
+    </div>
+    <div className="md:text-right">
+      {typeof total === "number" ? (
+        <>
+          <div className="text-sm font-medium">
+            {numberFormatter(total, 0, 2)}
+          </div>
+          <div className="text-muted-foreground text-xs">
+            {usageLabel ?? "uses"}
+          </div>
+        </>
+      ) : (
+        <span className="text-muted-foreground text-sm">Configuration</span>
+      )}
+    </div>
+  </div>
 );
 
 export const V4MigrationProjectCards = ({
   projectId,
+  projectName,
   summary,
   legacyApiUsage,
   traceLevelEvalExecutions,
@@ -132,6 +441,7 @@ export const V4MigrationProjectCards = ({
   hasTraceLevelEvalExecutionsError,
 }: {
   projectId: string;
+  projectName?: string;
   summary: V4MigrationSummary | undefined;
   legacyApiUsage: V4LegacyApiUsagePoint[] | undefined;
   traceLevelEvalExecutions: V4TraceLevelEvalExecutionPoint[] | undefined;
@@ -147,175 +457,149 @@ export const V4MigrationProjectCards = ({
     [projectId],
   );
 
+  const legacyApiBucketTimes = useMemo(
+    () => getBucketTimes(legacyApiUsage ?? []),
+    [legacyApiUsage],
+  );
+  const legacyApiSeries = useMemo(() => {
+    return groupUsageSeries({
+      rows: legacyApiUsage,
+      getName: (row) => normalizeLegacyApiEntrypoint(row.entrypoint),
+      bucketTimes: legacyApiBucketTimes,
+    });
+  }, [legacyApiBucketTimes, legacyApiUsage]);
+
+  const evalExecutionBucketTimes = useMemo(
+    () => getBucketTimes(traceLevelEvalExecutions ?? []),
+    [traceLevelEvalExecutions],
+  );
+  const evalExecutionSeries = useMemo(
+    () =>
+      groupUsageSeries({
+        rows: traceLevelEvalExecutions,
+        getName: (row) => row.scoreName,
+        bucketTimes: evalExecutionBucketTimes,
+      }),
+    [evalExecutionBucketTimes, traceLevelEvalExecutions],
+  );
+
   const legacyIntegrationLinks = useMemo(
     () =>
       INTEGRATION_LINKS.filter(
         (link) => summary?.legacyIntegrations[link.key] === true,
-      ).map((link) => ({
-        ...link,
-        href: `/project/${projectId}/settings/integrations/${link.path}`,
-      })),
-    [projectId, summary?.legacyIntegrations],
+      ),
+    [summary?.legacyIntegrations],
   );
 
-  const integrationsHref = `/project/${projectId}/settings/integrations`;
-
-  const chartData = useMemo(
-    () =>
-      legacyApiUsage?.map((row) => ({
-        time_dimension: row.time,
-        dimension: row.entrypoint,
-        metric: row.count,
-      })) ?? [],
-    [legacyApiUsage],
-  );
-
-  const evalExecutionChartData = useMemo(
-    () =>
-      traceLevelEvalExecutions?.map((row) => ({
-        time_dimension: row.time,
-        dimension: row.scoreName,
-        metric: row.count,
-      })) ?? [],
-    [traceLevelEvalExecutions],
-  );
+  const activeTaskCount =
+    legacyApiSeries.length +
+    (summary?.traceLevelEvalCount ?? 0) +
+    legacyIntegrationLinks.length;
+  const migrationStatus = getV4MigrationStatus(activeTaskCount);
+  const isLoading =
+    isSummaryLoading ||
+    isLegacyApiUsageLoading ||
+    isTraceLevelEvalExecutionsLoading;
 
   return (
-    <>
-      <div className="grid grid-cols-1 items-stretch gap-3 lg:grid-cols-[minmax(0,2fr)_minmax(20rem,1fr)]">
-        <DashboardCard
-          title="Trace-level evals"
-          description="Trace-targeting evaluator configs and non-cancelled execution jobs by generated score name."
-          isLoading={isSummaryLoading || isTraceLevelEvalExecutionsLoading}
-          cardContentClassName="min-h-[30rem]"
-          headerClassName="pr-12"
-          headerRight={
-            <ProductLinkButton href={traceLevelEvalsHref}>
-              View evals
-            </ProductLinkButton>
-          }
-        >
-          <div className="flex flex-col gap-4">
+    <DashboardCard
+      title="Required changes"
+      description={
+        isLoading
+          ? "Loading V4 migration data."
+          : `${projectName ? `${projectName} - ` : ""}${numberFormatter(
+              activeTaskCount,
+              0,
+            )} required ${
+              activeTaskCount === 1 ? "change" : "changes"
+            } in the selected time range`
+      }
+      isLoading={isLoading}
+      headerRight={
+        isLoading ? undefined : (
+          <div className="flex items-center gap-2">
+            <InlineLink href={V4_DOCS_LINK.href} external>
+              {V4_DOCS_LINK.label}
+            </InlineLink>
+            <Badge
+              variant={migrationStatus.badgeVariant}
+              className="whitespace-nowrap"
+            >
+              {migrationStatus.label}
+            </Badge>
+          </div>
+        )
+      }
+    >
+      {isLoading ? (
+        <div className="min-h-80" />
+      ) : (
+        <>
+          <Section
+            title="Legacy public APIs"
+            count={legacyApiSeries.length}
+            detailsHref={`/project/${projectId}/settings/api-keys`}
+          >
+            {hasLegacyApiUsageError ? (
+              <Notice>Failed to load public API usage.</Notice>
+            ) : legacyApiSeries.length ? (
+              <UsageStackedBarOverview
+                bucketTimes={legacyApiBucketTimes}
+                series={legacyApiSeries}
+                valueLabel="calls"
+              />
+            ) : (
+              <Notice>No legacy public API usage in this range.</Notice>
+            )}
+          </Section>
+
+          <Section
+            title="Trace-level evals"
+            count={summary?.traceLevelEvalCount ?? evalExecutionSeries.length}
+            detailsHref={traceLevelEvalsHref}
+          >
+            {hasSummaryError || hasTraceLevelEvalExecutionsError ? (
+              <Notice>Failed to load trace-level eval data.</Notice>
+            ) : evalExecutionSeries.length ? (
+              <UsageStackedBarOverview
+                bucketTimes={evalExecutionBucketTimes}
+                series={evalExecutionSeries}
+                valueLabel="executions"
+              />
+            ) : (summary?.traceLevelEvalCount ?? 0) > 0 ? (
+              <ActionRow
+                title={`${numberFormatter(
+                  summary?.traceLevelEvalCount ?? 0,
+                  0,
+                )} configured trace-level evals`}
+                detail="No executions found in the selected range."
+              />
+            ) : (
+              <Notice>No trace-level evals detected.</Notice>
+            )}
+          </Section>
+
+          <Section
+            title="Integrations"
+            count={legacyIntegrationLinks.length}
+            detailsHref={`/project/${projectId}/settings/integrations`}
+          >
             {hasSummaryError ? (
-              <CardError>Failed to load trace-level evals.</CardError>
-            ) : (
-              <div>
-                <p className="text-muted-foreground text-sm">
-                  Configured trace-level evals
-                </p>
-                <div className="text-4xl font-semibold">
-                  {numberFormatter(summary?.traceLevelEvalCount ?? 0, 0)}
-                </div>
-              </div>
-            )}
-
-            {hasTraceLevelEvalExecutionsError ? (
-              <CardError>Failed to load trace-level eval executions.</CardError>
-            ) : evalExecutionChartData.length > 0 ? (
-              <div className="h-[22rem] w-full">
-                <Chart
-                  chartType="BAR_TIME_SERIES"
-                  data={evalExecutionChartData}
-                  rowLimit={1_000}
-                  chartConfig={{
-                    type: "BAR_TIME_SERIES",
-                    unit: "short",
-                  }}
-                  overrideWarning
+              <Notice>Failed to load integration data.</Notice>
+            ) : legacyIntegrationLinks.length ? (
+              legacyIntegrationLinks.map((integration) => (
+                <ActionRow
+                  key={integration.key}
+                  title={integration.label}
+                  detail="Legacy traces and observations export is enabled."
                 />
-              </div>
+              ))
             ) : (
-              <NoDataOrLoading
-                isLoading={isTraceLevelEvalExecutionsLoading}
-                description="No trace-level eval executions were found for this project in the selected time range."
-                className="min-h-[22rem]"
-              />
+              <Notice>No legacy integration exports detected.</Notice>
             )}
-          </div>
-        </DashboardCard>
-
-        <DashboardCard
-          title="Integrations"
-          description="PostHog, Mixpanel, and Blob Storage exports that need review for V4."
-          isLoading={isSummaryLoading}
-        >
-          {hasSummaryError ? (
-            <CardError>Failed to load integrations.</CardError>
-          ) : (
-            <div className="flex min-h-32 flex-col gap-4">
-              <div>
-                <p className="text-muted-foreground text-sm">
-                  Configured integrations to review
-                </p>
-                <div className="text-4xl font-semibold">
-                  {numberFormatter(summary?.legacyIntegrationCount ?? 0, 0)}
-                </div>
-              </div>
-
-              <div className="flex flex-wrap gap-2">
-                <ProductLinkButton href={integrationsHref}>
-                  View integrations
-                </ProductLinkButton>
-                {legacyIntegrationLinks.length > 0
-                  ? legacyIntegrationLinks.map((link) => (
-                      <ProductLinkButton key={link.key} href={link.href}>
-                        {link.label}
-                      </ProductLinkButton>
-                    ))
-                  : null}
-              </div>
-            </div>
-          )}
-        </DashboardCard>
-      </div>
-
-      <DashboardCard
-        title="Public API calls to review"
-        description="ClickHouse-backed public API calls that may need changes for V4."
-        isLoading={isLegacyApiUsageLoading}
-        cardContentClassName="min-h-[32rem]"
-        headerClassName="pr-12"
-      >
-        {hasLegacyApiUsageError ? (
-          <div className="border-destructive/30 bg-destructive/10 text-destructive flex min-h-36 items-center rounded-md border p-4 text-sm">
-            Failed to load public API usage.
-          </div>
-        ) : (
-          <>
-            <div className="flex flex-wrap gap-2">
-              {PUBLIC_API_DOCS.map((doc) => (
-                <ExternalDocButton key={doc.href} href={doc.href}>
-                  {doc.label}
-                </ExternalDocButton>
-              ))}
-            </div>
-            <p className="text-muted-foreground text-sm">
-              We do not have query-log data for GET /api/public/sessions.
-            </p>
-
-            {chartData.length > 0 ? (
-              <div className="h-[30rem] w-full">
-                <Chart
-                  chartType="BAR_TIME_SERIES"
-                  data={chartData}
-                  rowLimit={1_000}
-                  chartConfig={{
-                    type: "BAR_TIME_SERIES",
-                    unit: "short",
-                  }}
-                  overrideWarning
-                />
-              </div>
-            ) : (
-              <NoDataOrLoading
-                isLoading={isLegacyApiUsageLoading}
-                description="No ClickHouse-backed public API usage was found for this project in the selected time range."
-                className="min-h-[30rem]"
-              />
-            )}
-          </>
-        )}
-      </DashboardCard>
-    </>
+          </Section>
+        </>
+      )}
+    </DashboardCard>
   );
 };

--- a/web/src/features/v4/utils.clienttest.ts
+++ b/web/src/features/v4/utils.clienttest.ts
@@ -1,0 +1,30 @@
+import {
+  countLegacyApiEntrypoints,
+  normalizeLegacyApiEntrypoint,
+} from "./utils";
+
+describe("normalizeLegacyApiEntrypoint", () => {
+  it("removes the legacy public API prefix", () => {
+    expect(
+      normalizeLegacyApiEntrypoint("publicapi: GET /api/public/traces"),
+    ).toBe("GET /api/public/traces");
+  });
+
+  it("keeps unprefixed entrypoints unchanged", () => {
+    expect(normalizeLegacyApiEntrypoint("GET /api/public/traces")).toBe(
+      "GET /api/public/traces",
+    );
+  });
+});
+
+describe("countLegacyApiEntrypoints", () => {
+  it("counts prefixed and unprefixed forms of the same endpoint once", () => {
+    expect(
+      countLegacyApiEntrypoints([
+        { entrypoint: "publicapi: GET /api/public/traces" },
+        { entrypoint: "GET /api/public/traces" },
+        { entrypoint: "publicapi: POST /api/public/scores" },
+      ]),
+    ).toBe(2);
+  });
+});

--- a/web/src/features/v4/utils.ts
+++ b/web/src/features/v4/utils.ts
@@ -1,0 +1,67 @@
+import {
+  toAbsoluteTimeRange,
+  type AbsoluteTimeRange,
+  type TimeRange,
+} from "@/src/utils/date-range-utils";
+
+export const V4_TIME_RANGE_PRESETS = [
+  "last5Minutes",
+  "last30Minutes",
+  "last1Hour",
+  "last3Hours",
+  "last1Day",
+  "last7Days",
+  "last30Days",
+] as const;
+
+export const MAX_V4_TIMELINE_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const getV4MigrationStatus = (migrationItemCount: number) =>
+  migrationItemCount > 0
+    ? ({
+        label: "Not migrated",
+        badgeVariant: "warning",
+      } as const)
+    : ({
+        label: "Migrated",
+        badgeVariant: "success",
+      } as const);
+
+export const normalizeLegacyApiEntrypoint = (entrypoint: string) =>
+  entrypoint.replace(/^publicapi:\s*/, "");
+
+export const countLegacyApiEntrypoints = (
+  rows: Array<{ entrypoint: string }> | undefined,
+): number => {
+  const entrypoints = new Set<string>();
+
+  for (const row of rows ?? []) {
+    const entrypoint = normalizeLegacyApiEntrypoint(row.entrypoint);
+    if (entrypoint) entrypoints.add(entrypoint);
+  }
+
+  return entrypoints.size;
+};
+
+export const getCappedAbsoluteTimeRange = (
+  timeRange: TimeRange,
+): AbsoluteTimeRange => {
+  const absoluteRange =
+    toAbsoluteTimeRange(timeRange) ??
+    ({
+      from: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      to: new Date(),
+    } satisfies AbsoluteTimeRange);
+
+  if (
+    absoluteRange.to.getTime() - absoluteRange.from.getTime() <=
+    MAX_V4_TIMELINE_RANGE_MS
+  ) {
+    return absoluteRange;
+  }
+
+  return {
+    from: new Date(absoluteRange.to.getTime() - MAX_V4_TIMELINE_RANGE_MS),
+    to: absoluteRange.to,
+  };
+};

--- a/web/src/features/v4/utils.ts
+++ b/web/src/features/v4/utils.ts
@@ -1,0 +1,51 @@
+import {
+  toAbsoluteTimeRange,
+  type AbsoluteTimeRange,
+  type TimeRange,
+} from "@/src/utils/date-range-utils";
+
+export const V4_TIME_RANGE_PRESETS = [
+  "last5Minutes",
+  "last30Minutes",
+  "last1Hour",
+  "last3Hours",
+  "last1Day",
+  "last7Days",
+  "last30Days",
+] as const;
+
+export const MAX_V4_TIMELINE_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const getV4MigrationStatus = (migrationItemCount: number) =>
+  migrationItemCount > 0
+    ? ({
+        label: "Not migrated",
+        badgeVariant: "warning",
+      } as const)
+    : ({
+        label: "Migrated",
+        badgeVariant: "success",
+      } as const);
+
+export const getCappedAbsoluteTimeRange = (
+  timeRange: TimeRange,
+): AbsoluteTimeRange => {
+  const absoluteRange =
+    toAbsoluteTimeRange(timeRange) ??
+    ({
+      from: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      to: new Date(),
+    } satisfies AbsoluteTimeRange);
+
+  if (
+    absoluteRange.to.getTime() - absoluteRange.from.getTime() <=
+    MAX_V4_TIMELINE_RANGE_MS
+  ) {
+    return absoluteRange;
+  }
+
+  return {
+    from: new Date(absoluteRange.to.getTime() - MAX_V4_TIMELINE_RANGE_MS),
+    to: absoluteRange.to,
+  };
+};

--- a/web/src/pages/organization/[organizationId]/v4/index.tsx
+++ b/web/src/pages/organization/[organizationId]/v4/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
@@ -7,16 +7,13 @@ import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganiz
 import Page from "@/src/components/layouts/page";
 import { ErrorPage } from "@/src/components/error-page";
 import { TimeRangePicker } from "@/src/components/date-picker";
-import {
-  DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
-  toAbsoluteTimeRange,
-  type AbsoluteTimeRange,
-  type TimeRange,
-} from "@/src/utils/date-range-utils";
-import { useGlobalDateRange } from "@/src/features/global-time-range/useGlobalDateRange";
+import { DEFAULT_DASHBOARD_AGGREGATION_SELECTION } from "@/src/utils/date-range-utils";
+import { useDashboardDateRange } from "@/src/hooks/useDashboardDateRange";
 import { api } from "@/src/utils/api";
-import { DashboardCard } from "@/src/features/dashboard/components/cards/DashboardCard";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
+import { Alert, AlertDescription } from "@/src/components/ui/alert";
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
 import {
   Table,
   TableBody,
@@ -27,13 +24,19 @@ import {
 } from "@/src/components/ui/table";
 import { numberFormatter } from "@/src/utils/numbers";
 import {
-  getTraceLevelEvalsHref,
-  ProductLinkButton,
   V4MigrationProjectCards,
   type V4LegacyApiUsagePoint,
   type V4MigrationSummary,
   type V4TraceLevelEvalExecutionPoint,
 } from "@/src/features/v4/components/V4MigrationProjectCards";
+import { DashboardCard } from "@/src/features/dashboard/components/cards/DashboardCard";
+import {
+  getCappedAbsoluteTimeRange,
+  getV4MigrationStatus,
+  MAX_V4_TIMELINE_RANGE_MS,
+  V4_TIME_RANGE_PRESETS,
+} from "@/src/features/v4/utils";
+import { cn } from "@/src/utils/tailwind";
 
 type ProjectSummary = V4MigrationSummary & {
   projectId: string;
@@ -46,41 +49,6 @@ type ProjectScopedLegacyApiUsagePoint = V4LegacyApiUsagePoint & {
 
 type ProjectScopedEvalExecutionPoint = V4TraceLevelEvalExecutionPoint & {
   projectId: string;
-};
-
-const V4_TIME_RANGE_PRESETS = [
-  "last5Minutes",
-  "last30Minutes",
-  "last1Hour",
-  "last3Hours",
-  "last1Day",
-  "last7Days",
-  "last30Days",
-] as const;
-
-const MAX_V4_TIMELINE_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
-
-const getCappedAbsoluteTimeRange = (
-  timeRange: TimeRange,
-): AbsoluteTimeRange => {
-  const absoluteRange =
-    toAbsoluteTimeRange(timeRange) ??
-    ({
-      from: new Date(Date.now() - 24 * 60 * 60 * 1000),
-      to: new Date(),
-    } satisfies AbsoluteTimeRange);
-
-  if (
-    absoluteRange.to.getTime() - absoluteRange.from.getTime() <=
-    MAX_V4_TIMELINE_RANGE_MS
-  ) {
-    return absoluteRange;
-  }
-
-  return {
-    from: new Date(absoluteRange.to.getTime() - MAX_V4_TIMELINE_RANGE_MS),
-    to: absoluteRange.to,
-  };
 };
 
 const groupByProjectId = <T extends { projectId: string }>(
@@ -101,21 +69,26 @@ const sumLegacyApiUsage = (
   rows: ProjectScopedLegacyApiUsagePoint[] | undefined,
 ): number => rows?.reduce((total, row) => total + row.count, 0) ?? 0;
 
+const countLegacyApiEntrypoints = (
+  rows: ProjectScopedLegacyApiUsagePoint[] | undefined,
+): number =>
+  new Set(rows?.filter((row) => row.entrypoint).map((row) => row.entrypoint))
+    .size;
+
 const getProjectActionCount = (
   project: ProjectSummary,
-  legacyApiUsageCount: number,
+  legacyApiEntrypointCount: number,
 ): number =>
   project.traceLevelEvalCount +
   project.legacyIntegrationCount +
-  legacyApiUsageCount;
+  legacyApiEntrypointCount;
 
 export default function OrganizationV4Page() {
   const router = useRouter();
   const session = useSession();
   const organizationId = router.query.organizationId as string | undefined;
-  const { timeRange, setTimeRange } = useGlobalDateRange({
-    allowedRanges: V4_TIME_RANGE_PRESETS,
-    fallback: DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
+  const { timeRange, setTimeRange } = useDashboardDateRange({
+    defaultRelativeAggregation: DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
   });
   const canViewOrgV4Page = useHasOrganizationAccess({
     organizationId,
@@ -191,11 +164,15 @@ export default function OrganizationV4Page() {
       [...(summaryByProject.data?.projects ?? [])].sort((a, b) => {
         const bActionCount = getProjectActionCount(
           b,
-          sumLegacyApiUsage(legacyApiUsageRowsByProjectId.get(b.projectId)),
+          countLegacyApiEntrypoints(
+            legacyApiUsageRowsByProjectId.get(b.projectId),
+          ),
         );
         const aActionCount = getProjectActionCount(
           a,
-          sumLegacyApiUsage(legacyApiUsageRowsByProjectId.get(a.projectId)),
+          countLegacyApiEntrypoints(
+            legacyApiUsageRowsByProjectId.get(a.projectId),
+          ),
         );
 
         if (bActionCount !== aActionCount) return bActionCount - aActionCount;
@@ -203,6 +180,46 @@ export default function OrganizationV4Page() {
       }),
     [summaryByProject.data?.projects, legacyApiUsageRowsByProjectId],
   );
+  const [selectedProjectId, setSelectedProjectId] = useState<
+    string | undefined
+  >();
+  const selectedProject = useMemo(
+    () =>
+      projects.find((project) => project.projectId === selectedProjectId) ??
+      projects[0],
+    [projects, selectedProjectId],
+  );
+  const migrationSummary = useMemo(() => {
+    return projects.reduce(
+      (summary, project) => {
+        const legacyApiRows = legacyApiUsageRowsByProjectId.get(
+          project.projectId,
+        );
+        const actionCount = getProjectActionCount(
+          project,
+          countLegacyApiEntrypoints(legacyApiRows),
+        );
+
+        return {
+          projectsNotMigrated:
+            summary.projectsNotMigrated + (actionCount > 0 ? 1 : 0),
+          actionCount: summary.actionCount + actionCount,
+        };
+      },
+      { projectsNotMigrated: 0, actionCount: 0 },
+    );
+  }, [legacyApiUsageRowsByProjectId, projects]);
+
+  useEffect(() => {
+    if (
+      selectedProjectId &&
+      projects.some((p) => p.projectId === selectedProjectId)
+    ) {
+      return;
+    }
+
+    setSelectedProjectId(projects[0]?.projectId);
+  }, [projects, selectedProjectId]);
 
   if (!organizationId || session.status === "loading") return null;
 
@@ -215,7 +232,7 @@ export default function OrganizationV4Page() {
       withPadding
       scrollable
       headerProps={{
-        title: "V4",
+        title: "Migrate to v4",
         breadcrumb: [
           { name: "Projects", href: `/organization/${organizationId}` },
         ],
@@ -233,42 +250,69 @@ export default function OrganizationV4Page() {
     >
       <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-6">
         <DashboardCard
-          title="Projects"
-          description="V4 migration signals split by project."
+          title="Project readiness"
+          description={`${numberFormatter(
+            migrationSummary.projectsNotMigrated,
+            0,
+          )} of ${numberFormatter(
+            projects.length,
+            0,
+          )} projects not migrated - ${numberFormatter(
+            migrationSummary.actionCount,
+            0,
+          )} required changes`}
           isLoading={
             summaryByProject.isPending || legacyApiUsageByProject.isPending
           }
         >
           {summaryByProject.error ? (
-            <div className="border-destructive/30 bg-destructive/10 text-destructive flex min-h-28 items-center rounded-md border p-4 text-sm">
-              Failed to load projects.
-            </div>
+            <Alert>
+              <AlertDescription>Failed to load projects.</AlertDescription>
+            </Alert>
+          ) : summaryByProject.isPending ||
+            legacyApiUsageByProject.isPending ? (
+            <div className="min-h-40" />
           ) : projects.length > 0 ? (
             <div className="overflow-x-auto">
-              <Table className="min-w-[56rem] table-auto">
+              <Table className="min-w-[60rem] table-auto">
                 <TableHeader>
                   <TableRow>
                     <TableHead>Project</TableHead>
-                    <TableHead className="w-36 text-right">
+                    <TableHead className="w-28">Status</TableHead>
+                    <TableHead className="w-32 text-right">
                       Trace evals
                     </TableHead>
-                    <TableHead className="w-36 text-right">
+                    <TableHead className="w-32 text-right">
                       Integrations
                     </TableHead>
-                    <TableHead className="w-36 text-right">
+                    <TableHead className="w-44 text-right">
                       Public API
                     </TableHead>
-                    <TableHead className="w-[24rem]">Links</TableHead>
+                    <TableHead className="w-32" />
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {projects.map((project) => {
-                    const legacyApiUsageCount = sumLegacyApiUsage(
-                      legacyApiUsageRowsByProjectId.get(project.projectId),
+                    const legacyApiRows = legacyApiUsageRowsByProjectId.get(
+                      project.projectId,
                     );
+                    const legacyApiUsageCount =
+                      sumLegacyApiUsage(legacyApiRows);
+                    const legacyApiEntrypointCount =
+                      countLegacyApiEntrypoints(legacyApiRows);
+                    const actionCount = getProjectActionCount(
+                      project,
+                      legacyApiEntrypointCount,
+                    );
+                    const migrationStatus = getV4MigrationStatus(actionCount);
+                    const isSelected =
+                      selectedProject?.projectId === project.projectId;
 
                     return (
-                      <TableRow key={project.projectId}>
+                      <TableRow
+                        key={project.projectId}
+                        className={cn(isSelected && "bg-muted/40")}
+                      >
                         <TableCell density="comfortable">
                           <Link
                             href={`/project/${project.projectId}`}
@@ -276,6 +320,14 @@ export default function OrganizationV4Page() {
                           >
                             {project.projectName}
                           </Link>
+                        </TableCell>
+                        <TableCell density="comfortable">
+                          <Badge
+                            variant={migrationStatus.badgeVariant}
+                            size="sm"
+                          >
+                            {migrationStatus.label}
+                          </Badge>
                         </TableCell>
                         <TableCell density="comfortable" className="text-right">
                           {numberFormatter(project.traceLevelEvalCount, 0)}
@@ -286,26 +338,28 @@ export default function OrganizationV4Page() {
                         <TableCell density="comfortable" className="text-right">
                           {legacyApiUsageByProject.error
                             ? "Failed"
-                            : numberFormatter(legacyApiUsageCount, 0, 2)}
+                            : legacyApiEntrypointCount > 0
+                              ? `${numberFormatter(
+                                  legacyApiEntrypointCount,
+                                  0,
+                                )} routes - ${numberFormatter(
+                                  legacyApiUsageCount,
+                                  0,
+                                  2,
+                                )} calls`
+                              : "0"}
                         </TableCell>
                         <TableCell density="comfortable">
-                          <div className="flex flex-wrap gap-2">
-                            <ProductLinkButton
-                              href={`/project/${project.projectId}/v4`}
-                            >
-                              V4 page
-                            </ProductLinkButton>
-                            <ProductLinkButton
-                              href={getTraceLevelEvalsHref(project.projectId)}
-                            >
-                              Evals
-                            </ProductLinkButton>
-                            <ProductLinkButton
-                              href={`/project/${project.projectId}/settings/integrations`}
-                            >
-                              Integrations
-                            </ProductLinkButton>
-                          </div>
+                          <Button
+                            variant={isSelected ? "secondary" : "outline"}
+                            size="sm"
+                            onClick={() =>
+                              setSelectedProjectId(project.projectId)
+                            }
+                            className="w-full"
+                          >
+                            Details
+                          </Button>
                         </TableCell>
                       </TableRow>
                     );
@@ -317,48 +371,33 @@ export default function OrganizationV4Page() {
             <NoDataOrLoading
               isLoading={summaryByProject.isPending}
               description="No active projects were found in this organization."
-              className="min-h-40"
             />
           )}
         </DashboardCard>
 
-        {projects.map((project) => (
-          <section key={project.projectId} className="flex flex-col gap-3">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="min-w-0">
-                <h2 className="truncate text-xl font-semibold">
-                  {project.projectName}
-                </h2>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <ProductLinkButton href={`/project/${project.projectId}/v4`}>
-                  Project V4 page
-                </ProductLinkButton>
-              </div>
-            </div>
-
-            <V4MigrationProjectCards
-              projectId={project.projectId}
-              summary={project}
-              legacyApiUsage={legacyApiUsageRowsByProjectId.get(
-                project.projectId,
-              )}
-              traceLevelEvalExecutions={evalExecutionRowsByProjectId.get(
-                project.projectId,
-              )}
-              isSummaryLoading={summaryByProject.isPending}
-              isLegacyApiUsageLoading={legacyApiUsageByProject.isPending}
-              isTraceLevelEvalExecutionsLoading={
-                traceLevelEvalExecutionsByProject.isPending
-              }
-              hasSummaryError={Boolean(summaryByProject.error)}
-              hasLegacyApiUsageError={Boolean(legacyApiUsageByProject.error)}
-              hasTraceLevelEvalExecutionsError={Boolean(
-                traceLevelEvalExecutionsByProject.error,
-              )}
-            />
-          </section>
-        ))}
+        {selectedProject ? (
+          <V4MigrationProjectCards
+            projectId={selectedProject.projectId}
+            projectName={selectedProject.projectName}
+            summary={selectedProject}
+            legacyApiUsage={legacyApiUsageRowsByProjectId.get(
+              selectedProject.projectId,
+            )}
+            traceLevelEvalExecutions={evalExecutionRowsByProjectId.get(
+              selectedProject.projectId,
+            )}
+            isSummaryLoading={summaryByProject.isPending}
+            isLegacyApiUsageLoading={legacyApiUsageByProject.isPending}
+            isTraceLevelEvalExecutionsLoading={
+              traceLevelEvalExecutionsByProject.isPending
+            }
+            hasSummaryError={Boolean(summaryByProject.error)}
+            hasLegacyApiUsageError={Boolean(legacyApiUsageByProject.error)}
+            hasTraceLevelEvalExecutionsError={Boolean(
+              traceLevelEvalExecutionsByProject.error,
+            )}
+          />
+        ) : null}
       </div>
     </Page>
   );

--- a/web/src/pages/organization/[organizationId]/v4/index.tsx
+++ b/web/src/pages/organization/[organizationId]/v4/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
@@ -7,16 +7,13 @@ import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganiz
 import Page from "@/src/components/layouts/page";
 import { ErrorPage } from "@/src/components/error-page";
 import { TimeRangePicker } from "@/src/components/date-picker";
-import {
-  DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
-  toAbsoluteTimeRange,
-  type AbsoluteTimeRange,
-  type TimeRange,
-} from "@/src/utils/date-range-utils";
-import { useGlobalDateRange } from "@/src/features/global-time-range/useGlobalDateRange";
+import { DEFAULT_DASHBOARD_AGGREGATION_SELECTION } from "@/src/utils/date-range-utils";
+import { useDashboardDateRange } from "@/src/hooks/useDashboardDateRange";
 import { api } from "@/src/utils/api";
-import { DashboardCard } from "@/src/features/dashboard/components/cards/DashboardCard";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
+import { Alert, AlertDescription } from "@/src/components/ui/alert";
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
 import {
   Table,
   TableBody,
@@ -27,13 +24,20 @@ import {
 } from "@/src/components/ui/table";
 import { numberFormatter } from "@/src/utils/numbers";
 import {
-  getTraceLevelEvalsHref,
-  ProductLinkButton,
   V4MigrationProjectCards,
   type V4LegacyApiUsagePoint,
   type V4MigrationSummary,
   type V4TraceLevelEvalExecutionPoint,
 } from "@/src/features/v4/components/V4MigrationProjectCards";
+import { DashboardCard } from "@/src/features/dashboard/components/cards/DashboardCard";
+import {
+  countLegacyApiEntrypoints,
+  getCappedAbsoluteTimeRange,
+  getV4MigrationStatus,
+  MAX_V4_TIMELINE_RANGE_MS,
+  V4_TIME_RANGE_PRESETS,
+} from "@/src/features/v4/utils";
+import { cn } from "@/src/utils/tailwind";
 
 type ProjectSummary = V4MigrationSummary & {
   projectId: string;
@@ -46,41 +50,6 @@ type ProjectScopedLegacyApiUsagePoint = V4LegacyApiUsagePoint & {
 
 type ProjectScopedEvalExecutionPoint = V4TraceLevelEvalExecutionPoint & {
   projectId: string;
-};
-
-const V4_TIME_RANGE_PRESETS = [
-  "last5Minutes",
-  "last30Minutes",
-  "last1Hour",
-  "last3Hours",
-  "last1Day",
-  "last7Days",
-  "last30Days",
-] as const;
-
-const MAX_V4_TIMELINE_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
-
-const getCappedAbsoluteTimeRange = (
-  timeRange: TimeRange,
-): AbsoluteTimeRange => {
-  const absoluteRange =
-    toAbsoluteTimeRange(timeRange) ??
-    ({
-      from: new Date(Date.now() - 24 * 60 * 60 * 1000),
-      to: new Date(),
-    } satisfies AbsoluteTimeRange);
-
-  if (
-    absoluteRange.to.getTime() - absoluteRange.from.getTime() <=
-    MAX_V4_TIMELINE_RANGE_MS
-  ) {
-    return absoluteRange;
-  }
-
-  return {
-    from: new Date(absoluteRange.to.getTime() - MAX_V4_TIMELINE_RANGE_MS),
-    to: absoluteRange.to,
-  };
 };
 
 const groupByProjectId = <T extends { projectId: string }>(
@@ -103,19 +72,18 @@ const sumLegacyApiUsage = (
 
 const getProjectActionCount = (
   project: ProjectSummary,
-  legacyApiUsageCount: number,
+  legacyApiEntrypointCount: number,
 ): number =>
   project.traceLevelEvalCount +
   project.legacyIntegrationCount +
-  legacyApiUsageCount;
+  legacyApiEntrypointCount;
 
 export default function OrganizationV4Page() {
   const router = useRouter();
   const session = useSession();
   const organizationId = router.query.organizationId as string | undefined;
-  const { timeRange, setTimeRange } = useGlobalDateRange({
-    allowedRanges: V4_TIME_RANGE_PRESETS,
-    fallback: DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
+  const { timeRange, setTimeRange } = useDashboardDateRange({
+    defaultRelativeAggregation: DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
   });
   const canViewOrgV4Page = useHasOrganizationAccess({
     organizationId,
@@ -191,11 +159,15 @@ export default function OrganizationV4Page() {
       [...(summaryByProject.data?.projects ?? [])].sort((a, b) => {
         const bActionCount = getProjectActionCount(
           b,
-          sumLegacyApiUsage(legacyApiUsageRowsByProjectId.get(b.projectId)),
+          countLegacyApiEntrypoints(
+            legacyApiUsageRowsByProjectId.get(b.projectId),
+          ),
         );
         const aActionCount = getProjectActionCount(
           a,
-          sumLegacyApiUsage(legacyApiUsageRowsByProjectId.get(a.projectId)),
+          countLegacyApiEntrypoints(
+            legacyApiUsageRowsByProjectId.get(a.projectId),
+          ),
         );
 
         if (bActionCount !== aActionCount) return bActionCount - aActionCount;
@@ -203,6 +175,46 @@ export default function OrganizationV4Page() {
       }),
     [summaryByProject.data?.projects, legacyApiUsageRowsByProjectId],
   );
+  const [selectedProjectId, setSelectedProjectId] = useState<
+    string | undefined
+  >();
+  const selectedProject = useMemo(
+    () =>
+      projects.find((project) => project.projectId === selectedProjectId) ??
+      projects[0],
+    [projects, selectedProjectId],
+  );
+  const migrationSummary = useMemo(() => {
+    return projects.reduce(
+      (summary, project) => {
+        const legacyApiRows = legacyApiUsageRowsByProjectId.get(
+          project.projectId,
+        );
+        const actionCount = getProjectActionCount(
+          project,
+          countLegacyApiEntrypoints(legacyApiRows),
+        );
+
+        return {
+          projectsNotMigrated:
+            summary.projectsNotMigrated + (actionCount > 0 ? 1 : 0),
+          actionCount: summary.actionCount + actionCount,
+        };
+      },
+      { projectsNotMigrated: 0, actionCount: 0 },
+    );
+  }, [legacyApiUsageRowsByProjectId, projects]);
+
+  useEffect(() => {
+    if (
+      selectedProjectId &&
+      projects.some((p) => p.projectId === selectedProjectId)
+    ) {
+      return;
+    }
+
+    setSelectedProjectId(projects[0]?.projectId);
+  }, [projects, selectedProjectId]);
 
   if (!organizationId || session.status === "loading") return null;
 
@@ -215,7 +227,7 @@ export default function OrganizationV4Page() {
       withPadding
       scrollable
       headerProps={{
-        title: "V4",
+        title: "Migrate to v4",
         breadcrumb: [
           { name: "Projects", href: `/organization/${organizationId}` },
         ],
@@ -233,42 +245,69 @@ export default function OrganizationV4Page() {
     >
       <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-6">
         <DashboardCard
-          title="Projects"
-          description="V4 migration signals split by project."
+          title="Project readiness"
+          description={`${numberFormatter(
+            migrationSummary.projectsNotMigrated,
+            0,
+          )} of ${numberFormatter(
+            projects.length,
+            0,
+          )} projects not migrated - ${numberFormatter(
+            migrationSummary.actionCount,
+            0,
+          )} required changes`}
           isLoading={
             summaryByProject.isPending || legacyApiUsageByProject.isPending
           }
         >
           {summaryByProject.error ? (
-            <div className="border-destructive/30 bg-destructive/10 text-destructive flex min-h-28 items-center rounded-md border p-4 text-sm">
-              Failed to load projects.
-            </div>
+            <Alert>
+              <AlertDescription>Failed to load projects.</AlertDescription>
+            </Alert>
+          ) : summaryByProject.isPending ||
+            legacyApiUsageByProject.isPending ? (
+            <div className="min-h-40" />
           ) : projects.length > 0 ? (
             <div className="overflow-x-auto">
-              <Table className="min-w-[56rem] table-auto">
+              <Table className="min-w-[60rem] table-auto">
                 <TableHeader>
                   <TableRow>
                     <TableHead>Project</TableHead>
-                    <TableHead className="w-36 text-right">
+                    <TableHead className="w-28">Status</TableHead>
+                    <TableHead className="w-32 text-right">
                       Trace evals
                     </TableHead>
-                    <TableHead className="w-36 text-right">
+                    <TableHead className="w-32 text-right">
                       Integrations
                     </TableHead>
-                    <TableHead className="w-36 text-right">
+                    <TableHead className="w-44 text-right">
                       Public API
                     </TableHead>
-                    <TableHead className="w-[24rem]">Links</TableHead>
+                    <TableHead className="w-32" />
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {projects.map((project) => {
-                    const legacyApiUsageCount = sumLegacyApiUsage(
-                      legacyApiUsageRowsByProjectId.get(project.projectId),
+                    const legacyApiRows = legacyApiUsageRowsByProjectId.get(
+                      project.projectId,
                     );
+                    const legacyApiUsageCount =
+                      sumLegacyApiUsage(legacyApiRows);
+                    const legacyApiEntrypointCount =
+                      countLegacyApiEntrypoints(legacyApiRows);
+                    const actionCount = getProjectActionCount(
+                      project,
+                      legacyApiEntrypointCount,
+                    );
+                    const migrationStatus = getV4MigrationStatus(actionCount);
+                    const isSelected =
+                      selectedProject?.projectId === project.projectId;
 
                     return (
-                      <TableRow key={project.projectId}>
+                      <TableRow
+                        key={project.projectId}
+                        className={cn(isSelected && "bg-muted/40")}
+                      >
                         <TableCell density="comfortable">
                           <Link
                             href={`/project/${project.projectId}`}
@@ -276,6 +315,14 @@ export default function OrganizationV4Page() {
                           >
                             {project.projectName}
                           </Link>
+                        </TableCell>
+                        <TableCell density="comfortable">
+                          <Badge
+                            variant={migrationStatus.badgeVariant}
+                            size="sm"
+                          >
+                            {migrationStatus.label}
+                          </Badge>
                         </TableCell>
                         <TableCell density="comfortable" className="text-right">
                           {numberFormatter(project.traceLevelEvalCount, 0)}
@@ -286,26 +333,28 @@ export default function OrganizationV4Page() {
                         <TableCell density="comfortable" className="text-right">
                           {legacyApiUsageByProject.error
                             ? "Failed"
-                            : numberFormatter(legacyApiUsageCount, 0, 2)}
+                            : legacyApiEntrypointCount > 0
+                              ? `${numberFormatter(
+                                  legacyApiEntrypointCount,
+                                  0,
+                                )} routes - ${numberFormatter(
+                                  legacyApiUsageCount,
+                                  0,
+                                  2,
+                                )} calls`
+                              : "0"}
                         </TableCell>
                         <TableCell density="comfortable">
-                          <div className="flex flex-wrap gap-2">
-                            <ProductLinkButton
-                              href={`/project/${project.projectId}/v4`}
-                            >
-                              V4 page
-                            </ProductLinkButton>
-                            <ProductLinkButton
-                              href={getTraceLevelEvalsHref(project.projectId)}
-                            >
-                              Evals
-                            </ProductLinkButton>
-                            <ProductLinkButton
-                              href={`/project/${project.projectId}/settings/integrations`}
-                            >
-                              Integrations
-                            </ProductLinkButton>
-                          </div>
+                          <Button
+                            variant={isSelected ? "secondary" : "outline"}
+                            size="sm"
+                            onClick={() =>
+                              setSelectedProjectId(project.projectId)
+                            }
+                            className="w-full"
+                          >
+                            Details
+                          </Button>
                         </TableCell>
                       </TableRow>
                     );
@@ -317,48 +366,33 @@ export default function OrganizationV4Page() {
             <NoDataOrLoading
               isLoading={summaryByProject.isPending}
               description="No active projects were found in this organization."
-              className="min-h-40"
             />
           )}
         </DashboardCard>
 
-        {projects.map((project) => (
-          <section key={project.projectId} className="flex flex-col gap-3">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="min-w-0">
-                <h2 className="truncate text-xl font-semibold">
-                  {project.projectName}
-                </h2>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <ProductLinkButton href={`/project/${project.projectId}/v4`}>
-                  Project V4 page
-                </ProductLinkButton>
-              </div>
-            </div>
-
-            <V4MigrationProjectCards
-              projectId={project.projectId}
-              summary={project}
-              legacyApiUsage={legacyApiUsageRowsByProjectId.get(
-                project.projectId,
-              )}
-              traceLevelEvalExecutions={evalExecutionRowsByProjectId.get(
-                project.projectId,
-              )}
-              isSummaryLoading={summaryByProject.isPending}
-              isLegacyApiUsageLoading={legacyApiUsageByProject.isPending}
-              isTraceLevelEvalExecutionsLoading={
-                traceLevelEvalExecutionsByProject.isPending
-              }
-              hasSummaryError={Boolean(summaryByProject.error)}
-              hasLegacyApiUsageError={Boolean(legacyApiUsageByProject.error)}
-              hasTraceLevelEvalExecutionsError={Boolean(
-                traceLevelEvalExecutionsByProject.error,
-              )}
-            />
-          </section>
-        ))}
+        {selectedProject ? (
+          <V4MigrationProjectCards
+            projectId={selectedProject.projectId}
+            projectName={selectedProject.projectName}
+            summary={selectedProject}
+            legacyApiUsage={legacyApiUsageRowsByProjectId.get(
+              selectedProject.projectId,
+            )}
+            traceLevelEvalExecutions={evalExecutionRowsByProjectId.get(
+              selectedProject.projectId,
+            )}
+            isSummaryLoading={summaryByProject.isPending}
+            isLegacyApiUsageLoading={legacyApiUsageByProject.isPending}
+            isTraceLevelEvalExecutionsLoading={
+              traceLevelEvalExecutionsByProject.isPending
+            }
+            hasSummaryError={Boolean(summaryByProject.error)}
+            hasLegacyApiUsageError={Boolean(legacyApiUsageByProject.error)}
+            hasTraceLevelEvalExecutionsError={Boolean(
+              traceLevelEvalExecutionsByProject.error,
+            )}
+          />
+        ) : null}
       </div>
     </Page>
   );

--- a/web/src/pages/organization/[organizationId]/v4/index.tsx
+++ b/web/src/pages/organization/[organizationId]/v4/index.tsx
@@ -8,7 +8,7 @@ import Page from "@/src/components/layouts/page";
 import { ErrorPage } from "@/src/components/error-page";
 import { TimeRangePicker } from "@/src/components/date-picker";
 import { DEFAULT_DASHBOARD_AGGREGATION_SELECTION } from "@/src/utils/date-range-utils";
-import { useDashboardDateRange } from "@/src/hooks/useDashboardDateRange";
+import { useGlobalDateRange } from "@/src/features/global-time-range/useGlobalDateRange";
 import { api } from "@/src/utils/api";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import { Alert, AlertDescription } from "@/src/components/ui/alert";
@@ -82,8 +82,9 @@ export default function OrganizationV4Page() {
   const router = useRouter();
   const session = useSession();
   const organizationId = router.query.organizationId as string | undefined;
-  const { timeRange, setTimeRange } = useDashboardDateRange({
-    defaultRelativeAggregation: DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
+  const { timeRange, setTimeRange } = useGlobalDateRange({
+    allowedRanges: V4_TIME_RANGE_PRESETS,
+    fallback: DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
   });
   const canViewOrgV4Page = useHasOrganizationAccess({
     organizationId,
@@ -204,6 +205,8 @@ export default function OrganizationV4Page() {
       { projectsNotMigrated: 0, actionCount: 0 },
     );
   }, [legacyApiUsageRowsByProjectId, projects]);
+  const isProjectReadinessLoading =
+    summaryByProject.isPending || legacyApiUsageByProject.isPending;
 
   useEffect(() => {
     if (
@@ -246,26 +249,27 @@ export default function OrganizationV4Page() {
       <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-6">
         <DashboardCard
           title="Project readiness"
-          description={`${numberFormatter(
-            migrationSummary.projectsNotMigrated,
-            0,
-          )} of ${numberFormatter(
-            projects.length,
-            0,
-          )} projects not migrated - ${numberFormatter(
-            migrationSummary.actionCount,
-            0,
-          )} required changes`}
-          isLoading={
-            summaryByProject.isPending || legacyApiUsageByProject.isPending
+          description={
+            isProjectReadinessLoading
+              ? "Loading V4 migration data."
+              : `${numberFormatter(
+                  migrationSummary.projectsNotMigrated,
+                  0,
+                )} of ${numberFormatter(
+                  projects.length,
+                  0,
+                )} projects not migrated - ${numberFormatter(
+                  migrationSummary.actionCount,
+                  0,
+                )} required changes`
           }
+          isLoading={isProjectReadinessLoading}
         >
           {summaryByProject.error ? (
             <Alert>
               <AlertDescription>Failed to load projects.</AlertDescription>
             </Alert>
-          ) : summaryByProject.isPending ||
-            legacyApiUsageByProject.isPending ? (
+          ) : isProjectReadinessLoading ? (
             <div className="min-h-40" />
           ) : projects.length > 0 ? (
             <div className="overflow-x-auto">

--- a/web/src/pages/project/[projectId]/v4/index.tsx
+++ b/web/src/pages/project/[projectId]/v4/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import Page from "@/src/components/layouts/page";
 import { TimeRangePicker } from "@/src/components/date-picker";
 import { DEFAULT_DASHBOARD_AGGREGATION_SELECTION } from "@/src/utils/date-range-utils";
-import { useDashboardDateRange } from "@/src/hooks/useDashboardDateRange";
+import { useGlobalDateRange } from "@/src/features/global-time-range/useGlobalDateRange";
 import { api } from "@/src/utils/api";
 import { V4MigrationProjectCards } from "@/src/features/v4/components/V4MigrationProjectCards";
 import {
@@ -15,8 +15,9 @@ import {
 export default function V4Page() {
   const router = useRouter();
   const projectId = router.query.projectId as string | undefined;
-  const { timeRange, setTimeRange } = useDashboardDateRange({
-    defaultRelativeAggregation: DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
+  const { timeRange, setTimeRange } = useGlobalDateRange({
+    allowedRanges: V4_TIME_RANGE_PRESETS,
+    fallback: DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
   });
 
   const absoluteTimeRange = useMemo(() => {

--- a/web/src/pages/project/[projectId]/v4/index.tsx
+++ b/web/src/pages/project/[projectId]/v4/index.tsx
@@ -2,57 +2,21 @@ import { useMemo } from "react";
 import { useRouter } from "next/router";
 import Page from "@/src/components/layouts/page";
 import { TimeRangePicker } from "@/src/components/date-picker";
-import {
-  DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
-  toAbsoluteTimeRange,
-  type AbsoluteTimeRange,
-  type TimeRange,
-} from "@/src/utils/date-range-utils";
-import { useGlobalDateRange } from "@/src/features/global-time-range/useGlobalDateRange";
+import { DEFAULT_DASHBOARD_AGGREGATION_SELECTION } from "@/src/utils/date-range-utils";
+import { useDashboardDateRange } from "@/src/hooks/useDashboardDateRange";
 import { api } from "@/src/utils/api";
 import { V4MigrationProjectCards } from "@/src/features/v4/components/V4MigrationProjectCards";
-
-const V4_TIME_RANGE_PRESETS = [
-  "last5Minutes",
-  "last30Minutes",
-  "last1Hour",
-  "last3Hours",
-  "last1Day",
-  "last7Days",
-  "last30Days",
-] as const;
-
-const MAX_V4_TIMELINE_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
-
-const getCappedAbsoluteTimeRange = (
-  timeRange: TimeRange,
-): AbsoluteTimeRange => {
-  const absoluteRange =
-    toAbsoluteTimeRange(timeRange) ??
-    ({
-      from: new Date(Date.now() - 24 * 60 * 60 * 1000),
-      to: new Date(),
-    } satisfies AbsoluteTimeRange);
-
-  if (
-    absoluteRange.to.getTime() - absoluteRange.from.getTime() <=
-    MAX_V4_TIMELINE_RANGE_MS
-  ) {
-    return absoluteRange;
-  }
-
-  return {
-    from: new Date(absoluteRange.to.getTime() - MAX_V4_TIMELINE_RANGE_MS),
-    to: absoluteRange.to,
-  };
-};
+import {
+  getCappedAbsoluteTimeRange,
+  MAX_V4_TIMELINE_RANGE_MS,
+  V4_TIME_RANGE_PRESETS,
+} from "@/src/features/v4/utils";
 
 export default function V4Page() {
   const router = useRouter();
   const projectId = router.query.projectId as string | undefined;
-  const { timeRange, setTimeRange } = useGlobalDateRange({
-    allowedRanges: V4_TIME_RANGE_PRESETS,
-    fallback: DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
+  const { timeRange, setTimeRange } = useDashboardDateRange({
+    defaultRelativeAggregation: DEFAULT_DASHBOARD_AGGREGATION_SELECTION,
   });
 
   const absoluteTimeRange = useMemo(() => {
@@ -108,7 +72,7 @@ export default function V4Page() {
       withPadding
       scrollable
       headerProps={{
-        title: "V4",
+        title: "Migrate to v4",
         breadcrumb: [{ name: "Home", href: `/project/${projectId}` }],
         actionButtonsLeft: (
           <TimeRangePicker


### PR DESCRIPTION
## Summary
- Simplify the project V4 migration page around required changes and Details/Docs links
- Move legacy API and trace-level eval breakdowns into the stacked usage chart legend
- Share V4 time range capping between project and organization pages
- Avoid module-level JSX in sidebar route config/notifications to keep dev runtime stable

## Verification
- PATH="$HOME/.nvm/versions/node/v24.6.0/bin:$PATH" pnpm --filter web run lint
- PATH="$HOME/.nvm/versions/node/v24.6.0/bin:$PATH" pnpm --filter web run typecheck

## Local notes
- Focused v4 router Vitest/browser auth are blocked locally by a dependency resolution issue in this checkout: NextAuth/Vitest resolve hoisted https-proxy-agent@8 via node_modules/.pnpm/node_modules, causing ERR_PACKAGE_PATH_NOT_EXPORTED. GitHub CI on current main is green and should be the source of truth for this environment-specific issue.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR polishes the V4 migration readiness pages by consolidating the project-level view into a single "Required changes" card with stacked bar charts, adding a project-selection UX to the org-level page (replacing all-at-once rendering with a selected-project detail panel), extracting shared time-range utilities into `utils.ts`, and fixing a module-level JSX issue in the sidebar route config by converting `menuNode` values to factory functions.

- **`routes.tsx` / `nav-main.tsx`**: `menuNode` type changes from `ReactNode` to `() => ReactNode`; all six sidebar entries updated to use factory functions; rendering updated from `||` to ternary with `.call`.
- **`V4MigrationProjectCards.tsx`**: Three separate `DashboardCard`s replaced by one card with three `Section` components, each backed by a new `UsageStackedBarOverview` recharts stacked bar chart and a custom legend.
- **`organization/v4/index.tsx`**: Per-project `selectedProjectId` state added; org table now shows a "Details" button that drives which project's `V4MigrationProjectCards` renders below; entrypoint counting switches from `sumLegacyApiUsage` (total call count) to `countLegacyApiEntrypoints` (distinct routes) for action-count/sort purposes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge. Changes are UI-only, touching read-only dashboard pages; no mutations, auth paths, or data-model changes are affected.

All changed files are display-only dashboard pages and nav configuration. The sidebar factory-function fix is straightforward. The main logic concern is a potential count discrepancy between the org-level table (which counts raw API entrypoints) and the project-level card (which groups by normalized entrypoints after stripping the "publicapi: " prefix), but in practice the API likely returns a consistent format so this is unlikely to surface.

The `countLegacyApiEntrypoints` function in `organization/[organizationId]/v4/index.tsx` and the `normalizeEntrypoint`+`groupUsageSeries` path in `V4MigrationProjectCards.tsx` should be reviewed together to confirm the entrypoint format returned by the API is consistent enough that no normalization mismatch can occur.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant OrgV4Page as Org V4 Page
    participant ProjV4Page as Project V4 Page
    participant tRPC as tRPC API

    User->>OrgV4Page: Visits /organization/[id]/v4
    OrgV4Page->>tRPC: summaryByProject (org-wide)
    OrgV4Page->>tRPC: timeSeriesByEntrypointByProject (capped 30d)
    OrgV4Page->>tRPC: traceLevelEvalExecutionsTimeSeriesByProject (capped 30d)
    tRPC-->>OrgV4Page: projects[], legacyApiUsage[], evalExecutions[]

    OrgV4Page->>OrgV4Page: countLegacyApiEntrypoints(raw rows)
    OrgV4Page->>OrgV4Page: getProjectActionCount → sort → migrationSummary
    OrgV4Page->>OrgV4Page: "useEffect: set selectedProjectId = projects[0]"

    User->>OrgV4Page: Clicks Details on a project row
    OrgV4Page->>OrgV4Page: setSelectedProjectId(project.projectId)

    OrgV4Page->>ProjV4Page: renders V4MigrationProjectCards (inline)
    ProjV4Page->>ProjV4Page: normalizeEntrypoint → groupUsageSeries → legacyApiSeries
    ProjV4Page->>ProjV4Page: "activeTaskCount = legacyApiSeries.length + traceLevelEvalCount + integrations"
    ProjV4Page->>ProjV4Page: getV4MigrationStatus(activeTaskCount) → badge
    ProjV4Page-->>User: Required changes card with stacked bar charts
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant OrgV4Page as Org V4 Page
    participant ProjV4Page as Project V4 Page
    participant tRPC as tRPC API

    User->>OrgV4Page: Visits /organization/[id]/v4
    OrgV4Page->>tRPC: summaryByProject (org-wide)
    OrgV4Page->>tRPC: timeSeriesByEntrypointByProject (capped 30d)
    OrgV4Page->>tRPC: traceLevelEvalExecutionsTimeSeriesByProject (capped 30d)
    tRPC-->>OrgV4Page: projects[], legacyApiUsage[], evalExecutions[]

    OrgV4Page->>OrgV4Page: countLegacyApiEntrypoints(raw rows)
    OrgV4Page->>OrgV4Page: getProjectActionCount → sort → migrationSummary
    OrgV4Page->>OrgV4Page: "useEffect: set selectedProjectId = projects[0]"

    User->>OrgV4Page: Clicks Details on a project row
    OrgV4Page->>OrgV4Page: setSelectedProjectId(project.projectId)

    OrgV4Page->>ProjV4Page: renders V4MigrationProjectCards (inline)
    ProjV4Page->>ProjV4Page: normalizeEntrypoint → groupUsageSeries → legacyApiSeries
    ProjV4Page->>ProjV4Page: "activeTaskCount = legacyApiSeries.length + traceLevelEvalCount + integrations"
    ProjV4Page->>ProjV4Page: getV4MigrationStatus(activeTaskCount) → badge
    ProjV4Page-->>User: Required changes card with stacked bar charts
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/organization/[organizationId]/v4/index.tsx:72-76
**Entrypoint count differs between org and project views**

`countLegacyApiEntrypoints` counts raw entrypoint strings from the API, while `V4MigrationProjectCards` builds `legacyApiSeries` after applying `normalizeEntrypoint` (which strips the `"publicapi: "` prefix). If the API ever returns both a prefixed form (`"publicapi: GET /api/public/traces"`) and an un-prefixed form (`"GET /api/public/traces"`) for the same endpoint, the org-level table would show 2 routes while the project detail card would collapse them to 1 — causing the per-project action count, sort order, and "Not migrated" badge on the overview to disagree with the count shown in the `V4MigrationProjectCards` header.

### Issue 2 of 2
web/src/features/v4/components/V4MigrationProjectCards.tsx:63-72
**`STACKED_CHART_COLORS` length intentionally exceeds `MAX_STACKED_CHART_SERIES`**

`MAX_STACKED_CHART_SERIES` is 6, but `STACKED_CHART_COLORS` has 7 entries. The 7th color (`chart-3`) is implicitly reserved for the auto-generated "Other" bucket that appears when there are more than 6 series. This works correctly today because `getStackedChartSeries` caps output at `MAX_STACKED_CHART_SERIES + 1 = 7` items. However, if `MAX_STACKED_CHART_SERIES` is ever changed without also updating `STACKED_CHART_COLORS`, the alignment will silently break (the "Other" bucket will reuse an existing series color). A comment or named constant pairing the two values would prevent this drift.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/v4-migrat..."](https://github.com/langfuse/langfuse/commit/ef027ae08ed51f1fff7b994e154c9a9f3e01ab79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40087670)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->