### PR TITLE
fix: clickhouse seeder column mismatch

### DIFF
--- a/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
+++ b/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
@@ -370,7 +370,10 @@ export class ClickHouseQueryBuilder {
         now() AS event_ts,
         0 AS is_deleted,
         NULL AS execution_trace_id,
-        '' AS long_string_value
+        '' AS long_string_value,
+        arrayElement(['pk-lf-seed-${idSuffix}-python','pk-lf-seed-${idSuffix}-javascript','pk-lf-seed-${idSuffix}-raw-api'], 1 + (h1 % 3)) AS ingestion_api_key,
+        arrayElement(['python','javascript','unknown'], 1 + (h1 % 3)) AS ingestion_sdk_name,
+        arrayElement(['4.2.1','5.1.3','unknown'], 1 + (h1 % 3)) AS ingestion_sdk_version
       FROM
       (
         SELECT


### PR DESCRIPTION
## Summary
- Populate seeded ClickHouse rows with deterministic ingestion API key, SDK name, and SDK version values
- Keep seed data aligned with the ingestion metadata shape expected by downstream views and tests

Likely introduced in https://github.com/langfuse/langfuse/pull/14593

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `buildBulkScoresInsert` SQL generator to include the three ingestion attribution columns (`ingestion_api_key`, `ingestion_sdk_name`, `ingestion_sdk_version`) that were added to the ClickHouse `scores` table by migration `0035_add_ingestion_attribution_columns`.

- The new column values mirror the pattern already established in `data-generators.ts`'s `buildSeedIngestionAttribution` helper, distributing rows deterministically across python-sdk, javascript-sdk, and raw-api archetypes based on a per-row hash.
- Without this fix, seeded bulk scores would carry empty/`'unknown'` defaults for these columns instead of the realistic seed values expected by downstream views and tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted seeder fix that populates three previously-missing columns with values that exactly mirror the existing helper in data-generators.ts.

The SQL change is mechanical and self-consistent: arrayElement uses correct 1-based indexing, the key/sdk-name/sdk-version triples match the buildSeedIngestionAttribution helper in data-generators.ts, and ClickHouse table defaults would have kept bulk inserts working anyway. No production code paths are affected.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildBulkScoresInsert called] --> B[Compute idSuffix from projectId]
    B --> C[Build ClickHouse SQL with numbers table]
    C --> D[Per-row hash h1 = xxHash32 of number * 4 + seed]
    D --> E{1 + h1 mod 3}
    E -->|1| F[python-sdk attribution]
    E -->|2| G[javascript-sdk attribution]
    E -->|3| H[raw-api attribution with unknown sdk fields]
    F --> I[INSERT INTO scores with ingestion columns]
    G --> I
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[buildBulkScoresInsert called] --> B[Compute idSuffix from projectId]
    B --> C[Build ClickHouse SQL with numbers table]
    C --> D[Per-row hash h1 = xxHash32 of number * 4 + seed]
    D --> E{1 + h1 mod 3}
    E -->|1| F[python-sdk attribution]
    E -->|2| G[javascript-sdk attribution]
    E -->|3| H[raw-api attribution with unknown sdk fields]
    F --> I[INSERT INTO scores with ingestion columns]
    G --> I
    H --> I
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add ingestion metadata to seeded ClickHo..."](https://github.com/langfuse/langfuse/commit/7551d0c6d355b09b1ccd550d0d93e2f369844ffa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41656725)</sub>

<!-- /greptile_comment -->