### PR TITLE
feat: implement multimodal content support for evaluators

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -9,6 +9,7 @@ import {
   BaseMessage,
   ContentBlock,
   HumanMessage,
+  type MessageContent,
   SystemMessage,
   ToolMessage,
 } from "@langchain/core/messages";
@@ -134,14 +135,32 @@ function shouldNormalizeContentBlocks(modelParams: ModelParams): boolean {
   );
 }
 
+// Converts our ChatMessage content into the shape langchain message
+// constructors accept. Strings pass through, arrays (multimodal content blocks,
+// e.g. `image_url` parts produced for LLM-as-a-judge media) are forwarded
+// untouched so they reach the provider as real images/audio, and any other
+// shape is safely JSON-stringified.
+const toLangchainMessageContent = (content: unknown): MessageContent => {
+  if (typeof content === "string") return content;
+  // Multimodal content parts (e.g. `image_url`) are passed through; langchain's
+  // message constructors accept these block arrays at runtime even though our
+  // ChatMessage content type is intentionally loose.
+  if (Array.isArray(content)) return content as unknown as MessageContent;
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return "[Unserializable content]";
+  }
+};
+
 const transformSystemMessageToUserMessage = (
   messages: ChatMessage[],
 ): BaseMessage[] => {
-  const safeContent =
-    typeof messages[0].content === "string"
-      ? messages[0].content
-      : JSON.stringify(messages[0].content);
-  return [new HumanMessage(safeContent)];
+  return [
+    new HumanMessage({
+      content: toLangchainMessageContent(messages[0].content),
+    }),
+  ];
 };
 
 const googleProviderOptionsSchema = z
