### PR TITLE
fix(events): restore trace-level score filtering in v4 (LFE-10596)

### DIFF
--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -3252,4 +3252,126 @@ describe("Clickhouse Events Repository Test", () => {
       expect(result.version).toBeUndefined();
     });
   });
+
+  // LFE-10596: trace-level score filtering returned empty in v4. The events
+  // table splits scores into observation-scoped (`scores_avg`, joined on
+  // span_id) and trace-scoped (`trace_scores_avg`, joined on trace_id). A
+  // trace-level score (observation_id NULL) can only match the trace-scoped
+  // column, so its NAME must be offered under `trace_scores_avg` only — never
+  // under `scores_avg`, where a filter on it can never match.
+  maybe("LFE-10596 trace-level score filtering", () => {
+    it("trace-level score matches trace_scores_avg but not scores_avg", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+      const spanId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: spanId,
+          span_id: spanId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "Help Assistant",
+        }),
+      ]);
+
+      await createScoresCh([
+        createTraceScore({
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          observation_id: null,
+          name: "CSAT",
+          value: 1,
+          data_type: "NUMERIC",
+        }),
+      ]);
+
+      const scoresAvgFilter: FilterCondition = {
+        type: "numberObject",
+        column: "scores_avg",
+        operator: "=",
+        key: "CSAT",
+        value: 1,
+      };
+      const traceScoresAvgFilter: FilterCondition = {
+        type: "numberObject",
+        column: "trace_scores_avg",
+        operator: "=",
+        key: "CSAT",
+        value: 1,
+      };
+
+      const [noFilterCount, scoresAvgCount, traceScoresAvgCount] =
+        await Promise.all([
+          getObservationsCountFromEventsTable({
+            projectId: uniqueProjectId,
+            filter: [],
+          }),
+          getObservationsCountFromEventsTable({
+            projectId: uniqueProjectId,
+            filter: [scoresAvgFilter],
+          }),
+          getObservationsCountFromEventsTable({
+            projectId: uniqueProjectId,
+            filter: [traceScoresAvgFilter],
+          }),
+        ]);
+
+      expect(noFilterCount).toBe(1);
+      expect(traceScoresAvgCount).toBe(1);
+      expect(scoresAvgCount).toBe(0);
+    });
+
+    it("offers a trace-level numeric score under trace_scores_avg, not scores_avg", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+      const spanId = randomUUID();
+      const observationId = randomUUID();
+      const traceScoreName = `csat-${randomUUID()}`;
+      const observationScoreName = `latency-rating-${randomUUID()}`;
+
+      await createEventsCh([
+        createEvent({
+          id: spanId,
+          span_id: spanId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "Help Assistant",
+        }),
+      ]);
+
+      await createScoresCh([
+        // Trace-level score (observation_id NULL) -> trace_scores_avg only.
+        createTraceScore({
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          observation_id: null,
+          name: traceScoreName,
+          value: 1,
+          data_type: "NUMERIC",
+        }),
+        // Observation-level score -> scores_avg only.
+        createTraceScore({
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          observation_id: observationId,
+          name: observationScoreName,
+          value: 1,
+          data_type: "NUMERIC",
+        }),
+      ]);
+
+      const options = await getEventFilterOptions({
+        projectId: uniqueProjectId,
+      });
+
+      expect(options.trace_scores_avg).toContain(traceScoreName);
+      expect(options.scores_avg).not.toContain(traceScoreName);
+
+      expect(options.scores_avg).toContain(observationScoreName);
+      expect(options.trace_scores_avg).not.toContain(observationScoreName);
+    });
+  });
 });

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -3373,5 +3373,63 @@ describe("Clickhouse Events Repository Test", () => {
       expect(options.scores_avg).toContain(observationScoreName);
       expect(options.trace_scores_avg).not.toContain(observationScoreName);
     });
