### PR TITLE
fix(agent): Add add user role and admin flag to tracing metadata

### DIFF
--- a/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
@@ -131,6 +131,8 @@ describe("InAppAgentInstrumentation", () => {
         metadata: {
           langfuse_project_id: "project-1",
           langfuse_user_email: "user@example.com",
+          langfuse_user_project_role: "ADMIN",
+          langfuse_user_is_admin: true,
         },
         targetProjectId: "project-1",
         traceId,
@@ -380,6 +382,8 @@ describe("InAppAgentInstrumentation", () => {
         metadata: {
           langfuse_project_id: "project-1",
           langfuse_user_email: "user@example.com",
+          langfuse_user_project_role: "ADMIN",
+          langfuse_user_is_admin: true,
           prompt_name: "in-app-agent-system-prompt",
           prompt_version: 3,
         },
@@ -390,6 +394,8 @@ describe("InAppAgentInstrumentation", () => {
         metadata: {
           langfuse_project_id: "project-1",
           langfuse_user_email: "user@example.com",
+          langfuse_user_project_role: "ADMIN",
+          langfuse_user_is_admin: true,
           prompt_name: "in-app-agent-system-prompt",
           prompt_version: 3,
         },
@@ -402,6 +408,8 @@ describe("InAppAgentInstrumentation", () => {
       metadata: {
         langfuse_project_id: "project-1",
         langfuse_user_email: "user@example.com",
+        langfuse_user_project_role: "ADMIN",
+        langfuse_user_is_admin: true,
         prompt_name: "in-app-agent-system-prompt",
         prompt_version: 3,
       },
@@ -660,6 +668,8 @@ function createInstrumentation(
     metadata: { langfuse_project_id: "project-1" },
     userId: "user-1",
     userEmail: "user@example.com",
+    userProjectRole: "ADMIN",
+    userIsAdmin: true,
     traceId,
     targetProjectId: "project-1",
     environment: "prod",

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -346,6 +346,8 @@ export default async function handler(request: Request) {
               ...error,
             });
 
+          const userAccess = getInAppAgentUserAccess(user, projectId);
+
           const stream = await createAgUiStream({
             input: agentInput,
             signal: request.signal,
@@ -423,7 +425,7 @@ export default async function handler(request: Request) {
                 url: getLangfuseMcpUrl(),
                 publicKey: mcpApiKey.publicKey,
                 secretKey: mcpApiKey.secretKey,
-                userAccess: getInAppAgentUserAccess(user, projectId),
+                userAccess,
                 runOverride,
               },
               redirectAction: {
@@ -440,6 +442,8 @@ export default async function handler(request: Request) {
                       user: {
                         id: userId,
                         email: user.email,
+                        projectRole: userAccess.projectRole,
+                        isAdmin: userAccess.isAdmin,
                       },
                       traceId: conversation.id,
                       metadata: {

--- a/web/src/ee/features/in-app-agent/server/instrumentation.ts
+++ b/web/src/ee/features/in-app-agent/server/instrumentation.ts
@@ -7,6 +7,7 @@ import type {
   AgUiRunAgentInput,
 } from "@/src/ee/features/in-app-agent/schema";
 import { compactTextMessageChunks } from "@/src/ee/features/in-app-agent/server/eventCompaction";
+import type { InAppAgentUserAccess } from "@/src/ee/features/in-app-agent/server/tools";
 
 export type InAppAgentTracingConfig = {
   environment: string;
@@ -14,6 +15,9 @@ export type InAppAgentTracingConfig = {
   user: {
     id: string;
     email?: string | null;
+    projectRole?: InAppAgentUserAccess["projectRole"];
+    // Global Langfuse admin flag. This bypasses project membership checks.
+    isAdmin: boolean;
   };
   traceId: string;
   targetProjectId: string;
@@ -88,6 +92,8 @@ export function createInAppAgentInstrumentation({
       metadata: tracing.metadata,
       userId: tracing.user.id,
       userEmail: tracing.user.email,
+      userProjectRole: tracing.user.projectRole,
+      userIsAdmin: tracing.user.isAdmin,
       traceId: tracing.traceId,
       targetProjectId: tracing.targetProjectId,
       environment: tracing.environment,
@@ -130,6 +136,8 @@ export class InAppAgentInstrumentation {
     metadata: Record<string, unknown>;
     userId: string;
     userEmail?: string | null;
+    userProjectRole?: InAppAgentUserAccess["projectRole"];
+    userIsAdmin: boolean;
     traceId: string;
     targetProjectId: string;
     environment: string;
@@ -138,6 +146,10 @@ export class InAppAgentInstrumentation {
     this.metadata = {
       ...params.metadata,
       ...(params.userEmail ? { langfuse_user_email: params.userEmail } : {}),
+      ...(params.userProjectRole
+        ? { langfuse_user_project_role: params.userProjectRole }
+        : {}),
+      langfuse_user_is_admin: params.userIsAdmin,
       ...(params.prompt
         ? {
             prompt_name: params.prompt.name,

--- a/web/src/ee/features/in-app-agent/server/tools.ts
+++ b/web/src/ee/features/in-app-agent/server/tools.ts
@@ -30,6 +30,7 @@ type InAppAgentMcpToolApproval = "auto" | "approval";
 
 export type InAppAgentUserAccess = {
   projectRole?: Role;
+  // Global Langfuse admin flag. This bypasses project membership checks.
   isAdmin: boolean;
 };
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enriches in-app agent tracing metadata with the user's project role and global admin flag, extracted from the existing `getInAppAgentUserAccess` call that was already being used for MCP tool-access control.

- **`handler.ts`**: `getInAppAgentUserAccess` is now assigned to a local variable `userAccess` (rather than inlined in the `langfuseMcp` config object), and the resulting `projectRole` and `isAdmin` values are forwarded into the `langfuseTracing` user config.
- **`instrumentation.ts`**: `InAppAgentInstrumentation` now accepts `userProjectRole` (optional) and `userIsAdmin` (required boolean), encoding them as `langfuse_user_project_role` and `langfuse_user_is_admin` in every trace and generation's metadata.
- **Tests**: All relevant fixtures and assertions are updated to include the two new fields.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are confined to tracing metadata enrichment with no effect on auth, access control, or agent execution paths.

The extraction of `userAccess` is a clean refactor of a pure synchronous function. The new metadata fields are additive and follow the same conditional-spread pattern already used for `userEmail`. Tests are updated consistently across all affected fixtures and assertions.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant H as handler.ts
    participant UA as getInAppAgentUserAccess
    participant S as createAgUiStream
    participant I as InAppAgentInstrumentation

    H->>UA: getInAppAgentUserAccess(user, projectId)
    UA-->>H: "{ projectRole, isAdmin }"
    H->>S: "createAgUiStream({ langfuseMcp: { userAccess }, langfuseTracing: { user: { projectRole, isAdmin } } })"
    S->>I: "new InAppAgentInstrumentation({ userProjectRole, userIsAdmin, ... })"
    I-->>I: "metadata = { langfuse_user_project_role, langfuse_user_is_admin, ... }"
    I-->>S: trace + generation with enriched metadata
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant H as handler.ts
    participant UA as getInAppAgentUserAccess
    participant S as createAgUiStream
    participant I as InAppAgentInstrumentation

    H->>UA: getInAppAgentUserAccess(user, projectId)
    UA-->>H: "{ projectRole, isAdmin }"
    H->>S: "createAgUiStream({ langfuseMcp: { userAccess }, langfuseTracing: { user: { projectRole, isAdmin } } })"
    S->>I: "new InAppAgentInstrumentation({ userProjectRole, userIsAdmin, ... })"
    I-->>I: "metadata = { langfuse_user_project_role, langfuse_user_is_admin, ... }"
    I-->>S: trace + generation with enriched metadata
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Add add user role and admin ..."](https://github.com/langfuse/langfuse/commit/72644cbdb50c0cddd8214297b96abd2450fa03a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41090613)</sub>

<!-- /greptile_comment -->