### PR TITLE
refactor(web): Create & enable `require-title-with-truncate` eslint rule

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -2,6 +2,7 @@ import { default as noTailwindOverflowScroll } from "./rules/no-tailwind-overflo
 import { default as noInSourceVitest } from "./rules/no-in-source-vitest.js";
 import { default as noMarginOnRootElements } from "./rules/no-margin-on-root-elements.js";
 import { default as noOverlayZindex } from "./rules/no-overlay-zindex.js";
+import { default as requireTitleWithTruncate } from "./rules/require-title-with-truncate.js";
 import { default as noStyleProps } from "./rules/no-style-props.js";
 import { default as noUnnecessaryCn } from "./rules/no-unnecessary-cn.js";
 
@@ -13,6 +14,7 @@ export const plugin = {
     "no-style-props": noStyleProps,
     "no-tailwind-overflow-scroll": noTailwindOverflowScroll,
     "no-unnecessary-cn": noUnnecessaryCn,
+    "require-title-with-truncate": requireTitleWithTruncate,
   },
 };
 

--- a/packages/eslint-plugin/src/rule-helpers/ast.ts
+++ b/packages/eslint-plugin/src/rule-helpers/ast.ts
@@ -1,0 +1,50 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+/**
+ * Returns the literal string value for expressions that are statically known at
+ * lint time.
+ *
+ * Supports plain string literals and template literals without expressions.
+ */
+export function getStaticStringValue(
+  node: TSESTree.Expression | TSESTree.SpreadElement,
+): string | null {
+  if (node.type === AST_NODE_TYPES.Literal && typeof node.value === "string") {
+    return node.value;
+  }
+
+  if (
+    node.type === AST_NODE_TYPES.TemplateLiteral &&
+    node.expressions.length === 0
+  ) {
+    return node.quasis[0].value.cooked;
+  }
+
+  return null;
+}
+
+/**
+ * Returns the static property key text when an object key can be resolved
+ * without executing code.
+ *
+ * Supports identifier keys, string literal keys, and template literal keys
+ * without expressions.
+ */
+export function getStaticPropertyKeyValue(
+  key: TSESTree.PropertyName | TSESTree.PrivateIdentifier,
+): string | null {
+  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
+
+  if (key.type === AST_NODE_TYPES.Literal && typeof key.value === "string") {
+    return key.value;
+  }
+
+  if (
+    key.type === AST_NODE_TYPES.TemplateLiteral &&
+    key.expressions.length === 0
+  ) {
+    return key.quasis[0].value.cooked;
+  }
+
+  return null;
+}

