### PR TITLE
feat(worker): add sfdc org id, user auth methods, and sso domain data to core data export

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -340,6 +340,9 @@ const EnvSchema = z.object({
     .default("false"),
   LANGFUSE_S3_CORE_DATA_UPLOAD_SSE: z.enum(["AES256", "aws:kms"]).optional(),
   LANGFUSE_S3_CORE_DATA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
+  // Same env var as in web; included in the core data export so the DWH knows
+  // which domains have SSO enforcement per environment
+  AUTH_DOMAINS_WITH_SSO_ENFORCEMENT: z.string().optional(),
 
   // Media upload
   LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: z.string().optional(),

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -340,9 +340,6 @@ const EnvSchema = z.object({
     .default("false"),
   LANGFUSE_S3_CORE_DATA_UPLOAD_SSE: z.enum(["AES256", "aws:kms"]).optional(),
   LANGFUSE_S3_CORE_DATA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
-  // Same env var as in web; included in the core data export so the DWH knows
-  // which domains have SSO enforcement per environment
-  AUTH_DOMAINS_WITH_SSO_ENFORCEMENT: z.string().optional(),
 
   // Media upload
   LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: z.string().optional(),

--- a/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
+++ b/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
@@ -49,18 +49,6 @@ describe("mapUserToCoreDataRow", () => {
   });
 });
 
-describe("parseSsoEnforcedDomains", () => {
-  it("splits, trims, lowercases, and drops empty entries", () => {
-    expect(
-      parseSsoEnforcedDomains(" Example.com, langfuse.com ,,other.ORG"),
-    ).toStrictEqual(["example.com", "langfuse.com", "other.org"]);
-  });
-
-  it("returns an empty list when unset", () => {
-    expect(parseSsoEnforcedDomains(undefined)).toStrictEqual([]);
-  });
-});
-
 describe("coreDataS3ExportQueue", () => {
   it("streams prompt core data in pages", async () => {
     const createdAt = new Date("2026-05-14T00:00:00.000Z");

--- a/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
+++ b/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { Readable } from "node:stream";
 import { type StorageService } from "@langfuse/shared/src/server";
-import { uploadPromptsCoreDataJsonl } from "../coreDataS3ExportQueue";
+import {
+  mapUserToCoreDataRow,
+  parseSsoEnforcedDomains,
+  uploadPromptsCoreDataJsonl,
+} from "../coreDataS3ExportQueue";
 
 const readStream = async (stream: Readable): Promise<string> => {
   const chunks: string[] = [];
@@ -12,6 +16,50 @@ const readStream = async (stream: Readable): Promise<string> => {
 
   return chunks.join("");
 };
+
+describe("mapUserToCoreDataRow", () => {
+  it("derives auth methods from password and account providers", () => {
+    const row = mapUserToCoreDataRow({
+      id: "user-1",
+      email: "user@example.com",
+      password: "hashed-password",
+      accounts: [
+        { provider: "google" },
+        { provider: "okta" },
+        { provider: "google" },
+      ],
+    });
+
+    expect(row).toStrictEqual({
+      id: "user-1",
+      email: "user@example.com",
+      authMethods: ["credentials", "google", "okta"],
+    });
+    expect(JSON.stringify(row)).not.toContain("hashed-password");
+  });
+
+  it("returns no auth methods for users without password and accounts", () => {
+    const row = mapUserToCoreDataRow({
+      id: "user-2",
+      password: null,
+      accounts: [],
+    });
+
+    expect(row).toStrictEqual({ id: "user-2", authMethods: [] });
+  });
+});
+
+describe("parseSsoEnforcedDomains", () => {
+  it("splits, trims, lowercases, and drops empty entries", () => {
+    expect(
+      parseSsoEnforcedDomains(" Example.com, langfuse.com ,,other.ORG"),
+    ).toStrictEqual(["example.com", "langfuse.com", "other.org"]);
+  });
+
+  it("returns an empty list when unset", () => {
+    expect(parseSsoEnforcedDomains(undefined)).toStrictEqual([]);
+  });
+});
 
 describe("coreDataS3ExportQueue", () => {
   it("streams prompt core data in pages", async () => {

--- a/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
+++ b/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
@@ -3,7 +3,6 @@ import { Readable } from "node:stream";
 import { type StorageService } from "@langfuse/shared/src/server";
 import {
   mapUserToCoreDataRow,
-  parseSsoEnforcedDomains,
   uploadPromptsCoreDataJsonl,
 } from "../coreDataS3ExportQueue";
 

--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -50,13 +50,6 @@ export const mapUserToCoreDataRow = ({
   ],
 });
 
-// Mirrors getSSOBlockedDomains in web/src/features/auth-credentials/server/signupApiHandler.ts
-export const parseSsoEnforcedDomains = (value: string | undefined) =>
-  value
-    ?.split(",")
-    .map((domain) => domain.trim().toLowerCase())
-    .filter(Boolean) ?? [];
-
 type PromptCoreData = {
   id: string;
   name: string;
@@ -276,11 +269,6 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
 
   const users = usersWithAuthData.map(mapUserToCoreDataRow);
 
-  // Domains with SSO enforcement are configured per environment via env var
-  const ssoEnforcedDomains = parseSsoEnforcedDomains(
-    env.AUTH_DOMAINS_WITH_SSO_ENFORCEMENT,
-  ).map((domain) => ({ domain }));
-
   // Iterate through the tables and upload them to S3 as JSONLs
   await Promise.all(
     Object.entries({
@@ -294,7 +282,6 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
       blobStorageIntegrations,
       ssoConfigs,
       verifiedDomains,
-      ssoEnforcedDomains,
     }).map(async ([key, value]) =>
       s3Client.uploadFile({
         fileName: `${env.LANGFUSE_S3_CORE_DATA_UPLOAD_PREFIX}${key}.jsonl`,

--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -30,6 +30,33 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
   return s3StorageServiceClient;
 };
 
+type UserCoreDataInput = {
+  password: string | null;
+  accounts: { provider: string }[];
+} & Record<string, unknown>;
+
+// Derives the auth methods per user from the linked next-auth accounts and the
+// presence of a password hash ("credentials"). The hash itself must never
+// reach the export.
+export const mapUserToCoreDataRow = ({
+  password,
+  accounts,
+  ...user
+}: UserCoreDataInput) => ({
+  ...user,
+  authMethods: [
+    ...(password ? ["credentials"] : []),
+    ...Array.from(new Set(accounts.map((account) => account.provider))),
+  ],
+});
+
+// Mirrors getSSOBlockedDomains in web/src/features/auth-credentials/server/signupApiHandler.ts
+export const parseSsoEnforcedDomains = (value: string | undefined) =>
+  value
+    ?.split(",")
+    .map((domain) => domain.trim().toLowerCase())
+    .filter(Boolean) ?? [];
+
 type PromptCoreData = {
   id: string;
   name: string;
@@ -120,13 +147,15 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
   // Fetch table data
   const [
     projects,
-    users,
+    usersWithAuthData,
     organizations,
     orgMemberships,
     projectMemberships,
     billingMeterBackup,
     surveys,
     blobStorageIntegrations,
+    ssoConfigs,
+    verifiedDomains,
   ] = await Promise.all([
     prisma.project.findMany({
       select: {
@@ -147,6 +176,14 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
         v4BetaEnabled: true,
         createdAt: true,
         updatedAt: true,
+        // password and accounts are mapped to authMethods below and must not
+        // be exported as-is
+        password: true,
+        accounts: {
+          select: {
+            provider: true,
+          },
+        },
       },
     }),
     prisma.organization.findMany({
@@ -154,6 +191,7 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
         id: true,
         name: true,
         cloudConfig: true,
+        sfdcOrgId: true,
         createdAt: true,
         updatedAt: true,
       },
@@ -215,7 +253,33 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
         updatedAt: true,
       },
     }),
+    // authConfig is excluded as it may contain client secrets
+    prisma.ssoConfig.findMany({
+      select: {
+        domain: true,
+        authProvider: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+    prisma.verifiedDomain.findMany({
+      select: {
+        id: true,
+        organizationId: true,
+        domain: true,
+        verifiedAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
   ]);
+
+  const users = usersWithAuthData.map(mapUserToCoreDataRow);
+
+  // Domains with SSO enforcement are configured per environment via env var
+  const ssoEnforcedDomains = parseSsoEnforcedDomains(
+    env.AUTH_DOMAINS_WITH_SSO_ENFORCEMENT,
+  ).map((domain) => ({ domain }));
 
   // Iterate through the tables and upload them to S3 as JSONLs
   await Promise.all(
@@ -228,6 +292,9 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
       billingMeterBackup,
       surveys,
       blobStorageIntegrations,
+      ssoConfigs,
+      verifiedDomains,
+      ssoEnforcedDomains,
     }).map(async ([key, value]) =>
       s3Client.uploadFile({
         fileName: `${env.LANGFUSE_S3_CORE_DATA_UPLOAD_PREFIX}${key}.jsonl`,


### PR DESCRIPTION
- organizations.jsonl now includes sfdc_org_id for DWH consumption
- users.jsonl now includes authMethods derived from next-auth account providers plus "credentials" when a password hash is set (the hash itself is stripped before serialization)
- new ssoConfigs.jsonl (domain + provider, secrets excluded) and verifiedDomains.jsonl (org linkage) exports
- new ssoEnforcedDomains.jsonl export of the per-environment AUTH_DOMAINS_WITH_SSO_ENFORCEMENT env var, now also read by the worker

Note: blob storage integration state (enabled, lastSyncAt, lastError, ...) was already exported via blobStorageIntegrations.jsonl.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the core data S3 export with four additions: `sfdc_org_id` on organizations, derived `authMethods` (credential providers) on users with the password hash stripped before serialization, new `ssoConfigs.jsonl` / `verifiedDomains.jsonl` exports (with `authConfig` secrets excluded), and a new `ssoEnforcedDomains.jsonl` built from the `AUTH_DOMAINS_WITH_SSO_ENFORCEMENT` env var now parsed by the worker.

- `mapUserToCoreDataRow` correctly destructs `password` and `accounts` before the S3 upload; a unit test confirms the hash never appears in serialized output.
- `ssoConfigs` explicitly excludes `authConfig` (OAuth client secrets); `verifiedDomains` includes full org linkage.
- `ssoEnforcedDomains` rows only carry `{ domain }` — no timestamps — which may cause schema inconsistency for DWH consumers that treat all export files uniformly.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The password hash is correctly stripped before export and secrets are excluded from SSO configs; the change is safe to merge as-is.

The security-sensitive parts (password stripping, authConfig exclusion) are handled correctly and covered by unit tests. The two findings are forward-looking: an open-ended Record<string, unknown> spread that could silently pass future sensitive fields through, and a missing timestamp on ssoEnforcedDomains rows that may cause friction for DWH consumers expecting a uniform schema. Neither is a current data leak or runtime failure.

The mapUserToCoreDataRow function and the ssoEnforcedDomains construction in coreDataS3ExportQueue.ts deserve a second look for the reasons noted in the inline comments.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W as Worker (coreDataS3ExportProcessor)
    participant DB as Prisma / Postgres
    participant ENV as env.ts
    participant S3 as S3 / Storage

    W->>DB: findMany(project, user+password+accounts, org+sfdcOrgId, ...)
    W->>DB: findMany(ssoConfig, verifiedDomain)
    DB-->>W: usersWithAuthData (includes password hash)
    W->>W: mapUserToCoreDataRow strips password, derives authMethods
    W->>ENV: read AUTH_DOMAINS_WITH_SSO_ENFORCEMENT
    ENV-->>W: comma-separated domain string
    W->>W: "parseSsoEnforcedDomains → [{domain}, ...]"
    W->>S3: uploadFile users.jsonl (authMethods, no password)
    W->>S3: uploadFile organizations.jsonl (incl. sfdcOrgId)
    W->>S3: uploadFile ssoConfigs.jsonl (domain+authProvider, no authConfig)
    W->>S3: uploadFile verifiedDomains.jsonl
    W->>S3: "uploadFile ssoEnforcedDomains.jsonl ({domain} only)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W as Worker (coreDataS3ExportProcessor)
    participant DB as Prisma / Postgres
    participant ENV as env.ts
    participant S3 as S3 / Storage

    W->>DB: findMany(project, user+password+accounts, org+sfdcOrgId, ...)
    W->>DB: findMany(ssoConfig, verifiedDomain)
    DB-->>W: usersWithAuthData (includes password hash)
    W->>W: mapUserToCoreDataRow strips password, derives authMethods
    W->>ENV: read AUTH_DOMAINS_WITH_SSO_ENFORCEMENT
    ENV-->>W: comma-separated domain string
    W->>W: "parseSsoEnforcedDomains → [{domain}, ...]"
    W->>S3: uploadFile users.jsonl (authMethods, no password)
    W->>S3: uploadFile organizations.jsonl (incl. sfdcOrgId)
    W->>S3: uploadFile ssoConfigs.jsonl (domain+authProvider, no authConfig)
    W->>S3: uploadFile verifiedDomains.jsonl
    W->>S3: "uploadFile ssoEnforcedDomains.jsonl ({domain} only)"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/queues/coreDataS3ExportQueue.ts:41-51
**Open-ended spread may silently include future sensitive fields**

`mapUserToCoreDataRow` destructs `password` and `accounts` but spreads everything else via `Record<string, unknown>`. If a new sensitive column (e.g. session token, TOTP secret) is ever added to the Prisma `select` block, it will flow straight into the S3 export without any compile-time warning, since `Record<string, unknown>` matches anything. An explicit allowlist of the fields that *should* appear in the export would make accidental leakage impossible.

### Issue 2 of 2
worker/src/queues/coreDataS3ExportQueue.ts:280-282
**`ssoEnforcedDomains` rows carry no timestamp**

Every other export file includes `createdAt`/`updatedAt`, which downstream DWH pipelines typically use for incremental-load watermarks and deduplication. `ssoEnforcedDomains` rows only contain `{ domain }` because they come from an env var rather than a database table. If the DWH consumer treats all `.jsonl` files uniformly it may fail on the missing timestamp columns, or silently produce a table with no time dimension for this entity.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): add sfdc org id, user auth..."](https://github.com/langfuse/langfuse/commit/787e20840fc2f0e3b7e1c776cc10a4b4c4c3e0e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41353874)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->