### PR TITLE
fix(session): guard byIdWithScoresFromEvents query to stop spurious "sessionId is required" toast (LFE-10667)

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -526,6 +526,7 @@ export const SessionEventsPage: React.FC<{
       projectId: projectId,
     },
     {
+      enabled: !!projectId && !!sessionId,
       retry(failureCount, error) {
         if (
           error.data?.code === "UNAUTHORIZED" ||


### PR DESCRIPTION
## TL;DR

The v4 session-detail page fires a spurious error toast on load — `Bad Request: Invalid input, sessionId is required` (`sessions.byIdWithScoresFromEvents`). One-line fix: add the same `enabled` guard the sibling query already uses. No toast, data still loads.

## Why

`api.sessions.byIdWithScoresFromEvents.useQuery` had a `retry` option but **no `enabled` guard**, so it fired on the very first render — before the Next router resolved the route params. That means it ran with an empty `sessionId`, tRPC input validation rejected it, and the rejection surfaced as an error toast. Its sibling `api.sessions.tracesFromEvents.useQuery` already guards with `enabled: !!projectId && !!sessionId` and stays quiet.

## What

Add `enabled: !!projectId && !!sessionId` to the options object of the `byIdWithScoresFromEvents` query, mirroring the sibling. Nothing else changed.

## Result

No spurious `sessionId is required` toast on load; the session data still loads normally. Cosmetic, pre-existing behavior — not introduced by LFE-10520.

Fixes LFE-10667.

<details>
<summary>Diff</summary>

```diff
     {
       sessionId,
       projectId: projectId,
     },
     {
+      enabled: !!projectId && !!sessionId,
       retry(failureCount, error) {
         if (
           error.data?.code === "UNAUTHORIZED" ||
```

Verified: `prettier --check` clean and `turbo run lint` green across all packages (via the pre-commit hook, 8/8 tasks passed).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a missing `enabled` guard to the `byIdWithScoresFromEvents` tRPC query in the session events page, preventing it from firing before Next.js resolves route params and surfacing a spurious "sessionId is required" error toast on load.

- The fix mirrors the identical `enabled: !!projectId && !!sessionId` guard already present on the sibling `tracesFromEvents` query in the same component.
- No logic changes, no data-loading behavior affected — the query simply no longer fires on the first render when `sessionId` is still an empty string.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change adds a single missing guard that was already present on the sibling query, with no behavioral change to data loading.

The fix is a one-line guard added to match an identical guard on the adjacent query. It prevents a premature API call when sessionId is an empty string during the initial render cycle. The session data still loads normally once params are resolved, and error handling paths (NOT_FOUND, UNAUTHORIZED) are unaffected. No other logic was touched.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Router as Next.js Router
    participant Component as SessionEventsPage
    participant tRPC as tRPC Client

    Note over Router,tRPC: Before fix — first render
    Router->>Component: "render (sessionId = "")"
    Component->>tRPC: "byIdWithScoresFromEvents({sessionId: ""})"
    tRPC-->>Component: ❌ Bad Request: sessionId is required
    Component-->>Component: ⚠️ Error toast shown

    Note over Router,tRPC: After fix — first render
    Router->>Component: "render (sessionId = "")"
    Component->>Component: "enabled = false → skip"
    Note over tRPC: query suppressed

    Note over Router,tRPC: After fix — params resolved
    Router->>Component: "render (sessionId = "abc123")"
    Component->>tRPC: "byIdWithScoresFromEvents({sessionId: "abc123"})"
    tRPC-->>Component: ✅ Session data returned
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Router as Next.js Router
    participant Component as SessionEventsPage
    participant tRPC as tRPC Client

    Note over Router,tRPC: Before fix — first render
    Router->>Component: "render (sessionId = "")"
    Component->>tRPC: "byIdWithScoresFromEvents({sessionId: ""})"
    tRPC-->>Component: ❌ Bad Request: sessionId is required
    Component-->>Component: ⚠️ Error toast shown

    Note over Router,tRPC: After fix — first render
    Router->>Component: "render (sessionId = "")"
    Component->>Component: "enabled = false → skip"
    Note over tRPC: query suppressed

    Note over Router,tRPC: After fix — params resolved
    Router->>Component: "render (sessionId = "abc123")"
    Component->>tRPC: "byIdWithScoresFromEvents({sessionId: "abc123"})"
    tRPC-->>Component: ✅ Session data returned
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(session): guard byIdWithScoresFromEv..."](https://github.com/langfuse/langfuse/commit/b060e6ab5614c145a68eb27b945e3cf3221cfe2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41628933)</sub>

<!-- /greptile_comment -->