### PR TITLE
feat(trace): show the playback transport only where there is something to play (LFE-10675)

### DIFF
--- a/web/src/components/trace/components/PlaybackControls.tsx
+++ b/web/src/components/trace/components/PlaybackControls.tsx
@@ -27,6 +27,7 @@ import {
 } from "../contexts/PlayheadContext";
 import { useTraceData } from "../contexts/TraceDataContext";
 import { useTraceGraphData } from "../contexts/TraceGraphDataContext";
+import { useSearch } from "../contexts/SearchContext";
 import { useViewPreferences } from "../contexts/ViewPreferencesContext";
 
 // A 22px ring around the ~28px (h-7) button; 2px stroke reads at this size.
@@ -37,8 +38,10 @@ const RING_C = 2 * Math.PI * RING_R;
 
 export function PlaybackControls() {
   const { traceDuration } = useTraceData();
-  const { isGraphViewAvailable } = useTraceGraphData();
+  const { isGraphViewAvailable, isLoading: isGraphDataLoading } =
+    useTraceGraphData();
   const { showGraph } = useViewPreferences();
+  const { searchQuery } = useSearch();
   const [viewMode] = useQueryParam("view", StringParam);
   const { play, pause, stop, getPlayheadSec, subscribePosition } =
     usePlayhead();
@@ -59,10 +62,17 @@ export function PlaybackControls() {
     return subscribePosition(apply);
   }, [traceDuration, getPlayheadSec, subscribePosition]);
 
-  // A playback surface exists in the timeline view or when the graph panel is
-  // visible; an actively-placed playhead keeps its controls regardless.
+  // A playback surface exists in the timeline view (unless a search query has
+  // replaced it with the search list) or when the graph panel renders — a
+  // COLLAPSED panel still counts (the surface is one click away; hiding the
+  // transport when the user collapses the panel would make it undiscoverable),
+  // and a pending graph query counts too, so graph-eligible traces don't get a
+  // transport pop-in after first load. An actively-placed playhead keeps its
+  // controls regardless.
+  const isSearching = searchQuery.trim().length > 0;
   const hasPlaybackSurface =
-    viewMode === "timeline" || (showGraph && isGraphViewAvailable);
+    (viewMode === "timeline" && !isSearching) ||
+    (showGraph && (isGraphViewAvailable || isGraphDataLoading));
   if (traceDuration <= 0 || (!hasPlaybackSurface && !showPlayhead)) {
     return null;
   }

