### PR TITLE
refactor(web): move experiments table selection into zustand store

### DIFF
--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -34,7 +34,7 @@ import Link from "next/link";
 import { TableActionMenu } from "@/src/features/table/components/TableActionMenu";
 import { type TableAction } from "@/src/features/table/types";
 import { Badge } from "@/src/components/ui/badge";
-import { type RowSelectionState } from "@tanstack/react-table";
+import { useStore } from "zustand";
 import TableIdOrName from "@/src/components/table/table-id";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
@@ -61,6 +61,11 @@ import {
 } from "@/src/components/ui/accordion";
 import { ExperimentChartsGrid } from "../ExperimentChartsGrid";
 import { useExperimentChartsAccordion } from "../../hooks/useExperimentChartsAccordion";
+import {
+  createExperimentsTableStore,
+  type ExperimentsTableStore,
+} from "@/src/features/experiments/store/experimentsTableStore";
+import { useExperimentsTableSelectionSync } from "@/src/features/experiments/hooks/useExperimentsTableSelectionSync";
 
 /**
  * LFE-10460: the metadata column's default position moved from last to right
@@ -88,6 +93,149 @@ const repositionTrailingMetadata = (order: string[]): string[] => {
   return next;
 };
 
+/**
+ * Owns every consumer of the selection state (action menu, compare navigation,
+ * run-evaluator dialog) so checkbox clicks re-render only this menu and the
+ * clicked checkbox — not the whole ExperimentsTable.
+ */
+function ExperimentsMultiSelectActionMenu({
+  projectId,
+  store,
+}: {
+  projectId: string;
+  store: ExperimentsTableStore;
+}) {
+  const router = useRouter();
+  const [showRunEvaluationDialog, setShowRunEvaluationDialog] = useState(false);
+  // Page-scoped and in table order, so the first id is the topmost selected
+  // row — the compare baseline.
+  const selectedExperimentIds = useStore(
+    store,
+    (state) => state.selectedPageRowIds,
+  );
+  const clearSelection = useStore(
+    store,
+    (state) => state.actions.clearSelection,
+  );
+
+  const hasEvalAccess = useHasProjectAccess({
+    projectId,
+    scope: "evalJob:CUD",
+  });
+
+  // Build query with experiment context filter for batch actions
+  const batchActionQuery = useMemo(
+    () => ({
+      filter:
+        selectedExperimentIds.length > 0
+          ? [
+              {
+                column: "experimentId" as const,
+                operator: "any of" as const,
+                value: selectedExperimentIds,
+                type: "stringOptions" as const,
+              },
+              {
+                column: "isExperimentItemRootSpan" as const,
+                operator: "=" as const,
+                value: true,
+                type: "boolean" as const,
+              },
+            ]
+          : [],
+      orderBy: { column: "startTime" as const, order: "DESC" as const },
+    }),
+    [selectedExperimentIds],
+  );
+
+  // Handler for comparing selected experiments
+  // First selected becomes baseline, rest become comparisons
+  const handleCompareSelected = () => {
+    if (selectedExperimentIds.length === 0) return;
+
+    const [baseline, ...comparisons] = selectedExperimentIds;
+    const params = new URLSearchParams();
+    params.set("baseline", baseline);
+    comparisons.forEach((id) => {
+      params.append("c", id);
+    });
+
+    router.push(
+      `/project/${projectId}/experiments/results?${params.toString()}`,
+    );
+  };
+
+  if (selectedExperimentIds.length === 0) return null;
+
+  // Build table actions - Compare is disabled (not hidden) when >5 rows selected
+  const tooManySelected = selectedExperimentIds.length > 5;
+  const tableActions: TableAction[] = [
+    {
+      id: ActionId.ExperimentCompare,
+      type: BatchActionType.Create,
+      label: "Compare",
+      description: "Compare selected experiments",
+      icon: <GitCompareArrows className="h-4 w-4 sm:mr-2" />,
+      customDialog: true,
+      disabled: tooManySelected,
+      disabledReason: tooManySelected
+        ? "Select only up to 5 experiments to compare"
+        : undefined,
+      accessCheck: {
+        scope: "project:read",
+      },
+    } as TableAction,
+    ...(hasEvalAccess
+      ? [
+          {
+            id: ActionId.ObservationBatchEvaluation,
+            type: BatchActionType.Create,
+            label: "Run Evaluator",
+            description: "Run evaluators on selected experiments",
+            icon: <LightbulbIcon className="h-4 w-4 sm:mr-2" />,
+            customDialog: true,
+            accessCheck: {
+              scope: "evalJob:CUD",
+            },
+          } as TableAction,
+        ]
+      : []),
+  ];
+
+  return (
+    <>
+      <TableActionMenu
+        projectId={projectId}
+        actions={tableActions}
+        tableName={BatchExportTableName.Sessions}
+        selectedCount={selectedExperimentIds.length}
+        onClearSelection={clearSelection}
+        onCustomAction={(actionId) => {
+          if (actionId === ActionId.ExperimentCompare) {
+            handleCompareSelected();
+          } else if (actionId === ActionId.ObservationBatchEvaluation) {
+            setShowRunEvaluationDialog(true);
+          }
+        }}
+      />
+      {showRunEvaluationDialog && (
+        <RunEvaluationDialog
+          projectId={projectId}
+          selectedObservationIds={[]}
+          query={batchActionQuery}
+          selectAll={true}
+          totalCount={selectedExperimentIds.length}
+          onClose={() => {
+            setShowRunEvaluationDialog(false);
+            clearSelection();
+          }}
+          sourceTable="experiments"
+        />
+      )}
+    </>
+  );
+}
+
 export default function ExperimentsTable({
   projectId,
   defaultFilter,
@@ -106,13 +254,9 @@ export default function ExperimentsTable({
   );
 
   const { setDetailPageList } = useDetailPageLists();
-  const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
-  const [showRunEvaluationDialog, setShowRunEvaluationDialog] = useState(false);
-
-  const hasEvalAccess = useHasProjectAccess({
-    projectId,
-    scope: "evalJob:CUD",
-  });
+  // Selection lives in a per-mount vanilla zustand store (not useState) so a
+  // checkbox click re-renders only its subscribers, not the whole table.
+  const [experimentsTableStore] = useState(() => createExperimentsTableStore());
 
   const [paginationState, setPaginationState] = usePaginationState(1, 50);
 
@@ -279,8 +423,9 @@ export default function ExperimentsTable({
   const { selectActionColumn } = TableSelectionManager<ExperimentsTableRow>({
     projectId,
     tableName: "experiments",
-    setSelectedRows,
-    setSelectAll: () => {}, // Experiments table doesn't support select-all
+    setSelectedRows: experimentsTableStore.getState().actions.setRowSelection,
+    setSelectAll: experimentsTableStore.getState().actions.setSelectAll,
+    selectionStore: experimentsTableStore,
   });
 
   const columns: LangfuseColumnDef<ExperimentsTableRow>[] = [
@@ -572,101 +717,15 @@ export default function ExperimentsTable({
   const { accordionValue, setAccordionValue } =
     useExperimentChartsAccordion(projectId);
 
-  // Get selected experiment IDs in the order they appear in the table
-  const selectedExperimentIds = useMemo(() => {
-    const selectedIds = Object.keys(selectedRows).filter((id) =>
-      rows.some((row) => row.id === id),
-    );
-    // Sort by table order to ensure first selected = first in table among selected
-    return rows
-      .filter((row) => selectedIds.includes(row.id))
-      .map((row) => row.id);
-  }, [selectedRows, rows]);
-
-  // Build query with experiment context filter for batch actions
-  const batchActionQuery = useMemo(
-    () => ({
-      filter:
-        selectedExperimentIds.length > 0
-          ? [
-              {
-                column: "experimentId" as const,
-                operator: "any of" as const,
-                value: selectedExperimentIds,
-                type: "stringOptions" as const,
-              },
-              {
-                column: "isExperimentItemRootSpan" as const,
-                operator: "=" as const,
-                value: true,
-                type: "boolean" as const,
-              },
-            ]
-          : [],
-      orderBy: { column: "startTime" as const, order: "DESC" as const },
-    }),
-    [selectedExperimentIds],
-  );
-
-  // Handler for comparing selected experiments
-  // First selected becomes baseline, rest become comparisons
-  const handleCompareSelected = useCallback(() => {
-    if (selectedExperimentIds.length === 0) return;
-
-    const [baseline, ...comparisons] = selectedExperimentIds;
-    const params = new URLSearchParams();
-    params.set("baseline", baseline);
-    comparisons.forEach((id) => {
-      params.append("c", id);
-    });
-
-    router.push(
-      `/project/${projectId}/experiments/results?${params.toString()}`,
-    );
-  }, [selectedExperimentIds, projectId, router]);
-
-  // Build table actions - Compare is disabled (not hidden) when >5 rows selected
-  const tableActions: TableAction[] = useMemo(() => {
-    const actions: TableAction[] = [];
-
-    // Compare action: disabled when >5 experiments selected
-    const tooManySelected = selectedExperimentIds.length > 5;
-    actions.push({
-      id: ActionId.ExperimentCompare,
-      type: BatchActionType.Create,
-      label: "Compare",
-      description: "Compare selected experiments",
-      icon: <GitCompareArrows className="h-4 w-4 sm:mr-2" />,
-      customDialog: true,
-      disabled: tooManySelected,
-      disabledReason: tooManySelected
-        ? "Select only up to 5 experiments to compare"
-        : undefined,
-      accessCheck: {
-        scope: "project:read",
-      },
-    } as TableAction);
-
-    // Run Evaluator action: only when user has eval access
-    if (hasEvalAccess) {
-      actions.push({
-        id: ActionId.ObservationBatchEvaluation,
-        type: BatchActionType.Create,
-        label: "Run Evaluator",
-        description: "Run evaluators on selected experiments",
-        icon: <LightbulbIcon className="h-4 w-4 sm:mr-2" />,
-        customDialog: true,
-        accessCheck: {
-          scope: "evalJob:CUD",
-        },
-      } as TableAction);
-    }
-
-    return actions;
-  }, [selectedExperimentIds.length, hasEvalAccess]);
-
-  const shouldShowActions =
-    selectedExperimentIds.length > 0 && tableActions.length > 0;
+  // Mirror the visible page's rows into the store (in table order, so
+  // selectedPageRowIds keeps the first-selected-in-table-order semantics
+  // the compare baseline relies on).
+  const pageRowIds = useMemo(() => rows.map((row) => row.id), [rows]);
+  useExperimentsTableSelectionSync({
+    store: experimentsTableStore,
+    pageRowIds,
+    totalCount,
+  });
 
   return (
     <>
@@ -692,27 +751,11 @@ export default function ExperimentsTable({
             timeRange={timeRange}
             setTimeRange={setTimeRange}
             actionButtons={[
-              ...(shouldShowActions
-                ? [
-                    <TableActionMenu
-                      key="experiments-multi-select-actions"
-                      projectId={projectId}
-                      actions={tableActions}
-                      tableName={BatchExportTableName.Sessions}
-                      selectedCount={selectedExperimentIds.length}
-                      onClearSelection={() => setSelectedRows({})}
-                      onCustomAction={(actionId) => {
-                        if (actionId === ActionId.ExperimentCompare) {
-                          handleCompareSelected();
-                        } else if (
-                          actionId === ActionId.ObservationBatchEvaluation
-                        ) {
-                          setShowRunEvaluationDialog(true);
-                        }
-                      }}
-                    />,
-                  ]
-                : []),
+              <ExperimentsMultiSelectActionMenu
+                key="experiments-multi-select-actions"
+                projectId={projectId}
+                store={experimentsTableStore}
+              />,
             ]}
           />
 
@@ -791,8 +834,7 @@ export default function ExperimentsTable({
                     pageSize: paginationState.limit,
                   },
                 }}
-                rowSelection={selectedRows}
-                setRowSelection={setSelectedRows}
+                selectionStore={experimentsTableStore}
                 setOrderBy={setOrderByState}
                 orderBy={orderByState}
                 columnOrder={columnOrder}
@@ -821,21 +863,6 @@ export default function ExperimentsTable({
           </ResizableFilterLayout>
         </div>
       </DataTableControlsProvider>
-
-      {showRunEvaluationDialog && selectedExperimentIds.length > 0 && (
-        <RunEvaluationDialog
-          projectId={projectId}
-          selectedObservationIds={[]}
-          query={batchActionQuery}
-          selectAll={true}
-          totalCount={selectedExperimentIds.length}
-          onClose={() => {
-            setShowRunEvaluationDialog(false);
-            setSelectedRows({});
-          }}
-          sourceTable="experiments"
-        />
-      )}
     </>
   );
 }

--- a/web/src/features/experiments/hooks/useExperimentsTableSelectionSync.ts
+++ b/web/src/features/experiments/hooks/useExperimentsTableSelectionSync.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { type ExperimentsTableStore } from "@/src/features/experiments/store/experimentsTableStore";
+
+/**
+ * Bridges React Query page data into the selection store so selection stays
+ * page-scoped. No scope-based reset (unlike datasets): consumers only read
+ * `selectedPageRowIds`, so selections outside the visible page are inert.
+ */
+export function useExperimentsTableSelectionSync({
+  store,
+  pageRowIds,
+  totalCount,
+}: {
+  store: ExperimentsTableStore;
+  pageRowIds: string[];
+  totalCount: number | null;
+}) {
+  useEffect(() => {
+    store.getState().actions.syncPageRows({ pageRowIds, totalCount });
+  }, [store, pageRowIds, totalCount]);
+}

--- a/web/src/features/experiments/store/experimentsTableStore.ts
+++ b/web/src/features/experiments/store/experimentsTableStore.ts
@@ -1,0 +1,116 @@
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { type RowSelectionState, type Updater } from "@tanstack/react-table";
+import { type TableSelectionStoreState } from "@/src/components/table/table-selection-store";
+
+type RowSelectionUpdater = Updater<RowSelectionState>;
+type BooleanUpdater = Updater<boolean>;
+
+export interface ExperimentsTableStoreState extends TableSelectionStoreState {
+  actions: TableSelectionStoreState["actions"] & {
+    syncPageRows: (payload: {
+      pageRowIds: string[];
+      totalCount: number | null;
+    }) => void;
+  };
+}
+
+export type ExperimentsTableStore = StoreApi<ExperimentsTableStoreState>;
+
+function resolveUpdater<TValue>(
+  updater: Updater<TValue>,
+  previousValue: TValue,
+): TValue {
+  return typeof updater === "function"
+    ? (updater as (old: TValue) => TValue)(previousValue)
+    : updater;
+}
+
+function getSelectedPageRowIds(
+  rowSelection: RowSelectionState,
+  pageRowIds: string[],
+) {
+  return pageRowIds.filter((rowId) => Boolean(rowSelection[rowId]));
+}
+
+export function createExperimentsTableStore(): ExperimentsTableStore {
+  return createStore<ExperimentsTableStoreState>((set, get) => {
+    const updateSelection = (
+      rowSelection: RowSelectionState,
+      selectAll = get().selectAll,
+    ) => {
+      const { pageRowIds } = get();
+
+      set({
+        rowSelection,
+        selectAll,
+        selectedPageRowIds: getSelectedPageRowIds(rowSelection, pageRowIds),
+      });
+    };
+
+    const setSelectAll = (updater: BooleanUpdater) => {
+      const nextSelectAll = resolveUpdater(updater, get().selectAll);
+      if (nextSelectAll === get().selectAll) return;
+
+      set({ selectAll: nextSelectAll });
+    };
+
+    const clearSelection = () => {
+      updateSelection({}, false);
+    };
+
+    const toggleRows = (rowIds: string[], nextSelected: boolean) => {
+      const nextRowSelection = { ...get().rowSelection };
+      for (const rowId of rowIds) {
+        if (nextSelected) {
+          nextRowSelection[rowId] = true;
+        } else {
+          delete nextRowSelection[rowId];
+        }
+      }
+
+      updateSelection(nextRowSelection, nextSelected ? get().selectAll : false);
+    };
+
+    return {
+      rowSelection: {},
+      // Experiments has no select-all banner, so selectAll stays false; the
+      // field only exists to satisfy the shared TableSelectionStoreState.
+      selectAll: false,
+      selectedPageRowIds: [],
+      pageRowIds: [],
+      totalCount: null,
+      actions: {
+        setRowSelection: (updater: RowSelectionUpdater) => {
+          updateSelection(resolveUpdater(updater, get().rowSelection));
+        },
+        setSelectAll,
+        toggleRow: (rowId: string, nextSelected: boolean) => {
+          toggleRows([rowId], nextSelected);
+        },
+        toggleRows,
+        togglePageRows: (rowIds: string[], nextSelected: boolean) => {
+          if (!nextSelected) {
+            clearSelection();
+            return;
+          }
+
+          const nextRowSelection = { ...get().rowSelection };
+          for (const rowId of rowIds) {
+            nextRowSelection[rowId] = true;
+          }
+
+          updateSelection(nextRowSelection);
+        },
+        clearSelection,
+        syncPageRows: ({ pageRowIds, totalCount }) => {
+          const { rowSelection } = get();
+          set({
+            pageRowIds,
+            totalCount,
+            selectedPageRowIds: getSelectedPageRowIds(rowSelection, pageRowIds),
+          });
+        },
+      },
+    };
+  });
+}


### PR DESCRIPTION
## Summary

- Row selection in the experiments table lived in component-level `useState`, so a single checkbox click re-rendered the entire table (all rows and cells). Selection now lives in a per-mount vanilla zustand store — mirroring the datasets table pattern — so a click re-renders only the clicked checkbox, the affected row highlight, and the multi-select action menu.
- New `experimentsTableStore` (datasets store minus folder/delete specifics) and `useExperimentsTableSelectionSync` hook that mirrors the visible page's row ids into the store in table order. `DataTable` and `TableSelectionManager` already supported an external `selectionStore`, so no shared-infra changes were needed.
- Everything that reads the selection (action menu, compare navigation, run-evaluator dialog) moved into a new `ExperimentsMultiSelectActionMenu` subcomponent. This boundary is load-bearing: it isolates the store subscription so the parent `ExperimentsTable` never re-renders on selection changes.

## Linear

- [LFE-10643](https://linear.app/langfuse/issue/LFE-10643/fix-experiments-table-rendering)

## Major Decisions

- Mirrored the datasets-table pattern 1:1 (feature-local store + same-file action-menu subcomponent) rather than extracting a generic shared selection-store factory — keeps the diff surgical; datasets/observations stores stay untouched.
- The store's `selectedPageRowIds` is page-scoped and preserves table order, so it fully replaces the old `selectedExperimentIds` memo — including the "first selected in table order becomes the compare baseline" semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the experiments table row-selection state from component-level `useState` into a per-mount vanilla Zustand store, mirroring the existing datasets table pattern. The goal is to isolate re-renders so a checkbox click only re-renders the clicked cell and the `ExperimentsMultiSelectActionMenu` subcomponent — not the entire `ExperimentsTable`.

- **New `experimentsTableStore`**: a self-contained vanilla Zustand store (parallel to `datasetsTableStore`) implementing `TableSelectionStoreState`, with a `syncPageRows` action and no select-all banner support.
- **New `useExperimentsTableSelectionSync` hook**: mirrors current-page row IDs into the store after each render (same `useEffect` pattern as the datasets hook, intentionally omitting the scope-reset variant since experiments have no folder/search context).
- **New `ExperimentsMultiSelectActionMenu` subcomponent**: isolates all selection consumers (action menu, compare navigation, run-evaluator dialog) behind a single store subscription boundary, preventing re-renders from bubbling into `ExperimentsTable`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactor is a faithful implementation of the established datasets-table pattern and no functional regressions were found.

The change is a surgical lift-and-shift of component-level useState into a vanilla Zustand store. The new store, hook, and subcomponent all mirror the well-tested datasets table pattern. The selection semantics (page-scoped, table-ordered IDs, intersection with current pageRowIds) are preserved exactly. All consumers of the selection state are correctly gated behind the ExperimentsMultiSelectActionMenu boundary, achieving the stated re-render isolation goal. No state-management edge cases, missing guards, or broken contracts were identified.

No files require special attention. The new store and hook are straightforward and parallel an existing implementation.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph ExperimentsTable ["ExperimentsTable (no re-render on selection)"]
        Store["experimentsTableStore\n(vanilla Zustand, per-mount)"]
        Sync["useExperimentsTableSelectionSync\n(useEffect → syncPageRows)"]
        TSM["TableSelectionManager\n(setRowSelection, setSelectAll)"]
        DT["DataTable\n(selectionStore prop)"]
        PageRowIds["pageRowIds memo\n(rows.map id)"]
    end

    subgraph Menu ["ExperimentsMultiSelectActionMenu\n(re-renders on selection changes only)"]
        UseStore1["useStore → selectedPageRowIds"]
        UseStore2["useStore → clearSelection"]
        TAM["TableActionMenu"]
        RED["RunEvaluationDialog"]
        Compare["router.push → /experiments/results"]
    end

    PageRowIds -->|"pageRowIds"| Sync
    Sync -->|"syncPageRows()"| Store
    TSM -->|"setRowSelection / setSelectAll"| Store
    DT -->|"checkbox click → toggleRow"| Store
    Store -->|"selectionStore prop"| DT
    Store -->|"store prop"| Menu
    UseStore1 -->|"selectedPageRowIds"| TAM
    UseStore1 -->|"selectedExperimentIds"| Compare
    UseStore2 -->|"clearSelection"| TAM
    TAM -->|"onCustomAction"| Compare
    TAM -->|"onCustomAction"| RED
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph ExperimentsTable ["ExperimentsTable (no re-render on selection)"]
        Store["experimentsTableStore\n(vanilla Zustand, per-mount)"]
        Sync["useExperimentsTableSelectionSync\n(useEffect → syncPageRows)"]
        TSM["TableSelectionManager\n(setRowSelection, setSelectAll)"]
        DT["DataTable\n(selectionStore prop)"]
        PageRowIds["pageRowIds memo\n(rows.map id)"]
    end

    subgraph Menu ["ExperimentsMultiSelectActionMenu\n(re-renders on selection changes only)"]
        UseStore1["useStore → selectedPageRowIds"]
        UseStore2["useStore → clearSelection"]
        TAM["TableActionMenu"]
        RED["RunEvaluationDialog"]
        Compare["router.push → /experiments/results"]
    end

    PageRowIds -->|"pageRowIds"| Sync
    Sync -->|"syncPageRows()"| Store
    TSM -->|"setRowSelection / setSelectAll"| Store
    DT -->|"checkbox click → toggleRow"| Store
    Store -->|"selectionStore prop"| DT
    Store -->|"store prop"| Menu
    UseStore1 -->|"selectedPageRowIds"| TAM
    UseStore1 -->|"selectedExperimentIds"| Compare
    UseStore2 -->|"clearSelection"| TAM
    TAM -->|"onCustomAction"| Compare
    TAM -->|"onCustomAction"| RED
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): move experiments table se..."](https://github.com/langfuse/langfuse/commit/49c01390ce6a74c995ef2467c6b888dfdcf21726) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41600383)</sub>

<!-- /greptile_comment -->