### PR TITLE
fix(web): allow public trace access in v4 events routes

### DIFF
--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -3,6 +3,7 @@ import { z as zodSchema } from "zod";
 import {
   createTRPCRouter,
   protectedProjectProcedure,
+  protectedGetTraceProcedure,
 } from "@/src/server/api/trpc";
 import {
   type OrderByState,
@@ -227,7 +228,7 @@ export const eventsRouter = createTRPCRouter({
    * Fetch scores and corrections for a trace.
    * Used by the v4 trace detail view where trace data comes from events table.
    */
-  scoresForTrace: protectedProjectProcedure
+  scoresForTrace: protectedGetTraceProcedure
     .input(
       zodSchema.object({
         projectId: zodSchema.string(),
@@ -235,7 +236,7 @@ export const eventsRouter = createTRPCRouter({
         timestamp: zodSchema.date().optional(),
       }),
     )
-    .query(async ({ input, ctx }) => {
+    .query(async ({ input }) => {
       return instrumentAsync(
         { name: "get-events-scores-for-trace-trpc" },
         async (span) => {
@@ -243,7 +244,7 @@ export const eventsRouter = createTRPCRouter({
           span.setAttribute("trace_id", input.traceId);
 
           return getScoresAndCorrectionsForTraces({
-            projectId: ctx.session.projectId,
+            projectId: input.projectId,
             traceIds: [input.traceId],
             timestamp: input.timestamp,
           });
@@ -255,7 +256,7 @@ export const eventsRouter = createTRPCRouter({
    * Returns up to MAX_OBSERVATIONS_PER_TRACE observations.
    * Sets cutoffObservationsAfterMaxCount=true if trace exceeds the cap.
    */
-  byTraceId: protectedProjectProcedure
+  byTraceId: protectedGetTraceProcedure
     .input(
       zodSchema.object({
         projectId: zodSchema.string(),
@@ -263,16 +264,16 @@ export const eventsRouter = createTRPCRouter({
         timestamp: zodSchema.date().optional(),
       }),
     )
-    .query(async ({ input, ctx }) => {
+    .query(async ({ input }) => {
       return instrumentAsync(
         { name: "get-events-by-trace-id-trpc" },
         async (span) => {
-          span.setAttribute("project_id", ctx.session.projectId);
+          span.setAttribute("project_id", input.projectId);
           span.setAttribute("trace_id", input.traceId);
 
           const { observations, totalCount } =
             await getObservationsForTraceFromEventsTable({
-              projectId: ctx.session.projectId,
+              projectId: input.projectId,
               traceId: input.traceId,
               timestamp: input.timestamp,
             });
@@ -290,7 +291,7 @@ export const eventsRouter = createTRPCRouter({
    * Used by v4 events-based trace detail view for graph visualization.
    * Returns same shape as traces.getAgentGraphData for frontend compatibility.
    */
-  getAgentGraphData: protectedProjectProcedure
+  getAgentGraphData: protectedGetTraceProcedure
     .input(
       zodSchema.object({
         projectId: zodSchema.string(),
@@ -299,77 +300,75 @@ export const eventsRouter = createTRPCRouter({
         maxStartTime: zodSchema.string(),
       }),
     )
-    .query(
-      async ({ input, ctx }): Promise<Required<AgentGraphDataResponse>[]> => {
-        return instrumentAsync(
-          { name: "get-events-agent-graph-data-trpc" },
-          async (span) => {
-            span.setAttribute("project_id", input.projectId);
-            span.setAttribute("trace_id", input.traceId);
+    .query(async ({ input }): Promise<Required<AgentGraphDataResponse>[]> => {
+      return instrumentAsync(
+        { name: "get-events-agent-graph-data-trpc" },
+        async (span) => {
+          span.setAttribute("project_id", input.projectId);
+          span.setAttribute("trace_id", input.traceId);
 
-            const { traceId, minStartTime, maxStartTime } = input;
+          const { traceId, minStartTime, maxStartTime } = input;
 
-            const chMinStartTime = convertDateToClickhouseDateTime(
-              new Date(minStartTime),
-            );
-            const chMaxStartTime = convertDateToClickhouseDateTime(
-              new Date(maxStartTime),
-            );
+          const chMinStartTime = convertDateToClickhouseDateTime(
+            new Date(minStartTime),
+          );
+          const chMaxStartTime = convertDateToClickhouseDateTime(
+            new Date(maxStartTime),
+          );
 
-            const records = await getAgentGraphDataFromEventsTable({
-              projectId: ctx.session.projectId,
-              traceId,
-              chMinStartTime,
-              chMaxStartTime,
-            });
+          const records = await getAgentGraphDataFromEventsTable({
+            projectId: input.projectId,
+            traceId,
+            chMinStartTime,
+            chMaxStartTime,
+          });
 
-            // Transform to AgentGraphDataResponse format
-            // TODO: Extract this transformation logic into a shared utility
-            // (duplicated from traces.getAgentGraphData in traces.ts)
-            const result = records
-              .map((r) => {
-                const parsed = AgentGraphDataSchema.safeParse(r);
-                if (!parsed.success) {
-                  return null;
-                }
-
-                const data = parsed.data;
-                const hasLangGraphData = data.step != null && data.node != null;
-                const hasAgentData = data.type !== "EVENT";
-
-                if (hasLangGraphData) {
-                  return {
-                    id: data.id,
-                    node: data.node,
-                    step: data.step,
-                    parentObservationId: data.parent_observation_id || null,
-                    name: data.name,
-                    startTime: data.start_time,
-                    endTime: data.end_time || undefined,
-                    observationType: data.type,
-                  };
-                } else if (hasAgentData) {
-                  return {
-                    id: data.id,
-                    node: data.name,
-                    step: 0,
-                    parentObservationId: data.parent_observation_id || null,
-                    name: data.name,
-                    startTime: data.start_time,
-                    endTime: data.end_time || undefined,
-                    observationType: data.type,
-                  };
-                }
-
+          // Transform to AgentGraphDataResponse format
+          // TODO: Extract this transformation logic into a shared utility
+          // (duplicated from traces.getAgentGraphData in traces.ts)
+          const result = records
+            .map((r) => {
+              const parsed = AgentGraphDataSchema.safeParse(r);
+              if (!parsed.success) {
                 return null;
-              })
-              .filter((r): r is Required<AgentGraphDataResponse> => Boolean(r));
+              }
 
-            return result;
-          },
-        );
-      },
-    ),
+              const data = parsed.data;
+              const hasLangGraphData = data.step != null && data.node != null;
+              const hasAgentData = data.type !== "EVENT";
+
+              if (hasLangGraphData) {
+                return {
+                  id: data.id,
+                  node: data.node,
+                  step: data.step,
+                  parentObservationId: data.parent_observation_id || null,
+                  name: data.name,
+                  startTime: data.start_time,
+                  endTime: data.end_time || undefined,
+                  observationType: data.type,
+                };
+              } else if (hasAgentData) {
+                return {
+                  id: data.id,
+                  node: data.name,
+                  step: 0,
+                  parentObservationId: data.parent_observation_id || null,
+                  name: data.name,
+                  startTime: data.start_time,
+                  endTime: data.end_time || undefined,
+                  observationType: data.type,
+                };
+              }
+
+              return null;
+            })
+            .filter((r): r is Required<AgentGraphDataResponse> => Boolean(r));
+
+          return result;
+        },
+      );
+    }),
   /**
    * Get SDK metadata for a project.
    * Returns info about the SDK being used (name, version, language).


### PR DESCRIPTION
The v4 events-based trace detail view (fast preview mode) calls events.byTraceId, events.scoresForTrace and events.getAgentGraphData. These used protectedProjectProcedure, so a viewer who is not a project member — including anyone opening a public/shared trace link — got a 401 "User is not a member of this project", while the legacy (non-v4) path renders the same link fine via protectedGetTraceProcedure.

Switch these three trace-scoped routes to protectedGetTraceProcedure so public traces are viewable, matching traces.byIdWithObservationsAndScores and traces.getAgentGraphData. Read projectId from the validated input instead of ctx.session.projectId, which the trace-access middleware does not populate (it only sets projectRole and attaches ctx.trace).

Known gap: root/observation input & output still load via events.batchIO, which stays project-scoped (it batches I/O across many traces and its input carries no top-level traceId). Public traces therefore render structure and scores but not I/O yet; a follow-up will add a trace-scoped I/O route gated by protectedGetTraceProcedure.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a 401 error for public/shared trace links in the v4 events-based trace detail view by switching three procedures (`events.byTraceId`, `events.scoresForTrace`, `events.getAgentGraphData`) from `protectedProjectProcedure` to `protectedGetTraceProcedure`, which allows access when a trace is public. It also aligns the data queries to use `input.projectId` instead of `ctx.session.projectId`, since the trace-access middleware does not populate a session project.

- **Access control switch**: `protectedGetTraceProcedure` fetches the trace by `(traceId, projectId)` and gates access on `trace.public`, session publicity, project membership, or admin status — matching the pattern already used by `traces.byIdWithObservationsAndScores` and `traces.getAgentGraphData`.
- **Known gap acknowledged**: `events.batchIO` (I/O data) remains on `protectedProjectProcedure`, so public trace viewers will see structure and scores but not input/output; a follow-up is planned.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the three changed routes now follow the same access-control pattern already used by the trace-detail routes they mirror, and the middleware independently validates the (traceId, projectId) pair before any data is returned.

The middleware fetches the trace by both traceId and projectId, so supplying a mismatched projectId in input returns NOT_FOUND rather than leaking data. Using input.projectId in the downstream queries is therefore safe. The known I/O gap (batchIO still project-scoped) is documented and intentional. No regressions on authenticated paths are expected since protectedGetTraceProcedure also permits project members.

web/src/features/events/server/eventsRouter.ts — specifically the batchIO route, which is the remaining gap for public trace I/O access, documented as a follow-up.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as Browser (public trace link)
    participant TRPC as tRPC Router
    participant MW as enforceTraceAccess middleware
    participant CH as ClickHouse / DB
    participant Handler as Route Handler

    Client->>TRPC: events.byTraceId / scoresForTrace / getAgentGraphData
    TRPC->>MW: enforceTraceAccess with input.projectId and input.traceId
    MW->>CH: getTraceById(traceId, projectId)
    CH-->>MW: trace or null
    alt trace not found
        MW-->>Client: 404 NOT_FOUND
    else trace found but not public and user not member
        MW-->>Client: 401 UNAUTHORIZED
    else trace public OR user is project member
        MW->>Handler: next with ctx.trace attached
        Handler->>CH: query data with input.projectId and input.traceId
        CH-->>Handler: observations / scores / graph data
        Handler-->>Client: 200 OK
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as Browser (public trace link)
    participant TRPC as tRPC Router
    participant MW as enforceTraceAccess middleware
    participant CH as ClickHouse / DB
    participant Handler as Route Handler

    Client->>TRPC: events.byTraceId / scoresForTrace / getAgentGraphData
    TRPC->>MW: enforceTraceAccess with input.projectId and input.traceId
    MW->>CH: getTraceById(traceId, projectId)
    CH-->>MW: trace or null
    alt trace not found
        MW-->>Client: 404 NOT_FOUND
    else trace found but not public and user not member
        MW-->>Client: 401 UNAUTHORIZED
    else trace public OR user is project member
        MW->>Handler: next with ctx.trace attached
        Handler->>CH: query data with input.projectId and input.traceId
        CH-->>Handler: observations / scores / graph data
        Handler-->>Client: 200 OK
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): allow public trace access in v..."](https://github.com/langfuse/langfuse/commit/1c5791fcd9a27b8bd31f6fd8f1c31df445e435fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41365201)</sub>

<!-- /greptile_comment -->