### PR TITLE
chore(shared): tag dataset item write counts

### DIFF
--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -139,6 +139,12 @@ export function instrumentSync<T>(
 
 export const getCurrentSpan = () => opentelemetry.trace.getActiveSpan();
 
+export const addTagsToCurrentSpan = (
+  attributes: Parameters<opentelemetry.Span["setAttributes"]>[0],
+) => {
+  getCurrentSpan()?.setAttributes(attributes);
+};
+
 export const traceException = (
   ex: unknown,
   span?: opentelemetry.Span,

--- a/packages/shared/src/server/repositories/dataset-item-media.ts
+++ b/packages/shared/src/server/repositories/dataset-item-media.ts
@@ -4,7 +4,11 @@ import { prisma } from "../../db";
 import { type DatasetItemMediaField } from "../../domain";
 import { InvalidRequestError, LangfuseNotFoundError } from "../../errors";
 import { findMediaReferences } from "../../utils/mediaReferences";
-import { recordHistogram, recordIncrement } from "../instrumentation";
+import {
+  addTagsToCurrentSpan,
+  recordHistogram,
+  recordIncrement,
+} from "../instrumentation";
 
 type DatasetItemMediaValues = {
   input?: unknown;
@@ -204,6 +208,9 @@ export async function linkDatasetItemMedia(
   },
 ) {
   const { projectId, items, replaceExisting } = props;
+  addTagsToCurrentSpan({
+    "langfuse.dataset_item_media.link.item_count": items.length,
+  });
   if (items.length === 0) return;
 
   const rowsToInsert: Prisma.DatasetItemMediaCreateManyInput[] = items.flatMap(
@@ -219,6 +226,9 @@ export async function linkDatasetItemMedia(
         mediaId: reference.mediaId,
       })),
   );
+  addTagsToCurrentSpan({
+    "langfuse.dataset_item_media.link.reference_count": rowsToInsert.length,
+  });
 
   // Hot path: items without media still need the replaceExisting delete.
   if (rowsToInsert.length === 0 && !replaceExisting) return;
@@ -228,12 +238,15 @@ export async function linkDatasetItemMedia(
   }
 
   if (rowsToInsert.length > 0) {
-    await tx.datasetItemMedia.createMany({
+    const createResult = await tx.datasetItemMedia.createMany({
       data: rowsToInsert,
       skipDuplicates: true,
     });
+    addTagsToCurrentSpan({
+      "langfuse.dataset_item_media.link.created_count": createResult.count,
+    });
     // Consume the claimed pending rows; unclaimed ones are swept by retention.
-    await tx.datasetItemMedia.deleteMany({
+    const pendingDeleteResult = await tx.datasetItemMedia.deleteMany({
       where: {
         projectId,
         datasetItemValidFrom: null,
@@ -242,6 +255,10 @@ export async function linkDatasetItemMedia(
           mediaId: row.mediaId,
         })),
       },
+    });
+    addTagsToCurrentSpan({
+      "langfuse.dataset_item_media.link.pending_deleted_count":
+        pendingDeleteResult.count,
     });
   }
 }
@@ -257,6 +274,10 @@ export async function deleteDatasetItemMediaLinks(
   },
 ) {
   const { projectId, itemVersions } = props;
+  addTagsToCurrentSpan({
+    "langfuse.dataset_item_media.delete.item_version_count":
+      itemVersions.length,
+  });
   if (itemVersions.length === 0) return;
 
   const versionFilters = itemVersions.map((itemVersion) => ({
@@ -264,10 +285,13 @@ export async function deleteDatasetItemMediaLinks(
     datasetItemValidFrom: itemVersion.datasetItemValidFrom,
   }));
 
-  await tx.datasetItemMedia.deleteMany({
+  const deleteResult = await tx.datasetItemMedia.deleteMany({
     where: {
       projectId,
       OR: versionFilters,
     },
+  });
+  addTagsToCurrentSpan({
+    "langfuse.dataset_item_media.delete.deleted_count": deleteResult.count,
   });
 }

--- a/packages/shared/src/server/repositories/dataset-items.ts
+++ b/packages/shared/src/server/repositories/dataset-items.ts
@@ -13,6 +13,7 @@ import {
   Implementation,
   OperationType,
 } from "../datasets/executeWithDatasetServiceStrategy";
+import { addTagsToCurrentSpan } from "../instrumentation";
 import { v4 } from "uuid";
 import {
   deleteDatasetItemMediaLinks,
@@ -319,6 +320,9 @@ export async function upsertDatasetItem(
       );
     }
   }
+  addTagsToCurrentSpan({
+    "langfuse.dataset_item.upsert.existing_item_count": existingItem ? 1 : 0,
+  });
 
   // 3. Merge incoming data with existing data
   // For fields where props value is undefined, use existing value
@@ -411,6 +415,10 @@ export async function upsertDatasetItem(
                 projectId: props.projectId,
               },
             });
+        addTagsToCurrentSpan({
+          "langfuse.dataset_item.upsert.updated_count": existingItem ? 1 : 0,
+          "langfuse.dataset_item.upsert.created_count": existingItem ? 0 : 1,
+        });
         item = res;
         await linkWrittenItemMedia(tx, res);
       });
