### PR TITLE
fix(worker): raise ClickHouse data export timeout default to 60 minutes (LFE-10648)

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -430,7 +430,7 @@ const EnvSchema = z.object({
     .number()
     .int()
     .positive()
-    .default(600_000), // 10 minutes
+    .default(3_600_000), // 60 minutes
 
   LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY: z.coerce
     .number()


### PR DESCRIPTION
## What does this PR do?

Raises the default of `LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS` from 10 minutes to 60 minutes.

Since #14730, the client-side `request_timeout` also derives a server-side `max_execution_time` of `ceil(request_timeout / 1000) + 5s`. All blob-storage export queries (and analytics-integration exports) pass this env var as their `request_timeout`, so ClickHouse now kills any export query running longer than ~605s. Full-history backfills for large projects exceed that: production shows `TIMEOUT_EXCEEDED` at 606,321ms elapsed against the 605,000ms limit.

Before #14730 these queries had no server-side cap, so a 60-minute ceiling is still stricter than the previous behavior while giving large backfills enough headroom (server-side limit becomes ~3605s). Deployments can still tune the value via the env var.

Fixes LFE-10648

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR raises the default value of `LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS` from 600,000 ms (10 minutes) to 3,600,000 ms (60 minutes) to prevent `TIMEOUT_EXCEEDED` errors on large project backfills that cross the server-side execution cap derived from that value.

- The single-line change in `packages/shared/src/env.ts` bumps the default, giving large ClickHouse export queries up to ~3,605 s on the server side while keeping the env-var override path intact for operators who need a different ceiling.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change only widens the default timeout window and operators retain full control via the env var override.

This is a one-line default value increase with a well-documented production failure as justification. The new 60-minute default still imposes a finite cap (previously there was none), and the existing env-var override mechanism ensures deployments that want a stricter or looser limit can set one. There are no logic changes, no new code paths, and no schema or API surface modifications.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Export Job Starts] --> B[Read LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS]
    B --> C{Env var set?}
    C -- Yes --> D[Use operator-configured value]
    C -- No --> E["Use default: 3,600,000 ms (60 min)"]
    D --> F[Pass as request_timeout to ClickHouse client]
    E --> F
    F --> G["Derive server-side max_execution_time\n= ceil(request_timeout / 1000) + 5 s"]
    G --> H{Query completes\nwithin limit?}
    H -- Yes --> I[Export succeeds]
    H -- No --> J[TIMEOUT_EXCEEDED error]
    style E fill:#90EE90
    style J fill:#FFB6C1
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Export Job Starts] --> B[Read LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS]
    B --> C{Env var set?}
    C -- Yes --> D[Use operator-configured value]
    C -- No --> E["Use default: 3,600,000 ms (60 min)"]
    D --> F[Pass as request_timeout to ClickHouse client]
    E --> F
    F --> G["Derive server-side max_execution_time\n= ceil(request_timeout / 1000) + 5 s"]
    G --> H{Query completes\nwithin limit?}
    H -- Yes --> I[Export succeeds]
    H -- No --> J[TIMEOUT_EXCEEDED error]
    style E fill:#90EE90
    style J fill:#FFB6C1
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): raise ClickHouse data expor..."](https://github.com/langfuse/langfuse/commit/943eec9ba18c91f7ee3b0f8541637dc280573183) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41597577)</sub>

<!-- /greptile_comment -->