### PR TITLE
fix(trace): dedupe observations at the source so the detail panel matches the timeline (LFE-10588)

### DIFF
--- a/web/src/components/trace/contexts/TraceDataContext.tsx
+++ b/web/src/components/trace/contexts/TraceDataContext.tsx
@@ -22,6 +22,7 @@ import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes"
 import { type TreeNode, type TraceSearchListItem } from "../lib/types";
 import {
   buildTraceUiData,
+  dedupeObservationsById,
   getObservationLevels,
   removeHiddenNodes,
 } from "../lib/tree-building";
@@ -74,13 +75,25 @@ interface TraceDataProviderProps {
  */
 export function TraceDataProvider({
   trace,
-  observations,
+  observations: rawObservations,
   serverScores,
   corrections,
   comments,
   children,
 }: TraceDataProviderProps) {
   const { minObservationLevel } = useViewPreferences();
+
+  // Collapse duplicate/colliding observation ids to one row per id up front, so
+  // the SAME de-duped set feeds the tree builder AND every consumer that resolves
+  // a row from `observations` (notably the detail panel's `observations.find`).
+  // Without this the tree picks the earliest-startTime row while the panel's
+  // `.find` returns the first row in the raw array — on corrupt traces those can
+  // differ, so the timeline and the opened detail panel could silently show
+  // different data. No-op (same reference) for well-formed traces.
+  const observations = useMemo(
+    () => dedupeObservationsById(rawObservations),
+    [rawObservations],
+  );
 
   // Build full tree (no level filtering) — only rebuilds when data changes
   const uiData = useMemo(() => {

--- a/web/src/components/trace/lib/tree-building.clienttest.ts
+++ b/web/src/components/trace/lib/tree-building.clienttest.ts
@@ -6,6 +6,7 @@
 
 import {
   buildTraceUiData,
+  dedupeObservationsById,
   removeHiddenNodes,
   getObservationLevels,
 } from "./tree-building";
@@ -2284,5 +2285,74 @@ describe("Duplicate / colliding observation IDs (LFE-10588)", () => {
     for (let i = 0; i <= N; i++) {
       expect(result.nodeMap.has(`n${i}`)).toBe(true);
     }
+  });
+
+  // The detail panel resolves the clicked observation via
+  // `observations.find(o => o.id === id)`. The tree node is built from the
+  // de-duped set (earliest-startTime row), so the array the panel searches must
+  // be de-duped the same way — otherwise, on a corrupt trace, the timeline row
+  // and the opened detail panel can silently show different data.
+
+  it("keeps the earliest-startTime row per id, independent of array order", () => {
+    // Array order lists the LATER row first, so a naive `.find` would pick it.
+    const later = createMockObservation({
+      id: "x",
+      name: "later",
+      parentObservationId: null,
+      startTime: new Date("2024-01-01T00:00:00.200Z"),
+    });
+    const earlier = createMockObservation({
+      id: "x",
+      name: "earlier",
+      parentObservationId: null,
+      startTime: new Date("2024-01-01T00:00:00.100Z"),
+    });
+
+    const deduped = dedupeObservationsById([later, earlier]);
+
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0].name).toBe("earlier");
+  });
+
+  it("returns the same array reference when all ids are unique (no-op)", () => {
+    const list = [
+      createMockObservation({ id: "a" }),
+      createMockObservation({ id: "b" }),
+    ];
+    expect(dedupeObservationsById(list)).toBe(list);
+  });
+
+  it("resolves the same row for the tree node and a find() on the deduped list", () => {
+    const trace = createMockTrace({ id: "t" });
+    // Two colliding rows for id "x" differing on a user-visible field, with the
+    // later-startTime row first in array order.
+    const raw: ObservationReturnType[] = [
+      createMockObservation({
+        id: "x",
+        name: "later",
+        parentObservationId: null,
+        startTime: new Date("2024-01-01T00:00:00.200Z"),
+      }),
+      createMockObservation({
+        id: "x",
+        name: "earlier",
+        parentObservationId: null,
+        startTime: new Date("2024-01-01T00:00:00.100Z"),
+      }),
+    ];
+    // On the RAW array the panel's `.find` returns the first (wrong) row.
+    expect(raw.find((o) => o.id === "x")?.name).toBe("later");
+
+    // De-dup once (as TraceDataProvider now does), then feed both.
+    const deduped = dedupeObservationsById(raw);
+    const result = buildTraceUiData(trace, deduped);
+
+    const treeNodeName = result.nodeMap.get("x")?.name;
+    const panelRowName = deduped.find((o) => o.id === "x")?.name;
+
+    expect(treeNodeName).toBe("earlier");
+    expect(panelRowName).toBe("earlier");
+    // The invariant: timeline (tree node) and detail panel (find) agree.
+    expect(panelRowName).toBe(treeNodeName);
   });
 });

