### PR TITLE
docs(mcp): clarify trace fetching via observations

### DIFF
--- a/web/src/features/mcp/features/observations/tools/listObservations.ts
+++ b/web/src/features/mcp/features/observations/tools/listObservations.ts
@@ -305,6 +305,7 @@ export const [listObservationsTool, handleListObservations] = defineTool({
   name: "listObservations",
   description: [
     "Find and review observations in the current Langfuse project, such as generations, spans, events, agent steps, and tool calls.",
+    "Traces consist of observations. Use this tool when the user asks to inspect a trace: pass traceId to page through the observations that make up that trace; those observation records are the trace data returned by the API.",
     "Use filters to narrow results by trace, name, type, level, environment, time range, or advanced filter conditions. Results are paginated with an opaque cursor.",
     "For metadata filters, first call getObservationFilterMetadataKeys with observationIds, traceId, or a bounded time range, then set the relevant key field in the filter.",
     "",


### PR DESCRIPTION
## Summary

- Updates the `listObservations` MCP tool description to tell clients that traces consist of observations.
- Clarifies that clients should pass `traceId` to page through the observations that make up a trace.
- Describes those observation records as the trace data returned by the API.

## Validation

- Pre-commit hook passed `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli`.
- Pre-commit hook passed `turbo run lint`.

## Notes

- This is tool-description copy only; no runtime behavior changed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a single clarifying sentence to the `listObservations` MCP tool description to help MCP clients understand the relationship between traces and observations in Langfuse. No runtime behavior, logic, or schema is changed.

- Adds guidance that traces are composed of observations and that clients should pass `traceId` to paginate through a trace's constituent observation records.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only the tool description string is modified; no logic, schema, or API behavior is affected.

The change is a single-line addition to a description array that is joined into a string. It improves MCP client guidance without touching any handler code, input validation, or data-access paths.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as MCP Client
    participant Tool as listObservations Tool
    participant API as Langfuse API

    Note over Client,Tool: Updated tool description now clarifies this flow
    Client->>Tool: "listObservations(traceId=X, cursor=null)"
    Tool->>API: "GET /observations?traceId=X"
    API-->>Tool: observations page 1 + nextCursor
    Tool-->>Client: "observation records (= trace data) + cursor"

    Client->>Tool: "listObservations(traceId=X, cursor=nextCursor)"
    Tool->>API: "GET /observations?traceId=X&cursor=..."
    API-->>Tool: observations page 2 + nextCursor
    Tool-->>Client: remaining observation records
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as MCP Client
    participant Tool as listObservations Tool
    participant API as Langfuse API

    Note over Client,Tool: Updated tool description now clarifies this flow
    Client->>Tool: "listObservations(traceId=X, cursor=null)"
    Tool->>API: "GET /observations?traceId=X"
    API-->>Tool: observations page 1 + nextCursor
    Tool-->>Client: "observation records (= trace data) + cursor"

    Client->>Tool: "listObservations(traceId=X, cursor=nextCursor)"
    Tool->>API: "GET /observations?traceId=X&cursor=..."
    API-->>Tool: observations page 2 + nextCursor
    Tool-->>Client: remaining observation records
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(mcp): clarify trace fetching via ob..."](https://github.com/langfuse/langfuse/commit/a79a8f0bb8767729f9cd2fcd8dec686c2b4cd71c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41225989)</sub>

<!-- /greptile_comment -->