+
+    it("offers a trace-level categorical score under trace_score_categories, not score_categories", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+      const spanId = randomUUID();
+      const observationId = randomUUID();
+      const traceCategoryName = `hallucination-check-${randomUUID()}`;
+      const observationCategoryName = `answer-relevancy-${randomUUID()}`;
+
+      await createEventsCh([
+        createEvent({
+          id: spanId,
+          span_id: spanId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "Help Assistant",
+        }),
+      ]);
+
+      await createScoresCh([
+        // Trace-level categorical (observation_id NULL) -> trace_score_categories only.
+        createTraceScore({
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          observation_id: null,
+          name: traceCategoryName,
+          value: 0,
+          string_value: "faithful",
+          data_type: "CATEGORICAL",
+        }),
+        // Observation-level categorical -> score_categories only.
+        createTraceScore({
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          observation_id: observationId,
+          name: observationCategoryName,
+          value: 0,
+          string_value: "relevant",
+          data_type: "CATEGORICAL",
+        }),
+      ]);
+
+      const options = await getEventFilterOptions({
+        projectId: uniqueProjectId,
+      });
+
+      const scoreCategoryLabels = options.score_categories.map((c) => c.label);
+      const traceScoreCategoryLabels = options.trace_score_categories.map(
+        (c) => c.label,
+      );
+
+      expect(traceScoreCategoryLabels).toContain(traceCategoryName);
+      expect(scoreCategoryLabels).not.toContain(traceCategoryName);
+
+      expect(scoreCategoryLabels).toContain(observationCategoryName);
+      expect(traceScoreCategoryLabels).not.toContain(observationCategoryName);
+    });
   });
 });

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -46,6 +46,21 @@ const TRACE_SCORE_SCOPE_FILTER: FilterCondition[] = [
   },
 ];
 
