### PR TITLE
feat: add missing gemini models to default pricing

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2,7 +2,7 @@
   {
     "id": "b9854a5c92dc496b997d99d20",
     "modelName": "gpt-4o",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o)$",
     "createdAt": "2024-05-13T23:15:07.670Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -30,7 +30,7 @@
   {
     "id": "b9854a5c92dc496b997d99d21",
     "modelName": "gpt-4o-2024-05-13",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-05-13)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-05-13)$",
     "createdAt": "2024-05-13T23:15:07.670Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -56,7 +56,7 @@
   {
     "id": "clrkvq6iq000008ju6c16gynt",
     "modelName": "gpt-4-1106-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-1106-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-1106-preview)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -82,7 +82,7 @@
   {
     "id": "clrkvx5gp000108juaogs54ea",
     "modelName": "gpt-4-turbo-vision",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4(-\\d{4})?-vision-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4(-\\d{4})?-vision-preview)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -108,7 +108,7 @@
   {
     "id": "clrkvyzgw000308jue4hse4j9",
     "modelName": "gpt-4-32k",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-32k)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -134,7 +134,7 @@
   {
     "id": "clrkwk4cb000108l5hwwh3zdi",
     "modelName": "gpt-4-32k-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-32k-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -160,7 +160,7 @@
   {
     "id": "clrkwk4cb000208l59yvb9yq8",
     "modelName": "gpt-3.5-turbo-1106",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-1106)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-1106)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -186,7 +186,7 @@
   {
     "id": "clrkwk4cc000808l51xmk4uic",
     "modelName": "gpt-3.5-turbo-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -212,7 +212,7 @@
   {
     "id": "clrkwk4cc000908l537kl0rx3",
     "modelName": "gpt-4-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -238,7 +238,7 @@
   {
     "id": "clrkwk4cc000a08l562uc3s9g",
     "modelName": "gpt-3.5-turbo-instruct",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-instruct)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-instruct)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -448,7 +448,7 @@
   {
     "id": "clrntjt89000a08jw0gcdbd5a",
     "modelName": "gpt-3.5-turbo-16k-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-16k-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-16k-0613)$",
     "createdAt": "2024-02-03T17:29:57.350Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -474,7 +474,7 @@
   {
     "id": "clrntkjgy000a08jx4e062mr0",
     "modelName": "gpt-3.5-turbo-0301",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0301)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0301)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -500,7 +500,7 @@
   {
     "id": "clrntkjgy000d08jx0p4y9h4l",
     "modelName": "gpt-4-32k-0314",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k-0314)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-32k-0314)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -526,7 +526,7 @@
   {
     "id": "clrntkjgy000e08jx4x6uawoo",
     "modelName": "gpt-4-0314",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-0314)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-0314)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -552,7 +552,7 @@
   {
     "id": "clrntkjgy000f08jx79v9g1xj",
     "modelName": "gpt-4",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -578,7 +578,7 @@
   {
     "id": "clrnwb41q000308jsfrac9uh6",
     "modelName": "claude-instant-1.2",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-instant-1.2)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-instant-1.2)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -599,7 +599,7 @@
   {
     "id": "clrnwb836000408jsallr6u11",
     "modelName": "claude-2.0",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-2.0)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-2.0)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -620,7 +620,7 @@
   {
     "id": "clrnwbd1m000508js4hxu6o7n",
     "modelName": "claude-2.1",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-2.1)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-2.1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -641,7 +641,7 @@
   {
     "id": "clrnwbg2b000608jse2pp4q2d",
     "modelName": "claude-1.3",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-1.3)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-1.3)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -662,7 +662,7 @@
   {
     "id": "clrnwbi9d000708jseiy44k26",
     "modelName": "claude-1.2",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-1.2)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-1.2)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -683,7 +683,7 @@
   {
     "id": "clrnwblo0000808jsc1385hdp",
     "modelName": "claude-1.1",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-1.1)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-1.1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -704,7 +704,7 @@
   {
     "id": "clrnwbota000908jsgg9mb1ml",
     "modelName": "claude-instant-1",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-instant-1)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-instant-1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -819,7 +819,7 @@
   {
     "id": "clruwnahl00030al7ab9rark7",
     "modelName": "gpt-3.5-turbo-0125",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0125)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0125)$",
     "createdAt": "2024-01-26T17:35:21.129Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -845,7 +845,7 @@
   {
     "id": "clruwnahl00040al78f1lb0at",
     "modelName": "gpt-3.5-turbo",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo)$",
     "createdAt": "2024-02-13T12:00:37.424Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -871,7 +871,7 @@
   {
     "id": "clruwnahl00050al796ck3p44",
     "modelName": "gpt-4-0125-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-0125-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-0125-preview)$",
     "createdAt": "2024-01-26T17:35:21.129Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1235,7 +1235,7 @@
   {
     "id": "clsk9lntu000008jwfc51bbqv",
     "modelName": "gpt-3.5-turbo-16k",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-16k)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-16k)$",
     "createdAt": "2024-02-13T12:00:37.424Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1261,7 +1261,7 @@
   {
     "id": "clsnq07bn000008l4e46v1ll8",
     "modelName": "gpt-4-turbo-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo-preview)$",
     "createdAt": "2024-02-15T21:21:50.947Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1287,7 +1287,7 @@
   {
     "id": "cltgy0iuw000008le3vod1hhy",
     "modelName": "claude-3-opus-20240229",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-opus-20240229|anthropic\\.claude-3-opus-20240229-v1:0|claude-3-opus@20240229)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-opus-20240229|anthropic\\.claude-3-opus-20240229-v1:0|claude-3-opus@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1308,7 +1308,7 @@
   {
     "id": "cltgy0pp6000108le56se7bl3",
     "modelName": "claude-3-sonnet-20240229",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-sonnet-20240229|anthropic\\.claude-3-sonnet-20240229-v1:0|claude-3-sonnet@20240229)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-sonnet-20240229|anthropic\\.claude-3-sonnet-20240229-v1:0|claude-3-sonnet@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1338,7 +1338,7 @@
   {
     "id": "cltr0w45b000008k1407o9qv1",
     "modelName": "claude-3-haiku-20240307",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-haiku-20240307|anthropic\\.claude-3-haiku-20240307-v1:0|claude-3-haiku@20240307)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-haiku-20240307|anthropic\\.claude-3-haiku-20240307-v1:0|claude-3-haiku@20240307)$",
     "createdAt": "2024-03-14T09:41:18.736Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1359,7 +1359,7 @@
   {
     "id": "cluv2sjeo000008ih0fv23hi0",
     "modelName": "gemini-1.0-pro-latest",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-1.0-pro-latest)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-1.0-pro-latest)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -1379,7 +1379,7 @@
   {
     "id": "cluv2subq000108ih2mlrga6a",
     "modelName": "gemini-1.0-pro",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-1.0-pro)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-1.0-pro)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -1399,7 +1399,7 @@
   {
     "id": "cluv2sx04000208ihbek75lsz",
     "modelName": "gemini-1.0-pro-001",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-1.0-pro-001)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-1.0-pro-001)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -1419,7 +1419,7 @@
   {
     "id": "cluv2szw0000308ihch3n79x7",
     "modelName": "gemini-pro",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-pro)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-pro)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -1439,7 +1439,7 @@
   {
     "id": "cluv2t2x0000408ihfytl45l1",
     "modelName": "gemini-1.5-pro-latest",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-1.5-pro-latest)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-1.5-pro-latest)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -1459,7 +1459,7 @@
   {
     "id": "cluv2t5k3000508ih5kve9zag",
     "modelName": "gpt-4-turbo-2024-04-09",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo-2024-04-09)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo-2024-04-09)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1485,7 +1485,7 @@
   {
     "id": "cluvpl4ls000008l6h2gx3i07",
     "modelName": "gpt-4-turbo",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo)$",
     "createdAt": "2024-04-11T21:13:44.989Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1511,7 +1511,7 @@
   {
     "id": "clv2o2x0p000008jsf9afceau",
     "modelName": " gpt-4-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-preview)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1537,7 +1537,7 @@
   {
     "id": "clxt0n0m60000pumz1j5b7zsf",
     "modelName": "claude-3-5-sonnet-20240620",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
     "createdAt": "2024-06-25T11:47:24.475Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1567,7 +1567,7 @@
   {
     "id": "clyrjp56f0000t0mzapoocd7u",
     "modelName": "gpt-4o-mini",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-mini)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-mini)$",
     "createdAt": "2024-07-18T17:56:09.591Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1595,7 +1595,7 @@
   {
     "id": "clyrjpbe20000t0mzcbwc42rg",
     "modelName": "gpt-4o-mini-2024-07-18",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-mini-2024-07-18)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-mini-2024-07-18)$",
     "createdAt": "2024-07-18T17:56:09.591Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1623,7 +1623,7 @@
   {
     "id": "clzjr85f70000ymmzg7hqffra",
     "modelName": "gpt-4o-2024-08-06",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-08-06)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-08-06)$",
     "createdAt": "2024-08-07T11:54:31.298Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1651,7 +1651,7 @@
   {
     "id": "cm10ivcdp0000gix7lelmbw80",
     "modelName": "o1-preview",
-    "matchPattern": "(?i)^(openai\/)?(o1-preview)$",
+    "matchPattern": "(?i)^(openai/)?(o1-preview)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1675,7 +1675,7 @@
   {
     "id": "cm10ivo130000n8x7qopcjjcg",
     "modelName": "o1-preview-2024-09-12",
-    "matchPattern": "(?i)^(openai\/)?(o1-preview-2024-09-12)$",
+    "matchPattern": "(?i)^(openai/)?(o1-preview-2024-09-12)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1699,7 +1699,7 @@
   {
     "id": "cm10ivwo40000r1x7gg3syjq0",
     "modelName": "o1-mini",
-    "matchPattern": "(?i)^(openai\/)?(o1-mini)$",
+    "matchPattern": "(?i)^(openai/)?(o1-mini)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1723,7 +1723,7 @@
   {
     "id": "cm10iw6p20000wgx7it1hlb22",
     "modelName": "o1-mini-2024-09-12",
-    "matchPattern": "(?i)^(openai\/)?(o1-mini-2024-09-12)$",
+    "matchPattern": "(?i)^(openai/)?(o1-mini-2024-09-12)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1747,7 +1747,7 @@
   {
     "id": "cm2krz1uf000208jjg5653iud",
     "modelName": "claude-3.5-sonnet-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
     "createdAt": "2024-10-22T18:48:01.676Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1777,7 +1777,7 @@
   {
     "id": "cm2ks2vzn000308jjh4ze1w7q",
     "modelName": "claude-3.5-sonnet-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-latest)$",
     "createdAt": "2024-10-22T18:48:01.676Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1807,7 +1807,7 @@
   {
     "id": "cm34aq60d000207ml0j1h31ar",
     "modelName": "claude-3-5-haiku-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1837,7 +1837,7 @@
   {
     "id": "cm34aqb9h000307ml6nypd618",
     "modelName": "claude-3.5-haiku-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-haiku-latest)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1893,7 +1893,7 @@
   {
     "id": "cm48akqgo000008ldbia24qg0",
     "modelName": "gpt-4o-2024-11-20",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-11-20)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-11-20)$",
     "createdAt": "2024-12-03T10:06:12.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1921,7 +1921,7 @@
   {
     "id": "cm48b2ksh000008l0hn3u0hl3",
     "modelName": "gpt-4o-audio-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-audio-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-audio-preview)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1945,7 +1945,7 @@
   {
     "id": "cm48bbm0k000008l69nsdakwf",
     "modelName": "gpt-4o-audio-preview-2024-10-01",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-audio-preview-2024-10-01)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-audio-preview-2024-10-01)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1969,7 +1969,7 @@
   {
     "id": "cm48c2qh4000008mhgy4mg2qc",
     "modelName": "gpt-4o-realtime-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-realtime-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-realtime-preview)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1995,7 +1995,7 @@
   {
     "id": "cm48cjxtc000008jrcsso3avv",
     "modelName": "gpt-4o-realtime-preview-2024-10-01",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-realtime-preview-2024-10-01)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-realtime-preview-2024-10-01)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2021,7 +2021,7 @@
   {
     "id": "cm48cjxtc000108jrcsso3avv",
     "modelName": "o1",
-    "matchPattern": "(?i)^(openai\/)?(o1)$",
+    "matchPattern": "(?i)^(openai/)?(o1)$",
     "createdAt": "2025-01-17T00:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2045,7 +2045,7 @@
   {
     "id": "cm48cjxtc000208jrcsso3avv",
     "modelName": "o1-2024-12-17",
-    "matchPattern": "(?i)^(openai\/)?(o1-2024-12-17)$",
+    "matchPattern": "(?i)^(openai/)?(o1-2024-12-17)$",
     "createdAt": "2025-01-17T00:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2069,7 +2069,7 @@
   {
     "id": "cm6l8j7vs0000tymz9vk7ew8t",
     "modelName": "o3-mini",
-    "matchPattern": "(?i)^(openai\/)?(o3-mini)$",
+    "matchPattern": "(?i)^(openai/)?(o3-mini)$",
     "createdAt": "2025-01-31T20:41:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2093,7 +2093,7 @@
   {
     "id": "cm6l8jan90000tymz52sh0ql8",
     "modelName": "o3-mini-2025-01-31",
-    "matchPattern": "(?i)^(openai\/)?(o3-mini-2025-01-31)$",
+    "matchPattern": "(?i)^(openai/)?(o3-mini-2025-01-31)$",
     "createdAt": "2025-01-31T20:41:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2117,7 +2117,7 @@
   {
     "id": "cm6l8jdef0000tymz52sh0ql0",
     "modelName": "gemini-2.0-flash-001",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.0-flash-001)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.0-flash-001)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-02-06T11:11:35.241Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -2137,7 +2137,7 @@
   {
     "id": "cm6l8jfgh0000tymz52sh0ql1",
     "modelName": "gemini-2.0-flash-lite-preview-02-05",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.0-flash-lite-preview-02-05)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.0-flash-lite-preview-02-05)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-02-06T11:11:35.241Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -2157,7 +2157,7 @@
   {
     "id": "cm7ka7561000108js3t9tb3at",
     "modelName": "claude-3.7-sonnet-20250219",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2187,7 +2187,7 @@
   {
     "id": "cm7ka7zob000208jsfs9h5ajj",
     "modelName": "claude-3.7-sonnet-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-7-sonnet-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-7-sonnet-latest)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2217,7 +2217,7 @@
   {
     "id": "cm7nusjvk0000tvmz71o85jwg",
     "modelName": "gpt-4.5-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.5-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.5-preview)$",
     "createdAt": "2025-02-27T21:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2240,7 +2240,7 @@
   {
     "id": "cm7nusn640000tvmzf10z2x65",
     "modelName": "gpt-4.5-preview-2025-02-27",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.5-preview-2025-02-27)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.5-preview-2025-02-27)$",
     "createdAt": "2025-02-27T21:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2263,7 +2263,7 @@
   {
     "id": "cm7nusn643377tvmzh27m33kl",
     "modelName": "gpt-4.1",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2292,7 +2292,7 @@
   {
     "id": "cm7qahw732891bpmzy45r3x70",
     "modelName": "gpt-4.1-2025-04-14",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-2025-04-14)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2321,7 +2321,7 @@
   {
     "id": "cm7sglt825463kxnza72p6v81",
     "modelName": "gpt-4.1-mini-2025-04-14",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-mini-2025-04-14)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-mini-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2350,7 +2350,7 @@
   {
     "id": "cm7vxpz967124dhjtb95w8f92",
     "modelName": "gpt-4.1-nano-2025-04-14",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-nano-2025-04-14)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-nano-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2379,7 +2379,7 @@
   {
     "id": "cm7wmny967124dhjtb95w8f81",
     "modelName": "o3",
-    "matchPattern": "(?i)^(openai\/)?(o3)$",
+    "matchPattern": "(?i)^(openai/)?(o3)$",
     "createdAt": "2025-04-16T23:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2403,7 +2403,7 @@
   {
     "id": "cm7wopq3327124dhjtb95w8f81",
     "modelName": "o3-2025-04-16",
-    "matchPattern": "(?i)^(openai\/)?(o3-2025-04-16)$",
+    "matchPattern": "(?i)^(openai/)?(o3-2025-04-16)$",
     "createdAt": "2025-04-16T23:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2475,7 +2475,7 @@
   {
     "id": "cm7zsrs1327124dhjtb95w8f74",
     "modelName": "gemini-2.0-flash",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.0-flash)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.0-flash)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -2495,7 +2495,7 @@
   {
     "id": "cm7ztrs1327124dhjtb95w8f19",
     "modelName": "gemini-2.0-flash-lite-preview",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.0-flash-lite-preview)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.0-flash-lite-preview)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -2515,7 +2515,7 @@
   {
     "id": "cm7zxrs1327124dhjtb95w8f45",
     "modelName": "gpt-4.1-nano",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-nano)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-nano)$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2544,7 +2544,7 @@
   {
     "id": "cm7zzrs1327124dhjtb95w8p96",
     "modelName": "gpt-4.1-mini",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-mini)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-mini)$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2573,7 +2573,7 @@
   {
     "id": "c5qmrqolku82tra3vgdixmys",
     "modelName": "claude-sonnet-4-5-20250929",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
     "createdAt": "2025-09-29T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2630,7 +2630,7 @@
   {
     "id": "cmazmkzlm00000djp1e1qe4k4",
     "modelName": "claude-sonnet-4-20250514",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?-v1(:0)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?-v1(:0)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2660,7 +2660,7 @@
   {
     "id": "cmazmlbnv00010djpazed91va",
     "modelName": "claude-sonnet-4-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4-latest)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2690,7 +2690,7 @@
   {
     "id": "cmazmlm2p00020djpa9s64jw5",
     "modelName": "claude-opus-4-20250514",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2720,7 +2720,7 @@
   {
     "id": "cmz9x72kq55721pqrs83y4n2bx",
     "modelName": "o3-pro",
-    "matchPattern": "(?i)^(openai\/)?(o3-pro)$",
+    "matchPattern": "(?i)^(openai/)?(o3-pro)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2742,7 +2742,7 @@
   {
     "id": "cmz9x72kq55721pqrs83y4n2by",
     "modelName": "o3-pro-2025-06-10",
-    "matchPattern": "(?i)^(openai\/)?(o3-pro-2025-06-10)$",
+    "matchPattern": "(?i)^(openai/)?(o3-pro-2025-06-10)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2764,7 +2764,7 @@
   {
     "id": "cmbrold5b000107lbftb9fdoo",
     "modelName": "o1-pro",
-    "matchPattern": "(?i)^(openai\/)?(o1-pro)$",
+    "matchPattern": "(?i)^(openai/)?(o1-pro)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2786,7 +2786,7 @@
   {
     "id": "cmbrolpax000207lb3xkedysz",
     "modelName": "o1-pro-2025-03-19",
-    "matchPattern": "(?i)^(openai\/)?(o1-pro-2025-03-19)$",
+    "matchPattern": "(?i)^(openai/)?(o1-pro-2025-03-19)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2808,7 +2808,7 @@
   {
     "id": "cmcnjkfwn000107l43bf5e8ax",
     "modelName": "gemini-2.5-flash",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.5-flash)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.5-flash)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -2842,7 +2842,7 @@
   {
     "id": "cmcnjkrfa000207l4fpnh5mnv",
     "modelName": "gemini-2.5-flash-lite",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.5-flash-lite)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.5-flash-lite)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -2876,7 +2876,7 @@
   {
     "id": "cmdysde5w0000rkmzbc1g5au3",
     "modelName": "claude-opus-4-1-20250805",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
     "createdAt": "2025-08-05T15:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2906,7 +2906,7 @@
   {
     "id": "38c3822a-09a3-457b-b200-2c6f17f7cf2f",
     "modelName": "gpt-5",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2936,7 +2936,7 @@
   {
     "id": "12543803-2d5f-4189-addc-821ad71c8b55",
     "modelName": "gpt-5-2025-08-07",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-2025-08-07)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2966,7 +2966,7 @@
   {
     "id": "3d6a975a-a42d-4ea2-a3ec-4ae567d5a364",
     "modelName": "gpt-5-mini",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-mini)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-mini)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2996,7 +2996,7 @@
   {
     "id": "03b83894-7172-4e1e-8e8b-37d792484efd",
     "modelName": "gpt-5-mini-2025-08-07",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-mini-2025-08-07)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-mini-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3026,7 +3026,7 @@
   {
     "id": "f0b40234-b694-4c40-9494-7b0efd860fb9",
     "modelName": "gpt-5-nano",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-nano)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-nano)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3056,7 +3056,7 @@
   {
     "id": "4489fde4-a594-4011-948b-526989300cd3",
     "modelName": "gpt-5-nano-2025-08-07",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-nano-2025-08-07)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-nano-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3086,7 +3086,7 @@
   {
     "id": "8ba72ee3-ebe8-4110-a614-bf81094447e5",
     "modelName": "gpt-5-chat-latest",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-chat-latest)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-chat-latest)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3116,7 +3116,7 @@
   {
     "id": "cmgg9zco3000004l258um9xk8",
     "modelName": "gpt-5-pro",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-pro)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-pro)$",
     "createdAt": "2025-10-07T08:03:54.727Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3144,7 +3144,7 @@
   {
     "id": "cmgga0vh9000104l22qe4fes4",
     "modelName": "gpt-5-pro-2025-10-06",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-pro-2025-10-06)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-pro-2025-10-06)$",
     "createdAt": "2025-10-07T08:03:54.727Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3172,7 +3172,7 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "modelName": "claude-haiku-4-5-20251001",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
     "updatedAt": "2026-04-20T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3202,7 +3202,7 @@
   {
     "id": "cmhymgpym000d04ih34rndvhr",
     "modelName": "gpt-5.1",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.1)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.1)$",
     "createdAt": "2025-11-14T08:57:23.481Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3232,7 +3232,7 @@
   {
     "id": "cmhymgxiw000e04ihh9pw12ef",
     "modelName": "gpt-5.1-2025-11-13",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.1-2025-11-13)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.1-2025-11-13)$",
     "createdAt": "2025-11-14T08:57:23.481Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3262,7 +3262,7 @@
   {
     "id": "cmieupdva000004l541kwae70",
     "modelName": "claude-opus-4-5-20251101",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-5(-20251101)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?|claude-opus-4-5(@20251101)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-5(-20251101)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?|claude-opus-4-5(@20251101)?)$",
     "createdAt": "2025-11-24T20:53:27.571Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3275,17 +3275,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_tokens": 5e-6,
-          "output": 25e-6,
-          "output_tokens": 25e-6,
-          "cache_creation_input_tokens": 6.25e-6,
-          "input_cache_creation": 6.25e-6,
-          "input_cache_creation_5m": 6.25e-6,
-          "input_cache_creation_1h": 10e-6,
-          "cache_read_input_tokens": 0.5e-6,
-          "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input": 0.000005,
+          "input_tokens": 0.000005,
+          "output": 0.000025,
+          "output_tokens": 0.000025,
+          "cache_creation_input_tokens": 0.00000625,
+          "input_cache_creation": 0.00000625,
+          "input_cache_creation_5m": 0.00000625,
+          "input_cache_creation_1h": 0.00001,
+          "cache_read_input_tokens": 5e-7,
+          "input_cached_tokens": 5e-7,
+          "input_cache_read": 5e-7
         }
       }
     ]
@@ -3306,14 +3306,14 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-6,
-          "input_tokens": 3e-6,
-          "output": 15e-6,
-          "output_tokens": 15e-6,
-          "cache_creation_input_tokens": 3.75e-6,
-          "input_cache_creation": 3.75e-6,
-          "input_cache_creation_5m": 3.75e-6,
-          "input_cache_creation_1h": 6e-6,
+          "input": 0.000003,
+          "input_tokens": 0.000003,
+          "output": 0.000015,
+          "output_tokens": 0.000015,
+          "cache_creation_input_tokens": 0.00000375,
+          "input_cache_creation": 0.00000375,
+          "input_cache_creation_5m": 0.00000375,
+          "input_cache_creation_1h": 0.000006,
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
           "input_cache_read": 3e-7
@@ -3333,14 +3333,14 @@
           }
         ],
         "prices": {
-          "input": 6e-6,
-          "input_tokens": 6e-6,
-          "output": 22.5e-6,
-          "output_tokens": 22.5e-6,
-          "cache_creation_input_tokens": 7.5e-6,
-          "input_cache_creation": 7.5e-6,
-          "input_cache_creation_5m": 7.5e-6,
-          "input_cache_creation_1h": 12e-6,
+          "input": 0.000006,
+          "input_tokens": 0.000006,
+          "output": 0.0000225,
+          "output_tokens": 0.0000225,
+          "cache_creation_input_tokens": 0.0000075,
+          "input_cache_creation": 0.0000075,
+          "input_cache_creation_5m": 0.0000075,
+          "input_cache_creation_1h": 0.000012,
           "cache_read_input_tokens": 6e-7,
           "input_cached_tokens": 6e-7,
           "input_cache_read": 6e-7
@@ -3351,7 +3351,7 @@
   {
     "id": "13458bc0-1c20-44c2-8753-172f54b67647",
     "modelName": "claude-opus-4-6",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
     "createdAt": "2026-02-09T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3364,17 +3364,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_tokens": 5e-6,
-          "output": 25e-6,
-          "output_tokens": 25e-6,
-          "cache_creation_input_tokens": 6.25e-6,
-          "input_cache_creation": 6.25e-6,
-          "input_cache_creation_5m": 6.25e-6,
-          "input_cache_creation_1h": 10e-6,
-          "cache_read_input_tokens": 0.5e-6,
-          "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input": 0.000005,
+          "input_tokens": 0.000005,
+          "output": 0.000025,
+          "output_tokens": 0.000025,
+          "cache_creation_input_tokens": 0.00000625,
+          "input_cache_creation": 0.00000625,
+          "input_cache_creation_5m": 0.00000625,
+          "input_cache_creation_1h": 0.00001,
+          "cache_read_input_tokens": 5e-7,
+          "input_cached_tokens": 5e-7,
+          "input_cache_read": 5e-7
         }
       }
     ]
@@ -3382,7 +3382,7 @@
   {
     "id": "d506b291-cc9c-4833-9014-0f387a8e1cc8",
     "modelName": "claude-opus-4-7",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-7|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7-v1(:0)?|claude-opus-4-7)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-7|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7-v1(:0)?|claude-opus-4-7)$",
     "createdAt": "2026-04-16T00:00:00.000Z",
     "updatedAt": "2026-04-16T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3395,17 +3395,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_tokens": 5e-6,
-          "output": 25e-6,
-          "output_tokens": 25e-6,
-          "cache_creation_input_tokens": 6.25e-6,
-          "input_cache_creation": 6.25e-6,
-          "input_cache_creation_5m": 6.25e-6,
-          "input_cache_creation_1h": 10e-6,
-          "cache_read_input_tokens": 0.5e-6,
-          "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input": 0.000005,
+          "input_tokens": 0.000005,
+          "output": 0.000025,
+          "output_tokens": 0.000025,
+          "cache_creation_input_tokens": 0.00000625,
+          "input_cache_creation": 0.00000625,
+          "input_cache_creation_5m": 0.00000625,
+          "input_cache_creation_1h": 0.00001,
+          "cache_read_input_tokens": 5e-7,
+          "input_cached_tokens": 5e-7,
+          "input_cache_read": 5e-7
         }
       }
     ]
@@ -3413,7 +3413,7 @@
   {
     "id": "80753fd5-342b-4ed3-bbb1-57d3d57b7e03",
     "modelName": "claude-opus-4-8",
-    "matchPattern": "(?i)^((anthropic\/)?claude-opus-4-8|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-8(-v1(:0)?)?)$",
+    "matchPattern": "(?i)^((anthropic/)?claude-opus-4-8|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-8(-v1(:0)?)?)$",
     "createdAt": "2026-05-28T00:00:00.000Z",
     "updatedAt": "2026-05-28T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3426,17 +3426,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_tokens": 5e-6,
-          "output": 25e-6,
-          "output_tokens": 25e-6,
-          "cache_creation_input_tokens": 6.25e-6,
-          "input_cache_creation": 6.25e-6,
-          "input_cache_creation_5m": 6.25e-6,
-          "input_cache_creation_1h": 10e-6,
-          "cache_read_input_tokens": 0.5e-6,
-          "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input": 0.000005,
+          "input_tokens": 0.000005,
+          "output": 0.000025,
+          "output_tokens": 0.000025,
+          "cache_creation_input_tokens": 0.00000625,
+          "input_cache_creation": 0.00000625,
+          "input_cache_creation_5m": 0.00000625,
+          "input_cache_creation_1h": 0.00001,
+          "cache_read_input_tokens": 5e-7,
+          "input_cached_tokens": 5e-7,
+          "input_cache_read": 5e-7
         }
       }
     ]
