### PR TITLE
chore(model-price-bot): update pricing URL

### DIFF
--- a/.agents/skills/add-model-price/references/provider-sources-and-price-keys.md
+++ b/.agents/skills/add-model-price/references/provider-sources-and-price-keys.md
@@ -15,9 +15,9 @@ Always fetch pricing from the provider's official docs before editing.
 
 ### Known source quirks (as of 2026-06)
 
-- **OpenAI** — `openai.com/api/pricing/` returns HTTP 403 to automated fetchers. No
-  accessible alternative has been confirmed. If this page fails, leave OpenAI prices
-  unchanged and report the 403 as an unresolved finding.
+- **OpenAI** — `openai.com/api/pricing/` often returns HTTP 403 to automated fetchers.
+  Use `https://developers.openai.com/api/docs/pricing` instead as that is often permitted.
+  If this page fails, leave OpenAI prices unchanged and report the 403 as an unresolved finding.
 - **OpenAI matchPattern prefix** — All OpenAI model entries must include `(openai\/)?`
   as an optional prefix in their matchPattern (e.g., `(?i)^(openai\/)?(gpt-4o)$`).
   Entries missing this prefix will not match model IDs sent with the `openai/` prefix.


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the reference documentation used by the model-price bot agent, replacing the previously broken OpenAI pricing URL with an alternative that is more permissive to automated fetchers.

- The wording for the OpenAI pricing source is softened from a definitive "returns HTTP 403" to "often returns HTTP 403", and a new fallback URL (`https://developers.openai.com/api/docs/pricing`) is provided as the preferred endpoint for automated fetching.
- No code logic, schemas, or test files are changed — only a single markdown reference file is affected.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to a markdown reference file used by an agent skill, with no impact on production code paths.

The only change is updating a fallback URL and softening the wording in a documentation/reference file. No logic, configuration, or data processing is touched, so the risk of introducing a regression is essentially zero.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Bot as Model Price Bot
    participant Primary as openai.com/api/pricing/
    participant Fallback as developers.openai.com/api/docs/pricing

    Bot->>Primary: Fetch pricing (GET)
    alt HTTP 403 (often)
        Primary-->>Bot: 403 Forbidden
        Bot->>Fallback: Fetch pricing (GET)
        alt Success
            Fallback-->>Bot: 200 OK + pricing data
            Bot->>Bot: Update model prices
        else Also fails
            Fallback-->>Bot: Error
            Bot->>Bot: Leave OpenAI prices unchanged, report unresolved finding
        end
    else Success
        Primary-->>Bot: 200 OK + pricing data
        Bot->>Bot: Update model prices
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Bot as Model Price Bot
    participant Primary as openai.com/api/pricing/
    participant Fallback as developers.openai.com/api/docs/pricing

    Bot->>Primary: Fetch pricing (GET)
    alt HTTP 403 (often)
        Primary-->>Bot: 403 Forbidden
        Bot->>Fallback: Fetch pricing (GET)
        alt Success
            Fallback-->>Bot: 200 OK + pricing data
            Bot->>Bot: Update model prices
        else Also fails
            Fallback-->>Bot: Error
            Bot->>Bot: Leave OpenAI prices unchanged, report unresolved finding
        end
    else Success
        Primary-->>Bot: 200 OK + pricing data
        Bot->>Bot: Update model prices
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(model-price-bot): update pricing U..."](https://github.com/langfuse/langfuse/commit/1f479f22329af6b8b991131dfc6c48f1b0d0e1d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40478611)</sub>

<!-- /greptile_comment -->