### PR TITLE
fix(assistant): better trace design

### DIFF
--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -19,6 +19,7 @@ const adapterEvents = vi.hoisted(() => ({
 const instrumentationMocks = vi.hoisted(() => {
   const instrumentation = {
     recordEvents: vi.fn(),
+    recordAvailableTools: vi.fn(),
     end: vi.fn(),
     endWithError: vi.fn(),
     flush: vi.fn(),

--- a/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
@@ -60,6 +60,9 @@ const input: AgUiRunAgentInput = {
   context: [],
   forwardedProps: {},
 };
+const expectedAgentRunInput = {
+  messages: [{ role: "user", content: "hello" }],
+};
 
 describe("InAppAgentInstrumentation", () => {
   beforeEach(() => {
@@ -68,6 +71,13 @@ describe("InAppAgentInstrumentation", () => {
 
   it("records agent output and tool calls as tool observations", () => {
     const instrumentation = createInstrumentation();
+    const toolCall = {
+      id: "tool-1",
+      name: "listObservations",
+      arguments: '{"limit":10}',
+      type: "function",
+    };
+    const toolOutput = { traces: [{ id: "trace-1" }] };
 
     instrumentation.recordEvents([
       {
@@ -82,6 +92,7 @@ describe("InAppAgentInstrumentation", () => {
         type: EventType.TOOL_CALL_START,
         toolCallId: "tool-1",
         toolCallName: "listObservations",
+        parentMessageId: "assistant-message-1",
       },
       {
         type: EventType.TOOL_CALL_ARGS,
@@ -100,7 +111,14 @@ describe("InAppAgentInstrumentation", () => {
       {
         type: EventType.TOOL_CALL_RESULT,
         toolCallId: "tool-1",
-        content: "tool result",
+        content: JSON.stringify({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(toolOutput),
+            },
+          ],
+        }),
       },
       {
         type: EventType.RUN_FINISHED,
@@ -130,7 +148,7 @@ describe("InAppAgentInstrumentation", () => {
       expect.objectContaining({
         id: agentRunObservationId,
         name: "agent-run",
-        input: "hello",
+        input: expectedAgentRunInput,
       }),
     );
     expect(mocks.handler.langfuse.enqueue).toHaveBeenCalledWith(
@@ -141,18 +159,38 @@ describe("InAppAgentInstrumentation", () => {
         parentObservationId: agentRunObservationId,
         name: "listObservations",
         input: { limit: 10 },
-        output: "tool result",
+        output: toolOutput,
         startTime: expect.any(Date),
         endTime: expect.any(Date),
         completionStartTime: expect.any(Date),
-        metadata: expect.objectContaining({ toolCallId: "tool-1" }),
+        metadata: expect.objectContaining({
+          toolCallId: "tool-1",
+          parentMessageId: "assistant-message-1",
+        }),
       }),
     );
     expect(mocks.agentGeneration.update).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "agent-run",
-        input: "hello",
-        output: "hi there",
+        input: expectedAgentRunInput,
+        output: {
+          messages: [
+            { role: "assistant", content: "hi there" },
+            {
+              role: "assistant",
+              content: "",
+              tool_calls: [toolCall],
+            },
+            {
+              role: "tool",
+              tool_call_id: "tool-1",
+              content: toolOutput,
+            },
+          ],
+          text: "hi there",
+          tool_calls: [toolCall],
+        },
+        completionStartTime: expect.any(Date),
       }),
     );
     expect(mocks.handler.langfuse.enqueue).not.toHaveBeenCalledWith(
@@ -164,6 +202,12 @@ describe("InAppAgentInstrumentation", () => {
 
   it("records run failures on the agent generation", () => {
     const instrumentation = createInstrumentation();
+    const toolCall = {
+      id: "tool-1",
+      name: "getTrace",
+      arguments: '{"traceId":"trace-1"}',
+      type: "function",
+    };
 
     instrumentation.recordEvents([
       {
@@ -191,12 +235,127 @@ describe("InAppAgentInstrumentation", () => {
     expect(mocks.agentGeneration.update).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "agent-run",
-        input: "hello",
+        input: expectedAgentRunInput,
+        output: {
+          messages: [
+            {
+              role: "assistant",
+              content: "",
+              tool_calls: [toolCall],
+            },
+          ],
+          tool_calls: [toolCall],
+        },
+        completionStartTime: expect.any(Date),
         level: "ERROR",
         statusMessage: "agent failed",
         metadata: expect.objectContaining({ error: "agent failed" }),
       }),
     );
+  });
+
+  it("records available tools on the agent generation input", () => {
+    const instrumentation = createInstrumentation();
+
+    instrumentation.recordAvailableTools({
+      langfuse_listObservations: {
+        description: "List observations in a project.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            limit: { type: "number" },
+          },
+        },
+      },
+      langfuse_redirect: {
+        description: "Redirect the user to a Langfuse page.",
+        inputSchema: {
+          parse: vi.fn(),
+        },
+      },
+    });
+    instrumentation.end();
+
+    expect(mocks.agentGeneration.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "agent-run",
+        input: {
+          messages: [{ role: "user", content: "hello" }],
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "langfuse_listObservations",
+                description: "List observations in a project.",
+                parameters: {
+                  type: "object",
+                  properties: {
+                    limit: { type: "number" },
+                  },
+                },
+              },
+            },
+            {
+              type: "function",
+              function: {
+                name: "langfuse_redirect",
+                description: "Redirect the user to a Langfuse page.",
+              },
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("marks tool observations with error outputs as error level", () => {
+    const instrumentation = createInstrumentation();
+
+    instrumentation.recordEvents([
+      {
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tool-1",
+        toolCallName: "listObservations",
+      },
+      {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: "tool-1",
+        delta: '{"type":"TRACE"}',
+      },
+      {
+        type: EventType.TOOL_CALL_END,
+        toolCallId: "tool-1",
+      },
+      {
+        type: EventType.TOOL_CALL_RESULT,
+        toolCallId: "tool-1",
+        content: JSON.stringify({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                error: true,
+                message: "Tool input validation failed",
+              }),
+            },
+          ],
+        }),
+      },
+    ]);
+
+    const toolCreateBody = mocks.handler.langfuse.enqueue.mock.calls[0]?.[1];
+
+    expect(toolCreateBody).toEqual(
+      expect.objectContaining({
+        input: { type: "TRACE" },
+        output: {
+          error: true,
+          message: "Tool input validation failed",
+        },
+        level: "ERROR",
+      }),
+    );
+    expect(toolCreateBody).not.toHaveProperty("statusMessage");
   });
 
   it("sets static prompt metadata on the trace and agent generation", () => {
@@ -232,7 +391,7 @@ describe("InAppAgentInstrumentation", () => {
     expect(mocks.trace.generation).toHaveBeenCalledWith({
       id: agentRunObservationId,
       name: "agent-run",
-      input: "hello",
+      input: expectedAgentRunInput,
       metadata: {
         langfuse_project_id: "project-1",
         langfuse_user_email: "user@example.com",
@@ -248,7 +407,7 @@ describe("InAppAgentInstrumentation", () => {
     expect(mocks.agentGeneration.update).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "agent-run",
-        input: "hello",
+        input: expectedAgentRunInput,
         promptName: "in-app-agent-system-prompt",
         promptVersion: 3,
       }),
@@ -274,8 +433,12 @@ describe("InAppAgentInstrumentation", () => {
     expect(mocks.agentGeneration.update).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "agent-run",
-        input: "hello",
-        output: "second turn output",
+        input: expectedAgentRunInput,
+        output: {
+          messages: [{ role: "assistant", content: "second turn output" }],
+          text: "second turn output",
+        },
+        completionStartTime: expect.any(Date),
       }),
     );
     expect(mocks.trace.update.mock.calls[0][0]).not.toHaveProperty("output");
@@ -289,6 +452,14 @@ describe("InAppAgentInstrumentation", () => {
           value:
             "https://cloud.langfuse.com/project/project-1/traces?filter=value",
         },
+        {
+          description: "browser_languages",
+          value: "en-US, en, de",
+        },
+        {
+          description: "current_trace",
+          value: JSON.stringify({ id: "trace-1" }),
+        },
       ],
     });
 
@@ -296,19 +467,91 @@ describe("InAppAgentInstrumentation", () => {
       expect.objectContaining({
         name: "agent-run",
         input: {
-          message: "hello",
-          context: [
-            {
-              description: "current_url",
-              value:
-                "https://cloud.langfuse.com/project/project-1/traces?filter=value",
-            },
-          ],
+          messages: [{ role: "user", content: "hello" }],
+          context: {
+            current_url:
+              "https://cloud.langfuse.com/project/project-1/traces?filter=value",
+            browser_languages: ["en-US", "en", "de"],
+            current_trace: { id: "trace-1" },
+          },
         },
       }),
     );
     expect(mocks.handler.langfuse.trace.mock.calls[0][0]).not.toHaveProperty(
       "input",
+    );
+  });
+
+  it("records replayed conversation messages in the agent generation input", () => {
+    createInstrumentation({
+      messages: [
+        {
+          id: "message-previous-user",
+          role: "user",
+          content: "previous question",
+        },
+        {
+          id: "message-previous-assistant",
+          role: "assistant",
+          content: "previous answer",
+          toolCalls: [
+            {
+              id: "tool-previous",
+              type: "function",
+              function: {
+                name: "getTrace",
+                arguments: '{"traceId":"trace-1"}',
+              },
+            },
+          ],
+        },
+        {
+          id: "message-previous-tool",
+          role: "tool",
+          toolCallId: "tool-previous",
+          content: '{"found":true}',
+        },
+        {
+          id: "message-activity",
+          role: "activity",
+          activityType: "loading",
+          content: { label: "Loading" },
+        },
+        {
+          id: "message-1",
+          role: "user",
+          content: "hello",
+        },
+      ],
+    });
+
+    expect(mocks.trace.generation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "agent-run",
+        input: {
+          messages: [
+            { role: "user", content: "previous question" },
+            {
+              role: "assistant",
+              content: "previous answer",
+              tool_calls: [
+                {
+                  id: "tool-previous",
+                  name: "getTrace",
+                  arguments: '{"traceId":"trace-1"}',
+                  type: "function",
+                },
+              ],
+            },
+            {
+              role: "tool",
+              tool_call_id: "tool-previous",
+              content: { found: true },
+            },
+            { role: "user", content: "hello" },
+          ],
+        },
+      }),
     );
   });
 
@@ -335,8 +578,12 @@ describe("InAppAgentInstrumentation", () => {
     expect(mocks.agentGeneration.update).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "agent-run",
-        input: "hello",
-        output: "chunk output",
+        input: expectedAgentRunInput,
+        output: {
+          messages: [{ role: "assistant", content: "chunk output" }],
+          text: "chunk output",
+        },
+        completionStartTime: expect.any(Date),
       }),
     );
   });
@@ -367,8 +614,12 @@ describe("InAppAgentInstrumentation", () => {
     expect(mocks.agentGeneration.update).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "agent-run",
-        input: "hello",
-        output: "Done",
+        input: expectedAgentRunInput,
+        output: {
+          messages: [{ role: "assistant", content: "Done" }],
+          text: "Done",
+        },
+        completionStartTime: expect.any(Date),
         metadata: expect.objectContaining({ reasoning: "Checking filters" }),
       }),
     );

--- a/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
@@ -205,7 +205,7 @@ describe("InAppAgentInstrumentation", () => {
     const toolCall = {
       id: "tool-1",
       name: "getTrace",
-      arguments: '{"traceId":"trace-1"}',
+      arguments: '{"traceId":',
       type: "function",
     };
 
@@ -218,7 +218,7 @@ describe("InAppAgentInstrumentation", () => {
       {
         type: EventType.TOOL_CALL_ARGS,
         toolCallId: "tool-1",
-        delta: '{"traceId":"trace-1"}',
+        delta: '{"traceId":',
       },
     ]);
     instrumentation.endWithError(new Error("agent failed"));
@@ -226,10 +226,13 @@ describe("InAppAgentInstrumentation", () => {
     expect(mocks.handler.langfuse.enqueue).toHaveBeenCalledWith(
       "tool-create",
       expect.objectContaining({
-        input: { traceId: "trace-1" },
+        input: '{"traceId":',
         level: "ERROR",
         statusMessage: "agent failed",
-        metadata: expect.objectContaining({ error: "agent failed" }),
+        metadata: expect.objectContaining({
+          argsComplete: false,
+          error: "agent failed",
+        }),
       }),
     );
     expect(mocks.agentGeneration.update).toHaveBeenCalledWith(

--- a/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
@@ -262,8 +262,10 @@ describe("InAppAgentInstrumentation", () => {
         description: "List observations in a project.",
         inputSchema: {
           type: "object",
+          additionalProperties: false,
           properties: {
-            limit: { type: "number" },
+            includeErrors: { type: "boolean", nullable: true },
+            limit: { type: "number", required: false },
           },
         },
       },
@@ -289,8 +291,10 @@ describe("InAppAgentInstrumentation", () => {
                 description: "List observations in a project.",
                 parameters: {
                   type: "object",
+                  additionalProperties: false,
                   properties: {
-                    limit: { type: "number" },
+                    includeErrors: { type: "boolean", nullable: true },
+                    limit: { type: "number", required: false },
                   },
                 },
               },

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -372,6 +372,8 @@ export async function createAgUiStream(params: {
         options: params.options,
         awsProfile,
         instructions,
+        onToolsAvailable: (tools) =>
+          instrumentation?.recordAvailableTools(tools),
       })
         .then(({ adapter, cleanup, interrupt }) => {
           if (ending || closed || params.signal.aborted) {
@@ -544,6 +546,7 @@ async function createMastraAdapter(params: {
   options: CreateAgUiStreamOptions;
   awsProfile?: string;
   instructions: string;
+  onToolsAvailable?: (tools: Record<string, unknown>) => void;
 }) {
   const bedrock = createAmazonBedrock({
     ...(params.options.awsBedrock.region
@@ -586,6 +589,10 @@ async function createMastraAdapter(params: {
       });
     }
 
+    // @ag-ui/mastra drives execution via adapter.run(input), not a direct
+    // agent.stream(..., { toolsets }) call. Keep Mastra's per-request MCP
+    // discovery, then prefix tool names for constructor-based tools so the
+    // model sees the same names that later appear in AG-UI tool-call events.
     const tools = {
       ...prefixToolsetTools("langfuse", toolsets.langfuse),
       ...prefixToolsetTools("langfuseDocs", toolsets.langfuseDocs),
@@ -594,6 +601,7 @@ async function createMastraAdapter(params: {
         isV4Enabled: params.options.redirectAction.isV4Enabled,
       }),
     };
+    params.onToolsAvailable?.(tools);
 
     const agent = new Agent({
       id: "langfuse-in-app-assistant",

--- a/web/src/ee/features/in-app-agent/server/instrumentation.ts
+++ b/web/src/ee/features/in-app-agent/server/instrumentation.ts
@@ -3,6 +3,7 @@ import { getInternalTracingHandler, logger } from "@langfuse/shared/src/server";
 
 import type {
   AgUiEvent,
+  AgUiMessage,
   AgUiRunAgentInput,
 } from "@/src/ee/features/in-app-agent/schema";
 import { compactTextMessageChunks } from "@/src/ee/features/in-app-agent/server/eventCompaction";
@@ -37,6 +38,27 @@ type InAppAgentTrace = ReturnType<
 >;
 type InAppAgentGeneration = ReturnType<InAppAgentTrace["generation"]>;
 type InAppAgentLangfuse = InternalTracingHandler["handler"]["langfuse"];
+type AgentRunToolCall = {
+  id: string;
+  name: string;
+  arguments: string;
+  type: "function";
+};
+type AgentRunToolDefinition = {
+  type: "function";
+  function: {
+    name: string;
+    description?: string;
+    parameters?: unknown;
+  };
+};
+type AgentRunChatMessage = {
+  role: string;
+  name?: string;
+  content?: unknown;
+  tool_calls?: AgentRunToolCall[];
+  tool_call_id?: string;
+};
 type ToolObservationBody = {
   id: string;
   traceId: string;
@@ -82,7 +104,7 @@ export class InAppAgentInstrumentation {
   private readonly langfuse: InAppAgentLangfuse;
   private readonly trace: InAppAgentTrace;
   private readonly agentRun: InAppAgentGeneration;
-  private readonly agentRunInput: unknown;
+  private agentRunInput: unknown;
   private readonly prompt?: InAppAgentPromptMetadata;
   private readonly toolSpans = new Map<
     string,
@@ -92,11 +114,15 @@ export class InAppAgentInstrumentation {
       args: string;
       argsComplete: boolean;
       output?: unknown;
+      parentMessageId?: string;
     }
   >();
   private readonly metadata: Record<string, unknown>;
+  private readonly agentRunOutputMessages: AgentRunChatMessage[] = [];
+  private readonly agentRunToolCalls: AgentRunToolCall[] = [];
   private output = "";
   private reasoning = "";
+  private completionStartTime?: Date;
   private ended = false;
 
   constructor(params: {
@@ -170,6 +196,23 @@ export class InAppAgentInstrumentation {
     }
   }
 
+  recordAvailableTools(tools: Record<string, unknown>) {
+    if (this.ended) {
+      return;
+    }
+
+    const availableTools = getAgentRunAvailableTools(tools);
+
+    if (availableTools.length === 0) {
+      return;
+    }
+
+    this.agentRunInput = addAvailableToolsToAgentRunInput(
+      this.agentRunInput,
+      availableTools,
+    );
+  }
+
   endWithError(error: unknown) {
     if (this.ended) {
       return;
@@ -180,7 +223,10 @@ export class InAppAgentInstrumentation {
     this.agentRun.update({
       name: IN_APP_AGENT_RUN_NAME,
       input: this.agentRunInput,
-      output: this.output || undefined,
+      output: this.getAgentRunOutput(),
+      ...(this.completionStartTime
+        ? { completionStartTime: this.completionStartTime }
+        : {}),
       level: "ERROR",
       statusMessage: message,
       metadata: {
@@ -217,7 +263,10 @@ export class InAppAgentInstrumentation {
     this.agentRun.update({
       name: IN_APP_AGENT_RUN_NAME,
       input: this.agentRunInput,
-      output: this.output || undefined,
+      output: this.getAgentRunOutput(),
+      ...(this.completionStartTime
+        ? { completionStartTime: this.completionStartTime }
+        : {}),
       metadata,
       ...(this.prompt
         ? {
@@ -242,7 +291,7 @@ export class InAppAgentInstrumentation {
       case EventType.TEXT_MESSAGE_CHUNK:
       case EventType.TEXT_MESSAGE_CONTENT:
         if (typeof event.delta === "string") {
-          this.output += event.delta;
+          this.recordAssistantText(event.delta);
         }
         return;
       case EventType.REASONING_MESSAGE_CHUNK:
@@ -308,6 +357,9 @@ export class InAppAgentInstrumentation {
       startTime: new Date(),
       args: "",
       argsComplete: false,
+      ...(typeof event.parentMessageId === "string"
+        ? { parentMessageId: event.parentMessageId }
+        : {}),
     });
   }
 
@@ -359,6 +411,7 @@ export class InAppAgentInstrumentation {
       args: string;
       argsComplete: boolean;
       output?: unknown;
+      parentMessageId?: string;
     },
   ) {
     if (!tool.argsComplete || tool.output === undefined) {
@@ -376,12 +429,17 @@ export class InAppAgentInstrumentation {
       startTime: Date;
       args: string;
       output?: unknown;
+      parentMessageId?: string;
     },
     options?: {
       metadata?: Record<string, unknown>;
       statusMessage?: string;
     },
   ) {
+    const input = parseJsonOrUndefined(tool.args);
+    const output =
+      tool.output === undefined ? undefined : normalizeToolOutput(tool.output);
+    const isError = options?.statusMessage !== undefined || isToolError(output);
     const body: ToolObservationBody = {
       id: toolCallId,
       traceId: this.agentRun.traceId,
@@ -390,16 +448,22 @@ export class InAppAgentInstrumentation {
       startTime: tool.startTime,
       endTime: new Date(),
       completionStartTime: tool.startTime,
-      input: parseJsonOrString(tool.args),
-      output: tool.output,
+      input,
+      output,
+      ...(isError ? { level: "ERROR" } : {}),
       ...(options?.statusMessage
-        ? { level: "ERROR", statusMessage: options.statusMessage }
+        ? { statusMessage: options.statusMessage }
         : {}),
       metadata: {
         ...(options?.metadata ?? {}),
         toolCallId,
+        ...(tool.parentMessageId
+          ? { parentMessageId: tool.parentMessageId }
+          : {}),
       },
     };
+
+    this.recordToolCall(toolCallId, tool, output);
 
     (
       this.langfuse as unknown as {
@@ -420,40 +484,316 @@ export class InAppAgentInstrumentation {
       this.toolSpans.delete(toolCallId);
     }
   }
+
+  private recordAssistantText(delta: string) {
+    this.output += delta;
+    this.completionStartTime ??= new Date();
+
+    const lastMessage = this.agentRunOutputMessages.at(-1);
+    if (lastMessage?.role === "assistant" && !lastMessage.tool_calls?.length) {
+      lastMessage.content = `${typeof lastMessage.content === "string" ? lastMessage.content : ""}${delta}`;
+      return;
+    }
+
+    this.agentRunOutputMessages.push({
+      role: "assistant",
+      content: delta,
+    });
+  }
+
+  private recordToolCall(
+    toolCallId: string,
+    tool: {
+      name: string;
+      args: string;
+      startTime: Date;
+    },
+    output: unknown,
+  ) {
+    this.completionStartTime ??= tool.startTime;
+
+    const toolCall: AgentRunToolCall = {
+      id: toolCallId,
+      name: tool.name,
+      arguments: tool.args || "{}",
+      type: "function",
+    };
+
+    this.agentRunToolCalls.push(toolCall);
+    this.agentRunOutputMessages.push({
+      role: "assistant",
+      content: "",
+      tool_calls: [toolCall],
+    });
+
+    if (output !== undefined) {
+      this.agentRunOutputMessages.push({
+        role: "tool",
+        tool_call_id: toolCallId,
+        content: output,
+      });
+    }
+  }
+
+  private getAgentRunOutput() {
+    if (this.agentRunOutputMessages.length === 0) {
+      return undefined;
+    }
+
+    return {
+      messages: this.agentRunOutputMessages,
+      ...(this.output ? { text: this.output } : {}),
+      ...(this.agentRunToolCalls.length > 0
+        ? { tool_calls: this.agentRunToolCalls }
+        : {}),
+    };
+  }
 }
 
 function getAgentRunInput(input: AgUiRunAgentInput): unknown {
-  const message = getLastUserMessageText(input);
+  const messages = getAgentRunMessages(input.messages);
+  const context = getAgentRunContext(input);
 
-  if (input.context.length === 0) {
-    return message;
+  if (!context) {
+    return { messages };
   }
 
   return {
-    message,
-    context: input.context,
+    messages,
+    context,
   };
 }
 
-function getLastUserMessageText(input: AgUiRunAgentInput): string | undefined {
-  const lastMessage = input.messages.at(-1);
+function addAvailableToolsToAgentRunInput(
+  input: unknown,
+  tools: AgentRunToolDefinition[],
+) {
+  if (!isRecord(input)) {
+    return input;
+  }
 
-  if (lastMessage?.role !== "user") {
+  return {
+    ...input,
+    tools,
+  };
+}
+
+function getAgentRunAvailableTools(
+  tools: Record<string, unknown>,
+): AgentRunToolDefinition[] {
+  return Object.entries(tools).map(([name, tool]) => {
+    const toolRecord = isRecord(tool) ? tool : {};
+    const description = getStringValue(toolRecord.description);
+    const parameters = getSerializableToolParameters(toolRecord);
+
+    return {
+      type: "function" as const,
+      function: {
+        name,
+        ...(description ? { description } : {}),
+        ...(parameters ? { parameters } : {}),
+      },
+    };
+  });
+}
+
+function getAgentRunMessages(messages: AgUiMessage[]): AgentRunChatMessage[] {
+  return messages.flatMap((message): AgentRunChatMessage[] => {
+    switch (message.role) {
+      case "developer":
+      case "system":
+        return [
+          {
+            role: message.role,
+            ...(message.name ? { name: message.name } : {}),
+            content: message.content,
+          },
+        ];
+      case "user":
+        return [
+          {
+            role: "user",
+            ...(message.name ? { name: message.name } : {}),
+            content: normalizeUserMessageContent(message.content),
+          },
+        ];
+      case "assistant": {
+        const toolCalls = message.toolCalls?.map((toolCall) => ({
+          id: toolCall.id,
+          name: toolCall.function.name,
+          arguments: toolCall.function.arguments,
+          type: "function" as const,
+        }));
+
+        if (!message.content && !toolCalls?.length) {
+          return [];
+        }
+
+        return [
+          {
+            role: "assistant",
+            ...(message.name ? { name: message.name } : {}),
+            content: message.content ?? "",
+            ...(toolCalls?.length ? { tool_calls: toolCalls } : {}),
+          },
+        ];
+      }
+      case "tool":
+        return [
+          {
+            role: "tool",
+            tool_call_id: message.toolCallId,
+            content: parseJsonOrString(message.content),
+          },
+        ];
+      case "activity":
+      case "reasoning":
+        return [];
+    }
+  });
+}
+
+function normalizeUserMessageContent(
+  content: Extract<AgUiMessage, { role: "user" }>["content"],
+): unknown {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (content.every((part) => part.type === "text")) {
+    return content.map((part) => part.text).join("");
+  }
+
+  return content;
+}
+
+function getAgentRunContext(input: AgUiRunAgentInput) {
+  if (input.context.length === 0) {
     return undefined;
   }
 
-  if (typeof lastMessage.content === "string") {
-    return lastMessage.content;
+  return Object.fromEntries(
+    input.context.map((item) => [
+      item.description,
+      parseContextValue(item.description, item.value),
+    ]),
+  );
+}
+
+function parseContextValue(description: string, value: string): unknown {
+  const parsed = parseJsonOrString(value);
+
+  if (description === "browser_languages" && typeof parsed === "string") {
+    return parsed
+      .split(",")
+      .map((language) => language.trim())
+      .filter(Boolean);
   }
 
-  return lastMessage.content
-    .flatMap((part) => (part.type === "text" ? [part.text] : []))
-    .join("");
+  return parsed;
+}
+
+function normalizeToolOutput(output: unknown): unknown {
+  const parsedOutput =
+    typeof output === "string" ? parseJsonOrString(output) : output;
+
+  if (!isRecord(parsedOutput) || !Array.isArray(parsedOutput.content)) {
+    return parsedOutput;
+  }
+
+  const firstContent = parsedOutput.content[0];
+
+  if (
+    parsedOutput.content.length !== 1 ||
+    !isRecord(firstContent) ||
+    firstContent.type !== "text" ||
+    typeof firstContent.text !== "string"
+  ) {
+    return parsedOutput;
+  }
+
+  return parseJsonOrString(firstContent.text);
+}
+
+function isToolError(output: unknown): boolean {
+  return isRecord(output) && output.error === true;
+}
+
+function getSerializableToolParameters(tool: Record<string, unknown>): unknown {
+  const parameters =
+    tool.parameters ??
+    tool.inputSchema ??
+    tool.parameters_json_schema ??
+    tool.input_schema;
+
+  return toSerializableJson(parameters);
+}
+
+function toSerializableJson(
+  value: unknown,
+  seen = new WeakSet<object>(),
+  depth = 0,
+): unknown {
+  if (value === null || typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (Array.isArray(value)) {
+    if (depth >= 8) {
+      return undefined;
+    }
+
+    return value
+      .map((item) => toSerializableJson(item, seen, depth + 1))
+      .filter((item) => item !== undefined);
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (Object.getPrototypeOf(value) !== Object.prototype) {
+    return undefined;
+  }
+
+  if (seen.has(value)) {
+    return undefined;
+  }
+
+  if (depth >= 8) {
+    return undefined;
+  }
+
+  seen.add(value);
+
+  const entries = Object.entries(value).flatMap(([key, item]) => {
+    const serializableItem = toSerializableJson(item, seen, depth + 1);
+
+    return serializableItem === undefined
+      ? []
+      : [[key, serializableItem] as const];
+  });
+
+  seen.delete(value);
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function parseJsonOrUndefined(value: string): unknown {
+  if (!value) {
+    return undefined;
+  }
+
+  return parseJsonOrString(value);
 }
 
 function parseJsonOrString(value: string): unknown {
   if (!value) {
-    return undefined;
+    return value;
   }
 
   try {
@@ -461,4 +801,12 @@ function parseJsonOrString(value: string): unknown {
   } catch {
     return value;
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getStringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
 }

--- a/web/src/ee/features/in-app-agent/server/instrumentation.ts
+++ b/web/src/ee/features/in-app-agent/server/instrumentation.ts
@@ -428,6 +428,7 @@ export class InAppAgentInstrumentation {
       name: string;
       startTime: Date;
       args: string;
+      argsComplete: boolean;
       output?: unknown;
       parentMessageId?: string;
     },
@@ -457,6 +458,7 @@ export class InAppAgentInstrumentation {
       metadata: {
         ...(options?.metadata ?? {}),
         toolCallId,
+        ...(tool.argsComplete ? {} : { argsComplete: false }),
         ...(tool.parentMessageId
           ? { parentMessageId: tool.parentMessageId }
           : {}),

--- a/web/src/ee/features/in-app-agent/server/instrumentation.ts
+++ b/web/src/ee/features/in-app-agent/server/instrumentation.ts
@@ -738,7 +738,11 @@ function toSerializableJson(
     return value;
   }
 
-  if (typeof value === "number" || typeof value === "boolean") {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
     return Number.isFinite(value) ? value : undefined;
   }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the in-app agent's Langfuse trace design to record richer, structured data: inputs now capture the full conversation message history, available tools, and a parsed context object; outputs now record a chat-style message list alongside convenience `text`/`tool_calls` summaries. A new `recordAvailableTools` method is wired through `agent.ts` so tool definitions (names, descriptions, parameter schemas) are persisted on the trace.

- **Input shape** — replaces the previous single-string "last user message" with `{ messages, context?, tools? }` using OpenAI chat format; conversation history (user, assistant, tool) is replayed from the AG-UI message list; `browser_languages` context is parsed from a comma-separated string into an array.
- **Output shape** — replaces the raw output string with `{ messages, text?, tool_calls? }`; each assistant turn and tool result is appended as it streams in, giving a complete conversation replay on the generation span.
- **Tool observation improvements** — tool results are now unwrapped from MCP's `{ content: [{ type: "text", text }] }` envelope; tool spans with an `error: true` result are automatically marked `level: ERROR` even without an explicit status message.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The refactor is well-structured and comprehensively tested, but a logic error in toSerializableJson causes boolean values in tool parameter schemas to be silently dropped before being persisted in Langfuse traces.

The toSerializableJson function applies Number.isFinite to both numbers and booleans in the same branch. Number.isFinite(true) returns false, so every boolean schema keyword (additionalProperties: false, nullable: true, etc.) is serialized as undefined and stripped from the stored tool definitions. The rest of the changes look correct and are well covered by tests.

instrumentation.ts — specifically the toSerializableJson function around line 741
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Agent as agent.ts
    participant Instr as InAppAgentInstrumentation
    participant LF as Langfuse

    Client->>Agent: createAgUiStream(params)
    Agent->>Instr: new InAppAgentInstrumentation(input)
    Instr->>LF: "trace.generation({ input: {messages, context?} })"

    Agent->>Agent: createMastraAdapter(onToolsAvailable)
    Agent->>Agent: MCP tool discovery
    Agent-->>Instr: onToolsAvailable(tools)
    Instr->>Instr: "agentRunInput = { ...input, tools }"

    loop AG-UI events
        Agent-->>Instr: recordEvents([TEXT_MESSAGE_CHUNK, ...])
        Instr->>Instr: recordAssistantText(delta) agentRunOutputMessages
        Agent-->>Instr: recordEvents([TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_END])
        Agent-->>Instr: recordEvents([TOOL_CALL_RESULT])
        Instr->>Instr: normalizeToolOutput(raw) output
        Instr->>LF: enqueue(tool-create, observation)
        Instr->>Instr: recordToolCall agentRunOutputMessages
    end

    alt RUN_FINISHED
        Instr->>LF: "agentRun.update({ input: {messages, tools?}, output: {messages, text?, tool_calls?} })"
    else RUN_ERROR
        Instr->>LF: "agentRun.update({ ..., level: ERROR })"
    end
    Instr->>LF: flush()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Agent as agent.ts
    participant Instr as InAppAgentInstrumentation
    participant LF as Langfuse

    Client->>Agent: createAgUiStream(params)
    Agent->>Instr: new InAppAgentInstrumentation(input)
    Instr->>LF: "trace.generation({ input: {messages, context?} })"

    Agent->>Agent: createMastraAdapter(onToolsAvailable)
    Agent->>Agent: MCP tool discovery
    Agent-->>Instr: onToolsAvailable(tools)
    Instr->>Instr: "agentRunInput = { ...input, tools }"

    loop AG-UI events
        Agent-->>Instr: recordEvents([TEXT_MESSAGE_CHUNK, ...])
        Instr->>Instr: recordAssistantText(delta) agentRunOutputMessages
        Agent-->>Instr: recordEvents([TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_END])
        Agent-->>Instr: recordEvents([TOOL_CALL_RESULT])
        Instr->>Instr: normalizeToolOutput(raw) output
        Instr->>LF: enqueue(tool-create, observation)
        Instr->>Instr: recordToolCall agentRunOutputMessages
    end

    alt RUN_FINISHED
        Instr->>LF: "agentRun.update({ input: {messages, tools?}, output: {messages, text?, tool_calls?} })"
    else RUN_ERROR
        Instr->>LF: "agentRun.update({ ..., level: ERROR })"
    end
    Instr->>LF: flush()
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/ee/features/in-app-agent/server/instrumentation.ts:741-743
**`Number.isFinite` silently drops all boolean values**

`Number.isFinite(true)` and `Number.isFinite(false)` both return `false` in JavaScript because booleans are not numbers. Every boolean in a tool's parameter schema (e.g., `"additionalProperties": false`, `"nullable": true`, `required: false`) will be serialized as `undefined` and silently filtered out of the persisted tool definitions in traces. The `typeof value === "number"` and `typeof value === "boolean"` branches need to be separated so the finite check applies only to numbers.

```suggestion
  if (typeof value === "boolean") {
    return value;
  }

  if (typeof value === "number") {
    return Number.isFinite(value) ? value : undefined;
  }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(assistant): better trace design"](https://github.com/langfuse/langfuse/commit/802f5e5aecdd67a1fc4e0645c26450a9226f59bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40564139)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->