### PR TITLE
fix(trace): guard markdown rendering against stack overflow on deeply nested payloads (LFE-10604)

### DIFF
--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -4,6 +4,7 @@ import {
   type ReactNode,
   type ReactElement,
   memo,
+  useMemo,
   isValidElement,
   Children,
   createElement,
@@ -52,6 +53,7 @@ import {
   getRenderedInlineMediaIds,
   getStandaloneMediaReferenceStrings,
 } from "@/src/components/ui/markdown-media.utils";
+import { exceedsMarkdownRenderLimits } from "@/src/components/ui/markdown-render-limits";
 
 type ReactMarkdownNode = ReactMarkdownExtraProps["node"];
 type ReactMarkdownNodeChildren = Exclude<
@@ -210,6 +212,30 @@ function MarkdownRenderer({
   customCodeHeaderClassName?: string;
 }) {
   const promptReferenceProjectId = usePromptReferenceProjectId();
+
+  // Guard against payloads that would overflow the JS call stack while
+  // react-markdown recursively walks the parsed tree (crashes Firefox, whose
+  // stack is much smaller than Chrome's). Rendered as plain text instead.
+  // See markdown-render-limits.ts for the mechanism.
+  const tooLargeOrDeep = useMemo(
+    () => exceedsMarkdownRenderLimits(markdown),
+    [markdown],
+  );
+
+  if (tooLargeOrDeep) {
+    return (
+      <div className={cn("space-y-2 overflow-x-auto text-sm", className)}>
+        <div className="text-muted-foreground flex items-center gap-1 text-xs">
+          <Info className="h-3 w-3" />
+          Content is too large or deeply nested to render as markdown.
+          Displaying as plain text.
+        </div>
+        <pre className="text-sm break-words whitespace-pre-wrap">
+          {markdown}
+        </pre>
+      </div>
+    );
+  }
 
   // Try to parse markdown content
 

--- a/web/src/components/ui/markdown-render-limits.clienttest.ts
+++ b/web/src/components/ui/markdown-render-limits.clienttest.ts
@@ -1,0 +1,96 @@
+import {
+  MARKDOWN_MAX_NESTING_DEPTH,
+  MARKDOWN_MAX_RENDER_BYTES,
+  estimateMarkdownNestingDepth,
+  exceedsMarkdownRenderLimits,
+} from "@/src/components/ui/markdown-render-limits";
+
+describe("estimateMarkdownNestingDepth", () => {
+  it("returns 0 for plain text", () => {
+    expect(estimateMarkdownNestingDepth("just a plain sentence")).toBe(0);
+    expect(estimateMarkdownNestingDepth("")).toBe(0);
+  });
+
+  it("stays low for typical markdown", () => {
+    const doc = [
+      "# Title",
+      "",
+      "Some **bold** and _italic_ and `code` text.",
+      "",
+      "- item one",
+      "  - nested item",
+      "    - deeper item",
+      "",
+      "> a short quote",
+      "",
+      "1. first",
+      "2. second",
+    ].join("\n");
+    expect(estimateMarkdownNestingDepth(doc)).toBeLessThan(
+      MARKDOWN_MAX_NESTING_DEPTH,
+    );
+  });
+
+  it("counts space-separated blockquote nesting exactly", () => {
+    expect(estimateMarkdownNestingDepth("> > > hi")).toBeGreaterThanOrEqual(3);
+  });
+
+  it("counts tightly-packed blockquote nesting exactly", () => {
+    const depth = 500;
+    expect(
+      estimateMarkdownNestingDepth(">".repeat(depth) + "text"),
+    ).toBeGreaterThanOrEqual(depth);
+  });
+
+  it("catches long emphasis/strikethrough delimiter runs", () => {
+    expect(
+      estimateMarkdownNestingDepth("*".repeat(400)),
+    ).toBeGreaterThanOrEqual(400);
+    expect(
+      estimateMarkdownNestingDepth("~".repeat(400)),
+    ).toBeGreaterThanOrEqual(400);
+  });
+
+  it("catches deeply indented (nested list) content", () => {
+    // Each level adds indentation; a 300-level list indents ~600 columns.
+    const lines = Array.from(
+      { length: 300 },
+      (_, i) => "  ".repeat(i) + "- item",
+    );
+    expect(estimateMarkdownNestingDepth(lines.join("\n"))).toBeGreaterThan(
+      MARKDOWN_MAX_NESTING_DEPTH,
+    );
+  });
+
+  it("does not count mid-line dashes or emphasis as nesting", () => {
+    expect(estimateMarkdownNestingDepth("a - b - c - d")).toBe(0);
+    expect(estimateMarkdownNestingDepth("use foo_bar_baz names")).toBeLessThan(
+      3,
+    );
+  });
+});
+
+describe("exceedsMarkdownRenderLimits", () => {
+  it("allows normal content", () => {
+    expect(exceedsMarkdownRenderLimits("Hello **world**")).toBe(false);
+    expect(exceedsMarkdownRenderLimits("- a\n  - b\n    - c")).toBe(false);
+  });
+
+  it("flags content over the size preempt", () => {
+    expect(
+      exceedsMarkdownRenderLimits("a".repeat(MARKDOWN_MAX_RENDER_BYTES + 1)),
+    ).toBe(true);
+  });
+
+  it("flags deeply nested content even when small", () => {
+    // A few KB of nested blockquotes overflows the parser/renderer in Firefox.
+    expect(exceedsMarkdownRenderLimits("> ".repeat(2000) + "boom")).toBe(true);
+    expect(exceedsMarkdownRenderLimits("*".repeat(2000))).toBe(true);
+  });
+
+  it("does not flag large-but-shallow markdown under the size cap", () => {
+    const shallow = "word ".repeat(10_000); // ~50KB, depth 0
+    expect(shallow.length).toBeLessThan(MARKDOWN_MAX_RENDER_BYTES);
+    expect(exceedsMarkdownRenderLimits(shallow)).toBe(false);
+  });
+});

--- a/web/src/components/ui/markdown-render-limits.ts
+++ b/web/src/components/ui/markdown-render-limits.ts
@@ -1,0 +1,133 @@
+// Safety limits for rendering user/model content as GFM markdown.
+//
+// react-markdown parses content to an mdast tree and then walks it recursively
+// (mdast -> hast conversion and remark plugins such as remark-gfm's
+// autolink-literal, via unist-util-visit). That walk recurses once per level of
+// *nesting depth*. Deeply nested markdown — e.g. long blockquote chains
+// (`> > > …`), nested lists, or long emphasis runs (`***…`) — therefore recurses
+// as deep as the tree and can overflow the JS call stack. Firefox's stack is much
+// smaller than Chrome's, so the same payload throws `InternalError: too much
+// recursion` in Firefox while rendering fine in Chrome.
+//
+// Byte size alone does not predict this: a flat multi-hundred-KB payload never
+// overflows, while a few KB of deeply nested markdown does. Even parsing such
+// input to *measure* its depth is unsafe — micromark's parser recurses too and
+// overflows on the same pathological input. So the depth check below is a single
+// pass, non-recursive scan that can never itself overflow.
+
+// Cheap preempt: individual strings larger than this are rendered as plain text
+// instead of markdown. Mirrors MARKDOWN_RENDER_CHARACTER_LIMIT (the caller-side
+// input+output+messages gate) as a per-string backstop for surfaces that do not
+// apply that gate (e.g. comments), and avoids scanning/rendering huge blobs.
+export const MARKDOWN_MAX_RENDER_BYTES = 150_000;
+
+// Content whose estimated markdown nesting depth exceeds this is rendered as
+// plain text. Legitimate markdown nests <20-30 levels deep; a stack-overflowing
+// payload needs hundreds+, so this threshold sits in a wide safe band.
+export const MARKDOWN_MAX_NESTING_DEPTH = 100;
+
+const isListBullet = (char: string): boolean =>
+  char === "-" || char === "+" || char === "*";
+
+const isEmphasisDelimiter = (char: string): boolean =>
+  char === "*" || char === "_" || char === "~";
+
+const isSpace = (char: string): boolean => char === " " || char === "\t";
+
+/**
+ * Returns a cheap, non-recursive over-estimate of the maximum markdown nesting
+ * depth in `content`. It is a safe upper bound for the byte-cheap vectors that
+ * can overflow a small stack without being large (blockquotes and emphasis
+ * runs); byte-expensive vectors (deep multi-line lists) are additionally bounded
+ * by the size preempt. Over-estimating is safe (worst case: content falls back
+ * to plain text); the scan never under-counts a pure blockquote chain.
+ */
+export function estimateMarkdownNestingDepth(content: string): number {
+  let maxDepth = 0;
+  let atLineStart = true;
+
+  // Leading container markers per line: each `>`, list bullet, or ordered-list
+  // marker opens a nesting level, plus a term for indentation-based list nesting.
+  let lineDepth = 0;
+  let leadingWhitespace = 0;
+  let inLeadingMarkers = false;
+
+  // Longest run of the same emphasis/strikethrough delimiter, an upper bound on
+  // inline emphasis nesting depth.
+  let runChar = "";
+  let runLength = 0;
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i];
+
+    if (char === "\n") {
+      atLineStart = true;
+      lineDepth = 0;
+      leadingWhitespace = 0;
+      runChar = "";
+      runLength = 0;
+      continue;
+    }
+
+    if (atLineStart) {
+      if (isSpace(char)) {
+        leadingWhitespace++;
+        inLeadingMarkers = true;
+        continue;
+      }
+      if (char === ">") {
+        lineDepth++;
+        const depth = lineDepth + Math.floor(leadingWhitespace / 2);
+        if (depth > maxDepth) maxDepth = depth;
+        inLeadingMarkers = true;
+        continue;
+      }
+      // A list bullet or ordered marker only opens a level when followed by
+      // whitespace (or end of content); otherwise it is emphasis / plain text.
+      const next = content[i + 1];
+      const followedByWs = next === undefined || isSpace(next) || next === "\n";
+      if (isListBullet(char) && followedByWs) {
+        lineDepth++;
+        const depth = lineDepth + Math.floor(leadingWhitespace / 2);
+        if (depth > maxDepth) maxDepth = depth;
+        inLeadingMarkers = true;
+        continue;
+      }
+      // Leading markers ended for this line; account for indentation depth once
+      // more (covers indented content with no explicit bullet) then fall through
+      // to inline scanning of the rest of the line.
+      if (inLeadingMarkers) {
+        const depth = lineDepth + Math.floor(leadingWhitespace / 2);
+        if (depth > maxDepth) maxDepth = depth;
+      }
+      atLineStart = false;
+      inLeadingMarkers = false;
+    }
+
+    // Inline emphasis / strikethrough delimiter runs.
+    if (isEmphasisDelimiter(char)) {
+      if (char === runChar) {
+        runLength++;
+      } else {
+        runChar = char;
+        runLength = 1;
+      }
+      if (runLength > maxDepth) maxDepth = runLength;
+    } else {
+      runChar = "";
+      runLength = 0;
+    }
+  }
+
+  return maxDepth;
+}
+
+/**
+ * Whether `content` should be rendered as plain text rather than parsed as GFM
+ * markdown, to avoid stack-overflow crashes on pathologically large or deeply
+ * nested payloads. See the module header for the mechanism.
+ */
+export function exceedsMarkdownRenderLimits(content: string): boolean {
+  if (content.length > MARKDOWN_MAX_RENDER_BYTES) return true;
+  return estimateMarkdownNestingDepth(content) > MARKDOWN_MAX_NESTING_DEPTH;
+}


