### PR TITLE
chore: Include config-eslint in knip scan

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -5,11 +5,13 @@
     "web",
     "worker",
     "packages/shared",
-    "packages/config-eslint",
   ],
   "workspaces": {
     "ee": {
       "project": ["src/**/*.ts"],
+    },
+    "packages/config-eslint": {
+      "project": ["*.js"],
     },
     "packages/eslint-plugin": {
       "project": ["src/**/*.ts"],


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves `packages/config-eslint` from `ignoreWorkspaces` (fully excluded from knip analysis) into the `workspaces` block with an explicit project glob, so knip now scans it for unused exports and dependencies.

- `packages/config-eslint` is removed from `ignoreWorkspaces` and added to `workspaces` with `"project": ["*.js"]`, which correctly matches all four root-level JS files (`index.js`, `library.js`, `next.js`, `shared.js`).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only affects knip tooling configuration and has no runtime impact.

The diff is a two-line knip config adjustment: the package is removed from the skip list and given an explicit project glob that correctly covers all four JS files at the package root. No logic or runtime code is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[knip scan starts] --> B{workspace in ignoreWorkspaces?}
    B -- "yes (before PR)\npackages/config-eslint" --> C[Skip workspace entirely]
    B -- "no" --> D{workspace in workspaces block?}
    D -- "yes\npackages/config-eslint (after PR)" --> E["Scan with project: ['*.js']\nindex.js, library.js, next.js, shared.js"]
    D -- "no" --> F[Use default project glob]
    E --> G[Report unused exports / deps]
    F --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[knip scan starts] --> B{workspace in ignoreWorkspaces?}
    B -- "yes (before PR)\npackages/config-eslint" --> C[Skip workspace entirely]
    B -- "no" --> D{workspace in workspaces block?}
    D -- "yes\npackages/config-eslint (after PR)" --> E["Scan with project: ['*.js']\nindex.js, library.js, next.js, shared.js"]
    D -- "no" --> F[Use default project glob]
    E --> G[Report unused exports / deps]
    F --> G
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: Include config-eslint in knip sca..."](https://github.com/langfuse/langfuse/commit/c06030d2b7856cf2d3bfbe53e6dbcf63aed426ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41633738)</sub>

<!-- /greptile_comment -->