### PR TITLE
fix(tracing): count input-history tool calls

### DIFF
--- a/web/src/components/trace/components/IOPreview/hooks/useChatMLParser.clienttest.tsx
+++ b/web/src/components/trace/components/IOPreview/hooks/useChatMLParser.clienttest.tsx
@@ -1,0 +1,64 @@
+import { renderHook } from "@testing-library/react";
+import type { Prisma } from "@langfuse/shared";
+import { describe, expect, it } from "vitest";
+
+import { useChatMLParser } from "./useChatMLParser";
+
+describe("useChatMLParser", () => {
+  it("marks tools as called when the call is in input history", () => {
+    const input: Prisma.JsonValue = {
+      messages: [
+        {
+          role: "user",
+          content: "yo where's my order",
+        },
+        {
+          id: "fc_order_status",
+          type: "function_call",
+          status: "completed",
+          arguments: '{"orderIds":null}',
+          call_id: "call_order_status",
+          name: "getOrderStatus",
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_order_status",
+          output: '[{"orderId":"#W001","status":"delivered"}]',
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          description: "Get order status.",
+          name: "getOrderStatus",
+          parameters: {
+            type: "object",
+            properties: {
+              orderIds: {
+                anyOf: [
+                  { type: "array", items: { type: "string" } },
+                  { type: "null" },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const { result } = renderHook(() =>
+      useChatMLParser(
+        input,
+        "Your order #W001 has been delivered.",
+        undefined,
+        "OpenAI.responses",
+      ),
+    );
+
+    expect(result.current.allTools.map((tool) => tool.name)).toEqual([
+      "getOrderStatus",
+    ]);
+    expect(result.current.toolCallCounts.get("getOrderStatus")).toBe(1);
+    expect(result.current.messageToToolCallNumbers.size).toBe(0);
+  });
+});

--- a/web/src/components/trace/components/IOPreview/hooks/useChatMLParser.ts
+++ b/web/src/components/trace/components/IOPreview/hooks/useChatMLParser.ts
@@ -52,7 +52,8 @@ function parseToolCallsFromMessage(
  * Handles:
  * - ChatML message normalization from various input formats
  * - Tool definition extraction from messages
- * - Tool call counting and numbering (output messages only)
+ * - Tool call counting across displayed messages
+ * - Tool call numbering for output messages only
  * - Additional non-message input extraction
  *
  * Performance optimization:
@@ -114,8 +115,10 @@ export function useChatMLParser(
       }
     }
 
-    // Count tool call invocations
-    // Only number tool calls from OUTPUT messages (current invocation), not input (history)
+    // Count tool call invocations across all displayed messages so the tool
+    // definition badge reflects calls from both current output and history.
+    // Only number output-side tool calls so invocation labels stay scoped to
+    // the current LLM response rather than historical input messages.
     const inputMessageCount = inResult.success ? inResult.data.length : 0;
     let toolCallCounter = 0;
     const messageToToolCallNumbers = new Map<number, number[]>();
@@ -140,12 +143,13 @@ export function useChatMLParser(
                 : undefined;
 
           if (calledToolName) {
+            toolCallCounts.set(
+              calledToolName,
+              (toolCallCounts.get(calledToolName) || 0) + 1,
+            );
+
             // Count tool calls from OUTPUT messages only
             if (isOutputMessage) {
-              toolCallCounts.set(
-                calledToolName,
-                (toolCallCounts.get(calledToolName) || 0) + 1,
-              );
               toolCallCounter++;
               messageToolNumbers.push(toolCallCounter);
             }


### PR DESCRIPTION
## Summary
- count tool calls across all displayed ChatML messages so tool definition badges mark calls from input history as called
- keep invocation numbering scoped to output messages only, so historical calls do not affect current response labels
- add a parser regression for OpenAI Responses input history containing getOrderStatus

## Tests
- DATABASE_URL=... DIRECT_URL=... NEXTAUTH_URL=... SALT=... CLICKHOUSE_URL=... CLICKHOUSE_USER=... CLICKHOUSE_PASSWORD=... LANGFUSE_S3_EVENT_UPLOAD_BUCKET=langfuse pnpm --filter web test-client "src/components/trace/components/IOPreview/hooks/useChatMLParser.clienttest.tsx" "src/utils/chatml/jumptoplayground.clienttest.ts"
- DATABASE_URL=... DIRECT_URL=... NEXTAUTH_URL=... SALT=... CLICKHOUSE_URL=... CLICKHOUSE_USER=... CLICKHOUSE_PASSWORD=... LANGFUSE_S3_EVENT_UPLOAD_BUCKET=langfuse pnpm --filter worker test "src/__tests__/extractToolsBackend.test.ts"

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where tool definition badges were not marked as "called" when the corresponding tool invocation appeared in the ChatML input history (e.g. an OpenAI Responses API conversation that already includes a `function_call` round-trip before the current LLM turn). The fix decouples two previously conflated concerns in `useChatMLParser`: counting how many times a tool was called (now accumulated across **all** displayed messages) vs. assigning sequential call-number labels (still scoped to output messages only).

- `toolCallCounts.set` is moved outside the `isOutputMessage` guard so that input-history `function_call` entries increment the count and flip the badge state, while `toolCallCounter` / `messageToToolCallNumbers` remain output-only.
- A new client test (`useChatMLParser.clienttest.tsx`) covers the exact OpenAI Responses input-history scenario described in the bug.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, well-scoped extraction of a single statement outside a conditional guard, with a new regression test that directly exercises the fixed scenario.

The diff touches only two files: a targeted one-hunk logic fix in useChatMLParser.ts and a new test that validates the exact regression. The fix correctly separates counting (all messages) from labelling (output only), and the surrounding logic — messageToToolCallNumbers, toolCallCounter, sort order — is unaffected. The new test covers the OpenAI Responses input-history path end-to-end.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useChatMLParser called] --> B[normalizeInput / normalizeOutput]
    B --> C[combineInputOutputMessages → messages array]
    C --> D{For each message i}
    D --> E[parseToolCallsFromMessage]
    E --> F{toolCallList length > 0?}
    F -- No --> D
    F -- Yes --> G{For each toolCall}
    G --> H{calledToolName found?}
    H -- No --> G
    H -- Yes --> I[toolCallCounts.set - ALL messages]
    I --> J{isOutputMessage?\n i >= inputMessageCount}
    J -- Yes --> K[toolCallCounter++\nmessageToolNumbers.push]
    J -- No --> G
    K --> G
    G --> L{messageToolNumbers.length > 0?}
    L -- Yes --> M[messageToToolCallNumbers.set i]
    L -- No --> D
    M --> D
    D --> N[Sort tools: called first, by count desc]
    N --> O[Assign toolNameToDefinitionNumber]
    O --> P[Return ChatMLParserResult]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[useChatMLParser called] --> B[normalizeInput / normalizeOutput]
    B --> C[combineInputOutputMessages → messages array]
    C --> D{For each message i}
    D --> E[parseToolCallsFromMessage]
    E --> F{toolCallList length > 0?}
    F -- No --> D
    F -- Yes --> G{For each toolCall}
    G --> H{calledToolName found?}
    H -- No --> G
    H -- Yes --> I[toolCallCounts.set - ALL messages]
    I --> J{isOutputMessage?\n i >= inputMessageCount}
    J -- Yes --> K[toolCallCounter++\nmessageToolNumbers.push]
    J -- No --> G
    K --> G
    G --> L{messageToolNumbers.length > 0?}
    L -- Yes --> M[messageToToolCallNumbers.set i]
    L -- No --> D
    M --> D
    D --> N[Sort tools: called first, by count desc]
    N --> O[Assign toolNameToDefinitionNumber]
    O --> P[Return ChatMLParserResult]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tracing): count input-history tool c..."](https://github.com/langfuse/langfuse/commit/a4ecd9ab9d6776d15b36a0c397858356257ab7f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40815225)</sub>

<!-- /greptile_comment -->