### PR TITLE
fix(tracing): parse standalone Responses tool calls

### DIFF
--- a/packages/shared/src/server/ingestion/extractToolsBackend.ts
+++ b/packages/shared/src/server/ingestion/extractToolsBackend.ts
@@ -91,7 +91,7 @@ function flattenToolCall(call: unknown): {
     typeof rawArgs === "string" ? rawArgs : JSON.stringify(rawArgs ?? {});
 
   return {
-    id: (c.id ?? c.toolCallId ?? c.call_id) as string | undefined,
+    id: (c.call_id ?? c.id ?? c.toolCallId) as string | undefined,
     name,
     arguments: args,
     type: (c.type ?? (func ? "function" : undefined)) as string | undefined,
@@ -306,6 +306,11 @@ function extractToolCallsFromRawOutput(
 
   if (typeof output !== "object") return;
   const obj = output as Record<string, unknown>;
+
+  if (isToolCallLike(obj) && !isMessageLike(obj)) {
+    addToolArgument(args, obj);
+    return;
+  }
 
   // Direct tool_calls at top level
   const directToolCalls =

--- a/packages/shared/src/utils/chatml/adapters/openai.ts
+++ b/packages/shared/src/utils/chatml/adapters/openai.ts
@@ -340,6 +340,16 @@ function preprocessData(data: unknown): unknown {
     }
   }
 
+  if (
+    typeof data === "object" &&
+    !Array.isArray(data) &&
+    ["function_call", "tool_call", "function_call_output"].includes(
+      String((data as Record<string, unknown>).type),
+    )
+  ) {
+    return normalizeMessage(data);
+  }
+
   // Array of messages
   if (Array.isArray(data)) {
     return data.map(normalizeMessage);

--- a/web/src/utils/chatml/jumptoplayground.clienttest.ts
+++ b/web/src/utils/chatml/jumptoplayground.clienttest.ts
@@ -763,6 +763,32 @@ describe("Playground Jump Full Pipeline", () => {
     }
   });
 
+  it("should normalize standalone OpenAI Responses function_call output", () => {
+    const output = {
+      id: "fc_order_status",
+      type: "function_call",
+      status: "completed",
+      arguments: '{"orderIds":null}',
+      call_id: "call_order_status",
+      name: "getOrderStatus",
+    };
+
+    const outputResult = normalizeOutput(output, { framework: "openai" });
+    expect(outputResult.success).toBe(true);
+
+    expect(outputResult.data![0]).toMatchObject({
+      role: "assistant",
+      tool_calls: [
+        {
+          id: "call_order_status",
+          name: "getOrderStatus",
+          arguments: '{"orderIds":null}',
+          type: "function",
+        },
+      ],
+    });
+  });
+
   it("should handle VAPI camelCase toolCalls and preserve IDs", () => {
     // VAPI uses camelCase toolCalls instead of tool_calls
     // Critical: Tool call IDs must be preserved for OpenAI API compatibility

--- a/worker/src/__tests__/extractToolsBackend.test.ts
+++ b/worker/src/__tests__/extractToolsBackend.test.ts
@@ -503,6 +503,27 @@ describe("extractToolsFromObservation", () => {
       });
     });
 
+    it("extracts standalone OpenAI Responses function_call output", () => {
+      const output = {
+        id: "fc_order_status",
+        type: "function_call",
+        status: "completed",
+        arguments: '{"orderIds":null}',
+        call_id: "call_order_status",
+        name: "getOrderStatus",
+      };
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toHaveLength(1);
+      expect(toolArguments[0]).toEqual({
+        id: "call_order_status",
+        name: "getOrderStatus",
+        arguments: '{"orderIds":null}',
+        type: "function_call",
+      });
+    });
+
     it("extracts Anthropic tool_use from content array", () => {
       const output = {
         content: [


### PR DESCRIPTION
## Summary

- Normalize standalone OpenAI Responses `function_call` / `tool_call` / `function_call_output` items into ChatML so tool-call badges can count them.
- Extract standalone Responses tool-call objects during ingestion and prefer `call_id` over the Responses item id for stored tool call ids.
- Add focused regressions for frontend ChatML normalization and backend tool extraction.

## Impacted packages

- `@langfuse/shared`
- `web`
- `worker`

## Verification

- `git diff --check`
- Attempted `pnpm --filter web test-client "web/src/utils/chatml/jumptoplayground.clienttest.ts"` and `pnpm --filter worker test "extractToolsBackend.test.ts"`, but this fresh worktree tried to hydrate missing `node_modules` and failed on registry DNS (`fetch failed` / `ENOTFOUND`) before running tests.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes tool-call extraction for standalone OpenAI Responses API items (`function_call`, `tool_call`, `function_call_output`) that are stored directly as observation output rather than nested inside a Responses `output` array. It also flips the ID-selection priority in `flattenToolCall` so that `call_id` (the stable cross-request Responses API identifier) is preferred over the internal item `id`.

- **Backend (`extractToolsBackend.ts`)**: `extractToolCallsFromRawOutput` now short-circuits and calls `addToolArgument` when the output object itself satisfies `isToolCallLike && !isMessageLike`, mirroring the identical guard already in the array-iteration path. `flattenToolCall` now resolves `call_id ?? id ?? toolCallId` instead of `id ?? toolCallId ?? call_id`.
- **Frontend (`openai.ts`)**: `preprocessData` gains a new branch that passes standalone Responses API tool-call items through `normalizeMessage` before any other path can consume them, producing a proper ChatML message so tool-call badges are counted correctly.
- **Tests**: Focused regression tests are added in both the worker (`extractToolsBackend.test.ts`) and the web client (`jumptoplayground.clienttest.ts`) for the `function_call` standalone case.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The changes are narrowly scoped to new data paths (standalone Responses API items) and the ID-priority flip only affects objects that carry both `call_id` and `id`, which is specific to the Responses API format.

The two logic changes are correct: the new `isToolCallLike && !isMessageLike` guard in `extractToolCallsFromRawOutput` mirrors an identical pattern already present in the array branch, and the `preprocessData` branch in the frontend correctly falls after the Responses-API-with-array-output guard. The `call_id` priority swap is intentional and matches the Responses API semantics. Only minor coverage gaps were found — no tests for `tool_call` type or for standalone `function_call_output` on either layer — but neither gap hides a current defect.

Test files could use two additional cases each, but the production code in `extractToolsBackend.ts` and `openai.ts` warrants no special attention beyond a quick read of the ID-priority change.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Raw output data] --> B{Is array?}
    B -- Yes --> C[Iterate items]
    C --> D{isToolCallLike AND NOT isMessageLike?}
    D -- Yes --> E[addToolArgument - standalone tool call]
    D -- No --> F[extractToolCallsFromMessage]
    B -- No --> G{is object?}
    G -- No --> Z[return]
    G -- Yes --> H{isToolCallLike AND NOT isMessageLike?}
    H -- Yes --> I[addToolArgument - NEW: standalone object path]
    H -- No --> J[Check tool_calls / choices / content / additional_kwargs]

    subgraph Frontend preprocessData
    K[Raw data] --> L{type in function_call, tool_call, function_call_output?}
    L -- Yes --> M[normalizeMessage - NEW standalone path]
    M --> N[Returns single ChatML message object]
    L -- No --> O[Existing paths: arrays, messages, choices, etc.]
    end

    subgraph ID priority in flattenToolCall
    P[NEW: call_id ?? id ?? toolCallId]
    Q[OLD: id ?? toolCallId ?? call_id]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Raw output data] --> B{Is array?}
    B -- Yes --> C[Iterate items]
    C --> D{isToolCallLike AND NOT isMessageLike?}
    D -- Yes --> E[addToolArgument - standalone tool call]
    D -- No --> F[extractToolCallsFromMessage]
    B -- No --> G{is object?}
    G -- No --> Z[return]
    G -- Yes --> H{isToolCallLike AND NOT isMessageLike?}
    H -- Yes --> I[addToolArgument - NEW: standalone object path]
    H -- No --> J[Check tool_calls / choices / content / additional_kwargs]

    subgraph Frontend preprocessData
    K[Raw data] --> L{type in function_call, tool_call, function_call_output?}
    L -- Yes --> M[normalizeMessage - NEW standalone path]
    M --> N[Returns single ChatML message object]
    L -- No --> O[Existing paths: arrays, messages, choices, etc.]
    end

    subgraph ID priority in flattenToolCall
    P[NEW: call_id ?? id ?? toolCallId]
    Q[OLD: id ?? toolCallId ?? call_id]
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/utils/chatml/jumptoplayground.clienttest.ts:763-794
**`function_call_output` standalone path is untested on the frontend**

The new `preprocessData` branch handles all three types — `function_call`, `tool_call`, and `function_call_output` — but the test suite only covers `function_call`. A standalone `function_call_output` item (e.g. `{ type: "function_call_output", call_id: "call_xyz", output: "sunny" }`) should normalize to `{ role: "tool", tool_call_id: "call_xyz", content: "sunny" }`. Since `function_call_output` items have an `output` field, they exercise a different fall-through path inside `preprocessData` (the "Responses API without tools" guard matches on `"output" in data` but then fails `Array.isArray(obj.output)`) before reaching the new branch — worth a dedicated assertion to lock in this behavior.

### Issue 2 of 2
worker/src/__tests__/extractToolsBackend.test.ts:503-528
**`tool_call` type variant and `function_call_output` isolation are untested**

The backend test only exercises `type: "function_call"`. Two additional cases would fully cover the new code path: (1) `type: "tool_call"` — handled identically by `normalizeMessage` but the `isToolCallLike` path in `extractToolCallsFromRawOutput` has no unit test for it; (2) a standalone `function_call_output` item passed as output — which should produce zero `toolArguments` (it has no `name` or `arguments`, so `isToolCallLike` returns false and `addToolArgument` would skip it). Without this assertion, a future regression that accidentally counts tool results as tool invocations would go undetected.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tracing): parse standalone Responses..."](https://github.com/langfuse/langfuse/commit/834930cab1269ca0e2e49f0e8370cfdd2976f9c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40793796)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->