### PR TITLE
fix(evals): stop code evaluator editor from scrolling to the page bottom on every keystroke

### DIFF
--- a/web/src/features/evals/components/code-eval-template-form-body.tsx
+++ b/web/src/features/evals/components/code-eval-template-form-body.tsx
@@ -270,28 +270,42 @@ export function CodeEvalTemplateFormBody({
       : "TypeScript";
   const shouldShowFormatButton = editable;
 
+  // Reveal the editable region only once, after the initial (possibly async)
+  // source code has loaded. Never scroll on subsequent edits.
+  const hasRevealedEditableRegionRef = useRef(false);
+
   const handleCreateEditor = useCallback(
     (view: EditorView) => {
       codeMirrorViewRef.current = view;
       foldContractTypes(view, sourceCodeLanguage);
-      scrollCodeMirrorToBottom(view);
+      if (view.state.doc.length > 0) {
+        scrollCodeMirrorToBottom(view);
+        hasRevealedEditableRegionRef.current = true;
+      }
     },
     [sourceCodeLanguage],
   );
 
   useEffect(() => {
-    const view = codeMirrorViewRef.current;
-    if (!view) return;
+    if (hasRevealedEditableRegionRef.current) return;
 
-    // Don't re-fold on every sourceCode change, only on language change
+    const view = codeMirrorViewRef.current;
+    if (!view || !sourceCode) return;
+
+    // Reveal the editable region once, after the initial source code has
+    // loaded (it may arrive asynchronously). Scrolling on every change would
+    // yank the editor -- and the surrounding page -- to the bottom while the
+    // user is typing.
     scrollCodeMirrorToBottom(view);
+    hasRevealedEditableRegionRef.current = true;
   }, [sourceCode]);
 
   useEffect(() => {
     const view = codeMirrorViewRef.current;
     if (!view) return;
 
-    // Re-fold when language changes
+    // The whole template is replaced when the language changes, so re-fold the
+    // contract and reveal the editable region again.
     foldContractTypes(view, sourceCodeLanguage);
     scrollCodeMirrorToBottom(view);
   }, [sourceCodeLanguage]);


### PR DESCRIPTION
Fixes #14679

## What does this PR do?

The code editor for **code evaluators** (`CodeEvalTemplateFormBody`) scrolls the editor  and the surrounding page  to the very bottom on **every keystroke**. As soon as you click into the field and start typing, the viewport jumps to the bottom of the page and won't stay where the cursor is, which makes the editor hard to use.

### Root cause

`web/src/features/evals/components/code-eval-template-form-body.tsx` scrolls to the bottom on every `sourceCode` change:

```ts
useEffect(() => {
  const view = codeMirrorViewRef.current;
  if (!view) return;
  // Don't re-fold on every sourceCode change, only on language change
  scrollCodeMirrorToBottom(view); // runs on every keystroke
}, [sourceCode]);
```

`sourceCode` is a controlled `react-hook-form` value (`form.watch("sourceCode")` in `template-form.tsx`), so it changes on every character typed. `scrollCodeMirrorToBottom` dispatches `EditorView.scrollIntoView(view.state.doc.length, { y: "end" })`, and CodeMirror's `scrollIntoView` also scrolls scrollable ancestor containers — so the whole page is dragged to the bottom while typing.

That effect was only meant to reveal the editable region: the top of the template is a folded, read-only "contract" and the editable `evaluate(...)` function sits at the bottom. That reveal already happens on mount in `handleCreateEditor` and on language switch in the `[sourceCodeLanguage]` effect, so scrolling again on every edit is a regression.

### Fix

Reveal the editable region **once**, after the initial (possibly async) source code has loaded, and never on subsequent edits. A `hasRevealedEditableRegionRef` guard keeps the one-time reveal working when `sourceCode` is populated asynchronously, without scrolling on every change. The language-change effect still re-folds and reveals because the whole template is replaced there.

Result: typing no longer moves the viewport; the editable region is still auto-revealed on first open and on language switch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test

1. Evaluators → create or edit a custom **code** evaluator (Python or TypeScript).
2. Click into the editor and type in the `evaluate(...)` body; also scroll up, click an earlier line, and type.
   - Before: the editor and page jump to the bottom on each keystroke.
   - After: the viewport stays put; the editable region is still revealed on first open and on language switch.

## Notes

- Minimal, localized change to one component's scroll effect. No API/schema/behavior changes elsewhere.
- CodeMirror scroll behavior is impractical to assert in jsdom, so this was verified manually per the steps above.