### PR TITLE
fix(evals): improve code eval error surfacing and retry behavior

### DIFF
--- a/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
@@ -109,14 +109,25 @@ if (typeof evaluate !== "function") {
   }
 }
 
+// Structural checks instead of `instanceof Error`: evaluator errors originate
+// in the vm realm, so they fail host-realm instanceof checks.
 function formatError(error: unknown): string {
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "message" in error &&
-    typeof error.message === "string"
-  ) {
-    return error.message;
+  if (typeof error === "object" && error !== null) {
+    const name =
+      "name" in error && typeof error.name === "string"
+        ? error.name
+        : undefined;
+    const message =
+      "message" in error && typeof error.message === "string"
+        ? error.message
+        : undefined;
+
+    if (message) {
+      // "Error" carries no signal; other names (TypeError, RangeError, custom
+      // classes) tell the evaluator author what went wrong.
+      return name && name !== "Error" ? `${name}: ${message}` : message;
+    }
+    if (name) return name;
   }
 
   return String(error);

--- a/packages/shared/src/server/redis/codeEvalExecutionQueue.ts
+++ b/packages/shared/src/server/redis/codeEvalExecutionQueue.ts
@@ -75,7 +75,9 @@ export class CodeEvalExecutionQueue {
             attempts: 3,
             backoff: {
               type: "exponential",
-              delay: 1000,
+              // Spaced for transient Lambda failures (e.g. regional capacity):
+              // retries fire ~30s and ~60s after the failed attempt.
+              delay: 30_000,
             },
           },
         })

