### PR TITLE
refactor(web): Move `Switch` to design-system folder

### DIFF
--- a/web/src/components/ModelParameters/index.tsx
+++ b/web/src/components/ModelParameters/index.tsx
@@ -10,7 +10,6 @@ import {
   SelectValue,
 } from "@/src/components/ui/select";
 import { Slider } from "@/src/components/ui/slider";
-import { Switch } from "@/src/components/ui/switch";
 import { CreateLLMApiKeyDialog } from "@/src/features/public-api/components/CreateLLMApiKeyDialog";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { cn } from "@/src/utils/tailwind";
@@ -36,6 +35,7 @@ import {
 import { LLMApiKeyComponent } from "./LLMApiKeyComponent";
 import { FormDescription } from "@/src/components/ui/form";
 import { CodeMirrorEditor } from "../editor";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 
 export type ModelParamsContext = {
   modelParams: UIModelParams;

--- a/web/src/components/design-system/Switch/Switch.stories.tsx
+++ b/web/src/components/design-system/Switch/Switch.stories.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { fn } from "storybook/test";
+import preview from "../../../../.storybook/preview";
+import { Switch } from "./Switch";
+
+type ComponentProps = React.ComponentProps<typeof Switch>;
+type Size = NonNullable<ComponentProps["size"]>;
+type Color = NonNullable<ComponentProps["color"]>;
+
+const meta = preview.meta({
+  component: Switch,
+  args: {
+    onCheckedChange: fn(),
+  },
+});
+
+const allSizes = Object.keys({
+  default: true,
+  sm: true,
+} satisfies Record<Size, true>) as Size[];
+
+const allColors = Object.keys({
+  default: true,
+  green: true,
+} satisfies Record<Color, true>) as Color[];
+
+export const Default = meta.story({});
+
+export const Checked = meta.story({
+  args: {
+    defaultChecked: true,
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+    defaultChecked: true,
+  },
+});
+
+export const Small = meta.story({
+  args: {
+    size: "sm",
+  },
+});
+
+export const VariantMatrix = meta.story({
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: () => (
+    <div
+      className="grid gap-4"
+      style={{ gridTemplateColumns: "repeat(2, max-content)" }}
+    >
+      {allSizes.map((size) =>
+        allColors.map((color) => (
+          <div key={`${size}-${color}`} className="flex items-center gap-3">
+            <Switch
+              size={size}
+              color={color}
+              defaultChecked
+              onCheckedChange={fn()}
+            />
+            <div className="text-sm">
+              {size} / {color}
+            </div>
+          </div>
+        )),
+      )}
+    </div>
+  ),
+});

--- a/web/src/components/design-system/Switch/Switch.tsx
+++ b/web/src/components/design-system/Switch/Switch.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/src/utils/tailwind";
 
 const switchVariants = cva(
-  "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 disabled:cursor-not-allowed data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-muted-foreground",
+  "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-muted-foreground",
   {
     variants: {
       size: {

--- a/web/src/components/design-system/Switch/Switch.tsx
+++ b/web/src/components/design-system/Switch/Switch.tsx
@@ -50,9 +50,9 @@ type SwitchProps = Omit<
 const Switch = React.forwardRef<
   React.ComponentRef<typeof SwitchPrimitives.Root>,
   SwitchProps
->(({ size, ...props }, ref) => (
+>(({ size, color, ...props }, ref) => (
   <SwitchPrimitives.Root
-    className={cn(switchVariants({ size }))}
+    className={cn(switchVariants({ size, color }))}
     {...props}
     ref={ref}
   >

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -42,7 +42,7 @@ import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes"
 import { LazyTraceRow } from "@/src/components/session/TraceRow";
 import { useParsedTrace } from "@/src/hooks/useParsedTrace";
 import useLocalStorage from "@/src/components/useLocalStorage";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { LazySessionTraceEventsRow } from "@/src/components/session/LazySessionTraceEventsRow";
 import { observationEventsFilterConfig } from "@/src/features/events/config/filter-config";
 import { useEventsFilterOptions } from "@/src/features/events/hooks/useEventsFilterOptions";

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -425,11 +425,13 @@ export const SessionPage: React.FC<{
                 />
               </div>
               <div className="flex items-center">
-                <Switch
-                  checked={showCorrections}
-                  onCheckedChange={setShowCorrectionsForSession}
-                  size="sm"
-                />
+                <div className="mx-1">
+                  <Switch
+                    checked={showCorrections}
+                    onCheckedChange={setShowCorrectionsForSession}
+                    size="sm"
+                  />
+                </div>
                 <span className="text-muted-foreground text-xs">
                   Show corrections
                 </span>
@@ -1018,11 +1020,13 @@ const LoadedSessionEventsPage: React.FC<{
                 />
               </div>
               <div className="flex items-center">
-                <Switch
-                  checked={showCorrections}
-                  onCheckedChange={setShowCorrectionsForSession}
-                  size="sm"
-                />
+                <div className="mx-1">
+                  <Switch
+                    checked={showCorrections}
+                    onCheckedChange={setShowCorrectionsForSession}
+                    size="sm"
+                  />
+                </div>
                 <span className="text-muted-foreground text-xs">
                   Show corrections
                 </span>

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -428,7 +428,7 @@ export const SessionPage: React.FC<{
                 <Switch
                   checked={showCorrections}
                   onCheckedChange={setShowCorrectionsForSession}
-                  className="scale-75"
+                  size="sm"
                 />
                 <span className="text-muted-foreground text-xs">
                   Show corrections
@@ -1021,7 +1021,7 @@ const LoadedSessionEventsPage: React.FC<{
                 <Switch
                   checked={showCorrections}
                   onCheckedChange={setShowCorrectionsForSession}
-                  className="scale-75"
+                  size="sm"
                 />
                 <span className="text-muted-foreground text-xs">
                   Show corrections

--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -13,7 +13,7 @@ import { LangfuseIcon } from "@/src/components/LangfuseLogo";
 import { UserCircle2Icon } from "lucide-react";
 import { StatusBadge } from "@/src/components/layouts/status-badge";
 import { DeactivateEvalConfig } from "@/src/features/evals/components/deactivate-config";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { useState } from "react";
 import { cn } from "@/src/utils/tailwind";

--- a/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
+++ b/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
@@ -256,7 +256,7 @@ export function CorrectedOutputField({
                   checked={strictJsonMode}
                   onCheckedChange={handleStrictJsonModeChange}
                   disabled={!isEditing}
-                  className="scale-75"
+                  size="sm"
                 />
                 <span className="text-muted-foreground text-xs">JSON</span>
               </div>

--- a/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
+++ b/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
@@ -8,7 +8,7 @@ import { useCorrectionEditor } from "./hooks/useCorrectionEditor";
 import { useMemo, useState } from "react";
 import { CodeMirrorEditor } from "@/src/components/editor/CodeMirrorEditor";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import useLocalStorage from "@/src/components/useLocalStorage";
 import { CorrectedOutputDiffDialog } from "./CorrectedOutputDiffDialog";
 import {

--- a/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
+++ b/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
@@ -252,12 +252,14 @@ export function CorrectedOutputField({
                 )}
               </div>
               <div className="flex items-center">
-                <Switch
-                  checked={strictJsonMode}
-                  onCheckedChange={handleStrictJsonModeChange}
-                  disabled={!isEditing}
-                  size="sm"
-                />
+                <div className="mx-1">
+                  <Switch
+                    checked={strictJsonMode}
+                    onCheckedChange={handleStrictJsonModeChange}
+                    disabled={!isEditing}
+                    size="sm"
+                  />
+                </div>
                 <span className="text-muted-foreground text-xs">JSON</span>
               </div>
             </div>

--- a/web/src/components/trace/components/IOPreview/components/ViewModeToggle.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ViewModeToggle.tsx
@@ -1,5 +1,5 @@
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { useJsonBetaToggle } from "@/src/components/trace/hooks/useJsonBetaToggle";
 
 export type ViewMode = "pretty" | "json" | "json-beta";

--- a/web/src/components/trace/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationDetailView.tsx
@@ -26,7 +26,7 @@ import {
   TabsBarTrigger,
 } from "@/src/components/ui/tabs-bar";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import {
   Tooltip,
   TooltipContent,

--- a/web/src/components/trace/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace/components/TraceDetailView/TraceDetailView.tsx
@@ -12,7 +12,7 @@ import {
   TabsBarTrigger,
 } from "@/src/components/ui/tabs-bar";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { useCallback, useMemo, useState } from "react";
 import { type SelectionData } from "@/src/features/comments/contexts/InlineCommentSelectionContext";
 import { api } from "@/src/utils/api";

--- a/web/src/components/trace/components/TraceSettingsDropdown.tsx
+++ b/web/src/components/trace/components/TraceSettingsDropdown.tsx
@@ -212,7 +212,6 @@ export function TraceViewOptionsMenuItems({
               checked={colorCodeMetrics}
               onCheckedChange={setColorCodeMetrics}
               disabled={!isColorCodeEnabled}
-              className={!isColorCodeEnabled ? "cursor-not-allowed" : ""}
             />
           </div>
         </DropdownMenuItem>

--- a/web/src/components/trace/components/TraceSettingsDropdown.tsx
+++ b/web/src/components/trace/components/TraceSettingsDropdown.tsx
@@ -26,7 +26,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuLabel,
 } from "@/src/components/ui/dropdown-menu";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { cn } from "@/src/utils/tailwind";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useViewPreferences } from "../contexts/ViewPreferencesContext";

--- a/web/src/components/trace/components/TraceSettingsDropdown.tsx
+++ b/web/src/components/trace/components/TraceSettingsDropdown.tsx
@@ -212,7 +212,7 @@ export function TraceViewOptionsMenuItems({
               checked={colorCodeMetrics}
               onCheckedChange={setColorCodeMetrics}
               disabled={!isColorCodeEnabled}
-              className={cn(!isColorCodeEnabled && "cursor-not-allowed")}
+              className={!isColorCodeEnabled ? "cursor-not-allowed" : ""}
             />
           </div>
         </DropdownMenuItem>

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -38,8 +38,19 @@ const switchThumbVariants = cva(
 
 interface SwitchProps
   extends
-    React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>,
-    VariantProps<typeof switchVariants> {}
+    Omit<
+      React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>,
+      "className"
+    >,
+    VariantProps<typeof switchVariants> {
+  className?:
+    | ""
+    | "cursor-not-allowed"
+    | "data-[state=checked]:bg-dark-green"
+    | "mt-1 ml-4"
+    | "scale-75"
+    | "shrink-0";
+}
 
 const Switch = React.forwardRef<
   React.ComponentRef<typeof SwitchPrimitives.Root>,

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -41,20 +41,18 @@ const switchThumbVariants = cva(
   },
 );
 
-interface SwitchProps
-  extends
-    Omit<
-      React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>,
-      "className"
-    >,
-    VariantProps<typeof switchVariants> {}
+type SwitchProps = Omit<
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>,
+  "className"
+> &
+  VariantProps<typeof switchVariants>;
 
 const Switch = React.forwardRef<
   React.ComponentRef<typeof SwitchPrimitives.Root>,
   SwitchProps
->(({ className, size, ...props }, ref) => (
+>(({ size, ...props }, ref) => (
   <SwitchPrimitives.Root
-    className={cn(switchVariants({ size, className }))}
+    className={cn(switchVariants({ size }))}
     {...props}
     ref={ref}
   >

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -47,7 +47,6 @@ interface SwitchProps
     | ""
     | "cursor-not-allowed"
     | "data-[state=checked]:bg-dark-green"
-    | "mt-1 ml-4"
     | "scale-75";
 }
 

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/src/utils/tailwind";
 
 const switchVariants = cva(
-  "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-muted-foreground",
+  "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 disabled:cursor-not-allowed data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-muted-foreground",
   {
     variants: {
       size: {
@@ -43,11 +43,7 @@ interface SwitchProps
       "className"
     >,
     VariantProps<typeof switchVariants> {
-  className?:
-    | ""
-    | "cursor-not-allowed"
-    | "data-[state=checked]:bg-dark-green"
-    | "scale-75";
+  className?: "data-[state=checked]:bg-dark-green" | "scale-75";
 }
 
 const Switch = React.forwardRef<

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -48,8 +48,7 @@ interface SwitchProps
     | "cursor-not-allowed"
     | "data-[state=checked]:bg-dark-green"
     | "mt-1 ml-4"
-    | "scale-75"
-    | "shrink-0";
+    | "scale-75";
 }
 
 const Switch = React.forwardRef<

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -47,9 +47,7 @@ interface SwitchProps
       React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>,
       "className"
     >,
-    VariantProps<typeof switchVariants> {
-  className?: "scale-75";
-}
+    VariantProps<typeof switchVariants> {}
 
 const Switch = React.forwardRef<
   React.ComponentRef<typeof SwitchPrimitives.Root>,

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -7,16 +7,21 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/src/utils/tailwind";
 
 const switchVariants = cva(
-  "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 disabled:cursor-not-allowed data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-muted-foreground",
+  "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 disabled:cursor-not-allowed data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-muted-foreground",
   {
     variants: {
       size: {
         default: "h-5 w-9",
         sm: "h-4 w-7",
       },
+      color: {
+        default: "data-[state=checked]:bg-primary",
+        green: "data-[state=checked]:bg-dark-green",
+      },
     },
     defaultVariants: {
       size: "default",
+      color: "default",
     },
   },
 );
@@ -43,7 +48,7 @@ interface SwitchProps
       "className"
     >,
     VariantProps<typeof switchVariants> {
-  className?: "data-[state=checked]:bg-dark-green" | "scale-75";
+  className?: "scale-75";
 }
 
 const Switch = React.forwardRef<

--- a/web/src/features/automations/components/automationForm.tsx
+++ b/web/src/features/automations/components/automationForm.tsx
@@ -16,7 +16,7 @@ import {
   SelectValue,
 } from "@/src/components/ui/select";
 import { Separator } from "@/src/components/ui/separator";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { useRouter } from "next/router";
 import { z } from "zod";
 import { type Control, useForm } from "react-hook-form";

--- a/web/src/features/datasets/components/DatasetSchemaInput.tsx
+++ b/web/src/features/datasets/components/DatasetSchemaInput.tsx
@@ -6,7 +6,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/src/components/ui/form";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { JSONSchemaEditor } from "@/src/components/JSONSchemaEditor";
 
 type DatasetSchemaInputProps = {

--- a/web/src/features/datasets/components/MappingCard.tsx
+++ b/web/src/features/datasets/components/MappingCard.tsx
@@ -195,7 +195,7 @@ export function MappingCard({
                   id="direct-mapping-input"
                   checked={useDirectMappingForInput}
                   onCheckedChange={onToggleDirectMappingForInput}
-                  className="scale-75"
+                  size="sm"
                 />
                 <Label
                   htmlFor="direct-mapping-input"
@@ -252,7 +252,7 @@ export function MappingCard({
                     id="direct-mapping-expected"
                     checked={useDirectMappingForExpectedOutput}
                     onCheckedChange={onToggleDirectMappingForExpectedOutput}
-                    className="scale-75"
+                    size="sm"
                   />
                   <Label
                     htmlFor="direct-mapping-expected"

--- a/web/src/features/datasets/components/MappingCard.tsx
+++ b/web/src/features/datasets/components/MappingCard.tsx
@@ -12,7 +12,7 @@ import {
   type FieldMapping,
 } from "@/src/features/datasets/lib/csv/types";
 import { isSchemaField } from "@/src/features/datasets/lib/csv/helpers";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { Label } from "@/src/components/ui/label";
 import {
   Tooltip,

--- a/web/src/features/datasets/components/MappingCard.tsx
+++ b/web/src/features/datasets/components/MappingCard.tsx
@@ -191,12 +191,14 @@ export function MappingCard({
             </h3>
             {inputSchemaKeys && inputSchemaKeys.length > 0 && (
               <div className="flex items-center gap-1.5">
-                <Switch
-                  id="direct-mapping-input"
-                  checked={useDirectMappingForInput}
-                  onCheckedChange={onToggleDirectMappingForInput}
-                  size="sm"
-                />
+                <div className="mx-1">
+                  <Switch
+                    id="direct-mapping-input"
+                    checked={useDirectMappingForInput}
+                    onCheckedChange={onToggleDirectMappingForInput}
+                    size="sm"
+                  />
+                </div>
                 <Label
                   htmlFor="direct-mapping-input"
                   className="text-muted-foreground cursor-pointer text-xs font-normal"
@@ -248,12 +250,14 @@ export function MappingCard({
             {expectedOutputSchemaKeys &&
               expectedOutputSchemaKeys.length > 0 && (
                 <div className="flex items-center gap-1.5">
-                  <Switch
-                    id="direct-mapping-expected"
-                    checked={useDirectMappingForExpectedOutput}
-                    onCheckedChange={onToggleDirectMappingForExpectedOutput}
-                    size="sm"
-                  />
+                  <div className="mx-1">
+                    <Switch
+                      id="direct-mapping-expected"
+                      checked={useDirectMappingForExpectedOutput}
+                      onCheckedChange={onToggleDirectMappingForExpectedOutput}
+                      size="sm"
+                    />
+                  </div>
                   <Label
                     htmlFor="direct-mapping-expected"
                     className="text-muted-foreground cursor-pointer text-xs font-normal"

--- a/web/src/features/evals/components/deactivate-config.tsx
+++ b/web/src/features/evals/components/deactivate-config.tsx
@@ -64,7 +64,7 @@ export function DeactivateEvalConfig({
                 evalConfig.timeScope[0] === "EXISTING")
             }
             checked={isActive}
-            className={isActive ? "data-[state=checked]:bg-dark-green" : ""}
+            color="green"
           />
         </div>
       </PopoverTrigger>

--- a/web/src/features/evals/components/deactivate-config.tsx
+++ b/web/src/features/evals/components/deactivate-config.tsx
@@ -9,7 +9,7 @@ import {
   PopoverTrigger,
 } from "@/src/components/ui/popover";
 import { Button } from "@/src/components/ui/button";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 
 export function DeactivateEvalConfig({
   projectId,

--- a/web/src/features/evals/components/eval-template-detail.tsx
+++ b/web/src/features/evals/components/eval-template-detail.tsx
@@ -14,7 +14,7 @@ import {
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import Page from "@/src/components/layouts/page";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { Command } from "@/src/components/ui/command";
 import { Badge } from "@/src/components/ui/badge";
 import { StatusBadge } from "@/src/components/layouts/status-badge";

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -46,7 +46,7 @@ import { Slider } from "@/src/components/ui/slider";
 import { Card } from "@/src/components/ui/card";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { Checkbox } from "@/src/components/ui/checkbox";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import {
   evalConfigFormSchema,
   type EvalFormType,

--- a/web/src/features/evals/components/variable-mapping-card.tsx
+++ b/web/src/features/evals/components/variable-mapping-card.tsx
@@ -43,7 +43,7 @@ import {
 } from "@/src/components/ui/form";
 import { useFieldArray, type UseFormReturn } from "react-hook-form";
 import { Input } from "@/src/components/ui/input";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { useEvalConfigMappingData } from "@/src/features/evals/hooks/useEvalConfigMappingData";
 import { useEffect, useState } from "react";

--- a/web/src/features/events/components/V4SidebarToggle.tsx
+++ b/web/src/features/events/components/V4SidebarToggle.tsx
@@ -127,7 +127,6 @@ export function V4SidebarToggle() {
                   checked={isBetaEnabled}
                   onCheckedChange={handleToggle}
                   disabled={isLoading}
-                  className="shrink-0"
                   aria-label="Toggle Preview (fast)"
                   aria-describedby={PREVIEW_FAST_DESCRIPTION_ID}
                 />

--- a/web/src/features/events/components/V4SidebarToggle.tsx
+++ b/web/src/features/events/components/V4SidebarToggle.tsx
@@ -1,4 +1,4 @@
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { Label } from "@/src/components/ui/label";
 import { SidebarMenuButton } from "@/src/components/ui/sidebar";
 import {

--- a/web/src/features/experiments/components/RemoteExperimentUpsertForm.tsx
+++ b/web/src/features/experiments/components/RemoteExperimentUpsertForm.tsx
@@ -20,7 +20,7 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { api } from "@/src/utils/api";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";

--- a/web/src/features/experiments/components/steps/PromptModelStep.tsx
+++ b/web/src/features/experiments/components/steps/PromptModelStep.tsx
@@ -23,7 +23,7 @@ import {
 import { ChevronDown, CheckIcon, PlusIcon, EyeIcon } from "lucide-react";
 import { CreateOrEditLLMSchemaDialog } from "@/src/features/playground/page/components/CreateOrEditLLMSchemaDialog";
 import { type LlmSchema } from "@langfuse/shared";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { api } from "@/src/utils/api";
 import { CardDescription } from "@/src/components/ui/card";
 import { cn } from "@/src/utils/tailwind";

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
@@ -9,7 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/src/components/ui/dialog";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
 

--- a/web/src/features/notifications/components/NotificationSettings.tsx
+++ b/web/src/features/notifications/components/NotificationSettings.tsx
@@ -4,7 +4,7 @@ import { api } from "@/src/utils/api";
 import Header from "@/src/components/layouts/header";
 import { Card, CardContent } from "@/src/components/ui/card";
 import { Label } from "@/src/components/ui/label";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 
 export function NotificationSettings() {

--- a/web/src/features/organizations/components/AIFeatureSwitch.tsx
+++ b/web/src/features/organizations/components/AIFeatureSwitch.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/src/components/ui/button";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { api } from "@/src/utils/api";
 import { useEffect, useState } from "react";
 import {

--- a/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { usePersistedWindowIds } from "@/src/features/playground/page/hooks/usePersistedWindowIds";
 import {
   type PlaygroundCache,

--- a/web/src/features/playground/page/components/Messages.tsx
+++ b/web/src/features/playground/page/components/Messages.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { Settings } from "lucide-react";
 import useLocalStorage from "@/src/components/useLocalStorage";
 import { env } from "@/src/env.mjs";

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -31,7 +31,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/src/components/ui/select";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
 import { api, type RouterOutputs } from "@/src/utils/api";
 import { cn } from "@/src/utils/tailwind";

--- a/web/src/features/web-callouts/components/WebCalloutSettingsPage.tsx
+++ b/web/src/features/web-callouts/components/WebCalloutSettingsPage.tsx
@@ -30,7 +30,7 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import {
   Table,
   TableBody,

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId]/index.tsx
@@ -8,7 +8,7 @@ import { DatasetVersionWarningBanner } from "@/src/features/datasets/components/
 import { api } from "@/src/utils/api";
 import { useDatasetVersion } from "@/src/features/datasets/hooks/useDatasetVersion";
 import { toDatasetSchema } from "@/src/features/datasets/utils/datasetItemUtils";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { Label } from "@/src/components/ui/label";
 import { Button } from "@/src/components/ui/button";
 import useSessionStorage from "@/src/components/useSessionStorage";

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -561,11 +561,12 @@ const BlobStorageIntegrationSettingsForm = ({
               <FormItem>
                 <FormLabel>Force Path Style</FormLabel>
                 <FormControl>
-                  <Switch
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                    className="mt-1 ml-4"
-                  />
+                  <div className="mt-1 ml-4">
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </div>
                 </FormControl>
                 <FormDescription>
                   Enable for MinIO and some other S3 compatible providers
@@ -979,11 +980,12 @@ const BlobStorageIntegrationSettingsForm = ({
               <FormItem>
                 <FormLabel>Gzip Compression</FormLabel>
                 <FormControl>
-                  <Switch
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                    className="mt-1 ml-4"
-                  />
+                  <div className="mt-1 ml-4">
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </div>
                 </FormControl>
                 <FormDescription>
                   Compress exported files with gzip (.csv.gz, .json.gz,
@@ -1002,11 +1004,12 @@ const BlobStorageIntegrationSettingsForm = ({
             <FormItem>
               <FormLabel>Enabled</FormLabel>
               <FormControl>
-                <Switch
-                  checked={field.value}
-                  onCheckedChange={field.onChange}
-                  className="mt-1 ml-4"
-                />
+                <div className="mt-1 ml-4">
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </div>
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { PasswordInput } from "@/src/components/ui/password-input";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { Checkbox } from "@/src/components/ui/checkbox";
 import {
   Select,

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -333,14 +333,15 @@ const MixpanelIntegrationSettingsForm = ({
             <FormItem>
               <FormLabel>Enabled</FormLabel>
               <FormControl>
-                <Switch
-                  id="mixpanel-integration-enabled"
-                  checked={field.value}
-                  onCheckedChange={() => {
-                    field.onChange(!field.value);
-                  }}
-                  className="mt-1 ml-4"
-                />
+                <div className="mt-1 ml-4">
+                  <Switch
+                    id="mixpanel-integration-enabled"
+                    checked={field.value}
+                    onCheckedChange={() => {
+                      field.onChange(!field.value);
+                    }}
+                  />
+                </div>
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -13,7 +13,7 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { PasswordInput } from "@/src/components/ui/password-input";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import {
   Select,
   SelectContent,

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -309,14 +309,15 @@ const PostHogIntegrationSettings = ({
             <FormItem>
               <FormLabel>Enabled</FormLabel>
               <FormControl>
-                <Switch
-                  id="posthog-integration-enabled"
-                  checked={field.value}
-                  onCheckedChange={() => {
-                    field.onChange(!field.value);
-                  }}
-                  className="mt-1 ml-4"
-                />
+                <div className="mt-1 ml-4">
+                  <Switch
+                    id="posthog-integration-enabled"
+                    checked={field.value}
+                    onCheckedChange={() => {
+                      field.onChange(!field.value);
+                    }}
+                  />
+                </div>
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { PasswordInput } from "@/src/components/ui/password-input";
-import { Switch } from "@/src/components/ui/switch";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 import {
   Select,
   SelectContent,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves the `Switch` component from `web/src/components/ui/switch.tsx` to the design-system folder (`web/src/components/design-system/Switch/Switch.tsx`) and adds a `color` variant alongside the existing `size` variant. All 29 call-sites are updated to import from the new path, and the old `className` escape hatch is removed in favour of proper props and wrapper divs.

- The `Switch` component gains a `color` variant (`default` | `green`) and has `className` omitted from its public API to enforce design-system consistency; existing uses of `scale-75` are replaced with `size="sm"` and ad-hoc spacing classes are replaced with wrapper `div`s.
- Storybook stories are added covering default, checked, disabled, small, and a full variant matrix.
- The old `web/src/components/ui/switch.tsx` file is removed (git rename); no remaining imports from the old path were found.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a straightforward component relocation with mechanical import updates across call-sites; all old usages have been migrated and the old file removed.

All 29 call-sites are updated to the new import path and verified to have no remaining references to the old ui/switch path. The only notable finding is a duplicated Tailwind class in the CVA base string, which is harmless at runtime. The new color and size variants correctly replace the ad-hoc className workarounds that existed before.

web/src/components/design-system/Switch/Switch.tsx — contains the duplicated class in the CVA base string; all other files are rote import-path updates.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumers e.g. TraceDetailView SessionPage etc.] -->|import Switch| B[design-system/Switch/Switch.tsx]
    B --> C[switchVariants CVA]
    C --> D{size}
    D --> D1[default: h-5 w-9]
    D --> D2[sm: h-4 w-7]
    C --> E{color}
    E --> E1[default: bg-primary]
    E --> E2[green: bg-dark-green]
    B --> F[SwitchPrimitives.Root]
    F --> G[SwitchPrimitives.Thumb switchThumbVariants]
    H[OLD: ui/switch.tsx] -.->|removed / renamed| B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Consumers e.g. TraceDetailView SessionPage etc.] -->|import Switch| B[design-system/Switch/Switch.tsx]
    B --> C[switchVariants CVA]
    C --> D{size}
    D --> D1[default: h-5 w-9]
    D --> D2[sm: h-4 w-7]
    C --> E{color}
    E --> E1[default: bg-primary]
    E --> E2[green: bg-dark-green]
    B --> F[SwitchPrimitives.Root]
    F --> G[SwitchPrimitives.Thumb switchThumbVariants]
    H[OLD: ui/switch.tsx] -.->|removed / renamed| B
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/design-system/Switch/Switch.tsx:10
The base class string has `disabled:cursor-not-allowed` duplicated — it appears both before and after `disabled:opacity-50`. This is a no-op at runtime but clutters the generated className output and may confuse future maintainers.

```suggestion
  "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-muted-foreground",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add \`mx-1\` around Switch components that..."](https://github.com/langfuse/langfuse/commit/3a0aec830bc69f3e8570214262257d092db5354c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40760690)</sub>

<!-- /greptile_comment -->