### PR TITLE
fix(playground): scroll to and focus new message on Add message (LFE-6864)

### DIFF
--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -38,6 +38,11 @@ import {
   useOptionalMessageSearchPageId,
 } from "./MessageSearch";
 
+export type MessageRowRefs = {
+  rowRef: RefObject<HTMLDivElement | null>;
+  editorRef: RefObject<ReactCodeMirrorRef | null>;
+};
+
 type ChatMessageProps = Pick<
   MessagesContext,
   | "deleteMessage"
@@ -45,7 +50,13 @@ type ChatMessageProps = Pick<
   | "availableRoles"
   | "toolCallIds"
   | "replaceMessage"
-> & { message: ChatMessageWithId; index: number };
+> & {
+  message: ChatMessageWithId;
+  index: number;
+  // Lets the parent ChatMessages track this row's DOM + editor refs so it can
+  // scroll to and focus a freshly added message (LFE-6864).
+  registerRow?: (id: string, refs: MessageRowRefs | null) => void;
+};
 
 const ROLES: ChatMessageRole[] = [
   ChatMessageRole.User,
@@ -94,6 +105,7 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
   availableRoles,
   index: _index,
   toolCallIds,
+  registerRow,
 }) => {
   const [roleIndex, setRoleIndex] = useState(1);
   const playgroundContext = useOptionalPlaygroundContext();
@@ -243,7 +255,19 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
     unregisterMessageTarget,
   ]);
 
+  // Keep the parent ChatMessages registry in sync so it can scroll to and
+  // focus this row when it is the newly added message (LFE-6864).
+  useEffect(() => {
+    registerRow?.(message.id, { rowRef, editorRef });
+
+    return () => {
+      registerRow?.(message.id, null);
+    };
+  }, [message.id, registerRow]);
+
   const handleEditorMount = useCallback(() => {
+    registerRow?.(message.id, { rowRef, editorRef });
+
     if (!pageId || !registerMessageTarget) {
       return;
     }
@@ -252,7 +276,7 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
       rowRef,
       editorRef,
     });
-  }, [message.id, pageId, registerMessageTarget]);
+  }, [message.id, pageId, registerMessageTarget, registerRow]);
 
   return (
     <Card

--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -256,10 +256,12 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
   ]);
 
   // Keep the parent ChatMessages registry in sync so it can scroll to and
-  // focus this row when it is the newly added message (LFE-6864).
+  // focus this row when it is the newly added message (LFE-6864). The actual
+  // registration happens in handleEditorMount once CodeMirror has mounted and
+  // editorRef.current is populated — registering here on first render would
+  // store a null editor (CodeMirror mounts async). This effect only handles
+  // unregistering the row when it unmounts.
   useEffect(() => {
-    registerRow?.(message.id, { rowRef, editorRef });
-
     return () => {
       registerRow?.(message.id, null);
     };

--- a/web/src/components/ChatMessages/index.tsx
+++ b/web/src/components/ChatMessages/index.tsx
@@ -64,13 +64,17 @@ export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
     }
   }, []);
 
-  // Scroll the newly added message into view and focus its editor so the user
-  // can type immediately (LFE-6864). Both the row and its CodeMirror editor
-  // mount asynchronously, and when the message is added from the dropdown menu
-  // the menu's own focus teardown competes with ours over several frames. So
-  // rather than guess a fixed delay, retry over a short bounded window until
+  // Scroll the newly added message into view and (by default) focus its editor
+  // so the user can type immediately (LFE-6864). Both the row and its CodeMirror
+  // editor mount asynchronously, and when the message is added from the dropdown
+  // menu the menu's own focus teardown competes with ours over several frames.
+  // So rather than guess a fixed delay, retry over a short bounded window until
   // the editor is mounted and actually holds focus (or we give up).
