### PR TITLE
revert: peek comfortable defaults (#14716) — prod crash (LFE-10640)

### DIFF
--- a/web/src/components/table/peek/README.md
+++ b/web/src/components/table/peek/README.md
@@ -53,23 +53,6 @@ State altitudes:
 | resize drag | high-frequency transient        | store `draftFraction` / `draftExpanded` / `isResizing`, committed on pointer-up                            |
 | which item  | route                           | the `peek` URL param (see below)                                                                           |
 
-The **default** width (no saved preference) is viewport-aware: 50vw, but capped
-in px (`PEEK_MAX_DEFAULT_WIDTH_PX`) so a bigger screen doesn't mean a
-proportionally bigger peek (LFE-10601). Normal laptops still open at 50vw; only
-very wide monitors trim the fraction so the peek stays comfortable and the list
-navigable.
-
-The **inner tree ↔ info split** inside the peek is a separate
-`react-resizable-panels` group (`TraceLayoutDesktop`), unified with the width to
-persist in **`localStorage`** under a peek-scoped group id (`trace-layout-peek-*`)
-rather than per-tab `sessionStorage`. Its default is computed as an explicit
-**percentage** from the width the peek opens at: the info panel gets a
-comfortable target and the tree/timeline takes the remainder, clamped to a
-comfortable band — so extra width on a big peek flows to info (the content), not
-the tree (the index). A percentage (not a px `defaultSize`, which the library
-resolves against a transient mid-open width) keeps that default deterministic.
-The full-page trace view keeps its own share-based, per-tab layout.
-
 The peek and the standalone trace page already share one beta-aware fetch
 ([`../../trace/useTraceDetailData.ts`](../../trace/useTraceDetailData.ts)), one
 body + title

--- a/web/src/components/table/peek/store/peekPanelStore.clienttest.ts
+++ b/web/src/components/table/peek/store/peekPanelStore.clienttest.ts
@@ -3,36 +3,14 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createPeekPanelStore,
   PEEK_DEFAULT_WIDTH_FRACTION,
-  PEEK_MAX_DEFAULT_WIDTH_PX,
   PEEK_MAX_WIDGET_WIDTH_FRACTION,
   PEEK_MIN_WIDTH_FRACTION,
-  resolveDefaultWidthFraction,
   selectDraftExpanded,
   selectWidgetWidth,
 } from "@/src/components/table/peek/store/peekPanelStore";
 
 const STORAGE_KEY = "peekViewWidthFraction";
 const pct = (fraction: number) => `${fraction * 100}vw`;
