### PR TITLE
fix(web): unquote media chips and untangle hover overlays in table IO cells

### DIFF
--- a/web/src/components/ui/IOTableCell.clienttest.tsx
+++ b/web/src/components/ui/IOTableCell.clienttest.tsx
@@ -1,0 +1,195 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { IOTableCell } from "@/src/components/ui/IOTableCell";
+import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ query: {} }),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    media: {
+      getById: {
+        useQuery: () => ({ isError: false, data: undefined }),
+      },
+    },
+  },
+}));
+
+const MEDIA_REF =
+  "@@@langfuseMedia:type=image/png|id=cc48838a-3da8-4ca4-a007-2cf8df930e69|source=bytes@@@";
+
+const renderCell = (props: {
+  data: unknown;
+  singleLine: boolean;
+  enableExpandOnHover?: boolean;
+}) =>
+  render(
+    <MarkdownContextProvider>
+      <IOTableCell {...props} />
+    </MarkdownContextProvider>,
+  );
+
+/**
+ * Native title tooltips render on top of open popovers (media peek, cell
+ * expand card), so the single-line cell title must yield whenever such a
+ * hover surface supersedes it.
+ */
+describe("IOTableCell native title suppression", () => {
+  it("single-line: drops the cell title while the pointer is over a media chip", () => {
+    const { container } = renderCell({
+      data: `Here is an image: ${MEDIA_REF} — nice.`,
+      singleLine: true,
+    });
+
+    const cell = container.querySelector("[title]")!;
+    expect(cell.getAttribute("title")).toContain("Here is an image");
+
+    fireEvent.pointerOver(screen.getByRole("button", { name: "PNG media" }));
+    expect(cell.getAttribute("title")).toBeNull();
+
+    // moving off the chip back onto cell text restores the title
+    fireEvent.pointerOver(cell);
+    expect(cell.getAttribute("title")).toContain("Here is an image");
+  });
+
+  it("single-line: has no cell title when the expand-on-hover card previews the content", () => {
+    const { container } = renderCell({
+      data: "Langfuse is an open-source LLM engineering platform.",
+      singleLine: true,
+      enableExpandOnHover: true,
+    });
+
+    expect(container.querySelector("[title]")).toBeNull();
+  });
+
+  it("single-line: keeps the cell title otherwise", () => {
+    const text = "Langfuse is an open-source LLM engineering platform.";
+    const { container } = renderCell({ data: text, singleLine: true });
+
+    expect(container.querySelector("[title]")?.getAttribute("title")).toBe(
+      text,
+    );
+  });
+});
+
+/**
+ * Chip quote consistency across row heights: JSON.stringify wraps media
+ * reference strings in quotes — as a lone compact-verbosity value
+ * ('"@@@ref@@@"') and nested inside stringified JSON — so single-line rows
+ * used to render quoted chips while the multi-line JSON view rendered bare
+ * chips. A quote pair directly enclosing a chip is now dropped, so chips
+ * render unquoted at every height; text keeps its existing rendering.
+ */
+describe("IOTableCell media chip rendering", () => {
+  it("single-line: lone JSON-encoded media ref renders as a bare chip", () => {
+    const { container } = renderCell({
+      data: JSON.stringify(MEDIA_REF),
+      singleLine: true,
+    });
+
+    expect(
+      screen.getByRole("button", { name: "PNG media" }),
+    ).toBeInTheDocument();
+    expect(container.textContent).not.toContain('"');
+  });
+
+  it("multi-line: lone JSON-encoded media ref renders as a bare chip", () => {
+    const { container } = renderCell({
+      data: JSON.stringify(MEDIA_REF),
+      singleLine: false,
+    });
+
+    expect(
+      screen.getByRole("button", { name: "PNG media" }),
+    ).toBeInTheDocument();
+    expect(container.textContent).not.toContain('"');
+  });
+
+  it("multi-line: bare media ref string renders as an unquoted chip", () => {
+    const { container } = renderCell({ data: MEDIA_REF, singleLine: false });
+
+    expect(
+      screen.getByRole("button", { name: "PNG media" }),
+    ).toBeInTheDocument();
+    expect(container.textContent).not.toContain('"');
+  });
+
+  it("single-line: media chip nested in JSON drops its enclosing quote pair", () => {
+    const { container } = renderCell({
+      data: { image: MEDIA_REF },
+      singleLine: true,
+    });
+
+    expect(
+      screen.getByRole("button", { name: "PNG media" }),
+    ).toBeInTheDocument();
+    expect(container.textContent).toContain('"image": PNG');
+    expect(container.textContent).not.toContain('"PNG"');
+  });
+
+  it("single-line: adjacent media refs in an array each drop their quote pair", () => {
+    const { container } = renderCell({
+      data: [MEDIA_REF, MEDIA_REF],
+      singleLine: true,
+    });
+
+    expect(screen.getAllByRole("button", { name: "PNG media" })).toHaveLength(
+      2,
+    );
+    expect(container.textContent).not.toContain('"');
+  });
+
+  it("single-line: media ref embedded in longer text renders as chip within the text", () => {
+    const { container } = renderCell({
+      data: `Here is an image: ${MEDIA_REF} — nice.`,
+      singleLine: true,
+    });
+
+    expect(
+      screen.getByRole("button", { name: "PNG media" }),
+    ).toBeInTheDocument();
+    expect(container.textContent).toContain("Here is an image: PNG — nice.");
+  });
+
+  it("single-line: top-level plain text renders unquoted", () => {
+    const text = "Langfuse is an open-source AI engineering platform";
+    const { container } = renderCell({ data: text, singleLine: true });
+
+    expect(container.textContent).toContain(text);
+    expect(container.textContent).not.toContain('"');
+  });
+
+  it("multi-line: object data still renders as a JSON tree", () => {
+    const { container } = renderCell({
+      data: { foo: "bar" },
+      singleLine: false,
+    });
+
+    expect(container.textContent).toContain("foo");
+    expect(container.textContent).toContain("bar");
+  });
+
+  it("multi-line: stringified JSON still deep-parses into a JSON tree", () => {
+    const { container } = renderCell({
+      data: '{"foo":"bar"}',
+      singleLine: false,
+    });
+
+    expect(container.textContent).toContain("foo");
+    expect(container.textContent).toContain("bar");
+  });
+
+  it("multi-line: long content is truncated", () => {
+    const { container } = renderCell({
+      data: "x".repeat(10_050),
+      singleLine: false,
+    });
+
+    expect(container.textContent).toContain("truncated");
+  });
+});

