### PR TITLE
ci: add AWS PR previews

### DIFF
--- a/.github/actions/aws-preview-comment/action.yml
+++ b/.github/actions/aws-preview-comment/action.yml
@@ -1,0 +1,55 @@
+name: AWS preview status comment
+description: >-
+  Create or update the single marker-tagged AWS preview status comment on a
+  pull request. Every preview lifecycle job funnels its state through this
+  action so each PR has exactly one authoritative status comment.
+
+inputs:
+  pr-number:
+    description: Pull request number
+    required: true
+  body:
+    description: Comment body (the hidden marker is prepended automatically)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        PREVIEW_PR_NUMBER: ${{ inputs.pr-number }}
+        PREVIEW_COMMENT_BODY: ${{ inputs.body }}
+      with:
+        script: |
+          const marker = "<!-- aws-pr-preview -->";
+          const issue_number = Number(process.env.PREVIEW_PR_NUMBER);
+          const body = `${marker}\n${process.env.PREVIEW_COMMENT_BODY}`;
+
+          const { owner, repo } = context.repo;
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            owner,
+            repo,
+            issue_number,
+            per_page: 100,
+          });
+          const previous = comments.find(
+            (comment) =>
+              comment.user?.login === "github-actions[bot]" &&
+              comment.body?.includes(marker),
+          );
+
+          if (previous) {
+            await github.rest.issues.updateComment({
+              owner,
+              repo,
+              comment_id: previous.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });
+          }

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -486,18 +486,60 @@ jobs:
           preview_host="pr-${pr_number}.${AWS_PREVIEW_DOMAIN_NAME}"
           ecr_registry="${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL%%/*}"
 
-          stable_secret() {
-            printf '%s' "$1" | sha256sum | cut -d' ' -f1
+          # Per-preview secret root. Every preview secret below is HMAC-derived
+          # from this random seed, so none is computable from this public repo
+          # (a plain sha256 of "<name>-<pr>" was). The seed is generated once on
+          # first deploy and persisted in AWS Secrets Manager, then reused on
+          # every redeploy and stop/resume so the derived secrets stay stable:
+          # Postgres and ClickHouse bake their password into the data volume at
+          # first init, so a changed secret against a surviving volume would lock
+          # the stack out of its own database.
+          seed_name="langfuse-preview/pr-${pr_number}/seed"
+          if seed="$(aws secretsmanager get-secret-value --secret-id "${seed_name}" \
+            --query "SecretString" --output text 2>/tmp/seed_err)"; then
+            echo "Reusing existing secret seed for PR ${pr_number}."
+          elif grep -q "ResourceNotFoundException" /tmp/seed_err; then
+            echo "Generating a new secret seed for PR ${pr_number}."
+            seed="$(openssl rand -hex 32)"
+            # create-secret fails if a concurrent deploy already created the
+            # seed; re-read the winner instead of clobbering it.
+            if ! aws secretsmanager create-secret --name "${seed_name}" \
+              --secret-string "${seed}" 2>/tmp/seed_put_err; then
+              if grep -q "ResourceExistsException" /tmp/seed_put_err; then
+                seed="$(aws secretsmanager get-secret-value --secret-id "${seed_name}" \
+                  --query "SecretString" --output text)"
+              else
+                cat /tmp/seed_put_err >&2
+                exit 1
+              fi
+            fi
+          else
+            # Fail closed: an unreadable (but not absent) seed must never fall
+            # through to regeneration — new secrets against a surviving volume
+            # would brick the preview. Throttling/permission/KMS errors land here.
+            echo "Secret seed for PR ${pr_number} is unreadable and not absent; refusing to regenerate." >&2
+            cat /tmp/seed_err >&2
+            exit 1
+          fi
+          echo "::add-mask::${seed}"
+
+          # HMAC-SHA256(seed, label) -> 64 hex chars: exactly the ENCRYPTION_KEY
+          # format (256-bit hex, per `openssl rand -hex 32`), and hex keeps
+          # connection strings free of URL/shell-special characters.
+          derive() {
+            printf '%s' "$1" | openssl dgst -sha256 -hmac "${seed}" | awk '{print $NF}'
           }
 
-          postgres_password="$(stable_secret "postgres-${pr_number}")"
-          clickhouse_password="$(stable_secret "clickhouse-${pr_number}")"
-          redis_auth="$(stable_secret "redis-${pr_number}")"
-          minio_password="$(stable_secret "minio-${pr_number}")"
-          nextauth_secret="$(stable_secret "nextauth-${pr_number}")"
-          salt="$(stable_secret "salt-${pr_number}")"
-          encryption_key="$(stable_secret "encryption-${pr_number}")"
-          login_password="langfuse-preview-${pr_number}"
+          postgres_password="$(derive postgres)"
+          clickhouse_password="$(derive clickhouse)"
+          redis_auth="$(derive redis)"
+          minio_password="$(derive minio)"
+          nextauth_secret="$(derive nextauth)"
+          salt="$(derive salt)"
+          encryption_key="$(derive encryption)"
+          login_password="$(derive login)"
+          public_key="pk-lf-preview-${pr_number}"
+          secret_key="sk-lf-preview-$(derive apikey)"
 
           for value in \
             "${postgres_password}" \
@@ -507,7 +549,8 @@ jobs:
             "${nextauth_secret}" \
             "${salt}" \
             "${encryption_key}" \
-            "${login_password}"; do
+            "${login_password}" \
+            "${secret_key}"; do
             echo "::add-mask::${value}"
           done
 
@@ -524,10 +567,10 @@ jobs:
             echo "postgres_password=${postgres_password}"
             echo "preview_host=${preview_host}"
             echo "pr_number=${pr_number}"
-            echo "public_key=pk-lf-preview-${pr_number}"
+            echo "public_key=${public_key}"
             echo "redis_auth=${redis_auth}"
             echo "salt=${salt}"
-            echo "secret_key=sk-lf-preview-${pr_number}"
+            echo "secret_key=${secret_key}"
             echo "short_sha=${short_sha}"
             echo "stack_name=${stack_name}"
             echo "web_image=${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}:${image_tag}"
@@ -1077,6 +1120,16 @@ jobs:
             fi
           done
 
+      - name: Delete preview secret seed
+        env:
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          aws secretsmanager delete-secret --secret-id "langfuse-preview/pr-${PR_NUMBER}/seed" \
+            --force-delete-without-recovery 2>/dev/null \
+            || echo "No secret seed for PR ${PR_NUMBER}."
+
       - name: Update status comment
         if: steps.delete.outputs.existed == 'true'
         uses: ./.github/actions/aws-preview-comment
@@ -1287,6 +1340,8 @@ jobs:
                       --image-ids "${image_ids}" >/dev/null
                   fi
                 done
+
+                aws secretsmanager delete-secret --secret-id "langfuse-preview/pr-${pr_number}/seed" --force-delete-without-recovery 2>/dev/null || true
               ); then
                 echo "Failed to reap ${stack_name}; continuing with the next stack."
                 continue
@@ -1364,6 +1419,8 @@ jobs:
                   fi
                 done
               fi
+
+              aws secretsmanager delete-secret --secret-id "langfuse-preview/pr-${pr_number}/seed" --force-delete-without-recovery 2>/dev/null || true
             ); then
               echo "Failed to reap ${stack_name}; continuing with the next stack."
               continue

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -756,11 +756,28 @@ jobs:
           EOF
 
           env_b64="$(base64 -w0 "${env_file}")"
+
+          # SSM parameters must be JSON: the base64 blob and the shell snippets
+          # below contain commas and pipes that the "commands=..." shorthand
+          # mis-parses (AWS CLI ParamValidationError). A file:// JSON document
+          # passes each command through verbatim.
+          params_file="$(mktemp)"
+          cat > "${params_file}" <<JSON
+          {"commands":[
+          "mkdir -p /opt/langfuse-preview",
+          "echo ${env_b64} | base64 -d > /opt/langfuse-preview/deploy.env",
+          "chmod 600 /opt/langfuse-preview/deploy.env",
+          "for i in \$(seq 1 60); do test -x /opt/langfuse-preview/deploy.sh && break || sleep 5; done",
+          "test -x /opt/langfuse-preview/deploy.sh",
+          "/opt/langfuse-preview/deploy.sh"
+          ]}
+          JSON
+
           command_id="$(aws ssm send-command \
             --document-name "AWS-RunShellScript" \
             --instance-ids "${INSTANCE_ID}" \
             --comment "Deploy Langfuse PR ${PR_NUMBER} preview" \
-            --parameters "commands=mkdir -p /opt/langfuse-preview,echo ${env_b64} | base64 -d > /opt/langfuse-preview/deploy.env,chmod 600 /opt/langfuse-preview/deploy.env,for i in \$(seq 1 60); do test -x /opt/langfuse-preview/deploy.sh && break || sleep 5; done,test -x /opt/langfuse-preview/deploy.sh,/opt/langfuse-preview/deploy.sh" \
+            --parameters "file://${params_file}" \
             --query "Command.CommandId" \
             --output text)"
 

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -8,8 +8,10 @@ name: AWS PR Preview
 #   /preview destroy   delete the CloudFormation stack and preview images
 #
 # Pushing new commits updates a preview only if one is already deployed and
-# running. Closing the PR destroys the preview. A nightly schedule stops all
-# running preview instances to cap cost; resume them with `/preview resume`.
+# running. Closing the PR destroys the preview. Each engineer may have at
+# most 5 previews running at once (best-effort, PreviewOwner tag). Running
+# previews are never stopped automatically; previews stopped for more than
+# 7 days are destroyed by a daily reaper.
 #
 # The shared AWS foundation (VPC, ECR, Route53 zone, IAM roles) lives in the
 # private langfuse/infrastructure repo under terraform/org/playground_previews.
@@ -20,7 +22,7 @@ on:
   pull_request:
     types: [synchronize, closed]
   schedule:
-    # Stop all running previews nightly (03:17 UTC) to cap cost.
+    # Daily reaper: destroy previews stopped for more than 7 days.
     - cron: "17 3 * * *"
   workflow_dispatch:
     inputs:
@@ -33,9 +35,10 @@ on:
           - resume
           - destroy
           - stop-all
+          - reap
         required: true
       pr_number:
-        description: "Pull request number (not needed for stop-all)"
+        description: "Pull request number (not needed for stop-all/reap)"
         required: false
 
 permissions: {}
@@ -80,6 +83,7 @@ jobs:
       command: ${{ steps.resolve.outputs.command }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}
+      actor: ${{ steps.resolve.outputs.actor }}
     steps:
       - name: Resolve command, PR, and authorization
         id: resolve
@@ -100,6 +104,9 @@ jobs:
             let command = "";
             let prNumber = "";
             let headSha = "";
+            // GitHub login whose command makes an env run; holds one of the
+            // per-engineer running-env slots via the PreviewOwner tag.
+            let actor = "";
 
             const reply = (body) =>
               github.rest.issues.createComment({
@@ -119,11 +126,12 @@ jobs:
             };
 
             if (context.eventName === "schedule") {
-              command = "stop-all";
+              command = "reap";
             } else if (context.eventName === "workflow_dispatch") {
               command = context.payload.inputs.action;
               prNumber = context.payload.inputs.pr_number || "";
-              if (command !== "stop-all") {
+              actor = context.actor;
+              if (!["stop-all", "reap"].includes(command)) {
                 if (!prNumber) {
                   core.setFailed("pr_number is required for per-PR actions.");
                   return;
@@ -200,12 +208,14 @@ jobs:
               command = parsed;
               prNumber = String(context.payload.issue.number);
               headSha = pr.head.sha;
+              actor = context.payload.comment.user.login;
             }
 
-            core.info(`command=${command} pr=${prNumber} sha=${headSha}`);
+            core.info(`command=${command} pr=${prNumber} sha=${headSha} actor=${actor}`);
             core.setOutput("command", command);
             core.setOutput("pr_number", prNumber);
             core.setOutput("head_sha", headSha);
+            core.setOutput("actor", actor);
 
   deploy_gate:
     name: Check deploy preconditions
@@ -214,7 +224,8 @@ jobs:
     if: contains(fromJSON('["deploy", "sync"]'), needs.context.outputs.command)
     permissions:
       id-token: write
-      pull-requests: read
+      issues: write
+      pull-requests: write
     outputs:
       proceed: ${{ steps.gate.outputs.proceed }}
     steps:
@@ -227,51 +238,75 @@ jobs:
       - name: Decide whether to deploy
         id: gate
         env:
+          ACTOR: ${{ needs.context.outputs.actor }}
           COMMAND: ${{ needs.context.outputs.command }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
         run: |
           set -euo pipefail
 
-          if [ "${COMMAND}" = "deploy" ]; then
-            # Re-check PR state at execution time: a deploy queued behind the
-            # close-triggered destroy must not recreate the preview stack for
-            # a PR that is now closed (nothing would ever clean it up again).
-            state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)"
-            if [ "${state}" != "open" ]; then
-              echo "PR ${PR_NUMBER} is ${state}; not deploying."
-              echo "proceed=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Push events only refresh previews that were explicitly deployed
-          # and are currently running. Stopped previews stay stopped.
           stack_name="langfuse-preview-pr-${PR_NUMBER}"
           instance_id="$(aws cloudformation describe-stacks \
             --stack-name "${stack_name}" \
             --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
             --output text 2>/dev/null || true)"
+          instance_state="absent"
+          if [ -n "${instance_id}" ] && [ "${instance_id}" != "None" ]; then
+            instance_state="$(aws ec2 describe-instances \
+              --instance-ids "${instance_id}" \
+              --query "Reservations[0].Instances[0].State.Name" \
+              --output text)"
+          fi
 
-          if [ -z "${instance_id}" ] || [ "${instance_id}" = "None" ]; then
-            echo "No preview stack for PR ${PR_NUMBER}; skipping auto-update."
+          if [ "${COMMAND}" = "sync" ]; then
+            # Push events only refresh previews that were explicitly deployed
+            # and are currently running. Stopped previews stay stopped, and no
+            # per-engineer slot changes hands.
+            if [ "${instance_state}" = "running" ]; then
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "Preview instance is ${instance_state}; skipping auto-update."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
+          # Re-check PR state at execution time: a deploy queued behind the
+          # close-triggered destroy must not recreate the preview stack for
+          # a PR that is now closed (nothing would ever clean it up again).
+          pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)"
+          if [ "${pr_state}" != "open" ]; then
+            echo "PR ${PR_NUMBER} is ${pr_state}; not deploying."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          state="$(aws ec2 describe-instances \
-            --instance-ids "${instance_id}" \
-            --query "Reservations[0].Instances[0].State.Name" \
-            --output text)"
-
-          if [ "${state}" = "running" ]; then
+          # Refreshing an already-running env does not consume a new slot.
+          if [ "${instance_state}" = "running" ] || [ "${instance_state}" = "pending" ]; then
             echo "proceed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Preview instance is ${state}; skipping auto-update."
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          # Per-engineer limit: at most 5 running envs, attributed by the
+          # PreviewOwner tag. Best-effort — concurrent commands can race.
+          running="$(aws ec2 describe-instances \
+            --filters \
+              "Name=tag:Project,Values=langfuse-preview" \
+              "Name=tag:PreviewOwner,Values=${ACTOR}" \
+              "Name=instance-state-name,Values=pending,running" \
+            --query "Reservations[].Instances[].[Tags[?Key=='PullRequest'] | [0].Value]" \
+            --output text | grep -v '^$' || true)"
+          count="$(printf '%s' "${running}" | grep -c . || true)"
+
+          if [ "${count}" -ge 5 ]; then
+            pr_list="$(printf '%s\n' "${running}" | sed 's/^/#/' | paste -sd ', ' -)"
+            gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+              --body "@${ACTOR} you already have ${count} running previews (PRs ${pr_list}). Stop or destroy one first (\`/preview stop\` / \`/preview destroy\`), then retry."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
 
   deploy:
     name: Deploy AWS preview
@@ -417,6 +452,7 @@ jobs:
 
       - name: Deploy preview host stack
         env:
+          ACTOR: ${{ needs.context.outputs.actor }}
           PR_NUMBER: ${{ steps.preview.outputs.pr_number }}
           STACK_NAME: ${{ steps.preview.outputs.stack_name }}
         run: |
@@ -436,21 +472,29 @@ jobs:
               ;;
           esac
 
+          overrides=(
+            PreviewName="${STACK_NAME}"
+            PullRequestNumber="${PR_NUMBER}"
+            SubnetId="${AWS_PREVIEW_SUBNET_ID}"
+            SecurityGroupId="${AWS_PREVIEW_SECURITY_GROUP_ID}"
+            InstanceProfileName="${AWS_PREVIEW_INSTANCE_PROFILE_NAME}"
+            HostedZoneId="${AWS_PREVIEW_HOSTED_ZONE_ID}"
+            DomainName="${AWS_PREVIEW_DOMAIN_NAME}"
+            InstanceType="${AWS_PREVIEW_INSTANCE_TYPE}"
+            VolumeSizeGb="${AWS_PREVIEW_VOLUME_SIZE_GB}"
+          )
+          # Push-triggered refreshes have no actor and keep the previous
+          # owner (omitted parameters retain their value on stack updates).
+          if [ -n "${ACTOR}" ]; then
+            overrides+=(PreviewOwner="${ACTOR}")
+          fi
+
           aws cloudformation deploy \
             --stack-name "${STACK_NAME}" \
             --template-file deployment/aws-preview/cloudformation.yaml \
             --role-arn "${AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN}" \
             --no-fail-on-empty-changeset \
-            --parameter-overrides \
-              PreviewName="${STACK_NAME}" \
-              PullRequestNumber="${PR_NUMBER}" \
-              SubnetId="${AWS_PREVIEW_SUBNET_ID}" \
-              SecurityGroupId="${AWS_PREVIEW_SECURITY_GROUP_ID}" \
-              InstanceProfileName="${AWS_PREVIEW_INSTANCE_PROFILE_NAME}" \
-              HostedZoneId="${AWS_PREVIEW_HOSTED_ZONE_ID}" \
-              DomainName="${AWS_PREVIEW_DOMAIN_NAME}" \
-              InstanceType="${AWS_PREVIEW_INSTANCE_TYPE}" \
-              VolumeSizeGb="${AWS_PREVIEW_VOLUME_SIZE_GB}" \
+            --parameter-overrides "${overrides[@]}" \
             --tags \
               Project=langfuse-preview \
               PullRequest="${PR_NUMBER}" \
@@ -485,6 +529,9 @@ jobs:
             aws ec2 start-instances --instance-ids "${instance_id}"
           fi
           aws ec2 wait instance-running --instance-ids "${instance_id}"
+
+          # A deployed env is running again; it is no longer reapable.
+          aws ec2 delete-tags --resources "${instance_id}" --tags Key=StoppedAt
 
           echo "instance_id=${instance_id}" >> "$GITHUB_OUTPUT"
           echo "public_ip=${public_ip}" >> "$GITHUB_OUTPUT"
@@ -605,7 +652,8 @@ jobs:
             **API keys:** `${{ steps.preview.outputs.public_key }}` / `${{ steps.preview.outputs.secret_key }}`
             **Commit:** ${{ steps.preview.outputs.commit_sha }}
 
-            Synthetic preview data only. Previews are stopped automatically overnight.
+            Synthetic preview data only. Each engineer can run up to 5 previews;
+            previews stopped for more than 7 days are destroyed automatically.
             Commands: `/preview deploy` · `/preview stop` · `/preview resume` · `/preview destroy`
 
       - name: Report failure
@@ -661,6 +709,9 @@ jobs:
 
           aws ec2 stop-instances --instance-ids "${instance_id}"
           aws ec2 wait instance-stopped --instance-ids "${instance_id}"
+          # The reaper destroys envs stopped for more than 7 days.
+          aws ec2 create-tags --resources "${instance_id}" \
+            --tags "Key=StoppedAt,Value=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           echo "exists=true" >> "$GITHUB_OUTPUT"
 
       - name: Update status comment
@@ -672,6 +723,7 @@ jobs:
             ### ⏸️ AWS preview stopped
 
             Data, URL, and TLS certificate are kept. Resume with `/preview resume`.
+            Previews stopped for more than 7 days are destroyed automatically.
 
       - name: Report missing preview
         if: steps.stop.outputs.exists == 'false'
@@ -718,6 +770,8 @@ jobs:
       - name: Start preview instance
         id: start
         env:
+          ACTOR: ${{ needs.context.outputs.actor }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
         run: |
           set -euo pipefail
@@ -730,15 +784,50 @@ jobs:
 
           if [ -z "${instance_id}" ] || [ "${instance_id}" = "None" ]; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+
+          state="$(aws ec2 describe-instances \
+            --instance-ids "${instance_id}" \
+            --query "Reservations[0].Instances[0].State.Name" \
+            --output text)"
+
+          # Per-engineer limit: resuming takes one of the actor's 5 running
+          # slots (unless this env is already running).
+          if [ "${state}" != "running" ] && [ "${state}" != "pending" ]; then
+            running="$(aws ec2 describe-instances \
+              --filters \
+                "Name=tag:Project,Values=langfuse-preview" \
+                "Name=tag:PreviewOwner,Values=${ACTOR}" \
+                "Name=instance-state-name,Values=pending,running" \
+              --query "Reservations[].Instances[].[Tags[?Key=='PullRequest'] | [0].Value]" \
+              --output text | grep -v '^$' || true)"
+            count="$(printf '%s' "${running}" | grep -c . || true)"
+
+            if [ "${count}" -ge 5 ]; then
+              pr_list="$(printf '%s\n' "${running}" | sed 's/^/#/' | paste -sd ', ' -)"
+              gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+                --body "@${ACTOR} you already have ${count} running previews (PRs ${pr_list}). Stop or destroy one first (\`/preview stop\` / \`/preview destroy\`), then retry."
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              echo "allowed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           aws ec2 start-instances --instance-ids "${instance_id}"
           aws ec2 wait instance-running --instance-ids "${instance_id}"
+
+          # The resumer now owns this env's running slot.
+          aws ec2 delete-tags --resources "${instance_id}" --tags Key=StoppedAt
+          aws ec2 create-tags --resources "${instance_id}" \
+            --tags "Key=PreviewOwner,Value=${ACTOR}"
+
           echo "exists=true" >> "$GITHUB_OUTPUT"
+          echo "allowed=true" >> "$GITHUB_OUTPUT"
 
       - name: Wait for preview health
-        if: steps.start.outputs.exists == 'true'
+        if: steps.start.outputs.exists == 'true' && steps.start.outputs.allowed == 'true'
         env:
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
         run: |
@@ -759,7 +848,7 @@ jobs:
           exit 1
 
       - name: Update status comment
-        if: steps.start.outputs.exists == 'true'
+        if: steps.start.outputs.exists == 'true' && steps.start.outputs.allowed == 'true'
         uses: ./.github/actions/aws-preview-comment
         with:
           pr-number: ${{ needs.context.outputs.pr_number }}
@@ -911,14 +1000,101 @@ jobs:
             exit 0
           fi
 
+          stopped_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           while read -r instance_id pr_number; do
             [ -z "${instance_id}" ] && continue
             echo "Stopping ${instance_id} (PR ${pr_number})"
             aws ec2 stop-instances --instance-ids "${instance_id}"
+            aws ec2 create-tags --resources "${instance_id}" \
+              --tags "Key=StoppedAt,Value=${stopped_at}"
 
             if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
               gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
-                --body "⏸️ AWS preview stopped automatically overnight. Resume with \`/preview resume\`." \
+                --body "⏸️ AWS preview stopped by a manual stop-all. Resume with \`/preview resume\`." \
+                || echo "Could not comment on PR ${pr_number}."
+            fi
+          done <<< "${instances}"
+
+  reap:
+    name: Reap long-stopped previews
+    runs-on: ubuntu-latest
+    needs: context
+    if: needs.context.outputs.command == 'reap'
+    permissions:
+      id-token: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          aws-region: ${{ env.AWS_PREVIEW_REGION }}
+          role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+
+      - name: Destroy previews stopped for more than 7 days
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          cutoff="$(date -u -d '7 days ago' +%s)"
+
+          instances="$(aws ec2 describe-instances \
+            --filters \
+              "Name=tag:Project,Values=langfuse-preview" \
+              "Name=instance-state-name,Values=stopped" \
+              "Name=tag-key,Values=StoppedAt" \
+            --query "Reservations[].Instances[].[InstanceId, Tags[?Key=='StoppedAt'] | [0].Value, Tags[?Key=='PullRequest'] | [0].Value, Tags[?Key=='aws:cloudformation:stack-name'] | [0].Value]" \
+            --output text)"
+
+          if [ -z "${instances}" ]; then
+            echo "No stopped previews with a StoppedAt tag."
+            exit 0
+          fi
+
+          while read -r instance_id stopped_at pr_number stack_name; do
+            [ -z "${instance_id}" ] && continue
+
+            stopped_epoch="$(date -u -d "${stopped_at}" +%s 2>/dev/null || echo 0)"
+            if [ "${stopped_epoch}" -eq 0 ]; then
+              echo "Skipping ${instance_id}: unparseable StoppedAt '${stopped_at}'."
+              continue
+            fi
+            if [ "${stopped_epoch}" -gt "${cutoff}" ]; then
+              continue
+            fi
+            case "${stack_name}" in
+              langfuse-preview-pr-*) ;;
+              *)
+                echo "Skipping ${instance_id}: unexpected stack name '${stack_name}'."
+                continue
+                ;;
+            esac
+
+            echo "Reaping ${stack_name} (stopped since ${stopped_at})"
+            aws cloudformation delete-stack --stack-name "${stack_name}"
+            aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
+
+            if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
+              for repository_url in \
+                "${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}" \
+                "${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}"; do
+                repository_name="${repository_url#*/}"
+                image_ids="$(aws ecr list-images \
+                  --repository-name "${repository_name}" \
+                  --filter tagStatus=TAGGED \
+                  --query "imageIds[?starts_with(imageTag, 'pr-${pr_number}-')]" \
+                  --output json)"
+
+                if [ "${image_ids}" != "[]" ]; then
+                  aws ecr batch-delete-image \
+                    --repository-name "${repository_name}" \
+                    --image-ids "${image_ids}" >/dev/null
+                fi
+              done
+
+              gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+                --body "🗑️ AWS preview destroyed after 7 days stopped. Recreate with \`/preview deploy\`." \
                 || echo "Could not comment on PR ${pr_number}."
             fi
           done <<< "${instances}"

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -7,11 +7,18 @@ name: AWS PR Preview
 #   /preview resume    start the instance again
 #   /preview destroy   delete the CloudFormation stack and preview images
 #
-# Pushing new commits updates a preview only if one is already deployed and
-# running. Closing the PR destroys the preview. Each engineer may have at
-# most 5 previews running at once (best-effort, PreviewOwner tag). A
-# housekeeping schedule stops previews that have been idle (low CPU) for
-# several hours and destroys previews stopped for more than 7 days.
+# Comment `/preview deploy` to build the PR head and (re)deploy its preview;
+# run it again after pushing commits to refresh a running preview. Each
+# engineer may have at most 5 previews running at once (best-effort,
+# PreviewOwner tag). A housekeeping schedule stops previews that have been
+# idle (low CPU) for several hours, destroys previews whose PR is closed,
+# and destroys previews stopped for more than 7 days.
+#
+# All AWS-touching jobs run only from the default branch: the OIDC role's
+# trust policy accepts only the refs/heads/main subject, so unreviewed
+# pull-request workflow code can never assume it. That is why this workflow
+# is not triggered by `pull_request` — PR lifecycle (refresh on push,
+# cleanup on close) is handled by /preview commands and reconciliation.
 #
 # The shared AWS foundation (VPC, ECR, Route53 zone, IAM roles) is managed
 # in Langfuse's internal infrastructure repository.
@@ -19,10 +26,9 @@ name: AWS PR Preview
 on:
   issue_comment:
     types: [created]
-  pull_request:
-    types: [synchronize, closed]
   schedule:
-    # Housekeeping: stop idle previews, destroy previews stopped > 7 days.
+    # Housekeeping: stop idle previews, destroy previews for closed PRs,
+    # destroy previews stopped > 7 days.
     - cron: "17 */2 * * *"
   workflow_dispatch:
     inputs:
@@ -75,7 +81,6 @@ jobs:
       ((github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/preview')) ||
-      github.event_name == 'pull_request' ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch')
     permissions:
@@ -145,17 +150,6 @@ jobs:
                 }
                 headSha = pr.head.sha;
               }
-            } else if (context.eventName === "pull_request") {
-              const pr = context.payload.pull_request;
-              prNumber = String(pr.number);
-              if (pr.head.repo.full_name !== sameRepo) {
-                core.info("Skipping: fork pull request.");
-              } else if (context.payload.action === "closed") {
-                command = "destroy";
-              } else {
-                command = "sync";
-                headSha = pr.head.sha;
-              }
             } else if (context.eventName === "issue_comment") {
               const body = (context.payload.comment.body || "").trim();
               const match = body.match(/^\/preview(?:\s+([a-z-]+))?/i);
@@ -223,7 +217,7 @@ jobs:
     name: Check deploy preconditions
     runs-on: ubuntu-latest
     needs: context
-    if: contains(fromJSON('["deploy", "sync"]'), needs.context.outputs.command)
+    if: needs.context.outputs.command == 'deploy'
     permissions:
       id-token: write
       issues: write
@@ -241,7 +235,6 @@ jobs:
         id: gate
         env:
           ACTOR: ${{ needs.context.outputs.actor }}
-          COMMAND: ${{ needs.context.outputs.command }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
         run: |
@@ -260,21 +253,8 @@ jobs:
               --output text)"
           fi
 
-          if [ "${COMMAND}" = "sync" ]; then
-            # Push events only refresh previews that were explicitly deployed
-            # and are currently running. Stopped previews stay stopped, and no
-            # per-engineer slot changes hands.
-            if [ "${instance_state}" = "running" ]; then
-              echo "proceed=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "Preview instance is ${instance_state}; skipping auto-update."
-              echo "proceed=false" >> "$GITHUB_OUTPUT"
-            fi
-            exit 0
-          fi
-
-          # Re-check PR state at execution time: a deploy queued behind the
-          # close-triggered destroy must not recreate the preview stack for
+          # Re-check PR state at execution time: a deploy queued behind a
+          # close/reconcile destroy must not recreate the preview stack for
           # a PR that is now closed (nothing would ever clean it up again).
           pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)"
           if [ "${pr_state}" != "open" ]; then
