### PR TITLE
chore(worker): record LLM-as-a-judge egress on export volume metric

### DIFF
--- a/worker/src/__tests__/exportVolumeMetric.test.ts
+++ b/worker/src/__tests__/exportVolumeMetric.test.ts
@@ -56,4 +56,21 @@ describe("recordExportVolume", () => {
     expect(tags).not.toHaveProperty("source");
     expect(tags).not.toHaveProperty("table");
   });
+
+  it("emits llmaj egress with only integration/projectId tags", () => {
+    recordExportVolume({
+      integration: "llmaj",
+      bytes: 5120,
+      projectId: "p4",
+    });
+    expect(recordIncrement).toHaveBeenCalledWith(EXPORT_VOLUME_METRIC, 5120, {
+      integration: "llmaj",
+      projectId: "p4",
+    });
+    const tags = recordIncrement.mock.calls[0][2];
+    expect(tags).not.toHaveProperty("destination_type");
+    expect(tags).not.toHaveProperty("source");
+    expect(tags).not.toHaveProperty("table");
+    expect(tags).not.toHaveProperty("path");
+  });
 });

--- a/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
+++ b/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { createProductionEvalExecutionDeps } from "../evalExecutionDeps";
+import { EXPORT_VOLUME_METRIC } from "../../../services/exportVolumeMetric";
 
-const { mockFetchLLMCompletion } = vi.hoisted(() => ({
+const { mockFetchLLMCompletion, mockRecordIncrement } = vi.hoisted(() => ({
   mockFetchLLMCompletion: vi.fn(),
+  mockRecordIncrement: vi.fn(),
 }));
 
 vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
@@ -11,6 +13,7 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
   return {
     ...original,
     fetchLLMCompletion: mockFetchLLMCompletion,
+    recordIncrement: mockRecordIncrement,
   };
 });
 
@@ -74,6 +77,45 @@ describe("createProductionEvalExecutionDeps", () => {
           }),
         }),
       }),
+    );
+  });
+
+  it("records llmaj export volume with a positive byte count", async () => {
+    const deps = createProductionEvalExecutionDeps();
+
+    const messages = [
+      { role: "user", type: "user", content: "Judge this answer" },
+    ];
+    const structuredOutputSchema = { type: "object" };
+
+    await deps.callLLM({
+      messages: messages as any,
+      modelConfig: {
+        provider: "openai",
+        model: "gpt-4.1",
+        apiKey: { adapter: "openai", secretKey: "secret" },
+        adapter: "openai" as any,
+        modelParams: {},
+      },
+      structuredOutputSchema: structuredOutputSchema as any,
+      traceSinkParams: {
+        targetProjectId: "project-123",
+        traceId: "trace-123",
+        traceName: "Judge trace",
+        environment: "langfuse-llm-as-a-judge",
+        metadata: {},
+      },
+    });
+
+    const expectedBytes =
+      Buffer.byteLength(JSON.stringify(messages), "utf8") +
+      Buffer.byteLength(JSON.stringify(structuredOutputSchema), "utf8");
+
+    expect(expectedBytes).toBeGreaterThan(0);
+    expect(mockRecordIncrement).toHaveBeenCalledWith(
+      EXPORT_VOLUME_METRIC,
+      expectedBytes,
+      { integration: "llmaj", projectId: "project-123" },
     );
   });
 });