--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -7,7 +7,7 @@ import {
 import { splitStringByMediaReferences } from "@/src/components/ui/media/mediaUtils";
 import { JsonMediaTag } from "@/src/components/ui/media/JsonMediaTag";
 import { cn } from "@/src/utils/tailwind";
-import { memo } from "react";
+import { memo, useRef, useState } from "react";
 import {
   HoverCard,
   HoverCardContent,
@@ -23,11 +23,37 @@ const ioTableCellPaddingClassNames: Record<IOTableCellPadding, string> = {
 };
 
 function renderStringWithMediaReferences(value: string) {
-  const segments = splitStringByMediaReferences(value);
+  // Copy the segments: the quote-trim below mutates `value` in place, and the
+  // originals belong to splitStringByMediaReferences (unsafe to mutate if it
+  // ever memoizes its result).
+  const segments = splitStringByMediaReferences(value).map((segment) => ({
+    ...segment,
+  }));
 
   if (segments.length === 1 && segments[0]?.type === "text") {
     return value;
   }
+
+  // JSON.stringify wraps media reference strings in quotes (both nested in
+  // stringified JSON and as a lone compact-verbosity value), which would
+  // render as a quoted chip — while the multi-line JSON view shows a bare
+  // chip. Drop a quote pair that directly encloses a chip; the escaped-quote
+  // check leaves a literal \" in user text alone.
+  segments.forEach((segment, index) => {
+    if (segment.type !== "media") return;
+    const prev = segments[index - 1];
+    const next = segments[index + 1];
+    if (
+      prev?.type === "text" &&
+      next?.type === "text" &&
+      prev.value.endsWith('"') &&
+      !prev.value.endsWith('\\"') &&
+      next.value.startsWith('"')
+    ) {
+      prev.value = prev.value.slice(0, -1);
+      next.value = next.value.slice(1);
+    }
+  });
 
   return segments.map((segment, index) =>
     segment.type === "media" ? (
@@ -46,15 +72,23 @@ const IOTableCellContent = ({
   singleLine,
   className,
   padding,
+  suppressTitle = false,
 }: {
   data: unknown;
   singleLine: boolean;
   className?: string;
   padding: IOTableCellPadding;
+  suppressTitle?: boolean;
 }) => {
   const stringifiedJson =
     data !== null && data !== undefined ? stringifyJsonNode(data) : undefined;
   const paddingClassName = ioTableCellPaddingClassNames[padding];
+
+  // Native title tooltips render on top of open popovers, so the single-line
+  // title is dropped whenever a hover surface supersedes it: entirely when the
+  // cell has an expand-on-hover card (which previews the same content), and
+  // while the pointer is over a media chip (which has its own hover peek).
+  const [isPointerOverMediaTag, setIsPointerOverMediaTag] = useState(false);
 
   // perf: truncate to IO_TABLE_CHAR_LIMIT characters as table becomes unresponsive attempting to render large JSONs with high levels of nesting
   const shouldTruncate =
@@ -71,7 +105,14 @@ const IOTableCellContent = ({
         paddingClassName,
         className,
       )}
-      title={singleLineText}
+      title={
+        suppressTitle || isPointerOverMediaTag ? undefined : singleLineText
+      }
+      onPointerOver={(event) =>
+        setIsPointerOverMediaTag(
+          Boolean((event.target as Element).closest("[data-media-tag]")),
+        )
+      }
     >
       {singleLineText ? renderStringWithMediaReferences(singleLineText) : null}
     </div>
@@ -128,6 +169,13 @@ export const IOTableCell = ({
 }) => {
   const paddingClassName = ioTableCellPaddingClassNames[padding];
 
+  // Media chips inside the cell carry their own hover peek; opening the
+  // cell-wide expand card on top of it stacks two popovers. Track whether the
+  // pointer is over a chip and keep the expand card closed for that region —
+  // hover a chip for the media peek, hover anywhere else for the full JSON.
+  const [isExpandOpen, setIsExpandOpen] = useState(false);
+  const isPointerOverMediaTag = useRef(false);
+
   if (isLoading) {
     return (
       <JsonSkeleton
@@ -154,14 +202,32 @@ export const IOTableCell = ({
   }
 
   return (
-    <HoverCard openDelay={700} closeDelay={100}>
+    <HoverCard
+      openDelay={700}
+      closeDelay={100}
+      open={isExpandOpen}
+      onOpenChange={(open) => {
+        if (open && isPointerOverMediaTag.current) return;
+        setIsExpandOpen(open);
+      }}
+    >
       <HoverCardTrigger asChild>
-        <div className="group/io-cell relative h-full w-full">
+        <div
+          className="group/io-cell relative h-full w-full"
+          onPointerOver={(event) => {
+            const overMediaTag = Boolean(
+              (event.target as Element).closest("[data-media-tag]"),
+            );
+            isPointerOverMediaTag.current = overMediaTag;
+            if (overMediaTag) setIsExpandOpen(false);
+          }}
+        >
           <IOTableCellContent
             data={data}
             singleLine={singleLine}
             className={className}
             padding={padding}
+            suppressTitle
           />
         </div>
       </HoverCardTrigger>

--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -108,10 +108,15 @@ const IOTableCellContent = ({
       title={
         suppressTitle || isPointerOverMediaTag ? undefined : singleLineText
       }
-      onPointerOver={(event) =>
-        setIsPointerOverMediaTag(
-          Boolean((event.target as Element).closest("[data-media-tag]")),
-        )
+      // With suppressTitle the state cannot affect output, so skip the
+      // handler to avoid re-rendering on every chip-boundary crossing.
+      onPointerOver={
+        suppressTitle
+          ? undefined
+          : (event) =>
+              setIsPointerOverMediaTag(
+                Boolean((event.target as Element).closest("[data-media-tag]")),
+              )
       }
     >
       {singleLineText ? renderStringWithMediaReferences(singleLineText) : null}

--- a/web/src/components/ui/media/MediaTag.clienttest.tsx
+++ b/web/src/components/ui/media/MediaTag.clienttest.tsx
@@ -47,6 +47,20 @@ describe("MediaTag", () => {
     expect(onOpenChange).toHaveBeenCalledTimes(1);
   });
 
+  it("empties the native title while the peek is open so no tooltip overlaps it", () => {
+    render(<MediaTag contentType="image/png" status="ready" open />);
+
+    const chip = screen.getByRole("button", { name: "PNG media" });
+    expect(chip.querySelector("span")?.getAttribute("title")).toBe("");
+  });
+
+  it("keeps the label title while the peek is closed", () => {
+    render(<MediaTag contentType="image/png" open={false} />);
+
+    const chip = screen.getByRole("button", { name: "PNG media" });
+    expect(chip.querySelector("span")?.getAttribute("title")).toBe("PNG");
+  });
+
   it("shows the fallback when resolved image media fails to render", async () => {
     render(
       <MediaTag

--- a/web/src/components/ui/media/MediaTag.tsx
+++ b/web/src/components/ui/media/MediaTag.tsx
@@ -195,6 +195,10 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
           <button
             ref={ref}
             type="button"
+            // Marker for containers to detect chip hover via event delegation
+            // (`closest("[data-media-tag]")`): IOTableCell suppresses its
+            // expand-on-hover card and native title while over a chip.
+            data-media-tag=""
             aria-label={`${chipLabel} media`}
             aria-expanded={isOpen}
             className="hover:bg-accent focus-visible:ring-ring bg-background inline-flex h-3.5 max-w-full items-center gap-1 rounded-sm border px-1 py-0 align-middle text-xs leading-none transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
@@ -209,7 +213,10 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
             <KindIcon kind={kind} className="h-2.5 w-2.5 shrink-0" />
             <span
               className="relative top-0.25 truncate align-baseline font-mono leading-none"
-              title={chipLabel}
+              // Empty while the peek is open: a native tooltip would render on
+              // top of the peek. Ancestors with a title still tooltip over the
+              // peek — containers must suppress theirs too (see IOTableCell).
+              title={isOpen ? "" : chipLabel}
             >
               {chipLabel}
             </span>


### PR DESCRIPTION
## Summary

- Media reference strings reach table IO cells wrapped in JSON quotes — compact-verbosity previews `JSON.stringify` the last ChatML message content, and refs nested inside stringified JSON carry their own quotes. Small (single-line) rows therefore rendered quoted chips (`"[PNG]"`) while medium/high rows rendered bare chips (reported as contradicting behavior in Slack). The single-line renderer now drops a quote pair that directly encloses a chip, so chips render unquoted at every row height.
- Hovering a chip in a single-line cell stacked up to three overlays: the chip's media peek, the cell-wide expand-on-hover card, and native `title` tooltips rendering on top of both. Now: while the pointer is over a chip the cell suppresses its expand card and its native title (chip detected via a `data-media-tag` marker + event delegation); cells with an expand card drop their native title entirely (the card previews the same content, bigger); the chip empties its own `title` while its peek is open.
- Component tests for both behaviors (quote stripping incl. lone/nested/adjacent/escaped cases, title + overlay suppression).

## Linear

- [LFE-10621](https://linear.app/langfuse/issue/LFE-10621/media-rendering-broken-in-dataset-table-with-s-row-height)

## Major Decisions

- Quote handling is a pure segment transformation in `renderStringWithMediaReferences`: no JSON parsing on the render path (an earlier deep-parse approach was dropped as too expensive for the default path), only trimming a `"` pair directly enclosing a chip, with escaped `\"` left alone. Objects/arrays otherwise keep their normal JSON quoting.
- Overlay priority is pointer-position based: hovering a chip yields only the media peek, hovering anywhere else in the cell yields only the expand card. The expand HoverCard is controlled for this; after peeking a chip it reopens only once the pointer re-enters the cell (Radix fires on enter) — accepted tradeoff.

## Review Focus

- The hover interplay is best checked manually at small row height on a trace with media in IO: chip hover → peek only; text hover → expand card only; no native tooltip on top of either popover.
- `IOTableCellContent` gains a state update on chip-boundary crossings; the cell's (pre-existing, unmemoized) stringify pipeline reruns on those transitions. Negligible for normal payloads — flagging in case anyone feels strongly about a `useMemo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two visual bugs in table IO cells that contain media reference chips: (1) single-line rows rendered quoted chips (`"[PNG]"`) because `JSON.stringify` wraps media refs in quotes, and (2) hovering a chip stacked up to three overlapping hover surfaces (media peek, cell expand card, native `title` tooltip).

- Quote stripping is implemented as a pure segment-level transformation in `renderStringWithMediaReferences`: a `"` pair directly enclosing a chip is trimmed, with escaped `\"` left alone, resolving the quoted/unquoted inconsistency across row heights.
- Overlay management uses a `data-media-tag` marker on `MediaTag` buttons and event delegation (`closest("[data-media-tag]")`) to toggle between the chip's peek and the cell's expand card; the expand card is fully controlled via `isExpandOpen` state, and a ref gates the Radix `onOpenChange` callback to prevent the expand card from opening while over a chip.
- Component tests cover quote stripping edge cases (lone, nested, adjacent, escaped) and title/overlay suppression behavior.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; fixes a UX inconsistency with no changes to data handling or auth.

The hover interaction logic is well-designed — the ref/state split correctly separates 'block the open' (synchronous ref) from 'close the card' (state), and the delay between onPointerOver and Radix's deferred onOpenChange means the ref is always current when the gate is checked. The quote-stripping transformation is narrow and correct for all tested cases. The one minor issue is that IOTableCellContent's onPointerOver handler fires and updates state on every chip-boundary crossing even when suppressTitle=true makes the state irrelevant, causing unnecessary re-renders of the stringify pipeline; for cells with large payloads this could be noticeable.

IOTableCell.tsx around the suppressTitle + onPointerOver interaction in IOTableCellContent.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User Pointer
    participant D as Wrapper div (onPointerOver)
    participant Ref as isPointerOverMediaTag (ref)
    participant HC as HoverCard (controlled)
    participant ITC as IOTableCellContent
    participant MT as MediaTag chip

    U->>D: pointerOver on chip
    D->>Ref: "current = true"
    D->>HC: setIsExpandOpen(false)
    Note over HC: Expand card closes (if open)
    ITC->>ITC: setIsPointerOverMediaTag(true) → re-render
    Note over ITC: title suppressed (suppressTitle=true anyway)

    U->>MT: hover persists 700ms
    HC-->>HC: onOpenChange(true) fires
    HC->>Ref: "check current=true → return early"
    Note over HC: Expand card stays closed ✓

    U->>D: pointerOver on text area
    D->>Ref: "current = false"
    ITC->>ITC: setIsPointerOverMediaTag(false) → re-render
    Note over ITC: title still suppressed (suppressTitle=true)

    U->>D: hover 700ms on text area
    HC-->>HC: onOpenChange(true) fires
    HC->>Ref: "check current=false → setIsExpandOpen(true)"
    Note over HC: Expand card opens ✓

    U->>MT: chip hover while expand open
    MT->>MT: onOpenChange(true) for peek
    Note over MT: title=empty while peek open
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User Pointer
    participant D as Wrapper div (onPointerOver)
    participant Ref as isPointerOverMediaTag (ref)
    participant HC as HoverCard (controlled)
    participant ITC as IOTableCellContent
    participant MT as MediaTag chip

    U->>D: pointerOver on chip
    D->>Ref: "current = true"
    D->>HC: setIsExpandOpen(false)
    Note over HC: Expand card closes (if open)
    ITC->>ITC: setIsPointerOverMediaTag(true) → re-render
    Note over ITC: title suppressed (suppressTitle=true anyway)

    U->>MT: hover persists 700ms
    HC-->>HC: onOpenChange(true) fires
    HC->>Ref: "check current=true → return early"
    Note over HC: Expand card stays closed ✓

    U->>D: pointerOver on text area
    D->>Ref: "current = false"
    ITC->>ITC: setIsPointerOverMediaTag(false) → re-render
    Note over ITC: title still suppressed (suppressTitle=true)

    U->>D: hover 700ms on text area
    HC-->>HC: onOpenChange(true) fires
    HC->>Ref: "check current=false → setIsExpandOpen(true)"
    Note over HC: Expand card opens ✓

    U->>MT: chip hover while expand open
    MT->>MT: onOpenChange(true) for peek
    Note over MT: title=empty while peek open
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/ui/IOTableCell.tsx:111-115
Redundant state churn when `suppressTitle` is already true: the `onPointerOver` handler unconditionally calls `setIsPointerOverMediaTag`, which triggers a re-render of `IOTableCellContent` (and re-runs `stringifyJsonNode`) on every chip-boundary crossing — even though `suppressTitle || isPointerOverMediaTag` is always `true` when `suppressTitle=true`, so the state has no effect on the output. Skipping the handler entirely when `suppressTitle` is true avoids these re-renders without changing behaviour.

```suggestion
      onPointerOver={
        suppressTitle
          ? undefined
          : (event) =>
              setIsPointerOverMediaTag(
                Boolean((event.target as Element).closest("[data-media-tag]")),
              )
      }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): unquote media chips and untang..."](https://github.com/langfuse/langfuse/commit/0cc0c295cc79b43bbc4967c4a8bd676292a68318) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41620337)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->