### PR TITLE
fix(auth): hide credentials form on sign-up when AUTH_DISABLE_USERNAME_PASSWORD

### DIFF
--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -223,84 +223,92 @@ function StandardSignupFlow({
 
   return (
     <SignupPageShell>
-      <Form {...form}>
-        <form
-          className="space-y-6"
-          onSubmit={
-            showPasswordStep
-              ? form.handleSubmit(onSubmit)
-              : (e) => {
-                  e.preventDefault();
-                  handleContinue();
-                }
-          }
-        >
-          {showPasswordStep && (
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Name</FormLabel>
-                  <FormControl>
-                    <Input placeholder="Jane Doe" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          )}
-          <FormField
-            control={form.control}
-            name="email"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Email</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="jsdoe@example.com"
-                    allowPasswordManager
-                    autoComplete="email"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          {showPasswordStep && (
-            <FormField
-              control={form.control}
-              name="password"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Password</FormLabel>
-                  <FormControl>
-                    <PasswordInput {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          )}
-          <Button
-            type="submit"
-            className="w-full"
-            loading={
-              showPasswordStep ? form.formState.isSubmitting : continueLoading
+      {/* Credentials form – only when credentials auth is enabled. Mirrors the
+          conditional in sign-in.tsx so an instance configured with
+          AUTH_DISABLE_USERNAME_PASSWORD (or AUTH_DISABLE_SIGNUP) does not
+          expose the email -> password flow. The backend already enforces
+          this, but the UI must match so users are not asked for fields the
+          server will reject. */}
+      {authProviders.credentials && (
+        <Form {...form}>
+          <form
+            className="space-y-6"
+            onSubmit={
+              showPasswordStep
+                ? form.handleSubmit(onSubmit)
+                : (e) => {
+                    e.preventDefault();
+                    handleContinue();
+                  }
             }
-            disabled={showPasswordStep ? false : form.watch("email") === ""}
-            data-testid="submit-email-password-sign-up-form"
           >
-            {showPasswordStep ? "Sign up" : "Continue"}
-          </Button>
-          {formError ? (
-            <div className="text-destructive text-center text-sm font-medium">
-              {formError}
-            </div>
-          ) : null}
-        </form>
-      </Form>
+            {showPasswordStep && (
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Jane Doe" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="jsdoe@example.com"
+                      allowPasswordManager
+                      autoComplete="email"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {showPasswordStep && (
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Password</FormLabel>
+                    <FormControl>
+                      <PasswordInput {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+            <Button
+              type="submit"
+              className="w-full"
+              loading={
+                showPasswordStep ? form.formState.isSubmitting : continueLoading
+              }
+              disabled={showPasswordStep ? false : form.watch("email") === ""}
+              data-testid="submit-email-password-sign-up-form"
+            >
+              {showPasswordStep ? "Sign up" : "Continue"}
+            </Button>
+            {formError ? (
+              <div className="text-destructive text-center text-sm font-medium">
+                {formError}
+              </div>
+            ) : null}
+          </form>
+        </Form>
+      )}
       <SSOButtons
         authProviders={authProviders}
         action="sign up"


### PR DESCRIPTION
## What does this PR do?

Fixes #13893.

The `sign-up` page (`web/src/pages/auth/sign-up.tsx`) was rendering the full credentials form (email -> name -> password) regardless of the `authProviders.credentials` flag set by `getServerSideProps`. The corresponding `sign-in` page already wrapped its credentials `<Form>` in `{authProviders.credentials && (...)}`; this PR mirrors that conditional on the sign-up page.

On a self-hosted instance configured with `AUTH_DISABLE_USERNAME_PASSWORD` or `AUTH_DISABLE_SIGNUP` the backend already rejects credential sign-up attempts (see `auth.ts` ~L101), but the UI was leaking fields the user would never be able to submit — a confusing dead-end since the form had no visible explanation.

The change is the surgical single conditional wrap, exactly matching the existing pattern on `sign-in.tsx`:

- `web/src/pages/auth/sign-up.tsx`: the entire credentials `<Form>` block is now wrapped in `{authProviders.credentials && (<Form>...</Form>)}`. The `VerifiedSignupFlow` (used when `emailVerificationRequired=true`) is untouched — it does not expose passwords and so does not need the conditional. `<SSOButtons>` and `<SignupFooter />` remain unconditional so OAuth providers stay available even when credentials are disabled.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the diff against `sign-in.tsx` to confirm the wrap mirrors the existing pattern.
- [x] Ran `eslint` on the modified file: clean (no errors, no warnings).
- [x] Ran `tsc --noEmit` across the web package; the only reported errors are pre-existing module-resolution issues from `@langfuse/shared` symlinks under the local pnpm-link behavior, none of them in `sign-up.tsx`. No new type errors were introduced.

## Checklist

- [x] The contributing guide was checked for branch / commit-message conventions; this PR uses Conventional Commits (`fix(auth): ...`) and the branch name follows the `fix/<area>-<short-topic>` convention.
- [x] Style: only an addition of one block-level conditional + a 5-line comment explaining why; indentation follows the existing 2-space convention used throughout the file.
- [x] Self-review: included a JSDoc-style comment linking the form to the existing `sign-in.tsx` pattern and naming the env vars it interacts with.
- [x] No documentation changes needed: this is a UI parity fix aligning sign-up with sign-in.
- [x] No new lint warnings.
- [x] No new tests added in this PR because the repo has no existing unit-test seam for the auth pages (they are tested end-to-end in `web/src/__e2e__/auth.spec.ts`). I want to leave adding one out of scope for this PR to keep the diff minimal; happy to add one in a follow-up if maintainers prefer.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hides the username/password credentials form on the sign-up page when `AUTH_DISABLE_USERNAME_PASSWORD` is configured, mirroring the guard that already existed on the sign-in page. The change is a surgical one-line conditional wrap of the `<Form>` block in `StandardSignupFlow`.

- The `{authProviders.credentials && (<Form>...</Form>)}` wrapper correctly prevents the email→name→password fields from rendering when credentials auth is disabled, eliminating the dead-end UX described in the linked issue.
- `VerifiedSignupFlow` (passwordless OTP path) and `<SSOButtons>` are left unconditional, preserving OAuth and email-verification flows regardless of the flag.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The credentials form is correctly hidden, but the shared SSOButtons component still shows an orphaned 'or sign up with' separator label when credentials are disabled on sign-up — a visible artifact that should be fixed before merging.

The core change is correct and minimal, but it breaks an assumption baked into the SSOButtons separator logic in sign-in.tsx. The separator was written expecting sign-up to always have a credentials form, so it remains visible even when the form is gone, leaving a floating 'or sign up with' label with nothing above it.

The showSeparator logic in web/src/pages/auth/sign-in.tsx (SSOButtons component, line 229) needs to be updated alongside this change.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant getServerSideProps
    participant SignUp Page
    participant SSOButtons

    getServerSideProps->>SignUp Page: authProviders.credentials = (AUTH_DISABLE_USERNAME_PASSWORD !== "true")

    alt credentials enabled
        SignUp Page->>Browser: Render credentials Form (email→name→password)
        SignUp Page->>SSOButtons: action="sign up", showSeparator = true → "or sign up with"
        SSOButtons->>Browser: Separator + SSO provider buttons
    else credentials disabled
        SignUp Page->>Browser: No credentials Form rendered
        SignUp Page->>SSOButtons: action="sign up", showSeparator = false||true = true ⚠️
        SSOButtons->>Browser: Orphaned separator + SSO provider buttons
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant getServerSideProps
    participant SignUp Page
    participant SSOButtons

    getServerSideProps->>SignUp Page: authProviders.credentials = (AUTH_DISABLE_USERNAME_PASSWORD !== "true")

    alt credentials enabled
        SignUp Page->>Browser: Render credentials Form (email→name→password)
        SignUp Page->>SSOButtons: action="sign up", showSeparator = true → "or sign up with"
        SSOButtons->>Browser: Separator + SSO provider buttons
    else credentials disabled
        SignUp Page->>Browser: No credentials Form rendered
        SignUp Page->>SSOButtons: action="sign up", showSeparator = false||true = true ⚠️
        SSOButtons->>Browser: Orphaned separator + SSO provider buttons
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/auth/sign-up.tsx:312-317
**Orphaned "or sign up with" separator when credentials are disabled**

`SSOButtons` (defined in `sign-in.tsx`) computes its separator visibility as `authProviders.credentials || action !== "sign in"` (line 229 of `sign-in.tsx`). The comment there reads: *"action is sign-up (which always has the form)"*. That assumption is now false after this PR. When `AUTH_DISABLE_USERNAME_PASSWORD=true`, `authProviders.credentials` is `false` and `action` is `"sign up"`, so `showSeparator` evaluates to `false || true = true`, and the "or sign up with" label is rendered above the SSO buttons with nothing above it — a floating label with no form to separate from.

The fix lives in `sign-in.tsx`: change `showSeparator` to just `authProviders.credentials` so the separator is only present when the credentials form actually exists on either page.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): hide credentials form on sign..."](https://github.com/langfuse/langfuse/commit/8a4221ce5236cc0640d94780540ae77276bc412c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41920290)</sub>

<!-- /greptile_comment -->