@@ -454,6 +462,9 @@ export async function upsertDatasetItem(
             },
           });
         }
+        addTagsToCurrentSpan({
+          "langfuse.dataset_item.upsert.updated_count": current ? 1 : 0,
+        });
 
         // 2. Create new version
         const res = await tx.datasetItem.create({
@@ -606,6 +617,10 @@ export async function createManyDatasetItems(props: {
       failedCount: number;
     }
 > {
+  addTagsToCurrentSpan({
+    "langfuse.dataset_items.create.input_count": props.items.length,
+  });
+
   let successCount = 0;
   let failedCount = 0;
 
@@ -765,6 +780,14 @@ export async function createManyDatasetItems(props: {
     preparedItems = preparedItems.filter((_, i) => !failedItemIndices.has(i));
   }
 
+  addTagsToCurrentSpan({
+    "langfuse.dataset_items.create.prepared_count": preparedItems.length,
+    "langfuse.dataset_items.create.validation_error_count":
+      validationErrors.length,
+    "langfuse.dataset_items.create.success_count": successCount,
+    "langfuse.dataset_items.create.failed_count": failedCount,
+  });
+
   // 4. If any validation errors and partial success not allowed, return early
   if (validationErrors.length > 0 && !props.allowPartialSuccess) {
     return {
@@ -791,15 +814,21 @@ export async function createManyDatasetItems(props: {
       expectedOutput: item.expectedOutput,
       metadata: item.metadata,
     }));
+    addTagsToCurrentSpan({
+      "langfuse.dataset_items.create.media_item_count": mediaItems.length,
+    });
 
     await executeWithDatasetServiceStrategy(OperationType.WRITE, {
       [Implementation.STATEFUL]: async () => {
         await prisma.$transaction(async (tx) => {
-          await tx.datasetItem.createMany({
+          const createResult = await tx.datasetItem.createMany({
             data: preparedItems.map((item) => ({
               ...item,
               validFrom: newValidFrom,
             })),
+          });
+          addTagsToCurrentSpan({
+            "langfuse.dataset_items.create.created_count": createResult.count,
           });
           await linkDatasetItemMedia(tx, {
             projectId: props.projectId,
@@ -820,9 +849,13 @@ export async function createManyDatasetItems(props: {
         await prisma.$transaction(async (tx) => {
           // 1. Get unique IDs from preparedItems
           const itemIds = [...new Set(preparedItems.map((item) => item.id))];
+          addTagsToCurrentSpan({
+            "langfuse.dataset_items.create.unique_item_id_count":
+              itemIds.length,
+          });
 
           // 2. Invalidate current versions if IDs already exist (no-op for new IDs)
-          await tx.datasetItem.updateMany({
+          const updateResult = await tx.datasetItem.updateMany({
             where: {
               id: { in: itemIds },
               projectId: props.projectId,
@@ -832,13 +865,19 @@ export async function createManyDatasetItems(props: {
               validTo: newValidFrom,
             },
           });
+          addTagsToCurrentSpan({
+            "langfuse.dataset_items.create.updated_count": updateResult.count,
+          });
 
           // 3. Create all new versions with the same validFrom timestamp
-          await tx.datasetItem.createMany({
+          const createResult = await tx.datasetItem.createMany({
             data: preparedItems.map((item) => ({
               ...item,
               validFrom: newValidFrom,
             })),
+          });
+          addTagsToCurrentSpan({
+            "langfuse.dataset_items.create.created_count": createResult.count,
           });
 
           // 4. Link media in the same transaction as the write

--- a/packages/shared/src/server/repositories/dataset-items.ts
+++ b/packages/shared/src/server/repositories/dataset-items.ts
@@ -464,6 +464,7 @@ export async function upsertDatasetItem(
         }
         addTagsToCurrentSpan({
           "langfuse.dataset_item.upsert.updated_count": current ? 1 : 0,
+          "langfuse.dataset_item.upsert.created_count": current ? 0 : 1,
         });
 
         // 2. Create new version


### PR DESCRIPTION
## Summary

- Add `addTagsToCurrentSpan` as a small helper for tagging the active span.
- Add dynamic dataset item create/upsert counts to traces so slow writes can be correlated with batch size, validation results, replacements, and affected rows.
- Add dataset item media link/delete counts to traces so media-reference fanout and delete cardinality are visible during timeout investigations.

## Linear

- None

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds observability instrumentation to dataset item write paths. A new `addTagsToCurrentSpan` helper wraps the OpenTelemetry `setAttributes` call, and both `createManyDatasetItems` and `upsertDatasetItem` (plus the media link/delete helpers) now emit counts for inputs, validation results, and affected DB rows onto the active span.

- Adds `addTagsToCurrentSpan` utility to `instrumentation/index.ts` with safe optional-chaining for the no-span case.
- Tags `linkDatasetItemMedia` and `deleteDatasetItemMediaLinks` with item counts, reference counts, and DB row counts — all tagged before early-return guards so they are always emitted.
- Tags `createManyDatasetItems` with input, prepared, validation-error, success, failed, and created counts across both STATEFUL and VERSIONED execution paths; tags `upsertDatasetItem` with `updated_count`/`created_count` in the STATEFUL path only.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are purely additive observability instrumentation with no effect on write logic or return values.

The VERSIONED path of `upsertDatasetItem` always creates a new row but never tags `created_count`, unlike the STATEFUL path that tags both counts. Dashboards or alerts that join on `created_count` will silently get no data from the VERSIONED code path, making the instrumentation misleading rather than just incomplete.

packages/shared/src/server/repositories/dataset-items.ts — the VERSIONED branch of `upsertDatasetItem` is missing `created_count`.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant upsertDatasetItem
    participant createManyDatasetItems
    participant linkDatasetItemMedia
    participant deleteDatasetItemMediaLinks
    participant Span as Active OTel Span

    Caller->>upsertDatasetItem: upsert single item
    upsertDatasetItem->>Span: existing_item_count
    alt STATEFUL path
        upsertDatasetItem->>Span: updated_count + created_count
        upsertDatasetItem->>linkDatasetItemMedia: link media
        linkDatasetItemMedia->>Span: item_count, reference_count, created_count, pending_deleted_count
    else VERSIONED path
        upsertDatasetItem->>Span: updated_count (created_count missing)
        upsertDatasetItem->>linkDatasetItemMedia: link media
        linkDatasetItemMedia->>Span: item_count, reference_count, created_count, pending_deleted_count
    end

    Caller->>createManyDatasetItems: bulk create
    createManyDatasetItems->>Span: input_count
    createManyDatasetItems->>Span: prepared_count, validation_error_count, success_count, failed_count
    createManyDatasetItems->>Span: media_item_count
    alt STATEFUL path
        createManyDatasetItems->>Span: created_count
        createManyDatasetItems->>linkDatasetItemMedia: link media
    else VERSIONED path
        createManyDatasetItems->>Span: unique_item_id_count, updated_count, created_count
        createManyDatasetItems->>linkDatasetItemMedia: link media
    end

    Caller->>deleteDatasetItemMediaLinks: delete media links
    deleteDatasetItemMediaLinks->>Span: item_version_count, deleted_count
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant upsertDatasetItem
    participant createManyDatasetItems
    participant linkDatasetItemMedia
    participant deleteDatasetItemMediaLinks
    participant Span as Active OTel Span

    Caller->>upsertDatasetItem: upsert single item
    upsertDatasetItem->>Span: existing_item_count
    alt STATEFUL path
        upsertDatasetItem->>Span: updated_count + created_count
        upsertDatasetItem->>linkDatasetItemMedia: link media
        linkDatasetItemMedia->>Span: item_count, reference_count, created_count, pending_deleted_count
    else VERSIONED path
        upsertDatasetItem->>Span: updated_count (created_count missing)
        upsertDatasetItem->>linkDatasetItemMedia: link media
        linkDatasetItemMedia->>Span: item_count, reference_count, created_count, pending_deleted_count
    end

    Caller->>createManyDatasetItems: bulk create
    createManyDatasetItems->>Span: input_count
    createManyDatasetItems->>Span: prepared_count, validation_error_count, success_count, failed_count
    createManyDatasetItems->>Span: media_item_count
    alt STATEFUL path
        createManyDatasetItems->>Span: created_count
        createManyDatasetItems->>linkDatasetItemMedia: link media
    else VERSIONED path
        createManyDatasetItems->>Span: unique_item_id_count, updated_count, created_count
        createManyDatasetItems->>linkDatasetItemMedia: link media
    end

    Caller->>deleteDatasetItemMediaLinks: delete media links
    deleteDatasetItemMediaLinks->>Span: item_version_count, deleted_count
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/repositories/dataset-items.ts:465-467
The VERSIONED path always creates a new row (line 470) but only tags `updated_count`, unlike the STATEFUL path which tracks both `updated_count` and `created_count`. This will produce inconsistent span data depending on which implementation is active — queries filtering or alerting on `created_count` won't get data from the VERSIONED path.

```suggestion
        addTagsToCurrentSpan({
          "langfuse.dataset_item.upsert.updated_count": current ? 1 : 0,
          "langfuse.dataset_item.upsert.created_count": 1,
        });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(shared): tag dataset item write co..."](https://github.com/langfuse/langfuse/commit/cd0c73eacdc75d0358a0900389ec189a9b3f7a4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40574944)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->