### PR TITLE
fix(web): close provider dropdown before opening New LLM Connection dialog (LFE-10615)

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -134,19 +134,12 @@ changes.
   imperatively-positioned content renders via `<Layer name="…">`. z-index stays
   local to a layer or component (1–2 max), never to escape the app — the
   `@repo/no-overlay-zindex` lint rule enforces it.
-- **Overlay lifecycle — an overlay should avoid spawning another overlay while
-  it stays open.** Layers decide who paints on top _when two overlays should
-  coexist_ (e.g. a Select inside a Dialog); they do NOT decide whether both
-  _should_ be alive at once. A dropdown that opens a modal is the second case:
-  the still-open dropdown (`popover` layer) paints over the modal (`modal`
-  layer) and the two focus/dismiss scopes fight — a lifecycle bug, not a z-order
-  one, so don't try to fix it by re-ranking layers. Instead **close the owning
-  dropdown before opening the modal** (and reopen it on close if the user still
-  owes a pick). Because a Radix Select/DropdownMenu unmounts its content when it
-  closes, render the spawned Dialog OUTSIDE the dropdown content (a sibling that
-  survives the close), with just a trigger left inside — as
-  `src/components/ModelParameters/index.tsx` does via `useAddLlmConnectionSelect`
-  (LFE-10615). Full nesting is sometimes unavoidable; prefer closing the owner.
+- **Overlay lifecycle — a dropdown that opens a modal should close first**, not
+  linger under it (a lifecycle bug, not z-order — don't fix it by re-ranking
+  layers). Radix unmounts a Select/DropdownMenu's content on close, so render the
+  Dialog as a SIBLING (trigger inside, dialog outside), as
+  `useAddLlmConnectionSelect` in `src/components/ModelParameters/index.tsx` does
+  (LFE-10615).
 - Public API routes should use
   `src/features/public-api/server/withMiddlewares.ts`, define strict request and
   response types in `src/features/public-api/types/*`, add server tests, and

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -134,6 +134,19 @@ changes.
   imperatively-positioned content renders via `<Layer name="…">`. z-index stays
   local to a layer or component (1–2 max), never to escape the app — the
   `@repo/no-overlay-zindex` lint rule enforces it.
+- **Overlay lifecycle — an overlay should avoid spawning another overlay while
+  it stays open.** Layers decide who paints on top _when two overlays should
+  coexist_ (e.g. a Select inside a Dialog); they do NOT decide whether both
+  _should_ be alive at once. A dropdown that opens a modal is the second case:
+  the still-open dropdown (`popover` layer) paints over the modal (`modal`
+  layer) and the two focus/dismiss scopes fight — a lifecycle bug, not a z-order
+  one, so don't try to fix it by re-ranking layers. Instead **close the owning
+  dropdown before opening the modal** (and reopen it on close if the user still
+  owes a pick). Because a Radix Select/DropdownMenu unmounts its content when it
+  closes, render the spawned Dialog OUTSIDE the dropdown content (a sibling that
+  survives the close), with just a trigger left inside — as
+  `src/components/ModelParameters/index.tsx` does via `useAddLlmConnectionSelect`
+  (LFE-10615). Full nesting is sometimes unavoidable; prefer closing the owner.
 - Public API routes should use
   `src/features/public-api/server/withMiddlewares.ts`, define strict request and
   response types in `src/features/public-api/types/*`, add server tests, and

