### PR TITLE
fix(worker): surface batch export config errors as user-facing messages

### DIFF
--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -5,6 +5,7 @@ import {
   BatchExportStatus,
   BatchExportTableName,
   exportOptions,
+  InvalidRequestError,
   LangfuseNotFoundError,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
@@ -35,7 +36,7 @@ export const handleBatchExportJob = async (
   batchExportJob: BatchExportJobType,
 ) => {
   if (env.LANGFUSE_S3_BATCH_EXPORT_ENABLED !== "true") {
-    throw new Error(
+    throw new InvalidRequestError(
       "Batch export is not enabled. Configure environment variables to use this feature. See https://langfuse.com/self-hosting/infrastructure/blobstorage#batch-exports for more details.",
     );
   }
@@ -245,7 +246,7 @@ export const handleBatchExportJob = async (
   // Stream upload results to blob storage
   const bucketName = env.LANGFUSE_S3_BATCH_EXPORT_BUCKET;
   if (!bucketName) {
-    throw new Error("No S3 bucket configured for exports.");
+    throw new InvalidRequestError("No S3 bucket configured for exports.");
   }
 
   const storageParams = {


### PR DESCRIPTION
## What does this PR do?

On self-hosted instances where batch exports are not configured (`LANGFUSE_S3_BATCH_EXPORT_ENABLED` unset/false, or no bucket set), every UI export fails and the exports page only shows "An internal error occurred", with no hint about the actual cause.

Root cause: `batchExportQueueProcessor` only persists `e.message` to the export's `log` column when the error is a `BaseError`:

```ts
const displayError =
  e instanceof BaseError ? e.message : "An internal error occurred";
```

The two configuration-related throws in `handleBatchExportJob` ("Batch export is not enabled. Configure environment variables..." and "No S3 bucket configured for exports.") were plain `Error`s, so the actionable message never reached users.

This PR changes those two throws to `InvalidRequestError` (a `BaseError` from `@langfuse/shared`) so the real message is stored on the export and shown in the UI.

## How to test

1. Self-host without `LANGFUSE_S3_BATCH_EXPORT_ENABLED=true` on the worker
2. 2. Trigger any table export from the UI
3. 3. Before: export fails with log "An internal error occurred"; after: log shows the actionable configuration message with the docs link

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a DX gap on self-hosted instances where misconfigured batch exports surface as "An internal error occurred" in the UI. The root cause was that two configuration checks in `handleBatchExportJob` threw plain `Error` objects, which were not matched by the `e instanceof BaseError` guard in `batchExportQueueProcessor`, so the descriptive message was swallowed.

- Changes both `throw new Error(...)` calls — one for the "feature disabled" check and one for the "no bucket configured" check — to `throw new InvalidRequestError(...)`, which extends `BaseError` and thus flows through to the `log` column and the UI.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted two-line type swap with no logic alterations.

Both changed throws now correctly extend `BaseError`, which is all that's needed to flow through the existing error handler in `batchExportQueueProcessor`. The `InvalidRequestError` import is placed at the top of the file in line with the team's module-import rule. No retry behaviour, DB schema, or API contract is affected.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as UI / User
    participant Q as batchExportQueueProcessor
    participant H as handleBatchExportJob
    participant DB as Prisma DB

    UI->>Q: job enqueued
    Q->>H: handleBatchExportJob(payload)

    alt "LANGFUSE_S3_BATCH_EXPORT_ENABLED != true"
        H-->>Q: throw InvalidRequestError (was: plain Error)
        Q->>DB: "UPDATE batchExport SET status=FAILED, log=e.message"
        Q-->>UI: log visible: Batch export is not enabled...
    else No S3 bucket configured
        H->>DB: "UPDATE status=PROCESSING"
        H->>DB: "open read stream & pipeline"
        H-->>Q: throw InvalidRequestError (was: plain Error)
        Q->>DB: "UPDATE batchExport SET status=FAILED, log=e.message"
        Q-->>UI: log visible: No S3 bucket configured for exports.
    else Happy path
        H->>DB: stream + upload to S3
        H->>DB: "UPDATE status=COMPLETED"
        Q-->>UI: success + email
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as UI / User
    participant Q as batchExportQueueProcessor
    participant H as handleBatchExportJob
    participant DB as Prisma DB

    UI->>Q: job enqueued
    Q->>H: handleBatchExportJob(payload)

    alt "LANGFUSE_S3_BATCH_EXPORT_ENABLED != true"
        H-->>Q: throw InvalidRequestError (was: plain Error)
        Q->>DB: "UPDATE batchExport SET status=FAILED, log=e.message"
        Q-->>UI: log visible: Batch export is not enabled...
    else No S3 bucket configured
        H->>DB: "UPDATE status=PROCESSING"
        H->>DB: "open read stream & pipeline"
        H-->>Q: throw InvalidRequestError (was: plain Error)
        Q->>DB: "UPDATE batchExport SET status=FAILED, log=e.message"
        Q-->>UI: log visible: No S3 bucket configured for exports.
    else Happy path
        H->>DB: stream + upload to S3
        H->>DB: "UPDATE status=COMPLETED"
        Q-->>UI: success + email
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): surface batch export config..."](https://github.com/langfuse/langfuse/commit/7e73b2de4e90d9a58462034756a1c64cec9ad8db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41666142)</sub>

<!-- /greptile_comment -->