### PR TITLE
ci: run Langfuse test servers with test env

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -537,6 +537,7 @@ jobs:
       - name: Start Langfuse
         run: (pnpm run start&)
         env:
+          NODE_ENV: test
           LANGFUSE_INIT_ORG_ID: "seed-org-id"
           LANGFUSE_INIT_ORG_NAME: "Seed Org"
           LANGFUSE_INIT_ORG_CLOUD_PLAN: "Team"
@@ -854,6 +855,8 @@ jobs:
           exit "$(cat /tmp/playwright-install.exit)"
       - name: Run e2e tests
         run: pnpm --filter=web run test:e2e
+        env:
+          NODE_ENV: test
 
   e2e-server-tests:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -935,6 +938,8 @@ jobs:
           pnpm --filter=shared run db:seed:examples
       - name: Run server
         run: (pnpm run start&)
+        env:
+          NODE_ENV: test
       - name: Check worker health
         run: |
           timeout 10 bash -c 'until curl -f http://localhost:3030/api/health; do sleep 2; done'


### PR DESCRIPTION
## Summary
- Set `NODE_ENV=test` on CI steps that start Langfuse test servers.
- Ensure the Playwright CI web server inherits test env instead of falling back to shared `development` defaults.

## Impacted packages
- CI only: `.github/workflows/pipeline.yml`

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pipeline.yml"); puts "yaml ok"'`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This CI-only PR sets `NODE_ENV=test` on the three steps that start or exercise Langfuse test servers across the `tests-web`, `e2e-tests`, and `e2e-server-tests` jobs. The goal is to prevent those servers from defaulting to `development` environment semantics during test runs.

- **`tests-web`**: `NODE_ENV=test` is added to "Start Langfuse" so the background server process runs with test configuration.
- **`e2e-tests`**: `NODE_ENV=test` is added to "Run e2e tests"; because `playwright.config.ts` spawns `npm run start` as its `webServer` in CI (with `reuseExistingServer: false`), the spawned server now correctly inherits `NODE_ENV=test` from the test step's environment.
- **`e2e-server-tests`**: `NODE_ENV=test` is added to "Run server"; the `test:e2e:server` script runs `vitest run --project e2e-server` (not Playwright), so there is no webServer conflict with the manually-started server.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

CI-only change with no impact on application or library code; safe to merge.

All three changes are additive env: blocks on steps that start background servers or drive test runners. The test:e2e:server script resolves to vitest run --project e2e-server (not Playwright), so there is no Playwright webServer conflict with the manually-started server. The e2e-tests Playwright config correctly inherits NODE_ENV=test from the runner step, which flows into the spawned npm run start webServer child process. No production or library code is touched.

No files require special attention; the single changed file is a GitHub Actions workflow.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph tests-web["tests-web job"]
        TW1["Start Langfuse\n(pnpm run start&)\nNODE_ENV=test"] --> TW2["run tests\n(vitest server/client projects)"]
    end

    subgraph e2e-tests["e2e-tests job"]
        E1["Build\n(Next.js production build)"] --> E2["Run e2e tests\n(pnpm --filter=web run test:e2e)\nNODE_ENV=test"]
        E2 -->|"Playwright spawns webserver\n(npm run start)\ninherits NODE_ENV=test"| E3["playwright test\n--reporter=line"]
    end

    subgraph e2e-server-tests["e2e-server-tests job"]
        S1["Build"] --> S2["Run server\n(pnpm run start&)\nNODE_ENV=test"]
        S2 --> S3["Check worker/server health"]
        S3 --> S4["Run e2e server tests\n(vitest --project e2e-server)"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph tests-web["tests-web job"]
        TW1["Start Langfuse\n(pnpm run start&)\nNODE_ENV=test"] --> TW2["run tests\n(vitest server/client projects)"]
    end

    subgraph e2e-tests["e2e-tests job"]
        E1["Build\n(Next.js production build)"] --> E2["Run e2e tests\n(pnpm --filter=web run test:e2e)\nNODE_ENV=test"]
        E2 -->|"Playwright spawns webserver\n(npm run start)\ninherits NODE_ENV=test"| E3["playwright test\n--reporter=line"]
    end

    subgraph e2e-server-tests["e2e-server-tests job"]
        S1["Build"] --> S2["Run server\n(pnpm run start&)\nNODE_ENV=test"]
        S2 --> S3["Check worker/server health"]
        S3 --> S4["Run e2e server tests\n(vitest --project e2e-server)"]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: run Langfuse test servers with test ..."](https://github.com/langfuse/langfuse/commit/059a35ffc3d21ee14fcb647610ea07fb335ddec7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40086185)</sub>

<!-- /greptile_comment -->