@@ -3444,7 +3444,7 @@
   {
     "id": "0b9a828d-9fdc-46d4-b5ec-f6574c42ad65",
     "modelName": "claude-fable-5",
-    "matchPattern": "(?i)^((anthropic\/)?claude-fable-5|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-fable-5(-v1(:0)?)?)$",
+    "matchPattern": "(?i)^((anthropic/)?claude-fable-5|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-fable-5(-v1(:0)?)?)$",
     "createdAt": "2026-06-09T00:00:00.000Z",
     "updatedAt": "2026-06-09T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3457,17 +3457,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 10e-6,
-          "input_tokens": 10e-6,
-          "output": 50e-6,
-          "output_tokens": 50e-6,
-          "cache_creation_input_tokens": 12.5e-6,
-          "input_cache_creation": 12.5e-6,
-          "input_cache_creation_5m": 12.5e-6,
-          "input_cache_creation_1h": 20e-6,
-          "cache_read_input_tokens": 1e-6,
-          "input_cached_tokens": 1e-6,
-          "input_cache_read": 1e-6
+          "input": 0.00001,
+          "input_tokens": 0.00001,
+          "output": 0.00005,
+          "output_tokens": 0.00005,
+          "cache_creation_input_tokens": 0.0000125,
+          "input_cache_creation": 0.0000125,
+          "input_cache_creation_5m": 0.0000125,
+          "input_cache_creation_1h": 0.00002,
+          "cache_read_input_tokens": 0.000001,
+          "input_cached_tokens": 0.000001,
+          "input_cache_read": 0.000001
         }
       }
     ]
