### PR TITLE
fix: enforce query timeout on the clickhouse side

### DIFF
--- a/packages/shared/src/server/clickhouse/client.test.ts
+++ b/packages/shared/src/server/clickhouse/client.test.ts
@@ -85,14 +85,14 @@ describe("ClickHouseClientManager compatibility settings", () => {
     expect(mocks.createClient).toHaveBeenCalledTimes(2);
   });
 
-  it("does not apply ClickHouse server timeout settings without a request timeout", () => {
+  it("sets ClickHouse server timeout after the default client request timeout", () => {
     clickhouseClient();
 
     expect(
       mocks.createClient.mock.calls[0][0].clickhouse_settings,
-    ).not.toMatchObject({
-      timeout_before_checking_execution_speed: expect.anything(),
-      max_execution_time: expect.anything(),
+    ).toMatchObject({
+      timeout_before_checking_execution_speed: 0,
+      max_execution_time: 35,
     });
   });
 

--- a/packages/shared/src/server/clickhouse/client.test.ts
+++ b/packages/shared/src/server/clickhouse/client.test.ts
@@ -84,4 +84,43 @@ describe("ClickHouseClientManager compatibility settings", () => {
 
     expect(mocks.createClient).toHaveBeenCalledTimes(2);
   });
+
+  it("does not apply ClickHouse server timeout settings without a request timeout", () => {
+    clickhouseClient();
+
+    expect(
+      mocks.createClient.mock.calls[0][0].clickhouse_settings,
+    ).not.toMatchObject({
+      timeout_before_checking_execution_speed: expect.anything(),
+      max_execution_time: expect.anything(),
+    });
+  });
+
+  it("sets ClickHouse server timeout just after the client request timeout", () => {
+    clickhouseClient({ request_timeout: 120_000 });
+
+    expect(
+      mocks.createClient.mock.calls[0][0].clickhouse_settings,
+    ).toMatchObject({
+      timeout_before_checking_execution_speed: 0,
+      max_execution_time: 125,
+    });
+  });
+
+  it("lets explicit client settings override derived timeout settings", () => {
+    clickhouseClient({
+      request_timeout: 120_000,
+      clickhouse_settings: {
+        timeout_before_checking_execution_speed: 10,
+        max_execution_time: 60,
+      } as ClickHouseSettings,
+    });
+
+    expect(
+      mocks.createClient.mock.calls[0][0].clickhouse_settings,
+    ).toMatchObject({
+      timeout_before_checking_execution_speed: 10,
+      max_execution_time: 60,
+    });
+  });
 });

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -23,6 +23,7 @@ type RequestTimeoutClickHouseSettings = ClickHouseSettings & {
   timeout_before_checking_execution_speed?: number;
 };
 
+const CLICKHOUSE_CLIENT_DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const CLICKHOUSE_SERVER_TIMEOUT_GRACE_SECONDS = 5;
 
 /**
@@ -184,6 +185,12 @@ export class ClickHouseClientManager {
         cloudOptions.input_format_json_throw_on_bad_escape_sequence = 0;
       }
 
+      const clickHouseRequestTimeout =
+        opts.request_timeout ?? CLICKHOUSE_CLIENT_DEFAULT_REQUEST_TIMEOUT_MS;
+      const shouldSendProgressInHttpHeaders =
+        opts.request_timeout !== undefined &&
+        opts.request_timeout > CLICKHOUSE_CLIENT_DEFAULT_REQUEST_TIMEOUT_MS;
+
       const client = createClient({
         ...opts,
         ...settings,
@@ -224,11 +231,11 @@ export class ClickHouseClientManager {
             : {}),
           ...cloudOptions,
           ...serviceClickhouseSettings,
-          ...this.getRequestTimeoutClickHouseSettings(opts.request_timeout),
+          ...this.getRequestTimeoutClickHouseSettings(clickHouseRequestTimeout),
           ...opts.clickhouse_settings,
           async_insert: 1,
           wait_for_async_insert: 1, // if disabled, we won't get errors from clickhouse
-          ...(opts.request_timeout && opts.request_timeout > 30000
+          ...(shouldSendProgressInHttpHeaders
             ? {
                 send_progress_in_http_headers: 1,
                 http_headers_progress_interval_ms: "10000", // UInt64, should be passed as a string

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -18,6 +18,13 @@ type ServiceClickhouseSettings = ClickHouseSettings & {
   enable_full_text_index?: 1;
 };
 
+type RequestTimeoutClickHouseSettings = ClickHouseSettings & {
+  max_execution_time?: number;
+  timeout_before_checking_execution_speed?: number;
+};
+
+const CLICKHOUSE_SERVER_TIMEOUT_GRACE_SECONDS = 5;
+
 /**
  * Remove these once we remove corresponding variables
  */
@@ -109,6 +116,19 @@ export class ClickHouseClientManager {
     return EVENTS_TABLE_READ_PATH_ENV_KEYS.some(
       (key) => process.env[key] === "true",
     );
+  }
+
+  private getRequestTimeoutClickHouseSettings(
+    requestTimeout?: number,
+  ): RequestTimeoutClickHouseSettings {
+    if (!requestTimeout) return {};
+
+    return {
+      timeout_before_checking_execution_speed: 0,
+      max_execution_time:
+        Math.ceil(requestTimeout / 1000) +
+        CLICKHOUSE_SERVER_TIMEOUT_GRACE_SECONDS,
+    };
   }
 
   private generateClientSettingsKey(
@@ -204,6 +224,7 @@ export class ClickHouseClientManager {
             : {}),
           ...cloudOptions,
           ...serviceClickhouseSettings,
+          ...this.getRequestTimeoutClickHouseSettings(opts.request_timeout),
           ...opts.clickhouse_settings,
           async_insert: 1,
           wait_for_async_insert: 1, // if disabled, we won't get errors from clickhouse


### PR DESCRIPTION
## Summary
- Derive ClickHouse server timeout settings from `request_timeout` when present
- Keep derived values out of the client config when no request timeout is set
- Allow explicit `clickhouse_settings` to override the derived timeout values

## Testing
- Added unit tests covering the no-timeout, derived-timeout, and override cases

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enforces a server-side ClickHouse query timeout derived from the client-level `request_timeout`, acting as a safety net that kills orphaned queries 5 seconds after the client gives up.

- **Derived timeout logic**: a new `getRequestTimeoutClickHouseSettings` helper converts `request_timeout` (ms) to `max_execution_time` (seconds + 5s grace) and is a no-op when no timeout is configured, keeping unaffected clients unchanged.
- **Override precedence**: derived settings are spread before `opts.clickhouse_settings`, so callers can still override individual timeout values explicitly.
- **Tests**: three new unit tests cover the no-timeout, derived-timeout, and explicit-override paths; the "no timeout" assertion is slightly weaker than ideal (see inline comment).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, the cache-key logic correctly accounts for the new derived settings, and the override order preserves backward compatibility.

The implementation is a pure addition: when no `request_timeout` is set the helper returns `{}` and nothing changes for existing callers. When a timeout is present the derived values are deterministic and the cache key already differentiates on `request_timeout`. The only findings are a slightly weak test assertion and a no-op setting that could confuse future readers — neither affects runtime behaviour.

The test file is worth a second look for the "no timeout" assertion strength; the production file is straightforward.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant clickhouseClient
    participant ClickHouseClientManager
    participant createClient as @clickhouse/client

    Caller->>clickhouseClient: "clickhouseClient({ request_timeout: T })"
    clickhouseClient->>ClickHouseClientManager: getClient(opts)
    ClickHouseClientManager->>ClickHouseClientManager: generateClientSettings(opts)
    ClickHouseClientManager->>ClickHouseClientManager: getRequestTimeoutClickHouseSettings(T)
    Note over ClickHouseClientManager: Returns { max_execution_time: ceil(T/1000)+5,<br/>timeout_before_checking_execution_speed: 0 }
    Note over ClickHouseClientManager: Spread order in clickhouse_settings:<br/>1. env async-insert overrides<br/>2. cloudOptions<br/>3. serviceClickhouseSettings<br/>4. derived timeout settings (NEW)<br/>5. opts.clickhouse_settings (caller override)<br/>6. async_insert=1, wait_for_async_insert=1<br/>7. send_progress_in_http_headers (if T>30s)
    ClickHouseClientManager->>createClient: "createClient({ ..., clickhouse_settings })"
    createClient-->>ClickHouseClientManager: ClickhouseClientType
    ClickHouseClientManager-->>Caller: cached client
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant clickhouseClient
    participant ClickHouseClientManager
    participant createClient as @clickhouse/client

    Caller->>clickhouseClient: "clickhouseClient({ request_timeout: T })"
    clickhouseClient->>ClickHouseClientManager: getClient(opts)
    ClickHouseClientManager->>ClickHouseClientManager: generateClientSettings(opts)
    ClickHouseClientManager->>ClickHouseClientManager: getRequestTimeoutClickHouseSettings(T)
    Note over ClickHouseClientManager: Returns { max_execution_time: ceil(T/1000)+5,<br/>timeout_before_checking_execution_speed: 0 }
    Note over ClickHouseClientManager: Spread order in clickhouse_settings:<br/>1. env async-insert overrides<br/>2. cloudOptions<br/>3. serviceClickhouseSettings<br/>4. derived timeout settings (NEW)<br/>5. opts.clickhouse_settings (caller override)<br/>6. async_insert=1, wait_for_async_insert=1<br/>7. send_progress_in_http_headers (if T>30s)
    ClickHouseClientManager->>createClient: "createClient({ ..., clickhouse_settings })"
    createClient-->>ClickHouseClientManager: ClickhouseClientType
    ClickHouseClientManager-->>Caller: cached client
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/clickhouse/client.test.ts:91-96
The "no timeout" assertion uses `.not.toMatchObject({a, b})`, which passes as long as the object is missing **at least one** of the two keys. A case where only `max_execution_time` is accidentally set (without `timeout_before_checking_execution_speed`) would still make this test pass, giving a false green. Two separate `.not.toHaveProperty` calls are more precise.

```suggestion
    const settings = mocks.createClient.mock.calls[0][0].clickhouse_settings;
    expect(settings).not.toHaveProperty("timeout_before_checking_execution_speed");
    expect(settings).not.toHaveProperty("max_execution_time");
```

### Issue 2 of 2
packages/shared/src/server/clickhouse/client.ts:127
`timeout_before_checking_execution_speed` controls the warm-up period before ClickHouse enforces `min_execution_speed` — it has no effect unless `min_execution_speed` is also set. Since `min_execution_speed` is not configured here, this setting is silently a no-op and could be confusing to future readers. If the intention is to prevent orphaned slow queries, `max_execution_time` alone is sufficient; otherwise this could be documented with a comment explaining when it becomes relevant.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Tune ClickHouse timeout settings"](https://github.com/langfuse/langfuse/commit/cc93645862328ecf6a217d6296b54431fb22babd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41404803)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->