+// Observation-level scores: written against a specific observation
+// (observation_id set). These are the scores the observation `scores_avg` /
+// `score_categories` columns aggregate and filter on (joined by span_id).
+// Trace-level scores (observation_id NULL) live under `trace_scores_avg` /
+// `trace_score_categories` instead, so they must NOT be offered here — filtering
+// a trace-level score name via the observation column can never match (LFE-10596).
+const OBSERVATION_SCORE_SCOPE_FILTER: FilterCondition[] = [
+  {
+    type: "null",
+    column: "observationId",
+    operator: "is not null",
+    value: "",
+  },
+];
+
 interface GetObservationsListParams {
   projectId: string;
   filter: any[];
@@ -550,30 +565,44 @@ export async function getEventFilterOptions(
     requestedColumns.has(column),
   );
   const shouldLoadScoresAvg = requestedColumns.has("scores_avg");
-  const shouldLoadScoreCategories =
-    requestedColumns.has("score_categories") ||
-    requestedColumns.has("trace_score_categories");
-  const shouldLoadTraceScores =
-    requestedColumns.has("trace_scores_avg") ||
-    requestedColumns.has("trace_score_categories");
+  const shouldLoadScoreCategories = requestedColumns.has("score_categories");
+  const shouldLoadTraceScores = requestedColumns.has("trace_scores_avg");
+  const shouldLoadTraceScoreCategories = requestedColumns.has(
+    "trace_score_categories",
+  );
 
+  // Observation-scoped and trace-scoped discovery are kept separate so each
+  // score column only offers names its filter/join can actually match.
   const [
     numericScoreNames,
     categoricalScoreNames,
     traceScoreColumns,
+    traceCategoricalScoreColumns,
     eventFilterOptions,
   ] = await Promise.all([
     shouldLoadScoresAvg
-      ? getNumericScoresGroupedByName(projectId, traceTimestampFilters)
+      ? getNumericScoresGroupedByName(projectId, [
+          ...OBSERVATION_SCORE_SCOPE_FILTER,
+          ...traceTimestampFilters,
+        ])
       : Promise.resolve([]),
     shouldLoadScoreCategories
-      ? getCategoricalScoresGroupedByName(projectId, traceTimestampFilters)
+      ? getCategoricalScoresGroupedByName(projectId, [
+          ...OBSERVATION_SCORE_SCOPE_FILTER,
+          ...traceTimestampFilters,
+        ])
       : Promise.resolve([]),
     shouldLoadTraceScores
       ? getScoresGroupedByNameSourceType({
           projectId,
           filter: [...TRACE_SCORE_SCOPE_FILTER, ...traceScoreTimestampFilters],
         })
+      : Promise.resolve([]),
+    shouldLoadTraceScoreCategories
+      ? getCategoricalScoresGroupedByName(projectId, [
+          ...TRACE_SCORE_SCOPE_FILTER,
+          ...traceTimestampFilters,
+        ])
       : Promise.resolve([]),
     eventColumns.length > 0
       ? getEventsFilterOptionsForColumns({
@@ -593,11 +622,6 @@ export async function getEventFilterOptions(
         .map((score) => score.name),
     ),
   );
-  const traceCategoricalScoreNames = new Set(
-    traceScoreColumns
-      .filter((score) => score.dataType === "CATEGORICAL")
-      .map((score) => score.name),
-  );
   const eventFilterOptionsByColumn =
     toEventFilterOptionsByColumn(eventFilterOptions);
 
@@ -606,16 +630,10 @@ export async function getEventFilterOptions(
     scores_avg: shouldLoadScoresAvg
       ? numericScoreNames.map((score) => score.name)
       : [],
-    score_categories: requestedColumns.has("score_categories")
-      ? categoricalScoreNames
-      : [],
-    trace_scores_avg: requestedColumns.has("trace_scores_avg")
-      ? traceNumericScoreNames
-      : [],
-    trace_score_categories: requestedColumns.has("trace_score_categories")
-      ? categoricalScoreNames.filter((score) =>
-          traceCategoricalScoreNames.has(score.label),
-        )
+    score_categories: shouldLoadScoreCategories ? categoricalScoreNames : [],
+    trace_scores_avg: shouldLoadTraceScores ? traceNumericScoreNames : [],
+    trace_score_categories: shouldLoadTraceScoreCategories
+      ? traceCategoricalScoreColumns
       : [],
   };
 }


### PR DESCRIPTION
## TL;DR

In v4, filtering the traces/observations list by a **trace-level** score (e.g. a trace-level CSAT) always returned empty, even though the same filter worked in v3. The filter builder offered trace-level score names under the wrong ("Scores") filter, where the query can never match them. This scopes the filter-option discovery by score level so each score name is only offered under a filter that can actually match it.

## Why

The v4 traces/observations list reads from the events table, which deliberately splits scores into two filter columns:

- **`scores_avg` / "Scores (numeric)"** — observation-level scores, joined on `span_id`.
- **`trace_scores_avg` / "Trace Scores (numeric)"** — trace-level scores, joined on `trace_id`.

A trace-level score has `observation_id = NULL`, so it can only ever match the trace-scoped column. But the events **filter-options** endpoint discovered numeric/categorical score *names* without any level scope — so trace-level names (like CSAT) were also listed under the observation "Scores" filter. Selecting one there produced a `scores_avg` predicate that can never match, and the filter silently returned empty. This regressed v3, where a single score filter rolled up **all** of a trace's scores. A customer reported this as a v4-adoption blocker.

## What

Scope filter-option discovery by score level, mirroring the table's own score columns and the search bar's `scores.` / `traceScores.` namespaces:

- Observation columns (`scores_avg`, `score_categories`) now only surface **observation-level** score names.
- Trace columns (`trace_scores_avg`, `trace_score_categories`) only surface **trace-level** names.
- `trace_score_categories` now gets its values from a dedicated trace-scoped query instead of intersecting the unscoped categorical list, so trace-only categorical scores keep their values.

No query-translation change was needed — `trace_scores_avg` already matches trace-level scores correctly. The bug was purely that the wrong column was being offered for those names.

## Result

A trace-level score is now offered only under "Trace Scores (numeric/categorical)", where filtering returns the matching traces; observation-level scores stay under "Scores". A score present at both levels appears under both.

<details>
<summary>Mechanism & verification</summary>

**Root cause.** `getEventFilterOptions` (`web/src/features/events/server/eventsService.ts`) loaded `scores_avg` options via `getNumericScoresGroupedByName(projectId, traceTimestampFilters)` with no level filter, so every numeric score name in the project was offered under the observation column. `getObservationsFromEventsTableInternal` joins `scores_agg ON s.observation_id = e.span_id`, which never matches a row whose `observation_id` is NULL.

**Fix.** Added an `OBSERVATION_SCORE_SCOPE_FILTER` (`observationId is not null`) to the observation-column discovery queries and a dedicated trace-scoped categorical query for `trace_score_categories`.

**Tests** (`web/src/__tests__/server/repositories/event-repository.servertest.ts`, `LFE-10596` block, run against ClickHouse):
- Query semantics: a trace-level score matches `trace_scores_avg` (count 1) but not `scores_avg` (count 0).
- Filter options: a trace-level numeric score is offered under `trace_scores_avg` only; an observation-level one under `scores_avg` only.

**End-to-end** (seeded `scored-traces --v4`, logged-in v4 session, real `events.filterOptions` payload captured in the browser): trace-level scores (`Faithfulness Score`, `accuracy`, `Hallucination Check`) appear only under the trace columns; observation-level scores (`Rouge Score`, `Score With A Space`, `Answer Relevancy`) only under the observation columns; scores present at both levels appear under both.

`pnpm --filter web run lint` and `typecheck` pass.
</details>

Related: LFE-10519 (filterOptions), #14515 (nested filters) — same v4 filter layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a v4 regression where filtering the observations list by a trace-level score always returned empty results. The root cause was that `getEventFilterOptions` discovered score names without any level scoping, causing trace-level score names (where `observation_id IS NULL`) to appear under the observation-column filter (`scores_avg`), whose join on `span_id` can never match those rows.

- Adds `OBSERVATION_SCORE_SCOPE_FILTER` (`observationId IS NOT NULL`) applied to the observation-level score-name discovery queries (`scores_avg`, `score_categories`), so trace-level names are no longer offered there.
- Introduces a dedicated `traceCategoricalScoreColumns` query using `TRACE_SCORE_SCOPE_FILTER` for `trace_score_categories`, replacing the previous approach of intersecting an unscoped categorical list with the trace numeric set (which missed trace-only categoricals).
- Adds ClickHouse server tests verifying that a trace-level numeric score matches `trace_scores_avg` (count = 1) but not `scores_avg` (count = 0), and that filter options correctly segregate names by level.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is narrowly scoped to filter-option discovery in getEventFilterOptions and does not touch the query execution path; the new OBSERVATION_SCORE_SCOPE_FILTER follows the exact same pattern as the existing TRACE_SCORE_SCOPE_FILTER and both are correctly applied.

The core logic is correct and well-tested for numeric scores. The only gap is that categorical score segregation (score_categories / trace_score_categories) has no integration test, so a regression there would be invisible in CI.

web/src/__tests__/server/repositories/event-repository.servertest.ts — the new test block covers numeric scores only; categorical score segregation has no coverage.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant getEventFilterOptions
    participant getNumericScoresGroupedByName
    participant getCategoricalScoresGroupedByName
    participant getScoresGroupedByNameSourceType

    Client->>getEventFilterOptions: "{projectId, columns}"

    Note over getEventFilterOptions: Build scope filters

    par Observation-level discovery
        getEventFilterOptions->>getNumericScoresGroupedByName: [OBSERVATION_SCOPE + timestamps]
        getNumericScoresGroupedByName-->>getEventFilterOptions: scores_avg names (obs only)

        getEventFilterOptions->>getCategoricalScoresGroupedByName: [OBSERVATION_SCOPE + timestamps]
        getCategoricalScoresGroupedByName-->>getEventFilterOptions: score_categories (obs only)
    and Trace-level discovery
        getEventFilterOptions->>getScoresGroupedByNameSourceType: [TRACE_SCOPE + timestamps]
        getScoresGroupedByNameSourceType-->>getEventFilterOptions: trace_scores_avg names (numeric+boolean)

        getEventFilterOptions->>getCategoricalScoresGroupedByName: [TRACE_SCOPE + timestamps]
        getCategoricalScoresGroupedByName-->>getEventFilterOptions: trace_score_categories (trace only)
    end

    getEventFilterOptions-->>Client: "{scores_avg, score_categories, trace_scores_avg, trace_score_categories, ...}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant getEventFilterOptions
    participant getNumericScoresGroupedByName
    participant getCategoricalScoresGroupedByName
    participant getScoresGroupedByNameSourceType

    Client->>getEventFilterOptions: "{projectId, columns}"

    Note over getEventFilterOptions: Build scope filters

    par Observation-level discovery
        getEventFilterOptions->>getNumericScoresGroupedByName: [OBSERVATION_SCOPE + timestamps]
        getNumericScoresGroupedByName-->>getEventFilterOptions: scores_avg names (obs only)

        getEventFilterOptions->>getCategoricalScoresGroupedByName: [OBSERVATION_SCOPE + timestamps]
        getCategoricalScoresGroupedByName-->>getEventFilterOptions: score_categories (obs only)
    and Trace-level discovery
        getEventFilterOptions->>getScoresGroupedByNameSourceType: [TRACE_SCOPE + timestamps]
        getScoresGroupedByNameSourceType-->>getEventFilterOptions: trace_scores_avg names (numeric+boolean)

        getEventFilterOptions->>getCategoricalScoresGroupedByName: [TRACE_SCOPE + timestamps]
        getCategoricalScoresGroupedByName-->>getEventFilterOptions: trace_score_categories (trace only)
    end

    getEventFilterOptions-->>Client: "{scores_avg, score_categories, trace_scores_avg, trace_score_categories, ...}"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/repositories/event-repository.servertest.ts:3326-3375
**Missing test coverage for categorical score segregation**

The second test only verifies numeric score names (`data_type: "NUMERIC"`). The PR also changes how `score_categories` and `trace_score_categories` are populated — `score_categories` now uses `OBSERVATION_SCORE_SCOPE_FILTER` and `trace_score_categories` is populated from a dedicated trace-scoped query. Neither the old intersection-based approach nor the new query has a test. A categorical trace-level score would formerly have been excluded from `trace_score_categories` if it wasn't also returned by the unscoped query; a test asserting the same segregation behaviour for `CATEGORICAL` data types would close this gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(events): restore trace-level score f..."](https://github.com/langfuse/langfuse/commit/a9d6e239262a559cfec0d46808fd7ff4d8bb6fff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41070969)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->