### PR TITLE
chore(blob-export): remove chSendTimeout export tuning

### DIFF
--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
@@ -27,7 +27,6 @@ function resolved(
     maxConcurrentParts: undefined,
     maxPartAttempts: undefined,
     skipEnrichment: false,
-    chSendTimeout: undefined,
     ...overrides,
   };
 }
@@ -233,56 +232,6 @@ describe("resolveBlobExportTuning", () => {
     });
   });
 
-  describe("chSendTimeout (ClickHouse send_timeout)", () => {
-    it("is undefined (CH default) when absent", () => {
-      expect(
-        resolveBlobExportTuning({}, DEFAULTS).resolved.chSendTimeout,
-      ).toBeUndefined();
-    });
-
-    it("honors an in-range value silently", () => {
-      const { resolved: res, warnings } = resolveBlobExportTuning(
-        { chSendTimeout: 600 },
-        DEFAULTS,
-      );
-      expect(res).toEqual(resolved({ chSendTimeout: 600 }));
-      expect(warnings).toEqual([]);
-    });
-
-    it("clamps above the ceiling and warns", () => {
-      const { resolved: res, warnings } = resolveBlobExportTuning(
-        { chSendTimeout: 99999 },
-        DEFAULTS,
-      );
-      expect(res.chSendTimeout).toBe(
-        BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout.max,
-      );
-      expect(warnings.some((w) => w.includes("clamped"))).toBe(true);
-    });
-
-    it("clamps below the floor and warns", () => {
-      const { resolved: res, warnings } = resolveBlobExportTuning(
-        { chSendTimeout: 0 },
-        DEFAULTS,
-      );
-      expect(res.chSendTimeout).toBe(
-        BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout.min,
-      );
-      expect(warnings.some((w) => w.includes("clamped"))).toBe(true);
-    });
-
-    it("falls back to undefined (CH default) when wrong-typed", () => {
-      const { resolved: res, warnings } = resolveBlobExportTuning(
-        { chSendTimeout: "300" },
-        DEFAULTS,
-      );
-      expect(res.chSendTimeout).toBeUndefined();
-      expect(warnings.some((w) => w.includes("expected a finite number"))).toBe(
-        true,
-      );
-    });
-  });
-
   describe("valid in-range upload knobs are honoured silently", () => {
     it("passes through values within bounds", () => {
       const { resolved: res, warnings } = resolveBlobExportTuning(
@@ -451,12 +400,6 @@ describe("BlobExportTuningSchema (write schema)", () => {
     );
   });
 
-  it("accepts an in-range chSendTimeout", () => {
-    expect(
-      BlobExportTuningSchema.safeParse({ chSendTimeout: 600 }).success,
-    ).toBe(true);
-  });
-
   it("rejects out-of-range values (writes reject; reads clamp)", () => {
     expect(
       BlobExportTuningSchema.safeParse({ maxConcurrentParts: 50 }).success,
@@ -464,9 +407,6 @@ describe("BlobExportTuningSchema (write schema)", () => {
     expect(BlobExportTuningSchema.safeParse({ gzipLevel: 12 }).success).toBe(
       false,
     );
-    expect(
-      BlobExportTuningSchema.safeParse({ chSendTimeout: 99999 }).success,
-    ).toBe(false);
   });
 
   it("strips unknown keys (forward-compat, not strict)", () => {

--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
@@ -44,11 +44,6 @@ export const BLOB_EXPORT_TUNING_BOUNDS = {
   partSizeBytes: { min: 5 * 1024 * 1024, max: 5 * 1024 * 1024 * 1024 },
   maxConcurrentParts: { min: 1, max: 32 },
   maxPartAttempts: { min: 1, max: 10 },
-  // ClickHouse `send_timeout` (seconds) applied to the export query. CH's default
-  // is 300s. Capped at 600s to match the HTTP `request_timeout` default
-  // (LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS, 600_000ms): a larger
-  // send_timeout would be silently defeated by the HTTP-layer timeout first.
-  chSendTimeout: { min: 1, max: 600 },
 } as const;
 
 // Default part size when the column does not specify one. Matches the value
@@ -99,16 +94,6 @@ export const BlobExportTuningSchema = z.object({
     .max(BLOB_EXPORT_TUNING_BOUNDS.maxPartAttempts.max)
     .optional(),
   skipEnrichment: z.boolean().optional(),
-  // ClickHouse `send_timeout` (seconds) for the export query, passed through as a
-  // per-query clickhouse_setting. Absent => CH keeps its own default (300s).
-  // Out-of-range values are REJECTED here (write path) but CLAMPED by the
-  // read-side resolver.
-  chSendTimeout: z
-    .number()
-    .int()
-    .min(BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout.min)
-    .max(BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout.max)
-    .optional(),
 });
 
 export type BlobExportTuning = z.infer<typeof BlobExportTuningSchema>;
@@ -134,9 +119,6 @@ export type ResolvedBlobExportTuning = {
   maxConcurrentParts: number | undefined;
   maxPartAttempts: number | undefined;
   skipEnrichment: boolean;
-  // undefined => not set by the operator; ClickHouse keeps its own send_timeout
-  // default (300s). A concrete value (seconds) is applied per-query.
-  chSendTimeout: number | undefined;
 };
 
 export interface ResolveBlobExportTuningResult {
@@ -275,7 +257,6 @@ export function resolveBlobExportTuning(
     maxConcurrentParts: undefined,
     maxPartAttempts: undefined,
     skipEnrichment: false,
-    chSendTimeout: undefined,
   };
 
   if (raw === null || raw === undefined) {
@@ -337,12 +318,6 @@ export function resolveBlobExportTuning(
       skipEnrichment: resolveBoolean(
         "skipEnrichment",
         obj.skipEnrichment,
-        warnings,
-      ),
-      chSendTimeout: resolveOptionalNumber(
-        "chSendTimeout",
-        obj.chSendTimeout,
-        BLOB_EXPORT_TUNING_BOUNDS.chSendTimeout,
         warnings,
       ),
     },

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2668,7 +2668,6 @@ const buildEventsForBlobStorageExportQuery = (
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[],
   convertLatencyToSecondsInSql: boolean,
-  chSendTimeout?: number,
 ) => {
   const queryBuilder = new EventsQueryBuilder({ projectId });
 
@@ -2710,9 +2709,6 @@ const buildEventsForBlobStorageExportQuery = (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
-    // Per-project ClickHouse send_timeout (seconds); undefined => CH default.
-    clickhouseSettings:
-      chSendTimeout !== undefined ? { send_timeout: chSendTimeout } : undefined,
     preferredClickhouseService: "EventsReadOnly" as const,
   };
 };
@@ -2722,7 +2718,6 @@ export const getEventsForBlobStorageExport = function (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
-  chSendTimeout?: number,
 ) {
   return queryClickhouseStream<Record<string, unknown>>(
     buildEventsForBlobStorageExportQuery(
@@ -2731,7 +2726,6 @@ export const getEventsForBlobStorageExport = function (
       maxTimestamp,
       fieldGroups,
       false, // standard path converts latency ms→s in JS
-      chSendTimeout,
     ),
   );
 };
@@ -2747,7 +2741,6 @@ export const getEventsForBlobStorageExportRaw = function (
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
   convertLatencyToSeconds = false,
-  chSendTimeout?: number,
 ) {
   return queryClickhouseStreamRawText(
     buildEventsForBlobStorageExportQuery(
@@ -2756,7 +2749,6 @@ export const getEventsForBlobStorageExportRaw = function (
       maxTimestamp,
       fieldGroups,
       convertLatencyToSeconds,
-      chSendTimeout,
     ),
   );
 };
@@ -2770,24 +2762,17 @@ export const getEventsForBlobStorageExportParquet = function (
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
   convertLatencyToSeconds = false,
-  chSendTimeout?: number,
 ) {
-  const base = buildEventsForBlobStorageExportQuery(
-    projectId,
-    minTimestamp,
-    maxTimestamp,
-    fieldGroups,
-    convertLatencyToSeconds,
-    chSendTimeout,
-  );
   return queryClickhouseExecRaw({
-    ...base,
+    ...buildEventsForBlobStorageExportQuery(
+      projectId,
+      minTimestamp,
+      maxTimestamp,
+      fieldGroups,
+      convertLatencyToSeconds,
+    ),
     format: "Parquet",
-    // Merge so the per-project send_timeout survives alongside Parquet tuning.
-    clickhouseSettings: {
-      ...base.clickhouseSettings,
-      ...BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
-    },
+    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
   });
 };
 

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1704,7 +1704,6 @@ const buildObservationsForBlobStorageExportQuery = (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[],
-  chSendTimeout?: number,
 ) => {
   // core is always required (provides id, trace_id, start/end_time used for deduplication)
   const effectiveGroups = new Set<ObservationFieldGroupFull>([
@@ -1742,9 +1741,6 @@ const buildObservationsForBlobStorageExportQuery = (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
-    // Per-project ClickHouse send_timeout (seconds); undefined => CH default.
-    clickhouseSettings:
-      chSendTimeout !== undefined ? { send_timeout: chSendTimeout } : undefined,
     preferredClickhouseService: "ReadOnly" as const,
   };
 };
@@ -1754,7 +1750,6 @@ export const getObservationsForBlobStorageExport = function (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
-  chSendTimeout?: number,
 ) {
   return queryClickhouseStream<Record<string, unknown>>(
     buildObservationsForBlobStorageExportQuery(
@@ -1762,7 +1757,6 @@ export const getObservationsForBlobStorageExport = function (
       minTimestamp,
       maxTimestamp,
       fieldGroups,
-      chSendTimeout,
     ),
   );
 };
@@ -1775,7 +1769,6 @@ export const getObservationsForBlobStorageExportRaw = function (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
-  chSendTimeout?: number,
 ) {
   return queryClickhouseStreamRawText(
     buildObservationsForBlobStorageExportQuery(
@@ -1783,7 +1776,6 @@ export const getObservationsForBlobStorageExportRaw = function (
       minTimestamp,
       maxTimestamp,
       fieldGroups,
-      chSendTimeout,
     ),
   );
 };
@@ -1796,23 +1788,16 @@ export const getObservationsForBlobStorageExportParquet = function (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
-  chSendTimeout?: number,
 ) {
-  const base = buildObservationsForBlobStorageExportQuery(
-    projectId,
-    minTimestamp,
-    maxTimestamp,
-    fieldGroups,
-    chSendTimeout,
-  );
   return queryClickhouseExecRaw({
-    ...base,
+    ...buildObservationsForBlobStorageExportQuery(
+      projectId,
+      minTimestamp,
+      maxTimestamp,
+      fieldGroups,
+    ),
     format: "Parquet",
-    // Merge so the per-project send_timeout survives alongside Parquet tuning.
-    clickhouseSettings: {
-      ...base.clickhouseSettings,
-      ...BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
-    },
+    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
   });
 };
 

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1912,7 +1912,6 @@ const buildScoresForBlobStorageExportQuery = (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
-  chSendTimeout?: number,
 ) => {
   const query = `
     SELECT
@@ -1952,9 +1951,6 @@ const buildScoresForBlobStorageExportQuery = (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
-    // Per-project ClickHouse send_timeout (seconds); undefined => CH default.
-    clickhouseSettings:
-      chSendTimeout !== undefined ? { send_timeout: chSendTimeout } : undefined,
   };
 };
 
@@ -1962,15 +1958,9 @@ export const getScoresForBlobStorageExport = function (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
-  chSendTimeout?: number,
 ) {
   return queryClickhouseStream<Record<string, unknown>>(
-    buildScoresForBlobStorageExportQuery(
-      projectId,
-      minTimestamp,
-      maxTimestamp,
-      chSendTimeout,
-    ),
+    buildScoresForBlobStorageExportQuery(projectId, minTimestamp, maxTimestamp),
   );
 };
 
@@ -1980,22 +1970,15 @@ export const getScoresForBlobStorageExportParquet = function (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
-  chSendTimeout?: number,
 ) {
-  const base = buildScoresForBlobStorageExportQuery(
-    projectId,
-    minTimestamp,
-    maxTimestamp,
-    chSendTimeout,
-  );
   return queryClickhouseExecRaw({
-    ...base,
+    ...buildScoresForBlobStorageExportQuery(
+      projectId,
+      minTimestamp,
+      maxTimestamp,
+    ),
     format: "Parquet",
-    // Merge so the per-project send_timeout survives alongside Parquet tuning.
-    clickhouseSettings: {
-      ...base.clickhouseSettings,
-      ...BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
-    },
+    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
   });
 };
 

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1280,7 +1280,6 @@ const buildTracesForBlobStorageExportQuery = (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
-  chSendTimeout?: number,
 ) => {
   const traceTable = "traces";
 
@@ -1321,9 +1320,6 @@ const buildTracesForBlobStorageExportQuery = (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
-    // Per-project ClickHouse send_timeout (seconds); undefined => CH default.
-    clickhouseSettings:
-      chSendTimeout !== undefined ? { send_timeout: chSendTimeout } : undefined,
   };
 };
 
@@ -1331,15 +1327,9 @@ export const getTracesForBlobStorageExport = function (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
-  chSendTimeout?: number,
 ) {
   return queryClickhouseStream<Record<string, unknown>>(
-    buildTracesForBlobStorageExportQuery(
-      projectId,
-      minTimestamp,
-      maxTimestamp,
-      chSendTimeout,
-    ),
+    buildTracesForBlobStorageExportQuery(projectId, minTimestamp, maxTimestamp),
   );
 };
 
@@ -1349,22 +1339,15 @@ export const getTracesForBlobStorageExportParquet = function (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
-  chSendTimeout?: number,
 ) {
-  const base = buildTracesForBlobStorageExportQuery(
-    projectId,
-    minTimestamp,
-    maxTimestamp,
-    chSendTimeout,
-  );
   return queryClickhouseExecRaw({
-    ...base,
+    ...buildTracesForBlobStorageExportQuery(
+      projectId,
+      minTimestamp,
+      maxTimestamp,
+    ),
     format: "Parquet",
-    // Merge so the per-project send_timeout survives alongside Parquet tuning.
-    clickhouseSettings: {
-      ...base.clickhouseSettings,
-      ...BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
-    },
+    clickhouseSettings: BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS,
   });
 };
 

--- a/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
+++ b/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
@@ -4,10 +4,6 @@ import { Readable } from "stream";
 // Records of every uploadFileBuffered call so we can assert the resolved tuning
 // was threaded through. Hoisted so the module mock can close over it.
 const uploadCalls = vi.hoisted(() => [] as any[]);
-// Records (fnName, args) for each standard-path export getter call so we can
-// assert tuning that targets the ClickHouse query (e.g. chSendTimeout) is
-// threaded all the way down.
-const exportCalls = vi.hoisted(() => [] as { fn: string; args: any[] }[]);
 
 vi.mock("@langfuse/shared/src/db", () => ({
   prisma: {
@@ -40,22 +36,10 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
         }),
       }),
     },
-    getTracesForBlobStorageExport: (...args: any[]) => {
-      exportCalls.push({ fn: "traces", args });
-      return empty();
-    },
-    getObservationsForBlobStorageExport: (...args: any[]) => {
-      exportCalls.push({ fn: "observations", args });
-      return empty();
-    },
-    getScoresForBlobStorageExport: (...args: any[]) => {
-      exportCalls.push({ fn: "scores", args });
-      return empty();
-    },
-    getEventsForBlobStorageExport: (...args: any[]) => {
-      exportCalls.push({ fn: "events", args });
-      return empty();
-    },
+    getTracesForBlobStorageExport: () => empty(),
+    getObservationsForBlobStorageExport: () => empty(),
+    getScoresForBlobStorageExport: () => empty(),
+    getEventsForBlobStorageExport: () => empty(),
     // LFE-10463 Parquet path: each returns an already-resolved
     // { stream } (the binary body) — a tiny Readable with the Parquet magic.
     getTracesForBlobStorageExportParquet: async () => ({
@@ -124,36 +108,7 @@ function baseRow(exportTuning: unknown) {
 describe("handleBlobStorageIntegrationProjectJob tuning wiring", () => {
   beforeEach(() => {
     uploadCalls.length = 0;
-    exportCalls.length = 0;
     vi.clearAllMocks();
-  });
-
-  it("threads chSendTimeout into the standard export query", async () => {
-    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue(
-      baseRow({ chSendTimeout: 600 }),
-    );
-
-    await handleBlobStorageIntegrationProjectJob(makeJob());
-
-    // Standard-path getters take chSendTimeout as the last positional arg:
-    // traces/scores at index 3, observations (fieldGroups before it) at index 4.
-    const traces = exportCalls.find((c) => c.fn === "traces");
-    expect(traces?.args[3]).toBe(600);
-    const scores = exportCalls.find((c) => c.fn === "scores");
-    expect(scores?.args[3]).toBe(600);
-    const observations = exportCalls.find((c) => c.fn === "observations");
-    expect(observations?.args[4]).toBe(600);
-  });
-
-  it("passes chSendTimeout=undefined when unset (ClickHouse keeps its default)", async () => {
-    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue(
-      baseRow(null),
-    );
-
-    await handleBlobStorageIntegrationProjectJob(makeJob());
-
-    const traces = exportCalls.find((c) => c.fn === "traces");
-    expect(traces?.args[3]).toBeUndefined();
   });
 
   it("clamps out-of-range tuning and threads it into uploadFileBuffered", async () => {

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -323,8 +323,6 @@ const processBlobStorageExport = async (config: {
   maxConcurrentParts: number | undefined;
   maxPartAttempts: number | undefined;
   skipEnrichment: boolean;
-  // ClickHouse send_timeout (seconds) for the export query; undefined => CH default.
-  chSendTimeout: number | undefined;
   bullmqJobId: string | undefined;
   bullmqAttemptsMade: number;
 }) => {
@@ -388,9 +386,6 @@ const processBlobStorageExport = async (config: {
           "blob.config.maxPartAttempts",
           config.maxPartAttempts,
         );
-      }
-      if (config.chSendTimeout !== undefined) {
-        span.setAttribute("blob.config.chSendTimeout", config.chSendTimeout);
       }
       span.setAttribute("blob.config.skipEnrichment", config.skipEnrichment);
       span.setAttribute("blob.config.rawPassthrough", config.rawPassthrough);
@@ -548,7 +543,6 @@ const processBlobStorageExport = async (config: {
                   config.projectId,
                   config.minTimestamp,
                   config.maxTimestamp,
-                  config.chSendTimeout,
                 )
               ).stream;
               break;
@@ -558,7 +552,6 @@ const processBlobStorageExport = async (config: {
                   config.projectId,
                   config.minTimestamp,
                   config.maxTimestamp,
-                  config.chSendTimeout,
                 )
               ).stream;
               break;
@@ -569,7 +562,6 @@ const processBlobStorageExport = async (config: {
                   config.minTimestamp,
                   config.maxTimestamp,
                   exportFieldGroups,
-                  config.chSendTimeout,
                 )
               ).stream;
               break;
@@ -581,7 +573,6 @@ const processBlobStorageExport = async (config: {
                   config.maxTimestamp,
                   exportFieldGroups,
                   config.convertV4LatencyToSeconds,
-                  config.chSendTimeout,
                 )
               ).stream;
               break;
@@ -608,7 +599,6 @@ const processBlobStorageExport = async (config: {
                   config.minTimestamp,
                   config.maxTimestamp,
                   exportFieldGroups,
-                  config.chSendTimeout,
                 )
               : getEventsForBlobStorageExportRaw(
                   config.projectId,
@@ -616,7 +606,6 @@ const processBlobStorageExport = async (config: {
                   config.maxTimestamp,
                   exportFieldGroups,
                   config.convertV4LatencyToSeconds,
-                  config.chSendTimeout,
                 );
 
           const dataStream = countedStream(rawRows, sourceStats);
@@ -647,7 +636,6 @@ const processBlobStorageExport = async (config: {
                 config.projectId,
                 config.minTimestamp,
                 config.maxTimestamp,
-                config.chSendTimeout,
               );
               break;
             case "observations":
@@ -659,7 +647,6 @@ const processBlobStorageExport = async (config: {
                     config.minTimestamp,
                     config.maxTimestamp,
                     exportFieldGroups,
-                    config.chSendTimeout,
                   ),
                   chStats,
                 ),
@@ -675,7 +662,6 @@ const processBlobStorageExport = async (config: {
                 config.projectId,
                 config.minTimestamp,
                 config.maxTimestamp,
-                config.chSendTimeout,
               );
               break;
             case "observations_v2": // observations_v2 is the events table
@@ -687,7 +673,6 @@ const processBlobStorageExport = async (config: {
                     config.minTimestamp,
                     config.maxTimestamp,
                     exportFieldGroups,
-                    config.chSendTimeout,
                   ),
                   chStats,
                 ),
@@ -1172,7 +1157,6 @@ export const handleBlobStorageIntegrationProjectJob = async (
       maxConcurrentParts: exportTuning.maxConcurrentParts,
       maxPartAttempts: exportTuning.maxPartAttempts,
       skipEnrichment: exportTuning.skipEnrichment,
-      chSendTimeout: exportTuning.chSendTimeout,
       bullmqJobId: job.id,
       bullmqAttemptsMade: job.attemptsMade,
     };


### PR DESCRIPTION
## What does this PR do?

Removes the `chSendTimeout` blob-export tuning option entirely, reverting #14625 (which added it) and #14626 (which capped it at 600s).

In production the option had **no observable effect**: any value within the allowed range is defeated by the HTTP-layer request timeout (`LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS`, default 600_000ms) before ClickHouse's `send_timeout` can fire. Rather than keep a no-op tunable, this removes it end to end:

- `BLOB_EXPORT_TUNING_BOUNDS`, `BlobExportTuningSchema`, `ResolvedBlobExportTuning`, and the resolver in `blob-export-tuning.ts`
- the `chSendTimeout` param / `send_timeout` clickhouse-setting threading across the traces / observations / scores / events export builders (standard, raw-passthrough, and Parquet paths)
- the handler wiring in `handleBlobStorageIntegrationProjectJob.ts`
- the associated resolver and wiring tests

`exportTuning` is a DB-set JSON column with no UI/tRPC write path, and the resolver ignores unknown keys, so any `chSendTimeout` value already written to the DB simply becomes a no-op after this lands — no migration or cleanup required.

Fixes # (issue)

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] New and existing unit tests pass locally with my changes (typecheck + reverted resolver/wiring tests)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the `chSendTimeout` per-project ClickHouse `send_timeout` tuning knob from the blob export pipeline. The feature was previously added to allow per-project override of ClickHouse's query send timeout, but is now being reverted as a maintenance cleanup.

- Deletes `chSendTimeout` from `BLOB_EXPORT_TUNING_BOUNDS`, `BlobExportTuningSchema`, `ResolvedBlobExportTuning`, and `resolveBlobExportTuning` in `blob-export-tuning.ts`.
- Removes the parameter from all four repository export functions (`traces`, `observations`, `scores`, `events`) and simplifies the Parquet variants by removing the now-unnecessary `clickhouseSettings` merge (since the only purpose of merging was to preserve `chSendTimeout` alongside Parquet-specific settings).
- Removes corresponding wiring in `handleBlobStorageIntegrationProjectJob.ts` and deletes all related tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — complete removal of a single tuning knob with no remaining references anywhere in the codebase.

All chSendTimeout usage sites are consistently removed across the tuning schema, resolver, four repository query builders, the job handler, and the test suite. The Parquet function simplification is correct because the underlying build functions no longer emit a clickhouseSettings field, so there is nothing to merge. The only behavioral change is that ClickHouse export queries will now always use CH's built-in default send_timeout (300s) rather than a configurable override.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(blob-export): remove chSendTimeout..."](https://github.com/langfuse/langfuse/commit/fb2d4b6830b03c1629f1370828a3526fd910f6a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40523335)</sub>

<!-- /greptile_comment -->