### PR TITLE
chore(worker): cut projectId tag and window-duration blob export metrics (LFE-10521)

### DIFF
--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -267,7 +267,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     expect(mockRecordIncrement).toHaveBeenCalledWith(
       "langfuse.blobstorage.table_export.count",
       1,
-      expect.objectContaining({ outcome: "failure", projectId }),
+      expect.objectContaining({ outcome: "failure" }),
     );
 
     // All four stage timers emitted with outcome=failure...
@@ -449,7 +449,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           expect(mockRecordIncrement).toHaveBeenCalledWith(
             "langfuse.blobstorage.table_export.count",
             1,
-            { outcome, table, projectId },
+            { outcome, table },
           );
         }
       }

--- a/worker/src/__tests__/inFlightExports.unit.test.ts
+++ b/worker/src/__tests__/inFlightExports.unit.test.ts
@@ -84,7 +84,6 @@ describe("inFlightExports", () => {
         outcome: "aborted",
         abortReason: "shutdown",
         table: "observations_v2",
-        projectId: "p-1",
       },
     );
     expect(mockRecordIncrement).toHaveBeenCalledWith(
@@ -94,7 +93,6 @@ describe("inFlightExports", () => {
         outcome: "aborted",
         abortReason: "shutdown",
         table: "scores",
-        projectId: "p-1",
       },
     );
 

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -414,7 +414,6 @@ const processBlobStorageExport = async (config: {
       recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
         outcome: "started" satisfies BlobTableExportOutcome,
         table: config.table,
-        projectId: config.projectId,
       });
 
       // Outside the try so the catch can distinguish a real upload success from
@@ -763,7 +762,6 @@ const processBlobStorageExport = async (config: {
           recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
             outcome: "success" satisfies BlobTableExportOutcome,
             table: config.table,
-            projectId: config.projectId,
           });
 
           const exportFormat = parquetEligible
@@ -977,7 +975,6 @@ const processBlobStorageExport = async (config: {
             outcome: "failure" satisfies BlobTableExportOutcome,
             abortReason: origin.reason,
             table: config.table,
-            projectId: config.projectId,
           });
         }
         logger.error(
@@ -1219,12 +1216,6 @@ export const handleBlobStorageIntegrationProjectJob = async (
       );
     }
 
-    // Elapsed time spent exporting this one window's data, used to detect
-    // exporters that can't keep up (see metric emit below). Monotonic
-    // performance.now() — matches the file's other deltas and avoids a clock
-    // step (NTP/suspend) producing a negative duration.
-    const exportStartedAt = performance.now();
-
     if (isTraceOnlyProject) {
       // Only process traces table for projects in the trace-only list (legacy behavior)
       logger.info(
@@ -1271,35 +1262,8 @@ export const handleBlobStorageIntegrationProjectJob = async (
       await Promise.all(processPromises);
     }
 
-    const exportDurationMs = performance.now() - exportStartedAt;
-
     // Determine if we've caught up with present-day data
     const caughtUp = maxTimestamp.getTime() >= uncappedMaxTimestamp.getTime();
-
-    // Falling-behind signal: how long it took to export one window's data
-    // relative to that window's scheduling cadence (the frequency interval).
-    // A ratio > 1 means a single run takes longer than the period it covers, so
-    // the exporter cannot keep up and lag grows over time. frequencyIntervalMs
-    // is the stable denominator the user reasons about ("exports every 20 min")
-    // — the actual data window collapses toward zero near the lag buffer in
-    // steady state and would make the ratio meaningless (LFE-10521). caughtUp
-    // is tagged so steady-state lag can be separated from expected back-to-back
-    // catch-up runs.
-    const durationTags = {
-      projectId,
-      exportFrequency: blobStorageIntegration.exportFrequency,
-      caughtUp: String(caughtUp),
-    };
-    recordHistogram(
-      "langfuse.blobstorage.window_export_duration_seconds",
-      exportDurationMs / 1000,
-      durationTags,
-    );
-    recordGauge(
-      "langfuse.blobstorage.window_export_duration_ratio",
-      exportDurationMs / frequencyIntervalMs,
-      durationTags,
-    );
 
     let nextSyncAt: Date;
     if (caughtUp) {

--- a/worker/src/features/blobstorage/inFlightExports.ts
+++ b/worker/src/features/blobstorage/inFlightExports.ts
@@ -71,7 +71,6 @@ export const logInFlightBlobExportsOnShutdown = (): void => {
       // Survivors at a graceful shutdown were aborted by the SIGTERM teardown.
       abortReason: "shutdown",
       table: entry.table,
-      projectId: entry.projectId,
     });
   }
 };


### PR DESCRIPTION
## What does this PR do?

Reduces Datadog custom-metric cardinality from the blob-export instrumentation by removing three low-value, high-cardinality signals:

- **Removes** the `langfuse.blobstorage.window_export_duration_seconds` histogram (which fanned out into 8 sub-metrics, each carrying `projectId`).
- **Removes** the `langfuse.blobstorage.window_export_duration_ratio` gauge (`projectId` / `exportFrequency` / `caughtUp`).
- **Drops** the `projectId` tag from `langfuse.blobstorage.table_export.count` (kept `outcome` / `table` / `abortReason`).

`projectId` was the dominant cardinality driver on these metrics, with no host/pod aggregation to offset it. The `caughtUp` computation is retained — it still drives export scheduling.

The reliability signal (started/success/failure/aborted counts by table) and the per-stage timing histograms are unchanged.

## Type of change

- [x] Chore (internal instrumentation; no user- or operator-visible behavior change)

## Checklist

- [x] `pnpm turbo run typecheck --filter=worker` passes
- [x] `pnpm turbo run lint --filter=worker` passes
- [x] Updated unit tests (`inFlightExports`, `blobExportAbortObservability`) and the integration-test assertions in `blobStorageIntegrationProcessing`