--- a/scripts/code-eval-runners/node/code-based-eval-handler.mjs
+++ b/scripts/code-eval-runners/node/code-based-eval-handler.mjs
@@ -70,7 +70,16 @@ function runnerError(code, message) {
 }
 
 function formatError(error) {
-  return error instanceof Error ? error.message : String(error);
+  if (error instanceof Error) {
+    if (!error.message) return error.name || "Error";
+    // "Error" carries no signal; other names (TypeError, RangeError, custom
+    // classes) tell the evaluator author what went wrong.
+    return error.name && error.name !== "Error"
+      ? `${error.name}: ${error.message}`
+      : error.message;
+  }
+
+  return String(error);
 }
 
 function withCodeEvalDocs(message) {

--- a/scripts/code-eval-runners/python/code_based_eval_handler.py
+++ b/scripts/code-eval-runners/python/code_based_eval_handler.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import json
+import traceback
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -82,7 +83,7 @@ def handler(event, context):
         exec(event["code"]["source"], namespace)
     except Exception as error:
         return runner_error(
-            "INVALID_SOURCE", f"Failed to load evaluator source: {error}"
+            "INVALID_SOURCE", f"Failed to load evaluator source: {format_error(error)}"
         )
 
     evaluate = namespace.get("evaluate")
@@ -96,7 +97,7 @@ def handler(event, context):
         if asyncio.iscoroutine(result):
             result = asyncio.run(result)
     except Exception as error:
-        return runner_error("USER_CODE_ERROR", str(error))
+        return runner_error("USER_CODE_ERROR", format_error(error))
 
     return normalize_result(result)
 
@@ -141,6 +142,29 @@ def to_jsonable(value):
         return value
     except TypeError:
         return str(value)
+
+
+def format_error(error: BaseException) -> str:
+    # Bare str() is cryptic for common exceptions — str(KeyError("text")) is
+    # just "'text'" — so always lead with the exception type, Python style.
+    name = type(error).__name__
+    message = str(error)
+    formatted = f"{name}: {message}" if message else name
+
+    line = _user_code_line(error)
+    if line is not None:
+        formatted = f"{formatted} (line {line})"
+
+    return formatted
+
+
+def _user_code_line(error: BaseException) -> int | None:
+    # exec() compiles the evaluator source with filename "<string>", so the
+    # innermost such frame is where the user's own code raised.
+    for frame in reversed(traceback.extract_tb(error.__traceback__)):
+        if frame.filename == "<string>":
+            return frame.lineno
+    return None
 
 
 def runner_error(code: str, message: str):

--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -542,7 +542,9 @@ describe("evals trpc", () => {
           delay: 0,
           timeScope: ["NEW"],
         }),
-      ).rejects.toThrow("Evaluator failed during test run");
+      ).rejects.toThrow(
+        "Evaluator failed when tested against sample data: Evaluator failed during test run",
+      );
 
       await expect(
         prisma.jobConfiguration.findFirst({

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -41,7 +41,7 @@ import {
   observationVariableMapping,
 } from "@langfuse/shared";
 import { useRouter } from "next/router";
-import { toast } from "sonner";
+import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 import { Slider } from "@/src/components/ui/slider";
 import { Card } from "@/src/components/ui/card";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
@@ -372,13 +372,9 @@ export const InnerEvaluatorForm = (props: {
   evalCapabilities: EvalCapabilities;
   defaultRunOnLive?: boolean;
   defaultTarget?: EvalTargetObject;
-  renderFooter?: (params: {
-    isLoading: boolean;
-    formError: string | null;
-  }) => React.ReactNode;
+  renderFooter?: (params: { isLoading: boolean }) => React.ReactNode;
   oldConfigId?: string;
 }) => {
-  const [formError, setFormError] = useState<string | null>(null);
   const capture = usePostHogClientCapture();
   const router = useRouter();
   const [showTraceConfirmDialog, setShowTraceConfirmDialog] = useState(false);
@@ -559,17 +555,13 @@ export const InnerEvaluatorForm = (props: {
   const utils = api.useUtils();
   const createJobMutation = api.evals.createJob.useMutation({
     onSuccess: () => utils.models.invalidate(),
-    onError: (error) => {
-      setFormError(error.message);
-      toast.error(error.message);
-    },
+    // Defining onError replaces the react-query default that shows the
+    // standard error toast, so trigger it explicitly.
+    onError: trpcErrorToast,
   });
   const updateJobMutation = api.evals.updateEvalJob.useMutation({
     onSuccess: () => utils.evals.invalidate(),
-    onError: (error) => {
-      setFormError(error.message);
-      toast.error(error.message);
-    },
+    onError: trpcErrorToast,
   });
   const [availableVariables, setAvailableVariables] = useState<
     typeof availableTraceEvalVariables | typeof availableDatasetEvalVariables
@@ -749,11 +741,10 @@ export const InnerEvaluatorForm = (props: {
         }
       })
       .catch((error) => {
-        if ("message" in error && typeof error.message === "string") {
-          setFormError(error.message as string);
-          return;
-        }
-        setFormError(JSON.stringify(error));
+        // Mutation failures are surfaced via the onError toast; this catch
+        // also swallows post-success errors (onFormSuccess, router.push),
+        // so keep a console trace for those.
+        console.error("Evaluator form submission failed", error);
       });
   }
 
@@ -1382,7 +1373,7 @@ export const InnerEvaluatorForm = (props: {
     createJobMutation.isPending || updateJobMutation.isPending;
 
   const formFooter = props.renderFooter ? (
-    props.renderFooter({ isLoading: mutationIsLoading, formError })
+    props.renderFooter({ isLoading: mutationIsLoading })
   ) : (
     <div className="flex w-full flex-col items-end gap-4">
       {!props.disabled ? (
@@ -1393,11 +1384,6 @@ export const InnerEvaluatorForm = (props: {
         >
           {props.mode === "edit" ? "Update" : "Execute"}
         </Button>
-      ) : null}
-      {formError ? (
-        <p className="w-full text-center">
-          <span className="font-bold">Error:</span> {formError}
-        </p>
       ) : null}
     </div>
   );

--- a/web/src/features/evals/components/template-form.tsx
+++ b/web/src/features/evals/components/template-form.tsx
@@ -945,9 +945,7 @@ export const InnerEvalTemplateForm = (props: {
         </Button>
       )}
       {formError ? (
-        <p className="w-full text-center">
-          <span className="font-bold">Error:</span> {formError}
-        </p>
+        <p className="text-destructive text-sm">{formError}</p>
       ) : null}
     </div>
   );

--- a/web/src/features/evals/pages/remap-evaluator.tsx
+++ b/web/src/features/evals/pages/remap-evaluator.tsx
@@ -248,7 +248,7 @@ export default function RemapEvaluatorPage() {
                   hideAdvancedSettings={true}
                   evalCapabilities={evalCapabilities}
                   oldConfigId={evalConfigId}
-                  renderFooter={({ isLoading, formError }) => (
+                  renderFooter={({ isLoading }) => (
                     <div className="flex w-full flex-col items-end gap-4">
                       <div className="flex items-center">
                         <Button
@@ -294,11 +294,6 @@ export default function RemapEvaluatorPage() {
                           </DropdownMenuContent>
                         </DropdownMenu>
                       </div>
-                      {formError ? (
-                        <p className="w-full text-center">
-                          <span className="font-bold">Error:</span> {formError}
-                        </p>
-                      ) : null}
                     </div>
                   )}
                 />

--- a/web/src/features/evals/server/codeEvalJobConfigValidation.ts
+++ b/web/src/features/evals/server/codeEvalJobConfigValidation.ts
@@ -95,7 +95,9 @@ export async function assertCodeEvalJobConfigCanRun(params: {
     }
 
     if (!result.success) {
-      throw new CodeEvalJobConfigError(result.error.message);
+      throw new CodeEvalJobConfigError(
+        `Evaluator failed when tested against sample data: ${result.error.message}`,
+      );
     }
   }
 }

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
@@ -131,4 +131,51 @@ describeWithFloci("AwsLambdaCodeEvalDispatcher Floci integration", () => {
     },
     FLOCI_TEST_TIMEOUT_MS,
   );
+
+  it(
+    "formats Python exceptions with type and evaluator line number",
+    async () => {
+      // Line 4 of the source raises; str(KeyError) alone would be just "'beer'".
+      await expect(
+        dispatcher.dispatch({
+          ...baseInput,
+          runtime: { language: "PYTHON" },
+          code: {
+            source: `
+def evaluate(ctx):
+    data = {"output": ctx.observation.output}
+    return data["beer"]
+`,
+          },
+        }),
+      ).rejects.toMatchObject({
+        code: "USER_CODE_ERROR",
+        message: "KeyError: 'beer' (line 4)",
+        retryable: false,
+      } satisfies Partial<CodeEvalDispatcherError>);
+    },
+    FLOCI_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "prefixes non-generic error names from the Node runner",
+    async () => {
+      await expect(
+        dispatcher.dispatch({
+          ...baseInput,
+          runtime: { language: "TYPESCRIPT" },
+          code: {
+            source: `function evaluate(ctx: any) { return ctx.observation.missing.deeply; }`,
+          },
+        }),
+      ).rejects.toMatchObject({
+        code: "USER_CODE_ERROR",
+        message: expect.stringMatching(
+          /^TypeError: Cannot read properties of undefined/,
+        ),
+        retryable: false,
+      } satisfies Partial<CodeEvalDispatcherError>);
+    },
+    FLOCI_TEST_TIMEOUT_MS,
+  );
 });

--- a/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
@@ -161,6 +161,24 @@ describe("LocalCodeEvalDispatcher", () => {
     } satisfies Partial<CodeEvalDispatcherError>);
   });
 
+  it("includes the error name for non-generic evaluator throws", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher();
+
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        runtime: { language: "TYPESCRIPT" },
+        code: {
+          source: `function evaluate(ctx) { return ctx.observation.output.definitely.missing; }`,
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "USER_CODE_ERROR",
+      retryable: false,
+      message: expect.stringMatching(/^TypeError: /),
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
   it("times out runaway evaluators", async () => {
     const dispatcher = new LocalCodeEvalDispatcher({ timeoutMs: 50 });
 

--- a/worker/src/queues/codeEvalQueue.ts
+++ b/worker/src/queues/codeEvalQueue.ts
@@ -32,10 +32,6 @@ export const codeEvalExecutionQueueProcessorBuilder = (
           "messaging.bullmq.job.input.projectId",
           job.data.payload.projectId,
         );
-        span.setAttribute(
-          "messaging.bullmq.job.input.retryBaggage.attempt",
-          job.data.retryBaggage?.attempt ?? 0,
-        );
       }
 
       await processObservationEval({


### PR DESCRIPTION
## Summary

- Python code eval errors now read `KeyError: 'text' (line 4)` instead of `'text'` — runners prefix the exception type and add the evaluator line number; Node runner and local dispatcher prefix non-generic error names. Unit + Floci integration tests added.
- Execute preflight failures are framed (`Evaluator failed when tested against sample data: …`) and shown via the standard `trpcErrorToast` instead of an unstyled sonner toast.
- Code eval BullMQ retry backoff bumped 1s → 30s; removed the always-zero `retryBaggage.attempt` span attribute (real counter: `messaging.bullmq.job.attempts`).

## Linear

- `None`

## Major Decisions

- Dropped the inline form error instead of restyling it — the persistent standard toast already shows the same message with more context. `template-form` keeps its inline error (it has no toast).

## Review Focus

- Regression risk from removing the form footer error: mutation failures still toast (verified in-browser); post-success errors (`onFormSuccess`/`router.push`) now only `console.error` instead of rendering inline.
- Rollout: runner changes need a Lambda redeploy; the new backoff only applies to newly enqueued jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves how code evaluator errors are surfaced: Python now formats exceptions as `KeyError: 'text' (line 4)` (with type name and user-code line number), the Node/local-dispatcher runners prefix non-generic error names, and the preflight check wraps its error in a consistent "Evaluator failed when tested against sample data: …" frame. The UI switches from a duplicate inline-form error + sonner toast to the standard `trpcErrorToast` only, and the BullMQ retry backoff is raised from 1 s to 30 s.

- **Error formatting**: Python `format_error` always prefixes the exception type and appends the innermost `<string>` traceback line; Node runner and local TS dispatcher skip the "Error" prefix (no-signal name) but keep all other error names.
- **UI**: `inner-evaluator-form` drops the `formError` state and inline error paragraph; `template-form` keeps its inline error with updated destructive styling; the `renderFooter` callback signature loses the `formError` parameter.
- **Queue**: BullMQ exponential-backoff seed bumped from 1 000 ms to 30 000 ms (retries ~30 s / ~60 s); always-zero `retryBaggage.attempt` span attribute removed.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The error-formatting improvements are additive and well-tested; the UI change consolidates duplicate error display into a single toast; the backoff increase only affects newly enqueued jobs.

The changes are focused and low-risk. The one observable behaviour change is that mutation failures in inner-evaluator-form now also log to console.error (via the .catch()) in addition to showing the toast — redundant but not harmful. Post-success errors (router.push, onFormSuccess) are silently console-logged instead of shown inline, which the PR description explicitly acknowledges. Lambda runner changes require a redeploy to take effect, but that is an operational concern, not a code defect.

web/src/features/evals/components/inner-evaluator-form.tsx — the .catch() double-logs mutation errors; worth confirming the UX trade-off is intentional before merging.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/evals/components/inner-evaluator-form.tsx:743-748
**`console.error` fires for mutation errors, not just post-success ones**

When the mutation itself fails, `onError: trpcErrorToast` fires (shows the toast) and the `mutateAsync` promise also rejects, which means this `.catch()` fires too — calling `console.error` for the same error that was already toasted. The comment says "keep a console trace for those" (referring to `onFormSuccess`/`router.push` errors), but the current code doesn't distinguish between the two sources. The result is redundant console noise on every mutation failure. If the intent is to only log post-success errors, the `onError` callback could set a flag (or the catch could re-check whether it's a TRPC error) to skip mutation failures.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): standardize evaluator Execute ..."](https://github.com/langfuse/langfuse/commit/659be3b4d50d75fc8d75030d8d9902463c2773e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41391133)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->