### PR TITLE
fix(ingestion): backfill body.id when missing so events aren't silently dropped

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -229,13 +229,30 @@ export const processEventBatch = async (
       >,
       event,
     ) => {
-      if (!event.body?.id) {
+      if (!event.body) {
         return acc;
       }
+      // Score/trace/dataset-run-item bodies allow an optional client id
+      // (BaseScoreBody.id, TraceBody.id, DatasetRunItemBody.id are all
+      // nullish). An event without one used to be silently excluded here —
+      // before ever reaching S3 or the queue — even though it was already
+      // counted as a `201` success in aggregateBatchResult above (see
+      // langfuse/langfuse#14797). Backfill a random id so every validated
+      // event is actually persisted; IngestionService already assumes this
+      // field is populated downstream (e.g. validateAndInflateScore's
+      // `scoreId` comes from this same eventBodyId).
+      const eventBodyId = event.body.id ?? randomUUID();
+      const eventWithId =
+        event.body.id === eventBodyId
+          ? event
+          : ({
+              ...event,
+              body: { ...event.body, id: eventBodyId },
+            } as typeof event);
+
       const entityType = getClickhouseEntityType(event.type);
-      const dedupKey = `${entityType}-${event.body.id}`;
+      const dedupKey = `${entityType}-${eventBodyId}`;
       if (!acc[dedupKey]) {
-        const eventBodyId = event.body.id;
         const safeEventBodyId = safeBlobKeySegment(eventBodyId);
         if (safeEventBodyId !== eventBodyId) {
           // Do not log the raw or sanitized ID itself: the prefix can carry
@@ -266,7 +283,7 @@ export const processEventBatch = async (
           }),
         };
       }
-      acc[dedupKey].data.push(event);
+      acc[dedupKey].data.push(eventWithId);
       return acc;
     },
     {},