--- a/web/src/components/trace/lib/tree-building.ts
+++ b/web/src/components/trace/lib/tree-building.ts
@@ -77,33 +77,55 @@ export function getObservationLevels(
 }
 
 /**
- * Prepares observations for tree building.
- * Cleans orphaned parent references and sorts by startTime.
- * Returns flat array (nesting happens in buildDependencyGraph).
+ * Collapse observations sharing the same id to a single row per id, keeping the
+ * earliest by startTime (deterministic).
+ *
+ * The tree builder assumes observation ids are unique, but real traces can
+ * contain multiple rows with the same id (colliding / reused ids in ingested
+ * data, or un-merged event rows), and those rows may each carry a DIFFERENT
+ * parentObservationId. Left un-deduped, one node gets wired under several
+ * parents, turning the parent→child graph into a dense multi-parent DAG whose
+ * root→node path count is exponential; the depth-propagation BFS then grows its
+ * queue without bound and the trace crashes the client with "RangeError:
+ * Invalid array length" / out of memory.
+ *
+ * The trace detail panel resolves the selected row from this same observation
+ * list, so tree and panel MUST agree on which duplicate wins — hence a single
+ * shared de-dup used both here (via prepareObservations) and by TraceDataContext
+ * for the array the panel searches.
+ *
+ * Generic over the row shape so ObservationReturnType and the with-metadata
+ * variant used by the UI context share one implementation. Returns the input
+ * array unchanged (same reference) when all ids are already unique — a no-op for
+ * well-formed traces that also preserves referential identity for memoization.
  */
