### PR TITLE
fix(api-keys): Add details on usage with MCP server

### DIFF
--- a/.agents/skills/storybook/SKILL.md
+++ b/.agents/skills/storybook/SKILL.md
@@ -31,6 +31,7 @@ Keep the existing component, but update it to use the newly created component fo
 - Use "CSF Next" format by default.
 - Cover only the relevant component by default.
 - Avoid custom render functions by default.
+- Never use `decorators` to add styling or layout to a story. Stories should render the components as they are.
 - Use `satisfies` and typed Storybook metadata so invalid args, decorators, and play functions are type-checked.
 - Use play functions to test user-relevant interactions after render, not to compensate for complex setup or hidden dependencies.
 - Prefix stories whose primary purpose is interaction test coverage with `(Test)` in the Storybook display name, for example `name: "(Test) Opens Menu"`.

--- a/.agents/skills/storybook/SKILL.md
+++ b/.agents/skills/storybook/SKILL.md
@@ -30,6 +30,7 @@ Keep the existing component, but update it to use the newly created component fo
 
 - Use "CSF Next" format by default.
 - Cover only the relevant component by default.
+- Do not use `args` on the meta story if most stories override these. Instead, define the args on each story.
 - Avoid custom render functions by default.
 - Never use `decorators` to add styling or layout to a story. Stories should render the components as they are.
 - Use `satisfies` and typed Storybook metadata so invalid args, decorators, and play functions are type-checked.

--- a/web/src/components/trace/components/IOPreview/components/ToolCallDefinitionCard.stories.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ToolCallDefinitionCard.stories.tsx
@@ -1,0 +1,185 @@
+import preview from "../../../../../../.storybook/preview";
+import {
+  ToolCallDefinitionCard,
+  type ToolDefinition,
+} from "./ToolCallDefinitionCard";
+import type { ToolCallInvocation } from "../hooks/useChatMLParser";
+
+const baseTools: ToolDefinition[] = [
+  {
+    name: "search_docs",
+    description: "Searches product docs for relevant troubleshooting steps.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "What to search for",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results",
+        },
+      },
+      required: ["query"],
+    },
+  },
+];
+
+const baseToolCalls = new Map<string, ToolCallInvocation[]>([
+  [
+    "search_docs",
+    [
+      {
+        id: "call_01HXYZ123",
+        name: "search_docs",
+        invocationNumber: 1,
+        arguments: JSON.stringify({ query: "rate limits", limit: 3 }),
+      },
+    ],
+  ],
+]);
+
+const meta = preview.meta({
+  component: ToolCallDefinitionCard,
+});
+
+export const Default = meta.story({
+  args: {
+    tools: baseTools,
+    toolCallCounts: new Map([["search_docs", 0]]),
+    toolCallsByName: new Map(),
+    toolNameToDefinitionNumber: new Map([["search_docs", 1]]),
+  },
+});
+
+export const Called = meta.story({
+  args: {
+    tools: baseTools,
+    toolCallCounts: new Map([["search_docs", 1]]),
+    toolCallsByName: baseToolCalls,
+    toolNameToDefinitionNumber: new Map([["search_docs", 1]]),
+  },
+});
+
+export const MultipleTools = meta.story({
+  args: {
+    tools: [
+      ...baseTools,
+      {
+        name: "create_ticket",
+        description: "Creates a support escalation ticket.",
+        parameters: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            priority: { type: "string", enum: ["low", "high"] },
+          },
+          required: ["title", "priority"],
+        },
+      },
+      {
+        name: "notify_team",
+      },
+    ],
+    toolCallCounts: new Map([
+      ["search_docs", 2],
+      ["create_ticket", 1],
+      ["notify_team", 0],
+    ]),
+    toolCallsByName: new Map<string, ToolCallInvocation[]>([
+      [
+        "search_docs",
+        [
+          {
+            id: "call_01HXYZ123",
+            name: "search_docs",
+            invocationNumber: 1,
+            arguments: JSON.stringify({ query: "rate limits", limit: 3 }),
+          },
+          {
+            id: "call_01HXYZ124",
+            name: "search_docs",
+            invocationNumber: 2,
+            arguments: JSON.stringify({ query: "retry policy" }),
+          },
+        ],
+      ],
+      [
+        "create_ticket",
+        [
+          {
+            id: "call_01HXYZ200",
+            name: "create_ticket",
+            invocationNumber: 1,
+            arguments: {
+              title: "API requests failing",
+              priority: "high",
+            },
+          },
+        ],
+      ],
+    ]),
+    toolNameToDefinitionNumber: new Map([
+      ["search_docs", 1],
+      ["create_ticket", 2],
+      ["notify_team", 3],
+    ]),
+  },
+});
+
+export const WithLongToolNames = meta.story({
+  args: {
+    tools: [
+      {
+        name: "search_enterprise_customer_documentation_for_multistep_api_rate_limit_troubleshooting_and_backoff_recommendations",
+        description:
+          "Looks up long-form support guidance for enterprise API incidents.",
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+          required: ["query"],
+        },
+      },
+      {
+        name: "create_cross_functional_incident_escalation_ticket_with_customer_context_and_internal_follow_up_requirements",
+        description: "Creates a detailed incident escalation ticket.",
+      },
+    ],
+    toolCallCounts: new Map([
+      [
+        "search_enterprise_customer_documentation_for_multistep_api_rate_limit_troubleshooting_and_backoff_recommendations",
+        1,
+      ],
+      [
+        "create_cross_functional_incident_escalation_ticket_with_customer_context_and_internal_follow_up_requirements",
+        0,
+      ],
+    ]),
+    toolCallsByName: new Map<string, ToolCallInvocation[]>([
+      [
+        "search_enterprise_customer_documentation_for_multistep_api_rate_limit_troubleshooting_and_backoff_recommendations",
+        [
+          {
+            id: "call_long_01",
+            name: "search_enterprise_customer_documentation_for_multistep_api_rate_limit_troubleshooting_and_backoff_recommendations",
+            invocationNumber: 1,
+            arguments: JSON.stringify({ query: "429 retry guidance" }),
+          },
+        ],
+      ],
+    ]),
+    toolNameToDefinitionNumber: new Map([
+      [
+        "search_enterprise_customer_documentation_for_multistep_api_rate_limit_troubleshooting_and_backoff_recommendations",
+        1,
+      ],
+      [
+        "create_cross_functional_incident_escalation_ticket_with_customer_context_and_internal_follow_up_requirements",
+        2,
+      ],
+    ]),
+  },
+});

