### PR TITLE
fix(web): show fallback for failed media previews

### DIFF
--- a/web/src/components/ui/media/MediaTag.clienttest.tsx
+++ b/web/src/components/ui/media/MediaTag.clienttest.tsx
@@ -46,4 +46,22 @@ describe("MediaTag", () => {
     expect(onOpenChange).toHaveBeenCalledWith(true);
     expect(onOpenChange).toHaveBeenCalledTimes(1);
   });
+
+  it("shows the fallback when resolved image media fails to render", async () => {
+    render(
+      <MediaTag
+        contentType="image/jpeg"
+        status="ready"
+        url="https://commons.wikimedia.org/wiki/File:Gull_portrait_ca_usa.jpg"
+        open
+      />,
+    );
+
+    const image = document.body.querySelector("img");
+    expect(image).toBeInTheDocument();
+
+    fireEvent.error(image!);
+
+    expect(await screen.findByText("Failed to load media")).toBeInTheDocument();
+  });
 });

--- a/web/src/components/ui/media/MediaTag.stories.tsx
+++ b/web/src/components/ui/media/MediaTag.stories.tsx
@@ -66,6 +66,17 @@ export const PreviewLargeImage = meta.story({
   },
 });
 
+// Wikimedia file pages can look like direct images by URL extension, but they
+// serve HTML. The preview should fall back once the image element errors.
+export const WikimediaFilePageFallback = meta.story({
+  args: {
+    contentType: "image/jpeg",
+    open: true,
+    status: "ready",
+    url: "https://commons.wikimedia.org/wiki/File:Gull_portrait_ca_usa.jpg",
+  },
+});
+
 // Peek popover while the URL is still resolving (hover-triggered fetch).
 export const Loading = meta.story({
   args: {

--- a/web/src/components/ui/media/MediaTag.tsx
+++ b/web/src/components/ui/media/MediaTag.tsx
@@ -83,20 +83,27 @@ function KindIcon({
   return <Icon className={className} />;
 }
 
+type PreviewRenderer = (params: {
+  url: string;
+  onError: () => void;
+}) => React.ReactNode;
+
 const MEDIA_KIND_PREVIEW = {
-  image: (url: string) => (
+  image: ({ url, onError }) => (
     // eslint-disable-next-line @next/next/no-img-element
     <img
       src={url}
       alt=""
+      onError={onError}
       // Bounded by the max-h cap and the card's max-w-sm; object-contain
       // keeps high-resolution images from blowing out the popover.
       className="max-h-64 max-w-full rounded object-contain"
     />
   ),
-  video: (url: string) => (
+  video: ({ url, onError }) => (
     <video
       src={url}
+      onError={onError}
       className="max-h-64 max-w-full rounded"
       controls
       muted
@@ -104,8 +111,14 @@ const MEDIA_KIND_PREVIEW = {
       preload="metadata"
     />
   ),
-  audio: (url: string) => (
-    <audio src={url} controls className="w-64" preload="metadata" />
+  audio: ({ url, onError }) => (
+    <audio
+      src={url}
+      onError={onError}
+      controls
+      className="w-64"
+      preload="metadata"
+    />
   ),
   file: () => (
     <div className="text-muted-foreground flex h-24 w-64 flex-col items-center justify-center gap-2">
@@ -113,7 +126,7 @@ const MEDIA_KIND_PREVIEW = {
       <span className="text-xs">No inline preview</span>
     </div>
   ),
-} satisfies Record<MediaKind, (url: string) => React.ReactNode>;
+} satisfies Record<MediaKind, PreviewRenderer>;
 
 /** The peek body — a glance, not a full player. Images/video show a thumbnail;
  *  audio gets an inline player; other types are open-in-new-tab only. */
@@ -121,10 +134,12 @@ function PeekBody({
   kind,
   status,
   url,
+  onPreviewError,
 }: {
   kind: MediaKind;
   status: MediaTagStatus;
   url?: string;
+  onPreviewError: () => void;
 }) {
   if (status === "error") {
     return (
@@ -139,7 +154,7 @@ function PeekBody({
     return <Skeleton className="h-32 w-64" />;
   }
 
-  return MEDIA_KIND_PREVIEW[kind](url);
+  return MEDIA_KIND_PREVIEW[kind]({ url, onError: onPreviewError });
 }
 
 /**
@@ -155,6 +170,11 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
     const kind = getMediaKind(contentType);
     const chipLabel = label ?? getDefaultLabel(contentType);
     const canOpen = status === "ready" && Boolean(url);
+    const [failedPreviewUrl, setFailedPreviewUrl] = React.useState<
+      string | null
+    >(null);
+    const previewStatus =
+      status === "ready" && url && failedPreviewUrl === url ? "error" : status;
     const isControlled = open !== undefined;
     const [uncontrolledOpen, setUncontrolledOpen] = React.useState(false);
     const isOpen = isControlled ? open : uncontrolledOpen;
@@ -225,7 +245,12 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
               </Button>
             )}
           </div>
-          <PeekBody kind={kind} status={status} url={url} />
+          <PeekBody
+            kind={kind}
+            status={previewStatus}
+            url={url}
+            onPreviewError={() => setFailedPreviewUrl(url ?? null)}
+          />
         </HoverCardContent>
       </HoverCard>
     );


### PR DESCRIPTION
## Summary

- Show the existing media fallback when a resolved image, audio, or video URL fails inside the browser preview.
- Add Storybook and client-test coverage for the Wikimedia Commons file-page URL that looks like a JPEG but serves HTML.

## Linear

- None

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires up `onError` handlers on the `img`, `video`, and `audio` preview elements inside `MediaTag`, so that a resource that loads successfully as a URL but fails to render in the browser (e.g. a Wikimedia file page that serves HTML with a `.jpg` extension) shows the existing "Failed to load media" fallback instead of a broken element. The error is tracked via a `failedPreviewUrl` state string that is compared to the current `url` prop so a URL change naturally resets the error condition.

- Refactored `MEDIA_KIND_PREVIEW` renderers from `(url: string) => ReactNode` to `({ url, onError }) => ReactNode` via a new `PreviewRenderer` type, preserving TypeScript satisfaction across all four media kinds.
- Added a client test that fires a synthetic error event on the rendered `<img>` and asserts the fallback text appears, plus a Storybook story using the real Wikimedia URL to exercise the path visually.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive, scoped to a single presentational component, and backed by a new client test and Storybook story.

The error-tracking logic is simple and self-correcting: `failedPreviewUrl === url` means a URL change naturally resets the error state, and the `file` kind renderer (which makes no network requests) correctly ignores the injected `onError` callback without any type issues. No existing behaviour is removed or mutated.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant MediaTag
    participant PeekBody
    participant MediaElement as img/video/audio

    Browser->>MediaTag: hover (open peek)
    MediaTag->>PeekBody: "status="ready", url, onPreviewError"
    PeekBody->>MediaElement: "render with src=url, onError=onPreviewError"
    MediaElement->>Browser: network request for src
    Browser-->>MediaElement: response (e.g. HTML instead of image)
    MediaElement->>MediaTag: onError() fires
    MediaTag->>MediaTag: setFailedPreviewUrl(url)
    Note over MediaTag: previewStatus = "error" (url === failedPreviewUrl)
    MediaTag->>PeekBody: "status="error""
    PeekBody->>Browser: render "Failed to load media" fallback
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant MediaTag
    participant PeekBody
    participant MediaElement as img/video/audio

    Browser->>MediaTag: hover (open peek)
    MediaTag->>PeekBody: "status="ready", url, onPreviewError"
    PeekBody->>MediaElement: "render with src=url, onError=onPreviewError"
    MediaElement->>Browser: network request for src
    Browser-->>MediaElement: response (e.g. HTML instead of image)
    MediaElement->>MediaTag: onError() fires
    MediaTag->>MediaTag: setFailedPreviewUrl(url)
    Note over MediaTag: previewStatus = "error" (url === failedPreviewUrl)
    MediaTag->>PeekBody: "status="error""
    PeekBody->>Browser: render "Failed to load media" fallback
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): show fallback for failed media..."](https://github.com/langfuse/langfuse/commit/5e487c4e6a8fc0d72e10411c31cdd9cce8c82e99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40878002)</sub>

<!-- /greptile_comment -->