### PR TITLE
fix(trace): restore timeline gutter touch-scrolling and trim oversized list overscan (LFE-10548)

### DIFF
--- a/web/src/components/trace/components/TraceSearchList.tsx
+++ b/web/src/components/trace/components/TraceSearchList.tsx
@@ -74,7 +74,6 @@ export function TraceSearchList() {
       onSelectItem={handleSelectItem}
       getItemId={(item) => item.node.id}
       estimatedItemSize={48}
-      overscan={500}
       renderItem={({ item, isSelected, onSelect }) => (
         <TraceSearchListItem
           item={item}

--- a/web/src/components/trace/components/TraceTimeline/index.tsx
+++ b/web/src/components/trace/components/TraceTimeline/index.tsx
@@ -226,8 +226,15 @@ export function TraceTimeline() {
     const drag = dragRef.current;
     const chart = chartRef.current;
     if (!drag || drag.pointerId !== e.pointerId || !chart) return;
+    // Clamp-aware: only consume the scroll delta the browser actually applied.
+    // The browser clamps scrollTop to [0, maxScroll], so advancing lastY to
+    // e.clientY unconditionally would record finger motion past a boundary that
+    // scrollTop discarded; a later direction reversal would then resurface as
+    // phantom scroll with zero net finger travel. Advancing lastY by only the
+    // applied delta keeps over-the-boundary motion from leaking back in.
+    const prev = chart.scrollTop;
     chart.scrollTop -= e.clientY - drag.lastY;
-    drag.lastY = e.clientY;
+    drag.lastY += prev - chart.scrollTop;
   }, []);
   const handleGutterPointerEnd = useCallback((e: React.PointerEvent) => {
     if (dragRef.current?.pointerId !== e.pointerId) return;

--- a/web/src/components/trace/components/TraceTimeline/index.tsx
+++ b/web/src/components/trace/components/TraceTimeline/index.tsx
@@ -4,8 +4,8 @@
  * Two panes, side by side, sharing the virtualized rows:
  *  - Gutter pane (fixed, resizable): the indented name tree. It never scrolls
  *    itself — its content is a one-way translateY projection of the chart's
- *    vertical scroll, so the two panes can't drift; wheeling over it drives the
- *    chart.
+ *    vertical scroll, so the two panes can't drift; wheeling or touch-dragging
+ *    over it drives the chart.
  *  - Chart pane (flex-1): the gantt bars. Owns the only scrollbars (horizontal
  *    and vertical) and is the virtualizer's scroll element.
  *
@@ -204,6 +204,39 @@ export function TraceTimeline() {
     chart.scrollTop += e.deltaY * unit;
   }, []);
 
+  // Touch (and pen/mouse drag) over the gutter scrolls it too. WheelEvents are
+  // never synthesized on touch, so on touch-capable screens that render this
+  // desktop layout the wheel handler alone leaves the gutter stuck. Pointer
+  // events cover touch + pen + mouse uniformly: we drag-scroll the chart (move
+  // a finger up → content scrolls up, so scrollTop -= dy), and the chart
+  // projects straight back onto the gutter via handleChartScroll — same
+  // pixel-locked path as the wheel, so the two panes still can't drift.
+  const dragRef = useRef<{ pointerId: number; lastY: number } | null>(null);
+  const handleGutterPointerDown = useCallback((e: React.PointerEvent) => {
+    // Only drag-scroll for touch/pen. Leave the mouse to clicks (rows are
+    // clickable) and the wheel; a mouse drag here would otherwise hijack
+    // text selection / row clicks.
+    if (e.pointerType === "mouse") return;
+    const chart = chartRef.current;
+    if (!chart) return;
+    dragRef.current = { pointerId: e.pointerId, lastY: e.clientY };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }, []);
+  const handleGutterPointerMove = useCallback((e: React.PointerEvent) => {
+    const drag = dragRef.current;
+    const chart = chartRef.current;
+    if (!drag || drag.pointerId !== e.pointerId || !chart) return;
+    chart.scrollTop -= e.clientY - drag.lastY;
+    drag.lastY = e.clientY;
+  }, []);
+  const handleGutterPointerEnd = useCallback((e: React.PointerEvent) => {
+    if (dragRef.current?.pointerId !== e.pointerId) return;
+    dragRef.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+  }, []);
+
   // Parent totals for heatmap coloring (aggregate across all roots).
   const parentTotalCost = useMemo(() => {
     return roots.reduce(
@@ -365,10 +398,16 @@ export function TraceTimeline() {
       >
         {/* Gutter pane — a one-way projection of the chart's vertical scroll
             (translateY), never its own scroll container, so it stays locked to
-            the chart. Wheeling over it drives the chart. */}
+            the chart. Wheeling or touch-dragging over it drives the chart.
+            touchAction:none stops the browser claiming the vertical pan gesture
+            (there's nothing to pan here) so our pointer-drag handlers fire. */}
         <div
           onWheel={handleGutterWheel}
-          className="shrink-0 overflow-hidden"
+          onPointerDown={handleGutterPointerDown}
+          onPointerMove={handleGutterPointerMove}
+          onPointerUp={handleGutterPointerEnd}
+          onPointerCancel={handleGutterPointerEnd}
+          className="shrink-0 touch-none overflow-hidden"
           style={{ width: `${gutterWidth}px` }}
         >
           <div

--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -167,9 +167,10 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
         >
           {children}
         </Group>
-        {/* When the detail panel is collapsed, the navigation header surfaces a
-            "show detail panel" button at its right edge (TracePanelNavigationHeader)
-            — no floating edge tab. */}
+        {/* When the detail panel is collapsed it renders its own collapsed rail
+            with a "Show detail panel" button (see DetailPanel below) — the
+            navigation header carries no re-open button, and there's no floating
+            edge tab. */}
       </div>
     </LayoutContext.Provider>
   );

--- a/web/src/components/trace/components/_layout/TracePanelNavigationHeader.tsx
+++ b/web/src/components/trace/components/_layout/TracePanelNavigationHeader.tsx
@@ -269,9 +269,10 @@ function TracePanelNavigationHeaderExpanded({
             isTimelineView={isTimelineView}
             onSelect={(timeline) => setViewMode(timeline ? "timeline" : null)}
           />
-          {/* When the detail panel is closed it shows its own collapsed rail +
-              expand button on the right edge (mirrors the navigation panel), so
-              the header needs no re-open button — see TraceLayoutDesktop. */}
+          {/* When the detail panel is closed it shows its own collapsed rail
+              with a "Show detail panel" button on the right edge (DetailPanel in
+              TraceLayoutDesktop, mirroring the navigation panel's rail), so the
+              header needs no re-open button of its own. */}
         </div>
       </div>
     </Command>

--- a/web/src/components/trace/components/_shared/VirtualizedList.tsx
+++ b/web/src/components/trace/components/_shared/VirtualizedList.tsx
@@ -30,7 +30,10 @@ export function VirtualizedList<T>({
   onSelectItem,
   getItemId,
   estimatedItemSize = 48,
-  overscan = 500,
+  // overscan is a ROW COUNT, not pixels: keep it small so a long list mounts
+  // only a few dozen extra rows per scroll step instead of ~1000 (the old "500"
+  // mistook it for pixels). ~16 rows ≈ half a viewport of headroom.
+  overscan = 16,
 }: VirtualizedListProps<T>) {
   const parentRef = useRef<HTMLDivElement>(null);
 

--- a/web/src/components/trace/components/_shared/VirtualizedTree.tsx
+++ b/web/src/components/trace/components/_shared/VirtualizedTree.tsx
@@ -39,7 +39,10 @@ export function VirtualizedTree<T extends { id: string; children: T[] }>({
   onToggleCollapse,
   onSelectNode,
   estimateSize,
-  overscan = 500,
+  // overscan is a ROW COUNT, not pixels: keep it small so a long tree mounts
+  // only a few dozen extra rows per scroll step instead of ~1000 (the old "500"
+  // mistook it for pixels). ~16 rows ≈ half a viewport of headroom.
+  overscan = 16,
   defaultRowHeight = 37,
   className,
 }: VirtualizedTreeProps<T>) {


### PR DESCRIPTION
## TL;DR
The condensed trace-timeline (#14598) made the left name-gutter a pure projection of the chart's scroll, driven by an `onWheel` handler. Touch devices never fire wheel events, so on touch-capable screens that render the desktop layout the gutter became un-scrollable by touch. This restores touch-scrolling (pixel-locked to the chart, no drift) and clears two review follow-ups from that PR: oversized virtualizer overscan in the other lists, and a couple of stale doc comments.

Follow-up to #14598 · Linear: **LFE-10548**

## Why
On the timeline, the gutter (the indented name tree) doesn't own a scrollbar — it's a one-way `translateY` projection of the chart pane's vertical scroll, so the two panes can't drift. Wheeling over the gutter proxied `deltaY` into `chart.scrollTop`. But **touch never synthesizes `WheelEvent`s**, so a finger-drag on the gutter did nothing (the chart pane itself still scrolled fine, which made it easy to miss). Reviewers on #14598 also flagged an `overscan: 500` left over elsewhere — that value is a **row count**, not pixels, so a long list mounted ~1000 rows — and two doc comments that no longer matched the UI.

## What
- **Gutter touch-scrolling (headline):** added `pointerdown/move/up/cancel` handlers (touch + pen) that drag-scroll the chart the same way the wheel handler does. The chart projects straight back onto the gutter, so both wheel and touch stay pixel-locked. `touch-action: none` on the gutter lets the pointer-move stream through; mouse is left to clicks/wheel so row clicks and text selection are untouched.
- **Overscan:** `VirtualizedTree` and `VirtualizedList` defaults drop from `500` to `16`; `TraceSearchList` now inherits the default instead of passing `500`. Behavior otherwise unchanged.
- **Stale comments:** the navigation header no longer renders a "Show detail panel" button — it lives on the DetailPanel's collapsed rail. Updated the comments in `TraceLayoutDesktop.tsx` and `TracePanelNavigationHeader.tsx` to match.

## Result
Touch and wheel both scroll the gutter, perfectly in sync with the chart. Long traces/lists mount a few dozen extra rows instead of ~1000. Comments tell the truth.

<details>
<summary>Mechanism, scope & verification</summary>

**Mechanism.** The gutter pane stays `overflow-hidden` (never its own scroller). A `dragRef` tracks the active pointer; on move we apply `chart.scrollTop -= dy` (drag a finger up → content scrolls down), and the existing chart `onScroll` projects the new `scrollTop` onto the gutter via `translateY(-scrollTop)`. Mouse pointers are skipped (`pointerType === "mouse"` early-return) so clicks/selection are unaffected; the wheel path is unchanged.

**Overscan.** `overscan` in `@tanstack/react-virtual` is a count of extra rows rendered beyond the viewport, not a pixel margin. `500` mounted ~1000 rows on long lists. `16` ≈ half a viewport of headroom — matches what the timeline already uses post-#14598.

**Out of scope (intentionally not touched):** condensing the tree-view rows / tightening the timeline header — that's a separate open design question, not this ticket.

**Verification (Playwright, Chrome, touch-enabled context, real trace with 29 observations, chart genuinely scrollable: scrollHeight 780 / client 496):**
- Touch drag on the gutter: finger up 150px → `chart.scrollTop` 0→150, gutter `translateY` exactly `-150` (pixel-locked, no drift). ✅
- Wheel on the gutter: `deltaY 200` → `chart.scrollTop` 0→200, gutter `translateY` exactly `-200`. ✅
- Tree view (uses `VirtualizedTree` with the new `overscan=16`): all 30 rows render correctly. ✅
- `prettier` + `turbo lint` pass; production source type-clean.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes touch-scroll on the trace timeline's gutter pane and corrects an overscan misconfiguration in shared virtualizer components. The gutter was previously only scrollable via `WheelEvent`, which touch devices never synthesize for programmatic scrolling, leaving touch users unable to scroll the gutter.

- **Touch scroll fix:** Adds `pointerdown/move/up/cancel` handlers on the gutter div (skipping `pointerType === "mouse"` to preserve click/wheel UX), using `setPointerCapture` for reliable drag tracking. Applies `touch-action: none` via Tailwind so the browser doesn't claim the vertical pan gesture before the pointer events can fire. The chart's existing `onScroll` handler propagates the scroll back onto the gutter via `translateY`, keeping the two panes pixel-locked regardless of input method.
- **Overscan fix:** Drops the `overscan` default in `VirtualizedList` and `VirtualizedTree` from `500` (misread as pixels — actually a row count) to `16`, and removes the explicit `overscan={500}` from `TraceSearchList`. This prevents ~1000 off-screen rows from mounting on long lists.
- **Comment cleanup:** Two doc comments in `TraceLayoutDesktop.tsx` and `TracePanelNavigationHeader.tsx` are updated to accurately describe where the "Show detail panel" button now lives.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the gutter's scroll projection architecture is unchanged, the pointer capture pattern is standard, and the overscan reduction only reduces off-screen row mounting with no behavioral change for users.

The pointer-event handlers follow the standard capture-move-release pattern correctly, `touch-action: none` is scoped to the gutter div only, and the early return on `pointerType === 'mouse'` preserves all existing click and wheel interactions. The overscan change from 500 to 16 is a straightforward default fix with no API-level impact. No new state, no new network calls, no schema changes.

All files look good; no files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Finger as Touch / Pen
    participant Gutter as Gutter Div (touch-action:none)
    participant DragRef as dragRef
    participant Chart as Chart Pane (scrollable)
    participant HandleChartScroll as handleChartScroll

    Finger->>Gutter: pointerdown
    Gutter->>DragRef: "store {pointerId, lastY}"
    Gutter->>Gutter: setPointerCapture(pointerId)

    loop pointer moves
        Finger->>Gutter: pointermove (captured)
        Gutter->>DragRef: read lastY
        Gutter->>Chart: "scrollTop -= (clientY - lastY)"
        Gutter->>DragRef: "update lastY = clientY"
        Chart->>HandleChartScroll: onScroll fires
        HandleChartScroll->>Gutter: translateY(-scrollTop)
    end

    Finger->>Gutter: pointerup / pointercancel
    Gutter->>DragRef: set null
    Gutter->>Gutter: releasePointerCapture(pointerId)

    note over Finger,HandleChartScroll: WheelEvent path (unchanged) also ends at Chart.scrollTop → handleChartScroll
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Finger as Touch / Pen
    participant Gutter as Gutter Div (touch-action:none)
    participant DragRef as dragRef
    participant Chart as Chart Pane (scrollable)
    participant HandleChartScroll as handleChartScroll

    Finger->>Gutter: pointerdown
    Gutter->>DragRef: "store {pointerId, lastY}"
    Gutter->>Gutter: setPointerCapture(pointerId)

    loop pointer moves
        Finger->>Gutter: pointermove (captured)
        Gutter->>DragRef: read lastY
        Gutter->>Chart: "scrollTop -= (clientY - lastY)"
        Gutter->>DragRef: "update lastY = clientY"
        Chart->>HandleChartScroll: onScroll fires
        HandleChartScroll->>Gutter: translateY(-scrollTop)
    end

    Finger->>Gutter: pointerup / pointercancel
    Gutter->>DragRef: set null
    Gutter->>Gutter: releasePointerCapture(pointerId)

    note over Finger,HandleChartScroll: WheelEvent path (unchanged) also ends at Chart.scrollTop → handleChartScroll
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): restore gutter touch-scrolli..."](https://github.com/langfuse/langfuse/commit/c01192c073544b5a1a6e0f6affb4f33b606ac08e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40127353)</sub>

<!-- /greptile_comment -->