### PR TITLE
fix(trace): decode unicode escapes in trace JSON download

### DIFF
--- a/packages/shared/src/server/utils/transforms/stringify.ts
+++ b/packages/shared/src/server/utils/transforms/stringify.ts
@@ -1,20 +1,25 @@
 import { decodeUnicodeEscapesOnly } from "../../../utils/unicode";
 
-export const stringify = (data: any, key?: string): string => {
-  // For comment fields, use pretty-print formatting for better readability
-  // Other fields use compact format to reduce file size
-  const indent = key === "comments" ? 2 : undefined;
+// Replacer that keeps bigints JSON-serializable and decodes \uXXXX escapes so
+// that non-ASCII content (e.g. Japanese ingested with Python ensure_ascii=True)
+// renders as real characters instead of escape sequences.
+const stringifyReplacer = (_key: string, value: unknown) => {
+  if (typeof value === "bigint") return Number.parseInt(value.toString());
+  if (typeof value === "string") return decodeUnicodeEscapesOnly(value, true);
+  return value;
+};
 
-  return JSON.stringify(
-    data,
-    (k, value) => {
-      if (typeof value === "bigint") return Number.parseInt(value.toString());
-      if (typeof value === "string")
-        return decodeUnicodeEscapesOnly(value, true);
-      return value;
-    },
-    indent,
-  );
+export const stringify = (
+  data: any,
+  key?: string,
+  indent?: number,
+): string => {
+  // For comment fields, use pretty-print formatting for better readability
+  // Other fields use compact format to reduce file size, unless an explicit
+  // indent is requested by the caller (e.g. human-readable trace downloads).
+  const resolvedIndent = indent ?? (key === "comments" ? 2 : undefined);
+
+  return JSON.stringify(data, stringifyReplacer, resolvedIndent);
 };
 
 /**

--- a/packages/shared/src/server/utils/transforms/stringify.ts
+++ b/packages/shared/src/server/utils/transforms/stringify.ts
@@ -9,11 +9,7 @@ const stringifyReplacer = (_key: string, value: unknown) => {
   return value;
 };
 
-export const stringify = (
-  data: any,
-  key?: string,
-  indent?: number,
-): string => {
+export const stringify = (data: any, key?: string, indent?: number): string => {
   // For comment fields, use pretty-print formatting for better readability
   // Other fields use compact format to reduce file size, unless an explicit
   // indent is requested by the caller (e.g. human-readable trace downloads).

--- a/web/src/pages/api/traces/[traceId]/download.ts
+++ b/web/src/pages/api/traces/[traceId]/download.ts
@@ -1,4 +1,5 @@
 import { InvalidRequestError, UnauthorizedError } from "@langfuse/shared";
+import { stringify } from "@langfuse/shared/src/server";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import {
   buildTraceExport,
@@ -67,6 +68,10 @@ export default withMiddlewares({
       `attachment; filename="trace-export.json"; filename*=UTF-8''${encodeURIComponent(downloadFilename)}`,
     );
 
-    return res.status(200).send(JSON.stringify(payload, null, 2));
+    // Use the shared stringify helper (not the raw JSON.stringify) so that
+    // \uXXXX escapes in string fields (e.g. Japanese ingested with Python
+    // ensure_ascii=True) are decoded to real characters. Pass indent=2 to keep
+    // the download human-readable, matching the previous pretty-printed output.
+    return res.status(200).send(stringify(payload, undefined, 2));
   },
 });

--- a/worker/src/__tests__/stringify.test.ts
+++ b/worker/src/__tests__/stringify.test.ts
@@ -41,7 +41,9 @@ describe("stringify", () => {
     // Mirrors the trace-download payload shape: input is a stringified JSON
     // blob whose Japanese characters were escaped by Python ensure_ascii=True.
     const data = {
-      observations: [{ input: '{"text": "\\u3053\\u3093\\u306b\\u3061\\u306f"}' }],
+      observations: [
+        { input: '{"text": "\\u3053\\u3093\\u306b\\u3061\\u306f"}' },
+      ],
     };
     const result = stringify(data, undefined, 2);
     expect(result).toContain("\n"); // pretty-printed

--- a/worker/src/__tests__/stringify.test.ts
+++ b/worker/src/__tests__/stringify.test.ts
@@ -29,6 +29,25 @@ describe("stringify", () => {
     const parsed = JSON.parse(result);
     expect(parsed.text).toBe('line1\\nline2\\t"quoted"');
   });
+
+  it("applies an explicit indent when provided", () => {
+    const data = { text: "hello" };
+    const result = stringify(data, undefined, 2);
+    expect(result).toContain("\n");
+    expect(result).toContain('  "text": "hello"');
+  });
+
+  it("decodes unicode escapes while keeping an explicit indent (trace download)", () => {
+    // Mirrors the trace-download payload shape: input is a stringified JSON
+    // blob whose Japanese characters were escaped by Python ensure_ascii=True.
+    const data = {
+      observations: [{ input: '{"text": "\\u3053\\u3093\\u306b\\u3061\\u306f"}' }],
+    };
+    const result = stringify(data, undefined, 2);
+    expect(result).toContain("\n"); // pretty-printed
+    expect(result).toContain("こんにちは"); // decoded, not こ...
+    expect(result).not.toContain("\\u3053");
+  });
 });
 
 describe("stringifyForCsv", () => {


### PR DESCRIPTION
## What does this PR do?

Routes the **"Download trace as JSON"** payload through the shared `stringify` helper (which decodes `\uXXXX` escapes) instead of raw `JSON.stringify`, so downloaded trace files render non-ASCII content (Japanese, Chinese, Korean, emoji, ...) as their original characters.

This is a follow-up to #12882 (batch CSV/JSON/JSONL export), #9686 (IOTableCell in the trace table) and #13223 (PrettyJsonView in the trace detail view). The trace-detail **download** endpoint was the one remaining path still emitting raw `\uXXXX`.

Refs #10972

### Motivation

The Python SDK defaults to `ensure_ascii=True` when serialising `input` / `output` / `metadata`, so a payload like `"以上"` is stored in ClickHouse as `"以上"`. After #9686, #12882 and #13223 these escaped sequences render correctly in the trace table, in exports, and in the trace detail view — but the **"Download trace as JSON"** button (`GET /api/public/... /traces/[traceId]/download`) still used raw `JSON.stringify`, so the downloaded file contained literal `\uXXXX`, which is hard to read for users of non-Latin languages.

### Changes

**`web/src/pages/api/traces/[traceId]/download.ts`** (+6 / -1)

- Import `stringify` from `@langfuse/shared/src/server`.
- Replace `JSON.stringify(payload, null, 2)` with `stringify(payload, undefined, 2)`. `stringify` already applies `decodeUnicodeEscapesOnly` (greedy) to every string value and handles bigint — it is the same helper used by the batch export pipeline (#12882), so the download is now consistent with exports.

**`packages/shared/src/server/utils/transforms/stringify.ts`** (+ optional indent arg)

- Extract the replacer into a named `stringifyReplacer` constant (readability, no behavior change).
- Add an optional `indent?: number` parameter to `stringify`. When provided it is used directly; otherwise the existing behavior is preserved (`key === "comments" ? 2 : undefined`). This lets the trace download keep its human-readable 2-space indentation while decoding escapes. Fully backward compatible — existing callers pass only `(data, key?)`.

**`worker/src/__tests__/stringify.test.ts`** (+ 2 tests)

- `stringify` applies an explicit indent when provided.
- `stringify` decodes unicode escapes while keeping an explicit indent (mirrors the trace-download payload shape: a stringified JSON blob whose Japanese characters were escaped by `ensure_ascii=True`).

### Backward compatibility

- No schema or API changes.
- Payloads without `\uXXXX` are unaffected (`decodeUnicodeEscapesOnly` early-returns when there is no backslash).
- `stringify(data, key?)` callers are unchanged; the new `indent` arg is optional.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code.
- [x] Added/updated unit tests (`worker/src/__tests__/stringify.test.ts`).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the "Download trace as JSON" endpoint to decode `\uXXXX` Unicode escapes (produced by Python's `ensure_ascii=True`) into their real characters, making downloaded trace files readable for non-Latin-script users. It routes the download payload through the shared `stringify` helper — already used by batch export — rather than raw `JSON.stringify`, and adds an optional `indent` parameter to `stringify` so the download can remain human-readable.

- **`packages/shared/src/server/utils/transforms/stringify.ts`**: Extracts the inline replacer to a module-level `stringifyReplacer` constant and adds an optional `indent` parameter; existing callers are fully unaffected because the new parameter is optional and the `??` operator preserves the old `key === "comments"` logic when no explicit indent is given.
- **`web/src/pages/api/traces/[traceId]/download.ts`**: Replaces `JSON.stringify(payload, null, 2)` with `stringify(payload, undefined, 2)` to decode escapes while retaining pretty-printed output.
- **`worker/src/__tests__/stringify.test.ts`**: Adds two focused tests covering explicit indent and Unicode-decode + indent together, mirroring the trace-download use case.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, additive fix that routes one endpoint through an already-battle-tested helper, with no schema or API changes.

The fix is narrowly scoped: one additional optional parameter on `stringify` (fully backward-compatible via `??`), one call-site change in the download handler, and two new tests. The `decodeUnicodeEscapesOnly` function used here is already exercised by the batch export pipeline. Existing callers of `stringify` pass only one or two arguments and are unchanged. The response header already specifies `charset=utf-8`, so decoded characters are transmitted correctly. No migrations, no schema changes, no auth boundary changes.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant DownloadAPI as "GET /api/traces/[traceId]/download"
    participant buildTraceExport
    participant stringify as "stringify (shared)"
    participant decodeUnicode as "decodeUnicodeEscapesOnly"

    Browser->>DownloadAPI: "GET /api/traces/{traceId}/download"
    DownloadAPI->>buildTraceExport: "buildTraceExport({ traceId, session })"
    buildTraceExport-->>DownloadAPI: "payload (may contain \\uXXXX strings)"
    DownloadAPI->>stringify: "stringify(payload, undefined, 2)"
    Note over stringify: "resolvedIndent = 2"
    stringify->>decodeUnicode: "decodeUnicodeEscapesOnly(strValue, true) per string"
    Note over decodeUnicode: "\\u3053... decoded to real chars"
    decodeUnicode-->>stringify: "decoded string"
    stringify-->>DownloadAPI: "pretty-printed JSON with real Unicode"
    DownloadAPI-->>Browser: "200 application/json with attachment header"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant DownloadAPI as "GET /api/traces/[traceId]/download"
    participant buildTraceExport
    participant stringify as "stringify (shared)"
    participant decodeUnicode as "decodeUnicodeEscapesOnly"

    Browser->>DownloadAPI: "GET /api/traces/{traceId}/download"
    DownloadAPI->>buildTraceExport: "buildTraceExport({ traceId, session })"
    buildTraceExport-->>DownloadAPI: "payload (may contain \\uXXXX strings)"
    DownloadAPI->>stringify: "stringify(payload, undefined, 2)"
    Note over stringify: "resolvedIndent = 2"
    stringify->>decodeUnicode: "decodeUnicodeEscapesOnly(strValue, true) per string"
    Note over decodeUnicode: "\\u3053... decoded to real chars"
    decodeUnicode-->>stringify: "decoded string"
    stringify-->>DownloadAPI: "pretty-printed JSON with real Unicode"
    DownloadAPI-->>Browser: "200 application/json with attachment header"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/unicode-dow..."](https://github.com/langfuse/langfuse/commit/2d9cf85801b415fc0e14f0f8cad14f0fdf3068bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41043548)</sub>

<!-- /greptile_comment -->