--- a/web/src/components/ModelParameters/index.tsx
+++ b/web/src/components/ModelParameters/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
 import {
@@ -11,6 +11,7 @@ import {
 } from "@/src/components/ui/select";
 import { Slider } from "@/src/components/ui/slider";
 import { CreateLLMApiKeyDialog } from "@/src/features/public-api/components/CreateLLMApiKeyDialog";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { cn } from "@/src/utils/tailwind";
 import {
@@ -20,7 +21,7 @@ import {
   type supportedModels,
   type UIModelParams,
 } from "@langfuse/shared";
-import { InfoIcon, Settings2 } from "lucide-react";
+import { InfoIcon, PlusIcon, Settings2 } from "lucide-react";
 import {
   Popover,
   PopoverContent,
@@ -71,8 +72,13 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
   const [modelSettingsOpen, setModelSettingsOpen] = useState(false);
   const [modelSettingsUsed, setModelSettingsUsed] = useState(false);
 
+  // Standalone dialog for the "no providers yet" empty state (renders its own
+  // trigger button, not inside a dropdown).
   const [createLlmApiKeyDialogOpen, setCreateLlmApiKeyDialogOpen] =
     useState(false);
+  // Coordinates the inline "Add LLM Connection" action inside the combined
+  // provider/model Select (compact layout) — see useAddLlmConnectionSelect.
+  const providerSelect = useAddLlmConnectionSelect();
 
   useEffect(() => {
     const hasEnabledModelSetting = Object.keys(modelParams).some(
@@ -229,8 +235,13 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
         <div className="flex items-center gap-2">
           <div className="min-w-0 flex-1 space-y-1">
             <Select
+              open={providerSelect.selectOpen}
+              onOpenChange={providerSelect.setSelectOpen}
               disabled={formDisabled}
-              onValueChange={handleCombinedSelection}
+              onValueChange={(value) => {
+                providerSelect.notifySelection();
+                handleCombinedSelection(value);
+              }}
               value={currentCombinedValue}
             >
               <SelectTrigger className="h-8">
@@ -242,13 +253,18 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
                     {option}
                   </SelectItem>
                 ))}
-                <SelectSeparator />
-                <CreateLLMApiKeyDialog
-                  open={createLlmApiKeyDialogOpen}
-                  setOpen={setCreateLlmApiKeyDialogOpen}
+                <AddLlmConnectionSelectAction
+                  onOpen={providerSelect.openConnectionDialog}
                 />
               </SelectContent>
             </Select>
+            {/* Dialog lives OUTSIDE the SelectContent so closing the Select does
+                not unmount it (see useAddLlmConnectionSelect). */}
+            <CreateLLMApiKeyDialog
+              hideTrigger
+              open={providerSelect.dialogOpen}
+              setOpen={providerSelect.handleDialogOpenChange}
+            />
             {modelParamsDescription ? (
               <FormDescription className="mt-1 text-xs">
                 {modelParamsDescription}
@@ -337,21 +353,35 @@ const ModelParamsSelect = ({
   modelParamsDescription,
   layout = "vertical",
 }: ModelParamsSelectProps) => {
-  const [createLlmApiKeyDialogOpen, setCreateLlmApiKeyDialogOpen] =
-    useState(false);
+  const providerSelect = useAddLlmConnectionSelect();
+
+  const handleValueChange = (next: string) => {
+    providerSelect.notifySelection();
+    updateModelParam(
+      modelParamsKey,
+      next as (typeof supportedModels)[LLMAdapter][number],
+    );
+  };
+
+  // Dialog lives OUTSIDE the SelectContent so closing the Select does not
+  // unmount it (see useAddLlmConnectionSelect).
+  const connectionDialog = (
+    <CreateLLMApiKeyDialog
+      hideTrigger
+      open={providerSelect.dialogOpen}
+      setOpen={providerSelect.handleDialogOpenChange}
+    />
+  );
 
   // Compact layout - simplified, space-efficient (no individual labels)
   if (layout === "compact") {
     return (
       <div className="space-y-1">
         <Select
+          open={providerSelect.selectOpen}
+          onOpenChange={providerSelect.setSelectOpen}
           disabled={disabled}
-          onValueChange={(value) =>
-            updateModelParam(
-              modelParamsKey,
-              value as (typeof supportedModels)[LLMAdapter][number],
-            )
-          }
+          onValueChange={handleValueChange}
           value={value}
         >
           <SelectTrigger className="h-8">
@@ -363,13 +393,12 @@ const ModelParamsSelect = ({
                 {option}
               </SelectItem>
             ))}
-            <SelectSeparator />
-            <CreateLLMApiKeyDialog
-              open={createLlmApiKeyDialogOpen}
-              setOpen={setCreateLlmApiKeyDialogOpen}
+            <AddLlmConnectionSelectAction
+              onOpen={providerSelect.openConnectionDialog}
             />
           </SelectContent>
         </Select>
+        {connectionDialog}
         {modelParamsDescription ? (
           <FormDescription className="mt-1 text-xs">
             {modelParamsDescription}
@@ -394,13 +423,10 @@ const ModelParamsSelect = ({
       </div>
       <div className="flex-1">
         <Select
+          open={providerSelect.selectOpen}
+          onOpenChange={providerSelect.setSelectOpen}
           disabled={disabled}
-          onValueChange={(value) =>
-            updateModelParam(
-              modelParamsKey,
-              value as (typeof supportedModels)[LLMAdapter][number],
-            )
-          }
+          onValueChange={handleValueChange}
           value={value}
         >
           <SelectTrigger>
@@ -412,13 +438,12 @@ const ModelParamsSelect = ({
                 {option}
               </SelectItem>
             ))}
-            <SelectSeparator />
-            <CreateLLMApiKeyDialog
-              open={createLlmApiKeyDialogOpen}
-              setOpen={setCreateLlmApiKeyDialogOpen}
+            <AddLlmConnectionSelectAction
+              onOpen={providerSelect.openConnectionDialog}
             />
           </SelectContent>
         </Select>
+        {connectionDialog}
         {modelParamsDescription ? (
           <FormDescription className="mt-1 text-xs">
             {modelParamsDescription}
@@ -593,3 +618,78 @@ const ProviderOptionsInput = ({
     </div>
   );
 };
+
+/**
+ * Coordinates a provider/model `Select` that offers an inline "Add LLM
+ * Connection" action which opens the {@link CreateLLMApiKeyDialog}.
+ *
+ * A dropdown should not stay open while it spawns a modal (see the overlay
+ * lifecycle note in web/AGENTS.md): the still-open Radix Select content sits in
+ * the `popover` layer, above the `modal` layer, so it would paint over the
+ * dialog and the two focus/dismiss scopes would fight. We therefore control the
+ * Select's open state, close it as the dialog opens, and — because a Radix
+ * Select unmounts its content when it closes (which would tear down a dialog
+ * nested inside it) — the dialog is rendered as a SIBLING of the Select, not a
+ * child of its content.
+ *
+ * When the dialog closes we reopen the dropdown, but only if the user hasn't
+ * committed a selection in the meantime, so they can finish the pick they came
+ * for (e.g. choose the connection they just added).
+ */
+function useAddLlmConnectionSelect() {
+  const [selectOpen, setSelectOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const madeSelectionRef = useRef(false);
+
+  const openConnectionDialog = useCallback(() => {
+    madeSelectionRef.current = false;
+    setSelectOpen(false);
+    setDialogOpen(true);
+  }, []);
+
+  const handleDialogOpenChange = useCallback((open: boolean) => {
+    setDialogOpen(open);
+    if (!open && !madeSelectionRef.current) {
+      setSelectOpen(true);
+    }
+  }, []);
+
+  const notifySelection = useCallback(() => {
+    madeSelectionRef.current = true;
+  }, []);
+
+  return {
+    selectOpen,
+    setSelectOpen,
+    dialogOpen,
+    openConnectionDialog,
+    handleDialogOpenChange,
+    notifySelection,
+  };
+}
+
+/**
+ * The inline "Add LLM Connection" action rendered at the bottom of a provider
+ * Select. Gated by `llmApiKeys:create` so we don't show a dead button (and so we
+ * don't leave a dangling separator) for users without access. On click it hands
+ * off to the coordinator, which closes the dropdown before opening the dialog.
+ */
+function AddLlmConnectionSelectAction({ onOpen }: { onOpen: () => void }) {
+  const projectId = useProjectIdFromURL();
+  const hasAccess = useHasProjectAccess({
+    projectId,
+    scope: "llmApiKeys:create",
+  });
+
+  if (!hasAccess) return null;
+
+  return (
+    <>
+      <SelectSeparator />
+      <Button type="button" variant="secondary" onClick={onOpen}>
+        <PlusIcon className="mr-1.5 -ml-0.5 h-5 w-5" aria-hidden="true" />
+        Add LLM Connection
+      </Button>
+    </>
+  );
+}

--- a/web/src/features/public-api/components/CreateLLMApiKeyDialog.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyDialog.tsx
@@ -15,9 +15,18 @@ import { CreateLLMApiKeyForm } from "@/src/features/public-api/components/Create
 export function CreateLLMApiKeyDialog({
   open,
   setOpen,
+  hideTrigger = false,
 }: {
   open: boolean;
   setOpen: (open: boolean) => void;
+  /**
+   * Hide the built-in "Add LLM Connection" trigger button and render only the
+   * (controlled) dialog. Use this when the dialog is opened from elsewhere — e.g.
+   * from inside a Select/dropdown, where the dialog must live OUTSIDE the
+   * dropdown content so it survives the dropdown closing. See the overlay
+   * lifecycle note in web/AGENTS.md.
+   */
+  hideTrigger?: boolean;
 }) {
   const projectId = useProjectIdFromURL();
   const hasAccess = useHasProjectAccess({
@@ -35,12 +44,14 @@ export function CreateLLMApiKeyDialog({
         setOpen(isOpen);
       }}
     >
-      <DialogTrigger asChild>
-        <Button variant="secondary">
-          <PlusIcon className="mr-1.5 -ml-0.5 h-5 w-5" aria-hidden="true" />
-          Add LLM Connection
-        </Button>
-      </DialogTrigger>
+      {!hideTrigger && (
+        <DialogTrigger asChild>
+          <Button variant="secondary">
+            <PlusIcon className="mr-1.5 -ml-0.5 h-5 w-5" aria-hidden="true" />
+            Add LLM Connection
+          </Button>
+        </DialogTrigger>
+      )}
       <DialogContent className="max-h-[90%] min-w-[40vw] overflow-auto">
         <DialogHeader>
           <DialogTitle>New LLM Connection</DialogTitle>


### PR DESCRIPTION
## TL;DR

Clicking **"Add LLM Connection"** from inside the model **provider dropdown** (Evaluators → set up LLM-as-a-judge, and the Playground) opened the *New LLM Connection* modal **while the dropdown stayed open** — the dropdown painted over the modal and the two overlays fought for focus. The dropdown now **closes before the modal opens**, and **reopens when the modal closes** if you still owe a pick.

## Why

The provider `Select` rendered the "Add LLM Connection" action *inside* its `SelectContent`. The overlay layer system correctly ranks dropdowns (`popover`) above modals (`modal`) for the common case (a Select opened *inside* a Dialog should float above it) — but here that ranking is exactly wrong: a modal spawned *from* a dropdown ends up **under** the still-open dropdown.

The key insight from triage: **this is a lifecycle problem, not a z-order one.** Re-ranking layers wouldn't fix it — even if the modal painted on top, the dropdown would still be a live, interactive listbox underneath, with two competing focus/dismiss scopes. The right fix is that a dropdown shouldn't stay alive while it owns a modal.

## What

- A small `useAddLlmConnectionSelect` coordinator controls the `Select`'s open state: it **closes the dropdown as the dialog opens**, and **reopens it when the dialog closes without a selection** (so you can pick the connection you just added).
- Because a Radix `Select` unmounts its content when it closes (which would tear down a dialog nested inside it), the dialog is now rendered as a **sibling** of the `Select`, not a child of its content — via a new `hideTrigger` prop on `CreateLLMApiKeyDialog`.
- Applied across all three affected render paths in `ModelParameters` (compact combined select + provider/model selects).
- Documented the convention in `web/AGENTS.md` so future "Add new…" actions inside dropdowns follow it.

Scoped deliberately: a codebase sweep found this was the **only** place with a dialog nested inside dropdown content — every other dropdown-opens-a-dialog already uses the sibling pattern. So this is a targeted fix plus a written convention, not a new shared primitive.

## Result

Verified live in the browser for both entry points (Playground compact select and the Evaluators "Create new evaluator" wizard, where the modal opens over another modal):

- ✅ The provider dropdown **closes** the moment the modal opens — no overlap, modal fully interactive.
- ✅ Closing the modal without creating a connection **reopens** the dropdown to finish the pick.
- ✅ Normal model selection still closes the dropdown and updates the value.
- ✅ The "Add LLM Connection" action stays gated behind `llmApiKeys:create` (and no longer leaves a dangling separator for users without access).

<details>
<summary>Verification & mechanism detail</summary>

- Reproduced with a project that has ≥1 LLM connection (otherwise `ModelParameters` shows its no-providers empty state, which uses the standalone dialog and is unaffected).
- Confirmed via `document.elementFromPoint` that the element at the modal's center is inside the modal (nothing painted over it) and that the Select content is fully removed from the DOM after clicking the action.
- The `notifySelection` guard makes "reopen" conditional on *no committed selection* — matching "reopen only when the user still owes input."
- No z-index changes; the `@repo/no-overlay-zindex` rule and full `turbo run lint` pass.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a focus/overlay conflict where clicking "Add LLM Connection" inside the provider dropdown (Playground and Evaluators) opened the New LLM Connection modal while the Select stayed open — the `popover` layer painted over the `modal` layer and the two focus scopes fought. The fix correctly identifies this as a lifecycle problem rather than a z-order one.

- Introduces `useAddLlmConnectionSelect`, a small coordinator hook that explicitly controls the Select's `open` state: it closes the dropdown when the dialog opens and reopens it when the dialog closes without a committed selection, using a `useRef` flag to distinguish "user cancelled" from "user picked something."
- Moves `CreateLLMApiKeyDialog` from inside `SelectContent` (where it would be unmounted when the Select closes) to a sibling position in the JSX tree, using a new `hideTrigger` prop to suppress the built-in trigger button. This pattern is applied across all three affected render paths in `ModelParameters`.
- Extracts the RBAC-gated action into `AddLlmConnectionSelectAction`, eliminating the dangling separator that previously showed for users without `llmApiKeys:create`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the overlay lifecycle bug is correctly fixed and all three affected render paths are updated consistently.

The core logic is sound: controlled open state, batched state transitions (close select → open dialog in one openConnectionDialog call), a ref guard preventing spurious reopen after a committed selection, and the dialog rendered as a sibling so it survives the Select unmounting its content. The hideTrigger addition is backward-compatible. Two style-level observations are pre-existing limitations carried forward, not regressions.

No files require special attention; changes are self-contained within ModelParameters/index.tsx and CreateLLMApiKeyDialog.tsx.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant S as Select (controlled open)
    participant H as useAddLlmConnectionSelect
    participant D as CreateLLMApiKeyDialog (sibling)

    U->>S: Opens provider/model dropdown
    S->>H: onOpenChange(true) → setSelectOpen(true)
    U->>S: Clicks "Add LLM Connection" button
    S->>H: openConnectionDialog()
    H->>S: setSelectOpen(false) — closes dropdown
    H->>D: setDialogOpen(true) — opens dialog
    Note over S: SelectContent unmounts (dialog survives as sibling)

    alt User cancels dialog
        U->>D: Closes dialog (Escape / overlay click)
        D->>H: handleDialogOpenChange(false)
        H-->>S: setSelectOpen(true) — reopens dropdown
    else User creates connection
        U->>D: Submits form → onSuccess → setOpen(false)
        D->>H: handleDialogOpenChange(false)
        H-->>S: setSelectOpen(true) — reopens to pick new connection
    else User selects an item
        U->>S: Selects an item
        S->>H: onValueChange → notifySelection()
        Note over H: madeSelectionRef = true — no reopen
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant S as Select (controlled open)
    participant H as useAddLlmConnectionSelect
    participant D as CreateLLMApiKeyDialog (sibling)

    U->>S: Opens provider/model dropdown
    S->>H: onOpenChange(true) → setSelectOpen(true)
    U->>S: Clicks "Add LLM Connection" button
    S->>H: openConnectionDialog()
    H->>S: setSelectOpen(false) — closes dropdown
    H->>D: setDialogOpen(true) — opens dialog
    Note over S: SelectContent unmounts (dialog survives as sibling)

    alt User cancels dialog
        U->>D: Closes dialog (Escape / overlay click)
        D->>H: handleDialogOpenChange(false)
        H-->>S: setSelectOpen(true) — reopens dropdown
    else User creates connection
        U->>D: Submits form → onSuccess → setOpen(false)
        D->>H: handleDialogOpenChange(false)
        H-->>S: setSelectOpen(true) — reopens to pick new connection
    else User selects an item
        U->>S: Selects an item
        S->>H: onValueChange → notifySelection()
        Note over H: madeSelectionRef = true — no reopen
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/ModelParameters/index.tsx:689
The "Add LLM Connection" `Button` is placed directly inside `SelectContent` without `w-full`, so it renders narrower than the `SelectItem` rows. The original code had the same styling gap. Adding `className="w-full justify-start"` would make it visually consistent with the other options.

```suggestion
      <Button type="button" variant="secondary" className="w-full justify-start" onClick={onOpen}>
```

### Issue 2 of 2
web/src/components/ModelParameters/index.tsx:677-694
**"Add LLM Connection" unreachable via keyboard arrow navigation**

The `Button` inside `SelectContent` is not a `SelectItem`, so Radix's arrow-key focus cycle skips it entirely — keyboard users can open the dropdown and navigate through all provider options but will never land on this action. The same limitation existed in the original code (a `DialogTrigger > Button` inside `SelectContent`), so this is not a regression, but worth noting as an accessibility gap since the action is now more deliberately designed. A `SelectItem` with `onSelect` + `event.preventDefault()` would participate in focus traversal while still preventing value commitment.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): close provider dropdown before..."](https://github.com/langfuse/langfuse/commit/527f109b49cf068d27f339f86e89c85a9a7ebd12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41174379)</sub>

<!-- /greptile_comment -->