-  const scrollToMessage = useCallback((id: string) => {
+  //
+  // Pass focus=false to scroll only, without stealing focus into the new editor
+  // — used by programmatic append sites (e.g. GenerationOutput's "Add to
+  // messages") where yanking the caret into a fresh editor would be jarring.
+  const scrollToMessage = useCallback((id: string, focus = true) => {
     let attempts = 0;
     const maxAttempts = 20; // ~20 animation frames (< ~350ms)
 
@@ -83,6 +87,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
           behavior: "smooth",
           block: "nearest",
         });
+        if (!focus) return;
         view.focus();
         // The dropdown menu can pull focus back for a frame after closing, so
         // keep retrying until the editor is the active element.

--- a/web/src/components/ChatMessages/index.tsx
+++ b/web/src/components/ChatMessages/index.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon, PlusCircleIcon } from "lucide-react";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { Button } from "@/src/components/ui/button";
 import {
@@ -43,10 +43,13 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { isString } from "@/src/utils/types";
+import { useOptionalPlaygroundContext } from "@/src/features/playground/page/context";
 
 type ChatMessagesProps = MessagesContext;
 export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
   const { messages } = props;
+  const playgroundContext = useOptionalPlaygroundContext();
+  const registerScrollToMessage = playgroundContext?.registerScrollToMessage;
 
   // Registry of the DOM row + editor refs for each message, keyed by id.
   // Populated by each ChatMessageComponent so that after a new message is
@@ -93,6 +96,18 @@ export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
 
     requestAnimationFrame(attempt);
   }, []);
