### PR TITLE
feat(redis): opt-in short-lived credentials via Azure Managed Identity

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -125,6 +125,14 @@ LANGFUSE_S3_EVENT_UPLOAD_PREFIX=events/
 REDIS_HOST="127.0.0.1"
 REDIS_PORT=6379
 REDIS_AUTH="myredissecret"
+# Short-lived / identity-based Redis credentials (opt-in; default "static" keeps
+# the REDIS_AUTH/REDIS_USERNAME behaviour above unchanged).
+# REDIS_AUTH_METHOD="static"  # "static" | "azure_managed_identity"
+#   azure_managed_identity: fetch a Microsoft Entra token via @azure/identity and
+#   use it as the Redis password, refreshing before expiry. Set REDIS_USERNAME to
+#   the identity's object id; optionally set REDIS_AZURE_CLIENT_ID (user-assigned MI).
+# REDIS_AZURE_CLIENT_ID=""
+# REDIS_AZURE_SCOPE="https://redis.azure.com/.default"
 # REDIS_KEY_PREFIX=""  # Optional: Prefix for Redis keys (useful for multi-tenant Redis instances)
                        # BullMQ queues will use this via BullMQ's native prefix option
                        # Cache operations will use this via ioredis keyPrefix

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -102,6 +102,7 @@
     "@aws-sdk/client-sesv2": "^3.1013.0",
     "@aws-sdk/lib-storage": "^3.1013.0",
     "@aws-sdk/s3-request-presigner": "^3.1013.0",
