### PR TITLE
chore(ee): Include in knip scan + fix knip issues

### DIFF
--- a/ee/package.json
+++ b/ee/package.json
@@ -27,10 +27,6 @@
   },
   "dependencies": {
     "@langfuse/shared": "workspace:*",
-    "@opentelemetry/api": ">=1.0.0 <1.10.0",
-    "https-proxy-agent": "^7.0.6",
-    "next": "16.2.9",
-    "next-auth": "^4.24.13",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -39,9 +35,6 @@
     "@types/node": "^24.3.0",
     "@typescript/native-preview": "7.0.0-dev.20260122.3",
     "eslint": "^9.39.2",
-    "prettier": "^3.8.3",
-    "ts-node": "^10.9.2",
-    "tsc-watch": "^6.2.0",
     "typescript": "^5.7.2"
   }
 }

--- a/ee/src/index.ts
+++ b/ee/src/index.ts
@@ -1,0 +1,2 @@
+export { env } from "./env";
+export { isEeAvailable } from "./ee-license-check";

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -4,11 +4,13 @@
   "ignoreWorkspaces": [
     "web",
     "worker",
-    "ee",
     "packages/shared",
     "packages/config-eslint",
   ],
   "workspaces": {
+    "ee": {
+      "project": ["src/**/*.ts"],
+    },
     "packages/eslint-plugin": {
       "project": ["src/**/*.ts"],
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
     devDependencies:
       '@release-it/bumper':
         specifier: ^7.0.6
-        version: 7.0.6(release-it@20.2.0)
+        version: 7.0.6(release-it@20.2.0(@types/node@24.3.0)(magicast@0.5.2))
       dotenv-cli:
         specifier: ^7.4.4
         version: 7.4.4
@@ -48,7 +48,7 @@ importers:
         version: 3.8.3
       release-it:
         specifier: ^20.2.0
-        version: 20.2.0
+        version: 20.2.0(@types/node@24.3.0)(magicast@0.5.2)
       turbo:
         specifier: 2.9.18
         version: 2.9.18
@@ -58,18 +58,6 @@ importers:
       '@langfuse/shared':
         specifier: workspace:*
         version: link:../packages/shared
-      '@opentelemetry/api':
-        specifier: '>=1.0.0 <1.10.0'
-        version: 1.9.1
-      https-proxy-agent:
-        specifier: ^7.0.6
-        version: 7.0.6
-      next:
-        specifier: 16.2.9
-        version: 16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      next-auth:
-        specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -89,15 +77,6 @@ importers:
       eslint:
         specifier: ^9.39.2
         version: 9.39.4(jiti@2.7.0)
-      prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@24.3.0)(typescript@5.9.2)
-      tsc-watch:
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.2)
       typescript:
         specifier: ^5.7.2
         version: 5.9.2
@@ -13795,12 +13774,14 @@ snapshots:
 
   '@inquirer/ansi@2.0.7': {}
 
-  '@inquirer/checkbox@5.2.1':
+  '@inquirer/checkbox@5.2.1(@types/node@24.3.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1
+      '@inquirer/core': 11.2.1(@types/node@24.3.0)
       '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.3.0)
+    optionalDependencies:
+      '@types/node': 24.3.0
 
   '@inquirer/confirm@5.1.21(@types/node@24.3.0)':
     dependencies:
@@ -13809,10 +13790,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.3.0
 
-  '@inquirer/confirm@6.1.1':
+  '@inquirer/confirm@6.1.1(@types/node@24.3.0)':
     dependencies:
-      '@inquirer/core': 11.2.1
-      '@inquirer/type': 4.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.3.0)
+      '@inquirer/type': 4.0.7(@types/node@24.3.0)
+    optionalDependencies:
+      '@types/node': 24.3.0
 
   '@inquirer/core@10.3.2(@types/node@24.3.0)':
     dependencies:
@@ -13827,88 +13810,112 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.3.0
 
-  '@inquirer/core@11.2.1':
+  '@inquirer/core@11.2.1(@types/node@24.3.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
       '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.3.0)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.2
       mute-stream: 3.0.0
       signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 24.3.0
 
-  '@inquirer/editor@5.2.2':
+  '@inquirer/editor@5.2.2(@types/node@24.3.0)':
     dependencies:
-      '@inquirer/core': 11.2.1
-      '@inquirer/external-editor': 3.0.3
-      '@inquirer/type': 4.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.3.0)
+      '@inquirer/external-editor': 3.0.3(@types/node@24.3.0)
+      '@inquirer/type': 4.0.7(@types/node@24.3.0)
+    optionalDependencies:
+      '@types/node': 24.3.0
 