@@ -1099,6 +1079,67 @@ jobs:
               fi
             fi
           done <<< "${instances}"
+
+      - name: Destroy previews for closed PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Reconciliation replaces the old pull_request:closed teardown: this
+          # runs from the default branch, so no unreviewed PR workflow code is
+          # ever trusted with the preview role. Worst-case cleanup latency is
+          # one housekeeping interval (2h).
+          instances="$(aws ec2 describe-instances \
+            --filters \
+              "Name=tag:Project,Values=langfuse-preview" \
+              "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+            --query "Reservations[].Instances[].[Tags[?Key=='PullRequest'] | [0].Value, Tags[?Key=='aws:cloudformation:stack-name'] | [0].Value]" \
+            --output text)"
+
+          if [ -z "${instances}" ]; then
+            echo "No preview instances."
+          else
+            while read -r pr_number stack_name; do
+              [ -z "${pr_number}" ] || [ "${pr_number}" = "None" ] && continue
+              case "${stack_name}" in
+                langfuse-preview-pr-*) ;;
+                *)
+                  echo "Skipping unexpected stack name '${stack_name}'."
+                  continue
+                  ;;
+              esac
+
+              pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq .state 2>/dev/null || echo "unknown")"
+              if [ "${pr_state}" != "closed" ]; then
+                continue
+              fi
+
+              echo "Destroying ${stack_name}: PR ${pr_number} is closed."
+              aws cloudformation delete-stack --stack-name "${stack_name}"
+              aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
+
+              for repository_url in \
+                "${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}" \
+                "${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}"; do
+                repository_name="${repository_url#*/}"
+                image_ids="$(aws ecr list-images \
+                  --repository-name "${repository_name}" \
+                  --filter tagStatus=TAGGED \
+                  --query "imageIds[?starts_with(imageTag, 'pr-${pr_number}-')]" \
+                  --output json)"
+                if [ "${image_ids}" != "[]" ]; then
+                  aws ecr batch-delete-image \
+                    --repository-name "${repository_name}" \
+                    --image-ids "${image_ids}" >/dev/null
+                fi
+              done
+
+              gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+                --body "🗑️ AWS preview destroyed because the PR is closed. Reopen and \`/preview deploy\` to recreate." \
+                || echo "Could not comment on PR ${pr_number}."
+            done <<< "${instances}"
+          fi
 
       - name: Destroy previews stopped for more than 7 days
         env:

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -13,8 +13,8 @@ name: AWS PR Preview
 # previews are never stopped automatically; previews stopped for more than
 # 7 days are destroyed by a daily reaper.
 #
-# The shared AWS foundation (VPC, ECR, Route53 zone, IAM roles) lives in the
-# private langfuse/infrastructure repo under terraform/org/playground_previews.
+# The shared AWS foundation (VPC, ECR, Route53 zone, IAM roles) is managed
+# in Langfuse's internal infrastructure repository.
 
 on:
   issue_comment:

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -27,7 +27,7 @@ name: AWS PR Preview
 on:
   issue_comment:
     types: [created]
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] safe usage: the gate checks out no PR code and holds no cloud credentials; it only reads PR metadata, checks the allowlist, and dispatches the deploy, which re-validates authorization from the default branch
     # Auto-deploy previews for allowlisted authors. pull_request_target runs
     # THIS (default-branch, reviewed) workflow definition — never the PR's —
     # so an untrusted PR cannot alter the gate or the allowlist. The gate job

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -7,8 +7,9 @@ name: AWS PR Preview
 #   /preview resume    start the instance again
 #   /preview destroy   delete the CloudFormation stack and preview images
 #
-# PRs opened by an allowlisted author (AWS_PREVIEW_ALLOWED_USERS) auto-deploy
-# and refresh on every push. Anyone on the allowlist can also drive previews
+# PRs opened by an allowlisted author (AWS_PREVIEW_ALLOWED_USERS) auto-deploy;
+# subsequent pushes refresh the preview only if it is already running (a push
+# never resurrects one stopped via /preview stop). Anyone on the allowlist can also drive previews
 # manually with the /preview comments above. Each engineer may have at most 5
 # previews running at once (best-effort, PreviewOwner tag). A housekeeping
 # schedule stops previews idle (low CPU) for several hours, destroys previews
@@ -54,6 +55,10 @@ on:
       pr_number:
         description: "Pull request number (not needed for stop-all/reap)"
         required: false
+      refresh_only:
+        description: "Only refresh an already-running preview; skip if stopped or absent. Set by push-triggered auto-deploy."
+        required: false
+        default: "false"
 
 permissions: {}
 
@@ -296,6 +301,12 @@ jobs:
               return;
             }
 
+            // A push (synchronize) may only REFRESH an already-running
+            // preview; opening or reopening a PR may create one. deploy_gate
+            // enforces this so a push never resurrects a /preview stop-ped env.
+            const refreshOnly =
+              context.payload.action === "synchronize" ? "true" : "false";
+
             // Hand off to the existing deploy path on the default branch, so
             // AWS is only ever assumed from a refs/heads/main run.
             await github.rest.actions.createWorkflowDispatch({
@@ -303,9 +314,15 @@ jobs:
               repo,
               workflow_id: "aws-preview.yml",
               ref: context.payload.repository.default_branch,
-              inputs: { action: "deploy", pr_number: String(pr.number) },
+              inputs: {
+                action: "deploy",
+                pr_number: String(pr.number),
+                refresh_only: refreshOnly,
+              },
             });
-            core.info(`Dispatched deploy for PR #${pr.number} (author ${author}).`);
+            core.info(
+              `Dispatched deploy for PR #${pr.number} (author ${author}, refresh_only=${refreshOnly}).`,
+            );
 
   deploy_gate:
     name: Check deploy preconditions
@@ -331,6 +348,7 @@ jobs:
           ACTOR: ${{ needs.context.outputs.actor }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+          REFRESH_ONLY: ${{ github.event.inputs.refresh_only }}
         run: |
           set -euo pipefail
 
@@ -353,6 +371,19 @@ jobs:
           pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)"
           if [ "${pr_state}" != "open" ]; then
             echo "PR ${PR_NUMBER} is ${pr_state}; not deploying."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Push-triggered auto-deploy (refresh_only) may only refresh a preview
+          # that is already running — it must never create or resurrect one.
+          # This keeps /preview stop sticky and matches the documented contract
+          # ("pushing refreshes only if already deployed and running"). Opening
+          # a PR and explicit /preview deploy leave refresh_only unset/false.
+          if [ "${REFRESH_ONLY:-}" = "true" ] \
+            && [ "${instance_state}" != "running" ] \
+            && [ "${instance_state}" != "pending" ]; then
+            echo "PR ${PR_NUMBER} preview is ${instance_state}; push refresh skipped."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -690,7 +721,31 @@ jobs:
             --query "Command.CommandId" \
             --output text)"
 
-          if ! aws ssm wait command-executed --command-id "${command_id}" --instance-id "${INSTANCE_ID}"; then
+          # Poll for completion rather than `aws ssm wait command-executed`,
+          # whose ~100s default (5s x 20 attempts) is far shorter than a cold
+          # deploy: the bundled cloud-init wait, ECR login, ~7 image pulls, and
+          # six container-readiness gates in deploy.sh run for several minutes.
+          # The short waiter would fail the step spuriously while the on-host
+          # deploy is still succeeding.
+          deploy_ok=false
+          for _ in $(seq 1 120); do
+            status="$(aws ssm get-command-invocation \
+              --command-id "${command_id}" \
+              --instance-id "${INSTANCE_ID}" \
+              --query "Status" --output text 2>/dev/null || echo "Pending")"
+            case "${status}" in
+              Success)
+                deploy_ok=true
+                break
+                ;;
+              Cancelled | TimedOut | Failed)
+                break
+                ;;
+            esac
+            sleep 10
+          done
+
+          if [ "${deploy_ok}" != "true" ]; then
             aws ssm get-command-invocation \
               --command-id "${command_id}" \
               --instance-id "${INSTANCE_ID}" \
@@ -1210,24 +1265,32 @@ jobs:
               fi
 
               echo "Destroying ${stack_name}: PR ${pr_number} is closed."
-              aws cloudformation delete-stack --stack-name "${stack_name}"
-              aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
+              # Isolate each teardown in a subshell so one stuck/failed
+              # deletion doesn't abort the whole batch under set -e.
+              if ! (
+                set -e
+                aws cloudformation delete-stack --stack-name "${stack_name}"
+                aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
 
-              for repository_url in \
-                "${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}" \
-                "${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}"; do
-                repository_name="${repository_url#*/}"
-                image_ids="$(aws ecr list-images \
-                  --repository-name "${repository_name}" \
-                  --filter tagStatus=TAGGED \
-                  --query "imageIds[?starts_with(imageTag, 'pr-${pr_number}-')]" \
-                  --output json)"
-                if [ "${image_ids}" != "[]" ]; then
-                  aws ecr batch-delete-image \
+                for repository_url in \
+                  "${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}" \
+                  "${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}"; do
+                  repository_name="${repository_url#*/}"
+                  image_ids="$(aws ecr list-images \
                     --repository-name "${repository_name}" \
-                    --image-ids "${image_ids}" >/dev/null
-                fi
-              done
+                    --filter tagStatus=TAGGED \
+                    --query "imageIds[?starts_with(imageTag, 'pr-${pr_number}-')]" \
+                    --output json)"
+                  if [ "${image_ids}" != "[]" ]; then
+                    aws ecr batch-delete-image \
+                      --repository-name "${repository_name}" \
+                      --image-ids "${image_ids}" >/dev/null
+                  fi
+                done
+              ); then
+                echo "Failed to reap ${stack_name}; continuing with the next stack."
+                continue
+              fi
 
               gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
                 --body "🗑️ AWS preview destroyed because the PR is closed. Reopen and \`/preview deploy\` to recreate." \
@@ -1276,27 +1339,37 @@ jobs:
             esac
 
             echo "Reaping ${stack_name} (stopped since ${stopped_at})"
-            aws cloudformation delete-stack --stack-name "${stack_name}"
-            aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
+            # Isolate each teardown in a subshell so one stuck/failed deletion
+            # doesn't abort the whole batch under set -e.
+            if ! (
+              set -e
+              aws cloudformation delete-stack --stack-name "${stack_name}"
+              aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
+
+              if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
+                for repository_url in \
+                  "${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}" \
+                  "${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}"; do
+                  repository_name="${repository_url#*/}"
+                  image_ids="$(aws ecr list-images \
+                    --repository-name "${repository_name}" \
+                    --filter tagStatus=TAGGED \
+                    --query "imageIds[?starts_with(imageTag, 'pr-${pr_number}-')]" \
+                    --output json)"
+
+                  if [ "${image_ids}" != "[]" ]; then
+                    aws ecr batch-delete-image \
+                      --repository-name "${repository_name}" \
+                      --image-ids "${image_ids}" >/dev/null
+                  fi
+                done
+              fi
+            ); then
+              echo "Failed to reap ${stack_name}; continuing with the next stack."
+              continue
+            fi
 
             if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
-              for repository_url in \
-                "${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}" \
-                "${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}"; do
-                repository_name="${repository_url#*/}"
-                image_ids="$(aws ecr list-images \
-                  --repository-name "${repository_name}" \
-                  --filter tagStatus=TAGGED \
-                  --query "imageIds[?starts_with(imageTag, 'pr-${pr_number}-')]" \
-                  --output json)"
-
-                if [ "${image_ids}" != "[]" ]; then
-                  aws ecr batch-delete-image \
-                    --repository-name "${repository_name}" \
-                    --image-ids "${image_ids}" >/dev/null
-                fi
-              done
-
               gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
                 --body "🗑️ AWS preview destroyed after 7 days stopped. Recreate with \`/preview deploy\`." \
                 || echo "Could not comment on PR ${pr_number}."

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -145,13 +145,31 @@ jobs:
               return pr;
             };
 
+            // Single source of truth for who may use previews. Same list
+            // gates the /preview comments, workflow_dispatch, and (in the
+            // separate autodeploy_gate job) pull_request_target auto-deploy.
+            const allowlist = (process.env.AWS_PREVIEW_ALLOWED_USERS || "")
+              .split(/[\s,]+/)
+              .filter(Boolean)
+              .map((u) => u.toLowerCase());
+            const isAllowed = (login) =>
+              !!login && allowlist.includes(login.toLowerCase());
+
             if (context.eventName === "schedule") {
               command = "reap";
             } else if (context.eventName === "workflow_dispatch") {
               command = context.payload.inputs.action;
               prNumber = context.payload.inputs.pr_number || "";
               actor = context.actor;
-              if (!["stop-all", "reap"].includes(command)) {
+              if (["stop-all", "reap"].includes(command)) {
+                // Account-wide manual ops: allowlisted operators only.
+                if (!isAllowed(context.actor)) {
+                  core.setFailed(
+                    `${context.actor} is not on the preview allowlist.`,
+                  );
+                  return;
+                }
+              } else {
                 if (!prNumber) {
                   core.setFailed("pr_number is required for per-PR actions.");
                   return;
@@ -161,7 +179,22 @@ jobs:
                   core.setFailed("AWS previews are not available for fork PRs.");
                   return;
                 }
+                // Authorize the dispatcher OR the PR author. The auto-deploy
+                // gate dispatches via the API, where the actor may be the
+                // Actions bot rather than a person, so the allowlisted PR
+                // author is what authorizes those runs. A forged dispatch can
+                // therefore only ever act on an allowlisted author's own PR.
+                if (!isAllowed(context.actor) && !isAllowed(pr.user.login)) {
+                  core.setFailed(
+                    "Not authorized: neither the dispatcher nor the PR author " +
+                      "is on the preview allowlist.",
+                  );
+                  return;
+                }
                 headSha = pr.head.sha;
+                // Attribute the running-env slot to the PR author when they
+                // are the allowlisted party (the normal auto-deploy case).
+                actor = isAllowed(pr.user.login) ? pr.user.login : context.actor;
               }
             } else if (context.eventName === "issue_comment") {
               const body = (context.payload.comment.body || "").trim();
@@ -186,15 +219,8 @@ jobs:
                 return;
               }
 
-              // Single source of truth for who may use previews: the
-              // AWS_PREVIEW_ALLOWED_USERS allowlist (same list gates
-              // pull_request_target auto-deploy). Empty list = nobody.
-              const allowed = (process.env.AWS_PREVIEW_ALLOWED_USERS || "")
-                .split(/[\s,]+/)
-                .filter(Boolean)
-                .map((u) => u.toLowerCase());
-              const commenter = context.payload.comment.user.login.toLowerCase();
-              if (!allowed.includes(commenter)) {
+              // Allowlist gate (shared with dispatch and auto-deploy).
+              if (!isAllowed(context.payload.comment.user.login)) {
                 await reply(
                   "`/preview` commands are limited to the preview allowlist. " +
                     "Ask an admin to add your GitHub username to the " +

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -1,29 +1,48 @@
 name: AWS PR Preview
 
+# Disposable per-PR Langfuse previews on AWS, driven by PR comments:
+#
+#   /preview deploy    build the PR head and (re)deploy the preview host
+#   /preview stop      stop the EC2 instance (data and URL are kept)
+#   /preview resume    start the instance again
+#   /preview destroy   delete the CloudFormation stack and preview images
+#
+# Pushing new commits updates a preview only if one is already deployed and
+# running. Closing the PR destroys the preview. A nightly schedule stops all
+# running preview instances to cap cost; resume them with `/preview resume`.
+#
+# The shared AWS foundation (VPC, ECR, Route53 zone, IAM roles) lives in the
+# private langfuse/infrastructure repo under terraform/org/playground_previews.
+
 on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [synchronize, closed]
+  schedule:
+    # Stop all running previews nightly (03:17 UTC) to cap cost.
+    - cron: "17 3 * * *"
   workflow_dispatch:
     inputs:
       action:
-        description: "Deploy or destroy the preview"
+        description: "Preview action"
         type: choice
         options:
           - deploy
+          - stop
+          - resume
           - destroy
+          - stop-all
         required: true
       pr_number:
-        description: "Pull request number"
-        required: true
-      ref:
-        description: "Ref to deploy when action=deploy"
+        description: "Pull request number (not needed for stop-all)"
         required: false
-  pull_request:
-    types: [opened, reopened, synchronize, closed]
 
 permissions: {}
 
 concurrency:
-  group: aws-preview-${{ github.event.pull_request.number || inputs.pr_number }}
-  cancel-in-progress: true
+  group: aws-preview-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number || 'global' }}
+  cancel-in-progress: false
 
 env:
   AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN: ${{ vars.AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN }}
@@ -40,14 +59,210 @@ env:
   AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL: ${{ vars.AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL }}
 
 jobs:
+  context:
+    name: Resolve preview command
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/preview')) ||
+      github.event_name == 'pull_request' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+    permissions:
+      issues: write
+      pull-requests: read
+    outputs:
+      command: ${{ steps.resolve.outputs.command }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+    steps:
+      - name: Resolve command, PR, and authorization
+        id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sameRepo = `${owner}/${repo}`;
+            const usage = [
+              "Available AWS preview commands:",
+              "",
+              "- `/preview deploy` — build this PR and (re)deploy the preview",
+              "- `/preview stop` — stop the preview instance (keeps data and URL)",
+              "- `/preview resume` — start a stopped preview instance",
+              "- `/preview destroy` — delete the preview stack and images",
+            ].join("\n");
+
+            let command = "";
+            let prNumber = "";
+            let headSha = "";
+
+            const reply = (body) =>
+              github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.payload.issue?.number,
+                body,
+              });
+
+            const loadPullRequest = async (number) => {
+              const { data: pr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: Number(number),
+              });
+              return pr;
+            };
+
+            if (context.eventName === "schedule") {
+              command = "stop-all";
+            } else if (context.eventName === "workflow_dispatch") {
+              command = context.payload.inputs.action;
+              prNumber = context.payload.inputs.pr_number || "";
+              if (command !== "stop-all") {
+                if (!prNumber) {
+                  core.setFailed("pr_number is required for per-PR actions.");
+                  return;
+                }
+                const pr = await loadPullRequest(prNumber);
+                if (pr.head.repo.full_name !== sameRepo) {
+                  core.setFailed("AWS previews are not available for fork PRs.");
+                  return;
+                }
+                headSha = pr.head.sha;
+              }
+            } else if (context.eventName === "pull_request") {
+              const pr = context.payload.pull_request;
+              prNumber = String(pr.number);
+              if (pr.head.repo.full_name !== sameRepo) {
+                core.info("Skipping: fork pull request.");
+              } else if (context.payload.action === "closed") {
+                command = "destroy";
+              } else {
+                command = "sync";
+                headSha = pr.head.sha;
+              }
+            } else if (context.eventName === "issue_comment") {
+              const body = (context.payload.comment.body || "").trim();
+              const match = body.match(/^\/preview(?:\s+([a-z-]+))?/i);
+              const aliases = {
+                deploy: "deploy",
+                redeploy: "deploy",
+                update: "deploy",
+                stop: "stop",
+                pause: "stop",
+                resume: "resume",
+                start: "resume",
+                destroy: "destroy",
+                delete: "destroy",
+                teardown: "destroy",
+              };
+              const word = (match?.[1] || "").toLowerCase();
+              const parsed = aliases[word];
+
+              if (!parsed) {
+                await reply(usage);
+                return;
+              }
+
+              const association = context.payload.comment.author_association;
+              if (!["OWNER", "MEMBER", "COLLABORATOR"].includes(association)) {
+                await reply(
+                  "Only maintainers can run `/preview` commands. " +
+                    `(author association: ${association})`,
+                );
+                return;
+              }
+
+              const pr = await loadPullRequest(context.payload.issue.number);
+              if (pr.head.repo.full_name !== sameRepo) {
+                await reply("AWS previews are not available for fork PRs.");
+                return;
+              }
+              if (pr.state !== "open" && parsed !== "destroy") {
+                await reply(
+                  "This PR is closed; only `/preview destroy` is available.",
+                );
+                return;
+              }
+
+              await github.rest.reactions.createForIssueComment({
+                owner,
+                repo,
+                comment_id: context.payload.comment.id,
+                content: "rocket",
+              });
+
+              command = parsed;
+              prNumber = String(context.payload.issue.number);
+              headSha = pr.head.sha;
+            }
+
+            core.info(`command=${command} pr=${prNumber} sha=${headSha}`);
+            core.setOutput("command", command);
+            core.setOutput("pr_number", prNumber);
+            core.setOutput("head_sha", headSha);
+
+  deploy_gate:
+    name: Check deploy preconditions
+    runs-on: ubuntu-latest
+    needs: context
+    if: contains(fromJSON('["deploy", "sync"]'), needs.context.outputs.command)
+    permissions:
+      id-token: write
+    outputs:
+      proceed: ${{ steps.gate.outputs.proceed }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          aws-region: ${{ env.AWS_PREVIEW_REGION }}
+          role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+
+      - name: Decide whether to deploy
+        id: gate
+        env:
+          COMMAND: ${{ needs.context.outputs.command }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          if [ "${COMMAND}" = "deploy" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Push events only refresh previews that were explicitly deployed
+          # and are currently running. Stopped previews stay stopped.
+          stack_name="langfuse-preview-pr-${PR_NUMBER}"
+          instance_id="$(aws cloudformation describe-stacks \
+            --stack-name "${stack_name}" \
+            --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
+            --output text 2>/dev/null || true)"
+
+          if [ -z "${instance_id}" ] || [ "${instance_id}" = "None" ]; then
+            echo "No preview stack for PR ${PR_NUMBER}; skipping auto-update."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          state="$(aws ec2 describe-instances \
+            --instance-ids "${instance_id}" \
+            --query "Reservations[0].Instances[0].State.Name" \
+            --output text)"
+
+          if [ "${state}" = "running" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Preview instance is ${state}; skipping auto-update."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   deploy:
     name: Deploy AWS preview
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: >-
-      (github.event_name == 'pull_request' &&
-      github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'workflow_dispatch' && inputs.action == 'deploy')
+    needs: [context, deploy_gate]
+    if: needs.deploy_gate.outputs.proceed == 'true'
     permissions:
       contents: read
       id-token: write
@@ -58,7 +273,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
+          ref: ${{ needs.context.outputs.head_sha }}
 
       - name: Validate preview configuration
         run: |
@@ -102,15 +317,11 @@ jobs:
       - name: Resolve preview metadata
         id: preview
         env:
-          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
         run: |
           set -euo pipefail
 
-          pr_number="${{ github.event.pull_request.number }}"
-          if [ -z "${pr_number}" ]; then
-            pr_number="${INPUT_PR_NUMBER}"
-          fi
-
+          pr_number="${PR_NUMBER}"
           commit_sha="$(git rev-parse HEAD)"
           short_sha="${commit_sha:0:12}"
           stack_name="langfuse-preview-pr-${pr_number}"
@@ -196,6 +407,20 @@ jobs:
         run: |
           set -euo pipefail
 
+          # A stack stuck in a failed create state cannot be updated;
+          # delete it and start fresh.
+          status="$(aws cloudformation describe-stacks \
+            --stack-name "${STACK_NAME}" \
+            --query "Stacks[0].StackStatus" \
+            --output text 2>/dev/null || true)"
+          case "${status}" in
+            ROLLBACK_COMPLETE|ROLLBACK_FAILED|CREATE_FAILED)
+              echo "Stack is in ${status}; deleting before redeploy."
+              aws cloudformation delete-stack --stack-name "${STACK_NAME}"
+              aws cloudformation wait stack-delete-complete --stack-name "${STACK_NAME}"
+              ;;
+          esac
+
           aws cloudformation deploy \
             --stack-name "${STACK_NAME}" \
             --template-file deployment/aws-preview/cloudformation.yaml \
@@ -231,6 +456,20 @@ jobs:
             --stack-name "${STACK_NAME}" \
             --query "Stacks[0].Outputs[?OutputKey=='PublicIp'].OutputValue" \
             --output text)"
+
+          # An explicit /preview deploy on a stopped preview boots it again.
+          state="$(aws ec2 describe-instances \
+            --instance-ids "${instance_id}" \
+            --query "Reservations[0].Instances[0].State.Name" \
+            --output text)"
+          if [ "${state}" = "stopping" ]; then
+            aws ec2 wait instance-stopped --instance-ids "${instance_id}"
+            state="stopped"
+          fi
+          if [ "${state}" != "running" ] && [ "${state}" != "pending" ]; then
+            aws ec2 start-instances --instance-ids "${instance_id}"
+          fi
+          aws ec2 wait instance-running --instance-ids "${instance_id}"
 
           echo "instance_id=${instance_id}" >> "$GITHUB_OUTPUT"
           echo "public_ip=${public_ip}" >> "$GITHUB_OUTPUT"
@@ -324,12 +563,13 @@ jobs:
 
       - name: Check preview health
         env:
-          PUBLIC_IP: ${{ steps.host.outputs.public_ip }}
+          PREVIEW_HOST: ${{ steps.preview.outputs.preview_host }}
         run: |
           set -euo pipefail
 
-          for _ in $(seq 1 60); do
-            if curl -fsS "http://${PUBLIC_IP}/api/public/health" >/dev/null; then
+          # TLS certificate issuance on first deploy can take a minute.
+          for _ in $(seq 1 90); do
+            if curl -fsS --max-time 10 "https://${PREVIEW_HOST}/api/public/health" >/dev/null; then
               exit 0
             fi
             sleep 5
@@ -338,68 +578,296 @@ jobs:
           echo "Preview did not become healthy."
           exit 1
 
-      - name: Comment preview link
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          COMMIT_SHA: ${{ steps.preview.outputs.commit_sha }}
-          LOGIN_EMAIL: ${{ steps.preview.outputs.login_email }}
-          LOGIN_PASSWORD: ${{ steps.preview.outputs.login_password }}
-          PREVIEW_URL: http://${{ steps.preview.outputs.preview_host }}
-          PR_NUMBER: ${{ steps.preview.outputs.pr_number }}
-          PUBLIC_KEY: ${{ steps.preview.outputs.public_key }}
-          SECRET_KEY: ${{ steps.preview.outputs.secret_key }}
+      - name: Update status comment
+        uses: ./.github/actions/aws-preview-comment
         with:
-          script: |
-            const marker = "<!-- aws-pr-preview -->";
-            const body = `${marker}
-            AWS preview: ${process.env.PREVIEW_URL}
+          pr-number: ${{ steps.preview.outputs.pr_number }}
+          body: |
+            ### 🟢 AWS preview running
 
-            Login: \`${process.env.LOGIN_EMAIL}\` / \`${process.env.LOGIN_PASSWORD}\`
-            API keys: \`${process.env.PUBLIC_KEY}\` / \`${process.env.SECRET_KEY}\`
+            **URL:** https://${{ steps.preview.outputs.preview_host }}
+            **Login:** `${{ steps.preview.outputs.login_email }}` / `${{ steps.preview.outputs.login_password }}`
+            **API keys:** `${{ steps.preview.outputs.public_key }}` / `${{ steps.preview.outputs.secret_key }}`
+            **Commit:** ${{ steps.preview.outputs.commit_sha }}
 
-            Synthetic preview data only. Updated at: ${new Date().toISOString()}
-            Commit: ${process.env.COMMIT_SHA}`;
+            Synthetic preview data only. Previews are stopped automatically overnight.
+            Commands: `/preview deploy` · `/preview stop` · `/preview resume` · `/preview destroy`
 
-            const { owner, repo } = context.repo;
-            const issue_number = Number(process.env.PR_NUMBER);
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-            const previousComment = comments.find(
-              (comment) =>
-                comment.user?.login === "github-actions[bot]" &&
-                comment.body?.includes(marker),
-            );
+      - name: Report failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+            --body "⚠️ AWS preview deploy failed: ${RUN_URL}"
 
-            if (previousComment) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: previousComment.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body,
-              });
-            }
-
-  teardown:
-    name: Destroy AWS preview
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: >-
-      (github.event_name == 'pull_request' &&
-      github.event.action == 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'workflow_dispatch' && inputs.action == 'destroy')
+  stop:
+    name: Stop AWS preview
+    runs-on: ubuntu-latest
+    needs: context
+    if: needs.context.outputs.command == 'stop'
     permissions:
-      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout composite actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          aws-region: ${{ env.AWS_PREVIEW_REGION }}
+          role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+
+      - name: Stop preview instance
+        id: stop
+        env:
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          stack_name="langfuse-preview-pr-${PR_NUMBER}"
+          instance_id="$(aws cloudformation describe-stacks \
+            --stack-name "${stack_name}" \
+            --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
+            --output text 2>/dev/null || true)"
+
+          if [ -z "${instance_id}" ] || [ "${instance_id}" = "None" ]; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          aws ec2 stop-instances --instance-ids "${instance_id}"
+          aws ec2 wait instance-stopped --instance-ids "${instance_id}"
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+
+      - name: Update status comment
+        if: steps.stop.outputs.exists == 'true'
+        uses: ./.github/actions/aws-preview-comment
+        with:
+          pr-number: ${{ needs.context.outputs.pr_number }}
+          body: |
+            ### ⏸️ AWS preview stopped
+
+            Data, URL, and TLS certificate are kept. Resume with `/preview resume`.
+
+      - name: Report missing preview
+        if: steps.stop.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+        run: |
+          gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+            --body "There is no AWS preview for this PR. Deploy one with \`/preview deploy\`."
+
+      - name: Report failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+            --body "⚠️ AWS preview stop failed: ${RUN_URL}"
+
+  resume:
+    name: Resume AWS preview
+    runs-on: ubuntu-latest
+    needs: context
+    if: needs.context.outputs.command == 'resume'
+    permissions:
+      id-token: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout composite actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          aws-region: ${{ env.AWS_PREVIEW_REGION }}
+          role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+
+      - name: Start preview instance
+        id: start
+        env:
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          stack_name="langfuse-preview-pr-${PR_NUMBER}"
+          instance_id="$(aws cloudformation describe-stacks \
+            --stack-name "${stack_name}" \
+            --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
+            --output text 2>/dev/null || true)"
+
+          if [ -z "${instance_id}" ] || [ "${instance_id}" = "None" ]; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          aws ec2 start-instances --instance-ids "${instance_id}"
+          aws ec2 wait instance-running --instance-ids "${instance_id}"
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for preview health
+        if: steps.start.outputs.exists == 'true'
+        env:
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          preview_host="pr-${PR_NUMBER}.${AWS_PREVIEW_DOMAIN_NAME}"
+
+          # Containers restart automatically on boot (docker restart policy);
+          # give the stack a few minutes to come back.
+          for _ in $(seq 1 90); do
+            if curl -fsS --max-time 10 "https://${preview_host}/api/public/health" >/dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "Preview did not become healthy after resume."
+          exit 1
+
+      - name: Update status comment
+        if: steps.start.outputs.exists == 'true'
+        uses: ./.github/actions/aws-preview-comment
+        with:
+          pr-number: ${{ needs.context.outputs.pr_number }}
+          body: |
+            ### 🟢 AWS preview running
+
+            **URL:** https://pr-${{ needs.context.outputs.pr_number }}.${{ env.AWS_PREVIEW_DOMAIN_NAME }}
+
+            Resumed with the previously deployed images. Run `/preview deploy` to update
+            to the latest commit.
+            Commands: `/preview deploy` · `/preview stop` · `/preview resume` · `/preview destroy`
+
+      - name: Report missing preview
+        if: steps.start.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+        run: |
+          gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+            --body "There is no AWS preview for this PR. Deploy one with \`/preview deploy\`."
+
+      - name: Report failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+            --body "⚠️ AWS preview resume failed: ${RUN_URL}"
+
+  destroy:
+    name: Destroy AWS preview
+    runs-on: ubuntu-latest
+    needs: context
+    if: needs.context.outputs.command == 'destroy'
+    permissions:
+      id-token: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout composite actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          aws-region: ${{ env.AWS_PREVIEW_REGION }}
+          role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+
+      - name: Delete preview stack
+        id: delete
+        env:
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          stack_name="langfuse-preview-pr-${PR_NUMBER}"
+
+          if aws cloudformation describe-stacks --stack-name "${stack_name}" >/dev/null 2>&1; then
+            aws cloudformation delete-stack --stack-name "${stack_name}"
+            aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
+            echo "existed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Preview stack ${stack_name} does not exist."
+            echo "existed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Delete preview images
+        env:
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          for repository_url in \
+            "${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}" \
+            "${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}"; do
+            repository_name="${repository_url#*/}"
+            image_ids="$(aws ecr list-images \
+              --repository-name "${repository_name}" \
+              --filter tagStatus=TAGGED \
+              --query "imageIds[?starts_with(imageTag, 'pr-${PR_NUMBER}-')]" \
+              --output json)"
+
+            if [ "${image_ids}" != "[]" ]; then
+              aws ecr batch-delete-image \
+                --repository-name "${repository_name}" \
+                --image-ids "${image_ids}" >/dev/null
+              echo "Deleted preview images from ${repository_name}."
+            fi
+          done
+
+      - name: Update status comment
+        if: steps.delete.outputs.existed == 'true'
+        uses: ./.github/actions/aws-preview-comment
+        with:
+          pr-number: ${{ needs.context.outputs.pr_number }}
+          body: |
+            ### 🗑️ AWS preview destroyed
+
+            The preview stack and its images were deleted. Start a new preview with
+            `/preview deploy`.
+
+      - name: Report failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+            --body "⚠️ AWS preview destroy failed: ${RUN_URL}"
+
+  stop_all:
+    name: Stop all AWS previews
+    runs-on: ubuntu-latest
+    needs: context
+    if: needs.context.outputs.command == 'stop-all'
+    permissions:
       id-token: write
       issues: write
       pull-requests: write
@@ -410,54 +878,32 @@ jobs:
           aws-region: ${{ env.AWS_PREVIEW_REGION }}
           role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
 
-      - name: Delete preview stack
+      - name: Stop running preview instances
         env:
-          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          pr_number="${{ github.event.pull_request.number }}"
-          if [ -z "${pr_number}" ]; then
-            pr_number="${INPUT_PR_NUMBER}"
-          fi
-          stack_name="langfuse-preview-pr-${pr_number}"
+          instances="$(aws ec2 describe-instances \
+            --filters \
+              "Name=tag:Project,Values=langfuse-preview" \
+              "Name=instance-state-name,Values=running" \
+            --query "Reservations[].Instances[].[InstanceId, Tags[?Key=='PullRequest'] | [0].Value]" \
+            --output text)"
 
-          if ! aws cloudformation describe-stacks --stack-name "${stack_name}" >/dev/null 2>&1; then
-            echo "Preview stack ${stack_name} does not exist."
+          if [ -z "${instances}" ]; then
+            echo "No running preview instances."
             exit 0
           fi
 
-          aws cloudformation delete-stack --stack-name "${stack_name}"
-          aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
+          while read -r instance_id pr_number; do
+            [ -z "${instance_id}" ] && continue
+            echo "Stopping ${instance_id} (PR ${pr_number})"
+            aws ec2 stop-instances --instance-ids "${instance_id}"
 
-      - name: Mark preview destroyed
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const marker = "<!-- aws-pr-preview -->";
-            const body = `${marker}
-            AWS preview destroyed at ${new Date().toISOString()}.`;
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-            const previousComment = comments.find(
-              (comment) =>
-                comment.user?.login === "github-actions[bot]" &&
-                comment.body?.includes(marker),
-            );
-
-            if (previousComment) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: previousComment.id,
-                body,
-              });
-            }
+            if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
+              gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+                --body "⏸️ AWS preview stopped automatically overnight. Resume with \`/preview resume\`." \
+                || echo "Could not comment on PR ${pr_number}."
+            fi
+          done <<< "${instances}"

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -9,8 +9,11 @@ name: AWS PR Preview
 #
 # PRs opened by an allowlisted author (AWS_PREVIEW_ALLOWED_USERS) auto-deploy;
 # subsequent pushes refresh the preview only if it is already running (a push
-# never resurrects one stopped via /preview stop). Anyone on the allowlist can also drive previews
-# manually with the /preview comments above. Each engineer may have at most 5
+# never resurrects one stopped via /preview stop). Allowlisted users drive
+# previews manually with the /preview comments above; because /preview deploy
+# builds the PR author's code with cloud credentials, it also requires the PR
+# author to be allowlisted (stop/resume/destroy do not). Each engineer may
+# have at most 5
 # previews running at once (best-effort, PreviewOwner tag). A housekeeping
 # schedule stops previews idle (low CPU) for several hours, destroys previews
 # whose PR is closed, and destroys previews stopped for more than 7 days.
@@ -201,6 +204,18 @@ jobs:
                   );
                   return;
                 }
+                // deploy builds the PR author's code with cloud credentials,
+                // so the author must be allowlisted — mirroring the comment
+                // path and the auto-deploy gate. Auto-deploy only ever
+                // dispatches allowlisted authors, so this never blocks it.
+                if (command === "deploy" && !isAllowed(pr.user.login)) {
+                  core.setFailed(
+                    "deploy builds the PR author's code with cloud " +
+                      "credentials, so the PR author must be on the preview " +
+                      "allowlist.",
+                  );
+                  return;
+                }
                 headSha = pr.head.sha;
                 // Attribute the running-env slot to the PR author when they
                 // are the allowlisted party (the normal auto-deploy case).
@@ -247,6 +262,21 @@ jobs:
               if (pr.state !== "open" && parsed !== "destroy") {
                 await reply(
                   "This PR is closed; only `/preview destroy` is available.",
+                );
+                return;
+              }
+
+              // Deploy builds the PR author's code with cloud credentials, so
+              // the author (not just the commenter) must be on the allowlist,
+              // mirroring the auto-deploy gate. stop/resume/destroy touch no PR
+              // code, so an allowlisted commenter alone may run them.
+              if (parsed === "deploy" && !isAllowed(pr.user.login)) {
+                await reply(
+                  "`/preview deploy` builds the PR author's code with cloud " +
+                    "credentials, so it is limited to PRs whose author is on " +
+                    "the preview allowlist. Ask an admin to add @" +
+                    pr.user.login +
+                    " to the `AWS_PREVIEW_ALLOWED_USERS` repository variable.",
                 );
                 return;
               }

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -7,18 +7,19 @@ name: AWS PR Preview
 #   /preview resume    start the instance again
 #   /preview destroy   delete the CloudFormation stack and preview images
 #
-# Comment `/preview deploy` to build the PR head and (re)deploy its preview;
-# run it again after pushing commits to refresh a running preview. Each
-# engineer may have at most 5 previews running at once (best-effort,
-# PreviewOwner tag). A housekeeping schedule stops previews that have been
-# idle (low CPU) for several hours, destroys previews whose PR is closed,
-# and destroys previews stopped for more than 7 days.
+# PRs opened by an allowlisted author (AWS_PREVIEW_ALLOWED_USERS) auto-deploy
+# and refresh on every push. Anyone on the allowlist can also drive previews
+# manually with the /preview comments above. Each engineer may have at most 5
+# previews running at once (best-effort, PreviewOwner tag). A housekeeping
+# schedule stops previews idle (low CPU) for several hours, destroys previews
+# whose PR is closed, and destroys previews stopped for more than 7 days.
 #
 # All AWS-touching jobs run only from the default branch: the OIDC role's
 # trust policy accepts only the refs/heads/main subject, so unreviewed
-# pull-request workflow code can never assume it. That is why this workflow
-# is not triggered by `pull_request` — PR lifecycle (refresh on push,
-# cleanup on close) is handled by /preview commands and reconciliation.
+# pull-request workflow code can never assume it. Auto-deploy therefore uses
+# `pull_request_target` (which runs this reviewed, default-branch workflow,
+# not the PR's) purely to check the allowlist and then dispatch the deploy
+# back onto the default branch — the gate job never touches AWS or PR code.
 #
 # The shared AWS foundation (VPC, ECR, Route53 zone, IAM roles) is managed
 # in Langfuse's internal infrastructure repository.
@@ -26,6 +27,13 @@ name: AWS PR Preview
 on:
   issue_comment:
     types: [created]
+  pull_request_target:
+    # Auto-deploy previews for allowlisted authors. pull_request_target runs
+    # THIS (default-branch, reviewed) workflow definition — never the PR's —
+    # so an untrusted PR cannot alter the gate or the allowlist. The gate job
+    # holds no AWS access and never checks out PR code; it only dispatches the
+    # main-branch deploy, which assumes AWS as refs/heads/main (unchanged).
+    types: [opened, synchronize, reopened]
   schedule:
     # Housekeeping: stop idle previews, destroy previews for closed PRs,
     # destroy previews stopped > 7 days.
@@ -54,6 +62,10 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  # Space/comma-separated GitHub logins allowed to use previews (both the
+  # /preview comment commands and pull_request_target auto-deploy). Empty =
+  # nobody, so previews stay dormant until this is populated.
+  AWS_PREVIEW_ALLOWED_USERS: ${{ vars.AWS_PREVIEW_ALLOWED_USERS }}
   AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN: ${{ vars.AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN }}
   AWS_PREVIEW_DOMAIN_NAME: ${{ vars.AWS_PREVIEW_DOMAIN_NAME }}
   AWS_PREVIEW_HOSTED_ZONE_ID: ${{ vars.AWS_PREVIEW_HOSTED_ZONE_ID }}
@@ -173,11 +185,19 @@ jobs:
                 return;
               }
 
-              const association = context.payload.comment.author_association;
-              if (!["OWNER", "MEMBER", "COLLABORATOR"].includes(association)) {
+              // Single source of truth for who may use previews: the
+              // AWS_PREVIEW_ALLOWED_USERS allowlist (same list gates
+              // pull_request_target auto-deploy). Empty list = nobody.
+              const allowed = (process.env.AWS_PREVIEW_ALLOWED_USERS || "")
+                .split(/[\s,]+/)
+                .filter(Boolean)
+                .map((u) => u.toLowerCase());
+              const commenter = context.payload.comment.user.login.toLowerCase();
+              if (!allowed.includes(commenter)) {
                 await reply(
-                  "Only maintainers can run `/preview` commands. " +
-                    `(author association: ${association})`,
+                  "`/preview` commands are limited to the preview allowlist. " +
+                    "Ask an admin to add your GitHub username to the " +
+                    "`AWS_PREVIEW_ALLOWED_USERS` repository variable.",
                 );
                 return;
               }
@@ -212,6 +232,53 @@ jobs:
             core.setOutput("pr_number", prNumber);
             core.setOutput("head_sha", headSha);
             core.setOutput("actor", actor);
+
+  autodeploy_gate:
+    name: Auto-deploy gate (allowlisted PRs)
+    runs-on: ubuntu-latest
+    if: vars.AWS_PREVIEW_ROLE_ARN != '' && github.event_name == 'pull_request_target'
+    permissions:
+      actions: write        # dispatch the main-branch deploy
+      pull-requests: read
+    steps:
+      - name: Dispatch deploy for allowlisted, same-repo PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Only allowlisted authors. This runs from the default branch
+            // (pull_request_target), so the PR cannot tamper with this check.
+            const allowed = (process.env.AWS_PREVIEW_ALLOWED_USERS || "")
+              .split(/[\s,]+/)
+              .filter(Boolean)
+              .map((u) => u.toLowerCase());
+            const author = pr.user.login.toLowerCase();
+            if (!allowed.includes(author)) {
+              core.info(`Author ${author} is not on the preview allowlist; skipping.`);
+              return;
+            }
+
+            // Same-repo branches only. The deploy checks out and builds the PR
+            // head with AWS credentials present, so we do not auto-build code
+            // pushed from a fork. Allowlisted collaborators have write access
+            // and should push a branch to this repo for an auto-preview.
+            const { owner, repo } = context.repo;
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.info("Fork PR; auto-deploy is limited to same-repo branches.");
+              return;
+            }
+
+            // Hand off to the existing deploy path on the default branch, so
+            // AWS is only ever assumed from a refs/heads/main run.
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: "aws-preview.yml",
+              ref: context.payload.repository.default_branch,
+              inputs: { action: "deploy", pr_number: String(pr.number) },
+            });
+            core.info(`Dispatched deploy for PR #${pr.number} (author ${author}).`);
 
   deploy_gate:
     name: Check deploy preconditions

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -63,9 +63,10 @@ concurrency:
 
 env:
   # Space/comma-separated GitHub logins allowed to use previews (both the