+    "@azure/identity": "^4.13.1",
     "@azure/storage-blob": "^12.26.0",
     "@clickhouse/client": "^1.18.5",
     "@clickhouse/client-common": "^1.18.5",

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -40,6 +40,12 @@ const EnvSchema = z.object({
   REDIS_AUTH: z.string().nullish(),
   REDIS_USERNAME: z.string().nullish(),
   REDIS_CONNECTION_STRING: z.string().nullish(),
+  // Opt-in short-lived Redis credentials; "static" keeps username/password auth.
+  REDIS_AUTH_METHOD: z
+    .enum(["static", "azure_managed_identity"])
+    .default("static"),
+  REDIS_AZURE_CLIENT_ID: z.string().optional(),
+  REDIS_AZURE_SCOPE: z.string().optional(),
   // Optional prefix for Redis keys. Used by BullMQ queues via their native prefix option
   // and by the singleton cache instance via ioredis keyPrefix. Useful for multi-tenant Redis.
   REDIS_KEY_PREFIX: z.string().nullish(),

--- a/packages/shared/src/server/auth/credentials/azureManagedIdentity.ts
+++ b/packages/shared/src/server/auth/credentials/azureManagedIdentity.ts
@@ -1,0 +1,45 @@
+import {
+  DefaultAzureCredential,
+  ManagedIdentityCredential,
+  type TokenCredential,
+} from "@azure/identity";
+import type { ManagedAccessToken, ManagedCredentialProvider } from "./types";
+
+export const AZURE_REDIS_SCOPE = "https://redis.azure.com/.default";
+
+export interface AzureManagedIdentityProviderOptions {
+  scope: string;
+  username?: string;
+  clientId?: string;
+  credential?: TokenCredential;
+}
+
+export class AzureManagedIdentityCredentialProvider implements ManagedCredentialProvider {
+  public readonly name = "azure_managed_identity";
+  public readonly username?: string;
+  private readonly scope: string;
+  private readonly credential: TokenCredential;
+
+  constructor(options: AzureManagedIdentityProviderOptions) {
+    this.scope = options.scope;
+    this.username = options.username;
+    this.credential =
+      options.credential ??
+      (options.clientId
+        ? new ManagedIdentityCredential({ clientId: options.clientId })
+        : new DefaultAzureCredential());
+  }
+
+  public async fetchToken(): Promise<ManagedAccessToken> {
+    const token = await this.credential.getToken(this.scope);
+    if (!token) {
+      throw new Error(
+        `Azure managed identity returned no token for scope "${this.scope}"`,
+      );
+    }
+    return {
+      token: token.token,
+      expiresOnTimestamp: token.expiresOnTimestamp,
+    };
+  }
+}

--- a/packages/shared/src/server/auth/credentials/credentials.test.ts
+++ b/packages/shared/src/server/auth/credentials/credentials.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Redis } from "ioredis";
+
+const azureMocks = vi.hoisted(() => ({
+  defaultGetToken: vi.fn(),
+  managedGetToken: vi.fn(),
+  managedCtor: vi.fn(),
+}));
+
+vi.mock("@azure/identity", () => ({
+  DefaultAzureCredential: class {
+    getToken = azureMocks.defaultGetToken;
+  },
+  ManagedIdentityCredential: class {
+    constructor(options: unknown) {
+      azureMocks.managedCtor(options);
+    }
+    getToken = azureMocks.managedGetToken;
+  },
+}));
+
+const envMock = vi.hoisted(() => ({
+  env: {
+    REDIS_AUTH_METHOD: "static" as "static" | "azure_managed_identity",
+    REDIS_USERNAME: undefined as string | undefined | null,
+    REDIS_AZURE_CLIENT_ID: undefined as string | undefined,
+    REDIS_AZURE_SCOPE: undefined as string | undefined,
+  },
+}));
+vi.mock("../../../env", () => envMock);
+
+// Mock the logger so the real env is not loaded through it.
+vi.mock("../../logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  AZURE_REDIS_SCOPE,
+  AzureManagedIdentityCredentialProvider,
+} from "./azureManagedIdentity";
+import {
+  bindManagedCredentialToRedis,
+  getRedisManagedCredentialProviderFromEnv,
+} from "./redisCredentials";
+import type { ManagedAccessToken, ManagedCredentialProvider } from "./types";
+
+const ONE_HOUR = 60 * 60 * 1000;
+
+// Controllable provider for the manager/bind tests.
+function fakeProvider(
+  options: { username?: string; ttlMs?: number } = {},
+): ManagedCredentialProvider & {
+  fetchToken: ReturnType<typeof vi.fn>;
+} {
+  const ttl = options.ttlMs ?? ONE_HOUR;
+  let counter = 0;
+  return {
+    name: "fake",
+    username: options.username,
+    fetchToken: vi.fn(
+      async (): Promise<ManagedAccessToken> => ({
+        token: `token-${++counter}`,
+        expiresOnTimestamp: Date.now() + ttl,
+      }),
+    ),
+  };
+}
+
+beforeEach(() => {
+  azureMocks.defaultGetToken.mockReset();
+  azureMocks.managedGetToken.mockReset();
+  azureMocks.managedCtor.mockReset();
+  envMock.env.REDIS_AUTH_METHOD = "static";
+  envMock.env.REDIS_USERNAME = undefined;
+  envMock.env.REDIS_AZURE_CLIENT_ID = undefined;
+  envMock.env.REDIS_AZURE_SCOPE = undefined;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("AzureManagedIdentityCredentialProvider", () => {
+  it("requests the configured scope via DefaultAzureCredential (system-assigned)", async () => {
+    azureMocks.defaultGetToken.mockResolvedValue({
+      token: "azure-access-token",
+      expiresOnTimestamp: Date.now() + ONE_HOUR,
+    });
+
+    const provider = new AzureManagedIdentityCredentialProvider({
+      scope: AZURE_REDIS_SCOPE,
+      username: "object-id-123",
+    });
+    const token = await provider.fetchToken();
+
+    expect(token.token).toBe("azure-access-token");
+    expect(provider.username).toBe("object-id-123");
+    expect(provider.name).toBe("azure_managed_identity");
+    expect(azureMocks.defaultGetToken).toHaveBeenCalledWith(AZURE_REDIS_SCOPE);
+    expect(azureMocks.managedCtor).not.toHaveBeenCalled();
+  });
+
+  it("uses ManagedIdentityCredential with clientId (user-assigned)", async () => {
+    azureMocks.managedGetToken.mockResolvedValue({
+      token: "user-assigned-token",
+      expiresOnTimestamp: Date.now() + ONE_HOUR,
+    });
+
+    const provider = new AzureManagedIdentityCredentialProvider({
+      scope: AZURE_REDIS_SCOPE,
+      clientId: "client-abc",
+    });
+    const token = await provider.fetchToken();
+
+    expect(token.token).toBe("user-assigned-token");
+    expect(azureMocks.managedCtor).toHaveBeenCalledWith({
+      clientId: "client-abc",
+    });
+    expect(azureMocks.defaultGetToken).not.toHaveBeenCalled();
+  });
+
+  it("throws when the credential yields no token", async () => {
+    azureMocks.defaultGetToken.mockResolvedValue(null);
+    const provider = new AzureManagedIdentityCredentialProvider({
+      scope: AZURE_REDIS_SCOPE,
+    });
+    await expect(provider.fetchToken()).rejects.toThrow(/no token/);
+  });
+});
+
+describe("bindManagedCredentialToRedis", () => {
+  function fakeRedisClient() {
+    const client = {
+      options: {} as { username?: string; password?: string },
+      status: "wait" as string,
+      connect: vi.fn(async () => {
+        client.status = "ready";
+      }),
+      call: vi.fn(async () => "OK"),
+    };
+    return client;
+  }
+
+  it("applies the first token before connecting, then re-AUTHs on refresh", async () => {
+    vi.useFakeTimers();
+    const provider = fakeProvider({ username: "object-id-123" });
+    const client = fakeRedisClient();
+    const originalConnect = client.connect;
+
+    const manager = bindManagedCredentialToRedis(
+      client as unknown as Redis,
+      provider,
+    );
+
+    // Nothing is fetched or connected until a caller triggers connect().
+    expect(client.options.password).toBeUndefined();
+    expect(originalConnect).not.toHaveBeenCalled();
+
+    await client.connect();
+    // The token is applied before the wrapped connect runs.
+    expect(client.options.password).toBe("token-1");
+    expect(client.options.username).toBe("object-id-123");
+    expect(originalConnect).toHaveBeenCalledTimes(1);
+    expect(client.call).not.toHaveBeenCalled();
+
+    // On refresh: options updated AND a live AUTH issued (no reconnect).
+    await vi.advanceTimersByTimeAsync(ONE_HOUR * 0.8);
+    expect(client.options.password).toBe("token-2");
+    expect(client.call).toHaveBeenCalledWith(
+      "AUTH",
+      "object-id-123",
+      "token-2",
+    );
+    manager.stop();
+  });
+
+  it("rejects connect when the first token fetch fails, and retries on the next connect", async () => {
+    const provider = fakeProvider();
+    (provider.fetchToken as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("token endpoint unavailable"),
+    );
+    const client = fakeRedisClient();
+    const originalConnect = client.connect;
+
+    const manager = bindManagedCredentialToRedis(
+      client as unknown as Redis,
+      provider,
+    );
+
+    await expect(client.connect()).rejects.toThrow(/token endpoint/);
+    expect(originalConnect).not.toHaveBeenCalled();
+
+    // Bootstrap reset on failure, so a later connect retries the fetch.
+    await client.connect();
+    expect(client.options.password).toBe("token-1");
+    expect(originalConnect).toHaveBeenCalledTimes(1);
+    manager.stop();
+  });
+});
+
+describe("getRedisManagedCredentialProviderFromEnv", () => {
+  it("returns null for the default static method (backward compatible)", () => {
+    envMock.env.REDIS_AUTH_METHOD = "static";
+    expect(getRedisManagedCredentialProviderFromEnv()).toBeNull();
+  });
+
+  it("builds an Azure provider with the object-id username and scope default", () => {
+    envMock.env.REDIS_AUTH_METHOD = "azure_managed_identity";
+    envMock.env.REDIS_USERNAME = "object-id-xyz";
+    const provider = getRedisManagedCredentialProviderFromEnv();
+    expect(provider).toBeInstanceOf(AzureManagedIdentityCredentialProvider);
+    expect(provider?.name).toBe("azure_managed_identity");
+    expect(provider?.username).toBe("object-id-xyz");
+  });
+});

--- a/packages/shared/src/server/auth/credentials/index.ts
+++ b/packages/shared/src/server/auth/credentials/index.ts
@@ -1,2 +1,4 @@
 export * from "./types";
 export * from "./RefreshingTokenManager";
+export * from "./azureManagedIdentity";
+export * from "./redisCredentials";

--- a/packages/shared/src/server/auth/credentials/redisCredentials.ts
+++ b/packages/shared/src/server/auth/credentials/redisCredentials.ts
@@ -1,0 +1,77 @@
+import type { Redis } from "ioredis";
+import { env } from "../../../env";
+import { logger } from "../../logger";
+import {
+  AZURE_REDIS_SCOPE,
+  AzureManagedIdentityCredentialProvider,
+} from "./azureManagedIdentity";
+import { RefreshingTokenManager } from "./RefreshingTokenManager";
+import type { ManagedAccessToken, ManagedCredentialProvider } from "./types";
+
+// Returns null for the default static auth, leaving the existing path unchanged.
+export function getRedisManagedCredentialProviderFromEnv(): ManagedCredentialProvider | null {
+  switch (env.REDIS_AUTH_METHOD) {
+    case "azure_managed_identity":
+      return new AzureManagedIdentityCredentialProvider({
+        scope: env.REDIS_AZURE_SCOPE ?? AZURE_REDIS_SCOPE,
+        username: env.REDIS_USERNAME ?? undefined,
+        clientId: env.REDIS_AZURE_CLIENT_ID ?? undefined,
+      });
+    case "static":
+    default:
+      return null;
+  }
+}
+
+// ioredis v5 has no credentials hook, so the binding wraps connect() to fetch
+// and apply the first token before the socket opens, then issues a live AUTH on
+// each later refresh and keeps options.password fresh for reconnects. The caller
+// uses lazyConnect so nothing connects until this wrapper runs; ioredis routes
+// both explicit connect() and command-triggered auto-connect through connect(),
+// which closes the race with callers like BullMQ that connect on their own.
+export function bindManagedCredentialToRedis(
+  client: Redis,
+  provider: ManagedCredentialProvider,
+  deps: { manager?: RefreshingTokenManager } = {},
+): RefreshingTokenManager {
+  const manager = deps.manager ?? new RefreshingTokenManager(provider);
+
+  const applyToken = (token: ManagedAccessToken) => {
+    client.options.password = token.token;
+    if (provider.username) client.options.username = provider.username;
+  };
+
+  manager.onRefresh((token) => {
+    applyToken(token);
+    const authArgs = provider.username
+      ? [provider.username, token.token]
+      : [token.token];
+    Promise.resolve(client.call("AUTH", ...authArgs)).catch((error) =>
+      logger.warn(
+        `Failed to re-authenticate Redis after ${provider.name} token refresh`,
+        error,
+      ),
+    );
+  });
+
+  const connect = client.connect.bind(client);
+  let bootstrap: Promise<void> | null = null;
+  client.connect = ((...args: Parameters<Redis["connect"]>) => {
+    if (!bootstrap) {
+      bootstrap = manager
+        .start()
+        .then(applyToken)
+        .catch((error) => {
+          bootstrap = null; // let the next connect attempt retry the token fetch
+          logger.error(
+            `Failed to fetch initial ${provider.name} token for Redis`,
+            error,
+          );
+          throw error;
+        });
+    }
+    return bootstrap.then(() => connect(...args));
+  }) as Redis["connect"];
+
+  return manager;
+}

--- a/packages/shared/src/server/auth/credentials/redisCredentials.ts
+++ b/packages/shared/src/server/auth/credentials/redisCredentials.ts
@@ -46,12 +46,14 @@ export function bindManagedCredentialToRedis(
     const authArgs = provider.username
       ? [provider.username, token.token]
       : [token.token];
-    Promise.resolve(client.call("AUTH", ...authArgs)).catch((error) =>
-      logger.warn(
-        `Failed to re-authenticate Redis after ${provider.name} token refresh`,
-        error,
-      ),
-    );
+    client
+      .call("AUTH", ...authArgs)
+      .catch((error) =>
+        logger.warn(
+          `Failed to re-authenticate Redis after ${provider.name} token refresh`,
+          error,
+        ),
+      );
   });
 
   const connect = client.connect.bind(client);

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -3,6 +3,10 @@ import type { QueueBaseOptions } from "bullmq";
 import fs from "fs";
 import { env } from "../../env";
 import { logger } from "../logger";
+import {
+  bindManagedCredentialToRedis,
+  getRedisManagedCredentialProviderFromEnv,
+} from "../auth/credentials/redisCredentials";
 
 const defaultRedisOptions: Partial<RedisOptions> = {
   enableReadyCheck: true,
@@ -209,23 +213,41 @@ export const createNewRedisInstance = (
 
   const tlsOptions = buildTlsOptions();
 
+  // null unless an opt-in short-lived credential method is configured.
+  const managedCredentialProvider = getRedisManagedCredentialProviderFromEnv();
+  const lazyConnectOptions = managedCredentialProvider
+    ? { lazyConnect: true }
+    : {};
+
   const instance = env.REDIS_CONNECTION_STRING
     ? new Redis(env.REDIS_CONNECTION_STRING, {
         ...defaultRedisOptions,
         ...additionalOptions,
         ...tlsOptions,
+        ...lazyConnectOptions,
       })
     : env.REDIS_HOST
       ? new Redis({
           host: String(env.REDIS_HOST),
           port: Number(env.REDIS_PORT),
-          username: env.REDIS_USERNAME || undefined,
-          password: String(env.REDIS_AUTH),
+          username: managedCredentialProvider
+            ? managedCredentialProvider.username
+            : env.REDIS_USERNAME || undefined,
+          password: managedCredentialProvider
+            ? undefined
+            : String(env.REDIS_AUTH),
           ...defaultRedisOptions,
           ...additionalOptions,
           ...tlsOptions,
+          ...lazyConnectOptions,
         })
       : null;
+
+  if (instance && managedCredentialProvider) {
+    // Wraps connect() to apply the first token before connecting and to refresh
+    // it ahead of expiry; connecting itself stays lazy until a caller triggers it.
+    bindManagedCredentialToRedis(instance, managedCredentialProvider);
+  }
 
   instance?.on("error", (error) => {
     logger.error("Redis error", error);

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -203,6 +203,19 @@ export const createNewRedisInstance = (
     return null;
   }
 
+  // Managed credentials are wired only into the single-node path below; warn so
+  // the combination is not silently ignored (which would fail with an opaque
+  // NOAUTH at connect time when no static REDIS_AUTH is set).
+  if (
+    env.REDIS_AUTH_METHOD !== "static" &&
+    (env.REDIS_CLUSTER_ENABLED === "true" ||
+      env.REDIS_SENTINEL_ENABLED === "true")
+  ) {
+    logger.warn(
+      `REDIS_AUTH_METHOD=${env.REDIS_AUTH_METHOD} is only supported for single-node Redis; cluster and sentinel modes use static credentials.`,
+    );
+  }
+
   if (env.REDIS_CLUSTER_ENABLED === "true") {
     return createRedisClusterInstance(additionalOptions);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1013.0
         version: 3.1024.0
+      '@azure/identity':
+        specifier: ^4.13.1
+        version: 4.13.1
       '@azure/storage-blob':
         specifier: ^12.26.0
         version: 12.26.0
@@ -1571,9 +1574,25 @@ packages:
     resolution: {integrity: sha512-D/sdlJBMJfx7gqoj66PKVmhDDaU6TKA49ptcolxdas29X7AfvLTmfAGLjAcIMBK7UZ2o4lygHIqVckOlQU3xWw==}
     engines: {node: '>=20.0.0'}
 
+  '@azure/identity@4.13.1':
+    resolution: {integrity: sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==}
+    engines: {node: '>=20.0.0'}
+
   '@azure/logger@1.3.0':
     resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
     engines: {node: '>=20.0.0'}
+
+  '@azure/msal-browser@5.13.0':
+    resolution: {integrity: sha512-Ea23x0U8XNFY+qJ9T44zO2BbY+AHdb+WdjmYnx36OhJ/KO+PGU5pmsNHf1DCElYX+6wyVRJz1HFeCPC/cHbRug==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-common@16.8.0':
+    resolution: {integrity: sha512-5S4RHOcInL2Nu2U217tDZbWGI6StMfcWCrA7TWvWdJmXQ+cYrrIqr84AsN62fGh2MDBysiBJPt6CfWceJfloEA==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-node@5.2.4':
+    resolution: {integrity: sha512-rpBUg9dA8UpC2WiFt3KeDKVQmmmVrfxdRnW+F1ebgou/jX/0tAvYuonaq5RUo8OaqzOrj4x/HaI8DmY56RXZ2Q==}
+    engines: {node: '>=20'}
 
   '@azure/storage-blob@12.26.0':
     resolution: {integrity: sha512-SriLPKezypIsiZ+TtlFfE46uuBIap2HeaQVS78e1P7rz5OSbq0rsd52WE1mC5f7vAeLiXqv7I7oRhL3WFZEw3Q==}
@@ -12515,12 +12534,39 @@ snapshots:
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
+  '@azure/identity@4.13.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@azure/msal-browser': 5.13.0
+      '@azure/msal-node': 5.2.4
+      open: 10.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@azure/logger@1.3.0':
     dependencies:
       '@typespec/ts-http-runtime': 0.3.4
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  '@azure/msal-browser@5.13.0':
+    dependencies:
+      '@azure/msal-common': 16.8.0
+
+  '@azure/msal-common@16.8.0': {}
+
+  '@azure/msal-node@5.2.4':
+    dependencies:
+      '@azure/msal-common': 16.8.0
+      jsonwebtoken: 9.0.3
 
   '@azure/storage-blob@12.26.0':
     dependencies:


### PR DESCRIPTION
## What does this PR do?

Adds optional short lived Redis credentials via Azure Managed Identity, building on the credential core merged in #14325. This is the Redis half of the plan in #14278; Postgres follows in a later PR.

An `azure_managed_identity` provider mints a Microsoft Entra token through `@azure/identity` (scope `https://redis.azure.com/.default`, username is the identity object id). On each refresh the Redis binding updates the connection password and issues a fresh AUTH on the open connection. New env vars: `REDIS_AUTH_METHOD` (defaults to `static`), `REDIS_AZURE_CLIENT_ID`, and `REDIS_AZURE_SCOPE`. The `static` default keeps today's username and password path unchanged, so the change is fully backward compatible and off by default.

## Testing

`credentials.test.ts` mocks `@azure/identity` and uses fake timers: provider token scope and username (system assigned and user assigned), the Redis bind (initial token, fresh AUTH on refresh, no op when already connected), and the env factory including the static fallback. No cloud resources required.

cc @Steffen911 @jannikmaierhoefer

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds opt-in short-lived Redis credentials via Azure Managed Identity, building on the `RefreshingTokenManager` from #14325. The `static` default leaves existing auth behaviour unchanged; opting in via `REDIS_AUTH_METHOD=azure_managed_identity` mints a Microsoft Entra token and re-AUTHs the live connection before each expiry.

- Adds `AzureManagedIdentityCredentialProvider` (wraps `@azure/identity`), `bindManagedCredentialToRedis` (applies token to ioredis options and issues live `AUTH` on refresh), and `getRedisManagedCredentialProviderFromEnv` (env-driven factory).
- Integrates with `createNewRedisInstance` using `lazyConnect: true` so the credential bootstrap can set `client.options.password` before the first connection attempt, but the bootstrap is launched fire-and-forget, creating a window where callers (notably BullMQ) can connect before credentials are applied.
- Cluster and sentinel code paths silently ignore the managed-credential setting with no log warning.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The static/default path is unchanged and safe to merge as-is; the managed-credential path has a real connection timing problem that would surface as NOAUTH errors in production for BullMQ queue connections when Azure Managed Identity is enabled.

The fire-and-forget bootstrap in createNewRedisInstance returns a lazyConnect Redis instance before the Azure token is fetched or applied. BullMQ calls .connect() on lazyConnect instances eagerly, so it will race to connect before bindManagedCredentialToRedis has written client.options.password, producing an unauthenticated connection. The enableOfflineQueue: false BullMQ queue path makes this failure immediate rather than silently queued. Since the Azure Managed Identity path is opt-in and off by default, this does not affect existing deployments today, but the new feature as shipped would not work reliably for BullMQ-heavy workloads.

packages/shared/src/server/redis/redis.ts — the fire-and-forget bindManagedCredentialToRedis call and the cluster/sentinel early-return paths both need attention before enabling this in production.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant createNewRedisInstance
    participant ioredis as ioredis (lazyConnect)
    participant bindManagedCredentialToRedis
    participant AzureIdentity as Azure Identity
    participant BullMQ

    App->>createNewRedisInstance: createNewRedisInstance(opts)
    createNewRedisInstance->>ioredis: "new Redis({lazyConnect:true, password:undefined})"
    createNewRedisInstance-->>App: instance (no credentials yet)
    createNewRedisInstance-)bindManagedCredentialToRedis: fire-and-forget

    par BullMQ uses instance immediately
        App->>BullMQ: pass instance
        BullMQ->>ioredis: .connect() — no token yet!
        ioredis-->>BullMQ: connected (unauthenticated)
        BullMQ->>ioredis: COMMAND
        ioredis-->>BullMQ: NOAUTH error
    and Async binding (may arrive too late)
        bindManagedCredentialToRedis->>AzureIdentity: fetchToken()
        AzureIdentity-->>bindManagedCredentialToRedis: token + expiresOn
        bindManagedCredentialToRedis->>ioredis: "options.password = token"
        bindManagedCredentialToRedis->>ioredis: ".connect() skipped if status != wait"
        Note over bindManagedCredentialToRedis,ioredis: onRefresh schedules future AUTH calls
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant createNewRedisInstance
    participant ioredis as ioredis (lazyConnect)
    participant bindManagedCredentialToRedis
    participant AzureIdentity as Azure Identity
    participant BullMQ

    App->>createNewRedisInstance: createNewRedisInstance(opts)
    createNewRedisInstance->>ioredis: "new Redis({lazyConnect:true, password:undefined})"
    createNewRedisInstance-->>App: instance (no credentials yet)
    createNewRedisInstance-)bindManagedCredentialToRedis: fire-and-forget

    par BullMQ uses instance immediately
        App->>BullMQ: pass instance
        BullMQ->>ioredis: .connect() — no token yet!
        ioredis-->>BullMQ: connected (unauthenticated)
        BullMQ->>ioredis: COMMAND
        ioredis-->>BullMQ: NOAUTH error
    and Async binding (may arrive too late)
        bindManagedCredentialToRedis->>AzureIdentity: fetchToken()
        AzureIdentity-->>bindManagedCredentialToRedis: token + expiresOn
        bindManagedCredentialToRedis->>ioredis: "options.password = token"
        bindManagedCredentialToRedis->>ioredis: ".connect() skipped if status != wait"
        Note over bindManagedCredentialToRedis,ioredis: onRefresh schedules future AUTH calls
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/shared/src/server/redis/redis.ts:246-255
**Fire-and-forget bootstrap races with callers that auto-connect**

`bindManagedCredentialToRedis` is launched without `await`, so `createNewRedisInstance` returns an instance that has `password: undefined` (line 237) and `lazyConnect: true` but has not yet had its token set or its `.connect()` called. BullMQ calls `client.connect()` on `lazyConnect` instances before the binding task can apply the token, resulting in an unauthenticated connection that will receive `NOAUTH` errors from Azure Cache for Redis on every command. The "does not connect if the client already left the 'wait' state" test case even documents that the binding skips `connect()` when it arrives too late — it just doesn't test the credential-less path that precedes it.

The synchronous-factory constraint is real, but it can be satisfied by making `createNewRedisInstance` return a thin wrapper or by returning a `Promise<Redis | null>` for the managed-credential path and updating callers accordingly.

### Issue 2 of 3
packages/shared/src/server/redis/redis.ts:206-212
**Managed credentials silently ignored for cluster and sentinel modes**

`createNewRedisInstance` returns early (before calling `getRedisManagedCredentialProviderFromEnv`) when `REDIS_CLUSTER_ENABLED` or `REDIS_SENTINEL_ENABLED` is `true`. An operator who sets `REDIS_AUTH_METHOD=azure_managed_identity` together with cluster or sentinel mode will silently fall back to static credentials with no log warning. A single `logger.warn` when `env.REDIS_AUTH_METHOD !== "static"` is detected alongside cluster/sentinel mode would make this unsupported combination explicit.

### Issue 3 of 3
packages/shared/src/server/auth/credentials/redisCredentials.ts:49-54
`Promise.resolve()` is redundant here — `client.call()` already returns a `Promise`. Wrapping it adds no value and may obscure that the error path is intentionally swallowed.

```suggestion
    client.call("AUTH", ...authArgs).catch((error) =>
      logger.warn(
        `Failed to re-authenticate Redis after ${provider.name} token refresh`,
        error,
      ),
    );
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(redis): opt-in short-lived credenti..."](https://github.com/langfuse/langfuse/commit/122ea43bcc38d2162eca53280dce191c4e353f6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40748335)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->