### PR TITLE
refactor(trace-graph-view): deterministic data-derived viewport (LFE-10675)

### DIFF
--- a/web/src/features/trace-graph-view/README.md
+++ b/web/src/features/trace-graph-view/README.md
@@ -20,10 +20,15 @@ agentGraphData (tRPC getAgentGraphData)
 
 ## Ownership
 
-- **Viewport**: the d3-zoom transform is the single source of truth. Per-frame
-  pan/zoom writes the world div's CSS transform (and the edge
-  stroke-compensation var) imperatively — React state holds only the discrete
-  derivations (`compact` label threshold, `fitted` reveal, layout/error).
+- **Viewport**: deterministic and data-derived — the rendered transform is
+  always `userOverride ?? fit(layout, size)`. The user's last gesture
+  (drag/wheel/pinch/toolbar zoom) is the ONLY viewport state; without one, fit
+  re-applies on every layout/size change. Selection never moves the viewport
+  (it's a ring/glow — under fit the node is always visible); Fit and a graph
+  change clear the override. Per-frame pan/zoom writes the world div's CSS
+  transform (and the edge stroke-compensation var) imperatively — React state
+  holds only the discrete derivations (`compact` label threshold, `fitted`
+  reveal, layout/error).
 - **Selection**: the `?observation=` URL param, wired in
   `components/TraceGraphView.tsx` (click-cycling through a node's observations,
   URL→node sync with a parent-walk fallback for descendants without their own

--- a/web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx
+++ b/web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx
@@ -43,9 +43,6 @@ const MAX_FIT_SCALE = 1.2;
 const ZOOM_STEP = 1.4;
 // Below this scale labels are unreadable noise — show only node shape + icon.
 const LABEL_HIDE_SCALE = 0.5;
-// One consistent scale to reveal a selection from a zoomed-out overview, so
-// navigating between nodes pans rather than re-zooms (no "zoom jumping").
-const SELECTION_REVEAL_SCALE = 0.9;
 const CLICK_MOVE_THRESHOLD = 4; // px; beyond this a pointerup is a drag, not a click
 
 function toPath(points: { x: number; y: number }[]): string {
@@ -92,19 +89,15 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
     null,
     undefined
   > | null>(null);
-  // What framed the current view. Programmatic framings ("fit", "focus") stay
-  // LIVE: when the container resizes (peek panel opening/settling, divider
-  // drag, window resize) they re-apply against the new size — otherwise a
-  // deep-link focus computed against a transient early size stays frozen and
-  // the focused node ends up cropped/off-view. Only a real user gesture
-  // ("gesture") freezes the view.
-  const framingRef = useRef<"fit" | "focus" | "gesture">("fit");
-  // The node id (or null for an empty click) of the last in-canvas selection, so
-  // the focus effect re-frames only for selections from the tree/timeline.
-  const lastCanvasClickRef = useRef<string | null | undefined>(undefined);
-  // The selection last reflected by the focus effect, so a resize (which also
-  // re-fires that effect) doesn't re-frame a still-selected node.
-  const prevSelectedRef = useRef<string | null>(null);
+  // THE deterministic viewport model: the rendered transform is always
+  //   overrideRef.current ?? fit(layout, size)
+  // The user's last explicit viewport (drag/wheel/pinch/toolbar zoom) is the
+  // ONLY real state; everything else derives. No override → the fit re-applies
+  // on every layout/size change (peek panels settling, divider drags, window
+  // resizes can never leave a stale frame). Selection does NOT move the
+  // viewport — it's a ring/glow, and under fit the node is always visible.
+  // Fit button and a graph change clear the override.
+  const overrideRef = useRef<Transform | null>(null);
   const pointerDownPos = useRef<{ x: number; y: number } | null>(null);
 
   const [layout, setLayout] = useState<GraphLayout | null>(null);
@@ -148,10 +141,8 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
     setLayout(null);
     setLayoutError(false);
     setFitted(false);
-    framingRef.current = "fit";
-    // Also clear cross-graph view state so a graph change re-focuses the
-    // selected node on the new instance and drops stale hover highlighting.
-    prevSelectedRef.current = null;
+    // A new graph gets a fresh fit; stale hover highlighting drops too.
+    overrideRef.current = null;
     setHoveredId(null);
     computeGraphLayout(graph, nodeToObservationsMap)
       .then((result) => {
@@ -188,10 +179,10 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
     const zoomBehavior = createZoom<HTMLDivElement, unknown>()
       .scaleExtent([SCALE_MIN, SCALE_MAX])
       .on("zoom", (event: D3ZoomEvent<HTMLDivElement, unknown>) => {
-        // sourceEvent is set only for real gestures (drag/wheel/pinch) —
-        // programmatic transforms (fit/focus) keep their live framing kind.
-        if (event.sourceEvent) framingRef.current = "gesture";
         const { x, y, k } = event.transform;
+        // sourceEvent is set only for real gestures (drag/wheel/pinch) — they
+        // become the override; programmatic fits keep deriving.
+        if (event.sourceEvent) overrideRef.current = { x, y, k };
         transformRef.current = { x, y, k };
         const world = worldRef.current;
         if (world) {
@@ -265,99 +256,19 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
     };
   }, [layout, size]);
 
-  // Live "fit" framing: re-fit on layout/size changes until a focus or a user
-  // gesture takes over.
+  // THE framing effect — the whole model. The viewport derives from data:
+  // no override → fit(layout, size), re-applied on every layout/size change
+  // (deterministic; a peek panel settling late or a divider drag can never
+  // strand a stale frame). With an override (user gesture) the view is the
+  // user's — untouched until Fit or a graph change clears it.
   useEffect(() => {
-    if (framingRef.current !== "fit") return;
+    if (overrideRef.current) return;
     const fit = computeFit();
     if (fit) applyTransform(fit);
   }, [computeFit, applyTransform]);
 
-  // Reflect external selection (tree/timeline): bring the node into view at the
-  // current zoom (or one reveal scale when zoomed out). In-canvas clicks don't
-  // move the view; selecting the root/empty returns to the full-graph overview.
-  // While the view is focus-framed, container size changes re-center the node
-  // against the NEW size (translate only — the zoom stays put), so a peek panel
-  // that finishes laying out after a deep-link focus, or a divider drag, can't
-  // leave the focused node cropped against a stale frame.
-  useEffect(() => {
-    const cameFromClick = lastCanvasClickRef.current === selectedNodeName;
-    lastCanvasClickRef.current = undefined;
-    // Wait for layout/size before acting — and don't mark the selection as
-    // reflected yet, so we retry once they're ready (e.g. a deep link with a
-    // preselected observation that arrives before the graph lays out).
-    if (!layout || size.width === 0) return;
-
-    // Read d3-zoom's synchronously-updated scale (set by applyTransform before
-    // React re-renders), not a state mirror that's stale in the same commit.
-    const currentK = containerRef.current
-      ? zoomTransform(containerRef.current).k
-      : 1;
-    // Clamped focus framing: aim the node at the viewport center, but never
-    // leave blank canvas the graph could cover — on an axis where the scaled
-    // graph is larger than the viewport, clamp the pan to the graph bounds
-    // (a node near the graph's edge sits off-center rather than dragging
-    // emptiness in); where the graph is smaller, just center the whole graph.
-    // Without this, deep-link-focusing a node near the top of a small graph
-    // pushed the rest out of the panel while half the canvas sat empty.
-    const centerNode = (nodeId: string, k: number): boolean => {
-      const node = layout.nodes.find((n) => n.id === nodeId);
-      if (!node) return false;
-      const cx = node.x + node.width / 2;
-      const cy = node.y + node.height / 2;
-      const graphW = layout.width * k;
-      const graphH = layout.height * k;
-      const x =
-        graphW <= size.width
-          ? (size.width - graphW) / 2
-          : Math.min(0, Math.max(size.width - graphW, size.width / 2 - cx * k));
-      const y =
-        graphH <= size.height
-          ? (size.height - graphH) / 2
-          : Math.min(
-              0,
-              Math.max(size.height - graphH, size.height / 2 - cy * k),
-            );
-      applyTransform({ k, x, y });
-      return true;
-    };
-
-    if (prevSelectedRef.current === selectedNodeName) {
-      // No selection change — this run is a size/layout change. Keep a live
-      // focus framing honest by re-centering at the current zoom; leave user
-      // gestures alone ("fit" re-applies via the auto-fit effect above).
-      if (framingRef.current === "focus" && selectedNodeName) {
-        centerNode(selectedNodeName, currentK);
-      }
-      return;
-    }
-    prevSelectedRef.current = selectedNodeName;
-    // In-canvas clicks already selected the node; don't move the view. A
-    // leftover "focus" framing must be demoted to "gesture" so a later
-    // container resize can't re-center onto the clicked node — but a live
-    // "fit" framing stays live (clicking a node in a fitted overview should
-    // not kill auto-fit-on-resize).
-    if (cameFromClick) {
-      if (framingRef.current === "focus") framingRef.current = "gesture";
-      return;
-    }
-
-    if (!selectedNodeName) {
-      framingRef.current = "fit";
-      const fit = computeFit();
-      if (fit) applyTransform(fit);
-      return;
-    }
-
-    const k = currentK >= LABEL_HIDE_SCALE ? currentK : SELECTION_REVEAL_SCALE;
-    if (centerNode(selectedNodeName, k)) {
-      framingRef.current = "focus";
-    }
-  }, [selectedNodeName, layout, size, computeFit, applyTransform]);
-
   const handleSelect = useCallback(
     (id: string) => {
-      lastCanvasClickRef.current = id;
       onCanvasNodeNameChange?.(id);
     },
     [onCanvasNodeNameChange],
@@ -373,7 +284,6 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
     ) {
       return;
     }
-    lastCanvasClickRef.current = null;
     onCanvasNodeNameChange?.(null);
   };
 
@@ -381,14 +291,17 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
     const selection = selectionRef.current;
     const zoomBehavior = zoomRef.current;
     if (!selection || !zoomBehavior) return;
-    // Toolbar zoom is a user decision — freeze the framing like a gesture
-    // (scaleBy goes through d3 without a sourceEvent, so set it explicitly).
-    framingRef.current = "gesture";
     zoomBehavior.scaleBy(selection, factor);
+    // Toolbar zoom is a user decision — it becomes the override (scaleBy goes
+    // through d3 without a sourceEvent, so record it explicitly).
+    if (containerRef.current) {
+      const { x, y, k } = zoomTransform(containerRef.current);
+      overrideRef.current = { x, y, k };
+    }
   };
 
   const handleFit = () => {
-    framingRef.current = "fit";
+    overrideRef.current = null;
     const fit = computeFit();
     if (fit) applyTransform(fit);
   };


### PR DESCRIPTION
## TL;DR

The graph viewport becomes **deterministic and data-derived**: `viewport = userOverride ?? fit(layout, size)`. The user's last gesture is the only viewport state; without one, fit re-applies on every layout/size change. Selection never moves the viewport (it's a ring/glow — under fit the node is always visible). Net: −118 lines of framing state machine, +36 of derivation.

## Why

The framing logic had become an effect-driven state machine — three interacting effects guarded by `framingRef`/`prevSelectedRef`/`lastCanvasClickRef`, patched four times across two PRs, and *still* producing unstable initial framings on deep-linked peeks (LFE-10675: "sizing and cropping of graph view is still unstable... when I press fit to view it's perfect"). Fit being "perfect" was the tell: the automatic framing should just BE fit, derived from data, not negotiated between effects.

## What

- One rule: `viewport = override ?? fit(layout, size)`. Gestures (drag/wheel/pinch/toolbar zoom) set the override; Fit and a graph change clear it; everything else derives.
- Deleted: the framing-kind enum, the selection-focus effect with clamped node-centering, the click-origin ref, the previous-selection ref, the reveal-scale constant. One framing effect remains.
- Selection is decoupled from the viewport entirely — deep links land on a fitted graph with the selected node ringed; tree/canvas clicks change the ring, never the camera.

## Result

Verified live: deep-linked peek → whole graph fitted + node ringed (the "perfect" state, now the default); panel/window resizes re-derive the fit (k 0.42 → 0.309, always fully visible); zoom-then-select leaves the viewport byte-identical; Fit restores. A stale or cropped frame is now structurally impossible rather than patched around.

Behavior trade-off (intentional): selecting a node in the tree no longer zooms the graph toward it — with fit as the default the node is always on screen, and gesture-zoomed views are never yanked. If large-graph node-finding needs help later, that's an ensure-visible affordance on top of this model, not a return to the state machine.

Linear: LFE-10675 (item 2) · Follow-up to #14780/#14767

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces a three-ref, two-effect viewport state machine (`framingRef` / `prevSelectedRef` / `lastCanvasClickRef` + fit effect + focus effect) with a single deterministic rule: the rendered transform is always `overrideRef.current ?? fit(layout, size)`. Real user gestures (drag/wheel/pinch/toolbar zoom) set the override; the Fit button and graph changes clear it; everything else derives from data.

- **Deleted**: `SELECTION_REVEAL_SCALE` constant, the `framingRef` / `prevSelectedRef` / `lastCanvasClickRef` refs, and the full selection-focus effect (~80 lines of clamped node-centering logic).
- **Added**: `overrideRef: Ref<Transform | null>`, a single framing effect that skips if the override is set, and post-`scaleBy` override capture in `zoomBy` (since `scaleBy` has no `sourceEvent`, the transform is read back from d3's state explicitly after the synchronous call completes).
- **Intentional UX trade-off**: selecting a node from the tree or timeline no longer pans/zooms the camera toward it. The PR acknowledges this and scopes a future \"ensure-visible\" affordance for large graphs.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the refactor correctly simplifies state and the new derivation model is sound, with one deliberate UX change (tree selection no longer pans the camera) that is documented and intentional.

The viewport logic is now fully deterministic: overrideRef.current ?? fit(layout, size) with clear write sites and a single effect. The post-scaleBy read-back in zoomBy is safe because d3-zoom fires its handler synchronously, and JavaScript's single-threaded model guarantees no React effect can interleave between the scaleBy call and the override assignment. The removed selection-focus effect eliminated 80 lines of clamped centering logic and three tracking refs without introducing any correctness gaps. The main thing worth a second look is the intentional removal of tree/timeline selection panning — users working with large, zoomed-in graphs will no longer have the selected node brought into view automatically, which could surface as a discoverability complaint before the follow-up ensure-visible affordance is added.

The only file of substance is ElkGraphRenderer.tsx — specifically the zoomBy function and the single framing effect, which embody the new model.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User gesture\ndrag / wheel / pinch] -->|zoom handler\nevent.sourceEvent set| B[overrideRef = transform]
    C[Toolbar zoom\nzoomBy] -->|scaleBy — no sourceEvent\nread-back after call| B
    D[Graph change\nnew layout prop] -->|layout effect| E[overrideRef = null]
    F[Fit button\nhandleFit] -->|explicit clear| E
    E --> G{overrideRef.current}
    B --> G
    G -->|non-null| H[Render user's override\nunchanged on resize]
    G -->|null| I[computeFit layout + size\nre-applied on every\nlayout / size change]
    I -->|applyTransform| J[d3-zoom DOM transform\nsetFitted = true]
    H -->|applyTransform| J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User gesture\ndrag / wheel / pinch] -->|zoom handler\nevent.sourceEvent set| B[overrideRef = transform]
    C[Toolbar zoom\nzoomBy] -->|scaleBy — no sourceEvent\nread-back after call| B
    D[Graph change\nnew layout prop] -->|layout effect| E[overrideRef = null]
    F[Fit button\nhandleFit] -->|explicit clear| E
    E --> G{overrideRef.current}
    B --> G
    G -->|non-null| H[Render user's override\nunchanged on resize]
    G -->|null| I[computeFit layout + size\nre-applied on every\nlayout / size change]
    I -->|applyTransform| J[d3-zoom DOM transform\nsetFitted = true]
    H -->|applyTransform| J
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(trace-graph-view): deterministi..."](https://github.com/langfuse/langfuse/commit/e317fd19fc4026cd2bca68ce6a67c01aa6867364) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41667955)</sub>

<!-- /greptile_comment -->