-  # /preview comment commands and pull_request_target auto-deploy). Empty =
-  # nobody, so previews stay dormant until this is populated.
-  AWS_PREVIEW_ALLOWED_USERS: ${{ vars.AWS_PREVIEW_ALLOWED_USERS }}
+  # /preview comment commands and pull_request_target auto-deploy). Defaults
+  # to the single initial owner; set the AWS_PREVIEW_ALLOWED_USERS repository
+  # variable to override (add or replace users) without a code change.
+  AWS_PREVIEW_ALLOWED_USERS: ${{ vars.AWS_PREVIEW_ALLOWED_USERS || 'maxdeichmann' }}
   AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN: ${{ vars.AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN }}
   AWS_PREVIEW_DOMAIN_NAME: ${{ vars.AWS_PREVIEW_DOMAIN_NAME }}
   AWS_PREVIEW_HOSTED_ZONE_ID: ${{ vars.AWS_PREVIEW_HOSTED_ZONE_ID }}

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -1,0 +1,463 @@
+name: AWS PR Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Deploy or destroy the preview"
+        type: choice
+        options:
+          - deploy
+          - destroy
+        required: true
+      pr_number:
+        description: "Pull request number"
+        required: true
+      ref:
+        description: "Ref to deploy when action=deploy"
+        required: false
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions: {}
+
+concurrency:
+  group: aws-preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+env:
+  AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN: ${{ vars.AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN }}
+  AWS_PREVIEW_DOMAIN_NAME: ${{ vars.AWS_PREVIEW_DOMAIN_NAME }}
+  AWS_PREVIEW_HOSTED_ZONE_ID: ${{ vars.AWS_PREVIEW_HOSTED_ZONE_ID }}
+  AWS_PREVIEW_INSTANCE_PROFILE_NAME: ${{ vars.AWS_PREVIEW_INSTANCE_PROFILE_NAME }}
+  AWS_PREVIEW_INSTANCE_TYPE: ${{ vars.AWS_PREVIEW_INSTANCE_TYPE || 't3.large' }}
+  AWS_PREVIEW_REGION: ${{ vars.AWS_PREVIEW_REGION }}
+  AWS_PREVIEW_ROLE_ARN: ${{ vars.AWS_PREVIEW_ROLE_ARN }}
+  AWS_PREVIEW_SECURITY_GROUP_ID: ${{ vars.AWS_PREVIEW_SECURITY_GROUP_ID }}
+  AWS_PREVIEW_SUBNET_ID: ${{ vars.AWS_PREVIEW_SUBNET_ID }}
+  AWS_PREVIEW_VOLUME_SIZE_GB: ${{ vars.AWS_PREVIEW_VOLUME_SIZE_GB || '80' }}
+  AWS_PREVIEW_WEB_ECR_REPOSITORY_URL: ${{ vars.AWS_PREVIEW_WEB_ECR_REPOSITORY_URL }}
+  AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL: ${{ vars.AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL }}
+
+jobs:
+  deploy:
+    name: Deploy AWS preview
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: >-
+      (github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'workflow_dispatch' && inputs.action == 'deploy')
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout preview ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
+
+      - name: Validate preview configuration
+        run: |
+          set -euo pipefail
+
+          required_vars=(
+            AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN
+            AWS_PREVIEW_DOMAIN_NAME
+            AWS_PREVIEW_HOSTED_ZONE_ID
+            AWS_PREVIEW_INSTANCE_PROFILE_NAME
+            AWS_PREVIEW_REGION
+            AWS_PREVIEW_ROLE_ARN
+            AWS_PREVIEW_SECURITY_GROUP_ID
+            AWS_PREVIEW_SUBNET_ID
+            AWS_PREVIEW_WEB_ECR_REPOSITORY_URL
+            AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL
+          )
+
+          missing=()
+          for var_name in "${required_vars[@]}"; do
+            if [ -z "${!var_name}" ]; then
+              missing+=("${var_name}")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing required GitHub repository variables:\n'
+            printf '  - %s\n' "${missing[@]}"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          aws-region: ${{ env.AWS_PREVIEW_REGION }}
+          role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+
+      - name: Login to AWS ECR
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+
+      - name: Resolve preview metadata
+        id: preview
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          pr_number="${{ github.event.pull_request.number }}"
+          if [ -z "${pr_number}" ]; then
+            pr_number="${INPUT_PR_NUMBER}"
+          fi
+
+          commit_sha="$(git rev-parse HEAD)"
+          short_sha="${commit_sha:0:12}"
+          stack_name="langfuse-preview-pr-${pr_number}"
+          image_tag="pr-${pr_number}-${short_sha}"
+          preview_host="pr-${pr_number}.${AWS_PREVIEW_DOMAIN_NAME}"
+          ecr_registry="${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL%%/*}"
+
+          stable_secret() {
+            printf '%s' "$1" | sha256sum | cut -d' ' -f1
+          }
+
+          postgres_password="$(stable_secret "postgres-${pr_number}")"
+          clickhouse_password="$(stable_secret "clickhouse-${pr_number}")"
+          redis_auth="$(stable_secret "redis-${pr_number}")"
+          minio_password="$(stable_secret "minio-${pr_number}")"
+          nextauth_secret="$(stable_secret "nextauth-${pr_number}")"
+          salt="$(stable_secret "salt-${pr_number}")"
+          encryption_key="$(stable_secret "encryption-${pr_number}")"
+          login_password="langfuse-preview-${pr_number}"
+
+          for value in \
+            "${postgres_password}" \
+            "${clickhouse_password}" \
+            "${redis_auth}" \
+            "${minio_password}" \
+            "${nextauth_secret}" \
+            "${salt}" \
+            "${encryption_key}" \
+            "${login_password}"; do
+            echo "::add-mask::${value}"
+          done
+
+          {
+            echo "clickhouse_password=${clickhouse_password}"
+            echo "commit_sha=${commit_sha}"
+            echo "ecr_registry=${ecr_registry}"
+            echo "encryption_key=${encryption_key}"
+            echo "image_tag=${image_tag}"
+            echo "login_email=preview-${pr_number}@langfuse.local"
+            echo "login_password=${login_password}"
+            echo "minio_password=${minio_password}"
+            echo "nextauth_secret=${nextauth_secret}"
+            echo "postgres_password=${postgres_password}"
+            echo "preview_host=${preview_host}"
+            echo "pr_number=${pr_number}"
+            echo "public_key=pk-lf-preview-${pr_number}"
+            echo "redis_auth=${redis_auth}"
+            echo "salt=${salt}"
+            echo "secret_key=sk-lf-preview-${pr_number}"
+            echo "short_sha=${short_sha}"
+            echo "stack_name=${stack_name}"
+            echo "web_image=${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}:${image_tag}"
+            echo "worker_image=${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}:${image_tag}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push preview images
+        env:
+          COMMIT_SHA: ${{ steps.preview.outputs.commit_sha }}
+          WEB_IMAGE: ${{ steps.preview.outputs.web_image }}
+          WORKER_IMAGE: ${{ steps.preview.outputs.worker_image }}
+        run: |
+          set -euo pipefail
+
+          docker build \
+            --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
+            --build-arg NEXT_PUBLIC_SIGN_UP_DISABLED=true \
+            -f ./web/Dockerfile \
+            -t "${WEB_IMAGE}" \
+            .
+          docker push "${WEB_IMAGE}"
+
+          docker build \
+            --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
+            -f ./worker/Dockerfile \
+            -t "${WORKER_IMAGE}" \
+            .
+          docker push "${WORKER_IMAGE}"
+
+      - name: Deploy preview host stack
+        env:
+          PR_NUMBER: ${{ steps.preview.outputs.pr_number }}
+          STACK_NAME: ${{ steps.preview.outputs.stack_name }}
+        run: |
+          set -euo pipefail
+
+          aws cloudformation deploy \
+            --stack-name "${STACK_NAME}" \
+            --template-file deployment/aws-preview/cloudformation.yaml \
+            --role-arn "${AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN}" \
+            --no-fail-on-empty-changeset \
+            --parameter-overrides \
+              PreviewName="${STACK_NAME}" \
+              PullRequestNumber="${PR_NUMBER}" \
+              SubnetId="${AWS_PREVIEW_SUBNET_ID}" \
+              SecurityGroupId="${AWS_PREVIEW_SECURITY_GROUP_ID}" \
+              InstanceProfileName="${AWS_PREVIEW_INSTANCE_PROFILE_NAME}" \
+              HostedZoneId="${AWS_PREVIEW_HOSTED_ZONE_ID}" \
+              DomainName="${AWS_PREVIEW_DOMAIN_NAME}" \
+              InstanceType="${AWS_PREVIEW_INSTANCE_TYPE}" \
+              VolumeSizeGb="${AWS_PREVIEW_VOLUME_SIZE_GB}" \
+            --tags \
+              Project=langfuse-preview \
+              PullRequest="${PR_NUMBER}" \
+              PreviewManagedBy=github-actions
+
+      - name: Resolve preview host
+        id: host
+        env:
+          STACK_NAME: ${{ steps.preview.outputs.stack_name }}
+        run: |
+          set -euo pipefail
+
+          instance_id="$(aws cloudformation describe-stacks \
+            --stack-name "${STACK_NAME}" \
+            --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
+            --output text)"
+          public_ip="$(aws cloudformation describe-stacks \
+            --stack-name "${STACK_NAME}" \
+            --query "Stacks[0].Outputs[?OutputKey=='PublicIp'].OutputValue" \
+            --output text)"
+
+          echo "instance_id=${instance_id}" >> "$GITHUB_OUTPUT"
+          echo "public_ip=${public_ip}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for SSM
+        env:
+          INSTANCE_ID: ${{ steps.host.outputs.instance_id }}
+        run: |
+          set -euo pipefail
+
+          for _ in $(seq 1 60); do
+            ping_status="$(aws ssm describe-instance-information \
+              --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
+              --query "InstanceInformationList[0].PingStatus" \
+              --output text 2>/dev/null || true)"
+
+            if [ "${ping_status}" = "Online" ]; then
+              exit 0
+            fi
+
+            sleep 5
+          done
+
+          echo "Instance ${INSTANCE_ID} did not become available in SSM."
+          exit 1
+
+      - name: Deploy containers through SSM
+        env:
+          CLICKHOUSE_PASSWORD: ${{ steps.preview.outputs.clickhouse_password }}
+          ECR_REGISTRY: ${{ steps.preview.outputs.ecr_registry }}
+          ENCRYPTION_KEY: ${{ steps.preview.outputs.encryption_key }}
+          INSTANCE_ID: ${{ steps.host.outputs.instance_id }}
+          LOGIN_EMAIL: ${{ steps.preview.outputs.login_email }}
+          LOGIN_PASSWORD: ${{ steps.preview.outputs.login_password }}
+          MINIO_PASSWORD: ${{ steps.preview.outputs.minio_password }}
+          NEXTAUTH_SECRET: ${{ steps.preview.outputs.nextauth_secret }}
+          POSTGRES_PASSWORD: ${{ steps.preview.outputs.postgres_password }}
+          PREVIEW_HOST: ${{ steps.preview.outputs.preview_host }}
+          PR_NUMBER: ${{ steps.preview.outputs.pr_number }}
+          PUBLIC_KEY: ${{ steps.preview.outputs.public_key }}
+          REDIS_AUTH: ${{ steps.preview.outputs.redis_auth }}
+          SALT: ${{ steps.preview.outputs.salt }}
+          SECRET_KEY: ${{ steps.preview.outputs.secret_key }}
+          WEB_IMAGE: ${{ steps.preview.outputs.web_image }}
+          WORKER_IMAGE: ${{ steps.preview.outputs.worker_image }}
+        run: |
+          set -euo pipefail
+
+          env_file="$(mktemp)"
+          cat > "${env_file}" <<EOF
+          AWS_REGION=${AWS_PREVIEW_REGION}
+          CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
+          ECR_REGISTRY=${ECR_REGISTRY}
+          ENCRYPTION_KEY=${ENCRYPTION_KEY}
+          LANGFUSE_INIT_ORG_ID=preview-org-${PR_NUMBER}
+          LANGFUSE_INIT_ORG_NAME=Preview-PR-${PR_NUMBER}
+          LANGFUSE_INIT_PROJECT_ID=preview-project-${PR_NUMBER}
+          LANGFUSE_INIT_PROJECT_NAME=Preview-Project
+          LANGFUSE_INIT_PROJECT_PUBLIC_KEY=${PUBLIC_KEY}
+          LANGFUSE_INIT_PROJECT_SECRET_KEY=${SECRET_KEY}
+          LANGFUSE_INIT_USER_EMAIL=${LOGIN_EMAIL}
+          LANGFUSE_INIT_USER_NAME=Preview-User
+          LANGFUSE_INIT_USER_PASSWORD=${LOGIN_PASSWORD}
+          MINIO_ROOT_PASSWORD=${MINIO_PASSWORD}
+          NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
+          POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+          PREVIEW_HOST=${PREVIEW_HOST}
+          REDIS_AUTH=${REDIS_AUTH}
+          SALT=${SALT}
+          WEB_IMAGE=${WEB_IMAGE}
+          WORKER_IMAGE=${WORKER_IMAGE}
+          EOF
+
+          env_b64="$(base64 -w0 "${env_file}")"
+          command_id="$(aws ssm send-command \
+            --document-name "AWS-RunShellScript" \
+            --instance-ids "${INSTANCE_ID}" \
+            --comment "Deploy Langfuse PR ${PR_NUMBER} preview" \
+            --parameters "commands=mkdir -p /opt/langfuse-preview,echo ${env_b64} | base64 -d > /opt/langfuse-preview/deploy.env,chmod 600 /opt/langfuse-preview/deploy.env,for i in \$(seq 1 60); do test -x /opt/langfuse-preview/deploy.sh && break || sleep 5; done,test -x /opt/langfuse-preview/deploy.sh,/opt/langfuse-preview/deploy.sh" \
+            --query "Command.CommandId" \
+            --output text)"
+
+          if ! aws ssm wait command-executed --command-id "${command_id}" --instance-id "${INSTANCE_ID}"; then
+            aws ssm get-command-invocation \
+              --command-id "${command_id}" \
+              --instance-id "${INSTANCE_ID}" \
+              --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
+              --output json
+            exit 1
+          fi
+
+      - name: Check preview health
+        env:
+          PUBLIC_IP: ${{ steps.host.outputs.public_ip }}
+        run: |
+          set -euo pipefail
+
+          for _ in $(seq 1 60); do
+            if curl -fsS "http://${PUBLIC_IP}/api/public/health" >/dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "Preview did not become healthy."
+          exit 1
+
+      - name: Comment preview link
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMMIT_SHA: ${{ steps.preview.outputs.commit_sha }}
+          LOGIN_EMAIL: ${{ steps.preview.outputs.login_email }}
+          LOGIN_PASSWORD: ${{ steps.preview.outputs.login_password }}
+          PREVIEW_URL: http://${{ steps.preview.outputs.preview_host }}
+          PR_NUMBER: ${{ steps.preview.outputs.pr_number }}
+          PUBLIC_KEY: ${{ steps.preview.outputs.public_key }}
+          SECRET_KEY: ${{ steps.preview.outputs.secret_key }}
+        with:
+          script: |
+            const marker = "<!-- aws-pr-preview -->";
+            const body = `${marker}
+            AWS preview: ${process.env.PREVIEW_URL}
+
+            Login: \`${process.env.LOGIN_EMAIL}\` / \`${process.env.LOGIN_PASSWORD}\`
+            API keys: \`${process.env.PUBLIC_KEY}\` / \`${process.env.SECRET_KEY}\`
+
+            Synthetic preview data only. Updated at: ${new Date().toISOString()}
+            Commit: ${process.env.COMMIT_SHA}`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previousComment = comments.find(
+              (comment) =>
+                comment.user?.login === "github-actions[bot]" &&
+                comment.body?.includes(marker),
+            );
+
+            if (previousComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previousComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+  teardown:
+    name: Destroy AWS preview
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: >-
+      (github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'workflow_dispatch' && inputs.action == 'destroy')
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          aws-region: ${{ env.AWS_PREVIEW_REGION }}
+          role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+
+      - name: Delete preview stack
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          pr_number="${{ github.event.pull_request.number }}"
+          if [ -z "${pr_number}" ]; then
+            pr_number="${INPUT_PR_NUMBER}"
+          fi
+          stack_name="langfuse-preview-pr-${pr_number}"
+
+          if ! aws cloudformation describe-stacks --stack-name "${stack_name}" >/dev/null 2>&1; then
+            echo "Preview stack ${stack_name} does not exist."
+            exit 0
+          fi
+
+          aws cloudformation delete-stack --stack-name "${stack_name}"
+          aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
+
+      - name: Mark preview destroyed
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = "<!-- aws-pr-preview -->";
+            const body = `${marker}
+            AWS preview destroyed at ${new Date().toISOString()}.`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previousComment = comments.find(
+              (comment) =>
+                comment.user?.login === "github-actions[bot]" &&
+                comment.body?.includes(marker),
+            );
+
+            if (previousComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previousComment.id,
+                body,
+              });
+            }

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -62,13 +62,17 @@ jobs:
   context:
     name: Resolve preview command
     runs-on: ubuntu-latest
+    # vars.AWS_PREVIEW_ROLE_ARN doubles as the feature flag: while it is
+    # unset (foundation not applied yet, or previews disabled) the whole
+    # workflow stays skipped instead of failing on every PR push.
     if: >-
-      (github.event_name == 'issue_comment' &&
+      vars.AWS_PREVIEW_ROLE_ARN != '' &&
+      ((github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/preview')) ||
       github.event_name == 'pull_request' ||
       github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch')
     permissions:
       issues: write
       pull-requests: read
@@ -210,6 +214,7 @@ jobs:
     if: contains(fromJSON('["deploy", "sync"]'), needs.context.outputs.command)
     permissions:
       id-token: write
+      pull-requests: read
     outputs:
       proceed: ${{ steps.gate.outputs.proceed }}
     steps:
@@ -223,11 +228,21 @@ jobs:
         id: gate
         env:
           COMMAND: ${{ needs.context.outputs.command }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
         run: |
           set -euo pipefail
 
           if [ "${COMMAND}" = "deploy" ]; then
+            # Re-check PR state at execution time: a deploy queued behind the
+            # close-triggered destroy must not recreate the preview stack for
+            # a PR that is now closed (nothing would ever clean it up again).
+            state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)"
+            if [ "${state}" != "open" ]; then
+              echo "PR ${PR_NUMBER} is ${state}; not deploying."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "proceed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -9,9 +9,9 @@ name: AWS PR Preview
 #
 # Pushing new commits updates a preview only if one is already deployed and
 # running. Closing the PR destroys the preview. Each engineer may have at
-# most 5 previews running at once (best-effort, PreviewOwner tag). Running
-# previews are never stopped automatically; previews stopped for more than
-# 7 days are destroyed by a daily reaper.
+# most 5 previews running at once (best-effort, PreviewOwner tag). A
+# housekeeping schedule stops previews that have been idle (low CPU) for
+# several hours and destroys previews stopped for more than 7 days.
 #
 # The shared AWS foundation (VPC, ECR, Route53 zone, IAM roles) is managed
 # in Langfuse's internal infrastructure repository.
@@ -22,8 +22,8 @@ on:
   pull_request:
     types: [synchronize, closed]
   schedule:
-    # Daily reaper: destroy previews stopped for more than 7 days.
-    - cron: "17 3 * * *"
+    # Housekeeping: stop idle previews, destroy previews stopped > 7 days.
+    - cron: "17 */2 * * *"
   workflow_dispatch:
     inputs:
       action:
@@ -52,7 +52,9 @@ env:
   AWS_PREVIEW_DOMAIN_NAME: ${{ vars.AWS_PREVIEW_DOMAIN_NAME }}
   AWS_PREVIEW_HOSTED_ZONE_ID: ${{ vars.AWS_PREVIEW_HOSTED_ZONE_ID }}
   AWS_PREVIEW_INSTANCE_PROFILE_NAME: ${{ vars.AWS_PREVIEW_INSTANCE_PROFILE_NAME }}
-  AWS_PREVIEW_INSTANCE_TYPE: ${{ vars.AWS_PREVIEW_INSTANCE_TYPE || 't3.large' }}
+  AWS_PREVIEW_IDLE_CPU_MAX: ${{ vars.AWS_PREVIEW_IDLE_CPU_MAX || '25' }}
+  AWS_PREVIEW_IDLE_HOURS: ${{ vars.AWS_PREVIEW_IDLE_HOURS || '6' }}
+  AWS_PREVIEW_INSTANCE_TYPE: ${{ vars.AWS_PREVIEW_INSTANCE_TYPE || 't3.xlarge' }}
   AWS_PREVIEW_REGION: ${{ vars.AWS_PREVIEW_REGION }}
   AWS_PREVIEW_ROLE_ARN: ${{ vars.AWS_PREVIEW_ROLE_ARN }}
   AWS_PREVIEW_SECURITY_GROUP_ID: ${{ vars.AWS_PREVIEW_SECURITY_GROUP_ID }}
@@ -652,8 +654,9 @@ jobs:
             **API keys:** `${{ steps.preview.outputs.public_key }}` / `${{ steps.preview.outputs.secret_key }}`
             **Commit:** ${{ steps.preview.outputs.commit_sha }}
 
-            Synthetic preview data only. Each engineer can run up to 5 previews;
-            previews stopped for more than 7 days are destroyed automatically.
+            Synthetic preview data only. Each engineer can run up to 5 previews.
+            Idle previews are stopped automatically after ~6h; previews stopped
+            for more than 7 days are destroyed.
             Commands: `/preview deploy` · `/preview stop` · `/preview resume` · `/preview destroy`
 
       - name: Report failure
@@ -1016,7 +1019,7 @@ jobs:
           done <<< "${instances}"
 
   reap:
-    name: Reap long-stopped previews
+    name: Preview housekeeping
     runs-on: ubuntu-latest
     needs: context
     if: needs.context.outputs.command == 'reap'
@@ -1030,6 +1033,72 @@ jobs:
         with:
           aws-region: ${{ env.AWS_PREVIEW_REGION }}
           role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+
+      - name: Stop idle running previews
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          start_time="$(date -u -d "${AWS_PREVIEW_IDLE_HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ)"
+          end_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          cutoff_epoch="$(( $(date -u +%s) - AWS_PREVIEW_IDLE_HOURS * 3600 ))"
+
+          instances="$(aws ec2 describe-instances \
+            --filters \
+              "Name=tag:Project,Values=langfuse-preview" \
+              "Name=instance-state-name,Values=running" \
+            --query "Reservations[].Instances[].[InstanceId, LaunchTime, Tags[?Key=='PullRequest'] | [0].Value]" \
+            --output text)"
+
+          if [ -z "${instances}" ]; then
+            echo "No running preview instances."
+            exit 0
+          fi
+
+          stopped_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          while read -r instance_id launch_time pr_number; do
+            [ -z "${instance_id}" ] && continue
+
+            # Grace period: instances started less than the idle window ago
+            # are left alone (LaunchTime resets on every start).
+            launch_epoch="$(date -u -d "${launch_time}" +%s 2>/dev/null || echo 0)"
+            if [ "${launch_epoch}" -eq 0 ] || [ "${launch_epoch}" -gt "${cutoff_epoch}" ]; then
+              continue
+            fi
+
+            # Idle = no 5-minute window above the CPU threshold. Real usage
+            # (UI clicks, SDK ingestion) spikes CPU well above the stack's
+            # baseline of background polling and merges.
+            max_cpu="$(aws cloudwatch get-metric-statistics \
+              --namespace AWS/EC2 \
+              --metric-name CPUUtilization \
+              --dimensions "Name=InstanceId,Value=${instance_id}" \
+              --start-time "${start_time}" \
+              --end-time "${end_time}" \
+              --period 300 \
+              --statistics Maximum \
+              --query "max(Datapoints[].Maximum)" \
+              --output text)"
+
+            # No datapoints means no evidence; never stop without evidence.
+            if [ -z "${max_cpu}" ] || [ "${max_cpu}" = "None" ]; then
+              continue
+            fi
+
+            if awk -v cpu="${max_cpu}" -v limit="${AWS_PREVIEW_IDLE_CPU_MAX}" 'BEGIN { exit !(cpu < limit) }'; then
+              echo "Stopping ${instance_id} (PR ${pr_number}): max CPU ${max_cpu}% over ${AWS_PREVIEW_IDLE_HOURS}h"
+              aws ec2 stop-instances --instance-ids "${instance_id}"
+              aws ec2 create-tags --resources "${instance_id}" \
+                --tags "Key=StoppedAt,Value=${stopped_at}"
+
+              if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
+                gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+                  --body "⏸️ AWS preview stopped after ~${AWS_PREVIEW_IDLE_HOURS}h without activity. Data and URL are kept; resume with \`/preview resume\`." \
+                  || echo "Could not comment on PR ${pr_number}."
+              fi
+            fi
+          done <<< "${instances}"
 
       - name: Destroy previews stopped for more than 7 days
         env:

--- a/.github/workflows/aws-preview.yml
+++ b/.github/workflows/aws-preview.yml
@@ -22,6 +22,11 @@ name: AWS PR Preview
 # not the PR's) purely to check the allowlist and then dispatch the deploy
 # back onto the default branch — the gate job never touches AWS or PR code.
 #
+# The per-step shell lives in deployment/aws-preview/scripts/*.sh. Every job
+# checks those scripts out from the DEFAULT BRANCH (never the PR head), so the
+# deploy logic stays reviewed code even in the deploy job, which additionally
+# checks out the PR head purely as the Docker build context.
+#
 # The shared AWS foundation (VPC, ECR, Route53 zone, IAM roles) is managed
 # in Langfuse's internal infrastructure repository.
 
@@ -333,9 +338,18 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    env:
+      SCRIPTS: deployment/aws-preview/scripts
     outputs:
       proceed: ${{ steps.gate.outputs.proceed }}
     steps:
+      - name: Checkout preview logic from the default branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch || 'main' }}
+          sparse-checkout: deployment/aws-preview/scripts
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
@@ -349,71 +363,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
           REFRESH_ONLY: ${{ github.event.inputs.refresh_only }}
-        run: |
-          set -euo pipefail
-
-          stack_name="langfuse-preview-pr-${PR_NUMBER}"
-          instance_id="$(aws cloudformation describe-stacks \
-            --stack-name "${stack_name}" \
-            --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
-            --output text 2>/dev/null || true)"
-          instance_state="absent"
-          if [ -n "${instance_id}" ] && [ "${instance_id}" != "None" ]; then
-            instance_state="$(aws ec2 describe-instances \
-              --instance-ids "${instance_id}" \
-              --query "Reservations[0].Instances[0].State.Name" \
-              --output text)"
-          fi
-
-          # Re-check PR state at execution time: a deploy queued behind a
-          # close/reconcile destroy must not recreate the preview stack for
-          # a PR that is now closed (nothing would ever clean it up again).
-          pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)"
-          if [ "${pr_state}" != "open" ]; then
-            echo "PR ${PR_NUMBER} is ${pr_state}; not deploying."
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Push-triggered auto-deploy (refresh_only) may only refresh a preview
-          # that is already running — it must never create or resurrect one.
-          # This keeps /preview stop sticky and matches the documented contract
-          # ("pushing refreshes only if already deployed and running"). Opening
-          # a PR and explicit /preview deploy leave refresh_only unset/false.
-          if [ "${REFRESH_ONLY:-}" = "true" ] \
-            && [ "${instance_state}" != "running" ] \
-            && [ "${instance_state}" != "pending" ]; then
-            echo "PR ${PR_NUMBER} preview is ${instance_state}; push refresh skipped."
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Refreshing an already-running env does not consume a new slot.
-          if [ "${instance_state}" = "running" ] || [ "${instance_state}" = "pending" ]; then
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Per-engineer limit: at most 5 running envs, attributed by the
-          # PreviewOwner tag. Best-effort — concurrent commands can race.
-          running="$(aws ec2 describe-instances \
-            --filters \
-              "Name=tag:Project,Values=langfuse-preview" \
-              "Name=tag:PreviewOwner,Values=${ACTOR}" \
-              "Name=instance-state-name,Values=pending,running" \
-            --query "Reservations[].Instances[].[Tags[?Key=='PullRequest'] | [0].Value]" \
-            --output text | grep -v '^$' || true)"
-          count="$(printf '%s' "${running}" | grep -c . || true)"
-
-          if [ "${count}" -ge 5 ]; then
-            pr_list="$(printf '%s\n' "${running}" | sed 's/^/#/' | paste -sd ', ' -)"
-            gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
-              --body "@${ACTOR} you already have ${count} running previews (PRs ${pr_list}). Stop or destroy one first (\`/preview stop\` / \`/preview destroy\`), then retry."
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "proceed=true" >> "$GITHUB_OUTPUT"
+        run: bash "$SCRIPTS/deploy-gate.sh"
 
   deploy:
     name: Deploy AWS preview
@@ -425,6 +375,10 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    env:
+      # Deploy logic is sourced from the default-branch checkout below, never
+      # from the PR head (which is checked out only as the Docker build context).
+      SCRIPTS: .preview-ci/deployment/aws-preview/scripts
     steps:
       - name: Checkout preview ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -432,35 +386,16 @@ jobs:
           persist-credentials: false
           ref: ${{ needs.context.outputs.head_sha }}
 
+      - name: Checkout preview logic from the default branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch || 'main' }}
+          sparse-checkout: deployment/aws-preview/scripts
+          path: .preview-ci
+
       - name: Validate preview configuration
-        run: |
-          set -euo pipefail
-
-          required_vars=(
-            AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN
-            AWS_PREVIEW_DOMAIN_NAME
-            AWS_PREVIEW_HOSTED_ZONE_ID
-            AWS_PREVIEW_INSTANCE_PROFILE_NAME
-            AWS_PREVIEW_REGION
-            AWS_PREVIEW_ROLE_ARN
-            AWS_PREVIEW_SECURITY_GROUP_ID
-            AWS_PREVIEW_SUBNET_ID
-            AWS_PREVIEW_WEB_ECR_REPOSITORY_URL
-            AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL
-          )
-
-          missing=()
-          for var_name in "${required_vars[@]}"; do
-            if [ -z "${!var_name}" ]; then
-              missing+=("${var_name}")
-            fi
-          done
-
-          if [ "${#missing[@]}" -gt 0 ]; then
-            printf 'Missing required GitHub repository variables:\n'
-            printf '  - %s\n' "${missing[@]}"
-            exit 1
-          fi
+        run: bash "$SCRIPTS/validate-config.sh"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
@@ -475,238 +410,32 @@ jobs:
         id: preview
         env:
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-
-          pr_number="${PR_NUMBER}"
-          commit_sha="$(git rev-parse HEAD)"
-          short_sha="${commit_sha:0:12}"
-          stack_name="langfuse-preview-pr-${pr_number}"
-          image_tag="pr-${pr_number}-${short_sha}"
-          preview_host="pr-${pr_number}.${AWS_PREVIEW_DOMAIN_NAME}"
-          ecr_registry="${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL%%/*}"
-
-          # Per-preview secret root. Every preview secret below is HMAC-derived
-          # from this random seed, so none is computable from this public repo
-          # (a plain sha256 of "<name>-<pr>" was). The seed is generated once on
-          # first deploy and persisted in AWS Secrets Manager, then reused on
-          # every redeploy and stop/resume so the derived secrets stay stable:
-          # Postgres and ClickHouse bake their password into the data volume at
-          # first init, so a changed secret against a surviving volume would lock
-          # the stack out of its own database.
-          seed_name="langfuse-preview/pr-${pr_number}/seed"
-          if seed="$(aws secretsmanager get-secret-value --secret-id "${seed_name}" \
-            --query "SecretString" --output text 2>/tmp/seed_err)"; then
-            echo "Reusing existing secret seed for PR ${pr_number}."
-          elif grep -q "ResourceNotFoundException" /tmp/seed_err; then
-            echo "Generating a new secret seed for PR ${pr_number}."
-            seed="$(openssl rand -hex 32)"
-            # create-secret fails if a concurrent deploy already created the
-            # seed; re-read the winner instead of clobbering it.
-            if ! aws secretsmanager create-secret --name "${seed_name}" \
-              --secret-string "${seed}" 2>/tmp/seed_put_err; then
-              if grep -q "ResourceExistsException" /tmp/seed_put_err; then
-                seed="$(aws secretsmanager get-secret-value --secret-id "${seed_name}" \
-                  --query "SecretString" --output text)"
-              else
-                cat /tmp/seed_put_err >&2
-                exit 1
-              fi
-            fi
-          else
-            # Fail closed: an unreadable (but not absent) seed must never fall
-            # through to regeneration — new secrets against a surviving volume
-            # would brick the preview. Throttling/permission/KMS errors land here.
-            echo "Secret seed for PR ${pr_number} is unreadable and not absent; refusing to regenerate." >&2
-            cat /tmp/seed_err >&2
-            exit 1
-          fi
-          echo "::add-mask::${seed}"
-
-          # HMAC-SHA256(seed, label) -> 64 hex chars: exactly the ENCRYPTION_KEY
-          # format (256-bit hex, per `openssl rand -hex 32`), and hex keeps
-          # connection strings free of URL/shell-special characters.
-          derive() {
-            printf '%s' "$1" | openssl dgst -sha256 -hmac "${seed}" | awk '{print $NF}'
-          }
-
-          postgres_password="$(derive postgres)"
-          clickhouse_password="$(derive clickhouse)"
-          redis_auth="$(derive redis)"
-          minio_password="$(derive minio)"
-          nextauth_secret="$(derive nextauth)"
-          salt="$(derive salt)"
-          encryption_key="$(derive encryption)"
-          login_password="$(derive login)"
-          public_key="pk-lf-preview-${pr_number}"
-          secret_key="sk-lf-preview-$(derive apikey)"
-
-          for value in \
-            "${postgres_password}" \
-            "${clickhouse_password}" \
-            "${redis_auth}" \
-            "${minio_password}" \
-            "${nextauth_secret}" \
-            "${salt}" \
-            "${encryption_key}" \
-            "${login_password}" \
-            "${secret_key}"; do
-            echo "::add-mask::${value}"
-          done
-
-          {
-            echo "clickhouse_password=${clickhouse_password}"
-            echo "commit_sha=${commit_sha}"
-            echo "ecr_registry=${ecr_registry}"
-            echo "encryption_key=${encryption_key}"
-            echo "image_tag=${image_tag}"
-            echo "login_email=preview-${pr_number}@langfuse.local"
-            echo "login_password=${login_password}"
-            echo "minio_password=${minio_password}"
-            echo "nextauth_secret=${nextauth_secret}"
-            echo "postgres_password=${postgres_password}"
-            echo "preview_host=${preview_host}"
-            echo "pr_number=${pr_number}"
-            echo "public_key=${public_key}"
-            echo "redis_auth=${redis_auth}"
-            echo "salt=${salt}"
-            echo "secret_key=${secret_key}"
-            echo "short_sha=${short_sha}"
-            echo "stack_name=${stack_name}"
-            echo "web_image=${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}:${image_tag}"
-            echo "worker_image=${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}:${image_tag}"
-          } >> "$GITHUB_OUTPUT"
+        run: bash "$SCRIPTS/resolve-metadata.sh"
 
       - name: Build and push preview images
         env:
           COMMIT_SHA: ${{ steps.preview.outputs.commit_sha }}
           WEB_IMAGE: ${{ steps.preview.outputs.web_image }}
           WORKER_IMAGE: ${{ steps.preview.outputs.worker_image }}
