### PR TITLE
fix(web): allow Azure Blob Storage in CSP connect-src

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -11,7 +11,9 @@ import { env } from "./src/env.mjs";
  * img-src https to allow loading images from SSO providers
  */
 // Dataset attachments PUT media directly to presigned storage URLs, so
-// connect-src must allow AWS S3 and the configured S3-compatible endpoint.
+// connect-src must allow AWS S3, Azure Blob Storage, and the configured
+// S3-compatible endpoint. The endpoint env var is only present at runtime in
+// official Docker images, so static wildcards cover the common providers too.
 const mediaUploadConnectSrc = (() => {
   const endpoint = env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT;
   if (!endpoint) return "";
@@ -35,7 +37,7 @@ const cspHeader = `
   base-uri 'self';
   form-action 'self' https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com;
   frame-ancestors 'none';
-  connect-src 'self' ${mediaUploadConnectSrc}https://*.langfuse.com https://*.langfuse.dev https://*.ingest.us.sentry.io https://*.sentry.io https://chat.uk.plain.com https://*.amazonaws.com https://prod-uk-services-attachm-attachmentsuploadbucket2-1l2e4906o2asm.s3.eu-west-2.amazonaws.com https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com https://graph.microsoft.com;
+  connect-src 'self' ${mediaUploadConnectSrc}https://*.langfuse.com https://*.langfuse.dev https://*.ingest.us.sentry.io https://*.sentry.io https://chat.uk.plain.com https://*.amazonaws.com https://*.blob.core.windows.net https://prod-uk-services-attachm-attachmentsuploadbucket2-1l2e4906o2asm.s3.eu-west-2.amazonaws.com https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com https://graph.microsoft.com;
   media-src 'self' https: http://localhost:*;
   ${env.LANGFUSE_CSP_ENFORCE_HTTPS === "true" ? "upgrade-insecure-requests; block-all-mixed-content;" : ""}
   ${env.SENTRY_CSP_REPORT_URI ? `report-uri ${env.SENTRY_CSP_REPORT_URI}; report-to csp-endpoint;` : ""}


### PR DESCRIPTION
## Problem

Self-hosting Langfuse and pointing media uploads at Azure Blob Storage via `LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT=https://<account>.blob.core.windows.net` fails on the browser side with a CSP error:

```
Refused to connect to 'https://<account>.blob.core.windows.net/...' because it violates the
following Content Security Policy directive: "connect-src 'self' ... https://*.amazonaws.com ..."
```

The backend Azure support (presigned URLs, upload headers) already works — only the browser CSP is missing an Azure entry. The `mediaUploadConnectSrc` value derived from the endpoint env var is empty during the Docker image build (`next build` runs before the runtime env var is injected), so it can't cover this case for the official images.

## Fix

Add a static `https://*.blob.core.windows.net` wildcard to `connect-src`, next to the existing `https://*.amazonaws.com` wildcard that already covers AWS S3 out of the box. This lets direct-to-storage uploads to standard Azure Blob accounts work without a custom image build.

Matches the approach the maintainers/Dosu and the reporter aligned on in #14613.

Closes #14613

<!-- oss-radar:idempotency=auto-20260628-100846.w3.langfuse_langfuse.14613 -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `https://*.blob.core.windows.net` as a static wildcard to the CSP `connect-src` directive, fixing browser CSP violations when self-hosters configure Azure Blob Storage as the media upload endpoint. The fix is necessary because the `LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT` env var is injected at runtime in Docker images — after `next build` runs — so the dynamic `mediaUploadConnectSrc` value is empty during the build, leaving Azure endpoints uncovered.

- Adds `https://*.blob.core.windows.net` to `connect-src`, mirroring the existing `https://*.amazonaws.com` wildcard for AWS S3, ensuring direct-to-storage PUT uploads to Azure Blob work out of the box.
- Updates the comment block above `mediaUploadConnectSrc` to document why static wildcards are needed alongside the runtime-derived value.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single, targeted addition to the CSP allowlist that unblocks a documented self-hosting scenario without relaxing security beyond what the existing AWS wildcard already establishes.

The change is one line in the CSP string. It adds the standard Azure Blob Storage wildcard in the same position as the AWS wildcard that has been in place for some time, and the comment is updated to match. There are no logic branches, no new code paths, and no credentials involved. The breadth of *.blob.core.windows.net is intentional and consistent with *.amazonaws.com.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant LangfuseAPI as Langfuse API (backend)
    participant AzureBlob as Azure Blob Storage (*.blob.core.windows.net)

    Browser->>LangfuseAPI: Request presigned upload URL
    LangfuseAPI-->>Browser: "Presigned URL (*.blob.core.windows.net/...)"
    Note over Browser: CSP connect-src checked for presigned URL host
    Browser->>AzureBlob: PUT file (direct upload via presigned URL)
    AzureBlob-->>Browser: 200 OK
    Browser->>LangfuseAPI: Confirm upload complete
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant LangfuseAPI as Langfuse API (backend)
    participant AzureBlob as Azure Blob Storage (*.blob.core.windows.net)

    Browser->>LangfuseAPI: Request presigned upload URL
    LangfuseAPI-->>Browser: "Presigned URL (*.blob.core.windows.net/...)"
    Note over Browser: CSP connect-src checked for presigned URL host
    Browser->>AzureBlob: PUT file (direct upload via presigned URL)
    AzureBlob-->>Browser: 200 OK
    Browser->>LangfuseAPI: Confirm upload complete
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): allow Azure Blob Storage in CS..."](https://github.com/langfuse/langfuse/commit/3e9f0b2254a811dd67cdd3e370bb6e3186cd1bd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40329506)</sub>

<!-- /greptile_comment -->