--- a/packages/eslint-plugin/src/rule-helpers/tailwind.ts
+++ b/packages/eslint-plugin/src/rule-helpers/tailwind.ts
@@ -1,0 +1,53 @@
+/**
+ * Removes Tailwind's leading or trailing important modifier markers from a
+ * single utility token.
+ */
+export function normalizeTailwindToken(token: string): string {
+  return token.replace(/^!|!$/g, "");
+}
+
+/**
+ * Removes variant prefixes from a Tailwind token while preserving colons that
+ * appear inside bracket expressions.
+ *
+ * For example, `data-[state=open]:truncate` becomes `truncate`.
+ */
+export function stripTailwindVariants(token: string): string {
+  let depth = 0;
+  let lastSeparator = -1;
+
+  for (let i = 0; i < token.length; i++) {
+    const ch = token[i];
+    if (ch === "[") depth++;
+    else if (ch === "]") depth = Math.max(0, depth - 1);
+    else if (ch === ":" && depth === 0) lastSeparator = i;
+  }
+
+  return lastSeparator === -1 ? token : token.slice(lastSeparator + 1);
+}
+
+/**
+ * Iterates over the Tailwind utility tokens contained in a whitespace-separated
+ * class string after normalizing important markers and stripping variants.
+ */
+export function* extractTailwindUtilityTokens(
+  value: string,
+): Generator<string> {
+  for (const match of value.matchAll(/\S+/g)) {
+    yield normalizeTailwindToken(stripTailwindVariants(match[0]));
+  }
+}
+
+/**
+ * Returns whether a whitespace-separated class string contains the requested
+ * Tailwind utility after stripping variants and important markers.
+ */
+export function hasTailwindUtility(value: string, utility: string): boolean {
+  for (const match of value.matchAll(/\S+/g)) {
+    if (normalizeTailwindToken(stripTailwindVariants(match[0])) === utility) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/eslint-plugin/src/rules/no-margin-on-root-elements.test.ts
+++ b/packages/eslint-plugin/src/rules/no-margin-on-root-elements.test.ts
@@ -32,6 +32,7 @@ ruleTester.run("no-margin-on-root-elements", rule, {
     `function Card() { return <div className={cn({ flex: isActive })} />; }`,
     `function Card() { return <div className={cn({ flex: isActive, "gap-2": hasGap })} />; }`,
     `function Card() { return <div className={cn({ [className]: isActive })} />; }`,
+    `function Card() { return <div className={cn({ [condition ? "mt-2" : "flex"]: isActive })} />; }`,
     `function Card() { return <div className={cn({ ...styles, flex: isActive })} />; }`,
     `function Card() { return <div className={condition && styles.root} />; }`,
     `function Card() { return <div className={"flex"!} />; }`,

--- a/packages/eslint-plugin/src/rules/no-margin-on-root-elements.ts
+++ b/packages/eslint-plugin/src/rules/no-margin-on-root-elements.ts
@@ -1,6 +1,15 @@
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
 import { createComponentRootElementVisitors } from "../react-components.js";
+import {
+  getStaticPropertyKeyValue,
+  getStaticStringValue,
+} from "../rule-helpers/ast.js";
+import {
+  extractTailwindUtilityTokens,
+  normalizeTailwindToken,
+  stripTailwindVariants,
+} from "../rule-helpers/tailwind.js";
 import { createRule } from "../util.js";
 
 const FORBIDDEN_STYLE_PROPERTIES = new Set([
@@ -27,7 +36,6 @@ const FORBIDDEN_STYLE_PROPERTIES = new Set([
   "margin-top",
 ]);
 
-const TAILWIND_TOKEN_RE = /\S+/g;
 const MARGIN_UTILITY_RE = /^(-?m[trblxyse]?)-(.+)$/;
 const ZERO_CSS_VALUE_RE = /^-?0(?:\.0+)?(?:%|[a-z]+)?$/i;
 const DEFAULT_CLASS_NAME_FUNCTIONS = ["cn", "clsx"];
@@ -35,30 +43,12 @@ const DEFAULT_CLASS_NAME_FUNCTIONS = ["cn", "clsx"];
 type Options = [{ classNameFunctions: string[] }];
 type MessageIds = "unexpectedClassName" | "unexpectedStyle";
 
-function normalizeTailwindToken(token: string): string {
-  return token.replace(/^!|!$/g, "");
-}
-
-function stripVariants(token: string): string {
-  let depth = 0;
-  let lastSeparator = -1;
-
-  for (let i = 0; i < token.length; i++) {
-    const ch = token[i];
-    if (ch === "[") depth++;
-    else if (ch === "]") depth = Math.max(0, depth - 1);
-    else if (ch === ":" && depth === 0) lastSeparator = i;
-  }
-
-  return lastSeparator === -1 ? token : token.slice(lastSeparator + 1);
-}
-
 function isZeroCssValue(value: string): boolean {
   return ZERO_CSS_VALUE_RE.test(value.trim());
 }
 
 function getReportableMarginUtility(rawToken: string): string | null {
-  const utility = normalizeTailwindToken(stripVariants(rawToken));
+  const utility = normalizeTailwindToken(stripTailwindVariants(rawToken));
   const match = MARGIN_UTILITY_RE.exec(utility);
   if (!match) return null;
 
@@ -70,45 +60,10 @@ function getReportableMarginUtility(rawToken: string): string | null {
 
   return utility;
 }
-
-function getStaticStringValue(
-  node: TSESTree.Expression | TSESTree.SpreadElement,
-): string | null {
-  if (node.type === AST_NODE_TYPES.Literal && typeof node.value === "string") {
-    return node.value;
-  }
-
-  if (
-    node.type === AST_NODE_TYPES.TemplateLiteral &&
-    node.expressions.length === 0
-  ) {
-    return node.quasis[0].value.cooked;
-  }
-
-  return null;
-}
-
 function getCallExpressionName(node: TSESTree.CallExpression): string | null {
   return node.callee.type === AST_NODE_TYPES.Identifier
     ? node.callee.name
     : null;
-}
-
-function getStaticPropertyKeyValue(
-  key: TSESTree.PropertyName | TSESTree.PrivateIdentifier,
-): string | null {
-  if (key.type === AST_NODE_TYPES.Literal && typeof key.value === "string") {
-    return key.value;
-  }
-
-  if (
-    key.type === AST_NODE_TYPES.TemplateLiteral &&
-    key.expressions.length === 0
-  ) {
-    return key.quasis[0].value.cooked;
-  }
-
-  return null;
 }
 
 function findReportableMarginUtilityInExpression(
@@ -238,8 +193,8 @@ function isZeroStyleValue(node: TSESTree.Node): boolean {
 }
 
 function findReportableMarginUtility(value: string): string | null {
-  for (const match of value.matchAll(TAILWIND_TOKEN_RE)) {
-    const utility = getReportableMarginUtility(match[0]);
+  for (const token of extractTailwindUtilityTokens(value)) {
+    const utility = getReportableMarginUtility(token);
     if (utility) return utility;
   }
   return null;

--- a/packages/eslint-plugin/src/rules/no-tailwind-overflow-scroll.ts
+++ b/packages/eslint-plugin/src/rules/no-tailwind-overflow-scroll.ts
@@ -1,30 +1,11 @@
 import { createRule } from "../util.js";
+import { extractTailwindUtilityTokens } from "../rule-helpers/tailwind.js";
 
 const FORBIDDEN_TAILWIND_UTILITIES = new Set([
   "overflow-scroll",
   "overflow-x-scroll",
   "overflow-y-scroll",
 ]);
-
-// Tailwind important modifiers can wrap a utility token in either position,
-// for example `!overflow-scroll` or `overflow-scroll!`.
-function normalizeTailwindToken(token: string): string {
-  return token.replace(/^!|!$/g, "");
-}
-
-// Yield normalized utility tokens, for example `md:overflow-scroll!` ->
-// `overflow-scroll`.
-function* extractTailwindUtilityTokens(value: string): Generator<string> {
-  for (const match of value.matchAll(/\S+/g)) {
-    const normalizedToken = normalizeTailwindToken(match[0]);
-    const variantSeparatorIndex = normalizedToken.lastIndexOf(":");
-    yield variantSeparatorIndex === -1
-      ? normalizedToken
-      : normalizeTailwindToken(
-          normalizedToken.slice(variantSeparatorIndex + 1),
-        );
-  }
-}
 
 const rule = createRule({
   name: "no-tailwind-overflow-scroll",

--- a/packages/eslint-plugin/src/rules/require-title-with-truncate.test.ts
+++ b/packages/eslint-plugin/src/rules/require-title-with-truncate.test.ts
@@ -1,0 +1,101 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as typescriptEslintParser from "@typescript-eslint/parser";
+import rule from "./require-title-with-truncate.js";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: typescriptEslintParser,
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run("require-title-with-truncate", rule, {
+  valid: [
+    `const Card = ({ value }: { value: string }) => <div className="truncate" title={value}>{value}</div>;`,
+    `function Card({ value }: { value: string }) { return <div className="truncate" title={value}>{value}</div>; }`,
+    `const Card = () => <div className="truncate" title="Full value" />;`,
+    `const Card = () => <div title="Full value" className="truncate" />;`,
+    `const Card = () => <div data-state="open" className="truncate" title="Full value" />;`,
+    `const Card = () => <div className="text-sm" />;`,
+    `const Card = ({ value }: { value: string }) => <div className={cn("truncate", "text-sm")} title={value} />;`,
+    `function Card({ value }: { value: string }) { return <div className={cn("truncate", "text-sm")} title={value} />; }`,
+    `const Card = ({ value }: { value: string }) => <div className={clsx({ truncate: true })} title={value} />;`,
+    `const Card = ({ value }: { value: string }) => <div className={clsx({ ...styles, truncate: true })} title={value} />;`,
+    `const Card = ({ value }: { value: string }) => <div className={condition ? "truncate" : "text-sm"} title={value} />;`,
+    `const Card = (props: JSX.IntrinsicElements["div"]) => <div {...props} className="text-sm" />;`,
+    `const Card = () => <div className={styles("truncate")} />;`,
+    `const Card = ({ value }: { value: string }) => <div className={styles.truncate} />;`,
+    `const Card = () => <div className={title ? "text-sm" : "font-medium"} />;`,
+    `const Card = () => <div className title={null} />;`,
+  ],
+  invalid: [
+    {
+      code: `const Card = () => <div className="truncate" />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `function Card() { return <div className="truncate" />; }`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className="md:truncate text-sm" />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className={cn("truncate", "text-sm")} />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `function Card() { return <div className={cn("truncate", "text-sm")} />; }`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className={clsx({ truncate: isVisible })} />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className={clsx({ ...styles, truncate: isVisible })} />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className={["text-sm", "truncate"]} />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className={condition ? "truncate" : "text-sm"} />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className={condition && "truncate"} />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className={"truncate" as string} />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className={"truncate"!} />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className={"truncate" satisfies string} />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className="truncate" title={null} />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div foo:bar="baz" className="truncate" />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+    {
+      code: `const Card = () => <div className="truncate" title />;`,
+      errors: [{ messageId: "missingTitle" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/require-title-with-truncate.ts
+++ b/packages/eslint-plugin/src/rules/require-title-with-truncate.ts
@@ -1,0 +1,168 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import {
+  getStaticPropertyKeyValue,
+  getStaticStringValue,
+} from "../rule-helpers/ast.js";
+import { hasTailwindUtility } from "../rule-helpers/tailwind.js";
+import { createRule } from "../util.js";
+
+const DEFAULT_CLASS_NAME_FUNCTIONS = ["cn", "clsx"];
+const TRUNCATE_UTILITY = "truncate";
+
+type Options = [{ classNameFunctions: string[] }];
+type MessageIds = "missingTitle";
+
+function containsTruncateToken(value: string): boolean {
+  return hasTailwindUtility(value, TRUNCATE_UTILITY);
+}
+
+const rule = createRule<Options, MessageIds>({
+  name: "require-title-with-truncate",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require a title attribute on JSX elements that use the truncate utility.",
+    },
+    schema: [
+      {
+        type: "object",
+        additionalProperties: false,
+        required: ["classNameFunctions"],
+        properties: {
+          classNameFunctions: {
+            type: "array",
+            items: { type: "string", minLength: 1 },
+            uniqueItems: true,
+          },
+        },
+      },
+    ],
+    messages: {
+      missingTitle:
+        "Elements using `truncate` must also set a `title` attribute so the full text remains available.",
+    },
+  },
+  defaultOptions: [{ classNameFunctions: DEFAULT_CLASS_NAME_FUNCTIONS }],
+  create(context, [{ classNameFunctions }]) {
+    const classNameFunctionNames = new Set(classNameFunctions);
+
+    function expressionContainsTruncate(
+      node: TSESTree.Expression | TSESTree.SpreadElement,
+    ): boolean {
+      const staticValue = getStaticStringValue(node);
+      if (staticValue !== null) {
+        return containsTruncateToken(staticValue);
+      }
+
+      switch (node.type) {
+        case AST_NODE_TYPES.ArrayExpression:
+          return node.elements.some(
+            (element) => element && expressionContainsTruncate(element),
+          );
+        case AST_NODE_TYPES.CallExpression: {
+          if (
+            node.callee.type === AST_NODE_TYPES.Identifier &&
+            classNameFunctionNames.has(node.callee.name)
+          ) {
+            return node.arguments.some((argument) =>
+              expressionContainsTruncate(argument),
+            );
+          }
+
+          return false;
+        }
+        case AST_NODE_TYPES.ObjectExpression:
+          return node.properties.some((property) => {
+            if (
+              property.type !== AST_NODE_TYPES.Property ||
+              property.computed
+            ) {
+              return false;
+            }
+
+            const key = getStaticPropertyKeyValue(property.key);
+            return key !== null && containsTruncateToken(key);
+          });
+        case AST_NODE_TYPES.ConditionalExpression:
+          return (
+            expressionContainsTruncate(node.consequent) ||
+            expressionContainsTruncate(node.alternate)
+          );
+        case AST_NODE_TYPES.LogicalExpression:
+          return (
+            expressionContainsTruncate(node.left) ||
+            expressionContainsTruncate(node.right)
+          );
+        case AST_NODE_TYPES.TSAsExpression:
+        case AST_NODE_TYPES.TSNonNullExpression:
+        case AST_NODE_TYPES.TSSatisfiesExpression:
+        case AST_NODE_TYPES.TSTypeAssertion:
+          return expressionContainsTruncate(node.expression);
+        default:
+          return false;
+      }
+    }
+
+    return {
+      JSXOpeningElement(node) {
+        let hasTitle = false;
+        let classNameAttribute: TSESTree.JSXAttribute | null = null;
+
+        for (const attribute of node.attributes) {
+          if (attribute.type !== AST_NODE_TYPES.JSXAttribute) continue;
+          if (attribute.name.type !== AST_NODE_TYPES.JSXIdentifier) continue;
+
+          if (attribute.name.name === "title") {
+            if (attribute.value) {
+              if (
+                attribute.value.type !== AST_NODE_TYPES.JSXExpressionContainer
+              ) {
+                hasTitle = true;
+              } else {
+                const expression = attribute.value.expression;
+                if (
+                  expression.type !== AST_NODE_TYPES.JSXEmptyExpression &&
+                  !(
+                    expression.type === AST_NODE_TYPES.Literal &&
+                    expression.value == null
+                  )
+                ) {
+                  hasTitle = true;
+                }
+              }
+            }
+            continue;
+          }
+
+          if (attribute.name.name === "className") {
+            classNameAttribute = attribute;
+          }
+        }
+
+        if (hasTitle || !classNameAttribute) return;
+
+        const value = classNameAttribute.value;
+        if (!value) return;
+
+        const hasTruncate =
+          (value.type === AST_NODE_TYPES.Literal &&
+            typeof value.value === "string" &&
+            containsTruncateToken(value.value)) ||
+          (value.type === AST_NODE_TYPES.JSXExpressionContainer &&
+            value.expression.type !== AST_NODE_TYPES.JSXEmptyExpression &&
+            expressionContainsTruncate(value.expression));
+
+        if (!hasTruncate) return;
+
+        context.report({
+          node: classNameAttribute,
+          messageId: "missingTitle",
+        });
+      },
+    };
+  },
+});
+
+export default rule;

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -73,6 +73,18 @@ export default [
   },
 
   {
+    name: "langfuse/web/require-title-with-truncate",
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["src/**/*.stories.{ts,tsx}"],
+    rules: {
+      "@repo/require-title-with-truncate": [
+        "error",
+        { classNameFunctions: ["cn", "clsx"] },
+      ],
+    },
+  },
+
+  {
     name: "langfuse/web/design-system-rules",
     files: ["src/components/design-system/**/*.{ts,tsx}"],
     ignores: ["src/components/design-system/**/*.stories.tsx"],

--- a/web/src/components/ItemBadge.tsx
+++ b/web/src/components/ItemBadge.tsx
@@ -125,6 +125,8 @@ export function ItemBadge({
   const label =
     String(type).charAt(0).toUpperCase() + String(type).slice(1).toLowerCase();
 
+  const displayLabel = label.replace(/_/g, " ");
+
   return (
     <Badge
       variant="outline"
@@ -136,8 +138,8 @@ export function ItemBadge({
     >
       <Icon className={iconClass} />
       {showLabel && (
-        <span className="truncate" title={label.replace(/_/g, " ")}>
-          {label.replace(/_/g, " ")}
+        <span className="truncate" title={displayLabel}>
+          {displayLabel}
         </span>
       )}
     </Badge>

--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -74,49 +74,53 @@ const ScoreGroupBadge = <
         {name}:
       </div>
       <div className="flex min-w-0 items-center gap-1 text-nowrap">
-        {scores.map((s, i) => (
-          <span
-            key={i}
-            className="group/score ml-1 flex min-w-0 items-center gap-1 rounded-sm first:ml-0"
-          >
-            <span className="truncate">
-              {s.stringValue ?? s.value?.toFixed(2) ?? ""}
+        {scores.map((s, i) => {
+          const scoreDisplayValue = s.stringValue ?? s.value?.toFixed(2) ?? "";
+
+          return (
+            <span
+              key={i}
+              className="group/score ml-1 flex min-w-0 items-center gap-1 rounded-sm first:ml-0"
+            >
+              <span className="truncate" title={scoreDisplayValue}>
+                {scoreDisplayValue}
+              </span>
+              {s.comment && (
+                <HoverCard>
+                  <HoverCardTrigger className="inline-block shrink-0">
+                    <MessageCircleMoreIcon className="mb-0.25 size-3!" />
+                  </HoverCardTrigger>
+                  <HoverCardContent className="max-h-[50dvh] overflow-y-auto text-xs break-normal whitespace-normal">
+                    <p className="whitespace-pre-wrap">{s.comment}</p>
+                    {"executionTraceId" in s &&
+                      s.executionTraceId &&
+                      projectId && (
+                        <Link
+                          href={`/project/${projectId}/traces/${encodeURIComponent(s.executionTraceId)}`}
+                          className="mt-2 flex items-center gap-1 text-blue-600 hover:underline"
+                          target="_blank"
+                        >
+                          <ExternalLinkIcon className="h-3 w-3" />
+                          View execution trace
+                        </Link>
+                      )}
+                  </HoverCardContent>
+                </HoverCard>
+              )}
+              {hasMetadata(s) && (
+                <HoverCard>
+                  <HoverCardTrigger className="inline-block shrink-0">
+                    <BracesIcon className="mb-0.25 size-3!" />
+                  </HoverCardTrigger>
+                  <HoverCardContent className="max-h-[50dvh] overflow-y-auto rounded-md border-none p-0 text-xs break-normal whitespace-normal">
+                    <JSONView codeClassName="rounded-md!" json={s.metadata} />
+                  </HoverCardContent>
+                </HoverCard>
+              )}
+              <span className="group-last/score:hidden">,</span>
             </span>
-            {s.comment && (
-              <HoverCard>
-                <HoverCardTrigger className="inline-block shrink-0">
-                  <MessageCircleMoreIcon className="mb-0.25 size-3!" />
-                </HoverCardTrigger>
-                <HoverCardContent className="max-h-[50dvh] overflow-y-auto text-xs break-normal whitespace-normal">
-                  <p className="whitespace-pre-wrap">{s.comment}</p>
-                  {"executionTraceId" in s &&
-                    s.executionTraceId &&
-                    projectId && (
-                      <Link
-                        href={`/project/${projectId}/traces/${encodeURIComponent(s.executionTraceId)}`}
-                        className="mt-2 flex items-center gap-1 text-blue-600 hover:underline"
-                        target="_blank"
-                      >
-                        <ExternalLinkIcon className="h-3 w-3" />
-                        View execution trace
-                      </Link>
-                    )}
-                </HoverCardContent>
-              </HoverCard>
-            )}
-            {hasMetadata(s) && (
-              <HoverCard>
-                <HoverCardTrigger className="inline-block shrink-0">
-                  <BracesIcon className="mb-0.25 size-3!" />
-                </HoverCardTrigger>
-                <HoverCardContent className="max-h-[50dvh] overflow-y-auto rounded-md border-none p-0 text-xs break-normal whitespace-normal">
-                  <JSONView codeClassName="rounded-md!" json={s.metadata} />
-                </HoverCardContent>
-              </HoverCard>
-            )}
-            <span className="group-last/score:hidden">,</span>
-          </span>
-        ))}
+          );
+        })}
       </div>
     </Badge>
   );

--- a/web/src/components/nav/nav-user.tsx
+++ b/web/src/components/nav/nav-user.tsx
@@ -99,7 +99,9 @@ export function NavUser({ user, items }: UserNavigationProps) {
                 </AvatarFallback>
               </Avatar>
               <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-semibold">{user.name}</span>
+                <span className="truncate font-semibold" title={user.name}>
+                  {user.name}
+                </span>
                 <span className="truncate text-xs" title={user.email}>
                   {user.email}
                 </span>
@@ -126,7 +128,9 @@ export function NavUser({ user, items }: UserNavigationProps) {
                   </AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-semibold">{user.name}</span>
+                  <span className="truncate font-semibold" title={user.name}>
+                    {user.name}
+                  </span>
                   <span className="truncate text-xs" title={user.email}>
                     {user.email}
                   </span>

--- a/web/src/components/scores-table-cell.tsx
+++ b/web/src/components/scores-table-cell.tsx
@@ -34,7 +34,9 @@ const ScoreValueCounts = ({
 }) => {
   return valueCounts.map(({ value, count }, index) => (
     <span key={value} className="inline-block">
-      <span className="truncate">{value}</span>
+      <span className="truncate" title={value}>
+        {value}
+      </span>
       <span>{`: ${numberFormatter(count, 0)}`}</span>
       {index < valueCounts.length - 1 && (
         <span className="mr-1">{wrap ? "" : "; "}</span>
@@ -79,7 +81,9 @@ export const ScoresTableCell = ({
           COLOR_MAP.get(value),
         )}
       >
-        <span className="truncate">{value}</span>
+        <span className="truncate" title={value}>
+          {value}
+        </span>
         {aggregate.comment && (
           <HoverCard>
             <HoverCardTrigger className="inline-block shrink-0 cursor-pointer">

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -107,19 +107,25 @@ export function SessionUsers({
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      {initialUsers.map((userId: string) => (
-        <Link
-          key={userId}
-          href={`/project/${projectId}/users/${encodeURIComponent(userId ?? "")}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Badge className="max-w-[300px]">
-            <span className="truncate">User ID: {userId}</span>
-            <ExternalLinkIcon className="ml-1 h-3 w-3" />
-          </Badge>
-        </Link>
-      ))}
+      {initialUsers.map((userId: string) => {
+        const userBadgeText = `User ID: ${userId}`;
+
+        return (
+          <Link
+            key={userId}
+            href={`/project/${projectId}/users/${encodeURIComponent(userId ?? "")}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Badge className="max-w-[300px]">
+              <span className="truncate" title={userBadgeText}>
+                {userBadgeText}
+              </span>
+              <ExternalLinkIcon className="ml-1 h-3 w-3" />
+            </Badge>
+          </Link>
+        );
+      })}
 
       {remainingUsers.length > 0 && (
         <Popover modal>
@@ -137,20 +143,26 @@ export function SessionUsers({
                     page * USERS_PER_PAGE_IN_POPOVER,
                     (page + 1) * USERS_PER_PAGE_IN_POPOVER,
                   )
-                  .map((userId: string) => (
-                    <Link
-                      key={userId}
-                      href={`/project/${projectId}/users/${encodeURIComponent(userId ?? "")}`}
-                      className="hover:bg-accent block"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <Badge className="max-w-[260px]">
-                        <span className="truncate">User ID: {userId}</span>
-                        <ExternalLinkIcon className="ml-1 h-3 w-3" />
-                      </Badge>
-                    </Link>
-                  ))}
+                  .map((userId: string) => {
+                    const userBadgeText = `User ID: ${userId}`;
+
+                    return (
+                      <Link
+                        key={userId}
+                        href={`/project/${projectId}/users/${encodeURIComponent(userId ?? "")}`}
+                        className="hover:bg-accent block"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <Badge className="max-w-[260px]">
+                          <span className="truncate" title={userBadgeText}>
+                            {userBadgeText}
+                          </span>
+                          <ExternalLinkIcon className="ml-1 h-3 w-3" />
+                        </Badge>
+                      </Link>
+                    );
+                  })}
               </div>
             </ScrollArea>
             {remainingUsers.length > USERS_PER_PAGE_IN_POPOVER && (

--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -270,6 +270,9 @@ function ValueCellActionsMenu({
     );
   };
 
+  const includeFilterText = `metadata.${metadataKey} ${includeOperator} ${displayValue}`;
+  const excludeFilterText = `metadata.${metadataKey} ${excludeOperator} ${displayValue}`;
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -307,8 +310,11 @@ function ValueCellActionsMenu({
               <Filter className="mr-2 h-3.5 w-3.5 shrink-0" />
               <span className="flex min-w-0 flex-col">
                 <span>Include in filter</span>
-                <span className="text-muted-foreground truncate font-mono">
-                  metadata.{metadataKey} {includeOperator} {displayValue}
+                <span
+                  className="text-muted-foreground truncate font-mono"
+                  title={includeFilterText}
+                >
+                  {includeFilterText}
                 </span>
               </span>
             </DropdownMenuItem>
@@ -319,8 +325,11 @@ function ValueCellActionsMenu({
               <FilterX className="mr-2 h-3.5 w-3.5 shrink-0" />
               <span className="flex min-w-0 flex-col">
                 <span>Exclude from filter</span>
-                <span className="text-muted-foreground truncate font-mono">
-                  metadata.{metadataKey} {excludeOperator} {displayValue}
+                <span
+                  className="text-muted-foreground truncate font-mono"
+                  title={excludeFilterText}
+                >
+                  {excludeFilterText}
                 </span>
               </span>
             </DropdownMenuItem>

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -243,6 +243,13 @@ export function DataTableToolbar<TData, TValue>({
     searchConfig?.updateQuery(query);
   };
 
+  const searchButtonLabel = searchConfig?.tableAllowsFullTextSearch
+    ? getSearchButtonLabel(
+        searchConfig.searchType,
+        searchConfig.customDropdownLabels?.metadata,
+      )
+    : undefined;
+
   // Only show the toggle button when we're using the new sidebar
   const hasNewSidebar = !filterColumnDefinition && filterState !== undefined;
   return (
@@ -321,12 +328,11 @@ export function DataTableToolbar<TData, TValue>({
                     size="default"
                     className="flex w-30 items-center justify-between gap-1 rounded-l-none border-l-0"
                   >
-                    <span className="flex items-center gap-1 truncate">
-                      {searchConfig.tableAllowsFullTextSearch &&
-                        getSearchButtonLabel(
-                          searchConfig.searchType,
-                          searchConfig.customDropdownLabels?.metadata,
-                        )}
+                    <span
+                      className="flex items-center gap-1 truncate"
+                      title={searchButtonLabel}
+                    >
+                      {searchButtonLabel}
                       <DocPopup
                         description={getSearchDescription(
                           searchConfig.searchType,

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -10,6 +10,7 @@ import React, {
 } from "react";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { DataTablePagination } from "@/src/components/table/data-table-pagination";
+import { getPlainTextFromReactNode } from "@/src/utils/react-node-plain-text";
 import {
   type CustomHeights,
   type RowHeight,
@@ -480,7 +481,15 @@ export function DataTable<TData extends object, TValue>({
                       >
                         {header.isPlaceholder ? null : (
                           <div className="flex items-center select-none">
-                            <span className="truncate leading-normal">
+                            <span
+                              className="truncate leading-normal"
+                              title={getPlainTextFromReactNode(
+                                flexRender(
+                                  header.column.columnDef.header,
+                                  header.getContext(),
+                                ),
+                              )}
+                            >
                               {flexRender(
                                 header.column.columnDef.header,
                                 header.getContext(),
@@ -806,7 +815,15 @@ function TableBodyComponent<TData>({
                     )}
                   >
                     {isStringCell && isSmallRowHeight ? (
-                      <div className="min-w-0 truncate leading-normal">
+                      <div
+                        className="min-w-0 truncate leading-normal"
+                        title={getPlainTextFromReactNode(
+                          flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          ),
+                        )}
+                      >
                         {flexRender(
                           cell.column.columnDef.cell,
                           cell.getContext(),

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -573,6 +573,7 @@ export function TableViewPresetsDrawer({
                                   ? "flex items-center gap-1.5"
                                   : "truncate",
                               )}
+                              title={view.name}
                             >
                               {isSystemView && <LangfuseIcon size={14} />}
                               {view.name}

--- a/web/src/components/table/use-cases/models.tsx
+++ b/web/src/components/table/use-cases/models.tsx
@@ -117,7 +117,10 @@ export default function ModelTable({ projectId }: { projectId: string }) {
       },
       cell: ({ row }) => {
         return (
-          <span className="truncate font-mono text-xs font-semibold">
+          <span
+            className="truncate font-mono text-xs font-semibold"
+            title={row.original.modelName}
+          >
             {row.original.modelName}
           </span>
         );
@@ -164,7 +167,9 @@ export default function ModelTable({ projectId }: { projectId: string }) {
         const value: string = row.getValue("matchPattern");
 
         return value ? (
-          <span className="truncate font-mono text-xs">{value}</span>
+          <span className="truncate font-mono text-xs" title={value}>
+            {value}
+          </span>
         ) : null;
       },
     },

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -966,6 +966,7 @@ export default function ObservationsTable({
           <Badge
             variant="secondary"
             className="max-w-fit truncate rounded-sm px-1 font-normal"
+            title={value}
           >
             {value}
           </Badge>

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -567,6 +567,7 @@ export default function ScoresTable({
           <Badge
             variant="secondary"
             className="max-w-fit truncate rounded-sm px-1 font-normal"
+            title={value}
           >
             {value}
           </Badge>

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -532,6 +532,7 @@ export default function SessionsTable({
           <Badge
             variant="secondary"
             className="max-w-fit truncate rounded-sm px-1 font-normal"
+            title={value}
           >
             {value}
           </Badge>

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -835,6 +835,7 @@ export default function TracesTable({
           <Badge
             variant="secondary"
             className="max-w-fit truncate rounded-sm px-1 font-normal"
+            title={value}
           >
             {value}
           </Badge>

--- a/web/src/components/trace/components/IOPreview/components/ToolCallDefinitionCard.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ToolCallDefinitionCard.tsx
@@ -70,7 +70,10 @@ function ToolCallArgumentsList({
                 Call {toolCall.invocationNumber}
               </div>
               {toolCall.id && (
-                <div className="text-muted-foreground truncate font-mono text-xs">
+                <div
+                  className="text-muted-foreground truncate font-mono text-xs"
+                  title={toolCall.id}
+                >
                   {toolCall.id}
                 </div>
               )}

--- a/web/src/components/trace/components/ObservationDetailView/ObservationMetadataBadgeModel.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationMetadataBadgeModel.tsx
@@ -30,7 +30,9 @@ export function ModelBadge({
           className="flex items-center"
           title="View model details"
         >
-          <span className="truncate">{model}</span>
+          <span className="truncate" title={model}>
+            {model}
+          </span>
           <ExternalLinkIcon className="ml-1 h-3 w-3" />
         </Link>
       </Badge>

--- a/web/src/components/trace/components/SpanContent.tsx
+++ b/web/src/components/trace/components/SpanContent.tsx
@@ -109,6 +109,8 @@ export function SpanContent({
           )
         : mergedScores.filter((s) => s.observationId === node.id);
 
+  const nodeDisplayName = node.name || `Unnamed ${node.type.toLowerCase()}`;
+
   return (
     <button
       type="button"
@@ -126,8 +128,8 @@ export function SpanContent({
       <div className="flex min-w-0 flex-col">
         {/* Name and badges row */}
         <div className="flex min-w-0 items-center gap-2 overflow-hidden">
-          <span className="shrink truncate text-xs">
-            {node.name || `Unnamed ${node.type.toLowerCase()}`}
+          <span className="shrink truncate text-xs" title={nodeDisplayName}>
+            {nodeDisplayName}
           </span>
 
           <div className="flex items-center gap-x-2">

--- a/web/src/components/trace/components/TraceDetailView/TraceMetadataBadges.tsx
+++ b/web/src/components/trace/components/TraceDetailView/TraceMetadataBadges.tsx
@@ -17,13 +17,18 @@ export function SessionBadge({
   projectId: string;
 }) {
   if (!sessionId) return null;
+
+  const text = `Session: ${sessionId}`;
+
   return (
     <Link
       href={`/project/${projectId}/sessions/${encodeURIComponent(sessionId)}`}
       className="inline-flex"
     >
       <Badge>
-        <span className="truncate">Session: {sessionId}</span>
+        <span className="truncate" title={text}>
+          {text}
+        </span>
         <ExternalLinkIcon className="ml-1 h-3 w-3" />
       </Badge>
     </Link>
@@ -38,13 +43,18 @@ export function UserIdBadge({
   projectId: string;
 }) {
   if (!userId) return null;
+
+  const text = `User ID: ${userId}`;
+
   return (
     <Link
       href={`/project/${projectId}/users/${encodeURIComponent(userId)}`}
       className="inline-flex"
     >
       <Badge>
-        <span className="truncate">User ID: {userId}</span>
+        <span className="truncate" title={text}>
+          {text}
+        </span>
         <ExternalLinkIcon className="ml-1 h-3 w-3" />
       </Badge>
     </Link>
@@ -59,13 +69,18 @@ export function TargetTraceBadge({
   projectId: string;
 }) {
   if (!targetTraceId) return null;
+
+  const text = `Target Trace: ${targetTraceId}`;
+
   return (
     <Link
       href={`/project/${projectId}/traces/${encodeURIComponent(targetTraceId)}`}
       className="inline-flex"
     >
       <Badge>
-        <span className="truncate">Target Trace: {targetTraceId}</span>
+        <span className="truncate" title={text}>
+          {text}
+        </span>
         <ExternalLinkIcon className="ml-1 h-3 w-3" />
       </Badge>
     </Link>

--- a/web/src/components/trace/components/TraceLogView/LogViewObservationCell.tsx
+++ b/web/src/components/trace/components/TraceLogView/LogViewObservationCell.tsx
@@ -88,7 +88,9 @@ export const LogViewObservationCell = memo(function LogViewObservationCell({
       style={{ paddingLeft: indent }}
     >
       <ItemBadge type={item.node.type} isSmall />
-      <span className="truncate">{displayName}</span>
+      <span className="truncate" title={displayName}>
+        {displayName}
+      </span>
       {childrenCount > 0 && (
         <span className="text-muted-foreground shrink-0 text-xs">
           {childrenCount} {childrenCount === 1 ? "item" : "items"}

--- a/web/src/components/trace/components/_shared/JSONTableView/JSONTableViewRow.tsx
+++ b/web/src/components/trace/components/_shared/JSONTableView/JSONTableViewRow.tsx
@@ -7,6 +7,7 @@
 import { memo } from "react";
 import { ChevronRight, ChevronDown } from "lucide-react";
 import { cn } from "@/src/utils/tailwind";
+import { getPlainTextFromReactNode } from "@/src/utils/react-node-plain-text";
 import { useClickWithoutSelection } from "@/src/hooks/useClickWithoutSelection";
 import { type JSONTableViewRowProps } from "./json-table-view-types";
 
@@ -67,20 +68,29 @@ function JSONTableViewRowInner<T>({
         )}
 
         {/* Column cells */}
-        {columns.map((column) => (
-          <div
-            key={column.key}
-            className={cn(
-              "shrink-0 text-sm",
-              column.width ?? "min-w-0 flex-1",
-              column.align === "right" && "text-right",
-              // Truncate flex-1 columns
-              column.width === "flex-1" && "truncate",
-            )}
-          >
-            {column.render(item, index)}
-          </div>
-        ))}
+        {columns.map((column) => {
+          const renderedCell = column.render(item, index);
+
+          return (
+            <div
+              key={column.key}
+              className={cn(
+                "shrink-0 text-sm",
+                column.width ?? "min-w-0 flex-1",
+                column.align === "right" && "text-right",
+                // Truncate flex-1 columns
+                column.width === "flex-1" && "truncate",
+              )}
+              title={
+                column.width === "flex-1"
+                  ? getPlainTextFromReactNode(renderedCell)
+                  : undefined
+              }
+            >
+              {renderedCell}
+            </div>
+          );
+        })}
       </div>
 
       {/* Expanded content */}

--- a/web/src/components/trace/components/_shared/PromptBadge.tsx
+++ b/web/src/components/trace/components/_shared/PromptBadge.tsx
@@ -11,16 +11,16 @@ export const PromptBadge = (props: { promptId: string; projectId: string }) => {
 
   if (prompt.isLoading || !prompt.data) return null;
 
+  const text = `Prompt: ${prompt.data.name} - v${prompt.data.version}`;
+
   return (
     <Link
       href={`/project/${props.projectId}/prompts/${encodeURIComponent(prompt.data.name)}?version=${prompt.data.version}`}
       className="inline-flex"
     >
       <Badge variant="tertiary">
-        <span className="truncate">
-          Prompt: {prompt.data.name}
-          {" - v"}
-          {prompt.data.version}
+        <span className="truncate" title={text}>
+          {text}
         </span>
         <ExternalLinkIcon className="ml-1 h-3 w-3" />
       </Badge>

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -269,7 +269,10 @@ export function CodeView(props: {
       <div className="animate-appear relative h-3">
         <Check className="h-3 w-3" />
         {copiedToClipboardMessage && (
-          <div className="text-secondary-foreground absolute top-0 right-0 mr-6 h-full max-w-[60vw] transform truncate overflow-hidden text-right text-sm leading-none whitespace-nowrap">
+          <div
+            className="text-secondary-foreground absolute top-0 right-0 mr-6 h-full max-w-[60vw] transform truncate overflow-hidden text-right text-sm leading-none whitespace-nowrap"
+            title={copiedToClipboardMessage}
+          >
             {copiedToClipboardMessage}
           </div>
         )}

--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -39,6 +39,10 @@ const IOTableCellContent = ({
   const shouldTruncate =
     stringifiedJson && stringifiedJson.length > IO_TABLE_CHAR_LIMIT;
 
+  const singleLineText = stringifiedJson
+    ? decodeUnicodeEscapesOnly(stringifiedJson, true)
+    : stringifiedJson;
+
   return singleLine ? (
     <div
       className={cn(
@@ -46,10 +50,9 @@ const IOTableCellContent = ({
         paddingClassName,
         className,
       )}
+      title={singleLineText}
     >
-      {stringifiedJson
-        ? decodeUnicodeEscapesOnly(stringifiedJson, true)
-        : stringifiedJson}
+      {singleLineText}
     </div>
   ) : shouldTruncate ? (
     <div className="grid h-full grid-cols-1">

--- a/web/src/components/ui/LangfuseMediaView.tsx
+++ b/web/src/components/ui/LangfuseMediaView.tsx
@@ -69,15 +69,20 @@ export const LangfuseMediaView = ({
     };
   }
 
-  if (!mediaData)
+  if (!mediaData) {
+    const text = "Invalid Langfuse Media Tag";
+
     return (
       <div className="flex items-center gap-2">
-        <span title="Invalid Langfuse Media Tag">
+        <span title={text}>
           <ImageOff className="h-4 w-4" />
         </span>
-        <span className="truncate text-sm">Invalid Langfuse Media Tag</span>
+        <span className="truncate text-sm" title={text}>
+          {text}
+        </span>
       </div>
     );
+  }
 
   const { data } = api.media.getById.useQuery(
     {

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -572,7 +572,10 @@ export function MarkdownView({
                   <span title="<Base64 data URI>" className="h-4 w-4">
                     <ImageOff className="h-4 w-4" />
                   </span>
-                  <span className="truncate text-sm">
+                  <span
+                    className="truncate text-sm"
+                    title={imageUrl.toString()}
+                  >
                     {imageUrl.toString()}
                   </span>
                 </div>

--- a/web/src/components/ui/PromptReferences.tsx
+++ b/web/src/components/ui/PromptReferences.tsx
@@ -162,6 +162,15 @@ export const PromptReferenceButton = ({
     );
   }
 
+  const promptRefSuffix =
+    promptRef.type === "version"
+      ? ` (v${promptRef.version})`
+      : promptRef.label
+        ? ` (${promptRef.label})`
+        : "";
+
+  const promptRefTitle = `${promptRef.name}${promptRefSuffix}`;
+
   return (
     <Button
       variant="outline"
@@ -171,10 +180,10 @@ export const PromptReferenceButton = ({
       onClick={() =>
         window.open(getPromptReferenceUrl(projectId, promptRef), "_blank")
       }
-      title={`Open prompt: ${promptRef.name}${promptRef.type === "version" ? ` (v${promptRef.version})` : promptRef.label ? ` (${promptRef.label})` : ""}`}
+      title={`Open prompt: ${promptRefTitle}`}
     >
       <FileCode className="text-muted-foreground h-3 w-3 shrink-0" />
-      <span className="truncate font-medium">
+      <span className="truncate font-medium" title={promptRefTitle}>
         {promptRef.name}
         {promptRef.type === "version" ? (
           <Badge variant="outline" className="ml-1 px-1 py-0 text-[10px]">

--- a/web/src/components/ui/chart.tsx
+++ b/web/src/components/ui/chart.tsx
@@ -10,6 +10,7 @@ import type {
 
 import { cn } from "@/src/utils/tailwind";
 import { Layer } from "@/src/components/ui/layer";
+import { getPlainTextFromReactNode } from "@/src/utils/react-node-plain-text";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;
@@ -243,6 +244,10 @@ const ChartTooltipContent = React.forwardRef<
           {displayPayload.map((item, index) => {
             const key = `${nameKey || item.name || item.dataKey || "value"}`;
             const itemConfig = getPayloadConfigFromPayload(config, item, key);
+            const itemDisplayName = nameFormatter
+              ? nameFormatter(String(item.name ?? item.dataKey ?? ""))
+              : itemConfig?.label || item.name;
+            const itemDisplayTitle = getPlainTextFromReactNode(itemDisplayName);
             const indicatorColor =
               color ||
               getFillColor(item.payload) ||
@@ -304,12 +309,9 @@ const ChartTooltipContent = React.forwardRef<
                             "text-muted-foreground truncate",
                             highlighted && "text-foreground font-medium",
                           )}
+                          title={itemDisplayTitle}
                         >
-                          {nameFormatter
-                            ? nameFormatter(
-                                String(item.name ?? item.dataKey ?? ""),
-                              )
-                            : itemConfig?.label || item.name}
+                          {itemDisplayName}
                         </span>
                       </div>
                       {item.value !== undefined && item.value !== null && (

--- a/web/src/components/ui/combobox.tsx
+++ b/web/src/components/ui/combobox.tsx
@@ -104,6 +104,10 @@ export function Combobox<T extends string | number | boolean | { id: string }>({
     return options.find((option) => isEqual(option.value, value));
   }, [options, value]);
 
+  const buttonText = selectedOption
+    ? (selectedOption.label ?? String(selectedOption.value))
+    : placeholder;
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -119,10 +123,8 @@ export function Combobox<T extends string | number | boolean | { id: string }>({
           disabled={disabled}
           name={name}
         >
-          <span className="truncate">
-            {selectedOption
-              ? (selectedOption.label ?? String(selectedOption.value))
-              : placeholder}
+          <span className="truncate" title={buttonText}>
+            {buttonText}
           </span>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>

--- a/web/src/components/ui/media/MediaTag.tsx
+++ b/web/src/components/ui/media/MediaTag.tsx
@@ -207,7 +207,10 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
             }}
           >
             <KindIcon kind={kind} className="h-2.5 w-2.5 shrink-0" />
-            <span className="relative top-0.25 truncate align-baseline font-mono leading-none">
+            <span
+              className="relative top-0.25 truncate align-baseline font-mono leading-none"
+              title={chipLabel}
+            >
               {chipLabel}
             </span>
           </button>
@@ -219,7 +222,10 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
           <div className="flex items-center justify-between gap-4">
             <div className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs">
               <KindIcon kind={kind} className="h-3.5 w-3.5 shrink-0" />
-              <span className="truncate font-mono leading-none">
+              <span
+                className="truncate font-mono leading-none"
+                title={contentType}
+              >
                 {contentType}
               </span>
             </div>

--- a/web/src/components/ui/resizable-image.tsx
+++ b/web/src/components/ui/resizable-image.tsx
@@ -46,13 +46,16 @@ const ImageErrorDisplay = ({
         <Link
           href={safeSrc}
           className="truncate text-sm underline"
+          title={src}
           target="_blank"
           rel="noopener noreferrer"
         >
           {src}
         </Link>
       ) : (
-        <span className="truncate text-sm">{src}</span>
+        <span className="truncate text-sm" title={src}>
+          {src}
+        </span>
       )}
     </div>
   );

--- a/web/src/components/ui/shadcn-io/dropzone/index.tsx
+++ b/web/src/components/ui/shadcn-io/dropzone/index.tsx
@@ -130,17 +130,20 @@ export const DropzoneContent = ({
     return children;
   }
 
+  const text =
+    src.length > maxLabelItems
+      ? `${new Intl.ListFormat("en").format(
+          src.slice(0, maxLabelItems).map((file) => file.name),
+        )} and ${src.length - maxLabelItems} more`
+      : new Intl.ListFormat("en").format(src.map((file) => file.name));
+
   return (
     <div className={cn("flex flex-col items-center justify-center", className)}>
       <div className="bg-muted text-muted-foreground flex size-8 items-center justify-center rounded-md">
         <UploadIcon size={16} />
       </div>
-      <p className="my-2 w-full truncate text-sm font-medium">
-        {src.length > maxLabelItems
-          ? `${new Intl.ListFormat("en").format(
-              src.slice(0, maxLabelItems).map((file) => file.name),
-            )} and ${src.length - maxLabelItems} more`
-          : new Intl.ListFormat("en").format(src.map((file) => file.name))}
+      <p className="my-2 w-full truncate text-sm font-medium" title={text}>
+        {text}
       </p>
       <p className="text-muted-foreground w-full text-xs text-wrap">
         Drag and drop or click to replace
@@ -183,16 +186,25 @@ export const DropzoneEmptyState = ({
     caption += ` less than ${renderBytes(maxSize)}`;
   }
 
+  const text1 = `Upload ${maxFiles === 1 ? "a file" : "files"}`;
+  const text2 = "Drag and drop or click to upload";
+
   return (
     <div className={cn("flex flex-col items-center justify-center", className)}>
       <div className="bg-muted text-muted-foreground flex size-8 items-center justify-center rounded-md">
         <UploadIcon size={16} />
       </div>
-      <p className="my-2 w-full truncate text-sm font-medium text-wrap">
-        Upload {maxFiles === 1 ? "a file" : "files"}
+      <p
+        className="my-2 w-full truncate text-sm font-medium text-wrap"
+        title={text1}
+      >
+        {text1}
       </p>
-      <p className="text-muted-foreground w-full truncate text-xs text-wrap">
-        Drag and drop or click to upload
+      <p
+        className="text-muted-foreground w-full truncate text-xs text-wrap"
+        title={text2}
+      >
+        {text2}
       </p>
       {caption && (
         <p className="text-muted-foreground text-xs text-wrap">{caption}.</p>

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -586,6 +586,7 @@ const SidebarMenuButton = React.forwardRef<
         data-size={size}
         data-active={isActive}
         className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+        title={props.title}
         {...props}
       />
     );
@@ -755,6 +756,7 @@ const SidebarMenuSubButton = React.forwardRef<
         "group-data-[collapsible=icon]:hidden",
         className,
       )}
+      title={props.title}
       {...props}
     />
   );

--- a/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -382,6 +382,8 @@ function MessageFeedbackControls({
       .catch(() => undefined);
   };
 
+  const commentButtonText = `Comment: ${committedComment}`;
+
   return (
     <Popover
       open={!isFeedbackDisabled && isCommentPopoverOpen}
@@ -423,10 +425,11 @@ function MessageFeedbackControls({
         <button
           type="button"
           className="text-muted-foreground hover:text-foreground ml-1 min-w-0 flex-1 truncate text-left text-xs disabled:cursor-not-allowed disabled:opacity-60"
+          title={commentButtonText}
           disabled={isDisabled}
           onClick={() => setIsCommentPopoverOpen(true)}
         >
-          Comment: {committedComment}
+          {commentButtonText}
         </button>
       ) : null}
       {selectedValue ? (
@@ -500,7 +503,10 @@ function SourcesPopover({
                 className="bg-muted size-3.5 shrink-0 rounded-sm bg-cover bg-center"
                 style={{ backgroundImage: `url("${source.faviconUrl}")` }}
               />
-              <span className="text-foreground min-w-0 flex-1 truncate text-xs">
+              <span
+                className="text-foreground min-w-0 flex-1 truncate text-xs"
+                title={source.title}
+              >
                 {source.title}
               </span>
             </a>
@@ -616,7 +622,9 @@ function ToolCallGroup({
         ) : (
           <Wrench className={cn("text-muted-foreground shrink-0", iconSize)} />
         )}
-        <span className="min-w-0 flex-1 truncate py-0.5">{label}</span>
+        <span className="min-w-0 flex-1 truncate py-0.5" title={label}>
+          {label}
+        </span>
         <span className="text-muted-foreground text-xs group-open/tool-group:hidden">
           Show
         </span>
@@ -629,14 +637,18 @@ function ToolCallGroup({
       >
         {tools.map((tool, index) => {
           const resultLabel = tool.error ? "Error" : "Result";
+          const toolLabel = `Used ${tool.name}`;
 
           return (
             <div key={`${tool.name}-${index}`} className="rounded-lg">
               <details className="group/tool min-w-0">
                 <summary className="flex cursor-pointer list-none items-center gap-2 text-xs leading-none font-medium [&::-webkit-details-marker]:hidden">
                   <Wrench className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-                  <span className="min-w-0 flex-1 truncate py-0.5">
-                    Used {tool.name}
+                  <span
+                    className="min-w-0 flex-1 truncate py-0.5"
+                    title={toolLabel}
+                  >
+                    {toolLabel}
                   </span>
                   <span className="text-muted-foreground text-xs group-open/tool:hidden">
                     Show

--- a/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.tsx
@@ -21,6 +21,8 @@ export function InAppAgentToolCallCard({
   const isApprovalPending = approval?.status === "pending";
   const isApprovalSubmitting = approval?.status === "submitting";
   const resultLabel = tool.error ? "Error" : "Result";
+  const approveLabel = `Approve ${tool.name}?`;
+  const usedLabel = `Used ${tool.name}`;
 
   return (
     <div
@@ -35,8 +37,11 @@ export function InAppAgentToolCallCard({
         <div className="min-w-0">
           <div className="flex items-center gap-2 text-xs leading-none font-medium">
             <Wrench className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-            <span className="min-w-0 flex-1 truncate py-0.5">
-              Approve {tool.name}?
+            <span
+              className="min-w-0 flex-1 truncate py-0.5"
+              title={approveLabel}
+            >
+              {approveLabel}
             </span>
           </div>
           <div className="mt-2 space-y-2">
@@ -82,8 +87,8 @@ export function InAppAgentToolCallCard({
         <details className="group/tool min-w-0">
           <summary className="flex cursor-pointer list-none items-center gap-2 text-xs leading-none font-medium [&::-webkit-details-marker]:hidden">
             <Wrench className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-            <span className="min-w-0 flex-1 truncate py-0.5">
-              Used {tool.name}
+            <span className="min-w-0 flex-1 truncate py-0.5" title={usedLabel}>
+              {usedLabel}
             </span>
             <span className="text-muted-foreground text-xs group-open/tool:hidden">
               Show

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -235,7 +235,12 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
         )}
       >
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <p className="shrink-0 truncate text-sm font-semibold">Assistant</p>
+          <p
+            className="shrink-0 truncate text-sm font-semibold"
+            title="Assistant"
+          >
+            Assistant
+          </p>
           <span className="text-muted-foreground rounded border px-1.5 py-1 text-xs leading-none font-medium">
             Beta
           </span>
@@ -292,37 +297,45 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                   No conversations yet
                 </DropdownMenuItem>
               ) : (
-                conversations.map((conversation) => (
-                  <DropdownMenuItem
-                    key={conversation.id}
-                    className={cn(
-                      "flex items-center gap-1",
-                      conversation.id === selectedConversationId &&
-                        "bg-accent text-accent-foreground",
-                    )}
-                    onSelect={() => onSelectConversation(conversation.id)}
-                  >
-                    <span className="min-w-0 flex-1 truncate">
-                      {conversation.title?.trim() || "Untitled conversation"}
-                    </span>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      className="text-muted-foreground hover:text-destructive -mr-1.5 shrink-0"
-                      disabled={isInputDisabled}
-                      aria-label="Delete conversation"
-                      onClick={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        setIsConversationHistoryOpen(false);
-                        onDeleteConversation(conversation);
-                      }}
+                conversations.map((conversation) => {
+                  const conversationTitle =
+                    conversation.title?.trim() || "Untitled conversation";
+
+                  return (
+                    <DropdownMenuItem
+                      key={conversation.id}
+                      className={cn(
+                        "flex items-center gap-1",
+                        conversation.id === selectedConversationId &&
+                          "bg-accent text-accent-foreground",
+                      )}
+                      onSelect={() => onSelectConversation(conversation.id)}
                     >
-                      <Trash2 className="size-3" />
-                    </Button>
-                  </DropdownMenuItem>
-                ))
+                      <span
+                        className="min-w-0 flex-1 truncate"
+                        title={conversationTitle}
+                      >
+                        {conversationTitle}
+                      </span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        className="text-muted-foreground hover:text-destructive -mr-1.5 shrink-0"
+                        disabled={isInputDisabled}
+                        aria-label="Delete conversation"
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          setIsConversationHistoryOpen(false);
+                          onDeleteConversation(conversation);
+                        }}
+                      >
+                        <Trash2 className="size-3" />
+                      </Button>
+                    </DropdownMenuItem>
+                  );
+                })
               )}
               {hasMoreConversations ? (
                 <>

--- a/web/src/features/annotation-queues/components/UserAssignmentSection.tsx
+++ b/web/src/features/annotation-queues/components/UserAssignmentSection.tsx
@@ -112,39 +112,52 @@ export const UserAssignmentSection = ({
             }, 100);
           }
         }}
-        renderSelectedItem={(user, onRemove) => (
-          <div className="bg-muted flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs">
-            <span className="max-w-32 truncate">{user.name || user.email}</span>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="hover:bg-muted-foreground/20 h-4 w-4 p-0"
-              onClick={onRemove}
-            >
-              <X className="h-3 w-3" />
-            </Button>
-          </div>
-        )}
-        renderItem={(user, isSelected, onToggle) => (
-          <div
-            className="hover:bg-muted/50 flex cursor-pointer items-center gap-3 px-3 py-2 transition-colors"
-            onClick={onToggle}
-          >
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-3">
-                <p className="truncate text-xs font-medium">
-                  {user.name || "Unnamed User"}
-                </p>
-                <p className="text-muted-foreground truncate text-xs">
-                  {user.email}
-                </p>
-              </div>
+        renderSelectedItem={(user, onRemove) => {
+          const userLabel = user.name || user.email;
+
+          return (
+            <div className="bg-muted flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs">
+              <span className="max-w-32 truncate" title={userLabel}>
+                {userLabel}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="hover:bg-muted-foreground/20 h-4 w-4 p-0"
+                onClick={onRemove}
+              >
+                <X className="h-3 w-3" />
+              </Button>
             </div>
-            {isSelected && (
-              <div className="text-muted-foreground text-xs">✓</div>
-            )}
-          </div>
-        )}
+          );
+        }}
+        renderItem={(user, isSelected, onToggle) => {
+          const userName = user.name || "Unnamed User";
+
+          return (
+            <div
+              className="hover:bg-muted/50 flex cursor-pointer items-center gap-3 px-3 py-2 transition-colors"
+              onClick={onToggle}
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-3">
+                  <p className="truncate text-xs font-medium" title={userName}>
+                    {userName}
+                  </p>
+                  <p
+                    className="text-muted-foreground truncate text-xs"
+                    title={user.email}
+                  >
+                    {user.email}
+                  </p>
+                </div>
+              </div>
+              {isSelected && (
+                <div className="text-muted-foreground text-xs">✓</div>
+              )}
+            </div>
+          );
+        }}
       />
 
       {/* Assigned Users Section */}
@@ -156,38 +169,48 @@ export const UserAssignmentSection = ({
             </h4>
             <div className="bg-background max-h-32 overflow-y-auto rounded-md border">
               {queueAssignmentsQuery.data?.assignments.map(
-                (user: any, index: number) => (
-                  <div key={user.id}>
-                    <div className="flex items-center justify-between gap-3 px-3 py-2">
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-3">
-                          <p className="truncate text-xs font-medium">
-                            {user.name || "Unnamed User"}
-                          </p>
-                          <p className="text-muted-foreground truncate text-xs">
-                            {user.email}
-                          </p>
+                (user: any, index: number) => {
+                  const userName = user.name || "Unnamed User";
+
+                  return (
+                    <div key={user.id}>
+                      <div className="flex items-center justify-between gap-3 px-3 py-2">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-3">
+                            <p
+                              className="truncate text-xs font-medium"
+                              title={userName}
+                            >
+                              {userName}
+                            </p>
+                            <p
+                              className="text-muted-foreground truncate text-xs"
+                              title={user.email}
+                            >
+                              {user.email}
+                            </p>
+                          </div>
                         </div>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          disabled={
+                            !hasQueueAssignmentWriteAccess ||
+                            deleteQueueAssignmentMutation.isPending
+                          }
+                          onClick={() => handleUserRemove(user.id)}
+                        >
+                          <X className="h-3 w-3" />
+                        </Button>
                       </div>
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        disabled={
-                          !hasQueueAssignmentWriteAccess ||
-                          deleteQueueAssignmentMutation.isPending
-                        }
-                        onClick={() => handleUserRemove(user.id)}
-                      >
-                        <X className="h-3 w-3" />
-                      </Button>
+                      {(index <
+                        queueAssignmentsQuery.data?.assignments.length - 1 ||
+                        hasMoreAssignedUsers) && (
+                        <div className="border-border/50 border-b" />
+                      )}
                     </div>
-                    {(index <
-                      queueAssignmentsQuery.data?.assignments.length - 1 ||
-                      hasMoreAssignedUsers) && (
-                      <div className="border-border/50 border-b" />
-                    )}
-                  </div>
-                ),
+                  );
+                },
               )}
               {hasMoreAssignedUsers && (
                 <div className="text-muted-foreground flex items-center gap-3 px-3 py-2">

--- a/web/src/features/automations/components/AutomationSidebar.tsx
+++ b/web/src/features/automations/components/AutomationSidebar.tsx
@@ -81,7 +81,10 @@ export const AutomationSidebar: React.FC<AutomationSidebarProps> = ({
                     <div className="space-y-2">
                       {/* Top row: Name and Active badge */}
                       <div className="flex items-center justify-between gap-2">
-                        <h4 className="truncate text-sm leading-tight font-medium">
+                        <h4
+                          className="truncate text-sm leading-tight font-medium"
+                          title={automation.name}
+                        >
                           {automation.name}
                         </h4>
                         {automation.trigger.status === JobConfigState.ACTIVE ? (

--- a/web/src/features/batch-actions/components/BatchActionsTable.tsx
+++ b/web/src/features/batch-actions/components/BatchActionsTable.tsx
@@ -167,7 +167,9 @@ export function BatchActionsTable(props: { projectId: string }) {
               <TooltipTrigger>
                 <div className="flex items-center gap-1">
                   <InfoIcon className="text-muted-foreground h-3 w-3" />
-                  <span className="max-w-[250px] truncate text-xs">{log}</span>
+                  <span className="max-w-[250px] truncate text-xs" title={log}>
+                    {log}
+                  </span>
                 </div>
               </TooltipTrigger>
               <TooltipContent className="max-w-md">

--- a/web/src/features/batch-actions/components/RunEvaluationDialog/EstimatedCostRow.tsx
+++ b/web/src/features/batch-actions/components/RunEvaluationDialog/EstimatedCostRow.tsx
@@ -88,7 +88,9 @@ export function EstimatedCostRow(props: EstimatedCostRowProps) {
                       key={id}
                       className="flex justify-between gap-4 text-xs"
                     >
-                      <span className="truncate">{name}</span>
+                      <span className="truncate" title={name}>
+                        {name}
+                      </span>
                       <span className="shrink-0 tabular-nums">
                         {entry
                           ? formatCostEstimate(entry.avgCost * observationCount)

--- a/web/src/features/batch-actions/components/RunEvaluationDialog/EvaluatorSelectionStep.tsx
+++ b/web/src/features/batch-actions/components/RunEvaluationDialog/EvaluatorSelectionStep.tsx
@@ -178,52 +178,61 @@ export function EvaluatorSelectionStep(props: EvaluatorSelectionStepProps) {
               </div>
             ) : (
               <div className="min-h-0 flex-1 overflow-y-auto rounded-md border">
-                {filteredEvaluators.map((item, index, array) => (
-                  <div key={item.id}>
-                    <div
-                      className="hover:bg-muted/50 flex cursor-pointer items-center gap-2 px-2 py-1.5 transition-colors"
-                      onClick={() => onToggleEvaluator(item.id)}
-                    >
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-medium">
-                          {item.scoreName}
-                        </p>
-                        <p className="text-muted-foreground truncate text-[11px]">
-                          Template:{" "}
-                          {item.evalTemplate?.name ?? "Deleted template"}
-                        </p>
-                      </div>
-                      <EvaluatorPromptPreview
-                        previewContent={getPromptPreview(item)}
-                        trigger={
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            className="h-7 w-7"
-                            onMouseDown={(event) => {
-                              event.preventDefault();
-                              event.stopPropagation();
-                            }}
-                            onClick={(event) => event.stopPropagation()}
-                            aria-label={`Preview ${item.scoreName}`}
+                {filteredEvaluators.map((item, index, array) => {
+                  const templateLabel = `Template: ${item.evalTemplate?.name ?? "Deleted template"}`;
+
+                  return (
+                    <div key={item.id}>
+                      <div
+                        className="hover:bg-muted/50 flex cursor-pointer items-center gap-2 px-2 py-1.5 transition-colors"
+                        onClick={() => onToggleEvaluator(item.id)}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <p
+                            className="truncate text-sm font-medium"
+                            title={item.scoreName}
                           >
-                            <Eye className="h-4 w-4" />
-                          </Button>
-                        }
-                      />
-                      <Checkbox
-                        checked={selectedEvaluatorIds.includes(item.id)}
-                        aria-label={`Select ${item.scoreName}`}
-                        onClick={(event) => event.stopPropagation()}
-                        onCheckedChange={() => onToggleEvaluator(item.id)}
-                        className="mr-1"
-                      />
+                            {item.scoreName}
+                          </p>
+                          <p
+                            className="text-muted-foreground truncate text-[11px]"
+                            title={templateLabel}
+                          >
+                            {templateLabel}
+                          </p>
+                        </div>
+                        <EvaluatorPromptPreview
+                          previewContent={getPromptPreview(item)}
+                          trigger={
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              className="h-7 w-7"
+                              onMouseDown={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                              }}
+                              onClick={(event) => event.stopPropagation()}
+                              aria-label={`Preview ${item.scoreName}`}
+                            >
+                              <Eye className="h-4 w-4" />
+                            </Button>
+                          }
+                        />
+                        <Checkbox
+                          checked={selectedEvaluatorIds.includes(item.id)}
+                          aria-label={`Select ${item.scoreName}`}
+                          onClick={(event) => event.stopPropagation()}
+                          onCheckedChange={() => onToggleEvaluator(item.id)}
+                          className="mr-1"
+                        />
+                      </div>
+                      {index < array.length - 1 ? (
+                        <div className="border-border/50 border-b" />
+                      ) : null}
                     </div>
-                    {index < array.length - 1 ? (
-                      <div className="border-border/50 border-b" />
-                    ) : null}
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </div>

--- a/web/src/features/comments/components/MentionAutocomplete.tsx
+++ b/web/src/features/comments/components/MentionAutocomplete.tsx
@@ -81,6 +81,7 @@ export function MentionAutocomplete({
                 {displayedUsers.map((user, index) => {
                   const displayName = user.name || user.email || "User";
                   const isSelected = index === selectedIndex;
+                  const userLabel = user.name || "Unknown";
                   return (
                     <CommandItem
                       key={user.id}
@@ -98,11 +99,14 @@ export function MentionAutocomplete({
                         </AvatarFallback>
                       </Avatar>
                       <div className="text-foreground flex-1 overflow-hidden">
-                        <div className="truncate font-medium">
-                          {user.name || "Unknown"}
+                        <div className="truncate font-medium" title={userLabel}>
+                          {userLabel}
                         </div>
                         {user.email && (
-                          <div className="text-muted-foreground truncate text-xs">
+                          <div
+                            className="text-muted-foreground truncate text-xs"
+                            title={user.email}
+                          >
                             {user.email}
                           </div>
                         )}

--- a/web/src/features/datasets/components/CsvColumnsCard.tsx
+++ b/web/src/features/datasets/components/CsvColumnsCard.tsx
@@ -30,7 +30,9 @@ function DraggableColumn({ column }: { column: CsvColumnPreview }) {
     >
       <GripVertical className="text-muted-foreground/70 group-hover:text-primary h-4 w-4 shrink-0" />
       <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
-        <span className="truncate text-sm">{column.name}</span>
+        <span className="truncate text-sm" title={column.name}>
+          {column.name}
+        </span>
         <span className="text-muted-foreground shrink-0 text-xs">
           {column.inferredType}
         </span>

--- a/web/src/features/datasets/components/DatasetVersionHistoryPanel.tsx
+++ b/web/src/features/datasets/components/DatasetVersionHistoryPanel.tsx
@@ -130,6 +130,8 @@ export function DatasetVersionHistoryPanel({
       (iv) => iv.getTime() === version.getTime(),
     );
 
+    const dateLabel = format(version, "MMM d, yyyy 'at' h:mm a");
+
     return (
       <div
         key={version.toISOString()}
@@ -157,8 +159,11 @@ export function DatasetVersionHistoryPanel({
                   title="Item modified in this version"
                 />
               )}
-              <span className={cn("truncate", isSelected && "text-foreground")}>
-                {format(version, "MMM d, yyyy 'at' h:mm a")}
+              <span
+                className={cn("truncate", isSelected && "text-foreground")}
+                title={dateLabel}
+              >
+                {dateLabel}
               </span>
             </div>
             {isLatest && (

--- a/web/src/features/datasets/components/PreviewCsvImport.tsx
+++ b/web/src/features/datasets/components/PreviewCsvImport.tsx
@@ -202,7 +202,10 @@ export function PreviewCsvImport({
                     <div className="bg-background flex cursor-grabbing items-center gap-2 rounded-md border p-2 shadow-xl">
                       <GripVertical className="text-muted-foreground/70 h-4 w-4 shrink-0" />
                       <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
-                        <span className="truncate text-sm">
+                        <span
+                          className="truncate text-sm"
+                          title={dragAndDrop.activeColumn}
+                        >
                           {dragAndDrop.activeColumn}
                         </span>
                         <span className="text-muted-foreground shrink-0 text-xs">

--- a/web/src/features/evals/components/evaluator-selector.tsx
+++ b/web/src/features/evals/components/evaluator-selector.tsx
@@ -209,7 +209,9 @@ export function EvaluatorSelector({
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <div className="flex min-w-0 items-center">
-                          <span className="truncate">{name}</span>
+                          <span className="truncate" title={name}>
+                            {name}
+                          </span>
                           {latestVersion.type === EvalTemplateType.CODE ? (
                             <CodeTemplateLanguageIcon
                               sourceCodeLanguage={
@@ -283,7 +285,9 @@ export function EvaluatorSelector({
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <div className="mr-1 flex min-w-0 items-center">
-                          <span className="truncate">{name}</span>
+                          <span className="truncate" title={name}>
+                            {name}
+                          </span>
                           {latestVersion.type === EvalTemplateType.CODE ? (
                             <CodeTemplateLanguageIcon
                               sourceCodeLanguage={

--- a/web/src/features/evals/components/template-selector.tsx
+++ b/web/src/features/evals/components/template-selector.tsx
@@ -154,6 +154,11 @@ export const TemplateSelector = ({
     projectId: projectId,
   });
 
+  const triggerLabel =
+    activeTemplates.length > 0
+      ? `${activeTemplates.length} active evaluators`
+      : "Select evaluators";
+
   return (
     <>
       <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
@@ -165,10 +170,8 @@ export const TemplateSelector = ({
             className={cn("w-full justify-between px-2 font-normal", className)}
           >
             <div className="flex items-center gap-1 overflow-hidden">
-              <span className="mr-1 truncate">
-                {activeTemplates.length > 0
-                  ? `${activeTemplates.length} active evaluators`
-                  : "Select evaluators"}
+              <span className="mr-1 truncate" title={triggerLabel}>
+                {triggerLabel}
               </span>
             </div>
             <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1203,6 +1203,7 @@ export default function ObservationsEventsTable({
           <Badge
             variant="secondary"
             className="max-w-fit truncate rounded-sm px-1 font-normal"
+            title={value}
           >
             {value}
           </Badge>

--- a/web/src/features/events/components/V4PromoBanner.tsx
+++ b/web/src/features/events/components/V4PromoBanner.tsx
@@ -94,7 +94,10 @@ export function V4PromoBanner() {
           className="flex flex-1 gap-1 overflow-hidden text-sm"
           title={`${pageMessage} Enable the Fast (Preview) toggle for a more performant experience.`}
         >
-          <span className="truncate">
+          <span
+            className="truncate"
+            title={`${pageMessage} Enable the Fast (Preview) toggle for a more performant experience.`}
+          >
             <span className="hidden font-semibold md:inline">
               {pageMessage}
             </span>{" "}

--- a/web/src/features/events/components/V4SidebarToggle.tsx
+++ b/web/src/features/events/components/V4SidebarToggle.tsx
@@ -102,6 +102,8 @@ export function V4SidebarToggle() {
     }
   };
 
+  const fastPreviewLabel = "Fast (Preview)";
+
   return (
     <>
       <SidebarMenuButton
@@ -114,8 +116,9 @@ export function V4SidebarToggle() {
             <Label
               htmlFor="v4-beta-toggle"
               className="block min-w-0 flex-1 cursor-pointer truncate text-sm font-normal"
+              title={fastPreviewLabel}
             >
-              Fast (Preview)
+              {fastPreviewLabel}
             </Label>
           </div>
           <Tooltip>

--- a/web/src/features/experiments/components/ExperimentComparisonSelector.tsx
+++ b/web/src/features/experiments/components/ExperimentComparisonSelector.tsx
@@ -91,7 +91,10 @@ export function ExperimentComparisonSelector({
               {isSelected && <Check className="text-primary h-4 w-4" />}
             </div>
             <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-medium">
+              <p
+                className="truncate text-sm font-medium"
+                title={item.experimentName}
+              >
                 {item.experimentName}
               </p>
             </div>
@@ -102,7 +105,10 @@ export function ExperimentComparisonSelector({
             variant="secondary"
             className="flex items-center gap-1 px-2 py-0.5"
           >
-            <span className="max-w-24 truncate text-xs">
+            <span
+              className="max-w-24 truncate text-xs"
+              title={item.experimentName}
+            >
               {item.experimentName}
             </span>
             <button

--- a/web/src/features/experiments/components/table/ExperimentFilterPills.tsx
+++ b/web/src/features/experiments/components/table/ExperimentFilterPills.tsx
@@ -79,6 +79,7 @@ function FilterPillWithTarget({
   onRemove,
 }: FilterPillWithTargetProps) {
   const [open, setOpen] = useState(false);
+  const filterLabel = formatFilterForPill(filter);
 
   return (
     <Badge
@@ -86,8 +87,8 @@ function FilterPillWithTarget({
       className="flex max-w-full items-center gap-1 px-2 py-1 text-xs"
     >
       <ListFilter className="h-3 w-3 shrink-0" />
-      <span className="truncate" title={formatFilterForPill(filter)}>
-        {formatFilterForPill(filter)}
+      <span className="truncate" title={filterLabel}>
+        {filterLabel}
       </span>
       <span className="text-muted-foreground shrink-0">→</span>
       <Popover open={open} onOpenChange={setOpen}>
@@ -96,7 +97,9 @@ function FilterPillWithTarget({
             className="flex shrink-0 items-center gap-0.5 font-medium hover:underline"
             title={experimentName}
           >
-            <span className="max-w-[100px] truncate">{experimentName}</span>
+            <span className="max-w-[100px] truncate" title={experimentName}>
+              {experimentName}
+            </span>
             <ChevronsUpDown className="h-3 w-3 opacity-50" />
           </button>
         </PopoverTrigger>

--- a/web/src/features/experiments/components/table/ExperimentGridCell.tsx
+++ b/web/src/features/experiments/components/table/ExperimentGridCell.tsx
@@ -29,6 +29,7 @@ import { Skeleton } from "@/src/components/ui/skeleton";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { decomposeAggregateScoreKey } from "@/src/features/scores/lib/aggregateScores";
 import { cn } from "@/src/utils/tailwind";
+import { getPlainTextFromReactNode } from "@/src/utils/react-node-plain-text";
 
 type ExperimentGridCellProps = {
   projectId: string;
@@ -205,7 +206,9 @@ const ScoreItem = ({
     <div className="flex items-center justify-between gap-1 text-xs">
       <HoverCard>
         <HoverCardTrigger className="max-w-[50%] cursor-default">
-          <span className="text-muted-foreground block truncate">{name}</span>
+          <span className="text-muted-foreground block truncate" title={name}>
+            {name}
+          </span>
         </HoverCardTrigger>
         <HoverCardContent
           side="left"
@@ -254,7 +257,12 @@ const MetadataItem = ({
 }) => (
   <div className="flex items-center justify-between gap-4 text-xs">
     <span className="text-muted-foreground shrink-0">{label}</span>
-    <div className="min-w-0 truncate">{children}</div>
+    <div
+      className="min-w-0 truncate"
+      title={getPlainTextFromReactNode(children)}
+    >
+      {children}
+    </div>
   </div>
 );
 

--- a/web/src/features/experiments/components/table/ExperimentGridView.tsx
+++ b/web/src/features/experiments/components/table/ExperimentGridView.tsx
@@ -103,6 +103,7 @@ export const ExperimentGridView = ({
           <div className="flex items-center gap-2">
             <span
               className={cn("truncate font-medium", colorStyles?.textClass)}
+              title={expName}
             >
               {expName}
             </span>

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -798,9 +798,11 @@ export default function ExperimentItemsTable({
               const expOption = selectedExperimentNames.find(
                 (e) => e.experimentId === exp.experimentId,
               );
+              const experimentLabel =
+                expOption?.experimentName ?? exp.experimentId.slice(0, 8);
               return (
-                <span className="truncate text-xs">
-                  {expOption?.experimentName ?? exp.experimentId.slice(0, 8)}
+                <span className="truncate text-xs" title={experimentLabel}>
+                  {experimentLabel}
                 </span>
               );
             }}

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -601,6 +601,7 @@ function FilterBuilderForm({
                         (o) => NonEmptyString.safeParse(o).success,
                       )
                     : undefined;
+                const columnLabel = column ? column.name : "Column";
                 return (
                   <tr key={i}>
                     <td className="p-1 text-sm">{i === 0 ? "Where" : "And"}</td>
@@ -615,8 +616,8 @@ function FilterBuilderForm({
                             disabled={disabled}
                             className="flex w-full min-w-32 items-center justify-between gap-2"
                           >
-                            <span className="truncate">
-                              {column ? column.name : "Column"}
+                            <span className="truncate" title={columnLabel}>
+                              {columnLabel}
                             </span>
                             <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
                           </Button>

--- a/web/src/features/monitors/components/MonitorAutomationsPanel.tsx
+++ b/web/src/features/monitors/components/MonitorAutomationsPanel.tsx
@@ -133,7 +133,9 @@ export const MonitorAutomationsPanel = ({
                           type={automation.action.type as ActionTypes}
                           className="h-3.5 w-3.5 shrink-0"
                         />
-                        <span className="truncate">{automation.name}</span>
+                        <span className="truncate" title={automation.name}>
+                          {automation.name}
+                        </span>
                       </div>
                     </li>
                   );

--- a/web/src/features/organizations/components/ProjectOverview.tsx
+++ b/web/src/features/organizations/components/ProjectOverview.tsx
@@ -51,7 +51,7 @@ const OrganizationProjectTiles = ({
         .map((project) => (
           <Card key={project.id}>
             <CardHeader>
-              <CardTitle className="truncate text-base">
+              <CardTitle className="truncate text-base" title={project.name}>
                 {project.name}
               </CardTitle>
             </CardHeader>

--- a/web/src/features/playground/page/components/StructuredOutputSchemaSection.tsx
+++ b/web/src/features/playground/page/components/StructuredOutputSchemaSection.tsx
@@ -109,7 +109,9 @@ export const StructuredOutputSchemaPopover = () => {
               <div className="flex min-w-0 flex-1 items-center gap-2">
                 <BoxIcon className="text-muted-foreground h-4 w-4 shrink-0" />
                 <div className="min-w-0 flex-1">
-                  <div className="truncate font-medium">{schema.name}</div>
+                  <div className="truncate font-medium" title={schema.name}>
+                    {schema.name}
+                  </div>
                   <div className="text-muted-foreground line-clamp-1 text-xs">
                     {schema.description}
                   </div>

--- a/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
@@ -307,7 +307,10 @@ export function SetPromptVersionLabels({
                       disabled={!isValidNewLabel}
                       onClick={handleCreateLabel}
                     >
-                      <span className="truncate">
+                      <span
+                        className="truncate"
+                        title={`Create a new label: ${trimmedSearch}`}
+                      >
                         Create a new label:{" "}
                         <strong className="text-foreground">
                           {trimmedSearch}

--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -141,6 +141,7 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
                     density="comfortable"
                     text={apiKey.publicKey}
                     className="truncate font-mono"
+                    title={apiKey.publicKey}
                   />
                   <TableCell density="comfortable" className="font-mono">
                     {apiKey.displaySecretKey}

--- a/web/src/features/score-analytics/components/charts/ScoreChartLegendContent.tsx
+++ b/web/src/features/score-analytics/components/charts/ScoreChartLegendContent.tsx
@@ -83,6 +83,7 @@ const LegendItem = ({
           !noTruncate && "max-w-[120px] truncate",
           !visible && "line-through", // Strike through when hidden
         )}
+        title={label}
       >
         {label}
       </span>

--- a/web/src/features/scores/components/ScoreRow.tsx
+++ b/web/src/features/scores/components/ScoreRow.tsx
@@ -111,7 +111,10 @@ export const ScoreRow = ({
   if (!aggregate) {
     return (
       <div className="flex h-6 w-full items-center gap-2">
-        <span className="text-muted-foreground w-32 shrink-0 truncate">
+        <span
+          className="text-muted-foreground w-32 shrink-0 truncate"
+          title={name}
+        >
           {name}
         </span>
         <ScoreValueSection aggregate={aggregate} diff={diff} />
@@ -122,7 +125,9 @@ export const ScoreRow = ({
   return (
     <HoverCard openDelay={700} closeDelay={100} onOpenChange={setIsHovered}>
       <div className="flex h-6 w-full items-center gap-2">
-        <span className="w-32 shrink-0 truncate font-medium">{name}</span>
+        <span className="w-32 shrink-0 truncate font-medium" title={name}>
+          {name}
+        </span>
         <HoverCardTrigger asChild>
           <div className="cursor-pointer">
             <ScoreValueSection aggregate={aggregate} diff={diff} />

--- a/web/src/features/search-bar/components/AutocompleteListbox.tsx
+++ b/web/src/features/search-bar/components/AutocompleteListbox.tsx
@@ -127,7 +127,10 @@ export function AutocompleteListbox({
               onMouseMove={highlightOnMove?.(o.id)}
             >
               <OptionIcon kind={o.kind} />
-              <span className="max-w-[480px] min-w-0 flex-none truncate">
+              <span
+                className="max-w-[480px] min-w-0 flex-none truncate"
+                title={o.label}
+              >
                 {o.label}
               </span>
               {o.kind === "value" && o.active && (

--- a/web/src/features/search-bar/components/SearchBarAiPrompt.tsx
+++ b/web/src/features/search-bar/components/SearchBarAiPrompt.tsx
@@ -145,7 +145,10 @@ export function SearchBarAiPrompt({
             className="text-muted-foreground mb-1.5 flex min-w-0 items-center gap-1.5 pl-1 text-xs"
           >
             <span className="shrink-0">Refining</span>
-            <code className="bg-muted text-foreground/80 min-w-0 truncate rounded px-1.5 py-0.5 font-mono text-[11px]">
+            <code
+              className="bg-muted text-foreground/80 min-w-0 truncate rounded px-1.5 py-0.5 font-mono text-[11px]"
+              title={refineContext}
+            >
               {refineContext}
             </code>
           </div>

--- a/web/src/features/search-bar/components/SearchComposer.tsx
+++ b/web/src/features/search-bar/components/SearchComposer.tsx
@@ -1318,6 +1318,7 @@ export function SearchComposer({
               "text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 truncate font-mono text-xs",
               onActivateAi !== undefined ? "pr-20" : "pr-8",
             )}
+            title={COMPOSER_PLACEHOLDER}
           >
             {COMPOSER_PLACEHOLDER}
           </div>

--- a/web/src/features/slack/components/ChannelSelector.tsx
+++ b/web/src/features/slack/components/ChannelSelector.tsx
@@ -242,7 +242,9 @@ export const ChannelSelector: React.FC<ChannelSelectorProps> = ({
       ) : (
         <Hash className="text-muted-foreground h-4 w-4" />
       )}
-      <span className="flex-1 truncate">{channel.name}</span>
+      <span className="flex-1 truncate" title={channel.name}>
+        {channel.name}
+      </span>
     </div>
   );
 
@@ -295,7 +297,10 @@ export const ChannelSelector: React.FC<ChannelSelectorProps> = ({
                       className="cursor-pointer"
                     >
                       <Hash className="text-muted-foreground h-4 w-4" />
-                      <span className="flex-1 truncate">
+                      <span
+                        className="flex-1 truncate"
+                        title={`Use &quot; ${effectiveName} &quot;`}
+                      >
                         Use &quot;{effectiveName}&quot;
                       </span>
                     </CommandItem>
@@ -342,7 +347,10 @@ export const ChannelSelector: React.FC<ChannelSelectorProps> = ({
                       className="text-muted-foreground"
                     >
                       <RefreshCw className="h-4 w-4 animate-spin" />
-                      <span className="flex-1 truncate">
+                      <span
+                        className="flex-1 truncate"
+                        title="Loading Slack channels. This can take a while for large workspaces."
+                      >
                         Loading Slack channels. This can take a while for large
                         workspaces.
                       </span>

--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -378,7 +378,9 @@ export function SupportFormSection({
                         size="default"
                         onClick={() => field.onChange(v)}
                       >
-                        <span className="truncate">{v}</span>
+                        <span className="truncate" title={v}>
+                          {v}
+                        </span>
                       </Button>
                     ))}
                   </RadioGroup>
@@ -573,7 +575,14 @@ export function SupportFormSection({
                   <DropzoneEmptyState>
                     <div className="flex w-full cursor-pointer items-center justify-start gap-2 p-2 text-xs">
                       <Paperclip className="h-4 w-4" />
-                      <span className="truncate">
+                      <span
+                        className="truncate"
+                        title={
+                          hasFiles
+                            ? `${files!.length} file${files!.length > 1 ? "s" : ""} • ${totalMB} MB`
+                            : "Attach files"
+                        }
+                      >
                         {hasFiles
                           ? `${files!.length} file${files!.length > 1 ? "s" : ""} • ${totalMB} MB`
                           : "Attach files"}
@@ -584,7 +593,9 @@ export function SupportFormSection({
                   <DropzoneContent>
                     <div className="flex w-full cursor-pointer items-center justify-start gap-2 p-2 text-xs">
                       <Paperclip className="h-4 w-4" />
-                      <span className="truncate">Attach files</span>
+                      <span className="truncate" title="Attach files">
+                        Attach files
+                      </span>
                     </div>
                   </DropzoneContent>
                 </Dropzone>

--- a/web/src/features/v4/components/V4MigrationProjectCards.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.tsx
@@ -398,7 +398,9 @@ const UsageStackedBarOverview = ({
               className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
               style={{ backgroundColor: item.color }}
             />
-            <span className="truncate font-medium">{item.name}</span>
+            <span className="truncate font-medium" title={item.name}>
+              {item.name}
+            </span>
             <span className="text-muted-foreground shrink-0">
               {numberFormatter(item.total, 0, 2)} {valueLabel}
             </span>
@@ -424,10 +426,16 @@ const ActionRow = ({
 }) => (
   <div className="grid gap-3 rounded-md border px-3 py-2 md:grid-cols-[minmax(0,1fr)_8rem] md:items-center">
     <div className="min-w-0">
-      <div className={cn("truncate text-sm font-medium", titleClassName)}>
+      <div
+        className={cn("truncate text-sm font-medium", titleClassName)}
+        title={title}
+      >
         {title}
       </div>
-      <div className="text-muted-foreground mt-0.5 truncate text-xs">
+      <div
+        className="text-muted-foreground mt-0.5 truncate text-xs"
+        title={detail}
+      >
         {detail}
       </div>
     </div>

--- a/web/src/features/widgets/chart-library/PivotTable.tsx
+++ b/web/src/features/widgets/chart-library/PivotTable.tsx
@@ -77,7 +77,9 @@ const StaticHeader: React.FC<{
   return (
     <TableHead className={cn("p-1", className)}>
       <div className="flex items-center select-none">
-        <span className="truncate">{label}</span>
+        <span className="truncate" title={label}>
+          {label}
+        </span>
       </div>
     </TableHead>
   );
@@ -117,7 +119,9 @@ const SortableHeader: React.FC<{
           rightAlign ? "justify-end" : "justify-start",
         )}
       >
-        <span className="truncate">{label}</span>
+        <span className="truncate" title={label}>
+          {label}
+        </span>
         {isSorted && (
           <span
             className="ml-1"

--- a/web/src/pages/project/[projectId]/users/index.tsx
+++ b/web/src/pages/project/[projectId]/users/index.tsx
@@ -319,6 +319,7 @@ const UsersTable = ({ isBetaEnabled }: { isBetaEnabled: boolean }) => {
           <Badge
             variant="secondary"
             className="max-w-fit truncate rounded-sm px-1 font-normal"
+            title={value}
           >
             {value}
           </Badge>

--- a/web/src/utils/react-node-plain-text.ts
+++ b/web/src/utils/react-node-plain-text.ts
@@ -1,0 +1,39 @@
+import {
+  Children,
+  isValidElement,
+  type ReactNode,
+  type ReactElement,
+} from "react";
+
+export function getPlainTextFromReactNode(node: ReactNode): string | undefined {
+  if (
+    typeof node === "string" ||
+    typeof node === "number" ||
+    typeof node === "bigint"
+  ) {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    const text = node
+      .map((child) => getPlainTextFromReactNode(child))
+      .filter((child): child is string => child !== undefined)
+      .join("");
+
+    return text || undefined;
+  }
+
+  if (isValidElement(node)) {
+    return getPlainTextFromReactNode(
+      (node as ReactElement<{ children?: ReactNode }>).props.children,
+    );
+  }
+
+  if (node && typeof node === "object" && Symbol.iterator in node) {
+    return getPlainTextFromReactNode(
+      Children.toArray(node as Iterable<ReactNode>),
+    );
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new `require-title-with-truncate` ESLint rule that enforces a `title` attribute on any JSX element using Tailwind's `truncate` utility, then enables it across the `web` package — fixing ~70 components to comply. It also extracts shared Tailwind and AST helper utilities from the existing rules.

- **New ESLint rule** (`require-title-with-truncate`): detects `truncate` in string literals, `cn`/`clsx` calls, object expressions, conditionals, and TypeScript type assertions; well-tested with both valid and invalid cases.
- **Shared helpers** (`rule-helpers/tailwind.ts`, `rule-helpers/ast.ts`): refactored out of `no-margin-on-root-elements` and `no-tailwind-overflow-scroll`, using a bracket-depth-aware variant stripper that's more correct than the previous `lastIndexOf(\":\")` approach.
- **`ValueCell.tsx` regression**: a single `filterText` variable (built with `includeOperator`) is now shared by both the \"Include in filter\" and \"Exclude in filter\" menu items, causing the exclude item's label and tooltip to display the wrong operator.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the exclude-filter label in ValueCell.tsx — the ESLint rule and helper refactors are correct.

The exclude-filter menu item label and tooltip now show the include operator (contains) instead of the correct exclude operator (does not contain), a user-visible defect introduced by sharing a single filterText variable across both items. The new ESLint rule, shared Tailwind/AST helpers, and the ~70 component title fixes are all correct.

web/src/components/table/ValueCell.tsx — the exclude filter text variable needs to use excludeOperator.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[JSXOpeningElement visited] --> B{Has className attribute?}
    B -- No --> Z[Skip]
    B -- Yes --> C{Has valid title attribute?}
    C -- Yes --> Z
    C -- No --> D{className value type?}
    D -- String Literal --> E[containsTruncateToken]
    D -- JSXExpressionContainer --> F[expressionContainsTruncate]
    F --> G{Expression type?}
    G -- Static string/template --> E
    G -- ArrayExpression --> H[Recurse into elements]
    G -- CallExpression + known fn --> I[Recurse into arguments]
    G -- ObjectExpression --> J[Check property keys for truncate]
    G -- ConditionalExpression --> K[Recurse consequent OR alternate]
    G -- LogicalExpression --> L[Recurse left OR right]
    G -- TS cast/assertion --> M[Recurse into inner expression]
    G -- Other --> N[false - no report]
    E -- contains truncate --> O[Report: missingTitle]
    E -- no truncate --> Z
    H --> E
    I --> E
    J --> E
    K --> E
    L --> E
    M --> E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[JSXOpeningElement visited] --> B{Has className attribute?}
    B -- No --> Z[Skip]
    B -- Yes --> C{Has valid title attribute?}
    C -- Yes --> Z
    C -- No --> D{className value type?}
    D -- String Literal --> E[containsTruncateToken]
    D -- JSXExpressionContainer --> F[expressionContainsTruncate]
    F --> G{Expression type?}
    G -- Static string/template --> E
    G -- ArrayExpression --> H[Recurse into elements]
    G -- CallExpression + known fn --> I[Recurse into arguments]
    G -- ObjectExpression --> J[Check property keys for truncate]
    G -- ConditionalExpression --> K[Recurse consequent OR alternate]
    G -- LogicalExpression --> L[Recurse left OR right]
    G -- TS cast/assertion --> M[Recurse into inner expression]
    G -- Other --> N[false - no report]
    E -- contains truncate --> O[Report: missingTitle]
    E -- no truncate --> Z
    H --> E
    I --> E
    J --> E
    K --> E
    L --> E
    M --> E
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(web): Fix \`require-title-with-t..."](https://github.com/langfuse/langfuse/commit/0e0dba2fceb0db7615dfbf8cb4dd235e7009f867) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40861141)</sub>

<!-- /greptile_comment -->