### PR TITLE
fix(shared): add LIMIT 1 BY dedup to v4 trace detail query

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -654,6 +654,7 @@ async function getObservationsFromEventsTableInternal<T>(
     .applyFilters(observationsFilter)
     .where(search)
     .when(orderByEntries.length > 0, (b) => b.orderByColumns(orderByEntries))
+    .when(opts.select === "rows", (b) => b.limitBy("e.span_id", "e.project_id"))
     .limit(limit, offset);
 
   const { query, params } = queryBuilder.buildWithParams();

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -2214,6 +2214,38 @@ describe("Clickhouse Events Repository Test", () => {
         usagePricingTierName: "Enterprise",
       });
     });
+
+    it("should deduplicate observations with the same span_id", async () => {
+      const traceId = randomUUID();
+      const spanId = randomUUID();
+
+      const baseEvent = createEvent({
+        id: spanId,
+        span_id: spanId,
+        project_id: projectId,
+        trace_id: traceId,
+        type: "SPAN",
+        name: "dedup-test-v1",
+      });
+
+      const updatedEvent = {
+        ...baseEvent,
+        name: "dedup-test-v2",
+        event_ts: baseEvent.event_ts + 1_000_000,
+      };
+
+      await createEventsCh([baseEvent, updatedEvent]);
+
+      const { observations, totalCount } =
+        await getObservationsForTraceFromEventsTable({
+          traceId,
+          projectId,
+        });
+
+      expect(totalCount).toBe(1);
+      expect(observations).toHaveLength(1);
+      expect(observations[0]!.id).toBe(spanId);
+    });
   });
 
   maybe("getObservationsFromEventsTableForPublicApi", () => {


### PR DESCRIPTION
## Summary
- `getObservationsFromEventsTableInternal` was missing `LIMIT 1 BY` dedup on `span_id`, unlike the other 3 row-level queries in `events.ts`
- When ClickHouse's `ReplacingMergeTree` hadn't merged yet, duplicate rows for the same observation caused `buildDependencyGraph`'s BFS queue to grow exponentially, crashing with `RangeError: Invalid array length`
- Only applied for `select=rows` since `LIMIT 1 BY` is incompatible with `count(*)` aggregation without `GROUP BY`

## Impacted packages
- `packages/shared` — `events.ts` query fix
- `web` — new server test in `event-repository.servertest.ts`

## Test plan
- [x] New test: `should deduplicate observations with the same span_id` — inserts two versions of the same span_id with different `event_ts`, verifies only 1 observation is returned
- [x] Full `event-repository.servertest.ts` suite passes (65/65)
- [x] Local browser verification: reproduced crash with 6240 duplicate rows, confirmed fix resolves it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a crash in the v4 trace detail query by adding `LIMIT 1 BY e.span_id, e.project_id` deduplication to `getObservationsFromEventsTableInternal` when `select === "rows"`, matching the behaviour of the three other observation-row queries in `events.ts`. A server integration test that inserts two versions of the same span is also included.

- The fix is gated on `select === \"rows\"` to avoid incompatibility with `count(*)` queries, which is the correct approach.
- The new `LIMIT 1 BY` call follows the established pattern in the file (lines 814, 2701, 2813) but, like those callers, does not order by `event_ts DESC`, so the dedup picks an arbitrary duplicate rather than guaranteeing the most-recent version is selected.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the one-line change directly prevents a crash that occurs when ReplacingMergeTree duplicates are present, and the fix is consistent with three other identical usages already in the file.

The change is minimal and targeted: a single `.when(opts.select === 'rows', ...)` guard followed by `.limitBy(...)` matches the established pattern for every other observation row query in `events.ts`. The accompanying test confirms deduplication occurs. The only open questions are whether the arbitrary-version selection (no `event_ts DESC`) could serve stale data in the pre-merge window, and whether the test should additionally assert the newest version is returned — both are non-blocking quality notes.

No files require special attention; both changed files are straightforward.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant getObservationsForTrace
    participant getObservationsInternal
    participant ClickHouse

    Client->>getObservationsForTrace: "{ traceId, projectId }"
    getObservationsForTrace->>getObservationsInternal: "select=rows, orderBy=startTime ASC"
    getObservationsInternal->>ClickHouse: "SELECT ... FROM events WHERE trace_id=? ORDER BY project_id ASC, start_time ASC LIMIT 1 BY e.span_id, e.project_id [NEW] LIMIT 10001"
    Note over ClickHouse: Before fix: duplicate span_id rows returned → BFS queue grows exponentially → crash
    Note over ClickHouse: After fix: one row per span_id returned (arbitrary version if pre-merge duplicates exist)
    ClickHouse-->>getObservationsInternal: deduplicated rows
    getObservationsInternal-->>getObservationsForTrace: observations[]
    getObservationsForTrace->>getObservationsForTrace: enrichObservationsWithModelData() + enrichObservationsWithTraceFields()
    getObservationsForTrace-->>Client: "{ observations, totalCount }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant getObservationsForTrace
    participant getObservationsInternal
    participant ClickHouse

    Client->>getObservationsForTrace: "{ traceId, projectId }"
    getObservationsForTrace->>getObservationsInternal: "select=rows, orderBy=startTime ASC"
    getObservationsInternal->>ClickHouse: "SELECT ... FROM events WHERE trace_id=? ORDER BY project_id ASC, start_time ASC LIMIT 1 BY e.span_id, e.project_id [NEW] LIMIT 10001"
    Note over ClickHouse: Before fix: duplicate span_id rows returned → BFS queue grows exponentially → crash
    Note over ClickHouse: After fix: one row per span_id returned (arbitrary version if pre-merge duplicates exist)
    ClickHouse-->>getObservationsInternal: deduplicated rows
    getObservationsInternal-->>getObservationsForTrace: observations[]
    getObservationsForTrace->>getObservationsForTrace: enrichObservationsWithModelData() + enrichObservationsWithTraceFields()
    getObservationsForTrace-->>Client: "{ observations, totalCount }"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/repositories/events.ts:657
**Dedup picks an arbitrary duplicate, not necessarily the latest one**

`LIMIT 1 BY e.span_id, e.project_id` selects the "first" row per group based on the current `ORDER BY`. For `getObservationsForTraceFromEventsTable` that ORDER BY is `start_time ASC` — it does not include `event_ts`. When two pre-merge duplicate rows share the same `start_time` (the common case for updated observations), ClickHouse falls back to physical storage order, so the row returned could be an older version rather than the most-recent `event_ts`. This is consistent with the three other `limitBy` call sites in this file (lines 814, 2701, 2813) which also omit `event_ts`, so fixing it here alone would be inconsistent — but it may be worth noting that all four sites could return stale data under concurrent write/merge windows.

### Issue 2 of 2
web/src/__tests__/server/repositories/event-repository.servertest.ts:2234-2248
**Test verifies count but not which version is returned**

The test inserts `baseEvent` (name `"dedup-test-v1"`) and `updatedEvent` (name `"dedup-test-v2"`, higher `event_ts`), then checks `observations[0]!.id === spanId`. It does not assert that the returned observation is the latest version (`name === "dedup-test-v2"`). Because the ORDER BY in the query does not include `event_ts DESC`, either version could be returned. Adding `expect(observations[0]!.name).toBe("dedup-test-v2")` would explicitly document and enforce the expected deduplication semantics (latest event wins), or alternatively reveal that the current implementation may not always return the newest version.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): add LIMIT 1 BY dedup to get..."](https://github.com/langfuse/langfuse/commit/80fe7576bb7e1c717ad348d1bca0c6f07b591b9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41034826)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->