### PR TITLE
docs(agents): document local database clients

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -78,6 +78,19 @@ langfuse/
 - Worktree maintenance: `bash scripts/codex/maintenance.sh`
 - Install Playwright Chromium: `pnpm run playwright:install`
 
+## Local Data Inspection
+
+- For feature testing and debugging, inspect the local databases directly when
+  it helps you understand the existing test data. Prefer read-only queries, and
+  continue to use the seed CLI to create frontend test state rather than
+  ad-hoc inserts.
+- Dev Docker Compose exposes these clients on `${HOST_IP:-127.0.0.1}`:
+  - Postgres: `PGPASSWORD="${POSTGRES_PASSWORD:-postgres}" psql -h "${HOST_IP:-127.0.0.1}" -p "${POSTGRES_HOST_PORT:-5432}" -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-postgres}"`
+  - ClickHouse: `clickhouse client --host "${HOST_IP:-127.0.0.1}" --port "${CLICKHOUSE_NATIVE_PORT:-9000}" --user "${CLICKHOUSE_USER:-clickhouse}" --password "${CLICKHOUSE_PASSWORD:-clickhouse}" --database default`
+  - Redis: `REDISCLI_AUTH="${REDIS_AUTH:-myredissecret}" redis-cli -h "${HOST_IP:-127.0.0.1}" -p "${REDIS_HOST_PORT:-6379}"`
+- If any connection fails, check `docker-compose.dev.yml` for local override
+  variables and confirm the services are running.
+
 ## Verification
 
 - `web/**`: `pnpm run lint` plus targeted web tests.


### PR DESCRIPTION
## Summary
- Document local Postgres, ClickHouse, and Redis client commands for inspecting test data
- Point agents at `docker-compose.dev.yml` env overrides when connection details differ
- Keep guidance read-oriented and preserve seed CLI as the path for creating frontend state

## Impacted packages
- `.agents` / shared agent guidance only

## Verification
- `pnpm run agents:sync`
- `pnpm run agents:check`
- Commit hook: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli`
- Commit hook: `turbo run lint`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new "Local Data Inspection" section to `.agents/AGENTS.md` that documents how agents can connect directly to the local Postgres, ClickHouse, and Redis instances during feature testing and debugging.

- The connection commands use shell variable expansion with fallbacks (`${VAR:-default}`) that match the actual defaults set in `docker-compose.dev.yml` exactly (Postgres: `postgres/postgres`, ClickHouse: `clickhouse/clickhouse`, Redis: `myredissecret`).
- Guidance keeps agents oriented toward read-only inspection and preserves the seed CLI as the approved path for creating frontend test state, consistent with the existing `How To Work` section.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no runtime impact; safe to merge.

The added commands use shell variable fallbacks that were cross-checked against docker-compose.dev.yml and match every default exactly. The guidance is internally consistent with the existing How To Work section — it steers agents toward read-only queries and keeps the seed CLI as the sanctioned path for writing state. No code is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent needs to inspect local data] --> B{Purpose?}
    B -- Read / debug existing data --> C[Use documented client commands]
    B -- Create frontend test state --> D[pnpm run seed]

    C --> E{Connection succeeds?}
    E -- Yes --> F[Run read-only queries]
    E -- No --> G[Check docker-compose.dev.yml\nfor local overrides]
    G --> H[Confirm services are running]
    H --> C

    C --> I[(Postgres\npsql)]
    C --> J[(ClickHouse\nclickhouse client)]
    C --> K[(Redis\nredis-cli)]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Agent needs to inspect local data] --> B{Purpose?}
    B -- Read / debug existing data --> C[Use documented client commands]
    B -- Create frontend test state --> D[pnpm run seed]

    C --> E{Connection succeeds?}
    E -- Yes --> F[Run read-only queries]
    E -- No --> G[Check docker-compose.dev.yml\nfor local overrides]
    G --> H[Confirm services are running]
    H --> C

    C --> I[(Postgres\npsql)]
    C --> J[(ClickHouse\nclickhouse client)]
    C --> K[(Redis\nredis-cli)]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): document local database cl..."](https://github.com/langfuse/langfuse/commit/ad566bf8324333e233a44bd5d362bac2d698f088) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41263336)</sub>

<!-- /greptile_comment -->