### PR TITLE
feat(llm): add AI SDK OpenAI executor

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -175,6 +175,9 @@ LANGFUSE_AI_FEATURES_PROJECT_ID=7a88fb47-b4e2-43b8-a06c-a5ce950dc53a
 # LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST=localhost
 # LANGFUSE_LLM_CONNECTION_WHITELISTED_IPS=127.0.0.1,::1
 # LANGFUSE_LLM_CONNECTION_WHITELISTED_IP_SEGMENTS=127.0.0.0/8
+# Enable AI SDK v7 side-by-side LLM completion executors by adapter name.
+# Supported v1 values: openai, openaiResponses, openaiChatCompletions.
+# LANGFUSE_LLM_COMPLETION_AI_SDK_ADAPTERS=openai
 # Self-hosted only: allow internal hosts/IPs for user-configured blob storage endpoints.
 # LANGFUSE_BLOB_STORAGE_ENDPOINT_WHITELISTED_HOST=localhost
 # LANGFUSE_BLOB_STORAGE_ENDPOINT_WHITELISTED_IPS=127.0.0.1,::1

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -335,6 +335,9 @@ LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG=true
 # LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST=
 # LANGFUSE_LLM_CONNECTION_WHITELISTED_IPS=
 # LANGFUSE_LLM_CONNECTION_WHITELISTED_IP_SEGMENTS=
