### PR TITLE
fix(otel): allow root span to set trace environment

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -936,6 +936,14 @@ export class IngestionService {
       immutableEntityKeys[TableName.Traces],
     );
 
+    // Resolve environment from the record with the earliest timestamp.
+    // In OTel, the root span always starts earliest, so its environment
+    // takes precedence regardless of ingestion order.
+    const earliestRecord = recordsToMerge.reduce((a, b) =>
+      a.timestamp <= b.timestamp ? a : b,
+    );
+    mergedRecord.environment = earliestRecord.environment;
+
     // If metadata exists, it is an object due to previous parsing
     mergedRecord.metadata = convertRecordValuesToString(
       (mergedRecord.metadata as Record<string, unknown>) ?? {},

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1476,6 +1476,106 @@ describe("Ingestion end-to-end tests", () => {
     expect(trace.project_id).toBe(projectId);
   }, 10_000);
 
+  it("should use root span environment when child span is ingested first", async () => {
+    const traceId = randomUUID();
+    const rootTimestamp = "2024-01-01T00:00:00.000Z";
+    const childTimestamp = "2024-01-01T00:00:01.000Z";
+
+    await ingestionService.processTraceEventList({
+      projectId,
+      entityId: traceId,
+      createdAtTimestamp: new Date(),
+      traceEventList: [
+        {
+          id: randomUUID(),
+          type: "trace-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: traceId,
+            timestamp: childTimestamp,
+            environment: "staging",
+          },
+        },
+      ],
+    });
+
+    await clickhouseWriter.flushAll(true);
+
+    await ingestionService.processTraceEventList({
+      projectId,
+      entityId: traceId,
+      createdAtTimestamp: new Date(),
+      traceEventList: [
+        {
+          id: randomUUID(),
+          type: "trace-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: traceId,
+            timestamp: rootTimestamp,
+            name: "root-operation",
+            environment: "production",
+          },
+        },
+      ],
+    });
+
+    await clickhouseWriter.flushAll(true);
+
+    const trace = await getClickhouseRecord(TableName.Traces, traceId);
+    expect(trace.environment).toBe("production");
+  }, 10_000);
+
+  it("should preserve root span environment when child span is ingested second", async () => {
+    const traceId = randomUUID();
+    const rootTimestamp = "2024-01-01T00:00:00.000Z";
+    const childTimestamp = "2024-01-01T00:00:01.000Z";
+
+    await ingestionService.processTraceEventList({
+      projectId,
+      entityId: traceId,
+      createdAtTimestamp: new Date(),
+      traceEventList: [
+        {
+          id: randomUUID(),
+          type: "trace-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: traceId,
+            timestamp: rootTimestamp,
+            name: "root-operation",
+            environment: "production",
+          },
+        },
+      ],
+    });
+
+    await clickhouseWriter.flushAll(true);
+
+    await ingestionService.processTraceEventList({
+      projectId,
+      entityId: traceId,
+      createdAtTimestamp: new Date(),
+      traceEventList: [
+        {
+          id: randomUUID(),
+          type: "trace-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: traceId,
+            timestamp: childTimestamp,
+            environment: "staging",
+          },
+        },
+      ],
+    });
+
+    await clickhouseWriter.flushAll(true);
+
+    const trace = await getClickhouseRecord(TableName.Traces, traceId);
+    expect(trace.environment).toBe("production");
+  }, 10_000);
+
   it("should merge observations and set negative tokens and cost to null", async () => {
     const modelId = randomUUID();
     const pricingTierId = randomUUID();


### PR DESCRIPTION
## What does this PR do?

When trace-create events arrive in separate batches, a non-root span's shallow trace sets `environment` before the root span's full trace arrives. Since `environment` was in `immutableEntityKeys` for Traces, the root span's event could never override it, leaving the trace labeled with the wrong environment.

This matches the described issue: a trace whose root operation runs in `local-dev` gets incorrectly labeled as `stg` because a few short-lived child spans from a downstream `stg` service complete and get ingested first.

Fixes #14651

## Type of change

- [x] Bug fix

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] My code doesn't follow the style guidelines of this project (`pnpm run format`) - *prettier passed on changed files*
- [x] I have checked if my PR needs changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked if new and existing unit tests pass locally with my changes - *unit tests pass; integration tests require Docker, which is not available locally*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an OTel ingestion race condition where a child span's `trace-create` event — ingested before the root span — locked the trace's `environment` field via `immutableEntityKeys`, preventing the root span from correcting it. The fix removes `"environment"` from the immutable-key list for the Traces table so that later arriving events can overwrite the field.

- **Core change**: `environment` is removed from `immutableEntityKeys[TableName.Traces]`, making it use the existing last-write-wins merge strategy across batches.
- **Test coverage**: an integration test validates the child-before-root ordering; however, the reverse scenario (root span ingested first, child span with a different environment arriving later) is not tested and would now incorrectly overwrite the root span's environment.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The fix correctly handles the described child-before-root ingestion order, but makes `environment` fully mutable so any batch that arrives last — including a child span from a different service — can silently overwrite a correctly set root-span environment.

The change trades one race condition for its symmetric counterpart. In OTel, child spans always finish before root spans, so root-arrives-last is the common case and the fix helps there. But nothing prevents the reverse: a delayed child-span batch arriving after the root span has already been stored, overwriting the correct environment. The reverse-ordering scenario has no test coverage and no guard in the merge logic.

`worker/src/services/IngestionService/index.ts` (the merge key list) and the integration test file — the test suite needs a complementary case that ingests root-then-child and asserts the root span's environment is preserved.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CS as Child Span (stg)
    participant RS as Root Span (prod)
    participant IS as IngestionService
    participant CH as ClickHouse

    Note over CS,CH: Scenario A — fixed by this PR (child arrives first)
    CS->>IS: "trace-create {env: stg}"
    IS->>CH: read existing record → null
    IS->>CH: "write {env: stg}"

    RS->>IS: "trace-create {env: production}"
    IS->>CH: "read existing record → {env: stg}"
    IS->>IS: mergeRecords([stg_record, prod_event]) → production wins ✓
    IS->>CH: "write {env: production}"

    Note over CS,CH: Scenario B — new regression (root arrives first)
    RS->>IS: "trace-create {env: production}"
    IS->>CH: read existing record → null
    IS->>CH: "write {env: production}"

    CS->>IS: "trace-create {env: stg}"
    IS->>CH: "read existing record → {env: production}"
    IS->>IS: mergeRecords([prod_record, stg_event]) → stg wins ✗
    IS->>CH: "write {env: stg}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CS as Child Span (stg)
    participant RS as Root Span (prod)
    participant IS as IngestionService
    participant CH as ClickHouse

    Note over CS,CH: Scenario A — fixed by this PR (child arrives first)
    CS->>IS: "trace-create {env: stg}"
    IS->>CH: read existing record → null
    IS->>CH: "write {env: stg}"

    RS->>IS: "trace-create {env: production}"
    IS->>CH: "read existing record → {env: stg}"
    IS->>IS: mergeRecords([stg_record, prod_event]) → production wins ✓
    IS->>CH: "write {env: production}"

    Note over CS,CH: Scenario B — new regression (root arrives first)
    RS->>IS: "trace-create {env: production}"
    IS->>CH: read existing record → null
    IS->>CH: "write {env: production}"

    CS->>IS: "trace-create {env: stg}"
    IS->>CH: "read existing record → {env: production}"
    IS->>IS: mergeRecords([prod_record, stg_event]) → stg wins ✗
    IS->>CH: "write {env: stg}"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/services/IngestionService/index.ts:92
**Last-write-wins for `environment` creates a symmetric race condition**

Removing `environment` from `immutableEntityKeys` for Traces means whichever batch is processed last always wins. `mergeTraceRecords` places the existing ClickHouse record first in `recordsToMerge` and the incoming events after it, so the incoming events always overwrite. This fixes the described bug (child spans arrive and are ingested before the root span), but introduces the reverse regression: if the root span is ingested first and a child span from a different environment arrives in a later batch, that child span's `environment` will overwrite the root span's value.

The test only exercises one ordering (child-then-root). A complementary assertion — root span with `"production"` ingested first, child span with `"staging"` arriving second — would currently fail with `"staging"`, demonstrating the new regression. Consider whether `environment` should be allowed to overwrite only when the incoming event's `timestamp` is earlier than the stored trace's `timestamp` (root span always has an earlier start time in OTel), or whether a dedicated `"root span wins"` heuristic is needed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): allow root span to set trace ..."](https://github.com/langfuse/langfuse/commit/2ba87b5c79ac7cb8df69e757bb7be34dfe100680) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40832250)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->