@@ -3475,7 +3475,7 @@
   {
     "id": "33f4e272-750f-49d9-90ed-313b3c920da1",
     "modelName": "claude-mythos-5",
-    "matchPattern": "(?i)^(anthropic\/)?claude-mythos-5$",
+    "matchPattern": "(?i)^(anthropic/)?claude-mythos-5$",
     "createdAt": "2026-06-09T00:00:00.000Z",
     "updatedAt": "2026-06-09T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3488,17 +3488,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 10e-6,
-          "input_tokens": 10e-6,
-          "output": 50e-6,
-          "output_tokens": 50e-6,
-          "cache_creation_input_tokens": 12.5e-6,
-          "input_cache_creation": 12.5e-6,
-          "input_cache_creation_5m": 12.5e-6,
-          "input_cache_creation_1h": 20e-6,
-          "cache_read_input_tokens": 1e-6,
-          "input_cached_tokens": 1e-6,
-          "input_cache_read": 1e-6
+          "input": 0.00001,
+          "input_tokens": 0.00001,
+          "output": 0.00005,
+          "output_tokens": 0.00005,
+          "cache_creation_input_tokens": 0.0000125,
+          "input_cache_creation": 0.0000125,
+          "input_cache_creation_5m": 0.0000125,
+          "input_cache_creation_1h": 0.00002,
+          "cache_read_input_tokens": 0.000001,
+          "input_cached_tokens": 0.000001,
+          "input_cache_read": 0.000001
         }
       }
     ]
