### PR TITLE
feat(worker): add event-propagation stuck health check

### DIFF
--- a/worker/src/__tests__/eventPropagationHealth.test.ts
+++ b/worker/src/__tests__/eventPropagationHealth.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateEventPropagationStuck } from "../features/health";
+
+describe("evaluateEventPropagationStuck", () => {
+  const nowMs = 1_700_000_000_000;
+  const thresholdSeconds = 15 * 60;
+
+  it("is not stuck when the last run started recently", () => {
+    const result = evaluateEventPropagationStuck({
+      enabled: true,
+      nowMs,
+      lastRunStartedAtMs: nowMs - 60_000, // 1 min ago
+      lastProcessedPartition: null,
+      thresholdSeconds,
+    });
+
+    expect(result.stuck).toBe(false);
+    expect(result.secondsSinceLastRun).toBe(60);
+    expect(result.lastRunStartedAt).toBe(
+      new Date(nowMs - 60_000).toISOString(),
+    );
+  });
+
+  it("is stuck when the last run started longer ago than the threshold", () => {
+    const result = evaluateEventPropagationStuck({
+      enabled: true,
+      nowMs,
+      lastRunStartedAtMs: nowMs - 20 * 60_000, // 20 min ago > 15 min
+      lastProcessedPartition: null,
+      thresholdSeconds,
+    });
+
+    expect(result.stuck).toBe(true);
+    expect(result.secondsSinceLastRun).toBe(1200);
+  });
+
+  it("is not stuck exactly at the threshold (strictly greater than)", () => {
+    const result = evaluateEventPropagationStuck({
+      enabled: true,
+      nowMs,
+      lastRunStartedAtMs: nowMs - thresholdSeconds * 1000,
+      lastProcessedPartition: null,
+      thresholdSeconds,
+    });
+
+    expect(result.secondsSinceLastRun).toBe(thresholdSeconds);
+    expect(result.stuck).toBe(false);
+  });
+
+  it("is not stuck when the job has never run yet (no heartbeat key)", () => {
+    const result = evaluateEventPropagationStuck({
+      enabled: true,
+      nowMs,
+      lastRunStartedAtMs: null,
+      lastProcessedPartition: null,
+      thresholdSeconds,
+    });
+
+    expect(result.stuck).toBe(false);
+    expect(result.secondsSinceLastRun).toBeNull();
+    expect(result.lastRunStartedAt).toBeNull();
+  });
+
+  it("is never stuck when event propagation is disabled, even if very stale", () => {
+    const result = evaluateEventPropagationStuck({
+      enabled: false,
+      nowMs,
+      lastRunStartedAtMs: nowMs - 60 * 60_000, // 1 hour ago
+      lastProcessedPartition: null,
+      thresholdSeconds,
+    });
+
+    expect(result.stuck).toBe(false);
+    expect(result.enabled).toBe(false);
+  });
+
+  it("reports the propagation delay but does NOT let it drive stuck", () => {
+    // A large propagation delay ("behind") combined with a recent run start
+    // ("running") must stay healthy — restart would not help a slow backlog.
+    const result = evaluateEventPropagationStuck({
+      enabled: true,
+      nowMs,
+      lastRunStartedAtMs: nowMs - 30_000, // ran 30s ago -> not stuck
+      lastProcessedPartition: new Date(nowMs - 45 * 60_000).toISOString(), // 45 min behind
+      thresholdSeconds,
+    });
+
+    expect(result.propagationDelaySeconds).toBe(45 * 60);
+    expect(result.stuck).toBe(false);
+  });
+
+  it("leaves the propagation delay null for an unparseable cursor value", () => {
+    const result = evaluateEventPropagationStuck({
+      enabled: true,
+      nowMs,
+      lastRunStartedAtMs: nowMs - 30_000,
+      lastProcessedPartition: "not-a-date",
+      thresholdSeconds,
+    });
+
+    expect(result.propagationDelaySeconds).toBeNull();
+  });
+});

