### PR TITLE
fix(ci): run test jobs with NODE_ENV test

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -213,6 +213,8 @@ jobs:
     # at run creation, so this job starts immediately (!cancelled() lets the
     # condition evaluate despite the skipped dependency).
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
+    env:
+      NODE_ENV: test
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -247,6 +249,8 @@ jobs:
     # at run creation, so this job starts immediately (!cancelled() lets the
     # condition evaluate despite the skipped dependency).
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
+    env:
+      NODE_ENV: test
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -297,6 +301,8 @@ jobs:
     # at run creation, so this job starts immediately (!cancelled() lets the
     # condition evaluate despite the skipped dependency).
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
+    env:
+      NODE_ENV: test
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -417,6 +423,8 @@ jobs:
     # condition evaluate despite the skipped dependency).
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
     name: tests-web (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, mode${{ matrix.deploy-mode }})
+    env:
+      NODE_ENV: test
     strategy:
       matrix:
         node-version: [24]
@@ -537,7 +545,6 @@ jobs:
       - name: Start Langfuse
         run: (pnpm run start&)
         env:
-          NODE_ENV: test
           LANGFUSE_INIT_ORG_ID: "seed-org-id"
           LANGFUSE_INIT_ORG_NAME: "Seed Org"
           LANGFUSE_INIT_ORG_CLOUD_PLAN: "Team"
@@ -578,6 +585,8 @@ jobs:
     # condition evaluate despite the skipped dependency).
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
     name: tests-worker (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, mode${{ matrix.deploy-mode }})
+    env:
+      NODE_ENV: test
     strategy:
       matrix:
         node-version: [24]
@@ -673,6 +682,8 @@ jobs:
       - llm-connections-filter
     if: ${{ !cancelled() && (startsWith(github.ref, 'refs/tags/') || ((github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') && (needs.llm-connections-filter.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'))) }}
     name: test-worker-llm-connections (node24, pg15)
+    env:
+      NODE_ENV: test
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -753,6 +764,8 @@ jobs:
     # at run creation, so this job starts immediately (!cancelled() lets the
     # condition evaluate despite the skipped dependency).
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
+    env:
+      NODE_ENV: test
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -855,8 +868,6 @@ jobs:
           exit "$(cat /tmp/playwright-install.exit)"
       - name: Run e2e tests
         run: pnpm --filter=web run test:e2e
-        env:
-          NODE_ENV: test
 
   e2e-server-tests:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -866,6 +877,8 @@ jobs:
     # at run creation, so this job starts immediately (!cancelled() lets the
     # condition evaluate despite the skipped dependency).
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
+    env:
+      NODE_ENV: test
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -938,8 +951,6 @@ jobs:
           pnpm --filter=shared run db:seed:examples
       - name: Run server
         run: (pnpm run start&)
-        env:
-          NODE_ENV: test
       - name: Check worker health
         run: |
           timeout 10 bash -c 'until curl -f http://localhost:3030/api/health; do sleep 2; done'


### PR DESCRIPTION
## Summary
- Set `NODE_ENV=test` at the job level for CI test jobs.
- Remove redundant step-level `NODE_ENV` overrides now covered by job-level env.
- Prevent test jobs from defaulting shared env parsing to development mode, which can emit verbose ClickHouse query logs on failed Vitest output.

## Impacted packages
- CI only: `.github/workflows/pipeline.yml`

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pipeline.yml"); puts "yaml ok"'`\n- Commit hook: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli`\n- Commit hook: `turbo run lint`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors CI environment configuration by promoting `NODE_ENV=test` from individual step-level overrides to the job level for all test jobs, preventing the shared environment-parsing code from defaulting to development mode (which causes verbose ClickHouse query logging on test failures).

- `NODE_ENV: test` added at the `jobs.<job_id>.env` level for all 8 test jobs: `tests-eslint-plugin`, `tests-storybook`, `tests-shared`, `tests-web`, `tests-worker`, `test-worker-llm-connections`, `e2e-tests`, and `e2e-server-tests`.
- Redundant step-level `NODE_ENV: test` entries removed from the `Start Langfuse`, `Run server`, and `Run e2e tests` steps — their effective value is unchanged since job-level env propagates to all steps.
- `test-docker-build` and non-test jobs (`lint`, `prettier-check`) are intentionally left without `NODE_ENV: test`, which is correct.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change touches only CI workflow configuration with no runtime code affected.

The only changed file is the GitHub Actions pipeline. Moving `NODE_ENV=test` from step level to job level is a clean deduplication; the effective value reaching each step that previously set it is identical. Steps that are newly receiving `NODE_ENV=test` (such as `pnpm run build` in the `e2e-tests` and `tests-web` jobs) are unaffected in practice because Next.js overrides `NODE_ENV` to `production` internally for both `next build` and `next start`. Jobs that should not carry `NODE_ENV=test` (`test-docker-build`, `lint`, `prettier-check`) are correctly omitted.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Actions Runner] --> B[job-level env\nNODE_ENV=test]
    B --> C[Step: checkout]
    B --> D[Step: install deps]
    B --> E[Step: Build\npnpm run build]
    B --> F[Step: Start Langfuse\npnpm run start]
    B --> G[Step: Run Tests\nvitest / playwright]

    E -->|Next.js internally sets\nNODE_ENV=production| H[Optimised production build]
    F -->|next start internally sets\nNODE_ENV=production| I[Production server]
    G -->|Inherits NODE_ENV=test\nfrom job level| J[Test runner\nin test mode]

    subgraph Before PR
        K[step-level env] --> L[Run e2e tests\nNODE_ENV=test]
        K --> M[Other steps\nno NODE_ENV set]
    end

    subgraph After PR
        B
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[GitHub Actions Runner] --> B[job-level env\nNODE_ENV=test]
    B --> C[Step: checkout]
    B --> D[Step: install deps]
    B --> E[Step: Build\npnpm run build]
    B --> F[Step: Start Langfuse\npnpm run start]
    B --> G[Step: Run Tests\nvitest / playwright]

    E -->|Next.js internally sets\nNODE_ENV=production| H[Optimised production build]
    F -->|next start internally sets\nNODE_ENV=production| I[Production server]
    G -->|Inherits NODE_ENV=test\nfrom job level| J[Test runner\nin test mode]

    subgraph Before PR
        K[step-level env] --> L[Run e2e tests\nNODE_ENV=test]
        K --> M[Other steps\nno NODE_ENV set]
    end

    subgraph After PR
        B
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): run test jobs with NODE\_ENV tes..."](https://github.com/langfuse/langfuse/commit/f15cad5b2125919a0d617e537640c5f66bd68a91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41095261)</sub>

<!-- /greptile_comment -->