### PR TITLE
docs(agents): require evidence-backed completion reports

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -72,6 +72,11 @@ langfuse/
 - Dev worker only: `pnpm run dev:worker`
 - Lint all: `pnpm run lint`
 - Typecheck all: `pnpm run typecheck` / `pnpm tc`
+- Run a single test file (vitest filters on the filename argument):
+  - web server tests: `pnpm --filter web run test <file>`
+    (client tests: `pnpm --filter web run test-client <file>`)
+  - worker: `pnpm --filter worker run test <file>`
+  - shared: `pnpm --filter @langfuse/shared run test <file>`
 - Build check: `pnpm run build:check`
 - Full build: `pnpm run build`
 - Worktree bootstrap: `bash scripts/codex/setup.sh`
@@ -93,9 +98,10 @@ langfuse/
 - Cross-package refactors: `pnpm run lint`, `pnpm run typecheck`, and targeted
   tests for impacted packages.
 
-End your turn with evidence, not claims: paste the output of the checks you
-ran (or say which you skipped and why) — never report work as done that you
-haven't verified in this session, and never end with work pending.
+End your turn with evidence, not claims: quote each check's summary line —
+e.g. `Tasks: 8 successful, 8 total` (turbo lint/typecheck) or
+`Tests  12 passed (12)` (vitest) — say which checks you skipped and why,
+never report unverified work as done, and never end with work pending.
 
 ## Generated Files
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -93,6 +93,10 @@ langfuse/
 - Cross-package refactors: `pnpm run lint`, `pnpm run typecheck`, and targeted
   tests for impacted packages.
 
+End your turn with evidence, not claims: paste the output of the checks you
+ran (or say which you skipped and why) — never report work as done that you
+haven't verified in this session, and never end with work pending.
+
 ## Generated Files
 
 Do not hand-edit generated or build artifacts:


### PR DESCRIPTION
## Summary

- Add a "definition of done" rule to the shared `.agents/AGENTS.md` Verification section: agents must end their turn by quoting each check's summary line (e.g. `Tasks: 8 successful, 8 total` for turbo, `Tests  12 passed (12)` for vitest), name any skipped checks, and never report unverified work as done or end the turn with work pending.
- Document single-test-file commands (`pnpm --filter web run test <file>`, worker, shared) in Core Commands so the required evidence is cheap to produce — previously the root guide only said "targeted tests" without the invocation. Both web and worker invocations were verified before documenting.
- Motivation: analysis of one week of traced agent coding sessions in the team's Langfuse project (Jun 29 – Jul 6) showed the largest real cost cluster was false or evidence-free "done" reports — e.g. "Done" with zero tool calls, completion claims listing validation commands without output, and turns ending with "I'll report back when the subagent finishes". Each incident costs a detect–verify–re-prompt cycle across multiple engineers.
- Deliberately kept to one sentence: instruction-file research and Anthropic/OpenAI guidance agree that long rule lists dilute adherence. The team's Langfuse evaluators ("Detect unproductive agent turns", "User Disagreement") will show whether this single rule moves the rate; bullets only get added for failure modes that persist.

## Linear

- None

## Major Decisions

- Placed the rule in the shared `.agents/AGENTS.md` (rather than a Claude-specific file or a Stop hook) so all three harnesses in use — Claude Code, Codex CLI, opencode — pick it up from one source. Escalation to a deterministic Stop hook stays as a follow-up if the evaluators show the prompt rule decaying.
- "Quote each check's summary line" with concrete examples acts as both floor and ceiling: it forbids the bare "Done." as well as full log dumps in final messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates `.agents/AGENTS.md` with two additions aimed at reducing evidence-free "done" reports from AI coding agents in the repo.

- Adds documented single-test-file invocations (`pnpm --filter <pkg> run test <file>`) for the `web`, `worker`, and `shared` packages to the Core Commands section, lowering the friction for agents to produce the required verification output.
- Appends a completion-evidence rule to the Verification section requiring agents to quote each check's summary line, name any skipped checks, and never close a turn with work pending or unverified claims.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no runtime code affected; safe to merge.

The only file changed is the shared agent guide. All three pnpm test invocations added match real scripts in their respective package.json files, and the new completion-evidence rule is clear, concise, and well-placed within the existing Verification section.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent completes work] --> B{Ran verification checks?}
    B -- No --> C[Run required checks\ne.g. pnpm --filter web run test file]
    C --> D{Checks pass?}
    B -- Yes --> D
    D -- Fail --> E[Fix issues, re-run checks]
    E --> D
    D -- Pass --> F[Collect summary lines\ne.g. 'Tests 12 passed 12']
    F --> G{Any checks skipped?}
    G -- Yes --> H[State skipped checks\nand reason]
    H --> I[End turn with\nevidence quoted]
    G -- No --> I
    I --> J[Turn complete ✓]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Agent completes work] --> B{Ran verification checks?}
    B -- No --> C[Run required checks\ne.g. pnpm --filter web run test file]
    C --> D{Checks pass?}
    B -- Yes --> D
    D -- Fail --> E[Fix issues, re-run checks]
    E --> D
    D -- Pass --> F[Collect summary lines\ne.g. 'Tests 12 passed 12']
    F --> G{Any checks skipped?}
    G -- Yes --> H[State skipped checks\nand reason]
    H --> I[End turn with\nevidence quoted]
    G -- No --> I
    I --> J[Turn complete ✓]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): add check summary examples..."](https://github.com/langfuse/langfuse/commit/9b9fff1d22806f7321a3d451bd05ad8ff982cf48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42064117)</sub>

<!-- /greptile_comment -->