### PR TITLE
fix(mcp): strip Unicode property escapes from emitted tool JSON Schema patterns

### DIFF
--- a/web/src/__tests__/server/unit/mcp-define-tool.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-define-tool.servertest.ts
@@ -105,4 +105,51 @@ describe("defineTool", () => {
       }),
     ).toThrow("Union and intersection schemas are not supported");
   });
+
+  it("strips Unicode property escapes from emitted pattern keywords", () => {
+    const schema = z.object({
+      name: z
+        .string()
+        .min(1)
+        .max(35)
+        .regex(/^[\p{L}\p{N}_ .()-]+$/u, "Name contains invalid characters"),
+    });
+
+    const [tool] = defineTool({
+      name: "scoreConfigTool",
+      description: "",
+      baseSchema: schema,
+      inputSchema: schema,
+      handler: async (input) => input,
+    });
+
+    const nameProperty = (
+      tool.inputSchema.properties as Record<string, unknown>
+    ).name as Record<string, unknown>;
+
+    expect(nameProperty.pattern).toBeUndefined();
+    expect(nameProperty.type).toBe("string");
+    expect(nameProperty.minLength).toBe(1);
+    expect(nameProperty.maxLength).toBe(35);
+  });
+
+  it("preserves ASCII-safe pattern keywords in emitted schemas", () => {
+    const schema = z.object({
+      slug: z.string().regex(/^[a-z0-9_-]+$/),
+    });
+
+    const [tool] = defineTool({
+      name: "slugTool",
+      description: "",
+      baseSchema: schema,
+      inputSchema: schema,
+      handler: async (input) => input,
+    });
+
+    const slugProperty = (
+      tool.inputSchema.properties as Record<string, unknown>
+    ).slug as Record<string, unknown>;
+
+    expect(slugProperty.pattern).toBe("^[a-z0-9_-]+$");
+  });
 });

