### PR TITLE
docs(mcp): pluralize traces in observations tool

### DIFF
--- a/web/src/features/mcp/features/observations/tools/listObservations.ts
+++ b/web/src/features/mcp/features/observations/tools/listObservations.ts
@@ -305,7 +305,7 @@ export const [listObservationsTool, handleListObservations] = defineTool({
   name: "listObservations",
   description: [
     "Find and review observations in the current Langfuse project, such as generations, spans, events, agent steps, and tool calls.",
-    "Traces consist of observations. Use this tool when the user asks to inspect a trace: pass traceId to page through the observations that make up that trace; those observation records are the trace data returned by the API.",
+    "Traces consist of observations. Use this tool when the user asks to inspect traces: pass traceId to page through the observations for a specific trace; those observation records are the trace data returned by the API.",
     "Use filters to narrow results by trace, name, type, level, environment, time range, or advanced filter conditions. Results are paginated with an opaque cursor.",
     "For metadata filters, first call getObservationFilterMetadataKeys with observationIds, traceId, or a bounded time range, then set the relevant key field in the filter.",
     "",


### PR DESCRIPTION
## Summary

- Changes the `listObservations` MCP tool description from singular `a trace` to plural `traces`.
- Keeps the `traceId` instruction accurate by describing it as paging through observations for a specific trace.

## Validation

- Pre-commit hook passed `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli`.
- Pre-commit hook passed `turbo run lint`.

## Notes

- This is tool-description copy only; no runtime behavior changed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates a single tool description string in the `listObservations` MCP tool, changing "a trace" to "traces" and clarifying that `traceId` is used to page through observations for a specific trace. No runtime behavior is affected.

- The description sentence now accurately reflects that the tool can inspect multiple traces, not just a single one.
- The `traceId` parameter guidance is preserved and slightly rephrased for clarity.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to a tool description string and does not touch any logic, schema, or handler code.

A one-line copy edit in a tool description. No logic, schema validation, or handler behavior is modified, so there is no meaningful risk of regression.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Client] -->|calls listObservations| B[listObservationsTool]
    B --> C{Filter by traceId?}
    C -- Yes --> D[Page through observations for a specific trace]
    C -- No --> E[Apply other filters: name, type, level, time range, etc.]
    D --> F[Return paginated observation records]
    E --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[MCP Client] -->|calls listObservations| B[listObservationsTool]
    B --> C{Filter by traceId?}
    C -- Yes --> D[Page through observations for a specific trace]
    C -- No --> E[Apply other filters: name, type, level, time range, etc.]
    D --> F[Return paginated observation records]
    E --> F
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(mcp): pluralize traces in observati..."](https://github.com/langfuse/langfuse/commit/18013dea0a50ea349eae2b190c419962097b2a74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41248875)</sub>

<!-- /greptile_comment -->