### PR TITLE
feat(instance-health): add OSS health dashboard

### DIFF
--- a/web/src/__tests__/organization-settings-pages.clienttest.tsx
+++ b/web/src/__tests__/organization-settings-pages.clienttest.tsx
@@ -5,9 +5,16 @@ import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { useIsCloudBillingAvailable } from "@/src/ee/features/billing/utils/isCloudBilling";
 import { useOrganizationSettingsPages } from "@/src/pages/organization/[organizationId]/settings";
+import { isCloudPlan } from "@langfuse/shared";
 
 vi.mock("@/src/components/PagedSettingsContainer", () => ({
   PagedSettingsContainer: () => null,
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: {
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined,
+  },
 }));
 
 vi.mock("@/src/components/layouts/header", () => ({
@@ -58,6 +65,13 @@ vi.mock("@langfuse/shared", () => ({
   isCloudPlan: vi.fn(() => false),
 }));
 
+vi.mock(
+  "@/src/features/instance-health/components/InstanceHealthSettingsPage",
+  () => ({
+    InstanceHealthSettingsPage: () => null,
+  }),
+);
+
 vi.mock("@/src/features/projects/hooks", () => ({
   useQueryProjectOrOrganization: vi.fn(),
 }));
@@ -102,6 +116,7 @@ describe("useOrganizationSettingsPages", () => {
     );
     vi.mocked(useHasOrganizationAccess).mockReturnValue(false);
     vi.mocked(usePlan).mockReturnValue("oss");
+    vi.mocked(isCloudPlan).mockReturnValue(false);
     vi.mocked(useIsCloudBillingAvailable).mockReturnValue(false);
   });
 
@@ -136,5 +151,23 @@ describe("useOrganizationSettingsPages", () => {
     expect(result.current.find((page) => page.slug === "api-keys")?.show).toBe(
       false,
     );
+  });
+
+  it("shows instance health settings for OSS organizations", () => {
+    const { result } = renderHook(() => useOrganizationSettingsPages());
+
+    expect(
+      result.current.find((page) => page.slug === "instance-health")?.show,
+    ).toBe(true);
+  });
+
+  it("hides instance health settings for Cloud organizations", () => {
+    vi.mocked(isCloudPlan).mockReturnValue(true);
+
+    const { result } = renderHook(() => useOrganizationSettingsPages());
+
+    expect(
+      result.current.find((page) => page.slug === "instance-health")?.show,
+    ).toBe(false);
   });
 });

--- a/web/src/__tests__/server/instance-health-query-safety.servertest.ts
+++ b/web/src/__tests__/server/instance-health-query-safety.servertest.ts
@@ -1,0 +1,35 @@
+import { assertSafeDiagnosticClickHouseQuery } from "@/src/features/instance-health/server/instanceHealthService";
+
+describe("instance health ClickHouse query safety", () => {
+  it("allows bounded freshness probes against app tables", () => {
+    expect(() =>
+      assertSafeDiagnosticClickHouseQuery(`
+        SELECT id
+        FROM traces
+        WHERE timestamp <= {now: DateTime64(3)}
+          AND timestamp >= {now: DateTime64(3)} - INTERVAL 3 MINUTE
+        LIMIT 1
+      `),
+    ).not.toThrow();
+  });
+
+  it("rejects app-table reads without a narrow freshness window", () => {
+    expect(() =>
+      assertSafeDiagnosticClickHouseQuery(`
+        SELECT id
+        FROM observations
+        LIMIT 100
+      `),
+    ).toThrow("missing narrow freshness window");
+  });
+
+  it.each([
+    "SELECT * FROM system.tables",
+    "SELECT id FROM traces FINAL LIMIT 1",
+    "OPTIMIZE TABLE traces FINAL",
+    "SYSTEM FLUSH LOGS",
+    "SELECT a.id FROM traces a JOIN observations b ON a.id = b.trace_id",
+  ])("rejects forbidden diagnostic SQL: %s", (query) => {
+    expect(() => assertSafeDiagnosticClickHouseQuery(query)).toThrow();
+  });
+});

--- a/web/src/components/VersionLabel.clienttest.tsx
+++ b/web/src/components/VersionLabel.clienttest.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  env: {
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined as string | undefined,
+  },
+  router: {
+    query: {} as Record<string, string>,
+  },
+  session: {
+    status: "authenticated",
+    data: {
+      environment: {
+        selfHostedInstancePlan: undefined,
+      },
+      user: {
+        organizations: [
+          {
+            id: "org-first",
+            plan: "oss",
+            projects: [{ id: "project-first" }],
+          },
+          {
+            id: "org-active",
+            plan: "oss",
+            projects: [{ id: "project-active" }],
+          },
+        ],
+      },
+    },
+  },
+  backgroundMigrationStatusUseQuery: vi.fn(),
+  checkUpdateUseQuery: vi.fn(),
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: mocks.env,
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.session,
+}));
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    backgroundMigrations: {
+      status: {
+        useQuery: mocks.backgroundMigrationStatusUseQuery,
+      },
+    },
+    public: {
+      checkUpdate: {
+        useQuery: mocks.checkUpdateUseQuery,
+      },
+    },
+  },
+}));
+
+import { VersionLabel } from "@/src/components/VersionLabel";
+
+describe("VersionLabel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    mocks.router.query = {};
+    mocks.backgroundMigrationStatusUseQuery.mockReturnValue({
+      data: { status: "FINISHED" },
+    });
+    mocks.checkUpdateUseQuery.mockReturnValue({ data: null });
+  });
+
+  it("links OSS operators to instance health from the active project organization", async () => {
+    mocks.router.query = { projectId: "project-active" };
+
+    render(<VersionLabel />);
+
+    openVersionMenu();
+
+    const instanceHealthItem = await screen.findByRole("menuitem", {
+      name: /instance health/i,
+    });
+
+    expect(instanceHealthItem.getAttribute("href")).toBe(
+      "/organization/org-active/settings/instance-health",
+    );
+    expect(
+      screen.getByRole("menuitem", { name: /background migrations/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the instance health entrypoint on Langfuse Cloud", () => {
+    mocks.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "US";
+    mocks.router.query = { organizationId: "org-active" };
+
+    render(<VersionLabel />);
+
+    openVersionMenu();
+
+    expect(screen.queryByRole("menuitem", { name: /instance health/i })).toBe(
+      null,
+    );
+    expect(
+      screen.queryByRole("menuitem", { name: /background migrations/i }),
+    ).toBe(null);
+  });
+});
+
+function openVersionMenu() {
+  const trigger = screen.getByRole("button");
+  trigger.focus();
+  fireEvent.keyDown(trigger, { key: "Enter", code: "Enter" });
+}

--- a/web/src/components/VersionLabel.tsx
+++ b/web/src/components/VersionLabel.tsx
@@ -1,4 +1,6 @@
 import {
+  Activity,
+  ArrowUp,
   ArrowUp10,
   BadgeCheck,
   HardDriveDownload,
@@ -17,17 +19,20 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/src/components/ui/dropdown-menu";
-import { ArrowUp } from "lucide-react";
 import { api } from "@/src/utils/api";
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
 import { usePlan } from "@/src/features/entitlements/hooks";
-import { isSelfHostedPlan, planLabels } from "@langfuse/shared";
+import { isCloudPlan, isSelfHostedPlan, planLabels } from "@langfuse/shared";
 import { StatusBadge } from "@/src/components/layouts/status-badge";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
+import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
+import { useSession } from "next-auth/react";
 
 export const VersionLabel = ({ className }: { className?: string }) => {
   const { isLangfuseCloud } = useLangfuseCloudRegion();
+  const { organization } = useQueryProjectOrOrganization();
+  const session = useSession();
 
   const backgroundMigrationStatus = api.backgroundMigrations.status.useQuery(
     undefined,
@@ -49,6 +54,15 @@ export const VersionLabel = ({ className }: { className?: string }) => {
   });
 
   const plan = usePlan();
+  const instanceHealthOrganizationId =
+    organization?.id ?? session.data?.user?.organizations[0]?.id;
+  const instanceHealthHref = instanceHealthOrganizationId
+    ? `/organization/${instanceHealthOrganizationId}/settings/instance-health`
+    : null;
+  const showInstanceHealthEntrypoint =
+    Boolean(instanceHealthHref) &&
+    !isLangfuseCloud &&
+    (!plan || !isCloudPlan(plan));
 
   const selfHostedPlanLabel = !isLangfuseCloud
     ? plan && isSelfHostedPlan(plan)
@@ -148,6 +162,14 @@ export const VersionLabel = ({ className }: { className?: string }) => {
                   className="bg-transparent"
                 />
               )}
+            </Link>
+          </DropdownMenuItem>
+        )}
+        {showInstanceHealthEntrypoint && instanceHealthHref && (
+          <DropdownMenuItem asChild>
+            <Link href={instanceHealthHref}>
+              <Activity size={16} className="mr-2" />
+              Instance Health
             </Link>
           </DropdownMenuItem>
         )}