@@ -3506,7 +3506,7 @@
   {
     "id": "cmig1hb7i000104l72qrzgc6h",
     "modelName": "gemini-2.5-pro",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.5-pro)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.5-pro)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -3517,21 +3517,21 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-6,
-          "input_text": 1.25e-6,
-          "input_modality_1": 1.25e-6,
-          "prompt_token_count": 1.25e-6,
-          "promptTokenCount": 1.25e-6,
-          "input_cached_tokens": 0.125e-6,
-          "cached_content_token_count": 0.125e-6,
-          "output": 10e-6,
-          "output_text": 10e-6,
-          "output_modality_1": 10e-6,
-          "candidates_token_count": 10e-6,
-          "candidatesTokenCount": 10e-6,
-          "thoughtsTokenCount": 10e-6,
-          "thoughts_token_count": 10e-6,
-          "output_reasoning": 10e-6
+          "input": 0.00000125,
+          "input_text": 0.00000125,
+          "input_modality_1": 0.00000125,
+          "prompt_token_count": 0.00000125,
+          "promptTokenCount": 0.00000125,
+          "input_cached_tokens": 1.25e-7,
+          "cached_content_token_count": 1.25e-7,
+          "output": 0.00001,
+          "output_text": 0.00001,
+          "output_modality_1": 0.00001,
+          "candidates_token_count": 0.00001,
+          "candidatesTokenCount": 0.00001,
+          "thoughtsTokenCount": 0.00001,
+          "thoughts_token_count": 0.00001,
+          "output_reasoning": 0.00001
         }
       },
       {
@@ -3548,21 +3548,21 @@
           }
         ],
         "prices": {
-          "input": 2.5e-6,
-          "input_text": 2.5e-6,
-          "input_modality_1": 2.5e-6,
-          "prompt_token_count": 2.5e-6,
-          "promptTokenCount": 2.5e-6,
-          "input_cached_tokens": 0.25e-6,
-          "cached_content_token_count": 0.25e-6,
-          "output": 15e-6,
-          "output_text": 15e-6,
-          "output_modality_1": 15e-6,
-          "candidates_token_count": 15e-6,
-          "candidatesTokenCount": 15e-6,
-          "thoughtsTokenCount": 15e-6,
-          "thoughts_token_count": 15e-6,
-          "output_reasoning": 15e-6
+          "input": 0.0000025,
+          "input_text": 0.0000025,
+          "input_modality_1": 0.0000025,
+          "prompt_token_count": 0.0000025,
+          "promptTokenCount": 0.0000025,
+          "input_cached_tokens": 2.5e-7,
+          "cached_content_token_count": 2.5e-7,
+          "output": 0.000015,
+          "output_text": 0.000015,
+          "output_modality_1": 0.000015,
+          "candidates_token_count": 0.000015,
+          "candidatesTokenCount": 0.000015,
+          "thoughtsTokenCount": 0.000015,
+          "thoughts_token_count": 0.000015,
+          "output_reasoning": 0.000015
         }
       }
     ]
