### PR TITLE
fix(chart-library): fix main typecheck in prepareTimeAxis test (LFE-10602)

### DIFF
--- a/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
+++ b/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
@@ -60,8 +60,11 @@ describe("prepareTimeAxis", () => {
     const axis = prepareTimeAxis(values, 6);
 
     expect(axis.mode).toBe("date");
-    // bucketsPerDay = 24 → shown ticks land a whole number of days apart
-    expect((axis.interval + 1) % 24).toBe(0);
+    // bucketsPerDay = 24 → shown ticks land a whole number of days apart.
+    // In date mode `interval` is always numeric (the string interval is only for
+    // the categorical branch), but its type is `number | "equidistantPreserveStart"`,
+    // so coerce for the arithmetic. (LFE-10602)
+    expect((Number(axis.interval) + 1) % 24).toBe(0);
     expect(MONTH_DAY.test(axis.formatTick(values[0]))).toBe(true);
   });
 


### PR DESCRIPTION
## TL;DR
Unbreak `main` typecheck. #14670 (LFE-10583) widened `TimeAxis.interval` to `number | "equidistantPreserveStart"`; the pre-existing date-mode test did `axis.interval + 1`, which no longer type-checks. In date mode the interval is always numeric, so coerce with `Number()`.

## Verify
`pnpm --filter=web run typecheck` (tsgo, same as the build) → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This is a one-line typecheck fix in a test file. The previous PR (#14670) widened `TimeAxis.interval` from `number` to `number | "equidistantPreserveStart"`, which broke arithmetic in an existing date-mode test that did `axis.interval + 1`.

- The fix wraps `axis.interval` in `Number()` before the modulo arithmetic, which is safe because in date mode the interval is always numeric — the string value is only produced for the categorical branch.
- An explanatory comment is added in-place to document why the coercion is needed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — touches only a single test assertion with no production code changes.

The change is a minimal, targeted coercion in one test line. The Number() call is correct for date mode (always numeric), and the existing categorical test at line 142 already guards against the string value appearing in the wrong branch. No production logic is touched.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chart-library): fix main typecheck i..."](https://github.com/langfuse/langfuse/commit/30890e5e9817a838f22ccb10235633c8365d7757) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41093159)</sub>

<!-- /greptile_comment -->