### PR TITLE
chore(worker): drop project_id tag from export volume metric for API integrations

### DIFF
--- a/worker/src/__tests__/exportVolumeMetric.test.ts
+++ b/worker/src/__tests__/exportVolumeMetric.test.ts
@@ -13,7 +13,7 @@ import {
 describe("recordExportVolume", () => {
   beforeEach(() => recordIncrement.mockClear());
 
-  it("emits the unified metric with the byte value", () => {
+  it("emits the unified metric with the byte value and omits projectId for API integrations", () => {
     recordExportVolume({
       integration: "mixpanel",
       bytes: 1234,
@@ -21,8 +21,8 @@ describe("recordExportVolume", () => {
     });
     expect(recordIncrement).toHaveBeenCalledWith(EXPORT_VOLUME_METRIC, 1234, {
       integration: "mixpanel",
-      projectId: "p1",
     });
+    expect(recordIncrement.mock.calls[0][2]).not.toHaveProperty("projectId");
   });
 
   it("includes blob dimensions and omits undefined tags", () => {
@@ -45,19 +45,20 @@ describe("recordExportVolume", () => {
     });
   });
 
-  it("omits API-integration tags that are not provided", () => {
+  it("omits projectId and unprovided tags for posthog", () => {
     recordExportVolume({
       integration: "posthog",
       bytes: 7,
       projectId: "p3",
     });
     const tags = recordIncrement.mock.calls[0][2];
+    expect(tags).not.toHaveProperty("projectId");
     expect(tags).not.toHaveProperty("destination_type");
     expect(tags).not.toHaveProperty("source");
     expect(tags).not.toHaveProperty("table");
   });
 
-  it("emits llmaj egress with only integration/projectId tags", () => {
+  it("emits llmaj egress with only the integration tag", () => {
     recordExportVolume({
       integration: "llmaj",
       bytes: 5120,
@@ -65,9 +66,9 @@ describe("recordExportVolume", () => {
     });
     expect(recordIncrement).toHaveBeenCalledWith(EXPORT_VOLUME_METRIC, 5120, {
       integration: "llmaj",
-      projectId: "p4",
     });
     const tags = recordIncrement.mock.calls[0][2];
+    expect(tags).not.toHaveProperty("projectId");
     expect(tags).not.toHaveProperty("destination_type");
     expect(tags).not.toHaveProperty("source");
     expect(tags).not.toHaveProperty("table");

--- a/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
+++ b/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
@@ -123,7 +123,7 @@ describe("createProductionEvalExecutionDeps", () => {
     expect(mockRecordIncrement).toHaveBeenCalledWith(
       EXPORT_VOLUME_METRIC,
       expectedBytes,
-      { integration: "llmaj", projectId: "project-123" },
+      { integration: "llmaj" },
     );
     // Not the Zod _def form.
     const zodDefBytes = Buffer.byteLength(

--- a/worker/src/services/exportVolumeMetric.ts
+++ b/worker/src/services/exportVolumeMetric.ts
@@ -13,6 +13,9 @@ type ExportVolume = {
   // On-wire egress bytes shipped this run: gzipped for blob/posthog/mixpanel,
   // uncompressed for llmaj (LLM requests aren't gzipped).
   bytes: number;
+  // Only tagged for blob_storage (per-project egress cost attribution); the
+  // API-based integrations (posthog/mixpanel/llmaj) omit it to keep custom
+  // metric cardinality down.
   projectId: string;
   // Egress-cost classification; blob only (S3 / S3_COMPATIBLE / AZURE_*).
   destinationType?: string;
@@ -26,7 +29,7 @@ type ExportVolume = {
  * Single metric for total outbound export volume, so egress can be summed
  * across integrations and split by `integration` / `destination_type` for
  * cost. Undefined tags are omitted so each integration sets only the
- * dimensions it has.
+ * dimensions it has. `projectId` is tagged for blob_storage only.
  */
 export const recordExportVolume = ({
   integration,
@@ -37,7 +40,8 @@ export const recordExportVolume = ({
   table,
   path,
 }: ExportVolume): void => {
-  const tags: Record<string, string> = { integration, projectId };
+  const tags: Record<string, string> = { integration };
+  if (integration === "blob_storage") tags.projectId = projectId;
   if (destinationType !== undefined) tags.destination_type = destinationType;
   if (source !== undefined) tags.source = source;
   if (table !== undefined) tags.table = table;


### PR DESCRIPTION
## What does this PR do?

Removes the `projectId` tag from the `langfuse.export.serialized_bytes` metric for the API-based export integrations: `llmaj`, `posthog`, and `mixpanel`.

`blob_storage` keeps the `projectId` tag since it needs per-project egress cost attribution. The three API integrations don't need per-project breakdown, so dropping the tag reduces custom-metric cardinality.

The `projectId` field stays in the `recordExportVolume` arguments (callers are unchanged); the tag is now only emitted when `integration === "blob_storage"`.

## Type of change

- [x] Chore (refactoring, infra, or non-user-facing change)

## Checklist

- [x] Updated unit tests (`worker/src/__tests__/exportVolumeMetric.test.ts`)
- [x] `pnpm run lint` passes
- [x] `pnpm run typecheck` passes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Drops `projectId` from the `langfuse.export.serialized_bytes` metric tags for the three API-based export integrations (`llmaj`, `posthog`, `mixpanel`), while preserving it for `blob_storage` where per-project egress attribution is needed.

- `recordExportVolume` now only appends `tags.projectId` when `integration === \"blob_storage\"`, leaving the public function signature unchanged so all call sites continue to compile without modification.
- Unit tests are updated in all four test cases to assert the new tag shape, including explicit `.not.toHaveProperty(\"projectId\")` checks for the API integrations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line conditional change in a metrics helper with complete test coverage and no impact on business logic.

The change is isolated to a single metric-emission helper. All four test cases are updated and each API integration now has an explicit assertion that projectId is absent. The blob_storage path is verified to still emit the tag. No callers needed modification, and the type signature is backward-compatible.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["recordExportVolume(integration, bytes, projectId, ...)"] --> B{integration === 'blob_storage'?}
    B -- Yes --> C["tags = { integration, projectId }"]
    B -- No --> D["tags = { integration }"]
    C --> E["Append optional tags\n(destination_type, source, table, path)"]
    D --> E
    E --> F["recordIncrement(EXPORT_VOLUME_METRIC, bytes, tags)"]
    F --> G[["DataDog / StatsD metric emitted"]]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["recordExportVolume(integration, bytes, projectId, ...)"] --> B{integration === 'blob_storage'?}
    B -- Yes --> C["tags = { integration, projectId }"]
    B -- No --> D["tags = { integration }"]
    C --> E["Append optional tags\n(destination_type, source, table, path)"]
    D --> E
    E --> F["recordIncrement(EXPORT_VOLUME_METRIC, bytes, tags)"]
    F --> G[["DataDog / StatsD metric emitted"]]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): drop project\_id tag from ..."](https://github.com/langfuse/langfuse/commit/06a49bd180832c060e586ac560484f8b63eaf475) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40803069)</sub>

<!-- /greptile_comment -->