--- a/worker/src/__tests__/processEventBatch.test.ts
+++ b/worker/src/__tests__/processEventBatch.test.ts
@@ -217,6 +217,12 @@ describe("processEventBatch", () => {
     const enqueuedData = queueAddMock.mock.calls[0][1].payload.data;
     expect(enqueuedData.eventBodyId).toBeTypeOf("string");
     expect(enqueuedData.eventBodyId.length).toBeGreaterThan(0);
+
+    // The invariant this fix relies on: the id backfilled into the S3-uploaded
+    // event body must be the exact same id used as the queue's eventBodyId,
+    // since IngestionService looks up/creates the score row by eventBodyId.
+    const uploadedEvents = uploadJsonMock.mock.calls[0][1];
+    expect(uploadedEvents[0].body.id).toBe(enqueuedData.eventBodyId);
   });
 
   it("enqueues a trace-create event that omits body.id", async () => {

--- a/worker/src/__tests__/processEventBatch.test.ts
+++ b/worker/src/__tests__/processEventBatch.test.ts
@@ -60,6 +60,40 @@ const createTraceCreateEvent = () => {
   };
 };
 
+// Regression test fixture for langfuse/langfuse#14797: score-create events are
+// commonly sent without a client-supplied `body.id` (unlike traces/observations).
+const createScoreCreateEvent = () => {
+  const timestamp = "2024-10-12T12:13:15.123Z";
+
+  return {
+    id: "score-event-id",
+    timestamp,
+    type: eventTypes.SCORE_CREATE,
+    body: {
+      traceId: "trace-id",
+      name: "relevance",
+      value: 0.9,
+      dataType: "NUMERIC" as const,
+      environment: "default",
+    },
+  };
+};
+
+const createTraceCreateEventWithoutId = () => {
+  const timestamp = "2024-10-12T12:13:14.123Z";
+
+  return {
+    id: "trace-event-id",
+    timestamp,
+    type: eventTypes.TRACE_CREATE,
+    body: {
+      timestamp,
+      name: "trace",
+      environment: "default",
+    },
+  };
+};
+
 describe("processEventBatch", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -146,5 +180,61 @@ describe("processEventBatch", () => {
       ingestionSdkName: UNKNOWN_INGESTION_SDK_VALUE,
       ingestionSdkVersion: UNKNOWN_INGESTION_SDK_VALUE,
     });
+  });
+
+  it("enqueues a score-create event that omits body.id (langfuse#14797)", async () => {
+    const authCheck = {
+      validKey: true as const,
+      scope: {
+        projectId: "project-id",
+        accessLevel: "project" as const,
+        publicKey: "pk-lf-public",
+      },
+    };
+
+    const result = await processEventBatch(
+      [createScoreCreateEvent()],
+      authCheck,
+      {
+        delay: 0,
+        attribution: createUnknownSdkIngestionAttribution({ authCheck }),
+      },
+    );
+
+    // The event is reported as a `201` success purely from passing schema
+    // validation — this is exactly what made the original drop invisible:
+    // the response says nothing about whether the event actually reached
+    // S3 or the ingestion queue.
+    expect(result).toEqual({
+      successes: [{ id: "score-event-id", status: 201 }],
+      errors: [],
+    });
+
+    // The real assertion: without a fallback id, this event never reaches
+    // either S3 or the queue, so both mocks stay uncalled.
+    expect(uploadJsonMock).toHaveBeenCalledTimes(1);
+    expect(queueAddMock).toHaveBeenCalledTimes(1);
+    const enqueuedData = queueAddMock.mock.calls[0][1].payload.data;
+    expect(enqueuedData.eventBodyId).toBeTypeOf("string");
+    expect(enqueuedData.eventBodyId.length).toBeGreaterThan(0);
+  });
+
+  it("enqueues a trace-create event that omits body.id", async () => {
+    const authCheck = {
+      validKey: true as const,
+      scope: {
+        projectId: "project-id",
+        accessLevel: "project" as const,
+        publicKey: "pk-lf-public",
+      },
+    };
+
+    await processEventBatch([createTraceCreateEventWithoutId()], authCheck, {
+      delay: 0,
+      attribution: createUnknownSdkIngestionAttribution({ authCheck }),
+    });
+
+    expect(uploadJsonMock).toHaveBeenCalledTimes(1);
+    expect(queueAddMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Fixes langfuse/langfuse#14797.

`processEventBatch`'s batch-grouping step (`packages/shared/src/server/ingestion/processEventBatch.ts`) silently excludes any event whose `body.id` is missing:

```js
if (!event.body?.id) {
  return acc;
}
```

This grouping map drives *both* the S3 event upload and the Redis/BullMQ enqueue to the worker. But the `201` HTTP response is built earlier, from the pre-grouping, schema-validated list (`aggregateBatchResult`) — decoupled from whether the event actually gets grouped/enqueued. So an event without `body.id` passes validation, is reported `201`, and then silently vanishes before ever reaching S3 or the worker: no error, no log line, nothing.

`BaseScoreBody.id`, `TraceBody.id`, and `DatasetRunItemBody.id` are all `idSchema.nullish()` — explicitly optional per the schema. Scores in particular are commonly sent without a client-supplied id (unlike observations, whose `id` is required via `CreateEventEvent`'s override), which is exactly the shape of the repro in langfuse/langfuse#14797.

I initially suspected the throw-based theory from the issue (an uncaught `scoreRecordInsertSchema.parse` in the worker), but ruled it out with direct evidence: BullMQ's failed-job list stayed empty, no `logger.error` ever fired for the dropped job, and ClickHouse's own `system.query_log` showed **zero** `INSERT` attempts for the dropped score — the event never got far enough to reach any of that. Tracing back through `processEventBatch` found the actual drop point above.

## Fix

Backfill a random id via the already-imported `randomUUID()` when `body.id` is absent, and thread it through consistently — the dedup key, the S3 upload, the queue payload, and the persisted event body all use the same generated id, so downstream code (e.g. `IngestionService`'s `validateAndInflateScore`, which already assumes `eventBodyId` is the score's row id) needs no changes.

Generic across all event types with optional `body.id`, not score-specific, since that's the actual shape of the bug. No existing event type has an "update" variant with a nullable `id` (span/generation/event updates all require `id` via `UpdateEventEvent`), so there's no risk of this accidentally creating a duplicate entity instead of erroring on a malformed update request.

## Test plan

* Added unit tests in `worker/src/__tests__/processEventBatch.test.ts` covering a score-create and a trace-create event that omit `body.id`. Both fail against the current code (`uploadJsonMock`/`queueAddMock` called 0 times) and pass after the fix.
* Ran the full existing `processEventBatch.test.ts` suite — no regressions, pre-existing tests unaffected.
* Manually reproduced end-to-end against a full local stack (real Postgres/ClickHouse/Redis/MinIO, `web` + `worker` dev servers) on current `main`:
  * **Before the fix:** `POST /api/public/ingestion` with a `score-create` event lacking `body.id` returns `201`, but the score never appears in ClickHouse (`SELECT count() FROM scores` stays `0` for that trace).
  * **After the fix:** identical request, score persists correctly and is queryable.
* `pnpm run format:check` and `pnpm run lint` (turbo, all packages) pass.

## Checklist

- [X] Bug reproduced against current `main`, not just the `v3.174.1` release the issue was originally filed against
- [X] Root cause identified with direct evidence (not just the original issue's hypothesis)
- [X] Regression test added (fails before, passes after)
- [X] Full local end-to-end verification (real infra, not just mocks)

<details><summary>Greptile Summary</summary>

This PR fixes a silent event-drop bug (langfuse/langfuse#14797) in `processEventBatch` where events with a missing `body.id` (valid per schema for scores, traces, and dataset run items) were excluded from grouping after already being counted as `201` successes, meaning they never reached S3 or the ingestion queue.

* **Core fix**: replaces the unconditional `!event.body?.id` early-return with a UUID backfill (`event.body.id ?? randomUUID()`), threads the generated id into the dedup key, S3 upload payload, and queue entry to keep all three consistent.
* **Tests**: adds two regression fixtures (score-create and trace-create without `body.id`) that fail before the fix and pass after; the score test also asserts the queue payload carries a non-empty `eventBodyId`.

</details>

<details><summary>Confidence Score: 4/5</summary>

The change is a well-scoped, targeted fix with regression tests; the backfill logic is structurally sound and consistent across S3, queue, and dedup key.

Both changed files are in the hot path for all ingestion. The fix itself is correct and the two comments are only style and test-coverage suggestions, neither blocking. The main gap is that the test does not assert S3-upload data contains the same generated id as the queue payload — the key consistency invariant the fix introduces — so a future refactor could silently break it.

No files require special attention; processEventBatch.ts and its test are both straightforward and the logic is easy to follow.

</details>

<details><summary>Sequence Diagram</summary>

[%%{init: {'theme': 'neutral'}}%% sequenceDiagram participant Client participant API as HTTP Handler participant PEB as processEventBatch participant Grp as Dedup Grouping participant S3 participant Queue as IngestionQueue Client->>API: POST /api/public/ingestion (score-create, no body.id) API->>PEB: processEventBatch(\[event\]) Note over PEB: Schema validation passes (body.id is nullish per schema) PEB->>Grp: reduce into sortedBatchByEventBodyId rect rgb(255,220,220) Note over Grp: BEFORE FIX: if (!event.body?.id) return acc → event silently dropped end rect rgb(220,255,220) Note over Grp: AFTER FIX: eventBodyId = event.body.id ?? randomUUID(), eventWithId patched → event added to group end Grp-->>PEB: "dedupKey → { data: \[eventWithId\], eventBodyId, ... }" PEB->>S3: uploadJson(bucketPath, \[eventWithId\]) S3-->>PEB: ok PEB->>Queue: "add(IngestionJob, { eventBodyId, fileKey, ... })" Queue-->>PEB: ok PEB-->>API: "{ successes: \[{id, status:201}\], errors:\[\] }" API-->>Client: 201](<#gh-light-mode-only>) [%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%% sequenceDiagram participant Client participant API as HTTP Handler participant PEB as processEventBatch participant Grp as Dedup Grouping participant S3 participant Queue as IngestionQueue Client->>API: POST /api/public/ingestion (score-create, no body.id) API->>PEB: processEventBatch(\[event\]) Note over PEB: Schema validation passes (body.id is nullish per schema) PEB->>Grp: reduce into sortedBatchByEventBodyId rect rgb(255,220,220) Note over Grp: BEFORE FIX: if (!event.body?.id) return acc → event silently dropped end rect rgb(220,255,220) Note over Grp: AFTER FIX: eventBodyId = event.body.id ?? randomUUID(), eventWithId patched → event added to group end Grp-->>PEB: "dedupKey → { data: \[eventWithId\], eventBodyId, ... }" PEB->>S3: uploadJson(bucketPath, \[eventWithId\]) S3-->>PEB: ok PEB->>Queue: "add(IngestionJob, { eventBodyId, fileKey, ... })" Queue-->>PEB: ok PEB-->>API: "{ successes: \[{id, status:201}\], errors:\[\] }" API-->>Client: 201](<#gh-dark-mode-only>)

</details>

<details><summary>Prompt To Fix All With AI</summary>

```markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/ingestion/processEventBatch.ts:244-251
The condition `event.body.id === eventBodyId` works correctly but is indirect — it essentially asks "did the id already exist?" by comparing the original field to the (possibly just-generated) fallback value. The intent is clearer expressed as a direct null check, which avoids the implicit coupling to the `?? randomUUID()` assignment above.

```suggestion
      const eventBodyId = event.body.id ?? randomUUID();
      const eventWithId =
        event.body.id != null
          ? event
          : ({
              ...event,
              body: { ...event.body, id: eventBodyId },
            } as typeof event);
```

### Issue 2 of 2
worker/src/__tests__/processEventBatch.test.ts:215-219
**Missing cross-assertion between S3 payload and queue id**

The test confirms both mocks are called once and that `eventBodyId` in the queue payload is a non-empty string, but it doesn't assert that the body written to S3 contains the same generated id. The key invariant introduced by this fix — that `event.body.id` in the S3 data and `eventBodyId` in the queue payload are identical — is left untested. A future refactor that regenerates the UUID separately for each path would silently break downstream consistency (the worker's `IngestionService` uses `eventBodyId` from the queue to look up the score row id).

Consider adding `const uploadedEvents = uploadJsonMock.mock.calls[0][1]; expect(uploadedEvents[0].body.id).toBe(enqueuedData.eventBodyId);`
```

</details>

Reviews (1): Last reviewed commit: ["fix(ingestion): backfill body.id when mi..."](<https://github.com/langfuse/langfuse/commit/4f3007a3620a320b130f265644204a9392afbb2c>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=41945427>)

> Greptile also left **1 inline comment** on this PR.