### PR TITLE
fix(trace): avoid minifier-dropped const in peek collapse boundary

### DIFF
--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -116,10 +116,12 @@ const NOOP_LAYOUT_STORAGE = {
 // small-share) nav on a wide peek is mis-seeded as collapsed and its content
 // unmounts for a frame until `onResize` corrects it. Boundary = midpoint between
 // the 40px rail and the smallest open min (nav 260px), as a share of the width.
-const COLLAPSED_RAIL_BOUNDARY_PX =
-  (COLLAPSED_PANEL_PX + NAVIGATION_PANEL_MIN_PX) / 2;
+// Kept LOCAL (not a module const): as a single-use top-level const it tripped
+// the SWC prod minifier — the binding was dropped but a dangling reference kept,
+// throwing a `ReferenceError` on peek open.
 function collapsedShareMaxForWidth(groupWidthPx: number): number {
-  return (COLLAPSED_RAIL_BOUNDARY_PX / groupWidthPx) * 100;
+  const boundaryPx = (COLLAPSED_PANEL_PX + NAVIGATION_PANEL_MIN_PX) / 2;
+  return (boundaryPx / groupWidthPx) * 100;
 }
 // Full-page fallback (its container width isn't known at seed time): the boundary
 // as a share of the narrowest both-open width, matching the prior heuristic.


### PR DESCRIPTION
## TL;DR

Opening a trace **peek** threw `ReferenceError: COLLAPSED_RAIL_BOUNDARY_PX is not defined` — but only in the **production build**, so dev never caught it. The SWC minifier constant-folded one call site of a small helper and **dropped the single-use module const it read**, while a second (dynamic) call site kept a dangling reference. Inlining the value as a **function-local const** removes the top-level binding the minifier could drop. Behavior is unchanged. Regression from #14716 (LFE-10601).

## Why

`db9ee72` (#14716) introduced a single-use, module-scoped const read **only** inside `collapsedShareMaxForWidth`, which runs in two places:

```ts
const COLLAPSED_RAIL_BOUNDARY_PX =
  (COLLAPSED_PANEL_PX + NAVIGATION_PANEL_MIN_PX) / 2;   // single-use, top-level
function collapsedShareMaxForWidth(groupWidthPx: number): number {
  return (COLLAPSED_RAIL_BOUNDARY_PX / groupWidthPx) * 100;
}
const COLLAPSED_LAYOUT_SHARE_MAX_PCT =
  collapsedShareMaxForWidth(BOTH_PANELS_MIN_WIDTH_PX); // module init — CONSTANT arg (621)

// …and at render, in peek mode — DYNAMIC arg:
isPeekMode && peekWidthPx > 0
  ? collapsedShareMaxForWidth(peekWidthPx)
  : COLLAPSED_LAYOUT_SHARE_MAX_PCT;
```

The SWC production minifier **constant-folds** the module-init call (`260 + 360 + 1 = 621` is compile-time), removing every init-time reference to the const. The dynamic render-time call can't be folded, so its body is kept — but the minifier, now seeing the const as unused outside the folded-away path, **drops the binding while leaving the reference dangling** (the un-mangled name in the error confirms it was treated as a free global).

That asymmetry is why it fails **only when opening a trace peek** (`?peek=…`), never on normal page load or the full-page trace view (which use the folded literal).

## What

- Inline the boundary as a **function-local** const, so there is no top-level binding for the minifier to drop. Byte-for-byte identical arithmetic — restores the safe shape the pre-#14716 code had.
- Swept `web/src` for the same shape (a small arithmetic helper reading a single-use module const, folded at a constant call but kept at a dynamic call elsewhere). This was the **only** instance: `buildFilterMappings` (dashboard) has no dynamic call site and returns non-foldable objects; `peekPanelStore` consts are literals / exported / multi-use.

## Linear

- None (regression from LFE-10601, #14716)

## Review focus

- **Behavior unchanged** — pure refactor of a numeric helper, no logic or UX change.
- The real gate is the **production build** (the minifier path this targets); dev never reproduced it.

<details>
<summary>Verification</summary>

- `turbo run lint` across all packages — passes (pre-commit hook).
- `TraceLayoutDesktop.tsx` typechecks clean.
- Correct by construction: the identifier no longer exists anywhere, so nothing can drop it or leave it dangling.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