--- a/worker/src/__tests__/eventPropagationHealth.test.ts
+++ b/worker/src/__tests__/eventPropagationHealth.test.ts
@@ -90,7 +90,7 @@ describe("evaluateEventPropagationStuck", () => {
     expect(result.stuck).toBe(false);
   });
 
-  it("leaves the propagation delay null for an unparseable cursor value", () => {
+  it("leaves the propagation delay null for an unparsable cursor value", () => {
     const result = evaluateEventPropagationStuck({
       enabled: true,
       nowMs,

--- a/worker/src/api/index.ts
+++ b/worker/src/api/index.ts
@@ -5,9 +5,13 @@ import { checkContainerHealth } from "../features/health";
 import { logger } from "@langfuse/shared/src/server";
 const router = express.Router();
 
-router.get<{}, { status: string }>("/health", async (_req, res) => {
+router.get<{}, { status: string }>("/health", async (req, res) => {
   try {
-    await checkContainerHealth(res, false);
+    await checkContainerHealth(res, {
+      failOnSigterm: false,
+      failIfEventPropagationStuck:
+        req.query.failIfEventPropagationStuck === "true",
+    });
   } catch (e) {
     traceException(e);
     logger.error("Health check failed", e);
@@ -17,9 +21,13 @@ router.get<{}, { status: string }>("/health", async (_req, res) => {
   }
 });
 
-router.get<{}, { status: string }>("/ready", async (_req, res) => {
+router.get<{}, { status: string }>("/ready", async (req, res) => {
   try {
-    await checkContainerHealth(res, true);
+    await checkContainerHealth(res, {
+      failOnSigterm: true,
+      failIfEventPropagationStuck:
+        req.query.failIfEventPropagationStuck === "true",
+    });
   } catch (e) {
     traceException(e);
     logger.error("Readiness check failed", e);

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -485,10 +485,17 @@ const EnvSchema = z.object({
 
   // Health-check threshold for the event-propagation ("dual write") job. When a
   // client opts in via /api/health?failIfEventPropagationStuck=true, the check
-  // returns 503 if the job has not started a run within this many minutes,
+  // returns 503 if the heartbeat has not been refreshed within this many minutes,
   // letting k8s liveness probes restart a container whose global-concurrency
-  // slot is wedged. Must exceed the longest legitimate single run (the CH INSERT
-  // request_timeout is 10 min), so 15 min leaves headroom.
+  // slot is wedged. The heartbeat is refreshed at the top of every invocation and
+  // per-chunk during the experiment backfill, so the threshold only needs to
+  // exceed the longest un-heartbeated step — a single CH INSERT (request_timeout
+  // 10 min). 15 min leaves headroom.
+  //
+  // Probes using this flag MUST set initialDelaySeconds >= 60s (one cron cycle):
+  // the heartbeat is only refreshed when the minute-boundary cron next runs, so a
+  // just-restarted (or just-re-enabled) container can carry a stale value until
+  // then. A shorter delay can crash-loop the very restart this check triggers.
   LANGFUSE_EVENT_PROPAGATION_STUCK_THRESHOLD_MINUTES: z.coerce
     .number()
     .positive()

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -483,6 +483,18 @@ const EnvSchema = z.object({
     .int()
     .default(10),
 
+  // Health-check threshold for the event-propagation ("dual write") job. When a
+  // client opts in via /api/health?failIfEventPropagationStuck=true, the check
+  // returns 503 if the job has not started a run within this many minutes,
+  // letting k8s liveness probes restart a container whose global-concurrency
+  // slot is wedged. Must exceed the longest legitimate single run (the CH INSERT
+  // request_timeout is 10 min), so 15 min leaves headroom.
+  LANGFUSE_EVENT_PROPAGATION_STUCK_THRESHOLD_MINUTES: z.coerce
+    .number()
+    .positive()
+    .int()
+    .default(15),
+
   LANGFUSE_WEBHOOK_QUEUE_PROCESSING_CONCURRENCY: z.coerce
     .number()
     .positive()

--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -15,6 +15,41 @@ import { env } from "../../env";
 const LAST_PROCESSED_PARTITION_KEY =
   "langfuse:event-propagation:last-processed-partition";
 
+const LAST_RUN_STARTED_AT_KEY =
+  "langfuse:event-propagation:last-run-started-at";
+
+/**
+ * Record (in Redis) that a propagation run just started. Written at the top of
+ * every job invocation — including the no-op "nothing to process" path — so its
+ * freshness reflects "the queue is still being drained", independent of whether
+ * the cursor advanced. The health check uses staleness of this value to detect a
+ * wedged global-concurrency slot. Stored as epoch millis.
+ */
+export const updateLastRunStartedAt = async (): Promise<void> => {
+  try {
+    await redis!.set(LAST_RUN_STARTED_AT_KEY, Date.now().toString());
+  } catch (error) {
+    // Don't throw - a failed heartbeat write must not fail the job itself.
+    logger.error("[DUAL WRITE] Failed to update last run started at", error);
+  }
+};
+
+/**
+ * Read the last-run-started-at heartbeat (epoch millis) from Redis.
+ * Returns null if the job has never run yet or if Redis is unavailable.
+ */
+export const getLastRunStartedAt = async (): Promise<number | null> => {
+  try {
+    const value = await redis!.get(LAST_RUN_STARTED_AT_KEY);
+    if (value === null) return null;
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  } catch (error) {
+    logger.error("[DUAL WRITE] Failed to get last run started at", error);
+    return null;
+  }
+};
+
 /**
  * Get the last processed partition timestamp from Redis.
  * Returns null if no partition has been processed yet or if Redis is unavailable.
@@ -62,6 +97,10 @@ export const handleEventPropagationJob = async (
     "messaging.bullmq.job.input.jobId",
     job.data.id,
   );
+
+  // Heartbeat: record that a run started so the health check can detect a wedged
+  // (never-invoked) job even when the cursor legitimately has nothing to advance.
+  await updateLastRunStartedAt();
 
   try {
     // Step 1: Get the last processed partition from Redis and find the next one to process

--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -20,9 +20,11 @@ const LAST_RUN_STARTED_AT_KEY =
 
 /**
  * Record (in Redis) that a propagation run just started. Written at the top of
- * every job invocation — including the no-op "nothing to process" path — so its
- * freshness reflects "the queue is still being drained", independent of whether
- * the cursor advanced. The health check uses staleness of this value to detect a
+ * every job invocation — including the no-op "nothing to process" path — and
+ * refreshed per-chunk as the experiment backfill progresses (both run under the
+ * same global-concurrency-1 slot), so its freshness reflects "the slot is still
+ * being worked / the queue is still being drained", independent of whether the
+ * cursor advanced. The health check uses staleness of this value to detect a
  * wedged global-concurrency slot. Stored as epoch millis.
  */
 export const updateLastRunStartedAt = async (): Promise<void> => {

--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -10,6 +10,7 @@ import {
 import { env } from "../../env";
 import { ClickhouseWriter, TableName } from "../../services/ClickhouseWriter";
 import { chunk } from "lodash";
+import { updateLastRunStartedAt } from "./handleEventPropagationJob";
 
 const EXPERIMENT_BACKFILL_TIMESTAMP_KEY =
   "langfuse:event-propagation:experiment-backfill:last-run";
@@ -847,6 +848,12 @@ async function processExperimentBackfill(
     logger.info(
       `[EXPERIMENT BACKFILL] Processing chunk ${i + 1}/${chunks.length} with ${driChunk.length} items`,
     );
+
+    // Refresh the event-propagation heartbeat as each chunk begins. The backfill
+    // runs in the same global-concurrency-1 invocation as handleEventPropagationJob
+    // but can loop for minutes over a backlog; without this a long-but-live
+    // backfill would let the heartbeat go stale and trip the stuck health check.
+    await updateLastRunStartedAt();
 
     // Extract project and trace IDs for this chunk
     const projectIds = [...new Set(driChunk.map((dri) => dri.project_id))];

--- a/worker/src/features/health/index.ts
+++ b/worker/src/features/health/index.ts
@@ -2,14 +2,148 @@ import { prisma } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
 import { Response } from "express";
 
+import { env, v4WritesToEventsTable } from "../../env";
+import {
+  getLastProcessedPartition,
+  getLastRunStartedAt,
+} from "../eventPropagation/handleEventPropagationJob";
+
+export type EventPropagationHealth = {
+  /** Whether the dual-write / event-propagation job runs in this deployment. */
+  enabled: boolean;
+  /** ISO timestamp of the last run start, or null if it has not run yet. */
+  lastRunStartedAt: string | null;
+  /** Seconds since the last run started, or null if it has not run yet. */
+  secondsSinceLastRun: number | null;
+  /** Informational: seconds between now and the last processed partition. */
+  propagationDelaySeconds: number | null;
+  /** Raw cursor value (partition timestamp) for debugging. */
+  lastProcessedPartition: string | null;
+  /** Staleness threshold that flips `stuck` to true. */
+  thresholdSeconds: number;
+  /** True when the job has not started a run within `thresholdSeconds`. */
+  stuck: boolean;
+};
+
+const isEventPropagationEnabled = (): boolean =>
+  env.QUEUE_CONSUMER_EVENT_PROPAGATION_QUEUE_IS_ENABLED === "true" &&
+  v4WritesToEventsTable(env);
+
+/**
+ * Pure evaluation of event-propagation health from already-fetched inputs.
+ * Kept side-effect free so it can be unit tested without Redis.
+ *
+ * `stuck` is intentionally only true when we have a reading that exceeds the
+ * threshold. A missing heartbeat (job never ran yet — e.g. fresh boot or during
+ * a rollout) is treated as NOT stuck to avoid restart loops before the first
+ * scheduled run. A disabled job is never stuck.
+ */
+export const evaluateEventPropagationStuck = (input: {
+  enabled: boolean;
+  nowMs: number;
+  lastRunStartedAtMs: number | null;
+  lastProcessedPartition: string | null;
+  thresholdSeconds: number;
+}): EventPropagationHealth => {
+  const {
+    enabled,
+    nowMs,
+    lastRunStartedAtMs,
+    lastProcessedPartition,
+    thresholdSeconds,
+  } = input;
+
+  const secondsSinceLastRun =
+    lastRunStartedAtMs !== null
+      ? Math.max(0, Math.round((nowMs - lastRunStartedAtMs) / 1000))
+      : null;
+
+  let propagationDelaySeconds: number | null = null;
+  if (lastProcessedPartition) {
+    const partitionMs = new Date(lastProcessedPartition).getTime();
+    if (!Number.isNaN(partitionMs)) {
+      propagationDelaySeconds = Math.max(
+        0,
+        Math.round((nowMs - partitionMs) / 1000),
+      );
+    }
+  }
+
+  const stuck =
+    enabled &&
+    secondsSinceLastRun !== null &&
+    secondsSinceLastRun > thresholdSeconds;
+
+  return {
+    enabled,
+    lastRunStartedAt:
+      lastRunStartedAtMs !== null
+        ? new Date(lastRunStartedAtMs).toISOString()
+        : null,
+    secondsSinceLastRun,
+    propagationDelaySeconds,
+    lastProcessedPartition: lastProcessedPartition ?? null,
+    thresholdSeconds,
+    stuck,
+  };
+};
+
+/**
+ * Fetch event-propagation health from Redis (cursor + run heartbeat) and
+ * evaluate it. Redis-only: no ClickHouse query, so it is cheap enough to run on
+ * every health probe.
+ */
+export const getEventPropagationHealth =
+  async (): Promise<EventPropagationHealth> => {
+    const thresholdSeconds =
+      env.LANGFUSE_EVENT_PROPAGATION_STUCK_THRESHOLD_MINUTES * 60;
+
+    if (!isEventPropagationEnabled()) {
+      return {
+        enabled: false,
+        lastRunStartedAt: null,
+        secondsSinceLastRun: null,
+        propagationDelaySeconds: null,
+        lastProcessedPartition: null,
+        thresholdSeconds,
+        stuck: false,
+      };
+    }
+
+    const [lastRunStartedAtMs, lastProcessedPartition] = await Promise.all([
+      getLastRunStartedAt(),
+      getLastProcessedPartition(),
+    ]);
+
+    return evaluateEventPropagationStuck({
+      enabled: true,
+      nowMs: Date.now(),
+      lastRunStartedAtMs,
+      lastProcessedPartition,
+      thresholdSeconds,
+    });
+  };
+
+type ContainerHealthOptions = {
+  /** Fail (500) once a SIGTERM/SIGINT has been received (readiness only). */
+  failOnSigterm: boolean;
+  /**
+   * Also fail (503) when the event-propagation job is stuck. Opt-in via the
+   * ?failIfEventPropagationStuck=true query parameter so only a dedicated probe
+   * pays the extra Redis lookups and only that probe forces a restart.
+   */
+  failIfEventPropagationStuck?: boolean;
+};
+
 /**
  * Check the health of the container.
- * If failOnSigterm is true, the health check will fail if a SIGTERM signal has been received.
  */
 export const checkContainerHealth = async (
   res: Response,
-  failOnSigterm: boolean,
+  options: ContainerHealthOptions,
 ) => {
+  const { failOnSigterm, failIfEventPropagationStuck = false } = options;
+
   if (failOnSigterm && isSigtermReceived()) {
     logger.info(
       "Health check failed: SIGTERM / SIGINT received, shutting down.",
@@ -35,6 +169,23 @@ export const checkContainerHealth = async (
       ),
     ),
   ]);
+
+  if (failIfEventPropagationStuck) {
+    const eventPropagation = await getEventPropagationHealth();
+    if (eventPropagation.stuck) {
+      logger.warn(
+        `Health check failed: event propagation stuck (last run ${eventPropagation.secondsSinceLastRun}s ago, threshold ${eventPropagation.thresholdSeconds}s)`,
+      );
+      return res.status(503).json({
+        status: "Event propagation stuck",
+        eventPropagation,
+      });
+    }
+    return res.json({
+      status: "ok",
+      eventPropagation,
+    });
+  }
 
   res.json({
     status: "ok",

--- a/worker/src/features/health/index.ts
+++ b/worker/src/features/health/index.ts
@@ -2,7 +2,7 @@ import { prisma } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
 import { Response } from "express";
 
-import { env, v4WritesToEventsTable } from "../../env";
+import { env } from "../../env";
 import {
   getLastProcessedPartition,
   getLastRunStartedAt,
@@ -27,12 +27,9 @@ export type EventPropagationHealth = {
 
 const isEventPropagationEnabled = (): boolean =>
   env.QUEUE_CONSUMER_EVENT_PROPAGATION_QUEUE_IS_ENABLED === "true" &&
-  v4WritesToEventsTable(env);
+  env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "dual";
 
 /**
- * Pure evaluation of event-propagation health from already-fetched inputs.
- * Kept side-effect free so it can be unit tested without Redis.
- *
  * `stuck` is intentionally only true when we have a reading that exceeds the
  * threshold. A missing heartbeat (job never ran yet — e.g. fresh boot or during
  * a rollout) is treated as NOT stuck to avoid restart loops before the first


### PR DESCRIPTION
The dual-write event-propagation job holds a single BullMQ global-concurrency slot. When the worker holding it is OOM-killed or wedges, the slot can stay occupied and the job silently stops running until a container restart frees it. Expose this so a k8s liveness probe can force that restart for self-hosters.

- Record a `last-run-started-at` heartbeat in Redis at the top of every run (including the no-op "nothing to process" path), so its staleness reflects "the queue is still being drained" independent of cursor advancement.
- Add opt-in `?failIfEventPropagationStuck=true` to the worker /health and /ready endpoints. Returns 503 when no run has started within LANGFUSE_EVENT_PROPAGATION_STUCK_THRESHOLD_MINUTES (default 15 — above the 10-min INSERT request_timeout so a slow-but-alive run is not killed). Redis-only, no ClickHouse query.
- Surface the propagation delay (now - last processed partition) and last-run timestamp in the response body for observability. The delay is informational and deliberately does NOT drive the 503: a growing backlog usually means slow ClickHouse, where a restart would crash-loop rather than help.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in liveness health check to detect when the event-propagation (dual-write) BullMQ job has stopped being invoked — the symptom of a wedged global-concurrency slot. It records a Redis heartbeat at the top of every job run, exposes `?failIfEventPropagationStuck=true` on the `/health` and `/ready` endpoints, and returns 503 when the heartbeat is stale beyond the configured threshold.

- **Heartbeat in `handleEventPropagationJob`**: `updateLastRunStartedAt` writes `Date.now()` to Redis before each run (including no-ops), but the key has no TTL — a stale key from a stuck predecessor pod persists indefinitely and would cause the replacement pod to immediately fail liveness checks until the job manages to run and refresh it.
- **Pure evaluation logic in `health/index.ts`**: `evaluateEventPropagationStuck` is cleanly separated from I/O and is well-covered by unit tests; propagation delay is informational and correctly does not drive the 503 response.
- **New env var**: `LANGFUSE_EVENT_PROPAGATION_STUCK_THRESHOLD_MINUTES` defaults to 15, designed to exceed the 10-minute ClickHouse INSERT timeout, though the 5-minute margin may be tight under load.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The feature logic is correct and well-tested, but the missing TTL on the heartbeat key creates a concrete crash-loop scenario that directly undermines the restart mechanism this PR enables.

When the liveness probe triggers a pod restart (the whole point of this feature), the new container starts with the same stale heartbeat still present in Redis. If the BullMQ job does not update the heartbeat before the next probe cycle, the probe fails again immediately — a loop that defeats the feature's purpose. Adding an EX TTL on the SET call closes this gap with a one-line change.

worker/src/features/eventPropagation/handleEventPropagationJob.ts — the updateLastRunStartedAt SET call needs a TTL; worker/src/env.ts — the default threshold warrants a note about k8s probe initialDelaySeconds.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant K8s as k8s Liveness Probe
    participant API as Worker /health endpoint
    participant Redis
    participant BullMQ as BullMQ Job Scheduler
    participant Job as handleEventPropagationJob
    participant CH as ClickHouse

    Note over BullMQ,Job: Every scheduled invocation
    BullMQ->>Job: dequeue (global-concurrency slot)
    Job->>Redis: "SET last-run-started-at = now() [heartbeat]"
    Job->>CH: queryClickhouse (next partition)
    Job->>CH: "commandClickhouse INSERT (<=10 min timeout)"
    Job->>Redis: "SET last-processed-partition = partition"

    Note over K8s,Redis: Opt-in health probe path
    K8s->>API: "GET /health?failIfEventPropagationStuck=true"
    API->>Redis: SELECT 1 (Postgres check)
    API->>Redis: PING (liveness check)
    API->>Redis: GET last-run-started-at
    API->>Redis: GET last-processed-partition
    Redis-->>API: heartbeat (epoch ms) or null
    Redis-->>API: partition timestamp or null

    alt heartbeat null (never ran)
        API-->>K8s: "200 OK (stuck=false)"
    else "secondsSinceLastRun <= threshold"
        API-->>K8s: "200 OK (stuck=false, eventPropagation in body)"
    else "secondsSinceLastRun > threshold"
        API-->>K8s: 503 Event propagation stuck
        K8s->>K8s: restart pod (frees global-concurrency slot)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant K8s as k8s Liveness Probe
    participant API as Worker /health endpoint
    participant Redis
    participant BullMQ as BullMQ Job Scheduler
    participant Job as handleEventPropagationJob
    participant CH as ClickHouse

    Note over BullMQ,Job: Every scheduled invocation
    BullMQ->>Job: dequeue (global-concurrency slot)
    Job->>Redis: "SET last-run-started-at = now() [heartbeat]"
    Job->>CH: queryClickhouse (next partition)
    Job->>CH: "commandClickhouse INSERT (<=10 min timeout)"
    Job->>Redis: "SET last-processed-partition = partition"

    Note over K8s,Redis: Opt-in health probe path
    K8s->>API: "GET /health?failIfEventPropagationStuck=true"
    API->>Redis: SELECT 1 (Postgres check)
    API->>Redis: PING (liveness check)
    API->>Redis: GET last-run-started-at
    API->>Redis: GET last-processed-partition
    Redis-->>API: heartbeat (epoch ms) or null
    Redis-->>API: partition timestamp or null

    alt heartbeat null (never ran)
        API-->>K8s: "200 OK (stuck=false)"
    else "secondsSinceLastRun <= threshold"
        API-->>K8s: "200 OK (stuck=false, eventPropagation in body)"
    else "secondsSinceLastRun > threshold"
        API-->>K8s: 503 Event propagation stuck
        K8s->>K8s: restart pod (frees global-concurrency slot)
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
worker/src/features/eventPropagation/handleEventPropagationJob.ts:30
The heartbeat key is written without an expiry. If a pod was already stuck (heartbeat stale > 15 min) and then gets restarted by the liveness probe, the new container inherits the old stale key. If the BullMQ job hasn't been dequeued and run yet when the first liveness probe fires after restart, the probe will immediately see the same stale timestamp and return 503 again — causing a crash-loop until the job manages to run and refresh the key. Setting an EX that is meaningfully longer than the threshold (e.g., `thresholdSeconds * 3`) lets the key self-expire on a truly dead deployment while still being refreshed on every normal run.

```suggestion
    const thresholdMs =
      env.LANGFUSE_EVENT_PROPAGATION_STUCK_THRESHOLD_MINUTES * 60;
    await redis!.set(
      LAST_RUN_STARTED_AT_KEY,
      Date.now().toString(),
      "EX",
      thresholdMs * 3,
    );
```

### Issue 2 of 3
worker/src/features/health/index.ts:173-188
**Early return bypasses the standard `"ok"` response for all opt-in callers**

When `failIfEventPropagationStuck` is `true` and the job is healthy, the code returns early at line 184-187 with `{ status: "ok", eventPropagation }` and never reaches the final `res.json({ status: "ok" })`. This is intentional, but it means the response schema diverges based on a query parameter — callers that parse the body strictly (e.g. expecting only `{ status }`) would need to handle the enriched shape. Worth adding a note in the JSDoc on `checkContainerHealth` so future callers know the body is augmented when the flag is set.

### Issue 3 of 3
worker/src/env.ts:492-496
**Threshold proximity to ClickHouse timeout may cause false positives on slow partitions**

The ClickHouse `commandClickhouse` call has a `request_timeout` of 600 000 ms (10 min). The threshold defaults to 15 min, leaving only 5 min of headroom. A job cycle also includes two Redis reads, a `queryClickhouse` for partition discovery, and a final Redis write — under load each can add seconds. If the INSERT runs close to its 10-minute timeout and the remaining operations take longer than expected, the heartbeat could be > 15 minutes old before the next invocation updates it, causing a transient false 503. The comment already calls this out, but it may be worth raising the default to 20 minutes or documenting the `initialDelaySeconds` requirement for k8s probes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): add event-propagation stuc..."](https://github.com/langfuse/langfuse/commit/a1fe4af6ade36bc18cc6a4eb190a1466ad039897) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41082011)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->