-        run: |
-          set -euo pipefail
-
-          docker build \
-            --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
-            --build-arg NEXT_PUBLIC_SIGN_UP_DISABLED=true \
-            -f ./web/Dockerfile \
-            -t "${WEB_IMAGE}" \
-            .
-          docker push "${WEB_IMAGE}"
-
-          docker build \
-            --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
-            -f ./worker/Dockerfile \
-            -t "${WORKER_IMAGE}" \
-            .
-          docker push "${WORKER_IMAGE}"
+        run: bash "$SCRIPTS/build-images.sh"
 
       - name: Deploy preview host stack
         env:
           ACTOR: ${{ needs.context.outputs.actor }}
           PR_NUMBER: ${{ steps.preview.outputs.pr_number }}
           STACK_NAME: ${{ steps.preview.outputs.stack_name }}
-        run: |
-          set -euo pipefail
-
-          # A stack stuck in a failed create state cannot be updated;
-          # delete it and start fresh.
-          status="$(aws cloudformation describe-stacks \
-            --stack-name "${STACK_NAME}" \
-            --query "Stacks[0].StackStatus" \
-            --output text 2>/dev/null || true)"
-          case "${status}" in
-            ROLLBACK_COMPLETE|ROLLBACK_FAILED|CREATE_FAILED)
-              echo "Stack is in ${status}; deleting before redeploy."
-              aws cloudformation delete-stack --stack-name "${STACK_NAME}"
-              aws cloudformation wait stack-delete-complete --stack-name "${STACK_NAME}"
-              ;;
-          esac
-
-          overrides=(
-            PreviewName="${STACK_NAME}"
-            PullRequestNumber="${PR_NUMBER}"
-            SubnetId="${AWS_PREVIEW_SUBNET_ID}"
-            SecurityGroupId="${AWS_PREVIEW_SECURITY_GROUP_ID}"
-            InstanceProfileName="${AWS_PREVIEW_INSTANCE_PROFILE_NAME}"
-            HostedZoneId="${AWS_PREVIEW_HOSTED_ZONE_ID}"
-            DomainName="${AWS_PREVIEW_DOMAIN_NAME}"
-            InstanceType="${AWS_PREVIEW_INSTANCE_TYPE}"
-            VolumeSizeGb="${AWS_PREVIEW_VOLUME_SIZE_GB}"
-          )
-          # Push-triggered refreshes have no actor and keep the previous
-          # owner (omitted parameters retain their value on stack updates).
-          if [ -n "${ACTOR}" ]; then
-            overrides+=(PreviewOwner="${ACTOR}")
-          fi
-
-          aws cloudformation deploy \
-            --stack-name "${STACK_NAME}" \
-            --template-file deployment/aws-preview/cloudformation.yaml \
-            --role-arn "${AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN}" \
-            --no-fail-on-empty-changeset \
-            --parameter-overrides "${overrides[@]}" \
-            --tags \
-              Project=langfuse-preview \
-              PullRequest="${PR_NUMBER}" \
-              PreviewManagedBy=github-actions
+        run: bash "$SCRIPTS/deploy-stack.sh"
 
       - name: Resolve preview host
         id: host
         env:
           STACK_NAME: ${{ steps.preview.outputs.stack_name }}
-        run: |
-          set -euo pipefail
-
-          instance_id="$(aws cloudformation describe-stacks \
-            --stack-name "${STACK_NAME}" \
-            --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
-            --output text)"
-          public_ip="$(aws cloudformation describe-stacks \
-            --stack-name "${STACK_NAME}" \
-            --query "Stacks[0].Outputs[?OutputKey=='PublicIp'].OutputValue" \
-            --output text)"
-
-          # An explicit /preview deploy on a stopped preview boots it again.
-          state="$(aws ec2 describe-instances \
-            --instance-ids "${instance_id}" \
-            --query "Reservations[0].Instances[0].State.Name" \
-            --output text)"
-          if [ "${state}" = "stopping" ]; then
-            aws ec2 wait instance-stopped --instance-ids "${instance_id}"
-            state="stopped"
-          fi
-          if [ "${state}" != "running" ] && [ "${state}" != "pending" ]; then
-            aws ec2 start-instances --instance-ids "${instance_id}"
-          fi
-          aws ec2 wait instance-running --instance-ids "${instance_id}"
-
-          # A deployed env is running again; it is no longer reapable.
-          aws ec2 delete-tags --resources "${instance_id}" --tags Key=StoppedAt
-
-          echo "instance_id=${instance_id}" >> "$GITHUB_OUTPUT"
-          echo "public_ip=${public_ip}" >> "$GITHUB_OUTPUT"
+        run: bash "$SCRIPTS/resolve-host.sh"
 
       - name: Wait for SSM
         env:
           INSTANCE_ID: ${{ steps.host.outputs.instance_id }}
-        run: |
-          set -euo pipefail
-
-          for _ in $(seq 1 60); do
-            ping_status="$(aws ssm describe-instance-information \
-              --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
-              --query "InstanceInformationList[0].PingStatus" \
-              --output text 2>/dev/null || true)"
-
-            if [ "${ping_status}" = "Online" ]; then
-              exit 0
-            fi
-
-            sleep 5
-          done
-
-          echo "Instance ${INSTANCE_ID} did not become available in SSM."
-          exit 1
+        run: bash "$SCRIPTS/wait-ssm.sh"
 
       - name: Deploy containers through SSM
         env:
@@ -727,109 +456,12 @@ jobs:
           SECRET_KEY: ${{ steps.preview.outputs.secret_key }}
           WEB_IMAGE: ${{ steps.preview.outputs.web_image }}
           WORKER_IMAGE: ${{ steps.preview.outputs.worker_image }}
-        run: |
-          set -euo pipefail
-
-          env_file="$(mktemp)"
-          cat > "${env_file}" <<EOF
-          AWS_REGION=${AWS_PREVIEW_REGION}
-          CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
-          ECR_REGISTRY=${ECR_REGISTRY}
-          ENCRYPTION_KEY=${ENCRYPTION_KEY}
-          LANGFUSE_INIT_ORG_ID=preview-org-${PR_NUMBER}
-          LANGFUSE_INIT_ORG_NAME=Preview-PR-${PR_NUMBER}
-          LANGFUSE_INIT_PROJECT_ID=preview-project-${PR_NUMBER}
-          LANGFUSE_INIT_PROJECT_NAME=Preview-Project
-          LANGFUSE_INIT_PROJECT_PUBLIC_KEY=${PUBLIC_KEY}
-          LANGFUSE_INIT_PROJECT_SECRET_KEY=${SECRET_KEY}
-          LANGFUSE_INIT_USER_EMAIL=${LOGIN_EMAIL}
-          LANGFUSE_INIT_USER_NAME=Preview-User
-          LANGFUSE_INIT_USER_PASSWORD=${LOGIN_PASSWORD}
-          MINIO_ROOT_PASSWORD=${MINIO_PASSWORD}
-          NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
-          POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-          PREVIEW_HOST=${PREVIEW_HOST}
-          REDIS_AUTH=${REDIS_AUTH}
-          SALT=${SALT}
-          WEB_IMAGE=${WEB_IMAGE}
-          WORKER_IMAGE=${WORKER_IMAGE}
-          EOF
-
-          env_b64="$(base64 -w0 "${env_file}")"
-
-          # SSM parameters must be JSON: the base64 blob and the shell snippets
-          # below contain commas and pipes that the "commands=..." shorthand
-          # mis-parses (AWS CLI ParamValidationError). A file:// JSON document
-          # passes each command through verbatim.
-          params_file="$(mktemp)"
-          cat > "${params_file}" <<JSON
-          {"commands":[
-          "mkdir -p /opt/langfuse-preview",
-          "echo ${env_b64} | base64 -d > /opt/langfuse-preview/deploy.env",
-          "chmod 600 /opt/langfuse-preview/deploy.env",
-          "for i in \$(seq 1 60); do test -x /opt/langfuse-preview/deploy.sh && break || sleep 5; done",
-          "test -x /opt/langfuse-preview/deploy.sh",
-          "/opt/langfuse-preview/deploy.sh"
-          ]}
-          JSON
-
-          command_id="$(aws ssm send-command \
-            --document-name "AWS-RunShellScript" \
-            --instance-ids "${INSTANCE_ID}" \
-            --comment "Deploy Langfuse PR ${PR_NUMBER} preview" \
-            --parameters "file://${params_file}" \
-            --query "Command.CommandId" \
-            --output text)"
-
-          # Poll for completion rather than `aws ssm wait command-executed`,
-          # whose ~100s default (5s x 20 attempts) is far shorter than a cold
-          # deploy: the bundled cloud-init wait, ECR login, ~7 image pulls, and
-          # six container-readiness gates in deploy.sh run for several minutes.
-          # The short waiter would fail the step spuriously while the on-host
-          # deploy is still succeeding.
-          deploy_ok=false
-          for _ in $(seq 1 120); do
-            status="$(aws ssm get-command-invocation \
-              --command-id "${command_id}" \
-              --instance-id "${INSTANCE_ID}" \
-              --query "Status" --output text 2>/dev/null || echo "Pending")"
-            case "${status}" in
-              Success)
-                deploy_ok=true
-                break
-                ;;
-              Cancelled | TimedOut | Failed)
-                break
-                ;;
-            esac
-            sleep 10
-          done
-
-          if [ "${deploy_ok}" != "true" ]; then
-            aws ssm get-command-invocation \
-              --command-id "${command_id}" \
-              --instance-id "${INSTANCE_ID}" \
-              --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
-              --output json
-            exit 1
-          fi
+        run: bash "$SCRIPTS/deploy-containers.sh"
 
       - name: Check preview health
         env:
           PREVIEW_HOST: ${{ steps.preview.outputs.preview_host }}
-        run: |
-          set -euo pipefail
-
-          # TLS certificate issuance on first deploy can take a minute.
-          for _ in $(seq 1 90); do
-            if curl -fsS --max-time 10 "https://${PREVIEW_HOST}/api/public/health" >/dev/null; then
-              exit 0
-            fi
-            sleep 5
-          done
-
-          echo "Preview did not become healthy."
-          exit 1
+        run: bash "$SCRIPTS/check-health.sh"
 
       - name: Update status comment
         uses: ./.github/actions/aws-preview-comment
@@ -867,13 +499,17 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    env:
+      SCRIPTS: deployment/aws-preview/scripts
     steps:
-      - name: Checkout composite actions
+      - name: Checkout preview logic and composite actions
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-          ref: ${{ github.event.repository.default_branch }}
-          sparse-checkout: .github
+          ref: ${{ github.event.repository.default_branch || 'main' }}
+          sparse-checkout: |
+            .github
+            deployment/aws-preview/scripts
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
@@ -885,26 +521,7 @@ jobs:
         id: stop
         env:
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-
-          stack_name="langfuse-preview-pr-${PR_NUMBER}"
-          instance_id="$(aws cloudformation describe-stacks \
-            --stack-name "${stack_name}" \
-            --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
-            --output text 2>/dev/null || true)"
-
-          if [ -z "${instance_id}" ] || [ "${instance_id}" = "None" ]; then
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          aws ec2 stop-instances --instance-ids "${instance_id}"
-          aws ec2 wait instance-stopped --instance-ids "${instance_id}"
-          # The reaper destroys envs stopped for more than 7 days.
-          aws ec2 create-tags --resources "${instance_id}" \
-            --tags "Key=StoppedAt,Value=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          echo "exists=true" >> "$GITHUB_OUTPUT"
+        run: bash "$SCRIPTS/stop.sh"
 
       - name: Update status comment
         if: steps.stop.outputs.exists == 'true'
@@ -945,13 +562,17 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    env:
+      SCRIPTS: deployment/aws-preview/scripts
     steps:
-      - name: Checkout composite actions
+      - name: Checkout preview logic and composite actions
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-          ref: ${{ github.event.repository.default_branch }}
-          sparse-checkout: .github
+          ref: ${{ github.event.repository.default_branch || 'main' }}
+          sparse-checkout: |
+            .github
+            deployment/aws-preview/scripts
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
@@ -965,79 +586,13 @@ jobs:
           ACTOR: ${{ needs.context.outputs.actor }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-
-          stack_name="langfuse-preview-pr-${PR_NUMBER}"
-          instance_id="$(aws cloudformation describe-stacks \
-            --stack-name "${stack_name}" \
-            --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
-            --output text 2>/dev/null || true)"
-
-          if [ -z "${instance_id}" ] || [ "${instance_id}" = "None" ]; then
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "allowed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          state="$(aws ec2 describe-instances \
-            --instance-ids "${instance_id}" \
-            --query "Reservations[0].Instances[0].State.Name" \
-            --output text)"
-
-          # Per-engineer limit: resuming takes one of the actor's 5 running
-          # slots (unless this env is already running).
-          if [ "${state}" != "running" ] && [ "${state}" != "pending" ]; then
-            running="$(aws ec2 describe-instances \
-              --filters \
-                "Name=tag:Project,Values=langfuse-preview" \
-                "Name=tag:PreviewOwner,Values=${ACTOR}" \
-                "Name=instance-state-name,Values=pending,running" \
-              --query "Reservations[].Instances[].[Tags[?Key=='PullRequest'] | [0].Value]" \
-              --output text | grep -v '^$' || true)"
-            count="$(printf '%s' "${running}" | grep -c . || true)"
-
-            if [ "${count}" -ge 5 ]; then
-              pr_list="$(printf '%s\n' "${running}" | sed 's/^/#/' | paste -sd ', ' -)"
-              gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
-                --body "@${ACTOR} you already have ${count} running previews (PRs ${pr_list}). Stop or destroy one first (\`/preview stop\` / \`/preview destroy\`), then retry."
-              echo "exists=true" >> "$GITHUB_OUTPUT"
-              echo "allowed=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-
-          aws ec2 start-instances --instance-ids "${instance_id}"
-          aws ec2 wait instance-running --instance-ids "${instance_id}"
-
-          # The resumer now owns this env's running slot.
-          aws ec2 delete-tags --resources "${instance_id}" --tags Key=StoppedAt
-          aws ec2 create-tags --resources "${instance_id}" \
-            --tags "Key=PreviewOwner,Value=${ACTOR}"
-
-          echo "exists=true" >> "$GITHUB_OUTPUT"
-          echo "allowed=true" >> "$GITHUB_OUTPUT"
+        run: bash "$SCRIPTS/resume.sh"
 
       - name: Wait for preview health
         if: steps.start.outputs.exists == 'true' && steps.start.outputs.allowed == 'true'
         env:
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-
-          preview_host="pr-${PR_NUMBER}.${AWS_PREVIEW_DOMAIN_NAME}"
-
-          # Containers restart automatically on boot (docker restart policy);
-          # give the stack a few minutes to come back.
-          for _ in $(seq 1 90); do
-            if curl -fsS --max-time 10 "https://${preview_host}/api/public/health" >/dev/null; then
-              exit 0
-            fi
-            sleep 5
-          done
-
-          echo "Preview did not become healthy after resume."
-          exit 1
+        run: bash "$SCRIPTS/check-health.sh"
 
       - name: Update status comment
         if: steps.start.outputs.exists == 'true' && steps.start.outputs.allowed == 'true'
@@ -1081,13 +636,17 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    env:
+      SCRIPTS: deployment/aws-preview/scripts
     steps:
-      - name: Checkout composite actions
+      - name: Checkout preview logic and composite actions
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-          ref: ${{ github.event.repository.default_branch }}
-          sparse-checkout: .github
+          ref: ${{ github.event.repository.default_branch || 'main' }}
+          sparse-checkout: |
+            .github
+            deployment/aws-preview/scripts
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
@@ -1095,57 +654,11 @@ jobs:
           aws-region: ${{ env.AWS_PREVIEW_REGION }}
           role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
 
-      - name: Delete preview stack
+      - name: Delete preview stack, images, and secret seed
         id: delete
         env:
           PR_NUMBER: ${{ needs.context.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-
-          stack_name="langfuse-preview-pr-${PR_NUMBER}"
-
-          if aws cloudformation describe-stacks --stack-name "${stack_name}" >/dev/null 2>&1; then
-            aws cloudformation delete-stack --stack-name "${stack_name}"
-            aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
-            echo "existed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Preview stack ${stack_name} does not exist."
-            echo "existed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Delete preview images
-        env:
-          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-
-          for repository_url in \
-            "${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}" \
-            "${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}"; do
-            repository_name="${repository_url#*/}"
-            image_ids="$(aws ecr list-images \
-              --repository-name "${repository_name}" \
-              --filter tagStatus=TAGGED \
-              --query "imageIds[?starts_with(imageTag, 'pr-${PR_NUMBER}-')]" \
-              --output json)"
-
-            if [ "${image_ids}" != "[]" ]; then
-              aws ecr batch-delete-image \
-                --repository-name "${repository_name}" \
-                --image-ids "${image_ids}" >/dev/null
-              echo "Deleted preview images from ${repository_name}."
-            fi
-          done
-
-      - name: Delete preview secret seed
-        env:
-          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-
-          aws secretsmanager delete-secret --secret-id "langfuse-preview/pr-${PR_NUMBER}/seed" \
-            --force-delete-without-recovery 2>/dev/null \
-            || echo "No secret seed for PR ${PR_NUMBER}."
+        run: bash "$SCRIPTS/destroy.sh"
 
       - name: Update status comment
         if: steps.delete.outputs.existed == 'true'
@@ -1177,7 +690,16 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    env:
+      SCRIPTS: deployment/aws-preview/scripts
     steps:
+      - name: Checkout preview logic from the default branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch || 'main' }}
+          sparse-checkout: deployment/aws-preview/scripts
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
@@ -1187,35 +709,7 @@ jobs:
       - name: Stop running preview instances
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          instances="$(aws ec2 describe-instances \
-            --filters \
-              "Name=tag:Project,Values=langfuse-preview" \
-              "Name=instance-state-name,Values=running" \
-            --query "Reservations[].Instances[].[InstanceId, Tags[?Key=='PullRequest'] | [0].Value]" \
-            --output text)"
-
-          if [ -z "${instances}" ]; then
-            echo "No running preview instances."
-            exit 0
-          fi
-
-          stopped_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          while read -r instance_id pr_number; do
-            [ -z "${instance_id}" ] && continue
-            echo "Stopping ${instance_id} (PR ${pr_number})"
-            aws ec2 stop-instances --instance-ids "${instance_id}"
-            aws ec2 create-tags --resources "${instance_id}" \
-              --tags "Key=StoppedAt,Value=${stopped_at}"
-
-            if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
-              gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
-                --body "⏸️ AWS preview stopped by a manual stop-all. Resume with \`/preview resume\`." \
-                || echo "Could not comment on PR ${pr_number}."
-            fi
-          done <<< "${instances}"
+        run: bash "$SCRIPTS/stop-all.sh"
 
   reap:
     name: Preview housekeeping
@@ -1226,7 +720,16 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    env:
+      SCRIPTS: deployment/aws-preview/scripts
     steps:
+      - name: Checkout preview logic from the default branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch || 'main' }}
+          sparse-checkout: deployment/aws-preview/scripts
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
@@ -1236,216 +739,14 @@ jobs:
       - name: Stop idle running previews
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          start_time="$(date -u -d "${AWS_PREVIEW_IDLE_HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ)"
-          end_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          cutoff_epoch="$(( $(date -u +%s) - AWS_PREVIEW_IDLE_HOURS * 3600 ))"
-
-          instances="$(aws ec2 describe-instances \
-            --filters \
-              "Name=tag:Project,Values=langfuse-preview" \
-              "Name=instance-state-name,Values=running" \
-            --query "Reservations[].Instances[].[InstanceId, LaunchTime, Tags[?Key=='PullRequest'] | [0].Value]" \
-            --output text)"
-
-          if [ -z "${instances}" ]; then
-            echo "No running preview instances."
-            exit 0
-          fi
-
-          stopped_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          while read -r instance_id launch_time pr_number; do
-            [ -z "${instance_id}" ] && continue
-
-            # Grace period: instances started less than the idle window ago
-            # are left alone (LaunchTime resets on every start).
-            launch_epoch="$(date -u -d "${launch_time}" +%s 2>/dev/null || echo 0)"
-            if [ "${launch_epoch}" -eq 0 ] || [ "${launch_epoch}" -gt "${cutoff_epoch}" ]; then
-              continue
-            fi
-
-            # Idle = no 5-minute window above the CPU threshold. Real usage
-            # (UI clicks, SDK ingestion) spikes CPU well above the stack's
-            # baseline of background polling and merges.
-            max_cpu="$(aws cloudwatch get-metric-statistics \
-              --namespace AWS/EC2 \
-              --metric-name CPUUtilization \
-              --dimensions "Name=InstanceId,Value=${instance_id}" \
-              --start-time "${start_time}" \
-              --end-time "${end_time}" \
-              --period 300 \
-              --statistics Maximum \
-              --query "max(Datapoints[].Maximum)" \
-              --output text)"
-
-            # No datapoints means no evidence; never stop without evidence.
-            if [ -z "${max_cpu}" ] || [ "${max_cpu}" = "None" ]; then
-              continue
-            fi
-
-            if awk -v cpu="${max_cpu}" -v limit="${AWS_PREVIEW_IDLE_CPU_MAX}" 'BEGIN { exit !(cpu < limit) }'; then
-              echo "Stopping ${instance_id} (PR ${pr_number}): max CPU ${max_cpu}% over ${AWS_PREVIEW_IDLE_HOURS}h"
-              aws ec2 stop-instances --instance-ids "${instance_id}"
-              aws ec2 create-tags --resources "${instance_id}" \
-                --tags "Key=StoppedAt,Value=${stopped_at}"
-
-              if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
-                gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
-                  --body "⏸️ AWS preview stopped after ~${AWS_PREVIEW_IDLE_HOURS}h without activity. Data and URL are kept; resume with \`/preview resume\`." \
-                  || echo "Could not comment on PR ${pr_number}."
-              fi
-            fi
-          done <<< "${instances}"
+        run: bash "$SCRIPTS/reap-idle.sh"
 
       - name: Destroy previews for closed PRs
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          # Reconciliation replaces the old pull_request:closed teardown: this
-          # runs from the default branch, so no unreviewed PR workflow code is
-          # ever trusted with the preview role. Worst-case cleanup latency is
-          # one housekeeping interval (2h).
-          instances="$(aws ec2 describe-instances \
-            --filters \
-              "Name=tag:Project,Values=langfuse-preview" \
-              "Name=instance-state-name,Values=pending,running,stopping,stopped" \
-            --query "Reservations[].Instances[].[Tags[?Key=='PullRequest'] | [0].Value, Tags[?Key=='aws:cloudformation:stack-name'] | [0].Value]" \
-            --output text)"
-
-          if [ -z "${instances}" ]; then
-            echo "No preview instances."
-          else
-            while read -r pr_number stack_name; do
-              [ -z "${pr_number}" ] || [ "${pr_number}" = "None" ] && continue
-              case "${stack_name}" in
-                langfuse-preview-pr-*) ;;
-                *)
-                  echo "Skipping unexpected stack name '${stack_name}'."
-                  continue
-                  ;;
-              esac
-
-              pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq .state 2>/dev/null || echo "unknown")"
-              if [ "${pr_state}" != "closed" ]; then
-                continue
-              fi
-
-              echo "Destroying ${stack_name}: PR ${pr_number} is closed."
-              # Isolate each teardown in a subshell so one stuck/failed
-              # deletion doesn't abort the whole batch under set -e.
-              if ! (
-                set -e
-                aws cloudformation delete-stack --stack-name "${stack_name}"
-                aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
-
-                for repository_url in \
-                  "${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}" \
-                  "${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}"; do
-                  repository_name="${repository_url#*/}"
-                  image_ids="$(aws ecr list-images \
-                    --repository-name "${repository_name}" \
-                    --filter tagStatus=TAGGED \
-                    --query "imageIds[?starts_with(imageTag, 'pr-${pr_number}-')]" \
-                    --output json)"
-                  if [ "${image_ids}" != "[]" ]; then
-                    aws ecr batch-delete-image \
-                      --repository-name "${repository_name}" \
-                      --image-ids "${image_ids}" >/dev/null
-                  fi
-                done
-
-                aws secretsmanager delete-secret --secret-id "langfuse-preview/pr-${pr_number}/seed" --force-delete-without-recovery 2>/dev/null || true
-              ); then
-                echo "Failed to reap ${stack_name}; continuing with the next stack."
-                continue
-              fi
-
-              gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
-                --body "🗑️ AWS preview destroyed because the PR is closed. Reopen and \`/preview deploy\` to recreate." \
-                || echo "Could not comment on PR ${pr_number}."
-            done <<< "${instances}"
-          fi
+        run: bash "$SCRIPTS/reap-closed.sh"
 
       - name: Destroy previews stopped for more than 7 days
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          cutoff="$(date -u -d '7 days ago' +%s)"
-
-          instances="$(aws ec2 describe-instances \
-            --filters \
-              "Name=tag:Project,Values=langfuse-preview" \
-              "Name=instance-state-name,Values=stopped" \
-              "Name=tag-key,Values=StoppedAt" \
-            --query "Reservations[].Instances[].[InstanceId, Tags[?Key=='StoppedAt'] | [0].Value, Tags[?Key=='PullRequest'] | [0].Value, Tags[?Key=='aws:cloudformation:stack-name'] | [0].Value]" \
-            --output text)"
-
-          if [ -z "${instances}" ]; then
-            echo "No stopped previews with a StoppedAt tag."
-            exit 0
-          fi
-
-          while read -r instance_id stopped_at pr_number stack_name; do
-            [ -z "${instance_id}" ] && continue
-
-            stopped_epoch="$(date -u -d "${stopped_at}" +%s 2>/dev/null || echo 0)"
-            if [ "${stopped_epoch}" -eq 0 ]; then
-              echo "Skipping ${instance_id}: unparseable StoppedAt '${stopped_at}'."
-              continue
-            fi
-            if [ "${stopped_epoch}" -gt "${cutoff}" ]; then
-              continue
-            fi
-            case "${stack_name}" in
-              langfuse-preview-pr-*) ;;
-              *)
-                echo "Skipping ${instance_id}: unexpected stack name '${stack_name}'."
-                continue
-                ;;
-            esac
-
-            echo "Reaping ${stack_name} (stopped since ${stopped_at})"
-            # Isolate each teardown in a subshell so one stuck/failed deletion
-            # doesn't abort the whole batch under set -e.
-            if ! (
-              set -e
-              aws cloudformation delete-stack --stack-name "${stack_name}"
-              aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
-
-              if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
-                for repository_url in \
-                  "${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}" \
-                  "${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}"; do
-                  repository_name="${repository_url#*/}"
-                  image_ids="$(aws ecr list-images \
-                    --repository-name "${repository_name}" \
-                    --filter tagStatus=TAGGED \
-                    --query "imageIds[?starts_with(imageTag, 'pr-${pr_number}-')]" \
-                    --output json)"
-
-                  if [ "${image_ids}" != "[]" ]; then
-                    aws ecr batch-delete-image \
-                      --repository-name "${repository_name}" \
-                      --image-ids "${image_ids}" >/dev/null
-                  fi
-                done
-              fi
-
-              aws secretsmanager delete-secret --secret-id "langfuse-preview/pr-${pr_number}/seed" --force-delete-without-recovery 2>/dev/null || true
-            ); then
-              echo "Failed to reap ${stack_name}; continuing with the next stack."
-              continue
-            fi
-
-            if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
-              gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
-                --body "🗑️ AWS preview destroyed after 7 days stopped. Recreate with \`/preview deploy\`." \
-                || echo "Could not comment on PR ${pr_number}."
-            fi
-          done <<< "${instances}"
+        run: bash "$SCRIPTS/reap-stale.sh"

