### PR TITLE
feat(v4): redesign migration audit page

### DIFF
--- a/web/src/features/v4/components/V4MigrationProjectCards.clienttest.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.clienttest.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { vi } from "vitest";
 import {
   UsageStackedBarOverview,
@@ -304,6 +304,11 @@ describe("V4MigrationProjectCards SDK usage", () => {
     expect(
       nonActionDetails.getByText("Details that do not require action"),
     ).toBeInTheDocument();
+    fireEvent.click(
+      nonActionDetails.getByRole("button", {
+        name: /Details that do not require action/i,
+      }),
+    );
     expect(nonActionDetails.queryByText("untracked")).not.toBeInTheDocument();
     expect(nonActionDetails.getByText("unknown@unknown")).toBeInTheDocument();
     expect(nonActionDetails.getByText("pk-lf-raw-api")).toBeInTheDocument();
@@ -403,6 +408,8 @@ describe("V4MigrationProjectCards SDK usage", () => {
     expect(requiredActions.getByText("Legacy public APIs")).toBeInTheDocument();
     expect(requiredActions.getByText("Trace-level evals")).toBeInTheDocument();
     expect(requiredActions.getByText("Legacy exports")).toBeInTheDocument();
+    expect(requiredActions.getByText("1 route")).toBeInTheDocument();
+    expect(requiredActions.getByText("1 integration")).toBeInTheDocument();
     expect(requiredActions.getAllByText("Due Nov 30, 2026")).toHaveLength(4);
   });
 
@@ -417,11 +424,17 @@ describe("V4MigrationProjectCards SDK usage", () => {
     expect(
       requiredActions.queryByText("Legacy public APIs"),
     ).not.toBeInTheDocument();
+    const nonActionDetails = within(screen.getByTestId("non-action-details"));
     expect(
-      screen.getByText("Details that do not require action"),
+      nonActionDetails.getByText("Details that do not require action"),
     ).toBeInTheDocument();
+    fireEvent.click(
+      nonActionDetails.getByRole("button", {
+        name: /Details that do not require action/i,
+      }),
+    );
     expect(
-      screen.getByText("No SDK usage detected in this range."),
+      nonActionDetails.getByText("No SDK usage detected in this range."),
     ).toBeInTheDocument();
   });
 });

--- a/web/src/features/v4/components/V4MigrationProjectCards.clienttest.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.clienttest.tsx
@@ -1,10 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { vi } from "vitest";
 import {
   UsageStackedBarOverview,
   V4MigrationProjectCards,
 } from "@/src/features/v4/components/V4MigrationProjectCards";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
 const rechartsProps = vi.hoisted(() => ({
   barCharts: [] as Array<{ margin?: { left?: number } }>,
@@ -143,84 +143,285 @@ describe("UsageStackedBarOverview", () => {
 });
 
 describe("V4MigrationProjectCards SDK usage", () => {
+  const baseProps = {
+    projectId: "project-v4",
+    legacyIntegrationSummary: {
+      legacyIntegrationCount: 0,
+      legacyIntegrations: {
+        posthog: false,
+        mixpanel: false,
+        blobStorage: false,
+      },
+    },
+    traceLevelEvalCount: 0,
+    legacyApiUsage: [],
+    traceLevelEvalExecutions: [],
+    sdkUsage: {
+      bucketTimes: ["2026-06-30T04:00:00.000Z", "2026-06-30T04:02:00.000Z"],
+      rows: [],
+    },
+    isLegacyIntegrationSummaryLoading: false,
+    isTraceLevelEvalSummaryLoading: false,
+    isLegacyApiUsageLoading: false,
+    isTraceLevelEvalExecutionsLoading: false,
+    isSdkUsageLoading: false,
+    hasLegacyIntegrationSummaryError: false,
+    hasTraceLevelEvalSummaryError: false,
+    hasLegacyApiUsageError: false,
+    hasTraceLevelEvalExecutionsError: false,
+    hasSdkUsageError: false,
+  } satisfies ComponentProps<typeof V4MigrationProjectCards>;
+
+  const renderCards = (
+    overrides: Partial<ComponentProps<typeof V4MigrationProjectCards>> = {},
+  ) =>
+    render(
+      <V4MigrationProjectCards
+        {...baseProps}
+        {...overrides}
+        legacyIntegrationSummary={
+          overrides.legacyIntegrationSummary ??
+          baseProps.legacyIntegrationSummary
+        }
+        sdkUsage={overrides.sdkUsage ?? baseProps.sdkUsage}
+      />,
+    );
+
   beforeEach(() => {
     rechartsProps.barCharts.length = 0;
     rechartsProps.bars.length = 0;
     rechartsProps.yAxes.length = 0;
   });
 
-  it("shows SDK usage by exact SDK version and API key", () => {
-    render(
-      <V4MigrationProjectCards
-        projectId="project-v4"
-        legacyIntegrationSummary={{
-          legacyIntegrationCount: 0,
-          legacyIntegrations: {
-            posthog: false,
-            mixpanel: false,
-            blobStorage: false,
+  it("shows only outdated major SDK usage as a required action", () => {
+    renderCards({
+      sdkUsage: {
+        bucketTimes: ["2026-06-30T04:00:00.000Z", "2026-06-30T04:02:00.000Z"],
+        rows: [
+          {
+            time: "2026-06-30T04:00:00.000Z",
+            sdkName: "python",
+            sdkVersion: "3.9.0",
+            publicKey: "pk-lf-old-python",
+            count: 5,
+            firstSeen: "2026-06-30T04:02:00.000Z",
+            lastSeen: "2026-06-30T04:04:00.000Z",
+            canonicalSdkName: "python",
+            latestMajor: 4,
+            major: 3,
+            upgradeStatus: "outdated_major",
           },
-        }}
-        traceLevelEvalCount={0}
-        legacyApiUsage={[]}
-        traceLevelEvalExecutions={[]}
-        sdkUsage={{
-          bucketTimes: ["2026-06-30T04:00:00.000Z", "2026-06-30T04:02:00.000Z"],
-          rows: [
-            {
-              time: "2026-06-30T04:00:00.000Z",
-              sdkName: "python",
-              sdkVersion: "3.9.0",
-              publicKey: "pk-lf-old-python",
-              count: 5,
-              firstSeen: "2026-06-30T04:02:00.000Z",
-              lastSeen: "2026-06-30T04:04:00.000Z",
-              canonicalSdkName: "python",
-              latestMajor: 4,
-              major: 3,
-              upgradeStatus: "outdated_major",
-            },
-            {
-              time: "2026-06-30T04:00:00.000Z",
-              sdkName: "unknown",
-              sdkVersion: "unknown",
-              publicKey: "",
-              count: 2,
-              firstSeen: "2026-06-30T04:00:00.000Z",
-              lastSeen: "2026-06-30T04:00:00.000Z",
-              canonicalSdkName: null,
-              latestMajor: null,
-              major: null,
-              upgradeStatus: "unknown",
-            },
-          ],
-        }}
-        isLegacyIntegrationSummaryLoading={false}
-        isTraceLevelEvalSummaryLoading={false}
-        isLegacyApiUsageLoading={false}
-        isTraceLevelEvalExecutionsLoading={false}
-        isSdkUsageLoading={false}
-        hasLegacyIntegrationSummaryError={false}
-        hasTraceLevelEvalSummaryError={false}
-        hasLegacyApiUsageError={false}
-        hasTraceLevelEvalExecutionsError={false}
-        hasSdkUsageError={false}
-      />,
-    );
+          {
+            time: "2026-06-30T04:00:00.000Z",
+            sdkName: "unknown",
+            sdkVersion: "unknown",
+            publicKey: "",
+            count: 2,
+            firstSeen: "2026-06-30T04:00:00.000Z",
+            lastSeen: "2026-06-30T04:00:00.000Z",
+            canonicalSdkName: null,
+            latestMajor: null,
+            major: null,
+            upgradeStatus: "unknown",
+          },
+          {
+            time: "2026-06-30T04:00:00.000Z",
+            sdkName: "unknown",
+            sdkVersion: "unknown",
+            publicKey: "pk-lf-raw-api",
+            count: 4,
+            firstSeen: "2026-06-30T04:00:00.000Z",
+            lastSeen: "2026-06-30T04:00:00.000Z",
+            canonicalSdkName: null,
+            latestMajor: null,
+            major: null,
+            upgradeStatus: "unknown",
+          },
+          {
+            time: "2026-06-30T04:00:00.000Z",
+            sdkName: "javascript",
+            sdkVersion: "5.0.0",
+            publicKey: "pk-lf-current-js",
+            count: 3,
+            firstSeen: "2026-06-30T04:00:00.000Z",
+            lastSeen: "2026-06-30T04:00:00.000Z",
+            canonicalSdkName: "javascript",
+            latestMajor: 5,
+            major: 5,
+            upgradeStatus: "current",
+          },
+          {
+            time: "2026-06-30T04:00:00.000Z",
+            sdkName: "custom-sdk",
+            sdkVersion: "1.0.0",
+            publicKey: "pk-lf-custom",
+            count: 1,
+            firstSeen: "2026-06-30T04:00:00.000Z",
+            lastSeen: "2026-06-30T04:00:00.000Z",
+            canonicalSdkName: null,
+            latestMajor: null,
+            major: null,
+            upgradeStatus: "unsupported_sdk",
+          },
+          {
+            time: "2026-06-30T04:00:00.000Z",
+            sdkName: "python",
+            sdkVersion: "dev",
+            publicKey: "pk-lf-invalid-python",
+            count: 1,
+            firstSeen: "2026-06-30T04:00:00.000Z",
+            lastSeen: "2026-06-30T04:00:00.000Z",
+            canonicalSdkName: "python",
+            latestMajor: 4,
+            major: null,
+            upgradeStatus: "invalid_version",
+          },
+        ],
+      },
+    });
 
-    expect(screen.getByText("SDK usage")).toBeInTheDocument();
-    expect(screen.getByText("python@3.9.0")).toBeInTheDocument();
-    expect(screen.getByText("pk-lf-old-python")).toBeInTheDocument();
+    const requiredActions = within(screen.getByTestId("required-actions"));
+    expect(requiredActions.getByText("SDK upgrades")).toBeInTheDocument();
+    expect(requiredActions.getByText("python@3.9.0")).toBeInTheDocument();
+    expect(requiredActions.getByText("pk-lf-old-python")).toBeInTheDocument();
+    expect(requiredActions.getByText("Upgrade")).toBeInTheDocument();
+    expect(requiredActions.queryByText("untracked")).not.toBeInTheDocument();
+    expect(
+      requiredActions.queryByText("unknown@unknown"),
+    ).not.toBeInTheDocument();
+    expect(
+      requiredActions.queryByText("pk-lf-raw-api"),
+    ).not.toBeInTheDocument();
+    expect(
+      requiredActions.queryByText("javascript@5.0.0"),
+    ).not.toBeInTheDocument();
+    expect(
+      requiredActions.queryByText("custom-sdk@1.0.0"),
+    ).not.toBeInTheDocument();
+    expect(requiredActions.queryByText("python@dev")).not.toBeInTheDocument();
+
+    const nonActionDetails = within(screen.getByTestId("non-action-details"));
+    expect(
+      nonActionDetails.getByText("Details that do not require action"),
+    ).toBeInTheDocument();
+    expect(nonActionDetails.queryByText("untracked")).not.toBeInTheDocument();
+    expect(nonActionDetails.getByText("unknown@unknown")).toBeInTheDocument();
+    expect(nonActionDetails.getByText("pk-lf-raw-api")).toBeInTheDocument();
+    expect(nonActionDetails.getByText("javascript@5.0.0")).toBeInTheDocument();
+    expect(nonActionDetails.getByText("custom-sdk@1.0.0")).toBeInTheDocument();
+    expect(nonActionDetails.getByText("python@dev")).toBeInTheDocument();
+    expect(
+      nonActionDetails.getByText(
+        "Current, unknown with API keys, unsupported, and invalid SDK telemetry is shown for context only.",
+      ),
+    ).toBeInTheDocument();
+
     expect(screen.queryByText("backend worker")).not.toBeInTheDocument();
-    expect(screen.getAllByText("untracked").length).toBeGreaterThan(0);
+    expect(screen.queryByText("untracked")).not.toBeInTheDocument();
+    expect(screen.queryByText("No API key")).not.toBeInTheDocument();
     expect(
       screen.queryByText("unknown@unknown - No API key"),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("Upgrade")).toBeInTheDocument();
     expect(screen.getByText("Upgrade guide")).toHaveAttribute(
       "href",
       "https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4",
     );
-    expect(rechartsProps.bars).toHaveLength(2);
+    expect(screen.getAllByText("Due Nov 30, 2026").length).toBeGreaterThan(1);
+  });
+
+  it("shows the legacy export auto-switch consequence", () => {
+    renderCards({
+      legacyIntegrationSummary: {
+        legacyIntegrationCount: 2,
+        legacyIntegrations: {
+          posthog: true,
+          mixpanel: false,
+          blobStorage: true,
+        },
+      },
+    });
+
+    const requiredActions = within(screen.getByTestId("required-actions"));
+    expect(requiredActions.getByText("Legacy exports")).toBeInTheDocument();
+    expect(requiredActions.getByText("PostHog")).toBeInTheDocument();
+    expect(requiredActions.getByText("Blob Storage")).toBeInTheDocument();
+    expect(
+      requiredActions.getByText(
+        "After November 30, 2026, Langfuse will auto-switch legacy exports to the new exports. Switch earlier to validate downstream schemas.",
+      ),
+    ).toBeInTheDocument();
+    expect(requiredActions.getByText("Due Nov 30, 2026")).toBeInTheDocument();
+  });
+
+  it("shows all required sections with the migration deadline", () => {
+    renderCards({
+      traceLevelEvalCount: 1,
+      legacyApiUsage: [
+        {
+          time: "2026-06-30T04:00:00.000Z",
+          entrypoint: "publicapi: GET /api/public/traces",
+          count: 12,
+        },
+      ],
+      traceLevelEvalExecutions: [
+        {
+          time: "2026-06-30T04:00:00.000Z",
+          scoreName: "quality",
+          count: 4,
+        },
+      ],
+      legacyIntegrationSummary: {
+        legacyIntegrationCount: 1,
+        legacyIntegrations: {
+          posthog: false,
+          mixpanel: true,
+          blobStorage: false,
+        },
+      },
+      sdkUsage: {
+        bucketTimes: ["2026-06-30T04:00:00.000Z"],
+        rows: [
+          {
+            time: "2026-06-30T04:00:00.000Z",
+            sdkName: "python",
+            sdkVersion: "3.9.0",
+            publicKey: "pk-lf-old-python",
+            count: 5,
+            firstSeen: "2026-06-30T04:00:00.000Z",
+            lastSeen: "2026-06-30T04:00:00.000Z",
+            canonicalSdkName: "python",
+            latestMajor: 4,
+            major: 3,
+            upgradeStatus: "outdated_major",
+          },
+        ],
+      },
+    });
+
+    const requiredActions = within(screen.getByTestId("required-actions"));
+    expect(requiredActions.getByText("SDK upgrades")).toBeInTheDocument();
+    expect(requiredActions.getByText("Legacy public APIs")).toBeInTheDocument();
+    expect(requiredActions.getByText("Trace-level evals")).toBeInTheDocument();
+    expect(requiredActions.getByText("Legacy exports")).toBeInTheDocument();
+    expect(requiredActions.getAllByText("Due Nov 30, 2026")).toHaveLength(4);
+  });
+
+  it("shows a success audit when no required changes exist", () => {
+    renderCards();
+
+    expect(
+      screen.getByText("No required v4 migration changes detected"),
+    ).toBeInTheDocument();
+    const requiredActions = within(screen.getByTestId("required-actions"));
+    expect(requiredActions.queryByText("SDK upgrades")).not.toBeInTheDocument();
+    expect(
+      requiredActions.queryByText("Legacy public APIs"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Details that do not require action"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("No SDK usage detected in this range."),
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/features/v4/components/V4MigrationProjectCards.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.tsx
@@ -132,6 +132,12 @@ const STACKED_CHART_COLORS = [
   "hsl(var(--chart-3))",
 ] as const;
 
+const formatCountLabel = (
+  count: number,
+  singular: string,
+  plural = `${singular}s`,
+) => `${numberFormatter(count, 0)} ${count === 1 ? singular : plural}`;
+
 export const INTEGRATION_LINKS = [
   {
     key: "posthog",
@@ -546,7 +552,7 @@ const NonActionDetails = ({
             </Badge>
           </span>
         </AccordionTrigger>
-        <AccordionContent forceMount className="flex flex-col gap-5 pt-1">
+        <AccordionContent className="flex flex-col gap-5 pt-1">
           {sdkUsageSeries.length ? (
             <section className="flex flex-col gap-2">
               <div>
@@ -1190,7 +1196,7 @@ export const V4MigrationProjectCards = ({
         ) : legacyApiSeries.length ? (
           <AuditSection
             title="Legacy public APIs"
-            countLabel={`${numberFormatter(legacyApiSeries.length, 0)} routes`}
+            countLabel={formatCountLabel(legacyApiSeries.length, "route")}
             consequence="Replace legacy public API reads with v4-compatible APIs before the migration deadline."
             detailsHref={`/project/${projectId}/settings/api-keys`}
           >
@@ -1239,10 +1245,10 @@ export const V4MigrationProjectCards = ({
         ) : legacyIntegrationLinks.length ? (
           <AuditSection
             title="Legacy exports"
-            countLabel={`${numberFormatter(
+            countLabel={formatCountLabel(
               legacyIntegrationLinks.length,
-              0,
-            )} integrations`}
+              "integration",
+            )}
             consequence={V4_LEGACY_EXPORT_AUTO_SWITCH_COPY}
             detailsHref={`/project/${projectId}/settings/integrations`}
           >

--- a/web/src/features/v4/components/V4MigrationProjectCards.tsx
+++ b/web/src/features/v4/components/V4MigrationProjectCards.tsx
@@ -1,11 +1,24 @@
 import { useMemo, type ReactNode } from "react";
 import Link from "next/link";
 import { format } from "date-fns";
-import { ChevronRight, ExternalLink } from "lucide-react";
+import {
+  ChevronRight,
+  CircleCheck,
+  Clock,
+  ExternalLink,
+  Info,
+  TriangleAlert,
+} from "lucide-react";
 import { Bar, BarChart, XAxis, YAxis } from "recharts";
 import { Badge } from "@/src/components/ui/badge";
 import { Alert, AlertDescription } from "@/src/components/ui/alert";
 import { Skeleton } from "@/src/components/ui/skeleton";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/src/components/ui/accordion";
 import {
   ChartContainer,
   ChartTooltip,
@@ -15,6 +28,8 @@ import {
 import { DashboardCard } from "@/src/features/dashboard/components/cards/DashboardCard";
 import { encodeFiltersGeneric } from "@/src/features/filters/lib/filter-query-encoding";
 import {
+  V4_LEGACY_EXPORT_AUTO_SWITCH_COPY,
+  V4_MIGRATION_DEADLINE_SHORT_LABEL,
   getV4MigrationStatus,
   normalizeLegacyApiEntrypoint,
 } from "@/src/features/v4/utils";
@@ -395,13 +410,13 @@ const Notice = ({ children }: { children: ReactNode }) => (
 );
 
 const SectionLoading = () => (
-  <div className="rounded-md border p-3">
+  <div className="border-dark-yellow/30 grid gap-3 border-l-2 py-1 pl-4">
     <div className="mb-3 flex items-center justify-between gap-3">
       <Skeleton className="h-4 w-32" />
       <Skeleton className="h-3 w-20" />
     </div>
     <Skeleton className="h-28 w-full" />
-    <div className="mt-3 flex gap-3 border-t pt-3">
+    <div className="flex gap-3">
       <Skeleton className="h-3 w-24" />
       <Skeleton className="h-3 w-32" />
       <Skeleton className="h-3 w-20" />
@@ -439,36 +454,135 @@ const InlineLink = ({
   );
 };
 
-const Section = ({
+const DeadlineBadge = () => (
+  <Badge variant="warning" className="inline-flex items-center gap-1">
+    <Clock className="h-3 w-3" />
+    {V4_MIGRATION_DEADLINE_SHORT_LABEL}
+  </Badge>
+);
+
+const AuditSection = ({
   title,
-  count,
-  isCountLoading,
+  countLabel,
+  consequence,
   detailsHref,
   children,
 }: {
   title: string;
-  count: number;
-  isCountLoading?: boolean;
+  countLabel: string;
+  consequence: string;
   detailsHref: ProductHref;
   children: ReactNode;
 }) => (
-  <section>
-    <div className="flex items-center justify-between gap-3">
-      <h3 className="text-sm font-medium">{title}</h3>
-      <div className="flex items-center gap-2">
-        {isCountLoading ? (
-          <Skeleton className="h-5 w-8 rounded-full" />
-        ) : (
+  <section className="border-dark-yellow/60 grid gap-3 border-l-2 py-1 pl-4">
+    <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <TriangleAlert className="text-dark-yellow h-4 w-4 shrink-0" />
+          <h3 className="text-sm font-semibold">{title}</h3>
           <Badge variant="outline-solid" size="sm">
-            {numberFormatter(count, 0)}
+            {countLabel}
           </Badge>
-        )}
+          <DeadlineBadge />
+        </div>
+        <p className="text-muted-foreground mt-1 text-sm">{consequence}</p>
+      </div>
+      <div className="shrink-0">
         <InlineLink href={detailsHref}>Go to details</InlineLink>
       </div>
     </div>
-    <div className="mt-3 flex flex-col gap-2">{children}</div>
+    <div className="flex flex-col gap-2">{children}</div>
   </section>
 );
+
+const SuccessAudit = () => (
+  <div className="border-light-green flex items-start gap-3 border-l-2 py-2 pl-4">
+    <CircleCheck className="text-dark-green mt-0.5 h-4 w-4 shrink-0" />
+    <div className="min-w-0">
+      <div className="text-sm font-semibold">
+        No required v4 migration changes detected
+      </div>
+      <div className="text-muted-foreground mt-0.5 text-sm">
+        The selected range has no required customer action for v4.
+      </div>
+    </div>
+  </div>
+);
+
+const PassedCheckRow = ({ children }: { children: ReactNode }) => (
+  <div className="flex items-start gap-2 py-1.5 text-sm">
+    <CircleCheck className="text-dark-green h-4 w-4 shrink-0" />
+    <span className="min-w-0">{children}</span>
+  </div>
+);
+
+const NonActionDetails = ({
+  bucketTimes,
+  sdkUsageSeries,
+  passedChecks,
+}: {
+  bucketTimes: string[];
+  sdkUsageSeries: SdkUsageSeries[];
+  passedChecks: ReactNode[];
+}) => {
+  if (sdkUsageSeries.length === 0 && passedChecks.length === 0) return null;
+
+  return (
+    <Accordion
+      type="single"
+      collapsible
+      className="pt-1"
+      data-testid="non-action-details"
+    >
+      <AccordionItem value="details" className="border-b-0">
+        <AccordionTrigger className="py-3 text-sm hover:no-underline">
+          <span className="flex min-w-0 items-center gap-2">
+            <Info className="text-muted-foreground h-4 w-4 shrink-0" />
+            <span className="font-medium">
+              Details that do not require action
+            </span>
+            <Badge variant="outline-solid" size="sm">
+              {numberFormatter(sdkUsageSeries.length + passedChecks.length, 0)}
+            </Badge>
+          </span>
+        </AccordionTrigger>
+        <AccordionContent forceMount className="flex flex-col gap-5 pt-1">
+          {sdkUsageSeries.length ? (
+            <section className="flex flex-col gap-2">
+              <div>
+                <h4 className="text-sm font-medium">SDK telemetry</h4>
+                <p className="text-muted-foreground text-xs">
+                  Current, unknown with API keys, unsupported, and invalid SDK
+                  telemetry is shown for context only.
+                </p>
+              </div>
+              <SdkUsageDetails
+                bucketTimes={bucketTimes}
+                series={sdkUsageSeries}
+              />
+            </section>
+          ) : null}
+          {passedChecks.length ? (
+            <section className="flex flex-col gap-2">
+              <div>
+                <h4 className="text-sm font-medium">Passed checks</h4>
+                <p className="text-muted-foreground text-xs">
+                  These checks did not produce required customer work in the
+                  selected range.
+                </p>
+              </div>
+              <div className="grid gap-1">
+                {passedChecks.map((check, index) => (
+                  <PassedCheckRow key={index}>{check}</PassedCheckRow>
+                ))}
+              </div>
+            </section>
+          ) : null}
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};
 
 const getStackedChartSeries = (
   series: UsageSeries[],
@@ -588,7 +702,7 @@ export const UsageStackedBarOverview = ({
   }
 
   return (
-    <div className="rounded-md border p-3">
+    <div className="py-2">
       <div className="mb-2 flex items-center justify-between gap-3">
         <span className="text-sm font-medium">Usage over time</span>
         <span className="text-muted-foreground text-xs">
@@ -644,7 +758,7 @@ export const UsageStackedBarOverview = ({
           ))}
         </BarChart>
       </ChartContainer>
-      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 border-t pt-3">
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2">
         {chartSeries.map((item) => (
           <div
             key={item.key}
@@ -678,15 +792,15 @@ const SdkUsageDetails = ({
   const total = series.reduce((sum, item) => sum + item.total, 0);
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-3">
       <UsageStackedBarOverview
         bucketTimes={bucketTimes}
         series={series}
         valueLabel="records"
         seriesLimit={null}
       />
-      <div className="overflow-hidden rounded-md border">
-        <div className="bg-muted/30 text-muted-foreground hidden grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)_7rem_7rem] gap-3 border-b px-3 py-2 text-xs font-medium md:grid">
+      <div className="overflow-hidden">
+        <div className="text-muted-foreground hidden grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)_7rem_7rem] gap-3 border-b py-2 text-xs font-medium md:grid">
           <span>SDK</span>
           <span>API key</span>
           <span className="text-right">Last seen</span>
@@ -708,7 +822,7 @@ const SdkUsageDetails = ({
             return (
               <div
                 key={getSdkUsageSeriesKey(item)}
-                className="grid gap-3 border-b px-3 py-2 last:border-b-0 md:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)_7rem_7rem] md:items-center"
+                className="grid gap-3 border-b py-2 last:border-b-0 md:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)_7rem_7rem] md:items-center"
               >
                 <div className="min-w-0">
                   <div className="flex min-w-0 items-center gap-2">
@@ -765,7 +879,7 @@ const SdkUsageDetails = ({
             );
           })}
         </div>
-        <div className="bg-muted/20 text-muted-foreground border-t px-3 py-2 text-right text-xs">
+        <div className="text-muted-foreground pt-2 text-right text-xs">
           {numberFormatter(total, 0, 2)} records
         </div>
       </div>
@@ -786,7 +900,7 @@ const ActionRow = ({
   total?: number;
   usageLabel?: string;
 }) => (
-  <div className="grid gap-3 rounded-md border px-3 py-2 md:grid-cols-[minmax(0,1fr)_8rem] md:items-center">
+  <div className="grid gap-3 border-b py-2 last:border-b-0 md:grid-cols-[minmax(0,1fr)_8rem] md:items-center">
     <div className="min-w-0">
       <div
         className={cn("truncate text-sm font-medium", titleClassName)}
@@ -899,10 +1013,19 @@ export const V4MigrationProjectCards = ({
       }),
     [sdkUsageBucketTimes, sdkUsageRows],
   );
-  const outdatedSdkUsageSeries = useMemo(
+  const requiredSdkUsageSeries = useMemo(
     () =>
       sdkUsageSeries.filter(
         (series) => series.upgradeStatus === "outdated_major",
+      ),
+    [sdkUsageSeries],
+  );
+  const nonActionSdkUsageSeries = useMemo(
+    () =>
+      sdkUsageSeries.filter(
+        (series) =>
+          series.upgradeStatus !== "outdated_major" &&
+          !isUntrackedSdkUsage(series),
       ),
     [sdkUsageSeries],
   );
@@ -928,7 +1051,7 @@ export const V4MigrationProjectCards = ({
     legacyApiSeries.length +
     traceLevelEvalCount +
     legacyIntegrationLinks.length +
-    outdatedSdkUsageSeries.length;
+    requiredSdkUsageSeries.length;
   const migrationStatus = getV4MigrationStatus(activeTaskCount);
   const isSummaryLoading =
     isLegacyIntegrationSummaryLoading || isTraceLevelEvalSummaryLoading;
@@ -936,10 +1059,66 @@ export const V4MigrationProjectCards = ({
     isLegacyApiUsageLoading ||
     isTraceLevelEvalExecutionsLoading ||
     isSdkUsageLoading;
+  const passedChecks = useMemo(() => {
+    const checks: ReactNode[] = [];
+
+    if (!isLegacyApiUsageLoading && !hasLegacyApiUsageError) {
+      if (legacyApiSeries.length === 0) {
+        checks.push("No legacy public API usage in this range.");
+      }
+    }
+
+    if (!isSdkUsageLoading && !hasSdkUsageError) {
+      if (requiredSdkUsageSeries.length === 0) {
+        checks.push(
+          sdkUsageSeries.length
+            ? "No outdated major SDK usage detected."
+            : "No SDK usage detected in this range.",
+        );
+      }
+    }
+
+    if (
+      !isTraceLevelEvalSummaryLoading &&
+      !isTraceLevelEvalExecutionsLoading &&
+      !hasTraceLevelEvalSummaryError &&
+      !hasTraceLevelEvalExecutionsError &&
+      traceLevelEvalCount === 0
+    ) {
+      checks.push("No trace-level evals detected.");
+    }
+
+    if (
+      !isLegacyIntegrationSummaryLoading &&
+      !hasLegacyIntegrationSummaryError &&
+      legacyIntegrationLinks.length === 0
+    ) {
+      checks.push("No legacy integration exports detected.");
+    }
+
+    return checks;
+  }, [
+    hasLegacyApiUsageError,
+    hasLegacyIntegrationSummaryError,
+    hasSdkUsageError,
+    hasTraceLevelEvalExecutionsError,
+    hasTraceLevelEvalSummaryError,
+    isLegacyApiUsageLoading,
+    isLegacyIntegrationSummaryLoading,
+    isSdkUsageLoading,
+    isTraceLevelEvalExecutionsLoading,
+    isTraceLevelEvalSummaryLoading,
+    legacyApiSeries.length,
+    legacyIntegrationLinks.length,
+    requiredSdkUsageSeries.length,
+    sdkUsageSeries.length,
+    traceLevelEvalCount,
+  ]);
 
   return (
     <DashboardCard
-      title="Required changes"
+      className="border-0 bg-transparent shadow-none"
+      title="V4 migration audit"
       description={
         isSummaryLoading
           ? "Loading V4 migration data."
@@ -957,7 +1136,7 @@ export const V4MigrationProjectCards = ({
       isLoading={isSummaryLoading}
       headerRight={
         isSummaryLoading ? undefined : (
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-end gap-2">
             <InlineLink href={V4_DOCS_LINK.href} external>
               {V4_DOCS_LINK.label}
             </InlineLink>
@@ -975,103 +1154,121 @@ export const V4MigrationProjectCards = ({
                   ? "Loading"
                   : migrationStatus.label}
             </Badge>
+            <DeadlineBadge />
           </div>
         )
       }
+      headerClassName="px-0 pt-0"
+      cardContentClassName="gap-5 px-0 pb-0"
     >
-      <Section
-        title="Legacy public APIs"
-        count={legacyApiSeries.length}
-        isCountLoading={isLegacyApiUsageLoading}
-        detailsHref={`/project/${projectId}/settings/api-keys`}
-      >
+      <div className="flex flex-col gap-5" data-testid="required-actions">
+        {isSdkUsageLoading ? (
+          <SectionLoading />
+        ) : hasSdkUsageError ? (
+          <Notice>Failed to load SDK usage.</Notice>
+        ) : requiredSdkUsageSeries.length ? (
+          <AuditSection
+            title="SDK upgrades"
+            countLabel={`${numberFormatter(
+              requiredSdkUsageSeries.length,
+              0,
+            )} outdated`}
+            consequence="Upgrade all SDKs that are not on the latest major version before the migration deadline."
+            detailsHref={`/project/${projectId}/settings/api-keys`}
+          >
+            <SdkUsageDetails
+              bucketTimes={sdkUsageBucketTimes}
+              series={requiredSdkUsageSeries}
+            />
+          </AuditSection>
+        ) : null}
+
         {isLegacyApiUsageLoading ? (
           <SectionLoading />
         ) : hasLegacyApiUsageError ? (
           <Notice>Failed to load public API usage.</Notice>
         ) : legacyApiSeries.length ? (
-          <UsageStackedBarOverview
-            bucketTimes={legacyApiBucketTimes}
-            series={legacyApiSeries}
-            valueLabel="calls"
-          />
-        ) : (
-          <Notice>No legacy public API usage in this range.</Notice>
-        )}
-      </Section>
+          <AuditSection
+            title="Legacy public APIs"
+            countLabel={`${numberFormatter(legacyApiSeries.length, 0)} routes`}
+            consequence="Replace legacy public API reads with v4-compatible APIs before the migration deadline."
+            detailsHref={`/project/${projectId}/settings/api-keys`}
+          >
+            <UsageStackedBarOverview
+              bucketTimes={legacyApiBucketTimes}
+              series={legacyApiSeries}
+              valueLabel="calls"
+            />
+          </AuditSection>
+        ) : null}
 
-      <Section
-        title="SDK usage"
-        count={sdkUsageSeries.length}
-        isCountLoading={isSdkUsageLoading}
-        detailsHref={`/project/${projectId}/settings/api-keys`}
-      >
-        {isSdkUsageLoading ? (
-          <SectionLoading />
-        ) : hasSdkUsageError ? (
-          <Notice>Failed to load SDK usage.</Notice>
-        ) : sdkUsageSeries.length ? (
-          <SdkUsageDetails
-            bucketTimes={sdkUsageBucketTimes}
-            series={sdkUsageSeries}
-          />
-        ) : (
-          <Notice>No SDK usage detected in this range.</Notice>
-        )}
-      </Section>
-
-      <Section
-        title="Trace-level evals"
-        count={traceLevelEvalCount}
-        isCountLoading={isTraceLevelEvalSummaryLoading}
-        detailsHref={traceLevelEvalsHref}
-      >
         {isTraceLevelEvalSummaryLoading || isTraceLevelEvalExecutionsLoading ? (
           <SectionLoading />
         ) : hasTraceLevelEvalSummaryError ||
           hasTraceLevelEvalExecutionsError ? (
           <Notice>Failed to load trace-level eval data.</Notice>
-        ) : evalExecutionSeries.length ? (
-          <UsageStackedBarOverview
-            bucketTimes={evalExecutionBucketTimes}
-            series={evalExecutionSeries}
-            valueLabel="executions"
-          />
         ) : traceLevelEvalCount > 0 ? (
-          <ActionRow
-            title={`${numberFormatter(
-              traceLevelEvalCount,
-              0,
-            )} configured trace-level evals`}
-            detail="No executions found in the selected range."
-          />
-        ) : (
-          <Notice>No trace-level evals detected.</Notice>
-        )}
-      </Section>
+          <AuditSection
+            title="Trace-level evals"
+            countLabel={`${numberFormatter(traceLevelEvalCount, 0)} configured`}
+            consequence="Move trace-level evals to supported v4 evaluation workflows before the migration deadline."
+            detailsHref={traceLevelEvalsHref}
+          >
+            {evalExecutionSeries.length ? (
+              <UsageStackedBarOverview
+                bucketTimes={evalExecutionBucketTimes}
+                series={evalExecutionSeries}
+                valueLabel="executions"
+              />
+            ) : (
+              <ActionRow
+                title={`${numberFormatter(
+                  traceLevelEvalCount,
+                  0,
+                )} configured trace-level evals`}
+                detail="No executions found in the selected range."
+              />
+            )}
+          </AuditSection>
+        ) : null}
 
-      <Section
-        title="Integrations"
-        count={legacyIntegrationLinks.length}
-        isCountLoading={isLegacyIntegrationSummaryLoading}
-        detailsHref={`/project/${projectId}/settings/integrations`}
-      >
         {isLegacyIntegrationSummaryLoading ? (
           <SectionLoading />
         ) : hasLegacyIntegrationSummaryError ? (
           <Notice>Failed to load integration data.</Notice>
         ) : legacyIntegrationLinks.length ? (
-          legacyIntegrationLinks.map((integration) => (
-            <ActionRow
-              key={integration.key}
-              title={integration.label}
-              detail="Legacy traces and observations export is enabled."
-            />
-          ))
-        ) : (
-          <Notice>No legacy integration exports detected.</Notice>
-        )}
-      </Section>
+          <AuditSection
+            title="Legacy exports"
+            countLabel={`${numberFormatter(
+              legacyIntegrationLinks.length,
+              0,
+            )} integrations`}
+            consequence={V4_LEGACY_EXPORT_AUTO_SWITCH_COPY}
+            detailsHref={`/project/${projectId}/settings/integrations`}
+          >
+            {legacyIntegrationLinks.map((integration) => (
+              <ActionRow
+                key={integration.key}
+                title={integration.label}
+                detail="Legacy traces and observations export is enabled."
+              />
+            ))}
+          </AuditSection>
+        ) : null}
+
+        {!isSummaryLoading &&
+        !isTimelineLoading &&
+        !hasAnyError &&
+        activeTaskCount === 0 ? (
+          <SuccessAudit />
+        ) : null}
+      </div>
+
+      <NonActionDetails
+        bucketTimes={sdkUsageBucketTimes}
+        sdkUsageSeries={nonActionSdkUsageSeries}
+        passedChecks={passedChecks}
+      />
     </DashboardCard>
   );
 };

--- a/web/src/features/v4/utils.clienttest.ts
+++ b/web/src/features/v4/utils.clienttest.ts
@@ -1,6 +1,8 @@
 import {
   countLegacyApiEntrypoints,
+  getV4ProjectRequiredActionCount,
   normalizeLegacyApiEntrypoint,
+  splitV4ProjectsByRequiredChanges,
 } from "./utils";
 
 describe("normalizeLegacyApiEntrypoint", () => {
@@ -26,5 +28,36 @@ describe("countLegacyApiEntrypoints", () => {
         { entrypoint: "publicapi: POST /api/public/scores" },
       ]),
     ).toBe(2);
+  });
+});
+
+describe("getV4ProjectRequiredActionCount", () => {
+  it("counts all customer-required v4 migration action categories", () => {
+    expect(
+      getV4ProjectRequiredActionCount({
+        traceLevelEvalCount: 2,
+        legacyIntegrationCount: 1,
+        legacyApiEntrypointCount: 3,
+        outdatedSdkUsageSeriesCount: 4,
+      }),
+    ).toBe(10);
+  });
+});
+
+describe("splitV4ProjectsByRequiredChanges", () => {
+  it("keeps required-change projects separate from migrated projects", () => {
+    expect(
+      splitV4ProjectsByRequiredChanges([
+        { projectId: "needs-work", requiredActionCount: 2 },
+        { projectId: "ready", requiredActionCount: 0 },
+      ]),
+    ).toEqual({
+      projectsWithRequiredChanges: [
+        { projectId: "needs-work", requiredActionCount: 2 },
+      ],
+      projectsWithoutRequiredChanges: [
+        { projectId: "ready", requiredActionCount: 0 },
+      ],
+    });
   });
 });

--- a/web/src/features/v4/utils.ts
+++ b/web/src/features/v4/utils.ts
@@ -15,6 +15,10 @@ export const V4_TIME_RANGE_PRESETS = [
 ] as const;
 
 export const MAX_V4_TIMELINE_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
+export const V4_MIGRATION_DEADLINE_LABEL = "November 30, 2026";
+export const V4_MIGRATION_DEADLINE_SHORT_LABEL = "Due Nov 30, 2026";
+export const V4_LEGACY_EXPORT_AUTO_SWITCH_COPY =
+  "After November 30, 2026, Langfuse will auto-switch legacy exports to the new exports. Switch earlier to validate downstream schemas.";
 
 export const getV4MigrationStatus = (migrationItemCount: number) =>
   migrationItemCount > 0
@@ -42,6 +46,38 @@ export const countLegacyApiEntrypoints = (
 
   return entrypoints.size;
 };
+
+export const getV4ProjectRequiredActionCount = ({
+  traceLevelEvalCount,
+  legacyIntegrationCount,
+  legacyApiEntrypointCount,
+  outdatedSdkUsageSeriesCount,
+}: {
+  traceLevelEvalCount: number;
+  legacyIntegrationCount: number;
+  legacyApiEntrypointCount: number;
+  outdatedSdkUsageSeriesCount: number;
+}): number =>
+  traceLevelEvalCount +
+  legacyIntegrationCount +
+  legacyApiEntrypointCount +
+  outdatedSdkUsageSeriesCount;
+
+export const splitV4ProjectsByRequiredChanges = <
+  T extends { requiredActionCount: number },
+>(
+  projects: T[],
+): {
+  projectsWithRequiredChanges: T[];
+  projectsWithoutRequiredChanges: T[];
+} => ({
+  projectsWithRequiredChanges: projects.filter(
+    (project) => project.requiredActionCount > 0,
+  ),
+  projectsWithoutRequiredChanges: projects.filter(
+    (project) => project.requiredActionCount === 0,
+  ),
+});
 
 export const getCappedAbsoluteTimeRange = (
   timeRange: TimeRange,

--- a/web/src/pages/organization/[organizationId]/v4/index.tsx
+++ b/web/src/pages/organization/[organizationId]/v4/index.tsx
@@ -15,6 +15,12 @@ import { Alert, AlertDescription } from "@/src/components/ui/alert";
 import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/src/components/ui/accordion";
+import {
   Table,
   TableBody,
   TableCell,
@@ -31,8 +37,11 @@ import { DashboardCard } from "@/src/features/dashboard/components/cards/Dashboa
 import {
   countLegacyApiEntrypoints,
   getCappedAbsoluteTimeRange,
+  getV4ProjectRequiredActionCount,
   getV4MigrationStatus,
   MAX_V4_TIMELINE_RANGE_MS,
+  splitV4ProjectsByRequiredChanges,
+  V4_MIGRATION_DEADLINE_SHORT_LABEL,
   V4_TIME_RANGE_PRESETS,
 } from "@/src/features/v4/utils";
 import { cn } from "@/src/utils/tailwind";
@@ -58,6 +67,14 @@ type ProjectSdkUsageSummary = {
   outdatedSdkUsageSeriesCount: number;
 };
 
+type ProjectReadinessRow = ProjectSummary & {
+  traceLevelEvalCount: number;
+  legacyApiEntrypointCount: number;
+  legacyApiUsageCount: number;
+  outdatedSdkUsageSeriesCount: number;
+  requiredActionCount: number;
+};
+
 const groupByProjectId = <T extends { projectId: string }>(
   rows: T[] | undefined,
 ): Map<string, T[]> => {
@@ -76,16 +93,130 @@ const sumLegacyApiUsage = (
   rows: Array<{ count: number }> | undefined,
 ): number => rows?.reduce((total, row) => total + row.count, 0) ?? 0;
 
-const getProjectActionCount = (
-  project: ProjectSummary,
-  traceLevelEvalCount: number,
-  legacyApiEntrypointCount: number,
-  outdatedSdkUsageSeriesCount: number,
-): number =>
-  traceLevelEvalCount +
-  project.legacyIntegrationCount +
-  legacyApiEntrypointCount +
-  outdatedSdkUsageSeriesCount;
+const ProjectReadinessTable = ({
+  rows,
+  selectedProjectId,
+  onSelectProject,
+  isStatusPending,
+  hasStatusError,
+  isTraceLevelEvalSummaryLoading,
+  hasTraceLevelEvalSummaryError,
+  isLegacyApiUsageLoading,
+  hasLegacyApiUsageError,
+  isSdkUsageLoading,
+  hasSdkUsageError,
+}: {
+  rows: ProjectReadinessRow[];
+  selectedProjectId: string | undefined;
+  onSelectProject: (projectId: string) => void;
+  isStatusPending: boolean;
+  hasStatusError: boolean;
+  isTraceLevelEvalSummaryLoading: boolean;
+  hasTraceLevelEvalSummaryError: boolean;
+  isLegacyApiUsageLoading: boolean;
+  hasLegacyApiUsageError: boolean;
+  isSdkUsageLoading: boolean;
+  hasSdkUsageError: boolean;
+}) => (
+  <div className="overflow-x-auto">
+    <Table className="min-w-[68rem] table-auto">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Project</TableHead>
+          <TableHead className="w-28">Status</TableHead>
+          <TableHead className="w-32 text-right">Trace evals</TableHead>
+          <TableHead className="w-32 text-right">Integrations</TableHead>
+          <TableHead className="w-44 text-right">Public API</TableHead>
+          <TableHead className="w-32 text-right">SDKs</TableHead>
+          <TableHead className="w-32" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((project) => {
+          const migrationStatus =
+            isStatusPending || hasStatusError
+              ? null
+              : getV4MigrationStatus(project.requiredActionCount);
+          const isSelected = selectedProjectId === project.projectId;
+
+          return (
+            <TableRow
+              key={project.projectId}
+              className={cn(isSelected && "bg-muted/40")}
+            >
+              <TableCell density="comfortable">
+                <Link
+                  href={`/project/${project.projectId}`}
+                  className="font-medium hover:underline"
+                >
+                  {project.projectName}
+                </Link>
+              </TableCell>
+              <TableCell density="comfortable">
+                <Badge
+                  variant={migrationStatus?.badgeVariant ?? "outline-solid"}
+                  size="sm"
+                >
+                  {hasStatusError
+                    ? "Unavailable"
+                    : (migrationStatus?.label ?? "Loading")}
+                </Badge>
+              </TableCell>
+              <TableCell density="comfortable" className="text-right">
+                {isTraceLevelEvalSummaryLoading
+                  ? "Loading..."
+                  : hasTraceLevelEvalSummaryError
+                    ? "Failed"
+                    : numberFormatter(project.traceLevelEvalCount, 0)}
+              </TableCell>
+              <TableCell density="comfortable" className="text-right">
+                {numberFormatter(project.legacyIntegrationCount, 0)}
+              </TableCell>
+              <TableCell density="comfortable" className="text-right">
+                {isLegacyApiUsageLoading
+                  ? "Loading..."
+                  : hasLegacyApiUsageError
+                    ? "Failed"
+                    : project.legacyApiEntrypointCount > 0
+                      ? `${numberFormatter(
+                          project.legacyApiEntrypointCount,
+                          0,
+                        )} routes - ${numberFormatter(
+                          project.legacyApiUsageCount,
+                          0,
+                          2,
+                        )} calls`
+                      : "0"}
+              </TableCell>
+              <TableCell density="comfortable" className="text-right">
+                {isSdkUsageLoading
+                  ? "Loading..."
+                  : hasSdkUsageError
+                    ? "Failed"
+                    : project.outdatedSdkUsageSeriesCount > 0
+                      ? `${numberFormatter(
+                          project.outdatedSdkUsageSeriesCount,
+                          0,
+                        )} outdated`
+                      : "0"}
+              </TableCell>
+              <TableCell density="comfortable">
+                <Button
+                  variant={isSelected ? "secondary" : "ghost"}
+                  size="sm"
+                  onClick={() => onSelectProject(project.projectId)}
+                  className="w-full"
+                >
+                  Details
+                </Button>
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  </div>
+);
 
 export default function OrganizationV4Page() {
   const router = useRouter();
@@ -167,76 +298,105 @@ export default function OrganizationV4Page() {
       },
     );
 
+  const projects = useMemo<ProjectSummary[]>(
+    () => summaryByProject.data?.projects ?? [],
+    [summaryByProject.data?.projects],
+  );
+  const legacyApiUsageRows = useMemo<ProjectScopedLegacyApiUsageSummary[]>(
+    () => legacyApiUsageSummaryByProject.data ?? [],
+    [legacyApiUsageSummaryByProject.data],
+  );
+  const traceLevelEvalRows = useMemo<ProjectTraceLevelEvalSummary[]>(
+    () => traceLevelEvalSummaryByProject.data ?? [],
+    [traceLevelEvalSummaryByProject.data],
+  );
+  const sdkUsageRows = useMemo<ProjectSdkUsageSummary[]>(
+    () => sdkUsageSummaryByProject.data ?? [],
+    [sdkUsageSummaryByProject.data],
+  );
+
   const legacyApiUsageRowsByProjectId = useMemo(
     () =>
-      groupByProjectId<ProjectScopedLegacyApiUsageSummary>(
-        legacyApiUsageSummaryByProject.data,
-      ),
-    [legacyApiUsageSummaryByProject.data],
+      groupByProjectId<ProjectScopedLegacyApiUsageSummary>(legacyApiUsageRows),
+    [legacyApiUsageRows],
   );
   const traceLevelEvalCountsByProjectId = useMemo(
     () =>
       new Map(
-        (traceLevelEvalSummaryByProject.data ?? []).map(
-          (row: ProjectTraceLevelEvalSummary) => [
-            row.projectId,
-            row.traceLevelEvalCount,
-          ],
-        ),
+        traceLevelEvalRows.map((row) => [
+          row.projectId,
+          row.traceLevelEvalCount,
+        ]),
       ),
-    [traceLevelEvalSummaryByProject.data],
+    [traceLevelEvalRows],
   );
   const outdatedSdkUsageSeriesCountsByProjectId = useMemo(
     () =>
       new Map(
-        (sdkUsageSummaryByProject.data ?? []).map(
-          (row: ProjectSdkUsageSummary) => [
-            row.projectId,
-            row.outdatedSdkUsageSeriesCount,
-          ],
-        ),
+        sdkUsageRows.map((row) => [
+          row.projectId,
+          row.outdatedSdkUsageSeriesCount,
+        ]),
       ),
-    [sdkUsageSummaryByProject.data],
+    [sdkUsageRows],
   );
 
-  const projects = useMemo(
+  const projectReadinessRows = useMemo(
     () =>
-      [...(summaryByProject.data?.projects ?? [])].sort((a, b) => {
-        const bActionCount = getProjectActionCount(
-          b,
-          traceLevelEvalCountsByProjectId.get(b.projectId) ?? 0,
-          countLegacyApiEntrypoints(
-            legacyApiUsageRowsByProjectId.get(b.projectId),
-          ),
-          outdatedSdkUsageSeriesCountsByProjectId.get(b.projectId) ?? 0,
-        );
-        const aActionCount = getProjectActionCount(
-          a,
-          traceLevelEvalCountsByProjectId.get(a.projectId) ?? 0,
-          countLegacyApiEntrypoints(
-            legacyApiUsageRowsByProjectId.get(a.projectId),
-          ),
-          outdatedSdkUsageSeriesCountsByProjectId.get(a.projectId) ?? 0,
-        );
+      projects
+        .map((project): ProjectReadinessRow => {
+          const legacyApiRows = legacyApiUsageRowsByProjectId.get(
+            project.projectId,
+          );
+          const traceLevelEvalCount =
+            traceLevelEvalCountsByProjectId.get(project.projectId) ?? 0;
+          const legacyApiEntrypointCount =
+            countLegacyApiEntrypoints(legacyApiRows);
+          const outdatedSdkUsageSeriesCount =
+            outdatedSdkUsageSeriesCountsByProjectId.get(project.projectId) ?? 0;
+          const requiredActionCount = getV4ProjectRequiredActionCount({
+            traceLevelEvalCount,
+            legacyIntegrationCount: project.legacyIntegrationCount,
+            legacyApiEntrypointCount,
+            outdatedSdkUsageSeriesCount,
+          });
 
-        if (bActionCount !== aActionCount) return bActionCount - aActionCount;
-        return a.projectName.localeCompare(b.projectName);
-      }),
+          return {
+            ...project,
+            traceLevelEvalCount,
+            legacyApiEntrypointCount,
+            legacyApiUsageCount: sumLegacyApiUsage(legacyApiRows),
+            outdatedSdkUsageSeriesCount,
+            requiredActionCount,
+          };
+        })
+        .sort((a, b) => {
+          if (b.requiredActionCount !== a.requiredActionCount) {
+            return b.requiredActionCount - a.requiredActionCount;
+          }
+          return a.projectName.localeCompare(b.projectName);
+        }),
     [
-      summaryByProject.data?.projects,
+      projects,
       legacyApiUsageRowsByProjectId,
       outdatedSdkUsageSeriesCountsByProjectId,
       traceLevelEvalCountsByProjectId,
     ],
   );
+  const { projectsWithRequiredChanges, projectsWithoutRequiredChanges } =
+    useMemo(
+      () => splitV4ProjectsByRequiredChanges(projectReadinessRows),
+      [projectReadinessRows],
+    );
   const [selectedProjectId, setSelectedProjectId] = useState<
     string | undefined
   >();
   const selectedProject = useMemo(
     () =>
-      projects.find((project) => project.projectId === selectedProjectId) ??
-      projects[0],
-    [projects, selectedProjectId],
+      projectReadinessRows.find(
+        (project) => project.projectId === selectedProjectId,
+      ) ?? projectReadinessRows[0],
+    [projectReadinessRows, selectedProjectId],
   );
 
   const selectedProjectLegacyApiUsage =
@@ -293,32 +453,18 @@ export default function OrganizationV4Page() {
   );
 
   const migrationSummary = useMemo(() => {
-    return projects.reduce(
+    return projectReadinessRows.reduce(
       (summary, project) => {
-        const legacyApiRows = legacyApiUsageRowsByProjectId.get(
-          project.projectId,
-        );
-        const actionCount = getProjectActionCount(
-          project,
-          traceLevelEvalCountsByProjectId.get(project.projectId) ?? 0,
-          countLegacyApiEntrypoints(legacyApiRows),
-          outdatedSdkUsageSeriesCountsByProjectId.get(project.projectId) ?? 0,
-        );
-
         return {
           projectsNotMigrated:
-            summary.projectsNotMigrated + (actionCount > 0 ? 1 : 0),
-          actionCount: summary.actionCount + actionCount,
+            summary.projectsNotMigrated +
+            (project.requiredActionCount > 0 ? 1 : 0),
+          actionCount: summary.actionCount + project.requiredActionCount,
         };
       },
       { projectsNotMigrated: 0, actionCount: 0 },
     );
-  }, [
-    legacyApiUsageRowsByProjectId,
-    outdatedSdkUsageSeriesCountsByProjectId,
-    projects,
-    traceLevelEvalCountsByProjectId,
-  ]);
+  }, [projectReadinessRows]);
   const isProjectListLoading = summaryByProject.isPending;
   const isProjectReadinessLoading =
     summaryByProject.isPending ||
@@ -334,13 +480,13 @@ export default function OrganizationV4Page() {
   useEffect(() => {
     if (
       selectedProjectId &&
-      projects.some((p) => p.projectId === selectedProjectId)
+      projectReadinessRows.some((p) => p.projectId === selectedProjectId)
     ) {
       return;
     }
 
-    setSelectedProjectId(projects[0]?.projectId);
-  }, [projects, selectedProjectId]);
+    setSelectedProjectId(projectReadinessRows[0]?.projectId);
+  }, [projectReadinessRows, selectedProjectId]);
 
   if (!organizationId || session.status === "loading") return null;
 
@@ -371,6 +517,7 @@ export default function OrganizationV4Page() {
     >
       <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-6">
         <DashboardCard
+          className="border-0 bg-transparent shadow-none"
           title="Project readiness"
           description={
             isProjectReadinessLoading
@@ -381,7 +528,7 @@ export default function OrganizationV4Page() {
                     migrationSummary.projectsNotMigrated,
                     0,
                   )} of ${numberFormatter(
-                    projects.length,
+                    projectReadinessRows.length,
                     0,
                   )} projects not migrated - ${numberFormatter(
                     migrationSummary.actionCount,
@@ -389,6 +536,15 @@ export default function OrganizationV4Page() {
                   )} required changes`
           }
           isLoading={isProjectReadinessLoading}
+          headerRight={
+            isProjectReadinessLoading ? undefined : (
+              <Badge variant="warning" className="whitespace-nowrap">
+                {V4_MIGRATION_DEADLINE_SHORT_LABEL}
+              </Badge>
+            )
+          }
+          headerClassName="px-0 pt-0"
+          cardContentClassName="px-0 pb-0"
         >
           {summaryByProject.error ? (
             <Alert>
@@ -396,146 +552,108 @@ export default function OrganizationV4Page() {
             </Alert>
           ) : isProjectListLoading ? (
             <div className="min-h-40" />
-          ) : projects.length > 0 ? (
-            <div className="overflow-x-auto">
-              <Table className="min-w-[68rem] table-auto">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Project</TableHead>
-                    <TableHead className="w-28">Status</TableHead>
-                    <TableHead className="w-32 text-right">
-                      Trace evals
-                    </TableHead>
-                    <TableHead className="w-32 text-right">
-                      Integrations
-                    </TableHead>
-                    <TableHead className="w-44 text-right">
-                      Public API
-                    </TableHead>
-                    <TableHead className="w-32 text-right">SDKs</TableHead>
-                    <TableHead className="w-32" />
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {projects.map((project) => {
-                    const legacyApiRows = legacyApiUsageRowsByProjectId.get(
-                      project.projectId,
-                    );
-                    const legacyApiUsageCount =
-                      sumLegacyApiUsage(legacyApiRows);
-                    const legacyApiEntrypointCount =
-                      countLegacyApiEntrypoints(legacyApiRows);
-                    const actionCount = getProjectActionCount(
-                      project,
-                      traceLevelEvalCountsByProjectId.get(project.projectId) ??
-                        0,
-                      legacyApiEntrypointCount,
-                      outdatedSdkUsageSeriesCountsByProjectId.get(
-                        project.projectId,
-                      ) ?? 0,
-                    );
-                    const traceLevelEvalCount =
-                      traceLevelEvalCountsByProjectId.get(project.projectId) ??
-                      0;
-                    const outdatedSdkUsageSeriesCount =
-                      outdatedSdkUsageSeriesCountsByProjectId.get(
-                        project.projectId,
-                      ) ?? 0;
-                    const isStatusPending =
+          ) : projectReadinessRows.length > 0 ? (
+            <div className="flex flex-col gap-4">
+              <section className="flex flex-col gap-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-sm font-medium">
+                    Projects with required changes
+                  </h3>
+                  <Badge variant="outline-solid" size="sm">
+                    {numberFormatter(projectsWithRequiredChanges.length, 0)}
+                  </Badge>
+                </div>
+                {projectsWithRequiredChanges.length ? (
+                  <ProjectReadinessTable
+                    rows={projectsWithRequiredChanges}
+                    selectedProjectId={selectedProject?.projectId}
+                    onSelectProject={setSelectedProjectId}
+                    isStatusPending={
                       legacyApiUsageSummaryByProject.isPending ||
                       sdkUsageSummaryByProject.isPending ||
-                      traceLevelEvalSummaryByProject.isPending;
-                    const hasStatusError =
+                      traceLevelEvalSummaryByProject.isPending
+                    }
+                    hasStatusError={
                       Boolean(legacyApiUsageSummaryByProject.error) ||
                       Boolean(sdkUsageSummaryByProject.error) ||
-                      Boolean(traceLevelEvalSummaryByProject.error);
-                    const migrationStatus =
-                      isStatusPending || hasStatusError
-                        ? null
-                        : getV4MigrationStatus(actionCount);
-                    const isSelected =
-                      selectedProject?.projectId === project.projectId;
+                      Boolean(traceLevelEvalSummaryByProject.error)
+                    }
+                    isTraceLevelEvalSummaryLoading={
+                      traceLevelEvalSummaryByProject.isPending
+                    }
+                    hasTraceLevelEvalSummaryError={Boolean(
+                      traceLevelEvalSummaryByProject.error,
+                    )}
+                    isLegacyApiUsageLoading={
+                      legacyApiUsageSummaryByProject.isPending
+                    }
+                    hasLegacyApiUsageError={Boolean(
+                      legacyApiUsageSummaryByProject.error,
+                    )}
+                    isSdkUsageLoading={sdkUsageSummaryByProject.isPending}
+                    hasSdkUsageError={Boolean(sdkUsageSummaryByProject.error)}
+                  />
+                ) : (
+                  <Alert>
+                    <AlertDescription>
+                      No projects with required v4 migration changes.
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </section>
 
-                    return (
-                      <TableRow
-                        key={project.projectId}
-                        className={cn(isSelected && "bg-muted/40")}
-                      >
-                        <TableCell density="comfortable">
-                          <Link
-                            href={`/project/${project.projectId}`}
-                            className="font-medium hover:underline"
-                          >
-                            {project.projectName}
-                          </Link>
-                        </TableCell>
-                        <TableCell density="comfortable">
-                          <Badge
-                            variant={
-                              migrationStatus?.badgeVariant ?? "outline-solid"
-                            }
-                            size="sm"
-                          >
-                            {hasStatusError
-                              ? "Unavailable"
-                              : (migrationStatus?.label ?? "Loading")}
-                          </Badge>
-                        </TableCell>
-                        <TableCell density="comfortable" className="text-right">
-                          {traceLevelEvalSummaryByProject.isPending
-                            ? "Loading..."
-                            : traceLevelEvalSummaryByProject.error
-                              ? "Failed"
-                              : numberFormatter(traceLevelEvalCount, 0)}
-                        </TableCell>
-                        <TableCell density="comfortable" className="text-right">
-                          {numberFormatter(project.legacyIntegrationCount, 0)}
-                        </TableCell>
-                        <TableCell density="comfortable" className="text-right">
-                          {legacyApiUsageSummaryByProject.isPending
-                            ? "Loading..."
-                            : legacyApiUsageSummaryByProject.error
-                              ? "Failed"
-                              : legacyApiEntrypointCount > 0
-                                ? `${numberFormatter(
-                                    legacyApiEntrypointCount,
-                                    0,
-                                  )} routes - ${numberFormatter(
-                                    legacyApiUsageCount,
-                                    0,
-                                    2,
-                                  )} calls`
-                                : "0"}
-                        </TableCell>
-                        <TableCell density="comfortable" className="text-right">
-                          {sdkUsageSummaryByProject.isPending
-                            ? "Loading..."
-                            : sdkUsageSummaryByProject.error
-                              ? "Failed"
-                              : outdatedSdkUsageSeriesCount > 0
-                                ? `${numberFormatter(
-                                    outdatedSdkUsageSeriesCount,
-                                    0,
-                                  )} outdated`
-                                : "0"}
-                        </TableCell>
-                        <TableCell density="comfortable">
-                          <Button
-                            variant={isSelected ? "secondary" : "outline"}
-                            size="sm"
-                            onClick={() =>
-                              setSelectedProjectId(project.projectId)
-                            }
-                            className="w-full"
-                          >
-                            Details
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
+              {projectsWithoutRequiredChanges.length ? (
+                <Accordion type="single" collapsible className="pt-1">
+                  <AccordionItem value="migrated" className="border-b-0">
+                    <AccordionTrigger className="py-3 text-sm hover:no-underline">
+                      <span className="flex min-w-0 items-center gap-2">
+                        <span className="font-medium">
+                          Projects without required changes
+                        </span>
+                        <Badge variant="outline-solid" size="sm">
+                          {numberFormatter(
+                            projectsWithoutRequiredChanges.length,
+                            0,
+                          )}
+                        </Badge>
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent className="pt-1">
+                      <ProjectReadinessTable
+                        rows={projectsWithoutRequiredChanges}
+                        selectedProjectId={selectedProject?.projectId}
+                        onSelectProject={setSelectedProjectId}
+                        isStatusPending={
+                          legacyApiUsageSummaryByProject.isPending ||
+                          sdkUsageSummaryByProject.isPending ||
+                          traceLevelEvalSummaryByProject.isPending
+                        }
+                        hasStatusError={
+                          Boolean(legacyApiUsageSummaryByProject.error) ||
+                          Boolean(sdkUsageSummaryByProject.error) ||
+                          Boolean(traceLevelEvalSummaryByProject.error)
+                        }
+                        isTraceLevelEvalSummaryLoading={
+                          traceLevelEvalSummaryByProject.isPending
+                        }
+                        hasTraceLevelEvalSummaryError={Boolean(
+                          traceLevelEvalSummaryByProject.error,
+                        )}
+                        isLegacyApiUsageLoading={
+                          legacyApiUsageSummaryByProject.isPending
+                        }
+                        hasLegacyApiUsageError={Boolean(
+                          legacyApiUsageSummaryByProject.error,
+                        )}
+                        isSdkUsageLoading={sdkUsageSummaryByProject.isPending}
+                        hasSdkUsageError={Boolean(
+                          sdkUsageSummaryByProject.error,
+                        )}
+                      />
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
+              ) : null}
             </div>
           ) : (
             <NoDataOrLoading

--- a/web/src/pages/organization/[organizationId]/v4/index.tsx
+++ b/web/src/pages/organization/[organizationId]/v4/index.tsx
@@ -465,7 +465,6 @@ export default function OrganizationV4Page() {
       { projectsNotMigrated: 0, actionCount: 0 },
     );
   }, [projectReadinessRows]);
-  const isProjectListLoading = summaryByProject.isPending;
   const isProjectReadinessLoading =
     summaryByProject.isPending ||
     legacyApiUsageSummaryByProject.isPending ||
@@ -550,7 +549,7 @@ export default function OrganizationV4Page() {
             <Alert>
               <AlertDescription>Failed to load projects.</AlertDescription>
             </Alert>
-          ) : isProjectListLoading ? (
+          ) : isProjectReadinessLoading ? (
             <div className="min-h-40" />
           ) : projectReadinessRows.length > 0 ? (
             <div className="flex flex-col gap-4">


### PR DESCRIPTION
## Summary
- Redesign the v4 migration page into an action-first audit layout with required work first and non-action details collapsed below.
- Show only outdated-major SDK usage in required actions, hide fully untracked SDK telemetry, and keep unknown telemetry with API keys visible for context.
- Flatten the project and organization v4 dashboard chrome so charts, tables, passed checks, and project rows use quieter separators instead of nested boxes.

## Verification
- `pnpm --dir web exec vitest run --project client src/features/v4/components/V4MigrationProjectCards.clienttest.tsx src/features/v4/utils.clienttest.ts`
- `pnpm --dir web exec eslint src/features/v4/components/V4MigrationProjectCards.tsx src/features/v4/components/V4MigrationProjectCards.clienttest.tsx src/features/v4/utils.ts src/features/v4/utils.clienttest.ts src/pages/organization/[organizationId]/v4/index.tsx --max-warnings 0`
- Commit hook: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli` and `turbo run lint`

## Notes
- Local `pnpm --dir web run typecheck` in a fresh worktree still reports unrelated existing errors outside this change under Node 26, but no v4 migration files remain in that error output after the typed org-page cleanup.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR redesigns the v4 migration audit page to use an action-first layout: required migration tasks surface first (outdated-major SDK upgrades, legacy APIs, trace-level evals, legacy exports), non-action SDK telemetry and passed checks are collapsed into a details accordion, and fully untracked SDK entries (no API key) are hidden entirely. The org-level project readiness table is split into two sections — projects with required changes shown immediately, and migrated projects collapsed into a secondary accordion.

- **`V4MigrationProjectCards.tsx`**: Replaces the flat `Section` component with `AuditSection` (warning accent border + deadline badge), adds `NonActionDetails` accordion (`forceMount` for test accessibility), `SuccessAudit` banner, and a `passedChecks` memo that builds per-category passing-check messages.
- **`utils.ts`**: Adds deadline label constants and two new pure helpers — `getV4ProjectRequiredActionCount` and `splitV4ProjectsByRequiredChanges` — both covered by new unit tests.
- **`index.tsx`**: Extracts `ProjectReadinessTable` into a standalone component, derives a typed `ProjectReadinessRow` via `getV4ProjectRequiredActionCount`, and renders a collapsible accordion for the already-migrated project subset.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a UI-only redesign of the v4 migration audit page with no backend modifications; the filtering logic and state derivations look correct throughout.

The SDK filtering change is the most load-bearing logic and both the unit tests and component tests cover it well. The `forceMount` on the non-action details accordion is a deliberate testability trade-off that will always render the SDK chart on page load, and the array-index key in `passedChecks.map` is stable in practice but could cause stale reconciliation if loading order changes. Neither affects data correctness. No data mutations, API calls, or auth flows are touched.

The `NonActionDetails` component in `V4MigrationProjectCards.tsx` — specifically the `forceMount` + chart rendering interaction — is worth a quick visual check to confirm the accordion's closed state still hides content correctly in the browser.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[V4MigrationProjectCards renders] --> B{isSdkUsageLoading?}
    B -- yes --> C[SectionLoading]
    B -- no --> D{hasSdkUsageError?}
    D -- yes --> E[Notice: error]
    D -- no --> F{requiredSdkUsageSeries.length > 0?}
    F -- yes --> G[AuditSection: SDK upgrades]
    F -- no --> H{legacyApiSeries.length > 0?}
    G --> H
    H -- yes --> I[AuditSection: Legacy public APIs]
    H -- no --> J{traceLevelEvalCount > 0?}
    I --> J
    J -- yes --> K[AuditSection: Trace-level evals]
    J -- no --> L{legacyIntegrationLinks.length > 0?}
    K --> L
    L -- yes --> M[AuditSection: Legacy exports]
    L -- no --> N{activeTaskCount === 0 and all loaded?}
    M --> N
    N -- yes --> O[SuccessAudit banner]
    N -- no --> P[nothing]
    O --> Q[NonActionDetails accordion]
    P --> Q
    Q --> R{nonActionSdkUsageSeries.length OR passedChecks.length?}
    R -- yes --> S[Accordion: Details that do not require action]
    S --> T[SDK telemetry section]
    S --> U[Passed checks section]
    R -- no --> V[null - hidden]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[V4MigrationProjectCards renders] --> B{isSdkUsageLoading?}
    B -- yes --> C[SectionLoading]
    B -- no --> D{hasSdkUsageError?}
    D -- yes --> E[Notice: error]
    D -- no --> F{requiredSdkUsageSeries.length > 0?}
    F -- yes --> G[AuditSection: SDK upgrades]
    F -- no --> H{legacyApiSeries.length > 0?}
    G --> H
    H -- yes --> I[AuditSection: Legacy public APIs]
    H -- no --> J{traceLevelEvalCount > 0?}
    I --> J
    J -- yes --> K[AuditSection: Trace-level evals]
    J -- no --> L{legacyIntegrationLinks.length > 0?}
    K --> L
    L -- yes --> M[AuditSection: Legacy exports]
    L -- no --> N{activeTaskCount === 0 and all loaded?}
    M --> N
    N -- yes --> O[SuccessAudit banner]
    N -- no --> P[nothing]
    O --> Q[NonActionDetails accordion]
    P --> Q
    Q --> R{nonActionSdkUsageSeries.length OR passedChecks.length?}
    R -- yes --> S[Accordion: Details that do not require action]
    S --> T[SDK telemetry section]
    S --> U[Passed checks section]
    R -- no --> V[null - hidden]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/features/v4/components/V4MigrationProjectCards.clienttest.tsx:175-188
The explicit `legacyIntegrationSummary` and `sdkUsage` JSX props are redundant here. `{...baseProps}` already provides the defaults, and `{...overrides}` already overwrites them when supplied — so the trailing `??` expressions produce the same result as the spread alone. The only time they would differ is when a caller explicitly passes `undefined`, which is not a valid use-case given the `satisfies ComponentProps<...>` contract on `baseProps`.

```suggestion
  const renderCards = (
    overrides: Partial<ComponentProps<typeof V4MigrationProjectCards>> = {},
  ) =>
    render(
      <V4MigrationProjectCards
        {...baseProps}
        {...overrides}
      />,
    );
```

### Issue 2 of 3
web/src/features/v4/components/V4MigrationProjectCards.tsx:549
`forceMount` always keeps `AccordionContent` in the DOM, even when the section is collapsed. This is intentional for testing (so `within(screen.getByTestId("non-action-details"))` can find elements without first expanding the accordion), but it means `SdkUsageDetails` — which renders a Recharts `BarChart` with layout computation — is rendered on every page load regardless of whether the user opens this section. Consider leaving a comment explaining the `forceMount` is required for testing, so future readers don't remove it thinking it's accidental.

### Issue 3 of 3
web/src/features/v4/components/V4MigrationProjectCards.tsx:559-561
Array index used as React `key` for `passedChecks` items. The list is built from a deterministic `useMemo` based on loading/error flags, so items never reorder mid-render, making this stable in practice. Still, if a loading flag changes (e.g., SDK data loads after API data), a check can be inserted at an earlier position, causing React to re-use a DOM node with stale content until the diff reconciles. Using a stable string key derived from the check text or category would be safer.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(v4): redesign migration audit page"](https://github.com/langfuse/langfuse/commit/9c15434b4bfd23aa60bc1158fa68876a8ed7441a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41907952)</sub>

<!-- /greptile_comment -->