### PR TITLE
chore(blob-export): add chSendTimeout ClickHouse export tuning

### DIFF
--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
@@ -27,6 +27,7 @@ function resolved(
     maxConcurrentParts: undefined,
     maxPartAttempts: undefined,
     skipEnrichment: false,
+    chSendTimeout: undefined,
     ...overrides,
   };
 }
@@ -232,6 +233,56 @@ describe("resolveBlobExportTuning", () => {
     });
   });
 
+  describe("chSendTimeout (ClickHouse send_timeout)", () => {
+    it("is undefined (CH default) when absent", () => {
+      expect(
+        resolveBlobExportTuning({}, DEFAULTS).resolved.chSendTimeout,
+      ).toBeUndefined();
+    });
+
+    it("honors an in-range value silently", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { chSendTimeout: 600 },
+        DEFAULTS,
+      );
+      expect(res).toEqual(resolved({ chSendTimeout: 600 }));
+      expect(warnings).toEqual([]);
+    });
+
+    it("clamps above the ceiling and warns", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { chSendTimeout: 99999 },
+        DEFAULTS,
+      );
+      expect(res.chSendTimeout).toBe(
+        BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout.max,
+      );
+      expect(warnings.some((w) => w.includes("clamped"))).toBe(true);
+    });
+
+    it("clamps below the floor and warns", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { chSendTimeout: 0 },
+        DEFAULTS,
+      );
+      expect(res.chSendTimeout).toBe(
+        BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout.min,
+      );
+      expect(warnings.some((w) => w.includes("clamped"))).toBe(true);
+    });
+
+    it("falls back to undefined (CH default) when wrong-typed", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { chSendTimeout: "300" },
+        DEFAULTS,
+      );
+      expect(res.chSendTimeout).toBeUndefined();
+      expect(warnings.some((w) => w.includes("expected a finite number"))).toBe(
+        true,
+      );
+    });
+  });
+
   describe("valid in-range upload knobs are honoured silently", () => {
     it("passes through values within bounds", () => {
       const { resolved: res, warnings } = resolveBlobExportTuning(
@@ -400,6 +451,12 @@ describe("BlobExportTuningSchema (write schema)", () => {
     );
   });
 
+  it("accepts an in-range chSendTimeout", () => {
+    expect(
+      BlobExportTuningSchema.safeParse({ chSendTimeout: 600 }).success,
+    ).toBe(true);
+  });
+
   it("rejects out-of-range values (writes reject; reads clamp)", () => {
     expect(
       BlobExportTuningSchema.safeParse({ maxConcurrentParts: 50 }).success,
@@ -407,6 +464,9 @@ describe("BlobExportTuningSchema (write schema)", () => {
     expect(BlobExportTuningSchema.safeParse({ gzipLevel: 12 }).success).toBe(
       false,
     );
+    expect(
+      BlobExportTuningSchema.safeParse({ chSendTimeout: 99999 }).success,
+    ).toBe(false);
   });
 
   it("strips unknown keys (forward-compat, not strict)", () => {

--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
@@ -44,6 +44,9 @@ export const BLOB_EXPORT_TUNING_BOUNDS = {
   partSizeBytes: { min: 5 * 1024 * 1024, max: 5 * 1024 * 1024 * 1024 },
   maxConcurrentParts: { min: 1, max: 32 },
   maxPartAttempts: { min: 1, max: 10 },
+  // ClickHouse `send_timeout` (seconds) applied to the export query. CH's default
+  // is 300s; allow 1s..1h for per-project tuning of long-running exports.
+  chSendTimeout: { min: 1, max: 3600 },
 } as const;
 
 // Default part size when the column does not specify one. Matches the value
@@ -94,6 +97,16 @@ export const BlobExportTuningSchema = z.object({
     .max(BLOB_EXPORT_TUNING_BOUNDS.maxPartAttempts.max)
     .optional(),
   skipEnrichment: z.boolean().optional(),
+  // ClickHouse `send_timeout` (seconds) for the export query, passed through as a
+  // per-query clickhouse_setting. Absent => CH keeps its own default (300s).
+  // Out-of-range values are REJECTED here (write path) but CLAMPED by the
+  // read-side resolver.
+  chSendTimeout: z
+    .number()
+    .int()
+    .min(BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout.min)
+    .max(BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout.max)
+    .optional(),
 });
 
 export type BlobExportTuning = z.infer<typeof BlobExportTuningSchema>;
@@ -119,6 +132,9 @@ export type ResolvedBlobExportTuning = {
   maxConcurrentParts: number | undefined;
   maxPartAttempts: number | undefined;
   skipEnrichment: boolean;
+  // undefined => not set by the operator; ClickHouse keeps its own send_timeout
+  // default (300s). A concrete value (seconds) is applied per-query.
+  chSendTimeout: number | undefined;
 };
 
 export interface ResolveBlobExportTuningResult {
@@ -257,6 +273,7 @@ export function resolveBlobExportTuning(
     maxConcurrentParts: undefined,
     maxPartAttempts: undefined,
     skipEnrichment: false,
+    chSendTimeout: undefined,
   };
 
   if (raw === null || raw === undefined) {
@@ -318,6 +335,12 @@ export function resolveBlobExportTuning(
       skipEnrichment: resolveBoolean(
         "skipEnrichment",
         obj.skipEnrichment,
+        warnings,
+      ),
+      chSendTimeout: resolveOptionalNumber(
+        "chSendTimeout",
+        obj.chSendTimeout,
+        BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout,
         warnings,
       ),
     },

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2668,6 +2668,7 @@ const buildEventsForBlobStorageExportQuery = (
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[],
   convertLatencyToSecondsInSql: boolean,
+  chSendTimeout?: number,
 ) => {
   const queryBuilder = new EventsQueryBuilder({ projectId });
 
@@ -2709,6 +2710,9 @@ const buildEventsForBlobStorageExportQuery = (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
+    // Per-project ClickHouse send_timeout (seconds); undefined => CH default.
+    clickhouseSettings:
+      chSendTimeout !== undefined ? { send_timeout: chSendTimeout } : undefined,
     preferredClickhouseService: "EventsReadOnly" as const,
   };
 };
@@ -2718,6 +2722,7 @@ export const getEventsForBlobStorageExport = function (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
+  chSendTimeout?: number,
 ) {
   return queryClickhouseStream<Record<string, unknown>>(
     buildEventsForBlobStorageExportQuery(
@@ -2726,6 +2731,7 @@ export const getEventsForBlobStorageExport = function (
       maxTimestamp,
       fieldGroups,
       false, // standard path converts latency ms→s in JS
+      chSendTimeout,
     ),
   );
 };
@@ -2741,6 +2747,7 @@ export const getEventsForBlobStorageExportRaw = function (
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
   convertLatencyToSeconds = false,
+  chSendTimeout?: number,
 ) {
   return queryClickhouseStreamRawText(
     buildEventsForBlobStorageExportQuery(
@@ -2749,6 +2756,7 @@ export const getEventsForBlobStorageExportRaw = function (
       maxTimestamp,
       fieldGroups,
       convertLatencyToSeconds,
+      chSendTimeout,
     ),
   );
 };
@@ -2762,17 +2770,24 @@ export const getEventsForBlobStorageExportParquet = function (
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
   convertLatencyToSeconds = false,
+  chSendTimeout?: number,
 ) {
+  const base = buildEventsForBlobStorageExportQuery(
+    projectId,
+    minTimestamp,
+    maxTimestamp,
+    fieldGroups,
+    convertLatencyToSeconds,
+    chSendTimeout,
+  );
   return queryClickhouseExecRaw({
-    ...buildEventsForBlobStorageExportQuery(
-      projectId,
-      minTimestamp,
-      maxTimestamp,
-      fieldGroups,
-      convertLatencyToSeconds,
-    ),
+    ...base,
     format: "Parquet",
-    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+    // Merge so the per-project send_timeout survives alongside Parquet tuning.
+    clickhouseSettings: {
+      ...base.clickhouseSettings,
+      ...BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+    },
   });
 };
 

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1704,6 +1704,7 @@ const buildObservationsForBlobStorageExportQuery = (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[],
+  chSendTimeout?: number,
 ) => {
   // core is always required (provides id, trace_id, start/end_time used for deduplication)
   const effectiveGroups = new Set<ObservationFieldGroupFull>([
@@ -1741,6 +1742,9 @@ const buildObservationsForBlobStorageExportQuery = (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
+    // Per-project ClickHouse send_timeout (seconds); undefined => CH default.
+    clickhouseSettings:
+      chSendTimeout !== undefined ? { send_timeout: chSendTimeout } : undefined,
     preferredClickhouseService: "ReadOnly" as const,
   };
 };
@@ -1750,6 +1754,7 @@ export const getObservationsForBlobStorageExport = function (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
+  chSendTimeout?: number,
 ) {
   return queryClickhouseStream<Record<string, unknown>>(
     buildObservationsForBlobStorageExportQuery(
@@ -1757,6 +1762,7 @@ export const getObservationsForBlobStorageExport = function (
       minTimestamp,
       maxTimestamp,
       fieldGroups,
+      chSendTimeout,
     ),
   );
 };
@@ -1769,6 +1775,7 @@ export const getObservationsForBlobStorageExportRaw = function (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
+  chSendTimeout?: number,
 ) {
   return queryClickhouseStreamRawText(
     buildObservationsForBlobStorageExportQuery(
@@ -1776,6 +1783,7 @@ export const getObservationsForBlobStorageExportRaw = function (
       minTimestamp,
       maxTimestamp,
       fieldGroups,
+      chSendTimeout,
     ),
   );
 };
@@ -1788,16 +1796,23 @@ export const getObservationsForBlobStorageExportParquet = function (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
+  chSendTimeout?: number,
 ) {
+  const base = buildObservationsForBlobStorageExportQuery(
+    projectId,
+    minTimestamp,
+    maxTimestamp,
+    fieldGroups,
+    chSendTimeout,
+  );
   return queryClickhouseExecRaw({
-    ...buildObservationsForBlobStorageExportQuery(
-      projectId,
-      minTimestamp,
-      maxTimestamp,
-      fieldGroups,
-    ),
+    ...base,
     format: "Parquet",
-    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+    // Merge so the per-project send_timeout survives alongside Parquet tuning.
+    clickhouseSettings: {
+      ...base.clickhouseSettings,
+      ...BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+    },
   });
 };
 

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1912,6 +1912,7 @@ const buildScoresForBlobStorageExportQuery = (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
+  chSendTimeout?: number,
 ) => {
   const query = `
     SELECT
@@ -1951,6 +1952,9 @@ const buildScoresForBlobStorageExportQuery = (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
+    // Per-project ClickHouse send_timeout (seconds); undefined => CH default.
+    clickhouseSettings:
+      chSendTimeout !== undefined ? { send_timeout: chSendTimeout } : undefined,
   };
 };
 
@@ -1958,9 +1962,15 @@ export const getScoresForBlobStorageExport = function (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
+  chSendTimeout?: number,
 ) {
   return queryClickhouseStream<Record<string, unknown>>(
-    buildScoresForBlobStorageExportQuery(projectId, minTimestamp, maxTimestamp),
+    buildScoresForBlobStorageExportQuery(
+      projectId,
+      minTimestamp,
+      maxTimestamp,
+      chSendTimeout,
+    ),
   );
 };
 
@@ -1970,15 +1980,22 @@ export const getScoresForBlobStorageExportParquet = function (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
+  chSendTimeout?: number,
 ) {
+  const base = buildScoresForBlobStorageExportQuery(
+    projectId,
+    minTimestamp,
+    maxTimestamp,
+    chSendTimeout,
+  );
   return queryClickhouseExecRaw({
-    ...buildScoresForBlobStorageExportQuery(
-      projectId,
-      minTimestamp,
-      maxTimestamp,
-    ),
+    ...base,
     format: "Parquet",
-    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+    // Merge so the per-project send_timeout survives alongside Parquet tuning.
+    clickhouseSettings: {
+      ...base.clickhouseSettings,
+      ...BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+    },
   });
 };
 

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1280,6 +1280,7 @@ const buildTracesForBlobStorageExportQuery = (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
+  chSendTimeout?: number,
 ) => {
   const traceTable = "traces";
 
@@ -1320,6 +1321,9 @@ const buildTracesForBlobStorageExportQuery = (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
+    // Per-project ClickHouse send_timeout (seconds); undefined => CH default.
+    clickhouseSettings:
+      chSendTimeout !== undefined ? { send_timeout: chSendTimeout } : undefined,
   };
 };
 
@@ -1327,9 +1331,15 @@ export const getTracesForBlobStorageExport = function (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
+  chSendTimeout?: number,
 ) {
   return queryClickhouseStream<Record<string, unknown>>(
-    buildTracesForBlobStorageExportQuery(projectId, minTimestamp, maxTimestamp),
+    buildTracesForBlobStorageExportQuery(
+      projectId,
+      minTimestamp,
+      maxTimestamp,
+      chSendTimeout,
+    ),
   );
 };
 
@@ -1339,15 +1349,22 @@ export const getTracesForBlobStorageExportParquet = function (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
+  chSendTimeout?: number,
 ) {
+  const base = buildTracesForBlobStorageExportQuery(
+    projectId,
+    minTimestamp,
+    maxTimestamp,
+    chSendTimeout,
+  );
   return queryClickhouseExecRaw({
-    ...buildTracesForBlobStorageExportQuery(
-      projectId,
-      minTimestamp,
-      maxTimestamp,
-    ),
+    ...base,
     format: "Parquet",
-    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+    // Merge so the per-project send_timeout survives alongside Parquet tuning.
+    clickhouseSettings: {
+      ...base.clickhouseSettings,
+      ...BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
+    },
   });
 };
 

--- a/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
+++ b/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
@@ -4,6 +4,10 @@ import { Readable } from "stream";
 // Records of every uploadFileBuffered call so we can assert the resolved tuning
 // was threaded through. Hoisted so the module mock can close over it.
 const uploadCalls = vi.hoisted(() => [] as any[]);
+// Records (fnName, args) for each standard-path export getter call so we can
+// assert tuning that targets the ClickHouse query (e.g. chSendTimeout) is
+// threaded all the way down.
+const exportCalls = vi.hoisted(() => [] as { fn: string; args: any[] }[]);
 
 vi.mock("@langfuse/shared/src/db", () => ({
   prisma: {
@@ -36,10 +40,22 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
         }),
       }),
     },
-    getTracesForBlobStorageExport: () => empty(),
-    getObservationsForBlobStorageExport: () => empty(),
-    getScoresForBlobStorageExport: () => empty(),
-    getEventsForBlobStorageExport: () => empty(),
+    getTracesForBlobStorageExport: (...args: any[]) => {
+      exportCalls.push({ fn: "traces", args });
+      return empty();
+    },
+    getObservationsForBlobStorageExport: (...args: any[]) => {
+      exportCalls.push({ fn: "observations", args });
+      return empty();
+    },
+    getScoresForBlobStorageExport: (...args: any[]) => {
+      exportCalls.push({ fn: "scores", args });
+      return empty();
+    },
+    getEventsForBlobStorageExport: (...args: any[]) => {
+      exportCalls.push({ fn: "events", args });
+      return empty();
+    },
     // LFE-10463 Parquet path: each returns an already-resolved
     // { stream } (the binary body) — a tiny Readable with the Parquet magic.
     getTracesForBlobStorageExportParquet: async () => ({
@@ -108,7 +124,36 @@ function baseRow(exportTuning: unknown) {
 describe("handleBlobStorageIntegrationProjectJob tuning wiring", () => {
   beforeEach(() => {
     uploadCalls.length = 0;
+    exportCalls.length = 0;
     vi.clearAllMocks();
+  });
+
+  it("threads chSendTimeout into the standard export query", async () => {
+    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue(
+      baseRow({ chSendTimeout: 600 }),
+    );
+
+    await handleBlobStorageIntegrationProjectJob(makeJob());
+
+    // Standard-path getters take chSendTimeout as the last positional arg:
+    // traces/scores at index 3, observations (fieldGroups before it) at index 4.
+    const traces = exportCalls.find((c) => c.fn === "traces");
+    expect(traces?.args[3]).toBe(600);
+    const scores = exportCalls.find((c) => c.fn === "scores");
+    expect(scores?.args[3]).toBe(600);
+    const observations = exportCalls.find((c) => c.fn === "observations");
+    expect(observations?.args[4]).toBe(600);
+  });
+
+  it("passes chSendTimeout=undefined when unset (ClickHouse keeps its default)", async () => {
+    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue(
+      baseRow(null),
+    );
+
+    await handleBlobStorageIntegrationProjectJob(makeJob());
+
+    const traces = exportCalls.find((c) => c.fn === "traces");
+    expect(traces?.args[3]).toBeUndefined();
   });
 
   it("clamps out-of-range tuning and threads it into uploadFileBuffered", async () => {

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -323,6 +323,8 @@ const processBlobStorageExport = async (config: {
   maxConcurrentParts: number | undefined;
   maxPartAttempts: number | undefined;
   skipEnrichment: boolean;
+  // ClickHouse send_timeout (seconds) for the export query; undefined => CH default.
+  chSendTimeout: number | undefined;
   bullmqJobId: string | undefined;
   bullmqAttemptsMade: number;
 }) => {
@@ -386,6 +388,9 @@ const processBlobStorageExport = async (config: {
           "blob.config.maxPartAttempts",
           config.maxPartAttempts,
         );
+      }
+      if (config.chSendTimeout !== undefined) {
+        span.setAttribute("blob.config.chSendTimeout", config.chSendTimeout);
       }
       span.setAttribute("blob.config.skipEnrichment", config.skipEnrichment);
       span.setAttribute("blob.config.rawPassthrough", config.rawPassthrough);
@@ -543,6 +548,7 @@ const processBlobStorageExport = async (config: {
                   config.projectId,
                   config.minTimestamp,
                   config.maxTimestamp,
+                  config.chSendTimeout,
                 )
               ).stream;
               break;
@@ -552,6 +558,7 @@ const processBlobStorageExport = async (config: {
                   config.projectId,
                   config.minTimestamp,
                   config.maxTimestamp,
+                  config.chSendTimeout,
                 )
               ).stream;
               break;
@@ -562,6 +569,7 @@ const processBlobStorageExport = async (config: {
                   config.minTimestamp,
                   config.maxTimestamp,
                   exportFieldGroups,
+                  config.chSendTimeout,
                 )
               ).stream;
               break;
@@ -573,6 +581,7 @@ const processBlobStorageExport = async (config: {
                   config.maxTimestamp,
                   exportFieldGroups,
                   config.convertV4LatencyToSeconds,
+                  config.chSendTimeout,
                 )
               ).stream;
               break;
@@ -599,6 +608,7 @@ const processBlobStorageExport = async (config: {
                   config.minTimestamp,
                   config.maxTimestamp,
                   exportFieldGroups,
+                  config.chSendTimeout,
                 )
               : getEventsForBlobStorageExportRaw(
                   config.projectId,
@@ -606,6 +616,7 @@ const processBlobStorageExport = async (config: {
                   config.maxTimestamp,
                   exportFieldGroups,
                   config.convertV4LatencyToSeconds,
+                  config.chSendTimeout,
                 );
 
           const dataStream = countedStream(rawRows, sourceStats);
@@ -636,6 +647,7 @@ const processBlobStorageExport = async (config: {
                 config.projectId,
                 config.minTimestamp,
                 config.maxTimestamp,
+                config.chSendTimeout,
               );
               break;
             case "observations":
@@ -647,6 +659,7 @@ const processBlobStorageExport = async (config: {
                     config.minTimestamp,
                     config.maxTimestamp,
                     exportFieldGroups,
+                    config.chSendTimeout,
                   ),
                   chStats,
                 ),
@@ -662,6 +675,7 @@ const processBlobStorageExport = async (config: {
                 config.projectId,
                 config.minTimestamp,
                 config.maxTimestamp,
+                config.chSendTimeout,
               );
               break;
             case "observations_v2": // observations_v2 is the events table
@@ -673,6 +687,7 @@ const processBlobStorageExport = async (config: {
                     config.minTimestamp,
                     config.maxTimestamp,
                     exportFieldGroups,
+                    config.chSendTimeout,
                   ),
                   chStats,
                 ),
@@ -1152,6 +1167,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
       maxConcurrentParts: exportTuning.maxConcurrentParts,
       maxPartAttempts: exportTuning.maxPartAttempts,
       skipEnrichment: exportTuning.skipEnrichment,
+      chSendTimeout: exportTuning.chSendTimeout,
       bullmqJobId: job.id,
       bullmqAttemptsMade: job.attemptsMade,
     };


### PR DESCRIPTION
## What does this PR do?

Adds `chSendTimeout` to the per-project blob-export `exportTuning` JSON column, mapping to the ClickHouse `send_timeout` query setting (in seconds) for blob storage exports.

Like the other tuning knobs, it is set via the DB directly (no UI/tRPC write path): the read-side resolver validates and clamps it to `1–3600s` (out-of-range warns), and an absent value leaves ClickHouse's own default (`300s`) in place.

It is threaded through all four export query builders (traces, observations, scores, events) across the standard, raw-passthrough, and Parquet paths. The Parquet path merges it with the existing Parquet settings rather than overwriting them. The value is applied as a per-query `clickhouse_setting` (not via the client config) so it does not fragment the cached ClickHouse client pool.

Tests: resolver unit tests (in-range / clamp / wrong-type / write-schema reject) and worker wiring assertions that the resolved value reaches the query layer.

Fixes # (issue)

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm run lint`, targeted shared + worker tests)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR threads a new `chSendTimeout` tuning knob through the blob export pipeline, allowing per-project configuration of ClickHouse's `send_timeout` setting (in seconds) for export queries. The implementation is consistent across all four export repositories (traces, observations, scores, events) and covers all three export paths (standard stream, raw passthrough, and Parquet).

- Adds `chSendTimeout` (bounded 1–3600s) to `BlobExportTuningSchema`, `ResolvedBlobExportTuning`, and the `resolveBlobExportTuning` resolver, reusing the existing `resolveOptionalNumber` helper.
- Threads `chSendTimeout` through every `build*ForBlobStorageExportQuery` builder function and into the Parquet merge spread so it survives alongside `BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS`.
- Adds unit tests for the resolver and a wiring test that verifies `chSendTimeout=600` reaches all three export getters invoked by the `TRACES_OBSERVATIONS` job.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is additive and opt-in: absent `chSendTimeout` leaves ClickHouse at its default, so existing exports are unaffected. The new knob is threaded consistently across all four table repositories and all three export paths.

The only gap is that the 3600 s ceiling on `chSendTimeout` is higher than the 600 s HTTP `request_timeout` default, meaning values in the 600–3600 s range are silently ineffective for operators who haven't also raised `LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS`. No data loss or correctness issue results, but operators could be misled about whether their tuning is working.

`blob-export-tuning.ts` — the bounds comment should note the dependency on `LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS`.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as handleBlobStorageIntegrationProjectJob
    participant Resolver as resolveBlobExportTuning
    participant Builder as buildXxxForBlobStorageExportQuery
    participant CH as ClickHouse

    Job->>Handler: job (projectId, exportTuning JSON)
    Handler->>Resolver: raw exportTuning JSON
    Resolver-->>Handler: "{ chSendTimeout, ... }"
    Handler->>Builder: (projectId, min, max, ..., chSendTimeout)
    Builder-->>Handler: "{ query, clickhouseSettings: { send_timeout } }"
    Handler->>CH: exec/stream (query + send_timeout setting)
    CH-->>Handler: row stream
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as handleBlobStorageIntegrationProjectJob
    participant Resolver as resolveBlobExportTuning
    participant Builder as buildXxxForBlobStorageExportQuery
    participant CH as ClickHouse

    Job->>Handler: job (projectId, exportTuning JSON)
    Handler->>Resolver: raw exportTuning JSON
    Resolver-->>Handler: "{ chSendTimeout, ... }"
    Handler->>Builder: (projectId, min, max, ..., chSendTimeout)
    Builder-->>Handler: "{ query, clickhouseSettings: { send_timeout } }"
    Handler->>CH: exec/stream (query + send_timeout setting)
    CH-->>Handler: row stream
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/features/analytics-integrations/blob-export-tuning.ts:47-49
**`chSendTimeout` ceiling exceeds the HTTP `request_timeout` default**

The maximum allowed `chSendTimeout` is 3600 s (1 h), but `LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS` defaults to 600 s (10 min). Any per-project value above that threshold is silently defeated by the HTTP-layer timeout before ClickHouse's `send_timeout` can fire, so the operator gets no benefit and no indication that their setting was ignored. Consider either documenting the dependency or adding a resolver warning when `chSendTimeout` exceeds the effective HTTP timeout.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(blob-export): add chSendTimeout Cl..."](https://github.com/langfuse/langfuse/commit/adfa5eb9cc84c336d5a6615e0ad8f824e41e21cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40499216)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->