### PR TITLE
perf(api): two-phase trace lookup for GET /api/public/sessions/:sessions

### DIFF
--- a/fern/apis/server/definition/sessions.yml
+++ b/fern/apis/server/definition/sessions.yml
@@ -50,6 +50,16 @@ service:
         sessionId:
           type: string
           docs: The unique id of a session
+      request:
+        name: GetSessionRequest
+        query-parameters:
+          fromTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional lower bound for the traces returned with the session (ISO 8601).
+              Only traces with a timestamp on or after this value are included.
+              Defaults to the session's createdAt minus 2 days, so traces backdated
+              further need an explicit fromTimestamp.
       response: commons.SessionWithTraces
 types:
   PaginatedSessions:

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -15,6 +15,7 @@ import { orderByToClickhouseSql } from "../queries";
 import { shouldSkipObservationsFinal } from "../queries/clickhouse-sql/query-options";
 import { LISTABLE_SCORE_TYPES } from "../../domain/scores";
 import { OrderByState } from "../../interfaces/orderBy";
+import chunk from "lodash/chunk";
 import snakeCase from "lodash/snakeCase";
 import { FilterState } from "../../types";
 import {
@@ -267,7 +268,13 @@ export const getTracesBySessionId = async (
   sessionIds: string[],
   timestamp?: Date,
 ) => {
-  const records = await measureAndReturn({
+  // Two-phase read: session_id is not part of the traces sorting key, so a
+  // `SELECT *` filtered only by session_id reads the heavy input/output
+  // columns for every matching row version across all partitions. Resolve the
+  // trace ids and their minimum timestamp over narrow columns first, then
+  // fetch full rows via getTracesByIds, whose timestamp bound enables
+  // partition and primary-key pruning.
+  const identifiers = await measureAndReturn({
     operationName: "getTracesBySessionId",
     projectId,
     input: {
@@ -283,15 +290,16 @@ export const getTracesBySessionId = async (
     },
     fn: (input) => {
       const query = `
-        SELECT *
+        SELECT
+          id,
+          min(timestamp) as min_timestamp
         FROM traces
         WHERE session_id IN ({sessionIds: Array(String)})
         AND project_id = {projectId: String}
         ${timestamp ? `AND timestamp >= {timestamp: DateTime64(3)}` : ""}
-        ORDER BY event_ts DESC
-        LIMIT 1 by id, project_id;
+        GROUP BY id;
       `;
-      return queryClickhouse<TraceRecordReadType>({
+      return queryClickhouse<{ id: string; min_timestamp: string }>({
         query,
         params: input.params,
         tags: input.tags,
@@ -299,9 +307,27 @@ export const getTracesBySessionId = async (
     },
   });
 
-  const traces = records.map((record) =>
-    convertClickhouseToDomain(record, DEFAULT_RENDERING_PROPS),
-  );
+  if (identifiers.length === 0) {
+    return [];
+  }
+
+  const traces = (
+    await Promise.all(
+      chunk(identifiers, 500).map((identifierChunk) =>
+        getTracesByIds(
+          identifierChunk.map((t) => t.id),
+          projectId,
+          new Date(
+            Math.min(
+              ...identifierChunk.map((t) =>
+                parseClickhouseUTCDateTimeFormat(t.min_timestamp).getTime(),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+  ).flat();
 
   traces.forEach((trace) => {
     recordDistribution(

--- a/web/src/__tests__/server/repositories/trace-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/trace-repository.servertest.ts
@@ -187,6 +187,70 @@ describe("Clickhouse Traces Repository Test", () => {
     expect(resultIds).toContain(trace2.id);
   });
 
+  it("should apply the timestamp lower bound when retrieving traces by session ID", async () => {
+    const sessionId = v4();
+    const recentTrace = createTrace({
+      id: v4(),
+      project_id: projectId,
+      session_id: sessionId,
+      timestamp: Date.now(),
+    });
+    const backdatedTrace = createTrace({
+      id: v4(),
+      project_id: projectId,
+      session_id: sessionId,
+      timestamp: Date.now() - 10 * 24 * 60 * 60 * 1000,
+    });
+
+    await createTracesCh([recentTrace, backdatedTrace]);
+
+    const results = await getTracesBySessionId(
+      projectId,
+      [sessionId],
+      new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(recentTrace.id);
+
+    const unboundedResults = await getTracesBySessionId(projectId, [sessionId]);
+    expect(unboundedResults.map((t) => t.id)).toEqual(
+      expect.arrayContaining([recentTrace.id, backdatedTrace.id]),
+    );
+  });
+
+  it("should return the latest version of a trace retrieved by session ID", async () => {
+    // ReplacingMergeTree keeps row versions until parts merge; the by-session
+    // read must dedupe to the version with the highest event_ts.
+    const sessionId = v4();
+    const traceId = v4();
+    const timestamp = Date.now();
+
+    const olderVersion = createTrace({
+      id: traceId,
+      project_id: projectId,
+      session_id: sessionId,
+      timestamp,
+      name: "old-name",
+      event_ts: timestamp,
+    });
+    const newerVersion = createTrace({
+      id: traceId,
+      project_id: projectId,
+      session_id: sessionId,
+      timestamp,
+      name: "new-name",
+      event_ts: timestamp + 5000,
+    });
+
+    await createTracesCh([olderVersion, newerVersion]);
+
+    const results = await getTracesBySessionId(projectId, [sessionId]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe("new-name");
+  });
+
   it("should check if trace exists with level filter", async () => {
     const traceId = v4();
     const trace = createTrace({

--- a/web/src/__tests__/server/sessions-api.servertest.ts
+++ b/web/src/__tests__/server/sessions-api.servertest.ts
@@ -85,6 +85,56 @@ describe("/api/public/sessions API Endpoint", () => {
       expect(traceIds).toContain(backdatedWithinLookback.id);
       expect(traceIds).not.toContain(backdatedBeyondLookback.id);
     });
+
+    it("should let fromTimestamp override the default trace lookback", async () => {
+      const sessionId = v4();
+
+      await prisma.traceSession.create({
+        data: {
+          id: sessionId,
+          projectId: projectId,
+        },
+      });
+
+      const recentTrace = createTrace({
+        session_id: sessionId,
+        project_id: projectId,
+        timestamp: Date.now(),
+      });
+      const backdatedTrace = createTrace({
+        session_id: sessionId,
+        project_id: projectId,
+        timestamp: Date.now() - 10 * 24 * 60 * 60 * 1000,
+      });
+
+      await createTracesCh([recentTrace, backdatedTrace]);
+
+      // Widening beyond the 2-day default includes traces backdated further.
+      const widened = await makeZodVerifiedAPICall(
+        GetSessionV1Response,
+        "GET",
+        `/api/public/sessions/${sessionId}?fromTimestamp=${encodeURIComponent(
+          new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+        )}`,
+      );
+      expect(widened.status).toBe(200);
+      expect(widened.body.traces.map((t) => t.id)).toEqual(
+        expect.arrayContaining([recentTrace.id, backdatedTrace.id]),
+      );
+
+      // Narrowing excludes traces older than the provided bound.
+      const narrowed = await makeZodVerifiedAPICall(
+        GetSessionV1Response,
+        "GET",
+        `/api/public/sessions/${sessionId}?fromTimestamp=${encodeURIComponent(
+          new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        )}`,
+      );
+      expect(narrowed.status).toBe(200);
+      const narrowedIds = narrowed.body.traces.map((t) => t.id);
+      expect(narrowedIds).toContain(recentTrace.id);
+      expect(narrowedIds).not.toContain(backdatedTrace.id);
+    });
   });
 
   describe("GET /api/public/sessions API Endpoint", () => {

--- a/web/src/__tests__/server/sessions-api.servertest.ts
+++ b/web/src/__tests__/server/sessions-api.servertest.ts
@@ -50,6 +50,41 @@ describe("/api/public/sessions API Endpoint", () => {
         expect.arrayContaining(traces.map((trace) => trace.id)),
       );
     });
+
+    it("should include traces backdated less than 2 days before session creation, but not older ones", async () => {
+      const sessionId = v4();
+
+      await prisma.traceSession.create({
+        data: {
+          id: sessionId,
+          projectId: projectId,
+        },
+      });
+
+      const backdatedWithinLookback = createTrace({
+        session_id: sessionId,
+        project_id: projectId,
+        timestamp: Date.now() - 1 * 24 * 60 * 60 * 1000,
+      });
+      const backdatedBeyondLookback = createTrace({
+        session_id: sessionId,
+        project_id: projectId,
+        timestamp: Date.now() - 10 * 24 * 60 * 60 * 1000,
+      });
+
+      await createTracesCh([backdatedWithinLookback, backdatedBeyondLookback]);
+
+      const getSession = await makeZodVerifiedAPICall(
+        GetSessionV1Response,
+        "GET",
+        `/api/public/sessions/${sessionId}`,
+      );
+
+      expect(getSession.status).toBe(200);
+      const traceIds = getSession.body.traces.map((t) => t.id);
+      expect(traceIds).toContain(backdatedWithinLookback.id);
+      expect(traceIds).not.toContain(backdatedBeyondLookback.id);
+    });
   });
 
   describe("GET /api/public/sessions API Endpoint", () => {

--- a/web/src/features/public-api/types/sessions.ts
+++ b/web/src/features/public-api/types/sessions.ts
@@ -41,6 +41,7 @@ export const GetSessionsV1Response = z
 // GET /sessions/:id
 export const GetSessionV1Query = z.object({
   sessionId: z.string(),
+  fromTimestamp: stringDateTime,
 });
 export const GetSessionV1Response = APISession.extend({
   traces: z.array(APITrace),

--- a/web/src/pages/api/public/sessions/[sessionId].ts
+++ b/web/src/pages/api/public/sessions/[sessionId].ts
@@ -12,7 +12,8 @@ import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/
 // Trace timestamps are client-supplied and may predate the session row's
 // ingestion-time createdAt (e.g. backfills, buffered OTEL exports). Two days
 // of slack covers realistic backdating while still letting ClickHouse prune
-// partitions by timestamp.
+// partitions by timestamp. Callers with older traces can widen the window
+// via the fromTimestamp query parameter.
 const SESSION_TRACE_LOOKBACK_MS = 2 * 24 * 60 * 60 * 1000;
 
 export default withMiddlewares({
@@ -26,7 +27,7 @@ export default withMiddlewares({
     // which has no events_full fallback.
     rejectInEventsOnlyMode: true,
     fn: async ({ query, auth }) => {
-      const { sessionId } = query;
+      const { sessionId, fromTimestamp } = query;
       const session = await prisma.traceSession.findUnique({
         where: {
           id_projectId: {
@@ -51,7 +52,9 @@ export default withMiddlewares({
       const traces = await getTracesBySessionId(
         auth.scope.projectId,
         [sessionId],
-        new Date(session.createdAt.getTime() - SESSION_TRACE_LOOKBACK_MS),
+        fromTimestamp
+          ? new Date(fromTimestamp)
+          : new Date(session.createdAt.getTime() - SESSION_TRACE_LOOKBACK_MS),
       );
 
       return {

--- a/web/src/pages/api/public/sessions/[sessionId].ts
+++ b/web/src/pages/api/public/sessions/[sessionId].ts
@@ -9,6 +9,12 @@ import { LangfuseNotFoundError } from "@langfuse/shared";
 import { getTracesBySessionId } from "@langfuse/shared/src/server";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
 
+// Trace timestamps are client-supplied and may predate the session row's
+// ingestion-time createdAt (e.g. backfills, buffered OTEL exports). Two days
+// of slack covers realistic backdating while still letting ClickHouse prune
+// partitions by timestamp.
+const SESSION_TRACE_LOOKBACK_MS = 2 * 24 * 60 * 60 * 1000;
+
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Session",
@@ -42,9 +48,11 @@ export default withMiddlewares({
         );
       }
 
-      const traces = await getTracesBySessionId(auth.scope.projectId, [
-        sessionId,
-      ]);
+      const traces = await getTracesBySessionId(
+        auth.scope.projectId,
+        [sessionId],
+        new Date(session.createdAt.getTime() - SESSION_TRACE_LOOKBACK_MS),
+      );
 
       return {
         ...session,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a two-phase ClickHouse lookup for `GET /api/public/sessions/:sessionId` to avoid reading wide `input`/`output` columns across all partitions when the query is filtered only by `session_id`. It also adds a `fromTimestamp` query parameter that controls the trace timestamp lower bound, defaulting to `session.createdAt - 2 days`.

- **Phase 1** runs a narrow `SELECT id, min(timestamp) GROUP BY id` to collect trace IDs and their minimum timestamps for a session. **Phase 2** calls `getTracesByIds` per 500-ID chunk using the per-chunk minimum timestamp to enable ClickHouse partition pruning.
- The `fromTimestamp` parameter is wired through the Fern API spec, Zod schema, and handler; when omitted, the handler substitutes the 2-day lookback default, which is a behavioral change from the previous behavior of returning all traces regardless of timestamp.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge only after verifying that no production callers rely on traces backdated more than 2 days before session creation, or after adding a mechanism that signals to clients when the response is incomplete.

The core two-phase ClickHouse optimization is logically correct and the tests cover the intended scenarios. The concern is the default 2-day lower bound: before this PR, the endpoint returned every trace for a session unconditionally; now any trace with a timestamp older than session.createdAt - 2 days is silently dropped from the response with no indication to the caller.

web/src/pages/api/public/sessions/[sessionId].ts — the default timestamp lower bound is a behavioral change for every existing consumer of this endpoint who does not pass fromTimestamp.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/api/public/sessions/[sessionId].ts:52-58
**Silent breaking change: traces silently dropped for existing clients**

Before this PR, `getTracesBySessionId` was called with no timestamp filter, so the response always included every trace for the session. Now a lower bound of `session.createdAt - 2 days` is applied by default. Any existing API consumer calling this endpoint without `fromTimestamp` will silently receive an incomplete list of traces if the session has backdated traces (e.g. OTEL backfills, offline agents). The API response contains no `truncated` flag or `totalCount` that would signal the omission, so callers have no way to detect the data loss.

### Issue 2 of 2
packages/shared/src/server/repositories/traces.ts:314-330
**Stale version returned when a trace's latest event has a timestamp below the lower bound**

The chunk-level lower bound passed to `getTracesByIds` is `Math.min(...chunk.map(t => t.min_timestamp))`. If a trace has its highest `event_ts` row stored at a `timestamp` below the user-provided lower bound, that row is excluded from both phases and the query silently returns an older version. This limitation pre-existed the timestamp-filter design but becomes more likely to affect real datasets now that the default 2-day lower bound is applied unconditionally.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api): fromTimestamp override for se..."](https://github.com/langfuse/langfuse/commit/cb4ee31e5052b86574ea3774eff3c5f7f5f1dadf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41373928)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->