--- a/web/src/features/instance-health/components/InstanceHealthSettingsPage.tsx
+++ b/web/src/features/instance-health/components/InstanceHealthSettingsPage.tsx
@@ -1,0 +1,857 @@
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/src/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/src/components/ui/table";
+import { ToggleGroup, ToggleGroupItem } from "@/src/components/ui/toggle-group";
+import type {
+  DiagnosticArea,
+  DiagnosticStatus,
+  InstanceHealthFinding,
+  InstanceHealthLedgerRow,
+  InstanceHealthResponse,
+  InstanceHealthTimeRange,
+} from "@/src/features/instance-health/types";
+import { INSTANCE_HEALTH_TIME_RANGES } from "@/src/features/instance-health/types";
+import {
+  prepareInstanceHealthView,
+  type PreparedClickHouseMetricPanel,
+  type PreparedOperatorMetric,
+} from "@/src/features/instance-health/lib/prepareInstanceHealthView";
+import { api } from "@/src/utils/api";
+import { cn } from "@/src/utils/tailwind";
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Clock3,
+  RefreshCw,
+  Server,
+  TriangleAlert,
+  XCircle,
+} from "lucide-react";
+import { Fragment, useMemo, useState } from "react";
+
+const STATUS_LABELS: Record<DiagnosticStatus, string> = {
+  ok: "OK",
+  warning: "Warning",
+  error: "Error",
+  unavailable: "Unavailable",
+};
+
+const AREA_LABELS: Record<DiagnosticArea, string> = {
+  web: "Web",
+  postgres: "Postgres",
+  redis: "Redis",
+  queues: "Queues",
+  worker: "Worker",
+  clickhouse: "ClickHouse",
+  capacity: "Capacity",
+};
+
+const STATUS_ICON = {
+  ok: CheckCircle2,
+  warning: TriangleAlert,
+  error: XCircle,
+  unavailable: AlertCircle,
+} satisfies Record<DiagnosticStatus, typeof CheckCircle2>;
+
+const TIME_RANGE_LABELS: Record<InstanceHealthTimeRange, string> = {
+  now: "Now",
+  "1h": "1h",
+  "6h": "6h",
+  "24h": "24h",
+};
+
+const statusTone = (status: DiagnosticStatus) =>
+  ({
+    ok: "border-dark-green/20 bg-light-green text-dark-green",
+    warning: "border-dark-yellow/30 bg-light-yellow text-dark-yellow",
+    error: "border-dark-red/20 bg-light-red text-dark-red",
+    unavailable: "border-border bg-muted text-muted-foreground",
+  })[status];
+
+const statusDotTone = (status: DiagnosticStatus) =>
+  ({
+    ok: "bg-dark-green",
+    warning: "bg-dark-yellow",
+    error: "bg-dark-red",
+    unavailable: "bg-muted-foreground",
+  })[status];
+
+const formatTimestamp = (value: string) =>
+  new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(new Date(value));
+
+const StatusBadge = ({ status }: { status: DiagnosticStatus }) => {
+  const Icon = STATUS_ICON[status];
+
+  return (
+    <Badge
+      variant="outline-solid"
+      size="sm"
+      className={cn(
+        "w-fit gap-1 self-start whitespace-nowrap",
+        statusTone(status),
+      )}
+    >
+      <Icon className="h-3 w-3" />
+      {STATUS_LABELS[status]}
+    </Badge>
+  );
+};
+
+const HeaderSummary = ({
+  data,
+  isFetching,
+  onRefresh,
+}: {
+  data: InstanceHealthResponse;
+  isFetching: boolean;
+  onRefresh: () => void;
+}) => {
+  const availableCount = data.ledgerRows.filter(
+    (row) => row.status !== "unavailable",
+  ).length;
+  const totalCount = data.ledgerRows.length;
+
+  return (
+    <div className="flex flex-col gap-3 border-b pb-4 md:flex-row md:items-center md:justify-between">
+      <div className="flex flex-wrap items-center gap-3">
+        <StatusBadge status={data.overallStatus} />
+        <div className="text-muted-foreground flex items-center gap-1 text-xs">
+          <Clock3 className="h-3 w-3" />
+          {formatTimestamp(data.generatedAt)}
+        </div>
+        <div className="text-muted-foreground text-xs">
+          {availableCount}/{totalCount} diagnostics available
+        </div>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onRefresh}
+        loading={isFetching}
+        aria-label="Refresh diagnostics"
+      >
+        <RefreshCw className="mr-2 h-3.5 w-3.5" />
+        Refresh
+      </Button>
+    </div>
+  );
+};
+
+const Sparkline = ({ metric }: { metric: PreparedOperatorMetric }) => {
+  const series = metric.series?.find((row) => row.points.length > 1);
+  if (!series) return null;
+
+  const width = 160;
+  const height = 36;
+  const points = series.points
+    .map((point, index) => {
+      const x = (index / (series.points.length - 1)) * width;
+      const y =
+        height -
+        3 -
+        (point.normalizedValue === null ? 0 : point.normalizedValue) *
+          (height - 6);
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="bg-muted/10 mt-3 h-10 w-full border"
+      role="img"
+      aria-label={`${metric.title} trend`}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        className={cn(
+          metric.status === "ok" && "text-dark-green",
+          metric.status === "warning" && "text-dark-yellow",
+          metric.status === "error" && "text-dark-red",
+          metric.status === "unavailable" && "text-muted-foreground",
+        )}
+      />
+    </svg>
+  );
+};
+
+const OperatorMetricsPanel = ({
+  metrics,
+}: {
+  metrics: PreparedOperatorMetric[];
+}) => (
+  <section className="min-w-0">
+    <div className="mb-2 flex items-center justify-between gap-3">
+      <h2 className="text-sm font-semibold">Operator Metrics</h2>
+      <span className="text-muted-foreground text-xs">
+        Current values and bounded history
+      </span>
+    </div>
+    <div className="grid min-w-0 gap-3 md:grid-cols-2 xl:grid-cols-4">
+      {metrics.map((metric) => (
+        <div key={metric.id} className="min-w-0 border p-3">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <div className="text-muted-foreground flex items-center gap-2 text-xs">
+                <span
+                  className={cn(
+                    "h-2 w-2 rounded-full",
+                    statusDotTone(metric.status),
+                  )}
+                />
+                <span className="truncate" title={AREA_LABELS[metric.area]}>
+                  {AREA_LABELS[metric.area]}
+                </span>
+              </div>
+              <div
+                className="mt-1 text-sm leading-5 font-medium break-words"
+                title={metric.title}
+              >
+                {metric.title}
+              </div>
+            </div>
+            <StatusBadge status={metric.status} />
+          </div>
+          <div className="mt-3 font-mono text-2xl leading-none">
+            {metric.value}
+          </div>
+          <div className="text-muted-foreground mt-2 min-h-8 text-xs">
+            {metric.detail}
+          </div>
+          <Sparkline metric={metric} />
+        </div>
+      ))}
+    </div>
+  </section>
+);
+
+const FixFirstPanel = ({ findings }: { findings: InstanceHealthFinding[] }) => (
+  <section className="min-w-0 border">
+    <div className="flex items-center justify-between border-b px-3 py-2">
+      <h2 className="text-sm font-semibold">Fix First</h2>
+      <span className="text-muted-foreground text-xs">
+        {findings.length ? `${findings.length} ranked` : "clear"}
+      </span>
+    </div>
+    {findings.length === 0 ? (
+      <div className="text-muted-foreground px-3 py-4 text-sm">
+        No immediate operator action detected.
+      </div>
+    ) : (
+      <div className="divide-y">
+        {findings.map((finding, index) => (
+          <div
+            key={finding.id}
+            className="grid gap-2 px-3 py-3 md:grid-cols-[32px_140px_1fr]"
+          >
+            <div className="text-muted-foreground font-mono text-xs">
+              {String(index + 1).padStart(2, "0")}
+            </div>
+            <div className="flex items-start gap-2">
+              <StatusBadge status={finding.status} />
+            </div>
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                <div className="text-sm font-medium">{finding.title}</div>
+                <span className="text-muted-foreground font-mono text-xs">
+                  {AREA_LABELS[finding.area]}
+                </span>
+              </div>
+              <div className="text-muted-foreground mt-1 text-xs">
+                {finding.evidence}
+              </div>
+              <div className="mt-2 text-xs">{finding.nextAction}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    )}
+  </section>
+);
+
+const TopologyStrip = ({
+  data,
+  selectedArea,
+  onSelectArea,
+}: {
+  data: InstanceHealthResponse;
+  selectedArea: DiagnosticArea | "all";
+  onSelectArea: (area: DiagnosticArea | "all") => void;
+}) => {
+  const nodesById = new Map(data.topologyNodes.map((node) => [node.id, node]));
+  const mainNodeIds = ["web", "redis", "queues", "worker", "clickhouse"];
+  const postgresNode = nodesById.get("postgres");
+
+  return (
+    <section className="min-w-0 border px-3 py-3">
+      <div className="flex flex-wrap items-center gap-2">
+        {mainNodeIds.map((nodeId, index) => {
+          const node = nodesById.get(nodeId);
+          if (!node) return null;
+          return (
+            <div key={node.id} className="flex items-center gap-2">
+              <button
+                className={cn(
+                  "hover:bg-muted flex min-h-9 items-center gap-2 border px-2 py-1 text-left text-xs transition-colors",
+                  selectedArea === node.area && "border-primary bg-muted",
+                )}
+                onClick={() => onSelectArea(node.area)}
+                type="button"
+              >
+                <span
+                  className={cn(
+                    "h-2 w-2 rounded-full",
+                    statusDotTone(node.status),
+                  )}
+                />
+                <span className="font-medium">{node.label}</span>
+                <span
+                  className="text-muted-foreground max-w-36 truncate"
+                  title={node.summary}
+                >
+                  {node.summary}
+                </span>
+              </button>
+              {index < mainNodeIds.length - 1 ? (
+                <ChevronRight className="text-muted-foreground h-4 w-4" />
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-2 border-t pt-2">
+        <Server className="text-muted-foreground h-3.5 w-3.5" />
+        <span className="text-muted-foreground text-xs">Dependency branch</span>
+        {postgresNode ? (
+          <button
+            className={cn(
+              "hover:bg-muted flex min-h-8 items-center gap-2 border px-2 py-1 text-xs",
+              selectedArea === "postgres" && "border-primary bg-muted",
+            )}
+            onClick={() => onSelectArea("postgres")}
+            type="button"
+          >
+            <StatusBadge status={postgresNode.status} />
+            Postgres
+          </button>
+        ) : null}
+        {selectedArea !== "all" ? (
+          <Button variant="ghost" size="sm" onClick={() => onSelectArea("all")}>
+            Clear
+          </Button>
+        ) : null}
+      </div>
+    </section>
+  );
+};
+
+const RunbookSteps = ({ data }: { data: InstanceHealthResponse }) => (
+  <section className="min-w-0 border">
+    <div className="border-b px-3 py-2">
+      <h2 className="text-sm font-semibold">Triage Runbook</h2>
+    </div>
+    <div className="divide-y">
+      {data.runbookSteps.map((step) => (
+        <div
+          key={step.id}
+          className="grid gap-2 px-3 py-3 md:grid-cols-[36px_120px_1fr]"
+        >
+          <div className="text-muted-foreground font-mono text-xs">
+            {String(step.order).padStart(2, "0")}
+          </div>
+          <StatusBadge status={step.status} />
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium">{step.title}</span>
+              <span className="text-muted-foreground font-mono text-xs">
+                {AREA_LABELS[step.area]}
+              </span>
+            </div>
+            <div className="text-muted-foreground mt-1 grid gap-1 text-xs md:grid-cols-2">
+              <span>{step.signal}</span>
+              <span>{step.expected}</span>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  </section>
+);
+
+const DiagnosticsLedger = ({
+  rows,
+  areaOptions,
+  statusOptions,
+  areaFilter,
+  statusFilter,
+  onAreaFilterChange,
+  onStatusFilterChange,
+}: {
+  rows: InstanceHealthLedgerRow[];
+  areaOptions: DiagnosticArea[];
+  statusOptions: DiagnosticStatus[];
+  areaFilter: DiagnosticArea | "all";
+  statusFilter: DiagnosticStatus | "all";
+  onAreaFilterChange: (area: DiagnosticArea | "all") => void;
+  onStatusFilterChange: (status: DiagnosticStatus | "all") => void;
+}) => {
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+
+  const toggleExpanded = (id: string) => {
+    setExpandedRows((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <section className="min-w-0 border">
+      <div className="flex flex-col gap-2 border-b px-3 py-2 md:flex-row md:items-center md:justify-between">
+        <h2 className="text-sm font-semibold">Ops Ledger</h2>
+        <div className="flex flex-wrap gap-2">
+          <Select
+            value={areaFilter}
+            onValueChange={(value) =>
+              onAreaFilterChange(value as DiagnosticArea | "all")
+            }
+          >
+            <SelectTrigger className="h-8 w-36">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All areas</SelectItem>
+              {areaOptions.map((area) => (
+                <SelectItem key={area} value={area}>
+                  {AREA_LABELS[area]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={statusFilter}
+            onValueChange={(value) =>
+              onStatusFilterChange(value as DiagnosticStatus | "all")
+            }
+          >
+            <SelectTrigger className="h-8 w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All statuses</SelectItem>
+              {statusOptions.map((status) => (
+                <SelectItem key={status} value={status}>
+                  {STATUS_LABELS[status]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="w-full max-w-full overflow-x-auto overscroll-x-contain">
+        <Table className="min-w-[960px]">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10" />
+              <TableHead className="w-28">Area</TableHead>
+              <TableHead className="w-28">Status</TableHead>
+              <TableHead className="w-44">Signal</TableHead>
+              <TableHead className="w-52">Current value</TableHead>
+              <TableHead className="w-64">Expected</TableHead>
+              <TableHead className="w-40">Last checked</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={7}
+                  className="text-muted-foreground h-14 text-center text-xs"
+                >
+                  No diagnostics match the selected filters.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => {
+                const isExpanded = expandedRows.has(row.id);
+                return (
+                  <Fragment key={row.id}>
+                    <TableRow key={row.id}>
+                      <TableCell>
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={() => toggleExpanded(row.id)}
+                          aria-label={
+                            isExpanded
+                              ? "Collapse diagnostic row"
+                              : "Expand diagnostic row"
+                          }
+                        >
+                          {isExpanded ? (
+                            <ChevronDown className="h-3.5 w-3.5" />
+                          ) : (
+                            <ChevronRight className="h-3.5 w-3.5" />
+                          )}
+                        </Button>
+                      </TableCell>
+                      <TableCell className="font-mono text-xs whitespace-nowrap">
+                        {AREA_LABELS[row.area]}
+                      </TableCell>
+                      <TableCell>
+                        <StatusBadge status={row.status} />
+                      </TableCell>
+                      <TableCell className="text-xs break-words">
+                        {row.signal}
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {row.currentValue}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-xs break-words">
+                        {row.expected}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground font-mono text-xs whitespace-nowrap">
+                        {formatTimestamp(row.lastChecked)}
+                      </TableCell>
+                    </TableRow>
+                    {isExpanded ? (
+                      <TableRow key={`${row.id}-details`}>
+                        <TableCell
+                          colSpan={7}
+                          className="bg-muted/30 px-3 py-3"
+                        >
+                          {row.details?.length ? (
+                            <div className="grid gap-2 md:grid-cols-2">
+                              {row.details.map((detail) => (
+                                <div
+                                  key={`${row.id}-${detail.label}-${detail.value}`}
+                                  className="bg-background flex min-h-8 items-center justify-between gap-3 border px-2 py-1 text-xs"
+                                >
+                                  <span className="text-muted-foreground">
+                                    {detail.label}
+                                  </span>
+                                  <span className="text-right font-mono">
+                                    {detail.value}
+                                  </span>
+                                </div>
+                              ))}
+                            </div>
+                          ) : (
+                            <span className="text-muted-foreground text-xs">
+                              No additional details.
+                            </span>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ) : null}
+                  </Fragment>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </section>
+  );
+};
+
+const HistoryStrip = ({ panel }: { panel: PreparedClickHouseMetricPanel }) => {
+  if (!panel.hasHistory) {
+    return (
+      <div className="bg-muted/20 text-muted-foreground flex h-20 items-center justify-center border px-3 text-center text-xs">
+        {panel.history.emptyState ?? "No history available"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid min-w-0 gap-2">
+      {panel.preparedSeries.slice(0, 4).map((series) => {
+        const width = 100;
+        const height = 28;
+        const points = series.points
+          .map((point, index) => {
+            const x =
+              series.points.length <= 1
+                ? width
+                : (index / (series.points.length - 1)) * width;
+            const y =
+              height -
+              2 -
+              (point.normalizedValue === null ? 0 : point.normalizedValue) *
+                (height - 4);
+            return `${x.toFixed(2)},${y.toFixed(2)}`;
+          })
+          .join(" ");
+
+        return (
+          <div
+            key={series.id}
+            className="grid min-w-0 grid-cols-[minmax(90px,140px)_1fr] items-center gap-2"
+          >
+            <div
+              className="text-muted-foreground truncate font-mono text-[11px]"
+              title={`${series.node} / ${series.label}`}
+            >
+              {series.node} / {series.label}
+            </div>
+            <svg
+              viewBox={`0 0 ${width} ${height}`}
+              className="bg-background h-8 w-full min-w-0 border"
+              role="img"
+              aria-label={`${series.label} history`}
+            >
+              <polyline
+                points={points}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                className="text-primary"
+              />
+            </svg>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const ClickHouseHealthPanel = ({
+  panels,
+}: {
+  panels: ReturnType<typeof prepareInstanceHealthView>["clickhousePanels"];
+}) => (
+  <section className="min-w-0 border">
+    <div className="border-b px-3 py-2">
+      <h2 className="text-sm font-semibold">ClickHouse Health</h2>
+    </div>
+    <div className="grid min-w-0 gap-3 p-3">
+      <div className="grid min-w-0 gap-2 md:grid-cols-3">
+        {panels.summary.map((item) => (
+          <div key={item.label} className="min-w-0 border px-3 py-2">
+            <div className="text-muted-foreground text-xs">{item.label}</div>
+            <div className="mt-1 flex items-center justify-between gap-2">
+              <span className="font-mono text-sm">{item.value}</span>
+              {item.status ? <StatusBadge status={item.status} /> : null}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="grid min-w-0 gap-3 lg:grid-cols-3">
+        {panels.metrics.map((panel) => (
+          <div key={panel.id} className="min-w-0 border">
+            <div className="flex items-center justify-between border-b px-3 py-2">
+              <h3 className="text-sm font-medium">{panel.title}</h3>
+              <StatusBadge status={panel.status} />
+            </div>
+            <div className="grid gap-3 p-3">
+              <div className="grid gap-1">
+                {panel.current.length ? (
+                  panel.current.slice(0, 6).map((detail) => (
+                    <div
+                      key={`${panel.id}-${detail.label}`}
+                      className="flex min-w-0 items-center justify-between gap-3 text-xs"
+                    >
+                      <span
+                        className="text-muted-foreground truncate"
+                        title={detail.label}
+                      >
+                        {detail.label}
+                      </span>
+                      <span className="shrink-0 font-mono">{detail.value}</span>
+                    </div>
+                  ))
+                ) : (
+                  <div className="text-muted-foreground text-xs">
+                    Current value unavailable.
+                  </div>
+                )}
+              </div>
+              <HistoryStrip panel={panel} />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="min-w-0 border">
+        <div className="flex items-center justify-between border-b px-3 py-2">
+          <h3 className="text-sm font-medium">Table Sizes</h3>
+          <StatusBadge status={panels.tables.status} />
+        </div>
+        {panels.tables.rows.length ? (
+          <div className="max-h-80 w-full max-w-full overflow-auto overscroll-x-contain">
+            <Table className="min-w-[760px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-36">Node</TableHead>
+                  <TableHead className="w-64">Table</TableHead>
+                  <TableHead className="w-44">Engine</TableHead>
+                  <TableHead className="w-24">Rows</TableHead>
+                  <TableHead className="w-24">Bytes</TableHead>
+                  <TableHead className="w-20">Parts</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {panels.tables.rows.map((row) => (
+                  <TableRow key={`${row.node}-${row.database}-${row.table}`}>
+                    <TableCell className="font-mono text-xs whitespace-nowrap">
+                      {row.node}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs whitespace-nowrap">
+                      {row.database}.{row.table}
+                    </TableCell>
+                    <TableCell className="text-xs whitespace-nowrap">
+                      {row.engine}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs whitespace-nowrap">
+                      {row.rows}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs whitespace-nowrap">
+                      {row.bytes}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs whitespace-nowrap">
+                      {row.parts}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        ) : (
+          <div className="text-muted-foreground px-3 py-6 text-sm">
+            {panels.tables.emptyState ?? "Table metadata unavailable."}
+          </div>
+        )}
+      </div>
+    </div>
+  </section>
+);
+
+const LoadingPanel = () => (
+  <div className="grid gap-3">
+    <div className="bg-muted/40 h-12 animate-pulse border" />
+    <div className="bg-muted/40 h-40 animate-pulse border" />
+    <div className="bg-muted/40 h-64 animate-pulse border" />
+  </div>
+);
+
+export const InstanceHealthSettingsPage = ({ orgId }: { orgId: string }) => {
+  const [timeRange, setTimeRange] = useState<InstanceHealthTimeRange>("1h");
+  const [areaFilter, setAreaFilter] = useState<DiagnosticArea | "all">("all");
+  const [statusFilter, setStatusFilter] = useState<DiagnosticStatus | "all">(
+    "all",
+  );
+
+  const query = api.instanceHealth.get.useQuery(
+    { orgId, timeRange },
+    {
+      enabled: Boolean(orgId),
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  const prepared = useMemo(
+    () =>
+      query.data
+        ? prepareInstanceHealthView(query.data, {
+            area: areaFilter,
+            status: statusFilter,
+          })
+        : null,
+    [areaFilter, query.data, statusFilter],
+  );
+
+  if (query.isLoading && !prepared) return <LoadingPanel />;
+
+  if (query.error) {
+    return (
+      <section className="border px-3 py-4">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <XCircle className="text-dark-red h-4 w-4" />
+          Instance health diagnostics unavailable
+        </div>
+        <div className="text-muted-foreground mt-2 text-sm">
+          {query.error.message}
+        </div>
+      </section>
+    );
+  }
+
+  if (!prepared) return null;
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      <HeaderSummary
+        data={prepared}
+        isFetching={query.isFetching}
+        onRefresh={() => {
+          query.refetch().catch(() => undefined);
+        }}
+      />
+      <div className="flex flex-col gap-2 border-b pb-4 md:flex-row md:items-center md:justify-between">
+        <div className="text-sm font-medium">Time range</div>
+        <ToggleGroup
+          type="single"
+          value={timeRange}
+          onValueChange={(value) => {
+            if (value) setTimeRange(value as InstanceHealthTimeRange);
+          }}
+          variant="outline"
+          size="xs"
+          className="justify-start"
+        >
+          {INSTANCE_HEALTH_TIME_RANGES.map((range) => (
+            <ToggleGroupItem key={range} value={range} className="min-w-12">
+              {TIME_RANGE_LABELS[range]}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+      <OperatorMetricsPanel metrics={prepared.operatorMetrics} />
+      <ClickHouseHealthPanel panels={prepared.clickhousePanels} />
+      {prepared.findings.length ? (
+        <FixFirstPanel findings={prepared.findings} />
+      ) : null}
+      <TopologyStrip
+        data={prepared}
+        selectedArea={areaFilter}
+        onSelectArea={setAreaFilter}
+      />
+      <DiagnosticsLedger
+        rows={prepared.ledgerRows}
+        areaOptions={prepared.areaOptions}
+        statusOptions={prepared.statusOptions}
+        areaFilter={areaFilter}
+        statusFilter={statusFilter}
+        onAreaFilterChange={setAreaFilter}
+        onStatusFilterChange={setStatusFilter}
+      />
+      <RunbookSteps data={prepared} />
+    </div>
+  );
+};

--- a/web/src/features/instance-health/lib/prepareInstanceHealthView.clienttest.ts
+++ b/web/src/features/instance-health/lib/prepareInstanceHealthView.clienttest.ts
@@ -1,0 +1,258 @@
+import {
+  prepareInstanceHealthView,
+  prepareMetricPanel,
+  sortLedgerRows,
+} from "@/src/features/instance-health/lib/prepareInstanceHealthView";
+import type {
+  InstanceHealthClickHouseMetricPanel,
+  InstanceHealthResponse,
+} from "@/src/features/instance-health/types";
+
+const baseResponse = {
+  overallStatus: "warning",
+  generatedAt: "2026-07-05T12:00:00.000Z",
+  findings: [],
+  topologyNodes: [],
+  topologyEdges: [],
+  runbookSteps: [],
+  ledgerRows: [
+    {
+      id: "ok",
+      area: "web",
+      status: "ok",
+      signal: "Web",
+      currentValue: "served",
+      expected: "served",
+      lastChecked: "2026-07-05T12:00:00.000Z",
+    },
+    {
+      id: "unavailable",
+      area: "worker",
+      status: "unavailable",
+      signal: "Worker",
+      currentValue: "inferred only",
+      expected: "direct signal",
+      lastChecked: "2026-07-05T12:00:00.000Z",
+    },
+    {
+      id: "error",
+      area: "clickhouse",
+      status: "error",
+      signal: "ClickHouse",
+      currentValue: "down",
+      expected: "responding",
+      lastChecked: "2026-07-05T12:00:00.000Z",
+    },
+    {
+      id: "warning",
+      area: "queues",
+      status: "warning",
+      signal: "Queues",
+      currentValue: "backlog",
+      expected: "bounded",
+      lastChecked: "2026-07-05T12:00:00.000Z",
+    },
+  ],
+  clickhousePanels: {
+    summary: [],
+    metrics: [
+      {
+        id: "memory",
+        title: "Memory",
+        status: "ok",
+        current: [],
+        history: {
+          range: "1h",
+          series: [],
+          emptyState: "current only",
+        },
+      },
+    ],
+    tables: {
+      status: "ok",
+      rows: [],
+    },
+  },
+  unavailableDiagnostics: [
+    {
+      id: "worker",
+      area: "worker",
+      reason: "Direct worker diagnostics are unavailable.",
+    },
+  ],
+} satisfies InstanceHealthResponse;
+
+describe("instance health view preparer", () => {
+  it("sorts ledger rows by operator urgency", () => {
+    expect(
+      sortLedgerRows(baseResponse.ledgerRows).map((row) => row.id),
+    ).toEqual(["error", "warning", "unavailable", "ok"]);
+  });
+
+  it("filters ledger rows by status and area", () => {
+    const prepared = prepareInstanceHealthView(baseResponse, {
+      area: "queues",
+      status: "warning",
+    });
+
+    expect(prepared.ledgerRows.map((row) => row.id)).toEqual(["warning"]);
+    expect(prepared.areaOptions).toEqual([
+      "clickhouse",
+      "queues",
+      "web",
+      "worker",
+    ]);
+    expect(prepared.statusOptions).toEqual([
+      "error",
+      "warning",
+      "unavailable",
+      "ok",
+    ]);
+  });
+
+  it("keeps ClickHouse current-only empty states explicit", () => {
+    const prepared = prepareInstanceHealthView(baseResponse, {
+      area: "all",
+      status: "all",
+    });
+
+    expect(prepared.clickhousePanels.metrics[0].hasHistory).toBe(false);
+    expect(prepared.clickhousePanels.metrics[0].history.emptyState).toBe(
+      "current only",
+    );
+  });
+
+  it("normalizes chart points per panel before rendering", () => {
+    const panel = {
+      id: "cpu",
+      title: "CPU",
+      status: "ok",
+      current: [],
+      history: {
+        range: "1h",
+        series: [
+          {
+            id: "cpu:n1",
+            node: "n1",
+            label: "OSUserTimeNormalized",
+            unit: "ratio",
+            points: [
+              { timestamp: "2026-07-05T11:55:00.000Z", value: 0.25 },
+              { timestamp: "2026-07-05T12:00:00.000Z", value: 0.5 },
+            ],
+          },
+        ],
+      },
+    } satisfies InstanceHealthClickHouseMetricPanel;
+
+    expect(
+      prepareMetricPanel(panel).preparedSeries[0].points.map(
+        (point) => point.normalizedValue,
+      ),
+    ).toEqual([0.5, 1]);
+  });
+
+  it("prepares numeric operator metrics from diagnostics", () => {
+    const prepared = prepareInstanceHealthView(
+      {
+        ...baseResponse,
+        ledgerRows: [
+          {
+            id: "queues",
+            area: "queues",
+            status: "warning",
+            signal: "BullMQ queue counts",
+            currentValue: "1,234 queued, 5 active, 2 failed",
+            expected: "bounded",
+            lastChecked: "2026-07-05T12:00:00.000Z",
+          },
+          {
+            id: "clickhouse-freshness",
+            area: "clickhouse",
+            status: "ok",
+            signal: "Recent rows",
+            currentValue: "traces and observations seen in the last 3 minutes",
+            expected: "recent rows",
+            lastChecked: "2026-07-05T12:00:00.000Z",
+            details: [
+              {
+                label: "traces",
+                value: "recent row present",
+                status: "ok",
+              },
+            ],
+          },
+        ],
+        clickhousePanels: {
+          summary: [
+            {
+              label: "Table metadata",
+              value: "20 tables",
+              status: "ok",
+            },
+          ],
+          metrics: [
+            {
+              id: "memory",
+              title: "Memory",
+              status: "ok",
+              current: [{ label: "node-1", value: "1.2 GB", status: "ok" }],
+              history: {
+                range: "1h",
+                series: [
+                  {
+                    id: "memory:node-1",
+                    node: "node-1",
+                    label: "MemoryResident",
+                    unit: "bytes",
+                    points: [
+                      {
+                        timestamp: "2026-07-05T11:55:00.000Z",
+                        value: 100,
+                      },
+                      {
+                        timestamp: "2026-07-05T12:00:00.000Z",
+                        value: 200,
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+          tables: {
+            status: "ok",
+            rows: [
+              {
+                node: "node-1",
+                database: "default",
+                table: "events_full",
+                engine: "ReplacingMergeTree",
+                rows: "10,000",
+                bytes: "25 MB",
+                parts: "2",
+                status: "ok",
+              },
+            ],
+          },
+        },
+      },
+      { area: "all", status: "all" },
+    );
+
+    expect(
+      prepared.operatorMetrics.map((metric) => [metric.id, metric.value]),
+    ).toEqual([
+      ["ingestion-freshness", "3 min window"],
+      ["queue-backlog", "1,234"],
+      ["queue-failures", "2"],
+      ["clickhouse-memory", "1.2 GB"],
+      ["largest-table", "25 MB"],
+    ]);
+    expect(
+      prepared.operatorMetrics
+        .find((metric) => metric.id === "clickhouse-memory")
+        ?.series?.[0].points.map((point) => point.normalizedValue),
+    ).toEqual([0.5, 1]);
+  });
+});

--- a/web/src/features/instance-health/lib/prepareInstanceHealthView.ts
+++ b/web/src/features/instance-health/lib/prepareInstanceHealthView.ts
@@ -1,0 +1,255 @@
+import type {
+  DiagnosticArea,
+  DiagnosticStatus,
+  InstanceHealthClickHousePanels,
+  InstanceHealthClickHouseMetricPanel,
+  InstanceHealthLedgerRow,
+  InstanceHealthMetricPoint,
+  InstanceHealthResponse,
+} from "@/src/features/instance-health/types";
+
+export const DIAGNOSTIC_STATUS_ORDER: DiagnosticStatus[] = [
+  "error",
+  "warning",
+  "unavailable",
+  "ok",
+];
+
+const STATUS_RANK = DIAGNOSTIC_STATUS_ORDER.reduce<
+  Record<DiagnosticStatus, number>
+>((acc, status, index) => ({ ...acc, [status]: index }), {
+  error: 0,
+  warning: 1,
+  unavailable: 2,
+  ok: 3,
+});
+
+export type InstanceHealthLedgerFilters = {
+  area: DiagnosticArea | "all";
+  status: DiagnosticStatus | "all";
+};
+
+export type PreparedMetricPoint = InstanceHealthMetricPoint & {
+  normalizedValue: number | null;
+};
+
+export type PreparedMetricSeries = {
+  id: string;
+  node: string;
+  label: string;
+  points: PreparedMetricPoint[];
+};
+
+export type PreparedClickHouseMetricPanel =
+  InstanceHealthClickHouseMetricPanel & {
+    hasHistory: boolean;
+    preparedSeries: PreparedMetricSeries[];
+  };
+
+export type PreparedClickHousePanels = Omit<
+  InstanceHealthClickHousePanels,
+  "metrics"
+> & {
+  metrics: PreparedClickHouseMetricPanel[];
+};
+
+export type PreparedOperatorMetric = {
+  id: string;
+  title: string;
+  area: DiagnosticArea;
+  status: DiagnosticStatus;
+  value: string;
+  detail: string;
+  series?: PreparedMetricSeries[];
+  emptyState?: string;
+};
+
+export const sortLedgerRows = (
+  rows: InstanceHealthLedgerRow[],
+): InstanceHealthLedgerRow[] =>
+  [...rows].sort((a, b) => {
+    const statusDiff = STATUS_RANK[a.status] - STATUS_RANK[b.status];
+    if (statusDiff !== 0) return statusDiff;
+    return a.area.localeCompare(b.area) || a.signal.localeCompare(b.signal);
+  });
+
+export const prepareMetricPanel = (
+  panel: InstanceHealthClickHouseMetricPanel,
+): PreparedClickHouseMetricPanel => {
+  const values = panel.history.series.flatMap((series) =>
+    series.points.flatMap((point) =>
+      point.value !== null && Number.isFinite(point.value) ? [point.value] : [],
+    ),
+  );
+  const maxValue = Math.max(0, ...values);
+  const preparedSeries = panel.history.series.map((series) => ({
+    id: series.id,
+    node: series.node,
+    label: series.label,
+    points: series.points.map((point) => ({
+      ...point,
+      normalizedValue:
+        point.value === null || maxValue === 0 ? null : point.value / maxValue,
+    })),
+  }));
+
+  return {
+    ...panel,
+    hasHistory: preparedSeries.some((series) => series.points.length > 0),
+    preparedSeries,
+  };
+};
+
+const QUEUE_COUNT_PATTERNS = {
+  queued: /([\d,]+)\s+queued\b/i,
+  failed: /([\d,]+)\s+failed\b/i,
+} as const;
+
+const parseQueueCount = (
+  value: string,
+  label: keyof typeof QUEUE_COUNT_PATTERNS,
+): string | null => {
+  const match = value.match(QUEUE_COUNT_PATTERNS[label]);
+  return match?.[1] ?? null;
+};
+
+const firstDetail = (
+  details: InstanceHealthLedgerRow["details"],
+): string | null => {
+  const detail = details?.find((row) => row.value);
+  if (!detail) return null;
+  return `${detail.label}: ${detail.value}`;
+};
+
+const metricFromPanel = (
+  panel: PreparedClickHouseMetricPanel | undefined,
+  area: DiagnosticArea,
+): PreparedOperatorMetric | null => {
+  if (!panel) return null;
+
+  const primary = panel.current[0];
+  return {
+    id: `clickhouse-${panel.id}`,
+    title: `ClickHouse ${panel.title}`,
+    area,
+    status: panel.status,
+    value: primary?.value ?? "unavailable",
+    detail: primary?.label ?? panel.history.emptyState ?? "Current only",
+    series: panel.preparedSeries.slice(0, 2),
+    emptyState: panel.history.emptyState,
+  };
+};
+
+const buildOperatorMetrics = (
+  response: InstanceHealthResponse,
+  clickhousePanels: PreparedClickHousePanels,
+): PreparedOperatorMetric[] => {
+  const ledgerById = new Map(response.ledgerRows.map((row) => [row.id, row]));
+  const queueRow = ledgerById.get("queues");
+  const freshnessRow = ledgerById.get("clickhouse-freshness");
+  const topTable = response.clickhousePanels.tables.rows[0];
+  const tableSummary = response.clickhousePanels.summary.find(
+    (row) => row.label === "Table metadata",
+  );
+
+  return [
+    freshnessRow
+      ? {
+          id: "ingestion-freshness",
+          title: "Ingestion freshness",
+          area: "clickhouse" as const,
+          status: freshnessRow.status,
+          value: "3 min window",
+          detail:
+            firstDetail(freshnessRow.details) ?? freshnessRow.currentValue,
+        }
+      : null,
+    queueRow
+      ? {
+          id: "queue-backlog",
+          title: "Queue backlog",
+          area: "queues" as const,
+          status: queueRow.status,
+          value: parseQueueCount(queueRow.currentValue, "queued") ?? "unknown",
+          detail: queueRow.currentValue,
+        }
+      : null,
+    queueRow
+      ? {
+          id: "queue-failures",
+          title: "Failed jobs",
+          area: "queues" as const,
+          status: queueRow.status === "ok" ? "ok" : queueRow.status,
+          value: parseQueueCount(queueRow.currentValue, "failed") ?? "unknown",
+          detail: "BullMQ failed count across queue families",
+        }
+      : null,
+    metricFromPanel(
+      clickhousePanels.metrics.find((panel) => panel.id === "memory"),
+      "capacity",
+    ),
+    metricFromPanel(
+      clickhousePanels.metrics.find((panel) => panel.id === "cpu"),
+      "capacity",
+    ),
+    metricFromPanel(
+      clickhousePanels.metrics.find((panel) => panel.id === "disk"),
+      "capacity",
+    ),
+    topTable
+      ? {
+          id: "largest-table",
+          title: "Largest ClickHouse table",
+          area: "capacity" as const,
+          status: topTable.status,
+          value: topTable.bytes,
+          detail: `${topTable.database}.${topTable.table} · ${topTable.rows} rows`,
+        }
+      : tableSummary
+        ? {
+            id: "table-metadata",
+            title: "ClickHouse tables",
+            area: "capacity" as const,
+            status:
+              tableSummary.status ?? response.clickhousePanels.tables.status,
+            value: tableSummary.value,
+            detail:
+              response.clickhousePanels.tables.emptyState ??
+              "Table metadata from system.tables",
+          }
+        : null,
+  ].flatMap((metric) => (metric ? [metric] : []));
+};
+
+export const prepareInstanceHealthView = (
+  response: InstanceHealthResponse,
+  filters: InstanceHealthLedgerFilters,
+) => {
+  const ledgerRows = sortLedgerRows(response.ledgerRows).filter((row) => {
+    if (filters.area !== "all" && row.area !== filters.area) return false;
+    if (filters.status !== "all" && row.status !== filters.status) return false;
+    return true;
+  });
+
+  const areaOptions = Array.from(
+    new Set(response.ledgerRows.map((row) => row.area)),
+  ).sort();
+
+  const statusOptions = DIAGNOSTIC_STATUS_ORDER.filter((status) =>
+    response.ledgerRows.some((row) => row.status === status),
+  );
+
+  const clickhousePanels = {
+    ...response.clickhousePanels,
+    metrics: response.clickhousePanels.metrics.map(prepareMetricPanel),
+  };
+
+  return {
+    ...response,
+    ledgerRows,
+    areaOptions,
+    statusOptions,
+    clickhousePanels,
+    operatorMetrics: buildOperatorMetrics(response, clickhousePanels),
+  };
+};

--- a/web/src/features/instance-health/server/instanceHealthRouter.ts
+++ b/web/src/features/instance-health/server/instanceHealthRouter.ts
@@ -1,0 +1,41 @@
+import {
+  createTRPCRouter,
+  protectedOrganizationProcedure,
+} from "@/src/server/api/trpc";
+import { throwIfNoOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
+import {
+  INSTANCE_HEALTH_TIME_RANGES,
+  type InstanceHealthTimeRange,
+} from "@/src/features/instance-health/types";
+import { getInstanceHealth } from "@/src/features/instance-health/server/instanceHealthService";
+import { env } from "@/src/env.mjs";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+export const instanceHealthRouter = createTRPCRouter({
+  get: protectedOrganizationProcedure
+    .input(
+      z.object({
+        orgId: z.string(),
+        timeRange: z
+          .enum(INSTANCE_HEALTH_TIME_RANGES)
+          .default("now" satisfies InstanceHealthTimeRange),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Not found" });
+      }
+
+      throwIfNoOrganizationAccess({
+        session: ctx.session,
+        organizationId: input.orgId,
+        scope: "organization:update",
+      });
+
+      return getInstanceHealth({
+        prisma: ctx.prisma,
+        timeRange: input.timeRange,
+      });
+    }),
+});

--- a/web/src/features/instance-health/server/instanceHealthService.ts
+++ b/web/src/features/instance-health/server/instanceHealthService.ts
@@ -1,0 +1,1544 @@
+import { env } from "@/src/env.mjs";
+import type {
+  DiagnosticArea,
+  DiagnosticDetail,
+  DiagnosticStatus,
+  InstanceHealthClickHouseMetricPanel,
+  InstanceHealthClickHousePanels,
+  InstanceHealthFinding,
+  InstanceHealthLedgerRow,
+  InstanceHealthMetricSeries,
+  InstanceHealthResponse,
+  InstanceHealthRunbookStep,
+  InstanceHealthTimeRange,
+  InstanceHealthUnavailableDiagnostic,
+} from "@/src/features/instance-health/types";
+import type { PrismaClient } from "@langfuse/shared/src/db";
+import {
+  CodeEvalExecutionQueue,
+  convertDateToClickhouseDateTime,
+  EvalExecutionQueue,
+  getQueue,
+  IngestionQueue,
+  LLMAsJudgeExecutionQueue,
+  logger,
+  OtelIngestionQueue,
+  queryClickhouse,
+  QueueName,
+  redis,
+  SecondaryEvalExecutionQueue,
+  SecondaryIngestionQueue,
+  SecondaryOtelIngestionQueue,
+  TraceUpsertQueue,
+} from "@langfuse/shared/src/server";
+import type { Queue } from "bullmq";
+
+const STATUS_RANK: Record<DiagnosticStatus, number> = {
+  ok: 0,
+  unavailable: 1,
+  warning: 2,
+  error: 3,
+};
+
+const CLICKHOUSE_QUERY_SETTINGS = {
+  max_execution_time: 3,
+  max_result_rows: "5000",
+  skip_unavailable_shards: 1,
+} as const;
+
+const CLICKHOUSE_QUERY_CONFIGS = {
+  request_timeout: 5_000,
+};
+
+const RECENT_WINDOW_MINUTES = 3;
+const QUEUE_BACKLOG_WARNING_THRESHOLD = 1_000;
+const QUEUE_BACKLOG_ERROR_THRESHOLD = 10_000;
+
+const MEMORY_METRICS = [
+  "CGroupMemoryUsed",
+  "CGroupMemoryTotal",
+  "MemoryResident",
+  "MemoryResidentWithoutPageCache",
+  "OSMemoryTotal",
+  "OSMemoryAvailable",
+] as const;
+
+const CPU_METRICS = [
+  "CGroupUserTimeNormalized",
+  "CGroupSystemTimeNormalized",
+  "OSUserTimeNormalized",
+  "OSSystemTimeNormalized",
+] as const;
+
+const CURRENT_CLICKHOUSE_METRICS = [
+  ...MEMORY_METRICS,
+  ...CPU_METRICS,
+  "TotalBytesOfMergeTreeTables",
+  "TotalRowsOfMergeTreeTables",
+  "TotalPartsOfMergeTreeTables",
+] as const;
+
+const TIME_RANGE_CONFIG = {
+  now: null,
+  "1h": { hours: 1, bucketMinutes: 5 },
+  "6h": { hours: 6, bucketMinutes: 15 },
+  "24h": { hours: 24, bucketMinutes: 60 },
+} as const;
+
+type ClickHouseSystemTable =
+  | "system.asynchronous_metrics"
+  | "system.asynchronous_metric_log"
+  | "system.disks"
+  | "system.tables";
+
+type ClickHouseMetricRow = {
+  node: string;
+  metric: string;
+  value: string | number | null;
+};
+
+type ClickHouseDiskRow = {
+  node: string;
+  name: string;
+  type: string;
+  free_space: string | number | null;
+  total_space: string | number | null;
+  unreserved_space: string | number | null;
+  keep_free_space: string | number | null;
+};
+
+type ClickHouseTableRow = {
+  node: string;
+  database: string;
+  table: string;
+  engine: string;
+  total_rows: string | number | null;
+  total_bytes: string | number | null;
+  parts: string | number | null;
+  active_parts: string | number | null;
+};
+
+type ClickHouseHistoryRow = {
+  node: string;
+  timestamp_ms: string | number;
+  metric: string;
+  value: string | number | null;
+};
+
+type QueueCounts = {
+  waiting: number;
+  paused: number;
+  delayed: number;
+  active: number;
+  failed: number;
+};
+
+type QueueFamily = {
+  id: string;
+  label: string;
+  getQueues: () => Array<{ name: string; queue: Queue | null }>;
+};
+
+type DependencyCheck = {
+  status: DiagnosticStatus;
+  currentValue: string;
+  details: DiagnosticDetail[];
+  unavailable?: InstanceHealthUnavailableDiagnostic;
+};
+
+type QueueDiagnostics = {
+  status: DiagnosticStatus;
+  currentValue: string;
+  details: DiagnosticDetail[];
+  unavailableDiagnostics: InstanceHealthUnavailableDiagnostic[];
+};
+
+type ClickHouseDiagnostics = {
+  status: DiagnosticStatus;
+  freshnessStatus: DiagnosticStatus;
+  freshnessValue: string;
+  freshnessDetails: DiagnosticDetail[];
+  capacityStatus: DiagnosticStatus;
+  capacityValue: string;
+  capacityDetails: DiagnosticDetail[];
+  panels: InstanceHealthClickHousePanels;
+  unavailableDiagnostics: InstanceHealthUnavailableDiagnostic[];
+};
+
+type NonShardedQueueName = Parameters<typeof getQueue>[0];
+
+export const assertSafeDiagnosticClickHouseQuery = (query: string) => {
+  const normalized = query.replace(/\s+/g, " ").trim();
+  const forbiddenPatterns: Array<{ label: string; pattern: RegExp }> = [
+    { label: "FINAL", pattern: /\bFINAL\b/i },
+    { label: "OPTIMIZE", pattern: /\bOPTIMIZE\b/i },
+    { label: "SYSTEM FLUSH LOGS", pattern: /\bSYSTEM\s+FLUSH\s+LOGS\b/i },
+    { label: "JOIN", pattern: /\bJOIN\b/i },
+    { label: "SELECT *", pattern: /\bSELECT\s+\*/i },
+  ];
+
+  for (const { label, pattern } of forbiddenPatterns) {
+    if (pattern.test(normalized)) {
+      throw new Error(`Forbidden ClickHouse diagnostic operation: ${label}`);
+    }
+  }
+
+  const appTableMatch = normalized.match(
+    /\bFROM\s+(events_core|events_full|traces|observations)\b/i,
+  );
+  if (!appTableMatch) return;
+
+  const table = appTableMatch[1].toLowerCase();
+  const timeColumn = table === "traces" ? "timestamp" : "start_time";
+  const hasUpperBound = new RegExp(
+    `\\b${timeColumn}\\s*<=\\s*\\{now:\\s*DateTime64\\(3\\)\\}`,
+    "i",
+  ).test(normalized);
+  const hasLowerBound = new RegExp(
+    `\\b${timeColumn}\\s*>=\\s*\\{now:\\s*DateTime64\\(3\\)\\}\\s*-\\s*INTERVAL\\s+${RECENT_WINDOW_MINUTES}\\s+MINUTE`,
+    "i",
+  ).test(normalized);
+  const hasLimit = /\bLIMIT\s+1\b/i.test(normalized);
+
+  if (!hasUpperBound || !hasLowerBound || !hasLimit) {
+    throw new Error(
+      `Unsafe ClickHouse diagnostic read from ${table}: missing narrow freshness window`,
+    );
+  }
+};
+
+const queryDiagnosticClickHouse = async <T>(opts: {
+  query: string;
+  params?: Record<string, unknown>;
+}) => {
+  assertSafeDiagnosticClickHouseQuery(opts.query);
+
+  return queryClickhouse<T>({
+    query: opts.query,
+    params: opts.params,
+    clickhouseSettings: CLICKHOUSE_QUERY_SETTINGS,
+    clickhouseConfigs: CLICKHOUSE_QUERY_CONFIGS,
+    preferredClickhouseService: "ReadOnly",
+    tags: {
+      surface: "trpc",
+      route: "instanceHealth.get",
+    },
+  });
+};
+
+const formatNumber = (value: number) =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
+
+const formatBytes = (value: number): string => {
+  if (!Number.isFinite(value)) return "unknown";
+  const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+  let size = Math.max(0, value);
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${size.toFixed(size >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+};
+
+const formatPercent = (ratio: number): string => {
+  if (!Number.isFinite(ratio)) return "unknown";
+  return `${Math.round(ratio * 100)}%`;
+};
+
+const toNumber = (value: string | number | null | undefined): number => {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") return Number(value);
+  return 0;
+};
+
+const worstStatus = (statuses: DiagnosticStatus[]): DiagnosticStatus =>
+  statuses.reduce<DiagnosticStatus>(
+    (worst, status) =>
+      STATUS_RANK[status] > STATUS_RANK[worst] ? status : worst,
+    "ok",
+  );
+
+const statusFromRatio = (ratio: number, warning: number, error: number) => {
+  if (!Number.isFinite(ratio)) return "unavailable" as const;
+  if (ratio >= error) return "error" as const;
+  if (ratio >= warning) return "warning" as const;
+  return "ok" as const;
+};
+
+const safeError = (area: DiagnosticArea, id: string, reason: string) => ({
+  id,
+  area,
+  reason,
+});
+
+const withTimeout = async <T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> =>
+  Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out`)), timeoutMs),
+    ),
+  ]);
+
+const escapeClickHouseString = (value: string) =>
+  value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+
+const systemTableRef = (table: ClickHouseSystemTable): string => {
+  if (env.CLICKHOUSE_CLUSTER_ENABLED === "true") {
+    return `clusterAllReplicas('${escapeClickHouseString(env.CLICKHOUSE_CLUSTER_NAME)}', '${table}')`;
+  }
+  return table;
+};
+
+const readPostgres = async (prisma: PrismaClient): Promise<DependencyCheck> => {
+  try {
+    await withTimeout(
+      prisma.$queryRaw<{ ok: number }[]>`SELECT 1 AS ok;`,
+      2_000,
+      "Postgres ping",
+    );
+
+    return {
+      status: "ok",
+      currentValue: "responding",
+      details: [{ label: "Ping", value: "SELECT 1 succeeded", status: "ok" }],
+    };
+  } catch (error) {
+    logger.warn("Instance health Postgres ping failed", { error });
+    return {
+      status: "error",
+      currentValue: "unavailable",
+      details: [
+        {
+          label: "Ping",
+          value: "Postgres did not respond to a bounded ping",
+          status: "error",
+        },
+      ],
+      unavailable: safeError(
+        "postgres",
+        "postgres-ping",
+        "Postgres ping failed. Check web container logs for connection details.",
+      ),
+    };
+  }
+};
+
+const readRedis = async (): Promise<DependencyCheck> => {
+  if (!redis) {
+    return {
+      status: "unavailable",
+      currentValue: "not configured",
+      details: [
+        {
+          label: "Redis client",
+          value: "No Redis client is available in this web container",
+          status: "unavailable",
+        },
+      ],
+      unavailable: safeError(
+        "redis",
+        "redis-client",
+        "Redis client is not available in this web container.",
+      ),
+    };
+  }
+
+  try {
+    await withTimeout(redis.ping(), 2_000, "Redis ping");
+    return {
+      status: "ok",
+      currentValue: "responding",
+      details: [{ label: "Ping", value: "PONG", status: "ok" }],
+    };
+  } catch (error) {
+    logger.warn("Instance health Redis ping failed", { error });
+    return {
+      status: "error",
+      currentValue: "unavailable",
+      details: [
+        {
+          label: "Ping",
+          value: "Redis did not respond within 2 seconds",
+          status: "error",
+        },
+      ],
+      unavailable: safeError(
+        "redis",
+        "redis-ping",
+        "Redis ping failed. Queue and worker diagnostics are limited.",
+      ),
+    };
+  }
+};
+
+const shardedQueueFamily = (
+  id: string,
+  label: string,
+  queueClass: {
+    getShardNames: () => string[];
+    getInstance: (input: { shardName?: string }) => Queue | null;
+  },
+): QueueFamily => ({
+  id,
+  label,
+  getQueues: () =>
+    queueClass.getShardNames().map((name) => ({
+      name,
+      queue: queueClass.getInstance({ shardName: name }),
+    })),
+});
+
+const nonShardedQueueFamily = (
+  id: string,
+  label: string,
+  queueName: NonShardedQueueName,
+): QueueFamily => ({
+  id,
+  label,
+  getQueues: () => [{ name: queueName, queue: getQueue(queueName) }],
+});
+
+const QUEUE_FAMILIES: QueueFamily[] = [
+  shardedQueueFamily("ingestion", "Ingestion", IngestionQueue),
+  shardedQueueFamily(
+    "secondary-ingestion",
+    "Secondary ingestion",
+    SecondaryIngestionQueue,
+  ),
+  shardedQueueFamily("otel-ingestion", "OTel ingestion", OtelIngestionQueue),
+  shardedQueueFamily(
+    "secondary-otel-ingestion",
+    "Secondary OTel ingestion",
+    SecondaryOtelIngestionQueue,
+  ),
+  shardedQueueFamily("trace-upsert", "Trace upsert", TraceUpsertQueue),
+  shardedQueueFamily(
+    "eval-execution",
+    "Evaluation execution",
+    EvalExecutionQueue,
+  ),
+  shardedQueueFamily(
+    "secondary-eval-execution",
+    "Secondary evaluation execution",
+    SecondaryEvalExecutionQueue,
+  ),
+  shardedQueueFamily(
+    "llm-as-judge",
+    "LLM-as-judge execution",
+    LLMAsJudgeExecutionQueue,
+  ),
+  shardedQueueFamily(
+    "code-eval",
+    "Code eval execution",
+    CodeEvalExecutionQueue,
+  ),
+  nonShardedQueueFamily(
+    "dataset-run-items",
+    "Dataset run item upsert",
+    QueueName.DatasetRunItemUpsert,
+  ),
+  nonShardedQueueFamily("batch-export", "Batch export", QueueName.BatchExport),
+  nonShardedQueueFamily(
+    "batch-action",
+    "Batch action",
+    QueueName.BatchActionQueue,
+  ),
+  nonShardedQueueFamily(
+    "data-retention",
+    "Data retention processing",
+    QueueName.DataRetentionProcessingQueue,
+  ),
+  nonShardedQueueFamily("webhook", "Webhooks", QueueName.WebhookQueue),
+  nonShardedQueueFamily("monitor", "Monitors", QueueName.MonitorQueue),
+  nonShardedQueueFamily(
+    "event-propagation",
+    "Event propagation",
+    QueueName.EventPropagationQueue,
+  ),
+  nonShardedQueueFamily(
+    "dead-letter-retry",
+    "Dead letter retry",
+    QueueName.DeadLetterRetryQueue,
+  ),
+];
+
+const getQueueCounts = async (queue: Queue): Promise<QueueCounts> => {
+  const counts = await withTimeout(
+    queue.getJobCounts("waiting", "paused", "delayed", "active", "failed"),
+    3_000,
+    `BullMQ ${queue.name} counts`,
+  );
+
+  return {
+    waiting: counts.waiting ?? 0,
+    paused: counts.paused ?? 0,
+    delayed: counts.delayed ?? 0,
+    active: counts.active ?? 0,
+    failed: counts.failed ?? 0,
+  };
+};
+
+const readQueues = async (): Promise<QueueDiagnostics> => {
+  if (!redis) {
+    return {
+      status: "unavailable",
+      currentValue: "Redis unavailable",
+      details: [],
+      unavailableDiagnostics: [
+        safeError(
+          "queues",
+          "queue-redis-client",
+          "Redis client is unavailable, so BullMQ queue counts cannot be read.",
+        ),
+      ],
+    };
+  }
+
+  const unavailableDiagnostics: InstanceHealthUnavailableDiagnostic[] = [];
+  const details: DiagnosticDetail[] = [];
+  const statuses: DiagnosticStatus[] = [];
+  let totalWaiting = 0;
+  let totalFailed = 0;
+  let totalActive = 0;
+
+  await Promise.all(
+    QUEUE_FAMILIES.map(async (family) => {
+      const queueRefs = family.getQueues();
+      const availableQueues = queueRefs.flatMap(({ queue }) =>
+        queue ? [queue] : [],
+      );
+
+      if (availableQueues.length === 0) {
+        statuses.push("unavailable");
+        unavailableDiagnostics.push(
+          safeError(
+            "queues",
+            `queue-${family.id}`,
+            `${family.label} queue is not available from this web container.`,
+          ),
+        );
+        details.push({
+          label: family.label,
+          value: "queue unavailable",
+          status: "unavailable",
+        });
+        return;
+      }
+
+      try {
+        const counts = await Promise.all(
+          availableQueues.map(async (queue) => ({
+            counts: await getQueueCounts(queue),
+          })),
+        );
+
+        const aggregate = counts.reduce<QueueCounts>(
+          (acc, row) => ({
+            waiting: acc.waiting + row.counts.waiting,
+            paused: acc.paused + row.counts.paused,
+            delayed: acc.delayed + row.counts.delayed,
+            active: acc.active + row.counts.active,
+            failed: acc.failed + row.counts.failed,
+          }),
+          { waiting: 0, paused: 0, delayed: 0, active: 0, failed: 0 },
+        );
+
+        const backlog =
+          aggregate.waiting + aggregate.paused + aggregate.delayed;
+        totalWaiting += backlog;
+        totalFailed += aggregate.failed;
+        totalActive += aggregate.active;
+
+        const status =
+          aggregate.failed > 0 || backlog >= QUEUE_BACKLOG_ERROR_THRESHOLD
+            ? "error"
+            : backlog >= QUEUE_BACKLOG_WARNING_THRESHOLD
+              ? "warning"
+              : "ok";
+        statuses.push(status);
+        details.push({
+          label: family.label,
+          value: `${formatNumber(backlog)} queued, ${formatNumber(aggregate.active)} active, ${formatNumber(aggregate.failed)} failed`,
+          status,
+        });
+      } catch (error) {
+        logger.warn("Instance health queue diagnostic failed", {
+          queueFamily: family.id,
+          error,
+        });
+        statuses.push("unavailable");
+        unavailableDiagnostics.push(
+          safeError(
+            "queues",
+            `queue-${family.id}-counts`,
+            `${family.label} counts could not be read.`,
+          ),
+        );
+        details.push({
+          label: family.label,
+          value: "counts unavailable",
+          status: "unavailable",
+        });
+      }
+    }),
+  );
+
+  const status = worstStatus(statuses);
+  return {
+    status,
+    currentValue: `${formatNumber(totalWaiting)} queued, ${formatNumber(totalActive)} active, ${formatNumber(totalFailed)} failed`,
+    details,
+    unavailableDiagnostics,
+  };
+};
+
+const readClickHouseFreshness = async (): Promise<{
+  status: DiagnosticStatus;
+  currentValue: string;
+  details: DiagnosticDetail[];
+  unavailable?: InstanceHealthUnavailableDiagnostic;
+}> => {
+  const now = convertDateToClickhouseDateTime(new Date());
+
+  try {
+    if (env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only") {
+      const rows = await queryDiagnosticClickHouse<{ span_id: string }>({
+        query: `
+          SELECT span_id
+          FROM events_core
+          WHERE start_time <= {now: DateTime64(3)}
+            AND start_time >= {now: DateTime64(3)} - INTERVAL ${RECENT_WINDOW_MINUTES} MINUTE
+          LIMIT 1
+        `,
+        params: { now },
+      });
+
+      return rows.length > 0
+        ? {
+            status: "ok",
+            currentValue: "events seen in the last 3 minutes",
+            details: [
+              {
+                label: "events_core",
+                value: "recent row present",
+                status: "ok",
+              },
+            ],
+          }
+        : {
+            status: "warning",
+            currentValue: "no events in the last 3 minutes",
+            details: [
+              {
+                label: "events_core",
+                value: "no recent row found",
+                status: "warning",
+              },
+            ],
+          };
+    }
+
+    const [traces, observations] = await Promise.all([
+      queryDiagnosticClickHouse<{ id: string }>({
+        query: `
+          SELECT id
+          FROM traces
+          WHERE timestamp <= {now: DateTime64(3)}
+            AND timestamp >= {now: DateTime64(3)} - INTERVAL ${RECENT_WINDOW_MINUTES} MINUTE
+          LIMIT 1
+        `,
+        params: { now },
+      }),
+      queryDiagnosticClickHouse<{ id: string }>({
+        query: `
+          SELECT id
+          FROM observations
+          WHERE start_time <= {now: DateTime64(3)}
+            AND start_time >= {now: DateTime64(3)} - INTERVAL ${RECENT_WINDOW_MINUTES} MINUTE
+          LIMIT 1
+        `,
+        params: { now },
+      }),
+    ]);
+
+    const details: DiagnosticDetail[] = [
+      {
+        label: "traces",
+        value: traces.length > 0 ? "recent row present" : "no recent row found",
+        status: traces.length > 0 ? "ok" : "warning",
+      },
+      {
+        label: "observations",
+        value:
+          observations.length > 0
+            ? "recent row present"
+            : "no recent row found",
+        status: observations.length > 0 ? "ok" : "warning",
+      },
+    ];
+
+    const status =
+      traces.length > 0 && observations.length > 0 ? "ok" : "warning";
+    return {
+      status,
+      currentValue:
+        status === "ok"
+          ? "traces and observations seen in the last 3 minutes"
+          : "missing recent traces or observations",
+      details,
+    };
+  } catch (error) {
+    logger.warn("Instance health ClickHouse freshness diagnostic failed", {
+      error,
+    });
+    return {
+      status: "unavailable",
+      currentValue: "freshness unavailable",
+      details: [
+        {
+          label: "Freshness",
+          value: "bounded recent-row query failed",
+          status: "unavailable",
+        },
+      ],
+      unavailable: safeError(
+        "clickhouse",
+        "clickhouse-freshness",
+        "Recent-row freshness queries could not be read.",
+      ),
+    };
+  }
+};
+
+const getMetricMap = (rows: ClickHouseMetricRow[]) => {
+  const map = new Map<string, Map<string, number>>();
+
+  for (const row of rows) {
+    const nodeMetrics = map.get(row.node) ?? new Map<string, number>();
+    nodeMetrics.set(row.metric, toNumber(row.value));
+    map.set(row.node, nodeMetrics);
+  }
+
+  return map;
+};
+
+const memoryDetails = (metrics: Map<string, Map<string, number>>) => {
+  const details: DiagnosticDetail[] = [];
+
+  for (const [node, values] of metrics) {
+    const used =
+      values.get("CGroupMemoryUsed") ??
+      values.get("MemoryResidentWithoutPageCache") ??
+      values.get("MemoryResident");
+    const total =
+      values.get("CGroupMemoryTotal") ??
+      (values.get("OSMemoryTotal") && values.get("OSMemoryAvailable")
+        ? values.get("OSMemoryTotal")
+        : undefined);
+
+    if (!used) continue;
+
+    if (total && total > 0) {
+      const ratio = used / total;
+      details.push({
+        label: node,
+        value: `${formatBytes(used)} / ${formatBytes(total)} (${formatPercent(ratio)})`,
+        status: statusFromRatio(ratio, 0.85, 0.95),
+      });
+    } else {
+      details.push({
+        label: node,
+        value: `${formatBytes(used)} resident`,
+        status: "ok",
+      });
+    }
+  }
+
+  return details;
+};
+
+const cpuDetails = (metrics: Map<string, Map<string, number>>) => {
+  const details: DiagnosticDetail[] = [];
+
+  for (const [node, values] of metrics) {
+    const cgroupCpu =
+      (values.get("CGroupUserTimeNormalized") ?? 0) +
+      (values.get("CGroupSystemTimeNormalized") ?? 0);
+    const osCpu =
+      (values.get("OSUserTimeNormalized") ?? 0) +
+      (values.get("OSSystemTimeNormalized") ?? 0);
+    const cpu = cgroupCpu > 0 ? cgroupCpu : osCpu;
+
+    if (!cpu) continue;
+
+    details.push({
+      label: node,
+      value: formatPercent(cpu),
+      status: statusFromRatio(cpu, 0.8, 0.95),
+    });
+  }
+
+  return details;
+};
+
+const diskDetails = (rows: ClickHouseDiskRow[]) =>
+  rows.flatMap<DiagnosticDetail>((row) => {
+    const total = toNumber(row.total_space);
+    const free = toNumber(row.free_space);
+    if (total <= 0) return [];
+
+    const used = Math.max(0, total - free);
+    const ratio = used / total;
+
+    return [
+      {
+        label: `${row.node} / ${row.name}`,
+        value: `${formatBytes(used)} / ${formatBytes(total)} (${formatPercent(ratio)})`,
+        status: statusFromRatio(ratio, 0.85, 0.95),
+      },
+    ];
+  });
+
+const prepareHistorySeries = (
+  rows: ClickHouseHistoryRow[],
+  range: InstanceHealthTimeRange,
+) => {
+  const panels: Record<
+    "memory" | "cpu" | "disk",
+    Map<string, InstanceHealthMetricSeries>
+  > = {
+    memory: new Map(),
+    cpu: new Map(),
+    disk: new Map(),
+  };
+
+  const panelForMetric = (metric: string): "memory" | "cpu" | "disk" | null => {
+    if ((MEMORY_METRICS as readonly string[]).includes(metric)) return "memory";
+    if ((CPU_METRICS as readonly string[]).includes(metric)) return "cpu";
+    if (metric.startsWith("Disk") || metric.startsWith("Filesystem"))
+      return "disk";
+    return null;
+  };
+
+  for (const row of rows) {
+    const panel = panelForMetric(row.metric);
+    if (!panel) continue;
+
+    const seriesId = `${panel}:${row.node}:${row.metric}`;
+    const existing =
+      panels[panel].get(seriesId) ??
+      ({
+        id: seriesId,
+        node: row.node,
+        label: row.metric,
+        unit: panel === "memory" || panel === "disk" ? "bytes" : "ratio",
+        points: [],
+      } satisfies InstanceHealthMetricSeries);
+
+    existing.points.push({
+      timestamp: new Date(toNumber(row.timestamp_ms)).toISOString(),
+      value: row.value === null ? null : toNumber(row.value),
+    });
+    panels[panel].set(seriesId, existing);
+  }
+
+  const topSeries = (series: InstanceHealthMetricSeries[]) =>
+    series
+      .sort((a, b) => {
+        const aLast = [...a.points]
+          .reverse()
+          .find((point) => point.value !== null);
+        const bLast = [...b.points]
+          .reverse()
+          .find((point) => point.value !== null);
+        return (bLast?.value ?? 0) - (aLast?.value ?? 0);
+      })
+      .slice(0, 12);
+
+  return {
+    memory: {
+      range,
+      series: topSeries(Array.from(panels.memory.values())),
+    },
+    cpu: {
+      range,
+      series: topSeries(Array.from(panels.cpu.values())),
+    },
+    disk: {
+      range,
+      series: topSeries(Array.from(panels.disk.values())),
+    },
+  };
+};
+
+const emptyClickHousePanels = (
+  range: InstanceHealthTimeRange,
+  emptyState: string,
+): InstanceHealthClickHousePanels => ({
+  summary: [{ label: "ClickHouse", value: emptyState, status: "unavailable" }],
+  metrics: [
+    {
+      id: "memory",
+      title: "Memory",
+      status: "unavailable",
+      current: [],
+      history: { range, series: [], emptyState },
+    },
+    {
+      id: "cpu",
+      title: "CPU",
+      status: "unavailable",
+      current: [],
+      history: { range, series: [], emptyState },
+    },
+    {
+      id: "disk",
+      title: "Disk",
+      status: "unavailable",
+      current: [],
+      history: { range, series: [], emptyState },
+    },
+  ],
+  tables: { status: "unavailable", rows: [], emptyState },
+});
+
+const readClickHouse = async (
+  range: InstanceHealthTimeRange,
+): Promise<ClickHouseDiagnostics> => {
+  const unavailableDiagnostics: InstanceHealthUnavailableDiagnostic[] = [];
+
+  try {
+    await queryDiagnosticClickHouse<{ ok: number }>({
+      query: "SELECT 1 AS ok",
+    });
+  } catch (error) {
+    logger.warn("Instance health ClickHouse ping failed", { error });
+    const unavailable = safeError(
+      "clickhouse",
+      "clickhouse-ping",
+      "ClickHouse ping failed. Check web container logs for connection details.",
+    );
+    return {
+      status: "error",
+      freshnessStatus: "unavailable",
+      freshnessValue: "freshness unavailable",
+      freshnessDetails: [],
+      capacityStatus: "unavailable",
+      capacityValue: "capacity unavailable",
+      capacityDetails: [],
+      panels: emptyClickHousePanels(range, "ClickHouse did not respond"),
+      unavailableDiagnostics: [unavailable],
+    };
+  }
+
+  const freshness = await readClickHouseFreshness();
+  if (freshness.unavailable) unavailableDiagnostics.push(freshness.unavailable);
+
+  let metricRows: ClickHouseMetricRow[] = [];
+  let diskRows: ClickHouseDiskRow[] = [];
+  let tableRows: ClickHouseTableRow[] = [];
+  let hasMetricLog = false;
+
+  await Promise.all([
+    queryDiagnosticClickHouse<ClickHouseMetricRow>({
+      query: `
+        SELECT hostName() AS node, metric, value
+        FROM ${systemTableRef("system.asynchronous_metrics")}
+        WHERE metric IN {metrics: Array(String)}
+        ORDER BY node ASC, metric ASC
+        LIMIT 1000
+      `,
+      params: { metrics: [...CURRENT_CLICKHOUSE_METRICS] },
+    })
+      .then((rows) => {
+        metricRows = rows;
+      })
+      .catch((error) => {
+        logger.warn("Instance health ClickHouse metric query failed", {
+          error,
+        });
+        unavailableDiagnostics.push(
+          safeError(
+            "clickhouse",
+            "clickhouse-current-metrics",
+            "Current ClickHouse asynchronous metrics could not be read.",
+          ),
+        );
+      }),
+    queryDiagnosticClickHouse<ClickHouseDiskRow>({
+      query: `
+        SELECT
+          hostName() AS node,
+          name,
+          type,
+          free_space,
+          total_space,
+          unreserved_space,
+          keep_free_space
+        FROM ${systemTableRef("system.disks")}
+        ORDER BY node ASC, name ASC
+        LIMIT 200
+      `,
+    })
+      .then((rows) => {
+        diskRows = rows;
+      })
+      .catch((error) => {
+        logger.warn("Instance health ClickHouse disk query failed", { error });
+        unavailableDiagnostics.push(
+          safeError(
+            "clickhouse",
+            "clickhouse-disks",
+            "ClickHouse disk metadata could not be read.",
+          ),
+        );
+      }),
+    queryDiagnosticClickHouse<ClickHouseTableRow>({
+      query: `
+        SELECT
+          hostName() AS node,
+          database,
+          name AS table,
+          engine,
+          total_rows,
+          total_bytes,
+          parts,
+          active_parts
+        FROM ${systemTableRef("system.tables")}
+        WHERE database = {database: String}
+          AND is_temporary = 0
+        ORDER BY total_bytes DESC
+        LIMIT 50
+      `,
+      params: { database: env.CLICKHOUSE_DB },
+    })
+      .then((rows) => {
+        tableRows = rows;
+      })
+      .catch((error) => {
+        logger.warn("Instance health ClickHouse table metadata query failed", {
+          error,
+        });
+        unavailableDiagnostics.push(
+          safeError(
+            "clickhouse",
+            "clickhouse-table-sizes",
+            "ClickHouse table-size metadata could not be read.",
+          ),
+        );
+      }),
+    queryDiagnosticClickHouse<{ count: string | number }>({
+      query: `
+        SELECT count() AS count
+        FROM ${systemTableRef("system.tables")}
+        WHERE database = {systemDatabase: String}
+          AND name = 'asynchronous_metric_log'
+        LIMIT 1
+      `,
+      params: { systemDatabase: "system" },
+    })
+      .then((rows) => {
+        hasMetricLog = toNumber(rows[0]?.count) > 0;
+      })
+      .catch((error) => {
+        logger.warn("Instance health ClickHouse metric-log detection failed", {
+          error,
+        });
+      }),
+  ]);
+
+  let historyRows: ClickHouseHistoryRow[] = [];
+  const rangeConfig = TIME_RANGE_CONFIG[range];
+  if (rangeConfig && hasMetricLog) {
+    try {
+      historyRows = await queryDiagnosticClickHouse<ClickHouseHistoryRow>({
+        query: `
+          SELECT
+            hostName() AS node,
+            toUnixTimestamp(toStartOfInterval(event_time, INTERVAL ${rangeConfig.bucketMinutes} MINUTE)) * 1000 AS timestamp_ms,
+            metric,
+            avg(value) AS value
+          FROM ${systemTableRef("system.asynchronous_metric_log")}
+          WHERE event_time >= now() - INTERVAL ${rangeConfig.hours} HOUR
+            AND (
+              metric IN {metrics: Array(String)}
+              OR startsWith(metric, 'Disk')
+              OR startsWith(metric, 'Filesystem')
+            )
+          GROUP BY node, timestamp_ms, metric
+          ORDER BY timestamp_ms ASC, node ASC, metric ASC
+          LIMIT 5000
+        `,
+        params: { metrics: [...MEMORY_METRICS, ...CPU_METRICS] },
+      });
+    } catch (error) {
+      logger.warn("Instance health ClickHouse history query failed", { error });
+      unavailableDiagnostics.push(
+        safeError(
+          "clickhouse",
+          "clickhouse-history",
+          "ClickHouse metric history could not be read.",
+        ),
+      );
+    }
+  } else if (rangeConfig && !hasMetricLog) {
+    unavailableDiagnostics.push(
+      safeError(
+        "clickhouse",
+        "clickhouse-history",
+        "ClickHouse system.asynchronous_metric_log is unavailable; showing current values only.",
+      ),
+    );
+  }
+
+  const metricMap = getMetricMap(metricRows);
+  const memory = memoryDetails(metricMap);
+  const cpu = cpuDetails(metricMap);
+  const disk = diskDetails(diskRows);
+  const history = prepareHistorySeries(historyRows, range);
+  const historyEmptyState =
+    range === "now"
+      ? "Select 1h, 6h, or 24h to load metric history"
+      : hasMetricLog
+        ? "No metric history returned for this range"
+        : "system.asynchronous_metric_log is unavailable; showing current values only";
+
+  const metricPanels: InstanceHealthClickHouseMetricPanel[] = [
+    {
+      id: "memory",
+      title: "Memory",
+      status: memory.length
+        ? worstStatus(memory.map((row) => row.status ?? "ok"))
+        : "unavailable",
+      current: memory,
+      history: {
+        ...history.memory,
+        emptyState:
+          history.memory.series.length === 0 ? historyEmptyState : undefined,
+      },
+    },
+    {
+      id: "cpu",
+      title: "CPU",
+      status: cpu.length
+        ? worstStatus(cpu.map((row) => row.status ?? "ok"))
+        : "unavailable",
+      current: cpu,
+      history: {
+        ...history.cpu,
+        emptyState:
+          history.cpu.series.length === 0 ? historyEmptyState : undefined,
+      },
+    },
+    {
+      id: "disk",
+      title: "Disk",
+      status: disk.length
+        ? worstStatus(disk.map((row) => row.status ?? "ok"))
+        : "unavailable",
+      current: disk,
+      history: {
+        ...history.disk,
+        emptyState:
+          history.disk.series.length === 0 ? historyEmptyState : undefined,
+      },
+    },
+  ];
+
+  const tableSizeRows = tableRows.map((row) => ({
+    node: row.node,
+    database: row.database,
+    table: row.table,
+    engine: row.engine,
+    rows: formatNumber(toNumber(row.total_rows)),
+    bytes: formatBytes(toNumber(row.total_bytes)),
+    parts: formatNumber(toNumber(row.active_parts ?? row.parts)),
+    status: "ok" as const,
+  }));
+
+  const capacityDetails = [
+    ...memory.slice(0, 8),
+    ...cpu.slice(0, 8),
+    ...disk.slice(0, 8),
+  ];
+  const capacityStatus = capacityDetails.length
+    ? worstStatus(capacityDetails.map((row) => row.status ?? "ok"))
+    : "unavailable";
+
+  const panels: InstanceHealthClickHousePanels = {
+    summary: [
+      {
+        label: "Nodes",
+        value: formatNumber(
+          new Set([...metricMap.keys(), ...diskRows.map((row) => row.node)])
+            .size || 1,
+        ),
+        status: "ok",
+      },
+      {
+        label: "Metric history",
+        value: hasMetricLog ? "available" : "current only",
+        status: hasMetricLog ? "ok" : "unavailable",
+      },
+      {
+        label: "Table metadata",
+        value: tableSizeRows.length
+          ? `${formatNumber(tableSizeRows.length)} tables`
+          : "unavailable",
+        status: tableSizeRows.length ? "ok" : "unavailable",
+      },
+    ],
+    metrics: metricPanels,
+    tables: {
+      status: tableSizeRows.length ? "ok" : "unavailable",
+      rows: tableSizeRows,
+      emptyState:
+        tableSizeRows.length === 0
+          ? "ClickHouse table metadata is unavailable"
+          : undefined,
+    },
+  };
+
+  return {
+    status: worstStatus([
+      "ok",
+      freshness.status,
+      capacityStatus,
+      ...metricPanels.map((panel) => panel.status),
+    ]),
+    freshnessStatus: freshness.status,
+    freshnessValue: freshness.currentValue,
+    freshnessDetails: freshness.details,
+    capacityStatus,
+    capacityValue: capacityDetails.length
+      ? `${formatNumber(capacityDetails.length)} current capacity signals`
+      : "capacity unavailable",
+    capacityDetails,
+    panels,
+    unavailableDiagnostics,
+  };
+};
+
+const addFinding = (
+  findings: InstanceHealthFinding[],
+  input: Omit<InstanceHealthFinding, "id">,
+) => {
+  if (input.status === "ok") return;
+
+  findings.push({
+    id: `${input.area}-${findings.length + 1}`,
+    ...input,
+  });
+};
+
+export const getInstanceHealth = async ({
+  prisma,
+  timeRange,
+}: {
+  prisma: PrismaClient;
+  timeRange: InstanceHealthTimeRange;
+}): Promise<InstanceHealthResponse> => {
+  const generatedAt = new Date().toISOString();
+  const [postgres, redisCheck, queues, clickhouse] = await Promise.all([
+    readPostgres(prisma),
+    readRedis(),
+    readQueues(),
+    readClickHouse(timeRange),
+  ]);
+
+  const unavailableDiagnostics = [
+    postgres.unavailable,
+    redisCheck.unavailable,
+    ...queues.unavailableDiagnostics,
+    ...clickhouse.unavailableDiagnostics,
+  ].filter(Boolean) as InstanceHealthUnavailableDiagnostic[];
+
+  const workerStatus =
+    queues.status === "unavailable"
+      ? "unavailable"
+      : queues.status === "error"
+        ? "warning"
+        : queues.status;
+
+  const findings: InstanceHealthFinding[] = [];
+  addFinding(findings, {
+    area: "postgres",
+    status: postgres.status,
+    title: "Postgres dependency is not healthy",
+    evidence: postgres.currentValue,
+    nextAction: "Check the Postgres container and DATABASE_URL wiring.",
+  });
+  addFinding(findings, {
+    area: "redis",
+    status: redisCheck.status,
+    title: "Redis dependency is not healthy",
+    evidence: redisCheck.currentValue,
+    nextAction: "Check Redis connectivity from the web container.",
+  });
+  addFinding(findings, {
+    area: "queues",
+    status: queues.status,
+    title: "Queue backlog or failed jobs need attention",
+    evidence: queues.currentValue,
+    nextAction: "Inspect worker logs and retry or drain failed BullMQ jobs.",
+  });
+  addFinding(findings, {
+    area: "clickhouse",
+    status: clickhouse.freshnessStatus,
+    title: "Ingestion freshness is stale or unavailable",
+    evidence: clickhouse.freshnessValue,
+    nextAction:
+      "Confirm ingestion workers are running and ClickHouse writes are succeeding.",
+  });
+  addFinding(findings, {
+    area: "capacity",
+    status: clickhouse.capacityStatus,
+    title: "ClickHouse capacity signals need attention",
+    evidence: clickhouse.capacityValue,
+    nextAction: "Check ClickHouse memory, CPU, disk, and table growth.",
+  });
+
+  const rankedFindings = findings
+    .sort((a, b) => STATUS_RANK[b.status] - STATUS_RANK[a.status])
+    .slice(0, 3);
+
+  const runbookSteps: InstanceHealthRunbookStep[] = [
+    {
+      id: "dependencies",
+      order: 1,
+      area: "postgres",
+      status: worstStatus([postgres.status, redisCheck.status]),
+      title: "Dependencies",
+      signal: "Postgres and Redis pings",
+      expected: "Both dependencies respond within 2 seconds",
+      lastChecked: generatedAt,
+      details: [...postgres.details, ...redisCheck.details],
+    },
+    {
+      id: "ingestion-freshness",
+      order: 2,
+      area: "clickhouse",
+      status: clickhouse.freshnessStatus,
+      title: "Ingestion freshness",
+      signal: "Recent ClickHouse rows",
+      expected: "At least one row in the last 3 minutes",
+      lastChecked: generatedAt,
+      details: clickhouse.freshnessDetails,
+    },
+    {
+      id: "queues",
+      order: 3,
+      area: "queues",
+      status: queues.status,
+      title: "Queues",
+      signal: "BullMQ waiting, delayed, active, and failed counts",
+      expected: "Failed jobs at 0 and queued jobs below 1,000 per family",
+      lastChecked: generatedAt,
+      details: queues.details,
+    },
+    {
+      id: "worker-signal",
+      order: 4,
+      area: "worker",
+      status: workerStatus,
+      title: "Worker signal",
+      signal: "Inferred from queue counters",
+      expected: "Workers are draining queues and failures are not accumulating",
+      lastChecked: generatedAt,
+      details: [
+        {
+          label: "Worker liveness",
+          value: "inferred from BullMQ metadata; no worker HTTP endpoint in V1",
+          status: workerStatus,
+        },
+      ],
+    },
+    {
+      id: "clickhouse-capacity",
+      order: 5,
+      area: "capacity",
+      status: clickhouse.capacityStatus,
+      title: "ClickHouse capacity",
+      signal: "System metrics, disks, and table metadata",
+      expected: "Memory, CPU, and disk stay below warning thresholds",
+      lastChecked: generatedAt,
+      details: clickhouse.capacityDetails,
+    },
+  ];
+
+  const ledgerRows: InstanceHealthLedgerRow[] = [
+    {
+      id: "web",
+      area: "web",
+      status: "ok",
+      signal: "Web diagnostics request",
+      currentValue: "served",
+      expected: "The organization settings page can fetch diagnostics",
+      lastChecked: generatedAt,
+      details: [
+        {
+          label: "Diagnostics surface",
+          value: "read-only tRPC request served by this web container",
+          status: "ok",
+        },
+      ],
+    },
+    {
+      id: "postgres",
+      area: "postgres",
+      status: postgres.status,
+      signal: "Postgres ping",
+      currentValue: postgres.currentValue,
+      expected: "SELECT 1 succeeds",
+      lastChecked: generatedAt,
+      details: postgres.details,
+    },
+    {
+      id: "redis",
+      area: "redis",
+      status: redisCheck.status,
+      signal: "Redis ping",
+      currentValue: redisCheck.currentValue,
+      expected: "PONG within 2 seconds",
+      lastChecked: generatedAt,
+      details: redisCheck.details,
+    },
+    {
+      id: "queues",
+      area: "queues",
+      status: queues.status,
+      signal: "BullMQ queue counts",
+      currentValue: queues.currentValue,
+      expected: "No failed jobs and bounded backlog",
+      lastChecked: generatedAt,
+      details: queues.details,
+    },
+    {
+      id: "worker-signal",
+      area: "worker",
+      status: workerStatus,
+      signal: "Worker signal",
+      currentValue: "inferred from queue activity",
+      expected: "Queues are draining without accumulated failures",
+      lastChecked: generatedAt,
+      details: [
+        {
+          label: "Direct worker diagnostics",
+          value: "not configured in V1",
+          status: "unavailable",
+        },
+      ],
+    },
+    {
+      id: "clickhouse-freshness",
+      area: "clickhouse",
+      status: clickhouse.freshnessStatus,
+      signal: "Recent rows",
+      currentValue: clickhouse.freshnessValue,
+      expected: "Recent trace/observation or event row within 3 minutes",
+      lastChecked: generatedAt,
+      details: clickhouse.freshnessDetails,
+    },
+    {
+      id: "clickhouse-capacity",
+      area: "capacity",
+      status: clickhouse.capacityStatus,
+      signal: "ClickHouse capacity",
+      currentValue: clickhouse.capacityValue,
+      expected: "Current system metrics remain below thresholds",
+      lastChecked: generatedAt,
+      details: clickhouse.capacityDetails,
+    },
+    ...unavailableDiagnostics.map((diagnostic) => ({
+      id: `unavailable-${diagnostic.id}`,
+      area: diagnostic.area,
+      status: "unavailable" as const,
+      signal: "Unavailable diagnostic",
+      currentValue: diagnostic.reason,
+      expected: "Diagnostic source is readable",
+      lastChecked: generatedAt,
+      details: [
+        {
+          label: "Reason",
+          value: diagnostic.reason,
+          status: "unavailable" as const,
+        },
+      ],
+    })),
+  ];
+
+  const overallStatus = worstStatus([
+    postgres.status,
+    redisCheck.status,
+    queues.status,
+    clickhouse.status,
+  ]);
+
+  return {
+    overallStatus,
+    generatedAt,
+    findings: rankedFindings,
+    topologyNodes: [
+      {
+        id: "web",
+        area: "web",
+        label: "Web",
+        status: "ok",
+        summary: "Dashboard request served by this web container",
+      },
+      {
+        id: "postgres",
+        area: "postgres",
+        label: "Postgres",
+        status: postgres.status,
+        summary: postgres.currentValue,
+      },
+      {
+        id: "redis",
+        area: "redis",
+        label: "Redis",
+        status: redisCheck.status,
+        summary: redisCheck.currentValue,
+      },
+      {
+        id: "queues",
+        area: "queues",
+        label: "Queues",
+        status: queues.status,
+        summary: queues.currentValue,
+      },
+      {
+        id: "worker",
+        area: "worker",
+        label: "Worker signal",
+        status: workerStatus,
+        summary: "inferred from queue counters",
+      },
+      {
+        id: "clickhouse",
+        area: "clickhouse",
+        label: "ClickHouse",
+        status: clickhouse.status,
+        summary: clickhouse.freshnessValue,
+      },
+    ],
+    topologyEdges: [
+      { from: "web", to: "redis", status: redisCheck.status },
+      { from: "redis", to: "queues", status: queues.status },
+      { from: "queues", to: "worker", status: workerStatus },
+      { from: "worker", to: "clickhouse", status: clickhouse.status },
+      { from: "web", to: "postgres", status: postgres.status },
+    ],
+    runbookSteps,
+    ledgerRows,
+    clickhousePanels: clickhouse.panels,
+    unavailableDiagnostics,
+  };
+};

--- a/web/src/features/instance-health/types.ts
+++ b/web/src/features/instance-health/types.ts
@@ -1,0 +1,131 @@
+export const INSTANCE_HEALTH_TIME_RANGES = ["now", "1h", "6h", "24h"] as const;
+
+export type InstanceHealthTimeRange =
+  (typeof INSTANCE_HEALTH_TIME_RANGES)[number];
+
+export type DiagnosticStatus = "ok" | "warning" | "error" | "unavailable";
+
+export type DiagnosticArea =
+  | "web"
+  | "postgres"
+  | "redis"
+  | "queues"
+  | "worker"
+  | "clickhouse"
+  | "capacity";
+
+export type DiagnosticDetail = {
+  label: string;
+  value: string;
+  status?: DiagnosticStatus;
+};
+
+export type InstanceHealthFinding = {
+  id: string;
+  area: DiagnosticArea;
+  status: DiagnosticStatus;
+  title: string;
+  evidence: string;
+  nextAction: string;
+};
+
+export type InstanceHealthTopologyNode = {
+  id: string;
+  area: DiagnosticArea;
+  label: string;
+  status: DiagnosticStatus;
+  summary: string;
+};
+
+export type InstanceHealthTopologyEdge = {
+  from: string;
+  to: string;
+  status: DiagnosticStatus;
+};
+
+export type InstanceHealthRunbookStep = {
+  id: string;
+  order: number;
+  area: DiagnosticArea;
+  status: DiagnosticStatus;
+  title: string;
+  signal: string;
+  expected: string;
+  lastChecked: string;
+  details?: DiagnosticDetail[];
+};
+
+export type InstanceHealthLedgerRow = {
+  id: string;
+  area: DiagnosticArea;
+  status: DiagnosticStatus;
+  signal: string;
+  currentValue: string;
+  expected: string;
+  lastChecked: string;
+  details?: DiagnosticDetail[];
+};
+
+export type InstanceHealthMetricPoint = {
+  timestamp: string;
+  value: number | null;
+};
+
+export type InstanceHealthMetricSeries = {
+  id: string;
+  node: string;
+  label: string;
+  unit: "bytes" | "ratio" | "count";
+  points: InstanceHealthMetricPoint[];
+};
+
+export type InstanceHealthClickHouseMetricPanel = {
+  id: "memory" | "cpu" | "disk";
+  title: string;
+  status: DiagnosticStatus;
+  current: DiagnosticDetail[];
+  history: {
+    range: InstanceHealthTimeRange;
+    series: InstanceHealthMetricSeries[];
+    emptyState?: string;
+  };
+};
+
+export type InstanceHealthClickHouseTableSize = {
+  node: string;
+  database: string;
+  table: string;
+  engine: string;
+  rows: string;
+  bytes: string;
+  parts: string;
+  status: DiagnosticStatus;
+};
+
+export type InstanceHealthClickHousePanels = {
+  summary: DiagnosticDetail[];
+  metrics: InstanceHealthClickHouseMetricPanel[];
+  tables: {
+    status: DiagnosticStatus;
+    rows: InstanceHealthClickHouseTableSize[];
+    emptyState?: string;
+  };
+};
+
+export type InstanceHealthUnavailableDiagnostic = {
+  id: string;
+  area: DiagnosticArea;
+  reason: string;
+};
+
+export type InstanceHealthResponse = {
+  overallStatus: DiagnosticStatus;
+  generatedAt: string;
+  findings: InstanceHealthFinding[];
+  topologyNodes: InstanceHealthTopologyNode[];
+  topologyEdges: InstanceHealthTopologyEdge[];
+  runbookSteps: InstanceHealthRunbookStep[];
+  ledgerRows: InstanceHealthLedgerRow[];
+  clickhousePanels: InstanceHealthClickHousePanels;
+  unavailableDiagnostics: InstanceHealthUnavailableDiagnostic[];
+};

--- a/web/src/pages/organization/[organizationId]/settings/index.tsx
+++ b/web/src/pages/organization/[organizationId]/settings/index.tsx
@@ -20,6 +20,7 @@ import { useIsCloudBillingAvailable } from "@/src/ee/features/billing/utils/isCl
 import { env } from "@/src/env.mjs";
 import { OrgAuditLogsSettingsPage } from "@/src/ee/features/audit-log-viewer/OrgAuditLogsSettingsPage";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
+import { InstanceHealthSettingsPage } from "@/src/features/instance-health/components/InstanceHealthSettingsPage";
 
 type OrganizationSettingsPage = {
   title: string;
@@ -39,7 +40,9 @@ export function useOrganizationSettingsPages(): OrganizationSettingsPage[] {
   const showOrgApiKeySettings = hasAdminApiEntitlement && hasOrgApiKeyAccess;
   const showAuditLogs = useHasEntitlement("audit-logs");
   const plan = usePlan();
-  const isLangfuseCloud = isCloudPlan(plan) ?? false;
+  const isLangfuseCloud =
+    Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) ||
+    (isCloudPlan(plan) ?? false);
   const isCloudBillingAvailable = useIsCloudBillingAvailable();
 
   if (!organization) return [];
@@ -110,6 +113,13 @@ export const getOrganizationSettingsPages = ({
       </div>
     ),
     show: showOrgApiKeySettings,
+  },
+  {
+    title: "Instance Health",
+    slug: "instance-health",
+    cmdKKeywords: ["health", "infra", "queues", "clickhouse", "diagnostics"],
+    content: <InstanceHealthSettingsPage orgId={organization.id} />,
+    show: !isLangfuseCloud,
   },
   {
     title: "Members",

--- a/web/src/server/api/root.ts
+++ b/web/src/server/api/root.ts
@@ -61,6 +61,7 @@ import { onboardingRouter } from "@/src/features/onboarding/server/onboardingRou
 import { webCalloutsRouter } from "@/src/features/web-callouts/server/router";
 import { inAppAgentRouter } from "@/src/ee/features/in-app-agent/server/router";
 import { v4TransitionRouter } from "@/src/features/v4/server/v4TransitionRouter";
+import { instanceHealthRouter } from "@/src/features/instance-health/server/instanceHealthRouter";
 
 /**
  * This is the primary router for your server.
@@ -130,6 +131,7 @@ export const appRouter = createTRPCRouter({
   webCallouts: webCalloutsRouter,
   inAppAgent: inAppAgentRouter,
   v4Transition: v4TransitionRouter,
+  instanceHealth: instanceHealthRouter,
 });
 
 // export type definition of API


### PR DESCRIPTION
Summary
- Add an OSS-only Organization Settings > Instance Health dashboard for self-hosted operators.
- Make the page metrics-first: 1h default range, top operator metric cards, ClickHouse memory/CPU/disk/table-size views, then fix-first findings, topology, ledger, and runbook drill-downs.
- Add bounded server diagnostics for Postgres, Redis, BullMQ queues, inferred worker signal, and ClickHouse system metrics/table metadata.
- Add the Instance Health entrypoint next to Background Migrations in the version dropdown for OSS/self-hosted operators.

Safety
- No worker diagnostics endpoint or worker internal secret/env wiring was added.
- Diagnostics are read-only and never return env secret values, connection URLs, API keys, job payloads, raw query text, or request headers.
- ClickHouse diagnostics stay bounded to ping/freshness/system metadata queries; tests assert no FINAL, OPTIMIZE, broad joins, or SELECT *.
- Queue count reads are now bounded with per-operation timeouts.

Verification
- pnpm run nuke
- pnpm run dx-f
- NEXT_PUBLIC_LANGFUSE_CLOUD_REGION= pnpm run dev
- pnpm --filter web run lint
- pnpm --filter web exec vitest run --project client src/components/VersionLabel.clienttest.tsx src/__tests__/organization-settings-pages.clienttest.tsx src/features/instance-health/lib/prepareInstanceHealthView.clienttest.ts
- pnpm --filter web exec vitest run --project server src/__tests__/server/instance-health-query-safety.servertest.ts
- Browser reviewed OSS version-dropdown entrypoint and Instance Health page on seeded OWNER org at desktop and 390px mobile widths.