### PR TITLE
fix(trace): let the peek keep both panels open (horizontal scroll) instead of force-collapsing (LFE-10550)

### DIFF
--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -47,11 +47,37 @@ const RESIZABLE_PANEL_PREVIEW_ID = "trace-layout-panel-preview";
 const NAVIGATION_PANEL_MIN_PX = 260;
 const DETAIL_PANEL_MIN_PX = 360;
 const RESIZE_HANDLE_PX = 1;
+const COLLAPSED_PANEL_PX = 40;
 // Width below which the two mins can't both fit; at-or-above this the group
 // fills the container normally, below it the group keeps this width and the
 // wrapper scrolls horizontally.
 const BOTH_PANELS_MIN_WIDTH_PX =
   NAVIGATION_PANEL_MIN_PX + DETAIL_PANEL_MIN_PX + RESIZE_HANDLE_PX;
+
+// Detect whether a panel is sitting on its collapsed rail in a RESTORED layout.
+// `useDefaultLayout` returns a `{ [panelId]: number }` map of flexGrow shares
+// that sum to ~100 (percentages of the group). A collapsed panel is exactly its
+// `collapsedSize` (40px) wide, while an open panel is always at least its
+// `minSize` (260/360px). For any peek width those two ranges never overlap: at
+// the narrowest both-panels-open width (~621px) the 40px rail is ~6% while the
+// smaller open min (nav 260px) is ~42%, and the gap only widens as the group
+// grows. We therefore treat a panel as collapsed-in-layout when its restored
+// share is at most the share its rail would occupy at the narrowest open width,
+// with a margin — comfortably below any open-min share. Used only to seed the
+// collapse flags on mount so `bothPanelsOpen` (and thus the min-width pin)
+// matches the layout the library is about to restore, avoiding a one-frame
+// scrollbar flash (see the useState initializers below).
+const COLLAPSED_LAYOUT_SHARE_MAX_PCT =
+  ((COLLAPSED_PANEL_PX / BOTH_PANELS_MIN_WIDTH_PX) * 100 +
+    (NAVIGATION_PANEL_MIN_PX / BOTH_PANELS_MIN_WIDTH_PX) * 100) /
+  2;
+function isPanelCollapsedInLayout(
+  layout: Record<string, number> | undefined,
+  panelId: string,
+): boolean {
+  const share = layout?.[panelId];
+  return typeof share === "number" && share <= COLLAPSED_LAYOUT_SHARE_MAX_PCT;
+}
 
 // Context for sharing panel state with compound components
 interface TraceLayoutDesktopContext {
@@ -98,15 +124,33 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
   // Get annotation mode from context to determine initial collapse state
   const { isAnnotationMode } = useViewPreferences();
 
-  const [isNavigationPanelCollapsed, setIsNavigationPanelCollapsed] =
-    useState(isAnnotationMode);
+  // Restored (sessionStorage) layout for this group. Read before the collapse
+  // flags so we can seed them from what the library is about to restore on
+  // mount — otherwise the first render derives `bothPanelsOpen` purely from the
+  // useState defaults (open), pins the group to 621px even when a persisted
+  // layout has a panel on its 40px rail, and a narrow peek flashes a useless
+  // horizontal scrollbar until the Panel's onResize corrects the flag a frame
+  // later.
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: RESIZABLE_PANEL_GROUP_ID,
+    panelIds: [RESIZABLE_PANEL_NAVIGATION_ID, RESIZABLE_PANEL_PREVIEW_ID],
+    storage: sessionStorage,
+  });
+
+  const [isNavigationPanelCollapsed, setIsNavigationPanelCollapsed] = useState(
+    () =>
+      isAnnotationMode ||
+      isPanelCollapsedInLayout(defaultLayout, RESIZABLE_PANEL_NAVIGATION_ID),
+  );
 
   // Ref to programmatically control the panel
   const panelRef = usePanelRef();
 
   // Detail (info/preview) panel collapse state + control.
   const detailPanelRef = usePanelRef();