@@ -296,15 +315,6 @@ export async function fetchLLMCompletion(
 
   finalCallbacks = finalCallbacks.length > 0 ? finalCallbacks : undefined;
 
-  // Helper function to safely stringify content
-  const safeStringify = (content: any): string => {
-    try {
-      return JSON.stringify(content);
-    } catch {
-      return "[Unserializable content]";
-    }
-  };
-
   let finalMessages: BaseMessage[];
   // Some providers require at least 1 user message
   if (
@@ -315,21 +325,19 @@ export async function fetchLLMCompletion(
     finalMessages = transformSystemMessageToUserMessage(messages);
   } else {
     finalMessages = messages.map((message, idx) => {
-      // For arbitrary content types, convert to string safely
-      const safeContent =
-        typeof message.content === "string"
-          ? message.content
-          : safeStringify(message.content);
+      // Preserve multimodal array content (e.g. `image_url` parts); otherwise
+      // fall back to a safe string representation.
+      const safeContent = toLangchainMessageContent(message.content);
 
       if (message.role === ChatMessageRole.User)
-        return new HumanMessage(safeContent);
+        return new HumanMessage({ content: safeContent });
       if (
         message.role === ChatMessageRole.System ||
         message.role === ChatMessageRole.Developer
       )
         return idx === 0
-          ? new SystemMessage(safeContent)
-          : new HumanMessage(safeContent);
+          ? new SystemMessage({ content: safeContent })
+          : new HumanMessage({ content: safeContent });
 
       if (message.type === ChatMessageType.ToolResult) {
         return new ToolMessage({

--- a/worker/src/features/evaluation/__tests__/buildEvalMessages.test.ts
+++ b/worker/src/features/evaluation/__tests__/buildEvalMessages.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ChatMessageRole } from "@langfuse/shared";
+
+const findUnique = vi.fn();
+const getSignedUrl = vi.fn();
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    media: {
+      findUnique: (...args: unknown[]) => findUnique(...args),
+    },
+  },
+}));
+
+vi.mock("../mediaStorageClient", () => ({
+  getMediaStorageClient: () => ({
+    getSignedUrl: (...args: unknown[]) => getSignedUrl(...args),
+  }),
+}));
+
+import { buildEvalMessages } from "../evalRuntime";
+
+const PROJECT_ID = "project-1";
+const imageRef = (id: string) =>
+  `@@@langfuseMedia:type=image/jpeg|id=${id}|source=base64@@@`;
+
+describe("buildEvalMessages", () => {
+  beforeEach(() => {
+    findUnique.mockReset();
+    getSignedUrl.mockReset();
+  });
+
+  it("returns a plain string user message when there is no media reference", async () => {
+    const messages = await buildEvalMessages("Rate this answer.", PROJECT_ID);
+
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: ChatMessageRole.User,
+        content: "Rate this answer.",
+      }),
+    ]);
+    expect(findUnique).not.toHaveBeenCalled();
+  });
+
+  it("emits multimodal image_url content for resolvable image media", async () => {
+    findUnique.mockResolvedValue({
+      id: "media-1",
+      uploadHttpStatus: 200,
+      bucketName: "media-bucket",
+      bucketPath: "project-1/media-1.jpg",
+    });
+    getSignedUrl.mockResolvedValue("https://signed.example/media-1.jpg");
+
+    const prompt = `Describe ${imageRef("media-1")} briefly.`;
+    const messages = await buildEvalMessages(prompt, PROJECT_ID);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe(ChatMessageRole.User);
+    expect(messages[0].content).toEqual([
+      { type: "text", text: "Describe " },
+      {
+        type: "image_url",
+        image_url: { url: "https://signed.example/media-1.jpg" },
+      },
+      { type: "text", text: " briefly." },
+    ]);
+    // presigned with inline disposition (asAttachment = false)
+    expect(getSignedUrl).toHaveBeenCalledWith(
+      "project-1/media-1.jpg",
+      expect.any(Number),
+      false,
+    );
+  });
+
+  it("falls back to a plain string message when the media is missing", async () => {
+    findUnique.mockResolvedValue(null);
+
+    const prompt = `Look at ${imageRef("missing")} please.`;
+    const messages = await buildEvalMessages(prompt, PROJECT_ID);
+
+    // No image resolved -> plain string content equal to the original prompt.
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: ChatMessageRole.User,
+        content: prompt,
+      }),
+    ]);
+    expect(getSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("falls back to text when presigning throws (no hard failure)", async () => {
+    findUnique.mockResolvedValue({
+      id: "media-1",
+      uploadHttpStatus: 200,
+      bucketName: "media-bucket",
+      bucketPath: "project-1/media-1.jpg",
+    });
+    getSignedUrl.mockRejectedValue(new Error("S3 down"));
+
+    const prompt = `Describe ${imageRef("media-1")} briefly.`;
+
+    // Should not throw; degrades to a plain-string message.
+    const messages = await buildEvalMessages(prompt, PROJECT_ID);
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: ChatMessageRole.User,
+        content: prompt,
+      }),
+    ]);
+  });
+
+  it("does not treat non-image media as an image", async () => {
+    const prompt = `Audio: @@@langfuseMedia:type=audio/mpeg|id=a1|source=base64@@@`;
+    const messages = await buildEvalMessages(prompt, PROJECT_ID);
+
+    // Non-image media is left as text, so no DB/storage lookups happen.
+    expect(findUnique).not.toHaveBeenCalled();
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: ChatMessageRole.User,
+        content: prompt,
+      }),
+    ]);
+  });
+});

