### PR TITLE
chore: fix v4 usage y axis

### DIFF
--- a/web/src/__tests__/server/unit/timelineBuckets.servertest.ts
+++ b/web/src/__tests__/server/unit/timelineBuckets.servertest.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { resolveTimelineGranularity } from "@/src/features/v4/server/timelineBuckets";
+
+const START = new Date("2026-06-01T00:00:00.000Z");
+const minuteMs = 60 * 1000;
+
+const rangeEndingAfter = (minutes: number) =>
+  new Date(START.getTime() + minutes * minuteMs);
+
+describe("resolveTimelineGranularity", () => {
+  it("keeps short V4 ranges granular", () => {
+    expect(resolveTimelineGranularity(START, rangeEndingAfter(5))).toBe(
+      "minute",
+    );
+    expect(resolveTimelineGranularity(START, rangeEndingAfter(30))).toBe(
+      "minute",
+    );
+  });
+
+  it("matches the V4 preset bucket strategy", () => {
+    expect(resolveTimelineGranularity(START, rangeEndingAfter(60))).toBe("2m");
+    expect(resolveTimelineGranularity(START, rangeEndingAfter(3 * 60))).toBe(
+      "5m",
+    );
+    expect(resolveTimelineGranularity(START, rangeEndingAfter(24 * 60))).toBe(
+      "hour",
+    );
+    expect(
+      resolveTimelineGranularity(START, rangeEndingAfter(7 * 24 * 60)),
+    ).toBe("hour");
+    expect(
+      resolveTimelineGranularity(START, rangeEndingAfter(30 * 24 * 60)),
+    ).toBe("day");
+  });
+});

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -299,10 +299,10 @@ describe("v4TransitionRouter", () => {
     );
   });
 