-  const [isDetailPanelCollapsed, setIsDetailPanelCollapsed] = useState(false);
+  const [isDetailPanelCollapsed, setIsDetailPanelCollapsed] = useState(() =>
+    isPanelCollapsedInLayout(defaultLayout, RESIZABLE_PANEL_PREVIEW_ID),
+  );
 
   // Group ref — drives the whole layout atomically (setLayout) when reopening a
   // collapsed panel, which is more robust than chaining the per-panel
@@ -163,9 +207,16 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
         const group = groupRef.current;
         const panel =
           target === "navigation" ? panelRef.current : detailPanelRef.current;
+        const siblingPanel =
+          target === "navigation" ? detailPanelRef.current : panelRef.current;
         const groupWidthPx =
           document.getElementById(RESIZABLE_PANEL_GROUP_ID)?.offsetWidth ?? 0;
         if (group && panel && groupWidthPx > 0) {
+          // Whether the sibling was deliberately collapsed (header toggle, rail
+          // button, or dragged onto its 40px rail). If so we keep it there:
+          // collapsing stays a manual action, so reopening one panel must not
+          // silently uncollapse the other (LFE-10550). Captured before expand().
+          const siblingCollapsed = siblingPanel?.isCollapsed() ?? false;
           panel.expand();
           const ownMinPx =
             target === "navigation"
@@ -175,24 +226,43 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
             target === "navigation"
               ? DETAIL_PANEL_MIN_PX
               : NAVIGATION_PANEL_MIN_PX;
-          const ownPx = Math.max(
-            ownMinPx,
-            Math.min(groupWidthPx / 2, groupWidthPx - siblingMinPx),
-          );
-          const ownPercent = (ownPx / groupWidthPx) * 100;
-          group.setLayout({
-            [RESIZABLE_PANEL_NAVIGATION_ID]:
-              target === "navigation" ? ownPercent : 100 - ownPercent,
-            [RESIZABLE_PANEL_PREVIEW_ID]:
-              target === "detail" ? ownPercent : 100 - ownPercent,
-          });
+          if (siblingCollapsed) {
+            // Sibling stays on its rail: give the target everything except the
+            // sibling's 40px rail. resize() (not the two-panel setLayout) leaves
+            // the collapsed sibling untouched so its onResize never fires.
+            const ownPx = Math.max(ownMinPx, groupWidthPx - COLLAPSED_PANEL_PX);
+            panel.resize(`${(ownPx / groupWidthPx) * 100}%`);
+          } else {
+            // Both open: balanced split that still leaves the sibling its min —
+            // groupWidth/2 clamped to [own min, groupWidth − sibling min]. On a
+            // too-narrow peek the upper clamp wins: target lands on its own min,
+            // sibling keeps its min (both at mins + horizontal scroll); on a wide
+            // peek it's a true 50/50.
+            const ownPx = Math.max(
+              ownMinPx,
+              Math.min(groupWidthPx / 2, groupWidthPx - siblingMinPx),
+            );
+            const ownPercent = (ownPx / groupWidthPx) * 100;
+            group.setLayout({
+              [RESIZABLE_PANEL_NAVIGATION_ID]:
+                target === "navigation" ? ownPercent : 100 - ownPercent,
+              [RESIZABLE_PANEL_PREVIEW_ID]:
+                target === "detail" ? ownPercent : 100 - ownPercent,
+            });
+          }
+          // Only update state when the expand actually applied (inside the
+          // guard) — otherwise the flags would flip to "open" while the library
+          // still has the panel collapsed, desyncing the min-width pin until the
+          // next onResize. Flip the target's flag before clearing pendingExpand
+          // so the group stays pinned across the render that clears the intent
+          // (otherwise it would briefly unpin and the solver could re-collapse
+          // the panel we just opened). The sibling's flag is left to its own
+          // onResize: when it stays collapsed nothing fires and the flag holds.
+          if (target === "navigation") setIsNavigationPanelCollapsed(false);
+          else setIsDetailPanelCollapsed(false);
         }
