### PR TITLE
fix(experiments): thin x-axis ticks so long-name charts stop smearing (LFE-10583)

### DIFF
--- a/web/src/features/widgets/chart-library/AreaChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/AreaChartTimeSeries.tsx
@@ -125,6 +125,7 @@ export const AreaChartTimeSeries: React.FC<ChartProps> = ({
             axisLine={false}
             interval={timeAxis.interval}
             tickFormatter={timeAxis.formatTick}
+            {...timeAxis.tickProps}
           />
           <YAxis
             type="number"

--- a/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
@@ -301,6 +301,7 @@ export const LineChartTimeSeries: React.FC<ChartProps> = ({
             axisLine={false}
             interval={timeAxis.interval}
             tickFormatter={timeAxis.formatTick}
+            {...timeAxis.tickProps}
           />
           <YAxis
             type="number"

--- a/web/src/features/widgets/chart-library/VerticalBarChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/VerticalBarChartTimeSeries.tsx
@@ -132,6 +132,7 @@ export const VerticalBarChartTimeSeries: React.FC<ChartProps> = ({
             axisLine={false}
             interval={timeAxis.interval}
             tickFormatter={timeAxis.formatTick}
+            {...timeAxis.tickProps}
           />
           <YAxis
             type="number"

--- a/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
+++ b/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
@@ -123,6 +123,24 @@ describe("prepareTimeAxis", () => {
     expect(axis.formatTooltip("1")).toBe("1");
   });
 
+  it("categorical axis thins width-aware (equidistant), not by a numeric index step (LFE-10583)", () => {
+    // The smear bug: a numeric recharts `interval` shows every Nth tick BY INDEX
+    // and skips the label-collision test, so long entity names overlap however
+    // few we target. The fix hands recharts "equidistantPreserveStart" so it
+    // picks the even step whose *rendered* labels don't collide — even spacing,
+    // width-aware, robust to hundreds of points.
+    const manyLongRuns = Array.from(
+      { length: 200 },
+      (_, i) => `demo-dataset-run-${i}-demo-english-transcription-dataset`,
+    );
+    const axis = prepareTimeAxis(manyLongRuns, 6);
+    expect(axis.mode).toBe("category");
+    // The crux: NOT a numeric index step (which smears) — the width-aware one.
+    expect(axis.interval).toBe("equidistantPreserveStart");
+    // A deliberate gap between the (thinned) ticks, so they read as a handful.
+    expect(axis.tickProps.minTickGap).toBeGreaterThan(0);
+  });
+
   it("long categorical labels are angled and end-truncated, full name in tooltip (LFE-10583)", () => {
     // The experiments / dataset-compare x-axis: long entity (run) names that
     // recharts would otherwise render flat and overlap into a smear.
@@ -150,17 +168,20 @@ describe("prepareTimeAxis", () => {
     expect(axis.formatTooltip(runs[1])).toBe(runs[1]);
   });
 
-  it("short categorical labels are not truncated and time ticks stay flat", () => {
+  it("short categorical labels are not truncated and time ticks stay flat + numeric (dashboards unchanged)", () => {
     const shortCats = prepareTimeAxis(["run-a", "run-b", "run-c"], 6);
     expect(shortCats.formatTick("run-a")).toBe("run-a");
     expect(shortCats.tickProps.angle).toBeLessThan(0);
 
-    // Time-mode ticks are unchanged (flat) so dashboards render identically.
+    // Time-mode ticks are unchanged: flat tickProps AND a numeric index step, so
+    // dashboards render pixel-identically (no width-aware equidistant thinning).
     const start = Date.UTC(2026, 5, 28, 0);
     const timeVals = Array.from({ length: 24 }, (_, h) =>
       iso(start + h * HOUR),
     );
-    expect(prepareTimeAxis(timeVals, 6).tickProps).toEqual({});
+    const timeAxis = prepareTimeAxis(timeVals, 6);
+    expect(timeAxis.tickProps).toEqual({});
+    expect(typeof timeAxis.interval).toBe("number");
   });
 
   it("does not coerce bare numeric strings into epoch dates", () => {

--- a/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
+++ b/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
@@ -123,6 +123,46 @@ describe("prepareTimeAxis", () => {
     expect(axis.formatTooltip("1")).toBe("1");
   });
 
+  it("long categorical labels are angled and end-truncated, full name in tooltip (LFE-10583)", () => {
+    // The experiments / dataset-compare x-axis: long entity (run) names that
+    // recharts would otherwise render flat and overlap into a smear.
+    const runs = [
+      "demo-dataset-run-0-demo-english-transcription-dataset",
+      "demo-dataset-run-1-demo-english-transcription-dataset",
+      "demo-dataset-run-2-demo-english-transcription-dataset",
+    ];
+    const axis = prepareTimeAxis(runs, 6);
+    expect(axis.mode).toBe("category");
+
+    // Angled + end-anchored so neighbours don't collide horizontally.
+    expect(axis.tickProps.angle).toBeLessThan(0);
+    expect(axis.tickProps.textAnchor).toBe("end");
+
+    // Shown tick is truncated (keeps the distinguishing head, drops the tail)…
+    const shown = axis.formatTick(runs[1]);
+    expect(shown.length).toBeLessThan(runs[1].length);
+    expect(shown.endsWith("…")).toBe(true);
+    expect(shown.startsWith("demo-dataset-run-1")).toBe(true);
+    // …but the different runs still truncate to DIFFERENT strings.
+    expect(axis.formatTick(runs[0])).not.toBe(axis.formatTick(runs[1]));
+
+    // …while the tooltip carries the full, untruncated name (nothing lost).
+    expect(axis.formatTooltip(runs[1])).toBe(runs[1]);
+  });
+
+  it("short categorical labels are not truncated and time ticks stay flat", () => {
+    const shortCats = prepareTimeAxis(["run-a", "run-b", "run-c"], 6);
+    expect(shortCats.formatTick("run-a")).toBe("run-a");
+    expect(shortCats.tickProps.angle).toBeLessThan(0);
+
+    // Time-mode ticks are unchanged (flat) so dashboards render identically.
+    const start = Date.UTC(2026, 5, 28, 0);
+    const timeVals = Array.from({ length: 24 }, (_, h) =>
+      iso(start + h * HOUR),
+    );
+    expect(prepareTimeAxis(timeVals, 6).tickProps).toEqual({});
+  });
+
   it("does not coerce bare numeric strings into epoch dates", () => {
     expect(parseChartTimestamp("1")).toBeNull();
     expect(parseChartTimestamp("20241230")).toBeNull();

--- a/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
+++ b/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
@@ -169,9 +169,9 @@ describe("prepareTimeAxis", () => {
   });
 
   it("short categorical labels are not truncated and time ticks stay flat + numeric (dashboards unchanged)", () => {
-    const shortCats = prepareTimeAxis(["run-a", "run-b", "run-c"], 6);
-    expect(shortCats.formatTick("run-a")).toBe("run-a");
-    expect(shortCats.tickProps.angle).toBeLessThan(0);
+    const shortCategories = prepareTimeAxis(["run-a", "run-b", "run-c"], 6);
+    expect(shortCategories.formatTick("run-a")).toBe("run-a");
+    expect(shortCategories.tickProps.angle).toBeLessThan(0);
 
     // Time-mode ticks are unchanged: flat tickProps AND a numeric index step, so
     // dashboards render pixel-identically (no width-aware equidistant thinning).

--- a/web/src/features/widgets/chart-library/prepareTimeAxis.ts
+++ b/web/src/features/widgets/chart-library/prepareTimeAxis.ts
@@ -31,6 +31,25 @@ const MONTH_SCALE_MIN = 180 * DAY;
 type AxisMode = "time" | "date" | "month" | "category";
 
 /**
+ * Max characters shown for a categorical (non-time) x-axis tick. Entity names
+ * (experiment / dataset-run names) are frequently long; recharts neither wraps
+ * nor truncates a tick. We render category ticks angled (so neighbours don't
+ * collide) and cap the *shown* label so a single very long outlier can't run
+ * off-canvas — the full value always stays in the tooltip. Generous, because
+ * angled labels have vertical room; short labels are untouched.
+ */
+const MAX_CATEGORY_LABEL_CHARS = 24;
+
+/** End-truncate a long categorical label ("foo-bar-…"). Entity names carry
+ * their distinguishing token early (e.g. "…-run-2-…"), so keeping the head and
+ * dropping the tail preserves what tells ticks apart; the tooltip has the full
+ * name. Short labels pass through untouched. */
+function truncateCategoryLabel(label: string): string {
+  if (label.length <= MAX_CATEGORY_LABEL_CHARS) return label;
+  return `${label.slice(0, MAX_CATEGORY_LABEL_CHARS - 1)}…`;
+}
+
+/**
  * Parse a raw bucket value into a Date, but ONLY when it actually looks like a
  * timestamp: an epoch-ms number, an ISO string, or a "YYYY-MM-DD[ T]HH:MM:SS"
  * ClickHouse datetime (optionally a bare "YYYY-MM-DD"). Values without an
@@ -101,6 +120,19 @@ export type TimeAxis = {
   /** Fuller label for the tooltip (always date + year, time when intraday). */
   formatTooltip: (raw: unknown) => string;
   mode: AxisMode;
+  /**
+   * Tick-label orientation the visualiser spreads onto the recharts `XAxis`.
+   * Time / date / month ticks are short single-units rendered flat (`{}` → the
+   * spread is a no-op, so dashboards are unchanged). Categorical entity names
+   * are long, so we render them angled + end-anchored — the standard way to fit
+   * long category labels without overlapping their neighbours. (LFE-10583)
+   */
+  tickProps: {
+    angle?: number;
+    textAnchor?: "start" | "middle" | "end";
+    /** Extra x-axis height (px) an angled label needs so it isn't clipped. */
+    height?: number;
+  };
 };
 
 /**
@@ -116,19 +148,26 @@ export function prepareTimeAxis(rawValues: unknown[], maxTicks = 6): TimeAxis {
 
   const target = Math.max(2, maxTicks);
 
-  // Non-temporal x-axis (e.g. dataset-compare run names): the labels aren't
-  // timestamps, so we don't invent dates — render them verbatim and only thin
-  // by index. We treat the axis as time only when most values actually parse.
+  // Non-temporal x-axis (e.g. the experiments / dataset-compare charts, whose
+  // ticks are entity names like "demo-dataset-run-2-…-transcription-dataset"):
+  // the labels aren't timestamps, so we don't invent dates. We treat the axis as
+  // time only when most values actually parse.
   const temporal =
     timestamps.length > 0 && timestamps.length >= rawValues.length / 2;
   if (!temporal) {
-    const passthrough = (raw: unknown): string =>
+    const full = (raw: unknown): string =>
       raw == null ? "" : typeof raw === "string" ? raw : String(raw);
     return {
       interval: getEvenTickInterval(rawValues.length, target),
-      formatTick: passthrough,
-      formatTooltip: passthrough,
+      // Entity names can be long (run / experiment names) — recharts neither
+      // wraps nor truncates a tick, so rendering them flat overlaps adjacent
+      // ticks into an unreadable smear. Render them angled + end-anchored (see
+      // tickProps) and end-truncate the shown label so an outlier name can't
+      // run off-canvas; the full name always stays in the tooltip. (LFE-10583)
+      formatTick: (raw: unknown) => truncateCategoryLabel(full(raw)),
+      formatTooltip: full,
       mode: "category",
+      tickProps: { angle: -30, textAnchor: "end", height: 60 },
     };
   }
 
@@ -205,5 +244,7 @@ export function prepareTimeAxis(rawValues: unknown[], maxTicks = 6): TimeAxis {
     });
   };
 
-  return { interval, formatTick, formatTooltip, mode };
+  // Time / date / month ticks are short single-units — rendered flat, exactly
+  // as the dashboards do today (no orientation change → pixel-identical).
+  return { interval, formatTick, formatTooltip, mode, tickProps: {} };
 }

--- a/web/src/features/widgets/chart-library/prepareTimeAxis.ts
+++ b/web/src/features/widgets/chart-library/prepareTimeAxis.ts
@@ -40,6 +40,14 @@ type AxisMode = "time" | "date" | "month" | "category";
  */
 const MAX_CATEGORY_LABEL_CHARS = 24;
 
+/**
+ * Minimum whitespace (px) recharts must leave between two shown categorical
+ * ticks. `equidistantPreserveStart` (see `prepareTimeAxis`) already drops ticks
+ * until their *labels* don't overlap; this adds a deliberate gap on top so the
+ * kept ticks read as a handful of clearly-separated labels, not a dense strip.
+ */
+const CATEGORY_MIN_TICK_GAP_PX = 16;
+
 /** End-truncate a long categorical label ("foo-bar-…"). Entity names carry
  * their distinguishing token early (e.g. "…-run-2-…"), so keeping the head and
  * dropping the tail preserves what tells ticks apart; the tooltip has the full
@@ -113,25 +121,37 @@ function inferBucketMs(timestamps: number[]): number {
 }
 
 export type TimeAxis = {
-  /** recharts numeric x-axis `interval` (ticks skipped between shown ticks). */
-  interval: number;
+  /**
+   * recharts x-axis `interval`. Two shapes, by axis kind:
+   * - time / date / month → a NUMERIC index-step (evenly spaced, width-blind).
+   *   Labels are short single units ("2 PM" / "Jun 28"), so an index step gives
+   *   uniform gaps that don't depend on chart width — the dashboard behaviour.
+   * - categorical entity names → `"equidistantPreserveStart"`. These labels are
+   *   long and variable-width; a numeric step skips recharts' collision test and
+   *   overlaps them into a smear. This string interval instead picks the largest
+   *   even step whose *rendered* labels don't collide. (LFE-10583)
+   */
+  interval: number | "equidistantPreserveStart";
   /** Scale-appropriate label for a shown tick. */
   formatTick: (raw: unknown) => string;
   /** Fuller label for the tooltip (always date + year, time when intraday). */
   formatTooltip: (raw: unknown) => string;
   mode: AxisMode;
   /**
-   * Tick-label orientation the visualiser spreads onto the recharts `XAxis`.
+   * Tick-label props the visualiser spreads onto the recharts `XAxis`.
    * Time / date / month ticks are short single-units rendered flat (`{}` → the
    * spread is a no-op, so dashboards are unchanged). Categorical entity names
    * are long, so we render them angled + end-anchored — the standard way to fit
-   * long category labels without overlapping their neighbours. (LFE-10583)
+   * long category labels — and set a `minTickGap` so the (width-aware thinned)
+   * ticks keep a real gap between them. (LFE-10583)
    */
   tickProps: {
     angle?: number;
     textAnchor?: "start" | "middle" | "end";
     /** Extra x-axis height (px) an angled label needs so it isn't clipped. */
     height?: number;
+    /** Minimum px gap recharts leaves between two shown ticks. */
+    minTickGap?: number;
   };
 };
 
@@ -158,16 +178,31 @@ export function prepareTimeAxis(rawValues: unknown[], maxTicks = 6): TimeAxis {
     const full = (raw: unknown): string =>
       raw == null ? "" : typeof raw === "string" ? raw : String(raw);
     return {
-      interval: getEvenTickInterval(rawValues.length, target),
-      // Entity names can be long (run / experiment names) — recharts neither
-      // wraps nor truncates a tick, so rendering them flat overlaps adjacent
-      // ticks into an unreadable smear. Render them angled + end-anchored (see
-      // tickProps) and end-truncate the shown label so an outlier name can't
-      // run off-canvas; the full name always stays in the tooltip. (LFE-10583)
+      // THE fix for the smear (LFE-10583). A numeric interval makes recharts
+      // show every Nth tick BY INDEX and skip its label-collision test, so a
+      // handful of long entity names (~50 chars each) still overlap into an
+      // illegible black strip — no matter how few we target, index-thinning is
+      // blind to how wide each label actually is. `equidistantPreserveStart`
+      // instead picks the largest even step at which every Nth *rendered* label
+      // fits without colliding (recharts measures the formatted, angled label +
+      // minTickGap), so long names collapse to a few evenly-spaced ticks with a
+      // real gap, robust to hundreds of points. This is the "measure labels,
+      // don't guess" principle (ARCHITECTURE.md #4) — the numeric time/date
+      // budget guesses ~64px/label, which is 5× too small for entity names.
+      interval: "equidistantPreserveStart",
+      // Angle + end-anchor the (now few) long labels — the standard long-category
+      // treatment, and it lets recharts fit a couple more without overlap. Also
+      // end-truncate the shown label so a single outlier name can't run
+      // off-canvas; the full name always stays in the tooltip.
       formatTick: (raw: unknown) => truncateCategoryLabel(full(raw)),
       formatTooltip: full,
       mode: "category",
-      tickProps: { angle: -30, textAnchor: "end", height: 60 },
+      tickProps: {
+        angle: -30,
+        textAnchor: "end",
+        height: 60,
+        minTickGap: CATEGORY_MIN_TICK_GAP_PX,
+      },
     };
   }
 

--- a/web/src/features/widgets/chart-library/prepareTimeAxis.ts
+++ b/web/src/features/widgets/chart-library/prepareTimeAxis.ts
@@ -32,11 +32,12 @@ type AxisMode = "time" | "date" | "month" | "category";
 
 /**
  * Max characters shown for a categorical (non-time) x-axis tick. Entity names
- * (experiment / dataset-run names) are frequently long; recharts neither wraps
- * nor truncates a tick. We render category ticks angled (so neighbours don't
- * collide) and cap the *shown* label so a single very long outlier can't run
- * off-canvas — the full value always stays in the tooltip. Generous, because
- * angled labels have vertical room; short labels are untouched.
+ * (experiment / dataset-run names) are frequently long and recharts neither
+ * wraps nor truncates a tick. The width-aware thinning (see `prepareTimeAxis`)
+ * is what keeps ticks from colliding; this cap just bounds the *shown* width so
+ * a single very long outlier can't force the step so wide that almost nothing
+ * shows (nor run off-canvas). The full value always stays in the tooltip; short
+ * labels are untouched.
  */
 const MAX_CATEGORY_LABEL_CHARS = 24;
 
@@ -178,9 +179,9 @@ export function prepareTimeAxis(rawValues: unknown[], maxTicks = 6): TimeAxis {
     const full = (raw: unknown): string =>
       raw == null ? "" : typeof raw === "string" ? raw : String(raw);
     return {
-      // THE fix for the smear (LFE-10583). A numeric interval makes recharts
-      // show every Nth tick BY INDEX and skip its label-collision test, so a
-      // handful of long entity names (~50 chars each) still overlap into an
+      // The fix for the categorical smear (LFE-10583). A numeric interval makes
+      // recharts show every Nth tick BY INDEX and skip its label-collision test,
+      // so a handful of long entity names (~50 chars each) still overlap into an
       // illegible black strip — no matter how few we target, index-thinning is
       // blind to how wide each label actually is. `equidistantPreserveStart`
       // instead picks the largest even step at which every Nth *rendered* label


### PR DESCRIPTION
## TL;DR

On the **Experiments** view (and the dataset **Compare runs → Charts** view), the line/bar chart x-axis rendered as an **illegible solid smear** — long entity names (experiment / dataset-run names) stacked on top of each other. The axis refactor in **#14618** replaced the old width-aware tick thinning with a numeric tick step, and recharts **skips its label-collision check for a numeric step** — so the long labels overlapped no matter how few we targeted. This makes the categorical axis width-aware again: it now shows a **handful of evenly-spaced ticks with a real gap**, robust to hundreds of long-named points. Dashboard time-series charts are **pixel-identical**.

Fixes **LFE-10583**. Regression from **#14618** (LFE-10549). _(This revises the first attempt on this branch, which only angled + truncated the labels — angling 200 labels is still a smear; the real fix is width-aware thinning.)_

## Why

`prepareTimeAxis` became the single source of truth for every time-series x-axis in #14618 — correct for dashboards, whose ticks are short timestamps (`Jun 28`). But the **experiments** and **dataset-compare** charts put *entity names* on the x-axis — e.g. `demo-dataset-run-2-demo-english-transcription-dataset` (~50 chars).

#14618 swapped the old recharts-native `interval="preserveStartEnd" + minTickGap` (which **measures each label and drops overlapping ones**) for a computed **numeric** `interval`. The catch: recharts takes a completely different code path for a numeric interval — `getNumberIntervalTicks`, which shows every _N_-th tick **purely by index and never checks whether the labels fit**. So a handful of ~50-char names still landed on top of each other. The tick *budget* compounds it: it assumes ~64 px per label (fine for `Jun 28`), which is ~5× too small for entity names.

## What

Scoped to the **categorical branch** of `prepareTimeAxis`:

- Hand recharts **`interval="equidistantPreserveStart"`** instead of a numeric step. recharts then picks the largest **even** step at which every _N_-th *rendered* label (formatted + angled) fits **without colliding** — even spacing **and** width-aware. This is the charts manifesto's own principle #4: *"Size axes by measuring labels, not guessing."*
- Add a `minTickGap` so the kept ticks keep a deliberate gap.
- Keep the angle + end-truncation as a complement (lets a couple more fit; the full name is always in the tooltip).

Time / date / month axes are **untouched** — same numeric index step, same flat `tickProps: {}` → dashboards render identically.

## Result

Verified live against the real chart component (`Chart` → `LineChartTimeSeries`, through the real `prepareTimeAxis`), rendering the exact experiments/compare data shape:

| | x-axis with a dense categorical axis |
| --- | --- |
| **Before** (numeric step) | one illegible overlapping smear of long names — every label collides |
| **After** (equidistant) | ~a dozen evenly-spaced, angled, gapped labels (`…run-38…`, `…run-57…`, `…run-190…`) — legible |

- **200 long-named runs on a 588 px chart:** the smear collapses to **~11 evenly-spaced, non-overlapping ticks**; with 6 runs, from 6 overlapping labels to 3 clean ones.
- **Dashboard time-series (90 daily points):** identical — `Apr 1 … Jun 21`, flat, evenly spaced.

<details>
<summary>Mechanism & verification</summary>

**recharts source (`getTicks`, v3.8):** `if (isNumber(interval)) return getNumberIntervalTicks(...)` — the numeric branch returns every _N_-th tick by index and never runs `isVisible`/`getTickSize`, so label width and `minTickGap` are ignored. The string intervals (`preserveStart*`, `equidistant*`) run the collision-aware path that measures each formatted, angled label via `getStringSize`/`getAngledTickWidth`. `equidistantPreserveStart` specifically *"selects a number N such that every Nth tick will be shown without collision"* — even gaps + width-aware, exactly what a long, variable-width categorical axis needs.

**Why dashboards can't change:** the temporal branches return a numeric `interval` and `tickProps: {}` (unchanged from before this PR), so `{...{}}` spreads nothing onto the `XAxis` and the numeric-interval code path is byte-identical. A unit test locks `typeof prepareTimeAxis(<timestamps>).interval === "number"` and `.tickProps === {}`.

**Files:**
- `prepareTimeAxis.ts` — category branch returns `interval: "equidistantPreserveStart"` + `minTickGap`; temporal branches unchanged.
- `prepareTimeAxis.clienttest.ts` — new test asserts the categorical axis thins width-aware (`equidistantPreserveStart`, not a numeric index step) at 200 points; existing time/date tests still lock the numeric interval + flat tickProps.

**Checks:** `prepareTimeAxis` client tests (16) green; `turbo run lint`, `prettier --check`, and web `typecheck` all pass. Live before/after captured in the browser (screenshots available).

The three `*TimeSeries.tsx` call-sites already spread `{...timeAxis.tickProps}` and pass `interval={timeAxis.interval}` (added earlier on this branch), so no visualiser change was needed for this fix.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
