### PR TITLE
fix(experiments): block wizard navigation on incomplete steps

### DIFF
--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -331,6 +331,16 @@ export const MultiStepExperimentForm = ({
   // Get dataset info for review step
   const selectedDataset = datasets.data?.find((d) => d.id === datasetId);
 
+  // Fields to validate before the "Next" button is allowed to advance past a given step.
+  // Steps not listed here (e.g. "evaluators") are optional and always allow navigation.
+  const stepFieldsToValidate: Partial<
+    Record<string, Array<keyof CreateExperiment>>
+  > = {
+    prompt: ["promptId", "modelConfig"],
+    dataset: ["datasetId"],
+    details: ["name"],
+  };
+
   // Step validation function
   const isStepValid = (stepId: string): boolean => {
     switch (stepId) {
@@ -553,8 +563,17 @@ export const MultiStepExperimentForm = ({
                 {activeStep !== "review" ? (
                   <Button
                     type="button"
-                    onClick={(e) => {
+                    onClick={async (e) => {
                       e.preventDefault();
+                      // Populate form.formState.errors for this step's fields so the step's
+                      // FormMessage can show *why* navigation is blocked.
+                      // isStepValid (single source of truth for "is this step complete")
+                      // is what actually gates the decision below.
+                      const fieldsToValidate = stepFieldsToValidate[activeStep];
+                      if (fieldsToValidate) {
+                        await form.trigger(fieldsToValidate);
+                      }
+                      if (!isStepValid(activeStep)) return;
                       const stepIds = steps.map((s) => s.id);
                       const currentIndex = stepIds.indexOf(activeStep);
                       if (currentIndex < steps.length - 1) {
@@ -568,11 +587,7 @@ export const MultiStepExperimentForm = ({
                 ) : (
                   <Button
                     type="submit"
-                    disabled={
-                      (Boolean(promptIdFromHook && datasetId) &&
-                        !validationResult.data?.isValid) ||
-                      !!form.formState.errors.name
-                    }
+                    disabled={!isStepValid("review")}
                     loading={form.formState.isSubmitting}
                   >
                     Run Experiment

--- a/web/src/features/experiments/components/steps/DatasetStep.clienttest.tsx
+++ b/web/src/features/experiments/components/steps/DatasetStep.clienttest.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Dialog, DialogContent } from "@/src/components/ui/dialog";
+import { Button } from "@/src/components/ui/button";
+import { Form } from "@/src/components/ui/form";
+import {
+  CreateExperimentData,
+  type CreateExperiment,
+} from "@/src/features/experiments/types";
+import { PromptType } from "@langfuse/shared";
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    datasets: {
+      listDatasetVersions: { useQuery: () => ({ data: [] }) },
+    },
+  },
+}));
+
+import { DatasetStep } from "./DatasetStep";
+
+// Regression test for https://github.com/langfuse/langfuse/issues/14719:
+// the experiment wizard let users advance past the Dataset step (and
+// eventually click "Run Experiment") without ever selecting a dataset, with
+// no visible validation error. The fix in MultiStepExperimentForm.tsx makes
+// the "Next" button call `form.trigger("datasetId")` before advancing, which
+// relies on this FormMessage actually surfacing the zod error. This test
+// exercises that mechanism directly against the real form + zod schema,
+// without mounting the full wizard (whose default "prompt" step has an
+// unrelated pre-existing render-loop issue in this test environment).
+const Harness = () => {
+  const form = useForm<CreateExperiment>({
+    resolver: zodResolver(CreateExperimentData),
+    defaultValues: {
+      promptId: "prompt-1",
+      datasetId: "",
+      name: "",
+      runName: "",
+      modelConfig: { provider: "openai", model: "gpt-4o", modelParams: {} },
+    },
+  });
+
+  return (
+    <Dialog open>
+      <DialogContent>
+        <Form {...form}>
+          <form>
+            <DatasetStep
+              projectId="project-1"
+              formState={{ form }}
+              datasetState={{
+                datasets: [{ id: "dataset-1", name: "First dataset" }],
+                selectedDatasetId: null,
+                selectedDataset: undefined,
+                selectedDatasetVersion: undefined,
+                validationResult: undefined,
+                expectedColumnsForDataset: {
+                  inputVariables: [],
+                  outputVariableType: PromptType.Text,
+                  outputVariableName: "expected_output",
+                },
+              }}
+              promptInfo={{
+                selectedPromptName: "my-prompt",
+                selectedPromptVersion: 1,
+              }}
+            />
+            <Button
+              type="button"
+              onClick={async () => {
+                await form.trigger("datasetId");
+              }}
+            >
+              Next
+            </Button>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+describe("DatasetStep validation (wizard Next-button gating)", () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("shows a validation error and does not clear datasetId when Next is clicked without a dataset", async () => {
+    render(<Harness />);
+
+    expect(screen.queryByText("Please select a dataset")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(
+      await screen.findByText("Please select a dataset"),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/features/experiments/components/steps/ReviewStep.tsx
+++ b/web/src/features/experiments/components/steps/ReviewStep.tsx
@@ -52,14 +52,22 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
             <CardTitle className="text-base">Prompt</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2 text-sm">
-            <div className="flex gap-2">
-              <span className="text-muted-foreground">Name:</span>
-              <span className="font-medium">{selectedPromptName}</span>
-            </div>
-            <div className="flex gap-2">
-              <span className="text-muted-foreground">Version:</span>
-              <span className="font-medium">v{selectedPromptVersion}</span>
-            </div>
+            {selectedPromptName ? (
+              <>
+                <div className="flex gap-2">
+                  <span className="text-muted-foreground">Name:</span>
+                  <span className="font-medium">{selectedPromptName}</span>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-muted-foreground">Version:</span>
+                  <span className="font-medium">v{selectedPromptVersion}</span>
+                </div>
+              </>
+            ) : (
+              <p className="text-destructive text-sm font-medium">
+                Please select a prompt
+              </p>
+            )}
           </CardContent>
         </Card>
 
@@ -72,14 +80,22 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
             <CardTitle className="text-base">Model</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2 text-sm">
-            <div className="flex gap-2">
-              <span className="text-muted-foreground">Provider:</span>
-              <span>{modelParams.provider.value}</span>
-            </div>
-            <div className="flex gap-2">
-              <span className="text-muted-foreground">Model:</span>
-              <span>{modelParams.model.value}</span>
-            </div>
+            {!modelParams.provider.value || !modelParams.model.value ? (
+              <p className="text-destructive text-sm font-medium">
+                Please select a model
+              </p>
+            ) : (
+              <>
+                <div className="flex gap-2">
+                  <span className="text-muted-foreground">Provider:</span>
+                  <span>{modelParams.provider.value}</span>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-muted-foreground">Model:</span>
+                  <span>{modelParams.model.value}</span>
+                </div>
+              </>
+            )}
             {modelParams.temperature.enabled && (
               <div className="flex gap-2">
                 <span className="text-muted-foreground">Temperature:</span>
@@ -112,10 +128,16 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
             <CardTitle className="text-base">Dataset</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2 text-sm">
-            <div className="flex gap-2">
-              <span className="text-muted-foreground">Name:</span>
-              <span className="font-medium">{selectedDataset?.name}</span>
-            </div>
+            {selectedDataset ? (
+              <div className="flex gap-2">
+                <span className="text-muted-foreground">Name:</span>
+                <span className="font-medium">{selectedDataset.name}</span>
+              </div>
+            ) : (
+              <p className="text-destructive text-sm font-medium">
+                Please select a dataset
+              </p>
+            )}
             {validationResult?.isValid && (
               <div className="flex gap-2">
                 <span className="text-muted-foreground">Items:</span>
@@ -157,10 +179,16 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
             <CardTitle className="text-base">Experiment Run Details</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2 text-sm">
-            <div className="flex gap-2">
-              <span className="text-muted-foreground">Experiment Name:</span>
-              <span className="font-medium">{formValues.name}</span>
-            </div>
+            {formValues.name ? (
+              <div className="flex gap-2">
+                <span className="text-muted-foreground">Experiment Name:</span>
+                <span className="font-medium">{formValues.name}</span>
+              </div>
+            ) : (
+              <p className="text-destructive text-sm font-medium">
+                Please enter an experiment name
+              </p>
+            )}
             <div className="flex items-center gap-2">
               <span className="text-muted-foreground">Run Name:</span>
               <span className="font-medium">{formValues.runName}</span>


### PR DESCRIPTION
## Summary
- The experiment creation wizard's "Next" button only read `isStepValid()` without first triggering zod validation, so `form.formState.errors` stayed empty and the step's inline `FormMessage` never rendered — users could advance through the wizard (and eventually click "Run Experiment") without selecting a prompt, dataset, or entering a name, with no visible error.
- `Next` now calls `form.trigger(fields)` for the current step before checking `isStepValid()`, so the existing inline error message can actually surface; `isStepValid()` remains the single source of truth for "is this step complete," shared with the breadcrumb checkmarks and the "Run Experiment" disabled state.
- Since the step breadcrumbs are always clickable, a user could still jump straight to the Review step without going through Next. The Review step's Prompt / Model / Dataset / Run Details cards now show an inline "Please select/enter X" message instead of a blank value when that field is missing.

Fixes #14719

## Test plan
- [x] Added `DatasetStep.clienttest.tsx`: regression test exercising the real form + zod schema, asserting the "Please select a dataset" error renders when Next is clicked without a dataset selected.
- [x] `pnpm --filter web run test-client -- DatasetStep.clienttest.tsx` passes.
- [x] `pnpm --filter web run lint` passes.
- [x] Manual verification in a running instance: try to advance each wizard step without filling required fields, and try jumping directly to Review via the breadcrumbs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the experiment creation wizard's \"Next\" button so it calls `form.trigger()` before checking `isStepValid()`, which populates `form.formState.errors` and makes inline `FormMessage` components visible when a step is incomplete. It also adds inline \"Please select/enter X\" error messages to the Review step's summary cards for users who jump directly there via breadcrumb navigation.

- `MultiStepExperimentForm.tsx`: Next button handler is now async; it triggers Zod validation for the current step's fields before gating navigation on `isStepValid()`. The \"Run Experiment\" disabled condition is simplified from a fragmented boolean to `!isStepValid(\"review\")`, which is strictly more correct.
- `ReviewStep.tsx`: Each required-field card now conditionally renders a destructive inline message instead of a blank value when the corresponding field is missing.
- `DatasetStep.clienttest.tsx`: New regression test that mounts the real RHF form with the Zod schema and asserts the \"Please select a dataset\" `FormMessage` fires on trigger.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The wizard navigation guard is mostly correct but has a silent failure path on the Dataset step that can leave users stuck with no feedback.

The prompt and details steps work well — trigger fires, errors appear, navigation is blocked with a visible message. The dataset step's guard relies on `validationResult.data?.isValid`, which is undefined while the tRPC query is in flight and also when the user jumps to the Dataset step via breadcrumb without a prompt selected (the query is not enabled). In those cases `form.trigger(["datasetId"])` sets no errors (the field is populated), yet `isStepValid("dataset")` returns false, and the Next click silently does nothing. This is a new failure mode not present before this PR — previously Next always advanced unconditionally.

web/src/features/experiments/components/MultiStepExperimentForm.tsx — specifically the Next button handler for the dataset step and its interaction with the async validationResult query.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant NB as Next Button
    participant FT as form.trigger
    participant ISV as isStepValid
    participant VR as validationResult query

    U->>NB: click
    NB->>FT: trigger(stepFieldsToValidate[activeStep])
    FT-->>NB: resolves, errors written to form state

    alt prompt or details step
        NB->>ISV: isStepValid(activeStep)
        ISV-->>NB: checks form values and form errors
        alt step is valid
            NB->>U: advance to next step
        else step is invalid
            NB->>U: stay on step, FormMessage shows error
        end
    else dataset step
        NB->>ISV: isStepValid(dataset)
        ISV->>VR: read validationResult.data?.isValid
        alt validationResult loaded and isValid true
            ISV-->>NB: true
            NB->>U: advance to next step
        else validationResult still loading or query not enabled
            ISV-->>NB: false, silent block
            NB->>U: stays on step, no FormMessage, no loading indicator
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant NB as Next Button
    participant FT as form.trigger
    participant ISV as isStepValid
    participant VR as validationResult query

    U->>NB: click
    NB->>FT: trigger(stepFieldsToValidate[activeStep])
    FT-->>NB: resolves, errors written to form state

    alt prompt or details step
        NB->>ISV: isStepValid(activeStep)
        ISV-->>NB: checks form values and form errors
        alt step is valid
            NB->>U: advance to next step
        else step is invalid
            NB->>U: stay on step, FormMessage shows error
        end
    else dataset step
        NB->>ISV: isStepValid(dataset)
        ISV->>VR: read validationResult.data?.isValid
        alt validationResult loaded and isValid true
            ISV-->>NB: true
            NB->>U: advance to next step
        else validationResult still loading or query not enabled
            ISV-->>NB: false, silent block
            NB->>U: stays on step, no FormMessage, no loading indicator
        end
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/experiments/components/MultiStepExperimentForm.tsx:572-576
**Silent block when dataset validation is pending**

After `form.trigger(["datasetId"])` resolves with no errors (the field is populated), `isStepValid("dataset")` can still return `false` if `validationResult.data?.isValid` is falsy — which happens both while the tRPC query is still loading and when the user arrives at the Dataset step via breadcrumb navigation without having selected a prompt (making the query not enabled at all). In either case, the click silently does nothing: no `FormMessage` fires, no loading indicator appears, no explanation is shown. A user who picks a dataset and immediately hits "Next" — or who jumps straight to Dataset via the breadcrumb — will see the button absorb the click with zero feedback.

### Issue 2 of 2
web/src/features/experiments/components/MultiStepExperimentForm.tsx:334-342
`stepFieldsToValidate` is a static object that doesn't reference any props, state, or hooks, so it is recreated on every render. Moving it to module scope avoids the allocation.

```suggestion
// Fields to validate before the "Next" button is allowed to advance past a given step.
// Steps not listed here (e.g. "evaluators") are optional and always allow navigation.
const stepFieldsToValidate: Partial<
  Record<string, Array<keyof CreateExperiment>>
> = {
  prompt: ["promptId", "modelConfig"],
  dataset: ["datasetId"],
  details: ["name"],
};
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): block wizard navigatio..."](https://github.com/langfuse/langfuse/commit/ca81cfadb0646753424ba89f9a789e94058b52f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41514116)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->