-  it("fills minute buckets for a non-special 45 minute timeline", async () => {
+  it("fills 2 minute buckets for a 45 minute timeline", async () => {
     mockedQueryClickhouse.mockResolvedValueOnce([
       {
-        time: "2026-06-24T00:15:00Z",
+        time: "2026-06-24T00:16:00Z",
         entrypoint: "publicapi: GET /api/public/traces",
         count: "8",
       },
@@ -317,24 +317,24 @@ describe("v4TransitionRouter", () => {
       granularity: "auto",
     });
 
-    expect(rows).toHaveLength(46);
-    expect(new Set(rows.map((row) => row.time)).size).toBe(45);
+    expect(rows).toHaveLength(24);
+    expect(new Set(rows.map((row) => row.time)).size).toBe(23);
     expect(rows[0]).toEqual({
       time: "2026-06-24T00:00:00Z",
       entrypoint: "",
       count: 0,
     });
-    expect(rows[15]).toEqual({
-      time: "2026-06-24T00:15:00Z",
+    expect(rows[8]).toEqual({
+      time: "2026-06-24T00:16:00Z",
       entrypoint: "",
       count: 0,
     });
-    expect(rows[16]).toEqual({
-      time: "2026-06-24T00:15:00Z",
+    expect(rows[9]).toEqual({
+      time: "2026-06-24T00:16:00Z",
       entrypoint: "publicapi: GET /api/public/traces",
       count: 8,
     });
-    expect(rows[45]).toEqual({
+    expect(rows[23]).toEqual({
       time: "2026-06-24T00:44:00Z",
       entrypoint: "",
       count: 0,
@@ -342,7 +342,7 @@ describe("v4TransitionRouter", () => {
 
     const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
     expect(clickhouseQuery?.query).toContain(
-      "toStartOfInterval(event_time_microseconds, INTERVAL 1 MINUTE, 'UTC') AS bucket_time",
+      "toStartOfInterval(event_time_microseconds, INTERVAL 2 MINUTE, 'UTC') AS bucket_time",
     );
   });
 
@@ -393,7 +393,7 @@ describe("v4TransitionRouter", () => {
     );
   });
 
-  it("uses minute buckets for a non-special 7 day timeline", async () => {
+  it("uses hour buckets for a 7 day timeline", async () => {
     mockedQueryClickhouse.mockResolvedValueOnce([]);
 
     const caller = createCaller();
@@ -409,7 +409,7 @@ describe("v4TransitionRouter", () => {
 
     const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
     expect(clickhouseQuery?.query).toContain(
-      "toStartOfInterval(event_time_microseconds, INTERVAL 1 MINUTE, 'UTC') AS bucket_time",
+      "toStartOfInterval(event_time_microseconds, INTERVAL 1 HOUR, 'UTC') AS bucket_time",
     );
   });
 
@@ -843,7 +843,7 @@ describe("v4TransitionRouter", () => {
     ]);
   });
 
-  it("uses minute buckets for non-special trace-level eval execution timelines", async () => {
+  it("uses hour buckets for 7 day trace-level eval execution timelines", async () => {
     const mockPrisma = {
       $queryRaw: vi.fn().mockResolvedValue([]),
     };
@@ -861,7 +861,7 @@ describe("v4TransitionRouter", () => {
     const query = mockPrisma.$queryRaw.mock.calls[0]?.[0] as
       | { sql?: string; text?: string; values?: unknown[] }
       | undefined;
-    expect(query?.values?.[0]).toBe("1 minute");
+    expect(query?.values?.[0]).toBe("1 hour");
   });
 
   it("summarizes legacy public API usage by organization project", async () => {

--- a/web/src/features/v4/components/V4MigrationProjectCards.clienttest.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.clienttest.tsx
@@ -1,0 +1,68 @@
+import { render } from "@testing-library/react";
+import { vi } from "vitest";
+import { UsageStackedBarOverview } from "@/src/features/v4/components/V4MigrationProjectCards";
+import type { ReactNode } from "react";
+
+const rechartsProps = vi.hoisted(() => ({
+  barCharts: [] as Array<{ margin?: { left?: number } }>,
+  yAxes: [] as Array<{
+    width?: number;
+    tickFormatter?: (value: number) => string;
+  }>,
+}));
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  BarChart: ({
+    children,
+    margin,
+  }: {
+    children: ReactNode;
+    margin?: { left?: number };
+  }) => {
+    rechartsProps.barCharts.push({ margin });
+    return <div data-testid="bar-chart">{children}</div>;
+  },
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: (props: Record<string, unknown>) => {
+    rechartsProps.yAxes.push({
+      width: typeof props.width === "number" ? props.width : undefined,
+      tickFormatter:
+        typeof props.tickFormatter === "function"
+          ? (props.tickFormatter as (value: number) => string)
+          : undefined,
+    });
+    return <div data-testid="y-axis" />;
+  },
+  Tooltip: () => null,
+  Bar: () => <div data-testid="bar" />,
+}));
+
+describe("UsageStackedBarOverview", () => {
+  beforeEach(() => {
+    rechartsProps.barCharts.length = 0;
+    rechartsProps.yAxes.length = 0;
+  });
+
+  it("keeps compact Y-axis labels within the chart bounds", () => {
+    render(
+      <UsageStackedBarOverview
+        bucketTimes={["2026-06-30T04:00:00.000Z"]}
+        valueLabel="calls"
+        series={[
+          {
+            name: "GET /api/public/traces",
+            total: 1800,
+            points: [1800],
+          },
+        ]}
+      />,
+    );
+
+    expect(rechartsProps.barCharts[0]?.margin?.left).toBeGreaterThanOrEqual(8);
+    expect(rechartsProps.yAxes[0]?.width).toBeGreaterThanOrEqual(42);
+    expect(rechartsProps.yAxes[0]?.tickFormatter?.(1800)).toBe("1.8K");
+  });
+});

--- a/web/src/features/v4/components/V4MigrationProjectCards.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.tsx
@@ -289,7 +289,7 @@ const getStackedChartSeries = (
   }));
 };
 
-const UsageStackedBarOverview = ({
+export const UsageStackedBarOverview = ({
   bucketTimes,
   series,
   valueLabel,
@@ -345,7 +345,7 @@ const UsageStackedBarOverview = ({
         <BarChart
           accessibilityLayer
           data={chartData}
-          margin={{ top: 4, right: 8, bottom: 0, left: -18 }}
+          margin={{ top: 4, right: 8, bottom: 0, left: 12 }}
         >
           <XAxis
             dataKey="timeLabel"

--- a/web/src/features/v4/server/timelineBuckets.ts
+++ b/web/src/features/v4/server/timelineBuckets.ts
@@ -1,0 +1,131 @@
+import { Prisma } from "@langfuse/shared/src/db";
+
+export type ResolvedTimelineGranularity =
+  | "minute"
+  | "2m"
+  | "5m"
+  | "hour"
+  | "day";
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+export const MAX_TIMELINE_RANGE_MS = 30 * DAY_MS;
+const TIMELINE_GRANULARITY_DURATION_TOLERANCE_MS = 1000;
+
+const timelineGranularityRules: ReadonlyArray<{
+  maxDurationMs: number;
+  granularity: ResolvedTimelineGranularity;
+}> = [
+  { maxDurationMs: 30 * MINUTE_MS, granularity: "minute" },
+  { maxDurationMs: HOUR_MS, granularity: "2m" },
+  { maxDurationMs: 3 * HOUR_MS, granularity: "5m" },
+  { maxDurationMs: 7 * DAY_MS, granularity: "hour" },
+  { maxDurationMs: MAX_TIMELINE_RANGE_MS, granularity: "day" },
+];
+
+export const resolveTimelineGranularity = (
+  fromTimestamp: Date,
+  toTimestamp: Date,
+): ResolvedTimelineGranularity => {
+  const diffMs = toTimestamp.getTime() - fromTimestamp.getTime();
+
+  return (
+    timelineGranularityRules.find(
+      (rule) =>
+        diffMs <=
+        rule.maxDurationMs + TIMELINE_GRANULARITY_DURATION_TOLERANCE_MS,
+    )?.granularity ?? "day"
+  );
+};
+
+export const getTimelineBucketSql = (
+  sql: string,
+  granularity: ResolvedTimelineGranularity,
+): string => {
+  const intervalByGranularity: Record<ResolvedTimelineGranularity, string> = {
+    minute: "1 MINUTE",
+    "2m": "2 MINUTE",
+    "5m": "5 MINUTE",
+    hour: "1 HOUR",
+    day: "1 DAY",
+  };
+
+  return `toStartOfInterval(${sql}, INTERVAL ${intervalByGranularity[granularity]}, 'UTC')`;
+};
+
+export const getPostgresTimelineBucketExpression = (
+  sql: Prisma.Sql,
+  granularity: ResolvedTimelineGranularity,
+): Prisma.Sql => {
+  const intervalByGranularity: Record<ResolvedTimelineGranularity, string> = {
+    minute: "1 minute",
+    "2m": "2 minutes",
+    "5m": "5 minutes",
+    hour: "1 hour",
+    day: "1 day",
+  };
+
+  return Prisma.sql`date_bin(${intervalByGranularity[granularity]}::interval, ${sql}, '1970-01-01T00:00:00Z'::timestamptz)`;
+};
+
+export const floorTimelineBucket = (
+  timestamp: Date,
+  granularity: ResolvedTimelineGranularity,
+): Date => {
+  const bucket = new Date(timestamp);
+
+  switch (granularity) {
+    case "minute":
+      bucket.setUTCSeconds(0, 0);
+      return bucket;
+    case "2m":
+      bucket.setUTCMinutes(Math.floor(bucket.getUTCMinutes() / 2) * 2, 0, 0);
+      return bucket;
+    case "5m":
+      bucket.setUTCMinutes(Math.floor(bucket.getUTCMinutes() / 5) * 5, 0, 0);
+      return bucket;
+    case "hour":
+      bucket.setUTCMinutes(0, 0, 0);
+      return bucket;
+    case "day":
+      bucket.setUTCHours(0, 0, 0, 0);
+      return bucket;
+    default: {
+      const exhaustiveCheck: never = granularity;
+      throw new Error(`Invalid timeline granularity: ${exhaustiveCheck}`);
+    }
+  }
+};
+
+export const addTimelineBucket = (
+  timestamp: Date,
+  granularity: ResolvedTimelineGranularity,
+): Date => {
+  const next = new Date(timestamp);
+
+  switch (granularity) {
+    case "minute":
+      next.setUTCMinutes(next.getUTCMinutes() + 1);
+      return next;
+    case "2m":
+      next.setUTCMinutes(next.getUTCMinutes() + 2);
+      return next;
+    case "5m":
+      next.setUTCMinutes(next.getUTCMinutes() + 5);
+      return next;
+    case "hour":
+      next.setUTCHours(next.getUTCHours() + 1);
+      return next;
+    case "day":
+      next.setUTCDate(next.getUTCDate() + 1);
+      return next;
+    default: {
+      const exhaustiveCheck: never = granularity;
+      throw new Error(`Invalid timeline granularity: ${exhaustiveCheck}`);
+    }
+  }
+};
+
+export const formatTimelineBucket = (timestamp: Date): string =>
+  timestamp.toISOString().replace(/\.\d{3}Z$/, "Z");

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -15,58 +15,18 @@ import {
   queryClickhouse,
   systemTableRef,
 } from "@langfuse/shared/src/server";
+import {
+  addTimelineBucket,
+  floorTimelineBucket,
+  formatTimelineBucket,
+  getPostgresTimelineBucketExpression,
+  getTimelineBucketSql,
+  MAX_TIMELINE_RANGE_MS,
+  resolveTimelineGranularity,
+  type ResolvedTimelineGranularity,
+} from "./timelineBuckets";
 
 const timelineGranularity = z.literal("auto");
-type ResolvedTimelineGranularity = "minute" | "2m" | "5m" | "hour" | "day";
-const MINUTE_MS = 60 * 1000;
-const MAX_TIMELINE_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
-const TIMELINE_GRANULARITY_DURATION_TOLERANCE_MS = 1000;
-
-const isTimelineDuration = (actualMs: number, expectedMs: number): boolean =>
-  Math.abs(actualMs - expectedMs) <= TIMELINE_GRANULARITY_DURATION_TOLERANCE_MS;
-
-const resolveTimelineGranularity = (
-  fromTimestamp: Date,
-  toTimestamp: Date,
-): ResolvedTimelineGranularity => {
-  const diffMs = toTimestamp.getTime() - fromTimestamp.getTime();
-
-  if (isTimelineDuration(diffMs, 60 * MINUTE_MS)) return "2m";
-  if (isTimelineDuration(diffMs, 3 * 60 * MINUTE_MS)) return "5m";
-  if (isTimelineDuration(diffMs, 24 * 60 * MINUTE_MS)) return "hour";
-  if (isTimelineDuration(diffMs, MAX_TIMELINE_RANGE_MS)) return "day";
-
-  return "minute";
-};
-
-const getTimelineBucketSql = (
-  sql: string,
-  granularity: ResolvedTimelineGranularity,
-): string => {
-  const intervalByGranularity: Record<ResolvedTimelineGranularity, string> = {
-    minute: "1 MINUTE",
-    "2m": "2 MINUTE",
-    "5m": "5 MINUTE",
-    hour: "1 HOUR",
-    day: "1 DAY",
-  };
-
-  return `toStartOfInterval(${sql}, INTERVAL ${intervalByGranularity[granularity]}, 'UTC')`;
-};
-
-const getPostgresTimelineBucketExpression = (
-  granularity: ResolvedTimelineGranularity,
-): Prisma.Sql => {
-  const intervalByGranularity: Record<ResolvedTimelineGranularity, string> = {
-    minute: "1 minute",
-    "2m": "2 minutes",
-    "5m": "5 minutes",
-    hour: "1 hour",
-    day: "1 day",
-  };
-
-  return Prisma.sql`date_bin(${intervalByGranularity[granularity]}::interval, je.created_at, '1970-01-01T00:00:00Z'::timestamptz)`;
-};
 
 const legacyIntegrationExportSources =
   new Set<AnalyticsIntegrationExportSource>([
@@ -149,67 +109,6 @@ type LegacyApiUsageSummaryByProjectResultRow = {
   entrypoint: string;
   count: number;
 };
-
-const floorTimelineBucket = (
-  timestamp: Date,
-  granularity: ResolvedTimelineGranularity,
-): Date => {
-  const bucket = new Date(timestamp);
-
-  switch (granularity) {
-    case "minute":
-      bucket.setUTCSeconds(0, 0);
-      return bucket;
-    case "2m":
-      bucket.setUTCMinutes(Math.floor(bucket.getUTCMinutes() / 2) * 2, 0, 0);
-      return bucket;
-    case "5m":
-      bucket.setUTCMinutes(Math.floor(bucket.getUTCMinutes() / 5) * 5, 0, 0);
-      return bucket;
-    case "hour":
-      bucket.setUTCMinutes(0, 0, 0);
-      return bucket;
-    case "day":
-      bucket.setUTCHours(0, 0, 0, 0);
-      return bucket;
-    default: {
-      const exhaustiveCheck: never = granularity;
-      throw new Error(`Invalid timeline granularity: ${exhaustiveCheck}`);
-    }
-  }
-};
-
-const addTimelineBucket = (
-  timestamp: Date,
-  granularity: ResolvedTimelineGranularity,
-): Date => {
-  const next = new Date(timestamp);
-
-  switch (granularity) {
-    case "minute":
-      next.setUTCMinutes(next.getUTCMinutes() + 1);
-      return next;
-    case "2m":
-      next.setUTCMinutes(next.getUTCMinutes() + 2);
-      return next;
-    case "5m":
-      next.setUTCMinutes(next.getUTCMinutes() + 5);
-      return next;
-    case "hour":
-      next.setUTCHours(next.getUTCHours() + 1);
-      return next;
-    case "day":
-      next.setUTCDate(next.getUTCDate() + 1);
-      return next;
-    default: {
-      const exhaustiveCheck: never = granularity;
-      throw new Error(`Invalid timeline granularity: ${exhaustiveCheck}`);
-    }
-  }
-};
-
-const formatTimelineBucket = (timestamp: Date): string =>
-  timestamp.toISOString().replace(/\.\d{3}Z$/, "Z");
 
 const getEmptyTimelineBuckets = (
   fromTimestamp: Date,
@@ -518,7 +417,10 @@ export const v4TransitionRouter = createTRPCRouter({
         input.fromTimestamp,
         input.toTimestamp,
       );
-      const bucketExpression = getPostgresTimelineBucketExpression(granularity);
+      const bucketExpression = getPostgresTimelineBucketExpression(
+        Prisma.sql`je.created_at`,
+        granularity,
+      );
 
       const rows = await ctx.prisma.$queryRaw<
         TraceLevelEvalExecutionTimeSeriesRow[]


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related v4 dashboard issues: the usage chart Y-axis labels were being clipped (negative `left` margin), and the timeline granularity logic defaulted to `"minute"` for any non-exact-preset range (such as 7 days), generating far too many data points.

- **Granularity logic rewritten**: `resolveTimelineGranularity` switches from exact-duration matching (only 1h/3h/24h/30d) to range-based rules, so any arbitrary time window now gets an appropriate bucket size instead of always falling back to `"minute"`.
- **`getPostgresTimelineBucketExpression` generalised**: the hardcoded `je.created_at` column is replaced with a caller-supplied `Prisma.Sql` argument, and the function is moved to the new `timelineBuckets.ts` shared module.
- **Y-axis margin fixed**: `margin.left` is corrected from `-18` to `12`; new client and unit tests cover both the chart layout and the granularity table.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are well-tested, scoped to a single feature area, and correct the intended behaviour.

The granularity rewrite is straightforward: a lookup-table with a single `find` replaces fragile exact-duration matching. The generalisation of `getPostgresTimelineBucketExpression` preserves the same parameterised-string-to-interval pattern already present in the original code. The chart margin fix (`-18` → `12`) is isolated to a single prop. All changed paths are covered by the new unit and client tests.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveTimelineGranularity\nfromTimestamp, toTimestamp] --> B{diffMs ≤ 30 min?}
    B -- yes --> C[granularity: minute]
    B -- no --> D{diffMs ≤ 1 hour?}
    D -- yes --> E[granularity: 2m]
    D -- no --> F{diffMs ≤ 3 hours?}
    F -- yes --> G[granularity: 5m]
    F -- no --> H{diffMs ≤ 7 days?}
    H -- yes --> I[granularity: hour]
    H -- no --> J{diffMs ≤ 30 days?}
    J -- yes --> K[granularity: day]
    J -- no --> L[fallback: day]

    C & E & G & I & K & L --> M[getTimelineBucketSql for ClickHouse]
    C & E & G & I & K & L --> N[getPostgresTimelineBucketExpression]
    C & E & G & I & K & L --> O[getEmptyTimelineBuckets]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[resolveTimelineGranularity\nfromTimestamp, toTimestamp] --> B{diffMs ≤ 30 min?}
    B -- yes --> C[granularity: minute]
    B -- no --> D{diffMs ≤ 1 hour?}
    D -- yes --> E[granularity: 2m]
    D -- no --> F{diffMs ≤ 3 hours?}
    F -- yes --> G[granularity: 5m]
    F -- no --> H{diffMs ≤ 7 days?}
    H -- yes --> I[granularity: hour]
    H -- no --> J{diffMs ≤ 30 days?}
    J -- yes --> K[granularity: day]
    J -- no --> L[fallback: day]

    C & E & G & I & K & L --> M[getTimelineBucketSql for ClickHouse]
    C & E & G & I & K & L --> N[getPostgresTimelineBucketExpression]
    C & E & G & I & K & L --> O[getEmptyTimelineBuckets]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): prevent usage chart y-axis clip..."](https://github.com/langfuse/langfuse/commit/8d07c8db6b5ea3652053af11f4f97e399ac00bf7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41223584)</sub>

<!-- /greptile_comment -->