### PR TITLE
fix(rbac): reject mismatched userId in updateProjectRole

### DIFF
--- a/web/src/__tests__/server/members-trpc.servertest.ts
+++ b/web/src/__tests__/server/members-trpc.servertest.ts
@@ -530,3 +530,81 @@ describe("membersRouter.updateProjectRole - audit log state capture", () => {
     expect(logs.map((l) => l.action)).toEqual(["create", "update", "delete"]);
   });
 });
+
+describe("membersRouter.updateProjectRole - orgMembership/userId consistency", () => {
+  it("rejects a mismatched orgMembershipId / userId pair with BAD_REQUEST and writes nothing", async () => {
+    const { org, project, caller } = await prepare("cloud:core");
+
+    // The org member who actually owns the targeted org membership.
+    const targetUser = await createTestUser();
+    const orgMembership = await prisma.organizationMembership.create({
+      data: {
+        userId: targetUser.id,
+        orgId: org.id,
+        role: Role.MEMBER,
+      },
+    });
+
+    // A different, unrelated user whose id the caller tries to smuggle in.
+    // Project access is resolved via orgMembershipId, so accepting this would
+    // grant the role to targetUser while recording it against otherUser in both
+    // the ProjectMembership row and the audit log.
+    const otherUser = await createTestUser();
+
+    await expect(
+      caller.members.updateProjectRole({
+        orgId: org.id,
+        orgMembershipId: orgMembership.id,
+        userId: otherUser.id,
+        projectId: project.id,
+        projectRole: Role.ADMIN,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    // No ProjectMembership row and no audit log entry should have been written.
+    const rows = await prisma.projectMembership.findMany({
+      where: { projectId: project.id },
+    });
+    expect(rows).toHaveLength(0);
+
+    const logs = await prisma.auditLog.findMany({
+      where: {
+        orgId: org.id,
+        resourceType: "projectMembership",
+        resourceId: `${project.id}--${otherUser.id}`,
+      },
+    });
+    expect(logs).toHaveLength(0);
+  });
+
+  it("allows a matching orgMembershipId / userId pair", async () => {
+    const { org, project, caller } = await prepare("cloud:core");
+
+    const targetUser = await createTestUser();
+    const orgMembership = await prisma.organizationMembership.create({
+      data: {
+        userId: targetUser.id,
+        orgId: org.id,
+        role: Role.MEMBER,
+      },
+    });
+
+    await expect(
+      caller.members.updateProjectRole({
+        orgId: org.id,
+        orgMembershipId: orgMembership.id,
+        userId: targetUser.id,
+        projectId: project.id,
+        projectRole: Role.ADMIN,
+      }),
+    ).resolves.toMatchObject({ userId: targetUser.id, role: Role.ADMIN });
+
+    const row = await prisma.projectMembership.findUnique({
+      where: {
+        projectId_userId: { projectId: project.id, userId: targetUser.id },
+      },
+    });
+    expect(row?.role).toBe(Role.ADMIN);
+    expect(row?.orgMembershipId).toBe(orgMembership.id);
+  });
+});

--- a/web/src/features/rbac/server/membersRouter.ts
+++ b/web/src/features/rbac/server/membersRouter.ts
@@ -666,6 +666,19 @@ export const membersRouter = createTRPCRouter({
         });
       }
 
+      // orgMembershipId and userId are independent client inputs, but project
+      // access is resolved via orgMembershipId (OrganizationMembership.userId),
+      // not this row's userId. A mismatched pair would grant the role to the
+      // org membership owner while recording it against a different user in both
+      // the ProjectMembership row and the audit log, so reject it.
+      if (orgMembership.userId !== input.userId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "The provided userId does not match the organization membership",
+        });
+      }
+
       // cannot edit project roles of users with higher org roles
       throwIfHigherRole({
         ownRole: ctx.session.orgRole,


### PR DESCRIPTION
updateProjectRole accepted orgMembershipId and userId as independent client inputs but never verified they referred to the same user. Project access is resolved via orgMembershipId (OrganizationMembership.userId), so a mismatched pair granted the role to the org membership owner while recording it against a different (potentially cross-org) user in both the ProjectMembership row and the audit log entry.

Reject the mismatch with BAD_REQUEST rather than silently overriding the input, and add server tests covering both the rejected and matching pairs.

**Security impact:** integrity/hardening fix, not an access-control bypass or
privilege escalation. input.userId is never used in any authorization
decision — access resolves via orgMembershipId (OrganizationMembership.userId)
and all role ceilings are enforced against the org-membership owner and the
caller regardless of the supplied userId. 

A malformed request could not grant access beyond what the caller could already grant, exceed the caller's ceiling,
or expose cross-tenant data. It could only write a ProjectMembership row and
audit-log entry naming a different user than the one who actually receives the
role (internal-consistency + audit-integrity + downstream mislabeling, e.g.
getProjectAdminEmails). Requires an already-authorized org/project admin and a
hand-crafted request; the UI always submits a consistent pair.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a server-side consistency check to `updateProjectRole` that rejects requests where the supplied `userId` does not match the user referenced by `orgMembershipId`. Without this check, an authorized caller could submit a hand-crafted request that granted a project role to the org-membership owner while recording a different user's ID in the `ProjectMembership` row and the audit log.

- Adds a strict equality check between `orgMembership.userId` and `input.userId` immediately after the org-membership lookup, throwing `BAD_REQUEST` before any database writes on a mismatch.
- Adds two targeted server tests: one verifying the rejection (including DB-state assertions for no written rows or audit-log entries) and one verifying the happy path for a correctly matched pair.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is a small, well-placed guard that rejects inconsistent input before any database writes and is fully covered by new server tests.

The fix is minimal and surgical — one equality check added at exactly the right point in the handler, after the membership lookup and before any mutations. The two new tests assert both the rejection path (no DB rows written, correct error code) and the acceptance path (correct ProjectMembership row and orgMembershipId stored). No existing behavior is altered for well-formed requests.

No files require special attention. Both changed files are straightforward and consistent with each other.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant updateProjectRole
    participant DB as Database

    Client->>updateProjectRole: "{ orgId, orgMembershipId, userId, projectId, projectRole }"
    updateProjectRole->>DB: hasOrganizationAccess / hasProjectAccess check
    DB-->>updateProjectRole: access result
    updateProjectRole->>DB: findUnique(OrganizationMembership) by orgMembershipId + orgId
    DB-->>updateProjectRole: orgMembership (or null)
    alt orgMembership not found
        updateProjectRole-->>Client: TRPCError NOT_FOUND
    end
    alt "orgMembership.userId != input.userId (NEW CHECK)"
        updateProjectRole-->>Client: TRPCError BAD_REQUEST
    end
    updateProjectRole->>updateProjectRole: throwIfHigherRole check
    updateProjectRole->>DB: findFirst(ProjectMembership) by projectId+userId+orgMembershipId
    DB-->>updateProjectRole: existing row (or null)
    alt projectRole is null / NONE
        updateProjectRole->>DB: delete ProjectMembership
        updateProjectRole->>DB: auditLog delete
        updateProjectRole-->>Client: "{ userId }"
    else
        updateProjectRole->>updateProjectRole: throwIfHigherProjectRole check
        updateProjectRole->>DB: upsert ProjectMembership
        updateProjectRole->>DB: auditLog create/update
        updateProjectRole-->>Client: updatedProjectMembership
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant updateProjectRole
    participant DB as Database

    Client->>updateProjectRole: "{ orgId, orgMembershipId, userId, projectId, projectRole }"
    updateProjectRole->>DB: hasOrganizationAccess / hasProjectAccess check
    DB-->>updateProjectRole: access result
    updateProjectRole->>DB: findUnique(OrganizationMembership) by orgMembershipId + orgId
    DB-->>updateProjectRole: orgMembership (or null)
    alt orgMembership not found
        updateProjectRole-->>Client: TRPCError NOT_FOUND
    end
    alt "orgMembership.userId != input.userId (NEW CHECK)"
        updateProjectRole-->>Client: TRPCError BAD_REQUEST
    end
    updateProjectRole->>updateProjectRole: throwIfHigherRole check
    updateProjectRole->>DB: findFirst(ProjectMembership) by projectId+userId+orgMembershipId
    DB-->>updateProjectRole: existing row (or null)
    alt projectRole is null / NONE
        updateProjectRole->>DB: delete ProjectMembership
        updateProjectRole->>DB: auditLog delete
        updateProjectRole-->>Client: "{ userId }"
    else
        updateProjectRole->>updateProjectRole: throwIfHigherProjectRole check
        updateProjectRole->>DB: upsert ProjectMembership
        updateProjectRole->>DB: auditLog create/update
        updateProjectRole-->>Client: updatedProjectMembership
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rbac): reject mismatched userId in u..."](https://github.com/langfuse/langfuse/commit/8e95df9e32ab41a9627ac97eb14a8e12e3316693) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41893357)</sub>

<!-- /greptile_comment -->