### PR TITLE
ci: Build storybook after running tests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -326,6 +326,8 @@ jobs:
         run: pnpm --filter=web exec playwright install --with-deps --only-shell chromium
       - name: run Storybook tests
         run: pnpm --filter web run test-storybook
+      - name: build Storybook
+        run: pnpm --filter web run build-storybook
 
   tests-shared:
     timeout-minutes: 15


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `build-storybook` step at the end of the `tests-storybook` CI job, so the production static Storybook build is validated in every CI run after tests pass.

- The new step runs after `test-storybook` (Vitest browser mode, which doesn't require a pre-built artifact), providing a fast-fail order: if tests fail the expensive build is skipped.
- The step reuses the same job environment (`NODE_ENV: test`) as the rest of the `tests-storybook` job; most bundlers override `NODE_ENV` to `production` during a static build, but any application-level code that branches on `NODE_ENV === 'test'` would produce a non-production build artifact here.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a safe, additive CI change — it appends a build verification step to an existing job without touching any application code or altering job dependencies.

The change is a two-line addition to a CI workflow. It runs build-storybook after test-storybook in the same job, reusing all existing setup (node, pnpm, prisma client). The ordering ensures tests act as a fast-fail gate so the build is only attempted when tests pass.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tests-storybook job starts] --> B[checkout & install deps]
    B --> C[generate prisma client]
    C --> D[install playwright / chromium]
    D --> E[run Storybook tests\npnpm test-storybook]
    E -->|tests pass| F[build Storybook NEW\npnpm build-storybook]
    E -->|tests fail| G[job fails — build skipped]
    F -->|build succeeds| H[job passes]
    F -->|build fails| I[job fails]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[tests-storybook job starts] --> B[checkout & install deps]
    B --> C[generate prisma client]
    C --> D[install playwright / chromium]
    D --> E[run Storybook tests\npnpm test-storybook]
    E -->|tests pass| F[build Storybook NEW\npnpm build-storybook]
    E -->|tests fail| G[job fails — build skipped]
    F -->|build succeeds| H[job passes]
    F -->|build fails| I[job fails]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: Build storybook after running tests"](https://github.com/langfuse/langfuse/commit/a9fd32411051496d279d5cbda3c4b39aefb867be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42064843)</sub>

<!-- /greptile_comment -->