--- a/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
+++ b/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
@@ -87,8 +87,7 @@ describe("createProductionEvalExecutionDeps", () => {
     const messages = [
       { role: "user", type: "user", content: "Judge this answer" },
     ];
-    // Production passes a Zod schema (eval output definition), not a plain
-    // object — the byte count must reflect its JSON Schema form, not Zod _def.
+    // Production passes a Zod schema, not a plain object.
     const structuredOutputSchema = z.object({
       reasoning: z.string().describe("why this score was given"),
       score: z.number().describe("score between 0 and 1"),
@@ -126,7 +125,7 @@ describe("createProductionEvalExecutionDeps", () => {
       expectedBytes,
       { integration: "llmaj", projectId: "project-123" },
     );
-    // Guard against regressing to Zod's internal _def serialization.
+    // Not the Zod _def form.
     const zodDefBytes = Buffer.byteLength(
       JSON.stringify(structuredOutputSchema),
       "utf8",

--- a/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
+++ b/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { z } from "zod";
 import { createProductionEvalExecutionDeps } from "../evalExecutionDeps";
 import { EXPORT_VOLUME_METRIC } from "../../../services/exportVolumeMetric";
 
@@ -80,13 +81,18 @@ describe("createProductionEvalExecutionDeps", () => {
     );
   });
 
-  it("records llmaj export volume with a positive byte count", async () => {
+  it("records llmaj export volume using the schema's JSON Schema form", async () => {
     const deps = createProductionEvalExecutionDeps();
 
     const messages = [
       { role: "user", type: "user", content: "Judge this answer" },
     ];
-    const structuredOutputSchema = { type: "object" };
+    // Production passes a Zod schema (eval output definition), not a plain
+    // object — the byte count must reflect its JSON Schema form, not Zod _def.
+    const structuredOutputSchema = z.object({
+      reasoning: z.string().describe("why this score was given"),
+      score: z.number().describe("score between 0 and 1"),
+    });
 
     await deps.callLLM({
       messages: messages as any,
@@ -109,13 +115,24 @@ describe("createProductionEvalExecutionDeps", () => {
 
     const expectedBytes =
       Buffer.byteLength(JSON.stringify(messages), "utf8") +
-      Buffer.byteLength(JSON.stringify(structuredOutputSchema), "utf8");
+      Buffer.byteLength(
+        JSON.stringify(z.toJSONSchema(structuredOutputSchema)),
+        "utf8",
+      );
 
     expect(expectedBytes).toBeGreaterThan(0);
     expect(mockRecordIncrement).toHaveBeenCalledWith(
       EXPORT_VOLUME_METRIC,
       expectedBytes,
       { integration: "llmaj", projectId: "project-123" },
+    );
+    // Guard against regressing to Zod's internal _def serialization.
+    const zodDefBytes = Buffer.byteLength(
+      JSON.stringify(structuredOutputSchema),
+      "utf8",
+    );
+    expect(expectedBytes).not.toBe(
+      Buffer.byteLength(JSON.stringify(messages), "utf8") + zodDefBytes,
     );
   });
 });

--- a/worker/src/features/evaluation/evalExecutionDeps.ts
+++ b/worker/src/features/evaluation/evalExecutionDeps.ts
@@ -203,10 +203,9 @@ export function createProductionEvalExecutionDeps(): EvalExecutionDeps {
         typeof fetchLLMCompletion
       >[0]["modelParams"]["adapter"];
 
-      // Record llmaj egress: the request body sent to the model provider is the
+      // llmaj egress: the request body sent to the model provider is the
       // serialized messages (the bulk) plus the structured-output schema. LLM
       // requests are not gzipped, so this uncompressed size ≈ on-wire bytes.
-      // Measured once per send; retries (maxRetries below) are not counted.
       const bytes =
         Buffer.byteLength(JSON.stringify(params.messages), "utf8") +
         (params.structuredOutputSchema
@@ -215,13 +214,8 @@ export function createProductionEvalExecutionDeps(): EvalExecutionDeps {
               "utf8",
             )
           : 0);
-      recordExportVolume({
-        integration: "llmaj",
-        bytes,
-        projectId: params.traceSinkParams.targetProjectId,
-      });
 
-      return fetchLLMCompletion({
+      const result = await fetchLLMCompletion({
         streaming: false,
         llmConnection,
         messages: params.messages,
@@ -242,6 +236,17 @@ export function createProductionEvalExecutionDeps(): EvalExecutionDeps {
           eventsWriter: createInternalEventsWriter(),
         },
       });
+
+      // Record only after a successful send, matching the "bytes shipped this
+      // run" contract and the other integrations (which report post-upload).
+      // Retries (maxRetries above) are not separately counted.
+      recordExportVolume({
+        integration: "llmaj",
+        bytes,
+        projectId: params.traceSinkParams.targetProjectId,
+      });
+
+      return result;
     },
 
     fetchModelConfig: async ({ projectId, provider, model, modelParams }) => {

--- a/worker/src/features/evaluation/evalExecutionDeps.ts
+++ b/worker/src/features/evaluation/evalExecutionDeps.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { z } from "zod";
 import { JobExecutionStatus } from "@prisma/client";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -132,6 +133,22 @@ export interface EvalExecutionDeps {
 }
 
 /**
+ * Serialize a structured-output schema the way it leaves the worker for egress
+ * accounting. Production passes a Zod schema, which LangChain converts to JSON
+ * Schema before sending; `JSON.stringify` on the Zod object would instead dump
+ * its internal `_def` and drop `.describe()` text, diverging from the on-wire
+ * payload. Convert Zod schemas to JSON Schema; fall back to the raw value for
+ * plain `LLMJSONSchema` inputs (or any unconvertible schema).
+ */
+function serializeSchemaForEgress(schema: unknown): string {
+  try {
+    return JSON.stringify(z.toJSONSchema(schema as z.ZodType));
+  } catch {
+    return JSON.stringify(schema);
+  }
+}
+
+/**
  * Creates the production implementation of eval execution dependencies.
  * This is the default implementation used in production code.
  */
@@ -206,11 +223,13 @@ export function createProductionEvalExecutionDeps(): EvalExecutionDeps {
       // llmaj egress: the request body sent to the model provider is the
       // serialized messages (the bulk) plus the structured-output schema. LLM
       // requests are not gzipped, so this uncompressed size ≈ on-wire bytes.
+      // The schema is measured as its JSON Schema form (what LangChain ships),
+      // not Zod's internal _def. See serializeSchemaForEgress.
       const bytes =
         Buffer.byteLength(JSON.stringify(params.messages), "utf8") +
         (params.structuredOutputSchema
           ? Buffer.byteLength(
-              JSON.stringify(params.structuredOutputSchema),
+              serializeSchemaForEgress(params.structuredOutputSchema),
               "utf8",
             )
           : 0);

--- a/worker/src/features/evaluation/evalExecutionDeps.ts
+++ b/worker/src/features/evaluation/evalExecutionDeps.ts
@@ -13,6 +13,7 @@ import {
 import { buildEvalMessages } from "./evalRuntime";
 import { getEvalS3StorageClient } from "./s3StorageClient";
 import { createInternalEventsWriter } from "../internal-tracing/createInternalEventsWriter";
+import { recordExportVolume } from "../../services/exportVolumeMetric";
 
 type StructuredOutputSchema = NonNullable<
   Parameters<typeof fetchLLMCompletion>[0]["structuredOutputSchema"]
@@ -201,6 +202,24 @@ export function createProductionEvalExecutionDeps(): EvalExecutionDeps {
         .adapter as unknown as Parameters<
         typeof fetchLLMCompletion
       >[0]["modelParams"]["adapter"];
+
+      // Record llmaj egress: the request body sent to the model provider is the
+      // serialized messages (the bulk) plus the structured-output schema. LLM
+      // requests are not gzipped, so this uncompressed size ≈ on-wire bytes.
+      // Measured once per send; retries (maxRetries below) are not counted.
+      const bytes =
+        Buffer.byteLength(JSON.stringify(params.messages), "utf8") +
+        (params.structuredOutputSchema
+          ? Buffer.byteLength(
+              JSON.stringify(params.structuredOutputSchema),
+              "utf8",
+            )
+          : 0);
+      recordExportVolume({
+        integration: "llmaj",
+        bytes,
+        projectId: params.traceSinkParams.targetProjectId,
+      });
 
       return fetchLLMCompletion({
         streaming: false,

--- a/worker/src/features/evaluation/evalExecutionDeps.ts
+++ b/worker/src/features/evaluation/evalExecutionDeps.ts
@@ -132,14 +132,7 @@ export interface EvalExecutionDeps {
   ) => Promise<ModelConfigResult>;
 }
 
-/**
- * Serialize a structured-output schema the way it leaves the worker for egress
- * accounting. Production passes a Zod schema, which LangChain converts to JSON
- * Schema before sending; `JSON.stringify` on the Zod object would instead dump
- * its internal `_def` and drop `.describe()` text, diverging from the on-wire
- * payload. Convert Zod schemas to JSON Schema; fall back to the raw value for
- * plain `LLMJSONSchema` inputs (or any unconvertible schema).
- */
+// Measure the schema as the JSON Schema LangChain ships, not Zod's _def.
 function serializeSchemaForEgress(schema: unknown): string {
   try {
     return JSON.stringify(z.toJSONSchema(schema as z.ZodType));
@@ -220,11 +213,7 @@ export function createProductionEvalExecutionDeps(): EvalExecutionDeps {
         typeof fetchLLMCompletion
       >[0]["modelParams"]["adapter"];
 
-      // llmaj egress: the request body sent to the model provider is the
-      // serialized messages (the bulk) plus the structured-output schema. LLM
-      // requests are not gzipped, so this uncompressed size ≈ on-wire bytes.
-      // The schema is measured as its JSON Schema form (what LangChain ships),
-      // not Zod's internal _def. See serializeSchemaForEgress.
+      // llmaj egress: serialized request body (messages + schema), uncompressed.
       const bytes =
         Buffer.byteLength(JSON.stringify(params.messages), "utf8") +
         (params.structuredOutputSchema
@@ -256,9 +245,7 @@ export function createProductionEvalExecutionDeps(): EvalExecutionDeps {
         },
       });
 
-      // Record only after a successful send, matching the "bytes shipped this
-      // run" contract and the other integrations (which report post-upload).
-      // Retries (maxRetries above) are not separately counted.
+      // Record only after a successful send, like the other integrations.
       recordExportVolume({
         integration: "llmaj",
         bytes,

--- a/worker/src/services/exportVolumeMetric.ts
+++ b/worker/src/services/exportVolumeMetric.ts
@@ -10,10 +10,8 @@ export type ExportIntegration =
 
 type ExportVolume = {
   integration: ExportIntegration;
-  // On-wire egress bytes the integration shipped this run. blob_storage /
-  // posthog / mixpanel report gzipped bytes (TimedGzip). For llmaj the value is
-  // the uncompressed serialized request body, which ≈ on-wire bytes since LLM
-  // provider requests are not gzipped.
+  // On-wire egress bytes shipped this run: gzipped for blob/posthog/mixpanel,
+  // uncompressed for llmaj (LLM requests aren't gzipped).
   bytes: number;
   projectId: string;
   // Egress-cost classification; blob only (S3 / S3_COMPATIBLE / AZURE_*).

--- a/worker/src/services/exportVolumeMetric.ts
+++ b/worker/src/services/exportVolumeMetric.ts
@@ -2,11 +2,18 @@ import { recordIncrement } from "@langfuse/shared/src/server";
 
 export const EXPORT_VOLUME_METRIC = "langfuse.export.serialized_bytes";
 
-export type ExportIntegration = "blob_storage" | "posthog" | "mixpanel";
+export type ExportIntegration =
+  | "blob_storage"
+  | "posthog"
+  | "mixpanel"
+  | "llmaj";
 
 type ExportVolume = {
   integration: ExportIntegration;
-  // Gzipped on-wire bytes the integration shipped this run.
+  // On-wire egress bytes the integration shipped this run. blob_storage /
+  // posthog / mixpanel report gzipped bytes (TimedGzip). For llmaj the value is
+  // the uncompressed serialized request body, which ≈ on-wire bytes since LLM
+  // provider requests are not gzipped.
   bytes: number;
   projectId: string;
   // Egress-cost classification; blob only (S3 / S3_COMPATIBLE / AZURE_*).


### PR DESCRIPTION
## What does this PR do?

Extends the `langfuse.export.serialized_bytes` metric to cover LLM-as-a-judge (llmaj) outbound traffic, so egress can be summed across integrations and split by `integration` for cost analysis. Previously the metric only covered data-export integrations (`blob_storage`, `posthog`, `mixpanel`); llmaj egress was uninstrumented.

- Adds `"llmaj"` to the `ExportIntegration` union in `worker/src/services/exportVolumeMetric.ts`.
- Emits `recordExportVolume({ integration: "llmaj", ... })` inside `callLLM` (`worker/src/features/evaluation/evalExecutionDeps.ts`) — the only point that knows the surface is llmaj, has the project id, and can import the worker metric. Bytes = serialized `messages` (the bulk) + structured-output schema.
- Updates the metric doc comment: LLM provider requests are not gzipped, so the uncompressed serialized size ≈ on-wire bytes; blob/posthog/mixpanel continue to report gzipped bytes.

Blob-only tag dimensions stay undefined for llmaj (already handled by tag omission).

### Known limitations

- Retries are not counted — `callLLM` measures a single send (`maxRetries: 1`).
- Excludes TLS/HTTP framing and downstream message rewrites; small relative to the prompt payload.

## Type of change

- [x] Chore (internal instrumentation; no user/operator-visible behavior change)

## Checklist

- [x] `pnpm run lint`
- [x] Targeted worker tests: `exportVolumeMetric.test.ts` (added llmaj case) and `evalExecutionDeps.test.ts` (added llmaj egress assertion)
- [x] `pnpm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR instruments LLM-as-a-judge (llmaj) egress on the existing `langfuse.export.serialized_bytes` metric by recording the serialized byte size of `messages` + `structuredOutputSchema` each time `callLLM` fires in the eval execution pipeline.

- Adds `"llmaj"` to `ExportIntegration` and updates the type comment to clarify that other integrations report gzip-compressed bytes whereas llmaj reports uncompressed request-body bytes.
- Calls `recordExportVolume` inside `callLLM` before delegating to `fetchLLMCompletion`, with tests covering both the metric helper and the integration path in `evalExecutionDeps`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change adds observability only and does not affect the eval execution data path.

The metric is emitted before `fetchLLMCompletion` is awaited, meaning any failed LLM call increments the counter even though no bytes were successfully delivered. On the happy path the accounting is correct, and the change is otherwise clean and well-tested.

worker/src/features/evaluation/evalExecutionDeps.ts — specifically the ordering of `recordExportVolume` relative to the `fetchLLMCompletion` call.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant callLLM
    participant recordExportVolume
    participant Datadog as Datadog (recordIncrement)
    participant fetchLLMCompletion
    participant LLMProvider as LLM Provider

    Caller->>callLLM: callLLM(params)
    callLLM->>callLLM: "bytes = byteLength(messages) + byteLength(structuredOutputSchema)"
    callLLM->>recordExportVolume: "recordExportVolume({ integration: llmaj, bytes, projectId })"
    recordExportVolume->>Datadog: recordIncrement(langfuse.export.serialized_bytes, bytes, tags)
    callLLM->>fetchLLMCompletion: "fetchLLMCompletion({ messages, modelParams, ... })"
    fetchLLMCompletion->>LLMProvider: HTTP POST (request body)
    LLMProvider-->>fetchLLMCompletion: response / error
    fetchLLMCompletion-->>callLLM: result / throws
    callLLM-->>Caller: result / throws
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant callLLM
    participant recordExportVolume
    participant Datadog as Datadog (recordIncrement)
    participant fetchLLMCompletion
    participant LLMProvider as LLM Provider

    Caller->>callLLM: callLLM(params)
    callLLM->>callLLM: "bytes = byteLength(messages) + byteLength(structuredOutputSchema)"
    callLLM->>recordExportVolume: "recordExportVolume({ integration: llmaj, bytes, projectId })"
    recordExportVolume->>Datadog: recordIncrement(langfuse.export.serialized_bytes, bytes, tags)
    callLLM->>fetchLLMCompletion: "fetchLLMCompletion({ messages, modelParams, ... })"
    fetchLLMCompletion->>LLMProvider: HTTP POST (request body)
    LLMProvider-->>fetchLLMCompletion: response / error
    fetchLLMCompletion-->>callLLM: result / throws
    callLLM-->>Caller: result / throws
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/features/evaluation/evalExecutionDeps.ts:206-224
The metric is emitted before `fetchLLMCompletion` is awaited, so a rejected promise (network failure, auth error, provider 5xx before the body is transmitted) will still increment the counter. The type comment on `ExportVolume.bytes` says "bytes the integration **shipped** this run," which implies successful delivery. Moving the call after the `await` keeps the metric consistent with that contract and with how the other integrations report only after a successful upload.

```suggestion
      // Record llmaj egress: the request body sent to the model provider is the
      // serialized messages (the bulk) plus the structured-output schema. LLM
      // requests are not gzipped, so this uncompressed size ≈ on-wire bytes.
      // Measured once per send; retries (maxRetries below) are not counted.
      const bytes =
        Buffer.byteLength(JSON.stringify(params.messages), "utf8") +
        (params.structuredOutputSchema
          ? Buffer.byteLength(
              JSON.stringify(params.structuredOutputSchema),
              "utf8",
            )
          : 0);

      const result = await fetchLLMCompletion({
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): record LLM-as-a-judge egr..."](https://github.com/langfuse/langfuse/commit/af1a8394f53b3cc6c8a60cd33a32e3cf5a3952a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40506777)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->