### PR TITLE
fix(trace): comfortable peek defaults, unify inner-split persistence (LFE-10601)

### DIFF
--- a/web/src/components/table/peek/README.md
+++ b/web/src/components/table/peek/README.md
@@ -53,6 +53,23 @@ State altitudes:
 | resize drag | high-frequency transient        | store `draftFraction` / `draftExpanded` / `isResizing`, committed on pointer-up                            |
 | which item  | route                           | the `peek` URL param (see below)                                                                           |
 
+The **default** width (no saved preference) is viewport-aware: 50vw, but capped
+in px (`PEEK_MAX_DEFAULT_WIDTH_PX`) so a bigger screen doesn't mean a
+proportionally bigger peek (LFE-10601). Normal laptops still open at 50vw; only
+very wide monitors trim the fraction so the peek stays comfortable and the list
+navigable.
+
+The **inner tree ↔ info split** inside the peek is a separate
+`react-resizable-panels` group (`TraceLayoutDesktop`), unified with the width to
+persist in **`localStorage`** under a peek-scoped group id (`trace-layout-peek-*`)
+rather than per-tab `sessionStorage`. Its default is computed as an explicit
+**percentage** from the width the peek opens at: the info panel gets a
+comfortable target and the tree/timeline takes the remainder, clamped to a
+comfortable band — so extra width on a big peek flows to info (the content), not
+the tree (the index). A percentage (not a px `defaultSize`, which the library
+resolves against a transient mid-open width) keeps that default deterministic.
+The full-page trace view keeps its own share-based, per-tab layout.
+
 The peek and the standalone trace page already share one beta-aware fetch
 ([`../../trace/useTraceDetailData.ts`](../../trace/useTraceDetailData.ts)), one
 body + title

--- a/web/src/components/table/peek/store/peekPanelStore.clienttest.ts
+++ b/web/src/components/table/peek/store/peekPanelStore.clienttest.ts
@@ -3,14 +3,36 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createPeekPanelStore,
   PEEK_DEFAULT_WIDTH_FRACTION,
+  PEEK_MAX_DEFAULT_WIDTH_PX,
   PEEK_MAX_WIDGET_WIDTH_FRACTION,
   PEEK_MIN_WIDTH_FRACTION,
+  resolveDefaultWidthFraction,
   selectDraftExpanded,
   selectWidgetWidth,
 } from "@/src/components/table/peek/store/peekPanelStore";
 
 const STORAGE_KEY = "peekViewWidthFraction";
 const pct = (fraction: number) => `${fraction * 100}vw`;
