### PR TITLE
fix(otel): map GenAI IO on AI SDK spans

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1607,6 +1607,11 @@ export class OtelIngestionProcessor {
                         : undefined;
       }
 
+      const genAiInputOutput =
+        this.extractOpenTelemetryGenAiInputAndOutput(attributes);
+      input ??= genAiInputOutput?.input;
+      output ??= genAiInputOutput?.output;
+
       return { input, output, filteredAttributes };
     }
 
@@ -1897,27 +1902,42 @@ export class OtelIngestionProcessor {
       };
     }
 
+    const genAiInputOutput =
+      this.extractOpenTelemetryGenAiInputAndOutput(attributes);
+    if (genAiInputOutput) {
+      return { ...genAiInputOutput, filteredAttributes };
+    }
+
+    return { input: null, output: null, filteredAttributes };
+  }
+
+  private extractOpenTelemetryGenAiInputAndOutput(
+    attributes: Record<string, unknown>,
+  ): { input: unknown; output: unknown } | null {
     // OpenTelemetry messages (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans)
-    input = attributes["gen_ai.input.messages"];
-    output = attributes["gen_ai.output.messages"];
+    let input = attributes["gen_ai.input.messages"];
+    let output = attributes["gen_ai.output.messages"];
+
     if (input && attributes["gen_ai.system_instructions"]) {
       input = this.prependSystemInstructions(
         input,
         attributes["gen_ai.system_instructions"],
       );
     }
+
     if (input || output) {
-      return { input, output, filteredAttributes };
+      return { input, output };
     }
 
     // OpenTelemetry tools (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans)
     input = attributes["gen_ai.tool.call.arguments"];
     output = attributes["gen_ai.tool.call.result"];
+
     if (input || output) {
-      return { input, output, filteredAttributes };
+      return { input, output };
     }
 
-    return { input: null, output: null, filteredAttributes };
+    return null;
   }
 
   /**

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -4612,6 +4612,158 @@ describe("OTel Resource Span Mapping", () => {
       );
     });
 
+    it("should map AI SDK v7 GenAI semantic convention input/output attributes", async () => {
+      const traceId = "abcdef1234567890abcdef1234567894";
+      const generationSpanId = "1234567890abcded";
+      const toolSpanId = "1234567890abcdee";
+      const resourceSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "service.name",
+              value: { stringValue: "otel-test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "ai",
+              version: "7.0.0",
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from(generationSpanId, "hex"),
+                name: "chat test-model",
+                kind: 1,
+                startTimeUnixNano: { low: 0, high: 406528574, unsigned: true },
+                endTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "gen_ai.operation.name",
+                    value: { stringValue: "chat" },
+                  },
+                  {
+                    key: "gen_ai.request.model",
+                    value: { stringValue: "test-model" },
+                  },
+                  {
+                    key: "gen_ai.system_instructions",
+                    value: { stringValue: "Answer concisely." },
+                  },
+                  {
+                    key: "gen_ai.input.messages",
+                    value: {
+                      stringValue: JSON.stringify([
+                        { role: "user", content: "hello" },
+                      ]),
+                    },
+                  },
+                  {
+                    key: "gen_ai.output.messages",
+                    value: {
+                      stringValue: JSON.stringify([
+                        { role: "assistant", content: "hi" },
+                      ]),
+                    },
+                  },
+                  {
+                    key: "custom.generation.attribute",
+                    value: { stringValue: "keep-generation" },
+                  },
+                ],
+                status: {},
+              },
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from(toolSpanId, "hex"),
+                parentSpanId: Buffer.from(generationSpanId, "hex"),
+                name: "execute_tool get_weather",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "gen_ai.operation.name",
+                    value: { stringValue: "execute_tool" },
+                  },
+                  {
+                    key: "gen_ai.tool.name",
+                    value: { stringValue: "get_weather" },
+                  },
+                  {
+                    key: "gen_ai.tool.call.arguments",
+                    value: { stringValue: '{"location":"Berlin"}' },
+                  },
+                  {
+                    key: "gen_ai.tool.call.result",
+                    value: { stringValue: '{"temperature":21}' },
+                  },
+                  {
+                    key: "custom.tool.attribute",
+                    value: { stringValue: "keep-tool" },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set([traceId]),
+      );
+
+      const generation = events.find((e) => e.type === "generation-create");
+      const tool = events.find((e) => e.type === "tool-create");
+
+      expect(generation?.body.input).toEqual(
+        JSON.stringify([
+          { role: "system", content: "Answer concisely." },
+          { role: "user", content: "hello" },
+        ]),
+      );
+      expect(generation?.body.output).toBe(
+        JSON.stringify([{ role: "assistant", content: "hi" }]),
+      );
+      expect(tool?.body.input).toBe('{"location":"Berlin"}');
+      expect(tool?.body.output).toBe('{"temperature":21}');
+
+      expect(
+        generation?.body.metadata?.attributes?.["gen_ai.input.messages"],
+      ).toBeUndefined();
+      expect(
+        generation?.body.metadata?.attributes?.["gen_ai.output.messages"],
+      ).toBeUndefined();
+      expect(
+        tool?.body.metadata?.attributes?.["gen_ai.tool.call.arguments"],
+      ).toBeUndefined();
+      expect(
+        tool?.body.metadata?.attributes?.["gen_ai.tool.call.result"],
+      ).toBeUndefined();
+      expect(
+        generation?.body.metadata?.attributes?.["custom.generation.attribute"],
+      ).toBe("keep-generation");
+      expect(tool?.body.metadata?.attributes?.["custom.tool.attribute"]).toBe(
+        "keep-tool",
+      );
+    });
+
     it("should filter all input/output attribute patterns from metadata.attributes while preserving custom attributes", async () => {
       // This test verifies that extractInputAndOutput's filteredAttributes correctly removes
       // all known input/output attribute patterns from multiple frameworks


### PR DESCRIPTION
## Summary

- Reuse the generic OpenTelemetry GenAI input/output mapper inside the Vercel AI SDK `scope: "ai"` branch.
- Preserve existing legacy `ai.*` priority, then fall back to `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.tool.call.arguments`, and `gen_ai.tool.call.result`.
- Add a regression fixture for AI SDK v7 spans carrying official GenAI semantic-convention attributes for both generation and tool observations.

## Root cause

AI SDK v7 spans are emitted under instrumentation scope `ai`, but their I/O can be carried on official `gen_ai.*` attributes. `extractInputAndOutput()` previously entered the `scope === "ai"` branch, looked only for legacy `ai.*` I/O attributes, and returned before the generic GenAI attribute mapping could run. The same `gen_ai.*` attributes were already removed from metadata, so the UI saw null observation I/O even though the raw span had the data.

This keeps the existing priority order but makes the AI SDK branch share the same GenAI extraction path as the generic OpenTelemetry branch.

Fixes #14633.

## Verification

- `pnpm --filter @langfuse/shared run db:generate`
- `pnpm --filter @langfuse/shared run build`
- Red test before fix: focused `otelMapping.servertest.ts` run failed with `generation.body.input` undefined
- `pnpm exec prettier --check 'packages/shared/src/server/otel/OtelIngestionProcessor.ts' 'web/src/__tests__/server/api/otel/otelMapping.servertest.ts'`
- `git diff --check`
- `DATABASE_URL=... NEXTAUTH_URL=... SALT=... CLICKHOUSE_URL=... CLICKHOUSE_USER=... CLICKHOUSE_PASSWORD=... LANGFUSE_S3_EVENT_UPLOAD_BUCKET=... pnpm exec vitest run --project server 'src/__tests__/server/api/otel/otelMapping.servertest.ts'`
- `pnpm --filter @langfuse/shared exec eslint 'src/server/otel/OtelIngestionProcessor.ts' --max-warnings 0`
- `pnpm --filter web exec eslint 'src/__tests__/server/api/otel/otelMapping.servertest.ts' --max-warnings 0`
- `pnpm --filter worker run build`

Attempted: `pnpm --filter worker exec vitest run 'src/queues/__tests__/otelToObservationForEval.test.ts'`, but it requires a live local Postgres database and failed connecting to `localhost:5432`, not on this change.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where AI SDK v7 spans emitted under the `ai` instrumentation scope could carry `gen_ai.*` semantic-convention attributes for I/O, but those attributes were never mapped because the `scope === "ai"` branch only looked for legacy `ai.*` attributes and returned early. The fix extracts the GenAI attribute extraction into a private `extractOpenTelemetryGenAiInputAndOutput()` method and calls it as a fallback in the `ai` scope branch.

- Legacy `ai.*` attributes are checked first and take priority; `gen_ai.*` attributes are only used when no legacy attribute is found (correct `??=` semantics).
- The pre-deletion of `gen_ai.*` keys from `filteredAttributes` already existed before scope-specific handling, so the new fallback path correctly strips those keys from metadata without any extra work.
- A new regression test covers both a generation span and a tool span carrying GenAI semantic-convention attributes under the `ai` scope, including system-instruction prepending and metadata stripping.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a clean refactor with a targeted fallback addition and is covered by a new regression test.

The refactoring is mechanically equivalent for the existing generic OTel path, and the new fallback in the `ai` scope branch uses `??=` which correctly preserves legacy `ai.*` attribute priority. The pre-deletion of all `gen_ai.*` keys from `filteredAttributes` already happened before any scope branch, so metadata stripping works without modification. The new test validates both the generation and tool-span cases end-to-end, including system-instruction prepending and metadata exclusion of the mapped keys.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[extractInputAndOutput\ncalled with attributes] --> B{Langfuse attrs\npresent?}
    B -- yes --> C[Return Langfuse I/O]
    B -- no --> D{scope === genkit-tracer?}
    D -- yes --> E[Return Genkit I/O]
    D -- no --> F{scope === 'ai'?\nVercel AI SDK}
    F -- yes --> G[Read legacy ai.* attrs\nfor input & output]
    G --> H{input or output\nresolved from legacy?}
    H -- no --> I[NEW: extractOpenTelemetryGenAiInputAndOutput]
    H -- yes --> J[Return with legacy\nvalues]
    I --> K{gen_ai.input.messages\nor gen_ai.output.messages?}
    K -- yes --> L[Optionally prepend\nsystem_instructions]
    L --> M[Return gen_ai messages I/O]
    K -- no --> N{gen_ai.tool.call.* attrs present?}
    N -- yes --> O[Return tool call I/O]
    N -- no --> P[Return null]
    P --> Q[input/output remain undefined]
    M --> J
    O --> J
    F -- no --> R[Other framework checks]
    R --> S[NEW: extractOpenTelemetryGenAiInputAndOutput\nrefactored from inline]
    S --> T{Found gen_ai attrs?}
    T -- yes --> U[Return with filteredAttributes]
    T -- no --> V[Return null input/output]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[extractInputAndOutput\ncalled with attributes] --> B{Langfuse attrs\npresent?}
    B -- yes --> C[Return Langfuse I/O]
    B -- no --> D{scope === genkit-tracer?}
    D -- yes --> E[Return Genkit I/O]
    D -- no --> F{scope === 'ai'?\nVercel AI SDK}
    F -- yes --> G[Read legacy ai.* attrs\nfor input & output]
    G --> H{input or output\nresolved from legacy?}
    H -- no --> I[NEW: extractOpenTelemetryGenAiInputAndOutput]
    H -- yes --> J[Return with legacy\nvalues]
    I --> K{gen_ai.input.messages\nor gen_ai.output.messages?}
    K -- yes --> L[Optionally prepend\nsystem_instructions]
    L --> M[Return gen_ai messages I/O]
    K -- no --> N{gen_ai.tool.call.* attrs present?}
    N -- yes --> O[Return tool call I/O]
    N -- no --> P[Return null]
    P --> Q[input/output remain undefined]
    M --> J
    O --> J
    F -- no --> R[Other framework checks]
    R --> S[NEW: extractOpenTelemetryGenAiInputAndOutput\nrefactored from inline]
    S --> T{Found gen_ai attrs?}
    T -- yes --> U[Return with filteredAttributes]
    T -- no --> V[Return null input/output]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into hassiebbot/fix-..."](https://github.com/langfuse/langfuse/commit/59773b2bc79f1d0c49aacd39490f9a98ffc534ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40791385)</sub>

<!-- /greptile_comment -->