### PR TITLE
fix(mcp): Add `.well-known/mcp.json` route

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -120,6 +120,15 @@ const nextConfig = {
   },
   output: "standalone",
 
+  async rewrites() {
+    return [
+      {
+        source: "/.well-known/mcp.json",
+        destination: "/api/well-known/mcp.json",
+      },
+    ];
+  },
+
   async headers() {
     return [
       {

--- a/web/src/features/mcp/server/security.ts
+++ b/web/src/features/mcp/server/security.ts
@@ -1,9 +1,9 @@
 import { env } from "@/src/env.mjs";
+import { getBaseUrl } from "@/src/utils/base-url";
 import { ForbiddenError } from "@langfuse/shared";
 import { type NextApiRequest, type NextApiResponse } from "next";
 
 const LOCALHOST_HOSTNAMES = ["localhost", "127.0.0.1", "[::1]"] as const;
-const LOCALHOST_HOST_PATTERN = /^(localhost|127\.0\.0\.1|\[::1\])(?::|\/|$)/i;
 
 function parseAllowedMcpHostEntry(
   entry: string,
@@ -39,12 +39,7 @@ function parseAllowedMcpHostEntry(
 }
 
 function getAllowedMcpOriginsAndHostnames() {
-  const rawBaseUrl = env.NEXTAUTH_URL;
-  const baseUrl = new URL(
-    /^https?:\/\//i.test(rawBaseUrl)
-      ? rawBaseUrl
-      : `${LOCALHOST_HOST_PATTERN.test(rawBaseUrl) ? "http" : "https"}://${rawBaseUrl}`,
-  );
+  const baseUrl = getBaseUrl();
   const allowedHostnames = new Set([baseUrl.hostname.toLowerCase()]);
   const allowedOrigins = new Set([baseUrl.origin.toLowerCase()]);
 

--- a/web/src/pages/api/well-known/mcp.json.ts
+++ b/web/src/pages/api/well-known/mcp.json.ts
@@ -1,0 +1,26 @@
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { getProductBaseUrl } from "@/src/utils/base-url";
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const baseUrl = getProductBaseUrl();
+  const payload = {
+    $schema:
+      "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+    title: "Langfuse",
+    description: "Use Langfuse over MCP.",
+    websiteUrl: "https://langfuse.com",
+    repository: {
+      url: "https://github.com/langfuse/langfuse",
+      source: "github",
+    },
+    remotes: [
+      {
+        type: "streamable-http",
+        url: new URL("api/public/mcp", baseUrl).toString(),
+      },
+    ],
+  };
+
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.status(200).send(`${JSON.stringify(payload, null, 2)}\n`);
+}

--- a/web/src/pages/api/well-known/mcp.json.ts
+++ b/web/src/pages/api/well-known/mcp.json.ts
@@ -1,7 +1,12 @@
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { getProductBaseUrl } from "@/src/utils/base-url";
 
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    res.status(405).end("Method Not Allowed");
+    return;
+  }
   const baseUrl = getProductBaseUrl();
   const payload = {
     $schema:

--- a/web/src/utils/base-url.ts
+++ b/web/src/utils/base-url.ts
@@ -1,0 +1,27 @@
+import { env } from "@/src/env.mjs";
+
+const LOCALHOST_HOST_PATTERN = /^(localhost|127\.0\.0\.1|\[::1\])(?::|\/|$)/i;
+
+export const getBaseUrl = () => {
+  const rawBaseUrl = env.NEXTAUTH_URL;
+
+  return new URL(
+    /^https?:\/\//i.test(rawBaseUrl)
+      ? rawBaseUrl
+      : `${LOCALHOST_HOST_PATTERN.test(rawBaseUrl) ? "http" : "https"}://${rawBaseUrl}`,
+  );
+};
+
+export const getProductBaseUrl = () => {
+  const baseUrl = getBaseUrl();
+
+  baseUrl.pathname = baseUrl.pathname.replace(/\/api\/auth\/?$/, "/");
+  baseUrl.search = "";
+  baseUrl.hash = "";
+
+  if (!baseUrl.pathname.endsWith("/")) {
+    baseUrl.pathname = `${baseUrl.pathname}/`;
+  }
+
+  return baseUrl;
+};

--- a/web/src/utils/product-url.ts
+++ b/web/src/utils/product-url.ts
@@ -1,12 +1,10 @@
 import type { FilterState } from "@langfuse/shared";
-import { env } from "@/src/env.mjs";
 import { encodeFiltersGeneric } from "@/src/features/filters/lib/filter-query-encoding";
+import { getProductBaseUrl } from "@/src/utils/base-url";
 import {
   rangeToString,
   type TABLE_AGGREGATION_OPTIONS,
 } from "@/src/utils/date-range-utils";
-
-const LOCALHOST_HOST_PATTERN = /^(localhost|127\.0\.0\.1|\[::1\])(?::|\/|$)/i;
 
 type ProductPathQuery = Record<string, string | string[] | null | undefined>;
 
@@ -40,21 +38,6 @@ type TracesPathParams = {
     type?: string[];
   };
   timeRange?: TracesPathTimeRange;
-};
-
-const getProductBaseUrl = () => {
-  const rawBaseUrl = env.NEXTAUTH_URL;
-  const baseUrl = new URL(
-    /^https?:\/\//i.test(rawBaseUrl)
-      ? rawBaseUrl
-      : `${LOCALHOST_HOST_PATTERN.test(rawBaseUrl) ? "http" : "https"}://${rawBaseUrl}`,
-  );
-
-  baseUrl.pathname = baseUrl.pathname.replace(/\/api\/auth\/?$/, "/");
-  baseUrl.search = "";
-  baseUrl.hash = "";
-
-  return baseUrl;
 };
 
 export const appendProductPathQuery = (


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `.well-known/mcp.json` MCP discovery endpoint by introducing a new API handler (`/api/well-known/mcp.json`) and a Next.js rewrite that serves it at `/.well-known/mcp.json`. It also refactors the duplicated `getBaseUrl`/`getProductBaseUrl` helpers into a new shared `web/src/utils/base-url.ts` module used by both the MCP security module and the product-URL builder.

- **New discovery endpoint** (`web/src/pages/api/well-known/mcp.json.ts`): returns the MCP server manifest, including the `streamable-http` remote URL derived from `getProductBaseUrl()`, which now guarantees a trailing slash so relative URL resolution works correctly for sub-path deployments.
- **Refactored URL utilities** (`web/src/utils/base-url.ts`): consolidates the previously duplicated `LOCALHOST_HOST_PATTERN` regex and URL-building logic from `security.ts` and `product-url.ts` into one place; the new `getProductBaseUrl` adds a trailing-slash normalisation step that is benign for existing callers (they already strip it) but required for correct relative URL construction in the new endpoint.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge. It adds a new public discovery endpoint and consolidates duplicated URL utility code with no breaking changes to existing behaviour.

The refactoring is clean and the trailing-slash normalisation in getProductBaseUrl is handled correctly by all callers. The only minor gap is that the new handler accepts all HTTP methods rather than GET-only, which is a non-critical convention issue rather than a functional defect.

web/src/pages/api/well-known/mcp.json.ts — HTTP method guard is missing.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as MCP Client
    participant Next as Next.js (rewrite)
    participant Handler as /api/well-known/mcp.json
    participant BaseUrl as getProductBaseUrl()
    participant MCP as /api/public/mcp

    Client->>Next: GET /.well-known/mcp.json
    Next->>Handler: rewrite → /api/well-known/mcp.json
    Handler->>BaseUrl: getProductBaseUrl()
    BaseUrl-->>Handler: base URL (trailing-slash normalised)
    Handler-->>Client: "200 application/json { remotes: [{ url: baseUrl + api/public/mcp }] }"

    Client->>MCP: POST /api/public/mcp (discovered URL)
    MCP-->>Client: MCP response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as MCP Client
    participant Next as Next.js (rewrite)
    participant Handler as /api/well-known/mcp.json
    participant BaseUrl as getProductBaseUrl()
    participant MCP as /api/public/mcp

    Client->>Next: GET /.well-known/mcp.json
    Next->>Handler: rewrite → /api/well-known/mcp.json
    Handler->>BaseUrl: getProductBaseUrl()
    BaseUrl-->>Handler: base URL (trailing-slash normalised)
    Handler-->>Client: "200 application/json { remotes: [{ url: baseUrl + api/public/mcp }] }"

    Client->>MCP: POST /api/public/mcp (discovered URL)
    MCP-->>Client: MCP response
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/api/well-known/mcp.json.ts:4
The handler responds to every HTTP method (POST, DELETE, etc.) with a 200 and the JSON payload. Discovery endpoints conventionally accept GET only; returning 200 to a POST is unexpected and could confuse some clients or proxies.

```suggestion
export default function handler(req: NextApiRequest, res: NextApiResponse) {
  if (req.method !== "GET") {
    res.setHeader("Allow", "GET");
    res.status(405).end("Method Not Allowed");
    return;
  }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Add \`.well-known/mcp.json\` rou..."](https://github.com/langfuse/langfuse/commit/26bf582e55a5fe538ad0765594bb7134e04f1b7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41383767)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->