### PR TITLE
chore: bump metrics v2 limits on cloud plans

### DIFF
--- a/packages/shared/src/interfaces/rate-limits.ts
+++ b/packages/shared/src/interfaces/rate-limits.ts
@@ -7,6 +7,7 @@ export const RateLimitResource = z.enum([
   "public-api",
   "public-api-legacy",
   "public-api-metrics",
+  "public-api-metrics-v2",
   "public-api-daily-metrics-legacy",
   "prompts",
   "legacy-ingestion",

--- a/web/src/__tests__/server/rate-limit.servertest.ts
+++ b/web/src/__tests__/server/rate-limit.servertest.ts
@@ -387,6 +387,48 @@ describe("RateLimitService", () => {
     }
   });
 
+  it("should apply public-api-metrics-v2 rate limits by cloud plan", async () => {
+    const cases = [
+      { plan: "cloud:hobby" as const, points: 100 },
+      { plan: "cloud:core" as const, points: 2000 },
+      { plan: "cloud:pro" as const, points: 10_000 },
+      { plan: "cloud:team" as const, points: 10_000 },
+      { plan: "cloud:enterprise" as const, points: 10_000 },
+    ];
+
+    const rateLimitService = RateLimitService.getInstance(redis);
+
+    for (const testCase of cases) {
+      await redis.del(
+        `${RATE_LIMIT_REDIS_KEY_PREFIX}:public-api-metrics-v2:${orgId}`,
+      );
+
+      const scope = {
+        orgId: orgId,
+        plan: testCase.plan,
+        projectId,
+        accessLevel: "project" as const,
+        rateLimitOverrides: [],
+      };
+
+      const result = await rateLimitService.rateLimitRequest(
+        scope,
+        "public-api-metrics-v2",
+      );
+
+      expect(result?.res).toEqual({
+        scope: scope,
+        resource: "public-api-metrics-v2",
+        points: testCase.points,
+        remainingPoints: testCase.points - 1,
+        msBeforeNext: expect.any(Number),
+        consumedPoints: 1,
+        isFirstInDuration: true,
+      });
+      expect(result?.isRateLimited()).toBe(false);
+    }
+  });
+
   it("should apply media-upload rate limits separately from ingestion", async () => {
     const scope = {
       orgId: orgId,

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -307,6 +307,12 @@ const getPlanBasedRateLimitConfig = (
             points: 100,
             durationInSec: 86400, // 100 requests per day
           };
+        case "public-api-metrics-v2":
+          return {
+            resource: "public-api-metrics-v2",
+            points: 100,
+            durationInSec: 86400, // 100 requests per day
+          };
         case "public-api-daily-metrics-legacy":
           return {
             resource: "public-api-daily-metrics-legacy",
@@ -392,6 +398,12 @@ const getPlanBasedRateLimitConfig = (
             points: 2000, // temporary: using pro limit
             durationInSec: 86400, // 2000 requests per day
           };
+        case "public-api-metrics-v2":
+          return {
+            resource: "public-api-metrics-v2",
+            points: 2000,
+            durationInSec: 86400, // 2000 requests per day
+          };
         case "public-api-daily-metrics-legacy":
           return {
             resource: "public-api-daily-metrics-legacy",
@@ -472,6 +484,12 @@ const getPlanBasedRateLimitConfig = (
             resource: "public-api-metrics",
             points: 2000,
             durationInSec: 86400, // 2000 requests per day
+          };
+        case "public-api-metrics-v2":
+          return {
+            resource: "public-api-metrics-v2",
+            points: 10_000,
+            durationInSec: 86400, // 10000 requests per day
           };
         case "public-api-daily-metrics-legacy":
           return {

--- a/web/src/pages/api/public/v2/metrics.ts
+++ b/web/src/pages/api/public/v2/metrics.ts
@@ -14,7 +14,7 @@ const DEFAULT_ROW_LIMIT = 100;
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Metrics V2",
-    rateLimitResource: "public-api-metrics", // Same rate limit as v1
+    rateLimitResource: "public-api-metrics-v2",
     querySchema: GetMetricsV2Query,
     responseSchema: GetMetricsV2Response,
     fn: async ({ query, auth }) => {


### PR DESCRIPTION
## Summary
- Add `public-api-metrics-v2` as a dedicated rate limit resource
- Route the v2 metrics endpoint to the new resource
- Cover cloud-plan-specific limits with a server test

## Testing
- Unit tests added for `RateLimitService` to verify plan-based limits for `public-api-metrics-v2`
- Not run (not requested)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR decouples the v2 metrics endpoint from the v1 `public-api-metrics` rate-limit bucket by introducing a dedicated `public-api-metrics-v2` resource, allowing independent (and higher) daily limits specifically for pro/team/enterprise cloud plans.

- **`packages/shared/src/interfaces/rate-limits.ts`**: Adds `"public-api-metrics-v2"` to the `RateLimitResource` enum, which also triggers the TypeScript exhaustive-check guard in `getPlanBasedRateLimitConfig`.
- **`web/src/features/public-api/server/RateLimitService.ts`**: Wires per-plan limits for the new resource — 100/day (hobby), 2,000/day (core), and 10,000/day (pro/team/enterprise, a 5× bump over v1).
- **`web/src/pages/api/public/v2/metrics.ts`**: Switches `rateLimitResource` from `"public-api-metrics"` to `"public-api-metrics-v2"`, and the test file adds a parametrized check covering all five cloud plan tiers.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, adds a new Redis key bucket without touching the existing v1 resource, and TypeScript's exhaustive switch guard ensures no plan branch is silently skipped.

Each cloud plan branch already has a `default: never` exhaustive check, so the new resource enum value was correctly required in all three plan sections. The v2 metrics endpoint now uses its own isolated bucket, meaning existing v1 usage is completely unaffected. Tests cover all five cloud plan tiers with the correct expected points values. No logic regressions are apparent.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add public-api-metrics-v2 rate limits"](https://github.com/langfuse/langfuse/commit/20949333160832186f26c03a5cd100dbeab0c450) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42090331)</sub>

<!-- /greptile_comment -->