### PR TITLE
fix(search-bar): keep caret in filter on operator pick; blank value stays unarmed (LFE-10501)

### DIFF
--- a/web/src/features/search-bar/components/SearchComposer.tsx
+++ b/web/src/features/search-bar/components/SearchComposer.tsx
@@ -25,13 +25,13 @@ import {
   deriveComposerSegments,
   type ComposerSegment,
 } from "@/src/features/search-bar/lib/composer-segments";
-import { serializeValue, termAt } from "@/src/features/search-bar/lib/langQ";
 import {
   scoreTypeContextFromObserved,
   type ObservedOptions,
 } from "@/src/features/search-bar/lib/observed-options";
 import { getRecentSearches } from "@/src/features/search-bar/lib/recent-searches";
 import {
+  applyPick,
   flattenOptions,
   planInputCompletions,
   type CompletionOption,
@@ -756,76 +756,18 @@ export function SearchComposer({
         return;
       }
 
-      const current = draftRef.current;
-      let insert: string;
-      let keepOpen: boolean;
-      let replaceFrom = currentPlan.from;
-      let replaceTo = currentPlan.to;
-      if (option.kind === "field") {
-        // Replacing the key of an existing filter: the span ends AT the colon,
-        // so the insert must not bring its own.
-        const colonFollows = current.slice(currentPlan.to).startsWith(":");
-        insert = option.fieldId.endsWith(".")
-          ? option.fieldId
-          : colonFollows
-            ? option.fieldId
-            : `${option.fieldId}:`;
-        keepOpen = true;
-        // A dot-prefix field (`metadata.`/`scores.`/`traceScores.`) is itself a
-        // partial key. When an existing `:value` follows the replaced key, the
-        // bare prefix would splice in front of it (`meta:foo` -> broken
-        // `metadata.:foo`). Consume the whole term so the user re-picks the key
-        // from observed options instead.
-        if (option.fieldId.endsWith(".") && colonFollows) {
-          replaceTo = termAt(current, currentPlan.from)?.to ?? currentPlan.to;
-        }
-      } else if (option.kind === "value") {
-        insert = serializeValue(option.value);
-        keepOpen = currentPlan.keepOpenOnPick ?? false;
-      } else {
-        insert = option.insert;
-        // A scope rewrite carries its own span (the whole coalesced free-text
-        // run), so it replaces that, not just the token under the caret.
-        if (option.kind === "pattern" && option.replaceSpan) {
-          replaceFrom = option.replaceSpan.from;
-          replaceTo = option.replaceSpan.to;
-        }
-        // A trailing `:`, ` `, or `(` drops the caret into an interactive
-        // context (value stage, next field, or an open array group like
-        // `tags:(`) — keep the popover open so the next pick is immediate.
-        keepOpen =
-          option.insert.endsWith(":") ||
-          option.insert.endsWith(" ") ||
-          option.insert.endsWith("(");
-      }
-
-      // A pick that COMPLETES a filter token — a value (`name:checkout`) or a
-      // ready-to-run suggestion (`level:DEFAULT`) — and sits at the END of the
-      // draft advances to a fresh token: append a trailing space, drop the caret
-      // AFTER it (OUTSIDE the just-completed pill), and reopen field suggestions
-      // for the next filter, instead of leaving the caret inside the pill where
-      // typing would edit what was just picked. Picks that invite more input (a
-      // bare `field:` key, a `metadata.` prefix, an open `tags:(` group), grouped
-      // value entry, and mid-query edits (non-whitespace follows) stay put.
-      const grouped = currentPlan.keepOpenOnPick ?? false;
-      const invitesMoreInput =
-        option.kind === "field" || // a `field:` key always needs a value next
-        insert.endsWith(":") ||
-        insert.endsWith(" ") ||
-        insert.endsWith("(");
-      const completesFilterAtEnd =
-        !grouped &&
-        !invitesMoreInput &&
-        current.slice(replaceTo).trim().length === 0;
-      if (completesFilterAtEnd) {
-        insert += " ";
-        // Consume any existing trailing whitespace so the space never doubles.
-        replaceTo = current.length;
-        keepOpen = true;
-      }
-
-      const next = replaceRange(current, replaceFrom, replaceTo, insert);
-      const caretAt = replaceFrom + insert.length;
+      // The pure text/caret computation — insert, caret placement, and whether
+      // to keep the popover open — lives in `applyPick` (unit-tested). A pick
+      // that COMPLETES a filter at the END of the draft appends a trailing space
+      // and drops the caret OUTSIDE the pill (next-filter affordance); a pick
+      // that INVITES MORE INPUT (a `field:` key, a `metadata.` prefix, an open
+      // `tags:(` group, a comparison/logical operator awaiting its value) keeps
+      // the caret in place.
+      const {
+        next,
+        caret: caretAt,
+        keepOpen,
+      } = applyPick(option, draftRef.current, currentPlan);
       setDraftWithSelection(next, caretAt);
       setAutocompleteOpen(keepOpen);
       setHighlightedOptionId(null);

--- a/web/src/features/search-bar/lib/completions.clienttest.ts
+++ b/web/src/features/search-bar/lib/completions.clienttest.ts
@@ -1,4 +1,5 @@
 import {
+  applyPick,
   flattenOptions,
   planInputCompletions,
   SECTION_COMPARE_OPS,
@@ -6,6 +7,7 @@ import {
   SECTION_MATCH_OPS,
   SECTION_RECENT,
   SECTION_VALUES,
+  type CompletionOption,
   type InputCompletionContext,
 } from "@/src/features/search-bar/lib/completions";
 import type { ObservedOptions } from "@/src/features/search-bar/lib/observed-options";
@@ -101,6 +103,51 @@ describe("planInputCompletions", () => {
     ).map((o) => o.label);
     expect(labels).toContain("*chat*"); // contains (the bare-value default)
     expect(labels).toContain("=chat"); // exact
+  });
+
+  it("keeps a whitespace-only value an unarmed plain list (space inside empty quotes)", () => {
+    // LFE-10501 BUG B. `-traceName:""` with the caret between the quotes lists
+    // observed values as a PLAIN, unarmed list — Enter commits the query, not a
+    // value. Typing a space between the quotes (`-traceName:" "`) must NOT flip
+    // that into an armed, committable value: a lone space matched every value
+    // that CONTAINS a space and auto-highlighted the first, so Enter yielded an
+    // unwanted `-traceName:"Codex Turn"`.
+    const observed = {
+      ...OBSERVED,
+      traceName: [{ value: "Codex Turn" }, { value: "Other Trace" }],
+    };
+    // Empty quotes, caret between them — the baseline "just a list" state.
+    const empty = plan('-traceName:""', 12, { observed });
+    expect(empty?.stage).toBe("value");
+    expect(empty?.autoHighlight ?? false).toBe(false);
+    expect(
+      flattenOptions(empty).some((o) => o.kind === "value" && o.active),
+    ).toBe(false);
+
+    // A space between the quotes, caret after it — must stay the same plain list.
+    const spaced = plan('-traceName:" "', 13, { observed });
+    expect(spaced?.stage).toBe("value");
+    expect(spaced?.autoHighlight ?? false).toBe(false);
+    const values = flattenOptions(spaced).filter((o) => o.kind === "value");
+    // Full observed list still offered for browsing, but nothing armed/active.
+    expect(values.map((o) => o.kind === "value" && o.value)).toEqual([
+      "Codex Turn",
+      "Other Trace",
+    ]);
+    expect(values.some((o) => o.kind === "value" && o.active)).toBe(false);
+    // A lone space must not wrap into match-op refinements (`*" "*`) either.
+    expect(spaced?.sections.map((s) => s.title) ?? []).not.toContain(
+      SECTION_MATCH_OPS,
+    );
+  });
+
+  it("still arms Enter for a real typed value prefix (space fix keeps normal typing)", () => {
+    // Guard on the BUG B fix: only empty/whitespace-only values go unarmed. A
+    // real prefix (`ER`) still ranks + arms Enter-to-complete.
+    const p = plan("level:ER", 8);
+    expect(p?.autoHighlight).toBe(true);
+    const first = flattenOptions(p).find((o) => o.kind === "value");
+    expect(first).toMatchObject({ kind: "value", value: "ERROR" });
   });
 
   it("marks a complete typed value active without arming Enter", () => {
@@ -503,5 +550,77 @@ describe("planInputCompletions", () => {
     const p = plan("O", 1);
     const operators = flattenOptions(p).filter((o) => o.kind === "operator");
     expect(operators.map((o) => o.label)).not.toContain("OR");
+  });
+});
+
+describe("applyPick", () => {
+  // Narrowing helper: the popover only picks non-recent options here.
+  const nonRecent = (o: CompletionOption | undefined) =>
+    o as Exclude<CompletionOption, { kind: "recent" }>;
+
+  it("keeps the caret INSIDE the block after picking a numeric operator", () => {
+    // LFE-10501 BUG A. Picking `>` for a numeric field must not append a
+    // trailing space and jump the caret outside the filter — an operator
+    // invites the value next, so the caret stays right after the symbol and the
+    // next keystroke types the number into `latency:>`.
+    const p = plan("latency:", 8);
+    const gt = flattenOptions(p).find(
+      (o) => o.kind === "operator" && o.label === ">",
+    );
+    expect(gt).toBeDefined();
+    const result = applyPick(nonRecent(gt), "latency:", p!);
+    expect(result.next).toBe("latency:>"); // no trailing space appended
+    expect(result.caret).toBe(9); // caret sits right after `>`, inside the block
+  });
+
+  it("keeps the caret inside the block for datetime operators too", () => {
+    const p = plan("startTime:", 10);
+    const gte = flattenOptions(p).find(
+      (o) => o.kind === "operator" && o.label === ">=",
+    );
+    expect(gte).toBeDefined();
+    const result = applyPick(nonRecent(gte), "startTime:", p!);
+    expect(result.next).toBe("startTime:>=");
+    expect(result.caret).toBe(12);
+  });
+
+  it("keeps the caret inside a score-path block for its comparison operators", () => {
+    const q = "scores.accuracy:";
+    const p = plan(q, q.length);
+    const lt = flattenOptions(p).find(
+      (o) => o.kind === "operator" && o.label === "<",
+    );
+    expect(lt).toBeDefined();
+    const result = applyPick(nonRecent(lt), q, p!);
+    expect(result.next).toBe(`${q}<`);
+    expect(result.caret).toBe(q.length + 1);
+  });
+
+  it("still appends a trailing space + jumps out when a VALUE completes the filter at end", () => {
+    // Guard: the operator fix must not disturb the completes-at-end affordance
+    // for value picks — `level:` + ERROR still lands `level:ERROR ` with the
+    // caret AFTER the trailing space so the next filter starts outside the pill.
+    const p = plan("level:", 6);
+    const err = flattenOptions(p).find(
+      (o) => o.kind === "value" && o.value === "ERROR",
+    );
+    expect(err).toBeDefined();
+    const result = applyPick(nonRecent(err), "level:", p!);
+    expect(result.next).toBe("level:ERROR ");
+    expect(result.caret).toBe(12);
+    expect(result.keepOpen).toBe(true);
+  });
+
+  it("keeps the caret put for an AND/NOT connective (trailing space already inserted)", () => {
+    // AND/NOT already carry their own trailing space, so they were never the
+    // BUG A case — assert the operator clause leaves them unchanged.
+    const p = plan("level:ERROR N", 13);
+    const not = flattenOptions(p).find(
+      (o) => o.kind === "operator" && o.label === "NOT",
+    );
+    expect(not).toBeDefined();
+    const result = applyPick(nonRecent(not), "level:ERROR N", p!);
+    expect(result.next).toBe("level:ERROR NOT ");
+    expect(result.caret).toBe("level:ERROR NOT ".length);
   });
 });

--- a/web/src/features/search-bar/lib/completions.ts
+++ b/web/src/features/search-bar/lib/completions.ts
@@ -1082,9 +1082,17 @@ export function planInputCompletions(
   // Drop quotes so the typed text matches observed values (both the grouped
   // and non-grouped value segments go through the same helper). For a glob
   // value the typed text is the bare core inside the `*`s.
-  const typed = stripValueQuotes(
+  const typedRaw = stripValueQuotes(
     glob !== null ? glob.core : activeValueText.slice(valuePrefix.length),
   );
+  // An empty OR whitespace-only value is "no value typed yet": normalize it to
+  // "" so the value stage stays a plain, unarmed list — no active value, no
+  // autoHighlight, no match-op refinements. Without this, a lone space typed
+  // between empty quotes (`traceName:" "`) ranked every observed value that
+  // CONTAINS a space and armed the first for Enter, committing an unwanted
+  // value (LFE-10501 BUG B). A value with real content plus surrounding spaces
+  // (`"foo "`) still counts as typed.
+  const typed = typedRaw.trim().length === 0 ? "" : typedRaw;
   const groupedPlanAttrs =
     grouped === null ? {} : { keepOpenOnPick: !grouped.completeGroup };
 
@@ -1124,6 +1132,94 @@ export function planInputCompletions(
     sections: staged.sections,
     ...groupedPlanAttrs,
   };
+}
+
+/**
+ * Apply a picked completion option to the draft — the pure text/caret half of
+ * the composer's `pickOption` (the composer keeps the DOM/selection side
+ * effects and the whole-query `recent` replacement, which is why `recent` is
+ * excluded here). Returns the rewritten draft, the caret offset to place inside
+ * it, and whether the popover should stay open.
+ *
+ * The classification is the crux: an option that INVITES MORE INPUT leaves the
+ * caret where it lands — a `field:` key awaiting a value, a `metadata.` prefix,
+ * an open `tags:(` group, and a comparison/logical OPERATOR awaiting its value.
+ * An option that COMPLETES a filter at the END of the draft appends a trailing
+ * space and drops the caret AFTER it (outside the finished pill), reopening
+ * field suggestions for the next filter.
+ */
+export function applyPick(
+  option: Exclude<CompletionOption, { kind: "recent" }>,
+  current: string,
+  plan: CompletionPlan,
+): { next: string; caret: number; keepOpen: boolean } {
+  let insert: string;
+  let keepOpen: boolean;
+  let replaceFrom = plan.from;
+  let replaceTo = plan.to;
+  if (option.kind === "field") {
+    // Replacing the key of an existing filter: the span ends AT the colon, so
+    // the insert must not bring its own.
+    const colonFollows = current.slice(plan.to).startsWith(":");
+    insert = option.fieldId.endsWith(".")
+      ? option.fieldId
+      : colonFollows
+        ? option.fieldId
+        : `${option.fieldId}:`;
+    keepOpen = true;
+    // A dot-prefix field (`metadata.`/`scores.`/`traceScores.`) is itself a
+    // partial key. When an existing `:value` follows, consume the whole term so
+    // the user re-picks the key from observed options instead.
+    if (option.fieldId.endsWith(".") && colonFollows) {
+      replaceTo = termAt(current, plan.from)?.to ?? plan.to;
+    }
+  } else if (option.kind === "value") {
+    insert = serializeValue(option.value);
+    keepOpen = plan.keepOpenOnPick ?? false;
+  } else {
+    insert = option.insert;
+    // A scope rewrite carries its own span (the whole coalesced free-text run),
+    // so it replaces that, not just the token under the caret.
+    if (option.kind === "pattern" && option.replaceSpan) {
+      replaceFrom = option.replaceSpan.from;
+      replaceTo = option.replaceSpan.to;
+    }
+    // A trailing `:`, ` `, or `(` drops the caret into an interactive context
+    // (value stage, next field, or an open `tags:(` group) — keep the popover
+    // open so the next pick is immediate.
+    keepOpen =
+      option.insert.endsWith(":") ||
+      option.insert.endsWith(" ") ||
+      option.insert.endsWith("(");
+  }
+
+  const grouped = plan.keepOpenOnPick ?? false;
+  const invitesMoreInput =
+    option.kind === "field" || // a `field:` key always needs a value next
+    // A comparison (`>`, `>=`, …) or logical (AND/NOT) OPERATOR awaits its
+    // value next, so keep the caret in the block instead of appending a space
+    // and jumping outside it. Without this, a `latency:` → `>` pick landed
+    // `latency:> ` with the caret after the space, so the number typed OUTSIDE
+    // the filter (LFE-10501 BUG A). AND/NOT already carry a trailing space, so
+    // this only changes the value-stage comparison operators.
+    option.kind === "operator" ||
+    insert.endsWith(":") ||
+    insert.endsWith(" ") ||
+    insert.endsWith("(");
+  const completesFilterAtEnd =
+    !grouped &&
+    !invitesMoreInput &&
+    current.slice(replaceTo).trim().length === 0;
+  if (completesFilterAtEnd) {
+    insert += " ";
+    // Consume any existing trailing whitespace so the space never doubles.
+    replaceTo = current.length;
+    keepOpen = true;
+  }
+
+  const next =
+    current.slice(0, replaceFrom) + insert + current.slice(replaceTo);
+  return { next, caret: replaceFrom + insert.length, keepOpen };
 }
 
 /** Flat option list in render order (keyboard navigation walks this). */


### PR DESCRIPTION
## TL;DR

Two autocomplete papercuts in the events search bar: picking a numeric/date **operator** then pressing Enter jumped the caret **out** of the filter block, and typing a **space between empty quotes** silently armed a random observed value for commit. Both fixed; the composer's pick logic is now a unit-tested pure function.

## Why (LFE-10501)

- **A — operator pick + Enter escapes the block.** On numeric/datetime fields the bar suggests operators (`>`, `>=`, …). Picking one landed `latency:> ` with the caret **after a trailing space, outside the block** — so the next keystroke typed the number *outside* the filter instead of building `latency:>500`.
- **B — space in empty quotes auto-selects a value.** With `-name:""` (or `-traceName:""`) and the caret between the quotes, pressing **space** flipped the value list from a plain, browsable list into an **armed, committable** one: a lone space matched every observed value *containing* a space, so Enter committed an unwanted value (e.g. `-name:"Agent workflow"`).

## What

- **A.** An operator pick now counts as *inviting more input* (like a `field:` key or an open `tags:(` group): it keeps the caret in the block and does not append a trailing space / mark the filter complete. AND/NOT already carried their own trailing space, so only the value-stage comparisons change.
- **B.** An empty **or whitespace-only** value is treated as "no value yet" — plain list, nothing active/armed, no match-op refinements. A value with real content plus surrounding spaces (`"foo "`) still counts as typed.
- Extracted the composer's pure pick text/caret computation into `applyPick` and added client coverage for both defects (the ~1.3k-LOC contenteditable controller had none for this path).

## Result

Verified live in the browser on the v4 observations table:

- `latency:` → pick `>` → caret stays at `latency:>|` → type `500` → `latency:>500` → Enter → `latency > 500` applied.
- `-name:""` caret between quotes → 0 armed; press space → `-name:" "`, still 0 armed; Enter does **not** insert an observed value.
- Normal typing unaffected: `level:ERR` still ranks + arms `ERROR` for Enter.

<details>
<summary>Mechanism &amp; tests</summary>

- **A** lived in the pick classifier: an operator insert ends with no `:`/space/`(`, so `invitesMoreInput` was false and `completesFilterAtEnd` appended a space + extended `replaceTo` to end-of-draft, placing the caret outside the token. Fix: add `option.kind === "operator"` to `invitesMoreInput`.
- **B** lived in value planning: `stripValueQuotes('" "')` → `" "`, which `rankFilter` matched against every value containing a space and `autoHighlight` then armed. Fix: normalize a whitespace-only typed value to `""` at the source in `planInputCompletions`, so every downstream empty-value path (list, match-ops, autoHighlight) applies uniformly.
- Tests: `completions.clienttest.ts` — `applyPick` caret assertions for numeric/datetime/score operators (plus AND/NOT and value-completes-at-end guards) and a `planInputCompletions` case for space-in-empty-quotes (plus a real-prefix-still-arms guard). All 185 search-bar client tests pass; lint + typecheck clean.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two autocomplete bugs in the search bar (LFE-10501): picking a comparison operator (`>`, `>=`, etc.) was jumping the caret outside the filter block due to a missing `operator` guard in the `invitesMoreInput` classification, and typing a space between empty quotes was silently arming an observed value for commit because whitespace-only typed text was not normalized to empty.

- **Bug A (operator pick)**: `applyPick` now treats `option.kind === "operator"` as `invitesMoreInput = true`, preventing the trailing space + `completesFilterAtEnd` path that was placing the caret after the space and outside the token.
- **Bug B (space in empty quotes)**: `planInputCompletions` normalizes `typed` to `""` when `typedRaw.trim()` is empty, keeping the value-stage list plain and unarmed.
- The inline pick logic from `SearchComposer.tsx` was extracted into a pure, exported `applyPick` function in `completions.ts`, and new unit tests were added covering both defects and their guard cases.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the changes are narrowly scoped to two autocomplete papercuts, the extracted `applyPick` function is logic-equivalent to the code it replaces, and both bug scenarios are covered by new unit tests.

The refactoring moves pure text/caret computation into a well-tested function without touching the DOM or state layers. Both fixes are one-liners in terms of semantic change (one guard added to `invitesMoreInput`, one whitespace normalization), and all 185 existing tests continue to pass alongside the five new assertions. No regressions were introduced in adjacent paths (AND/NOT connectives, value completes-at-end, dot-prefix field picks).

No files require special attention. `completions.ts` carries the entire behavioral change and is the most important file to re-read, but the logic is clearly commented and tested.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pickOption called] --> B{option.kind?}
    B -- recent --> C[Replace full draft, commit, close popover]
    B -- field/value/operator/pattern/... --> D[applyPick]

    D --> E{option.kind}
    E -- field --> F[insert = fieldId or fieldId:, keepOpen = true]
    E -- value --> G[insert = serializeValue, keepOpen = plan.keepOpenOnPick]
    E -- operator / pattern / other --> H[insert = option.insert
keepOpen = ends with : or space or open-paren]

    F & G & H --> I{invitesMoreInput?}
    I -- field / operator / insert ends with :, space, or open-paren --> J[invitesMoreInput = true]
    I -- none of the above --> K[invitesMoreInput = false]

    J --> L[completesFilterAtEnd = false
No trailing space appended]
    K --> M{grouped or text follows?}
    M -- yes --> L
    M -- no: at end of draft --> N[append trailing space
replaceTo = current.length
keepOpen = true]

    L & N --> O[return next draft, caret, keepOpen]
    O --> P[setDraftWithSelection
setAutocompleteOpen
commitStructuredEdit]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pickOption called] --> B{option.kind?}
    B -- recent --> C[Replace full draft, commit, close popover]
    B -- field/value/operator/pattern/... --> D[applyPick]

    D --> E{option.kind}
    E -- field --> F[insert = fieldId or fieldId:, keepOpen = true]
    E -- value --> G[insert = serializeValue, keepOpen = plan.keepOpenOnPick]
    E -- operator / pattern / other --> H[insert = option.insert
keepOpen = ends with : or space or open-paren]

    F & G & H --> I{invitesMoreInput?}
    I -- field / operator / insert ends with :, space, or open-paren --> J[invitesMoreInput = true]
    I -- none of the above --> K[invitesMoreInput = false]

    J --> L[completesFilterAtEnd = false
No trailing space appended]
    K --> M{grouped or text follows?}
    M -- yes --> L
    M -- no: at end of draft --> N[append trailing space
replaceTo = current.length
keepOpen = true]

    L & N --> O[return next draft, caret, keepOpen]
    O --> P[setDraftWithSelection
setAutocompleteOpen
commitStructuredEdit]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search-bar): operator pick keeps car..."](https://github.com/langfuse/langfuse/commit/70f86cc7c8e0b6eaef71cae6eff5ee5b53bc7ddc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41354112)</sub>

<!-- /greptile_comment -->