### PR TITLE
fix(otel): map GenAI IO on AI SDK spans

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -4566,6 +4566,130 @@ describe("OTel Resource Span Mapping", () => {
       );
     });
 
+    it("should map official GenAI I/O attributes on AI SDK scope spans", async () => {
+      const traceId = "abcdef1234567890abcdef1234567894";
+      const generationSpanId = "1234567890abcded";
+      const toolSpanId = "1234567890abcdee";
+
+      const resourceSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "service.name",
+              value: { stringValue: "otel-test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "ai",
+              version: "7.0.0",
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from(generationSpanId, "hex"),
+                name: "chat test-model",
+                kind: 1,
+                startTimeUnixNano: { low: 0, high: 406528574, unsigned: true },
+                endTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "gen_ai.operation.name",
+                    value: { stringValue: "chat" },
+                  },
+                  {
+                    key: "gen_ai.request.model",
+                    value: { stringValue: "test-model" },
+                  },
+                  {
+                    key: "gen_ai.input.messages",
+                    value: {
+                      stringValue: '[{"role":"user","content":"hello"}]',
+                    },
+                  },
+                  {
+                    key: "gen_ai.output.messages",
+                    value: {
+                      stringValue: '[{"role":"assistant","content":"hi"}]',
+                    },
+                  },
+                ],
+                status: {},
+              },
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from(toolSpanId, "hex"),
+                parentSpanId: Buffer.from(generationSpanId, "hex"),
+                name: "execute_tool get_weather",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "gen_ai.operation.name",
+                    value: { stringValue: "execute_tool" },
+                  },
+                  {
+                    key: "gen_ai.tool.name",
+                    value: { stringValue: "get_weather" },
+                  },
+                  {
+                    key: "gen_ai.tool.call.arguments",
+                    value: { stringValue: '{"location":"Berlin"}' },
+                  },
+                  {
+                    key: "gen_ai.tool.call.result",
+                    value: { stringValue: '{"temperature":21}' },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set([traceId]),
+      );
+
+      const generation = events.find((e) => e.type === "generation-create");
+      const tool = events.find((e) => e.type === "tool-create");
+
+      expect(generation?.body.input).toBe(
+        '[{"role":"user","content":"hello"}]',
+      );
+      expect(generation?.body.output).toBe(
+        '[{"role":"assistant","content":"hi"}]',
+      );
+      expect(tool?.body.input).toBe('{"location":"Berlin"}');
+      expect(tool?.body.output).toBe('{"temperature":21}');
+      expect(
+        generation?.body.metadata?.attributes?.["gen_ai.output.messages"],
+      ).toBeUndefined();
+      expect(
+        tool?.body.metadata?.attributes?.["gen_ai.tool.call.arguments"],
+      ).toBeUndefined();
+      expect(
+        tool?.body.metadata?.attributes?.["gen_ai.tool.call.result"],
+      ).toBeUndefined();
+    });
+
     it("should extract AI SDK available tools after metadata normalization in processToEvent", () => {
       const tools = aiSdkWeatherTools;
       const resourceSpan = buildAiSdkToolResourceSpan({

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -4680,6 +4680,9 @@ describe("OTel Resource Span Mapping", () => {
       expect(tool?.body.input).toBe('{"location":"Berlin"}');
       expect(tool?.body.output).toBe('{"temperature":21}');
       expect(
+        generation?.body.metadata?.attributes?.["gen_ai.input.messages"],
+      ).toBeUndefined();
+      expect(
         generation?.body.metadata?.attributes?.["gen_ai.output.messages"],
       ).toBeUndefined();
       expect(


### PR DESCRIPTION
## Summary

- Map official `gen_ai.input.messages` / `gen_ai.output.messages` on AI SDK scope generation spans when `ai.*` I/O fields are absent.
- Map official `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` on AI SDK scope tool spans when `ai.*` I/O fields are absent.
- Add an OTel mapping regression test covering AI SDK scope spans that emit official GenAI I/O attributes.

## Context

This addresses the mapping gap reported in #14633: AI SDK 7 can emit spans under instrumentation scope `ai` while carrying official `gen_ai.*` I/O attributes. The existing AI SDK branch returned before the generic OpenTelemetry I/O mapper, so those attributes were removed from metadata but not promoted to observation input/output.

The fix keeps existing `ai.*` fields as the priority path and only falls back to official `gen_ai.*` fields when the AI SDK-specific fields are missing.

## Verification

- `pnpm exec prettier --check packages/shared/src/server/otel/OtelIngestionProcessor.ts web/src/__tests__/server/api/otel/otelMapping.servertest.ts`
- `git diff --check`
- `pnpm --filter @langfuse/shared run db:generate`
- `pnpm --filter @langfuse/shared run typecheck`

I also attempted the targeted Vitest server test locally on Windows, but this checkout's Vitest server project collected zero server files even without a path filter while still printing `src\__tests__\server\api\otel\otelMapping.servertest.ts` in the generated include list. I did not count that as a passing test run.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a mapping gap for AI SDK 7 spans emitted under instrumentation scope `ai` that carry official `gen_ai.*` I/O attributes instead of the `ai.*`-prefixed ones. The fix appends a nullish-assignment fallback at the end of the existing `ai`-scope branch so that `gen_ai.input.messages`/`gen_ai.output.messages` and `gen_ai.tool.call.arguments`/`gen_ai.tool.call.result` are promoted to observation `input`/`output` when no `ai.*` I/O field is present.

- **Processor change** (`OtelIngestionProcessor.ts`): seventeen new lines inside the `instrumentationScopeName === "ai"` guard; uses `??=` to preserve the existing `ai.*` priority chain and only apply the GenAI fallback when those fields are absent. All four `gen_ai.*` keys are already in `potentialInputOutputKeys` (lines 1488–1491), so they are stripped from `filteredAttributes` before the branch runs.
- **Test** (`otelMapping.servertest.ts`): new regression test asserts that values are lifted to `body.input`/`body.output` and absent from `metadata.attributes` for both a generation span and a tool span. One of the four filtered attributes (`gen_ai.input.messages` on the generation span) is not explicitly checked for metadata absence, leaving a small gap in the filter-cleanup assertions.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the production logic is correct and the change is tightly scoped to the AI SDK instrumentation-scope branch.

The fallback uses ??= correctly so existing ai.* mappings are never displaced. All four gen_ai.* keys were already in the filter list before this PR, so they will not bleed into metadata. The only gap is a missing test assertion for gen_ai.input.messages being absent from generation-span metadata — a cosmetic omission that does not affect runtime behaviour.

The test file (otelMapping.servertest.ts) is missing one of four expected metadata-filter assertions; the processor file (OtelIngestionProcessor.ts) needs no further attention.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/api/otel/otelMapping.servertest.ts:4682-4684
The test verifies that `gen_ai.output.messages`, `gen_ai.tool.call.arguments`, and `gen_ai.tool.call.result` are stripped from metadata, but the symmetric check for `gen_ai.input.messages` on the generation span is missing. While the attribute IS removed (it lives in `potentialInputOutputKeys` on line 1488 of the processor), the test's own goal of confirming filtered-attribute cleanup is stated incompletely. A future refactor of the filter list could silently reintroduce the key without a failing test.

```suggestion
      expect(
        generation?.body.metadata?.attributes?.["gen_ai.input.messages"],
      ).toBeUndefined();
      expect(
        generation?.body.metadata?.attributes?.["gen_ai.output.messages"],
      ).toBeUndefined();
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): map GenAI IO on AI SDK spans"](https://github.com/langfuse/langfuse/commit/72a496534e9e6c886a87e887dbd26c5c27bf8133) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41246842)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->