+
+// jsdom's default innerWidth is 1024; override per-test to exercise the
+// viewport-aware default, then restore.
+function withViewportWidth(width: number, run: () => void) {
+  const original = window.innerWidth;
+  Object.defineProperty(window, "innerWidth", {
+    value: width,
+    configurable: true,
+    writable: true,
+  });
+  try {
+    run();
+  } finally {
+    Object.defineProperty(window, "innerWidth", {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  }
+}
 
 describe("peekPanelStore", () => {
   beforeEach(() => window.localStorage.clear());
@@ -23,6 +45,48 @@ describe("peekPanelStore", () => {
     expect(state.draftExpanded).toBe(false);
     expect(state.widthFraction).toBeCloseTo(PEEK_DEFAULT_WIDTH_FRACTION);
     expect(selectWidgetWidth(state)).toBe(pct(PEEK_DEFAULT_WIDTH_FRACTION));
+  });
+
+  describe("default width caps px growth on wide screens (LFE-10601)", () => {
+    it("keeps 50vw on a normal laptop where 50vw is under the px cap", () => {
+      withViewportWidth(1440, () => {
+        expect(resolveDefaultWidthFraction()).toBeCloseTo(
+          PEEK_DEFAULT_WIDTH_FRACTION,
+        );
+        expect(createPeekPanelStore().getState().widthFraction).toBeCloseTo(
+          PEEK_DEFAULT_WIDTH_FRACTION,
+        );
+      });
+    });
+
+    it("trims the fraction on a wide screen so the peek stays near the px cap", () => {
+      // 3000px: 50vw = 1500px > cap → fraction shrinks so width ≈ cap.
+      withViewportWidth(3000, () => {
+        const fraction = resolveDefaultWidthFraction();
+        expect(fraction).toBeLessThan(PEEK_DEFAULT_WIDTH_FRACTION);
+        expect(fraction * 3000).toBeCloseTo(PEEK_MAX_DEFAULT_WIDTH_PX, 0);
+        expect(createPeekPanelStore().getState().widthFraction).toBeCloseTo(
+          fraction,
+        );
+      });
+    });
+
+    it("never falls below the drag minimum, even on an ultra-wide screen", () => {
+      withViewportWidth(6000, () => {
+        expect(resolveDefaultWidthFraction()).toBeCloseTo(
+          PEEK_MIN_WIDTH_FRACTION,
+        );
+      });
+    });
+
+    it("a saved preference always wins over the viewport-aware default", () => {
+      withViewportWidth(3000, () => {
+        window.localStorage.setItem(STORAGE_KEY, "0.5");
+        expect(createPeekPanelStore().getState().widthFraction).toBeCloseTo(
+          0.5,
+        );
+      });
+    });
   });
 
   it("reads and clamps the persisted width on creation", () => {

--- a/web/src/components/table/peek/store/peekPanelStore.ts
+++ b/web/src/components/table/peek/store/peekPanelStore.ts
@@ -31,26 +31,51 @@ export const PEEK_DEFAULT_WIDTH_FRACTION = 0.5;
 export const PEEK_EXPAND_ENTER_FRACTION = 0.95;
 const KEYBOARD_RESIZE_STEP = 0.05;
 
+// Cap the *default* peek width in px so a bigger screen doesn't mean a
+// proportionally bigger peek (LFE-10601): at 50vw the peek balloons on large
+// monitors, covering the table and — with a share-based inner split — inflating
+// the tree. We keep 50vw on normal laptops (where 50vw < this cap) and only trim
+// the fraction on very wide screens, giving a comfortable-but-bounded default
+// that still leaves the underlying list navigable. The floor is the drag min so
+// the default never lands narrower than the user could drag back to.
+export const PEEK_MAX_DEFAULT_WIDTH_PX = 1400;
+
 export const clampWidthFraction = (fraction: number) =>
   Math.min(
     PEEK_MAX_WIDGET_WIDTH_FRACTION,
     Math.max(PEEK_MIN_WIDTH_FRACTION, fraction),
   );
 
-// Cross-view width preference, persisted as a raw fraction. SSR-safe: reads the
-// default on the server and the first client render, the real value after mount.
-function readStoredWidthFraction(): number {
+// Default width when the user has no saved preference. Viewport-aware: the plain
+// 50vw fraction, but capped so the resulting px never exceeds
+// PEEK_MAX_DEFAULT_WIDTH_PX, then floored at the drag minimum. SSR-safe (returns
+// the plain fraction when there's no window).
+export function resolveDefaultWidthFraction(): number {
+  const vw = typeof window === "undefined" ? 0 : window.innerWidth;
+  if (vw <= 0) return PEEK_DEFAULT_WIDTH_FRACTION;
+  return Math.max(
+    PEEK_MIN_WIDTH_FRACTION,
+    Math.min(PEEK_DEFAULT_WIDTH_FRACTION, PEEK_MAX_DEFAULT_WIDTH_PX / vw),
+  );
+}
+
+// The width fraction that will actually be used to open the peek: the saved
+// preference (clamped) if present, else the viewport-aware default. SSR-safe
+// (returns the plain default when there's no window). Exported so the inner
+// tree↔info split can size its default against the real peek width without
+// re-measuring the DOM.
+export function resolveEffectiveWidthFraction(): number {
   if (typeof window === "undefined") return PEEK_DEFAULT_WIDTH_FRACTION;
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (raw === null) return PEEK_DEFAULT_WIDTH_FRACTION;
-    const parsed = JSON.parse(raw);
-    return typeof parsed === "number"
-      ? clampWidthFraction(parsed)
-      : PEEK_DEFAULT_WIDTH_FRACTION;
+    if (raw !== null) {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed === "number") return clampWidthFraction(parsed);
+    }
   } catch {
-    return PEEK_DEFAULT_WIDTH_FRACTION;
+    // Fall through to the default on any read/parse failure.
   }
+  return resolveDefaultWidthFraction();
 }
 
 function writeStoredWidthFraction(fraction: number): void {
@@ -90,7 +115,7 @@ export type PeekPanelStore = StoreApi<PeekPanelStoreState>;
 
 export function createPeekPanelStore(): PeekPanelStore {
   return createStore<PeekPanelStoreState>((set, get) => ({
-    widthFraction: readStoredWidthFraction(),
+    widthFraction: resolveEffectiveWidthFraction(),
     draftFraction: null,
     draftExpanded: false,
     isResizing: false,

--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -11,6 +11,7 @@ import {
 import {
   useState,
   useEffect,
+  useMemo,
   createContext,
   useContext,
   type ReactNode,
@@ -20,13 +21,54 @@ import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
 import { useViewPreferences } from "@/src/components/trace/contexts/ViewPreferencesContext";
 import { useSelection } from "@/src/components/trace/contexts/SelectionContext";
+import { resolveEffectiveWidthFraction } from "@/src/components/table/peek/store/peekPanelStore";
 
-// v2: the default split now gives the trace (tree/timeline) the central space
-// with a slimmer detail panel. Bumped so a stale saved layout doesn't mask it.
+// v2: the default split gives the trace (tree/timeline) the central space with a
+// slimmer detail panel. Bumped so a stale saved layout doesn't mask it. Used by
+// the full-page trace view; the peek uses its own id/storage/default (below).
 const RESIZABLE_PANEL_GROUP_ID = "trace-layout-v2";
+// Peek gets a distinct group so its computed-percentage default and localStorage
+// persistence don't leak into the full-page view (which stays share-based, per
+// tab). Same panels, different layout scope (LFE-10601).
+const PEEK_RESIZABLE_PANEL_GROUP_ID = "trace-layout-peek-v1";
 const RESIZABLE_PANEL_HANDLE_ID = "trace-layout-handle";
 const RESIZABLE_PANEL_NAVIGATION_ID = "trace-layout-panel-navigation";
 const RESIZABLE_PANEL_PREVIEW_ID = "trace-layout-panel-preview";
+
+// Full-page default (unchanged): a share-based split — tree gets the majority.
+const FULL_NAVIGATION_DEFAULT_SIZE = "60%";
+const FULL_DETAIL_DEFAULT_SIZE = "40%";
+
+// Peek default split (LFE-10601). We size the tree/timeline (the index) to a
+// comfortable band and give the *rest* to the detail panel (the content), so on
+// a wide peek the extra width flows to info, not the tree — killing the old
+// "very wide tree, cramped info" that the 60/40 share produced on big screens.
+//
+// We express this as an explicit *percentage* layout computed from the known
+// peek width, NOT as a px `defaultSize`. The library converts a px defaultSize
+// to a percentage against whatever group width it happens to measure first,
+// which on a peek is a transient mid-open value — so the resolved ratio (and
+// thus what gets persisted) was non-deterministic. A percentage is
+// width-independent, so the default is stable across opens.
+const PEEK_INFO_COMFORTABLE_TARGET_PX = 560; // info wants ~this to read JSON/scores
+const PEEK_NAV_COMFORTABLE_MIN_PX = 340; // tree's comfortable floor (> the 260 hard min)
+const PEEK_NAV_COMFORTABLE_MAX_PX = 460; // never default the tree wider than this
+
+// Tree/info split (as a nav-panel percentage) for a peek of `peekWidthPx`: give
+// info its comfortable target, hand the remainder to the tree clamped to its
+// comfortable band. Returns undefined when the width is unknown (SSR).
+function computePeekNavPercent(peekWidthPx: number): number | undefined {
+  if (!(peekWidthPx > 0)) return undefined;
+  const navPx = Math.min(
+    PEEK_NAV_COMFORTABLE_MAX_PX,
+    Math.max(
+      PEEK_NAV_COMFORTABLE_MIN_PX,
+      peekWidthPx - PEEK_INFO_COMFORTABLE_TARGET_PX,
+    ),
+  );
+  // Keep it a sane share; the panels' own min/collapse constraints do the rest.
+  return Math.min(90, Math.max(10, (navPx / peekWidthPx) * 100));
+}
 
 // Min widths of the two collapsible panels (kept here so the Panel props and the
 // toggle/scroll logic below can't drift apart).
@@ -91,6 +133,12 @@ interface TraceLayoutDesktopContext {
   isDetailPanelCollapsed: boolean;
   setIsDetailPanelCollapsed: (collapsed: boolean) => void;
   expandDetailPanel: () => void;
+  // Fallback panel sizes (peek is driven by the computed-percentage
+  // `defaultLayout`; these apply only when it's absent, e.g. the full-page view
+  // or SSR). Detail is `undefined` when nav carries the sole default so it
+  // auto-fills the remainder.
+  navigationDefaultSize: string;
+  detailDefaultSize: string | undefined;
 }
 
 const LayoutContext = createContext<TraceLayoutDesktopContext | null>(null);
@@ -121,20 +169,56 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
   const [viewMode] = useQueryParam("view", StringParam);
   const isTimelineView = viewMode === "timeline";
 
-  // Get annotation mode from context to determine initial collapse state
-  const { isAnnotationMode } = useViewPreferences();
+  // Get annotation mode + peek mode from context. Peek scopes the layout to its
+  // own group so its px-anchored default + cross-session persistence stay out of
+  // the full-page view (LFE-10601).
+  const { isAnnotationMode, isPeekMode } = useViewPreferences();
 
-  // Restored (sessionStorage) layout for this group. Read before the collapse
-  // flags so we can seed them from what the library is about to restore on
-  // mount — otherwise the first render derives `bothPanelsOpen` purely from the
-  // useState defaults (open), pins the group to 621px even when a persisted
-  // layout has a panel on its 40px rail, and a narrow peek flashes a useless
-  // horizontal scrollbar until the Panel's onResize corrects the flag a frame
-  // later.
+  const groupId = isPeekMode
+    ? PEEK_RESIZABLE_PANEL_GROUP_ID
+    : RESIZABLE_PANEL_GROUP_ID;
+  // Unify the peek's persistence with its outer width: both live in
+  // localStorage, so a resized tree/info ratio sticks across tabs and reloads
+  // instead of resetting per tab (the old sessionStorage behavior). The
+  // full-page view keeps its per-tab sessionStorage. Bare globals mirror the
+  // existing pattern — this component is client-only (see the SSR-null gate on
+  // the peek and the mounted trace page).
+  const storage = isPeekMode ? localStorage : sessionStorage;
+
+  // Peek drives its split via an explicit percentage `defaultLayout` (below);
+  // the panel `defaultSize`s are the SSR/fallback only. Full-page keeps its
+  // share-based 60/40. Detail has no default so it fills the remainder there.
+  const navigationDefaultSize = FULL_NAVIGATION_DEFAULT_SIZE;
+  const detailDefaultSize = isPeekMode ? undefined : FULL_DETAIL_DEFAULT_SIZE;
+
+  // Deterministic peek default split, computed once from the width the peek will
+  // actually open at (saved preference or viewport-aware default × viewport).
+  // Only used on first open (no saved layout); memoized so the Group sees a
+  // stable prop. Undefined for the full-page view and during SSR.
+  const peekDefaultLayout = useMemo(() => {
+    if (!isPeekMode || typeof window === "undefined") return undefined;
+    const peekWidthPx = resolveEffectiveWidthFraction() * window.innerWidth;
+    const navPercent = computePeekNavPercent(peekWidthPx);
+    if (navPercent === undefined) return undefined;
+    return {
+      [RESIZABLE_PANEL_NAVIGATION_ID]: navPercent,
+      [RESIZABLE_PANEL_PREVIEW_ID]: 100 - navPercent,
+    };
+    // Depends only on isPeekMode: the width is a mount-time default (a saved
+    // layout wins after first open), so we intentionally don't recompute it as
+    // the viewport changes.
+  }, [isPeekMode]);
+
+  // Restored layout for this group. Read before the collapse flags so we can
+  // seed them from what the library is about to restore on mount — otherwise the
+  // first render derives `bothPanelsOpen` purely from the useState defaults
+  // (open), pins the group to 621px even when a persisted layout has a panel on
+  // its 40px rail, and a narrow peek flashes a useless horizontal scrollbar
+  // until the Panel's onResize corrects the flag a frame later.
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-    id: RESIZABLE_PANEL_GROUP_ID,
+    id: groupId,
     panelIds: [RESIZABLE_PANEL_NAVIGATION_ID, RESIZABLE_PANEL_PREVIEW_ID],
-    storage: sessionStorage,
+    storage,
   });
 
   const [isNavigationPanelCollapsed, setIsNavigationPanelCollapsed] = useState(
@@ -209,8 +293,7 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
           target === "navigation" ? panelRef.current : detailPanelRef.current;
         const siblingPanel =
           target === "navigation" ? detailPanelRef.current : panelRef.current;
-        const groupWidthPx =
-          document.getElementById(RESIZABLE_PANEL_GROUP_ID)?.offsetWidth ?? 0;
+        const groupWidthPx = document.getElementById(groupId)?.offsetWidth ?? 0;
         if (group && panel && groupWidthPx > 0) {
           // Whether the sibling was deliberately collapsed (header toggle, rail
           // button, or dragged onto its 40px rail). If so we keep it there:
@@ -345,6 +428,8 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
     isDetailPanelCollapsed,
     setIsDetailPanelCollapsed,
     expandDetailPanel,
+    navigationDefaultSize,
+    detailDefaultSize,
   };
 
   return (
@@ -359,9 +444,9 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
       <div className="relative h-full w-full overflow-x-auto overflow-y-hidden">
         <Group
           orientation="horizontal"
-          id={RESIZABLE_PANEL_GROUP_ID}
+          id={groupId}
           groupRef={groupRef}
-          defaultLayout={defaultLayout}
+          defaultLayout={defaultLayout ?? peekDefaultLayout}
           onLayoutChanged={isAnnotationMode ? undefined : onLayoutChanged}
           className={bothPanelsOpen ? undefined : "min-w-0"}
           style={
@@ -387,7 +472,8 @@ TraceLayoutDesktop.NavigationPanel = function Navigation({
 }: {
   children: ReactNode;
 }) {
-  const { setIsNavigationPanelCollapsed, panelRef } = useLayoutContext();
+  const { setIsNavigationPanelCollapsed, panelRef, navigationDefaultSize } =
+    useLayoutContext();
 
   return (
     <Panel
@@ -396,7 +482,7 @@ TraceLayoutDesktop.NavigationPanel = function Navigation({
       collapsible={true}
       collapsedSize="40px"
       minSize={`${NAVIGATION_PANEL_MIN_PX}px`}
-      defaultSize="60%"
+      defaultSize={navigationDefaultSize}
       onResize={() => {
         setIsNavigationPanelCollapsed(panelRef.current?.isCollapsed() ?? false);
       }}
@@ -430,6 +516,7 @@ TraceLayoutDesktop.DetailPanel = function Detail({
     setIsDetailPanelCollapsed,
     isDetailPanelCollapsed,
     expandDetailPanel,
+    detailDefaultSize,
   } = useLayoutContext();
 
   return (
@@ -441,7 +528,7 @@ TraceLayoutDesktop.DetailPanel = function Detail({
     <Panel
       id={RESIZABLE_PANEL_PREVIEW_ID}
       panelRef={detailPanelRef}
-      defaultSize="40%"
+      defaultSize={detailDefaultSize}
       collapsible={true}
       collapsedSize="40px"
       minSize={`${DETAIL_PANEL_MIN_PX}px`}

--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -96,29 +96,46 @@ const COLLAPSED_PANEL_PX = 40;
 const BOTH_PANELS_MIN_WIDTH_PX =
   NAVIGATION_PANEL_MIN_PX + DETAIL_PANEL_MIN_PX + RESIZE_HANDLE_PX;
 
+// A no-op layout storage so `useDefaultLayout` never touches a real Storage
+// during SSR / DOM-less tests (its default `= localStorage` is a bare global
+// that would throw). Mirrors the pattern in `ui/resizable-split-layout.tsx`.
+const NOOP_LAYOUT_STORAGE = {
+  getItem: () => null,
+  setItem: () => {},
+};
+
 // Detect whether a panel is sitting on its collapsed rail in a RESTORED layout.
 // `useDefaultLayout` returns a `{ [panelId]: number }` map of flexGrow shares
 // that sum to ~100 (percentages of the group). A collapsed panel is exactly its
 // `collapsedSize` (40px) wide, while an open panel is always at least its
-// `minSize` (260/360px). For any peek width those two ranges never overlap: at
-// the narrowest both-panels-open width (~621px) the 40px rail is ~6% while the
-// smaller open min (nav 260px) is ~42%, and the gap only widens as the group
-// grows. We therefore treat a panel as collapsed-in-layout when its restored
-// share is at most the share its rail would occupy at the narrowest open width,
-// with a margin — comfortably below any open-min share. Used only to seed the
-// collapse flags on mount so `bothPanelsOpen` (and thus the min-width pin)
-// matches the layout the library is about to restore, avoiding a one-frame
-// scrollbar flash (see the useState initializers below).
-const COLLAPSED_LAYOUT_SHARE_MAX_PCT =
-  ((COLLAPSED_PANEL_PX / BOTH_PANELS_MIN_WIDTH_PX) * 100 +
-    (NAVIGATION_PANEL_MIN_PX / BOTH_PANELS_MIN_WIDTH_PX) * 100) /
-  2;
+// `minSize` (260/360px) — or, for the peek's width-capped nav default, ~460px.
+// The rail share and the open share never overlap, but WHERE the boundary sits
+// depends on the group's actual pixel width: a 460px open nav is ~42% at a 621px
+// peek but only ~15% at a 3000px one. So the threshold must be computed against
+// the real width, not a fixed percent — otherwise a legitimately-open (but
+// small-share) nav on a wide peek is mis-seeded as collapsed and its content
+// unmounts for a frame until `onResize` corrects it. Boundary = midpoint between
+// the 40px rail and the smallest open min (nav 260px), as a share of the width.
+const COLLAPSED_RAIL_BOUNDARY_PX =
+  (COLLAPSED_PANEL_PX + NAVIGATION_PANEL_MIN_PX) / 2;
+function collapsedShareMaxForWidth(groupWidthPx: number): number {
+  return (COLLAPSED_RAIL_BOUNDARY_PX / groupWidthPx) * 100;
+}
+// Full-page fallback (its container width isn't known at seed time): the boundary
+// as a share of the narrowest both-open width, matching the prior heuristic.
+const COLLAPSED_LAYOUT_SHARE_MAX_PCT = collapsedShareMaxForWidth(
+  BOTH_PANELS_MIN_WIDTH_PX,
+);
+// Used only to seed the collapse flags on mount so `bothPanelsOpen` (and thus
+// the min-width pin) matches the layout the library is about to restore,
+// avoiding a one-frame scrollbar flash (see the useState initializers below).
 function isPanelCollapsedInLayout(
   layout: Record<string, number> | undefined,
   panelId: string,
+  maxSharePct: number,
 ): boolean {
   const share = layout?.[panelId];
-  return typeof share === "number" && share <= COLLAPSED_LAYOUT_SHARE_MAX_PCT;
+  return typeof share === "number" && share <= maxSharePct;
 }
 
 // Context for sharing panel state with compound components
@@ -180,10 +197,14 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
   // Unify the peek's persistence with its outer width: both live in
   // localStorage, so a resized tree/info ratio sticks across tabs and reloads
   // instead of resetting per tab (the old sessionStorage behavior). The
-  // full-page view keeps its per-tab sessionStorage. Bare globals mirror the
-  // existing pattern — this component is client-only (see the SSR-null gate on
-  // the peek and the mounted trace page).
-  const storage = isPeekMode ? localStorage : sessionStorage;
+  // full-page view keeps its per-tab sessionStorage. Guarded so SSR / DOM-less
+  // tests fall back to a no-op store instead of throwing on the bare global.
+  const storage =
+    typeof window === "undefined"
+      ? NOOP_LAYOUT_STORAGE
+      : isPeekMode
+        ? window.localStorage
+        : window.sessionStorage;
 
   // Peek drives its split via an explicit percentage `defaultLayout` (below);
   // the panel `defaultSize`s are the SSR/fallback only. Full-page keeps its
@@ -191,23 +212,34 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
   const navigationDefaultSize = FULL_NAVIGATION_DEFAULT_SIZE;
   const detailDefaultSize = isPeekMode ? undefined : FULL_DETAIL_DEFAULT_SIZE;
 
-  // Deterministic peek default split, computed once from the width the peek will
-  // actually open at (saved preference or viewport-aware default × viewport).
-  // Only used on first open (no saved layout); memoized so the Group sees a
-  // stable prop. Undefined for the full-page view and during SSR.
+  // The width the peek actually opens at. When expanded (a shared/reloaded
+  // `?peekView=expanded` link) the panel renders at ~viewport width, NOT the
+  // widget fraction — so we must size the split against that, or a first-open
+  // expanded peek on a big screen re-creates the wide-tree bug. The sidebar
+  // offset is ignored (the nav is width-capped at these sizes, so the small
+  // difference doesn't move the split). 0 outside peek / during SSR. Mount-time
+  // default only (a saved layout wins after first open), so it doesn't track
+  // viewport changes.
+  const [peekView] = useQueryParam("peekView", StringParam);
+  const isPeekExpanded = isPeekMode && peekView === "expanded";
+  const peekWidthPx = useMemo(() => {
+    if (!isPeekMode || typeof window === "undefined") return 0;
+    return isPeekExpanded
+      ? window.innerWidth
+      : resolveEffectiveWidthFraction() * window.innerWidth;
+  }, [isPeekMode, isPeekExpanded]);
+
+  // Deterministic peek default split, computed from `peekWidthPx`. Only used on
+  // first open (no saved layout); memoized so the Group sees a stable prop.
+  // Undefined for the full-page view and during SSR.
   const peekDefaultLayout = useMemo(() => {
-    if (!isPeekMode || typeof window === "undefined") return undefined;
-    const peekWidthPx = resolveEffectiveWidthFraction() * window.innerWidth;
     const navPercent = computePeekNavPercent(peekWidthPx);
     if (navPercent === undefined) return undefined;
     return {
       [RESIZABLE_PANEL_NAVIGATION_ID]: navPercent,
       [RESIZABLE_PANEL_PREVIEW_ID]: 100 - navPercent,
     };
-    // Depends only on isPeekMode: the width is a mount-time default (a saved
-    // layout wins after first open), so we intentionally don't recompute it as
-    // the viewport changes.
-  }, [isPeekMode]);
+  }, [peekWidthPx]);
 
   // Restored layout for this group. Read before the collapse flags so we can
   // seed them from what the library is about to restore on mount — otherwise the
@@ -221,10 +253,22 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
     storage,
   });
 
+  // Collapse-seed threshold: width-aware for the peek (whose width we know), so
+  // a small-share-but-open nav on a wide peek isn't mis-seeded as collapsed;
+  // fixed fallback for the full-page view (its width isn't known here).
+  const collapseSeedMaxSharePct =
+    isPeekMode && peekWidthPx > 0
+      ? collapsedShareMaxForWidth(peekWidthPx)
+      : COLLAPSED_LAYOUT_SHARE_MAX_PCT;
+
   const [isNavigationPanelCollapsed, setIsNavigationPanelCollapsed] = useState(
     () =>
       isAnnotationMode ||
-      isPanelCollapsedInLayout(defaultLayout, RESIZABLE_PANEL_NAVIGATION_ID),
+      isPanelCollapsedInLayout(
+        defaultLayout,
+        RESIZABLE_PANEL_NAVIGATION_ID,
+        collapseSeedMaxSharePct,
+      ),
   );
 
   // Ref to programmatically control the panel
@@ -233,7 +277,11 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
   // Detail (info/preview) panel collapse state + control.
   const detailPanelRef = usePanelRef();
   const [isDetailPanelCollapsed, setIsDetailPanelCollapsed] = useState(() =>
-    isPanelCollapsedInLayout(defaultLayout, RESIZABLE_PANEL_PREVIEW_ID),
+    isPanelCollapsedInLayout(
+      defaultLayout,
+      RESIZABLE_PANEL_PREVIEW_ID,
+      collapseSeedMaxSharePct,
+    ),
   );
 
   // Group ref — drives the whole layout atomically (setLayout) when reopening a


### PR DESCRIPTION
## TL;DR
The trace **peek** opened with worse defaults the bigger your screen — a very wide tree and a cramped info panel — and the tree/info ratio reset between tabs. This makes the peek open at a **comfortable, screen-aware default** (info wide, tree bounded, list still navigable) and **remembers your inner split in `localStorage`** like it already does the outer width. Scoped to the peek; the full-page trace view is untouched.

## Why
Two independent, separately-persisted resize systems stack in the peek:
1. **Outer width** — `0.5 × viewport`, so on a 2560px+ monitor the peek was ~1280px+ and kept growing.
2. **Inner tree ↔ info split** — a *share-based* 60% tree / 40% info, persisted in **per-tab `sessionStorage`**.

Because the tree was a *percentage of an already-large peek*, "bigger screen → bigger tree": at 2560px the tree was ~768px and info a cramped ~512px. And per-tab storage is why the split felt inconsistent between tabs and between people (one long-lived tab vs. many "open in new tab" tabs).

## What
- **Outer width — cap the default's px growth.** Default = `min(0.5·vw, PEEK_MAX_DEFAULT_WIDTH_PX)`, floored at the drag minimum. Normal laptops keep 50vw (zero change ≤ ~2800px); wide monitors stop ballooning so the underlying list stays navigable. User drags still go up to 90%.
- **Inner split (peek only) — anchor to comfort, give extra to info.** Give the info panel a comfortable target and hand the tree the remainder, clamped to a comfortable band, so extra width on a wide peek flows to the *content* (info), not the *index* (tree).
- **Unify persistence → `localStorage`.** The peek's inner split now persists cross-tab under a peek-scoped group id, matching the outer width. The full-page trace view keeps its own share-based, per-tab layout.

## Result (verified in-browser across widths)
| Viewport | Peek width | Tree | Info |
|---|---|---|---|
| 2560 | 1280 (50%) | **459** (was ~768) | **819** (was ~512) |
| 3440 | **1400** (capped, was 1720) | 460 | 940 |
| 1512 (laptop) | 756 (50%, unchanged) | 339 | 415 |
| 1280 | 640 | 278 (min-area) | 360 |
| 1100 | 550 | 260 (rail-min + horizontal scroll preserved) | 360 |

Dragging the inner split now survives reload and new tabs (localStorage). Small screens still collapse gracefully (260/360 mins + 40px rails + horizontal-scroll pin). Annotation mode is a separate `traceContext`, so none of the peek-scoped changes apply there.

<details>
<summary>Engineering detail</summary>

- **Why a computed percentage, not a px `defaultSize`.** react-resizable-panels resolves a px `defaultSize` to a percentage against whatever group width it measures *first* — on a peek that's a transient mid-open width, and the library then persists it. In practice the same laptop resolved to 316px one load and 394px the next. Percentages are width-independent, so the default is deterministic. `TraceLayoutDesktop` computes the split from the width the peek will actually open at (`resolveEffectiveWidthFraction() × innerWidth`) and passes it as the group `defaultLayout`.
- **Peek scoping.** `isPeekMode` (from `ViewPreferencesContext`) selects a peek group id (`trace-layout-peek-v1`) + `localStorage` + the computed default; everything else keeps `trace-layout-v2` + `sessionStorage` + 60/40. The full-page trace view would otherwise get a ~2000px-wide info panel on a 4K monitor.
- **Untouched:** the collapse rails, the both-panels-min horizontal-scroll pin (LFE-10550), the annotation-mode collapse + save-suppression.
- **Tests:** `peekPanelStore.clienttest.ts` covers the viewport-aware capped default (normal / wide / ultra-wide / saved-preference-wins). Split behavior verified in-browser at the five widths above + drag-persistence across reload.

**Design calls made (open to change):** persistence is **global** (consistent with every existing trace preference — `showGraph`, `logViewMode`, … — which are all global `localStorage`); **view-mode memory (timeline vs tree) deferred** to keep this scoped to the reported bug. The exact comfort numbers (info target 560px, tree band 340–460px, width cap 1400px) were tuned in-browser and are easy to nudge.
</details>

Fixes LFE-10601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the trace peek panel's layout defaults: the outer width now caps at `PEEK_MAX_DEFAULT_WIDTH_PX` (1400 px) on wide monitors instead of growing unboundedly at 50vw, and the inner tree ↔ info split is computed from the real peek width (anchor-to-comfort, extra space flows to info) rather than a flat 60/40 share. Persistence is unified to `localStorage` for the peek (matching the outer-width preference), replacing the previous per-tab `sessionStorage` that caused split inconsistency across tabs.

- **`peekPanelStore.ts`** — adds `resolveDefaultWidthFraction()` (viewport-aware, px-capped) and renames/exports `resolveEffectiveWidthFraction()` (saved preference or default); store initializes from the new function.
- **`TraceLayoutDesktop.tsx`** — switches on `isPeekMode` to pick a separate group ID (`trace-layout-peek-v1`) + `localStorage`; computes `peekDefaultLayout` percentages once on mount so the library gets a stable, width-independent default rather than a non-deterministic px `defaultSize`.
- **Tests** — `peekPanelStore.clienttest.ts` adds four viewport-width scenarios covering the cap, the floor, and the saved-preference-wins case.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The layout change is scoped to the peek panel with no changes to the full-page trace view; the new viewport-aware width cap and inner-split computation are both covered by tests and the math has been verified.

The core logic — resolveDefaultWidthFraction, resolveEffectiveWidthFraction, and computePeekNavPercent — is correct and well-tested. The one concern is the direct bare localStorage/sessionStorage reference on line 186 of TraceLayoutDesktop.tsx without a typeof-window guard; this mirrors a pre-existing sessionStorage omission but is now extended to localStorage too, and could surface in any SSR or test context that doesn't provide a DOM globals shim.

web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx — line 186, bare localStorage/sessionStorage access without typeof-window guard.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TraceLayoutDesktop mounts] --> B{isPeekMode?}
    B -->|yes| C[groupId = trace-layout-peek-v1\nstorage = localStorage]
    B -->|no| D[groupId = trace-layout-v2\nstorage = sessionStorage]

    C --> E[useDefaultLayout reads\nlocalStorage trace-layout-peek-v1]
    D --> F[useDefaultLayout reads\nsessionStorage trace-layout-v2]

    E --> G{savedLayout\nexists?}
    G -->|yes| H[defaultLayout = saved]
    G -->|no| I[peekDefaultLayout computed\nfrom resolveEffectiveWidthFraction x vw]
    I --> J[computePeekNavPercent\nclamped to 340-460 px band]
    J --> K[defaultLayout = peekDefaultLayout]

    H --> L[Group defaultLayout drives\ninitial tree/info split]
    K --> L

    F --> M[Group defaultLayout from\nsessionStorage or undefined - 60/40 panel defaults]

    subgraph peekPanelStore
        N[resolveEffectiveWidthFraction] --> O{localStorage\npeekViewWidthFraction?}
        O -->|yes| P[clampWidthFraction saved]
        O -->|no| Q[resolveDefaultWidthFraction\nmin 0.5, max 1400px div vw, floor 0.4]
    end

    I -.->|calls| N
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[TraceLayoutDesktop mounts] --> B{isPeekMode?}
    B -->|yes| C[groupId = trace-layout-peek-v1\nstorage = localStorage]
    B -->|no| D[groupId = trace-layout-v2\nstorage = sessionStorage]

    C --> E[useDefaultLayout reads\nlocalStorage trace-layout-peek-v1]
    D --> F[useDefaultLayout reads\nsessionStorage trace-layout-v2]

    E --> G{savedLayout\nexists?}
    G -->|yes| H[defaultLayout = saved]
    G -->|no| I[peekDefaultLayout computed\nfrom resolveEffectiveWidthFraction x vw]
    I --> J[computePeekNavPercent\nclamped to 340-460 px band]
    J --> K[defaultLayout = peekDefaultLayout]

    H --> L[Group defaultLayout drives\ninitial tree/info split]
    K --> L

    F --> M[Group defaultLayout from\nsessionStorage or undefined - 60/40 panel defaults]

    subgraph peekPanelStore
        N[resolveEffectiveWidthFraction] --> O{localStorage\npeekViewWidthFraction?}
        O -->|yes| P[clampWidthFraction saved]
        O -->|no| Q[resolveDefaultWidthFraction\nmin 0.5, max 1400px div vw, floor 0.4]
    end

    I -.->|calls| N
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx:186
**Bare `localStorage`/`sessionStorage` globals in render body**

`localStorage` and `sessionStorage` are referenced as bare globals during the component's render phase. In any environment where the component is instantiated server-side (SSR, static generation, tests without a DOM shim), this throws `ReferenceError: localStorage is not defined`. The pre-existing `storage: sessionStorage` pattern had the same omission; this PR extends it to `localStorage`. Both sides of the ternary now need the window guard. The relevant functions in `peekPanelStore.ts` (`resolveEffectiveWidthFraction`, `resolveDefaultWidthFraction`) already set the correct precedent with `typeof window === "undefined"` checks — the same idiom should be applied here.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): comfortable peek defaults, u..."](https://github.com/langfuse/langfuse/commit/81dd5b48b6a7532b11e5a5f98e7b827db0182f86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41358372)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->