### PR TITLE
fix(blob-export): tag ClickHouse export queries with surface and route

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2704,7 +2704,8 @@ const buildEventsForBlobStorageExportQuery = (
   return {
     query,
     params,
-    tags: { projectId },
+    // Tagged explicitly: worker baggage isn't active during the deferred stream send.
+    tags: { projectId, surface: "worker", route: "blob_export" },
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1736,7 +1736,8 @@ const buildObservationsForBlobStorageExportQuery = (
       minTimestamp: convertDateToClickhouseDateTime(minTimestamp),
       maxTimestamp: convertDateToClickhouseDateTime(maxTimestamp),
     },
-    tags: { projectId },
+    // Tagged explicitly: worker baggage isn't active during the deferred stream send.
+    tags: { projectId, surface: "worker", route: "blob_export" },
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1946,7 +1946,8 @@ const buildScoresForBlobStorageExportQuery = (
       maxTimestamp: convertDateToClickhouseDateTime(maxTimestamp),
       dataTypes: LISTABLE_SCORE_TYPES,
     },
-    tags: { projectId },
+    // Tagged explicitly: worker baggage isn't active during the deferred stream send.
+    tags: { projectId, surface: "worker", route: "blob_export" },
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1315,7 +1315,8 @@ const buildTracesForBlobStorageExportQuery = (
       minTimestamp: convertDateToClickhouseDateTime(minTimestamp),
       maxTimestamp: convertDateToClickhouseDateTime(maxTimestamp),
     },
-    tags: { projectId },
+    // Tagged explicitly: worker baggage isn't active during the deferred stream send.
+    tags: { projectId, surface: "worker", route: "blob_export" },
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },


### PR DESCRIPTION
## What does this PR do?

Blob-storage export query builders set `tags: { projectId }` and relied on the worker's `surface=worker` baggage (set in `metricWrapper` via `otelContext.with`). But these exports run through `queryClickhouseStream` / `queryClickhouseStreamRawText` / `queryClickhouseExecRaw`, where the query is sent during **deferred stream iteration** — after the baggage context is gone. As a result `normalizeClickHouseQueryTags` fell back to `surface=unknown` in both the ClickHouse `query_log` `log_comment` and APM spans.

Confirmed in Datadog (prod-us): worker `clickhouse - query - stream` spans running export queries are tagged `surface: unknown`, while awaited `queryClickhouse` queries (e.g. `trace_upsert`) correctly show `surface: worker`.

Fix: set `surface: "worker"` **and** `route: "blob_export"` explicitly in the `observations`, `events`, `traces`, and `scores` export builders. `surface` no longer depends on baggage propagation, and `route=blob_export` makes blob exports identifiable in `query_log` / APM. Covers all three export paths (standard / raw-passthrough / parquet) since they share the builders.

Fixes # (no issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Verified with `pnpm turbo run typecheck lint` for `@langfuse/shared` and `worker` (pre-commit lint also passed across all packages).
