### PR TITLE
fix(trace): deduplicate observations by id so colliding ids can't crash trace load (LFE-10588)

### DIFF
--- a/web/src/components/trace/components/TraceTimeline/TimelineScale.tsx
+++ b/web/src/components/trace/components/TraceTimeline/TimelineScale.tsx
@@ -11,8 +11,18 @@ export function TimelineScale({
   scaleWidth,
   stepSize,
 }: TimelineScaleProps) {
-  // Calculate how many markers to show
-  const numMarkers = Math.ceil(scaleWidth / STEP_SIZE) + 1;
+  // Calculate how many markers to show. scaleWidth is expected to be the finite
+  // SCALE_WIDTH constant, but guard against a non-finite / absurd value ever
+  // reaching here: Array.from({ length }) throws "RangeError: Invalid array
+  // length" for Infinity and OOMs for an enormous finite length, so clamp to a
+  // finite, sane upper bound.
+  const safeScaleWidth = Number.isFinite(scaleWidth)
+    ? Math.max(0, scaleWidth)
+    : 0;
+  const numMarkers = Math.min(
+    Math.ceil(safeScaleWidth / STEP_SIZE) + 1,
+    10_000,
+  );
 
   return (
     // No left margin: the 0s tick must sit exactly at the track origin so the

--- a/web/src/components/trace/components/_shared/VirtualizedTreeNodeWrapper.tsx
+++ b/web/src/components/trace/components/_shared/VirtualizedTreeNodeWrapper.tsx
@@ -78,7 +78,9 @@ export function VirtualizedTreeNodeWrapper({
         {/* 1. Indents: ancestor level indicators */}
         {depth > 0 && (
           <div className="flex shrink-0">
-            {Array.from({ length: depth - 1 }, (_, i) => (
+            {/* Math.max floors the length at 0 so a stray non-positive/NaN depth
+                can never reach Array.from as a value that throws RangeError. */}
+            {Array.from({ length: Math.max(0, depth - 1) }, (_, i) => (
               <div key={i} className="relative w-5">
                 {treeLines[i] && (
                   <div className="bg-border absolute top-0 bottom-0 left-3 w-px" />

--- a/web/src/components/trace/lib/tree-building.clienttest.ts
+++ b/web/src/components/trace/lib/tree-building.clienttest.ts
@@ -2185,7 +2185,7 @@ describe("getSubtreeDurationOverflowMs", () => {
 
 describe("Duplicate / colliding observation IDs (LFE-10588)", () => {
   // Regression guard for a prod trace crash. Real traces can contain multiple
-  // rows that share the same observation id (colliding / re-used ids in ingested
+  // rows that share the same observation id (colliding / reused ids in ingested
   // data), and those rows may each carry a DIFFERENT parentObservationId. The
   // tree builder keys nodes by id, so duplicate rows wire one node under several
   // parents — turning the parent→child graph into a dense multi-parent DAG whose
@@ -2228,7 +2228,7 @@ describe("Duplicate / colliding observation IDs (LFE-10588)", () => {
 
   it("does not explode on colliding ids that form a multi-parent DAG", () => {
     // Shortcut ladder: node i is a child of BOTH i-1 and i-2, each via a separate
-    // row that reuses id `n{i}`. Without de-duplication the root→node path count
+    // row that reuses id `n{i}`. Without deduplication the root→node path count
     // is Fibonacci-large and the depth BFS / flatten grow without bound (the prod
     // crash). Sized so the pre-fix blowup stays finite (~Fib(24)) rather than
     // OOM-ing the test worker, while still being orders of magnitude too big.
@@ -2254,7 +2254,7 @@ describe("Duplicate / colliding observation IDs (LFE-10588)", () => {
       }),
     );
     for (let i = 2; i <= N; i++) {
-      // primary edge (earlier startTime → survives de-dup): parent = i-1
+      // primary edge (earlier startTime → survives dedup): parent = i-1
       observations.push(
         createMockObservation({
           id: `n${i}`,
@@ -2275,7 +2275,7 @@ describe("Duplicate / colliding observation IDs (LFE-10588)", () => {
 
     const result = buildTraceUiData(trace, observations);
 
-    // De-dup keeps the earliest-startTime row per id → a clean chain
+    // Dedup keeps the earliest-startTime row per id → a clean chain
     // n0→n1→…→nN. Every distinct id survives exactly once (+ TRACE wrapper), and
     // the flattened list is bounded — pre-fix the duplicated edges either dropped
     // nodes (in-degree never hit zero) or blew the traversal up Fibonacci-large.

--- a/web/src/components/trace/lib/tree-building.clienttest.ts
+++ b/web/src/components/trace/lib/tree-building.clienttest.ts
@@ -2182,3 +2182,107 @@ describe("getSubtreeDurationOverflowMs", () => {
     expect(getSubtreeDurationOverflowMs(64_000, 65_000)).toBe(65_000);
   });
 });
+
+describe("Duplicate / colliding observation IDs (LFE-10588)", () => {
+  // Regression guard for a prod trace crash. Real traces can contain multiple
+  // rows that share the same observation id (colliding / re-used ids in ingested
+  // data), and those rows may each carry a DIFFERENT parentObservationId. The
+  // tree builder keys nodes by id, so duplicate rows wire one node under several
+  // parents — turning the parent→child graph into a dense multi-parent DAG whose
+  // root→node path count grows exponentially. The depth-propagation BFS then grew
+  // its queue without bound, so loading such a trace threw
+  // "RangeError: Invalid array length" / ran out of memory. The builder must
+  // collapse to one row per id so the structure stays a proper forest.
+
+  it("collapses duplicate rows for the same id to a single node", () => {
+    const trace = createMockTrace({ id: "t" });
+    const observations: ObservationReturnType[] = [
+      createMockObservation({
+        id: "a",
+        parentObservationId: null,
+        startTime: new Date("2024-01-01T00:00:00.100Z"),
+      }),
+      createMockObservation({
+        id: "b",
+        parentObservationId: "a",
+        startTime: new Date("2024-01-01T00:00:00.200Z"),
+      }),
+      // duplicate row for child "b" — must not be double-wired under "a"
+      createMockObservation({
+        id: "b",
+        parentObservationId: "a",
+        startTime: new Date("2024-01-01T00:00:00.250Z"),
+      }),
+    ];
+
+    const result = buildTraceUiData(trace, observations);
+
+    // one node per distinct id (+ TRACE wrapper); each appears exactly once.
+    expect(result.nodeMap.size).toBe(3); // trace + a + b
+    expect(result.searchItems).toHaveLength(3);
+    expect(result.searchItems.filter((i) => i.node.id === "b")).toHaveLength(1);
+    // "a" must survive: pre-fix a duplicated child inflated a's in-degree so it
+    // never hit zero in the topological sort and the whole subtree was dropped.
+    expect(result.roots[0].children.map((c) => c.id)).toEqual(["a"]);
+  });
+
+  it("does not explode on colliding ids that form a multi-parent DAG", () => {
+    // Shortcut ladder: node i is a child of BOTH i-1 and i-2, each via a separate
+    // row that reuses id `n{i}`. Without de-duplication the root→node path count
+    // is Fibonacci-large and the depth BFS / flatten grow without bound (the prod
+    // crash). Sized so the pre-fix blowup stays finite (~Fib(24)) rather than
+    // OOM-ing the test worker, while still being orders of magnitude too big.
+    const trace = createMockTrace({ id: "t" });
+    const N = 22;
+    const observations: ObservationReturnType[] = [];
+    let clock = 0;
+    const nextStart = () =>
+      new Date(`2024-01-01T00:00:00.${String(clock++).padStart(3, "0")}Z`);
+
+    observations.push(
+      createMockObservation({
+        id: "n0",
+        parentObservationId: null,
+        startTime: nextStart(),
+      }),
+    );
+    observations.push(
+      createMockObservation({
+        id: "n1",
+        parentObservationId: "n0",
+        startTime: nextStart(),
+      }),
+    );
+    for (let i = 2; i <= N; i++) {
+      // primary edge (earlier startTime → survives de-dup): parent = i-1
+      observations.push(
+        createMockObservation({
+          id: `n${i}`,
+          parentObservationId: `n${i - 1}`,
+          startTime: nextStart(),
+        }),
+      );
+      // shortcut edge (duplicate id, later startTime): parent = i-2
+      observations.push(
+        createMockObservation({
+          id: `n${i}`,
+          parentObservationId: `n${i - 2}`,
+          startTime: nextStart(),
+        }),
+      );
+    }
+    const distinctIds = N + 1; // n0..nN
+
+    const result = buildTraceUiData(trace, observations);
+
+    // De-dup keeps the earliest-startTime row per id → a clean chain
+    // n0→n1→…→nN. Every distinct id survives exactly once (+ TRACE wrapper), and
+    // the flattened list is bounded — pre-fix the duplicated edges either dropped
+    // nodes (in-degree never hit zero) or blew the traversal up Fibonacci-large.
+    expect(result.nodeMap.size).toBe(distinctIds + 1);
+    expect(result.searchItems).toHaveLength(distinctIds + 1);
+    for (let i = 0; i <= N; i++) {
+      expect(result.nodeMap.has(`n${i}`)).toBe(true);
+    }
+  });
+});

--- a/web/src/components/trace/lib/tree-building.ts
+++ b/web/src/components/trace/lib/tree-building.ts
@@ -86,9 +86,9 @@ function prepareObservations(list: ObservationReturnType[]): {
 } {
   if (list.length === 0) return { sortedObservations: [] };
 
-  // De-duplicate by observation id. The tree builder assumes ids are unique, but
+  // Deduplicate by observation id. The tree builder assumes ids are unique, but
   // real traces can contain multiple rows sharing the same id (colliding /
-  // re-used ids in ingested data) — and those rows may each carry a DIFFERENT
+  // reused ids in ingested data) — and those rows may each carry a DIFFERENT
   // parentObservationId. Left un-deduped, one node gets wired under several
   // parents, turning the parent→child graph into a dense multi-parent DAG whose
   // root→node path count is exponential; the depth-propagation BFS below then
@@ -169,7 +169,7 @@ function buildDependencyGraph(sortedObservations: ObservationReturnType[]): {
   // BFS to propagate depth down the tree.
   //
   // Defense in depth: track visited nodes so a node is enqueued at most once.
-  // prepareObservations already de-dups by id (making the graph a proper forest),
+  // prepareObservations already dedupes by id (making the graph a proper forest),
   // but guarding here means even a pathological multi-parent / cyclic graph can
   // never grow the queue without bound — the failure mode that crashed the trace
   // peek with "RangeError: Invalid array length" / OOM. For a well-formed forest

--- a/web/src/components/trace/lib/tree-building.ts
+++ b/web/src/components/trace/lib/tree-building.ts
@@ -86,11 +86,30 @@ function prepareObservations(list: ObservationReturnType[]): {
 } {
   if (list.length === 0) return { sortedObservations: [] };
 
+  // De-duplicate by observation id. The tree builder assumes ids are unique, but
+  // real traces can contain multiple rows sharing the same id (colliding /
+  // re-used ids in ingested data) — and those rows may each carry a DIFFERENT
+  // parentObservationId. Left un-deduped, one node gets wired under several
+  // parents, turning the parent→child graph into a dense multi-parent DAG whose
+  // root→node path count is exponential; the depth-propagation BFS below then
+  // grows its queue without bound, so loading such a trace crashed the client
+  // with "RangeError: Invalid array length" / out of memory. Collapse to one row
+  // per id (earliest by startTime, deterministic) so the structure stays a
+  // proper forest. No-op for well-formed traces (all ids already unique).
+  const byId = new Map<string, ObservationReturnType>();
+  for (const o of list) {
+    const existing = byId.get(o.id);
+    if (!existing || o.startTime.getTime() < existing.startTime.getTime()) {
+      byId.set(o.id, o);
+    }
+  }
+  const dedupedList = Array.from(byId.values());
+
   // Build a Set of all observation IDs for O(1) lookup
-  const observationIds = new Set(list.map((o) => o.id));
+  const observationIds = new Set(dedupedList.map((o) => o.id));
 
   // Remove parentObservationId if parent doesn't exist in the list
-  const mutableList = list.map((o) => {
+  const mutableList = dedupedList.map((o) => {
     if (o.parentObservationId && !observationIds.has(o.parentObservationId)) {
       return { ...o, parentObservationId: null };
     }
@@ -147,14 +166,25 @@ function buildDependencyGraph(sortedObservations: ObservationReturnType[]): {
     }
   }
 
-  // BFS to propagate depth down the tree
+  // BFS to propagate depth down the tree.
+  //
+  // Defense in depth: track visited nodes so a node is enqueued at most once.
+  // prepareObservations already de-dups by id (making the graph a proper forest),
+  // but guarding here means even a pathological multi-parent / cyclic graph can
+  // never grow the queue without bound — the failure mode that crashed the trace
+  // peek with "RangeError: Invalid array length" / OOM. For a well-formed forest
+  // each node has a single parent, so it is visited exactly once and depths are
+  // unchanged.
   const queue = [...rootIds];
+  const visited = new Set(rootIds);
   let queueIndex = 0;
   while (queueIndex < queue.length) {
     const currentId = queue[queueIndex++];
     const currentNode = nodeRegistry.get(currentId)!;
 
     for (const childId of currentNode.childrenIds) {
+      if (visited.has(childId)) continue;
+      visited.add(childId);
       const childNode = nodeRegistry.get(childId)!;
       childNode.depth = currentNode.depth + 1;
       queue.push(childId);


### PR DESCRIPTION
## TL;DR
Loading certain large traces crashed the client with **`RangeError: Invalid array length`** / out-of-memory (a customer-reported prod issue, both fast-mode on and off). The culprit wasn't the timeline/tree array math — it was **duplicate observation rows sharing the same id** blowing up the tree builder. Fixed by de-duplicating observations by id, plus a couple of defensive guards. Normal traces render identically.

## Why
A customer hit a hard client-side crash opening a trace. The crashing trace's response had **632 observation rows but only 187 distinct ids** — many rows reused the same `id`, and those duplicates carried **different `parentObservationId`s**.

The tree builder keys nodes by `id`, so duplicate rows wired one node under several parents, turning the parent→child graph into a dense **multi-parent DAG**. The depth-propagation BFS in `buildDependencyGraph` has no visited guard, so it enqueued each node **once per root→node path** — an exponential blowup that grew the `queue` array without bound until it either hit JS's 2³²-element array limit (**`RangeError: Invalid array length`**) or exhausted the heap (**OOM**). Same root cause explains both reported symptoms, both fast-modes, and why it's in the *shared* render path.

## What
- **Root fix:** de-duplicate observations by `id` in `prepareObservations` (keep the earliest by `startTime`), collapsing the graph back to a proper forest. **No-op for well-formed traces** (ids already unique).
- **Defense in depth:** a visited guard on the depth BFS so no pathological graph can ever grow the queue without bound.
- **Hardening:** clamped the two `Array.from({ length })` sites the crash was first attributed to (timeline marker count, tree indent count) against non-finite / negative lengths.

## Result
Verified against the **real 632-observation trace**: builds in **~1 ms**, one node per id, no crash. All 208 trace client tests pass; added regression tests for duplicate / colliding observation ids.

<details>
<summary>Engineering detail — why the "obvious" suspects were red herrings</summary>

The crash was initially attributed to two `Array.from({ length })` calls (timeline `numMarkers`, tree `depth - 1`). Neither can actually produce the error as wired:

- `Array.from({ length })` runs `ToLength`, which **clamps negatives/`NaN`/`undefined` to `0`** (returns `[]`) — it only throws `RangeError: Invalid array length` for **`Infinity`** or a length **> 2³²−1**, and OOMs for a huge-but-finite length. So a `depth` of `0`/`undefined` can't throw there.
- `numMarkers` is fed the constant `SCALE_WIDTH` (900) ⇒ always `10`; and tree `depth` is a bounded tree depth. Neither reaches the throwing range.

The actual throw/OOM is the unbounded `queue.push` in the depth BFS under exponential path growth. Confirmed by replaying the saved tRPC response through the real `buildTraceUiData`:
- **before:** BFS runs away (10M+ iterations, reaches only 187/632 nodes before it explodes)
- **after:** 632 rows → 187 nodes, builds in ~1 ms.

The `numMarkers`/`depth` clamps are kept as cheap defense-in-depth (they were explicitly flagged and guard the same *class* of bug), but the dedup + BFS guard are what fix the crash.

**Verification:** `pnpm --filter web run test-client "trace/"` (208 pass), `typecheck`, `lint`, prettier — all green.
</details>

Fixes LFE-10588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a client-side crash (`RangeError: Invalid array length` / OOM) when loading traces with duplicate observation IDs — a production issue confirmed on a real 632-row trace with only 187 distinct IDs. The duplicate rows wired one graph node under multiple parents, producing an exponential BFS blowup that overwhelmed the JS heap.

- **Root fix:** `prepareObservations` now de-duplicates observations by `id` (keeping the earliest by `startTime`) before handing the list to the graph builder, collapsing any multi-parent DAG back to a proper forest with O(N) build time.
- **Defense-in-depth:** A `visited` set is added to the depth-propagation BFS in `buildDependencyGraph`, so even a pathological input graph (cycle or remaining multi-parent edge) can never grow the queue without bound.
- **Defensive guards:** `TimelineScale` and `VirtualizedTreeNodeWrapper` clamp their `Array.from` length arguments, and regression tests covering the duplicate-ID scenario are included.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the root cause is correctly identified and fixed, all existing tests pass, and regression tests covering the crash scenario are included.

The deduplication in `prepareObservations` and the BFS `visited` guard together eliminate the exponential blowup confirmed on the production trace. The changes are strictly additive for well-formed traces (no-op when all IDs are already unique), and the defensive `Array.from` clamps in `TimelineScale` and `VirtualizedTreeNodeWrapper` are inert for valid inputs. The only note is a slightly misleading comment in `VirtualizedTreeNodeWrapper` about `Math.max` and NaN, which has no runtime effect.

No files require special attention; `tree-building.ts` carries the substantive logic change and is well-covered by the new regression tests.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["buildTraceUiData(trace, observations)"] --> B["prepareObservations(list)"]
    B --> C{"list empty?"}
    C -- yes --> Z["return empty"]
    C -- no --> D["De-duplicate by id\n(keep earliest startTime)\nNEW ✓"]
    D --> E["Build observationIds Set"]
    E --> F["Null out orphaned parentObservationIds"]
    F --> G["Sort by startTime"]
    G --> H["buildDependencyGraph(sortedObservations)"]
    H --> I["Create ProcessingNodes for all obs"]
    I --> J["Wire parent→child relationships"]
    J --> K["BFS depth propagation\n+ visited guard NEW ✓"]
    K --> L["Compute inDegrees & leaf set"]
    L --> M["buildTreeNodesBottomUp(leafIds)"]
    M --> N["Topological sort\n(leaves → roots)"]
    N --> O["Wrap in TRACE node\nor return obs roots"]
    O --> P["Flatten to searchItems (DFS)"]
    P --> Q["Return roots, nodeMap, searchItems"]

    style D fill:#bbf,stroke:#44a
    style K fill:#bbf,stroke:#44a
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["buildTraceUiData(trace, observations)"] --> B["prepareObservations(list)"]
    B --> C{"list empty?"}
    C -- yes --> Z["return empty"]
    C -- no --> D["De-duplicate by id\n(keep earliest startTime)\nNEW ✓"]
    D --> E["Build observationIds Set"]
    E --> F["Null out orphaned parentObservationIds"]
    F --> G["Sort by startTime"]
    G --> H["buildDependencyGraph(sortedObservations)"]
    H --> I["Create ProcessingNodes for all obs"]
    I --> J["Wire parent→child relationships"]
    J --> K["BFS depth propagation\n+ visited guard NEW ✓"]
    K --> L["Compute inDegrees & leaf set"]
    L --> M["buildTreeNodesBottomUp(leafIds)"]
    M --> N["Topological sort\n(leaves → roots)"]
    N --> O["Wrap in TRACE node\nor return obs roots"]
    O --> P["Flatten to searchItems (DFS)"]
    P --> Q["Return roots, nodeMap, searchItems"]

    style D fill:#bbf,stroke:#44a
    style K fill:#bbf,stroke:#44a
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/trace/components/_shared/VirtualizedTreeNodeWrapper.tsx:81-83
The inline comment slightly overstates what `Math.max(0, depth - 1)` protects against. `Math.max(0, NaN)` evaluates to `NaN` (not `0`) in JavaScript, so the guard doesn't cover NaN — it's actually the outer `depth > 0` predicate that blocks NaN before this code is reached. The guard is genuinely useful only for the narrow case where `depth` is a non-integer in `(0, 1)`, which cannot happen given that `depth` is always set by integer-step BFS increments. The comment can be tightened to avoid future confusion.

```suggestion
            {/* Math.max(0, ...) floors the length so a fractional depth in (0,1)
                can't produce a negative length. NaN / non-positive depth are
                already excluded by the `depth > 0` guard above. */}
            {Array.from({ length: Math.max(0, depth - 1) }, (_, i) => (
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): de-duplicate observations by..."](https://github.com/langfuse/langfuse/commit/7dcf3ca2a0fad2fb21c3afd721553d75885062d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41045787)</sub>

<!-- /greptile_comment -->