--- a/web/src/components/trace/components/IOPreview/components/ToolCallDefinitionCard.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ToolCallDefinitionCard.tsx
@@ -109,7 +109,7 @@ function ToolCallStatusBadge({
     <Badge
       variant={isCalled ? undefined : "secondary"}
       className={cn(
-        "text-xs font-medium",
+        "text-xs font-medium whitespace-nowrap",
         isCalled &&
           "bg-light-green text-dark-green hover:bg-light-green border-transparent select-none",
       )}
@@ -201,9 +201,12 @@ export function ToolCallDefinitionCard({
               }}
             >
               {/* Left: Tool icon + definition number + name */}
-              <div className="flex items-center gap-2">
-                <Wrench className="text-muted-foreground h-3.5 w-3.5" />
-                <span className="text-foreground font-mono text-xs font-medium">
+              <div className="flex min-w-0 items-center gap-2">
+                <Wrench className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+                <span
+                  className="text-foreground block truncate font-mono text-xs font-medium"
+                  title={tool.name}
+                >
                   {toolDefinitionNumber !== undefined && (
                     <span className="mr-1">{toolDefinitionNumber}.</span>
                   )}
@@ -212,7 +215,7 @@ export function ToolCallDefinitionCard({
               </div>
 
               {/* Right: Status badge + chevron indicator */}
-              <div className="flex items-center gap-1.5">
+              <div className="flex shrink-0 items-center gap-1.5">
                 <ToolCallStatusBadge
                   isCalled={isCalled}
                   statusText={statusText}

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -231,8 +231,10 @@ export function CodeView(props: {
   title?: string;
   scrollable?: boolean;
   copiedToClipboardMessage?: string;
+  lineWrap?: boolean;
 }) {
   const { copiedToClipboardMessage } = props;
+  const lineWrap = props.lineWrap ?? true;
 
   const [isCollapsed, setCollapsed] = useState(props.defaultCollapsed);
 
@@ -321,7 +323,11 @@ export function CodeView(props: {
         )}
         <code
           className={cn(
-            "relative max-w-full min-w-0 flex-1 px-4 py-3 font-mono text-xs wrap-break-word whitespace-pre-wrap",
+            "relative max-w-full min-w-0 flex-1 px-4 py-3 font-mono text-xs",
+            !props.title && !lineWrap ? "w-[calc(100%-2.5rem)] pr-12" : "",
+            lineWrap
+              ? "wrap-break-word whitespace-pre-wrap"
+              : "overflow-x-auto whitespace-pre",
             isCollapsed ? `line-clamp-6` : "block",
             props.scrollable ? "overflow-y-auto" : "",
           )}

--- a/web/src/features/public-api/components/ApiKeyCreateDialogContent.stories.tsx
+++ b/web/src/features/public-api/components/ApiKeyCreateDialogContent.stories.tsx
@@ -1,0 +1,40 @@
+import preview from "../../../../.storybook/preview";
+import { Dialog } from "@/src/components/ui/dialog";
+import { fn } from "storybook/test";
+
+import { ApiKeyCreateDialogContent } from "./ApiKeyCreateDialogContent";
+
+const meta = preview.meta({
+  component: ApiKeyCreateDialogContent,
+  decorators: [
+    (Story) => (
+      <Dialog open onOpenChange={fn()}>
+        <Story />
+      </Dialog>
+    ),
+  ],
+  parameters: {
+    layout: "fullscreen",
+  },
+});
+
+export const Default = meta.story({
+  args: {
+    type: "form",
+    scope: "project",
+    note: "Production key",
+    onNoteChange: fn(),
+    onSubmit: fn(),
+    isPending: false,
+  },
+});
+
+export const Created = meta.story({
+  args: {
+    type: "detail",
+    scope: "project",
+    secretKey: "sk-lf-1234567890abcdef",
+    publicKey: "pk-lf-1234567890abcdef",
+    baseUrl: "https://cloud.langfuse.com",
+  },
+});

--- a/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
+++ b/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
@@ -1,0 +1,111 @@
+import { SubHeader } from "@/src/components/layouts/header";
+import { CodeView } from "@/src/components/ui/CodeJsonViewer";
+import { Button } from "@/src/components/ui/button";
+import {
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import { Input } from "@/src/components/ui/input";
+import { Label } from "@/src/components/ui/label";
+import { getLangfuseEnvCode } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
+
+type ApiKeyScope = "project" | "organization";
+
+type ApiKeyCreateDialogBaseProps = {
+  scope: ApiKeyScope;
+};
+
+type ApiKeyCreateDialogFormProps = ApiKeyCreateDialogBaseProps & {
+  type: "form";
+  note: string;
+  onNoteChange: (value: string) => void;
+  onSubmit: () => void;
+  isPending?: boolean;
+};
+
+type ApiKeyCreateDialogDetailProps = ApiKeyCreateDialogBaseProps & {
+  type: "detail";
+  secretKey: string;
+  publicKey: string;
+  baseUrl: string;
+};
+
+export type ApiKeyCreateDialogContentProps =
+  | ApiKeyCreateDialogFormProps
+  | ApiKeyCreateDialogDetailProps;
+
+export function ApiKeyCreateDialogContent(
+  props: ApiKeyCreateDialogContentProps,
+) {
+  const { scope } = props;
+
+  if (props.type === "detail") {
+    const { secretKey, publicKey, baseUrl } = props;
+    const envCode = getLangfuseEnvCode(baseUrl, { secretKey, publicKey });
+
+    return (
+      <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>API Keys</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <div className="space-y-6">
+            <div>
+              <SubHeader title="Secret Key" />
+              <div className="text-muted-foreground text-sm">
+                This key can only be viewed once. You can always create new keys
+                in the {scope} settings.
+              </div>
+              <CodeView content={secretKey} className="mt-2" />
+            </div>
+            <div>
+              <SubHeader title="Public Key" />
+              <CodeView content={publicKey} className="mt-2" />
+            </div>
+            <div>
+              <SubHeader title=".env" />
+              <CodeView content={envCode} className="mt-2" />
+            </div>
+          </div>
+        </DialogBody>
+      </DialogContent>
+    );
+  }
+
+  const { note, onNoteChange, onSubmit, isPending } = props;
+
+  return (
+    <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
+      <DialogHeader>
+        <DialogTitle>Create API Keys</DialogTitle>
+      </DialogHeader>
+      <DialogBody>
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="note">Note (optional)</Label>
+            <Input
+              id="note"
+              placeholder="Production key"
+              value={note}
+              onChange={(e) => onNoteChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  onSubmit();
+                }
+              }}
+              className="mt-1.5"
+            />
+          </div>
+        </div>
+      </DialogBody>
+      <DialogFooter>
+        <Button onClick={onSubmit} loading={isPending}>
+          Create API keys
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
+}

--- a/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
+++ b/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
@@ -37,6 +37,16 @@ export type ApiKeyCreateDialogContentProps =
   | ApiKeyCreateDialogFormProps
   | ApiKeyCreateDialogDetailProps;
 
+function encodeMcpCredential(publicKey: string, secretKey: string) {
+  const credential = `${publicKey}:${secretKey}`;
+
+  if (typeof globalThis.btoa === "function") {
+    return globalThis.btoa(credential);
+  }
+
+  return Buffer.from(credential).toString("base64");
+}
+
 export function ApiKeyCreateDialogContent(
   props: ApiKeyCreateDialogContentProps,
 ) {
@@ -45,6 +55,7 @@ export function ApiKeyCreateDialogContent(
   if (props.type === "detail") {
     const { secretKey, publicKey, baseUrl } = props;
     const envCode = getLangfuseEnvCode(baseUrl, { secretKey, publicKey });
+    const mcpCredential = encodeMcpCredential(publicKey, secretKey);
 
     return (
       <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
@@ -52,7 +63,7 @@ export function ApiKeyCreateDialogContent(
           <DialogTitle>API Keys</DialogTitle>
         </DialogHeader>
         <DialogBody>
-          <div className="space-y-6">
+          <div>
             <div>
               <SubHeader title="Secret Key" />
               <div className="text-muted-foreground text-sm">
@@ -61,13 +72,36 @@ export function ApiKeyCreateDialogContent(
               </div>
               <CodeView content={secretKey} className="mt-2" />
             </div>
-            <div>
+            <div className="mt-6">
               <SubHeader title="Public Key" />
               <CodeView content={publicKey} className="mt-2" />
             </div>
-            <div>
+            <div className="mt-6">
               <SubHeader title=".env" />
               <CodeView content={envCode} className="mt-2" />
+            </div>
+            <hr className="my-6" />
+            <SubHeader title="Using with MCP" />
+            <p className="text-muted-foreground text-sm">
+              For a detailed guide on how to use this API key to connect to the
+              Langfuse MCP server, see the{" "}
+              <a
+                href="https://langfuse.com/docs/api-and-data-platform/features/mcp-server"
+                target="_blank"
+                rel="noreferrer"
+                className="text-foreground underline"
+              >
+                MCP setup docs
+              </a>
+              .
+            </p>
+            <div className="mt-4">
+              <Label>Header</Label>
+              <CodeView
+                content={`Authorization: Basic ${mcpCredential}`}
+                className="mt-2"
+                lineWrap={false}
+              />
             </div>
           </div>
         </DialogBody>

--- a/web/src/features/public-api/components/CreateApiKeyButton.tsx
+++ b/web/src/features/public-api/components/CreateApiKeyButton.tsx
@@ -1,25 +1,13 @@
 import { Button } from "@/src/components/ui/button";
+import { Dialog, DialogTrigger } from "@/src/components/ui/dialog";
 import { api } from "@/src/utils/api";
 import { useState } from "react";
 import { PlusIcon } from "lucide-react";
-import {
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/src/components/ui/dialog";
-import { CodeView } from "@/src/components/ui/CodeJsonViewer";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { Input } from "@/src/components/ui/input";
-import { useLangfuseEnvCode } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
-import { Label } from "@/src/components/ui/label";
-import { cn } from "@/src/utils/tailwind";
-import { SubHeader } from "@/src/components/layouts/header";
+import { useLangfuseBaseUrl } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
+import { ApiKeyCreateDialogContent } from "@/src/features/public-api/components/ApiKeyCreateDialogContent";
 
 type ApiKeyScope = "project" | "organization";
 
@@ -55,6 +43,7 @@ export function CreateApiKeyButton(props: {
     secretKey: string;
     publicKey: string;
   } | null>(null);
+  const baseUrl = useLangfuseBaseUrl();
 
   const handleOpenChange = (newOpen: boolean) => {
     setOpen(newOpen);
@@ -111,87 +100,25 @@ export function CreateApiKeyButton(props: {
           Create new API keys
         </Button>
       </DialogTrigger>
-      <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
-        <DialogHeader>
-          <DialogTitle>
-            {generatedKeys ? "API Keys" : "Create API Keys"}
-          </DialogTitle>
-        </DialogHeader>
-        <DialogBody>
-          {generatedKeys ? (
-            <ApiKeyRender scope={props.scope} generatedKeys={generatedKeys} />
-          ) : (
-            <div className="space-y-4">
-              <div>
-                <Label htmlFor="note">Note (optional)</Label>
-                <Input
-                  id="note"
-                  placeholder="Production key"
-                  value={note}
-                  onChange={(e) => setNote(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      createApiKey();
-                    }
-                  }}
-                  className="mt-1.5"
-                />
-              </div>
-            </div>
-          )}
-        </DialogBody>
-        {!generatedKeys && (
-          <DialogFooter>
-            <Button
-              onClick={createApiKey}
-              loading={
-                mutCreateProjectApiKey.isPending || mutCreateOrgApiKey.isPending
-              }
-            >
-              Create API keys
-            </Button>
-          </DialogFooter>
-        )}
-      </DialogContent>
+      <ApiKeyCreateDialogContent
+        scope={props.scope}
+        {...(generatedKeys
+          ? {
+              type: "detail" as const,
+              secretKey: generatedKeys.secretKey,
+              publicKey: generatedKeys.publicKey,
+              baseUrl,
+            }
+          : {
+              type: "form" as const,
+              note,
+              onNoteChange: setNote,
+              onSubmit: createApiKey,
+              isPending:
+                mutCreateProjectApiKey.isPending ||
+                mutCreateOrgApiKey.isPending,
+            })}
+      />
     </Dialog>
   );
 }
-
-export const ApiKeyRender = ({
-  scope,
-  generatedKeys,
-  className,
-}: {
-  scope: ApiKeyScope;
-  generatedKeys?: { secretKey: string; publicKey: string };
-  className?: string;
-}) => {
-  const envCode = useLangfuseEnvCode(generatedKeys);
-
-  return (
-    <div className={cn("space-y-6", className)}>
-      <div>
-        <SubHeader title="Secret Key" />
-        <div className="text-muted-foreground text-sm">
-          This key can only be viewed once. You can always create new keys in
-          the {scope} settings.
-        </div>
-        <CodeView
-          content={generatedKeys?.secretKey ?? "Loading ..."}
-          className="mt-2"
-        />
-      </div>
-      <div>
-        <SubHeader title="Public Key" />
-        <CodeView
-          content={generatedKeys?.publicKey ?? "Loading ..."}
-          className="mt-2"
-        />
-      </div>
-      <div>
-        <SubHeader title=".env" />
-        <CodeView content={envCode} className="mt-2" />
-      </div>
-    </div>
-  );
-};

--- a/web/src/features/public-api/hooks/useLangfuseEnvCode.ts
+++ b/web/src/features/public-api/hooks/useLangfuseEnvCode.ts
@@ -1,20 +1,45 @@
 import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
 import { env } from "@/src/env.mjs";
 
+type LangfuseKeys = {
+  secretKey: string;
+  publicKey: string;
+};
+
+export function getLangfuseBaseUrl(baseUrl: string): string {
+  return `${baseUrl}${env.NEXT_PUBLIC_BASE_PATH ?? ""}`;
+}
+
+export function getLangfuseEnvCode(
+  baseUrl: string,
+  keys?: LangfuseKeys,
+): string {
+  if (keys) {
+    return `
+LANGFUSE_SECRET_KEY="${keys.secretKey}"
+LANGFUSE_PUBLIC_KEY="${keys.publicKey}"
+LANGFUSE_BASE_URL="${baseUrl}"
+`.trim();
+  }
+
+  return `
+LANGFUSE_SECRET_KEY="sk-lf-..."
+LANGFUSE_PUBLIC_KEY="pk-lf-..."
+LANGFUSE_BASE_URL="${baseUrl}"
+`.trim();
+}
+
+export function useLangfuseBaseUrl(): string {
+  const uiCustomization = useUiCustomization();
+
+  return getLangfuseBaseUrl(uiCustomization?.hostname ?? window.origin);
+}
+
 export function useLangfuseEnvCode(keys?: {
   secretKey: string;
   publicKey: string;
 }): string {
-  const uiCustomization = useUiCustomization();
-  const baseUrl = `${uiCustomization?.hostname ?? window.origin}${env.NEXT_PUBLIC_BASE_PATH ?? ""}`;
+  const baseUrl = useLangfuseBaseUrl();
 
-  if (keys) {
-    return `LANGFUSE_SECRET_KEY="${keys.secretKey}"
-LANGFUSE_PUBLIC_KEY="${keys.publicKey}"
-LANGFUSE_BASE_URL="${baseUrl}"`;
-  }
-
-  return `LANGFUSE_SECRET_KEY="sk-lf-..."
-LANGFUSE_PUBLIC_KEY="pk-lf-..."
-LANGFUSE_BASE_URL="${baseUrl}"`;
+  return getLangfuseEnvCode(baseUrl, keys);
 }


### PR DESCRIPTION
- **Create story for `ToolCallDefinitionCard`**
- **Update storybook skill to include a rule about decorators.**
- **Fix styling of tool calls with long names**
- **Create `ApiKeyCreateDialogContent` and add stories**
- **Update storybook skills**
- **Add MCP details to `ApiKeyCreateDialogContent`**

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the API key creation dialog into a standalone `ApiKeyCreateDialogContent` component and adds an MCP usage section to the post-creation detail view, displaying a pre-formatted Basic auth header. It also fixes tool-name overflow in `ToolCallDefinitionCard` and adds a `lineWrap` prop to `CodeView`.

- **`ApiKeyCreateDialogContent`** extracts dialog rendering from `CreateApiKeyButton` and adds a "Using with MCP" panel that encodes `publicKey:secretKey` as a Basic auth header via `btoa` / `Buffer` fallback.
- **`useLangfuseEnvCode`** is split into pure helpers (`getLangfuseBaseUrl`, `getLangfuseEnvCode`) and two React hooks, letting the detail view call them without React context.
- **`ToolCallDefinitionCard`** gains `shrink-0` on the icon/badge containers and `truncate` + a `title` attribute on the name span, preventing layout overflow for very long tool names.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are additive UI/component work with no data-layer impact.

The refactoring is clean and the MCP credential encoding is correct. The one rough edge is that the new stories file wraps the component in a decorator to satisfy the Radix Dialog context requirement, which directly contradicts the decorator prohibition added to SKILL.md in this same PR. Everything else — the layout truncation fix, the lineWrap prop, the useLangfuseEnvCode split into pure helpers — looks correct and non-breaking.

ApiKeyCreateDialogContent.stories.tsx — uses a decorator that conflicts with the new SKILL.md rule introduced in this PR.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant CreateApiKeyButton
    participant useLangfuseBaseUrl
    participant ApiKeyCreateDialogContent
    participant getLangfuseEnvCode
    participant encodeMcpCredential

    User->>CreateApiKeyButton: clicks "Create new API keys"
    CreateApiKeyButton->>useLangfuseBaseUrl: resolve base URL
    useLangfuseBaseUrl-->>CreateApiKeyButton: baseUrl (with base path)
    CreateApiKeyButton->>ApiKeyCreateDialogContent: "type="form" props"
    User->>ApiKeyCreateDialogContent: submits form
    ApiKeyCreateDialogContent-->>CreateApiKeyButton: onSubmit()
    CreateApiKeyButton->>CreateApiKeyButton: mutate API (project/org)
    CreateApiKeyButton->>ApiKeyCreateDialogContent: "type="detail" + secretKey/publicKey/baseUrl"
    ApiKeyCreateDialogContent->>getLangfuseEnvCode: "(baseUrl, {secretKey, publicKey})"
    getLangfuseEnvCode-->>ApiKeyCreateDialogContent: .env snippet
    ApiKeyCreateDialogContent->>encodeMcpCredential: (publicKey, secretKey)
    encodeMcpCredential-->>ApiKeyCreateDialogContent: base64(publicKey:secretKey)
    ApiKeyCreateDialogContent-->>User: shows keys + .env + MCP auth header
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant CreateApiKeyButton
    participant useLangfuseBaseUrl
    participant ApiKeyCreateDialogContent
    participant getLangfuseEnvCode
    participant encodeMcpCredential

    User->>CreateApiKeyButton: clicks "Create new API keys"
    CreateApiKeyButton->>useLangfuseBaseUrl: resolve base URL
    useLangfuseBaseUrl-->>CreateApiKeyButton: baseUrl (with base path)
    CreateApiKeyButton->>ApiKeyCreateDialogContent: "type="form" props"
    User->>ApiKeyCreateDialogContent: submits form
    ApiKeyCreateDialogContent-->>CreateApiKeyButton: onSubmit()
    CreateApiKeyButton->>CreateApiKeyButton: mutate API (project/org)
    CreateApiKeyButton->>ApiKeyCreateDialogContent: "type="detail" + secretKey/publicKey/baseUrl"
    ApiKeyCreateDialogContent->>getLangfuseEnvCode: "(baseUrl, {secretKey, publicKey})"
    getLangfuseEnvCode-->>ApiKeyCreateDialogContent: .env snippet
    ApiKeyCreateDialogContent->>encodeMcpCredential: (publicKey, secretKey)
    encodeMcpCredential-->>ApiKeyCreateDialogContent: base64(publicKey:secretKey)
    ApiKeyCreateDialogContent-->>User: shows keys + .env + MCP auth header
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/public-api/components/ApiKeyCreateDialogContent.stories.tsx:9-15
**Decorator usage conflicts with the new SKILL.md rule**

The same PR that introduces the rule "Never use `decorators` to add styling or layout to a story" also adds this `Dialog` wrapper decorator. While the wrapper is needed because `ApiKeyCreateDialogContent` renders `<DialogContent>` internally (which requires a `<Dialog>` ancestor), the component's design makes it impossible to render in isolation without a decorator — if the rule should apply here, the fix would be to restructure `ApiKeyCreateDialogContent` so it accepts an optional `asDialogContent` flag or is tested via a thin wrapper story component rather than a decorator.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add MCP details to \`ApiKeyCreateDialogCo..."](https://github.com/langfuse/langfuse/commit/8f0ac38f4f56d1fac440e34b54de5f5d404d06a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41327224)</sub>

<!-- /greptile_comment -->