### PR TITLE
Use upsert for dataset run creation to handle retries safely

### DIFF
--- a/web/src/features/experiments/server/router.ts
+++ b/web/src/features/experiments/server/router.ts
@@ -247,8 +247,15 @@ export const experimentsRouter = createTRPCRouter({
         }),
       };
 
-      const datasetRun = await ctx.prisma.datasetRuns.create({
-        data: {
+      const datasetRun = await ctx.prisma.datasetRuns.upsert({
+        where: {
+          datasetId_projectId_name: {
+            datasetId: input.datasetId,
+            projectId: input.projectId,
+            name: input.runName,
+          },
+        },
+        create: {
           name: input.runName,
           description: input.description,
           datasetId: input.datasetId,
@@ -259,6 +266,7 @@ export const experimentsRouter = createTRPCRouter({
           },
           projectId: input.projectId,
         },
+        update: {},
       });
 
       const queue = ExperimentCreateQueue.getInstance();


### PR DESCRIPTION
Fixes #14525

## Problem

The `createExperiment` mutation uses `prisma.datasetRuns.create()`. If the Redis enqueue at line ~267 fails after the DB write succeeds (or if the HTTP response never reaches the client after a successful create), the client sees an error and the user retries. The retry hits the `@@unique([datasetId, projectId, name])` constraint, so the second `create()` also throws — the dataset run appears permanently broken from the UI even though the record exists in the database.

## Fix

Replace `create` with `upsert` using `update: {}`:

```ts
const datasetRun = await ctx.prisma.datasetRuns.upsert({
  where: {
    datasetId_projectId_name: {
      datasetId: input.datasetId,
      projectId: input.projectId,
      name: input.runName,
    },
  },
  create: { /* existing fields */ },
  update: {},   // no-op: return the existing row unchanged on retry
});
```

On retry the upsert returns the already-created run and the mutation continues to enqueue the background job. Re-enqueueing is safe — the worker can handle duplicate or in-flight jobs for the same `runId`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces `prisma.datasetRuns.create()` with `prisma.datasetRuns.upsert()` (using a no-op `update: {}`) in the `createExperiment` mutation so that client retries after a partial failure (DB write succeeded but Redis enqueue or HTTP response failed) no longer hit a unique constraint violation.

- **Upsert for idempotent DB writes**: The `where` clause uses the existing `@@unique([datasetId, projectId, name])` constraint, so a retry returns the pre-existing row unchanged instead of throwing.
- **Re-enqueue on every call**: Because `queue.add(...)` is unconditional, every retry — including cases where the original job already reached Redis — enqueues a second job for the same `runId`. The fix's safety depends entirely on the `ExperimentCreate` worker being idempotent for duplicate `runId` jobs, which is asserted in the PR description but not verified in this diff.
- **Silent no-op for same-name collisions**: Non-retry calls that happen to share a `(datasetId, projectId, name)` tuple will now silently succeed and return the stale record rather than surfacing an error.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change fixes a real retry bug but introduces unconditional re-enqueueing; whether that is safe depends on worker idempotency that is not demonstrated in this diff.

The upsert itself is sound — Prisma handles the unique constraint gracefully. However, queue.add(...) now fires on every invocation unconditionally, which means a retry where the original job was already picked up by the worker sends a second job for the same runId. If the ExperimentCreate worker re-processes items without checking for existing entries, this produces duplicate datasetRunItems. That dependency isn't visible in the one changed file.

The worker that consumes ExperimentCreateQueue (not in this diff) needs to be verified for runId-level idempotency before merging.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant tRPC as createExperiment (tRPC)
    participant DB as Postgres (datasetRuns)
    participant Redis as ExperimentCreateQueue

    Note over Client,Redis: Happy path (first attempt)
    Client->>tRPC: createExperiment(input)
    tRPC->>DB: upsert (create branch)
    DB-->>tRPC: datasetRun (new record)
    tRPC->>Redis: queue.add(runId)
    Redis-->>tRPC: ok
    tRPC-->>Client: "{ success, runId }"

    Note over Client,Redis: Retry — Redis failed before (or HTTP response lost after DB write)
    Client->>tRPC: createExperiment(input) [retry]
    tRPC->>DB: "upsert (update:{} branch — existing row returned)"
    DB-->>tRPC: datasetRun (existing record, no fields changed)
    tRPC->>Redis: queue.add(runId) ← second job for same runId
    Note over Redis: If worker already processed runId, duplicate jobs possible
    Redis-->>tRPC: ok
    tRPC-->>Client: "{ success, runId }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant tRPC as createExperiment (tRPC)
    participant DB as Postgres (datasetRuns)
    participant Redis as ExperimentCreateQueue

    Note over Client,Redis: Happy path (first attempt)
    Client->>tRPC: createExperiment(input)
    tRPC->>DB: upsert (create branch)
    DB-->>tRPC: datasetRun (new record)
    tRPC->>Redis: queue.add(runId)
    Redis-->>tRPC: ok
    tRPC-->>Client: "{ success, runId }"

    Note over Client,Redis: Retry — Redis failed before (or HTTP response lost after DB write)
    Client->>tRPC: createExperiment(input) [retry]
    tRPC->>DB: "upsert (update:{} branch — existing row returned)"
    DB-->>tRPC: datasetRun (existing record, no fields changed)
    tRPC->>Redis: queue.add(runId) ← second job for same runId
    Note over Redis: If worker already processed runId, duplicate jobs possible
    Redis-->>tRPC: ok
    tRPC-->>Client: "{ success, runId }"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/experiments/server/router.ts:272-290
**Re-enqueue on every retry may duplicate experiment runs**

`queue.add(...)` is called unconditionally on every invocation — both the first attempt and any retry. If the original job was already enqueued and is in-flight (or has already completed) when the client retries, the worker will receive a second job for the same `runId`. The PR description asserts the worker is idempotent for duplicate `runId` jobs, but if it is not, this will re-process all dataset items for the run, creating duplicate `datasetRunItems`.

The scenario that is now newly reachable: HTTP response is lost *after* both the DB write and the Redis enqueue succeed. The old `create` would have thrown a unique constraint error on retry (blocking re-enqueue), whereas the new `upsert` silently succeeds and enqueues a second job for the same `runId`.

### Issue 2 of 2
web/src/features/experiments/server/router.ts:250-269
**Silent no-op for non-retry duplicate name**

With `update: {}`, any call that matches an existing `(datasetId, projectId, name)` tuple returns the existing row silently — whether it's a genuine retry or an intentional attempt to create a different run with the same name. Fields like `description`, `metadata` (which holds `prompt_id`, `provider`, `model`, `model_params`), and `experiment_name` from a new request will be silently discarded and the stale record returned. This is a behavior change from the previous explicit unique-constraint error, which at least signaled the collision to the caller.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Use upsert for dataset run creation to h..."](https://github.com/langfuse/langfuse/commit/86f49838e0d1199cb38937ffc2cebc7d21681bf7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41987437)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->