### PR TITLE
chore(blob-export): classify and log abort origin cause (LFE-10388)

### DIFF
--- a/worker/src/__tests__/blobExportAbortClassification.unit.test.ts
+++ b/worker/src/__tests__/blobExportAbortClassification.unit.test.ts
@@ -87,6 +87,37 @@ describe("BlobExportAbortTracker.origin", () => {
     expect(origin?.chain).toContain("[query_id: qid-123]");
   });
 
+  it("does not misclassify an S3 HTTP 'status code: 503' as ch-error", () => {
+    // Regression: a bare `code:\s*\d+` matched "status code: 503" and flipped
+    // upload errors to ch-error. The S3 message has no upload-fault keyword, so
+    // it must fall through to stage attribution (upload), not CH detection.
+    const t = new BlobExportAbortTracker();
+    t.record(
+      "upload",
+      uploadWrapped(
+        new Error(
+          "InternalError: We encountered an internal error. status code: 503",
+        ),
+      ),
+      1,
+    );
+    expect(t.origin()?.reason).toBe("upload-error");
+  });
+
+  it("classifies a DB::NetException socket timeout as ch-error", () => {
+    const t = new BlobExportAbortTracker();
+    t.record(
+      "upload",
+      uploadWrapped(
+        withQueryId(
+          "Code: 209. DB::NetException: Timeout exceeded while reading from socket",
+        ),
+      ),
+      1,
+    );
+    expect(t.origin()?.reason).toBe("ch-error");
+  });
+
   it("classifies a shutdown-stage record as shutdown", () => {
     const t = new BlobExportAbortTracker();
     t.record("ch-read", new Error("aborted"), 1);

--- a/worker/src/__tests__/blobExportAbortClassification.unit.test.ts
+++ b/worker/src/__tests__/blobExportAbortClassification.unit.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  BlobExportAbortTracker,
+  classifyBlobExportError,
+  errorChainText,
+} from "../features/blobstorage/abortClassification";
+
+// Mirrors the ClickHouse repository's enrichWithQueryId wrapping.
+function withQueryId(message: string, queryId = "qid-123"): Error {
+  const base = new Error(message);
+  return new Error(`${base.message} [query_id: ${queryId}]`, { cause: base });
+}
+
+// Mirrors handleStorageError's wrapping of the underlying cause.
+function uploadWrapped(cause: unknown): Error {
+  return new Error("Failed to upload file to S3 (buffered)", { cause });
+}
+
+describe("errorChainText", () => {
+  it("flattens the cause chain with messages and codes", () => {
+    const root: NodeJS.ErrnoException = new Error("socket hang up");
+    root.code = "ECONNRESET";
+    const wrapped = uploadWrapped(root);
+    const text = errorChainText(wrapped);
+    expect(text).toContain("Failed to upload file to S3 (buffered)");
+    expect(text).toContain("socket hang up");
+    expect(text).toContain("ECONNRESET");
+  });
+
+  it("is cycle-safe", () => {
+    const a = new Error("a");
+    const b = new Error("b", { cause: a });
+    (a as Error & { cause?: unknown }).cause = b;
+    expect(() => errorChainText(a)).not.toThrow();
+  });
+
+  it("preserves an appended query_id", () => {
+    expect(errorChainText(withQueryId("aborted"))).toContain(
+      "[query_id: qid-123]",
+    );
+  });
+});
+
+describe("BlobExportAbortTracker.origin", () => {
+  it("returns undefined when nothing recorded", () => {
+    expect(new BlobExportAbortTracker().origin()).toBeUndefined();
+  });
+
+  it("classifies a concrete ClickHouse exception as ch-error", () => {
+    const t = new BlobExportAbortTracker();
+    t.record(
+      "ch-read",
+      withQueryId("Code: 241. DB::Exception: Memory limit exceeded"),
+      1,
+    );
+    const origin = t.origin();
+    expect(origin?.reason).toBe("ch-error");
+    expect(origin?.stage).toBe("ch-read");
+    expect(origin?.concrete).toBe(true);
+    expect(origin?.chain).toContain("query_id");
+  });
+
+  it("classifies a concrete S3 fault as upload-error even when ch-read also tore down", () => {
+    const t = new BlobExportAbortTracker();
+    // ch-read records the teardown first (earlier timestamp)...
+    t.record("ch-read", new Error("Premature close"), 1);
+    // ...but the concrete S3 fault is the real cause and must win.
+    t.record("upload", uploadWrapped(new Error("SlowDown: reduce rate")), 2);
+    const origin = t.origin();
+    expect(origin?.reason).toBe("upload-error");
+    expect(origin?.stage).toBe("upload");
+    expect(origin?.concrete).toBe(true);
+  });
+
+  it("attributes a bare mutual 'aborted' to the stage that failed first (ch-read)", () => {
+    // The prod-us signature: CH stream aborts first, the upload then surfaces
+    // the same wrapped 'aborted [query_id]'. Both are generic teardown, so the
+    // earliest (ch-read) wins with best-effort attribution.
+    const t = new BlobExportAbortTracker();
+    const chAborted = withQueryId("aborted");
+    t.record("ch-read", chAborted, 1);
+    t.record("upload", uploadWrapped(chAborted), 2);
+    const origin = t.origin();
+    expect(origin?.reason).toBe("ch-error");
+    expect(origin?.stage).toBe("ch-read");
+    expect(origin?.concrete).toBe(false);
+    expect(origin?.chain).toContain("[query_id: qid-123]");
+  });
+
+  it("classifies a shutdown-stage record as shutdown", () => {
+    const t = new BlobExportAbortTracker();
+    t.record("ch-read", new Error("aborted"), 1);
+    t.record("shutdown", new Error("aborted"), 2);
+    expect(t.origin()?.reason).toBe("shutdown");
+  });
+
+  it("prefers a concrete fault over an earlier generic teardown regardless of order", () => {
+    const t = new BlobExportAbortTracker();
+    t.record("upload", uploadWrapped(new Error("socket hang up")), 5);
+    t.record(
+      "ch-read",
+      withQueryId("Code: 159. DB::Exception: Timeout exceeded"),
+      10,
+    );
+    expect(t.origin()?.reason).toBe("ch-error");
+  });
+});
+
+describe("classifyBlobExportError", () => {
+  it("classifies an unknown-stage generic error as unknown", () => {
+    const origin = classifyBlobExportError(new Error("aborted"));
+    expect(origin.reason).toBe("unknown");
+    expect(origin.stage).toBe("unknown");
+  });
+
+  it("classifies a ClickHouse exception by its chain even without stage", () => {
+    const origin = classifyBlobExportError(
+      withQueryId("Code: 241. DB::Exception: Memory limit exceeded"),
+    );
+    expect(origin.reason).toBe("ch-error");
+  });
+});

--- a/worker/src/__tests__/blobExportAbortObservability.unit.test.ts
+++ b/worker/src/__tests__/blobExportAbortObservability.unit.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Captured recordIncrement calls so we can assert the abortReason tag is
+// emitted on the failure metric. Hoisted so the module mock can close over it.
+const incrementCalls = vi.hoisted(
+  () => [] as { stat: string; tags: Record<string, string | number> }[],
+);
+const errorLogs = vi.hoisted(() => [] as { msg: string; meta: unknown }[]);
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    blobStorageIntegration: {
+      findUnique: vi.fn(),
+      update: vi.fn().mockResolvedValue({}),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    project: { findUnique: vi.fn().mockResolvedValue({ name: "p" }) },
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+
+  // Mirrors enrichWithQueryId: a real CH exception with a query_id appended.
+  async function* throwsChException(): AsyncGenerator<Record<string, unknown>> {
+    const root = new Error("Code: 241. DB::Exception: Memory limit exceeded");
+    throw new Error(`${root.message} [query_id: qid-xyz]`, { cause: root });
+    // eslint-disable-next-line no-unreachable
+    yield {};
+  }
+  async function* empty(): AsyncGenerator<Record<string, unknown>> {
+    // no rows
+  }
+
+  return {
+    ...mod,
+    recordIncrement: vi.fn(
+      (stat: string, _value?: number, tags?: Record<string, string | number>) =>
+        incrementCalls.push({ stat, tags: tags ?? {} }),
+    ),
+    logger: {
+      ...mod.logger,
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn((msg: string, meta: unknown) =>
+        errorLogs.push({ msg, meta }),
+      ),
+    },
+    StorageServiceFactory: {
+      getInstance: () => ({
+        uploadFileBuffered: vi.fn(async (params: any) => {
+          // Draining the pipeline stream throws the CH error mid-stream — the
+          // real teardown path the worker sees in prod.
+          for await (const _chunk of params.data) {
+            void _chunk;
+          }
+          return undefined;
+        }),
+      }),
+    },
+    getTracesForBlobStorageExport: () => empty(),
+    getScoresForBlobStorageExport: () => empty(),
+    getObservationsForBlobStorageExport: () => throwsChException(),
+    createModelCache: () => ({ getModel: async () => null }),
+    blobStorageEndpointConnectionValidationOptions: () => undefined,
+  };
+});
+
+import { prisma } from "@langfuse/shared/src/db";
+import { handleBlobStorageIntegrationProjectJob } from "../features/blobstorage/handleBlobStorageIntegrationProjectJob";
+import type { Job } from "bullmq";
+
+function makeJob(): Job<any> {
+  return {
+    id: "job-1",
+    attemptsMade: 0,
+    data: { id: "payload-1", payload: { projectId: "project-1" } },
+  } as unknown as Job<any>;
+}
+
+function baseRow() {
+  return {
+    projectId: "project-1",
+    type: "S3",
+    bucketName: "bucket",
+    prefix: "",
+    accessKeyId: "k",
+    secretAccessKey: null,
+    region: "auto",
+    endpoint: null,
+    forcePathStyle: false,
+    enabled: true,
+    exportFrequency: "daily",
+    fileType: "JSONL",
+    exportMode: "FROM_CUSTOM_DATE",
+    exportStartDate: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    exportSource: "TRACES_OBSERVATIONS",
+    exportFieldGroups: ["core"],
+    compressed: false,
+    lastSyncAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    exportTuning: null,
+  };
+}
+
+describe("blob export abort observability", () => {
+  beforeEach(() => {
+    incrementCalls.length = 0;
+    errorLogs.length = 0;
+    vi.clearAllMocks();
+    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue(
+      baseRow(),
+    );
+  });
+
+  it("surfaces a mid-stream ClickHouse teardown as abortReason=ch-error", async () => {
+    await expect(
+      handleBlobStorageIntegrationProjectJob(makeJob()),
+    ).rejects.toBeTruthy();
+
+    // Failure metric carries the classified abort reason for the observations
+    // table (the one whose CH read threw).
+    const failure = incrementCalls.find(
+      (c) =>
+        c.stat === "langfuse.blobstorage.table_export.count" &&
+        c.tags.outcome === "failure" &&
+        c.tags.table === "observations",
+    );
+    expect(failure).toBeDefined();
+    expect(failure?.tags.abortReason).toBe("ch-error");
+
+    // Per-table error log names the reason, stage, and preserves the query_id.
+    const exportErr = errorLogs.find((l) =>
+      l.msg.includes("Error exporting observations"),
+    );
+    expect(exportErr).toBeDefined();
+    expect(exportErr?.msg).toContain("abortReason=ch-error");
+    expect(exportErr?.msg).toContain("abortStage=ch-read");
+    expect(exportErr?.msg).toContain("[query_id: qid-xyz]");
+  });
+});

