### PR TITLE
fix(sessions): Do not generate router history for autoselected view

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -892,9 +892,13 @@ const LoadedSessionEventsPage: React.FC<{
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
 
   const setFiltersWrapper = useCallback(
-    (filters: FilterState) =>
+    (
+      filters: FilterState,
+      updateType?: Parameters<typeof queryFilter.setFilterState>[1],
+    ) =>
       queryFilter.setFilterState(
         normalizeLegacySessionPositionInTraceFilters(filters),
+        updateType,
       ),
     [queryFilter],
   );
@@ -921,8 +925,8 @@ const LoadedSessionEventsPage: React.FC<{
 
   const applySystemPreset = useCallback(
     (preset: SessionDetailSystemPreset) => {
-      viewControllers.handleSetViewId(preset.id);
-      queryFilter.setFilterState(preset.filters);
+      viewControllers.handleSetViewId(preset.id, "replaceIn");
+      queryFilter.setFilterState(preset.filters, "replaceIn");
     },
     [queryFilter, viewControllers],
   );
@@ -983,7 +987,9 @@ const LoadedSessionEventsPage: React.FC<{
     const shouldRecover =
       filterMatchedView.id === initialViewIdRef.current ||
       visibleFilterState.length > 0;
-    if (shouldRecover) viewControllers.handleSetViewId(filterMatchedView.id);
+    if (shouldRecover) {
+      viewControllers.handleSetViewId(filterMatchedView.id, "replaceIn");
+    }
   }, [isViewLoading, selectedViewId, visibleFilterState, viewControllers]);
 
   // Fresh load with nothing in the URL → apply the default view. Skipped on

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -12,6 +12,7 @@ import {
   type TableViewPresetTableName,
   type TracingSearchType,
 } from "@langfuse/shared";
+import { type TableViewUrlUpdateType } from "@/src/components/table/table-view-presets/hooks/useTableViewManager";
 import {
   type RowSelectionState,
   type ColumnOrderState,
@@ -95,7 +96,10 @@ interface TableViewControllers {
   applyViewState: (viewData: TableViewPresetState) => void;
   selectedViewId: string | null;
   appliedViewId: string | null;
-  handleSetViewId: (viewId: string | null) => void;
+  handleSetViewId: (
+    viewId: string | null,
+    updateType?: TableViewUrlUpdateType,
+  ) => void;
 }
 
 interface TableViewConfig {

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -20,12 +20,27 @@ import { validateOrderBy, validateFilters } from "../validation";
 import { isSystemPresetId } from "../components/data-table-view-presets-drawer";
 import type { FilterStateMigration } from "@/src/features/filters/lib/filter-config";
 
+export type TableViewUrlUpdateType =
+  | "push"
+  | "pushIn"
+  | "replace"
+  | "replaceIn";
+
 interface TableStateUpdaters {
   setColumnOrder: (columnOrder: string[]) => void;
   setColumnVisibility: (columnVisibility: VisibilityState) => void;
-  setOrderBy?: (orderBy: OrderByState) => void;
-  setFilters?: (filters: FilterState) => void;
-  setSearchQuery?: (searchQuery: string | null) => void;
+  setOrderBy?: (
+    orderBy: OrderByState,
+    updateType?: TableViewUrlUpdateType,
+  ) => void;
+  setFilters?: (
+    filters: FilterState,
+    updateType?: TableViewUrlUpdateType,
+  ) => void;
+  setSearchQuery?: (
+    searchQuery: string | null,
+    updateType?: TableViewUrlUpdateType,
+  ) => void;
   setExpandedFilters?: (expandedFilters: string[]) => void;
 }
 
@@ -124,9 +139,9 @@ export function useTableViewManager({
 
   // Keep track of the viewId in session storage and in the query params
   const handleSetViewId = useCallback(
-    (viewId: string | null) => {
+    (viewId: string | null, updateType?: TableViewUrlUpdateType) => {
       setStoredViewId(viewId);
-      setSelectedViewId(viewId);
+      setSelectedViewId(viewId, updateType);
 
       // Explicitly selecting "My view (default)" should stop bootstrap restore.
       // Otherwise an in-flight bootstrap can restore a previously selected view.
@@ -179,7 +194,7 @@ export function useTableViewManager({
       isSystemPresetId(selectedViewId) &&
       !allowBackendSystemPresets
     ) {
-      handleSetViewId(null);
+      handleSetViewId(null, "replaceIn");
       return;
     }
 
@@ -214,7 +229,7 @@ export function useTableViewManager({
       storedViewId &&
       (!isSystemPresetId(storedViewId) || allowBackendSystemPresets)
     ) {
-      setSelectedViewId(storedViewId);
+      setSelectedViewId(storedViewId, "replaceIn");
       return;
     }
 
@@ -223,11 +238,11 @@ export function useTableViewManager({
 
     if (defaultViewId) {
       if (isSystemPresetId(defaultViewId) && !allowBackendSystemPresets) {
-        handleSetViewId(null);
+        handleSetViewId(null, "replaceIn");
         return;
       }
       setStoredViewId(defaultViewId);
-      setSelectedViewId(defaultViewId);
+      setSelectedViewId(defaultViewId, "replaceIn");
       return;
     }
 
@@ -251,7 +266,7 @@ export function useTableViewManager({
 
   // Method to apply state from a view
   const applyViewState = useCallback(
-    (viewData: TableViewPresetState) => {
+    (viewData: TableViewPresetState, updateType?: TableViewUrlUpdateType) => {
       // lock table
       setIsLoading(true);
 
@@ -288,7 +303,9 @@ export function useTableViewManager({
         );
       }
 
-      if (setOrderByRef.current) setOrderByRef.current(validOrderBy);
+      if (setOrderByRef.current) {
+        setOrderByRef.current(validOrderBy, updateType);
+      }
 
       const filtersAlreadyApplied = isEqual(currentFilterState, validFilters);
 
@@ -314,14 +331,14 @@ export function useTableViewManager({
       // sidebar filter hook updates optimistically, so the applied filter state
       // — and the URL it writes to — reflect the view synchronously.
       if (setFiltersRef.current && !filtersAlreadyApplied) {
-        setFiltersRef.current(validFilters);
+        setFiltersRef.current(validFilters, updateType);
       }
 
       if (setSearchQueryRef.current) {
         // `||` (not `??`): a persisted empty string — the common case for views
         // saved without a free-text search — must map to null too, or it
         // serializes as a literal empty `?search=` param in the URL.
-        setSearchQueryRef.current(viewData.searchQuery || null);
+        setSearchQueryRef.current(viewData.searchQuery || null, updateType);
       }
 
       // Apply column order and visibility without validation since UI will handle gracefully.
@@ -409,7 +426,7 @@ export function useTableViewManager({
       name: selectedViewData.name,
     });
 
-    applyViewState(selectedViewData);
+    applyViewState(selectedViewData, "replaceIn");
     if (storedViewId !== requestedViewId) {
       setStoredViewId(requestedViewId);
     }

--- a/web/src/components/table/table-view-presets/hooks/useViewMutations.ts
+++ b/web/src/components/table/table-view-presets/hooks/useViewMutations.ts
@@ -2,9 +2,13 @@ import { showSuccessToast } from "@/src/features/notifications/showSuccessToast"
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { api } from "@/src/utils/api";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
+import { type TableViewUrlUpdateType } from "./useTableViewManager";
 
 type UseViewMutationsProps = {
-  handleSetViewId: (viewId: string | null) => void;
+  handleSetViewId: (
+    viewId: string | null,
+    updateType?: TableViewUrlUpdateType,
+  ) => void;
 };
 
 export const useViewMutations = ({

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -18,6 +18,7 @@ import { TokenUsageBadge } from "@/src/components/token-usage-badge";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
 import {
+  type FilterUrlUpdateType,
   type UseSidebarFilterStateOptions,
   useSidebarFilterState,
 } from "@/src/features/filters/hooks/useSidebarFilterState";
@@ -520,7 +521,8 @@ export default function ObservationsTable({
   queryFilterRef.current = queryFilter;
 
   const setFiltersWrapper = useCallback(
-    (filters: FilterState) => queryFilterRef.current?.setFilterState(filters),
+    (filters: FilterState, updateType?: FilterUrlUpdateType) =>
+      queryFilterRef.current?.setFilterState(filters, updateType),
     [],
   );
 

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -16,6 +16,7 @@ import { IOTableCell } from "../../ui/IOTableCell";
 import { Avatar, AvatarImage } from "@/src/components/ui/avatar";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import {
+  type FilterUrlUpdateType,
   type UseSidebarFilterStateOptions,
   useSidebarFilterState,
 } from "@/src/features/filters/hooks/useSidebarFilterState";
@@ -364,7 +365,8 @@ export default function ScoresTable({
   queryFilterRef.current = queryFilter;
 
   const setFiltersWrapper = useCallback(
-    (filters: FilterState) => queryFilterRef.current?.setFilterState(filters),
+    (filters: FilterState, updateType?: FilterUrlUpdateType) =>
+      queryFilterRef.current?.setFilterState(filters, updateType),
     [],
   );
 

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -16,6 +16,7 @@ import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { TokenUsageBadge } from "@/src/components/token-usage-badge";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import {
+  type FilterUrlUpdateType,
   type UseSidebarFilterStateOptions,
   useSidebarFilterState,
 } from "@/src/features/filters/hooks/useSidebarFilterState";
@@ -280,7 +281,8 @@ export default function SessionsTable({
   queryFilterRef.current = queryFilter;
 
   const setFiltersWrapper = useCallback(
-    (filters: FilterState) => queryFilterRef.current?.setFilterState(filters),
+    (filters: FilterState, updateType?: FilterUrlUpdateType) =>
+      queryFilterRef.current?.setFilterState(filters, updateType),
     [],
   );
 

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -80,6 +80,7 @@ import {
 import { Button } from "@/src/components/ui/button";
 import TableIdOrName from "@/src/components/table/table-id";
 import {
+  type FilterUrlUpdateType,
   type UseSidebarFilterStateOptions,
   useSidebarFilterState,
 } from "@/src/features/filters/hooks/useSidebarFilterState";
@@ -1326,7 +1327,8 @@ export default function TracesTable({
   queryFilterRef.current = queryFilter;
 
   const setFiltersWrapper = useCallback(
-    (filters: FilterState) => queryFilterRef.current?.setFilterState(filters),
+    (filters: FilterState, updateType?: FilterUrlUpdateType) =>
+      queryFilterRef.current?.setFilterState(filters, updateType),
     [],
   );
 

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useState, useRef, useCallback } from "react";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
 import {
+  type FilterUrlUpdateType,
   type UseSidebarFilterStateOptions,
   useSidebarFilterState,
 } from "@/src/features/filters/hooks/useSidebarFilterState";
@@ -498,7 +499,8 @@ export default function ObservationsEventsTable({
   queryFilterRef.current = queryFilter;
 
   const setFiltersWrapper = useCallback(
-    (filters: FilterState) => queryFilterRef.current?.setFilterState(filters),
+    (filters: FilterState, updateType?: FilterUrlUpdateType) =>
+      queryFilterRef.current?.setFilterState(filters, updateType),
     [],
   );
 

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -12,7 +12,10 @@ import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAcces
 import { TableActionMenu } from "@/src/features/table/components/TableActionMenu";
 import { type TableAction } from "@/src/features/table/types";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
-import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
+import {
+  type FilterUrlUpdateType,
+  useSidebarFilterState,
+} from "@/src/features/filters/hooks/useSidebarFilterState";
 import {
   getExperimentItemsColumnName,
   experimentItemsFilterConfig,
@@ -341,7 +344,8 @@ export default function ExperimentItemsTable({
   queryFilterRef.current = queryFilter;
 
   const setFiltersWrapper = useCallback(
-    (filters: FilterState) => queryFilterRef.current?.setFilterState(filters),
+    (filters: FilterState, updateType?: FilterUrlUpdateType) =>
+      queryFilterRef.current?.setFilterState(filters, updateType),
     [],
   );
 

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -8,7 +8,10 @@ import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-l
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
-import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
+import {
+  type FilterUrlUpdateType,
+  useSidebarFilterState,
+} from "@/src/features/filters/hooks/useSidebarFilterState";
 import {
   getExperimentsFilterConfig,
   getExperimentsColumnName,
@@ -333,7 +336,8 @@ export default function ExperimentsTable({
   queryFilterRef.current = queryFilter;
 
   const setFiltersWrapper = useCallback(
-    (filters: FilterState) => queryFilterRef.current?.setFilterState(filters),
+    (filters: FilterState, updateType?: FilterUrlUpdateType) =>
+      queryFilterRef.current?.setFilterState(filters, updateType),
     [],
   );
 

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -342,6 +342,8 @@ type UpdateFilter = (
   operator?: "any of" | "none of" | "all of",
 ) => void;
 
+export type FilterUrlUpdateType = "push" | "pushIn" | "replace" | "replaceIn";
+
 type BaseUseSidebarFilterStateOptions = {
   loading?: boolean;
   implicitDefaultConfig?: ManagedEnvironmentPolicyInput;
@@ -666,7 +668,7 @@ export function useSidebarFilterState(
   );
 
   const setFilterState = useCallback(
-    (newFilters: FilterState) => {
+    (newFilters: FilterState, updateType?: FilterUrlUpdateType) => {
       const explicitFilters = stripImplicitEnvironmentFilterFromExplicitState({
         explicitFilters: newFilters,
         config: managedEnvironmentPolicyConfig,
@@ -687,7 +689,7 @@ export function useSidebarFilterState(
 
       const encoded = encodeFiltersGeneric(explicitFilters);
       setPendingFiltersQuery(encoded);
-      setUrlFiltersQuery(encoded || null);
+      setUrlFiltersQuery(encoded || null, updateType);
       if (stateLocationType === "urlAndSessionStorage") {
         setStoredFiltersQuery(encoded);
       }


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes spurious browser history entries that were created when the table view manager auto-selected or auto-corrected a view on page load (e.g., restoring from session storage, applying a default view, or recovering filters in the session detail page). It achieves this by threading an optional `updateType` parameter through `handleSetViewId`, `applyViewState`, and the filter/orderBy/searchQuery state updaters, then calling them with `"replaceIn"` at every bootstrap call site.

- **`useTableViewManager.ts`**: Adds `TableViewUrlUpdateType`, extends all internal state-setter signatures, and changes every bootstrap/auto-selection call site to `"replaceIn"`. Two `handleSetViewId(null)` calls in the success (wrong-table view) and error (view load failure) effects were missed and still use the default `"pushIn"`.
- **`useSidebarFilterState.tsx`**: Adds `FilterUrlUpdateType` and forwards it to `setUrlFiltersQuery` inside `setFilterState` — an identical union type to `TableViewUrlUpdateType`, defined separately.
- **`session/index.tsx` and eight table use-cases**: Propagate the new `updateType` parameter through their local `setFiltersWrapper` wrappers so the view manager can control URL update behaviour end-to-end.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The fix is mostly correct, but two auto-correction paths in `useTableViewManager.ts` still use the default `"pushIn"` and will push history entries under the same conditions the PR is trying to eliminate.

The wrong-table and view-load-error branches in `useTableViewManager.ts` call `handleSetViewId(null)` without `"replaceIn"`. These fire automatically during page bootstrap when a stale or cross-table `viewId` is in the URL, which is a realistic situation for shared links or bookmarks — meaning the history regression will be visible to real users in those flows.

web/src/components/table/table-view-presets/hooks/useTableViewManager.ts — the two `handleSetViewId(null)` calls at the wrong-table guard (line 418) and the error-recovery effect (line 460) need `"replaceIn"` to match the rest of the PR.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant TVM as useTableViewManager
    participant SFS as useSidebarFilterState
    participant URL as URL / History

    Note over TVM: Bootstrap: stored/default view or view in URL
    TVM->>TVM: setSelectedViewId(storedViewId, "replaceIn")
    TVM->>URL: replaceIn — no new history entry ✅

    TVM->>TVM: applyViewState(selectedViewData, "replaceIn")
    TVM->>SFS: setFilters(filters, "replaceIn")
    SFS->>URL: replaceIn — no new history entry ✅

    Note over TVM: ⚠️ Wrong-table or load-error paths (not yet fixed)
    TVM->>TVM: handleSetViewId(null) [missing replaceIn]
    TVM->>URL: pushIn — spurious history entry ❌

    Note over TVM: User explicitly selects a view
    TVM->>TVM: handleSetViewId(viewId) [default pushIn]
    TVM->>URL: pushIn — new history entry (intended) ✅
    TVM->>TVM: applyViewState(view) [default pushIn]
    TVM->>SFS: setFilters(filters)
    SFS->>URL: pushIn — new history entry (intended) ✅
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant TVM as useTableViewManager
    participant SFS as useSidebarFilterState
    participant URL as URL / History

    Note over TVM: Bootstrap: stored/default view or view in URL
    TVM->>TVM: setSelectedViewId(storedViewId, "replaceIn")
    TVM->>URL: replaceIn — no new history entry ✅

    TVM->>TVM: applyViewState(selectedViewData, "replaceIn")
    TVM->>SFS: setFilters(filters, "replaceIn")
    SFS->>URL: replaceIn — no new history entry ✅

    Note over TVM: ⚠️ Wrong-table or load-error paths (not yet fixed)
    TVM->>TVM: handleSetViewId(null) [missing replaceIn]
    TVM->>URL: pushIn — spurious history entry ❌

    Note over TVM: User explicitly selects a view
    TVM->>TVM: handleSetViewId(viewId) [default pushIn]
    TVM->>URL: pushIn — new history entry (intended) ✅
    TVM->>TVM: applyViewState(view) [default pushIn]
    TVM->>SFS: setFilters(filters)
    SFS->>URL: pushIn — new history entry (intended) ✅
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/components/table/table-view-presets/hooks/useTableViewManager.ts:417-420
Two `handleSetViewId(null)` calls in bootstrap `useEffect` blocks were not updated to use `"replaceIn"`, leaving them on the default `"pushIn"` path. Both fire automatically during page load (wrong-table view in URL, and view-load error), so they will still push a forward history entry — which is exactly the behaviour this PR is fixing everywhere else.

```suggestion
    if (!isViewApplicableToTable(tableName, selectedViewData.tableName)) {
      handleSetViewId(null, "replaceIn");
      return;
    }
```

### Issue 2 of 3
web/src/components/table/table-view-presets/hooks/useTableViewManager.ts:457-461
Same issue as the "wrong table" branch above: when the API returns an error for the view, the auto-correction `handleSetViewId(null)` still uses the default `"pushIn"` and will push a spurious history entry.

```suggestion
    isInitializedRef.current = true;
    setIsInitialized(true);
    setIsLoading(false);
    handleSetViewId(null, "replaceIn");
    showErrorToast("Error applying view", selectedViewError.message, "WARNING");
```

### Issue 3 of 3
web/src/features/filters/hooks/useSidebarFilterState.tsx:345
**Duplicate type definition** — `FilterUrlUpdateType` here and `TableViewUrlUpdateType` in `useTableViewManager.ts` are identical string-literal unions. TypeScript's structural typing means they're compatible today, but if one is extended (e.g., a new update mode is added to one and not the other), callers will silently accept the wrong type. Consider re-exporting a single shared type from a common location.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sessions): Do not generate router hi..."](https://github.com/langfuse/langfuse/commit/28ec98a9f94ab87d86bc4fb9feccc1fc32515d83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42305671)</sub>

<!-- /greptile_comment -->