### PR TITLE
fix(openai-models): add gpt-5.5 and gpt-5.5-pro to model selector

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -303,6 +303,10 @@ export const openAIModels = [
   "gpt-4.1-mini-2025-04-14",
   "gpt-4.1-nano",
   "gpt-4.1-nano-2025-04-14",
+  "gpt-5.5",
+  "gpt-5.5-2026-04-23",
+  "gpt-5.5-pro",
+  "gpt-5.5-pro-2026-04-23",
   "gpt-5.4",
   "gpt-5.4-2026-03-05",
   "gpt-5.4-pro",
@@ -354,6 +358,10 @@ export const openAIModels = [
 type OpenAIReasoningMap = Record<OpenAIModel, boolean>;
 export const openAIModelToReasoning: OpenAIReasoningMap = {
   // reasoning models
+  "gpt-5.5": true,
+  "gpt-5.5-2026-04-23": true,
+  "gpt-5.5-pro": true,
+  "gpt-5.5-pro-2026-04-23": true,
   "gpt-5.4": true,
   "gpt-5.4-2026-03-05": true,
   "gpt-5.4-pro": true,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `gpt-5.5` and `gpt-5.5-pro` (plus their dated snapshot variants) to the OpenAI model selector and reasoning map, making them available in the Langfuse playground.

- Both `gpt-5.5` / `gpt-5.5-2026-04-23` and `gpt-5.5-pro` / `gpt-5.5-pro-2026-04-23` are appended to `openAIModels` before the existing `gpt-5.4` entries, keeping a descending-version order.
- All four new model IDs are marked `true` in `openAIModelToReasoning`, consistent with how every other `gpt-5.x` model is classified; the corresponding price entries already exist in `worker/src/constants/default-model-prices.json`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, additive update to a static model list.

Four model IDs are added to the allow-list array and the reasoning map; no logic is changed. The pricing entries for these models already exist in `default-model-prices.json`, so cost tracking will work out of the box. The reasoning flag is `true` for all four, matching every other `gpt-5.x` model, which is consistent with the established pattern.

No files require special attention. The only file touched is `packages/shared/src/server/llm/types.ts`, and the companion pricing data in `worker/src/constants/default-model-prices.json` was already up to date.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects model in Playground] --> B{openAIModels array}
    B --> C[gpt-5.5 / gpt-5.5-2026-04-23]
    B --> D[gpt-5.5-pro / gpt-5.5-pro-2026-04-23]
    B --> E[gpt-5.4 / other existing models]
    C --> F{openAIModelToReasoning map}
    D --> F
    E --> F
    F -- true --> G[Reasoning mode enabled]
    F -- false --> H[Standard chat mode]
    G --> I[LLM API call with reasoning params]
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User selects model in Playground] --> B{openAIModels array}
    B --> C[gpt-5.5 / gpt-5.5-2026-04-23]
    B --> D[gpt-5.5-pro / gpt-5.5-pro-2026-04-23]
    B --> E[gpt-5.4 / other existing models]
    C --> F{openAIModelToReasoning map}
    D --> F
    E --> F
    F -- true --> G[Reasoning mode enabled]
    F -- false --> H[Standard chat mode]
    G --> I[LLM API call with reasoning params]
    H --> I
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(openai-models): add gpt-5.5 and gpt-..."](https://github.com/langfuse/langfuse/commit/994d16e6f0a1c1110308690c0413a0dbb0192420) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40553692)</sub>

<!-- /greptile_comment -->