-  '@inquirer/expand@5.1.1':
+  '@inquirer/expand@5.1.1(@types/node@24.3.0)':
     dependencies:
-      '@inquirer/core': 11.2.1
-      '@inquirer/type': 4.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.3.0)
+      '@inquirer/type': 4.0.7(@types/node@24.3.0)
+    optionalDependencies:
+      '@types/node': 24.3.0
 
-  '@inquirer/external-editor@3.0.3':
+  '@inquirer/external-editor@3.0.3(@types/node@24.3.0)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 24.3.0
 
   '@inquirer/figures@1.0.15': {}
 
   '@inquirer/figures@2.0.7': {}
 
-  '@inquirer/input@5.1.2':
+  '@inquirer/input@5.1.2(@types/node@24.3.0)':
     dependencies:
-      '@inquirer/core': 11.2.1
-      '@inquirer/type': 4.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.3.0)
+      '@inquirer/type': 4.0.7(@types/node@24.3.0)
+    optionalDependencies:
+      '@types/node': 24.3.0
 
-  '@inquirer/number@4.1.1':
+  '@inquirer/number@4.1.1(@types/node@24.3.0)':
     dependencies:
-      '@inquirer/core': 11.2.1
-      '@inquirer/type': 4.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.3.0)
+      '@inquirer/type': 4.0.7(@types/node@24.3.0)
+    optionalDependencies:
+      '@types/node': 24.3.0
 
-  '@inquirer/password@5.1.1':
+  '@inquirer/password@5.1.1(@types/node@24.3.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1
-      '@inquirer/type': 4.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.3.0)
+      '@inquirer/type': 4.0.7(@types/node@24.3.0)
+    optionalDependencies:
+      '@types/node': 24.3.0
 
-  '@inquirer/prompts@8.4.2':
+  '@inquirer/prompts@8.4.2(@types/node@24.3.0)':
     dependencies:
-      '@inquirer/checkbox': 5.2.1
-      '@inquirer/confirm': 6.1.1
-      '@inquirer/editor': 5.2.2
-      '@inquirer/expand': 5.1.1
-      '@inquirer/input': 5.1.2
-      '@inquirer/number': 4.1.1
-      '@inquirer/password': 5.1.1
-      '@inquirer/rawlist': 5.3.1
-      '@inquirer/search': 4.2.1
-      '@inquirer/select': 5.2.1
+      '@inquirer/checkbox': 5.2.1(@types/node@24.3.0)
+      '@inquirer/confirm': 6.1.1(@types/node@24.3.0)
+      '@inquirer/editor': 5.2.2(@types/node@24.3.0)
+      '@inquirer/expand': 5.1.1(@types/node@24.3.0)
+      '@inquirer/input': 5.1.2(@types/node@24.3.0)
+      '@inquirer/number': 4.1.1(@types/node@24.3.0)
+      '@inquirer/password': 5.1.1(@types/node@24.3.0)
+      '@inquirer/rawlist': 5.3.1(@types/node@24.3.0)
+      '@inquirer/search': 4.2.1(@types/node@24.3.0)
+      '@inquirer/select': 5.2.1(@types/node@24.3.0)
+    optionalDependencies:
+      '@types/node': 24.3.0
 
-  '@inquirer/rawlist@5.3.1':
+  '@inquirer/rawlist@5.3.1(@types/node@24.3.0)':
     dependencies:
-      '@inquirer/core': 11.2.1
-      '@inquirer/type': 4.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.3.0)
+      '@inquirer/type': 4.0.7(@types/node@24.3.0)
+    optionalDependencies:
+      '@types/node': 24.3.0
 
-  '@inquirer/search@4.2.1':
+  '@inquirer/search@4.2.1(@types/node@24.3.0)':
     dependencies:
-      '@inquirer/core': 11.2.1
+      '@inquirer/core': 11.2.1(@types/node@24.3.0)
       '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.3.0)
+    optionalDependencies:
+      '@types/node': 24.3.0
 
-  '@inquirer/select@5.2.1':
+  '@inquirer/select@5.2.1(@types/node@24.3.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1
+      '@inquirer/core': 11.2.1(@types/node@24.3.0)
       '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.3.0)
+    optionalDependencies:
+      '@types/node': 24.3.0
 
   '@inquirer/type@3.0.10(@types/node@24.3.0)':
     optionalDependencies:
       '@types/node': 24.3.0
 
