### PR TITLE
fix(search-bar): unbreak web build — type error in observedMetadataStore test (LFE-10666)

### DIFF
--- a/web/src/features/search-bar/store/observedMetadataStore.clienttest.ts
+++ b/web/src/features/search-bar/store/observedMetadataStore.clienttest.ts
@@ -176,17 +176,17 @@ describe("mergeIntoProject", () => {
   it("types keys shadowing Object.prototype members correctly", () => {
     // `nextPaths["toString"]` must not read the inherited function as the
     // "existing" entry — that would skip the cap counter and pin the type to
-    // "mixed" forever (review find: greptile/claude on PR #14771).
-    const merged = mergeIntoProject(
-      {},
-      "p1",
-      paths({
-        toString: { type: "string", values: ["hello"] },
-        constructor: { type: "number", values: ["1"] },
-        hasOwnProperty: { type: "boolean" },
-      }),
-      1000,
-    );
+    // "mixed" forever (review find: greptile/claude on PR #14771). Built from
+    // tuples, not an object literal: TS contextual typing breaks on literal
+    // properties named after Object.prototype members (the values widen to
+    // `string` and fail assignability — broke the `next build` type pass,
+    // which unlike tsconfig.build.json includes clienttest files).
+    const shadowing = new Map<string, StoredKeyInfo>([
+      ["toString", { type: "string", values: ["hello"] }],
+      ["constructor", { type: "number", values: ["1"] }],
+      ["hasOwnProperty", { type: "boolean" }],
+    ]);
+    const merged = mergeIntoProject({}, "p1", shadowing, 1000);
     expect(merged?.p1.paths.toString).toEqual({
       type: "string",
       values: ["hello"],
@@ -201,7 +201,9 @@ describe("mergeIntoProject", () => {
       mergeIntoProject(
         merged!,
         "p1",
-        paths({ toString: { type: "string", values: ["hello"] } }),
+        new Map<string, StoredKeyInfo>([
+          ["toString", { type: "string", values: ["hello"] }],
+        ]),
         2000,
       ),
     ).toBe(null);


### PR DESCRIPTION
## TL;DR

Main's production `next build` fails on a type error in `observedMetadataStore.clienttest.ts` introduced by #14771. Test-only fix: build the test's input map from explicit tuples instead of an object literal. Verified by running the full `pnpm run build:check` (the failing check) locally — green.

## Why

The regression test for Object.prototype-shadowing metadata keys used an object literal with properties literally named `toString`/`constructor`/`hasOwnProperty`. TypeScript's contextual typing breaks on exactly those property names: the `type: "string"` literals widen to `string` and fail assignability against `StoredPathType`.

It slipped through because no gate on the PR path type-checks colocated clienttest files: `pnpm typecheck` uses `tsconfig.build.json` (excludes `**/*.clienttest.*`) and CI test builds set `NEXT_IGNORE_BUILD_ERRORS=true` — only the production/Docker `next build` enforces the full `tsconfig.json` pass, which is where main broke.

## What

Construct the map via `new Map<string, StoredKeyInfo>([[...], ...])` tuples — same runtime coverage, no literal-key quirk. No production code touched.

## Result

`pnpm run build:check` (full `next build` with type check, alternate dist dir) passes; the store's 10 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a type error in a test file that broke `next build` on main. The regression was introduced by #14771, which added a test using object literals with keys literally named `toString`, `constructor`, and `hasOwnProperty` — TypeScript's contextual typing widens those property values from string literals to `string`, causing an assignability failure against `StoredKeyInfo`.

- The fix replaces the affected `paths({...})` calls with explicit `new Map<string, StoredKeyInfo>([...])` tuple constructors, which have no contextual-typing quirk and preserve identical runtime coverage.
- No production code is changed; only the test file is touched.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only the test file changes, and the fix correctly preserves the original runtime coverage while resolving the build-breaking type error.

The change is narrow: two paths({…}) call sites in a single test are replaced with semantically equivalent new Map tuple constructors. No production code is modified, no new dependencies introduced, and the failing next build type check is directly addressed by the fix. The remaining paths() usages in the file use safe key names and are untouched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["object literal\n{ toString: { type: 'string' } }"]
    B["TypeScript contextual typing\nwidened 'string' → string"]
    C["Assignability failure vs StoredPathType\nnext build type-check fails"]
    D["new Map<string, StoredKeyInfo>([...])\ntuples instead of object literal"]
    E["TypeScript sees explicit\nMap type parameter"]
    F["Literal types preserved\nnext build passes"]

    A --> B --> C
    D --> E --> F

    style C fill:#f88,stroke:#c00
    style F fill:#8f8,stroke:#090
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["object literal\n{ toString: { type: 'string' } }"]
    B["TypeScript contextual typing\nwidened 'string' → string"]
    C["Assignability failure vs StoredPathType\nnext build type-check fails"]
    D["new Map<string, StoredKeyInfo>([...])\ntuples instead of object literal"]
    E["TypeScript sees explicit\nMap type parameter"]
    F["Literal types preserved\nnext build passes"]

    A --> B --> C
    D --> E --> F

    style C fill:#f88,stroke:#c00
    style F fill:#8f8,stroke:#090
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search-bar): unbreak web build — tup..."](https://github.com/langfuse/langfuse/commit/2729a1d7517679c05e41b70263ef77471c749cdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41653909)</sub>

<!-- /greptile_comment -->