### PR TITLE
fix(web): allow storage upload URLs in CSP

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -11,7 +11,9 @@ import { env } from "./src/env.mjs";
  * img-src https to allow loading images from SSO providers
  */
 // Dataset attachments PUT media directly to presigned storage URLs, so
-// connect-src must allow AWS S3 and the configured S3-compatible endpoint.
+// connect-src must allow AWS S3, Azure Blob Storage, GCS, and the configured
+// S3-compatible endpoint. The endpoint env var is only present at runtime in
+// official Docker images, so static wildcards cover the common providers too.
 const mediaUploadConnectSrc = (() => {
   const endpoint = env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT;
   if (!endpoint) return "";
@@ -35,7 +37,7 @@ const cspHeader = `
   base-uri 'self';
   form-action 'self' https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com;
   frame-ancestors 'none';
-  connect-src 'self' ${mediaUploadConnectSrc}https://*.langfuse.com https://*.langfuse.dev https://*.ingest.us.sentry.io https://*.sentry.io https://chat.uk.plain.com https://*.amazonaws.com https://prod-uk-services-attachm-attachmentsuploadbucket2-1l2e4906o2asm.s3.eu-west-2.amazonaws.com https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com https://graph.microsoft.com;
+  connect-src 'self' ${mediaUploadConnectSrc}https://*.langfuse.com https://*.langfuse.dev https://*.ingest.us.sentry.io https://*.sentry.io https://chat.uk.plain.com https://*.amazonaws.com https://*.blob.core.windows.net https://storage.googleapis.com https://prod-uk-services-attachm-attachmentsuploadbucket2-1l2e4906o2asm.s3.eu-west-2.amazonaws.com https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com https://graph.microsoft.com;
   media-src 'self' https: http://localhost:*;
   ${env.LANGFUSE_CSP_ENFORCE_HTTPS === "true" ? "upgrade-insecure-requests; block-all-mixed-content;" : ""}
   ${env.SENTRY_CSP_REPORT_URI ? `report-uri ${env.SENTRY_CSP_REPORT_URI}; report-to csp-endpoint;` : ""}


### PR DESCRIPTION
## Summary

- Allow browser media uploads to Azure Blob Storage by adding `https://*.blob.core.windows.net` to the CSP `connect-src` allowlist.
- Allow native GCS media upload signed URLs by adding `https://storage.googleapis.com`, while keeping custom S3-compatible endpoints covered by the existing runtime-derived CSP entry.

## Linear

- Closes [LFE-10553](https://linear.app/langfuse/issue/LFE-10553/bug-csp-connect-src-blocks-azure-blob-storage-endpoints-when-self)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `https://*.blob.core.windows.net` (Azure Blob Storage) and `https://storage.googleapis.com` (GCS) to the `connect-src` allowlist in the Next.js CSP header, fixing browser-side media uploads that were blocked for self-hosted users using these providers.

- **Azure Blob Storage**: Adds `https://*.blob.core.windows.net` wildcard to cover all Azure storage accounts, matching how Azure exposes signed upload URLs.
- **GCS**: Adds `https://storage.googleapis.com` (the canonical GCS XML/JSON API upload endpoint used by all signed URLs) alongside the existing runtime-derived entry for custom S3-compatible endpoints.
- **Comment update**: The block comment above `mediaUploadConnectSrc` is updated to accurately describe all covered providers.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both new CSP origins are the canonical endpoints for their respective storage providers and are correctly scoped.

The change is a targeted, two-origin addition to the connect-src allowlist. https://*.blob.core.windows.net is the standard wildcard for Azure Blob Storage signed URLs, and https://storage.googleapis.com is the sole endpoint used by GCS signed URL uploads. Neither entry over-broadens the policy: img-src already has https: so display of stored media was already covered, and AWS S3 was already covered by https://*.amazonaws.com. No logic paths were changed, only the static CSP string was extended.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant LangfuseApp as Langfuse App (Next.js)
    participant StorageProvider as Storage Provider

    Browser->>LangfuseApp: Request presigned upload URL
    LangfuseApp-->>Browser: Returns presigned URL (AWS S3 / Azure Blob / GCS / custom S3)

    alt AWS S3
        Browser->>StorageProvider: "PUT file to *.amazonaws.com (allowed by existing CSP)"
    else Azure Blob Storage (new)
        Browser->>StorageProvider: "PUT file to *.blob.core.windows.net (allowed by new CSP entry)"
    else Google Cloud Storage (new)
        Browser->>StorageProvider: PUT file to storage.googleapis.com (allowed by new CSP entry)
    else Custom S3-compatible endpoint
        Browser->>StorageProvider: PUT file to custom endpoint (allowed by runtime-derived mediaUploadConnectSrc)
    end

    StorageProvider-->>Browser: Upload success
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant LangfuseApp as Langfuse App (Next.js)
    participant StorageProvider as Storage Provider

    Browser->>LangfuseApp: Request presigned upload URL
    LangfuseApp-->>Browser: Returns presigned URL (AWS S3 / Azure Blob / GCS / custom S3)

    alt AWS S3
        Browser->>StorageProvider: "PUT file to *.amazonaws.com (allowed by existing CSP)"
    else Azure Blob Storage (new)
        Browser->>StorageProvider: "PUT file to *.blob.core.windows.net (allowed by new CSP entry)"
    else Google Cloud Storage (new)
        Browser->>StorageProvider: PUT file to storage.googleapis.com (allowed by new CSP entry)
    else Custom S3-compatible endpoint
        Browser->>StorageProvider: PUT file to custom endpoint (allowed by runtime-derived mediaUploadConnectSrc)
    end

    StorageProvider-->>Browser: Upload success
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): allow storage upload URLs in C..."](https://github.com/langfuse/langfuse/commit/3e5d7428c8b32282d09609076aa35f516bcca240) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41034461)</sub>

<!-- /greptile_comment -->