### PR TITLE
fix(trace): reopen peek nav panel on toggle at narrow widths (LFE-10547)

### DIFF
--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -27,6 +27,18 @@ const RESIZABLE_PANEL_HANDLE_ID = "trace-layout-handle";
 const RESIZABLE_PANEL_NAVIGATION_ID = "trace-layout-panel-navigation";
 const RESIZABLE_PANEL_PREVIEW_ID = "trace-layout-panel-preview";
 
+// Min widths of the two collapsible panels (kept here so the Panel props and the
+// toggle logic below can't drift apart). In a narrow peek the container can be
+// too small to satisfy BOTH mins at once: react-resizable-panels' constraint
+// solver then refuses to grow one panel past the other's min and the layout is
+// left unchanged — which made expand() a silent no-op (LFE-10547). When that's
+// the case we collapse the opposite panel first so the one being opened has room.
+const NAVIGATION_PANEL_MIN_PX = 260;
+const DETAIL_PANEL_MIN_PX = 360;
+// Small slack so we don't fight the solver on layouts that only just fit.
+const BOTH_PANELS_FIT_MIN_PX =
+  NAVIGATION_PANEL_MIN_PX + DETAIL_PANEL_MIN_PX + 8;
+
 // Context for sharing panel state with compound components
 interface TraceLayoutDesktopContext {
   isNavigationPanelCollapsed: boolean;
@@ -81,10 +93,35 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
   // Detail (info/preview) panel collapse state + control.
   const detailPanelRef = usePanelRef();
   const [isDetailPanelCollapsed, setIsDetailPanelCollapsed] = useState(false);
+
+  // Total width of the panel group, summed from both panels' current pixel
+  // sizes (the imperative handle has no group-size getter). Either ref alone
+  // covers the group: a collapsed panel still reports its 40px rail. 0 if the
+  // refs aren't mounted yet — callers treat that as "can't tell, don't gate".
+  const getGroupWidthPx = () => {
+    const nav = panelRef.current?.getSize().inPixels ?? 0;
+    const detail = detailPanelRef.current?.getSize().inPixels ?? 0;
+    return nav + detail;
+  };
+  // True when the container is too narrow to hold both panels at their mins, so
+  // opening one requires the other to yield (collapse) first.
+  const bothPanelsFit = () => {
+    const width = getGroupWidthPx();
+    return width === 0 || width >= BOTH_PANELS_FIT_MIN_PX;
+  };
+
   // Guarded so it's a no-op (not a resize) when already open — safe to call on
   // every row click, which is how re-selecting the same node reopens it.
   const expandDetailPanel = () => {
-    if (detailPanelRef.current?.isCollapsed()) detailPanelRef.current.expand();
+    if (!detailPanelRef.current?.isCollapsed()) return;
+    // Narrow peek: both mins can't coexist, so the solver would refuse to grow
+    // the detail panel and expand() would no-op. Collapse the nav panel first
+    // so the detail panel has room (LFE-10547).
+    if (!bothPanelsFit() && !panelRef.current?.isCollapsed()) {
+      panelRef.current?.collapse();
+      setIsNavigationPanelCollapsed(true);
+    }
+    detailPanelRef.current.expand();
   };
 
   // Selecting another node (timeline/tree) while the detail panel is collapsed
@@ -117,6 +154,13 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
     if (!panelRef.current) return;
 
     if (panelRef.current.isCollapsed()) {
+      // Narrow peek: both mins can't coexist, so the solver would refuse to grow
+      // the nav panel and expand() would silently no-op (the reported bug). Make
+      // the detail panel yield first so the nav panel has room (LFE-10547).
+      if (!bothPanelsFit() && !detailPanelRef.current?.isCollapsed()) {
+        detailPanelRef.current?.collapse();
+        setIsDetailPanelCollapsed(true);
+      }
       panelRef.current.expand();
     } else {
       panelRef.current.collapse();
@@ -189,7 +233,7 @@ TraceLayoutDesktop.NavigationPanel = function Navigation({
       panelRef={panelRef}
       collapsible={true}
       collapsedSize="40px"
-      minSize="260px"
+      minSize={`${NAVIGATION_PANEL_MIN_PX}px`}
       defaultSize="60%"
       onResize={() => {
         setIsNavigationPanelCollapsed(panelRef.current?.isCollapsed() ?? false);
@@ -238,7 +282,7 @@ TraceLayoutDesktop.DetailPanel = function Detail({
       defaultSize="40%"
       collapsible={true}
       collapsedSize="40px"
-      minSize="360px"
+      minSize={`${DETAIL_PANEL_MIN_PX}px`}
       onResize={() => {
         setIsDetailPanelCollapsed(
           detailPanelRef.current?.isCollapsed() ?? false,


### PR DESCRIPTION
## TL;DR
In the trace **peek** view, when the peek is narrow the left navigation panel (tree/timeline) auto-collapses — and clicking the sidebar toggle to reopen it did **nothing**. This makes the toggle reliably reopen the panel at any peek width. ([LFE-10547](https://linear.app/langfuse/issue/LFE-10547))

## Why
The peek hosts two resizable panels side by side: the navigation panel (min **260px**) and the detail panel (min **360px**). When the peek is dragged narrow, the container can't fit both mins at once (260 + 360 = 620px), so the navigation panel auto-collapses to its 40px rail. Clicking the toggle then called `expand()` — but the panel library's constraint solver refuses to grow the nav panel past the detail panel's min, discards the resulting (invalid) layout, and the click becomes a **silent no-op**. The panel was stuck collapsed with no way back.

## What
When expanding one collapsible panel while the container is too narrow to hold both at their mins, **collapse the other panel first** so the one being opened has room — mirroring the auto-collapse that happens on shrink. Applied to both the nav toggle and the detail panel's own expand path. Panel min widths are now shared constants so the `Panel` props and the toggle logic can't drift apart.

## Result
The nav toggle reliably reopens the panel at **any** peek width; at widths where both panels can't coexist, the detail panel yields. Wide layouts are unchanged.

<details>
<summary>Mechanism &amp; verification</summary>

**Root cause.** The panel library's imperative `expand()` computes a resize delta toward the panel's remembered size (or its min) and runs it through the constraint solver. The solver clamps every panel to its `minSize`; when two mins can't both be satisfied in the available width, the candidate layout fails the "must sum to 100%" check and the solver returns the **previous layout unchanged**. So `expand()` silently does nothing — the panel stays at its 40px collapsed rail.

**Fix.** Before expanding, sum the two panels' current pixel widths (the imperative handle exposes `getSize().inPixels`; a collapsed panel still reports its 40px rail, so either ref covers the group). If that's below `260 + 360 + 8`, collapse the opposite panel first, then expand — guaranteeing room. When there's room, behavior is identical to before.

**Verified live** (dev server + browser automation) by reproducing the exact reported flow — open a trace peek, drag it narrow until the nav panel auto-collapses, click the toggle:

| Peek width | Before | After |
| --- | --- | --- |
| ~480px (nav auto-collapsed to 40px) | toggle click → nav stays **40px** (no-op) | toggle click → nav reopens to **438px**, detail yields ✅ |

A width sweep (multiple narrow viewports) confirmed every nav-collapsed case reopens with the fix, and wide layouts are untouched.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent no-op when clicking the nav panel toggle in a narrow trace peek view. The root cause was that `react-resizable-panels`' constraint solver refused to expand the nav panel (min 260 px) when the container couldn't also satisfy the detail panel's min (360 px), leaving the toggle click with no visible effect.

- Introduces shared `NAVIGATION_PANEL_MIN_PX` / `DETAIL_PANEL_MIN_PX` constants so the `Panel` props and the toggle logic stay in sync; adds a `getGroupWidthPx` helper that sums both panels' imperative pixel sizes to detect whether the container is too narrow for both panels to coexist.
- Before calling `expand()` on either panel, the fix now collapses the opposite panel first when the container can't hold both at their minimums, mirroring the auto-collapse that already happened on shrink — this ensures the solver always has room for the expansion.
- The change is scoped to the narrow-peek path; wide layouts that can comfortably host both panels at their minimums are unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is tightly scoped to imperative panel toggle logic and does not touch rendering, data fetching, or shared state beyond the existing panel collapse flags.

The fix correctly addresses the silent no-op by collapsing the opposing panel before expanding the target panel, matching the same constraint-solver reasoning the library already uses for auto-collapse on resize. The `getGroupWidthPx` helper uses the same object-property access pattern (`getSize().inPixels`) already established by `getSize().asPercentage` in the existing `resizable-split-layout.tsx`, so the API usage is consistent. Wide-layout behavior is unchanged; the narrow path is guarded by the `bothPanelsFit` check. Explicit `setIs*Collapsed(true)` calls defensively synchronise React state alongside the imperative `collapse()` calls (the `onResize` callbacks would eventually do the same, but this removes any timing ambiguity). One documentation gap exists in the `selectedNodeId` effect comment, which doesn't mention the new nav-collapse side effect introduced by the updated `expandDetailPanel`.

No files require special attention; `TraceLayoutDesktop.tsx` is the only changed file and the modification is well-isolated.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User clicks nav toggle\n(handleTogglePanel)"]
    B{"Nav panel\ncollapsed?"}
    C{"bothPanelsFit()\n(group width ≥ 628px)?"}
    D{"Detail panel\nalready collapsed?"}
    E["collapse detail panel\nsetIsDetailPanelCollapsed(true)"]
    F["panelRef.expand()\n→ nav reopens"]
    G["panelRef.collapse()\n→ nav collapses"]

    A --> B
    B -- "No (toggle off)" --> G
    B -- "Yes (toggle on)" --> C
    C -- "No (narrow peek)" --> D
    D -- "No" --> E
    D -- "Yes" --> F
    E --> F
    C -- "Yes (wide enough)" --> F

    style E fill:#f90,color:#000
    style F fill:#4CAF50,color:#fff
    style G fill:#9e9e9e,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["User clicks nav toggle\n(handleTogglePanel)"]
    B{"Nav panel\ncollapsed?"}
    C{"bothPanelsFit()\n(group width ≥ 628px)?"}
    D{"Detail panel\nalready collapsed?"}
    E["collapse detail panel\nsetIsDetailPanelCollapsed(true)"]
    F["panelRef.expand()\n→ nav reopens"]
    G["panelRef.collapse()\n→ nav collapses"]

    A --> B
    B -- "No (toggle off)" --> G
    B -- "Yes (toggle on)" --> C
    C -- "No (narrow peek)" --> D
    D -- "No" --> E
    D -- "Yes" --> F
    E --> F
    C -- "Yes (wide enough)" --> F

    style E fill:#f90,color:#000
    style F fill:#4CAF50,color:#fff
    style G fill:#9e9e9e,color:#fff
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx:132-137
**Side-effect not documented in the useEffect comment**

The comment above this effect says it "reopens the detail panel" on node selection, but after this PR it also silently collapses the nav panel when the peek container is too narrow to hold both panels simultaneously. A developer later reading this effect won't know that selecting a node in narrow-peek mode causes `expandDetailPanel` to call `panelRef.current?.collapse()` as a side effect. The comment is worth updating to reflect that behavior.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): reopen peek nav panel on tog..."](https://github.com/langfuse/langfuse/commit/27a280050980495ad7969eeed16c98e6eca8a788) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40131286)</sub>

<!-- /greptile_comment -->