### PR TITLE
fix(monitors): restore Type/Level filter value options (LFE-10616)

### DIFF
--- a/web/src/features/monitors/components/MonitorForm.clienttest.ts
+++ b/web/src/features/monitors/components/MonitorForm.clienttest.ts
@@ -10,9 +10,19 @@ import {
   MonitorThresholdOperatorSchema,
 } from "@langfuse/shared/monitors";
 
+import {
+  getWidgetColumnsWithCustomSelect,
+  getWidgetFilterColumns,
+} from "@/src/features/widgets/components/widgetFilterColumns";
+
 import { __test } from "./MonitorForm";
 
-const { createDefaults, monitorToDefaults, nameOrPlaceholder } = __test;
+const {
+  createDefaults,
+  monitorToDefaults,
+  nameOrPlaceholder,
+  buildFilterColumnsParams,
+} = __test;
 
 describe("createDefaults", () => {
   it("only surfaces name + alertThreshold as missing base fields (no hidden missing fields)", () => {
@@ -86,6 +96,61 @@ describe("nameOrPlaceholder", () => {
 
   it("non-blank name: wins over the placeholder", () => {
     expect(nameOrPlaceholder("My Monitor", placeholder)).toBe("My Monitor");
+  });
+});
+
+describe("buildFilterColumnsParams", () => {
+  // A monitor's filter-option discovery is scoped to its (default 5m) evaluation
+  // window, so it is often empty — the whole point of an alert like
+  // "type=TOOL AND level=ERROR" is to catch events that have NOT happened yet.
+  // Type and Level are closed enums and their value pickers are not searchable
+  // (no free-text fallback), so they must list every domain value regardless of
+  // what the discovery window returned, otherwise they dead-end on
+  // "No results found" (LFE-10616).
+  const getColumn = (view: "observations", id: string) => {
+    const params = buildFilterColumnsParams({
+      view,
+      filterOptions: undefined, // empty discovery window
+      datasets: undefined,
+    });
+    return getWidgetFilterColumns(params).find((c) => c.id === id);
+  };
+
+  it("offers every Observation Type value even when discovery data is empty", () => {
+    const typeColumn = getColumn("observations", "type");
+    expect(typeColumn?.type).toBe("stringOptions");
+    const values =
+      typeColumn?.type === "stringOptions"
+        ? typeColumn.options.map((o) => o.value)
+        : [];
+    expect(values).toContain("TOOL");
+    expect(values).toContain("GENERATION");
+    expect(values.length).toBeGreaterThan(0);
+  });
+
+  it("offers every Observation Level value even when discovery data is empty", () => {
+    const levelColumn = getColumn("observations", "level");
+    expect(levelColumn?.type).toBe("stringOptions");
+    const values =
+      levelColumn?.type === "stringOptions"
+        ? levelColumn.options.map((o) => o.value)
+        : [];
+    expect(values).toContain("ERROR");
+    expect(values).toContain("WARNING");
+    expect(values.length).toBeGreaterThan(0);
+  });
+
+  it("keeps Type/Level as non-searchable columns (they rely on complete option lists)", () => {
+    // Confirms the fix must be complete enum lists: Type/Level are NOT custom
+    // (searchable/free-text) selects, so an empty option list is a hard dead-end.
+    const params = buildFilterColumnsParams({
+      view: "observations",
+      filterOptions: undefined,
+      datasets: undefined,
+    });
+    const custom = getWidgetColumnsWithCustomSelect(params);
+    expect(custom).not.toContain("type");
+    expect(custom).not.toContain("level");
   });
 });
 

--- a/web/src/features/monitors/components/MonitorForm.tsx
+++ b/web/src/features/monitors/components/MonitorForm.tsx
@@ -5,7 +5,7 @@ import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { startCase } from "lodash";
 
-import { api } from "@/src/utils/api";
+import { api, type RouterOutputs } from "@/src/utils/api";
 import { Button } from "@/src/components/ui/button";
 import {
   Accordion,
@@ -75,7 +75,12 @@ import {
   UpdateMonitorSchema,
   type UpdateMonitor,
 } from "@langfuse/shared/monitors";
-import { viewDeclarations, type FilterState } from "@langfuse/shared";
+import {
+  ObservationLevelDomain,
+  ObservationTypeDomain,
+  viewDeclarations,
+  type FilterState,
+} from "@langfuse/shared";
 
 import TagManager from "@/src/features/tag/components/TagManager";
 
@@ -138,6 +143,57 @@ const nameOrPlaceholder = (
   name: string | undefined,
   placeholder: string,
 ): string => name || placeholder;
+
+// Observation Level and Type are closed enums, so their filter value pickers
+// list every domain value. Deriving them from the monitor's (short, default 5m)
+// evaluation window instead left them empty whenever that window happened to
+// contain no matching events — e.g. a fresh monitor whose lookback saw no errors
+// or tool calls yet — so the non-searchable "Level"/"Type" value dropdowns
+// showed "No results found" with no way to pick a value (LFE-10616). Mirrors
+// WidgetForm, which builds these two option lists from the domain enums too.
+const observationLevelOptions = ObservationLevelDomain.options.map((value) => ({
+  value,
+}));
+const observationTypeOptions = ObservationTypeDomain.options.map((value) => ({
+  value,
+}));
+
+/**
+ * buildFilterColumnsParams assembles the InlineFilterBuilder option dictionaries
+ * for the picked view. Open-ended facets (environment, model, tags, …) come from
+ * the time-windowed events filter-options discovery; the closed Type/Level enums
+ * come from the domain schemas so their value pickers are always complete.
+ */
+const buildFilterColumnsParams = ({
+  view,
+  filterOptions,
+  datasets,
+}: {
+  view: "traces" | "observations" | "scores-numeric" | "scores-categorical";
+  filterOptions: RouterOutputs["events"]["filterOptions"] | undefined;
+  datasets: Array<{ id: string; name: string }> | undefined;
+}) => {
+  const datasetIds = new Set(
+    (filterOptions?.experimentDatasetId ?? []).map((e) => e.value),
+  );
+  return {
+    selectedView: view,
+    viewVersion: "v2" as const,
+    environmentOptions: filterOptions?.environment ?? [],
+    nameOptions: normalizeSingleValueOptions(filterOptions?.traceName),
+    tagsOptions: filterOptions?.traceTags ?? [],
+    modelOptions: filterOptions?.providedModelName ?? [],
+    toolNamesOptions: filterOptions?.toolNames ?? [],
+    calledToolNamesOptions: filterOptions?.calledToolNames ?? [],
+    observationLevelOptions,
+    experimentNameOptions: filterOptions?.experimentName ?? [],
+    experimentDatasetOptions:
+      datasets
+        ?.filter((d) => datasetIds.has(d.id))
+        .map((d) => ({ value: d.id, displayValue: d.name })) ?? [],
+    observationTypeOptions,
+  };
+};
 
 /** MonitorForm renders the create/edit form for a Monitor. */
 export const MonitorForm = ({
@@ -286,39 +342,19 @@ export const MonitorForm = ({
   );
 
   /** filterColumnsParams collects the filter-column descriptor for InlineFilterBuilder, derived from the picked view and live option dictionaries. */
-  const filterColumnsParams = useMemo(() => {
-    const data = eventsFilterOptions.data;
-    return {
-      selectedView: (watched.view ?? "observations") as
-        | "traces"
-        | "observations"
-        | "scores-numeric"
-        | "scores-categorical",
-      viewVersion: "v2" as const,
-      environmentOptions: data?.environment ?? [],
-      nameOptions: normalizeSingleValueOptions(data?.traceName),
-      tagsOptions: data?.traceTags ?? [],
-      modelOptions: data?.providedModelName ?? [],
-      toolNamesOptions: data?.toolNames ?? [],
-      calledToolNamesOptions: data?.calledToolNames ?? [],
-      observationLevelOptions: data?.level ?? [],
-      experimentNameOptions: data?.experimentName ?? [],
-      experimentDatasetOptions: (() => {
-        const ids = new Set(
-          (data?.experimentDatasetId ?? []).map((e) => e.value),
-        );
-        return (
-          datasets.data
-            ?.filter((d: { id: string }) => ids.has(d.id))
-            .map((d: { id: string; name: string }) => ({
-              value: d.id,
-              displayValue: d.name,
-            })) ?? []
-        );
-      })(),
-      observationTypeOptions: data?.type ?? [],
-    };
-  }, [eventsFilterOptions.data, datasets.data, watched.view]);
+  const filterColumnsParams = useMemo(
+    () =>
+      buildFilterColumnsParams({
+        view: (watched.view ?? "observations") as
+          | "traces"
+          | "observations"
+          | "scores-numeric"
+          | "scores-categorical",
+        filterOptions: eventsFilterOptions.data,
+        datasets: datasets.data,
+      }),
+    [eventsFilterOptions.data, datasets.data, watched.view],
+  );
 
   /** filterColumns is the InlineFilterBuilder column schema for the picked view. */
   const filterColumns = useMemo(
@@ -1092,4 +1128,5 @@ export const __test = {
   createDefaults,
   monitorToDefaults,
   nameOrPlaceholder,
+  buildFilterColumnsParams,
 };


### PR DESCRIPTION
## TL;DR
Building a Monitor/Alert filter like **`type = TOOL AND level = ERROR`** was impossible: the **Type** and **Level** value dropdowns showed **"No results found"** with no way to pick a value. This restores them — they now always list every Type/Level, matching the widget builder.

## Why
Monitor filter-value options are discovered from the monitor's **evaluation window**, which defaults to **5 minutes**. Observation **Type** and **Level** were derived from whatever events landed in that window — but the whole point of an alert like "tool calls that errored" is to catch events that *haven't happened yet*. So a fresh monitor's short lookback routinely returned nothing, and because Type/Level render a **non-searchable** picker (no free-text fallback, unlike Environment/Model/Tags), an empty option list became a hard dead-end.

A customer hit this while trying to alert on failed tool calls; it reproduces on any project with no matching events in the last few minutes.

## What
**Type** and **Level** are closed enums, so build their option lists from the domain schemas (`ObservationTypeDomain` / `ObservationLevelDomain`) instead of from time-windowed discovery — exactly as the sibling **WidgetForm** already does through the same `getWidgetFilterColumns` contract. Open-ended facets (environment, model, tags, …) still come from discovery and keep their free-text fallback.

## Result
Type and Level always list every value regardless of recent traffic, so `type = TOOL AND level = ERROR` is buildable again. Verified live in the browser on a project with **no data in the default 5m window** (screenshot below).

<details>
<summary>Mechanism, scope & verification</summary>

**Root cause vs. the ticket's hypothesis.** The ticket suspected #14675 (which reworked `getEventFilterOptions`). That change is scores-only and does not touch Type/Level; it's a red herring here. The real divergence: `MonitorForm` mapped `observationLevelOptions: data?.level ?? []` / `observationTypeOptions: data?.type ?? []` (window-derived), whereas `WidgetForm` uses the static domain enums. This fix aligns `MonitorForm` with `WidgetForm`.

**Change is localized to `MonitorForm.tsx`** and deliberately does **not** touch `getEventFilterOptions` (which is under concurrent rework), so no double-fix/merge risk there.

**Implementation.** Extracted the InlineFilterBuilder option-dictionary assembly into a pure `buildFilterColumnsParams` helper; Type/Level now come from the domain enums.

**Tests.** New `buildFilterColumnsParams` unit tests assert Type/Level stay complete (`TOOL`, `ERROR`, …) even when discovery data is empty, and confirm Type/Level remain non-searchable columns (so complete option lists are required, not optional). Confirmed failing on the old behavior, passing on the fix. `pnpm --filter web run lint` + `typecheck` clean.

**Browser verification** (default 5m window, project had no events in the last day): Type dropdown lists SPAN…TOOL…GUARDRAIL; Level lists DEBUG/DEFAULT/WARNING/ERROR; built `Where Type any of TOOL` / `And Level any of ERROR` end-to-end.

Note: open-ended facets (Environment/Model/Name/Tags) are still discovered from the monitor window and can be sparse on low-traffic windows — but they expose a free-text input, so they never dead-end. Broadening *their* discovery window is a possible follow-up, intentionally out of scope here.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a dead-end UX bug in the Monitor filter builder where the **Type** and **Level** value dropdowns showed "No results found" on projects with no recent traffic, because their options were derived from the short (default 5-minute) evaluation window instead of the closed enum definitions. The fix sources `observationTypeOptions` and `observationLevelOptions` from `ObservationTypeDomain`/`ObservationLevelDomain` at module scope, mirroring the existing `WidgetForm` pattern, and extracts the option-dictionary assembly into a testable `buildFilterColumnsParams` helper.

- **Root cause patched**: `MonitorForm` was mapping `data?.level ?? []` / `data?.type ?? []` (window-derived), while `WidgetForm` already used static domain enums for these two closed-enum fields — this PR aligns the two forms.
- **Scope is minimal**: only `MonitorForm.tsx` is changed; `getEventFilterOptions` and all other open-ended facets (environment, model, tags) are untouched and keep their free-text fallback.
- **Tests added**: `buildFilterColumnsParams` unit tests verify Type/Level are fully populated when discovery data is empty and that both columns remain non-searchable (no free-text fallback).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is narrowly scoped to how Type/Level filter options are populated in MonitorForm, with no schema, API, or data-persistence side effects.

Both changed files are well-contained: MonitorForm.tsx replaces two window-derived option arrays with static domain enum arrays matching the existing WidgetForm pattern, and the new test file exercises the exact invariant being fixed. The buildFilterColumnsParams refactor preserves all other option sources unchanged, the useMemo dependencies are the same, and type-check passes.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(monitors): always offer Type/Level f..."](https://github.com/langfuse/langfuse/commit/94d243f8d0662e256e77ea7be80072d211cb9ed3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41302305)</sub>

<!-- /greptile_comment -->