--- a/web/src/components/trace/components/PlaybackControls.tsx
+++ b/web/src/components/trace/components/PlaybackControls.tsx
@@ -1,10 +1,15 @@
 /**
- * PlaybackControls - view-agnostic transport for the trace playhead.
+ * PlaybackControls - transport for the trace playhead, in the navigation
+ * header. The play/pause button is wrapped in a circular progress ring that
+ * fills as the playhead sweeps the trace's total time — a compact "where are
+ * we in the trace" indicator that isn't tied to the gantt. Stop resets it.
  *
- * Lives in the navigation header (shown in Tree AND Timeline views). The
- * play/pause button is wrapped in a circular progress ring that fills as the
- * playhead sweeps the trace's total time — a compact "where are we in the
- * trace" indicator that isn't tied to the gantt. Stop resets it.
+ * Shown only when there is something to WATCH play: the timeline view (the
+ * sweeping playhead) or a visible graph panel (the node glow). In the default
+ * tree view without a graph the transport is hidden — the row glow alone
+ * isn't a playback surface — but it never disappears while a playhead is
+ * actively placed, so an in-flight playback keeps its controls across view
+ * switches.
  *
  * The ring is driven imperatively off the playhead position feed, so it
  * animates at 60fps without re-rendering (only the play/pause icon flips, via
@@ -13,9 +18,16 @@
 
 import { useEffect, useRef } from "react";
 import { Pause, Play, Square } from "lucide-react";
+import { StringParam, useQueryParam } from "use-query-params";
 import { Button } from "@/src/components/ui/button";
-import { usePlayhead, useIsPlaying } from "../contexts/PlayheadContext";
+import {
+  usePlayhead,
+  useIsPlaying,
+  useShowPlayhead,
+} from "../contexts/PlayheadContext";
 import { useTraceData } from "../contexts/TraceDataContext";
+import { useTraceGraphData } from "../contexts/TraceGraphDataContext";
+import { useViewPreferences } from "../contexts/ViewPreferencesContext";
 
 // A 22px ring around the ~28px (h-7) button; 2px stroke reads at this size.
 const RING_SIZE = 22;
@@ -25,9 +37,13 @@ const RING_C = 2 * Math.PI * RING_R;
 
 export function PlaybackControls() {
   const { traceDuration } = useTraceData();
+  const { isGraphViewAvailable } = useTraceGraphData();
+  const { showGraph } = useViewPreferences();
+  const [viewMode] = useQueryParam("view", StringParam);
   const { play, pause, stop, getPlayheadSec, subscribePosition } =
     usePlayhead();
   const isPlaying = useIsPlaying();
+  const showPlayhead = useShowPlayhead();
   const ringRef = useRef<SVGCircleElement>(null);
 
   // Fill the ring to the current playhead fraction; update imperatively as the
@@ -43,7 +59,13 @@ export function PlaybackControls() {
     return subscribePosition(apply);
   }, [traceDuration, getPlayheadSec, subscribePosition]);
 
-  if (traceDuration <= 0) return null;
+  // A playback surface exists in the timeline view or when the graph panel is
+  // visible; an actively-placed playhead keeps its controls regardless.
+  const hasPlaybackSurface =
+    viewMode === "timeline" || (showGraph && isGraphViewAvailable);
+  if (traceDuration <= 0 || (!hasPlaybackSurface && !showPlayhead)) {
+    return null;
+  }
 
   return (
     <div className="ml-1 flex shrink-0 flex-row items-center gap-0.5">

--- a/web/src/components/trace/contexts/TraceGraphDataContext.tsx
+++ b/web/src/components/trace/contexts/TraceGraphDataContext.tsx
@@ -145,15 +145,22 @@ export function TraceGraphDataProvider({
     }
 
     // Otherwise the graph is still available whenever it would draw more than
-    // one node — the panel just defaults to collapsed for these. Exact mirror
-    // of the timing-based inference these traces go through (buildStepData):
-    // it drops EVENT observations, then keys every node on the observation
-    // NAME (`obs.node = obs.name`), so count distinct non-EVENT names.
-    const distinctNodes = new Set(
-      agentGraphData
-        .filter((obs) => obs.observationType !== "EVENT")
-        .map((obs) => obs.name),
+    // one MEANINGFUL node — the panel just defaults to collapsed for these.
+    // Mirrors the timing-based inference these traces go through
+    // (buildStepData drops EVENTs and keys nodes on the observation NAME),
+    // with one extra rule: a single parentless root (v4 mirrors the trace
+    // itself as a root span, so it exists on every trace) doesn't count —
+    // a root→child chain is the tree again, not structure worth a graph.
+    // Multiple parallel roots ARE structure and count fully.
+    const nonEvent = agentGraphData.filter(
+      (obs) => obs.observationType !== "EVENT",
     );
+    const parentless = nonEvent.filter((obs) => !obs.parentObservationId);
+    const counted =
+      parentless.length === 1
+        ? nonEvent.filter((obs) => obs.parentObservationId)
+        : nonEvent;
+    const distinctNodes = new Set(counted.map((obs) => obs.name));
     return { isGraphViewAvailable: distinctNodes.size > 1, isAgentGraph };
   }, [agentGraphData]);
 

--- a/web/src/components/trace/contexts/TraceGraphDataContext.tsx
+++ b/web/src/components/trace/contexts/TraceGraphDataContext.tsx
@@ -148,10 +148,12 @@ export function TraceGraphDataProvider({
     // one MEANINGFUL node — the panel just defaults to collapsed for these.
     // Mirrors the timing-based inference these traces go through
     // (buildStepData drops EVENTs and keys nodes on the observation NAME),
-    // with one extra rule: a single parentless root (v4 mirrors the trace
-    // itself as a root span, so it exists on every trace) doesn't count —
-    // a root→child chain is the tree again, not structure worth a graph.
-    // Multiple parallel roots ARE structure and count fully.
+    // with one extra rule: a single parentless root doesn't count. v4 makes
+    // this mandatory (the trace itself is mirrored as a root span, so EVERY
+    // trace has one), and it's deliberately unconditional — a v3 root→child
+    // chain is exactly as uninformative as a v4 one; the graph only earns its
+    // panel when there's structure beyond the tree. Multiple parallel roots
+    // ARE structure and count fully.
     const nonEvent = agentGraphData.filter(
       (obs) => obs.observationType !== "EVENT",
     );


### PR DESCRIPTION
## TL;DR

Playback transport now appears only where there is **something to watch play**: the timeline view (sweeping playhead) or a visible graph panel (node glow). In the default tree view without a graph it's hidden — but an actively-placed playhead always keeps its controls. Also tightens the graph-availability rule so trivial `root → child` v4 traces don't get a pointless graph panel.

## Why

Follow-up to #14767 (LFE-10675): the transport rendered on every trace in every view, including the default tree view of traces with no graph — a play button with nothing visible to play.

## What

- `PlaybackControls` renders when `view == timeline`, or the graph panel is available + enabled, or a playhead is actively placed (so in-flight playback never loses its pause/stop across view switches).
- Availability refinement: a single parentless root doesn't count toward the >1-node rule — the v4 model mirrors the trace itself as a root span, so *every* v4 trace has one, and a root→single-child chain is the tree again, not structure worth a graph. Parallel multi-root traces still count fully.

## Result

Verified live on a root+child v4 trace: tree → no transport, no graph bar; timeline → transport; play-then-switch-to-tree → transport stays; stop in tree → gone. Multi-node and agent traces keep their graphs and transport exactly as before.

Also from the ticket: the "sizing/cropping unstable" and "agent workflows without graphs" screenshots are from cloud, which runs pre-#14767 code — the framing-intent + clamped-centering fixes and the broadened availability that address both merged there but aren't deployed yet. If either still reproduces on this branch, a repro link would pin it down (note: Linear image links expire in ~5 minutes, so I couldn't see the screenshots).

Linear: LFE-10675 · Follow-up to #14767

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds conditional rendering logic to `PlaybackControls` so the transport only appears when there is a visible playback surface (timeline view, or graph panel open and available), while preserving it whenever a playhead is actively placed. It also refines graph availability in `TraceGraphDataContext` to exclude a single parentless root from the "more than one meaningful node" count, preventing trivial v4 root→single-child traces from generating a graph panel.

- **`PlaybackControls.tsx`**: Transport is now gated on `viewMode === "timeline"`, `showGraph && isGraphViewAvailable`, or `showPlayhead` (the playhead has been placed, keeping controls across view switches).
- **`TraceGraphDataContext.tsx`**: When exactly one parentless root exists, it is excluded from the distinct-node count; only its descendants are counted. Multiple parallel roots still count in full.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the changes are additive visibility guards with a well-designed fallback for active playback, and no data-mutating paths are touched.

Both concerns are non-blocking. The transport pop-in during the initial graph-data fetch is a transient UX issue on first visit only, invisible on revisit due to the long stale time. The root-exclusion logic change is intentional per the PR description but quietly affects non-v4 traces as well, which is worth a quick confirmation from the author before shipping.

TraceGraphDataContext.tsx — the parentless-root exclusion rule has broader scope than the v4 framing in the description implies.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PlaybackControls renders] --> B{traceDuration > 0?}
    B -- No --> Z[return null]
    B -- Yes --> C{viewMode === 'timeline'?}
    C -- Yes --> SHOW[Show transport]
    C -- No --> D{showGraph && isGraphViewAvailable?}
    D -- Yes --> SHOW
    D -- No --> E{showPlayhead?}
    E -- Yes --> SHOW
    E -- No --> Z

    subgraph isGraphViewAvailable logic
        G1[agentGraphData] --> G2{isAgentGraph?}
        G2 -- Yes --> GA[available = true]
        G2 -- No --> G3[filter out EVENTs → nonEvent]
        G3 --> G4[find parentless in nonEvent]
        G4 --> G5{parentless.length === 1?}
        G5 -- Yes --> G6[counted = nonEvent with parentObservationId]
        G5 -- No --> G7[counted = nonEvent]
        G6 --> G8[distinctNodes = Set of names]
        G7 --> G8
        G8 --> G9{distinctNodes.size > 1?}
        G9 -- Yes --> GA
        G9 -- No --> GN[available = false]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PlaybackControls renders] --> B{traceDuration > 0?}
    B -- No --> Z[return null]
    B -- Yes --> C{viewMode === 'timeline'?}
    C -- Yes --> SHOW[Show transport]
    C -- No --> D{showGraph && isGraphViewAvailable?}
    D -- Yes --> SHOW
    D -- No --> E{showPlayhead?}
    E -- Yes --> SHOW
    E -- No --> Z

    subgraph isGraphViewAvailable logic
        G1[agentGraphData] --> G2{isAgentGraph?}
        G2 -- Yes --> GA[available = true]
        G2 -- No --> G3[filter out EVENTs → nonEvent]
        G3 --> G4[find parentless in nonEvent]
        G4 --> G5{parentless.length === 1?}
        G5 -- Yes --> G6[counted = nonEvent with parentObservationId]
        G5 -- No --> G7[counted = nonEvent]
        G6 --> G8[distinctNodes = Set of names]
        G7 --> G8
        G8 --> G9{distinctNodes.size > 1?}
        G9 -- Yes --> GA
        G9 -- No --> GN[available = false]
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/trace/components/PlaybackControls.tsx:64-68
**Transport pop-in on first visit to graph-eligible traces**

`isGraphViewAvailable` begins as `false` while the graph data query is in flight (empty `agentGraphData`), so the transport will be absent for the first render and then flash into view once the query resolves. For users on slow connections visiting a graph-eligible trace in tree view with the graph panel expanded, this is a visible pop-in that did not occur before this change. Revisits are unaffected thanks to the 50-minute `staleTime`, but first-load UX is slightly degraded. Checking `isLoading` from `useTraceGraphData()` and treating a pending load as "surface might become available" would eliminate the pop-in.

### Issue 2 of 2
web/src/components/trace/contexts/TraceGraphDataContext.tsx:155-164
**Root-exclusion rule applies to non-v4 traces too**

The PR description frames the single-parentless-root exclusion as a v4-specific concern ("the v4 model mirrors the trace itself as a root span"), but the code is not gated on `isBetaEnabled`. For existing non-v4 traces that previously qualified for a collapsed graph panel purely via the >1-node rule — e.g., a root span (parentless) plus a single distinctly-named child — `distinctNodes.size` drops to 1 after the exclusion and the graph panel disappears. Whether that loss of a 2-node graph is acceptable for non-v4 traces is worth confirming, since the PR's stated motivation is specific to v4's guaranteed root span.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(trace): show the transport only whe..."](https://github.com/langfuse/langfuse/commit/1df88444bce906e2500d7fadabe7ca4282a19842) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41659857)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->