-function prepareObservations(list: ObservationReturnType[]): {
-  sortedObservations: ObservationReturnType[];
-} {
-  if (list.length === 0) return { sortedObservations: [] };
-
-  // Deduplicate by observation id. The tree builder assumes ids are unique, but
-  // real traces can contain multiple rows sharing the same id (colliding /
-  // reused ids in ingested data) — and those rows may each carry a DIFFERENT
-  // parentObservationId. Left un-deduped, one node gets wired under several
-  // parents, turning the parent→child graph into a dense multi-parent DAG whose
-  // root→node path count is exponential; the depth-propagation BFS below then
-  // grows its queue without bound, so loading such a trace crashed the client
-  // with "RangeError: Invalid array length" / out of memory. Collapse to one row
-  // per id (earliest by startTime, deterministic) so the structure stays a
-  // proper forest. No-op for well-formed traces (all ids already unique).
-  const byId = new Map<string, ObservationReturnType>();
+export function dedupeObservationsById<
+  T extends { id: string; startTime: Date },
+>(list: T[]): T[] {
+  const byId = new Map<string, T>();
   for (const o of list) {
     const existing = byId.get(o.id);
     if (!existing || o.startTime.getTime() < existing.startTime.getTime()) {
       byId.set(o.id, o);
     }
   }
-  const dedupedList = Array.from(byId.values());
+  return byId.size === list.length ? list : Array.from(byId.values());
+}
+
+/**
+ * Prepares observations for tree building.
+ * De-duplicates colliding ids, cleans orphaned parent references, sorts by
+ * startTime. Returns flat array (nesting happens in buildDependencyGraph).
+ */
+function prepareObservations(list: ObservationReturnType[]): {
+  sortedObservations: ObservationReturnType[];
+} {
+  if (list.length === 0) return { sortedObservations: [] };
+
+  // One row per id (earliest by startTime) so the parent→child graph stays a
+  // proper forest — see dedupeObservationsById for why duplicates crash the
+  // builder. No-op for well-formed traces.
+  const dedupedList = dedupeObservationsById(list);
 
   // Build a Set of all observation IDs for O(1) lookup
   const observationIds = new Set(dedupedList.map((o) => o.id));


### PR DESCRIPTION
## TL;DR
Follow-up to #14669. That PR stopped large/corrupt traces from crashing the client by de-duplicating colliding observation ids **inside the tree builder** — but the **detail panel** resolves the clicked observation from a *separate, un-deduped* array, so on a corrupt trace the timeline row and the opened detail panel could silently show **different data**. This dedupes once at the source so both agree. No-op for well-formed traces.

## Why
The detail panel resolves the selected observation with:
```ts
observations.find((obs) => obs.id === selectedNode.id)
```
`.find` returns the **first row in array order**, while the tree/`nodeMap` is built from the **de-duped** set (earliest-startTime row per id). For a trace with duplicate ids that differ on user-visible fields (`name` / `type` / `input` / `output`), those two can resolve to **different rows** → the timeline says one thing, the panel shows another. No crash, no data loss — but confusing, and reachable in practice: for OTel projects the observations query skips dedup and has no `ORDER BY`, so array order is arbitrary.

## What
De-duplicate **once at the source** rather than in each consumer:
- Extract the dedup into a shared **`dedupeObservationsById`** helper.
- Run it in **`TraceDataProvider`** so the same de-duped array feeds the tree builder *and* everything that resolves a row from `observations` (detail panel, trace-level view).
- `prepareObservations` now delegates to the same helper (behaviour unchanged).

## Result
Timeline (tree node) and detail panel (`.find`) now resolve the same row. Adds tests; all 81 trace-building tests pass; typecheck/lint/prettier green.

<details>
<summary>Engineering detail</summary>

- `dedupeObservationsById<T extends { id: string; startTime: Date }>` keeps the earliest-`startTime` row per id and is **generic** so `ObservationReturnType` and the with-metadata UI variant share one implementation.
- It returns the **input array unchanged (same reference)** when all ids are already unique — a true no-op for well-formed traces that also preserves referential identity, so the provider's `useMemo` doesn't force downstream recomputes.
- New tests: earliest-startTime row wins regardless of array order; unique-id lists are returned by reference; and the tree node + a `find()` on the deduped list resolve the same row (the panel/timeline invariant).
- The backend query fix in #14666 (`LIMIT 1 BY span_id`) removes the duplicates for the **v4/events** path, so this mainly hardens the **v3 / OTel-`skipDedup`** path and any future caller — belt to the backend's suspenders.

**Verification:** `pnpm --filter web run test-client "tree-building"` (81 pass), `typecheck`, `lint`, prettier — all green.
</details>

Follow-up to #14669. Relates to LFE-10588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts the observation deduplication logic from `prepareObservations` into a shared `dedupeObservationsById` generic helper, then runs it once in `TraceDataProvider` so both the tree builder and the detail panel's `.find()` resolve from the same deduped set — eliminating a class of silent inconsistency on corrupt/OTel traces where the timeline and the opened detail panel could show different data for the same observation id.

- **`dedupeObservationsById<T>`** is now exported, generic over any `{ id: string; startTime: Date }` shape, and returns the input reference unchanged when all ids are already unique (true no-op for well-formed traces).
- **`TraceDataProvider`** dedupes `rawObservations` once via `useMemo`, feeding the deduped array to both `buildTraceUiData` and the context value consumed by the detail panel.
- Three new tests verify: earliest-startTime wins regardless of array order; the unique-id path returns the same reference; and tree node + `find()` on the deduped list resolve the same row.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is a focused, well-tested deduplication at the data-provider boundary with a true no-op path for well-formed traces.

The change is narrow and mechanically correct: `dedupeObservationsById` returns the original array reference when all ids are unique, so well-formed traces incur no observable difference. The three new tests cover the key invariants (earliest-startTime wins, no-op reference equality, tree/panel agreement). The only observation is that `prepareObservations` will now run a redundant O(n) dedup scan on already-deduped input, but that is provably a no-op and poses no correctness risk.

No files require special attention. `tree-building.ts` has a minor redundant dedup pass after this change, but it is safe.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[rawObservations prop] --> B["dedupeObservationsById()\nTraceDataProvider useMemo"]
    B --> C[observations - deduped array]
    C --> D["buildTraceUiData()\nTree builder"]
    C --> E["observations.find(o => o.id === selectedNode.id)\nDetail panel"]
    D --> F[nodeMap / TreeNode]
    D --> G["prepareObservations()\ncalls dedupeObservationsById again\nno-op: already deduped"]
    F --> H[Timeline row - tree node]
    E --> I[Detail panel row]
    H -- "agree on same row" --> I
    style B fill:#c8e6c9
    style C fill:#c8e6c9
    style G fill:#fff9c4
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[rawObservations prop] --> B["dedupeObservationsById()\nTraceDataProvider useMemo"]
    B --> C[observations - deduped array]
    C --> D["buildTraceUiData()\nTree builder"]
    C --> E["observations.find(o => o.id === selectedNode.id)\nDetail panel"]
    D --> F[nodeMap / TreeNode]
    D --> G["prepareObservations()\ncalls dedupeObservationsById again\nno-op: already deduped"]
    F --> H[Timeline row - tree node]
    E --> I[Detail panel row]
    H -- "agree on same row" --> I
    style B fill:#c8e6c9
    style C fill:#c8e6c9
    style G fill:#fff9c4
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/trace/lib/tree-building.ts:125-128
`dedupeObservationsById` is now called twice for every `buildTraceUiData` invoked from `TraceDataProvider`: once explicitly in the provider's `useMemo`, and again inside `prepareObservations`. The second call is a safe no-op (returns the same reference) because the input is already deduped, but it still iterates the full list to build a throw-away Map. For well-formed production traces this is harmless, but it does add O(n) redundant work on each tree rebuild.

```suggestion
  // One row per id (earliest by startTime) so the parent→child graph stays a
  // proper forest — see dedupeObservationsById for why duplicates crash the
  // builder. No-op for well-formed traces (same reference returned).
  // Note: TraceDataProvider already dedupes before calling buildTraceUiData, so
  // this is typically a true no-op (O(n) scan confirms byId.size === list.length
  // and returns list unchanged).
  const dedupedList = dedupeObservationsById(list);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): dedupe observations at the s..."](https://github.com/langfuse/langfuse/commit/411bf2c102befb6dda983fcdd72fe2e85b1f3d55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41073867)</sub>

<!-- /greptile_comment -->