--- a/web/src/features/mcp/core/define-tool.ts
+++ b/web/src/features/mcp/core/define-tool.ts
@@ -62,8 +62,46 @@ export interface ToolDefinition<TName extends string = string> {
 
 type JsonSchemaObject = Record<string, unknown>;
 
+/** Matches JSON Schema patterns that use ECMAScript Unicode property escapes. */
+const UNICODE_PROPERTY_ESCAPE_PATTERN = /\\p\{/;
+
 function isObjectJsonSchema(schema: JsonSchemaObject): boolean {
   return schema.type === "object";
+}
+
+/**
+ * Remove MCP-incompatible JSON Schema keywords from emitted tool schemas.
+ *
+ * OpenAI and Vertex function-calling validators reject `pattern` values that use
+ * Unicode property escapes (`\p{L}`, `\p{N}`, etc.). Runtime validation still
+ * runs through Zod, so dropping the advertised pattern is safe.
+ */
+function sanitizeMcpJsonSchema(schema: unknown): unknown {
+  if (typeof schema !== "object" || schema === null) {
+    return schema;
+  }
+
+  if (Array.isArray(schema)) {
+    return schema.map(sanitizeMcpJsonSchema);
+  }
+
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(
+    schema as Record<string, unknown>,
+  )) {
+    if (
+      key === "pattern" &&
+      typeof value === "string" &&
+      UNICODE_PROPERTY_ESCAPE_PATTERN.test(value)
+    ) {
+      continue;
+    }
+
+    sanitized[key] = sanitizeMcpJsonSchema(value);
+  }
+
+  return sanitized;
 }
 
 function hasJsonSchemaUnion(value: unknown): boolean {
@@ -141,7 +179,9 @@ export function defineTool<TInput, const TName extends string>(
     );
   }
 
-  const jsonSchemaObject = jsonSchema as JsonSchemaObject;
+  const jsonSchemaObject = sanitizeMcpJsonSchema(
+    jsonSchema,
+  ) as JsonSchemaObject;
 
   // Validate that we got a usable plain object schema.
   if (!isObjectJsonSchema(jsonSchemaObject)) {


### PR DESCRIPTION
## Summary

Strip JSON Schema `pattern` keywords that use ECMAScript Unicode property escapes (`\p{L}`, `\p{N}`, etc.) from MCP tool schemas emitted by `defineTool()`.

## Motivation

Score config MCP tools (`createScoreConfig`, `updateScoreConfig`) inherit Unicode-aware name validation regexes from Zod. When converted to JSON Schema, these patterns break OpenAI and Google Vertex function-calling validators. Because those providers validate the **entire** tool catalog atomically, a single incompatible pattern disables all Langfuse MCP tools on Codex/GPT and Gemini hosts.

Fixes #14770

## Changes

- Add `sanitizeMcpJsonSchema()` in `web/src/features/mcp/core/define-tool.ts` to recursively drop `pattern` values containing `\p{` before building the MCP tool definition.
- Keep runtime validation unchanged — Zod `inputSchema` still enforces the strict Unicode-aware rules server-side.
- Add unit tests covering both stripped Unicode patterns and preserved ASCII-safe patterns.

## Tests

```bash
cd web && NODE_ENV=test pnpm exec vitest run --project server-unit src/__tests__/server/unit/mcp-define-tool.servertest.ts
```

Result: **8/8 passed**

Pre-commit hooks also ran `prettier --check` and `turbo run lint` successfully before commit.

## Notes

- This follows the approach suggested in the issue: sanitize at MCP schema emission time rather than weakening shared Zod schemas.
- Field `.describe()` text for score config names is preserved, so LLMs still see human-readable character guidance even without the `pattern` keyword.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a `sanitizeMcpJsonSchema()` helper to `defineTool` that recursively strips `pattern` keywords containing Unicode property escapes (`\p{…}`) from the emitted MCP tool JSON Schema. This prevents OpenAI and Google Vertex function-calling validators from rejecting the entire tool catalog when a single score-config tool carries a Zod-generated Unicode-aware regex.

- **`define-tool.ts`**: New `sanitizeMcpJsonSchema` function is applied after `z.toJSONSchema` and before the `isObjectJsonSchema` guard; runtime validation via Zod's `inputSchema` is unaffected, so the fix is safe.
- **`mcp-define-tool.servertest.ts`**: Two new unit tests verify that Unicode patterns are dropped (while `type`, `minLength`, `maxLength` survive) and that plain ASCII-safe patterns are preserved unchanged.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the sanitizer is applied only to the schema advertised to LLM hosts, and Zod continues to enforce all constraints at runtime, so stripping patterns cannot weaken actual input validation.

The change is narrowly scoped and the runtime validation path is untouched. The one gap is that the detection regex covers only lowercase \p{ and would miss negated Unicode property escapes (\P{…}), which are equally unsupported by the same validators. This is a latent hole rather than a present breakage, since no \P{ patterns currently exist in the codebase.

web/src/features/mcp/core/define-tool.ts — the UNICODE_PROPERTY_ESCAPE_PATTERN constant should cover both \p{ and \P{ forms.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[defineTool called] --> B[z.toJSONSchema baseSchema]
    B --> C{jsonSchema truthy?}
    C -- No --> D[throw Error]
    C -- Yes --> E{hasJsonSchemaUnion?}
    E -- Yes --> F[throw Error]
    E -- No --> G[sanitizeMcpJsonSchema]
    G --> H[Recurse through all keys]
    H --> I{key is pattern AND value contains backslash-p-brace?}
    I -- Yes --> J[Drop pattern key]
    I -- No --> K[Keep key, recurse into value]
    J --> L[Return sanitized schema]
    K --> L
    L --> M{isObjectJsonSchema?}
    M -- No --> N[throw Error]
    M -- Yes --> O[Emit ToolDefinition without Unicode patterns]
    O --> P[MCP tool schema sent to LLM host]
    O --> Q[Runtime Zod schema still validates input]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[defineTool called] --> B[z.toJSONSchema baseSchema]
    B --> C{jsonSchema truthy?}
    C -- No --> D[throw Error]
    C -- Yes --> E{hasJsonSchemaUnion?}
    E -- Yes --> F[throw Error]
    E -- No --> G[sanitizeMcpJsonSchema]
    G --> H[Recurse through all keys]
    H --> I{key is pattern AND value contains backslash-p-brace?}
    I -- Yes --> J[Drop pattern key]
    I -- No --> K[Keep key, recurse into value]
    J --> L[Return sanitized schema]
    K --> L
    L --> M{isObjectJsonSchema?}
    M -- No --> N[throw Error]
    M -- Yes --> O[Emit ToolDefinition without Unicode patterns]
    O --> P[MCP tool schema sent to LLM host]
    O --> Q[Runtime Zod schema still validates input]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/mcp/core/define-tool.ts:65-66
The detection regex only matches lowercase `\p{` but ECMAScript Unicode property escapes also have a negated form `\P{` (uppercase), e.g. `\P{Cc}` (not a control character) or `\P{Z}` (not a separator). Validators that reject `\p{L}` will equally reject `\P{L}`, so a pattern like `/^[\P{C}]+$/u` converted to JSON Schema would still break OpenAI/Vertex function-calling — the sanitizer would pass it through unchanged.

```suggestion
/** Matches JSON Schema patterns that use ECMAScript Unicode property escapes. */
const UNICODE_PROPERTY_ESCAPE_PATTERN = /\\[pP]\{/;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): strip Unicode property escapes..."](https://github.com/langfuse/langfuse/commit/80366c9c61ae5d05bae500fc93849d782eaf9489) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41797062)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->