### PR TITLE
fix(worker): emit blob export stage timing on failures (LFE-10441)

### DIFF
--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -15,12 +15,18 @@ const originalCloudRegion = vi.hoisted(() => {
   return cloudRegion;
 });
 
-// Override only recordIncrement so the attempt counter is assertable.
+// Override recordIncrement + recordHistogram so the attempt counter and
+// per-stage timing metrics are assertable.
 const mockRecordIncrement = vi.hoisted(() => vi.fn());
+const mockRecordHistogram = vi.hoisted(() => vi.fn());
 vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@langfuse/shared/src/server")>();
-  return { ...actual, recordIncrement: mockRecordIncrement };
+  return {
+    ...actual,
+    recordIncrement: mockRecordIncrement,
+    recordHistogram: mockRecordHistogram,
+  };
 });
 
 import { env } from "../env";
@@ -201,6 +207,89 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     // Then
     const files = await storageService.listFiles(s3Prefix);
     expect(files.filter((f) => f.file.includes(projectId))).toHaveLength(0);
+  });
+
+  // LFE-10441: per-stage timing histograms must also be emitted when an export
+  // fails (originally gated on upload success), tagged outcome="failure" so the
+  // happy-path percentiles stay clean.
+  it("emits per-stage timing histograms tagged outcome=failure when the upload fails", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    s3Prefix = projectId;
+
+    await prisma.blobStorageIntegration.create({
+      data: {
+        projectId,
+        type: BlobStorageIntegrationType.S3,
+        bucketName,
+        prefix: s3Prefix,
+        accessKeyId: minioAccessKeyId,
+        secretAccessKey: encrypt(minioAccessKeySecret),
+        region: region ? region : "auto",
+        // endpoint null -> skip the persisted-endpoint preflight; the storage
+        // service is mocked anyway, so no real connection is made.
+        endpoint: null,
+        forcePathStyle:
+          env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+        enabled: true,
+        exportFrequency: "daily",
+        // Non-enriched source: sidesteps the enriched-export guard regardless of
+        // V4 preview state, so this runs outside maybeDescribe on every CI leg.
+        exportSource: "TRACES_OBSERVATIONS",
+        // A past lastSyncAt yields a non-empty export window without requiring
+        // the ClickHouse min-timestamp probe.
+        lastSyncAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+      },
+    });
+
+    // Force every upload to reject so the export takes the failure path.
+    const getInstanceSpy = vi
+      .spyOn(StorageServiceFactory, "getInstance")
+      .mockReturnValue({
+        uploadFileBuffered: vi
+          .fn()
+          .mockRejectedValue(new Error("simulated upload failure")),
+      } as unknown as StorageService);
+
+    mockRecordIncrement.mockClear();
+    mockRecordHistogram.mockClear();
+
+    try {
+      await expect(
+        handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+        } as Job),
+      ).rejects.toThrow(/simulated upload failure/i);
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+
+    // Failure attempt counter fired.
+    expect(mockRecordIncrement).toHaveBeenCalledWith(
+      "langfuse.blobstorage.table_export.count",
+      1,
+      expect.objectContaining({ outcome: "failure", projectId }),
+    );
+
+    // All four stage timers emitted with outcome=failure...
+    for (const metric of [
+      "langfuse.blob_export.ch_read_ms",
+      "langfuse.blob_export.enrich_ms",
+      "langfuse.blob_export.gzip_cpu_ms",
+      "langfuse.blob_export.upload_wait_ms",
+    ]) {
+      expect(mockRecordHistogram).toHaveBeenCalledWith(
+        metric,
+        expect.any(Number),
+        expect.objectContaining({ outcome: "failure" }),
+      );
+    }
+
+    // ...and never with outcome=success, since no upload succeeded.
+    expect(mockRecordHistogram).not.toHaveBeenCalledWith(
+      "langfuse.blob_export.ch_read_ms",
+      expect.any(Number),
+      expect.objectContaining({ outcome: "success" }),
+    );
   });
 
   maybeDescribe("events table export tests", () => {

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -838,49 +838,54 @@ const processBlobStorageExport = async (config: {
               uploadDurationMsFinal ??
               Math.round(performance.now() - uploadStartMs);
             span.setAttribute("blob.uploadDurationMs", totalUploadMs);
-            if (uploadSucceeded) {
-              const finalGzipCpuMs = gzipStats
-                ? Math.max(
-                    0,
-                    Math.round(gzipStats.activeMs - gzipStats.backpressureMs),
-                  )
-                : 0;
-              const finalUploadWaitMs = gzipStats
-                ? Math.round(gzipStats.backpressureMs)
-                : parquetEligible
-                  ? Math.round(sourceStats.backpressureMs)
-                  : Math.max(0, totalUploadMs - finalChReadMs - finalEnrichMs);
-              span.setAttribute("blob.gzipCpuMs", finalGzipCpuMs);
-              span.setAttribute("blob.uploadWaitMs", finalUploadWaitMs);
-              const finalExportFormat = parquetEligible
-                ? BlobExportFormat.PARQUET
-                : resolveBlobExportFormat(config.fileType, config.compressed);
-              const stageTags = {
-                table: config.table,
-                path: exportPath,
-                source: finalExportFormat,
-              };
-              recordHistogram(
-                "langfuse.blob_export.ch_read_ms",
-                finalChReadMs,
-                stageTags,
-              );
-              recordHistogram(
-                "langfuse.blob_export.enrich_ms",
-                finalEnrichMs,
-                stageTags,
-              );
-              recordHistogram(
-                "langfuse.blob_export.gzip_cpu_ms",
-                finalGzipCpuMs,
-                stageTags,
-              );
-              recordHistogram(
-                "langfuse.blob_export.upload_wait_ms",
-                finalUploadWaitMs,
-                stageTags,
-              );
-            }
+            // Emit stage timings on both success and failure. On failure the
+            // values are partial (the upload aborted mid-stream), so an
+            // `outcome` tag keeps them out of the happy-path percentiles while
+            // still capturing where a failed export spent its time.
+            const finalGzipCpuMs = gzipStats
+              ? Math.max(
+                  0,
+                  Math.round(gzipStats.activeMs - gzipStats.backpressureMs),
+                )
+              : 0;
+            const finalUploadWaitMs = gzipStats
+              ? Math.round(gzipStats.backpressureMs)
+              : parquetEligible
+                ? Math.round(sourceStats.backpressureMs)
+                : Math.max(0, totalUploadMs - finalChReadMs - finalEnrichMs);
+            span.setAttribute("blob.gzipCpuMs", finalGzipCpuMs);
+            span.setAttribute("blob.uploadWaitMs", finalUploadWaitMs);
+            const finalExportFormat = parquetEligible
+              ? BlobExportFormat.PARQUET
+              : resolveBlobExportFormat(config.fileType, config.compressed);
+            const stageTags = {
+              table: config.table,
+              path: exportPath,
+              source: finalExportFormat,
+              outcome: (uploadSucceeded
+                ? "success"
+                : "failure") satisfies BlobTableExportOutcome,
+            };
+            recordHistogram(
+              "langfuse.blob_export.ch_read_ms",
+              finalChReadMs,
+              stageTags,
+            );
+            recordHistogram(
+              "langfuse.blob_export.enrich_ms",
+              finalEnrichMs,
+              stageTags,
+            );
+            recordHistogram(
+              "langfuse.blob_export.gzip_cpu_ms",
+              finalGzipCpuMs,
+              stageTags,
+            );
+            recordHistogram(
+              "langfuse.blob_export.upload_wait_ms",
+              finalUploadWaitMs,
+              stageTags,
+            );
           }
           if (producesUploadStats) {
             span.setAttribute("blob.upload.parts", uploadStats.partsUploaded);


### PR DESCRIPTION
## What does this PR do?

LFE-10441 added per-stage timing to the blob export pipeline (`ch_read_ms`, `enrich_ms`, `gzip_cpu_ms`, `upload_wait_ms`), but these histograms and their `blob.gzipCpuMs` / `blob.uploadWaitMs` span attributes were nested inside `if (uploadSucceeded)`. As a result, no stage timing was emitted when an export failed — exactly the case where knowing where time was spent is most useful.

This lifts the four histograms out of that gate so they emit whenever an upload was attempted (on both success and failure), and adds an `outcome: "success" | "failure"` tag (typed against the existing `BlobTableExportOutcome`) so partial failure timings don't pollute the happy-path percentiles.

Notes:
- Failures that occur before the upload starts (e.g. an invalid file type, or a Parquet source connection error during setup) still emit nothing — there is no meaningful timing yet. ClickHouse read failures on the standard/passthrough/Parquet paths surface mid-stream during upload consumption, so they are now captured.
- Dashboard impact: the success-path series now carries an extra `outcome:success` tag. Aggregate queries are unaffected; consumers can now split success vs. failure, and dashboards wanting the prior behaviour can filter `outcome:success`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] Added a regression test that forces the upload to fail and asserts all four histograms fire with `outcome=failure` (and none with `success`).
- [x] `pnpm turbo run typecheck lint --filter=worker` passes; the new test passes against local ClickHouse/MinIO/Postgres.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where per-stage timing histograms (`ch_read_ms`, `enrich_ms`, `gzip_cpu_ms`, `upload_wait_ms`) were only emitted on successful blob export uploads, making the failure path — the most diagnostically interesting case — invisible in metrics. The fix lifts the four `recordHistogram` calls out of the `if (uploadSucceeded)` guard in the `finally` block and adds an `outcome: "success" | "failure"` tag (typed with `satisfies BlobTableExportOutcome`) so failure-path timings don't pollute success-percentile dashboards.

- The histogram emission and `span.setAttribute` calls for `gzipCpuMs`/`uploadWaitMs` are now unconditional within the `if (uploadStartMs !== undefined)` gate, preserving the existing guard that skips timings for failures before any upload was attempted.
- A new integration test forces `uploadFileBuffered` to reject via a `StorageServiceFactory.getInstance` spy, then asserts all four histograms fire with `outcome=failure` and none with `outcome=success`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge — it expands metric emission in a finally block without altering business logic or the error propagation path.

The fix is minimal and well-scoped: four recordHistogram calls move out of a guard and gain an outcome tag, with no changes to control flow, error handling, or stream processing. The satisfies BlobTableExportOutcome type assertion catches any future tag-name drift at compile time. The new integration test covers the failure case end-to-end.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): emit blob export stage timi..."](https://github.com/langfuse/langfuse/commit/ef862a5fd9dc9138c997debd3f29b7030be08eb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40480970)</sub>

<!-- /greptile_comment -->