+# Enable AI SDK v7 side-by-side LLM completion executors by adapter name.
+# Supported v1 values: openai, openaiResponses, openaiChatCompletions.
+# LANGFUSE_LLM_COMPLETION_AI_SDK_ADAPTERS=
 # Self-hosted only: allow internal hosts/IPs for user-configured blob storage endpoints.
 # LANGFUSE_BLOB_STORAGE_ENDPOINT_WHITELISTED_HOST=
 # LANGFUSE_BLOB_STORAGE_ENDPOINT_WHITELISTED_IPS=

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -94,6 +94,8 @@
     "seed": "ts-node -r dotenv/config --compiler-options {\"module\":\"CommonJS\"} scripts/seeder/seed-postgres.ts"
   },
   "dependencies": {
+    "@ai-sdk/openai": "4.0.2",
+    "@ai-sdk/otel": "1.0.4",
     "@anthropic-ai/tokenizer": "^0.0.4",
     "@anthropic-ai/vertex-sdk": "^0.17.1",
     "@aws-sdk/client-cloudwatch": "^3.1013.0",
@@ -112,6 +114,8 @@
     "@langchain/google": "^0.1.11",
     "@langchain/openai": "^1.4.2",
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
+    "@opentelemetry/otlp-transformer": "0.219.0",
+    "@opentelemetry/sdk-trace-base": "2.8.0",
     "@prisma/client": "^6.19.3",
     "@react-email/components": "^0.5.1",
     "@react-email/render": "^1.2.1",
@@ -119,6 +123,7 @@
     "@slack/web-api": "^7.15.0",
     "@smithy/node-http-handler": "4.5.1",
     "@types/bcryptjs": "^2.4.6",
+    "ai": "7.0.4",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "bcryptjs": "^2.4.3",

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -442,6 +442,17 @@ const EnvSchema = z.object({
     .int()
     .positive()
     .default(120_000), // 2 minutes
+  LANGFUSE_LLM_COMPLETION_AI_SDK_ADAPTERS: z
+    .string()
+    .optional()
+    .transform((s) =>
+      s
+        ? s
+            .split(",")
+            .map((adapter) => adapter.trim())
+            .filter(Boolean)
+        : [],
+    ),
 
   LANGFUSE_AWS_BEDROCK_REGION: z.string().optional(),
   LANGFUSE_AWS_BEDROCK_SMALL_MODEL: z.string().optional(),

--- a/packages/shared/src/server/llm/ai-sdk/executeAiSdkCompletion.ts
+++ b/packages/shared/src/server/llm/ai-sdk/executeAiSdkCompletion.ts
@@ -1,0 +1,402 @@
+import {
+  generateText,
+  jsonSchema,
+  Output,
+  streamText,
+  tool,
+  type ModelMessage,
+  type ToolSet,
+} from "ai";
+import { IterableReadableStream } from "@langchain/core/utils/stream";
+import type { ZodType } from "zod";
+
+import type { LLMConnectionConfig } from "../../../interfaces/customLLMProviderConfigSchemas";
+import { LLMCompletionError } from "../errors";
+import { mapUnknownErrorToLLMCompletionError } from "../errorMapping";
+import {
+  ChatMessageRole,
+  ChatMessageType,
+  type ChatMessage,
+  type LLMJSONSchema,
+  type LLMToolDefinition,
+  type ModelParams,
+  type ToolCallResponse,
+  ToolCallResponseSchema,
+  type TraceSinkParams,
+} from "../types";
+import { executeWithRuntimeTimeout, RUNTIME_TIMEOUT_ADAPTERS } from "../utils";
+import { getUnsupportedOpenAIProviderOptionKeys } from "./providerOptionsTranslation";
+import { resolveOpenAIModel } from "./providers/openai";
+import { createAiSdkTelemetryContext } from "./telemetry";
+
+type ExecuteAiSdkCompletionParams = {
+  messages: ChatMessage[];
+  tools?: LLMToolDefinition[];
+  modelParams: ModelParams;
+  streaming: boolean;
+  llmConnection: {
+    apiKey: string;
+    extraHeaders?: Record<string, string>;
+    baseURL?: string | null;
+    config?: LLMConnectionConfig | null;
+  };
+  structuredOutputSchema?: ZodType | LLMJSONSchema;
+  maxRetries?: number;
+  timeoutMs: number;
+  traceSinkParams?: TraceSinkParams;
+  secureFetch: typeof globalThis.fetch;
+};
+
+export async function executeAiSdkCompletion(
+  params: ExecuteAiSdkCompletionParams,
+): Promise<
+  | string
+  | { text: string; reasoning?: string }
+  | IterableReadableStream<Uint8Array>
+  | Record<string, unknown>
+  | (ToolCallResponse & { reasoning?: string })
+> {
+  assertOpenAIProviderOptionsTranslated(params.modelParams.providerOptions);
+
+  const modelResolution = resolveOpenAIModel({
+    apiKey: params.llmConnection.apiKey,
+    baseURL: params.llmConnection.baseURL,
+    config: params.llmConnection.config,
+    extraHeaders: params.llmConnection.extraHeaders,
+    fetch: params.secureFetch,
+    modelParams: params.modelParams,
+  });
+  const telemetryContext = createAiSdkTelemetryContext({
+    traceSinkParams: params.traceSinkParams,
+    rootSpanAttributes: modelResolution.metadata,
+  });
+  const aiMessages = mapMessagesToAiSdkMessages(params.messages);
+  const aiTools = params.tools?.length
+    ? buildAiSdkToolSet(params.tools)
+    : undefined;
+
+  if (params.streaming) {
+    return createStreamingCompletion({
+      params,
+      aiMessages,
+      aiTools,
+      modelResolution,
+      telemetryContext,
+    });
+  }
+
+  const scope = telemetryContext.startScope();
+  const runtimeTimeoutController = new AbortController();
+  try {
+    const result = await executeWithRuntimeTimeout<
+      Awaited<ReturnType<typeof generateText>>
+    >({
+      enabled: RUNTIME_TIMEOUT_ADAPTERS.has(params.modelParams.adapter),
+      timeoutMs: params.timeoutMs,
+      abortController: runtimeTimeoutController,
+      operation: () => {
+        return scope.run(() =>
+          generateText({
+            ...buildCommonGenerateTextArgs({
+              params,
+              aiMessages,
+              modelResolution,
+              telemetryContext,
+              abortSignal: runtimeTimeoutController.signal,
+            }),
+            tools: aiTools,
+            toolChoice: aiTools ? "auto" : undefined,
+            output: params.structuredOutputSchema
+              ? Output.object({
+                  schema: toAiSdkSchema(params.structuredOutputSchema),
+                })
+              : undefined,
+          } as any),
+        );
+      },
+    });
+
+    scope.end();
+
+    if (params.structuredOutputSchema) {
+      return (result as any).output as Record<string, unknown>;
+    }
+
+    if (params.tools && params.tools.length > 0) {
+      return parseToolCallResponse(result as any);
+    }
+
+    return normalizeTextResult(result as any);
+  } catch (error) {
+    scope.end(error);
+    throw mapUnknownErrorToLLMCompletionError(error);
+  } finally {
+    await telemetryContext.flushAndPublish();
+  }
+}
+
+async function createStreamingCompletion(params: {
+  params: ExecuteAiSdkCompletionParams;
+  aiMessages: ModelMessage[];
+  aiTools?: ToolSet;
+  modelResolution: ReturnType<typeof resolveOpenAIModel>;
+  telemetryContext: ReturnType<typeof createAiSdkTelemetryContext>;
+}): Promise<IterableReadableStream<Uint8Array>> {
+  const {
+    params: executeParams,
+    aiMessages,
+    aiTools,
+    modelResolution,
+    telemetryContext,
+  } = params;
+  const scope = telemetryContext.startScope();
+  const runtimeTimeoutController = new AbortController();
+
+  try {
+    const result = await executeWithRuntimeTimeout<
+      ReturnType<typeof streamText>
+    >({
+      enabled: RUNTIME_TIMEOUT_ADAPTERS.has(executeParams.modelParams.adapter),
+      timeoutMs: executeParams.timeoutMs,
+      abortController: runtimeTimeoutController,
+      operation: () =>
+        Promise.resolve(
+          scope.run(() =>
+            streamText({
+              ...buildCommonGenerateTextArgs({
+                params: executeParams,
+                aiMessages,
+                modelResolution,
+                telemetryContext,
+                abortSignal: runtimeTimeoutController.signal,
+              }),
+              tools: aiTools,
+              toolChoice: aiTools ? "auto" : undefined,
+            } as any),
+          ),
+        ),
+    });
+
+    const iterator = result.textStream[Symbol.asyncIterator]();
+    const encoder = new TextEncoder();
+
+    return IterableReadableStream.fromAsyncGenerator(
+      (async function* () {
+        try {
+          while (true) {
+            const next = await scope.run(() => iterator.next());
+            if (next.done) break;
+            yield encoder.encode(next.value);
+          }
+          scope.end();
+        } catch (error) {
+          scope.end(error);
+          throw mapUnknownErrorToLLMCompletionError(error);
+        } finally {
+          await iterator.return?.();
+          scope.end();
+          await telemetryContext.flushAndPublish();
+        }
+      })(),
+    );
+  } catch (error) {
+    scope.end(error);
+    await telemetryContext.flushAndPublish();
+    throw mapUnknownErrorToLLMCompletionError(error);
+  }
+}
+
+function buildCommonGenerateTextArgs(params: {
+  params: ExecuteAiSdkCompletionParams;
+  aiMessages: ModelMessage[];
+  modelResolution: ReturnType<typeof resolveOpenAIModel>;
+  telemetryContext: ReturnType<typeof createAiSdkTelemetryContext>;
+  abortSignal?: AbortSignal;
+}) {
+  const {
+    params: executeParams,
+    aiMessages,
+    modelResolution,
+    telemetryContext,
+    abortSignal,
+  } = params;
+
+  return {
+    model: modelResolution.model,
+    messages: aiMessages,
+    maxRetries: executeParams.maxRetries,
+    abortSignal,
+    timeout: executeParams.timeoutMs,
+    temperature: executeParams.modelParams.temperature,
+    topP: executeParams.modelParams.top_p,
+    maxOutputTokens: executeParams.modelParams.max_tokens,
+    providerOptions: modelResolution.providerOptions,
+    telemetry: telemetryContext.telemetry,
+    ...modelResolution.callSettings,
+  };
+}
+
+function normalizeTextResult(result: {
+  text: string;
+  reasoningText?: string;
+}): string | { text: string; reasoning?: string } {
+  return result.reasoningText
+    ? { text: result.text, reasoning: result.reasoningText }
+    : result.text;
+}
+
+function parseToolCallResponse(result: {
+  text: string;
+  reasoningText?: string;
+  toolCalls: Array<{
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+  }>;
+}): ToolCallResponse & { reasoning?: string } {
+  const parsed = ToolCallResponseSchema.safeParse({
+    content: result.text,
+    tool_calls: result.toolCalls.map((toolCall) => ({
+      id: toolCall.toolCallId,
+      name: toolCall.toolName,
+      args: toolCall.input,
+    })),
+  });
+
+  if (!parsed.success) {
+    throw new LLMCompletionError({
+      message: "Failed to parse LLM tool call result",
+      responseStatusCode: 500,
+      isRetryable: false,
+    });
+  }
+
+  return {
+    ...parsed.data,
+    ...(result.reasoningText ? { reasoning: result.reasoningText } : {}),
+  };
+}
+
+function buildAiSdkToolSet(tools: LLMToolDefinition[]): ToolSet {
+  return Object.fromEntries(
+    tools.map((definition) => [
+      definition.name,
+      tool({
+        description: definition.description,
+        inputSchema: jsonSchema(definition.parameters as any),
+      }),
+    ]),
+  ) as ToolSet;
+}
+
+function mapMessagesToAiSdkMessages(messages: ChatMessage[]): ModelMessage[] {
+  const toolCallNamesById = new Map<string, string>();
+  const mapped = messages.map((message, index): ModelMessage => {
+    const safeContent =
+      typeof message.content === "string"
+        ? message.content
+        : safeStringify(message.content);
+
+    if (message.role === ChatMessageRole.User) {
+      return { role: "user", content: safeContent };
+    }
+
+    if (
+      message.role === ChatMessageRole.System ||
+      message.role === ChatMessageRole.Developer
+    ) {
+      return index === 0
+        ? { role: "system", content: safeContent }
+        : { role: "user", content: safeContent };
+    }
+
+    if (message.type === ChatMessageType.ToolResult) {
+      const toolName = toolCallNamesById.get(message.toolCallId);
+      if (!toolName) {
+        throw new LLMCompletionError({
+          message: `Tool result references unknown tool call id: ${message.toolCallId}`,
+          responseStatusCode: 400,
+          isRetryable: false,
+        });
+      }
+
+      return {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: message.toolCallId,
+            toolName,
+            output: { type: "text", value: safeContent },
+          },
+        ],
+      };
+    }
+
+    if (message.type === ChatMessageType.AssistantToolCall) {
+      const content = [
+        ...(safeContent ? [{ type: "text" as const, text: safeContent }] : []),
+        ...message.toolCalls.map((toolCall) => {
+          toolCallNamesById.set(toolCall.id, toolCall.name);
+          return {
+            type: "tool-call" as const,
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            input: toolCall.args,
+          };
+        }),
+      ];
+
+      return {
+        role: "assistant",
+        content,
+      };
+    }
+
+    return { role: "assistant", content: safeContent };
+  });
+
+  return mapped.filter(hasMessageContent);
+}
+
+function hasMessageContent(message: ModelMessage): boolean {
+  if (typeof message.content === "string") {
+    return message.content.length > 0;
+  }
+  return message.content.length > 0;
+}
+
+function toAiSdkSchema(schema: ZodType | LLMJSONSchema) {
+  return isZodSchema(schema) ? schema : jsonSchema(schema as any);
+}
+
+function isZodSchema(schema: ZodType | LLMJSONSchema): schema is ZodType {
+  return (
+    typeof schema === "object" &&
+    schema !== null &&
+    "parse" in schema &&
+    "_def" in schema
+  );
+}
+
+function safeStringify(content: unknown): string {
+  try {
+    return JSON.stringify(content) ?? "[Unserializable content]";
+  } catch {
+    return "[Unserializable content]";
+  }
+}
+
+function assertOpenAIProviderOptionsTranslated(
+  providerOptions: Record<string, unknown> | undefined,
+): void {
+  const unsupportedKeys =
+    getUnsupportedOpenAIProviderOptionKeys(providerOptions);
+  if (unsupportedKeys.length === 0) return;
+
+  throw new LLMCompletionError({
+    message: `Unsupported AI SDK OpenAI provider options: ${unsupportedKeys.join(", ")}`,
+    responseStatusCode: 400,
+    isRetryable: false,
+  });
+}

--- a/packages/shared/src/server/llm/ai-sdk/providerOptionsTranslation.ts
+++ b/packages/shared/src/server/llm/ai-sdk/providerOptionsTranslation.ts
@@ -1,0 +1,89 @@
+import type { AiSdkProviderOptions } from "./types";
+
+type TranslatedOpenAIProviderOptions = {
+  providerOptions?: AiSdkProviderOptions;
+  callSettings: {
+    seed?: number;
+  };
+  unsupportedKeys: string[];
+};
+
+const TOP_LEVEL_PROVIDER_OPTION_TRANSLATORS = new Set([
+  "openai",
+  "reasoning_effort",
+  "reasoningEffort",
+  "seed",
+  "store",
+  "user",
+  "max_completion_tokens",
+  "maxCompletionTokens",
+]);
+
+export function getUnsupportedOpenAIProviderOptionKeys(
+  providerOptions: Record<string, unknown> | undefined,
+): string[] {
+  if (!providerOptions) return [];
+
+  const unsupportedKeys = Object.keys(providerOptions).filter(
+    (key) => !TOP_LEVEL_PROVIDER_OPTION_TRANSLATORS.has(key),
+  );
+
+  if ("openai" in providerOptions && !isPlainObject(providerOptions.openai)) {
+    unsupportedKeys.push("openai");
+  }
+
+  return unsupportedKeys;
+}
+
+export function translateOpenAIProviderOptions(
+  providerOptions: Record<string, unknown> | undefined,
+): TranslatedOpenAIProviderOptions {
+  const unsupportedKeys =
+    getUnsupportedOpenAIProviderOptionKeys(providerOptions);
+  if (!providerOptions) {
+    return { callSettings: {}, unsupportedKeys };
+  }
+
+  const openaiOptions = isPlainObject(providerOptions.openai)
+    ? { ...providerOptions.openai }
+    : {};
+  const callSettings: TranslatedOpenAIProviderOptions["callSettings"] = {};
+
+  const reasoningEffort =
+    providerOptions.reasoningEffort ?? providerOptions.reasoning_effort;
+  if (typeof reasoningEffort === "string") {
+    openaiOptions.reasoningEffort = reasoningEffort;
+  }
+
+  if (typeof providerOptions.seed === "number") {
+    callSettings.seed = providerOptions.seed;
+  }
+
+  if (typeof providerOptions.store === "boolean") {
+    openaiOptions.store = providerOptions.store;
+  }
+
+  if (typeof providerOptions.user === "string") {
+    openaiOptions.user = providerOptions.user;
+  }
+
+  const maxCompletionTokens =
+    providerOptions.maxCompletionTokens ??
+    providerOptions.max_completion_tokens;
+  if (typeof maxCompletionTokens === "number") {
+    openaiOptions.maxCompletionTokens = maxCompletionTokens;
+  }
+
+  return {
+    providerOptions:
+      Object.keys(openaiOptions).length > 0
+        ? ({ openai: openaiOptions } as AiSdkProviderOptions)
+        : undefined,
+    callSettings,
+    unsupportedKeys,
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/shared/src/server/llm/ai-sdk/providers/openai.ts
+++ b/packages/shared/src/server/llm/ai-sdk/providers/openai.ts
@@ -1,0 +1,48 @@
+import { createOpenAI } from "@ai-sdk/openai";
+
+import {
+  LLMConnectionConfig,
+  OpenAIConfigSchema,
+} from "../../../../interfaces/customLLMProviderConfigSchemas";
+import { processOpenAIBaseURL } from "../../openaiBaseUrl";
+import type { ModelParams } from "../../types";
+import { translateOpenAIProviderOptions } from "../providerOptionsTranslation";
+import type { AiSdkModelResolution } from "./types";
+
+export function resolveOpenAIModel(params: {
+  apiKey: string;
+  baseURL?: string | null;
+  config?: LLMConnectionConfig | null;
+  extraHeaders?: Record<string, string>;
+  fetch: typeof globalThis.fetch;
+  modelParams: ModelParams;
+}): AiSdkModelResolution {
+  const { apiKey, baseURL, config, extraHeaders, fetch, modelParams } = params;
+
+  const openAIConfig = OpenAIConfigSchema.parse(config ?? {});
+  const processedBaseURL = processOpenAIBaseURL({
+    url: baseURL,
+    modelName: modelParams.model,
+  });
+  const openai = createOpenAI({
+    apiKey,
+    baseURL: processedBaseURL ?? undefined,
+    headers: extraHeaders,
+    fetch,
+  });
+  const providerOptions = translateOpenAIProviderOptions(
+    modelParams.providerOptions,
+  );
+
+  return {
+    model: openAIConfig.useResponsesApi
+      ? openai.responses(modelParams.model)
+      : openai.chat(modelParams.model),
+    providerOptions: providerOptions.providerOptions,
+    callSettings: providerOptions.callSettings,
+    metadata: {
+      adapter: "openai",
+      apiMode: openAIConfig.useResponsesApi ? "responses" : "chat-completions",
+    },
+  };
+}

--- a/packages/shared/src/server/llm/ai-sdk/providers/types.ts
+++ b/packages/shared/src/server/llm/ai-sdk/providers/types.ts
@@ -1,0 +1,12 @@
+import type { LanguageModel } from "ai";
+
+import type { AiSdkProviderMetadata, AiSdkProviderOptions } from "../types";
+
+export type AiSdkModelResolution = {
+  model: LanguageModel;
+  providerOptions?: AiSdkProviderOptions;
+  callSettings: {
+    seed?: number;
+  };
+  metadata: AiSdkProviderMetadata;
+};

--- a/packages/shared/src/server/llm/ai-sdk/resolveLlmExecutionDecision.ts
+++ b/packages/shared/src/server/llm/ai-sdk/resolveLlmExecutionDecision.ts
@@ -1,0 +1,101 @@
+import { OpenAIConfigSchema } from "../../../interfaces/customLLMProviderConfigSchemas";
+import { LLMAdapter, type ModelParams, type TraceSinkParams } from "../types";
+import type { AiSdkOpenAIApiMode } from "./types";
+import { getUnsupportedOpenAIProviderOptionKeys } from "./providerOptionsTranslation";
+
+export type LlmExecutionDecision =
+  | {
+      engine: "ai-sdk";
+      adapter: "openai";
+      apiMode: AiSdkOpenAIApiMode;
+    }
+  | {
+      engine: "langchain-js";
+      declineReason?:
+        | "ai-sdk-adapter-not-enabled"
+        | "ai-sdk-adapter-not-supported"
+        | "ai-sdk-experiment-trace-sink"
+        | "ai-sdk-untranslated-provider-options";
+      declineDetail?: string;
+    };
+
+export function getOpenAIApiModeFromConfig(
+  config: Record<string, string | boolean> | null | undefined,
+): AiSdkOpenAIApiMode {
+  const openAIConfig = OpenAIConfigSchema.parse(config ?? {});
+  return openAIConfig.useResponsesApi ? "responses" : "chat-completions";
+}
+
+export function resolveLlmExecutionDecision(params: {
+  modelParams: ModelParams;
+  enabledAdapters: string[];
+  traceSinkParams?: TraceSinkParams;
+  connectionConfig?: Record<string, string | boolean> | null;
+}): LlmExecutionDecision {
+  const { modelParams, enabledAdapters, traceSinkParams, connectionConfig } =
+    params;
+
+  if (modelParams.adapter !== LLMAdapter.OpenAI) {
+    return enabledAdapters.includes(modelParams.adapter)
+      ? {
+          engine: "langchain-js",
+          declineReason: "ai-sdk-adapter-not-supported",
+          declineDetail: modelParams.adapter,
+        }
+      : {
+          engine: "langchain-js",
+          declineReason: "ai-sdk-adapter-not-enabled",
+          declineDetail: modelParams.adapter,
+        };
+  }
+
+  const apiMode = getOpenAIApiModeFromConfig(connectionConfig);
+  if (!isOpenAIEnabled(enabledAdapters, apiMode)) {
+    return {
+      engine: "langchain-js",
+      declineReason: "ai-sdk-adapter-not-enabled",
+      declineDetail: apiMode,
+    };
+  }
+
+  if (traceSinkParams?.eventsWriter?.experimentContext) {
+    return {
+      engine: "langchain-js",
+      declineReason: "ai-sdk-experiment-trace-sink",
+    };
+  }
+
+  const unsupportedProviderOptionKeys = getUnsupportedOpenAIProviderOptionKeys(
+    modelParams.providerOptions,
+  );
+  if (unsupportedProviderOptionKeys.length > 0) {
+    return {
+      engine: "langchain-js",
+      declineReason: "ai-sdk-untranslated-provider-options",
+      declineDetail: unsupportedProviderOptionKeys.join(","),
+    };
+  }
+
+  return {
+    engine: "ai-sdk",
+    adapter: "openai",
+    apiMode,
+  };
+}
+
+function isOpenAIEnabled(
+  enabledAdapters: string[],
+  apiMode: AiSdkOpenAIApiMode,
+): boolean {
+  if (enabledAdapters.includes("openai")) return true;
+  if (apiMode === "responses" && enabledAdapters.includes("openaiResponses")) {
+    return true;
+  }
+  if (
+    apiMode === "chat-completions" &&
+    enabledAdapters.includes("openaiChatCompletions")
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/packages/shared/src/server/llm/ai-sdk/telemetry.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetry.ts
@@ -1,0 +1,251 @@
+import { randomBytes } from "crypto";
+
+import {
+  context,
+  ROOT_CONTEXT,
+  SpanKind,
+  SpanStatusCode,
+  TraceFlags,
+  isValidTraceId,
+  trace,
+  type Attributes,
+  type Exception,
+  type Span,
+  type SpanContext,
+} from "@opentelemetry/api";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { JsonTraceSerializer } from "@opentelemetry/otlp-transformer";
+import { OpenTelemetry } from "@ai-sdk/otel";
+import type { TelemetryOptions } from "ai";
+
+import { logger } from "../../logger";
+import { traceException } from "../../instrumentation";
+import {
+  OtelIngestionProcessor,
+  type ResourceSpan,
+} from "../../otel/OtelIngestionProcessor";
+import { LangfuseOtelSpanAttributes } from "../../otel/attributes";
+import type { TraceSinkParams } from "../types";
+import type {
+  AiSdkRootSpanAttributes,
+  AiSdkTelemetryContext,
+  AiSdkTelemetryScope,
+} from "./types";
+
+export function createAiSdkTelemetryContext(params: {
+  traceSinkParams?: TraceSinkParams;
+  rootSpanAttributes: AiSdkRootSpanAttributes;
+}): AiSdkTelemetryContext {
+  const { traceSinkParams, rootSpanAttributes } = params;
+
+  if (!traceSinkParams) {
+    return createNoopTelemetryContext();
+  }
+
+  if (!traceSinkParams.environment?.startsWith("langfuse")) {
+    logger.warn(
+      "Skipping AI SDK trace creation: internal traces must use LangfuseInternalTraceEnvironment enum",
+      {
+        environment: traceSinkParams.environment,
+        traceId: traceSinkParams.traceId,
+      },
+    );
+    return createNoopTelemetryContext();
+  }
+
+  if (!isValidTraceId(traceSinkParams.traceId)) {
+    logger.warn("Skipping AI SDK trace creation: invalid W3C trace id", {
+      traceId: traceSinkParams.traceId,
+      projectId: traceSinkParams.targetProjectId,
+    });
+    return createNoopTelemetryContext();
+  }
+
+  const exporter = new InMemorySpanExporter();
+  const tracerProvider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  const tracer = tracerProvider.getTracer("langfuse-ai-sdk-executor", "1");
+  const parentContext = trace.setSpanContext(
+    ROOT_CONTEXT,
+    createRemoteParentSpanContext(traceSinkParams.traceId),
+  );
+
+  const telemetry: TelemetryOptions = {
+    isEnabled: true,
+    recordInputs: true,
+    recordOutputs: true,
+    functionId: "fetchLLMCompletion",
+    integrations: [
+      new OpenTelemetry({
+        tracer,
+        usage: true,
+        providerMetadata: true,
+        toolChoice: true,
+        schema: true,
+        enrichSpan: () => ({
+          "llm.execution_engine": "ai-sdk",
+          "llm.ai_sdk.adapter": rootSpanAttributes.adapter,
+          "llm.openai.api_mode": rootSpanAttributes.apiMode,
+        }),
+      }),
+    ],
+  };
+
+  return {
+    telemetry,
+    startScope: () =>
+      createTelemetryScope({
+        tracer,
+        parentContext,
+        traceSinkParams,
+        rootSpanAttributes,
+      }),
+    flushAndPublish: async () => {
+      try {
+        await tracerProvider.forceFlush();
+        const finishedSpans = exporter.getFinishedSpans();
+        if (finishedSpans.length === 0) return;
+
+        const resourceSpans =
+          serializeReadableSpansToResourceSpans(finishedSpans);
+        if (resourceSpans.length === 0) return;
+
+        await new OtelIngestionProcessor({
+          projectId: traceSinkParams.targetProjectId,
+          publicKey: "",
+          sdkName: "ai-sdk",
+          sdkVersion: "7",
+          ingestionVersion: "4",
+        }).publishToOtelIngestionQueue(resourceSpans);
+      } catch (error) {
+        logger.error("Failed to publish AI SDK telemetry to OTEL ingestion", {
+          error,
+          traceId: traceSinkParams.traceId,
+          projectId: traceSinkParams.targetProjectId,
+        });
+        traceException(error);
+      }
+    },
+  };
+}
+
+function createNoopTelemetryContext(): AiSdkTelemetryContext {
+  return {
+    startScope: () => ({
+      run: (operation) => operation(),
+      end: () => undefined,
+    }),
+    flushAndPublish: () => Promise.resolve(),
+  };
+}
+
+function createTelemetryScope(params: {
+  tracer: ReturnType<BasicTracerProvider["getTracer"]>;
+  parentContext: ReturnType<typeof trace.setSpanContext>;
+  traceSinkParams: TraceSinkParams;
+  rootSpanAttributes: AiSdkRootSpanAttributes;
+}): AiSdkTelemetryScope {
+  const { tracer, parentContext, traceSinkParams, rootSpanAttributes } = params;
+  const span = tracer.startSpan(
+    traceSinkParams.traceName,
+    {
+      kind: SpanKind.INTERNAL,
+      attributes: buildRootSpanAttributes(traceSinkParams, rootSpanAttributes),
+    },
+    parentContext,
+  );
+  const activeContext = trace.setSpan(parentContext, span);
+  let ended = false;
+
+  return {
+    run: (operation) => context.with(activeContext, operation),
+    end: (error?: unknown) => {
+      if (ended) return;
+      ended = true;
+      endScope(span, error);
+    },
+  };
+}
+
+function endScope(span: Span, error?: unknown): void {
+  if (error) {
+    span.recordException(toOtelException(error));
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  } else {
+    span.setStatus({ code: SpanStatusCode.OK });
+  }
+  span.end();
+}
+
+function toOtelException(error: unknown): Exception {
+  return error instanceof Error ? error : String(error);
+}
+
+function buildRootSpanAttributes(
+  traceSinkParams: TraceSinkParams,
+  rootSpanAttributes: AiSdkRootSpanAttributes,
+): Attributes {
+  const attributes: Attributes = {
+    [LangfuseOtelSpanAttributes.TRACE_NAME]: traceSinkParams.traceName,
+    [LangfuseOtelSpanAttributes.ENVIRONMENT]: traceSinkParams.environment,
+    [LangfuseOtelSpanAttributes.AS_ROOT]: "true",
+    "llm.execution_engine": "ai-sdk",
+    "llm.ai_sdk.adapter": rootSpanAttributes.adapter,
+    "llm.openai.api_mode": rootSpanAttributes.apiMode,
+  };
+
+  if (traceSinkParams.userId) {
+    attributes[LangfuseOtelSpanAttributes.TRACE_USER_ID] =
+      traceSinkParams.userId;
+  }
+  if (traceSinkParams.metadata) {
+    attributes[LangfuseOtelSpanAttributes.TRACE_METADATA] = JSON.stringify(
+      traceSinkParams.metadata,
+    );
+  }
+  if (traceSinkParams.prompt) {
+    attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME] =
+      traceSinkParams.prompt.name;
+    attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION] =
+      traceSinkParams.prompt.version;
+  }
+
+  return attributes;
+}
+
+function createRemoteParentSpanContext(traceId: string): SpanContext {
+  return {
+    traceId,
+    spanId: randomSpanId(),
+    isRemote: true,
+    traceFlags: TraceFlags.SAMPLED,
+  };
+}
+
+function randomSpanId(): string {
+  let spanId = "";
+  do {
+    spanId = randomBytes(8).toString("hex");
+  } while (spanId === "0000000000000000");
+  return spanId;
+}
+
+function serializeReadableSpansToResourceSpans(
+  spans: ReadableSpan[],
+): ResourceSpan[] {
+  const serialized = JsonTraceSerializer.serializeRequest(spans);
+  const decoded = JSON.parse(new TextDecoder().decode(serialized)) as {
+    resourceSpans?: ResourceSpan[];
+  };
+
+  return decoded.resourceSpans ?? [];
+}

--- a/packages/shared/src/server/llm/ai-sdk/types.ts
+++ b/packages/shared/src/server/llm/ai-sdk/types.ts
@@ -1,0 +1,31 @@
+import type { TelemetryOptions } from "ai";
+
+export type AiSdkAdapterName =
+  | "openai"
+  | "openaiResponses"
+  | "openaiChatCompletions";
+
+export type AiSdkOpenAIApiMode = "responses" | "chat-completions";
+
+export type AiSdkProviderMetadata = {
+  adapter: "openai";
+  apiMode: AiSdkOpenAIApiMode;
+};
+
+export type AiSdkProviderOptions = Record<string, Record<string, unknown>>;
+
+export type AiSdkTelemetryScope = {
+  run<T>(operation: () => T): T;
+  end(error?: unknown): void;
+};
+
+export type AiSdkTelemetryContext = {
+  telemetry?: TelemetryOptions;
+  startScope(): AiSdkTelemetryScope;
+  flushAndPublish(): Promise<void>;
+};
+
+export type AiSdkRootSpanAttributes = {
+  adapter: "openai";
+  apiMode: AiSdkOpenAIApiMode;
+};

--- a/packages/shared/src/server/llm/errorMapping.ts
+++ b/packages/shared/src/server/llm/errorMapping.ts
@@ -1,0 +1,166 @@
+import { ContextOverflowError } from "@langchain/core/errors";
+
+import { LLMCompletionError } from "./errors";
+
+const NON_RETRYABLE_LLM_ERROR_PATTERNS = [
+  "Request timed out",
+  "is not valid JSON",
+  "Unterminated string in JSON at position",
+  "TypeError",
+  "reached the end of its life",
+  "prompt is too long",
+  // secureLlmFetch validation failures: synchronous, status-less errors that
+  // would otherwise default to 500 + retryable and burn the eval-retry budget
+  // on permanent config or redirect-target failures.
+  "Only HTTP and HTTPS protocols are allowed",
+  "Only HTTPS base URLs are allowed",
+  "Blocked hostname detected",
+  "Blocked IP address detected",
+  "Redirect validation failed",
+  "Maximum redirects",
+  "Circular redirect detected",
+] as const;
+
+export function mapUnknownErrorToLLMCompletionError(
+  error: unknown,
+): LLMCompletionError {
+  if (isAlreadyLLMCompletionError(error)) {
+    return error as LLMCompletionError;
+  }
+
+  const responseStatusCode = getErrorResponseStatusCode(error) ?? 500;
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  // Anthropic/OpenAI/Azure SDKs wrap synchronous fetch errors as
+  // `APIConnectionError { message: "Connection error.", cause: original }`,
+  // hiding the actual secureLlmFetch validation reason. Walk the `.cause`
+  // chain for both retryability classification and the user-visible message
+  // so operators see "Blocked hostname detected" / "Redirect validation
+  // failed ..." instead of the unhelpful wrapper text.
+  const nonRetryableCauseMessage = findNonRetryableCauseMessage(error);
+  const message =
+    nonRetryableCauseMessage ?? extractCleanErrorMessage(rawMessage);
+
+  const hasNonRetryablePattern = nonRetryableCauseMessage !== undefined;
+
+  // Determine retryability:
+  // - 429 (rate limit): retryable with custom delay
+  // - 5xx (server errors): retryable with custom delay
+  // - 4xx (client errors): not retryable
+  // - Non-retryable patterns: not retryable
+  let isRetryable = false;
+
+  if (ContextOverflowError.isInstance(error)) {
+    isRetryable = false;
+  } else if (
+    error instanceof Error &&
+    (error.name === "InsufficientQuotaError" ||
+      error.name === "ThrottlingException")
+  ) {
+    // Explicit 429 handling
+    isRetryable = true;
+  } else if (responseStatusCode >= 500) {
+    // 5xx errors are retryable (server issues)
+    isRetryable = true;
+  } else if (responseStatusCode === 429) {
+    // Rate limit is retryable
+    isRetryable = true;
+  }
+
+  // Override if error message indicates non-retryable issue
+  if (hasNonRetryablePattern) {
+    isRetryable = false;
+  }
+
+  return new LLMCompletionError({
+    message,
+    responseStatusCode,
+    isRetryable,
+    cause: error,
+  });
+}
+
+function isAlreadyLLMCompletionError(error: unknown): boolean {
+  return error instanceof Error && error.name === "LLMCompletionError";
+}
+
+// Walks an error and its `.cause` chain (cycle-safe), yielding each link.
+function* walkCauseChain(error: unknown): Generator<unknown> {
+  const visited = new Set<unknown>();
+  for (
+    let current: unknown = error;
+    current && !visited.has(current);
+    current = (current as any).cause
+  ) {
+    visited.add(current);
+    yield current;
+  }
+}
+
+function findNonRetryableCauseMessage(error: unknown): string | undefined {
+  for (const current of walkCauseChain(error)) {
+    if (!(current instanceof Error)) continue;
+    const message = extractCleanErrorMessage(current.message);
+    if (NON_RETRYABLE_LLM_ERROR_PATTERNS.some((p) => message.includes(p))) {
+      return message;
+    }
+  }
+  return undefined;
+}
+
+function getErrorResponseStatusCode(error: unknown): number | undefined {
+  for (const current of walkCauseChain(error)) {
+    if (!current || typeof current !== "object") continue;
+    const errorLike = current as any;
+    const statusCode = [
+      errorLike.response?.status,
+      errorLike.status,
+      errorLike.statusCode,
+      // Bedrock errors have status code in $metadata.httpStatusCode.
+      errorLike.$metadata?.httpStatusCode,
+    ]
+      .map(toHttpStatusCode)
+      .find((code) => code !== undefined);
+    if (statusCode !== undefined) return statusCode;
+  }
+  return undefined;
+}
+
+function toHttpStatusCode(value: unknown): number | undefined {
+  return typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 100 &&
+    value <= 599
+    ? value
+    : undefined;
+}
+
+function extractCleanErrorMessage(rawMessage: string): string {
+  // Try to parse JSON error format (common in Google/Vertex AI errors)
+  // Example: '[{"error":{"code":404,"message":"Model not found..."}}]'
+  try {
+    // Check if the message starts with [ or { indicating JSON
+    const trimmed = rawMessage.trim();
+    if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+      const parsed = JSON.parse(trimmed);
+
+      // Handle array format: [{"error": {"message": "..."}}]
+      if (Array.isArray(parsed) && parsed[0]?.error?.message) {
+        return parsed[0].error.message;
+      }
+
+      // Handle object format: {"error": {"message": "..."}}
+      if (parsed?.error?.message) {
+        return parsed.error.message;
+      }
+
+      // Handle direct message format: {"message": "..."}
+      if (parsed?.message) {
+        return parsed.message;
+      }
+    }
+  } catch {
+    // Not valid JSON, return as-is
+  }
+
+  return rawMessage;
+}

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -16,7 +16,6 @@ import {
   SystemMessage,
   ToolMessage,
 } from "@langchain/core/messages";
-import { ContextOverflowError } from "@langchain/core/errors";
 import {
   BytesOutputParser,
   StringOutputParser,
@@ -59,12 +58,16 @@ import {
   RUNTIME_TIMEOUT_ADAPTERS,
 } from "./utils";
 import { logger } from "../logger";
-import { LLMCompletionError } from "./errors";
 import {
   createSecureGoogleAIStudioApiClient,
   createSecureVertexAIApiClient,
 } from "./googleSecureApiClient";
 import { createSecureLlmFetch } from "./secureLlmFetch";
+import { mapUnknownErrorToLLMCompletionError } from "./errorMapping";
+import { processOpenAIBaseURL } from "./openaiBaseUrl";
+import { resolveLlmExecutionDecision } from "./ai-sdk/resolveLlmExecutionDecision";
+import { executeAiSdkCompletion } from "./ai-sdk/executeAiSdkCompletion";
+import { getCurrentSpan } from "../instrumentation";
 
 export type CompletionWithReasoning = { text: string; reasoning?: string };
 type SplitAIMessageContent = {
@@ -75,25 +78,6 @@ type SplitAIMessageContent = {
   contentWithoutThinking: string | Array<ContentBlock.Standard>;
   reasoning?: string;
 };
-
-const NON_RETRYABLE_LLM_ERROR_PATTERNS = [
-  "Request timed out",
-  "is not valid JSON",
-  "Unterminated string in JSON at position",
-  "TypeError",
-  "reached the end of its life",
-  "prompt is too long",
-  // secureLlmFetch validation failures: synchronous, status-less errors that
-  // would otherwise default to 500 + retryable and burn the eval-retry budget
-  // on permanent config or redirect-target failures.
-  "Only HTTP and HTTPS protocols are allowed",
-  "Only HTTPS base URLs are allowed",
-  "Blocked hostname detected",
-  "Blocked IP address detected",
-  "Redirect validation failed",
-  "Maximum redirects",
-  "Circular redirect detected",
-] as const;
 
 const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 const AZURE_OPENAI_API_KEY_HEADER = "api-key";
@@ -370,6 +354,64 @@ export async function fetchLLMCompletion(
   const apiKey = decrypt(llmConnection.secretKey); // the apiKey must never be printed to the console
   const extraHeaders = decryptAndParseExtraHeaders(llmConnection.extraHeaders);
 
+  // Common proxy configuration for all adapters
+  const proxyUrl = env.HTTPS_PROXY;
+  const proxyDispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined;
+  const timeoutMs = env.LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS;
+  const secureLlmFetch = (
+    logContext: string,
+    additionalSensitiveHeaders?: string[],
+  ) =>
+    createSecureLlmFetch({
+      logContext,
+      additionalSensitiveHeaders,
+      dispatcher: proxyDispatcher,
+    });
+
+  const executionDecision = resolveLlmExecutionDecision({
+    modelParams,
+    enabledAdapters: env.LANGFUSE_LLM_COMPLETION_AI_SDK_ADAPTERS,
+    traceSinkParams,
+    connectionConfig: config,
+  });
+  const activeSpan = getCurrentSpan();
+  activeSpan?.setAttribute("llm.execution_engine", executionDecision.engine);
+  if (executionDecision.engine === "langchain-js") {
+    if (executionDecision.declineReason) {
+      activeSpan?.setAttribute(
+        "llm.execution_decline_reason",
+        executionDecision.declineReason,
+      );
+    }
+    if (executionDecision.declineDetail) {
+      activeSpan?.setAttribute(
+        "llm.execution_decline_detail",
+        executionDecision.declineDetail,
+      );
+    }
+  } else {
+    activeSpan?.setAttribute("llm.ai_sdk.adapter", executionDecision.adapter);
+    activeSpan?.setAttribute("llm.openai.api_mode", executionDecision.apiMode);
+
+    return executeAiSdkCompletion({
+      messages,
+      tools,
+      modelParams,
+      streaming,
+      llmConnection: {
+        apiKey,
+        extraHeaders,
+        baseURL,
+        config,
+      },
+      structuredOutputSchema: params.structuredOutputSchema,
+      maxRetries,
+      timeoutMs,
+      traceSinkParams,
+      secureFetch: secureLlmFetch("OpenAI LLM base URL"),
+    });
+  }
+
   let finalCallbacks: BaseCallbackHandler[] | undefined = callbacks ?? [];
   let processTracedEvents: ProcessTracedEvents = () => Promise.resolve();
 
@@ -450,20 +492,6 @@ export async function fetchLLMCompletion(
   finalMessages = finalMessages.filter(
     (m) => m.content.length > 0 || "tool_calls" in m,
   );
-
-  // Common proxy configuration for all adapters
-  const proxyUrl = env.HTTPS_PROXY;
-  const proxyDispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined;
-  const timeoutMs = env.LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS;
-  const secureLlmFetch = (
-    logContext: string,
-    additionalSensitiveHeaders?: string[],
-  ) =>
-    createSecureLlmFetch({
-      logContext,
-      additionalSensitiveHeaders,
-      dispatcher: proxyDispatcher,
-    });
 
   let chatModel: ChatOpenAI | ChatAnthropic | ChatBedrockConverse | ChatGoogle;
   let usesOpenAIResponsesApi = false;
@@ -880,54 +908,7 @@ export async function fetchLLMCompletion(
 
     return completion;
   } catch (e) {
-    const responseStatusCode = getErrorResponseStatusCode(e) ?? 500;
-    const rawMessage = e instanceof Error ? e.message : String(e);
-    // Anthropic/OpenAI/Azure SDKs wrap synchronous fetch errors as
-    // `APIConnectionError { message: "Connection error.", cause: original }`,
-    // hiding the actual secureLlmFetch validation reason. Walk the `.cause`
-    // chain for both retryability classification and the user-visible message
-    // so operators see "Blocked hostname detected" / "Redirect validation
-    // failed ..." instead of the unhelpful wrapper text.
-    const nonRetryableCauseMessage = findNonRetryableCauseMessage(e);
-    const message =
-      nonRetryableCauseMessage ?? extractCleanErrorMessage(rawMessage);
-
-    const hasNonRetryablePattern = nonRetryableCauseMessage !== undefined;
-
-    // Determine retryability:
-    // - 429 (rate limit): retryable with custom delay
-    // - 5xx (server errors): retryable with custom delay
-    // - 4xx (client errors): not retryable
-    // - Non-retryable patterns: not retryable
-    let isRetryable = false;
-
-    if (ContextOverflowError.isInstance(e)) {
-      isRetryable = false;
-    } else if (
-      e instanceof Error &&
-      (e.name === "InsufficientQuotaError" || e.name === "ThrottlingException")
-    ) {
-      // Explicit 429 handling
-      isRetryable = true;
-    } else if (responseStatusCode >= 500) {
-      // 5xx errors are retryable (server issues)
-      isRetryable = true;
-    } else if (responseStatusCode === 429) {
-      // Rate limit is retryable
-      isRetryable = true;
-    }
-
-    // Override if error message indicates non-retryable issue
-    if (hasNonRetryablePattern) {
-      isRetryable = false;
-    }
-
-    throw new LLMCompletionError({
-      message,
-      responseStatusCode,
-      isRetryable,
-      cause: e,
-    });
+    throw mapUnknownErrorToLLMCompletionError(e);
   } finally {
     await processTracedEvents();
   }
@@ -1005,105 +986,4 @@ function splitAIMessage(
       ? { reasoning: reasoningParts.join("") }
       : {}),
   };
-}
-
-/**
- * Process baseURL template for OpenAI adapter only.
- * Replaces {model} placeholder with actual model name.
- * This is a workaround for proxies that require the model name in the URL azureOpenAIBasePath
- * while having OpenAI compliance otherwise
- */
-function processOpenAIBaseURL(params: {
-  url: string | null | undefined;
-  modelName: string;
-}): string | null | undefined {
-  const { url, modelName } = params;
-
-  if (!url || !url.includes("{model}")) {
-    return url;
-  }
-
-  return url.replace("{model}", modelName);
-}
-
-// Walks an error and its `.cause` chain (cycle-safe), yielding each link.
-function* walkCauseChain(error: unknown): Generator<unknown> {
-  const visited = new Set<unknown>();
-  for (
-    let current: unknown = error;
-    current && !visited.has(current);
-    current = (current as any).cause
-  ) {
-    visited.add(current);
-    yield current;
-  }
-}
-
-function findNonRetryableCauseMessage(error: unknown): string | undefined {
-  for (const current of walkCauseChain(error)) {
-    if (!(current instanceof Error)) continue;
-    const message = extractCleanErrorMessage(current.message);
-    if (NON_RETRYABLE_LLM_ERROR_PATTERNS.some((p) => message.includes(p))) {
-      return message;
-    }
-  }
-  return undefined;
-}
-
-function getErrorResponseStatusCode(error: unknown): number | undefined {
-  for (const current of walkCauseChain(error)) {
-    if (!current || typeof current !== "object") continue;
-    const errorLike = current as any;
-    const statusCode = [
-      errorLike.response?.status,
-      errorLike.status,
-      errorLike.statusCode,
-      // Bedrock errors have status code in $metadata.httpStatusCode.
-      errorLike.$metadata?.httpStatusCode,
-    ]
-      .map(toHttpStatusCode)
-      .find((code) => code !== undefined);
-    if (statusCode !== undefined) return statusCode;
-  }
-  return undefined;
-}
-
-function toHttpStatusCode(value: unknown): number | undefined {
-  return typeof value === "number" &&
-    Number.isInteger(value) &&
-    value >= 100 &&
-    value <= 599
-    ? value
-    : undefined;
-}
-
-function extractCleanErrorMessage(rawMessage: string): string {
-  // Try to parse JSON error format (common in Google/Vertex AI errors)
-  // Example: '[{"error":{"code":404,"message":"Model not found..."}}]'
-  try {
-    // Check if the message starts with [ or { indicating JSON
-    const trimmed = rawMessage.trim();
-    if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
-      const parsed = JSON.parse(trimmed);
-
-      // Handle array format: [{"error": {"message": "..."}}]
-      if (Array.isArray(parsed) && parsed[0]?.error?.message) {
-        return parsed[0].error.message;
-      }
-
-      // Handle object format: {"error": {"message": "..."}}
-      if (parsed?.error?.message) {
-        return parsed.error.message;
-      }
-
-      // Handle direct message format: {"message": "..."}
-      if (parsed?.message) {
-        return parsed.message;
-      }
-    }
-  } catch {
-    // Not valid JSON, return as-is
-  }
-
-  return rawMessage;
 }

--- a/packages/shared/src/server/llm/openaiBaseUrl.ts
+++ b/packages/shared/src/server/llm/openaiBaseUrl.ts
@@ -1,0 +1,18 @@
+/**
+ * Process baseURL template for OpenAI adapter only.
+ * Replaces {model} placeholder with actual model name.
+ * This is a workaround for proxies that require the model name in the URL
+ * while having OpenAI compatibility otherwise.
+ */
+export function processOpenAIBaseURL(params: {
+  url: string | null | undefined;
+  modelName: string;
+}): string | null | undefined {
+  const { url, modelName } = params;
+
+  if (!url || !url.includes("{model}")) {
+    return url;
+  }
+
+  return url.replace("{model}", modelName);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,12 @@ importers:
 
   packages/shared:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: 4.0.2
+        version: 4.0.2(zod@4.3.6)
+      '@ai-sdk/otel':
+        specifier: 1.0.4
+        version: 1.0.4(zod@4.3.6)
       '@anthropic-ai/tokenizer':
         specifier: ^0.0.4
         version: 0.0.4
@@ -205,6 +211,12 @@ importers:
       '@opentelemetry/api':
         specifier: '>=1.0.0 <1.10.0'
         version: 1.9.1
+      '@opentelemetry/otlp-transformer':
+        specifier: 0.219.0
+        version: 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.1)
       '@prisma/client':
         specifier: ^6.19.3
         version: 6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2)
@@ -226,6 +238,9 @@ importers:
       '@types/bcryptjs':
         specifier: ^2.4.6
         version: 2.4.6
+      ai:
+        specifier: 7.0.4
+        version: 7.0.4(zod@4.3.6)
       ajv:
         specifier: ^8.18.0
         version: 8.20.0
@@ -279,7 +294,7 @@ importers:
         version: 11.2.7
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nodemailer:
         specifier: ^7.0.11
         version: 7.0.13
@@ -700,7 +715,7 @@ importers:
         version: 16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-query-params:
         specifier: ^5.1.0
         version: 5.1.0(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(use-query-params@2.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -1214,6 +1229,12 @@ packages:
     peerDependencies:
       zod: 4.3.6
 
+  '@ai-sdk/gateway@4.0.4':
+    resolution: {integrity: sha512-xO0e9duft/uZlnDaIeBZmzTMjfdEz1kkDzWnhQNkJZZljsKWVi6IREZW9nAa+Dx6jYJssyxSUggaFYBAV1WZpw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: 4.3.6
+
   '@ai-sdk/google@2.0.74':
     resolution: {integrity: sha512-Lhw1742RXc+4pRIvqVXa0jdl5+qdpmw8lj0lm6OchUg9rVGHzymlaxe7CDiYX5U2af4jbjKeTY22LDi3bIycgQ==}
     engines: {node: '>=18'}
@@ -1232,9 +1253,25 @@ packages:
     peerDependencies:
       zod: 4.3.6
 
+  '@ai-sdk/openai@4.0.2':
+    resolution: {integrity: sha512-/oxY+VpWgTrmqCOho1AD/jF5ZaHizkAEsrEVBhIHEzxSHpbJI0Ws8VSpfJPPBeTF7Ebz6eaNGOvKm2RzN5EcdQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: 4.3.6
+
+  '@ai-sdk/otel@1.0.4':
+    resolution: {integrity: sha512-4u8wmyPK3nZNBTD49ssRkjnBhv95XVTJ+NR/WR1rSyq+R66S/WY3LqTS+sTaBFrFgHfhWqLLAh/s7YstWwcO4w==}
+    engines: {node: '>=22'}
+
   '@ai-sdk/provider-utils@4.0.27':
     resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@5.0.1':
+    resolution: {integrity: sha512-p9Ra+dN4jjHrssXvklNf4nFvWbj1KePMfUOs7nue0NuoIMbYFBULhX4Vu0+6DWLnw3+UsLL9+RCKLtzzU43Qpg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: 4.3.6
 
@@ -1257,6 +1294,10 @@ packages:
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/provider@4.0.0':
+    resolution: {integrity: sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==}
+    engines: {node: '>=22'}
 
   '@ai-sdk/ui-utils@1.2.11':
     resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
@@ -6151,6 +6192,10 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -6290,6 +6335,9 @@ packages:
     resolution: {integrity: sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg==}
     engines: {node: '>=18.0.0'}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
@@ -6345,6 +6393,12 @@ packages:
   ai@5.0.195:
     resolution: {integrity: sha512-tWoeMhKZ2Gtx4SrcZM1PnhdlledqdrWgtdsJbPS+LEC2O3C0ZaPGjgxHcew+hhc0E5Vu5fpaGB0sLx3qU/ajgA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: 4.3.6
+
+  ai@7.0.4:
+    resolution: {integrity: sha512-mZub080RWRxpWg8OY56KVnI3AoMVniccSWG+dwVb3nH81+GiNMDYBIdP41RLUivLpmU49pB7ssD7tvfIUaSaCA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: 4.3.6
 
@@ -11921,6 +11975,13 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
+  '@ai-sdk/gateway@4.0.4(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.1(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
   '@ai-sdk/google@2.0.74(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
@@ -11940,10 +12001,32 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/openai@4.0.2(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.1(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/otel@1.0.4(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0
+      '@opentelemetry/api': 1.9.1
+      ai: 7.0.4(zod@4.3.6)
+    transitivePeerDependencies:
+      - zod
+
   '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@5.0.1(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
       eventsource-parser: 3.0.8
       zod: 4.3.6
 
@@ -11964,6 +12047,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.0':
     dependencies:
       json-schema: 0.4.0
 
@@ -13753,7 +13840,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -14356,7 +14443,7 @@ snapshots:
   '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@prisma/client': 6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2)
-      next-auth: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-auth: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   '@next/env@16.0.0': {}
 
@@ -17533,6 +17620,8 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@4.7.0(vite@7.3.5(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.6
@@ -17766,6 +17855,8 @@ snapshots:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
 
+  '@workflow/serde@4.1.0': {}
+
   '@workflow/serde@4.1.0-beta.2': {}
 
   '@xtuc/ieee754@1.2.0': {}
@@ -17814,6 +17905,13 @@ snapshots:
       '@ai-sdk/provider': 2.0.3
       '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
+  ai@7.0.4(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.4(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.1(zod@4.3.6)
       zod: 4.3.6
 
   ajv-formats@2.1.1(ajv@8.20.0):
@@ -21432,7 +21530,7 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@babel/runtime': 7.29.2
       '@panva/hkdf': 1.2.1
@@ -23478,7 +23576,7 @@ snapshots:
   tsx@4.20.5:
     dependencies:
       esbuild: 0.28.1
-      get-tsconfig: 4.13.7
+      get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -23832,7 +23930,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.13
       rollup: 4.60.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.3.0
       fsevents: 2.3.3

--- a/worker/src/__tests__/fetchLLMCompletionAiSdk.test.ts
+++ b/worker/src/__tests__/fetchLLMCompletionAiSdk.test.ts
@@ -1,0 +1,420 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+  startLocalLlmServer,
+  type LocalLlmServer,
+} from "./helpers/localLlmServer";
+
+process.env.CLICKHOUSE_URL ??= "http://localhost:8123";
+process.env.CLICKHOUSE_USER ??= "default";
+process.env.CLICKHOUSE_PASSWORD ??= "password";
+process.env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET ??= "test-bucket";
+process.env.ENCRYPTION_KEY ??=
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const TEST_MODEL = "gpt-4o-mini";
+
+function chatCompletionResponse(params: {
+  content?: string | null;
+  toolCalls?: Array<{
+    id: string;
+    name: string;
+    arguments: string;
+  }>;
+}) {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion",
+    created: 1,
+    model: TEST_MODEL,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: params.content ?? null,
+          ...(params.toolCalls
+            ? {
+                tool_calls: params.toolCalls.map((toolCall) => ({
+                  id: toolCall.id,
+                  type: "function",
+                  function: {
+                    name: toolCall.name,
+                    arguments: toolCall.arguments,
+                  },
+                })),
+              }
+            : {}),
+        },
+        finish_reason: params.toolCalls ? "tool_calls" : "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: 3,
+      completion_tokens: 2,
+      total_tokens: 5,
+    },
+  };
+}
+
+function responsesApiResponse(content: string) {
+  return {
+    id: "resp_test",
+    object: "response",
+    created_at: 1,
+    status: "completed",
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    max_output_tokens: null,
+    model: TEST_MODEL,
+    output: [
+      {
+        id: "msg_test",
+        type: "message",
+        status: "completed",
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text: content,
+            annotations: [],
+          },
+        ],
+      },
+    ],
+    parallel_tool_calls: true,
+    previous_response_id: null,
+    reasoning: null,
+    store: true,
+    temperature: 0,
+    text: { format: { type: "text" } },
+    tool_choice: "auto",
+    tools: [],
+    top_p: 1,
+    truncation: "disabled",
+    usage: {
+      input_tokens: 3,
+      output_tokens: 2,
+      total_tokens: 5,
+    },
+    user: null,
+    metadata: {},
+  };
+}
+
+describe("fetchLLMCompletion AI SDK executor", () => {
+  let env: typeof import("../../../packages/shared/src/env").env;
+  let encrypt: typeof import("../../../packages/shared/src/encryption").encrypt;
+  let fetchLLMCompletion: typeof import("../../../packages/shared/src/server/llm/fetchLLMCompletion").fetchLLMCompletion;
+  let resolveLlmExecutionDecision: typeof import("../../../packages/shared/src/server/llm/ai-sdk/resolveLlmExecutionDecision").resolveLlmExecutionDecision;
+  let ChatMessageType: typeof import("../../../packages/shared/src/server/llm/types").ChatMessageType;
+  let LLMAdapter: typeof import("../../../packages/shared/src/server/llm/types").LLMAdapter;
+  let originalEnabledAdapters: string[];
+  let originalWhitelistedHosts: string[];
+  let originalCloudRegion: string | undefined;
+
+  const servers: LocalLlmServer[] = [];
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    ({ env } = await import("../../../packages/shared/src/env"));
+    ({ encrypt } = await import("../../../packages/shared/src/encryption"));
+    ({ ChatMessageType, LLMAdapter } =
+      await import("../../../packages/shared/src/server/llm/types"));
+    ({ resolveLlmExecutionDecision } =
+      await import("../../../packages/shared/src/server/llm/ai-sdk/resolveLlmExecutionDecision"));
+
+    originalEnabledAdapters = [...env.LANGFUSE_LLM_COMPLETION_AI_SDK_ADAPTERS];
+    originalWhitelistedHosts = [
+      ...env.LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST,
+    ];
+    originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+
+    env.LANGFUSE_LLM_COMPLETION_AI_SDK_ADAPTERS = ["openai"];
+    env.LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST = ["127.0.0.1"];
+    env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+
+    ({ fetchLLMCompletion } =
+      await import("../../../packages/shared/src/server/llm/fetchLLMCompletion"));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(servers.splice(0).map((server) => server.close()));
+
+    env.LANGFUSE_LLM_COMPLETION_AI_SDK_ADAPTERS = originalEnabledAdapters;
+    env.LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST = originalWhitelistedHosts;
+    env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+  });
+
+  async function spinUp(handler: Parameters<typeof startLocalLlmServer>[0]) {
+    const server = await startLocalLlmServer(handler);
+    servers.push(server);
+    return server;
+  }
+
+  function baseModelParams(
+    overrides: Partial<
+      import("../../../packages/shared/src/server/llm/types").ModelParams
+    > = {},
+  ): import("../../../packages/shared/src/server/llm/types").ModelParams {
+    return {
+      provider: "openai",
+      adapter: LLMAdapter.OpenAI,
+      model: TEST_MODEL,
+      temperature: 0.2,
+      max_tokens: 64,
+      top_p: 0.9,
+      ...overrides,
+    };
+  }
+
+  function userMessage(content = "What is 2+2?") {
+    return {
+      role: "user" as const,
+      content,
+      type: ChatMessageType.PublicAPICreated,
+    };
+  }
+
+  it("routes enabled OpenAI chat completions through the AI SDK executor", async () => {
+    const server = await spinUp((_req, _body, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(chatCompletionResponse({ content: "chat-ok" })));
+    });
+
+    const completion = await fetchLLMCompletion({
+      streaming: false,
+      messages: [userMessage()],
+      modelParams: baseModelParams({
+        providerOptions: {
+          reasoning_effort: "low",
+          seed: 42,
+          store: true,
+          user: "test-user",
+          max_completion_tokens: 32,
+        },
+      }),
+      llmConnection: {
+        secretKey: encrypt("openai-api-key"),
+        extraHeaders: encrypt(JSON.stringify({ "x-test-header": "enabled" })),
+        baseURL: `${server.url}/{model}/v1`,
+      },
+      maxRetries: 1,
+    });
+
+    expect(completion).toBe("chat-ok");
+    expect(server.requests).toHaveLength(1);
+    const [request] = server.requests;
+    expect(request.method).toBe("POST");
+    expect(request.url).toBe(`/${TEST_MODEL}/v1/chat/completions`);
+    expect(request.headers.authorization).toBe("Bearer openai-api-key");
+    expect(request.headers["x-test-header"]).toBe("enabled");
+
+    const body = JSON.parse(request.body) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      model: TEST_MODEL,
+      temperature: 0.2,
+      top_p: 0.9,
+      seed: 42,
+      store: true,
+      user: "test-user",
+      reasoning_effort: "low",
+      max_completion_tokens: 32,
+    });
+  });
+
+  it("routes OpenAI Responses API config through the AI SDK responses model", async () => {
+    const server = await spinUp((_req, _body, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(responsesApiResponse("responses-ok")));
+    });
+
+    const completion = await fetchLLMCompletion({
+      streaming: false,
+      messages: [userMessage()],
+      modelParams: baseModelParams(),
+      llmConnection: {
+        secretKey: encrypt("openai-api-key"),
+        baseURL: `${server.url}/v1`,
+        config: {
+          useResponsesApi: true,
+        },
+      },
+    });
+
+    expect(completion).toBe("responses-ok");
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0].url).toBe("/v1/responses");
+  });
+
+  it("streams OpenAI chat completion text through the AI SDK executor", async () => {
+    const server = await spinUp((_req, _body, res) => {
+      res.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      });
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-stream-test",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: TEST_MODEL,
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant", content: "stream-" },
+              finish_reason: null,
+            },
+          ],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-stream-test",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: TEST_MODEL,
+          choices: [
+            {
+              index: 0,
+              delta: { content: "ok" },
+              finish_reason: "stop",
+            },
+          ],
+        })}\n\n`,
+      );
+      res.write("data: [DONE]\n\n");
+      res.end();
+    });
+
+    const stream = await fetchLLMCompletion({
+      streaming: true,
+      messages: [userMessage()],
+      modelParams: baseModelParams(),
+      llmConnection: {
+        secretKey: encrypt("openai-api-key"),
+        baseURL: `${server.url}/v1`,
+      },
+    });
+
+    const decoder = new TextDecoder();
+    let text = "";
+    for await (const chunk of stream) {
+      text += decoder.decode(chunk);
+    }
+
+    expect(text).toBe("stream-ok");
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0].url).toBe("/v1/chat/completions");
+  });
+
+  it("returns structured output parsed by AI SDK Output.object", async () => {
+    const structuredPayload = { score: 1, reasoning: "valid json" };
+    const server = await spinUp((_req, _body, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify(
+          chatCompletionResponse({
+            content: JSON.stringify(structuredPayload),
+          }),
+        ),
+      );
+    });
+
+    const completion = await fetchLLMCompletion({
+      streaming: false,
+      messages: [userMessage("Return JSON.")],
+      modelParams: baseModelParams(),
+      structuredOutputSchema: z.object({
+        score: z.number(),
+        reasoning: z.string(),
+      }),
+      llmConnection: {
+        secretKey: encrypt("openai-api-key"),
+        baseURL: `${server.url}/v1`,
+      },
+    });
+
+    expect(completion).toEqual(structuredPayload);
+    const body = JSON.parse(server.requests[0].body) as Record<string, unknown>;
+    expect(body.response_format).toMatchObject({
+      type: "json_schema",
+    });
+  });
+
+  it("returns tool calls from the AI SDK executor", async () => {
+    const server = await spinUp((_req, _body, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify(
+          chatCompletionResponse({
+            toolCalls: [
+              {
+                id: "call_test",
+                name: "lookup",
+                arguments: JSON.stringify({ query: "langfuse" }),
+              },
+            ],
+          }),
+        ),
+      );
+    });
+
+    const completion = await fetchLLMCompletion({
+      streaming: false,
+      messages: [userMessage("Call the lookup tool.")],
+      modelParams: baseModelParams(),
+      tools: [
+        {
+          name: "lookup",
+          description: "Look up a query.",
+          parameters: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+            },
+            required: ["query"],
+            additionalProperties: false,
+          },
+        },
+      ],
+      llmConnection: {
+        secretKey: encrypt("openai-api-key"),
+        baseURL: `${server.url}/v1`,
+      },
+    });
+
+    expect(completion).toEqual({
+      content: "",
+      tool_calls: [
+        {
+          id: "call_test",
+          name: "lookup",
+          args: { query: "langfuse" },
+        },
+      ],
+    });
+  });
+
+  it("declines to LangChain when OpenAI provider options are not translated", () => {
+    const decision = resolveLlmExecutionDecision({
+      modelParams: baseModelParams({
+        providerOptions: {
+          unsupported_option: true,
+        },
+      }),
+      enabledAdapters: ["openai"],
+    });
+
+    expect(decision).toEqual({
+      engine: "langchain-js",
+      declineReason: "ai-sdk-untranslated-provider-options",
+      declineDetail: "unsupported_option",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add an env-gated AI SDK v7 executor path for OpenAI inside `fetchLLMCompletion`
- support OpenAI Chat Completions and Responses API side by side with the existing LangChain executor
- add native AI SDK OTel telemetry with per-call isolated tracer providers and OTel ingestion v4 direct-write eligibility
- preserve LangChain fallback for disabled adapters, unsupported adapters, experiment trace sinks, and untranslated provider options
- add focused local-server coverage for chat, responses, streaming, structured output, tool calls, headers, base URL templating, and fallback decisions

## Impacted packages
- `packages/shared`
- `worker`

## Verification
- `pnpm --filter '@langfuse/shared' db:generate`
- `pnpm --filter '@langfuse/shared' typecheck`
- `pnpm --filter '@langfuse/shared' build`
- `pnpm --filter '@langfuse/shared' lint`
- `pnpm --filter worker typecheck`
- `pnpm --filter worker lint`
- `pnpm --filter worker test "fetchLLMCompletionAiSdk.test.ts"`
- `CLICKHOUSE_URL="http://localhost:8123" CLICKHOUSE_USER="default" CLICKHOUSE_PASSWORD="password" LANGFUSE_S3_EVENT_UPLOAD_BUCKET="test-bucket" ENCRYPTION_KEY="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" pnpm --filter worker test "secureLlmFetch.test.ts"`