@@ -3570,7 +3570,7 @@
   {
     "id": "cmig1wmep000404l7fh6q5uog",
     "modelName": "gemini-3-pro-preview",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3-pro-preview)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3-pro-preview)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -3581,21 +3581,21 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-6,
-          "input_text": 2e-6,
-          "input_modality_1": 2e-6,
-          "prompt_token_count": 2e-6,
-          "promptTokenCount": 2e-6,
-          "input_cached_tokens": 0.2e-6,
-          "cached_content_token_count": 0.2e-6,
-          "output": 12e-6,
-          "output_text": 12e-6,
-          "output_modality_1": 12e-6,
-          "candidates_token_count": 12e-6,
-          "candidatesTokenCount": 12e-6,
-          "thoughtsTokenCount": 12e-6,
-          "thoughts_token_count": 12e-6,
-          "output_reasoning": 12e-6
+          "input": 0.000002,
+          "input_text": 0.000002,
+          "input_modality_1": 0.000002,
+          "prompt_token_count": 0.000002,
+          "promptTokenCount": 0.000002,
+          "input_cached_tokens": 2e-7,
+          "cached_content_token_count": 2e-7,
+          "output": 0.000012,
+          "output_text": 0.000012,
+          "output_modality_1": 0.000012,
+          "candidates_token_count": 0.000012,
+          "candidatesTokenCount": 0.000012,
+          "thoughtsTokenCount": 0.000012,
+          "thoughts_token_count": 0.000012,
+          "output_reasoning": 0.000012
         }
       },
       {
@@ -3612,21 +3612,21 @@
           }
         ],
         "prices": {
-          "input": 4e-6,
-          "input_text": 4e-6,
-          "input_modality_1": 4e-6,
-          "prompt_token_count": 4e-6,
-          "promptTokenCount": 4e-6,
-          "input_cached_tokens": 0.4e-6,
-          "cached_content_token_count": 0.4e-6,
-          "output": 18e-6,
-          "output_text": 18e-6,
-          "output_modality_1": 18e-6,
-          "candidates_token_count": 18e-6,
-          "candidatesTokenCount": 18e-6,
-          "thoughtsTokenCount": 18e-6,
-          "thoughts_token_count": 18e-6,
-          "output_reasoning": 18e-6
+          "input": 0.000004,
+          "input_text": 0.000004,
+          "input_modality_1": 0.000004,
+          "prompt_token_count": 0.000004,
+          "promptTokenCount": 0.000004,
+          "input_cached_tokens": 4e-7,
+          "cached_content_token_count": 4e-7,
+          "output": 0.000018,
+          "output_text": 0.000018,
+          "output_modality_1": 0.000018,
+          "candidates_token_count": 0.000018,
+          "candidatesTokenCount": 0.000018,
+          "thoughtsTokenCount": 0.000018,
+          "thoughts_token_count": 0.000018,
+          "output_reasoning": 0.000018
         }
       }
     ]
@@ -3634,7 +3634,7 @@
   {
     "id": "55106bba-a5dd-441b-bc0d-5652582b349d",
     "modelName": "gemini-3.1-pro-preview",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.1-pro-preview(-customtools)?)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3.1-pro-preview(-customtools)?)$",
     "createdAt": "2026-02-19T00:00:00.000Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -3645,21 +3645,21 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-6,
-          "input_modality_1": 2e-6,
-          "input_text": 2e-6,
-          "prompt_token_count": 2e-6,
-          "promptTokenCount": 2e-6,
-          "input_cached_tokens": 0.2e-6,
-          "cached_content_token_count": 0.2e-6,
-          "output": 12e-6,
-          "output_text": 12e-6,
-          "output_modality_1": 12e-6,
-          "candidates_token_count": 12e-6,
-          "candidatesTokenCount": 12e-6,
-          "thoughtsTokenCount": 12e-6,
-          "thoughts_token_count": 12e-6,
-          "output_reasoning": 12e-6
+          "input": 0.000002,
+          "input_modality_1": 0.000002,
+          "input_text": 0.000002,
+          "prompt_token_count": 0.000002,
+          "promptTokenCount": 0.000002,
+          "input_cached_tokens": 2e-7,
+          "cached_content_token_count": 2e-7,
+          "output": 0.000012,
+          "output_text": 0.000012,
+          "output_modality_1": 0.000012,
+          "candidates_token_count": 0.000012,
+          "candidatesTokenCount": 0.000012,
+          "thoughtsTokenCount": 0.000012,
+          "thoughts_token_count": 0.000012,
+          "output_reasoning": 0.000012
         }
       },
       {
@@ -3676,21 +3676,21 @@
           }
         ],
         "prices": {
-          "input": 4e-6,
-          "input_modality_1": 4e-6,
-          "input_text": 4e-6,
-          "prompt_token_count": 4e-6,
-          "promptTokenCount": 4e-6,
-          "input_cached_tokens": 0.4e-6,
-          "cached_content_token_count": 0.4e-6,
-          "output": 18e-6,
-          "output_text": 18e-6,
-          "output_modality_1": 18e-6,
-          "candidates_token_count": 18e-6,
-          "candidatesTokenCount": 18e-6,
-          "thoughtsTokenCount": 18e-6,
-          "thoughts_token_count": 18e-6,
-          "output_reasoning": 18e-6
+          "input": 0.000004,
+          "input_modality_1": 0.000004,
+          "input_text": 0.000004,
+          "prompt_token_count": 0.000004,
+          "promptTokenCount": 0.000004,
+          "input_cached_tokens": 4e-7,
+          "cached_content_token_count": 4e-7,
+          "output": 0.000018,
+          "output_text": 0.000018,
+          "output_modality_1": 0.000018,
+          "candidates_token_count": 0.000018,
+          "candidatesTokenCount": 0.000018,
+          "thoughtsTokenCount": 0.000018,
+          "thoughts_token_count": 0.000018,
+          "output_reasoning": 0.000018
         }
       }
     ]
@@ -3698,7 +3698,7 @@
   {
     "id": "cmj2n4f2a000304kz49g4c43u",
     "modelName": "gpt-5.2",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3715,12 +3715,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.75e-6,
-          "input_cached_tokens": 0.175e-6,
-          "input_cache_read": 0.175e-6,
-          "output": 14e-6,
-          "output_reasoning_tokens": 14e-6,
-          "output_reasoning": 14e-6
+          "input": 0.00000175,
+          "input_cached_tokens": 1.75e-7,
+          "input_cache_read": 1.75e-7,
+          "output": 0.000014,
+          "output_reasoning_tokens": 0.000014,
+          "output_reasoning": 0.000014
         }
       }
     ]
@@ -3728,7 +3728,7 @@
   {
     "id": "cmj2muxg6000104kzd2tc8953",
     "modelName": "gpt-5.2-2025-12-11",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-2025-12-11)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2-2025-12-11)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3745,12 +3745,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.75e-6,
-          "input_cached_tokens": 0.175e-6,
-          "input_cache_read": 0.175e-6,
-          "output": 14e-6,
-          "output_reasoning_tokens": 14e-6,
-          "output_reasoning": 14e-6
+          "input": 0.00000175,
+          "input_cached_tokens": 1.75e-7,
+          "input_cache_read": 1.75e-7,
+          "output": 0.000014,
+          "output_reasoning_tokens": 0.000014,
+          "output_reasoning": 0.000014
         }
       }
     ]
@@ -3758,7 +3758,7 @@
   {
     "id": "cmj2n6pkq000404kz2s0b6if7",
     "modelName": "gpt-5.2-pro",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-pro)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2-pro)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3775,10 +3775,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 21e-6,
-          "output": 168e-6,
-          "output_reasoning_tokens": 168e-6,
-          "output_reasoning": 168e-6
+          "input": 0.000021,
+          "output": 0.000168,
+          "output_reasoning_tokens": 0.000168,
+          "output_reasoning": 0.000168
         }
       }
     ]
