### PR TITLE
chore: link upstream swc issue in minifier-workaround comments (LFE-10645)

### DIFF
--- a/scripts/scan-client-bundle.mjs
+++ b/scripts/scan-client-bundle.mjs
@@ -32,7 +32,8 @@
  * minifier while code still reads it. The canonical first-party fix is to
  * move the module-level const into the (single) function that reads it — see
  * the LFE-10640 fix in TraceLayoutDesktop.tsx (#14735) — and to link the
- * upstream SWC issue in a comment so the workaround is deletable once fixed.
+ * upstream SWC issue (swc-project/swc#11983) in a comment so the workaround
+ * is deletable once fixed.
  * For vendored dependency code, change how the dependency is shipped (see the
  * prettier/plugins/typescript → babel-ts swap in #14738).
  */

--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -120,7 +120,8 @@ const NOOP_LAYOUT_STORAGE = {
 // single-use top-level const it tripped the SWC prod minifier's dropped-binding
 // bug — the declaration was deleted while this function's inlined body kept the
 // reference, throwing `ReferenceError` on peek open (LFE-10640; the CI
-// client-bundle scan now guards the class, LFE-10645).
+// client-bundle scan now guards the class, LFE-10645). Delete this workaround
+// once swc-project/swc#11983 is fixed in the Next-vendored swc_core.
 function collapsedShareMaxForWidth(groupWidthPx: number): number {
   const boundaryPx = (COLLAPSED_PANEL_PX + NAVIGATION_PANEL_MIN_PX) / 2;
   return (boundaryPx / groupWidthPx) * 100;


### PR DESCRIPTION
## TL;DR

The SWC dropped-binding bug behind LFE-10640 is now filed upstream as [swc-project/swc#11983](https://github.com/swc-project/swc/issues/11983). This links it from the two places that reference the workaround — the `TraceLayoutDesktop` boundary comment and the bundle scanner's fix guidance — so both are findable and deletable the day it's fixed in the Next-vendored swc_core.

Comment-only change; no behavior.

Story: LFE-10640 (crash) · LFE-10645 / #14738 (analysis + scanner) · #14766 (re-land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a reference to the upstream SWC bug report ([swc-project/swc#11983](https://github.com/swc-project/swc/issues/11983)) in the two places that document the minifier-workaround — the `TraceLayoutDesktop.tsx` boundary comment and the bundle scanner's fix guidance. No code behavior changes.

- `TraceLayoutDesktop.tsx`: extends the existing LFE-10640 comment with a `Delete this workaround once swc-project/swc#11983 is fixed` note, making the future cleanup obvious.
- `scripts/scan-client-bundle.mjs`: embeds the issue reference directly in the guidance sentence so both artefacts point to the same canonical upstream ticket.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is two comment lines with no effect on runtime behaviour.

Both changed lines are inside block/inline comments — no executable code is touched. The workaround itself is unchanged; only the tracking reference is added.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SWC prod minifier drops binding\nLFE-10640 / ReferenceError on peek open] --> B[Workaround: move const inside function\nTraceLayoutDesktop.tsx #14735]
    A --> C[Bundle scanner guard added\nscan-client-bundle.mjs LFE-10645]
    B --> D[Comment updated with upstream issue\nswc-project/swc#11983]
    C --> D
    D --> E[Future: delete workaround once\nswc_core ships the fix]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SWC prod minifier drops binding\nLFE-10640 / ReferenceError on peek open] --> B[Workaround: move const inside function\nTraceLayoutDesktop.tsx #14735]
    A --> C[Bundle scanner guard added\nscan-client-bundle.mjs LFE-10645]
    B --> D[Comment updated with upstream issue\nswc-project/swc#11983]
    C --> D
    D --> E[Future: delete workaround once\nswc_core ships the fix]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: link upstream swc issue #11983 in..."](https://github.com/langfuse/langfuse/commit/f02db543f1f8bd3bfb9cda28bc3a42cccf501783) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41636306)</sub>

<!-- /greptile_comment -->