### PR TITLE
chore(web): Fix sentry deprecation warnings

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -268,11 +268,6 @@ const sentryConfig = withSentryConfig(nextConfig, {
   // Upload a larger set of source maps for prettier stack traces (increases build time)
   widenClientFileUpload: true,
 
-  // Automatically annotate React components to show their full name in breadcrumbs and session replay
-  reactComponentAnnotation: {
-    enabled: true,
-  },
-
   // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
   // This can increase your server load as well as your hosting bill.
   // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
@@ -284,14 +279,23 @@ const sentryConfig = withSentryConfig(nextConfig, {
     disable: true,
   },
 
-  // Automatically tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
-
   // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
   // See the following for more information:
   // https://docs.sentry.io/product/crons/
   // https://vercel.com/docs/cron-jobs
   automaticVercelMonitors: false,
-});
+
+  webpack: {
+    // Automatically annotate React components to show their full name in breadcrumbs and session replay.
+    reactComponentAnnotation: {
+      enabled: true,
+    },
+
+    // Automatically tree-shake Sentry logger statements to reduce bundle size.
+    treeshake: {
+      removeDebugLogging: true,
+    },
+  },
+  });
 
 export default sentryConfig;


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Sentry deprecation warnings in `web/next.config.mjs` by migrating two deprecated top-level `withSentryConfig` options to their new `webpack`-namespaced equivalents in the `@sentry/nextjs` v8+ API.

- `disableLogger: true` is replaced by `webpack.treeshake.removeDebugLogging: true`, and `reactComponentAnnotation` is moved from the top level into `webpack.reactComponentAnnotation`. Both are confirmed correct placements per the Sentry Next.js v8 documentation.
- `automaticVercelMonitors: false` correctly remains at the top level (not inside `webpack`).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change correctly migrates two deprecated Sentry options to their new webpack-namespaced form with no functional regression.

Both moved options land in the correct `webpack` sub-object per the Sentry Next.js v8 docs, `automaticVercelMonitors` stays at the top level where it belongs, and the only remaining nit is a two-space indentation on the closing `});`.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[withSentryConfig options] --> B[Top-level options]
    A --> C[webpack namespace]
    B --> D[org / project / authToken]
    B --> E[widenClientFileUpload]
    B --> F[sourcemaps.disable]
    B --> G[automaticVercelMonitors: false]
    C --> H[reactComponentAnnotation.enabled]
    C --> I[treeshake.removeDebugLogging]
    style C fill:#d4edda,stroke:#28a745
    style H fill:#d4edda,stroke:#28a745
    style I fill:#d4edda,stroke:#28a745
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[withSentryConfig options] --> B[Top-level options]
    A --> C[webpack namespace]
    B --> D[org / project / authToken]
    B --> E[widenClientFileUpload]
    B --> F[sourcemaps.disable]
    B --> G[automaticVercelMonitors: false]
    C --> H[reactComponentAnnotation.enabled]
    C --> I[treeshake.removeDebugLogging]
    style C fill:#d4edda,stroke:#28a745
    style H fill:#d4edda,stroke:#28a745
    style I fill:#d4edda,stroke:#28a745
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(web): Fix sentry deprecation warni..."](https://github.com/langfuse/langfuse/commit/5198a071e773d43bccc03680c4a5056bcb160227) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42075786)</sub>

<!-- /greptile_comment -->