-        // Hand the pin to bothPanelsOpen via the collapse flags, then drop the
-        // transient intent. Order matters: flip the flags first so the group stays
-        // pinned across the render that clears pendingExpand (otherwise it would
-        // briefly unpin and the solver could re-collapse the panel we just opened).
-        if (target === "navigation") setIsNavigationPanelCollapsed(false);
-        else setIsDetailPanelCollapsed(false);
+        // Always clear the transient intent — even on a failed expand — so a
+        // later resize/onResize isn't blocked by a stale pendingExpand.
         setPendingExpand(null);
       });
     });
@@ -264,12 +334,6 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
     // Reset pulse when leaving timeline view
     setShouldPulseToggle(false);
   }, [isTimelineView]);
-
-  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-    id: RESIZABLE_PANEL_GROUP_ID,
-    panelIds: [RESIZABLE_PANEL_NAVIGATION_ID, RESIZABLE_PANEL_PREVIEW_ID],
-    storage: sessionStorage,
-  });
 
   const contextValue: TraceLayoutDesktopContext = {
     isNavigationPanelCollapsed,

--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -4,6 +4,7 @@ import {
   Separator,
   Panel,
   usePanelRef,
+  useGroupRef,
   useDefaultLayout,
   type PanelImperativeHandle,
 } from "react-resizable-panels";
@@ -28,16 +29,29 @@ const RESIZABLE_PANEL_NAVIGATION_ID = "trace-layout-panel-navigation";
 const RESIZABLE_PANEL_PREVIEW_ID = "trace-layout-panel-preview";
 
 // Min widths of the two collapsible panels (kept here so the Panel props and the
-// toggle logic below can't drift apart). In a narrow peek the container can be
-// too small to satisfy BOTH mins at once: react-resizable-panels' constraint
-// solver then refuses to grow one panel past the other's min and the layout is
-// left unchanged — which made expand() a silent no-op (LFE-10547). When that's
-// the case we collapse the opposite panel first so the one being opened has room.
+// toggle/scroll logic below can't drift apart).
+//
+// react-resizable-panels is percentage-based and its constraint solver refuses
+// to shrink a panel below its min. In a narrow peek the container can be too
+// small to satisfy BOTH mins at once. The previous fix (LFE-10547) reacted by
+// force-collapsing the opposite panel so only one was ever open when narrow —
+// too radical: users want both panels open at once.
+//
+// Instead we let BOTH panels stay open at their mins and make the peek scroll
+// horizontally: when both are open we pin the panel group to a min-width equal
+// to the sum of the mins (plus the 1px handle) inside an `overflow-x-auto`
+// wrapper. The library measures the group from its panels' own widths, so it
+// sees enough room for both mins and never collapses one — the overflow simply
+// scrolls. When either panel is collapsed the pin is dropped so the open panel
+// fills the available width as usual.
 const NAVIGATION_PANEL_MIN_PX = 260;
 const DETAIL_PANEL_MIN_PX = 360;
-// Small slack so we don't fight the solver on layouts that only just fit.
-const BOTH_PANELS_FIT_MIN_PX =
-  NAVIGATION_PANEL_MIN_PX + DETAIL_PANEL_MIN_PX + 8;
+const RESIZE_HANDLE_PX = 1;
+// Width below which the two mins can't both fit; at-or-above this the group
+// fills the container normally, below it the group keeps this width and the
+// wrapper scrolls horizontally.
+const BOTH_PANELS_MIN_WIDTH_PX =
+  NAVIGATION_PANEL_MIN_PX + DETAIL_PANEL_MIN_PX + RESIZE_HANDLE_PX;
 
 // Context for sharing panel state with compound components
 interface TraceLayoutDesktopContext {
@@ -94,34 +108,106 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
   const detailPanelRef = usePanelRef();
   const [isDetailPanelCollapsed, setIsDetailPanelCollapsed] = useState(false);
 
-  // Total width of the panel group, summed from both panels' current pixel
-  // sizes (the imperative handle has no group-size getter). Either ref alone
-  // covers the group: a collapsed panel still reports its 40px rail. 0 if the
-  // refs aren't mounted yet — callers treat that as "can't tell, don't gate".
-  const getGroupWidthPx = () => {
-    const nav = panelRef.current?.getSize().inPixels ?? 0;
-    const detail = detailPanelRef.current?.getSize().inPixels ?? 0;
-    return nav + detail;
-  };
-  // True when the container is too narrow to hold both panels at their mins, so
-  // opening one requires the other to yield (collapse) first.
-  const bothPanelsFit = () => {
-    const width = getGroupWidthPx();
-    return width === 0 || width >= BOTH_PANELS_FIT_MIN_PX;
-  };
+  // Group ref — drives the whole layout atomically (setLayout) when reopening a
+  // collapsed panel, which is more robust than chaining the per-panel
+  // expand()+resize() imperatives (those validate against a momentarily stale
+  // store and silently no-op on a narrow peek).
+  const groupRef = useGroupRef();
+
+  // Which collapsed panel a click asked to open, awaiting room. We pin the group
+  // (below) for it, let React commit the wider min-width to the DOM, then run
+  // the actual expand from the effect — so the solver has room for both mins.
+  // Without this, expanding while the peek is too narrow for both mins is a
+  // silent no-op: the group stays at its current width and the solver refuses to
+  // shrink the open panel below its min (the original LFE-10547 symptom).
+  const [pendingExpand, setPendingExpand] = useState<
+    "navigation" | "detail" | null
+  >(null);
+
+  // Both panels open (neither collapsed) — drives the min-width pin on the group
+  // so a too-narrow peek scrolls horizontally instead of force-collapsing one.
+  // When either is collapsed the pin is dropped so the open panel fills the
+  // width. Mirrors the two collapse flags (kept in sync by each Panel's
+  // onResize) rather than reading the refs, so it re-renders the group; a
+  // `pendingExpand` keeps the pin on while a click's expand is in flight.
+  const bothPanelsOpen =
+    pendingExpand !== null ||
+    (!isNavigationPanelCollapsed && !isDetailPanelCollapsed);
+
+  // Reopen the queued panel once the pin's wider min-width has taken effect.
+  //
+  // Subtlety: setting `pendingExpand` commits `min-width: <sum of mins>` to the
+  // GROUP element, growing it so there's room for both mins (the wrapper
+  // scrolls). But react-resizable-panels derives its internal group size from
+  // the summed widths of its panels, and only recomputes that when its own
+  // ResizeObserver notices the group element grew — which is delivered a couple
+  // of frames later. Until then the library still thinks the group is the old
+  // (too-narrow) width, so expanding clamps the panel straight back to its
+  // collapsed rail (the silent no-op behind LFE-10547). We therefore defer the
+  // reopen across two animation frames, by which point the observer has fired
+  // and the library sees the full width.
+  //
+  // expand() alone can also land on a degenerate size (LFE-10550): it restores
+  // the panel's pre-collapse size, which may swallow the whole peek or sit below
+  // its min. So after expanding we set the whole layout explicitly to a balanced
+  // split that still leaves the sibling its min — groupWidth/2 clamped to
+  // [own min, groupWidth − sibling min]. On a too-narrow peek the upper clamp
+  // wins: the panel lands on its own min and the sibling keeps its min (both at
+  // mins + horizontal scroll); on a wide peek it's a true 50/50.
+  useEffect(() => {
+    if (!pendingExpand) return;
+    const target = pendingExpand;
+    let innerRaf = 0;
+    const outerRaf = requestAnimationFrame(() => {
+      innerRaf = requestAnimationFrame(() => {
+        const group = groupRef.current;
+        const panel =
+          target === "navigation" ? panelRef.current : detailPanelRef.current;
+        const groupWidthPx =
+          document.getElementById(RESIZABLE_PANEL_GROUP_ID)?.offsetWidth ?? 0;
+        if (group && panel && groupWidthPx > 0) {
+          panel.expand();
+          const ownMinPx =
+            target === "navigation"
+              ? NAVIGATION_PANEL_MIN_PX
+              : DETAIL_PANEL_MIN_PX;
+          const siblingMinPx =
+            target === "navigation"
+              ? DETAIL_PANEL_MIN_PX
+              : NAVIGATION_PANEL_MIN_PX;
+          const ownPx = Math.max(
+            ownMinPx,
+            Math.min(groupWidthPx / 2, groupWidthPx - siblingMinPx),
+          );
+          const ownPercent = (ownPx / groupWidthPx) * 100;
+          group.setLayout({
+            [RESIZABLE_PANEL_NAVIGATION_ID]:
+              target === "navigation" ? ownPercent : 100 - ownPercent,
+            [RESIZABLE_PANEL_PREVIEW_ID]:
+              target === "detail" ? ownPercent : 100 - ownPercent,
+          });
+        }
+        // Hand the pin to bothPanelsOpen via the collapse flags, then drop the
+        // transient intent. Order matters: flip the flags first so the group stays
+        // pinned across the render that clears pendingExpand (otherwise it would
+        // briefly unpin and the solver could re-collapse the panel we just opened).
+        if (target === "navigation") setIsNavigationPanelCollapsed(false);
+        else setIsDetailPanelCollapsed(false);
+        setPendingExpand(null);
+      });
+    });
+    return () => {
+      cancelAnimationFrame(outerRaf);
+      cancelAnimationFrame(innerRaf);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingExpand]);
 
   // Guarded so it's a no-op (not a resize) when already open — safe to call on
   // every row click, which is how re-selecting the same node reopens it.
   const expandDetailPanel = () => {
     if (!detailPanelRef.current?.isCollapsed()) return;
-    // Narrow peek: both mins can't coexist, so the solver would refuse to grow
-    // the detail panel and expand() would no-op. Collapse the nav panel first
-    // so the detail panel has room (LFE-10547).
-    if (!bothPanelsFit() && !panelRef.current?.isCollapsed()) {
-      panelRef.current?.collapse();
-      setIsNavigationPanelCollapsed(true);
-    }
-    detailPanelRef.current.expand();
+    setPendingExpand("detail");
   };
 
   // Selecting another node (timeline/tree) while the detail panel is collapsed
@@ -149,19 +235,16 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // v4 has built-in collapse()/expand() that remembers last size
+  // Manual toggle for the navigation panel (header button + handle double-click).
+  // Collapse stays fully manual; expanding restores a balanced size so the nav
+  // panel never swallows the whole peek, and both panels can be open at once —
+  // a too-narrow peek scrolls horizontally rather than collapsing the detail
+  // panel (LFE-10550).
   const handleTogglePanel = () => {
     if (!panelRef.current) return;
 
     if (panelRef.current.isCollapsed()) {
-      // Narrow peek: both mins can't coexist, so the solver would refuse to grow
-      // the nav panel and expand() would silently no-op (the reported bug). Make
-      // the detail panel yield first so the nav panel has room (LFE-10547).
-      if (!bothPanelsFit() && !detailPanelRef.current?.isCollapsed()) {
-        detailPanelRef.current?.collapse();
-        setIsDetailPanelCollapsed(true);
-      }
-      panelRef.current.expand();
+      setPendingExpand("navigation");
     } else {
       panelRef.current.collapse();
     }
@@ -202,12 +285,26 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
 
   return (
     <LayoutContext.Provider value={contextValue}>
-      <div className="relative h-full w-full">
+      {/* Horizontal-scroll wrapper: when both panels are open we pin the panel
+          group to the sum of the two mins so a peek too narrow for both keeps
+          them at their mins and scrolls horizontally instead of force-collapsing
+          one (LFE-10550). The library can't override `width`/`min-width` on the
+          group's own style, so the pin lives there; the wrapper owns the scroll.
+          When either panel is collapsed there's no pin and the group fills the
+          width (`min-w-0`) as before. */}
+      <div className="relative h-full w-full overflow-x-auto overflow-y-hidden">
         <Group
           orientation="horizontal"
           id={RESIZABLE_PANEL_GROUP_ID}
+          groupRef={groupRef}
           defaultLayout={defaultLayout}
           onLayoutChanged={isAnnotationMode ? undefined : onLayoutChanged}
+          className={bothPanelsOpen ? undefined : "min-w-0"}
+          style={
+            bothPanelsOpen
+              ? { minWidth: `${BOTH_PANELS_MIN_WIDTH_PX}px` }
+              : undefined
+          }
         >
           {children}
         </Group>


### PR DESCRIPTION
## TL;DR

At a narrow peek width the trace peek used to **force-collapse one panel** so only the tree/timeline *or* the detail panel could be open — and expanding a collapsed panel made it **take the whole space**. This reworks that: both panels can now stay open, expanding restores a **balanced split**, and when the peek is too narrow for both min widths the panels **keep their mins and the peek scrolls horizontally** instead of collapsing one. Reworks #14601 (LFE-10547).

Linear: LFE-10550

## Why

The peek's two panels (tree/timeline ↔ detail) have min widths of 260px and 360px. `react-resizable-panels` is percentage-based and its solver refuses to shrink a panel below its min, so a narrow peek can't satisfy both at once. The previous fix reacted by collapsing the opposite panel — only one panel open when narrow. That was too radical: people legitimately want both panels open side by side, even if it means scrolling. And separately, expanding a collapsed panel restored its pre-collapse size, which was often the near-full width it held right before collapsing — so "expand" looked like "take the whole space."

## What

- **Both panels can be open at once.** Auto/force collapse-the-opposite is gone. Collapsing stays a manual action (rail button, header toggle, handle double-click).
- **Too-narrow peek → horizontal scroll, mins respected.** When both panels are open the panel group is pinned to a `min-width` equal to the sum of the two mins inside an `overflow-x-auto` wrapper. If the peek is narrower than that, each panel stays at its min and the peek scrolls horizontally rather than collapsing one.
- **Expand restores a balanced split, never the whole peek.** Reopening a collapsed panel targets `groupWidth / 2`, clamped so the sibling keeps its min. Wide peek → true 50/50; narrow peek → both land on their mins (+ scroll).

## Result

Verified in-browser (Playwright) across widths against a seeded trace peek:

| Scenario | Result |
| --- | --- |
| Wide — expand either panel | balanced 50/50, both open (not whole-space) |
| Medium | both open at comfortable sizes |
| Narrow (< sum of mins) | both stay at their mins, peek scrolls horizontally, nothing force-collapsed |
| Manual collapse + re-expand (narrow & wide) | works from header toggle and the detail rail; reopen is no longer a silent no-op |

<details>
<summary>Mechanism & edge cases</summary>

- **The min-width pin** lives on the `Group`'s own style (`min-width: 260+360+1`). The library forbids overriding `display`/`flex-direction`/`flex-wrap` on the group but *not* `width`/`min-width`, so the pin is safe; the `overflow-x-auto` wrapper owns the scroll. The pin is applied only while **both** panels are open (`bothPanelsOpen`); when either is collapsed it's dropped so the open panel fills the width as before.
- **Reopen sequencing.** Setting the pin grows the group element, but the library derives its internal group size from the summed panel widths and only recomputes when its `ResizeObserver` fires — a couple of frames later. Expanding synchronously would still see the old (too-narrow) size and clamp the panel back to its rail (the original LFE-10547 silent no-op). So a click queues `pendingExpand` (which holds the pin), and the actual reopen runs after two `requestAnimationFrame`s — by which point the observer has run and there's room for both mins. The reopen then sets the whole layout atomically via the group's `setLayout` (more robust than chaining the per-panel `expand()` + `resize()`, which validate against a momentarily stale store and quietly fail).
- **No-op safety.** `expandDetailPanel` (called on every row click / node re-selection) early-returns when the detail panel is already open, so it never spuriously re-pins or resizes.
- Scope is a single component (`TraceLayoutDesktop.tsx`); typecheck + full lint pass.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the previous narrow-peek workaround (force-collapsing the opposite panel) with a horizontal-scroll approach: when both panels are open the panel group is pinned to the sum of both panel minimums (`260 + 360 + 1 = 621px`) inside an `overflow-x-auto` wrapper, so each panel can stay at its minimum width and the peek scrolls rather than collapsing. Reopening a collapsed panel is now deferred across two `requestAnimationFrame` calls to let the library's `ResizeObserver` pick up the new min-width before `setLayout` is called, and the restored split is computed as `groupWidth / 2` clamped so the sibling always keeps its minimum.

- Removes all auto-collapse-the-opposite logic; collapsing is now entirely manual (header button, handle double-click, or drag below min).
- Introduces `pendingExpand` state and a `useGroupRef`-driven `setLayout` call to atomically set a balanced 50/50 split when a collapsed panel is reopened, replacing the fragile `expand()` + `resize()` chain.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is scoped to a single layout component and the core approach — min-width pin + horizontal scroll instead of forced panel collapse — is sound. The two-rAF defer and atomic setLayout are well-reasoned; normal collapse/expand flows work correctly.

The only code-level concern is that the collapse-flag setters and `setPendingExpand(null)` fire unconditionally outside the `if (group && panel && groupWidthPx > 0)` guard. A failed expand (null refs or zero width after the rAF delay, which is very unlikely for a mounted component) would leave React's collapse flags flipped while the library still considers the panel collapsed. It is an edge case but represents a genuine state inconsistency path.

web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx — specifically the unconditional state updates at the end of the double-rAF callback.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Component as TraceLayoutDesktop
    participant Library as react-resizable-panels
    participant DOM

    User->>Component: click toggle / row (collapsed panel)
    Component->>Component: "setPendingExpand("navigation"|"detail")"
    Note over Component: bothPanelsOpen=true → pin min-width on Group
    Component->>DOM: render min-width:621px on Group element
    DOM-->>Library: ResizeObserver fires (1-2 rAFs later)
    Library->>Library: recompute internal group width

    Note over Component: rAF 1 fires
    Note over Component: rAF 2 fires — library now sees full width

    Component->>Library: panel.expand()
    Component->>Library: "group.setLayout({nav: ownPercent, preview: 100-ownPercent})"
    Library->>DOM: resize both panels to balanced split
    Component->>Component: setIsXxxCollapsed(false) + setPendingExpand(null)
    Note over Component: bothPanelsOpen stays true via collapse flags

    User->>Component: manual collapse (button / drag)
    Component->>Library: panelRef.current.collapse()
    Library-->>Component: onResize → setIsXxxCollapsed(true)
    Note over Component: bothPanelsOpen=false → pin dropped, group fills container
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Component as TraceLayoutDesktop
    participant Library as react-resizable-panels
    participant DOM

    User->>Component: click toggle / row (collapsed panel)
    Component->>Component: "setPendingExpand("navigation"|"detail")"
    Note over Component: bothPanelsOpen=true → pin min-width on Group
    Component->>DOM: render min-width:621px on Group element
    DOM-->>Library: ResizeObserver fires (1-2 rAFs later)
    Library->>Library: recompute internal group width

    Note over Component: rAF 1 fires
    Note over Component: rAF 2 fires — library now sees full width

    Component->>Library: panel.expand()
    Component->>Library: "group.setLayout({nav: ownPercent, preview: 100-ownPercent})"
    Library->>DOM: resize both panels to balanced split
    Component->>Component: setIsXxxCollapsed(false) + setPendingExpand(null)
    Note over Component: bothPanelsOpen stays true via collapse flags

    User->>Component: manual collapse (button / drag)
    Component->>Library: panelRef.current.collapse()
    Library-->>Component: onResize → setIsXxxCollapsed(true)
    Note over Component: bothPanelsOpen=false → pin dropped, group fills container
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx:190-196
**State update outside the guard block**

`setIsNavigationPanelCollapsed(false)` / `setIsDetailPanelCollapsed(false)` and `setPendingExpand(null)` are called unconditionally even when the `if (group && panel && groupWidthPx > 0)` guard fails. If any of those conditions are falsy after the two rAFs (e.g., the component re-mounted between renders, or the group element has no layout yet), the actual `expand()` / `setLayout()` calls are skipped but the React flags are flipped as if they succeeded. After that: `bothPanelsOpen` becomes `true` (min-width pin stays on), the context reports the panel as open, and the library's internal state still has the panel collapsed — a desync that persists until the next `onResize` event.

The state updates should be moved inside the `if` block, with an `else` that only clears `pendingExpand` (without flipping the collapse flag) so failed expansions don't corrupt state.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): let the peek keep both panel..."](https://github.com/langfuse/langfuse/commit/984e6b3fa65ff0612b7c6e49a750b49440bb2347) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40156907)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->