@@ -3786,7 +3786,7 @@
   {
     "id": "cmj2n70oe000504kz21b76mes",
     "modelName": "gpt-5.2-pro-2025-12-11",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-pro-2025-12-11)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2-pro-2025-12-11)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3803,10 +3803,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 21e-6,
-          "output": 168e-6,
-          "output_reasoning_tokens": 168e-6,
-          "output_reasoning": 168e-6
+          "input": 0.000021,
+          "output": 0.000168,
+          "output_reasoning_tokens": 0.000168,
+          "output_reasoning": 0.000168
         }
       }
     ]
@@ -3814,7 +3814,7 @@
   {
     "id": "bee3c111-fe6f-4641-8775-73ea33b29fca",
     "modelName": "gpt-5.4",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.4)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.4)$",
     "createdAt": "2026-03-05T00:00:00.000Z",
     "updatedAt": "2026-03-05T00:00:00.000Z",
     "tokenizerConfig": {
@@ -3831,12 +3831,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-6,
-          "input_cached_tokens": 0.25e-6,
-          "input_cache_read": 0.25e-6,
-          "output": 15e-6,
-          "output_reasoning_tokens": 15e-6,
-          "output_reasoning": 15e-6
+          "input": 0.0000025,
+          "input_cached_tokens": 2.5e-7,
+          "input_cache_read": 2.5e-7,
+          "output": 0.000015,
+          "output_reasoning_tokens": 0.000015,
+          "output_reasoning": 0.000015
         }
       }
     ]
@@ -3844,7 +3844,7 @@
   {
     "id": "68d32054-8748-4d25-9f64-d78d483601bd",
     "modelName": "gpt-5.4-pro",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.4-pro)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.4-pro)$",
     "createdAt": "2026-03-05T00:00:00.000Z",
     "updatedAt": "2026-03-05T00:00:00.000Z",
     "tokenizerConfig": {
@@ -3861,10 +3861,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 30e-6,
-          "output": 180e-6,
-          "output_reasoning_tokens": 180e-6,
-          "output_reasoning": 180e-6
+          "input": 0.00003,
+          "output": 0.00018,
+          "output_reasoning_tokens": 0.00018,
+          "output_reasoning": 0.00018
         }
       }
     ]
@@ -3872,7 +3872,7 @@
   {
     "id": "22dfc7e1-1fe1-4286-b1af-928635e7ecb9",
     "modelName": "gpt-5.4-2026-03-05",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.4-2026-03-05)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.4-2026-03-05)$",
     "createdAt": "2026-03-05T00:00:00.000Z",
     "updatedAt": "2026-03-05T00:00:00.000Z",
     "tokenizerConfig": {
@@ -3889,12 +3889,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-6,
-          "input_cached_tokens": 0.25e-6,
-          "input_cache_read": 0.25e-6,
-          "output": 15e-6,
-          "output_reasoning_tokens": 15e-6,
-          "output_reasoning": 15e-6
+          "input": 0.0000025,
+          "input_cached_tokens": 2.5e-7,
+          "input_cache_read": 2.5e-7,
+          "output": 0.000015,
+          "output_reasoning_tokens": 0.000015,
+          "output_reasoning": 0.000015
         }
       }
     ]
@@ -3902,7 +3902,7 @@
   {
     "id": "d8873413-05ab-4374-8223-e8c9005c4a0e",
     "modelName": "gpt-5.4-pro-2026-03-05",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.4-pro-2026-03-05)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.4-pro-2026-03-05)$",
     "createdAt": "2026-03-05T00:00:00.000Z",
     "updatedAt": "2026-03-05T00:00:00.000Z",
     "tokenizerConfig": {
@@ -3919,10 +3919,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 30e-6,
-          "output": 180e-6,
-          "output_reasoning_tokens": 180e-6,
-          "output_reasoning": 180e-6
+          "input": 0.00003,
+          "output": 0.00018,
+          "output_reasoning_tokens": 0.00018,
+          "output_reasoning": 0.00018
         }
       }
     ]
@@ -3947,10 +3947,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.75e-6,
-          "input_cached_tokens": 0.075e-6,
-          "input_cache_read": 0.075e-6,
-          "output": 4.5e-6
+          "input": 7.5e-7,
+          "input_cached_tokens": 7.5e-8,
+          "input_cache_read": 7.5e-8,
+          "output": 0.0000045
         }
       }
     ]
@@ -3975,10 +3975,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.75e-6,
-          "input_cached_tokens": 0.075e-6,
-          "input_cache_read": 0.075e-6,
-          "output": 4.5e-6
+          "input": 7.5e-7,
+          "input_cached_tokens": 7.5e-8,
+          "input_cache_read": 7.5e-8,
+          "output": 0.0000045
         }
       }
     ]
@@ -4003,10 +4003,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.2e-6,
-          "input_cached_tokens": 0.02e-6,
-          "input_cache_read": 0.02e-6,
-          "output": 1.25e-6
+          "input": 2e-7,
+          "input_cached_tokens": 2e-8,
+          "input_cache_read": 2e-8,
+          "output": 0.00000125
         }
       }
     ]
@@ -4031,10 +4031,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.2e-6,
-          "input_cached_tokens": 0.02e-6,
-          "input_cache_read": 0.02e-6,
-          "output": 1.25e-6
+          "input": 2e-7,
+          "input_cached_tokens": 2e-8,
+          "input_cache_read": 2e-8,
+          "output": 0.00000125
         }
       }
     ]
@@ -4042,7 +4042,7 @@
   {
     "id": "0a8ec527-44e0-4ee3-8005-a1865d712ec6",
     "modelName": "gpt-5.5-2026-04-23",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.5(-2026-04-23)?)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.5(-2026-04-23)?)$",
     "createdAt": "2026-04-25T00:00:00.000Z",
     "updatedAt": "2026-04-25T00:00:00.000Z",
     "tokenizerConfig": {
@@ -4059,12 +4059,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6,
-          "output": 30e-6,
-          "output_reasoning_tokens": 30e-6,
-          "output_reasoning": 30e-6
+          "input": 0.000005,
+          "input_cached_tokens": 5e-7,
+          "input_cache_read": 5e-7,
+          "output": 0.00003,
+          "output_reasoning_tokens": 0.00003,
+          "output_reasoning": 0.00003
         }
       }
     ]
@@ -4072,7 +4072,7 @@
   {
     "id": "913d4e67-7472-49d1-97de-0a707ca3e31e",
     "modelName": "gpt-5.5-pro-2026-04-23",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.5-pro(-2026-04-23)?)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.5-pro(-2026-04-23)?)$",
     "createdAt": "2026-04-25T00:00:00.000Z",
     "updatedAt": "2026-04-25T00:00:00.000Z",
     "tokenizerConfig": {
@@ -4089,10 +4089,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 30e-6,
-          "output": 180e-6,
-          "output_reasoning_tokens": 180e-6,
-          "output_reasoning": 180e-6
+          "input": 0.00003,
+          "output": 0.00018,
+          "output_reasoning_tokens": 0.00018,
+          "output_reasoning": 0.00018
         }
       }
     ]
@@ -4100,7 +4100,7 @@
   {
     "id": "6ed696e7-5f3a-4113-a233-019155fb3ff0",
     "modelName": "gemini-3.5-flash",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.5-flash)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3.5-flash)$",
     "createdAt": "2026-05-20T00:00:00.000Z",
     "updatedAt": "2026-05-20T00:00:00.000Z",
     "pricingTiers": [
@@ -4111,21 +4111,21 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-6,
-          "input_modality_1": 1.5e-6,
-          "input_text": 1.5e-6,
-          "prompt_token_count": 1.5e-6,
-          "promptTokenCount": 1.5e-6,
-          "input_cached_tokens": 0.15e-6,
-          "cached_content_token_count": 0.15e-6,
-          "output": 9e-6,
-          "output_text": 9e-6,
-          "output_modality_1": 9e-6,
-          "candidates_token_count": 9e-6,
-          "candidatesTokenCount": 9e-6,
-          "thoughtsTokenCount": 9e-6,
-          "thoughts_token_count": 9e-6,
-          "output_reasoning": 9e-6
+          "input": 0.0000015,
+          "input_modality_1": 0.0000015,
+          "input_text": 0.0000015,
+          "prompt_token_count": 0.0000015,
+          "promptTokenCount": 0.0000015,
+          "input_cached_tokens": 1.5e-7,
+          "cached_content_token_count": 1.5e-7,
+          "output": 0.000009,
+          "output_text": 0.000009,
+          "output_modality_1": 0.000009,
+          "candidates_token_count": 0.000009,
+          "candidatesTokenCount": 0.000009,
+          "thoughtsTokenCount": 0.000009,
+          "thoughts_token_count": 0.000009,
+          "output_reasoning": 0.000009
         }
       }
     ]
