### PR TITLE
fix: ensure hasAny* tRPC checks run against readonly events server pool

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2132,6 +2132,11 @@ export const deleteEventsByTraceIds = async (
   ]);
 };
 
+/**
+ * This method is used by deleteEventsByProjectId and therefore
+ * should NOT be using EventsReadOnly to prevent lagging replicas
+ * from changing the outcome.
+ */
 export const hasAnyEvent = async (projectId: string) => {
   const query = `
     SELECT 1
@@ -2224,6 +2229,11 @@ export async function getAgentGraphDataFromEventsTable(params: {
   });
 }
 
+/**
+ * This method is used by deleteEventsByProjectId and therefore
+ * should NOT be using EventsReadOnly to prevent lagging replicas
+ * from changing the outcome.
+ */
 export const hasAnyEventOlderThan = async (
   projectId: string,
   beforeDate: Date,
@@ -2640,6 +2650,7 @@ export const hasAnyUserFromEventsTable = async (
     query,
     params: { projectId },
     tags: { projectId },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   return rows.length > 0;
@@ -2885,6 +2896,7 @@ export const hasAnySessionFromEventsTable = async (
         query,
         params: input.params,
         tags: { projectId },
+        preferredClickhouseService: "EventsReadOnly",
       });
     },
   });


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes four `hasAny*` existence-check functions in `events.ts` (`hasAnyEvent`, `hasAnyEventOlderThan`, `hasAnyUserFromEventsTable`, `hasAnySessionFromEventsTable`) that were inadvertently routing their ClickHouse queries to the default read-write pool instead of the dedicated events read-only pool.

- Adds `preferredClickhouseService: "EventsReadOnly"` to all four functions, aligning them with the pattern used by the rest of the read-query surface in `events.ts`.
- No logic or schema changes — purely a routing correction so these lightweight `SELECT 1 … LIMIT 1` checks hit `CLICKHOUSE_EVENTS_READ_ONLY_URL` (falling back through `CLICKHOUSE_READ_ONLY_URL` → `CLICKHOUSE_URL`) rather than the write endpoint.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive (adds a routing hint to four read-only existence checks) and follows an established pattern used everywhere else in the same file.

All four modified functions perform simple SELECT 1 … LIMIT 1 reads; adding preferredClickhouseService: EventsReadOnly is consistent with every other read query in the file and cannot introduce data mutation risk. The fallback chain (CLICKHOUSE_EVENTS_READ_ONLY_URL → CLICKHOUSE_READ_ONLY_URL → CLICKHOUSE_URL) means the change degrades gracefully when the dedicated pool is not configured.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant tRPC as tRPC handler
    participant fn as hasAny* fn
    participant qCH as queryClickhouse
    participant mgr as ClickHouseClientManager
    participant RW as ClickHouse Read-Write
    participant RO as ClickHouse EventsReadOnly

    note over fn,RW: Before this PR (missing preferredClickhouseService)
    tRPC->>fn: hasAnyEvent(projectId)
    fn->>qCH: "{ query, params, tags }"
    qCH->>mgr: getClient(opts, undefined → ReadWrite)
    mgr->>RW: SELECT 1 FROM events_core LIMIT 1
    RW-->>fn: rows

    note over fn,RO: After this PR (preferredClickhouseService: EventsReadOnly)
    tRPC->>fn: hasAnyEvent(projectId)
    fn->>qCH: "{ query, params, tags, preferredClickhouseService: EventsReadOnly }"
    qCH->>mgr: getClient(opts, EventsReadOnly)
    mgr->>RO: SELECT 1 FROM events_core LIMIT 1
    RO-->>fn: rows
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant tRPC as tRPC handler
    participant fn as hasAny* fn
    participant qCH as queryClickhouse
    participant mgr as ClickHouseClientManager
    participant RW as ClickHouse Read-Write
    participant RO as ClickHouse EventsReadOnly

    note over fn,RW: Before this PR (missing preferredClickhouseService)
    tRPC->>fn: hasAnyEvent(projectId)
    fn->>qCH: "{ query, params, tags }"
    qCH->>mgr: getClient(opts, undefined → ReadWrite)
    mgr->>RW: SELECT 1 FROM events_core LIMIT 1
    RW-->>fn: rows

    note over fn,RO: After this PR (preferredClickhouseService: EventsReadOnly)
    tRPC->>fn: hasAnyEvent(projectId)
    fn->>qCH: "{ query, params, tags, preferredClickhouseService: EventsReadOnly }"
    qCH->>mgr: getClient(opts, EventsReadOnly)
    mgr->>RO: SELECT 1 FROM events_core LIMIT 1
    RO-->>fn: rows
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: ensure hasAny\* tRPC checks run agai..."](https://github.com/langfuse/langfuse/commit/335dc6d49943aeea4e7d51185e9ab6564caa6fd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41338477)</sub>

<!-- /greptile_comment -->