--- a/worker/src/features/evaluation/evalExecutionDeps.ts
+++ b/worker/src/features/evaluation/evalExecutionDeps.ts
@@ -44,7 +44,7 @@ export type ModelConfigResult =
  * Parameters for calling the LLM.
  */
 export interface LLMCallParams {
-  messages: ReturnType<typeof buildEvalMessages>;
+  messages: Awaited<ReturnType<typeof buildEvalMessages>>;
   modelConfig: Extract<ModelConfigResult, { valid: true }>["config"];
   structuredOutputSchema: StructuredOutputSchema;
   traceSinkParams: {

--- a/worker/src/features/evaluation/evalRuntime.ts
+++ b/worker/src/features/evaluation/evalRuntime.ts
@@ -2,8 +2,12 @@ import {
   ChatMessageRole,
   ChatMessageType,
   parseUnknownToString,
+  MediaReferenceStringSchema,
+  type ChatMessage,
 } from "@langfuse/shared";
-import { type ExtractedVariable } from "@langfuse/shared/src/server";
+import { type ExtractedVariable, logger } from "@langfuse/shared/src/server";
+import { prisma } from "@langfuse/shared/src/db";
+import { getMediaStorageClient } from "./mediaStorageClient";
 import { compileTemplateString } from "../utils";
 
 export interface CompileEvalPromptParams {
@@ -43,13 +47,138 @@ export function buildEvalExecutionMetadata(params: {
   ) as Record<string, string>;
 }
 
-export function buildEvalMessages(prompt: string) {
+const MEDIA_REFERENCE_PATTERN = /@@@langfuseMedia:[\s\S]*?@@@/g;
+const MEDIA_URL_TTL_SECONDS = 3600;
+
+type EvalContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
+/**
+ * Resolves a Langfuse media reference to a presigned download URL the LLM
+ * provider can fetch. Returns null when the media record is missing, was not
+ * uploaded successfully, or the lookup/presign fails, so callers can fall back
+ * to plain text rather than failing the whole eval job on a transient storage
+ * error.
+ */
+async function resolveMediaUrl(
+  projectId: string,
+  mediaId: string,
+): Promise<string | null> {
+  try {
+    const media = await prisma.media.findUnique({
+      where: { projectId_id: { projectId, id: mediaId } },
+    });
+
+    if (
+      !media ||
+      !(media.uploadHttpStatus === 200 || media.uploadHttpStatus === 201)
+    ) {
+      return null;
+    }
+
+    return await getMediaStorageClient(media.bucketName).getSignedUrl(
+      media.bucketPath,
+      MEDIA_URL_TTL_SECONDS,
+      false, // inline disposition so providers can fetch the image directly
+    );
+  } catch (error) {
+    logger.warn(
+      `Failed to resolve media ${mediaId} for eval in project ${projectId}; falling back to text`,
+      error,
+    );
+    return null;
+  }
+}
+
+/**
+ * Builds the chat messages sent to the LLM-as-a-judge model.
+ *
+ * When the compiled prompt contains `@@@langfuseMedia:...@@@` image references,
+ * they are resolved to presigned URLs and emitted as multimodal `image_url`
+ * content parts so the judge can actually see the image. Prompts without
+ * resolvable image media keep their plain-string content.
+ */
+export async function buildEvalMessages(
+  prompt: string,
+  projectId: string,
+): Promise<ChatMessage[]> {
+  const matches = [...prompt.matchAll(MEDIA_REFERENCE_PATTERN)];
+
+  if (matches.length === 0) {
+    return [
+      { type: ChatMessageType.User, role: ChatMessageRole.User, content: prompt },
+    ];
+  }
+
+  // First pass: split the prompt into ordered segments. Image media records the
+  // id to resolve; non-image media and invalid references stay as text so the
+  // judge still sees that media was referenced.
+  type Segment =
+    | { kind: "text"; text: string }
+    | { kind: "image"; mediaId: string; referenceString: string; url?: string | null };
+
+  const segments: Segment[] = [];
+  let lastIndex = 0;
+
+  for (const match of matches) {
+    const matchIndex = match.index ?? 0;
+    if (matchIndex > lastIndex) {
+      segments.push({ kind: "text", text: prompt.substring(lastIndex, matchIndex) });
+    }
+
+    const referenceString = match[0];
+    const parsed = MediaReferenceStringSchema.safeParse(referenceString);
+
+    if (parsed.success && parsed.data.type?.startsWith("image/")) {
+      segments.push({ kind: "image", mediaId: parsed.data.id, referenceString });
+    } else {
+      segments.push({ kind: "text", text: referenceString });
+    }
+
+    lastIndex = matchIndex + referenceString.length;
+  }
+
+  if (lastIndex < prompt.length) {
+    segments.push({ kind: "text", text: prompt.substring(lastIndex) });
+  }
+
+  // Resolve all image references concurrently, then assemble parts in order.
+  const imageSegments = segments.filter(
+    (segment): segment is Extract<Segment, { kind: "image" }> =>
+      segment.kind === "image",
+  );
+  await Promise.all(
+    imageSegments.map(async (segment) => {
+      segment.url = await resolveMediaUrl(projectId, segment.mediaId);
+    }),
+  );
+
+  const contentParts: EvalContentPart[] = segments.map((segment) =>
+    segment.kind === "text"
+      ? { type: "text", text: segment.text }
+      : segment.url
+        ? { type: "image_url", image_url: { url: segment.url } }
+        : { type: "text", text: segment.referenceString },
+  );
+
+  // If nothing resolved to an actual image, send a plain-string message to keep
+  // behavior identical to the non-multimodal path.
+  const hasImage = contentParts.some((part) => part.type === "image_url");
+  if (!hasImage) {
+    return [
+      { type: ChatMessageType.User, role: ChatMessageRole.User, content: prompt },
+    ];
+  }
+
   return [
     {
-      type: ChatMessageType.User,
+      // PublicAPICreated is the ChatMessage variant that carries array content;
+      // role drives the downstream langchain message construction.
+      type: ChatMessageType.PublicAPICreated,
       role: ChatMessageRole.User,
-      content: prompt,
-    } as const,
+      content: contentParts,
+    },
   ];
 }
 

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -856,7 +856,7 @@ export async function runLLMAsJudgeEvaluation({
       span.setAttribute("eval.model.name", modelConfig.config.model);
 
       // Prepare LLM call
-      const messages = buildEvalMessages(prompt);
+      const messages = await buildEvalMessages(prompt, projectId);
 
       const executionTraceId = createW3CTraceId(jobExecutionId);
 

--- a/worker/src/features/evaluation/evaluationHelpers.test.ts
+++ b/worker/src/features/evaluation/evaluationHelpers.test.ts
@@ -468,10 +468,10 @@ describe("evaluation helpers", () => {
   });
 
   describe("buildEvalMessages", () => {
-    it("should build user message array", () => {
+    it("should build user message array", async () => {
       const prompt = "Evaluate this response";
 
-      const result = buildEvalMessages(prompt);
+      const result = await buildEvalMessages(prompt, "project-id");
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
@@ -481,10 +481,10 @@ describe("evaluation helpers", () => {
       });
     });
 
-    it("should handle multiline prompts", () => {
+    it("should handle multiline prompts", async () => {
       const prompt = "First line\nSecond line\nThird line";
 
-      const result = buildEvalMessages(prompt);
+      const result = await buildEvalMessages(prompt, "project-id");
 
       expect(result[0].content).toBe("First line\nSecond line\nThird line");
     });

--- a/worker/src/features/evaluation/mediaStorageClient.ts
+++ b/worker/src/features/evaluation/mediaStorageClient.ts
@@ -1,0 +1,37 @@
+import {
+  type StorageService,
+  StorageServiceFactory,
+} from "@langfuse/shared/src/server";
+import { env } from "../../env";
+
+/**
+ * Singleton S3 storage client for media stored via the multi-modality upload
+ * flow. Used when resolving `@@@langfuseMedia:...@@@` references for
+ * LLM-as-a-judge evaluators so the worker can presign media download URLs.
+ *
+ * Mirrors the web `getMediaStorageServiceClient` helper but reads the worker
+ * env. The media bucket is determined by the persisted media record, so the
+ * client is cached per bucket name (different media records may live in
+ * different buckets).
+ */
+const mediaStorageClientsByBucket = new Map<string, StorageService>();
+
+export function getMediaStorageClient(bucketName: string): StorageService {
+  const cached = mediaStorageClientsByBucket.get(bucketName);
+  if (cached) {
+    return cached;
+  }
+
+  const client = StorageServiceFactory.getInstance({
+    bucketName,
+    accessKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID,
+    secretAccessKey: env.LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY,
+    endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
+    region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
+    forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
+    awsSse: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE,
+    awsSseKmsKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID,
+  });
+  mediaStorageClientsByBucket.set(bucketName, client);
+  return client;
+}


### PR DESCRIPTION
## Problem

LLM-as-a-judge evaluators could not access images stored as `LangfuseMedia`. When a trace field containing a `@@@langfuseMedia:...@@@` reference was mapped into an evaluator prompt, the judge received the raw reference/URL as text and responded that it could not see the image. Closes #13799.

## Root cause

`buildEvalMessages` produced a plain-string user message, and the underlying `fetchLLMCompletion` only ever constructed string-content messages — any non-string content was `JSON.stringify`'d before being passed to the model. So even a structured multimodal message would have been flattened to text and never reach the provider as an image.

## Changes

- `fetchLLMCompletion`: pass array (multimodal) message content through to the langchain message constructors instead of stringifying it, via a `toLangchainMessageContent` helper used in both the single-message and multi-message paths. Strings and other shapes behave exactly as before.
- `buildEvalMessages`: detect `@@@langfuseMedia:...@@@` references in the compiled prompt, resolve image media to a presigned download URL, and emit multimodal `image_url` content parts interleaved with the surrounding text.
  - Reuses the shared `StorageService` (new `mediaStorageClient` helper mirroring the web media client) rather than a hand-rolled S3 client.
  - Only `image/*` media is sent as `image_url`; non-image media and unresolvable/missing references fall back to text, and a prompt with no resolvable image still produces a plain-string message (unchanged behavior).

## Tests

- New `buildEvalMessages.test.ts`: no-media passthrough, image resolution to `image_url`, missing-media fallback, and non-image media handling.
- Updated `evaluationHelpers.test.ts` for the async signature.

Verified locally: shared build, worker typecheck, targeted tests, and lint all pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds multimodal image support to LLM-as-a-judge evaluators by detecting `@@@langfuseMedia:...@@@` references in compiled prompts, resolving them to presigned S3 URLs, and emitting structured `image_url` content blocks that reach the provider as real images rather than raw text strings.

- **`fetchLLMCompletion`** gains a `toLangchainMessageContent` helper that passes array content (multimodal blocks) through to LangChain message constructors unchanged, instead of JSON-stringifying them.
- **`buildEvalMessages`** is promoted to `async`, gains a `projectId` parameter, and emits a `PublicAPICreated`-typed message with an array of `text`/`image_url` parts when the prompt contains resolvable image references; prompts without images keep their existing plain-string path.
- A new `mediaStorageClient.ts` singleton wraps `StorageServiceFactory` for the worker, mirroring the web's `getMediaStorageServiceClient`, and new unit tests cover the no-media, resolved-image, missing-media, and non-image-media cases.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core logic is sound and the happy path works correctly, but a transient S3 error during presigned URL generation will now throw and fail the whole eval job rather than gracefully degrading to text.

The `resolveMediaUrl` function calls `getSignedUrl` without a try/catch. Any transient storage error (S3 timeout, credential issue, network blip) propagates out of `buildEvalMessages` and kills the evaluation job entirely. Before this PR, unresolvable media silently fell back to plain text. Restoring that graceful-degradation behaviour for storage errors is important for eval reliability.

`worker/src/features/evaluation/evalRuntime.ts` — the `resolveMediaUrl` function needs error handling around the `getSignedUrl` call. `worker/src/features/evaluation/mediaStorageClient.ts` — the singleton ignores bucket name changes after first construction.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
worker/src/features/evaluation/evalRuntime.ts:62-82
**Unhandled storage error causes eval job to hard-fail**

`getSignedUrl` can throw (transient S3 error, misconfigured credentials, network timeout). When it does, the exception propagates straight out of `buildEvalMessages` and then out of `runLLMAsJudgeEvaluation`, failing the entire eval job. Before this PR, unresolvable media simply left the reference string as text and the job succeeded. Wrapping the storage call in a `try/catch` and returning `null` on error would restore the graceful-degradation behaviour for transient failures.

### Issue 2 of 3
worker/src/features/evaluation/mediaStorageClient.ts:18-32
**Singleton ignores `bucketName` after first initialisation**

The singleton is initialised with the first `bucketName` passed in. If a later call provides a different bucket name (e.g., a second media record stored in a different bucket), the same client — pointing at the original bucket — is returned silently. Any presigned URL generated for the second bucket would be malformed or denied. This mirrors the web's `getMediaStorageServiceClient`, but worth noting here as `resolveMediaUrl` calls this per media record and each record carries its own `bucketName`.

### Issue 3 of 3
worker/src/features/evaluation/evalRuntime.ts:107-133
**Sequential media resolution — consider parallelising**

Each image reference is resolved one-at-a-time with `await resolveMediaUrl(...)` inside the `for` loop. A prompt with N images triggers N serial DB + storage round-trips. Collecting the image references first and then using `Promise.all` would resolve them concurrently without any change in observable behaviour.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: implement multimodal content suppo..."](https://github.com/langfuse/langfuse/commit/1fe4ea041f88967b154e0ec3020276696ff8d166) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40202825)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->