### PR TITLE
chore(blob-export): cap chSendTimeout at 600s to match HTTP timeout

### DIFF
--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
@@ -45,8 +45,10 @@ export const BLOB_EXPORT_TUNING_BOUNDS = {
   maxConcurrentParts: { min: 1, max: 32 },
   maxPartAttempts: { min: 1, max: 10 },
   // ClickHouse `send_timeout` (seconds) applied to the export query. CH's default
-  // is 300s; allow 1s..1h for per-project tuning of long-running exports.
-  chSendTimeout: { min: 1, max: 3600 },
+  // is 300s. Capped at 600s to match the HTTP `request_timeout` default
+  // (LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS, 600_000ms): a larger
+  // send_timeout would be silently defeated by the HTTP-layer timeout first.
+  chSendTimeout: { min: 1, max: 600 },
 } as const;
 
 // Default part size when the column does not specify one. Matches the value


### PR DESCRIPTION
## What does this PR do?

Caps the `chSendTimeout` blob-export tuning bound at **600s** (was 3600s).

Addresses the review note on #14625: the previous 3600s (1h) ceiling exceeded the HTTP `request_timeout` default (`LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS` = `600_000`ms). A `send_timeout` larger than that would be silently defeated by the HTTP-layer timeout before ClickHouse's `send_timeout` could fire — the operator would get no benefit and no signal. With the bound at 600s, the resolver now clamps (and warns) any larger value instead of accepting one that can't take effect.

Stacked on #14625 (the `chSendTimeout` option only exists on that branch, not yet on `main`).

Fixes # (issue)

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes (resolver clamp/reject tests cover the new ceiling)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR lowers the maximum allowed `chSendTimeout` tuning value from 3600s (1 hour) to 600s to align it with `LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS` (the HTTP-layer request timeout, which defaults to 600 000ms). Without this cap, a project-level ClickHouse `send_timeout` above 600s would be silently pre-empted by the HTTP connection being torn down first, making any value in that range effectively useless.

- The bounds constant `BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout.max` is reduced from 3600 to 600; the Zod write-validation schema and read-side clamp resolver both derive from this constant automatically.
- Any already-stored value between 601–3600 will continue to be gracefully clamped to 600 (with a resolver warning) by the existing read-side logic, so no DB migration or data-fix is needed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single constant reduction with a thorough inline explanation, and both the write-side Zod schema and the read-side clamp resolver automatically pick up the new bound.

The single-line change is well-motivated and correctly propagates through the codebase: the Zod schema and clamp resolver both reference BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout directly, so no other code needs updating. Existing DB rows with values above 600 are handled gracefully by the already-present clamping logic.

No files require special attention — only blob-export-tuning.ts changed, and the update is isolated to a single bounds constant.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Project exportTuning JSON\nfrom DB column] --> B{resolveBlobExportTuning}
    B --> C{chSendTimeout present?}
    C -- absent --> D[chSendTimeout = undefined\nClickHouse keeps own default 300s]
    C -- present --> E{Is value a finite number?}
    E -- no --> F[chSendTimeout = undefined\n+ resolver warning]
    E -- yes --> G[Round to nearest integer]
    G --> H{In range\n1 .. 600?}
    H -- yes --> I[Use value as-is]
    H -- no --> J[Clamp to 1..600\n+ resolver warning]
    I --> K[Apply as per-query\nClickHouse send_timeout setting]
    J --> K
    D --> L[No send_timeout override sent to ClickHouse]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Project exportTuning JSON\nfrom DB column] --> B{resolveBlobExportTuning}
    B --> C{chSendTimeout present?}
    C -- absent --> D[chSendTimeout = undefined\nClickHouse keeps own default 300s]
    C -- present --> E{Is value a finite number?}
    E -- no --> F[chSendTimeout = undefined\n+ resolver warning]
    E -- yes --> G[Round to nearest integer]
    G --> H{In range\n1 .. 600?}
    H -- yes --> I[Use value as-is]
    H -- no --> J[Clamp to 1..600\n+ resolver warning]
    I --> K[Apply as per-query\nClickHouse send_timeout setting]
    J --> K
    D --> L[No send_timeout override sent to ClickHouse]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(blob-export): cap chSendTimeout at..."](https://github.com/langfuse/langfuse/commit/78c3b714f17f75d25cc91ac2e28d6c31b65744a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40502531)</sub>

<!-- /greptile_comment -->