--- a/deployment/aws-preview/README.md
+++ b/deployment/aws-preview/README.md
@@ -9,10 +9,27 @@ Route53 zone, GitHub OIDC role, CloudFormation service role, and EC2 instance
 profile, and exposes an output listing the `AWS_PREVIEW_*` GitHub repository
 variables this workflow expects.
 
+## Access: the allowlist
+
+A single repository variable, `AWS_PREVIEW_ALLOWED_USERS` (space- or
+comma-separated GitHub logins), controls who may use previews. It governs both
+the auto-deploy trigger and the manual commands. Empty or unset means nobody —
+previews stay dormant until it is populated. Edit it in
+Settings → Secrets and variables → Actions → Variables.
+
+## Auto-deploy on PRs
+
+When an allowlisted author opens (or pushes to, or reopens) a **same-repo**
+pull request, its preview is deployed automatically and refreshed on each push.
+Fork PRs are not auto-built; an allowlisted collaborator should push a branch to
+this repo instead. This uses a `pull_request_target` gate that runs the
+reviewed default-branch workflow — it only checks the allowlist and then
+dispatches the normal deploy on `main`, so unreviewed PR code never runs with
+AWS credentials.
+
 ## Commands
 
-Previews are driven by PR comments from maintainers (members, owners, and
-collaborators):
+Anyone on the allowlist can also drive previews manually by commenting:
 
 | Command | Effect |
 | --- | --- |
@@ -21,7 +38,8 @@ collaborators):
 | `/preview resume` | Start the instance again with the previously deployed images |
 | `/preview destroy` | Delete the CloudFormation stack and the PR's ECR image tags |
 
-Comment commands only work once the workflow exists on the default branch.
+Auto-deploy and comment commands only work once the workflow exists on the
+default branch.
 
 ## Lifecycle
 

--- a/deployment/aws-preview/README.md
+++ b/deployment/aws-preview/README.md
@@ -33,8 +33,10 @@ Comment commands only work once the workflow exists on the default branch.
   `https://pr-<number>.<preview domain>`.
 - An Elastic IP keeps the address stable across stop/resume, so DNS and the
   TLS certificate survive.
-- Pushing new commits auto-updates a preview only if it is already deployed
-  and running; stopped previews stay stopped.
+- To pick up new commits, comment `/preview deploy` again — this rebuilds and
+  refreshes a running preview in place. (There is no silent auto-deploy on
+  push: every AWS action runs only from reviewed default-branch workflow code,
+  so `pull_request`-triggered runs are intentionally not used.)
 - Each engineer may have at most 5 previews running at once, attributed to
   whoever's command made the env run (`PreviewOwner` tag). The limit is
   best-effort; commands beyond it are rejected with a comment listing your
@@ -43,11 +45,13 @@ Comment commands only work once the workflow exists on the default branch.
   are stopped automatically — data and URL survive, `/preview resume` brings
   them back. Actively used envs, overnight soak tests, and demos keep
   running. A manual stop-all exists as workflow dispatch for emergencies.
-- Housekeeping also destroys previews that have been stopped for more than
-  7 days. Closing the PR destroys the preview and deletes its images. ECR
+- Housekeeping also destroys previews whose PR is closed (reconciled every
+  2 hours) and previews that have been stopped for more than 7 days. ECR
   images also expire 14 days after push, so a long-paused preview may need a
   fresh `/preview deploy`.
-- Fork PRs are skipped entirely.
+- Fork PRs are skipped entirely, and only reviewed default-branch workflow
+  code can assume the AWS role (the OIDC trust accepts only the
+  `refs/heads/main` subject).
 
 Preview data must stay synthetic: the login and API keys are posted publicly
 on the PR, so anyone on the internet can sign in to a running preview. Never

--- a/deployment/aws-preview/README.md
+++ b/deployment/aws-preview/README.md
@@ -3,11 +3,10 @@
 This directory contains the app-side CloudFormation template used by the
 `AWS PR Preview` workflow (`.github/workflows/aws-preview.yml`).
 
-The shared AWS foundation lives in the private `langfuse/infrastructure` repo
-under `terraform/org/playground_previews`. That Terraform stack owns the
-playground VPC, ECR repositories, Route53 zone, GitHub OIDC role,
-CloudFormation service role, and EC2 instance profile. Its
-`github_actions_variables` output lists the `AWS_PREVIEW_*` GitHub repository
+The shared AWS foundation is managed in Langfuse's internal infrastructure
+repository. That Terraform stack owns the playground VPC, ECR repositories,
+Route53 zone, GitHub OIDC role, CloudFormation service role, and EC2 instance
+profile, and exposes an output listing the `AWS_PREVIEW_*` GitHub repository
 variables this workflow expects.
 
 ## Commands

--- a/deployment/aws-preview/README.md
+++ b/deployment/aws-preview/README.md
@@ -13,9 +13,11 @@ variables this workflow expects.
 
 A single repository variable, `AWS_PREVIEW_ALLOWED_USERS` (space- or
 comma-separated GitHub logins), controls who may use previews. It governs both
-the auto-deploy trigger and the manual commands. Empty or unset means nobody —
-previews stay dormant until it is populated. Edit it in
-Settings → Secrets and variables → Actions → Variables.
+the auto-deploy trigger and the manual commands. It defaults to `maxdeichmann`
+(the initial owner); set the variable in
+Settings → Secrets and variables → Actions → Variables to add or replace users
+without a code change. (Previews as a whole stay dormant until the
+`AWS_PREVIEW_ROLE_ARN` variable is set, regardless of the allowlist.)
 
 ## Auto-deploy on PRs
 

--- a/deployment/aws-preview/README.md
+++ b/deployment/aws-preview/README.md
@@ -12,8 +12,9 @@ variables this workflow expects.
 ## Access: the allowlist
 
 A single repository variable, `AWS_PREVIEW_ALLOWED_USERS` (space- or
-comma-separated GitHub logins), controls who may use previews. It governs both
-the auto-deploy trigger and the manual commands. It defaults to `maxdeichmann`
+comma-separated GitHub logins), controls who may use previews. It governs every
+entry point — auto-deploy on PRs, `/preview` comments, and manual
+`workflow_dispatch` runs. It defaults to `maxdeichmann`
 (the initial owner); set the variable in
 Settings → Secrets and variables → Actions → Variables to add or replace users
 without a code change. (Previews as a whole stay dormant until the

--- a/deployment/aws-preview/README.md
+++ b/deployment/aws-preview/README.md
@@ -44,4 +44,6 @@ Comment commands only work once the workflow exists on the default branch.
 - Fork PRs are skipped entirely.
 
 Preview data must stay synthetic: the login and API keys are posted publicly
-on the PR.
+on the PR, so anyone on the internet can sign in to a running preview. Never
+enter real LLM provider keys, production data, or any other secrets into a
+preview instance.

--- a/deployment/aws-preview/README.md
+++ b/deployment/aws-preview/README.md
@@ -36,11 +36,17 @@ Comment commands only work once the workflow exists on the default branch.
   TLS certificate survive.
 - Pushing new commits auto-updates a preview only if it is already deployed
   and running; stopped previews stay stopped.
-- All running previews are stopped nightly to cap cost; resume with
-  `/preview resume`.
-- Closing the PR destroys the preview and deletes its images. ECR images also
-  expire 14 days after push, so a long-paused preview may need a fresh
-  `/preview deploy`.
+- Each engineer may have at most 5 previews running at once, attributed to
+  whoever's command made the env run (`PreviewOwner` tag). The limit is
+  best-effort; commands beyond it are rejected with a comment listing your
+  running previews.
+- Running previews are never stopped automatically — stop or destroy your
+  envs when done (a running env costs ≈$67/month). A manual stop-all exists
+  as workflow dispatch for emergencies.
+- A daily reaper destroys previews that have been stopped for more than
+  7 days. Closing the PR destroys the preview and deletes its images. ECR
+  images also expire 14 days after push, so a long-paused preview may need a
+  fresh `/preview deploy`.
 - Fork PRs are skipped entirely.
 
 Preview data must stay synthetic: the login and API keys are posted publicly

--- a/deployment/aws-preview/README.md
+++ b/deployment/aws-preview/README.md
@@ -39,10 +39,11 @@ Comment commands only work once the workflow exists on the default branch.
   whoever's command made the env run (`PreviewOwner` tag). The limit is
   best-effort; commands beyond it are rejected with a comment listing your
   running previews.
-- Running previews are never stopped automatically — stop or destroy your
-  envs when done (a running env costs ≈$67/month). A manual stop-all exists
-  as workflow dispatch for emergencies.
-- A daily reaper destroys previews that have been stopped for more than
+- Previews that show no activity (no CPU spike above baseline) for ~6 hours
+  are stopped automatically — data and URL survive, `/preview resume` brings
+  them back. Actively used envs, overnight soak tests, and demos keep
+  running. A manual stop-all exists as workflow dispatch for emergencies.
+- Housekeeping also destroys previews that have been stopped for more than
   7 days. Closing the PR destroys the preview and deletes its images. ECR
   images also expire 14 days after push, so a long-paused preview may need a
   fresh `/preview deploy`.

--- a/deployment/aws-preview/README.md
+++ b/deployment/aws-preview/README.md
@@ -1,18 +1,47 @@
 # AWS PR Previews
 
 This directory contains the app-side CloudFormation template used by the
-`AWS PR Preview` workflow.
+`AWS PR Preview` workflow (`.github/workflows/aws-preview.yml`).
 
 The shared AWS foundation lives in the private `langfuse/infrastructure` repo
 under `terraform/org/playground_previews`. That Terraform stack owns the
 playground VPC, ECR repositories, Route53 zone, GitHub OIDC role,
-CloudFormation service role, and EC2 instance profile.
+CloudFormation service role, and EC2 instance profile. Its
+`github_actions_variables` output lists the `AWS_PREVIEW_*` GitHub repository
+variables this workflow expects.
 
-Each same-repository PR gets one disposable CloudFormation stack named
-`langfuse-preview-pr-<number>`. The stack creates a single EC2 host. The
-workflow builds the `web` and `worker` images, pushes them to preview ECR
-repositories, deploys or updates the stack, and then uses SSM to run the
-containers with Postgres, ClickHouse, Redis, and MinIO on the host.
+## Commands
 
-Closing the PR deletes the CloudFormation stack and the attached data volume.
-Preview data must stay synthetic.
+Previews are driven by PR comments from maintainers (members, owners, and
+collaborators):
+
+| Command | Effect |
+| --- | --- |
+| `/preview deploy` | Build the PR head, push images to ECR, and create or update the preview |
+| `/preview stop` | Stop the EC2 instance; data, URL, and TLS certificate are kept |
+| `/preview resume` | Start the instance again with the previously deployed images |
+| `/preview destroy` | Delete the CloudFormation stack and the PR's ECR image tags |
+
+Comment commands only work once the workflow exists on the default branch.
+
+## Lifecycle
+
+- Each preview is one CloudFormation stack named `langfuse-preview-pr-<number>`
+  running a single EC2 host. All Langfuse components run as Docker containers:
+  `web` and `worker` from the preview ECR repositories, plus Postgres,
+  ClickHouse, Redis, and MinIO from public images. Caddy terminates TLS with an
+  automatic Let's Encrypt certificate at
+  `https://pr-<number>.<preview domain>`.
+- An Elastic IP keeps the address stable across stop/resume, so DNS and the
+  TLS certificate survive.
+- Pushing new commits auto-updates a preview only if it is already deployed
+  and running; stopped previews stay stopped.
+- All running previews are stopped nightly to cap cost; resume with
+  `/preview resume`.
+- Closing the PR destroys the preview and deletes its images. ECR images also
+  expire 14 days after push, so a long-paused preview may need a fresh
+  `/preview deploy`.
+- Fork PRs are skipped entirely.
+
+Preview data must stay synthetic: the login and API keys are posted publicly
+on the PR.

--- a/deployment/aws-preview/README.md
+++ b/deployment/aws-preview/README.md
@@ -1,0 +1,18 @@
+# AWS PR Previews
+
+This directory contains the app-side CloudFormation template used by the
+`AWS PR Preview` workflow.
+
+The shared AWS foundation lives in the private `langfuse/infrastructure` repo
+under `terraform/org/playground_previews`. That Terraform stack owns the
+playground VPC, ECR repositories, Route53 zone, GitHub OIDC role,
+CloudFormation service role, and EC2 instance profile.
+
+Each same-repository PR gets one disposable CloudFormation stack named
+`langfuse-preview-pr-<number>`. The stack creates a single EC2 host. The
+workflow builds the `web` and `worker` images, pushes them to preview ECR
+repositories, deploys or updates the stack, and then uses SSM to run the
+containers with Postgres, ClickHouse, Redis, and MinIO on the host.
+
+Closing the PR deletes the CloudFormation stack and the attached data volume.
+Preview data must stay synthetic.

--- a/deployment/aws-preview/cloudformation.yaml
+++ b/deployment/aws-preview/cloudformation.yaml
@@ -57,6 +57,13 @@ Resources:
       IamInstanceProfile: !Ref InstanceProfileName
       ImageId: !Ref AmiId
       InstanceType: !Ref InstanceType
+      # IMDSv2 only: blocks SSRF-based credential theft from the web app,
+      # and the hop limit of 1 stops containers from reaching instance
+      # credentials at all. Host-level ECR login and SSM are unaffected.
+      MetadataOptions:
+        HttpEndpoint: enabled
+        HttpPutResponseHopLimit: 1
+        HttpTokens: required
       SecurityGroupIds:
         - !Ref SecurityGroupId
       SubnetId: !Ref SubnetId

--- a/deployment/aws-preview/cloudformation.yaml
+++ b/deployment/aws-preview/cloudformation.yaml
@@ -125,8 +125,10 @@ Resources:
           docker volume create langfuse_clickhouse_logs >/dev/null
           docker volume create langfuse_minio_data >/dev/null
           docker volume create langfuse_redis_data >/dev/null
+          # Persists TLS certificates across redeploys and stop/resume cycles.
+          docker volume create langfuse_caddy_data >/dev/null
 
-          for container in langfuse-web langfuse-worker postgres redis clickhouse minio; do
+          for container in caddy langfuse-web langfuse-worker postgres redis clickhouse minio; do
             docker rm -f "${container}" >/dev/null 2>&1 || true
           done
 
@@ -211,7 +213,7 @@ Resources:
             --env LANGFUSE_S3_BATCH_EXPORT_BUCKET=langfuse
             --env LANGFUSE_S3_BATCH_EXPORT_ENABLED=false
             --env LANGFUSE_S3_BATCH_EXPORT_ENDPOINT=http://minio:9000
-            --env LANGFUSE_S3_BATCH_EXPORT_EXTERNAL_ENDPOINT="http://${PREVIEW_HOST}"
+            --env LANGFUSE_S3_BATCH_EXPORT_EXTERNAL_ENDPOINT="https://${PREVIEW_HOST}"
             --env LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE=true
             --env LANGFUSE_S3_BATCH_EXPORT_PREFIX=exports/
             --env LANGFUSE_S3_BATCH_EXPORT_REGION=auto
@@ -232,7 +234,7 @@ Resources:
             --env LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY="${MINIO_ROOT_PASSWORD}"
             --env NEXT_PUBLIC_SIGN_UP_DISABLED=true
             --env NEXTAUTH_SECRET="${NEXTAUTH_SECRET}"
-            --env NEXTAUTH_URL="http://${PREVIEW_HOST}"
+            --env NEXTAUTH_URL="https://${PREVIEW_HOST}"
             --env REDIS_AUTH="${REDIS_AUTH}"
             --env REDIS_HOST=redis
             --env REDIS_PORT=6379
@@ -246,7 +248,6 @@ Resources:
             --name langfuse-web \
             --network langfuse-preview \
             --restart unless-stopped \
-            -p 80:3000 \
             "${common_env[@]}" \
             --env LANGFUSE_INIT_ORG_ID="${LANGFUSE_INIT_ORG_ID}" \
             --env LANGFUSE_INIT_ORG_NAME="${LANGFUSE_INIT_ORG_NAME}" \
@@ -270,17 +271,52 @@ Resources:
             "${WORKER_IMAGE}"
 
           wait_for langfuse-worker "docker exec langfuse-worker wget --no-verbose --tries=1 --spider http://127.0.0.1:3030/api/health"
+
+          # Caddy terminates TLS with an automatic Let's Encrypt certificate
+          # for the preview hostname and redirects HTTP to HTTPS.
+          docker run -d \
+            --name caddy \
+            --network langfuse-preview \
+            --restart unless-stopped \
+            -p 80:80 \
+            -p 443:443 \
+            -v langfuse_caddy_data:/data \
+            docker.io/caddy:2 \
+            caddy reverse-proxy --from "https://${PREVIEW_HOST}" --to http://langfuse-web:3000
           DEPLOY
 
           chmod +x /opt/langfuse-preview/deploy.sh
 
+  # The Elastic IP keeps the preview address (and therefore DNS and the TLS
+  # certificate) stable across /preview stop and /preview resume cycles.
+  PreviewEip:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: !Ref PreviewName
+        - Key: Project
+          Value: langfuse-preview
+        - Key: PullRequest
+          Value: !Ref PullRequestNumber
+        - Key: PreviewManagedBy
+          Value: github-actions
+
+  PreviewEipAssociation:
+    Type: AWS::EC2::EIPAssociation
+    Properties:
+      AllocationId: !GetAtt PreviewEip.AllocationId
+      InstanceId: !Ref PreviewInstance
+
   PreviewDnsRecord:
     Type: AWS::Route53::RecordSet
+    DependsOn: PreviewEipAssociation
     Properties:
       HostedZoneId: !Ref HostedZoneId
       Name: !Sub "pr-${PullRequestNumber}.${DomainName}"
       ResourceRecords:
-        - !GetAtt PreviewInstance.PublicIp
+        - !Ref PreviewEip
       TTL: 60
       Type: A
 
@@ -289,8 +325,8 @@ Outputs:
     Description: EC2 instance ID for SSM commands.
     Value: !Ref PreviewInstance
   PublicIp:
-    Description: Public IPv4 address for health checks.
-    Value: !GetAtt PreviewInstance.PublicIp
+    Description: Public IPv4 address (Elastic IP) for health checks.
+    Value: !Ref PreviewEip
   PreviewUrl:
     Description: Public preview URL.
-    Value: !Sub "http://pr-${PullRequestNumber}.${DomainName}"
+    Value: !Sub "https://pr-${PullRequestNumber}.${DomainName}"

--- a/deployment/aws-preview/cloudformation.yaml
+++ b/deployment/aws-preview/cloudformation.yaml
@@ -27,6 +27,13 @@ Parameters:
     Type: String
     Default: t3.large
     Description: EC2 instance type for the single-node preview.
+  PreviewOwner:
+    Type: String
+    Default: unassigned
+    Description: >-
+      GitHub login whose command made this env run. The workflow counts
+      running instances by this tag to enforce the per-engineer limit;
+      omitted on push-triggered updates so the previous owner is retained.
   VolumeSizeGb:
     Type: Number
     Default: 80
@@ -62,6 +69,8 @@ Resources:
           Value: !Ref PullRequestNumber
         - Key: PreviewManagedBy
           Value: github-actions
+        - Key: PreviewOwner
+          Value: !Ref PreviewOwner
       UserData:
         Fn::Base64: |
           #!/bin/bash

--- a/deployment/aws-preview/cloudformation.yaml
+++ b/deployment/aws-preview/cloudformation.yaml
@@ -25,7 +25,7 @@ Parameters:
     Description: Base domain for preview hostnames.
   InstanceType:
     Type: String
-    Default: t3.large
+    Default: t3.xlarge
     Description: EC2 instance type for the single-node preview.
   PreviewOwner:
     Type: String

--- a/deployment/aws-preview/cloudformation.yaml
+++ b/deployment/aws-preview/cloudformation.yaml
@@ -1,0 +1,296 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Disposable single-node Langfuse AWS PR preview host.
+
+Parameters:
+  PreviewName:
+    Type: String
+    Description: Unique preview stack name.
+  PullRequestNumber:
+    Type: String
+    Description: Pull request number used in tags and DNS.
+  SubnetId:
+    Type: AWS::EC2::Subnet::Id
+    Description: Public subnet for the preview instance.
+  SecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+    Description: Security group allowing public HTTP/HTTPS ingress.
+  InstanceProfileName:
+    Type: String
+    Description: Instance profile with SSM and ECR read permissions.
+  HostedZoneId:
+    Type: AWS::Route53::HostedZone::Id
+    Description: Route53 hosted zone for preview hostnames.
+  DomainName:
+    Type: String
+    Description: Base domain for preview hostnames.
+  InstanceType:
+    Type: String
+    Default: t3.large
+    Description: EC2 instance type for the single-node preview.
+  VolumeSizeGb:
+    Type: Number
+    Default: 80
+    Description: Root EBS volume size in GiB.
+  AmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
+    Description: Amazon Linux 2023 AMI.
+
+Resources:
+  PreviewInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: !Ref VolumeSizeGb
+            VolumeType: gp3
+      IamInstanceProfile: !Ref InstanceProfileName
+      ImageId: !Ref AmiId
+      InstanceType: !Ref InstanceType
+      SecurityGroupIds:
+        - !Ref SecurityGroupId
+      SubnetId: !Ref SubnetId
+      Tags:
+        - Key: Name
+          Value: !Ref PreviewName
+        - Key: Project
+          Value: langfuse-preview
+        - Key: PullRequest
+          Value: !Ref PullRequestNumber
+        - Key: PreviewManagedBy
+          Value: github-actions
+      UserData:
+        Fn::Base64: |
+          #!/bin/bash
+          set -euxo pipefail
+
+          dnf update -y
+          if ! command -v aws >/dev/null 2>&1; then
+            dnf install -y awscli || dnf install -y awscli-2
+          fi
+          dnf install -y docker
+          systemctl enable --now docker
+          systemctl enable --now amazon-ssm-agent || true
+
+          mkdir -p /opt/langfuse-preview
+
+          cat > /opt/langfuse-preview/deploy.sh <<'DEPLOY'
+          #!/bin/bash
+          set -euo pipefail
+
+          source /opt/langfuse-preview/deploy.env
+
+          required_vars=(
+            AWS_REGION
+            CLICKHOUSE_PASSWORD
+            ECR_REGISTRY
+            ENCRYPTION_KEY
+            LANGFUSE_INIT_ORG_ID
+            LANGFUSE_INIT_ORG_NAME
+            LANGFUSE_INIT_PROJECT_ID
+            LANGFUSE_INIT_PROJECT_NAME
+            LANGFUSE_INIT_PROJECT_PUBLIC_KEY
+            LANGFUSE_INIT_PROJECT_SECRET_KEY
+            LANGFUSE_INIT_USER_EMAIL
+            LANGFUSE_INIT_USER_NAME
+            LANGFUSE_INIT_USER_PASSWORD
+            MINIO_ROOT_PASSWORD
+            NEXTAUTH_SECRET
+            POSTGRES_PASSWORD
+            PREVIEW_HOST
+            REDIS_AUTH
+            SALT
+            WEB_IMAGE
+            WORKER_IMAGE
+          )
+
+          for var_name in "${required_vars[@]}"; do
+            if [ -z "${!var_name:-}" ]; then
+              echo "Missing required variable: ${var_name}"
+              exit 1
+            fi
+          done
+
+          systemctl is-active --quiet docker || systemctl start docker
+
+          aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+
+          docker network inspect langfuse-preview >/dev/null 2>&1 || docker network create langfuse-preview
+
+          docker volume create langfuse_postgres_data >/dev/null
+          docker volume create langfuse_clickhouse_data >/dev/null
+          docker volume create langfuse_clickhouse_logs >/dev/null
+          docker volume create langfuse_minio_data >/dev/null
+          docker volume create langfuse_redis_data >/dev/null
+
+          for container in langfuse-web langfuse-worker postgres redis clickhouse minio; do
+            docker rm -f "${container}" >/dev/null 2>&1 || true
+          done
+
+          docker run -d \
+            --name postgres \
+            --network langfuse-preview \
+            --restart unless-stopped \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
+            -e POSTGRES_DB=postgres \
+            -e TZ=UTC \
+            -e PGTZ=UTC \
+            -v langfuse_postgres_data:/var/lib/postgresql/data \
+            docker.io/postgres:17
+
+          docker run -d \
+            --name redis \
+            --network langfuse-preview \
+            --restart unless-stopped \
+            -v langfuse_redis_data:/data \
+            docker.io/redis:7 \
+            --requirepass "${REDIS_AUTH}" \
+            --maxmemory-policy noeviction
+
+          docker run -d \
+            --name clickhouse \
+            --network langfuse-preview \
+            --restart unless-stopped \
+            --user "101:101" \
+            -e CLICKHOUSE_DB=default \
+            -e CLICKHOUSE_USER=clickhouse \
+            -e CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD}" \
+            -v langfuse_clickhouse_data:/var/lib/clickhouse \
+            -v langfuse_clickhouse_logs:/var/log/clickhouse-server \
+            docker.io/clickhouse/clickhouse-server
+
+          docker run -d \
+            --name minio \
+            --network langfuse-preview \
+            --restart unless-stopped \
+            --entrypoint sh \
+            -e MINIO_ROOT_USER=minio \
+            -e MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD}" \
+            -v langfuse_minio_data:/data \
+            cgr.dev/chainguard/minio \
+            -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
+
+          wait_for() {
+            local name="$1"
+            local command="$2"
+
+            for _ in $(seq 1 90); do
+              if eval "${command}" >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep 2
+            done
+
+            docker logs "${name}" || true
+            echo "Container ${name} did not become ready."
+            return 1
+          }
+
+          wait_for postgres "docker exec postgres pg_isready -U postgres"
+          wait_for redis "docker exec redis redis-cli -a '${REDIS_AUTH}' ping"
+          wait_for clickhouse "docker exec clickhouse wget --no-verbose --tries=1 --spider http://127.0.0.1:8123/ping"
+          wait_for minio "docker exec minio mc ready local"
+
+          common_env=(
+            --env AUTH_DISABLE_SIGNUP=true
+            --env CLICKHOUSE_CLUSTER_ENABLED=false
+            --env CLICKHOUSE_MIGRATION_URL=clickhouse://clickhouse:9000
+            --env CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD}"
+            --env CLICKHOUSE_URL=http://clickhouse:8123
+            --env CLICKHOUSE_USER=clickhouse
+            --env DATABASE_URL="postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres"
+            --env EMAIL_FROM_ADDRESS=
+            --env ENCRYPTION_KEY="${ENCRYPTION_KEY}"
+            --env HOSTNAME=0.0.0.0
+            --env LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES=false
+            --env LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID=minio
+            --env LANGFUSE_S3_BATCH_EXPORT_BUCKET=langfuse
+            --env LANGFUSE_S3_BATCH_EXPORT_ENABLED=false
+            --env LANGFUSE_S3_BATCH_EXPORT_ENDPOINT=http://minio:9000
+            --env LANGFUSE_S3_BATCH_EXPORT_EXTERNAL_ENDPOINT="http://${PREVIEW_HOST}"
+            --env LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE=true
+            --env LANGFUSE_S3_BATCH_EXPORT_PREFIX=exports/
+            --env LANGFUSE_S3_BATCH_EXPORT_REGION=auto
+            --env LANGFUSE_S3_BATCH_EXPORT_SECRET_ACCESS_KEY="${MINIO_ROOT_PASSWORD}"
+            --env LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID=minio
+            --env LANGFUSE_S3_EVENT_UPLOAD_BUCKET=langfuse
+            --env LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=http://minio:9000
+            --env LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE=true
+            --env LANGFUSE_S3_EVENT_UPLOAD_PREFIX=events/
+            --env LANGFUSE_S3_EVENT_UPLOAD_REGION=auto
+            --env LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY="${MINIO_ROOT_PASSWORD}"
+            --env LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID=minio
+            --env LANGFUSE_S3_MEDIA_UPLOAD_BUCKET=langfuse
+            --env LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT=http://minio:9000
+            --env LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE=true
+            --env LANGFUSE_S3_MEDIA_UPLOAD_PREFIX=media/
+            --env LANGFUSE_S3_MEDIA_UPLOAD_REGION=auto
+            --env LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY="${MINIO_ROOT_PASSWORD}"
+            --env NEXT_PUBLIC_SIGN_UP_DISABLED=true
+            --env NEXTAUTH_SECRET="${NEXTAUTH_SECRET}"
+            --env NEXTAUTH_URL="http://${PREVIEW_HOST}"
+            --env REDIS_AUTH="${REDIS_AUTH}"
+            --env REDIS_HOST=redis
+            --env REDIS_PORT=6379
+            --env REDIS_TLS_ENABLED=false
+            --env SALT="${SALT}"
+            --env SMTP_CONNECTION_URL=
+            --env TELEMETRY_ENABLED=false
+          )
+
+          docker run -d \
+            --name langfuse-web \
+            --network langfuse-preview \
+            --restart unless-stopped \
+            -p 80:3000 \
+            "${common_env[@]}" \
+            --env LANGFUSE_INIT_ORG_ID="${LANGFUSE_INIT_ORG_ID}" \
+            --env LANGFUSE_INIT_ORG_NAME="${LANGFUSE_INIT_ORG_NAME}" \
+            --env LANGFUSE_INIT_PROJECT_ID="${LANGFUSE_INIT_PROJECT_ID}" \
+            --env LANGFUSE_INIT_PROJECT_NAME="${LANGFUSE_INIT_PROJECT_NAME}" \
+            --env LANGFUSE_INIT_PROJECT_PUBLIC_KEY="${LANGFUSE_INIT_PROJECT_PUBLIC_KEY}" \
+            --env LANGFUSE_INIT_PROJECT_SECRET_KEY="${LANGFUSE_INIT_PROJECT_SECRET_KEY}" \
+            --env LANGFUSE_INIT_USER_EMAIL="${LANGFUSE_INIT_USER_EMAIL}" \
+            --env LANGFUSE_INIT_USER_NAME="${LANGFUSE_INIT_USER_NAME}" \
+            --env LANGFUSE_INIT_USER_PASSWORD="${LANGFUSE_INIT_USER_PASSWORD}" \
+            "${WEB_IMAGE}"
+
+          wait_for langfuse-web "docker exec langfuse-web wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/public/health"
+
+          docker run -d \
+            --name langfuse-worker \
+            --network langfuse-preview \
+            --restart unless-stopped \
+            -p 127.0.0.1:3030:3030 \
+            "${common_env[@]}" \
+            "${WORKER_IMAGE}"
+
+          wait_for langfuse-worker "docker exec langfuse-worker wget --no-verbose --tries=1 --spider http://127.0.0.1:3030/api/health"
+          DEPLOY
+
+          chmod +x /opt/langfuse-preview/deploy.sh
+
+  PreviewDnsRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Sub "pr-${PullRequestNumber}.${DomainName}"
+      ResourceRecords:
+        - !GetAtt PreviewInstance.PublicIp
+      TTL: 60
+      Type: A
+
+Outputs:
+  InstanceId:
+    Description: EC2 instance ID for SSM commands.
+    Value: !Ref PreviewInstance
+  PublicIp:
+    Description: Public IPv4 address for health checks.
+    Value: !GetAtt PreviewInstance.PublicIp
+  PreviewUrl:
+    Description: Public preview URL.
+    Value: !Sub "http://pr-${PullRequestNumber}.${DomainName}"