-
-// jsdom's default innerWidth is 1024; override per-test to exercise the
-// viewport-aware default, then restore.
-function withViewportWidth(width: number, run: () => void) {
-  const original = window.innerWidth;
-  Object.defineProperty(window, "innerWidth", {
-    value: width,
-    configurable: true,
-    writable: true,
-  });
-  try {
-    run();
-  } finally {
-    Object.defineProperty(window, "innerWidth", {
-      value: original,
-      configurable: true,
-      writable: true,
-    });
-  }
-}
 
 describe("peekPanelStore", () => {
   beforeEach(() => window.localStorage.clear());
@@ -45,48 +23,6 @@ describe("peekPanelStore", () => {
     expect(state.draftExpanded).toBe(false);
     expect(state.widthFraction).toBeCloseTo(PEEK_DEFAULT_WIDTH_FRACTION);
     expect(selectWidgetWidth(state)).toBe(pct(PEEK_DEFAULT_WIDTH_FRACTION));
-  });
-
-  describe("default width caps px growth on wide screens (LFE-10601)", () => {
-    it("keeps 50vw on a normal laptop where 50vw is under the px cap", () => {
-      withViewportWidth(1440, () => {
-        expect(resolveDefaultWidthFraction()).toBeCloseTo(
-          PEEK_DEFAULT_WIDTH_FRACTION,
-        );
-        expect(createPeekPanelStore().getState().widthFraction).toBeCloseTo(
-          PEEK_DEFAULT_WIDTH_FRACTION,
-        );
-      });
-    });
-
-    it("trims the fraction on a wide screen so the peek stays near the px cap", () => {
-      // 3000px: 50vw = 1500px > cap → fraction shrinks so width ≈ cap.
-      withViewportWidth(3000, () => {
-        const fraction = resolveDefaultWidthFraction();
-        expect(fraction).toBeLessThan(PEEK_DEFAULT_WIDTH_FRACTION);
-        expect(fraction * 3000).toBeCloseTo(PEEK_MAX_DEFAULT_WIDTH_PX, 0);
-        expect(createPeekPanelStore().getState().widthFraction).toBeCloseTo(
-          fraction,
-        );
-      });
-    });
-
-    it("never falls below the drag minimum, even on an ultra-wide screen", () => {
-      withViewportWidth(6000, () => {
-        expect(resolveDefaultWidthFraction()).toBeCloseTo(
-          PEEK_MIN_WIDTH_FRACTION,
-        );
-      });
-    });
-
-    it("a saved preference always wins over the viewport-aware default", () => {
-      withViewportWidth(3000, () => {
-        window.localStorage.setItem(STORAGE_KEY, "0.5");
-        expect(createPeekPanelStore().getState().widthFraction).toBeCloseTo(
-          0.5,
-        );
-      });
-    });
   });
 
   it("reads and clamps the persisted width on creation", () => {

--- a/web/src/components/table/peek/store/peekPanelStore.ts
+++ b/web/src/components/table/peek/store/peekPanelStore.ts
@@ -31,51 +31,26 @@ export const PEEK_DEFAULT_WIDTH_FRACTION = 0.5;
 export const PEEK_EXPAND_ENTER_FRACTION = 0.95;
 const KEYBOARD_RESIZE_STEP = 0.05;
 
-// Cap the *default* peek width in px so a bigger screen doesn't mean a
-// proportionally bigger peek (LFE-10601): at 50vw the peek balloons on large
-// monitors, covering the table and — with a share-based inner split — inflating
-// the tree. We keep 50vw on normal laptops (where 50vw < this cap) and only trim
-// the fraction on very wide screens, giving a comfortable-but-bounded default
-// that still leaves the underlying list navigable. The floor is the drag min so
-// the default never lands narrower than the user could drag back to.
-export const PEEK_MAX_DEFAULT_WIDTH_PX = 1400;
-
 export const clampWidthFraction = (fraction: number) =>
   Math.min(
     PEEK_MAX_WIDGET_WIDTH_FRACTION,
     Math.max(PEEK_MIN_WIDTH_FRACTION, fraction),
   );
 
-// Default width when the user has no saved preference. Viewport-aware: the plain
-// 50vw fraction, but capped so the resulting px never exceeds
-// PEEK_MAX_DEFAULT_WIDTH_PX, then floored at the drag minimum. SSR-safe (returns
-// the plain fraction when there's no window).
-export function resolveDefaultWidthFraction(): number {
-  const vw = typeof window === "undefined" ? 0 : window.innerWidth;
-  if (vw <= 0) return PEEK_DEFAULT_WIDTH_FRACTION;
-  return Math.max(
-    PEEK_MIN_WIDTH_FRACTION,
-    Math.min(PEEK_DEFAULT_WIDTH_FRACTION, PEEK_MAX_DEFAULT_WIDTH_PX / vw),
-  );
-}
-
-// The width fraction that will actually be used to open the peek: the saved
-// preference (clamped) if present, else the viewport-aware default. SSR-safe
-// (returns the plain default when there's no window). Exported so the inner
-// tree↔info split can size its default against the real peek width without
-// re-measuring the DOM.
-export function resolveEffectiveWidthFraction(): number {
+// Cross-view width preference, persisted as a raw fraction. SSR-safe: reads the
+// default on the server and the first client render, the real value after mount.
+function readStoredWidthFraction(): number {
   if (typeof window === "undefined") return PEEK_DEFAULT_WIDTH_FRACTION;
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (raw !== null) {
-      const parsed = JSON.parse(raw);
-      if (typeof parsed === "number") return clampWidthFraction(parsed);
-    }
+    if (raw === null) return PEEK_DEFAULT_WIDTH_FRACTION;
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "number"
+      ? clampWidthFraction(parsed)
+      : PEEK_DEFAULT_WIDTH_FRACTION;
   } catch {
-    // Fall through to the default on any read/parse failure.
+    return PEEK_DEFAULT_WIDTH_FRACTION;
   }
-  return resolveDefaultWidthFraction();
 }
 
 function writeStoredWidthFraction(fraction: number): void {
@@ -115,7 +90,7 @@ export type PeekPanelStore = StoreApi<PeekPanelStoreState>;
 
 export function createPeekPanelStore(): PeekPanelStore {
   return createStore<PeekPanelStoreState>((set, get) => ({
-    widthFraction: resolveEffectiveWidthFraction(),
+    widthFraction: readStoredWidthFraction(),
     draftFraction: null,
     draftExpanded: false,
     isResizing: false,

--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -11,7 +11,6 @@ import {
 import {
   useState,
   useEffect,
-  useMemo,
   createContext,
   useContext,
   type ReactNode,
@@ -21,54 +20,13 @@ import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
 import { useViewPreferences } from "@/src/components/trace/contexts/ViewPreferencesContext";
 import { useSelection } from "@/src/components/trace/contexts/SelectionContext";
-import { resolveEffectiveWidthFraction } from "@/src/components/table/peek/store/peekPanelStore";
 
-// v2: the default split gives the trace (tree/timeline) the central space with a
-// slimmer detail panel. Bumped so a stale saved layout doesn't mask it. Used by
-// the full-page trace view; the peek uses its own id/storage/default (below).
+// v2: the default split now gives the trace (tree/timeline) the central space
+// with a slimmer detail panel. Bumped so a stale saved layout doesn't mask it.
 const RESIZABLE_PANEL_GROUP_ID = "trace-layout-v2";
-// Peek gets a distinct group so its computed-percentage default and localStorage
-// persistence don't leak into the full-page view (which stays share-based, per
-// tab). Same panels, different layout scope (LFE-10601).
-const PEEK_RESIZABLE_PANEL_GROUP_ID = "trace-layout-peek-v1";
 const RESIZABLE_PANEL_HANDLE_ID = "trace-layout-handle";
 const RESIZABLE_PANEL_NAVIGATION_ID = "trace-layout-panel-navigation";
 const RESIZABLE_PANEL_PREVIEW_ID = "trace-layout-panel-preview";
-
-// Full-page default (unchanged): a share-based split — tree gets the majority.
-const FULL_NAVIGATION_DEFAULT_SIZE = "60%";
-const FULL_DETAIL_DEFAULT_SIZE = "40%";
-
-// Peek default split (LFE-10601). We size the tree/timeline (the index) to a
-// comfortable band and give the *rest* to the detail panel (the content), so on
-// a wide peek the extra width flows to info, not the tree — killing the old
-// "very wide tree, cramped info" that the 60/40 share produced on big screens.
-//
-// We express this as an explicit *percentage* layout computed from the known
-// peek width, NOT as a px `defaultSize`. The library converts a px defaultSize
-// to a percentage against whatever group width it happens to measure first,
-// which on a peek is a transient mid-open value — so the resolved ratio (and
-// thus what gets persisted) was non-deterministic. A percentage is
-// width-independent, so the default is stable across opens.
-const PEEK_INFO_COMFORTABLE_TARGET_PX = 560; // info wants ~this to read JSON/scores
-const PEEK_NAV_COMFORTABLE_MIN_PX = 340; // tree's comfortable floor (> the 260 hard min)
-const PEEK_NAV_COMFORTABLE_MAX_PX = 460; // never default the tree wider than this
-
-// Tree/info split (as a nav-panel percentage) for a peek of `peekWidthPx`: give
-// info its comfortable target, hand the remainder to the tree clamped to its
-// comfortable band. Returns undefined when the width is unknown (SSR).
-function computePeekNavPercent(peekWidthPx: number): number | undefined {
-  if (!(peekWidthPx > 0)) return undefined;
-  const navPx = Math.min(
-    PEEK_NAV_COMFORTABLE_MAX_PX,
-    Math.max(
-      PEEK_NAV_COMFORTABLE_MIN_PX,
-      peekWidthPx - PEEK_INFO_COMFORTABLE_TARGET_PX,
-    ),
-  );
-  // Keep it a sane share; the panels' own min/collapse constraints do the rest.
-  return Math.min(90, Math.max(10, (navPx / peekWidthPx) * 100));
-}
 
 // Min widths of the two collapsible panels (kept here so the Panel props and the
 // toggle/scroll logic below can't drift apart).
@@ -96,46 +54,29 @@ const COLLAPSED_PANEL_PX = 40;
 const BOTH_PANELS_MIN_WIDTH_PX =
   NAVIGATION_PANEL_MIN_PX + DETAIL_PANEL_MIN_PX + RESIZE_HANDLE_PX;
 
-// A no-op layout storage so `useDefaultLayout` never touches a real Storage
-// during SSR / DOM-less tests (its default `= localStorage` is a bare global
-// that would throw). Mirrors the pattern in `ui/resizable-split-layout.tsx`.
-const NOOP_LAYOUT_STORAGE = {
-  getItem: () => null,
-  setItem: () => {},
-};
-
 // Detect whether a panel is sitting on its collapsed rail in a RESTORED layout.
 // `useDefaultLayout` returns a `{ [panelId]: number }` map of flexGrow shares
 // that sum to ~100 (percentages of the group). A collapsed panel is exactly its
 // `collapsedSize` (40px) wide, while an open panel is always at least its
-// `minSize` (260/360px) — or, for the peek's width-capped nav default, ~460px.
-// The rail share and the open share never overlap, but WHERE the boundary sits
-// depends on the group's actual pixel width: a 460px open nav is ~42% at a 621px
-// peek but only ~15% at a 3000px one. So the threshold must be computed against
-// the real width, not a fixed percent — otherwise a legitimately-open (but
-// small-share) nav on a wide peek is mis-seeded as collapsed and its content
-// unmounts for a frame until `onResize` corrects it. Boundary = midpoint between
-// the 40px rail and the smallest open min (nav 260px), as a share of the width.
-const COLLAPSED_RAIL_BOUNDARY_PX =
-  (COLLAPSED_PANEL_PX + NAVIGATION_PANEL_MIN_PX) / 2;
-function collapsedShareMaxForWidth(groupWidthPx: number): number {
-  return (COLLAPSED_RAIL_BOUNDARY_PX / groupWidthPx) * 100;
-}
-// Full-page fallback (its container width isn't known at seed time): the boundary
-// as a share of the narrowest both-open width, matching the prior heuristic.
-const COLLAPSED_LAYOUT_SHARE_MAX_PCT = collapsedShareMaxForWidth(
-  BOTH_PANELS_MIN_WIDTH_PX,
-);
-// Used only to seed the collapse flags on mount so `bothPanelsOpen` (and thus
-// the min-width pin) matches the layout the library is about to restore,
-// avoiding a one-frame scrollbar flash (see the useState initializers below).
+// `minSize` (260/360px). For any peek width those two ranges never overlap: at
+// the narrowest both-panels-open width (~621px) the 40px rail is ~6% while the
+// smaller open min (nav 260px) is ~42%, and the gap only widens as the group
+// grows. We therefore treat a panel as collapsed-in-layout when its restored
+// share is at most the share its rail would occupy at the narrowest open width,
+// with a margin — comfortably below any open-min share. Used only to seed the
+// collapse flags on mount so `bothPanelsOpen` (and thus the min-width pin)
+// matches the layout the library is about to restore, avoiding a one-frame
+// scrollbar flash (see the useState initializers below).
+const COLLAPSED_LAYOUT_SHARE_MAX_PCT =
+  ((COLLAPSED_PANEL_PX / BOTH_PANELS_MIN_WIDTH_PX) * 100 +
+    (NAVIGATION_PANEL_MIN_PX / BOTH_PANELS_MIN_WIDTH_PX) * 100) /
+  2;
 function isPanelCollapsedInLayout(
   layout: Record<string, number> | undefined,
   panelId: string,
-  maxSharePct: number,
 ): boolean {
   const share = layout?.[panelId];
-  return typeof share === "number" && share <= maxSharePct;
+  return typeof share === "number" && share <= COLLAPSED_LAYOUT_SHARE_MAX_PCT;
 }
 
 // Context for sharing panel state with compound components
@@ -150,12 +91,6 @@ interface TraceLayoutDesktopContext {
   isDetailPanelCollapsed: boolean;
   setIsDetailPanelCollapsed: (collapsed: boolean) => void;
   expandDetailPanel: () => void;
-  // Fallback panel sizes (peek is driven by the computed-percentage
-  // `defaultLayout`; these apply only when it's absent, e.g. the full-page view
-  // or SSR). Detail is `undefined` when nav carries the sole default so it
-  // auto-fills the remainder.
-  navigationDefaultSize: string;
-  detailDefaultSize: string | undefined;
 }
 
 const LayoutContext = createContext<TraceLayoutDesktopContext | null>(null);
@@ -186,89 +121,26 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
   const [viewMode] = useQueryParam("view", StringParam);
   const isTimelineView = viewMode === "timeline";
 
-  // Get annotation mode + peek mode from context. Peek scopes the layout to its
-  // own group so its px-anchored default + cross-session persistence stay out of
-  // the full-page view (LFE-10601).
-  const { isAnnotationMode, isPeekMode } = useViewPreferences();
+  // Get annotation mode from context to determine initial collapse state
+  const { isAnnotationMode } = useViewPreferences();
 
-  const groupId = isPeekMode
-    ? PEEK_RESIZABLE_PANEL_GROUP_ID
-    : RESIZABLE_PANEL_GROUP_ID;
-  // Unify the peek's persistence with its outer width: both live in
-  // localStorage, so a resized tree/info ratio sticks across tabs and reloads
-  // instead of resetting per tab (the old sessionStorage behavior). The
-  // full-page view keeps its per-tab sessionStorage. Guarded so SSR / DOM-less
-  // tests fall back to a no-op store instead of throwing on the bare global.
-  const storage =
-    typeof window === "undefined"
-      ? NOOP_LAYOUT_STORAGE
-      : isPeekMode
-        ? window.localStorage
-        : window.sessionStorage;
-
-  // Peek drives its split via an explicit percentage `defaultLayout` (below);
-  // the panel `defaultSize`s are the SSR/fallback only. Full-page keeps its
-  // share-based 60/40. Detail has no default so it fills the remainder there.
-  const navigationDefaultSize = FULL_NAVIGATION_DEFAULT_SIZE;
-  const detailDefaultSize = isPeekMode ? undefined : FULL_DETAIL_DEFAULT_SIZE;
-
-  // The width the peek actually opens at. When expanded (a shared/reloaded
-  // `?peekView=expanded` link) the panel renders at ~viewport width, NOT the
-  // widget fraction — so we must size the split against that, or a first-open
-  // expanded peek on a big screen re-creates the wide-tree bug. The sidebar
-  // offset is ignored (the nav is width-capped at these sizes, so the small
-  // difference doesn't move the split). 0 outside peek / during SSR. Mount-time
-  // default only (a saved layout wins after first open), so it doesn't track
-  // viewport changes.
-  const [peekView] = useQueryParam("peekView", StringParam);
-  const isPeekExpanded = isPeekMode && peekView === "expanded";
-  const peekWidthPx = useMemo(() => {
-    if (!isPeekMode || typeof window === "undefined") return 0;
-    return isPeekExpanded
-      ? window.innerWidth
-      : resolveEffectiveWidthFraction() * window.innerWidth;
-  }, [isPeekMode, isPeekExpanded]);
-
-  // Deterministic peek default split, computed from `peekWidthPx`. Only used on
-  // first open (no saved layout); memoized so the Group sees a stable prop.
-  // Undefined for the full-page view and during SSR.
-  const peekDefaultLayout = useMemo(() => {
-    const navPercent = computePeekNavPercent(peekWidthPx);
-    if (navPercent === undefined) return undefined;
-    return {
-      [RESIZABLE_PANEL_NAVIGATION_ID]: navPercent,
-      [RESIZABLE_PANEL_PREVIEW_ID]: 100 - navPercent,
-    };
-  }, [peekWidthPx]);
-
-  // Restored layout for this group. Read before the collapse flags so we can
-  // seed them from what the library is about to restore on mount — otherwise the
-  // first render derives `bothPanelsOpen` purely from the useState defaults
-  // (open), pins the group to 621px even when a persisted layout has a panel on
-  // its 40px rail, and a narrow peek flashes a useless horizontal scrollbar
-  // until the Panel's onResize corrects the flag a frame later.
+  // Restored (sessionStorage) layout for this group. Read before the collapse
+  // flags so we can seed them from what the library is about to restore on
+  // mount — otherwise the first render derives `bothPanelsOpen` purely from the
+  // useState defaults (open), pins the group to 621px even when a persisted
+  // layout has a panel on its 40px rail, and a narrow peek flashes a useless
+  // horizontal scrollbar until the Panel's onResize corrects the flag a frame
+  // later.
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-    id: groupId,
+    id: RESIZABLE_PANEL_GROUP_ID,
     panelIds: [RESIZABLE_PANEL_NAVIGATION_ID, RESIZABLE_PANEL_PREVIEW_ID],
-    storage,
+    storage: sessionStorage,
   });
-
-  // Collapse-seed threshold: width-aware for the peek (whose width we know), so
-  // a small-share-but-open nav on a wide peek isn't mis-seeded as collapsed;
-  // fixed fallback for the full-page view (its width isn't known here).
-  const collapseSeedMaxSharePct =
-    isPeekMode && peekWidthPx > 0
-      ? collapsedShareMaxForWidth(peekWidthPx)
-      : COLLAPSED_LAYOUT_SHARE_MAX_PCT;
 
   const [isNavigationPanelCollapsed, setIsNavigationPanelCollapsed] = useState(
     () =>
       isAnnotationMode ||
-      isPanelCollapsedInLayout(
-        defaultLayout,
-        RESIZABLE_PANEL_NAVIGATION_ID,
-        collapseSeedMaxSharePct,
-      ),
+      isPanelCollapsedInLayout(defaultLayout, RESIZABLE_PANEL_NAVIGATION_ID),
   );
 
   // Ref to programmatically control the panel
@@ -277,11 +149,7 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
   // Detail (info/preview) panel collapse state + control.
   const detailPanelRef = usePanelRef();
   const [isDetailPanelCollapsed, setIsDetailPanelCollapsed] = useState(() =>
-    isPanelCollapsedInLayout(
-      defaultLayout,
-      RESIZABLE_PANEL_PREVIEW_ID,
-      collapseSeedMaxSharePct,
-    ),
+    isPanelCollapsedInLayout(defaultLayout, RESIZABLE_PANEL_PREVIEW_ID),
   );
 
   // Group ref — drives the whole layout atomically (setLayout) when reopening a
@@ -341,7 +209,8 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
           target === "navigation" ? panelRef.current : detailPanelRef.current;
         const siblingPanel =
           target === "navigation" ? detailPanelRef.current : panelRef.current;
-        const groupWidthPx = document.getElementById(groupId)?.offsetWidth ?? 0;
+        const groupWidthPx =
+          document.getElementById(RESIZABLE_PANEL_GROUP_ID)?.offsetWidth ?? 0;
         if (group && panel && groupWidthPx > 0) {
           // Whether the sibling was deliberately collapsed (header toggle, rail
           // button, or dragged onto its 40px rail). If so we keep it there:
@@ -476,8 +345,6 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
     isDetailPanelCollapsed,
     setIsDetailPanelCollapsed,
     expandDetailPanel,
-    navigationDefaultSize,
-    detailDefaultSize,
   };
 
   return (
@@ -492,9 +359,9 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
       <div className="relative h-full w-full overflow-x-auto overflow-y-hidden">
         <Group
           orientation="horizontal"
-          id={groupId}
+          id={RESIZABLE_PANEL_GROUP_ID}
           groupRef={groupRef}
-          defaultLayout={defaultLayout ?? peekDefaultLayout}
+          defaultLayout={defaultLayout}
           onLayoutChanged={isAnnotationMode ? undefined : onLayoutChanged}
           className={bothPanelsOpen ? undefined : "min-w-0"}
           style={
@@ -520,8 +387,7 @@ TraceLayoutDesktop.NavigationPanel = function Navigation({
 }: {
   children: ReactNode;
 }) {
-  const { setIsNavigationPanelCollapsed, panelRef, navigationDefaultSize } =
-    useLayoutContext();
+  const { setIsNavigationPanelCollapsed, panelRef } = useLayoutContext();
 
   return (
     <Panel
@@ -530,7 +396,7 @@ TraceLayoutDesktop.NavigationPanel = function Navigation({
       collapsible={true}
       collapsedSize="40px"
       minSize={`${NAVIGATION_PANEL_MIN_PX}px`}
-      defaultSize={navigationDefaultSize}
+      defaultSize="60%"
       onResize={() => {
         setIsNavigationPanelCollapsed(panelRef.current?.isCollapsed() ?? false);
       }}
@@ -564,7 +430,6 @@ TraceLayoutDesktop.DetailPanel = function Detail({
     setIsDetailPanelCollapsed,
     isDetailPanelCollapsed,
     expandDetailPanel,
-    detailDefaultSize,
   } = useLayoutContext();
 
   return (
@@ -576,7 +441,7 @@ TraceLayoutDesktop.DetailPanel = function Detail({
     <Panel
       id={RESIZABLE_PANEL_PREVIEW_ID}
       panelRef={detailPanelRef}
-      defaultSize={detailDefaultSize}
+      defaultSize="40%"
       collapsible={true}
       collapsedSize="40px"
       minSize={`${DETAIL_PANEL_MIN_PX}px`}


### PR DESCRIPTION
Reverts #14716; module-eval TDZ crashes the prod bundle. Hardened re-land in LFE-10640.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reverts #14716 ("peek comfortable defaults") because its module-evaluation code triggered a Temporal Dead Zone crash in the production bundle. The revert removes viewport-aware peek width logic (`resolveDefaultWidthFraction`, `resolveEffectiveWidthFraction`), the peek-scoped resizable-panel group, and the computed inner tree↔info split default.

- **`peekPanelStore.ts`**: Replaces the exported `resolveEffectiveWidthFraction` (which accessed `window.innerWidth` at call time) with a simpler, unexported `readStoredWidthFraction` that only reads from `localStorage` with proper SSR guards — eliminating the TDZ-prone reference path.
- **`TraceLayoutDesktop.tsx`**: Removes `isPeekMode` branching, `PEEK_RESIZABLE_PANEL_GROUP_ID`, `computePeekNavPercent`, and the conditional `localStorage`/`sessionStorage` logic; peek and full-page views revert to sharing a single `RESIZABLE_PANEL_GROUP_ID` with `sessionStorage`.
- **`peekPanelStore.clienttest.ts`**: Removes the viewport-width override tests that exercised the now-deleted `resolveDefaultWidthFraction` and `resolveEffectiveWidthFraction` exports.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Clean revert of a single feature that crashed in production; restores the pre-#14716 behavior with no logic regressions.

The revert removes all viewport-aware width logic and replaces it with a simpler, well-guarded localStorage read. The COLLAPSED_LAYOUT_SHARE_MAX_PCT inline formula is mathematically identical to the removed helper. No new logic is introduced, no existing tests are broken, and the prod crash path is fully eliminated.

No files require special attention; all four changed files are mechanically consistent with each other and with the pre-#14716 state.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createPeekPanelStore] --> B{typeof window === 'undefined'?}
    B -- "SSR/test" --> C[return PEEK_DEFAULT_WIDTH_FRACTION\n0.5]
    B -- "Browser" --> D[localStorage.getItem\n'peekViewWidthFraction']
    D --> E{raw === null?}
    E -- "No saved pref" --> C
    E -- "Has saved pref" --> F[JSON.parse]
    F --> G{typeof parsed === 'number'?}
    G -- "No" --> C
    G -- "Yes" --> H[clampWidthFraction\nmin=0.4, max=0.9]
    H --> I[widthFraction set in store]
    C --> I

    I --> J[TraceLayoutDesktop\nsessionStorage layout]
    J --> K{defaultLayout restored?}
    K -- "Yes" --> L[isPanelCollapsedInLayout\nshare <= COLLAPSED_LAYOUT_SHARE_MAX_PCT]
    K -- "No" --> M[defaultLayout = undefined\nfalls back to static defaultSize\n60% nav / 40% detail]
    L --> N[Seed collapse flags\non mount]
    M --> N
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[createPeekPanelStore] --> B{typeof window === 'undefined'?}
    B -- "SSR/test" --> C[return PEEK_DEFAULT_WIDTH_FRACTION\n0.5]
    B -- "Browser" --> D[localStorage.getItem\n'peekViewWidthFraction']
    D --> E{raw === null?}
    E -- "No saved pref" --> C
    E -- "Has saved pref" --> F[JSON.parse]
    F --> G{typeof parsed === 'number'?}
    G -- "No" --> C
    G -- "Yes" --> H[clampWidthFraction\nmin=0.4, max=0.9]
    H --> I[widthFraction set in store]
    C --> I

    I --> J[TraceLayoutDesktop\nsessionStorage layout]
    J --> K{defaultLayout restored?}
    K -- "Yes" --> L[isPanelCollapsedInLayout\nshare <= COLLAPSED_LAYOUT_SHARE_MAX_PCT]
    K -- "No" --> M[defaultLayout = undefined\nfalls back to static defaultSize\n60% nav / 40% detail]
    L --> N[Seed collapse flags\non mount]
    M --> N
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;fix(trace): comfortable peek def..."](https://github.com/langfuse/langfuse/commit/13a65a631e39cca407757c70b46fc1f4c23c0a1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41419218)</sub>

<!-- /greptile_comment -->