### PR TITLE
refactor(web): Move `LangfuseIcon` to design-system folder

### DIFF
--- a/web/src/components/LangfuseLogo.tsx
+++ b/web/src/components/LangfuseLogo.tsx
@@ -5,13 +5,16 @@ import { env } from "@/src/env.mjs";
 import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
 import { PlusIcon } from "lucide-react";
 
-export const LangfuseIcon = ({
-  size = 32,
-  className,
-}: {
+type LangfuseIconProps = {
   size?: number;
-  className?: string;
-}) => (
+  className?:
+    | "h-8 w-8"
+    | "hidden scale-120 group-data-[collapsible=icon]:block"
+    | "mx-auto motion-safe:animate-spin"
+    | "mx-auto";
+};
+
+export const LangfuseIcon = ({ size = 32, className }: LangfuseIconProps) => (
   // eslint-disable-next-line @next/next/no-img-element
   <img
     src={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/icon.svg`}

--- a/web/src/components/LangfuseLogo.tsx
+++ b/web/src/components/LangfuseLogo.tsx
@@ -7,20 +7,15 @@ import { PlusIcon } from "lucide-react";
 
 type LangfuseIconProps = {
   size?: 14 | 16 | 28 | 32 | 42;
-  className?:
-    | "hidden scale-120 group-data-[collapsible=icon]:block"
-    | "mx-auto motion-safe:animate-spin"
-    | "mx-auto";
 };
 
-export const LangfuseIcon = ({ size = 32, className }: LangfuseIconProps) => (
+export const LangfuseIcon = ({ size = 32 }: LangfuseIconProps) => (
   // eslint-disable-next-line @next/next/no-img-element
   <img
     src={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/icon.svg`}
     width={size}
     height={size}
     alt="Langfuse Icon"
-    className={className}
   />
 );
 
@@ -69,10 +64,9 @@ const LangfuseLogotypeOrCustomized = () => {
         src={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/wordart-white.svg`}
         alt="Langfuse Logo"
       />
-      <LangfuseIcon
-        size={28}
-        className="hidden scale-120 group-data-[collapsible=icon]:block"
-      />
+      <div className="hidden scale-120 group-data-[collapsible=icon]:block">
+        <LangfuseIcon size={28} />
+      </div>
     </div>
   );
 };

--- a/web/src/components/LangfuseLogo.tsx
+++ b/web/src/components/LangfuseLogo.tsx
@@ -6,7 +6,7 @@ import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCust
 import { PlusIcon } from "lucide-react";
 
 type LangfuseIconProps = {
-  size?: number;
+  size?: 14 | 16 | 28 | 32 | 42;
   className?:
     | "h-8 w-8"
     | "hidden scale-120 group-data-[collapsible=icon]:block"

--- a/web/src/components/LangfuseLogo.tsx
+++ b/web/src/components/LangfuseLogo.tsx
@@ -8,7 +8,6 @@ import { PlusIcon } from "lucide-react";
 type LangfuseIconProps = {
   size?: 14 | 16 | 28 | 32 | 42;
   className?:
-    | "h-8 w-8"
     | "hidden scale-120 group-data-[collapsible=icon]:block"
     | "mx-auto motion-safe:animate-spin"
     | "mx-auto";

--- a/web/src/components/LangfuseLogo.tsx
+++ b/web/src/components/LangfuseLogo.tsx
@@ -4,20 +4,7 @@ import { VersionLabel } from "./VersionLabel";
 import { env } from "@/src/env.mjs";
 import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
 import { PlusIcon } from "lucide-react";
-
-type LangfuseIconProps = {
-  size?: 14 | 16 | 28 | 32 | 42;
-};
-
-export const LangfuseIcon = ({ size = 32 }: LangfuseIconProps) => (
-  // eslint-disable-next-line @next/next/no-img-element
-  <img
-    src={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/icon.svg`}
-    width={size}
-    height={size}
-    alt="Langfuse Icon"
-  />
-);
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 
 const LangfuseLogotypeOrCustomized = () => {
   const uiCustomization = useUiCustomization();

--- a/web/src/components/design-system/LangfuseIcon/LangfuseIcon.stories.tsx
+++ b/web/src/components/design-system/LangfuseIcon/LangfuseIcon.stories.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import preview from "../../../../.storybook/preview";
+import { LangfuseIcon } from "./LangfuseIcon";
+
+type ComponentProps = React.ComponentProps<typeof LangfuseIcon>;
+type Size = NonNullable<ComponentProps["size"]>;
+
+const meta = preview.meta({
+  component: LangfuseIcon,
+});
+
+const allSizes = Object.keys({
+  14: true,
+  16: true,
+  28: true,
+  32: true,
+  42: true,
+} satisfies Record<Size, true>).map(Number) as Size[];
+
+export const Default = meta.story({
+  args: {
+    size: 32,
+  },
+});
+
+export const AllSizes = meta.story({
+  render: () => (
+    <div className="flex items-end gap-6 p-2">
+      {allSizes.map((size) => (
+        <div key={size} className="flex flex-col items-center gap-2">
+          <LangfuseIcon size={size} />
+          <span className="text-muted-foreground text-xs">{size}px</span>
+        </div>
+      ))}
+    </div>
+  ),
+});

--- a/web/src/components/design-system/LangfuseIcon/LangfuseIcon.tsx
+++ b/web/src/components/design-system/LangfuseIcon/LangfuseIcon.tsx
@@ -1,0 +1,15 @@
+import { env } from "@/src/env.mjs";
+
+type LangfuseIconProps = {
+  size?: 14 | 16 | 28 | 32 | 42;
+};
+
+export const LangfuseIcon = ({ size = 32 }: LangfuseIconProps) => (
+  // eslint-disable-next-line @next/next/no-img-element
+  <img
+    src={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/icon.svg`}
+    width={size}
+    height={size}
+    alt="Langfuse Icon"
+  />
+);

--- a/web/src/components/layouts/spinner.tsx
+++ b/web/src/components/layouts/spinner.tsx
@@ -4,7 +4,7 @@ export function Spinner(props: { message: string }) {
   return (
     <div className="flex min-h-full flex-1 flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="mx-auto motion-safe:animate-spin">
+        <div className="mx-auto w-fit motion-safe:animate-spin">
           <LangfuseIcon size={42} />
         </div>
         <h2 className="text-primary mt-5 text-center text-2xl leading-9 font-bold tracking-tight">

--- a/web/src/components/layouts/spinner.tsx
+++ b/web/src/components/layouts/spinner.tsx
@@ -4,7 +4,9 @@ export function Spinner(props: { message: string }) {
   return (
     <div className="flex min-h-full flex-1 flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <LangfuseIcon className="mx-auto motion-safe:animate-spin" size={42} />
+        <div className="mx-auto motion-safe:animate-spin">
+          <LangfuseIcon size={42} />
+        </div>
         <h2 className="text-primary mt-5 text-center text-2xl leading-9 font-bold tracking-tight">
           {props.message} ...
         </h2>

--- a/web/src/components/layouts/spinner.tsx
+++ b/web/src/components/layouts/spinner.tsx
@@ -1,4 +1,4 @@
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 
 export function Spinner(props: { message: string }) {
   return (

--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -9,7 +9,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
 import { UserCircle2Icon } from "lucide-react";
 import { StatusBadge } from "@/src/components/layouts/status-badge";
 import { DeactivateEvalConfig } from "@/src/features/evals/components/deactivate-config";
@@ -24,6 +23,7 @@ import { EvaluatorPausedCallout } from "@/src/features/evals/components/evaluato
 import { isLegacyEvalTarget } from "@/src/features/evals/utils/typeHelpers";
 import { useLazyEvaluatorExecutionCounts } from "@/src/features/evals/hooks/useLazyEvaluatorExecutionCounts";
 import { TablePeekView } from "@/src/components/table/peek";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 
 const PeekViewEvaluatorConfigDetail = ({
   projectId,

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -9,7 +9,7 @@ import {
   Lock,
 } from "lucide-react";
 import { Badge } from "@/src/components/ui/badge";
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import {
   DrawerTrigger,
   DrawerContent,

--- a/web/src/components/table/use-cases/models.tsx
+++ b/web/src/components/table/use-cases/models.tsx
@@ -22,7 +22,7 @@ import {
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
 import { Skeleton } from "@/src/components/ui/skeleton";
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { useRouter } from "next/router";
 import { PriceUnitSelector } from "@/src/features/models/components/PriceUnitSelector";
 import { usePriceUnitMultiplier } from "@/src/features/models/hooks/usePriceUnitMultiplier";

--- a/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
@@ -134,7 +134,9 @@ export function ResetPasswordPage({
       <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-center sm:px-6 sm:py-12 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
           <Link href="/">
-            <LangfuseIcon className="mx-auto" />
+            <div className="mx-auto">
+              <LangfuseIcon />
+            </div>
           </Link>
           <h2 className="text-primary mt-4 text-center text-2xl leading-9 font-bold tracking-tight">
             {title}

--- a/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
@@ -134,7 +134,7 @@ export function ResetPasswordPage({
       <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-center sm:px-6 sm:py-12 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
           <Link href="/">
-            <div className="mx-auto">
+            <div className="mx-auto w-fit">
               <LangfuseIcon />
             </div>
           </Link>

--- a/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { PasswordInput } from "@/src/components/ui/password-input";
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { useSession } from "next-auth/react";
 import { ArrowLeft, ShieldCheck } from "lucide-react";
 import { api } from "@/src/utils/api";

--- a/web/src/features/evals/components/eval-template-detail.tsx
+++ b/web/src/features/evals/components/eval-template-detail.tsx
@@ -24,7 +24,7 @@ import {
   SidePanelHeader,
   SidePanelTitle,
 } from "@/src/components/ui/side-panel";
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { DeleteEvalTemplateButton } from "@/src/features/evals/components/delete-eval-template-button";
 
 export const EvalTemplateDetail = () => {

--- a/web/src/features/evals/components/maintainer-tooltip.tsx
+++ b/web/src/features/evals/components/maintainer-tooltip.tsx
@@ -1,4 +1,4 @@
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import {
   Tooltip,
   TooltipTrigger,

--- a/web/src/features/onboarding/components/OnboardingSurvey.tsx
+++ b/web/src/features/onboarding/components/OnboardingSurvey.tsx
@@ -115,7 +115,7 @@ export function OnboardingSurvey() {
     return (
       <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-start sm:px-6 sm:py-12 lg:px-8">
         <div className="flex items-center justify-center gap-2 sm:mx-auto sm:w-full sm:max-w-md">
-          <LangfuseIcon className="h-8 w-8" />
+          <LangfuseIcon size={32} />
         </div>
 
         <div className="bg-background mt-6 rounded-lg px-6 py-10 shadow-sm sm:mx-auto sm:mt-16 sm:w-full sm:max-w-[480px] sm:px-12 sm:py-12">
@@ -137,7 +137,7 @@ export function OnboardingSurvey() {
     return (
       <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-start sm:px-6 sm:py-12 lg:px-8">
         <div className="flex items-center justify-center gap-2 sm:mx-auto sm:w-full sm:max-w-md">
-          <LangfuseIcon className="h-8 w-8" />
+          <LangfuseIcon size={32} />
         </div>
 
         <div className="bg-background mt-6 rounded-lg px-6 py-10 shadow-sm sm:mx-auto sm:mt-16 sm:w-full sm:max-w-[480px] sm:px-12 sm:py-12">
@@ -155,7 +155,7 @@ export function OnboardingSurvey() {
   return (
     <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-start sm:px-6 sm:py-12 lg:px-8">
       <div className="flex items-center justify-center gap-2 sm:mx-auto sm:w-full sm:max-w-md">
-        <LangfuseIcon className="h-8 w-8" />
+        <LangfuseIcon size={32} />
       </div>
 
       <div className="bg-background mt-6 rounded-lg px-6 py-6 shadow-sm sm:mx-auto sm:mt-16 sm:w-full sm:max-w-[480px] sm:px-12 sm:py-10">

--- a/web/src/features/onboarding/components/OnboardingSurvey.tsx
+++ b/web/src/features/onboarding/components/OnboardingSurvey.tsx
@@ -12,7 +12,7 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { api } from "@/src/utils/api";

--- a/web/src/pages/auth/enterprise-sso-required.tsx
+++ b/web/src/pages/auth/enterprise-sso-required.tsx
@@ -143,7 +143,7 @@ export default function EnterpriseSsoRequiredPage() {
       </Head>
       <div className="min-h-screen-with-banner bg-background flex flex-col justify-center px-6 py-12 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
-          <div className="mx-auto">
+          <div className="mx-auto w-fit">
             <LangfuseIcon />
           </div>
           <h1 className="text-primary mt-6 text-center text-2xl font-bold">

--- a/web/src/pages/auth/enterprise-sso-required.tsx
+++ b/web/src/pages/auth/enterprise-sso-required.tsx
@@ -143,7 +143,9 @@ export default function EnterpriseSsoRequiredPage() {
       </Head>
       <div className="min-h-screen-with-banner bg-background flex flex-col justify-center px-6 py-12 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
-          <LangfuseIcon className="mx-auto" />
+          <div className="mx-auto">
+            <LangfuseIcon />
+          </div>
           <h1 className="text-primary mt-6 text-center text-2xl font-bold">
             Use your Enterprise SSO
           </h1>

--- a/web/src/pages/auth/enterprise-sso-required.tsx
+++ b/web/src/pages/auth/enterprise-sso-required.tsx
@@ -6,7 +6,7 @@ import { signIn } from "next-auth/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { useForm } from "react-hook-form";
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { Button } from "@/src/components/ui/button";
 import {
   Form,

--- a/web/src/pages/auth/hf-spaces.tsx
+++ b/web/src/pages/auth/hf-spaces.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Button } from "@/src/components/ui/button";
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import Head from "next/head";
 import Link from "next/link";
 import { type GetServerSideProps } from "next";

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -726,7 +726,9 @@ export default function SignIn({
       </Head>
       <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-center sm:px-6 sm:py-12 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
-          <LangfuseIcon className="mx-auto" />
+          <div className="mx-auto">
+            <LangfuseIcon />
+          </div>
           <h2 className="text-primary mt-4 text-center text-2xl leading-9 font-bold tracking-tight">
             Sign in to your account
           </h2>

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -726,7 +726,7 @@ export default function SignIn({
       </Head>
       <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-center sm:px-6 sm:py-12 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
-          <div className="mx-auto">
+          <div className="mx-auto w-fit">
             <LangfuseIcon />
           </div>
           <h2 className="text-primary mt-4 text-center text-2xl leading-9 font-bold tracking-tight">

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -1,5 +1,5 @@
 import { type GetServerSideProps } from "next";
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { Button } from "@/src/components/ui/button";
 import {
   Form,

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -407,7 +407,7 @@ function VerifiedSignupFlow({
         </Head>
         <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-center sm:px-6 sm:py-12 lg:px-8">
           <div className="sm:mx-auto sm:w-full sm:max-w-md">
-            <div className="mx-auto">
+            <div className="mx-auto w-fit">
               <LangfuseIcon />
             </div>
             <h2 className="text-primary mt-4 text-center text-2xl leading-9 font-bold tracking-tight">
@@ -554,7 +554,7 @@ function SignupPageShell({ children }: { children: React.ReactNode }) {
       </Head>
       <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-center sm:px-6 sm:py-12 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
-          <div className="mx-auto">
+          <div className="mx-auto w-fit">
             <LangfuseIcon />
           </div>
           <h2 className="text-primary mt-4 text-center text-2xl leading-9 font-bold tracking-tight">

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -407,7 +407,9 @@ function VerifiedSignupFlow({
         </Head>
         <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-center sm:px-6 sm:py-12 lg:px-8">
           <div className="sm:mx-auto sm:w-full sm:max-w-md">
-            <LangfuseIcon className="mx-auto" />
+            <div className="mx-auto">
+              <LangfuseIcon />
+            </div>
             <h2 className="text-primary mt-4 text-center text-2xl leading-9 font-bold tracking-tight">
               Check your email
             </h2>
@@ -552,7 +554,9 @@ function SignupPageShell({ children }: { children: React.ReactNode }) {
       </Head>
       <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-center sm:px-6 sm:py-12 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
-          <LangfuseIcon className="mx-auto" />
+          <div className="mx-auto">
+            <LangfuseIcon />
+          </div>
           <h2 className="text-primary mt-4 text-center text-2xl leading-9 font-bold tracking-tight">
             Create new account
           </h2>

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -17,7 +17,7 @@ import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { env } from "@/src/env.mjs";
 import { useState } from "react";
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { CloudPrivacyNotice } from "@/src/features/auth/components/AuthCloudPrivacyNotice";
 import { CloudRegionSwitch } from "@/src/features/auth/components/AuthCloudRegionSwitch";
 import {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves `LangfuseIcon` from `LangfuseLogo.tsx` into a dedicated `web/src/components/design-system/LangfuseIcon/` folder, adds a Storybook story, and updates all 13 import sites to point to the new location.

- The new component drops the open-ended `className` prop and replaces it with a constrained `size?: 14 | 16 | 28 | 32 | 42` union type; call sites that previously passed `className` for layout/animation purposes (e.g. `mx-auto`, `animate-spin`) are updated to use wrapper `<div>` elements instead.
- `OnboardingSurvey` call sites that passed `className="h-8 w-8"` (Tailwind rem-based sizing) are replaced with `size={32}` (fixed px); at the browser default of 16 px/rem these are visually identical, though the old approach would scale with the user's font-size setting.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Pure import-path refactor with no logic changes; all call sites are updated consistently and the wrapper-div approach faithfully preserves the original layout and animation behaviour.

Every consumer in the PR is updated to the new import path, the size values used at every call site fall within the new constrained union type, and the wrapper-div replacements for the dropped `className` prop are structurally correct. No logic, data, or auth paths are touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph before["Before (source: LangfuseLogo.tsx)"]
        A["LangfuseLogo.tsx\n(defined & exported LangfuseIcon)"]
    end

    subgraph after["After (source: design-system)"]
        B["design-system/LangfuseIcon/\nLangfuseIcon.tsx"]
        C["design-system/LangfuseIcon/\nLangfuseIcon.stories.tsx"]
    end

    B --> D["LangfuseLogo.tsx"]
    B --> E["spinner.tsx"]
    B --> F["peek-evaluator-config-detail.tsx"]
    B --> G["data-table-view-presets-drawer.tsx"]
    B --> H["models.tsx"]
    B --> I["ResetPasswordPage.tsx"]
    B --> J["eval-template-detail.tsx"]
    B --> K["maintainer-tooltip.tsx"]
    B --> L["OnboardingSurvey.tsx"]
    B --> M["enterprise-sso-required.tsx"]
    B --> N["hf-spaces.tsx"]
    B --> O["sign-in.tsx"]
    B --> P["sign-up.tsx"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph before["Before (source: LangfuseLogo.tsx)"]
        A["LangfuseLogo.tsx\n(defined & exported LangfuseIcon)"]
    end

    subgraph after["After (source: design-system)"]
        B["design-system/LangfuseIcon/\nLangfuseIcon.tsx"]
        C["design-system/LangfuseIcon/\nLangfuseIcon.stories.tsx"]
    end

    B --> D["LangfuseLogo.tsx"]
    B --> E["spinner.tsx"]
    B --> F["peek-evaluator-config-detail.tsx"]
    B --> G["data-table-view-presets-drawer.tsx"]
    B --> H["models.tsx"]
    B --> I["ResetPasswordPage.tsx"]
    B --> J["eval-template-detail.tsx"]
    B --> K["maintainer-tooltip.tsx"]
    B --> L["OnboardingSurvey.tsx"]
    B --> M["enterprise-sso-required.tsx"]
    B --> N["hf-spaces.tsx"]
    B --> O["sign-in.tsx"]
    B --> P["sign-up.tsx"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Move component to design system folder +..."](https://github.com/langfuse/langfuse/commit/cc87dc8135e2ed61078a1a93fadb624eac15176e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40547862)</sub>

<!-- /greptile_comment -->