+
+  // Expose scrollToMessage to the playground context so append sites other than
+  // AddMessageButton (e.g. GenerationOutput's "Add to messages") can scroll the
+  // newly appended message into view too (LFE-6864). No-op outside the
+  // playground (e.g. the New Prompt chat editor), where the context is absent.
+  useEffect(() => {
+    if (!registerScrollToMessage) return;
+    registerScrollToMessage(scrollToMessage);
+    return () => {
+      registerScrollToMessage(null);
+    };
+  }, [registerScrollToMessage, scrollToMessage]);
 
   const sensors = useSensors(
     useSensor(MouseSensor, {}),
@@ -168,6 +183,13 @@ const AddMessageButton: React.FC<AddMessageButtonProps> = ({
   addMessage,
   scrollToMessage,
 }) => {
+  // Tracks whether the role dropdown is closing because a menu item was
+  // selected (vs. Escape / click-outside). Only then do we suppress Radix's
+  // focus-return to the trigger, so our scrollToMessage can focus the new
+  // editor. On dismissal we let Radix return focus to the trigger button per
+  // the WAI-ARIA menu button pattern (LFE-6864).
+  const selectedViaItemRef = useRef(false);
+
   // Skip placeholder messages when determining last roles
   const lastMessageWithRole = messages
     .slice()
@@ -199,6 +221,9 @@ const AddMessageButton: React.FC<AddMessageButtonProps> = ({
   };
 
   const addMessageWithRole = (role: ChatMessageRole) => {
+    // A menu item was selected: keep focus on the editor we're about to focus
+    // rather than letting Radix return it to the trigger on close.
+    selectedViaItemRef.current = true;
     let newMessage: ChatMessageWithId;
     switch (role) {
       case ChatMessageRole.User:
@@ -276,10 +301,19 @@ const AddMessageButton: React.FC<AddMessageButtonProps> = ({
           </DropdownMenuTrigger>
           <DropdownMenuContent
             align="end"
-            // Let the newly added message's editor keep focus: without this,
-            // Radix restores focus to the trigger button on close, stealing it
-            // back from the editor we focus after appending (LFE-6864).
-            onCloseAutoFocus={(event) => event.preventDefault()}
+            // When a menu item was selected, let the newly added message's
+            // editor keep focus: without this, Radix restores focus to the
+            // trigger button on close, stealing it back from the editor we
+            // focus after appending. On Escape / click-outside we leave Radix's
+            // default focus-return to the trigger intact so keyboard users
+            // aren't dropped onto <body> (WAI-ARIA menu button pattern,
+            // LFE-6864).
+            onCloseAutoFocus={(event) => {
+              if (selectedViaItemRef.current) {
+                event.preventDefault();
+                selectedViaItemRef.current = false;
+              }
+            }}
           >
             <DropdownMenuItem
               onClick={() => addMessageWithRole(ChatMessageRole.User)}

--- a/web/src/components/ChatMessages/index.tsx
+++ b/web/src/components/ChatMessages/index.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon, PlusCircleIcon } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useCallback, useRef } from "react";
 
 import { Button } from "@/src/components/ui/button";
 import {
@@ -20,7 +20,10 @@ import {
   type ChatMessageWithId,
 } from "@langfuse/shared";
 
-import { ChatMessageComponent } from "./ChatMessageComponent";
+import {
+  ChatMessageComponent,
+  type MessageRowRefs,
+} from "./ChatMessageComponent";
 
 import type { MessagesContext } from "./types";
 import {
@@ -44,17 +47,52 @@ import { isString } from "@/src/utils/types";
 type ChatMessagesProps = MessagesContext;
 export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
   const { messages } = props;
-  const scrollAreaRef = useRef<HTMLDivElement | null>(null);
-  const prevMessageCount = useRef(0);
 
-  // Scroll to bottom when new messages are added
-  useEffect(() => {
-    if (prevMessageCount.current < messages.length && scrollAreaRef.current) {
-      const scrollElement = scrollAreaRef.current;
-      scrollElement.scrollTop = scrollElement.scrollHeight;
+  // Registry of the DOM row + editor refs for each message, keyed by id.
+  // Populated by each ChatMessageComponent so that after a new message is
+  // appended we can scroll it into view and focus its editor (LFE-6864).
+  const rowRefsById = useRef(new Map<string, MessageRowRefs>());
+
+  const registerRow = useCallback((id: string, refs: MessageRowRefs | null) => {
+    if (refs) {
+      rowRefsById.current.set(id, refs);
+    } else {
+      rowRefsById.current.delete(id);
     }
-    prevMessageCount.current = messages.length;
-  }, [scrollAreaRef, messages.length]);
+  }, []);
+
+  // Scroll the newly added message into view and focus its editor so the user
+  // can type immediately (LFE-6864). Both the row and its CodeMirror editor
+  // mount asynchronously, and when the message is added from the dropdown menu
+  // the menu's own focus teardown competes with ours over several frames. So
+  // rather than guess a fixed delay, retry over a short bounded window until
+  // the editor is mounted and actually holds focus (or we give up).
+  const scrollToMessage = useCallback((id: string) => {
+    let attempts = 0;
+    const maxAttempts = 20; // ~20 animation frames (< ~350ms)
+
+    const attempt = () => {
+      const refs = rowRefsById.current.get(id);
+      const view = refs?.editorRef.current?.view;
+
+      if (view) {
+        refs?.rowRef.current?.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
+        view.focus();
+        // The dropdown menu can pull focus back for a frame after closing, so
+        // keep retrying until the editor is the active element.
+        if (view.hasFocus) return;
+      }
+
+      if (attempts++ < maxAttempts) {
+        requestAnimationFrame(attempt);
+      }
+    };
+
+    requestAnimationFrame(attempt);
+  }, []);
 
   const sensors = useSensors(
     useSensor(MouseSensor, {}),
@@ -87,7 +125,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
       sensors={sensors}
     >
       <div className="flex h-full flex-col">
-        <div className="flex-1 overflow-auto scroll-smooth" ref={scrollAreaRef}>
+        <div className="flex-1 overflow-auto scroll-smooth">
           <div className="flex-1 space-y-2">
             <SortableContext
               items={props.messages.map((message) => message.id)}
@@ -104,12 +142,13 @@ export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
                     replaceMessage={props.replaceMessage}
                     availableRoles={props.availableRoles}
                     toolCallIds={props.toolCallIds}
+                    registerRow={registerRow}
                   />
                 );
               })}
             </SortableContext>
             <div className="mb-4 py-3">
-              <AddMessageButton {...props} />
+              <AddMessageButton {...props} scrollToMessage={scrollToMessage} />
             </div>
           </div>
         </div>
@@ -118,10 +157,16 @@ export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
   );
 };
 
-type AddMessageButtonProps = Pick<MessagesContext, "messages" | "addMessage">;
+type AddMessageButtonProps = Pick<
+  MessagesContext,
+  "messages" | "addMessage"
+> & {
+  scrollToMessage: (id: string) => void;
+};
 const AddMessageButton: React.FC<AddMessageButtonProps> = ({
   messages,
   addMessage,
+  scrollToMessage,
 }) => {
   // Skip placeholder messages when determining last roles
   const lastMessageWithRole = messages
@@ -138,53 +183,54 @@ const AddMessageButton: React.FC<AddMessageButtonProps> = ({
       : ChatMessageRole.User;
 
   const addRegularMessage = () => {
-    if (nextMessageRole === ChatMessageRole.User) {
-      addMessage({
-        role: nextMessageRole,
-        content: "",
-        type: ChatMessageType.User,
-      });
-    } else {
-      addMessage({
-        role: nextMessageRole,
-        content: "",
-        type: ChatMessageType.AssistantText,
-      });
-    }
+    const newMessage =
+      nextMessageRole === ChatMessageRole.User
+        ? addMessage({
+            role: nextMessageRole,
+            content: "",
+            type: ChatMessageType.User,
+          })
+        : addMessage({
+            role: nextMessageRole,
+            content: "",
+            type: ChatMessageType.AssistantText,
+          });
+    scrollToMessage(newMessage.id);
   };
 
   const addMessageWithRole = (role: ChatMessageRole) => {
+    let newMessage: ChatMessageWithId;
     switch (role) {
       case ChatMessageRole.User:
-        addMessage({
+        newMessage = addMessage({
           role: ChatMessageRole.User,
           content: "",
           type: ChatMessageType.User,
         });
         break;
       case ChatMessageRole.Assistant:
-        addMessage({
+        newMessage = addMessage({
           role: ChatMessageRole.Assistant,
           content: "",
           type: ChatMessageType.AssistantText,
         });
         break;
       case ChatMessageRole.System:
-        addMessage({
+        newMessage = addMessage({
           role: ChatMessageRole.System,
           content: "",
           type: ChatMessageType.System,
         });
         break;
       case ChatMessageRole.Developer:
-        addMessage({
+        newMessage = addMessage({
           role: ChatMessageRole.Developer,
           content: "",
           type: ChatMessageType.Developer,
         });
         break;
       case ChatMessageRole.Tool:
-        addMessage({
+        newMessage = addMessage({
           role: ChatMessageRole.Tool,
           content: "",
           type: ChatMessageType.ToolResult,
@@ -193,14 +239,17 @@ const AddMessageButton: React.FC<AddMessageButtonProps> = ({
         break;
       default:
         addRegularMessage();
+        return;
     }
+    scrollToMessage(newMessage.id);
   };
 
   const addPlaceholderMessage = () => {
-    addMessage({
+    const newMessage = addMessage({
       type: ChatMessageType.Placeholder,
       name: "",
     });
+    scrollToMessage(newMessage.id);
   };
 
   return (
@@ -225,7 +274,13 @@ const AddMessageButton: React.FC<AddMessageButtonProps> = ({
               <ChevronDownIcon size={14} />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
+          <DropdownMenuContent
+            align="end"
+            // Let the newly added message's editor keep focus: without this,
+            // Radix restores focus to the trigger button on close, stealing it
+            // back from the editor we focus after appending (LFE-6864).
+            onCloseAutoFocus={(event) => event.preventDefault()}
+          >
             <DropdownMenuItem
               onClick={() => addMessageWithRole(ChatMessageRole.User)}
             >

--- a/web/src/features/playground/page/components/GenerationOutput.tsx
+++ b/web/src/features/playground/page/components/GenerationOutput.tsx
@@ -12,8 +12,14 @@ export const GenerationOutput = () => {
   const [isAdded, setIsAdded] = useState(false);
   const [isJson, setIsJson] = useState(false);
   const scrollAreaRef = useRef<HTMLDivElement | null>(null);
-  const { output, outputReasoning, outputJson, addMessage, outputToolCalls } =
-    usePlaygroundContext();
+  const {
+    output,
+    outputReasoning,
+    outputJson,
+    addMessage,
+    outputToolCalls,
+    scrollToMessage,
+  } = usePlaygroundContext();
 
   const handleCopy = () => {
     setIsCopied(true);
@@ -24,20 +30,22 @@ export const GenerationOutput = () => {
 
   const handleAddAssistantMessage = () => {
     setIsAdded(true);
-    if (outputToolCalls.length > 0) {
-      addMessage({
-        type: ChatMessageType.AssistantToolCall,
-        role: ChatMessageRole.Assistant,
-        content: output,
-        toolCalls: outputToolCalls,
-      });
-    } else {
-      addMessage({
-        type: ChatMessageType.AssistantText,
-        role: ChatMessageRole.Assistant,
-        content: output,
-      });
-    }
+    const newMessage =
+      outputToolCalls.length > 0
+        ? addMessage({
+            type: ChatMessageType.AssistantToolCall,
+            role: ChatMessageRole.Assistant,
+            content: output,
+            toolCalls: outputToolCalls,
+          })
+        : addMessage({
+            type: ChatMessageType.AssistantText,
+            role: ChatMessageRole.Assistant,
+            content: output,
+          });
+    // Scroll the appended assistant message into view; unlike the button path
+    // we don't steal focus for a programmatic add (LFE-6864).
+    scrollToMessage(newMessage.id);
     setTimeout(() => setIsAdded(false), 1000);
   };
 

--- a/web/src/features/playground/page/components/GenerationOutput.tsx
+++ b/web/src/features/playground/page/components/GenerationOutput.tsx
@@ -43,9 +43,12 @@ export const GenerationOutput = () => {
             role: ChatMessageRole.Assistant,
             content: output,
           });
-    // Scroll the appended assistant message into view; unlike the button path
-    // we don't steal focus for a programmatic add (LFE-6864).
-    scrollToMessage(newMessage.id);
+    // Scroll the appended row into view without stealing focus: this is a
+    // programmatic add from the Output panel, so unlike the Add-message button
+    // path (focus=true) we shouldn't yank the caret into the new editor. For a
+    // tool-call add, addMessage returns the last appended row (the final
+    // ToolResult placeholder), so we reveal the newest content (LFE-6864).
+    scrollToMessage(newMessage.id, false);
     setTimeout(() => setIsAdded(false), 1000);
   };
 

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -79,9 +79,12 @@ type PlaygroundContextType = {
   // owns the row/editor registry and registers its scroll helper here; append
   // sites outside AddMessageButton (e.g. GenerationOutput's "Add to messages")
   // call scrollToMessage so the new row lands in view rather than below the
-  // fold.
-  scrollToMessage: (id: string) => void;
-  registerScrollToMessage: (fn: ((id: string) => void) | null) => void;
+  // fold. Pass focus=false to scroll without stealing focus into the new
+  // editor (the default true keeps the Add-message button focusing behavior).
+  scrollToMessage: (id: string, focus?: boolean) => void;
+  registerScrollToMessage: (
+    fn: ((id: string, focus?: boolean) => void) | null,
+  ) => void;
 } & ModelParamsContext &
   MessagesContext;
 
@@ -149,15 +152,17 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
   // ChatMessages registers its scroll-into-view helper here so sibling append
   // sites (e.g. GenerationOutput) can scroll a newly added message into view
   // (LFE-6864).
-  const scrollToMessageRef = useRef<((id: string) => void) | null>(null);
+  const scrollToMessageRef = useRef<
+    ((id: string, focus?: boolean) => void) | null
+  >(null);
   const registerScrollToMessage = useCallback(
-    (fn: ((id: string) => void) | null) => {
+    (fn: ((id: string, focus?: boolean) => void) | null) => {
       scrollToMessageRef.current = fn;
     },
     [],
   );
-  const scrollToMessage = useCallback((id: string) => {
-    scrollToMessageRef.current?.(id);
+  const scrollToMessage = useCallback((id: string, focus = true) => {
+    scrollToMessageRef.current?.(id, focus);
   }, []);
 
   const toolCallIds = messages.reduce((acc, m) => {
@@ -291,7 +296,12 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
           ...toolResultMessages,
         ]);
 
-        return toolCallMessage;
+        // Return the last appended row so callers scroll to the newest content:
+        // for a tool-call add we append the tool-call row plus one ToolResult
+        // placeholder per tool call, and the final placeholder is what should
+        // land in view (LFE-6864). Falls back to the tool-call row when there
+        // are no tool calls.
+        return toolResultMessages.at(-1) ?? toolCallMessage;
       } else if (message.type === ChatMessageType.Placeholder) {
         const placeholderMessage = {
           ...message,

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -74,6 +74,14 @@ type PlaygroundContextType = {
 
   handleSubmit: (streaming?: boolean) => Promise<void>;
   isStreaming: boolean;
+
+  // Scroll-into-view for a freshly appended message (LFE-6864). ChatMessages
+  // owns the row/editor registry and registers its scroll helper here; append
+  // sites outside AddMessageButton (e.g. GenerationOutput's "Add to messages")
+  // call scrollToMessage so the new row lands in view rather than below the
+  // fold.
+  scrollToMessage: (id: string) => void;
+  registerScrollToMessage: (fn: ((id: string) => void) | null) => void;
 } & ModelParamsContext &
   MessagesContext;
 
@@ -137,6 +145,20 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
     providerModelCombinations,
   } = useModelParams(windowId);
   const { registerWindow, unregisterWindow } = useWindowCoordination();
+
+  // ChatMessages registers its scroll-into-view helper here so sibling append
+  // sites (e.g. GenerationOutput) can scroll a newly added message into view
+  // (LFE-6864).
+  const scrollToMessageRef = useRef<((id: string) => void) | null>(null);
+  const registerScrollToMessage = useCallback(
+    (fn: ((id: string) => void) | null) => {
+      scrollToMessageRef.current = fn;
+    },
+    [],
+  );
+  const scrollToMessage = useCallback((id: string) => {
+    scrollToMessageRef.current?.(id);
+  }, []);
 
   const toolCallIds = messages.reduce((acc, m) => {
     if (m.type === ChatMessageType.AssistantToolCall) {
@@ -712,6 +734,8 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
         outputToolCalls,
         handleSubmit,
         isStreaming,
+        scrollToMessage,
+        registerScrollToMessage,
 
         availableProviders,
         availableModels,


### PR DESCRIPTION
## TL;DR
In the Playground, clicking **Add message** with a long system prompt did nothing visible — the new input was appended far below the fold and the view didn't move. Now, after adding a message (any role, plus Placeholder), the new input **scrolls into view and is focused**, so you can type immediately. Because `ChatMessages` is shared, this also fixes the **New Prompt (chat) editor**.

Fixes LFE-6864.

## Why
There was already a "scroll to bottom on new message" effect in `ChatMessages`, but it was effectively a no-op. Two root causes:

1. **Wrong scroll strategy / timing.** It set `scrollAreaRef.scrollTop = scrollElement.scrollHeight` synchronously in a `useEffect`. The freshly-appended row hosts a CodeMirror editor that mounts *asynchronously*, so `scrollHeight` was read before the new row had laid out — and in the Prompt editor the inner `overflow-auto` div isn't even the element that scrolls (an outer container does), so writing its `scrollTop` did nothing at all.
2. **No focus.** The add handlers discarded the new message returned by `addMessage`, so there was no way to target the new row for focus.

## What
- `ChatMessages` keeps a small registry of each message's row + editor refs (populated by `ChatMessageComponent`, reusing the refs it already holds).
- After `addMessage` returns the new message, a `scrollToMessage(id)` helper `scrollIntoView({ block: "nearest" })`s the new row and focuses its editor. It runs on `requestAnimationFrame` and **retries over a short bounded window** until the editor is mounted and actually holds focus — robust against the async editor mount without guessing a fixed delay.
- The role dropdown additionally prevents Radix's close-time focus restoration (`onCloseAutoFocus`) so focus can land on the new editor instead of snapping back to the trigger.

## Result
Add via the **Message** button, the **role dropdown** (User/Assistant/System/Developer/Tool), and **Placeholder** all scroll the new input into view and focus it. Verified live in the browser for every path; the shared New Prompt (chat) editor behaves the same.

<details>
<summary>Verification detail</summary>

Driven in a real browser against a long system prompt:

- **Message button:** new editor focused (active element inside the new `.cm-editor`) and within the viewport.
- **Dropdown roles (System, Assistant, …):** new editor focused + in view. Without the `onCloseAutoFocus` guard + focus retry, focus fell back to the popover then `<body>` — now it lands on the editor.
- **Placeholder:** new editor focused + in view.
- **New Prompt (chat) editor:** typing after Add lands the caret in the new message's editor, which is scrolled into view.

Lint / typecheck / prettier all clean (pre-commit `turbo run lint` across all packages passed).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the \"Add message\" scroll-and-focus behavior in the Playground's `ChatMessages` component. The previous approach was a no-op because it set `scrollTop` synchronously before CodeMirror had laid out, and the outer container did not scroll anyway.

- Replaces the broken `scrollTop` effect with a ref registry (`rowRefsById` Map) populated by each `ChatMessageComponent` via a new `registerRow` prop; a bounded `requestAnimationFrame` retry loop in `scrollToMessage` handles the asynchronous CodeMirror mount and Radix focus teardown competition.
- Captures the return value of `addMessage` in all three add paths (regular button, role dropdown, placeholder) and calls `scrollToMessage(newMessage.id)` so the new row scrolls into view and its editor receives focus.
- Adds `onCloseAutoFocus={(e) => e.preventDefault()}` to the role dropdown to prevent Radix from stealing focus back to the trigger after an item is selected — however this prevention fires on all closes (including Escape/click-outside), dropping keyboard focus to `<body>`.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core scroll-and-focus fix works correctly, but the blanket onCloseAutoFocus suppression introduces a keyboard accessibility regression on the role dropdown.

The retry-loop and ref-registry approach is well-designed and resolves the stated bug. However, onCloseAutoFocus fires unconditionally: a keyboard user who opens the dropdown and presses Escape without selecting a role now loses focus entirely instead of returning to the trigger button.

web/src/components/ChatMessages/index.tsx — specifically the DropdownMenuContent onCloseAutoFocus handler.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant AddMessageButton
    participant ChatMessages
    participant ChatMessageComponent
    participant CodeMirror

    User->>AddMessageButton: clicks Message or role dropdown item
    AddMessageButton->>ChatMessages: addMessage returns newMessage
    AddMessageButton->>ChatMessages: scrollToMessage(newMessage.id)
    Note over ChatMessages: requestAnimationFrame(attempt)
    ChatMessages->>ChatMessageComponent: render with registerRow
    ChatMessageComponent->>ChatMessages: registerRow useEffect editorRef null
    ChatMessageComponent->>CodeMirror: mount editor
    CodeMirror-->>ChatMessageComponent: onEditorMount
    ChatMessageComponent->>ChatMessages: registerRow editorRef populated
    loop rAF retry up to 21 frames
        ChatMessages->>ChatMessages: check editorRef.current.view
        ChatMessages->>ChatMessageComponent: scrollIntoView nearest
        ChatMessages->>CodeMirror: view.focus
        alt view.hasFocus
            ChatMessages->>ChatMessages: return done
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant AddMessageButton
    participant ChatMessages
    participant ChatMessageComponent
    participant CodeMirror

    User->>AddMessageButton: clicks Message or role dropdown item
    AddMessageButton->>ChatMessages: addMessage returns newMessage
    AddMessageButton->>ChatMessages: scrollToMessage(newMessage.id)
    Note over ChatMessages: requestAnimationFrame(attempt)
    ChatMessages->>ChatMessageComponent: render with registerRow
    ChatMessageComponent->>ChatMessages: registerRow useEffect editorRef null
    ChatMessageComponent->>CodeMirror: mount editor
    CodeMirror-->>ChatMessageComponent: onEditorMount
    ChatMessageComponent->>ChatMessages: registerRow editorRef populated
    loop rAF retry up to 21 frames
        ChatMessages->>ChatMessages: check editorRef.current.view
        ChatMessages->>ChatMessageComponent: scrollIntoView nearest
        ChatMessages->>CodeMirror: view.focus
        alt view.hasFocus
            ChatMessages->>ChatMessages: return done
        end
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/ChatMessages/index.tsx:277-283
**`onCloseAutoFocus` blanket prevention breaks keyboard dismiss**

`onCloseAutoFocus` fires on every close — including when the user presses Escape or clicks outside without selecting an item. In those cases Radix's default focus-return to the trigger is prevented, so focus is silently dropped to `<body>`. A keyboard user who opens the dropdown and reconsiders (Escape) now has no focused element and must Tab through the whole page to get back to the button.

The fix would be to only suppress the default when an add-message action actually ran. One approach: track a flag (`didAddMessage`) that is set in the `onClick` handler and cleared in `onCloseAutoFocus`, then call `event.preventDefault()` only when that flag is true.

### Issue 2 of 2
web/src/components/ChatMessages/ChatMessageComponent.tsx:260-266
**Initial `registerRow` call passes refs before the editor has mounted**

The `useEffect` runs after the first render and registers `{ rowRef, editorRef }` immediately, but at that point `editorRef.current` is still `null` because CodeMirror hasn't mounted yet. The `handleEditorMount` callback then re-registers with the populated ref. The retry loop in `scrollToMessage` compensates for this, but the initial registration is functionally a no-op and only adds noise to the map. Consider registering only from `handleEditorMount` (and keeping the cleanup in the `useEffect`) to make the flow cleaner and avoid relying on the retry to cover the window where `editorRef.current === null`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(playground): scroll to and focus new..."](https://github.com/langfuse/langfuse/commit/2705c9e5086252a55da29717959f78d08c4d969b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42067769)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->