### PR TITLE
feat(agents): trace model price audit workflow

### DIFF
--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -178,6 +178,22 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
           github_token: ${{ github.token }}
           display_report: "true"
+          # Keep telemetry in Claude Code settings because this pinned composite
+          # action only forwards a subset of step-level OTEL env vars.
+          settings: |
+            {
+              "env": {
+                "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+                "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "1",
+                "OTEL_TRACES_EXPORTER": "otlp",
+                "OTEL_METRICS_EXPORTER": "none",
+                "OTEL_LOGS_EXPORTER": "none",
+                "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "${{ secrets.LANGFUSE_OTEL_TRACES_ENDPOINT }}",
+                "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Basic ${{ secrets.LANGFUSE_OTEL_BASIC_AUTH }}",
+                "OTEL_RESOURCE_ATTRIBUTES": "service.name=model-price-audit-agent,service.namespace=github-actions,github.repository=${{ github.repository }},github.workflow=${{ github.workflow }},github.run_id=${{ github.run_id }},github.run_attempt=${{ github.run_attempt }},github.ref=${{ github.ref_name }},github.actor=${{ github.actor }}"
+              }
+            }
           prompt: |
             You are running Langfuse's scheduled default model price audit.
 


### PR DESCRIPTION
## Summary

- Enable Claude Code native OTel tracing for the model price audit workflow via inline settings.env
- Send only traces to the Langfuse OTLP traces endpoint and disable metrics/log exports for this workflow
- Add GitHub Actions resource attributes so traces can be tied back to workflow runs

Linear: https://linear.app/langfuse/issue/LFE-10633/trace-model-price-audit-github-action-via-claude-code-otel

## Verification

- ruby YAML parse for .github/workflows/model-price-audit.yml
- ruby JSON parse for the inline Claude Code settings block
- git diff --check -- .github/workflows/model-price-audit.yml
- actionlint -ignore 'label "blacksmith-4vcpu-ubuntu-2404" is unknown' .github/workflows/model-price-audit.yml
- pre-commit hook: turbo run lint

## Follow-up test

A real non-mock model-price-audit workflow run is needed after LANGFUSE_OTEL_TRACES_ENDPOINT and LANGFUSE_OTEL_BASIC_AUTH are configured as GitHub Secrets. Mock mode skips the Claude Code Action step and therefore will not emit Claude Code OTel spans.