@@ -4133,7 +4133,7 @@
   {
     "id": "cmjfoeykl000004l8ffzra8c7",
     "modelName": "gemini-3-flash-preview",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3-flash-preview)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3-flash-preview)$",
     "createdAt": "2025-12-21T12:01:42.282Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -4144,21 +4144,21 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.5e-6,
-          "input_text": 0.5e-6,
-          "input_modality_1": 0.5e-6,
-          "prompt_token_count": 0.5e-6,
-          "promptTokenCount": 0.5e-6,
-          "input_cached_tokens": 0.05e-6,
-          "cached_content_token_count": 0.05e-6,
-          "output": 3e-6,
-          "output_text": 3e-6,
-          "output_modality_1": 3e-6,
-          "candidates_token_count": 3e-6,
-          "candidatesTokenCount": 3e-6,
-          "thoughtsTokenCount": 3e-6,
-          "thoughts_token_count": 3e-6,
-          "output_reasoning": 3e-6
+          "input": 5e-7,
+          "input_text": 5e-7,
+          "input_modality_1": 5e-7,
+          "prompt_token_count": 5e-7,
+          "promptTokenCount": 5e-7,
+          "input_cached_tokens": 5e-8,
+          "cached_content_token_count": 5e-8,
+          "output": 0.000003,
+          "output_text": 0.000003,
+          "output_modality_1": 0.000003,
+          "candidates_token_count": 0.000003,
+          "candidatesTokenCount": 0.000003,
+          "thoughtsTokenCount": 0.000003,
+          "thoughts_token_count": 0.000003,
+          "output_reasoning": 0.000003
         }
       }
     ]
@@ -4166,7 +4166,7 @@
   {
     "id": "79f4d62c-22fb-4ec3-82e1-6e56cdd5e23c",
     "modelName": "gemini-3.1-flash-lite",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.1-flash-lite)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3.1-flash-lite)$",
     "createdAt": "2026-05-20T00:00:00.000Z",
     "updatedAt": "2026-05-20T00:00:00.000Z",
     "pricingTiers": [
@@ -4177,22 +4177,22 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.25e-6,
-          "input_modality_1": 0.25e-6,
-          "input_text": 0.25e-6,
-          "prompt_token_count": 0.25e-6,
-          "promptTokenCount": 0.25e-6,
-          "input_cached_tokens": 0.025e-6,
-          "cached_content_token_count": 0.025e-6,
-          "output": 1.5e-6,
-          "output_text": 1.5e-6,
-          "output_modality_1": 1.5e-6,
-          "candidates_token_count": 1.5e-6,
-          "candidatesTokenCount": 1.5e-6,
-          "thoughtsTokenCount": 1.5e-6,
-          "thoughts_token_count": 1.5e-6,
-          "output_reasoning": 1.5e-6,
-          "input_audio_tokens": 0.5e-6
+          "input": 2.5e-7,
+          "input_modality_1": 2.5e-7,
+          "input_text": 2.5e-7,
+          "prompt_token_count": 2.5e-7,
+          "promptTokenCount": 2.5e-7,
+          "input_cached_tokens": 2.5e-8,
+          "cached_content_token_count": 2.5e-8,
+          "output": 0.0000015,
+          "output_text": 0.0000015,
+          "output_modality_1": 0.0000015,
+          "candidates_token_count": 0.0000015,
+          "candidatesTokenCount": 0.0000015,
+          "thoughtsTokenCount": 0.0000015,
+          "thoughts_token_count": 0.0000015,
+          "output_reasoning": 0.0000015,
+          "input_audio_tokens": 5e-7
         }
       }
     ]
@@ -4200,7 +4200,7 @@
   {
     "id": "0707bef8-10c8-46e2-a871-0436f05f0b92",
     "modelName": "gemini-3.1-flash-lite-preview",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.1-flash-lite-preview)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3.1-flash-lite-preview)$",
     "createdAt": "2026-03-03T00:00:00.000Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -4211,22 +4211,22 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.25e-6,
-          "input_modality_1": 0.25e-6,
-          "input_text": 0.25e-6,
-          "prompt_token_count": 0.25e-6,
-          "promptTokenCount": 0.25e-6,
-          "input_cached_tokens": 0.025e-6,
-          "cached_content_token_count": 0.025e-6,
-          "output": 1.5e-6,
-          "output_text": 1.5e-6,
-          "output_modality_1": 1.5e-6,
-          "candidates_token_count": 1.5e-6,
-          "candidatesTokenCount": 1.5e-6,
-          "thoughtsTokenCount": 1.5e-6,
-          "thoughts_token_count": 1.5e-6,
-          "output_reasoning": 1.5e-6,
-          "input_audio_tokens": 0.5e-6
+          "input": 2.5e-7,
+          "input_modality_1": 2.5e-7,
+          "input_text": 2.5e-7,
+          "prompt_token_count": 2.5e-7,
+          "promptTokenCount": 2.5e-7,
+          "input_cached_tokens": 2.5e-8,
+          "cached_content_token_count": 2.5e-8,
+          "output": 0.0000015,
+          "output_text": 0.0000015,
+          "output_modality_1": 0.0000015,
+          "candidates_token_count": 0.0000015,
+          "candidatesTokenCount": 0.0000015,
+          "thoughtsTokenCount": 0.0000015,
+          "thoughts_token_count": 0.0000015,
+          "output_reasoning": 0.0000015,
+          "input_audio_tokens": 5e-7
         }
       }
     ]
@@ -4234,7 +4234,7 @@
   {
     "id": "029e6695-ff24-47f0-b37b-7285fb2e5785",
     "modelName": "gemini-live-2.5-flash-native-audio",
-    "matchPattern": "(?i)^(google\/)?(gemini-live-2.5-flash-native-audio)$",
+    "matchPattern": "(?i)^(google/)?(gemini-live-2.5-flash-native-audio)$",
     "createdAt": "2026-03-16T00:00:00.000Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -4247,11 +4247,159 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text": 0.5e-6,
-          "input_audio": 3e-6,
-          "input_image": 3e-6,
-          "output_text": 2e-6,
-          "output_audio": 12e-6
+          "input_text": 5e-7,
+          "input_audio": 0.000003,
+          "input_image": 0.000003,
+          "output_text": 0.000002,
+          "output_audio": 0.000012
+        }
+      }
+    ]
+  },
+  {
+    "id": "6250de37-6f53-4f54-8636-21ef30238cb8",
+    "modelName": "gemini-2.5-flash-preview-09-2025",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2\\.5-flash-preview-09-2025)$",
+    "createdAt": "2026-06-15T02:58:49.976Z",
+    "updatedAt": "2026-06-15T02:58:49.976Z",
+    "pricingTiers": [
+      {
+        "id": "6250de37-6f53-4f54-8636-21ef30238cb8_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 3e-7,
+          "input_text": 3e-7,
+          "input_modality_1": 3e-7,
+          "prompt_token_count": 3e-7,
+          "promptTokenCount": 3e-7,
+          "input_cached_tokens": 3e-8,
+          "cached_content_token_count": 3e-8,
+          "output": 0.0000025,
+          "output_text": 0.0000025,
+          "output_modality_1": 0.0000025,
+          "candidates_token_count": 0.0000025,
+          "candidatesTokenCount": 0.0000025,
+          "thoughtsTokenCount": 0.0000025,
+          "thoughts_token_count": 0.0000025,
+          "output_reasoning": 0.0000025,
+          "input_audio_tokens": 0.000001
+        }
+      }
+    ]
+  },
+  {
+    "id": "711fd428-7ca8-4840-8cc8-45bb0e6e2db6",
+    "modelName": "gemini-2.5-flash-lite-preview-09-2025",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2\\.5-flash-lite-preview-09-2025)$",
+    "createdAt": "2026-06-15T02:58:49.976Z",
+    "updatedAt": "2026-06-15T02:58:49.976Z",
+    "pricingTiers": [
+      {
+        "id": "711fd428-7ca8-4840-8cc8-45bb0e6e2db6_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 1e-7,
+          "input_text": 1e-7,
+          "input_modality_1": 1e-7,
+          "prompt_token_count": 1e-7,
+          "promptTokenCount": 1e-7,
+          "input_cached_tokens": 2.5e-8,
+          "cached_content_token_count": 2.5e-8,
+          "output": 4e-7,
+          "output_text": 4e-7,
+          "output_modality_1": 4e-7,
+          "candidates_token_count": 4e-7,
+          "candidatesTokenCount": 4e-7,
+          "thoughtsTokenCount": 4e-7,
+          "thoughts_token_count": 4e-7,
+          "output_reasoning": 4e-7,
+          "input_audio_tokens": 5e-7
+        }
+      }
+    ]
+  },
+  {
+    "id": "659d26a7-11a2-45cc-af39-9af5bbe4b89f",
+    "modelName": "gemini-2.0-pro-exp-02-05",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2\\.0-pro-exp-02-05)(@[a-zA-Z0-9]+)?$",
+    "createdAt": "2026-06-15T02:58:49.976Z",
+    "updatedAt": "2026-06-15T02:58:49.976Z",
+    "pricingTiers": [
+      {
+        "id": "659d26a7-11a2-45cc-af39-9af5bbe4b89f_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 0.0000025,
+          "output": 0.0000075
+        }
+      }
+    ]
+  },
+  {
+    "id": "66f689e7-7a0a-4e2e-80d4-f4fa70c5a4a7",
+    "modelName": "gemini-2.0-flash-exp",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2\\.0-flash-exp)(@[a-zA-Z0-9]+)?$",
+    "createdAt": "2026-06-15T02:58:49.976Z",
+    "updatedAt": "2026-06-15T02:58:49.976Z",
+    "pricingTiers": [
+      {
+        "id": "66f689e7-7a0a-4e2e-80d4-f4fa70c5a4a7_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 1e-7,
+          "output": 4e-7
+        }
+      }
+    ]
+  },
+  {
+    "id": "dc914b72-c2cc-436a-a421-b7a7690a19b7",
+    "modelName": "gemini-1.5-pro",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-1\\.5-pro)(@[a-zA-Z0-9]+)?$",
+    "createdAt": "2026-06-15T02:58:49.976Z",
+    "updatedAt": "2026-06-15T02:58:49.976Z",
+    "pricingTiers": [
+      {
+        "id": "dc914b72-c2cc-436a-a421-b7a7690a19b7_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 0.0000025,
+          "output": 0.0000075
+        }
+      }
+    ]
+  },
+  {
+    "id": "cb88fb73-ad70-4315-96e0-886ee77d232e",
+    "modelName": "gemini-1.5-flash",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-1\\.5-flash)(@[a-zA-Z0-9]+)?$",
+    "createdAt": "2026-06-15T02:58:49.976Z",
+    "updatedAt": "2026-06-15T02:58:49.976Z",
+    "pricingTiers": [
+      {
+        "id": "cb88fb73-ad70-4315-96e0-886ee77d232e_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 7.5e-8,
+          "output": 3e-7
         }
       }
     ]