-  '@inquirer/type@4.0.7': {}
+  '@inquirer/type@4.0.7(@types/node@24.3.0)':
+    optionalDependencies:
+      '@types/node': 24.3.0
 
   '@ioredis/commands@1.5.1': {}
 
@@ -15860,7 +15867,7 @@ snapshots:
       react: 19.2.4
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
 
-  '@release-it/bumper@7.0.6(release-it@20.2.0)':
+  '@release-it/bumper@7.0.6(release-it@20.2.0(@types/node@24.3.0)(magicast@0.5.2))':
     dependencies:
       '@decimalturn/toml-patch': 1.3.0
       '@iarna/toml': 3.0.0
@@ -15870,7 +15877,7 @@ snapshots:
       ini: 6.0.0
       js-yaml: 4.2.0
       lodash-es: 4.18.1
-      release-it: 20.2.0
+      release-it: 20.2.0(@types/node@24.3.0)(magicast@0.5.2)
       semver: 7.8.4
 
   '@repeaterjs/repeater@3.0.6': {}
@@ -18140,7 +18147,7 @@ snapshots:
     optionalDependencies:
       magicast: 0.5.2
 
-  c12@3.3.3:
+  c12@3.3.3(magicast@0.5.2):
     dependencies:
       chokidar: 5.0.0
       confbox: 0.2.4
@@ -18154,6 +18161,8 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       rc9: 2.1.2
+    optionalDependencies:
+      magicast: 0.5.2
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -22543,13 +22552,13 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-sanitize: 5.0.2
 
-  release-it@20.2.0:
+  release-it@20.2.0(@types/node@24.3.0)(magicast@0.5.2):
     dependencies:
-      '@inquirer/prompts': 8.4.2
+      '@inquirer/prompts': 8.4.2(@types/node@24.3.0)
       '@octokit/rest': 22.0.1
       '@phun-ky/typeof': 2.0.3
       async-retry: 1.3.3
-      c12: 3.3.3
+      c12: 3.3.3(magicast@0.5.2)
       ci-info: 4.4.0
       defu: 6.1.7
       eta: 4.5.1


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the `ee` (enterprise edition) package to the knip dead-code scan, removes the dependencies and dev dependencies that knip flagged as unused, and populates the previously empty `ee/src/index.ts` with public re-exports that serve as the package's entry point.

- **`knip.jsonc`**: `ee` is removed from `ignoreWorkspaces` and given an explicit `workspaces` config (`src/**/*.ts`), so knip now scans it on every run.
- **`ee/package.json`**: Four runtime deps (`@opentelemetry/api`, `https-proxy-agent`, `next`, `next-auth`) and three dev deps (`prettier`, `ts-node`, `tsc-watch`) are removed; none are referenced in the current source files.
- **`ee/src/index.ts`**: Now re-exports `env` and `isEeAvailable`, completing the public surface that knip needs to see as \"used\".
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Straightforward housekeeping change with no runtime behaviour modifications — safe to merge.

All removed dependencies are genuinely absent from every source file in `ee/src/`. The new `index.ts` exports match the exact named exports in `env.ts` and `ee-license-check/index.ts`. The knip config change is consistent with how other workspaces are configured. The lockfile re-resolution is mechanical and introduces no new packages.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[knip scan] -->|now includes| B[ee workspace src files]
    B --> C[ee/src/index.ts entry point]
    C -->|re-exports env| D[ee/src/env.ts]
    C -->|re-exports isEeAvailable| E[ee/src/ee-license-check/index.ts]
    D -->|uses removeEmptyEnvVariables| F[langfuse/shared]
    E -->|reads env| D
    D -->|validates| G[process.env NEXT_PUBLIC_LANGFUSE_CLOUD_REGION and LANGFUSE_EE_LICENSE_KEY]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[knip scan] -->|now includes| B[ee workspace src files]
    B --> C[ee/src/index.ts entry point]
    C -->|re-exports env| D[ee/src/env.ts]
    C -->|re-exports isEeAvailable| E[ee/src/ee-license-check/index.ts]
    D -->|uses removeEmptyEnvVariables| F[langfuse/shared]
    E -->|reads env| D
    D -->|validates| G[process.env NEXT_PUBLIC_LANGFUSE_CLOUD_REGION and LANGFUSE_EE_LICENSE_KEY]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ee): Include in knip scan + fix kn..."](https://github.com/langfuse/langfuse/commit/d9a2d4863eed6d420e974b689b47d65b2ee2fd92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41605064)</sub>

<!-- /greptile_comment -->