### PR TITLE
fix(shared): retry GCS signed-URL generation on transient signing failures

### DIFF
--- a/packages/shared/src/server/services/StorageService.test.ts
+++ b/packages/shared/src/server/services/StorageService.test.ts
@@ -1,6 +1,6 @@
 import { Readable } from "stream";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { StorageServiceFactory } from "./StorageService";
 
@@ -98,5 +98,136 @@ describe("AzureBlobStorageService.streamToString", () => {
     const result = await streamToString([]);
 
     expect(result).toBe("");
+  });
+});
+
+/**
+ * Regression tests for Google Cloud Storage signed-URL generation.
+ *
+ * Generating a v4 signed URL calls Google's `iamcredentials:signBlob` endpoint
+ * through `@google-cloud/storage` -> `google-auth-library` -> `gaxios`. That
+ * call can fail transiently with "Premature close" (the socket to Google's IAM
+ * API is dropped mid-response), which previously surfaced as a hard failure for
+ * the whole export/media flow (issue #14460). `deleteFiles` already wraps its
+ * GCS call in `backOff`; these tests cover the same hardening now applied to
+ * `getSignedUrl` / `getSignedUploadUrl`: a single transient failure is retried,
+ * a persistent failure still propagates (never masked), and retries are bounded.
+ */
+describe("GoogleCloudStorageService signed-URL retry", () => {
+  // A "Premature close" from the underlying signBlob HTTP call, as seen in #14460.
+  const prematureClose = () =>
+    Object.assign(
+      new Error(
+        "Invalid response body while trying to fetch " +
+          "https://iamcredentials.googleapis.com/...:signBlob: Premature close",
+      ),
+      { name: "SigningError" },
+    );
+
+  // Build a real GoogleCloudStorageService (its constructor performs no network
+  // I/O without credentials) and replace its private `bucket` with a stub whose
+  // `file().getSignedUrl` we control, so we exercise the retry wrapper without a
+  // live GCS backend.
+  const makeService = (getSignedUrl: ReturnType<typeof vi.fn>) => {
+    const service = StorageServiceFactory.getInstance({
+      accessKeyId: undefined,
+      secretAccessKey: undefined,
+      bucketName: "test-bucket",
+      endpoint: undefined,
+      region: undefined,
+      forcePathStyle: false,
+      useGoogleCloudStorage: true,
+      awsSse: undefined,
+      awsSseKmsKeyId: undefined,
+    });
+
+    (
+      service as unknown as { bucket: { file: (name: string) => unknown } }
+    ).bucket = {
+      file: () => ({ getSignedUrl }),
+    };
+
+    return service as unknown as {
+      getSignedUrl(fileName: string, ttlSeconds: number): Promise<string>;
+      getSignedUrlNonRetrying(
+        fileName: string,
+        ttlSeconds: number,
+      ): Promise<string>;
+      getSignedUploadUrl(params: {
+        path: string;
+        ttlSeconds: number;
+        sha256Hash: string;
+        contentType: string;
+        contentLength: number;
+      }): Promise<string>;
+    };
+  };
+
+  const uploadParams = {
+    path: "media/p.png",
+    ttlSeconds: 3600,
+    sha256Hash: "hash",
+    contentType: "image/png",
+    contentLength: 1,
+  };
+
+  // Reproduction: the un-retried path (old behavior) fails on a single
+  // transient "Premature close" -- exactly what issue #14460 reports.
+  it("getSignedUrlNonRetrying rejects on a single transient failure (repro)", async () => {
+    const getSignedUrl = vi.fn().mockRejectedValueOnce(prematureClose());
+    const service = makeService(getSignedUrl);
+
+    await expect(
+      service.getSignedUrlNonRetrying("f.png", 3600),
+    ).rejects.toThrow();
+    expect(getSignedUrl).toHaveBeenCalledTimes(1);
+  });
+
+  // Fix: the public method retries the transient failure and succeeds.
+  it("getSignedUrl retries a transient failure and returns the URL", async () => {
+    const getSignedUrl = vi
+      .fn()
+      .mockRejectedValueOnce(prematureClose())
+      .mockResolvedValue(["https://signed-read-url"]);
+    const service = makeService(getSignedUrl);
+
+    await expect(service.getSignedUrl("f.png", 3600)).resolves.toBe(
+      "https://signed-read-url",
+    );
+    expect(getSignedUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("getSignedUploadUrl retries a transient failure and returns the URL", async () => {
+    const getSignedUrl = vi
+      .fn()
+      .mockRejectedValueOnce(prematureClose())
+      .mockResolvedValue(["https://signed-write-url"]);
+    const service = makeService(getSignedUrl);
+
+    await expect(service.getSignedUploadUrl(uploadParams)).resolves.toBe(
+      "https://signed-write-url",
+    );
+    expect(getSignedUrl).toHaveBeenCalledTimes(2);
+  });
+
+  // Guard: a persistent failure is not masked -- it still throws, after a
+  // bounded number of attempts (3), not indefinitely.
+  it("getSignedUrl gives up after 3 attempts and still throws", async () => {
+    const getSignedUrl = vi.fn().mockRejectedValue(prematureClose());
+    const service = makeService(getSignedUrl);
+
+    await expect(service.getSignedUrl("f.png", 3600)).rejects.toThrow();
+    expect(getSignedUrl).toHaveBeenCalledTimes(3);
+  });
+
+  // No retry overhead on the happy path.
+  it("getSignedUrl calls the backend once when it succeeds immediately", async () => {
+    const getSignedUrl = vi.fn().mockResolvedValue(["https://signed-read-url"]);
+    const service = makeService(getSignedUrl);
+
+    await expect(service.getSignedUrl("f.png", 3600)).resolves.toBe(
+      "https://signed-read-url",
+    );
+    expect(getSignedUrl).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -1159,6 +1159,17 @@ class GoogleCloudStorageService implements StorageService {
     ttlSeconds: number,
     asAttachment = false,
   ): Promise<string> {
+    return backOff(
+      () => this.getSignedUrlNonRetrying(fileName, ttlSeconds, asAttachment),
+      { numOfAttempts: 3 },
+    );
+  }
+
+  async getSignedUrlNonRetrying(
+    fileName: string,
+    ttlSeconds: number,
+    asAttachment = false,
+  ): Promise<string> {
     try {
       const file = this.bucket.file(fileName);
 
@@ -1184,6 +1195,18 @@ class GoogleCloudStorageService implements StorageService {
   }
 
   public async getSignedUploadUrl(params: {
+    path: string;
+    ttlSeconds: number;
+    sha256Hash: string;
+    contentType: string;
+    contentLength: number;
+  }): Promise<string> {
+    return backOff(() => this.getSignedUploadUrlNonRetrying(params), {
+      numOfAttempts: 3,
+    });
+  }
+
+  async getSignedUploadUrlNonRetrying(params: {
     path: string;
     ttlSeconds: number;
     sha256Hash: string;


### PR DESCRIPTION
## What does this PR do?

`GoogleCloudStorageService.getSignedUrl` and `getSignedUploadUrl` call `file.getSignedUrl()`, which generates a v4 signed URL by calling Google's `iamcredentials:signBlob` endpoint through `@google-cloud/storage` → `google-auth-library` → `gaxios`. That outbound call can fail transiently with `Premature close` (the socket to Google's IAM API is dropped mid-response), and today a single such failure aborts the whole media/export flow.

This wraps both signing methods in `backOff({ numOfAttempts: 3 })` — the same retry the GCS path already applies to `deleteFiles`. A transient failure is retried; a persistent failure still propagates unchanged after the bounded attempts, so no error is masked.

There's a good chance the underlying `Premature close` is environment/network-level (it originates in the outbound connection to Google's IAM API, below Langfuse). The retry is a small, bounded mitigation consistent with how the neighbouring `deleteFiles` path is already hardened; it shouldn't change happy-path behavior or mask persistent failures. Happy to adjust the attempt count/backoff or the scope.

Relates to #14460

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Added unit tests in `StorageService.test.ts` that mock the GCS client (no live backend):
- reproduce the single `Premature close` failure on the un-retried path
- verify `getSignedUrl` / `getSignedUploadUrl` retry the transient failure and return the URL
- verify a persistent failure still throws after exactly 3 bounded attempts (error not masked)
- verify the happy path makes a single call

## Mandatory Tasks

- [x] Self-reviewed the code.

## Checklist

- Code follows the style guidelines (`pnpm run format` clean; `turbo run lint` passes)
- Added tests that prove the fix is effective
- New and existing unit tests pass locally

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Wraps `GoogleCloudStorageService.getSignedUrl` and `getSignedUploadUrl` in `backOff({ numOfAttempts: 3 })` to retry transient `Premature close` failures from the underlying `iamcredentials:signBlob` call, consistent with how `deleteFiles` is already hardened. The implementation refactors each public method into a public wrapper + a non-retrying helper, and adds unit tests covering the retry, exhaustion, and happy-path cases.

- The retry logic follows the established `deleteFilesNonRetrying` pattern exactly, keeping the change minimal and consistent.
- Both helper methods (`getSignedUrlNonRetrying`, `getSignedUploadUrlNonRetrying`) are missing a `private` access modifier, inadvertently exposing them as public API.
- The `try/catch` inside each helper logs at `error` level before re-throwing, so every failed attempt (including transient ones that ultimately succeed on retry) emits an error log entry.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a bounded retry wrapper around two GCS signing calls and does not affect the happy path or mask persistent failures.

The retry logic is correct and mirrors an existing, tested pattern in the codebase. The helper methods should be marked `private`, and the error-logging-before-retry pattern means transient recoverable failures still emit error log entries — neither issue affects correctness.

StorageService.ts — the two `NonRetrying` helpers should be `private` to avoid accidental external coupling.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant getSignedUrl
    participant backOff
    participant getSignedUrlNonRetrying
    participant GCS IAM API

    Caller->>getSignedUrl: getSignedUrl(fileName, ttlSeconds)
    getSignedUrl->>backOff: "backOff(() => getSignedUrlNonRetrying(...), {numOfAttempts:3})"

    loop Up to 3 attempts
        backOff->>getSignedUrlNonRetrying: attempt N
        getSignedUrlNonRetrying->>GCS IAM API: file.getSignedUrl()
        alt Transient failure (e.g. Premature close)
            GCS IAM API-->>getSignedUrlNonRetrying: error
            getSignedUrlNonRetrying->>getSignedUrlNonRetrying: log error + handleStorageError (throws)
            getSignedUrlNonRetrying-->>backOff: throw
            Note over backOff: wait & retry
        else Success
            GCS IAM API-->>getSignedUrlNonRetrying: [signedUrl]
            getSignedUrlNonRetrying-->>backOff: return url
            backOff-->>getSignedUrl: url
            getSignedUrl-->>Caller: url
        end
    end

    alt All 3 attempts fail
        backOff-->>getSignedUrl: throw (last error)
        getSignedUrl-->>Caller: throw
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant getSignedUrl
    participant backOff
    participant getSignedUrlNonRetrying
    participant GCS IAM API

    Caller->>getSignedUrl: getSignedUrl(fileName, ttlSeconds)
    getSignedUrl->>backOff: "backOff(() => getSignedUrlNonRetrying(...), {numOfAttempts:3})"

    loop Up to 3 attempts
        backOff->>getSignedUrlNonRetrying: attempt N
        getSignedUrlNonRetrying->>GCS IAM API: file.getSignedUrl()
        alt Transient failure (e.g. Premature close)
            GCS IAM API-->>getSignedUrlNonRetrying: error
            getSignedUrlNonRetrying->>getSignedUrlNonRetrying: log error + handleStorageError (throws)
            getSignedUrlNonRetrying-->>backOff: throw
            Note over backOff: wait & retry
        else Success
            GCS IAM API-->>getSignedUrlNonRetrying: [signedUrl]
            getSignedUrlNonRetrying-->>backOff: return url
            backOff-->>getSignedUrl: url
            getSignedUrl-->>Caller: url
        end
    end

    alt All 3 attempts fail
        backOff-->>getSignedUrl: throw (last error)
        getSignedUrl-->>Caller: throw
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/shared/src/server/services/StorageService.ts:1168-1195
**Error logged on every failed retry attempt**

Because the `try/catch` inside `getSignedUrlNonRetrying` (and `getSignedUploadUrlNonRetrying`) logs at `error` level and then re-throws, each failed attempt produces an error log entry before `backOff` retries. For a transient failure that succeeds on the second attempt, production logs will still show one (or two) error entries even though the operation ultimately succeeded — this can trigger false alerts or confusion. The same pattern exists in the sibling `deleteFilesNonRetrying`, so it's an accepted trade-off, but worth noting that moving logging to the outer `backOff` caller (only logging after all retries are exhausted) would be cleaner observability.

### Issue 2 of 3
packages/shared/src/server/services/StorageService.ts:1168-1172
`getSignedUrlNonRetrying` and `getSignedUploadUrlNonRetrying` lack a `private` access modifier. Without it, TypeScript exposes them as part of the public class API. They're implementation details of the retry wrapper and should be private — the tests already cast through `unknown` to reach them, so making them `private` costs nothing at the test boundary.

```suggestion
  private async getSignedUrlNonRetrying(
    fileName: string,
    ttlSeconds: number,
    asAttachment = false,
  ): Promise<string> {
```

### Issue 3 of 3
packages/shared/src/server/services/StorageService.ts:1209-1215
Same as `getSignedUrlNonRetrying` — missing `private` modifier.

```suggestion
  private async getSignedUploadUrlNonRetrying(params: {
    path: string;
    ttlSeconds: number;
    sha256Hash: string;
    contentType: string;
    contentLength: number;
  }): Promise<string> {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): retry GCS signed-URL genera..."](https://github.com/langfuse/langfuse/commit/92e0ece01d8971cf432a53ae18fce44188229461) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40564032)</sub>

<!-- /greptile_comment -->