--- a/worker/src/__tests__/inFlightExports.unit.test.ts
+++ b/worker/src/__tests__/inFlightExports.unit.test.ts
@@ -82,6 +82,7 @@ describe("inFlightExports", () => {
       1,
       {
         outcome: "aborted",
+        abortReason: "shutdown",
         table: "observations_v2",
         projectId: "p-1",
       },
@@ -91,6 +92,7 @@ describe("inFlightExports", () => {
       1,
       {
         outcome: "aborted",
+        abortReason: "shutdown",
         table: "scores",
         projectId: "p-1",
       },

--- a/worker/src/features/blobstorage/abortClassification.ts
+++ b/worker/src/features/blobstorage/abortClassification.ts
@@ -1,31 +1,23 @@
 /**
  * Blob-export abort classification (LFE-10063 / LFE-10388).
  *
- * A table export runs two concurrent stages joined by a Node `stream.pipeline`:
- * the ClickHouse read pipeline and the S3/object-storage upload. When either
- * stage fails, the shared pipeline tears down and *every other* stage then
- * surfaces a generic teardown error ("aborted", "Premature close") — so the
- * worker logs a bare `aborted` and the originating cause is lost.
- *
- * This module records the error each stage observed (with a monotonic
- * timestamp) and picks the originating cause: a concrete fault (a ClickHouse
- * server exception, a named S3 error, a shutdown) outranks a generic teardown
- * signature, and ties are broken by recency. The result is a single
- * `abortReason` that is filterable in Datadog plus the full cause chain for the
- * log line, so one log answers "why did this abort?" without spelunking
- * traces / ClickHouse / host logs.
+ * A table export joins two concurrent stages with a Node `stream.pipeline`: the
+ * ClickHouse read and the S3/object-storage upload. When either fails the
+ * pipeline tears down and *both* stages surface a generic "aborted" — so the
+ * worker logged a bare `aborted` and lost the originating cause. This module
+ * records each stage's error and picks the cause (a concrete fault outranks a
+ * generic teardown; ties broken by recency), yielding a filterable
+ * `abortReason` plus the full cause chain for the log line.
  */
 
-// The stage that observed an error. "ch-read" is the ClickHouse read pipeline
-// (its `stream.pipeline` callback), "upload" is the object-storage upload,
-// "shutdown" is a graceful SIGTERM teardown, "unknown" is anything else.
+// "ch-read" = the ClickHouse read pipeline (its `stream.pipeline` callback),
+// "upload" = the object-storage upload, "shutdown" = graceful SIGTERM.
 export type BlobExportAbortStage =
   | "ch-read"
   | "upload"
   | "shutdown"
   | "unknown";
 
-// Coarse failure class, tagged on logs/metrics/spans for filtering.
 export type BlobExportAbortReason =
   | "ch-error"
   | "upload-error"
@@ -36,11 +28,9 @@ export type BlobExportAbortReason =
 export interface BlobExportAbortOrigin {
   reason: BlobExportAbortReason;
   stage: BlobExportAbortStage;
-  // Whether the originating error was a concrete fault (vs. a generic teardown
-  // signature we could only attribute by stage). Surfaced so the log can flag
-  // a best-effort attribution.
+  // False when the cause was only a generic teardown attributed by stage; the
+  // log flags this as best-effort.
   concrete: boolean;
-  // Full cause chain of the originating error, for the human-readable log line.
   chain: string;
 }
 
@@ -50,8 +40,7 @@ interface RecordedStageError {
   at: number;
 }
 
-// Generic teardown signatures: a stream/socket being aborted tells us *that* the
-// pipeline collapsed, not *why*. These never count as a concrete fault.
+// A teardown signature tells us the pipeline collapsed, not why — never concrete.
 const GENERIC_TEARDOWN_PATTERNS = [
   "aborted",
   "premature close",
@@ -63,23 +52,22 @@ const GENERIC_TEARDOWN_PATTERNS = [
   "broken pipe",
 ];
 
-// ClickHouse server-side exceptions: a real CH fault (timeout, memory, etc.).
+// `db::\w*exception` covers DB::Exception, DB::NetException, etc. A bare
+// `code:\s*\d+` is excluded: it also matches S3/Azure "status code: 503" and
+// would misclassify upload errors as ch-error.
 const CH_EXCEPTION_PATTERN =
-  /db::exception|code:\s*\d+|memory_limit_exceeded|timeout_exceeded|too_many_simultaneous_queries|socket_timeout|cannot_schedule_task/;
+  /db::\w*exception|memory_limit_exceeded|timeout_exceeded|too_many_simultaneous_queries|socket_timeout|cannot_schedule_task/;
 
-// Concrete S3 / object-storage faults (named SDK errors / HTTP conditions).
 const UPLOAD_FAULT_PATTERN =
   /slowdown|access denied|accessdenied|nosuchupload|nosuchbucket|entitytoolarge|requesttimeout|invalidpart|signaturedoesnotmatch|notimplemented|preconditionfailed/;
 
-// Stall / lock-lapse markers (LFE-10063). Rarely surfaced into this code path
-// (a BullMQ stall re-enqueues rather than throwing here), but classified when
-// it does.
+// Rarely reaches this path (a BullMQ stall re-enqueues rather than throwing).
 const STALL_PATTERN = /stalled|missing lock|lock.*(lapse|renew)/;
 
 /**
- * Flatten an error's `cause` chain into a single string of messages, codes, and
- * names. Cycle-safe. A `query_id` appended by the ClickHouse repository survives
- * here, so the log retains the pointer into `system.query_log`.
+ * Flatten an error's `cause` chain into one string. Cycle-safe. A `query_id`
+ * appended by the ClickHouse repository survives here, keeping the pointer into
+ * `system.query_log`.
  */
 export function errorChainText(error: unknown): string {
   const parts: string[] = [];
@@ -107,48 +95,40 @@ function classifyOne(rec: RecordedStageError): {
 } {
   const text = errorChainText(rec.error).toLowerCase();
 
-  // Shutdown is known from the caller's stage, not the message.
   if (rec.stage === "shutdown" || text.includes("sigterm")) {
     return { reason: "shutdown", concrete: true };
   }
   if (STALL_PATTERN.test(text)) {
     return { reason: "stall", concrete: true };
   }
-  // A real ClickHouse exception wins regardless of which stage observed it —
-  // the wrapped upload error carries the CH cause in its chain.
+  // CH/upload faults win regardless of stage — the wrapped upload error carries
+  // the CH cause in its chain.
   if (CH_EXCEPTION_PATTERN.test(text)) {
     return { reason: "ch-error", concrete: true };
   }
-  // A concrete object-storage fault.
   if (UPLOAD_FAULT_PATTERN.test(text)) {
     return { reason: "upload-error", concrete: true };
   }
 
-  // Only generic teardown signatures left: attribute by the observing stage but
-  // mark non-concrete (we saw the collapse, not the trigger).
-  const generic = GENERIC_TEARDOWN_PATTERNS.some((p) => text.includes(p));
-  if (generic) {
+  // Only a generic teardown left: attribute by the observing stage, non-concrete.
+  if (GENERIC_TEARDOWN_PATTERNS.some((p) => text.includes(p))) {
     if (rec.stage === "ch-read") return { reason: "ch-error", concrete: false };
     if (rec.stage === "upload")
       return { reason: "upload-error", concrete: false };
     return { reason: "unknown", concrete: false };
   }
 
-  // Some other message with real content — attribute by stage, treat as
-  // concrete (it is not a bare teardown).
+  // Other real message (not a bare teardown): attribute by stage, concrete.
   if (rec.stage === "ch-read") return { reason: "ch-error", concrete: true };
   if (rec.stage === "upload") return { reason: "upload-error", concrete: true };
   return { reason: "unknown", concrete: false };
 }
 
-/**
- * Accumulates the errors observed across an export's concurrent stages and
- * resolves the originating cause. One instance per table export.
- */
+/** Collects per-stage errors for one table export and resolves the cause. */
 export class BlobExportAbortTracker {
   private readonly records: RecordedStageError[] = [];
 
-  // `now` is injectable for deterministic tests; defaults to performance.now().
+  // `now` is injectable for deterministic tests.
   record(
     stage: BlobExportAbortStage,
     error: unknown,
@@ -163,10 +143,8 @@ export class BlobExportAbortTracker {
   }
 
   /**
-   * Pick the originating cause. Concrete faults outrank generic teardown
-   * signatures; among equally-concrete candidates the earliest wins (the stage
-   * that failed first tore down the rest). Returns undefined if nothing was
-   * recorded.
+   * Concrete faults outrank generic teardowns; ties go to the earliest (the
+   * stage that failed first tore down the rest). Undefined if nothing recorded.
    */
   origin(): BlobExportAbortOrigin | undefined {
     if (this.records.length === 0) return undefined;
@@ -191,11 +169,7 @@ export class BlobExportAbortTracker {
   }
 }
 
-/**
- * Classify a single already-caught error with no per-stage context — used by
- * the outer catch when the tracker recorded nothing (e.g. a failure before the
- * pipeline started). `stage` defaults to "unknown".
- */
+/** Classify a single error with no per-stage context (tracker recorded nothing). */
 export function classifyBlobExportError(
   error: unknown,
   stage: BlobExportAbortStage = "unknown",

--- a/worker/src/features/blobstorage/abortClassification.ts
+++ b/worker/src/features/blobstorage/abortClassification.ts
@@ -1,0 +1,205 @@
+/**
+ * Blob-export abort classification (LFE-10063 / LFE-10388).
+ *
+ * A table export runs two concurrent stages joined by a Node `stream.pipeline`:
+ * the ClickHouse read pipeline and the S3/object-storage upload. When either
+ * stage fails, the shared pipeline tears down and *every other* stage then
+ * surfaces a generic teardown error ("aborted", "Premature close") — so the
+ * worker logs a bare `aborted` and the originating cause is lost.
+ *
+ * This module records the error each stage observed (with a monotonic
+ * timestamp) and picks the originating cause: a concrete fault (a ClickHouse
+ * server exception, a named S3 error, a shutdown) outranks a generic teardown
+ * signature, and ties are broken by recency. The result is a single
+ * `abortReason` that is filterable in Datadog plus the full cause chain for the
+ * log line, so one log answers "why did this abort?" without spelunking
+ * traces / ClickHouse / host logs.
+ */
+
+// The stage that observed an error. "ch-read" is the ClickHouse read pipeline
+// (its `stream.pipeline` callback), "upload" is the object-storage upload,
+// "shutdown" is a graceful SIGTERM teardown, "unknown" is anything else.
+export type BlobExportAbortStage =
+  | "ch-read"
+  | "upload"
+  | "shutdown"
+  | "unknown";
+
+// Coarse failure class, tagged on logs/metrics/spans for filtering.
+export type BlobExportAbortReason =
+  | "ch-error"
+  | "upload-error"
+  | "stall"
+  | "shutdown"
+  | "unknown";
+
+export interface BlobExportAbortOrigin {
+  reason: BlobExportAbortReason;
+  stage: BlobExportAbortStage;
+  // Whether the originating error was a concrete fault (vs. a generic teardown
+  // signature we could only attribute by stage). Surfaced so the log can flag
+  // a best-effort attribution.
+  concrete: boolean;
+  // Full cause chain of the originating error, for the human-readable log line.
+  chain: string;
+}
+
+interface RecordedStageError {
+  stage: BlobExportAbortStage;
+  error: unknown;
+  at: number;
+}
+
+// Generic teardown signatures: a stream/socket being aborted tells us *that* the
+// pipeline collapsed, not *why*. These never count as a concrete fault.
+const GENERIC_TEARDOWN_PATTERNS = [
+  "aborted",
+  "premature close",
+  "operation was aborted",
+  "econnreset",
+  "connection reset",
+  "socket hang up",
+  "epipe",
+  "broken pipe",
+];
+
+// ClickHouse server-side exceptions: a real CH fault (timeout, memory, etc.).
+const CH_EXCEPTION_PATTERN =
+  /db::exception|code:\s*\d+|memory_limit_exceeded|timeout_exceeded|too_many_simultaneous_queries|socket_timeout|cannot_schedule_task/;
+
+// Concrete S3 / object-storage faults (named SDK errors / HTTP conditions).
+const UPLOAD_FAULT_PATTERN =
+  /slowdown|access denied|accessdenied|nosuchupload|nosuchbucket|entitytoolarge|requesttimeout|invalidpart|signaturedoesnotmatch|notimplemented|preconditionfailed/;
+
+// Stall / lock-lapse markers (LFE-10063). Rarely surfaced into this code path
+// (a BullMQ stall re-enqueues rather than throwing here), but classified when
+// it does.
+const STALL_PATTERN = /stalled|missing lock|lock.*(lapse|renew)/;
+
+/**
+ * Flatten an error's `cause` chain into a single string of messages, codes, and
+ * names. Cycle-safe. A `query_id` appended by the ClickHouse repository survives
+ * here, so the log retains the pointer into `system.query_log`.
+ */
+export function errorChainText(error: unknown): string {
+  const parts: string[] = [];
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  while (current != null && !seen.has(current)) {
+    seen.add(current);
+    if (current instanceof Error) {
+      if (current.message) parts.push(current.message);
+      const code = (current as NodeJS.ErrnoException).code;
+      if (code) parts.push(String(code));
+      if (current.name && current.name !== "Error") parts.push(current.name);
+      current = current.cause;
+    } else {
+      parts.push(String(current));
+      break;
+    }
+  }
+  return parts.join(" caused by ");
+}
+
+function classifyOne(rec: RecordedStageError): {
+  reason: BlobExportAbortReason;
+  concrete: boolean;
+} {
+  const text = errorChainText(rec.error).toLowerCase();
+
+  // Shutdown is known from the caller's stage, not the message.
+  if (rec.stage === "shutdown" || text.includes("sigterm")) {
+    return { reason: "shutdown", concrete: true };
+  }
+  if (STALL_PATTERN.test(text)) {
+    return { reason: "stall", concrete: true };
+  }
+  // A real ClickHouse exception wins regardless of which stage observed it —
+  // the wrapped upload error carries the CH cause in its chain.
+  if (CH_EXCEPTION_PATTERN.test(text)) {
+    return { reason: "ch-error", concrete: true };
+  }
+  // A concrete object-storage fault.
+  if (UPLOAD_FAULT_PATTERN.test(text)) {
+    return { reason: "upload-error", concrete: true };
+  }
+
+  // Only generic teardown signatures left: attribute by the observing stage but
+  // mark non-concrete (we saw the collapse, not the trigger).
+  const generic = GENERIC_TEARDOWN_PATTERNS.some((p) => text.includes(p));
+  if (generic) {
+    if (rec.stage === "ch-read") return { reason: "ch-error", concrete: false };
+    if (rec.stage === "upload")
+      return { reason: "upload-error", concrete: false };
+    return { reason: "unknown", concrete: false };
+  }
+
+  // Some other message with real content — attribute by stage, treat as
+  // concrete (it is not a bare teardown).
+  if (rec.stage === "ch-read") return { reason: "ch-error", concrete: true };
+  if (rec.stage === "upload") return { reason: "upload-error", concrete: true };
+  return { reason: "unknown", concrete: false };
+}
+
+/**
+ * Accumulates the errors observed across an export's concurrent stages and
+ * resolves the originating cause. One instance per table export.
+ */
+export class BlobExportAbortTracker {
+  private readonly records: RecordedStageError[] = [];
+
+  // `now` is injectable for deterministic tests; defaults to performance.now().
+  record(
+    stage: BlobExportAbortStage,
+    error: unknown,
+    now: number = performance.now(),
+  ): void {
+    if (error == null) return;
+    this.records.push({ stage, error, at: now });
+  }
+
+  hasErrors(): boolean {
+    return this.records.length > 0;
+  }
+
+  /**
+   * Pick the originating cause. Concrete faults outrank generic teardown
+   * signatures; among equally-concrete candidates the earliest wins (the stage
+   * that failed first tore down the rest). Returns undefined if nothing was
+   * recorded.
+   */
+  origin(): BlobExportAbortOrigin | undefined {
+    if (this.records.length === 0) return undefined;
+
+    const classified = this.records.map((rec) => ({
+      rec,
+      ...classifyOne(rec),
+    }));
+
+    classified.sort((a, b) => {
+      if (a.concrete !== b.concrete) return a.concrete ? -1 : 1;
+      return a.rec.at - b.rec.at;
+    });
+
+    const winner = classified[0];
+    return {
+      reason: winner.reason,
+      stage: winner.rec.stage,
+      concrete: winner.concrete,
+      chain: errorChainText(winner.rec.error),
+    };
+  }
+}
+
+/**
+ * Classify a single already-caught error with no per-stage context — used by
+ * the outer catch when the tracker recorded nothing (e.g. a failure before the
+ * pipeline started). `stage` defaults to "unknown".
+ */
+export function classifyBlobExportError(
+  error: unknown,
+  stage: BlobExportAbortStage = "unknown",
+): BlobExportAbortOrigin {
+  const { reason, concrete } = classifyOne({ stage, error, at: 0 });
+  return { reason, stage, concrete, chain: errorChainText(error) };
+}

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -40,6 +40,11 @@ import {
   BLOB_TABLE_EXPORT_METRIC,
   type BlobTableExportOutcome,
 } from "./inFlightExports";
+import {
+  BlobExportAbortTracker,
+  classifyBlobExportError,
+} from "./abortClassification";
+import { isSigtermReceived } from "../health";
 import { TimedGzip, ZLIB_DEFAULT_LEVEL, type GzipStats } from "./gzipStream";
 import { ByteCounter, TimedByteCounter } from "./byteCounters";
 import { WORKER_HOST_ID } from "../../utils/hostId";
@@ -421,6 +426,11 @@ const processBlobStorageExport = async (config: {
       let uploadSucceeded = false;
       let heartbeat: ReturnType<typeof setInterval> | undefined;
 
+      // Records the error each concurrent stage (CH read pipeline, S3 upload)
+      // observed, so the catch can name the originating cause instead of the
+      // bare "aborted" the shared pipeline teardown propagates to every stage.
+      const abortTracker = new BlobExportAbortTracker();
+
       try {
         const blobStorageProps = getFileTypeProperties(config.fileType);
 
@@ -479,6 +489,9 @@ const processBlobStorageExport = async (config: {
 
         const pipelineCallback = (err: NodeJS.ErrnoException | null) => {
           if (err) {
+            // The pipeline source is the ClickHouse read; record it so the
+            // catch can tell a CH-origin failure from an upload-side teardown.
+            abortTracker.record("ch-read", err);
             logger.error(
               "[BLOB INTEGRATION] Getting data from DB for blob storage integration failed: ",
               err,
@@ -743,15 +756,24 @@ const processBlobStorageExport = async (config: {
         try {
           uploadStartMs = performance.now();
 
-          await storageService.uploadFileBuffered({
-            fileName: filePath,
-            fileType: uploadContentType,
-            data: fileStream,
-            partSizeBytes: config.partSizeBytes,
-            maxConcurrentParts: config.maxConcurrentParts,
-            maxPartAttempts: config.maxPartAttempts,
-            stats: uploadStats,
-          });
+          try {
+            await storageService.uploadFileBuffered({
+              fileName: filePath,
+              fileType: uploadContentType,
+              data: fileStream,
+              partSizeBytes: config.partSizeBytes,
+              maxConcurrentParts: config.maxConcurrentParts,
+              maxPartAttempts: config.maxPartAttempts,
+              stats: uploadStats,
+            });
+          } catch (uploadError) {
+            // Record before rethrowing so the catch can attribute the failure to
+            // the upload stage. The cause chain is preserved (handleStorageError
+            // wraps via { cause }), so a CH-origin error surfacing here is still
+            // classified as ch-error by its chain.
+            abortTracker.record("upload", uploadError);
+            throw uploadError;
+          }
           // Record at the upload boundary so a throw in the `finally` below
           // can't miscount a real success as a failure.
           uploadSucceeded = true;
@@ -956,17 +978,32 @@ const processBlobStorageExport = async (config: {
           }
         }
       } catch (error) {
+        // A graceful SIGTERM in flight reclassifies any teardown as a shutdown
+        // abort regardless of which stage observed it first.
+        if (isSigtermReceived()) {
+          abortTracker.record("shutdown", error);
+        }
+        // Prefer the originating cause captured per-stage; fall back to the
+        // propagated error when nothing was recorded (e.g. a pre-pipeline throw).
+        const origin = abortTracker.origin() ?? classifyBlobExportError(error);
+
+        span.setAttribute("blob.abortReason", origin.reason);
+        span.setAttribute("blob.abortStage", origin.stage);
+
         // Skip if `success` already fired (a later step threw post-upload).
         if (!uploadSucceeded) {
           recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
             outcome: "failure" satisfies BlobTableExportOutcome,
+            abortReason: origin.reason,
             table: config.table,
             projectId: config.projectId,
           });
         }
         logger.error(
           `[BLOB INTEGRATION] Error exporting ${config.table} for project ${config.projectId} ` +
-            `(jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${WORKER_HOST_ID})`,
+            `(jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${WORKER_HOST_ID} ` +
+            `abortReason=${origin.reason} abortStage=${origin.stage}` +
+            `${origin.concrete ? "" : " attribution=best-effort"}): ${origin.chain}`,
           error,
         );
         throw error;

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -43,6 +43,7 @@ import {
 import {
   BlobExportAbortTracker,
   classifyBlobExportError,
+  errorChainText,
 } from "./abortClassification";
 import { isSigtermReceived } from "../health";
 import { TimedGzip, ZLIB_DEFAULT_LEVEL, type GzipStats } from "./gzipStream";
@@ -974,7 +975,8 @@ const processBlobStorageExport = async (config: {
           }
         }
       } catch (error) {
-        // A graceful SIGTERM in flight reclassifies the teardown as shutdown.
+        // On SIGTERM, add a concrete shutdown record. It wins origin() only when
+        // no earlier concrete fault (e.g. a real CH exception) was recorded.
         if (isSigtermReceived()) {
           abortTracker.record("shutdown", error);
         }
@@ -1389,7 +1391,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
 
     notifyBlobStorageExportFailedInBackground(projectId);
 
-    const chain = formatErrorChain(error);
+    const chain = errorChainText(error);
     logger.error(
       `[BLOB INTEGRATION] Error processing blob storage integration for project ${projectId}: ${chain}`,
       error instanceof Error ? { stack: error.stack } : {},
@@ -1506,15 +1508,4 @@ function extractStorageErrorMessage(error: unknown): string {
 
   const full = details ? `${message} Details: ${details}` : message;
   return full.slice(0, 1000);
-}
-
-function formatErrorChain(error: unknown): string {
-  if (!(error instanceof Error)) return String(error);
-  const parts: string[] = [];
-  let current: unknown = error;
-  while (current instanceof Error) {
-    parts.push(current.message);
-    current = current.cause;
-  }
-  return parts.join(" caused by ");
 }

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -426,9 +426,8 @@ const processBlobStorageExport = async (config: {
       let uploadSucceeded = false;
       let heartbeat: ReturnType<typeof setInterval> | undefined;
 
-      // Records the error each concurrent stage (CH read pipeline, S3 upload)
-      // observed, so the catch can name the originating cause instead of the
-      // bare "aborted" the shared pipeline teardown propagates to every stage.
+      // Per-stage errors so the catch can name the originating cause instead of
+      // the bare "aborted" the pipeline teardown propagates to every stage.
       const abortTracker = new BlobExportAbortTracker();
 
       try {
@@ -489,8 +488,7 @@ const processBlobStorageExport = async (config: {
 
         const pipelineCallback = (err: NodeJS.ErrnoException | null) => {
           if (err) {
-            // The pipeline source is the ClickHouse read; record it so the
-            // catch can tell a CH-origin failure from an upload-side teardown.
+            // The pipeline source is the ClickHouse read.
             abortTracker.record("ch-read", err);
             logger.error(
               "[BLOB INTEGRATION] Getting data from DB for blob storage integration failed: ",
@@ -767,10 +765,8 @@ const processBlobStorageExport = async (config: {
               stats: uploadStats,
             });
           } catch (uploadError) {
-            // Record before rethrowing so the catch can attribute the failure to
-            // the upload stage. The cause chain is preserved (handleStorageError
-            // wraps via { cause }), so a CH-origin error surfacing here is still
-            // classified as ch-error by its chain.
+            // Attribute to the upload stage; a CH-origin error surfacing here is
+            // still classified as ch-error by its preserved cause chain.
             abortTracker.record("upload", uploadError);
             throw uploadError;
           }
@@ -978,13 +974,11 @@ const processBlobStorageExport = async (config: {
           }
         }
       } catch (error) {
-        // A graceful SIGTERM in flight reclassifies any teardown as a shutdown
-        // abort regardless of which stage observed it first.
+        // A graceful SIGTERM in flight reclassifies the teardown as shutdown.
         if (isSigtermReceived()) {
           abortTracker.record("shutdown", error);
         }
-        // Prefer the originating cause captured per-stage; fall back to the
-        // propagated error when nothing was recorded (e.g. a pre-pipeline throw).
+        // Fall back to the propagated error if no stage recorded one.
         const origin = abortTracker.origin() ?? classifyBlobExportError(error);
 
         span.setAttribute("blob.abortReason", origin.reason);

--- a/worker/src/features/blobstorage/inFlightExports.ts
+++ b/worker/src/features/blobstorage/inFlightExports.ts
@@ -68,6 +68,8 @@ export const logInFlightBlobExportsOnShutdown = (): void => {
     // May double with `success` if the export finishes within the grace period.
     recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
       outcome: "aborted" satisfies BlobTableExportOutcome,
+      // Survivors at a graceful shutdown were aborted by the SIGTERM teardown.
+      abortReason: "shutdown",
       table: entry.table,
       projectId: entry.projectId,
     });

--- a/worker/src/features/health/index.ts
+++ b/worker/src/features/health/index.ts
@@ -48,4 +48,4 @@ export const setSigtermReceived = () => {
   sigtermReceived = true;
 };
 
-const isSigtermReceived = () => sigtermReceived;
+export const isSigtermReceived = () => sigtermReceived;


### PR DESCRIPTION
## What does this PR do?

Makes blob-export aborts self-explaining in the logs. Today a failing
blob-export table job logs a bare `aborted` and discards *what* triggered it,
which blocked root-causing the repeated prod-us export failures (project
`cm8fr0fvb00rvad07yx9nyonh`).

A table export runs two concurrent stages joined by a Node `stream.pipeline`:
the ClickHouse read pipeline and the object-storage upload. When either stage
fails, the shared pipeline tears down and *every* stage then surfaces a generic
`aborted` / `Premature close` — so the originating cause was lost even though
the cause chain was preserved on the error.

This PR records the error each stage observes (CH read via the pipeline
callback, the upload via its call site) and resolves the originating cause:
a concrete fault (ClickHouse exception, named S3 error, SIGTERM shutdown)
outranks a generic teardown signature, ties broken by recency. It then surfaces:

- a coarse `abortReason` ∈ `ch-error | upload-error | stall | shutdown | unknown`
  and `abortStage` on the per-table error log, plus the full cause chain
  (with the ClickHouse `query_id` preserved) — and an `attribution=best-effort`
  marker when only generic teardown signatures were available;
- `blob.abortReason` / `blob.abortStage` span attributes;
- an `abortReason` tag on the `langfuse.blobstorage.table_export.count` metric
  (both `outcome=failure` and the shutdown `outcome=aborted` increment).

Observability only — it does **not** change export behavior or fix the
underlying slow-export failure (tracked separately).

Fixes # (issue)

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have self-reviewed the code.
- [x] My code follows the style guidelines of this project (`pnpm run format`, `pnpm run lint`).
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I added tests that prove the change is effective (classification unit tests + a handler-level mid-stream-teardown test that asserts the injected reason reaches the log and metric).
- [x] New and existing unit tests pass locally (worker blobstorage suites + typecheck + lint).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds observability to blob-export aborts: a new `BlobExportAbortTracker` captures the error each concurrent stage (ClickHouse read pipeline, S3 upload) observes, resolves the originating cause (concrete faults over generic teardown signatures, earliest timestamp breaks ties), and surfaces an `abortReason`/`abortStage` on the per-table error log, metric, and OTel span.

- **`abortClassification.ts`** — new module: `BlobExportAbortTracker`, `classifyBlobExportError`, `errorChainText`; classifies errors into `ch-error | upload-error | stall | shutdown | unknown`.
- **`handleBlobStorageIntegrationProjectJob.ts`** — records errors at two points (pipeline callback for CH read, inner catch for upload), adds `abortReason` tag to the failure metric and the error log message, and checks `isSigtermReceived()` in the catch to add a shutdown record.
- **`inFlightExports.ts` / `health/index.ts`** — adds `abortReason="shutdown"` to the graceful-shutdown metric counter and exports `isSigtermReceived` for use in the handler.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Pure observability change — no export behavior is altered. The worst outcome of a misclassification bug is a misleading log tag, not data loss or a broken export.

The core classification logic is sound and well-tested. The `code:\s*\d+` sub-pattern in `CH_EXCEPTION_PATTERN` can match HTTP status codes in S3/Azure error messages, producing incorrect `abortReason=ch-error` tags on upload-side failures — the opposite of the distinction the PR is meant to provide. The misleading SIGTERM comment and the duplicate `formatErrorChain` function are minor quality issues. None of these affect production export correctness.

abortClassification.ts — the CH_EXCEPTION_PATTERN definition; handleBlobStorageIntegrationProjectJob.ts — the SIGTERM comment and the formatErrorChain duplication at the bottom of the file.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CH as ClickHouse Source
    participant P as stream.pipeline
    participant U as uploadFileBuffered
    participant AT as BlobExportAbortTracker
    participant C as catch block

    CH->>P: throw (e.g. DB::Exception)
    P->>AT: pipelineCallback → record("ch-read", err)
    P->>P: destroy all pipeline stages
    P->>U: fileStream errored / closed
    U->>AT: catch(uploadError) → record("upload", err)
    U->>C: rethrow
    C->>C: isSigtermReceived()? → maybe record("shutdown", err)
    C->>AT: origin()
    AT->>AT: "classify each record (concrete > non-concrete, earliest wins)"
    AT-->>C: "BlobExportAbortOrigin { reason, stage, concrete, chain }"
    C->>C: span.setAttribute("blob.abortReason", ...)
    C->>C: "recordIncrement(metric, {abortReason})"
    C->>C: "logger.error(...abortReason=... abortStage=...): chain"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CH as ClickHouse Source
    participant P as stream.pipeline
    participant U as uploadFileBuffered
    participant AT as BlobExportAbortTracker
    participant C as catch block

    CH->>P: throw (e.g. DB::Exception)
    P->>AT: pipelineCallback → record("ch-read", err)
    P->>P: destroy all pipeline stages
    P->>U: fileStream errored / closed
    U->>AT: catch(uploadError) → record("upload", err)
    U->>C: rethrow
    C->>C: isSigtermReceived()? → maybe record("shutdown", err)
    C->>AT: origin()
    AT->>AT: "classify each record (concrete > non-concrete, earliest wins)"
    AT-->>C: "BlobExportAbortOrigin { reason, stage, concrete, chain }"
    C->>C: span.setAttribute("blob.abortReason", ...)
    C->>C: "recordIncrement(metric, {abortReason})"
    C->>C: "logger.error(...abortReason=... abortStage=...): chain"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
worker/src/features/blobstorage/abortClassification.ts:67-68
**`code:\s*\d+` is too broad — can match S3/HTTP status codes**

The sub-pattern `code:\s*\d+` matches any substring of the form `"code: <number>"`. Many S3-SDK and HTTP-transport error messages include the HTTP status code inline — e.g., `"SlowDown: Reduce your request rate. status code: 503, request id: …"` or Azure's `"ServiceRequestError: status code: 429, ..."`. After lowercasing, `"status code: 503"` satisfies `code:\s*\d+`, so these upload-side errors would be classified as `ch-error` instead of `upload-error` — exactly the opposite of the intended distinction.

ClickHouse exceptions have a more distinctive form (always contain `db::exception` or one of the named keywords already in the pattern). Removing `code:\s*\d+` from `CH_EXCEPTION_PATTERN` or replacing it with something that requires the ClickHouse-specific prefix would avoid the false positives without losing real CH classification.

### Issue 2 of 3
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:981-983
The comment says SIGTERM "reclassifies any teardown as a shutdown abort **regardless** of which stage observed it first", but the actual behaviour is that `record("shutdown", error)` just adds another entry to the tracker — a concrete `ch-error` recorded earlier by `pipelineCallback` still wins the sort (concrete, earliest timestamp). The comment should accurately reflect that SIGTERM wins only when no prior concrete fault was recorded.

```suggestion
        // A graceful SIGTERM in flight adds a concrete shutdown record. It wins
        // the origin sort when all other errors are generic teardown signatures;
        // an earlier concrete fault (e.g. a real CH exception) still takes precedence.
        if (isSigtermReceived()) {
```

### Issue 3 of 3
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:1517-1526
**`formatErrorChain` duplicates `errorChainText` from `abortClassification.ts`**

Both functions walk the `.cause` chain and join messages with `" caused by "`. `errorChainText` is the richer version (it also captures `ErrnoException.code` and non-default `name`). The outer job-level catch at line 1398 uses `formatErrorChain` while the per-table catch uses `errorChainText`; the two log lines therefore have subtly different chain representations for the same error. Replacing the `formatErrorChain` call with the imported `errorChainText` (and removing the local function) would keep them consistent and remove dead code.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(blob-export): classify and log abo..."](https://github.com/langfuse/langfuse/commit/96b9cb9a0a9dadc7dc50e20727da938e2e3c356c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40528928)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->