--- a/deployment/aws-preview/scripts/build-images.sh
+++ b/deployment/aws-preview/scripts/build-images.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Build and push the preview web + worker images. Runs with the PR head as the
+# working directory (the Docker build context). Env: COMMIT_SHA, WEB_IMAGE,
+# WORKER_IMAGE.
+
+docker build \
+  --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
+  --build-arg NEXT_PUBLIC_SIGN_UP_DISABLED=true \
+  -f ./web/Dockerfile \
+  -t "${WEB_IMAGE}" \
+  .
+docker push "${WEB_IMAGE}"
+
+docker build \
+  --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
+  -f ./worker/Dockerfile \
+  -t "${WORKER_IMAGE}" \
+  .
+docker push "${WORKER_IMAGE}"

--- a/deployment/aws-preview/scripts/check-health.sh
+++ b/deployment/aws-preview/scripts/check-health.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Poll the preview's public health endpoint until it responds or we give up
+# (TLS issuance on first deploy, or container restart on resume, can take a
+# minute). Callers pass PREVIEW_HOST directly (deploy); if unset it is derived
+# from PR_NUMBER + AWS_PREVIEW_DOMAIN_NAME (resume).
+
+preview_host="${PREVIEW_HOST:-pr-${PR_NUMBER}.${AWS_PREVIEW_DOMAIN_NAME}}"
+
+for _ in $(seq 1 90); do
+  if curl -fsS --max-time 10 "https://${preview_host}/api/public/health" >/dev/null; then
+    exit 0
+  fi
+  sleep 5
+done
+
+echo "Preview ${preview_host} did not become healthy."
+exit 1

--- a/deployment/aws-preview/scripts/deploy-containers.sh
+++ b/deployment/aws-preview/scripts/deploy-containers.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Render the on-host deploy.env, ship it to the instance over SSM, run deploy.sh,
+# and poll to completion. Env: INSTANCE_ID, PR_NUMBER, PREVIEW_HOST, ECR_REGISTRY,
+# WEB_IMAGE, WORKER_IMAGE, PUBLIC_KEY, SECRET_KEY, LOGIN_EMAIL, LOGIN_PASSWORD,
+# and the CLICKHOUSE_PASSWORD/ENCRYPTION_KEY/MINIO_PASSWORD/NEXTAUTH_SECRET/
+# POSTGRES_PASSWORD/REDIS_AUTH/SALT secrets + AWS_PREVIEW_REGION.
+
+env_file="$(mktemp)"
+cat > "${env_file}" <<EOF
+AWS_REGION=${AWS_PREVIEW_REGION}
+CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
+ECR_REGISTRY=${ECR_REGISTRY}
+ENCRYPTION_KEY=${ENCRYPTION_KEY}
+LANGFUSE_INIT_ORG_ID=preview-org-${PR_NUMBER}
+LANGFUSE_INIT_ORG_NAME=Preview-PR-${PR_NUMBER}
+LANGFUSE_INIT_PROJECT_ID=preview-project-${PR_NUMBER}
+LANGFUSE_INIT_PROJECT_NAME=Preview-Project
+LANGFUSE_INIT_PROJECT_PUBLIC_KEY=${PUBLIC_KEY}
+LANGFUSE_INIT_PROJECT_SECRET_KEY=${SECRET_KEY}
+LANGFUSE_INIT_USER_EMAIL=${LOGIN_EMAIL}
+LANGFUSE_INIT_USER_NAME=Preview-User
+LANGFUSE_INIT_USER_PASSWORD=${LOGIN_PASSWORD}
+MINIO_ROOT_PASSWORD=${MINIO_PASSWORD}
+NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+PREVIEW_HOST=${PREVIEW_HOST}
+REDIS_AUTH=${REDIS_AUTH}
+SALT=${SALT}
+WEB_IMAGE=${WEB_IMAGE}
+WORKER_IMAGE=${WORKER_IMAGE}
+EOF
+
+env_b64="$(base64 -w0 "${env_file}")"
+
+# SSM parameters must be JSON: the base64 blob and the shell snippets
+# below contain commas and pipes that the "commands=..." shorthand
+# mis-parses (AWS CLI ParamValidationError). A file:// JSON document
+# passes each command through verbatim.
+params_file="$(mktemp)"
+cat > "${params_file}" <<JSON
+{"commands":[
+"mkdir -p /opt/langfuse-preview",
+"echo ${env_b64} | base64 -d > /opt/langfuse-preview/deploy.env",
+"chmod 600 /opt/langfuse-preview/deploy.env",
+"for i in \$(seq 1 60); do test -x /opt/langfuse-preview/deploy.sh && break || sleep 5; done",
+"test -x /opt/langfuse-preview/deploy.sh",
+"/opt/langfuse-preview/deploy.sh"
+]}
+JSON
+
+command_id="$(aws ssm send-command \
+  --document-name "AWS-RunShellScript" \
+  --instance-ids "${INSTANCE_ID}" \
+  --comment "Deploy Langfuse PR ${PR_NUMBER} preview" \
+  --parameters "file://${params_file}" \
+  --query "Command.CommandId" \
+  --output text)"
+
+# Poll for completion rather than `aws ssm wait command-executed`,
+# whose ~100s default (5s x 20 attempts) is far shorter than a cold
+# deploy: the bundled cloud-init wait, ECR login, ~7 image pulls, and
+# six container-readiness gates in deploy.sh run for several minutes.
+# The short waiter would fail the step spuriously while the on-host
+# deploy is still succeeding.
+deploy_ok=false
+for _ in $(seq 1 120); do
+  status="$(aws ssm get-command-invocation \
+    --command-id "${command_id}" \
+    --instance-id "${INSTANCE_ID}" \
+    --query "Status" --output text 2>/dev/null || echo "Pending")"
+  case "${status}" in
+    Success)
+      deploy_ok=true
+      break
+      ;;
+    Cancelled | TimedOut | Failed)
+      break
+      ;;
+  esac
+  sleep 10
+done
+
+if [ "${deploy_ok}" != "true" ]; then
+  aws ssm get-command-invocation \
+    --command-id "${command_id}" \
+    --instance-id "${INSTANCE_ID}" \
+    --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
+    --output json
+  exit 1
+fi

--- a/deployment/aws-preview/scripts/deploy-gate.sh
+++ b/deployment/aws-preview/scripts/deploy-gate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Decide whether a deploy should proceed. Writes proceed=true|false to
+# GITHUB_OUTPUT. Env: PR_NUMBER, ACTOR, REFRESH_ONLY, GH_TOKEN,
+# GITHUB_REPOSITORY, GITHUB_OUTPUT.
+source "$(dirname "$0")/lib.sh"
+
+stack_name="langfuse-preview-pr-${PR_NUMBER}"
+instance_id="$(pf_stack_instance_id "${stack_name}")"
+instance_state="absent"
+if [ -n "${instance_id}" ]; then
+  instance_state="$(aws ec2 describe-instances \
+    --instance-ids "${instance_id}" \
+    --query "Reservations[0].Instances[0].State.Name" \
+    --output text)"
+fi
+
+# Re-check PR state at execution time: a deploy queued behind a
+# close/reconcile destroy must not recreate the preview stack for
+# a PR that is now closed (nothing would ever clean it up again).
+pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)"
+if [ "${pr_state}" != "open" ]; then
+  echo "PR ${PR_NUMBER} is ${pr_state}; not deploying."
+  echo "proceed=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Push-triggered auto-deploy (refresh_only) may only refresh a preview
+# that is already running — it must never create or resurrect one.
+# This keeps /preview stop sticky and matches the documented contract
+# ("pushing refreshes only if already deployed and running"). Opening
+# a PR and explicit /preview deploy leave refresh_only unset/false.
+if [ "${REFRESH_ONLY:-}" = "true" ] \
+  && [ "${instance_state}" != "running" ] \
+  && [ "${instance_state}" != "pending" ]; then
+  echo "PR ${PR_NUMBER} preview is ${instance_state}; push refresh skipped."
+  echo "proceed=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Refreshing an already-running env does not consume a new slot.
+if [ "${instance_state}" = "running" ] || [ "${instance_state}" = "pending" ]; then
+  echo "proceed=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Per-engineer limit: at most 5 running envs, attributed by the PreviewOwner tag.
+if ! pf_slot_limit_reached "${ACTOR}" "${PR_NUMBER}"; then
+  echo "proceed=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "proceed=true" >> "$GITHUB_OUTPUT"

--- a/deployment/aws-preview/scripts/deploy-stack.sh
+++ b/deployment/aws-preview/scripts/deploy-stack.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Deploy (or update) the per-PR CloudFormation stack via the scoped preview
+# service role, using the PR's own template. Runs with the PR head as the
+# working directory so deployment/aws-preview/cloudformation.yaml is the PR's.
+# Env: ACTOR, PR_NUMBER, STACK_NAME + the AWS_PREVIEW_* variables.
+
+# A stack stuck in a failed create state cannot be updated;
+# delete it and start fresh.
+status="$(aws cloudformation describe-stacks \
+  --stack-name "${STACK_NAME}" \
+  --query "Stacks[0].StackStatus" \
+  --output text 2>/dev/null || true)"
+case "${status}" in
+  ROLLBACK_COMPLETE|ROLLBACK_FAILED|CREATE_FAILED)
+    echo "Stack is in ${status}; deleting before redeploy."
+    aws cloudformation delete-stack --stack-name "${STACK_NAME}"
+    aws cloudformation wait stack-delete-complete --stack-name "${STACK_NAME}"
+    ;;
+esac
+
+overrides=(
+  PreviewName="${STACK_NAME}"
+  PullRequestNumber="${PR_NUMBER}"
+  SubnetId="${AWS_PREVIEW_SUBNET_ID}"
+  SecurityGroupId="${AWS_PREVIEW_SECURITY_GROUP_ID}"
+  InstanceProfileName="${AWS_PREVIEW_INSTANCE_PROFILE_NAME}"
+  HostedZoneId="${AWS_PREVIEW_HOSTED_ZONE_ID}"
+  DomainName="${AWS_PREVIEW_DOMAIN_NAME}"
+  InstanceType="${AWS_PREVIEW_INSTANCE_TYPE}"
+  VolumeSizeGb="${AWS_PREVIEW_VOLUME_SIZE_GB}"
+)
+# Push-triggered refreshes have no actor and keep the previous
+# owner (omitted parameters retain their value on stack updates).
+if [ -n "${ACTOR}" ]; then
+  overrides+=(PreviewOwner="${ACTOR}")
+fi
+
+aws cloudformation deploy \
+  --stack-name "${STACK_NAME}" \
+  --template-file deployment/aws-preview/cloudformation.yaml \
+  --role-arn "${AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN}" \
+  --no-fail-on-empty-changeset \
+  --parameter-overrides "${overrides[@]}" \
+  --tags \
+    Project=langfuse-preview \
+    PullRequest="${PR_NUMBER}" \
+    PreviewManagedBy=github-actions

--- a/deployment/aws-preview/scripts/destroy.sh
+++ b/deployment/aws-preview/scripts/destroy.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Delete the per-PR stack, then its ECR images and secret seed (both run
+# whether or not the stack existed, matching the original separate steps).
+# Writes existed=true|false to GITHUB_OUTPUT. Env: PR_NUMBER, GITHUB_OUTPUT.
+source "$(dirname "$0")/lib.sh"
+
+stack_name="langfuse-preview-pr-${PR_NUMBER}"
+
+if aws cloudformation describe-stacks --stack-name "${stack_name}" >/dev/null 2>&1; then
+  aws cloudformation delete-stack --stack-name "${stack_name}"
+  aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
+  echo "existed=true" >> "$GITHUB_OUTPUT"
+else
+  echo "Preview stack ${stack_name} does not exist."
+  echo "existed=false" >> "$GITHUB_OUTPUT"
+fi
+
+pf_delete_images "${PR_NUMBER}"
+pf_delete_seed "${PR_NUMBER}"

--- a/deployment/aws-preview/scripts/lib.sh
+++ b/deployment/aws-preview/scripts/lib.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Shared helpers for the AWS PR preview workflow steps.
+#
+# Sourced by the per-step scripts in this directory. Every function assumes the
+# workflow's AWS_PREVIEW_* environment variables and (where it comments on a PR)
+# GH_TOKEN + GITHUB_REPOSITORY are already present in the environment.
+#
+# These scripts are always executed from a checkout of the default branch, never
+# from the pull request head, so the deploy logic here stays reviewed code even
+# though the deploy job also checks out PR code to build it.
+
+# Echo the InstanceId output of a preview stack, or an empty string when the
+# stack (or the output) is absent. Never fails the caller.
+pf_stack_instance_id() {
+  local stack_name="$1" id
+  id="$(aws cloudformation describe-stacks \
+    --stack-name "${stack_name}" \
+    --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
+    --output text 2>/dev/null || true)"
+  if [ "${id}" = "None" ]; then
+    id=""
+  fi
+  printf '%s' "${id}"
+}
+
+# Echo the PR numbers (one per line) that have a pending/running preview owned
+# by <actor> via the PreviewOwner tag. Empty output means none.
+pf_owner_running_prs() {
+  local actor="$1"
+  aws ec2 describe-instances \
+    --filters \
+      "Name=tag:Project,Values=langfuse-preview" \
+      "Name=tag:PreviewOwner,Values=${actor}" \
+      "Name=instance-state-name,Values=pending,running" \
+    --query "Reservations[].Instances[].[Tags[?Key=='PullRequest'] | [0].Value]" \
+    --output text | grep -v '^$' || true
+}
+
+# Per-engineer limit (best-effort, concurrent commands can race). If <actor>
+# already has >= 5 running previews, post a nudge comment on <pr_number> and
+# return 1 so the caller can stop; otherwise return 0.
+pf_slot_limit_reached() {
+  local actor="$1" pr_number="$2" running count pr_list
+  running="$(pf_owner_running_prs "${actor}")"
+  count="$(printf '%s' "${running}" | grep -c . || true)"
+
+  if [ "${count}" -ge 5 ]; then
+    pr_list="$(printf '%s\n' "${running}" | sed 's/^/#/' | paste -sd ', ' -)"
+    gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+      --body "@${actor} you already have ${count} running previews (PRs ${pr_list}). Stop or destroy one first (\`/preview stop\` / \`/preview destroy\`), then retry."
+    return 1
+  fi
+  return 0
+}
+
+# Delete every ECR image tagged pr-<pr_number>-* from both preview repositories.
+pf_delete_images() {
+  local pr_number="$1" repository_url repository_name image_ids
+  for repository_url in \
+    "${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}" \
+    "${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}"; do
+    repository_name="${repository_url#*/}"
+    image_ids="$(aws ecr list-images \
+      --repository-name "${repository_name}" \
+      --filter tagStatus=TAGGED \
+      --query "imageIds[?starts_with(imageTag, 'pr-${pr_number}-')]" \
+      --output json)"
+
+    if [ "${image_ids}" != "[]" ]; then
+      aws ecr batch-delete-image \
+        --repository-name "${repository_name}" \
+        --image-ids "${image_ids}" >/dev/null
+      echo "Deleted preview images from ${repository_name}."
+    fi
+  done
+}
+
+# Force-delete the per-PR secret seed (no recovery window). Never fails the
+# caller: a missing seed is fine.
+pf_delete_seed() {
+  local pr_number="$1"
+  aws secretsmanager delete-secret \
+    --secret-id "langfuse-preview/pr-${pr_number}/seed" \
+    --force-delete-without-recovery >/dev/null 2>&1 \
+    || echo "No secret seed for PR ${pr_number}."
+}

--- a/deployment/aws-preview/scripts/reap-closed.sh
+++ b/deployment/aws-preview/scripts/reap-closed.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Destroy previews whose PR is closed. Reconciliation replaces the old
+# pull_request:closed teardown: this runs from the default branch, so no
+# unreviewed PR workflow code is ever trusted with the preview role.
+# Worst-case cleanup latency is one housekeeping interval.
+# Env: GH_TOKEN, GITHUB_REPOSITORY + the AWS_PREVIEW_* variables.
+source "$(dirname "$0")/lib.sh"
+
+instances="$(aws ec2 describe-instances \
+  --filters \
+    "Name=tag:Project,Values=langfuse-preview" \
+    "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+  --query "Reservations[].Instances[].[Tags[?Key=='PullRequest'] | [0].Value, Tags[?Key=='aws:cloudformation:stack-name'] | [0].Value]" \
+  --output text)"
+
+if [ -z "${instances}" ]; then
+  echo "No preview instances."
+else
+  while read -r pr_number stack_name; do
+    [ -z "${pr_number}" ] || [ "${pr_number}" = "None" ] && continue
+    case "${stack_name}" in
+      langfuse-preview-pr-*) ;;
+      *)
+        echo "Skipping unexpected stack name '${stack_name}'."
+        continue
+        ;;
+    esac
+
+    pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq .state 2>/dev/null || echo "unknown")"
+    if [ "${pr_state}" != "closed" ]; then
+      continue
+    fi
+
+    echo "Destroying ${stack_name}: PR ${pr_number} is closed."
+    # Isolate each teardown in a subshell so one stuck/failed
+    # deletion doesn't abort the whole batch under set -e.
+    if ! (
+      set -e
+      aws cloudformation delete-stack --stack-name "${stack_name}"
+      aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
+      pf_delete_images "${pr_number}"
+      pf_delete_seed "${pr_number}"
+    ); then
+      echo "Failed to reap ${stack_name}; continuing with the next stack."
+      continue
+    fi
+
+    gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+      --body "🗑️ AWS preview destroyed because the PR is closed. Reopen and \`/preview deploy\` to recreate." \
+      || echo "Could not comment on PR ${pr_number}."
+  done <<< "${instances}"
+fi

--- a/deployment/aws-preview/scripts/reap-idle.sh
+++ b/deployment/aws-preview/scripts/reap-idle.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Stop previews with no CPU activity above the threshold over the idle window.
+# Env: GH_TOKEN, GITHUB_REPOSITORY, AWS_PREVIEW_IDLE_HOURS, AWS_PREVIEW_IDLE_CPU_MAX.
+
+start_time="$(date -u -d "${AWS_PREVIEW_IDLE_HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ)"
+end_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+cutoff_epoch="$(( $(date -u +%s) - AWS_PREVIEW_IDLE_HOURS * 3600 ))"
+
+instances="$(aws ec2 describe-instances \
+  --filters \
+    "Name=tag:Project,Values=langfuse-preview" \
+    "Name=instance-state-name,Values=running" \
+  --query "Reservations[].Instances[].[InstanceId, LaunchTime, Tags[?Key=='PullRequest'] | [0].Value]" \
+  --output text)"
+
+if [ -z "${instances}" ]; then
+  echo "No running preview instances."
+  exit 0
+fi
+
+stopped_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+while read -r instance_id launch_time pr_number; do
+  [ -z "${instance_id}" ] && continue
+
+  # Grace period: instances started less than the idle window ago
+  # are left alone (LaunchTime resets on every start).
+  launch_epoch="$(date -u -d "${launch_time}" +%s 2>/dev/null || echo 0)"
+  if [ "${launch_epoch}" -eq 0 ] || [ "${launch_epoch}" -gt "${cutoff_epoch}" ]; then
+    continue
+  fi
+
+  # Idle = no 5-minute window above the CPU threshold. Real usage
+  # (UI clicks, SDK ingestion) spikes CPU well above the stack's
+  # baseline of background polling and merges.
+  max_cpu="$(aws cloudwatch get-metric-statistics \
+    --namespace AWS/EC2 \
+    --metric-name CPUUtilization \
+    --dimensions "Name=InstanceId,Value=${instance_id}" \
+    --start-time "${start_time}" \
+    --end-time "${end_time}" \
+    --period 300 \
+    --statistics Maximum \
+    --query "max(Datapoints[].Maximum)" \
+    --output text)"
+
+  # No datapoints means no evidence; never stop without evidence.
+  if [ -z "${max_cpu}" ] || [ "${max_cpu}" = "None" ]; then
+    continue
+  fi
+
+  if awk -v cpu="${max_cpu}" -v limit="${AWS_PREVIEW_IDLE_CPU_MAX}" 'BEGIN { exit !(cpu < limit) }'; then
+    echo "Stopping ${instance_id} (PR ${pr_number}): max CPU ${max_cpu}% over ${AWS_PREVIEW_IDLE_HOURS}h"
+    aws ec2 stop-instances --instance-ids "${instance_id}"
+    aws ec2 create-tags --resources "${instance_id}" \
+      --tags "Key=StoppedAt,Value=${stopped_at}"
+
+    if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
+      gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+        --body "⏸️ AWS preview stopped after ~${AWS_PREVIEW_IDLE_HOURS}h without activity. Data and URL are kept; resume with \`/preview resume\`." \
+        || echo "Could not comment on PR ${pr_number}."
+    fi
+  fi
+done <<< "${instances}"

