### PR TITLE
fix(worker): add Google AI Studio model fallback

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -95,6 +95,7 @@ jobs:
               - 'packages/shared/src/server/llm/fetchLLMCompletion.ts'
               - 'packages/shared/src/server/llm/secureLlmFetch.ts'
               - 'packages/shared/src/server/llm/utils.ts'
+              - 'worker/src/__tests__/llmConnections.test.ts'
 
   lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/worker/src/__tests__/llmConnections.test.ts
+++ b/worker/src/__tests__/llmConnections.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest";
 import {
   fetchLLMCompletion,
+  isLLMCompletionError,
   type CompletionWithReasoning,
 } from "@langfuse/shared/src/server";
 import { encrypt } from "@langfuse/shared/encryption";
@@ -46,6 +47,54 @@ type TestLLMConnection = {
   baseURL?: string | null;
   config?: Record<string, string> | null;
 };
+
+const googleAIStudioFallbackModels = [
+  "gemini-3.1-flash-lite",
+  "gemini-2.5-flash",
+  "gemini-3.5-flash",
+] as const;
+
+async function runWithGoogleAIStudioModelFallback<T>(
+  operation: (model: string) => Promise<T>,
+): Promise<T> {
+  let lastError: unknown;
+
+  for (const [index, model] of googleAIStudioFallbackModels.entries()) {
+    try {
+      return await operation(model);
+    } catch (error) {
+      lastError = error;
+
+      if (
+        index === googleAIStudioFallbackModels.length - 1 ||
+        !isRetryableProviderError(error)
+      ) {
+        throw error;
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+function isRetryableProviderError(error: unknown): boolean {
+  if (isLLMCompletionError(error)) return error.isRetryable;
+
+  if (!error || typeof error !== "object") return false;
+
+  const errorLike = error as {
+    response?: { status?: unknown };
+    status?: unknown;
+    statusCode?: unknown;
+  };
+  const statusCode = [
+    errorLike.response?.status,
+    errorLike.status,
+    errorLike.statusCode,
+  ].find((code): code is number => typeof code === "number");
+
+  return statusCode === 429 || (statusCode !== undefined && statusCode >= 500);
+}
 
 const numericEvalResponseSchema = z.object({
   score: z.number(),
@@ -130,9 +179,10 @@ const evalStructuredOutputTestCases: EvalStructuredOutputTestCase[] = [
 
 function registerEvalStructuredOutputTests(params: {
   checkEnv: () => void;
-  getModelParams: () => ModelParams;
+  getModelParams: (model?: string) => ModelParams;
   getLLMConnection: () => TestLLMConnection;
   timeoutMs: number;
+  runWithModel?: <T>(operation: (model?: string) => Promise<T>) => Promise<T>;
 }) {
   evalStructuredOutputTestCases.forEach((testCase) => {
     test(
@@ -140,21 +190,25 @@ function registerEvalStructuredOutputTests(params: {
       async () => {
         params.checkEnv();
 
-        const completion = await fetchLLMCompletion({
-          streaming: false,
-          messages: [
-            {
-              role: "user",
-              content: testCase.prompt,
-              type: ChatMessageType.PublicAPICreated,
-            },
-          ],
-          modelParams: params.getModelParams(),
-          structuredOutputSchema: buildEvalOutputResultSchema(
-            testCase.outputDefinition,
-          ),
-          llmConnection: params.getLLMConnection(),
-        });
+        const completion = await (
+          params.runWithModel ?? ((operation) => operation())
+        )((model) =>
+          fetchLLMCompletion({
+            streaming: false,
+            messages: [
+              {
+                role: "user",
+                content: testCase.prompt,
+                type: ChatMessageType.PublicAPICreated,
+              },
+            ],
+            modelParams: params.getModelParams(model),
+            structuredOutputSchema: buildEvalOutputResultSchema(
+              testCase.outputDefinition,
+            ),
+            llmConnection: params.getLLMConnection(),
+          }),
+        );
 
         const parsed = testCase.responseSchema.safeParse(completion);
         expect(parsed.success).toBe(true);
@@ -1095,8 +1149,6 @@ describe("LLM Connection Tests", () => {
   });
 
   describe("GoogleAIStudio", () => {
-    const MODEL = "gemini-2.5-flash-lite";
-
     const checkEnvVar = () => {
       if (!process.env.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY) {
         throw new Error(
@@ -1110,28 +1162,30 @@ describe("LLM Connection Tests", () => {
     test("simple completion", async () => {
       checkEnvVar();
 
-      const completion = await fetchLLMCompletion({
-        streaming: false,
-        messages: [
-          {
-            role: "user",
-            content: "What is 2+2? Answer only with the number.",
-            type: ChatMessageType.PublicAPICreated,
+      const completion = await runWithGoogleAIStudioModelFallback((model) =>
+        fetchLLMCompletion({
+          streaming: false,
+          messages: [
+            {
+              role: "user",
+              content: "What is 2+2? Answer only with the number.",
+              type: ChatMessageType.PublicAPICreated,
+            },
+          ],
+          modelParams: {
+            provider: "google-ai-studio",
+            adapter: LLMAdapter.GoogleAIStudio,
+            model,
+            temperature: 0,
+            max_tokens: 10,
           },
-        ],
-        modelParams: {
-          provider: "google-ai-studio",
-          adapter: LLMAdapter.GoogleAIStudio,
-          model: MODEL,
-          temperature: 0,
-          max_tokens: 10,
-        },
-        llmConnection: {
-          secretKey: encrypt(
-            process.env.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY!,
-          ),
-        },
-      });
+          llmConnection: {
+            secretKey: encrypt(
+              process.env.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY!,
+            ),
+          },
+        }),
+      );
 
       // GoogleAIStudio always returns CompletionWithReasoning (text + optional reasoning)
       expect(typeof completion).toBe("object");
@@ -1141,48 +1195,50 @@ describe("LLM Connection Tests", () => {
     test("streaming completion", async () => {
       checkEnvVar();
 
-      const stream = await fetchLLMCompletion({
-        streaming: true,
-        messages: [
-          {
-            role: "user",
-            content: "What is 2+2? Answer only with the number.",
-            type: ChatMessageType.PublicAPICreated,
+      await runWithGoogleAIStudioModelFallback(async (model) => {
+        const stream = await fetchLLMCompletion({
+          streaming: true,
+          messages: [
+            {
+              role: "user",
+              content: "What is 2+2? Answer only with the number.",
+              type: ChatMessageType.PublicAPICreated,
+            },
+          ],
+          modelParams: {
+            provider: "google-ai-studio",
+            adapter: LLMAdapter.GoogleAIStudio,
+            model,
+            temperature: 0,
+            max_tokens: 10,
           },
-        ],
-        modelParams: {
-          provider: "google-ai-studio",
-          adapter: LLMAdapter.GoogleAIStudio,
-          model: MODEL,
-          temperature: 0,
-          max_tokens: 10,
-        },
-        llmConnection: {
-          secretKey: encrypt(
-            process.env.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY!,
-          ),
-        },
+          llmConnection: {
+            secretKey: encrypt(
+              process.env.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY!,
+            ),
+          },
+        });
+
+        const decoder = new TextDecoder();
+        let fullResponse = "";
+        let chunkCount = 0;
+
+        for await (const chunk of stream) {
+          fullResponse += decoder.decode(chunk);
+          chunkCount++;
+        }
+
+        expect(chunkCount).toBeGreaterThan(0);
+        expect(fullResponse).toContain("4");
       });
-
-      const decoder = new TextDecoder();
-      let fullResponse = "";
-      let chunkCount = 0;
-
-      for await (const chunk of stream) {
-        fullResponse += decoder.decode(chunk);
-        chunkCount++;
-      }
-
-      expect(chunkCount).toBeGreaterThan(0);
-      expect(fullResponse).toContain("4");
     }, 30_000);
 
     registerEvalStructuredOutputTests({
       checkEnv: checkEnvVar,
-      getModelParams: () => ({
+      getModelParams: (model = googleAIStudioFallbackModels[0]) => ({
         provider: "google-ai-studio",
         adapter: LLMAdapter.GoogleAIStudio,
-        model: MODEL,
+        model,
         temperature: 0,
         max_tokens: 200,
       }),
@@ -1192,34 +1248,37 @@ describe("LLM Connection Tests", () => {
         ),
       }),
       timeoutMs: 30_000,
+      runWithModel: runWithGoogleAIStudioModelFallback,
     });
 
     test("tool calling", async () => {
       checkEnvVar();
 
-      const completion = await fetchLLMCompletion({
-        streaming: false,
-        messages: [
-          {
-            role: "user",
-            content: "What's the weather like in Paris?",
-            type: ChatMessageType.PublicAPICreated,
+      const completion = await runWithGoogleAIStudioModelFallback((model) =>
+        fetchLLMCompletion({
+          streaming: false,
+          messages: [
+            {
+              role: "user",
+              content: "What's the weather like in Paris?",
+              type: ChatMessageType.PublicAPICreated,
+            },
+          ],
+          modelParams: {
+            provider: "google-ai-studio",
+            adapter: LLMAdapter.GoogleAIStudio,
+            model,
+            temperature: 0,
+            max_tokens: 100,
           },
-        ],
-        modelParams: {
-          provider: "google-ai-studio",
-          adapter: LLMAdapter.GoogleAIStudio,
-          model: MODEL,
-          temperature: 0,
-          max_tokens: 100,
-        },
-        tools: [weatherTool],
-        llmConnection: {
-          secretKey: encrypt(
-            process.env.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY!,
-          ),
-        },
-      });
+          tools: [weatherTool],
+          llmConnection: {
+            secretKey: encrypt(
+              process.env.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY!,
+            ),
+          },
+        }),
+      );
 
       expect(completion).toHaveProperty("tool_calls");
       expect(Array.isArray(completion.tool_calls)).toBe(true);
@@ -1234,28 +1293,30 @@ describe("LLM Connection Tests", () => {
       // Regression test: Text prompts create a single system message.
       // GoogleAIStudio must convert it to a user message to prevent:
       // "GenerateContentRequest.contents is not specified" error
-      const completion = await fetchLLMCompletion({
-        streaming: false,
-        messages: [
-          {
-            role: "system",
-            content: "What is 2+2? Answer only with the number.",
-            type: ChatMessageType.System,
+      const completion = await runWithGoogleAIStudioModelFallback((model) =>
+        fetchLLMCompletion({
+          streaming: false,
+          messages: [
+            {
+              role: "system",
+              content: "What is 2+2? Answer only with the number.",
+              type: ChatMessageType.System,
+            },
+          ],
+          modelParams: {
+            provider: "google-ai-studio",
+            adapter: LLMAdapter.GoogleAIStudio,
+            model,
+            temperature: 0,
+            max_tokens: 10,
           },
-        ],
-        modelParams: {
-          provider: "google-ai-studio",
-          adapter: LLMAdapter.GoogleAIStudio,
-          model: MODEL,
-          temperature: 0,
-          max_tokens: 10,
-        },
-        llmConnection: {
-          secretKey: encrypt(
-            process.env.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY!,
-          ),
-        },
-      });
+          llmConnection: {
+            secretKey: encrypt(
+              process.env.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY!,
+            ),
+          },
+        }),
+      );
 
       // GoogleAIStudio always returns CompletionWithReasoning
       expect(typeof completion).toBe("object");


### PR DESCRIPTION
## Summary

- Add ordered Google AI Studio fallback models for live LLM connection tests to reduce CI flakes from transient model capacity errors.
- Retry Google AI Studio test calls with `gemini-3.1-flash-lite`, `gemini-2.5-flash`, then `gemini-3.5-flash` only for retryable provider failures, while keeping auth, assertion, and schema failures hard-failing.

## Linear

- None

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the single hardcoded `gemini-2.5-flash-lite` model in the Google AI Studio integration tests with an ordered list of fallback models (`gemini-3.1-flash-lite` → `gemini-2.5-flash` → `gemini-3.5-flash`), retrying only on transient provider failures (HTTP 429 / 5xx or `isRetryable` errors from `LLMCompletionError`).

- Adds `runWithGoogleAIStudioModelFallback` and `isRetryableProviderError` helpers in the test file, and wires them into all five Google AI Studio test cases (simple, streaming, tool calling, system-message regression, and eval structured-output tests).
- Extends `registerEvalStructuredOutputTests` with an optional `runWithModel` hook and updates `getModelParams` to accept an optional `model` argument with a default of the first fallback model, keeping all non-Google provider test cases unchanged.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are confined to test infrastructure and do not affect production code paths.

The fallback logic is sound: auth errors, assertion failures, and schema errors all propagate immediately without being retried, and the type signatures are mutually compatible. The only gap is that when a fallback model is silently used, no warning is emitted, which can make CI flake investigations harder over time.

worker/src/__tests__/llmConnections.test.ts — the runWithGoogleAIStudioModelFallback helper and its interaction with the registerEvalStructuredOutputTests wrapper are worth a quick read.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Test Case
    participant Fallback as runWithGoogleAIStudioModelFallback
    participant Check as isRetryableProviderError
    participant API as Google AI Studio API

    Test->>Fallback: operation(model)
    loop For each model in [gemini-3.1-flash-lite, gemini-2.5-flash, gemini-3.5-flash]
        Fallback->>API: fetchLLMCompletion(model)
        alt Success
            API-->>Fallback: completion
            Fallback-->>Test: return result
        else Error
            API-->>Fallback: error
            Fallback->>Check: isRetryableProviderError(error)
            alt isLLMCompletionError
                Check-->>Fallback: error.isRetryable
            else HTTP-like error
                Check-->>Fallback: "status 429 or >= 500"
            end
            alt Last model OR not retryable
                Fallback-->>Test: throw error
            else Not last AND retryable
                Note over Fallback: Continue to next model
            end
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Test Case
    participant Fallback as runWithGoogleAIStudioModelFallback
    participant Check as isRetryableProviderError
    participant API as Google AI Studio API

    Test->>Fallback: operation(model)
    loop For each model in [gemini-3.1-flash-lite, gemini-2.5-flash, gemini-3.5-flash]
        Fallback->>API: fetchLLMCompletion(model)
        alt Success
            API-->>Fallback: completion
            Fallback-->>Test: return result
        else Error
            API-->>Fallback: error
            Fallback->>Check: isRetryableProviderError(error)
            alt isLLMCompletionError
                Check-->>Fallback: error.isRetryable
            else HTTP-like error
                Check-->>Fallback: "status 429 or >= 500"
            end
            alt Last model OR not retryable
                Fallback-->>Test: throw error
            else Not last AND retryable
                Note over Fallback: Continue to next model
            end
        end
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/__tests__/llmConnections.test.ts:57-77
**No visibility when a fallback model is used**

When a retryable error causes the loop to advance to the next model, no information is logged or emitted. In CI, a test can silently succeed on `gemini-2.5-flash` or `gemini-3.5-flash` while leaving no trace that the primary model was unavailable. Printing the error and the upcoming model (e.g., `console.warn`) before continuing would make transient failures visible in test output and help distinguish infrastructure flakes from real regressions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): add Google AI Studio model ..."](https://github.com/langfuse/langfuse/commit/c96e8ed326db44bc22eecbcae47da5f275dc9a5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41397297)</sub>

<!-- /greptile_comment -->