### PR TITLE
fix(v4): show evenly spaced usage chart y-axis ticks

### DIFF
--- a/web/src/features/v4/components/V4MigrationProjectCards.clienttest.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.clienttest.tsx
@@ -7,6 +7,9 @@ const rechartsProps = vi.hoisted(() => ({
   barCharts: [] as Array<{ margin?: { left?: number } }>,
   yAxes: [] as Array<{
     width?: number;
+    domain?: [number, number];
+    interval?: number;
+    ticks?: number[];
     tickFormatter?: (value: number) => string;
   }>,
 }));
@@ -29,6 +32,11 @@ vi.mock("recharts", () => ({
   YAxis: (props: Record<string, unknown>) => {
     rechartsProps.yAxes.push({
       width: typeof props.width === "number" ? props.width : undefined,
+      domain: Array.isArray(props.domain)
+        ? (props.domain as [number, number])
+        : undefined,
+      interval: typeof props.interval === "number" ? props.interval : undefined,
+      ticks: Array.isArray(props.ticks) ? (props.ticks as number[]) : undefined,
       tickFormatter:
         typeof props.tickFormatter === "function"
           ? (props.tickFormatter as (value: number) => string)
@@ -64,5 +72,43 @@ describe("UsageStackedBarOverview", () => {
     expect(rechartsProps.barCharts[0]?.margin?.left).toBeGreaterThanOrEqual(8);
     expect(rechartsProps.yAxes[0]?.width).toBeGreaterThanOrEqual(42);
     expect(rechartsProps.yAxes[0]?.tickFormatter?.(1800)).toBe("1.8K");
+  });
+
+  it("passes evenly spaced Y-axis ticks so intermediate values are not skipped", () => {
+    render(
+      <UsageStackedBarOverview
+        bucketTimes={["2026-06-30T04:00:00.000Z"]}
+        valueLabel="calls"
+        series={[
+          {
+            name: "GET /api/public/traces",
+            total: 1200,
+            points: [1200],
+          },
+        ]}
+      />,
+    );
+
+    expect(rechartsProps.yAxes[0]?.ticks).toEqual([0, 300, 600, 900, 1200]);
+    expect(rechartsProps.yAxes[0]?.domain).toEqual([0, 1200]);
+    expect(rechartsProps.yAxes[0]?.interval).toBe(0);
+  });
+
+  it("keeps Y-axis ticks as whole numbers for small count ranges", () => {
+    render(
+      <UsageStackedBarOverview
+        bucketTimes={["2026-06-30T04:00:00.000Z"]}
+        valueLabel="calls"
+        series={[
+          {
+            name: "GET /api/public/traces",
+            total: 5,
+            points: [5],
+          },
+        ]}
+      />,
+    );
+
+    expect(rechartsProps.yAxes[0]?.ticks).toEqual([0, 2, 4, 6, 8]);
   });
 });

--- a/web/src/features/v4/components/V4MigrationProjectCards.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.tsx
@@ -64,6 +64,7 @@ const V4_DOCS_LINK = {
 } as const;
 
 const MAX_STACKED_CHART_SERIES = 6;
+const STACKED_CHART_Y_AXIS_TICK_COUNT = 5;
 const STACKED_CHART_COLORS = [
   "hsl(var(--chart-1))",
   "hsl(var(--chart-2))",
@@ -289,6 +290,38 @@ const getStackedChartSeries = (
   }));
 };
 
+const getNiceCountStep = (rawStep: number): number => {
+  if (!Number.isFinite(rawStep) || rawStep <= 0) return 1;
+
+  const magnitude = 10 ** Math.floor(Math.log10(rawStep));
+  const normalizedStep = rawStep / magnitude;
+  const niceStep =
+    [1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 7.5, 10].find(
+      (step) => normalizedStep <= step,
+    ) ?? 10;
+
+  return Math.max(1, Math.ceil(niceStep * magnitude));
+};
+
+const getStackedYAxisTicks = (
+  series: UsageSeries[],
+  tickCount = STACKED_CHART_Y_AXIS_TICK_COUNT,
+): number[] => {
+  const bucketCount = Math.max(0, ...series.map((item) => item.points.length));
+  let maxStackedValue = 0;
+
+  for (let bucketIndex = 0; bucketIndex < bucketCount; bucketIndex += 1) {
+    const bucketTotal = series.reduce((sum, item) => {
+      const value = item.points[bucketIndex] ?? 0;
+      return Number.isFinite(value) && value > 0 ? sum + value : sum;
+    }, 0);
+    maxStackedValue = Math.max(maxStackedValue, bucketTotal);
+  }
+
+  const step = getNiceCountStep(maxStackedValue / (tickCount - 1));
+  return Array.from({ length: tickCount }, (_, index) => index * step);
+};
+
 export const UsageStackedBarOverview = ({
   bucketTimes,
   series,
@@ -299,6 +332,11 @@ export const UsageStackedBarOverview = ({
   valueLabel: string;
 }) => {
   const chartSeries = useMemo(() => getStackedChartSeries(series), [series]);
+  const yAxisTicks = useMemo(
+    () => getStackedYAxisTicks(chartSeries),
+    [chartSeries],
+  );
+  const yAxisMax = yAxisTicks[yAxisTicks.length - 1] ?? 0;
   const chartData = useMemo(
     () =>
       bucketTimes.map((time, bucketIndex) => {
@@ -359,6 +397,9 @@ export const UsageStackedBarOverview = ({
             axisLine={false}
             width={42}
             fontSize={11}
+            domain={[0, yAxisMax]}
+            ticks={yAxisTicks}
+            interval={0}
             tickFormatter={(value) => compactNumberFormatter(Number(value), 1)}
           />
           <ChartTooltip


### PR DESCRIPTION
## Summary
- Add explicit evenly spaced Y-axis ticks for V4 migration usage stacked bar charts so intermediate values are not skipped.
- Keep count ticks as whole numbers for small ranges.
- Add client regression tests for the missing intermediate tick and small-count tick behavior.

## Impacted packages
- `web`

## Verification
- `pnpm --filter web run test-client 'src/features/v4/components/V4MigrationProjectCards.clienttest.tsx'`
- `pnpm --filter web run lint`
- Browser check on local `web` dev server (`v3.203.1`) confirmed the V4 usage chart rendered the intermediate tick (`0, 25, 50, 75, 100`) on the Y-axis. A later repeat browser attempt hit a local `EMFILE` watcher-limit issue, but the final code is covered by the client test and lint checks.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the V4 migration usage stacked bar chart Y-axis by computing evenly spaced ticks instead of relying on Recharts' automatic (sometimes gappy) tick selection. It introduces `getNiceCountStep` and `getStackedYAxisTicks` helpers and wires the resulting `ticks`, `domain`, and `interval={0}` props to `<YAxis>`.

- **Tick computation**: `getStackedYAxisTicks` iterates all stacked buckets to find the true maximum stacked height, then uses `getNiceCountStep` to round up to a visually "nice" step value (e.g. 300, 500, etc.), producing exactly 5 evenly spaced ticks.
- **Edge-case handling**: Fractional steps are rounded up to whole integers via `Math.max(1, Math.ceil(...))`, zero/empty series default to a [0, 1, 2, 3, 4] axis, and small count ranges yield readable whole-number ticks.
- **Tests**: Two new client tests verify the intermediate-tick case (max=1200 → [0,300,600,900,1200]) and the small-count case (max=5 → [0,2,4,6,8]).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are isolated to the V4 usage chart Y-axis computation with no data mutations or side effects.

The tick-generation helpers are pure functions with well-reasoned edge-case handling (zero, Infinity, NaN, empty series). The step produced by getNiceCountStep is always >= rawStep, guaranteeing the domain covers all bar heights. Two new regression tests validate the specific behaviors being fixed. No risk to other features.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["series: UsageSeries[]"] --> B["getStackedChartSeries\ncap to 6 + Others"]
    B --> C["chartSeries"]
    C --> D["getStackedYAxisTicks\nfind maxStackedValue per bucket"]
    D --> E{"maxStackedValue > 0?"}
    E -->|No| F["step = 1"]
    E -->|Yes| G["rawStep = max / tickCount-1\nstep = getNiceCountStep"]
    F --> H["ticks = index x step for 0..4"]
    G --> H
    H --> I["yAxisMax = last tick"]
    I --> J["YAxis props\ndomain and ticks and interval=0"]
    C --> K["chartData built from bucketTimes"]
    K --> L["BarChart rendered"]
    J --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["series: UsageSeries[]"] --> B["getStackedChartSeries\ncap to 6 + Others"]
    B --> C["chartSeries"]
    C --> D["getStackedYAxisTicks\nfind maxStackedValue per bucket"]
    D --> E{"maxStackedValue > 0?"}
    E -->|No| F["step = 1"]
    E -->|Yes| G["rawStep = max / tickCount-1\nstep = getNiceCountStep"]
    F --> H["ticks = index x step for 0..4"]
    G --> H
    H --> I["yAxisMax = last tick"]
    I --> J["YAxis props\ndomain and ticks and interval=0"]
    C --> K["chartData built from bucketTimes"]
    K --> L["BarChart rendered"]
    J --> L
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): show evenly spaced usage chart ..."](https://github.com/langfuse/langfuse/commit/f506397554ff1b7834440d6a1ddcb24210c4fd8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41263504)</sub>

<!-- /greptile_comment -->