### PR DESCRIPTION
## TL;DR
Large or deeply nested IO payloads could crash the trace/observation view in **Firefox** with `InternalError: too much recursion`. This adds a cheap, crash-proof guard at the single markdown-rendering chokepoint that renders such content as plain text instead of attempting the recursive GFM parse. Verified live in the app.

## Why
A customer-reported "recursion loop in tracing" reproduced locally: opening a peek that renders a large IO payload as markdown threw `too much recursion` in Firefox, while Chrome survived (its call stack is much larger — so it looked fine under Chrome/Playwright, a false pass).

Root cause: `react-markdown` recurses **once per level of nesting depth** while walking the parsed tree (mdast→hast conversion, and remark-gfm's autolink-literal via `unist-util-visit`). Deeply nested markdown — long blockquote chains (`> > > …`), nested lists, or long emphasis runs (`***…`) — recurses as deep as the tree and overflows the stack.

Two findings shaped the fix (reproduced deterministically outside the browser against react-markdown's exact pipeline):
- **Byte size does not predict the crash.** A flat multi-hundred-KB payload never overflows; a few KB of deeply nested markdown does. The trigger is *nesting depth*, not size.
- **Even parsing to measure depth is unsafe** — micromark's parser recurses too and overflows on the same pathological input (a few KB of `>>>>…`). So the guard must never itself parse deeply.

## What
A single-pass, **non-recursive** scan at the `MarkdownRenderer` chokepoint (`MarkdownViewer.tsx`) — which every IOPreview, comment, and JSON-view surface routes through. Content is rendered as plain text instead of GFM when it exceeds either:
- a **size** preempt (mirrors the existing per-surface limit as a per-string backstop), or
- an estimated **nesting-depth** limit (legit markdown nests <20–30; a stack-overflowing payload needs hundreds+).

The depth estimate is a safe over-approximation that can never overflow: exact for blockquote chains, upper-bounded for lists (indentation) and inline emphasis (delimiter runs).

## Result
No more stack-overflow crash on pathological payloads across all markdown surfaces; oversized/deep content degrades gracefully to a labelled plain-text block. Normal markdown is unaffected.

<details>
<summary>Mechanism, threshold, and verification detail</summary>

**Where:** `web/src/components/ui/markdown-render-limits.ts` (pure, dependency-free scan + limits) is called from `MarkdownRenderer` before it hands content to `react-markdown`. Placing it at that one chokepoint covers IO peek, comments, `PrettyJsonView`, and `MarkdownJsonView` with a single guard.

**Why not the alternatives:** a byte-size cap alone misses small-but-deeply-nested payloads (the actual mechanism); a parse-based depth check is unsafe because the parser itself overflows. The scan targets the real mechanism without ever recursing.

**Thresholds:** size preempt = 150 KB (mirrors `MARKDOWN_RENDER_CHARACTER_LIMIT`); nesting depth = 100 (wide safe band — legit content is <30, overflow needs hundreds+).

**Verification:**
- Deterministic reproduction against react-markdown's exact `remark-parse → remark-gfm → remark-rehype` pipeline (reduced stack, mimicking Firefox): nested blockquotes overflow at ~6 KB; the guard prevents the parse from ever running.
- 11 unit tests (`markdown-render-limits.clienttest.ts`) covering blockquote/list/emphasis vectors, size, and benign content (no false positives).
- Live in-app (chat prompt, which renders message content as markdown): a depth-160 payload renders the plain-text fallback with **zero** `<blockquote>` nodes created; a normal-markdown control still renders full markdown (`h1`/`strong`/`em`/`code`/`blockquote`/`li`).
- Since the fix removes the recursion entirely for flagged content, Firefox now renders the same plain-text fallback as Chrome — the crash cannot occur.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a cheap, non-recursive scan at the `MarkdownRenderer` chokepoint to prevent JS call-stack overflows on deeply nested payloads in Firefox, where the stack is much smaller than in Chrome. Content that exceeds a 150K-character size preempt or an estimated nesting depth of 100 is rendered as labeled plain text instead of being fed to `react-markdown`.

- **`markdown-render-limits.ts`** — new pure module with a single-pass `estimateMarkdownNestingDepth` scanner (counts blockquote markers, list bullets, indentation, and emphasis delimiter runs) and a `exceedsMarkdownRenderLimits` guard; 11 unit tests cover all main overflow vectors.
- **`MarkdownViewer.tsx`** — early-return guard in `MarkdownRenderer` using `useMemo`; flagged content degrades gracefully to a `<pre>` block with an informational banner, covering every markdown surface (IOPreview, comments, JSON views) through a single chokepoint.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The guard only affects content that would already crash the renderer; all normal markdown paths are untouched.

The implementation is well-reasoned and thoroughly tested. The only notable issue is a naming inconsistency — the exported constant is called MARKDOWN_MAX_RENDER_BYTES but the check uses JavaScript's .length which counts UTF-16 code units (characters), not bytes. This doesn't affect runtime correctness since the over-approximation is in the safe direction, but it could mislead future maintainers who might try to align it with a byte-based measurement.

markdown-render-limits.ts — the MARKDOWN_MAX_RENDER_BYTES constant name.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MarkdownRenderer receives markdown string] --> B{content.length > 150 000?}
    B -- Yes --> F[Render plain-text fallback\nwith Info banner]
    B -- No --> C[estimateMarkdownNestingDepth\nsingle-pass scan]
    C --> D{estimated depth > 100?}
    D -- Yes --> F
    D -- No --> E[ReactMarkdown\nremark-gfm pipeline\nrecursive tree walk]
    E --> G[Rendered GFM output]
    F --> H[Labeled pre block\nno recursion]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[MarkdownRenderer receives markdown string] --> B{content.length > 150 000?}
    B -- Yes --> F[Render plain-text fallback\nwith Info banner]
    B -- No --> C[estimateMarkdownNestingDepth\nsingle-pass scan]
    C --> D{estimated depth > 100?}
    D -- Yes --> F
    D -- No --> E[ReactMarkdown\nremark-gfm pipeline\nrecursive tree walk]
    E --> G[Rendered GFM output]
    F --> H[Labeled pre block\nno recursion]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/ui/markdown-render-limits.ts:22
The constant is named `MARKDOWN_MAX_RENDER_BYTES` but `content.length` returns UTF-16 code units (characters), not bytes. For ASCII content they're equal, but a string of emoji or CJK characters can be several times larger in bytes than its `.length`. The comment above the constant already says "individual strings larger than this are rendered as plain text", which confirms character-based intent — the name `BYTES` is just misleading and could confuse future readers who might switch to `TextEncoder.encode(content).byteLength` expecting parity.

```suggestion
export const MARKDOWN_MAX_RENDER_CHARS = 150_000;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): guard markdown rendering aga..."](https://github.com/langfuse/langfuse/commit/7497fcf295d81db4a5370a3cac504a10dc7f13dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41163597)</sub>

<!-- /greptile_comment -->