--- a/deployment/aws-preview/scripts/reap-stale.sh
+++ b/deployment/aws-preview/scripts/reap-stale.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Destroy previews stopped for more than 7 days.
+# Env: GH_TOKEN, GITHUB_REPOSITORY + the AWS_PREVIEW_* variables.
+source "$(dirname "$0")/lib.sh"
+
+cutoff="$(date -u -d '7 days ago' +%s)"
+
+instances="$(aws ec2 describe-instances \
+  --filters \
+    "Name=tag:Project,Values=langfuse-preview" \
+    "Name=instance-state-name,Values=stopped" \
+    "Name=tag-key,Values=StoppedAt" \
+  --query "Reservations[].Instances[].[InstanceId, Tags[?Key=='StoppedAt'] | [0].Value, Tags[?Key=='PullRequest'] | [0].Value, Tags[?Key=='aws:cloudformation:stack-name'] | [0].Value]" \
+  --output text)"
+
+if [ -z "${instances}" ]; then
+  echo "No stopped previews with a StoppedAt tag."
+  exit 0
+fi
+
+while read -r instance_id stopped_at pr_number stack_name; do
+  [ -z "${instance_id}" ] && continue
+
+  stopped_epoch="$(date -u -d "${stopped_at}" +%s 2>/dev/null || echo 0)"
+  if [ "${stopped_epoch}" -eq 0 ]; then
+    echo "Skipping ${instance_id}: unparseable StoppedAt '${stopped_at}'."
+    continue
+  fi
+  if [ "${stopped_epoch}" -gt "${cutoff}" ]; then
+    continue
+  fi
+  case "${stack_name}" in
+    langfuse-preview-pr-*) ;;
+    *)
+      echo "Skipping ${instance_id}: unexpected stack name '${stack_name}'."
+      continue
+      ;;
+  esac
+
+  echo "Reaping ${stack_name} (stopped since ${stopped_at})"
+  # Isolate each teardown in a subshell so one stuck/failed deletion
+  # doesn't abort the whole batch under set -e.
+  if ! (
+    set -e
+    aws cloudformation delete-stack --stack-name "${stack_name}"
+    aws cloudformation wait stack-delete-complete --stack-name "${stack_name}"
+
+    if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
+      pf_delete_images "${pr_number}"
+    fi
+
+    pf_delete_seed "${pr_number}"
+  ); then
+    echo "Failed to reap ${stack_name}; continuing with the next stack."
+    continue
+  fi
+
+  if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
+    gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+      --body "🗑️ AWS preview destroyed after 7 days stopped. Recreate with \`/preview deploy\`." \
+      || echo "Could not comment on PR ${pr_number}."
+  fi
+done <<< "${instances}"

--- a/deployment/aws-preview/scripts/resolve-host.sh
+++ b/deployment/aws-preview/scripts/resolve-host.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Read the stack's instance/EIP outputs, boot the instance if it is stopped
+# (an explicit /preview deploy resumes a stopped preview), clear the StoppedAt
+# reaper tag, and write instance_id/public_ip to GITHUB_OUTPUT.
+# Env: STACK_NAME, GITHUB_OUTPUT.
+
+instance_id="$(aws cloudformation describe-stacks \
+  --stack-name "${STACK_NAME}" \
+  --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
+  --output text)"
+public_ip="$(aws cloudformation describe-stacks \
+  --stack-name "${STACK_NAME}" \
+  --query "Stacks[0].Outputs[?OutputKey=='PublicIp'].OutputValue" \
+  --output text)"
+
+# An explicit /preview deploy on a stopped preview boots it again.
+state="$(aws ec2 describe-instances \
+  --instance-ids "${instance_id}" \
+  --query "Reservations[0].Instances[0].State.Name" \
+  --output text)"
+if [ "${state}" = "stopping" ]; then
+  aws ec2 wait instance-stopped --instance-ids "${instance_id}"
+  state="stopped"
+fi
+if [ "${state}" != "running" ] && [ "${state}" != "pending" ]; then
+  aws ec2 start-instances --instance-ids "${instance_id}"
+fi
+aws ec2 wait instance-running --instance-ids "${instance_id}"
+
+# A deployed env is running again; it is no longer reapable.
+aws ec2 delete-tags --resources "${instance_id}" --tags Key=StoppedAt
+
+echo "instance_id=${instance_id}" >> "$GITHUB_OUTPUT"
+echo "public_ip=${public_ip}" >> "$GITHUB_OUTPUT"

--- a/deployment/aws-preview/scripts/resolve-metadata.sh
+++ b/deployment/aws-preview/scripts/resolve-metadata.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Resolve stack name, image tags, preview host, and the per-PR secrets, then
+# write them to GITHUB_OUTPUT (masking the secret values). Runs with the PR
+# head checked out as the working directory, so `git rev-parse HEAD` is the PR
+# commit being built. Env: PR_NUMBER + the AWS_PREVIEW_* variables.
+
+pr_number="${PR_NUMBER}"
+commit_sha="$(git rev-parse HEAD)"
+short_sha="${commit_sha:0:12}"
+stack_name="langfuse-preview-pr-${pr_number}"
+image_tag="pr-${pr_number}-${short_sha}"
+preview_host="pr-${pr_number}.${AWS_PREVIEW_DOMAIN_NAME}"
+ecr_registry="${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL%%/*}"
+
+# Per-preview secret root. Every preview secret below is HMAC-derived
+# from this random seed, so none is computable from this public repo
+# (a plain sha256 of "<name>-<pr>" was). The seed is generated once on
+# first deploy and persisted in AWS Secrets Manager, then reused on
+# every redeploy and stop/resume so the derived secrets stay stable:
+# Postgres and ClickHouse bake their password into the data volume at
+# first init, so a changed secret against a surviving volume would lock
+# the stack out of its own database.
+seed_name="langfuse-preview/pr-${pr_number}/seed"
+if seed="$(aws secretsmanager get-secret-value --secret-id "${seed_name}" \
+  --query "SecretString" --output text 2>/tmp/seed_err)"; then
+  echo "Reusing existing secret seed for PR ${pr_number}."
+elif grep -q "ResourceNotFoundException" /tmp/seed_err; then
+  echo "Generating a new secret seed for PR ${pr_number}."
+  seed="$(openssl rand -hex 32)"
+  # create-secret fails if a concurrent deploy already created the
+  # seed; re-read the winner instead of clobbering it.
+  if ! aws secretsmanager create-secret --name "${seed_name}" \
+    --secret-string "${seed}" 2>/tmp/seed_put_err; then
+    if grep -q "ResourceExistsException" /tmp/seed_put_err; then
+      seed="$(aws secretsmanager get-secret-value --secret-id "${seed_name}" \
+        --query "SecretString" --output text)"
+    else
+      cat /tmp/seed_put_err >&2
+      exit 1
+    fi
+  fi
+else
+  # Fail closed: an unreadable (but not absent) seed must never fall
+  # through to regeneration — new secrets against a surviving volume
+  # would brick the preview. Throttling/permission/KMS errors land here.
+  echo "Secret seed for PR ${pr_number} is unreadable and not absent; refusing to regenerate." >&2
+  cat /tmp/seed_err >&2
+  exit 1
+fi
+echo "::add-mask::${seed}"
+
+# HMAC-SHA256(seed, label) -> 64 hex chars: exactly the ENCRYPTION_KEY
+# format (256-bit hex, per `openssl rand -hex 32`), and hex keeps
+# connection strings free of URL/shell-special characters.
+derive() {
+  printf '%s' "$1" | openssl dgst -sha256 -hmac "${seed}" | awk '{print $NF}'
+}
+
+postgres_password="$(derive postgres)"
+clickhouse_password="$(derive clickhouse)"
+redis_auth="$(derive redis)"
+minio_password="$(derive minio)"
+nextauth_secret="$(derive nextauth)"
+salt="$(derive salt)"
+encryption_key="$(derive encryption)"
+login_password="$(derive login)"
+public_key="pk-lf-preview-${pr_number}"
+secret_key="sk-lf-preview-$(derive apikey)"
+
+for value in \
+  "${postgres_password}" \
+  "${clickhouse_password}" \
+  "${redis_auth}" \
+  "${minio_password}" \
+  "${nextauth_secret}" \
+  "${salt}" \
+  "${encryption_key}" \
+  "${login_password}" \
+  "${secret_key}"; do
+  echo "::add-mask::${value}"
+done
+
+{
+  echo "clickhouse_password=${clickhouse_password}"
+  echo "commit_sha=${commit_sha}"
+  echo "ecr_registry=${ecr_registry}"
+  echo "encryption_key=${encryption_key}"
+  echo "image_tag=${image_tag}"
+  echo "login_email=preview-${pr_number}@langfuse.local"
+  echo "login_password=${login_password}"
+  echo "minio_password=${minio_password}"
+  echo "nextauth_secret=${nextauth_secret}"
+  echo "postgres_password=${postgres_password}"
+  echo "preview_host=${preview_host}"
+  echo "pr_number=${pr_number}"
+  echo "public_key=${public_key}"
+  echo "redis_auth=${redis_auth}"
+  echo "salt=${salt}"
+  echo "secret_key=${secret_key}"
+  echo "short_sha=${short_sha}"
+  echo "stack_name=${stack_name}"
+  echo "web_image=${AWS_PREVIEW_WEB_ECR_REPOSITORY_URL}:${image_tag}"
+  echo "worker_image=${AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL}:${image_tag}"
+} >> "$GITHUB_OUTPUT"

--- a/deployment/aws-preview/scripts/resume.sh
+++ b/deployment/aws-preview/scripts/resume.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Resume a stopped preview (subject to the per-engineer slot limit) and take
+# over its running slot. Writes exists and allowed to GITHUB_OUTPUT.
+# Env: ACTOR, PR_NUMBER, GH_TOKEN, GITHUB_REPOSITORY, GITHUB_OUTPUT.
+source "$(dirname "$0")/lib.sh"
+
+stack_name="langfuse-preview-pr-${PR_NUMBER}"
+instance_id="$(pf_stack_instance_id "${stack_name}")"
+
+if [ -z "${instance_id}" ]; then
+  echo "exists=false" >> "$GITHUB_OUTPUT"
+  echo "allowed=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+state="$(aws ec2 describe-instances \
+  --instance-ids "${instance_id}" \
+  --query "Reservations[0].Instances[0].State.Name" \
+  --output text)"
+
+# Per-engineer limit: resuming takes one of the actor's 5 running
+# slots (unless this env is already running).
+if [ "${state}" != "running" ] && [ "${state}" != "pending" ]; then
+  if ! pf_slot_limit_reached "${ACTOR}" "${PR_NUMBER}"; then
+    echo "exists=true" >> "$GITHUB_OUTPUT"
+    echo "allowed=false" >> "$GITHUB_OUTPUT"
+    exit 0
+  fi
+fi
+
+aws ec2 start-instances --instance-ids "${instance_id}"
+aws ec2 wait instance-running --instance-ids "${instance_id}"
+
+# The resumer now owns this env's running slot.
+aws ec2 delete-tags --resources "${instance_id}" --tags Key=StoppedAt
+aws ec2 create-tags --resources "${instance_id}" \
+  --tags "Key=PreviewOwner,Value=${ACTOR}"
+
+echo "exists=true" >> "$GITHUB_OUTPUT"
+echo "allowed=true" >> "$GITHUB_OUTPUT"

--- a/deployment/aws-preview/scripts/stop-all.sh
+++ b/deployment/aws-preview/scripts/stop-all.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Manual account-wide op: stop every running preview and stamp StoppedAt.
+# Env: GH_TOKEN, GITHUB_REPOSITORY.
+
+instances="$(aws ec2 describe-instances \
+  --filters \
+    "Name=tag:Project,Values=langfuse-preview" \
+    "Name=instance-state-name,Values=running" \
+  --query "Reservations[].Instances[].[InstanceId, Tags[?Key=='PullRequest'] | [0].Value]" \
+  --output text)"
+
+if [ -z "${instances}" ]; then
+  echo "No running preview instances."
+  exit 0
+fi
+
+stopped_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+while read -r instance_id pr_number; do
+  [ -z "${instance_id}" ] && continue
+  echo "Stopping ${instance_id} (PR ${pr_number})"
+  aws ec2 stop-instances --instance-ids "${instance_id}"
+  aws ec2 create-tags --resources "${instance_id}" \
+    --tags "Key=StoppedAt,Value=${stopped_at}"
+
+  if [ -n "${pr_number}" ] && [ "${pr_number}" != "None" ]; then
+    gh pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+      --body "⏸️ AWS preview stopped by a manual stop-all. Resume with \`/preview resume\`." \
+      || echo "Could not comment on PR ${pr_number}."
+  fi
+done <<< "${instances}"

--- a/deployment/aws-preview/scripts/stop.sh
+++ b/deployment/aws-preview/scripts/stop.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Stop the preview instance and stamp StoppedAt for the 7-day reaper.
+# Writes exists=true|false to GITHUB_OUTPUT. Env: PR_NUMBER, GITHUB_OUTPUT.
+source "$(dirname "$0")/lib.sh"
+
+stack_name="langfuse-preview-pr-${PR_NUMBER}"
+instance_id="$(pf_stack_instance_id "${stack_name}")"
+
+if [ -z "${instance_id}" ]; then
+  echo "exists=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+aws ec2 stop-instances --instance-ids "${instance_id}"
+aws ec2 wait instance-stopped --instance-ids "${instance_id}"
+# The reaper destroys envs stopped for more than 7 days.
+aws ec2 create-tags --resources "${instance_id}" \
+  --tags "Key=StoppedAt,Value=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "exists=true" >> "$GITHUB_OUTPUT"

--- a/deployment/aws-preview/scripts/validate-config.sh
+++ b/deployment/aws-preview/scripts/validate-config.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Fail early with a clear message if any required repository variable is unset.
+
+required_vars=(
+  AWS_PREVIEW_CLOUDFORMATION_ROLE_ARN
+  AWS_PREVIEW_DOMAIN_NAME
+  AWS_PREVIEW_HOSTED_ZONE_ID
+  AWS_PREVIEW_INSTANCE_PROFILE_NAME
+  AWS_PREVIEW_REGION
+  AWS_PREVIEW_ROLE_ARN
+  AWS_PREVIEW_SECURITY_GROUP_ID
+  AWS_PREVIEW_SUBNET_ID
+  AWS_PREVIEW_WEB_ECR_REPOSITORY_URL
+  AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL
+)
+
+missing=()
+for var_name in "${required_vars[@]}"; do
+  if [ -z "${!var_name}" ]; then
+    missing+=("${var_name}")
+  fi
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  printf 'Missing required GitHub repository variables:\n'
+  printf '  - %s\n' "${missing[@]}"
+  exit 1
+fi

--- a/deployment/aws-preview/scripts/wait-ssm.sh
+++ b/deployment/aws-preview/scripts/wait-ssm.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Wait until the instance is registered and Online in SSM. Env: INSTANCE_ID.
+
+for _ in $(seq 1 60); do
+  ping_status="$(aws ssm describe-instance-information \
+    --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
+    --query "InstanceInformationList[0].PingStatus" \
+    --output text 2>/dev/null || true)"
+
+  if [ "${ping_status}" = "Online" ]; then
+    exit 0
+  fi
+
+  sleep 5
+done
+
+echo "Instance ${INSTANCE_ID} did not become available in SSM."
+exit 1


### PR DESCRIPTION
## Summary

Adds disposable per-PR Langfuse previews on AWS, driven by PR comments (any org member):

- `/preview deploy` — build the PR head, push `web`/`worker` images to the playground ECR, and create/update one CloudFormation stack (`langfuse-preview-pr-<number>`) running the full stack (web, worker, Postgres, ClickHouse, Redis, MinIO) as Docker containers on a single EC2 host, TLS via Caddy/Let's Encrypt.
- `/preview stop` / `/preview resume` — stop/start the EC2 instance. An Elastic IP keeps `https://pr-<number>.<preview domain>` stable across cycles; containers restart on boot.
- `/preview destroy` — delete the stack and the PR's ECR image tags.
- **Per-engineer limit:** at most 5 running previews per engineer, attributed via a `PreviewOwner` tag to whoever's command made the env run; commands beyond the limit are rejected with a comment listing the engineer's running previews (best-effort — concurrent commands can race).
- **Lifecycle:** pushing commits refreshes a preview only if it is already deployed and running; running previews are never stopped automatically; a daily reaper destroys previews stopped for more than 7 days (`StoppedAt` tag); closing the PR destroys the preview. Manual `stop-all` remains available via workflow dispatch as break-glass.
- The whole workflow is feature-flagged on the `AWS_PREVIEW_ROLE_ARN` repo variable: unset ⇒ every job skips, so this can merge before the AWS foundation exists.

## Prerequisites

Requires the shared AWS foundation (OIDC role, CloudFormation service role, ECR repositories, Route53 zone, tag-scoped stop/resume/tagging permissions) provisioned via Langfuse's internal infrastructure repository, with its Terraform outputs copied into this repo's `AWS_PREVIEW_*` Actions variables.

## Safety

- Comment commands require `OWNER`/`MEMBER`/`COLLABORATOR` author association; fork PRs are skipped entirely; the deploy gate re-checks PR state so a queued deploy cannot recreate an env for a closed PR.
- GitHub OIDC only (trust restricted to `main` + `pull_request` subs), no long-lived AWS keys. Stop/start, tagging, and SSM are IAM-restricted to instances tagged `Project=langfuse-preview`.
- Previews are public by decision (v1); data is synthetic only and the login/API keys are intentionally posted on the PR. Never enter real provider keys.

## Validation

- YAML parsed workflow, composite action, and CloudFormation template; asserted job graph (8 jobs incl. reaper), quota checks in gate+resume, `StoppedAt` stamping, EIP/DNS wiring, and `PreviewOwner` parameter/tag.
- Not yet exercised end-to-end: requires the infrastructure PR applied and repo variables set. `issue_comment` commands activate once this workflow is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a disposable-per-PR AWS preview system driven by PR comments (`/preview deploy|stop|resume|destroy`) and a `pull_request_target` auto-deploy gate for allowlisted authors. All AWS access runs from the default branch via GitHub OIDC (`refs/heads/main` only), and a CloudFormation stack per PR spins up a single EC2 host running the full Langfuse stack (web, worker, Postgres, ClickHouse, Redis, MinIO) with TLS via Caddy/Let's Encrypt and a stable Elastic IP.

- The reaper job (cron every 2h) runs three cleanup steps serially with `set -euo pipefail`; a stuck or failing CloudFormation deletion for one stack aborts the entire loop and leaves all subsequent stacks unprocessed.
- The `autodeploy_gate` dispatches a deploy unconditionally for `opened`, `synchronize`, and `reopened` events without distinguishing them — contrary to the stated behaviour that pushes should only refresh an already-running preview.
- All service credentials (including the `ENCRYPTION_KEY`) are deterministically derived from the public PR number via sha256, meaning anyone can compute them; this is an accepted tradeoff for fully-public previews but is worth explicit documentation.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge as infrastructure-only CI code that only activates once AWS_PREVIEW_ROLE_ARN is set, but the reaper loop bug should be fixed before the AWS foundation is applied.

The reaper uses set -euo pipefail inside a while read loop that calls aws cloudformation wait stack-delete-complete. If a single CloudFormation deletion hangs or fails, the shell exits and every remaining stack in that batch is silently skipped — potentially leaving stale preview environments and EC2 instances running indefinitely. The concurrency group serialises reaper runs and the wait can block for up to 20 minutes per stack, so a cluster of stuck deletions could lock out cleanup for the entire lifetime of the previews.

.github/workflows/aws-preview.yml — specifically the two while read loops in the reap job's Destroy previews for closed PRs and Destroy previews stopped for more than 7 days steps.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Predictable encryption key** (`aws-preview.yml` lines 499–510): All service credentials, including `ENCRYPTION_KEY` and `SALT`, are derived deterministically from the public PR number via `sha256("prefix-N")`. Any sensitive data a user stores in the preview (e.g., LLM provider keys) is protected by a key anyone can compute. Accepted tradeoff for a fully-public preview, but no technical control prevents real secrets from being entered.
- **Untrusted PR Dockerfile runs during docker build with AWS credentials in the runner environment** (`aws-preview.yml` lines 555–568): The deploy job checks out the PR head commit and runs `docker build`. A malicious Dockerfile `RUN` step could exfiltrate runner-level AWS credentials. Mitigated by the allowlist restricting deploys to known org members.
- **IMDSv2 with hop-limit 1 enforced** (`cloudformation.yaml` lines 1499–1501): Containers cannot reach the instance metadata service, preventing SSRF-based credential theft. Well-implemented.
- No long-lived AWS keys; OIDC trust scoped to `refs/heads/main` only.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Engineer
    participant GH as GitHub Actions
    participant Gate as autodeploy_gate / context
    participant DG as deploy_gate
    participant ECR as AWS ECR
    participant CF as CloudFormation
    participant EC2 as EC2 Instance
    participant SSM as AWS SSM
    participant R53 as Route53

    Dev->>GH: /preview deploy (issue_comment)
    GH->>Gate: context job resolves command + actor
    Gate->>DG: "deploy_gate checks quota & PR state"
    DG->>CF: describe-stacks (check existing)
    CF-->>DG: instance state
    DG-->>GH: "proceed=true"

    GH->>ECR: docker build + push web/worker images
    GH->>CF: cloudformation deploy (create/update stack)
    CF->>EC2: launch instance (IMDSv2, EIP, encrypted EBS)
    CF->>R53: create A record pr-N.domain
    EC2-->>GH: instance running
    GH->>SSM: send-command (deploy.sh via base64 env)
    SSM->>EC2: run deploy.sh
    EC2->>EC2: pull images, start postgres/redis/clickhouse/minio/web/worker/caddy
    EC2-->>GH: command succeeded
    GH->>EC2: health check https://pr-N.domain/api/public/health
    GH->>Dev: status comment with URL + credentials

    Note over GH,EC2: Schedule (every 2h) — reaper
    GH->>EC2: describe-instances (idle CPU check)
    EC2-->>GH: "max CPU < threshold"
    GH->>EC2: stop-instances + StoppedAt tag
    GH->>CF: "delete-stack (closed PR / stopped > 7d)"
    GH->>ECR: "batch-delete-image (pr-N-* tags)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Engineer
    participant GH as GitHub Actions
    participant Gate as autodeploy_gate / context
    participant DG as deploy_gate
    participant ECR as AWS ECR
    participant CF as CloudFormation
    participant EC2 as EC2 Instance
    participant SSM as AWS SSM
    participant R53 as Route53

    Dev->>GH: /preview deploy (issue_comment)
    GH->>Gate: context job resolves command + actor
    Gate->>DG: "deploy_gate checks quota & PR state"
    DG->>CF: describe-stacks (check existing)
    CF-->>DG: instance state
    DG-->>GH: "proceed=true"

    GH->>ECR: docker build + push web/worker images
    GH->>CF: cloudformation deploy (create/update stack)
    CF->>EC2: launch instance (IMDSv2, EIP, encrypted EBS)
    CF->>R53: create A record pr-N.domain
    EC2-->>GH: instance running
    GH->>SSM: send-command (deploy.sh via base64 env)
    SSM->>EC2: run deploy.sh
    EC2->>EC2: pull images, start postgres/redis/clickhouse/minio/web/worker/caddy
    EC2-->>GH: command succeeded
    GH->>EC2: health check https://pr-N.domain/api/public/health
    GH->>Dev: status comment with URL + credentials

    Note over GH,EC2: Schedule (every 2h) — reaper
    GH->>EC2: describe-instances (idle CPU check)
    EC2-->>GH: "max CPU < threshold"
    GH->>EC2: stop-instances + StoppedAt tag
    GH->>CF: "delete-stack (closed PR / stopped > 7d)"
    GH->>ECR: "batch-delete-image (pr-N-* tags)"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
.github/workflows/aws-preview.yml:1218-1254
**Reaper loop aborts on first failed deletion**

Both reaper steps run inside `set -euo pipefail`. If `aws cloudformation wait stack-delete-complete` blocks indefinitely or fails for one stack (e.g., a resource stuck in `DELETE_IN_PROGRESS`), the shell exits immediately and all subsequent stacks in that batch are never processed. Because the concurrency group serialises reap runs, this can lock out every cleanup cycle until the stuck deletion is resolved manually — leaving multiple stale previews running for days. The same pattern affects "Destroy previews for closed PRs" (line 1253–1255). Wrapping each iteration's destructive commands in a subshell with `|| true` / per-item error trapping would isolate failures and let the loop continue to the next stack.

### Issue 2 of 4
.github/workflows/aws-preview.yml:304-349
**`synchronize` events auto-create previews when none exists**

`autodeploy_gate` dispatches a deploy for all three `pull_request_target` types: `opened`, `synchronize`, and `reopened`. The dispatch is unconditional — it passes no event-type information. The `deploy_gate` job only short-circuits to `proceed=true` when the instance is already running or pending; for an absent or stopped stack it falls through to the per-engineer quota check and then deploys. Consequently, every push by an allowlisted author creates a new preview if one doesn't already exist, which is inconsistent with the stated behaviour: "pushing commits refreshes a preview only if it is already deployed and running". An allowlisted author who pushes repeatedly on a PR with no preview will consume a quota slot on the first push, which may be surprising.

### Issue 3 of 4
.github/workflows/aws-preview.yml:499-510
**All service credentials are deterministically derivable from the public PR number**

`stable_secret` hashes a known string prefix concatenated with the PR number — both pieces of public information. Anyone can reproduce every credential with `echo -n "postgres-<N>" | sha256sum`. This includes the `ENCRYPTION_KEY` and `SALT`, which Langfuse uses to protect stored data (e.g., user-saved LLM provider keys). The README and PR description call for synthetic data only, but there is no technical control preventing a reviewer from entering real credentials into the preview UI. If that happens, the stored ciphertext is protected by a key computable from the PR number. For v1 with fully-public previews this may be an accepted tradeoff, but it is worth documenting explicitly alongside the synthetic-data warning and considering a randomly-generated key stored in SSM or Secrets Manager for a future iteration.

### Issue 4 of 4
.github/workflows/aws-preview.yml:1238-1240
**`while` loop guard skips the first field only**

The guard `[ -z "${instance_id}" ] && continue` on a line that reads four fields (`instance_id stopped_at pr_number stack_name`) only checks `instance_id`. If the `aws ec2 describe-instances` output contains a row where the first column is empty but subsequent columns are not (e.g., a malformed row due to a `None` interpolation), the check passes and later commands receive wrong values for `pr_number` and `stack_name`. The same pattern is repeated in the closed-PR loop. A more defensive check would validate all required fields before proceeding.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: gate workflow\_dispatch on the previe..."](https://github.com/langfuse/langfuse/commit/9f4e4cd2a2f296101f68139b3da296f0fb4c920d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43354190)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->