### PR DESCRIPTION
## Problem

Several Gemini models were missing from `worker/src/constants/default-model-prices.json`, so usage on those models produced no cost data (e.g. `gemini-1.5-flash`, `gemini-1.5-pro`). Closes #13650.

## Changes

Adds the following Gemini models to default pricing:

| Model | input / output (USD per token) |
|---|---|
| `gemini-1.5-flash` | 7.5e-08 / 3e-07 |
| `gemini-1.5-pro` | 2.5e-06 / 7.5e-06 |
| `gemini-2.0-flash-exp` | 1e-07 / 4e-07 |
| `gemini-2.0-pro-exp-02-05` | 2.5e-06 / 7.5e-06 |
| `gemini-2.5-flash-preview-09-2025` | 3e-07 / 2.5e-06 (full usage-detail key set) |
| `gemini-2.5-flash-lite-preview-09-2025` | 1e-07 / 4e-07 (full usage-detail key set) |

Notes:
- The 2.5-era preview models carry the full usage-detail/modality price key set (`prompt_token_count`, `candidates_token_count`, `input_cached_tokens`, etc.), mirroring their GA counterparts, so cost tracking matches the keys Gemini/Vertex actually report.
- The 1.5/2.0-era models use the `input`/`output` convention consistent with the existing entries in the file.
- No existing model entries were changed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds six missing Gemini model entries to `worker/src/constants/default-model-prices.json` so that usage on those models generates cost data. It also applies two sweeping cosmetic cleanups across the whole file: replacing escaped forward-slashes (`\/`) with plain slashes in every existing `matchPattern`, and reformatting several price values between scientific-notation and decimal forms without changing their magnitudes.

- **New entries** (`gemini-1.5-flash`, `gemini-1.5-pro`, `gemini-2.0-flash-exp`, `gemini-2.0-pro-exp-02-05`, `gemini-2.5-flash-preview-09-2025`, `gemini-2.5-flash-lite-preview-09-2025`) are appended at the end of the array; the 2.5-era preview models carry the full usage-detail key set mirroring their respective GA entries, while the 1.5/2.0 models use the simpler `input`/`output` flat convention.
- **Regex cleanup**: `\/` is not a special character that requires escaping in JSON-embedded regexes, so the bulk replacement is semantically safe.
- **Price reformatting**: All changed values are algebraically identical before and after (e.g. `5e-6` → `0.000005`); no pricing is altered.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all changed price values are algebraically identical to their originals, and the new Gemini entries are additive-only with no conflicts against existing matchPatterns.

The six new pricing entries mirror their corresponding GA models exactly (verified by diffing against the `gemini-2.5-flash` and `gemini-2.5-flash-lite` GA entries in the same file). The `\/`→`/` regex change and scientific-notation reformatting are both no-ops. The one gap — `@version` suffix support missing from the 1.5 and 2.0-era entries — means a narrow class of Vertex AI version-pinned model strings won't produce cost data, but this doesn't break anything that currently works.

worker/src/constants/default-model-prices.json — specifically the matchPatterns for `gemini-1.5-flash`, `gemini-1.5-pro`, `gemini-2.0-flash-exp`, and `gemini-2.0-pro-exp-02-05` if Vertex AI `@version`-pinned usage needs to be covered.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Gemini API call] --> B{Model string matches\ndefault-model-prices.json?}
    B -- "No match (before PR)" --> C[No cost recorded\ne.g. gemini-1.5-flash]
    B -- "Match found" --> D[Cost computed from\npricingTiers]

    subgraph "New entries added by PR"
        E[gemini-1.5-flash\n7.5e-8 / 3e-7]
        F[gemini-1.5-pro\n2.5e-6 / 7.5e-6]
        G[gemini-2.0-flash-exp\n1e-7 / 4e-7]
        H[gemini-2.0-pro-exp-02-05\n2.5e-6 / 7.5e-6]
        I[gemini-2.5-flash-preview-09-2025\n3e-7 / 2.5e-6 + full key set]
        J[gemini-2.5-flash-lite-preview-09-2025\n1e-7 / 4e-7 + full key set]
    end

    C --> E & F & G & H & I & J
    E & F & G & H & I & J --> D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Gemini API call] --> B{Model string matches\ndefault-model-prices.json?}
    B -- "No match (before PR)" --> C[No cost recorded\ne.g. gemini-1.5-flash]
    B -- "Match found" --> D[Cost computed from\npricingTiers]

    subgraph "New entries added by PR"
        E[gemini-1.5-flash\n7.5e-8 / 3e-7]
        F[gemini-1.5-pro\n2.5e-6 / 7.5e-6]
        G[gemini-2.0-flash-exp\n1e-7 / 4e-7]
        H[gemini-2.0-pro-exp-02-05\n2.5e-6 / 7.5e-6]
        I[gemini-2.5-flash-preview-09-2025\n3e-7 / 2.5e-6 + full key set]
        J[gemini-2.5-flash-lite-preview-09-2025\n1e-7 / 4e-7 + full key set]
    end

    C --> E & F & G & H & I & J
    E & F & G & H & I & J --> D
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/constants/default-model-prices.json:4388-4397
**Missing `@version` suffix support in matchPattern**

The new `gemini-1.5-flash` and `gemini-1.5-pro` matchPatterns are anchored to an exact string, so Vertex AI–style version-pinned calls like `gemini-1.5-flash@001` or `googleai/gemini-1.5-pro@002` won't be matched. By contrast, the existing `gemini-1.5-pro-latest` entry appends `(@[a-zA-Z0-9]+)?` to handle that family. The same pattern applies to the `gemini-2.0-flash-exp` and `gemini-2.0-pro-exp-02-05` entries. If your users ever pin a specific snapshot via the `@` syntax, those calls will produce no cost data.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add missing gemini models to defau..."](https://github.com/langfuse/langfuse/commit/78f7b3891f918fd65c6b058eb84b1e115333d4e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40202775)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->