### PR TITLE
fix(tracing): avoid LangGraph for Responses tool calls

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/langgraph.ts
+++ b/packages/shared/src/utils/chatml/adapters/langgraph.ts
@@ -33,6 +33,14 @@ const LangGraphMessageSchema = z
   )
   .refine(
     (data) => {
+      const hasLangGraphMessageShape = data.every(
+        (msg) =>
+          typeof msg === "object" &&
+          msg !== null &&
+          ("role" in msg || "additional_kwargs" in msg),
+      );
+      if (!hasLangGraphMessageShape) return false;
+
       // Reject if any message has top-level parts (Microsoft Agent/Gemini format)
       return !data.some(
         (msg) =>

--- a/web/src/utils/chatml/jumptoplayground.clienttest.ts
+++ b/web/src/utils/chatml/jumptoplayground.clienttest.ts
@@ -789,6 +789,57 @@ describe("Playground Jump Full Pipeline", () => {
     });
   });
 
+  it("should normalize OpenAI Responses function_call output arrays", () => {
+    const output = [
+      {
+        id: "fc_order_status",
+        type: "function_call",
+        status: "completed",
+        arguments: '{"orderIds":null}',
+        call_id: "call_order_status",
+        name: "getOrderStatus",
+      },
+      {
+        id: "fc_promotions",
+        type: "function_call",
+        status: "completed",
+        arguments: "{}",
+        call_id: "call_promotions",
+        name: "getPromotions",
+      },
+    ];
+
+    const outputResult = normalizeOutput(output, {
+      observationName: "OpenAI.responses",
+    });
+    expect(outputResult.success).toBe(true);
+
+    expect(outputResult.data).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "call_order_status",
+            name: "getOrderStatus",
+            arguments: '{"orderIds":null}',
+            type: "function",
+          },
+        ],
+      }),
+      expect.objectContaining({
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "call_promotions",
+            name: "getPromotions",
+            arguments: "{}",
+            type: "function",
+          },
+        ],
+      }),
+    ]);
+  });
+
   it("should handle VAPI camelCase toolCalls and preserve IDs", () => {
     // VAPI uses camelCase toolCalls instead of tool_calls
     // Critical: Tool call IDs must be preserved for OpenAI API compatibility


### PR DESCRIPTION
## Summary
- require LangGraph structural detection to see an actual LangGraph-style message marker before it claims an array
- allow OpenAI Responses output arrays of function_call items to reach the OpenAI adapter and normalize into ChatML tool_calls
- add a regression for two OpenAI Responses tool calls from an OpenAI.responses observation

## Impacted packages
- packages/shared: ChatML adapter detection
- web: ChatML normalization regression coverage

## Tests
- DATABASE_URL=... DIRECT_URL=... pnpm --filter @langfuse/shared run db:generate
- pnpm --filter @langfuse/shared run build
- DATABASE_URL=... DIRECT_URL=... NEXTAUTH_URL=... SALT=... CLICKHOUSE_URL=... CLICKHOUSE_USER=... CLICKHOUSE_PASSWORD=... LANGFUSE_S3_EVENT_UPLOAD_BUCKET=langfuse pnpm --filter web test-client "src/utils/chatml/jumptoplayground.clienttest.ts"
- pnpm exec tsx -e '<exact trace normalization check for trace-eb3adeb40107dcf1a081c495ed941498.json>'
- pnpm --filter @repo/eslint-plugin run build
- pnpm --filter @langfuse/shared run lint

## Browser review
- Not run. This is a ChatML normalization fix; the exported trace shape was verified directly through the normalizer because the seed flow does not provide this exact OpenAI Responses tool-call array shape.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a false-positive in the LangGraph adapter's structural detection that caused OpenAI Responses API `function_call` output arrays to be incorrectly claimed by the LangGraph normalizer instead of reaching the OpenAI adapter. The fix adds a `hasLangGraphMessageShape` guard inside `LangGraphMessageSchema`'s `.refine()` that requires every item in an array to carry at least a `role` or `additional_kwargs` key before LangGraph detection succeeds.

- **`langgraph.ts`**: Adds an early exit in the Zod `.refine()` callback: if any element lacks both `role` and `additional_kwargs`, the schema match fails, letting the data fall through to the correct adapter.
- **`jumptoplayground.clienttest.ts`**: Adds a regression test asserting that a two-item `function_call` array from `OpenAI.responses` normalises into two `assistant` messages each carrying a `tool_calls` array with the correct `call_id`→`id` mapping.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a narrow, additive guard in the LangGraph schema refine; it only tightens the detection condition and cannot break existing LangGraph normalization because real LangGraph messages always carry `role` or `additional_kwargs`.

The guard is surgical — it adds one early-exit check before the already-passing Microsoft Agent/Gemini rejection, so it cannot regress existing LangGraph flows. The regression test directly covers the previously broken path (two `function_call` items reaching the OpenAI adapter), and the broader adapter detection matrix is unchanged. No custom rules are violated.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming output array\ne.g. OpenAI Responses function_call items] --> B{LangChainMessageSchema\nmatch?}
    B -- yes --> C[LangGraph adapter]
    B -- no --> D{LangGraphMessageSchema\nmatch?}
    D --> E{NEW: hasLangGraphMessageShape?\nEvery item has 'role' OR 'additional_kwargs'}
    E -- no --> F[Schema refine returns false\nLangGraph adapter SKIPPED]
    E -- yes --> G{Parts check passes?}
    G -- no --> F
    G -- yes --> C
    F --> H{OpenAI adapter\ndetect?}
    H -- yes --> I[OpenAI adapter normalizes\nfunction_call → tool_calls]
    H -- no --> J[Other adapters / generic]

    style E fill:#d4edda,stroke:#28a745
    style F fill:#d4edda,stroke:#28a745
    style I fill:#cce5ff,stroke:#004085
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming output array\ne.g. OpenAI Responses function_call items] --> B{LangChainMessageSchema\nmatch?}
    B -- yes --> C[LangGraph adapter]
    B -- no --> D{LangGraphMessageSchema\nmatch?}
    D --> E{NEW: hasLangGraphMessageShape?\nEvery item has 'role' OR 'additional_kwargs'}
    E -- no --> F[Schema refine returns false\nLangGraph adapter SKIPPED]
    E -- yes --> G{Parts check passes?}
    G -- no --> F
    G -- yes --> C
    F --> H{OpenAI adapter\ndetect?}
    H -- yes --> I[OpenAI adapter normalizes\nfunction_call → tool_calls]
    H -- no --> J[Other adapters / generic]

    style E fill:#d4edda,stroke:#28a745
    style F fill:#d4edda,stroke:#28a745
    style I fill:#cce5ff,stroke:#004085
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tracing): avoid LangGraph for Respon..."](https://github.com/langfuse/langfuse/commit/ec383342b9858d7319f32db23693dd8f1b8a967a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41051595)</sub>

<!-- /greptile_comment -->