### PR TITLE
fix(ci): deflake dataset-run-delete test and cut slow-test log noise

### DIFF
--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -1325,23 +1325,10 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
     expect(dbRunAfterDelete).toBeNull();
 
-    // Verify run items are also deleted. Deletion propagates asynchronously
-    // through the worker queue and a ClickHouse mutation, which can take well
-    // over 30s on a loaded CI runner.
-    await waitForExpect(async () => {
-      const dbRunItems = await getDatasetRunItemsByDatasetIdCh({
-        projectId: dataset.body.projectId,
-        datasetId: dataset.body.id,
-        filter: [],
-        orderBy: {
-          column: "createdAt",
-          order: "DESC",
-        },
-        limit: 10,
-      });
-      expect(dbRunItems).toHaveLength(0);
-    }, 90000);
-  }, 120000);
+    // ClickHouse run-item deletion propagates asynchronously via the worker
+    // queue; it is covered deterministically in
+    // worker/src/__tests__/datasetDelete.test.ts.
+  });
 
   it("dataset-run-items should fail when neither trace nor observation provided", async () => {
     const response = await makeAPICall(

--- a/web/vitest.config.mts
+++ b/web/vitest.config.mts
@@ -71,6 +71,10 @@ export default defineConfig({
     silent: process.env.CI ? "passed-only" : false,
     globals: true,
     retry: process.env.CI ? 3 : 0,
+    // Servertests are DB-roundtrip bound, so hundreds cross the default 300ms
+    // slow threshold on CI and the default reporter prints a line for each.
+    // VitestCiReporter's top-10 slowest summary is unaffected (own accounting).
+    slowTestThreshold: process.env.CI ? 2_000 : 300,
     testTimeout: 30_000,
     server: {
       deps: {

--- a/worker/src/__tests__/datasetDelete.test.ts
+++ b/worker/src/__tests__/datasetDelete.test.ts
@@ -1,0 +1,128 @@
+import { expect, describe, it } from "vitest";
+import {
+  createDatasetRunItem,
+  createDatasetRunItemsCh,
+  createOrgProjectAndApiKey,
+  getDatasetRunItemsByDatasetIdCh,
+} from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+import { prisma } from "@langfuse/shared/src/db";
+import { processClickhouseDatasetDelete } from "../features/datasets/processClickhouseDatasetDelete";
+
+const getRunItems = (projectId: string, datasetId: string) =>
+  getDatasetRunItemsByDatasetIdCh({
+    projectId,
+    datasetId,
+    filter: [],
+    limit: 100,
+  });
+
+describe("dataset deletion", () => {
+  it("should delete only the targeted runs' items for deletionType dataset-runs", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const { projectId: otherProjectId } = await createOrgProjectAndApiKey();
+
+    const datasetId = randomUUID();
+    const targetRunId = randomUUID();
+    const otherRunId = randomUUID();
+
+    await createDatasetRunItemsCh([
+      createDatasetRunItem({
+        project_id: projectId,
+        dataset_id: datasetId,
+        dataset_run_id: targetRunId,
+      }),
+      createDatasetRunItem({
+        project_id: projectId,
+        dataset_id: datasetId,
+        dataset_run_id: targetRunId,
+      }),
+      createDatasetRunItem({
+        project_id: projectId,
+        dataset_id: datasetId,
+        dataset_run_id: otherRunId,
+      }),
+      // same dataset and run ids in another project must survive the delete
+      createDatasetRunItem({
+        project_id: otherProjectId,
+        dataset_id: datasetId,
+        dataset_run_id: targetRunId,
+      }),
+    ]);
+
+    await processClickhouseDatasetDelete({
+      deletionType: "dataset-runs",
+      projectId,
+      datasetId,
+      datasetRunIds: [targetRunId],
+    });
+
+    const remaining = await getRunItems(projectId, datasetId);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].datasetRunId).toBe(otherRunId);
+
+    await expect(getRunItems(otherProjectId, datasetId)).resolves.toHaveLength(
+      1,
+    );
+  });
+
+  it("should delete all run items and media links for deletionType dataset", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const datasetId = randomUUID();
+    const otherDatasetId = randomUUID();
+
+    await createDatasetRunItemsCh([
+      createDatasetRunItem({ project_id: projectId, dataset_id: datasetId }),
+      createDatasetRunItem({ project_id: projectId, dataset_id: datasetId }),
+      createDatasetRunItem({
+        project_id: projectId,
+        dataset_id: otherDatasetId,
+      }),
+    ]);
+
+    // dataset_item_media rows have no FK cascading on dataset deletion; the
+    // delete processor is the only path that removes them.
+    const mediaId = randomUUID();
+    await prisma.datasetItemMedia.createMany({
+      data: [
+        {
+          id: randomUUID(),
+          projectId,
+          datasetId,
+          datasetItemId: randomUUID(),
+          mediaId,
+          field: "input",
+        },
+        {
+          id: randomUUID(),
+          projectId,
+          datasetId: otherDatasetId,
+          datasetItemId: randomUUID(),
+          mediaId,
+          field: "input",
+        },
+      ],
+    });
+
+    await processClickhouseDatasetDelete({
+      deletionType: "dataset",
+      projectId,
+      datasetId,
+    });
+
+    await expect(getRunItems(projectId, datasetId)).resolves.toHaveLength(0);
+    await expect(getRunItems(projectId, otherDatasetId)).resolves.toHaveLength(
+      1,
+    );
+
+    await expect(
+      prisma.datasetItemMedia.findMany({ where: { projectId, datasetId } }),
+    ).resolves.toHaveLength(0);
+    await expect(
+      prisma.datasetItemMedia.findMany({
+        where: { projectId, datasetId: otherDatasetId },
+      }),
+    ).resolves.toHaveLength(1);
+  });
+});

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
       : ["default"],
     silent: process.env.CI ? "passed-only" : false,
     retry: process.env.CI ? 3 : 0,
+    // Worker tests are DB-roundtrip bound, so many cross the default 300ms
+    // slow threshold on CI and the default reporter prints a line for each.
+    // VitestCiReporter's top-10 slowest summary is unaffected (own accounting).
+    slowTestThreshold: process.env.CI ? 2_000 : 300,
     dir: "./src",
     pool: "forks",
     server: {


### PR DESCRIPTION
## Summary

- The web servertest `"should delete a dataset run and its run items"` flaked on loaded CI runners (e.g. `tests-web (node24, pg12, mode-azure)` in [run 28770939027](https://github.com/langfuse/langfuse/actions/runs/28770939027/job/85304384160)): it polled ClickHouse for up to 90s for an outcome that crosses HTTP → Postgres → BullMQ → worker → ClickHouse, burning ~7 min per failure (4 attempts × 90s). The test now keeps all HTTP-contract and Postgres assertions and drops the cross-system poll.
- The ClickHouse deletion path had zero direct coverage; a new deterministic worker test (`worker/src/__tests__/datasetDelete.test.ts`) calls `processClickhouseDatasetDelete` directly and covers both payload shapes: `dataset-runs` (targeted run deleted, sibling run and same-IDs-in-other-project survive) and `dataset` (run items gone, `dataset_item_media` link rows cleaned up, other datasets untouched). No queue involved — ClickHouse lightweight DELETE completes before returning.
- Raised `slowTestThreshold` to 2s on CI for web and worker vitest configs: DB-roundtrip-bound servertests cross the 300ms default by the hundreds, bloating raw CI logs. Reporting-only; the curated `VitestCiReporter` top-10 slowest summary has its own duration accounting and is unaffected.

## Linear

- None

## Major Decisions

- Slimmed the e2e test instead of asserting "job was enqueued": the test talks to the real HTTP server in a separate process, so `vi.mock` can't intercept the queue, and reading it via Redis races the worker (`removeOnComplete: true`). The web→worker queue wiring is generic BullMQ plumbing already exercised e2e by other deletion tests (e.g. traces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors a flaky web server test for dataset run deletion by removing a 90s ClickHouse poll (which could take up to 7 minutes on a slow CI runner) and replacing it with a new deterministic worker-level integration test that calls `processClickhouseDatasetDelete` directly.

- **`worker/src/__tests__/datasetDelete.test.ts`**: New test covering both `dataset-runs` and `dataset` deletion payloads, asserting ClickHouse row removal and cross-project isolation for the targeted deletion path, plus `datasetItemMedia` link cleanup for full-dataset deletion.
- **`web/src/__tests__/server/datasets-api.servertest.ts`**: Flaky `waitForExpect` poll over ClickHouse (90 s timeout, 4 CI retries) removed; Postgres-level assertion that the run row is gone is preserved.
- **`vitest.config.mts` / `vitest.config.ts`**: `slowTestThreshold` raised from 300 ms to 2 s on CI to suppress per-test log noise from DB-bound tests, with no effect on the curated top-10 slowest summary.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are test-only and config-only, with no production code modified.

The web server test simply drops a cross-system poll that was inherently racy and replaces it with a comment pointing to the new worker test. The new worker test directly exercises both deletion payloads against real ClickHouse/Postgres and verifies cross-project isolation for the targeted run case and media-link cleanup for the full-dataset case. The vitest config changes are reporting-only. There are no changes to production logic.

No files require special attention. The new worker/src/__tests__/datasetDelete.test.ts is the most substantive addition and its assertions are straightforward to verify.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before ["Before (flaky web test)"]
        A["HTTP DELETE /dataset-run"] --> B["Postgres: delete run row"]
        B --> C["BullMQ: enqueue deletion job"]
        C --> D["Worker: processClickhouseDatasetDelete"]
        D --> E["ClickHouse: delete run items"]
        E --> F["waitForExpect poll (up to 90s)"]
        F -->|timeout on loaded CI| G["❌ Test flakes"]
    end

    subgraph After ["After (split test coverage)"]
        H["HTTP DELETE /dataset-run"] --> I["Postgres: delete run row ✓"]
        J["processClickhouseDatasetDelete (direct call)"] --> K["ClickHouse: delete run items ✓"]
        K --> L{deletionType?}
        L -->|dataset-runs| M["deleteDatasetRunItemsByDatasetRunIds\n(cross-project isolation verified)"]
        L -->|dataset| N["deleteDatasetMediaLinksByDatasetId\n+ deleteDatasetRunItemsByDatasetId\n(media link cleanup verified)"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before ["Before (flaky web test)"]
        A["HTTP DELETE /dataset-run"] --> B["Postgres: delete run row"]
        B --> C["BullMQ: enqueue deletion job"]
        C --> D["Worker: processClickhouseDatasetDelete"]
        D --> E["ClickHouse: delete run items"]
        E --> F["waitForExpect poll (up to 90s)"]
        F -->|timeout on loaded CI| G["❌ Test flakes"]
    end

    subgraph After ["After (split test coverage)"]
        H["HTTP DELETE /dataset-run"] --> I["Postgres: delete run row ✓"]
        J["processClickhouseDatasetDelete (direct call)"] --> K["ClickHouse: delete run items ✓"]
        K --> L{deletionType?}
        L -->|dataset-runs| M["deleteDatasetRunItemsByDatasetRunIds\n(cross-project isolation verified)"]
        L -->|dataset| N["deleteDatasetMediaLinksByDatasetId\n+ deleteDatasetRunItemsByDatasetId\n(media link cleanup verified)"]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): deflake dataset-run-delete test..."](https://github.com/langfuse/langfuse/commit/8f2499a23b08be3d6c513b02ff93e3efa83750d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42010338)</sub>

<!-- /greptile_comment -->