### PR TITLE
fix(api-keys): Add details on usage with MCP server

### DIFF
--- a/.agents/skills/storybook/SKILL.md
+++ b/.agents/skills/storybook/SKILL.md
@@ -30,6 +30,7 @@ Keep the existing component, but update it to use the newly created component fo
 
 - Use "CSF Next" format by default.
 - Cover only the relevant component by default.
+- Do not use `args` on the meta story if most stories override these. Instead, define the args on each story.
 - Avoid custom render functions by default.
 - Never use `decorators` to add styling or layout to a story. Stories should render the components as they are.
 - Use `satisfies` and typed Storybook metadata so invalid args, decorators, and play functions are type-checked.

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -231,8 +231,10 @@ export function CodeView(props: {
   title?: string;
   scrollable?: boolean;
   copiedToClipboardMessage?: string;
+  lineWrap?: boolean;
 }) {
   const { copiedToClipboardMessage } = props;
+  const lineWrap = props.lineWrap ?? true;
 
   const [isCollapsed, setCollapsed] = useState(props.defaultCollapsed);
 
@@ -321,7 +323,11 @@ export function CodeView(props: {
         )}
         <code
           className={cn(
-            "relative max-w-full min-w-0 flex-1 px-4 py-3 font-mono text-xs wrap-break-word whitespace-pre-wrap",
+            "relative max-w-full min-w-0 flex-1 px-4 py-3 font-mono text-xs",
+            !props.title && !lineWrap ? "w-[calc(100%-2.5rem)] pr-12" : "",
+            lineWrap
+              ? "wrap-break-word whitespace-pre-wrap"
+              : "overflow-x-auto whitespace-pre",
             isCollapsed ? `line-clamp-6` : "block",
             props.scrollable ? "overflow-y-auto" : "",
           )}

--- a/web/src/features/developer-tools/components/DeveloperToolsSettings.tsx
+++ b/web/src/features/developer-tools/components/DeveloperToolsSettings.tsx
@@ -13,7 +13,15 @@ const DocsButton = ({ href }: { href: string }) => (
   </Button>
 );
 
-export function DeveloperToolsSettings() {
+const ManageApiKeysButton = ({ projectId }: { projectId: string }) => (
+  <Button asChild variant="secondary">
+    <Link href={`/project/${projectId}/settings/api-keys`}>
+      Manage API keys
+    </Link>
+  </Button>
+);
+
+export function DeveloperToolsSettings({ projectId }: { projectId: string }) {
   return (
     <div>
       <Header title="MCP & CLI" />
@@ -63,6 +71,7 @@ export function DeveloperToolsSettings() {
   --header "Authorization: Basic {your-base64-token}"`}
           />
           <div className="mt-4 flex items-center gap-2">
+            <ManageApiKeysButton projectId={projectId} />
             <DocsButton href="https://langfuse.com/docs/api-and-data-platform/features/mcp-server" />
           </div>
         </Card>
@@ -86,6 +95,7 @@ export LANGFUSE_SECRET_KEY="sk-lf-..."
 npx langfuse-cli api <resource> <action>`}
           />
           <div className="mt-4 flex items-center gap-2">
+            <ManageApiKeysButton projectId={projectId} />
             <DocsButton href="https://langfuse.com/docs/api-and-data-platform/features/cli" />
           </div>
         </Card>

--- a/web/src/features/public-api/components/ApiKeyCreateDialogContent.stories.tsx
+++ b/web/src/features/public-api/components/ApiKeyCreateDialogContent.stories.tsx
@@ -1,0 +1,40 @@
+import preview from "../../../../.storybook/preview";
+import { Dialog } from "@/src/components/ui/dialog";
+import { fn } from "storybook/test";
+
+import { ApiKeyCreateDialogContent } from "./ApiKeyCreateDialogContent";
+
+const meta = preview.meta({
+  component: ApiKeyCreateDialogContent,
+  decorators: [
+    (Story) => (
+      <Dialog open onOpenChange={fn()}>
+        <Story />
+      </Dialog>
+    ),
+  ],
+  parameters: {
+    layout: "fullscreen",
+  },
+});
+
+export const Default = meta.story({
+  args: {
+    type: "form",
+    scope: "project",
+    note: "Production key",
+    onNoteChange: fn(),
+    onSubmit: fn(),
+    isPending: false,
+  },
+});
+
+export const Created = meta.story({
+  args: {
+    type: "detail",
+    scope: "project",
+    secretKey: "sk-lf-1234567890abcdef",
+    publicKey: "pk-lf-1234567890abcdef",
+    baseUrl: "https://cloud.langfuse.com",
+  },
+});

--- a/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
+++ b/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
@@ -1,0 +1,111 @@
+import { SubHeader } from "@/src/components/layouts/header";
+import { CodeView } from "@/src/components/ui/CodeJsonViewer";
+import { Button } from "@/src/components/ui/button";
+import {
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import { Input } from "@/src/components/ui/input";
+import { Label } from "@/src/components/ui/label";
+import { getLangfuseEnvCode } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
+
+type ApiKeyScope = "project" | "organization";
+
+type ApiKeyCreateDialogBaseProps = {
+  scope: ApiKeyScope;
+};
+
+type ApiKeyCreateDialogFormProps = ApiKeyCreateDialogBaseProps & {
+  type: "form";
+  note: string;
+  onNoteChange: (value: string) => void;
+  onSubmit: () => void;
+  isPending?: boolean;
+};
+
+type ApiKeyCreateDialogDetailProps = ApiKeyCreateDialogBaseProps & {
+  type: "detail";
+  secretKey: string;
+  publicKey: string;
+  baseUrl: string;
+};
+
+export type ApiKeyCreateDialogContentProps =
+  | ApiKeyCreateDialogFormProps
+  | ApiKeyCreateDialogDetailProps;
+
+export function ApiKeyCreateDialogContent(
+  props: ApiKeyCreateDialogContentProps,
+) {
+  const { scope } = props;
+
+  if (props.type === "detail") {
+    const { secretKey, publicKey, baseUrl } = props;
+    const envCode = getLangfuseEnvCode(baseUrl, { secretKey, publicKey });
+
+    return (
+      <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>API Keys</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <div className="space-y-6">
+            <div>
+              <SubHeader title="Secret Key" />
+              <div className="text-muted-foreground text-sm">
+                This key can only be viewed once. You can always create new keys
+                in the {scope} settings.
+              </div>
+              <CodeView content={secretKey} className="mt-2" />
+            </div>
+            <div>
+              <SubHeader title="Public Key" />
+              <CodeView content={publicKey} className="mt-2" />
+            </div>
+            <div>
+              <SubHeader title=".env" />
+              <CodeView content={envCode} className="mt-2" />
+            </div>
+          </div>
+        </DialogBody>
+      </DialogContent>
+    );
+  }
+
+  const { note, onNoteChange, onSubmit, isPending } = props;
+
+  return (
+    <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
+      <DialogHeader>
+        <DialogTitle>Create API Keys</DialogTitle>
+      </DialogHeader>
+      <DialogBody>
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="note">Note (optional)</Label>
+            <Input
+              id="note"
+              placeholder="Production key"
+              value={note}
+              onChange={(e) => onNoteChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  onSubmit();
+                }
+              }}
+              className="mt-1.5"
+            />
+          </div>
+        </div>
+      </DialogBody>
+      <DialogFooter>
+        <Button onClick={onSubmit} loading={isPending}>
+          Create API keys
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
+}

--- a/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
+++ b/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
@@ -1,5 +1,4 @@
-import { SubHeader } from "@/src/components/layouts/header";
-import { CodeView } from "@/src/components/ui/CodeJsonViewer";
+import React from "react";
 import { Button } from "@/src/components/ui/button";
 import {
   DialogBody,
@@ -10,42 +9,25 @@ import {
 } from "@/src/components/ui/dialog";
 import { Input } from "@/src/components/ui/input";
 import { Label } from "@/src/components/ui/label";
-import { getLangfuseEnvCode } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
+import { ApiKeyDetailContent } from "@/src/features/public-api/components/ApiKeyDetailContent";
 
 type ApiKeyScope = "project" | "organization";
 
-type ApiKeyCreateDialogBaseProps = {
-  scope: ApiKeyScope;
-};
-
-type ApiKeyCreateDialogFormProps = ApiKeyCreateDialogBaseProps & {
-  type: "form";
-  note: string;
-  onNoteChange: (value: string) => void;
-  onSubmit: () => void;
-  isPending?: boolean;
-};
-
-type ApiKeyCreateDialogDetailProps = ApiKeyCreateDialogBaseProps & {
-  type: "detail";
-  secretKey: string;
-  publicKey: string;
-  baseUrl: string;
-};
-
 export type ApiKeyCreateDialogContentProps =
-  | ApiKeyCreateDialogFormProps
-  | ApiKeyCreateDialogDetailProps;
-
-function encodeMcpCredential(publicKey: string, secretKey: string) {
-  const credential = `${publicKey}:${secretKey}`;
-
-  if (typeof globalThis.btoa === "function") {
-    return globalThis.btoa(credential);
-  }
-
-  return Buffer.from(credential).toString("base64");
-}
+  | {
+      scope: ApiKeyScope;
+      type: "form";
+      note: string;
+      onNoteChange: (value: string) => void;
+      onSubmit: () => void;
+      isPending?: boolean;
+    }
+  | (Omit<
+      React.ComponentProps<typeof ApiKeyDetailContent>,
+      "showMcpSection"
+    > & {
+      type: "detail";
+    });
 
 export function ApiKeyCreateDialogContent(
   props: ApiKeyCreateDialogContentProps,
@@ -54,8 +36,6 @@ export function ApiKeyCreateDialogContent(
 
   if (props.type === "detail") {
     const { secretKey, publicKey, baseUrl } = props;
-    const envCode = getLangfuseEnvCode(baseUrl, { secretKey, publicKey });
-    const mcpCredential = encodeMcpCredential(publicKey, secretKey);
 
     return (
       <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
@@ -63,47 +43,13 @@ export function ApiKeyCreateDialogContent(
           <DialogTitle>API Keys</DialogTitle>
         </DialogHeader>
         <DialogBody>
-          <div>
-            <div>
-              <SubHeader title="Secret Key" />
-              <div className="text-muted-foreground text-sm">
-                This key can only be viewed once. You can always create new keys
-                in the {scope} settings.
-              </div>
-              <CodeView content={secretKey} className="mt-2" />
-            </div>
-            <div className="mt-6">
-              <SubHeader title="Public Key" />
-              <CodeView content={publicKey} className="mt-2" />
-            </div>
-            <div className="mt-6">
-              <SubHeader title=".env" />
-              <CodeView content={envCode} className="mt-2" />
-            </div>
-            <hr className="my-6" />
-            <SubHeader title="Using with MCP" />
-            <p className="text-muted-foreground text-sm">
-              For a detailed guide on how to use this API key to connect to the
-              Langfuse MCP server, see the{" "}
-              <a
-                href="https://langfuse.com/docs/api-and-data-platform/features/mcp-server"
-                target="_blank"
-                rel="noreferrer"
-                className="text-foreground underline"
-              >
-                MCP setup docs
-              </a>
-              .
-            </p>
-            <div className="mt-4">
-              <Label>Header</Label>
-              <CodeView
-                content={`Authorization: Basic ${mcpCredential}`}
-                className="mt-2"
-                lineWrap={false}
-              />
-            </div>
-          </div>
+          <ApiKeyDetailContent
+            scope={scope}
+            secretKey={secretKey}
+            publicKey={publicKey}
+            baseUrl={baseUrl}
+            showMcpSection={true}
+          />
         </DialogBody>
       </DialogContent>
     );

--- a/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
+++ b/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
@@ -37,6 +37,16 @@ export type ApiKeyCreateDialogContentProps =
   | ApiKeyCreateDialogFormProps
   | ApiKeyCreateDialogDetailProps;
 
+function encodeMcpCredential(publicKey: string, secretKey: string) {
+  const credential = `${publicKey}:${secretKey}`;
+
+  if (typeof globalThis.btoa === "function") {
+    return globalThis.btoa(credential);
+  }
+
+  return Buffer.from(credential).toString("base64");
+}
+
 export function ApiKeyCreateDialogContent(
   props: ApiKeyCreateDialogContentProps,
 ) {
@@ -45,6 +55,7 @@ export function ApiKeyCreateDialogContent(
   if (props.type === "detail") {
     const { secretKey, publicKey, baseUrl } = props;
     const envCode = getLangfuseEnvCode(baseUrl, { secretKey, publicKey });
+    const mcpCredential = encodeMcpCredential(publicKey, secretKey);
 
     return (
       <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
@@ -52,7 +63,7 @@ export function ApiKeyCreateDialogContent(
           <DialogTitle>API Keys</DialogTitle>
         </DialogHeader>
         <DialogBody>
-          <div className="space-y-6">
+          <div>
             <div>
               <SubHeader title="Secret Key" />
               <div className="text-muted-foreground text-sm">
@@ -61,13 +72,36 @@ export function ApiKeyCreateDialogContent(
               </div>
               <CodeView content={secretKey} className="mt-2" />
             </div>
-            <div>
+            <div className="mt-6">
               <SubHeader title="Public Key" />
               <CodeView content={publicKey} className="mt-2" />
             </div>
-            <div>
+            <div className="mt-6">
               <SubHeader title=".env" />
               <CodeView content={envCode} className="mt-2" />
+            </div>
+            <hr className="my-6" />
+            <SubHeader title="Using with MCP" />
+            <p className="text-muted-foreground text-sm">
+              For a detailed guide on how to use this API key to connect to the
+              Langfuse MCP server, see the{" "}
+              <a
+                href="https://langfuse.com/docs/api-and-data-platform/features/mcp-server"
+                target="_blank"
+                rel="noreferrer"
+                className="text-foreground underline"
+              >
+                MCP setup docs
+              </a>
+              .
+            </p>
+            <div className="mt-4">
+              <Label>Header</Label>
+              <CodeView
+                content={`Authorization: Basic ${mcpCredential}`}
+                className="mt-2"
+                lineWrap={false}
+              />
             </div>
           </div>
         </DialogBody>

--- a/web/src/features/public-api/components/ApiKeyDetailContent.tsx
+++ b/web/src/features/public-api/components/ApiKeyDetailContent.tsx
@@ -1,0 +1,83 @@
+import { SubHeader } from "@/src/components/layouts/header";
+import { CodeView } from "@/src/components/ui/CodeJsonViewer";
+import { Label } from "@/src/components/ui/label";
+import { getLangfuseEnvCode } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
+import { cn } from "@/src/utils/tailwind";
+
+type ApiKeyScope = "project" | "organization";
+
+export type ApiKeyDetailContentProps = {
+  scope: ApiKeyScope;
+  secretKey: string;
+  publicKey: string;
+  baseUrl: string;
+  className?: string;
+  showMcpSection: boolean;
+};
+
+function encodeMcpCredential(publicKey: string, secretKey: string) {
+  const credential = `${publicKey}:${secretKey}`;
+
+  if (typeof globalThis.btoa === "function") {
+    return globalThis.btoa(credential);
+  }
+
+  return Buffer.from(credential).toString("base64");
+}
+
+export function ApiKeyDetailContent(props: ApiKeyDetailContentProps) {
+  const { scope, secretKey, publicKey, baseUrl, className, showMcpSection } =
+    props;
+  const envCode = getLangfuseEnvCode(baseUrl, { secretKey, publicKey });
+  const mcpCredential = encodeMcpCredential(publicKey, secretKey);
+
+  return (
+    <div className={cn("space-y-6", className)}>
+      <div>
+        <SubHeader title="Secret Key" />
+        <div className="text-muted-foreground text-sm">
+          This key can only be viewed once. You can always create new keys in
+          the {scope} settings.
+        </div>
+        <CodeView content={secretKey} className="mt-2" />
+      </div>
+      <div>
+        <SubHeader title="Public Key" />
+        <CodeView content={publicKey} className="mt-2" />
+      </div>
+      <div>
+        <SubHeader title=".env" />
+        <CodeView content={envCode} className="mt-2" />
+      </div>
+      {showMcpSection ? (
+        <>
+          <hr />
+          <div>
+            <SubHeader title="Using with MCP" />
+            <p className="text-muted-foreground text-sm">
+              For a detailed guide on how to use this API key to connect to the
+              Langfuse MCP server, see the{" "}
+              <a
+                href="https://langfuse.com/docs/api-and-data-platform/features/mcp-server"
+                target="_blank"
+                rel="noreferrer"
+                className="text-foreground underline"
+              >
+                MCP setup docs
+              </a>
+              .
+            </p>
+            <div className="mt-4">
+              <Label>Header</Label>
+              <CodeView
+                content={`Authorization: Basic ${mcpCredential}`}
+                className="mt-2"
+                lineWrap={false}
+              />
+            </div>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/features/public-api/components/CreateApiKeyButton.tsx
+++ b/web/src/features/public-api/components/CreateApiKeyButton.tsx
@@ -1,25 +1,13 @@
 import { Button } from "@/src/components/ui/button";
+import { Dialog, DialogTrigger } from "@/src/components/ui/dialog";
 import { api } from "@/src/utils/api";
 import { useState } from "react";
 import { PlusIcon } from "lucide-react";
-import {
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/src/components/ui/dialog";
-import { CodeView } from "@/src/components/ui/CodeJsonViewer";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { Input } from "@/src/components/ui/input";
-import { useLangfuseEnvCode } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
-import { Label } from "@/src/components/ui/label";
-import { cn } from "@/src/utils/tailwind";
-import { SubHeader } from "@/src/components/layouts/header";
+import { useLangfuseBaseUrl } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
+import { ApiKeyCreateDialogContent } from "@/src/features/public-api/components/ApiKeyCreateDialogContent";
 
 type ApiKeyScope = "project" | "organization";
 
@@ -55,6 +43,7 @@ export function CreateApiKeyButton(props: {
     secretKey: string;
     publicKey: string;
   } | null>(null);
+  const baseUrl = useLangfuseBaseUrl();
 
   const handleOpenChange = (newOpen: boolean) => {
     setOpen(newOpen);
@@ -111,87 +100,25 @@ export function CreateApiKeyButton(props: {
           Create new API keys
         </Button>
       </DialogTrigger>
-      <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
-        <DialogHeader>
-          <DialogTitle>
-            {generatedKeys ? "API Keys" : "Create API Keys"}
-          </DialogTitle>
-        </DialogHeader>
-        <DialogBody>
-          {generatedKeys ? (
-            <ApiKeyRender scope={props.scope} generatedKeys={generatedKeys} />
-          ) : (
-            <div className="space-y-4">
-              <div>
-                <Label htmlFor="note">Note (optional)</Label>
-                <Input
-                  id="note"
-                  placeholder="Production key"
-                  value={note}
-                  onChange={(e) => setNote(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      createApiKey();
-                    }
-                  }}
-                  className="mt-1.5"
-                />
-              </div>
-            </div>
-          )}
-        </DialogBody>
-        {!generatedKeys && (
-          <DialogFooter>
-            <Button
-              onClick={createApiKey}
-              loading={
-                mutCreateProjectApiKey.isPending || mutCreateOrgApiKey.isPending
-              }
-            >
-              Create API keys
-            </Button>
-          </DialogFooter>
-        )}
-      </DialogContent>
+      <ApiKeyCreateDialogContent
+        scope={props.scope}
+        {...(generatedKeys
+          ? {
+              type: "detail" as const,
+              secretKey: generatedKeys.secretKey,
+              publicKey: generatedKeys.publicKey,
+              baseUrl,
+            }
+          : {
+              type: "form" as const,
+              note,
+              onNoteChange: setNote,
+              onSubmit: createApiKey,
+              isPending:
+                mutCreateProjectApiKey.isPending ||
+                mutCreateOrgApiKey.isPending,
+            })}
+      />
     </Dialog>
   );
 }
-
-export const ApiKeyRender = ({
-  scope,
-  generatedKeys,
-  className,
-}: {
-  scope: ApiKeyScope;
-  generatedKeys?: { secretKey: string; publicKey: string };
-  className?: string;
-}) => {
-  const envCode = useLangfuseEnvCode(generatedKeys);
-
-  return (
-    <div className={cn("space-y-6", className)}>
-      <div>
-        <SubHeader title="Secret Key" />
-        <div className="text-muted-foreground text-sm">
-          This key can only be viewed once. You can always create new keys in
-          the {scope} settings.
-        </div>
-        <CodeView
-          content={generatedKeys?.secretKey ?? "Loading ..."}
-          className="mt-2"
-        />
-      </div>
-      <div>
-        <SubHeader title="Public Key" />
-        <CodeView
-          content={generatedKeys?.publicKey ?? "Loading ..."}
-          className="mt-2"
-        />
-      </div>
-      <div>
-        <SubHeader title=".env" />
-        <CodeView content={envCode} className="mt-2" />
-      </div>
-    </div>
-  );
-};

--- a/web/src/features/public-api/components/CreateApiKeyButton.tsx
+++ b/web/src/features/public-api/components/CreateApiKeyButton.tsx
@@ -108,6 +108,7 @@ export function CreateApiKeyButton(props: {
               secretKey: generatedKeys.secretKey,
               publicKey: generatedKeys.publicKey,
               baseUrl,
+              showMcpSection: true,
             }
           : {
               type: "form" as const,

--- a/web/src/features/public-api/hooks/useLangfuseEnvCode.ts
+++ b/web/src/features/public-api/hooks/useLangfuseEnvCode.ts
@@ -1,20 +1,45 @@
 import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
 import { env } from "@/src/env.mjs";
 
+type LangfuseKeys = {
+  secretKey: string;
+  publicKey: string;
+};
+
+export function getLangfuseBaseUrl(baseUrl: string): string {
+  return `${baseUrl}${env.NEXT_PUBLIC_BASE_PATH ?? ""}`;
+}
+
+export function getLangfuseEnvCode(
+  baseUrl: string,
+  keys?: LangfuseKeys,
+): string {
+  if (keys) {
+    return `
+LANGFUSE_SECRET_KEY="${keys.secretKey}"
+LANGFUSE_PUBLIC_KEY="${keys.publicKey}"
+LANGFUSE_BASE_URL="${baseUrl}"
+`.trim();
+  }
+
+  return `
+LANGFUSE_SECRET_KEY="sk-lf-..."
+LANGFUSE_PUBLIC_KEY="pk-lf-..."
+LANGFUSE_BASE_URL="${baseUrl}"
+`.trim();
+}
+
+export function useLangfuseBaseUrl(): string {
+  const uiCustomization = useUiCustomization();
+
+  return getLangfuseBaseUrl(uiCustomization?.hostname ?? window.origin);
+}
+
 export function useLangfuseEnvCode(keys?: {
   secretKey: string;
   publicKey: string;
 }): string {
-  const uiCustomization = useUiCustomization();
-  const baseUrl = `${uiCustomization?.hostname ?? window.origin}${env.NEXT_PUBLIC_BASE_PATH ?? ""}`;
+  const baseUrl = useLangfuseBaseUrl();
 
-  if (keys) {
-    return `LANGFUSE_SECRET_KEY="${keys.secretKey}"
-LANGFUSE_PUBLIC_KEY="${keys.publicKey}"
-LANGFUSE_BASE_URL="${baseUrl}"`;
-  }
-
-  return `LANGFUSE_SECRET_KEY="sk-lf-..."
-LANGFUSE_PUBLIC_KEY="pk-lf-..."
-LANGFUSE_BASE_URL="${baseUrl}"`;
+  return getLangfuseEnvCode(baseUrl, keys);
 }

--- a/web/src/features/setup/components/TracesSetupOnboardingCard.tsx
+++ b/web/src/features/setup/components/TracesSetupOnboardingCard.tsx
@@ -3,7 +3,8 @@ import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
 import { SplashScreen } from "@/src/components/ui/splash-screen";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
-import { ApiKeyRender } from "@/src/features/public-api/components/CreateApiKeyButton";
+import { ApiKeyDetailContent } from "@/src/features/public-api/components/ApiKeyDetailContent";
+import { useLangfuseBaseUrl } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api } from "@/src/utils/api";
 import { type RouterOutput } from "@/src/utils/types";
@@ -62,6 +63,7 @@ export function TracesSetupOnboardingCard({
   projectId: string;
 }) {
   const capture = usePostHogClientCapture();
+  const baseUrl = useLangfuseBaseUrl();
   const hasApiKeyCreateAccess = useHasProjectAccess({
     projectId,
     scope: "apiKeys:CUD",
@@ -99,10 +101,13 @@ export function TracesSetupOnboardingCard({
           description:
             "Your application needs API keys to send traces to Langfuse.",
           content: apiKeys ? (
-            <ApiKeyRender
-              generatedKeys={apiKeys}
+            <ApiKeyDetailContent
               scope="project"
+              secretKey={apiKeys.secretKey}
+              publicKey={apiKeys.publicKey}
+              baseUrl={baseUrl}
               className="mt-1"
+              showMcpSection={false}
             />
           ) : (
             <div className="flex flex-wrap gap-2">

--- a/web/src/pages/project/[projectId]/settings/index.tsx
+++ b/web/src/pages/project/[projectId]/settings/index.tsx
@@ -150,7 +150,7 @@ export const getProjectSettingsPages = ({
       "claude code",
       "cursor",
     ],
-    content: <DeveloperToolsSettings />,
+    content: <DeveloperToolsSettings projectId={project.id} />,
   },
   {
     title: "LLM Connections",

--- a/web/src/pages/project/[projectId]/traces/setup.tsx
+++ b/web/src/pages/project/[projectId]/traces/setup.tsx
@@ -6,7 +6,8 @@ import ContainerPage from "@/src/components/layouts/container-page";
 import { ActionButton } from "@/src/components/ActionButton";
 import { SubHeader } from "@/src/components/layouts/header";
 import { Button } from "@/src/components/ui/button";
-import { ApiKeyRender } from "@/src/features/public-api/components/CreateApiKeyButton";
+import { ApiKeyDetailContent } from "@/src/features/public-api/components/ApiKeyDetailContent";
+import { useLangfuseBaseUrl } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
 import { type RouterOutput } from "@/src/utils/types";
 import { useState } from "react";
 import { useQueryProject } from "@/src/features/projects/hooks";
@@ -18,6 +19,7 @@ export const TracingSetup = ({
   projectId: string;
   hasTracingConfigured?: boolean;
 }) => {
+  const baseUrl = useLangfuseBaseUrl();
   const [apiKeys, setApiKeys] = useState<
     RouterOutput["projectApiKeys"]["create"] | null
   >(null);
@@ -42,10 +44,13 @@ export const TracingSetup = ({
       <div>
         <SubHeader title="1. Get API keys" />
         {apiKeys ? (
-          <ApiKeyRender
-            generatedKeys={apiKeys}
-            scope={"project"}
+          <ApiKeyDetailContent
+            scope="project"
+            secretKey={apiKeys.secretKey}
+            publicKey={apiKeys.publicKey}
+            baseUrl={baseUrl}
             className="mt-4"
+            showMcpSection={false}
           />
         ) : (
           <div className="flex flex-col gap-4">


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the API key creation flow by adding MCP server setup instructions (a ready-to-use `Authorization: Basic` header) to the post-creation dialog, and refactors the key detail rendering into a reusable `ApiKeyDetailContent` component.

- **Component extraction**: The old `ApiKeyRender` export inside `CreateApiKeyButton.tsx` is replaced by the standalone `ApiKeyDetailContent` component and a new `ApiKeyCreateDialogContent` that handles both the creation form and the detail (post-creation) views.
- **Pure utility helpers**: `useLangfuseEnvCode.ts` is refactored to expose `getLangfuseBaseUrl` and `getLangfuseEnvCode` as pure functions, making them usable outside of React hooks (e.g., in `ApiKeyDetailContent`).
- **UX additions**: A "Manage API keys" button is added to the `DeveloperToolsSettings` MCP/CLI cards, and a `lineWrap={false}` prop is added to `CodeView` to support horizontal scrolling for the long Basic auth header string.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are a UI refactor extracting existing rendering logic into smaller components plus a new MCP Basic auth header display feature.

The refactoring is straightforward: ApiKeyRender is split into ApiKeyDetailContent and ApiKeyCreateDialogContent, all existing call sites are updated correctly, the pure-function extraction in useLangfuseEnvCode.ts avoids any double-application of NEXT_PUBLIC_BASE_PATH, and the btoa credential encoding uses only ASCII key characters. No logic is broken.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CreateApiKeyButton] -->|no keys yet| B[ApiKeyCreateDialogContent\ntype=form]
    A -->|keys generated| C[ApiKeyCreateDialogContent\ntype=detail]
    C --> D[ApiKeyDetailContent\nshowMcpSection=true]
    D --> E[Secret Key / Public Key / .env\nCodeView blocks]
    D -->|showMcpSection| F[MCP Section\nAuthorization: Basic header\nCodeView lineWrap=false]
    F --> G[encodeMcpCredential\nbtoa publicKey:secretKey]

    H[TracesSetupOnboardingCard] --> I[ApiKeyDetailContent\nshowMcpSection=false]
    J[setup.tsx TracingSetup] --> K[ApiKeyDetailContent\nshowMcpSection=false]

    L[useLangfuseBaseUrl] -->|origin + base path| A
    L --> H
    L --> J
    M[getLangfuseBaseUrl\npure fn] --> L
    N[getLangfuseEnvCode\npure fn] --> D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[CreateApiKeyButton] -->|no keys yet| B[ApiKeyCreateDialogContent\ntype=form]
    A -->|keys generated| C[ApiKeyCreateDialogContent\ntype=detail]
    C --> D[ApiKeyDetailContent\nshowMcpSection=true]
    D --> E[Secret Key / Public Key / .env\nCodeView blocks]
    D -->|showMcpSection| F[MCP Section\nAuthorization: Basic header\nCodeView lineWrap=false]
    F --> G[encodeMcpCredential\nbtoa publicKey:secretKey]

    H[TracesSetupOnboardingCard] --> I[ApiKeyDetailContent\nshowMcpSection=false]
    J[setup.tsx TracingSetup] --> K[ApiKeyDetailContent\nshowMcpSection=false]

    L[useLangfuseBaseUrl] -->|origin + base path| A
    L --> H
    L --> J
    M[getLangfuseBaseUrl\npure fn] --> L
    N[getLangfuseEnvCode\npure fn] --> D
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Add link to api key settings to \`Develop..."](https://github.com/langfuse/langfuse/commit/bad7c47f1e0e34b9e972a6443f5055f48d5a0aa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41328110)</sub>

<!-- /greptile_comment -->