### PR TITLE
fix(evals): stop flagging E402 on imports in Python code evaluators

### DIFF
--- a/web/src/features/evals/utils/code-eval-template-validation.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.ts
@@ -579,6 +579,10 @@ const PYTHON_RUFF_SETTINGS = {
   "indent-width": 2,
   lint: {
     select: ["E4", "E7", "E9", "F"],
+    // The contract is prepended to the user's source before linting (and at
+    // execution time), so user imports are never at the literal top of the
+    // file — E402 would flag every import.
+    ignore: ["E402"],
   },
 };
 const PYTHON_ERROR_DIAGNOSTIC_CODES = new Set([


### PR DESCRIPTION
## Summary

- Ignore Ruff's E402 ("module level import not at top of file") when linting Python code evaluators in the editor. The evaluation contract (dataclass declarations for `EvaluationContext`, `Score`, etc.) is prepended to the user's source before linting — and at execution time — so user imports are never at the literal top of the linted file and every `import` line was flagged with a false E402 warning.

## Linear

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a false-positive linting warning in the Python code evaluator editor. Because `PYTHON_CODE_EVAL_CONTRACT` (dataclass declarations for `EvaluationContext`, `Score`, etc.) is always prepended to the user's source before Ruff lints it, any `import` statement in the user's code appears after module-level declarations — correctly triggering Ruff's E402 rule, but incorrectly from the user's perspective.

- Adds `ignore: ["E402"]` to `PYTHON_RUFF_SETTINGS` in `code-eval-template-validation.ts`, suppressing the spurious "module level import not at top of file" diagnostic that users would otherwise always see on their imports.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the single-line change correctly silences a well-understood false-positive without disabling any rule that catches real errors.

The prepended contract structure is confirmed in the code: PYTHON_CODE_EVAL_CONTRACT + newlines + source always places user imports after class declarations, making E402 fire on every import. Ignoring E402 is the standard Ruff mechanism for exactly this pattern and does not affect any of the error-catching rules (E4, E7, E9, F) that remain selected.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as User (editor)
    participant Validator as validateCodeEvalSourceWithPython
    participant Ruff as Ruff (WASM)

    User->>Validator: source (user's Python code with imports)
    Validator->>Validator: hasPythonContractDeclarations(source)?
    alt contract NOT already present
        Validator->>Validator: "validationSource = PYTHON_CODE_EVAL_CONTRACT + source"
    else contract already present
        Validator->>Validator: "validationSource = source"
    end
    Validator->>Ruff: check(validationSource) with PYTHON_RUFF_SETTINGS
    Note over Ruff: ignore: ["E402"] prevents false positives
    Ruff-->>Validator: diagnostics (no E402)
    Validator-->>User: mapped diagnostics with offset applied
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as User (editor)
    participant Validator as validateCodeEvalSourceWithPython
    participant Ruff as Ruff (WASM)

    User->>Validator: source (user's Python code with imports)
    Validator->>Validator: hasPythonContractDeclarations(source)?
    alt contract NOT already present
        Validator->>Validator: "validationSource = PYTHON_CODE_EVAL_CONTRACT + source"
    else contract already present
        Validator->>Validator: "validationSource = source"
    end
    Validator->>Ruff: check(validationSource) with PYTHON_RUFF_SETTINGS
    Note over Ruff: ignore: ["E402"] prevents false positives
    Ruff-->>Validator: diagnostics (no E402)
    Validator-->>User: mapped diagnostics with offset applied
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): stop flagging E402 on import..."](https://github.com/langfuse/langfuse/commit/ce374ff4bdab1cd1ac7f64e66e716be58e100ef6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41645706)</sub>

<!-- /greptile_comment -->