### PR TITLE
fix(agent): Refocus input after generation

### DIFF
--- a/.agents/skills/storybook/SKILL.md
+++ b/.agents/skills/storybook/SKILL.md
@@ -31,10 +31,12 @@ Keep the existing component, but update it to use the newly created component fo
 - Use "CSF Next" format by default.
 - Cover only the relevant component by default.
 - Avoid custom render functions by default.
+- Do not define helper components inside story files unless the helper component is reused by multiple stories. For one-off setup, inline the stateful render logic directly in the story `render` function.
 - Never use `decorators` to add styling or layout to a story. Stories should render the components as they are.
 - Use `satisfies` and typed Storybook metadata so invalid args, decorators, and play functions are type-checked.
 - Use play functions to test user-relevant interactions after render, not to compensate for complex setup or hidden dependencies.
 - Prefix stories whose primary purpose is interaction test coverage with `(Test)` in the Storybook display name, for example `name: "(Test) Opens Menu"`.
+- Keep `(Test)` stories sorted at the bottom of the file so showcase and product-facing stories stay grouped first.
 - Name stories after the state they represent, not the implementation. Also do not include the component name in the story name.
   - Prefer: `Default`, `Empty`, `WithLongName`, `Error`, `Disabled`, `Loading`
   - Avoid: `Test1`, `CustomRenderExample`, `ButtonWithLongNameAndIcon`

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1,6 +1,6 @@
 import preview from "../../../../../.storybook/preview";
 import { type ReactNode, useEffect, useRef, useState } from "react";
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import {
   InAppAgentWindow,
   type InAppAgentWindowMessage,
@@ -800,3 +800,76 @@ export const Error = meta.story({
     ],
   },
 });
+
+export const RefocusAfterSubmit = {
+  name: "(Test) Refocus After Submit",
+  render: function Render(args: InAppAgentWindowProps) {
+    const [isExpanded, setIsExpanded] = useState(args.isExpanded);
+    const [isInputDisabled, setIsInputDisabled] = useState(false);
+    const [messages, setMessages] = useState<InAppAgentWindowMessage[]>([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: {
+          type: "text",
+          text: "Assistant answer",
+        },
+      },
+    ]);
+
+    return (
+      <InAppAgentWindowStoryShell isExpanded={isExpanded}>
+        {({ isHeaderDragHandleEnabled }) => (
+          <InAppAgentWindow
+            {...args}
+            isHeaderDragHandleEnabled={isHeaderDragHandleEnabled}
+            isExpanded={isExpanded}
+            isInputDisabled={isInputDisabled}
+            messages={messages}
+            onExpandedChange={(isExpanded) => {
+              setIsExpanded(isExpanded);
+              args.onExpandedChange(isExpanded);
+            }}
+            onSubmit={(input) => {
+              setIsInputDisabled(true);
+              window.setTimeout(() => {
+                setMessages((currentMessages) => [
+                  ...currentMessages,
+                  {
+                    id: `assistant-${currentMessages.length + 1}`,
+                    role: "assistant",
+                    content: {
+                      type: "text",
+                      text: `Answer for: ${input}`,
+                    },
+                  },
+                ]);
+                setIsInputDisabled(false);
+              }, 50);
+
+              args.onSubmit(input);
+              return true;
+            }}
+          />
+        )}
+      </InAppAgentWindowStoryShell>
+    );
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByLabelText("Ask the assistant a question");
+
+    await userEvent.type(textarea, "Check the latest latency regression");
+    await userEvent.click(canvas.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(
+        canvas.getByText("Answer for: Check the latest latency regression"),
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(textarea).toHaveFocus();
+    });
+  },
+};

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -137,6 +137,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const isAutoScrollAttachedRef = useRef(true);
   const previousScrollTopRef = useRef(0);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const previousIsInputDisabledRef = useRef(isInputDisabled);
   const [input, setInput] = useState("");
   const [isConversationHistoryOpen, setIsConversationHistoryOpen] =
     useState(false);
@@ -208,6 +209,17 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
 
     scrollViewportToBottom(viewportRef.current);
   }, [selectedConversationId]);
+
+  useEffect(() => {
+    const wasInputDisabled = previousIsInputDisabledRef.current;
+    previousIsInputDisabledRef.current = isInputDisabled;
+
+    if (!wasInputDisabled || isInputDisabled) {
+      return;
+    }
+
+    inputRef.current?.focus();
+  }, [isInputDisabled]);
 
   useEffect(() => {
     const input = inputRef.current;


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a UX issue in the `InAppAgentWindow` component where the text input loses focus after a generation completes. It also adds two new Storybook authoring guidelines to `SKILL.md`.

- A `useEffect` in `InAppAgentWindow.tsx` tracks the previous value of `isInputDisabled` via a ref and refocuses the textarea when the prop transitions from `true` → `false` (i.e., when the assistant finishes generating).
- A Storybook `(Test) Refocus After Submit` story is added to validate the behavior end-to-end, correctly inlining stateful render logic rather than extracting a one-off helper component (per the new SKILL.md guidance).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is minimal, self-contained, and fully covered by a new Storybook interaction test.

The refocus logic correctly detects only the disabled→enabled transition (avoiding spurious focus on initial mount or while generation is running), and the companion Storybook play function verifies the full round-trip from submission through response arrival to focus restoration.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant InAppAgentWindow
    participant Parent

    User->>InAppAgentWindow: "Types message & clicks Send"
    InAppAgentWindow->>Parent: onSubmit(input)
    Parent->>InAppAgentWindow: "isInputDisabled = true"
    Note over InAppAgentWindow: useEffect detects disabled=true<br/>previousIsInputDisabledRef = true<br/>early-return (no focus change)
    Parent->>InAppAgentWindow: "isInputDisabled = false (generation done)"
    Note over InAppAgentWindow: useEffect detects disabled=false<br/>wasInputDisabled=true, isInputDisabled=false<br/>Condition false → inputRef.focus()
    InAppAgentWindow->>User: Input textarea is focused again
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant InAppAgentWindow
    participant Parent

    User->>InAppAgentWindow: "Types message & clicks Send"
    InAppAgentWindow->>Parent: onSubmit(input)
    Parent->>InAppAgentWindow: "isInputDisabled = true"
    Note over InAppAgentWindow: useEffect detects disabled=true<br/>previousIsInputDisabledRef = true<br/>early-return (no focus change)
    Parent->>InAppAgentWindow: "isInputDisabled = false (generation done)"
    Note over InAppAgentWindow: useEffect detects disabled=false<br/>wasInputDisabled=true, isInputDisabled=false<br/>Condition false → inputRef.focus()
    InAppAgentWindow->>User: Input textarea is focused again
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Update Storybook skill"](https://github.com/langfuse/langfuse/commit/e21829e11b0b904fec66b9752fbece32977d2573) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41331758)</sub>

<!-- /greptile_comment -->