### PR TITLE
ci: warm main-scoped pnpm and turbo caches on a schedule

### DIFF
--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -1,0 +1,103 @@
+name: Warm CI caches
+
+# Cross-branch cache reuse flows exclusively through caches saved on the
+# default branch: Actions caches are scoped per ref, and PR / merge-queue /
+# branch runs may only restore their own ref's caches plus main's. Full
+# pipeline runs on main are sparse (pre-job skips pushes whose tree the merge
+# queue already tested; none happen on weekends), which was fine while cache
+# retention was days — but since the Blacksmith cache-store resets of
+# 2026-07-02/03, saved caches have been observed to vanish within ~a day
+# (contradicting their documented 7-day LRU eviction), so most branch runs
+# find nothing and pay a cold pnpm install plus a cold turbo build (~+2min on
+# the tests-web critical path). This workflow re-saves the pnpm store and the
+# mode-scoped turbo caches from main every few hours so branch runs keep
+# hitting them. Once Blacksmith retention is back to days, drop the schedule
+# to daily or delete the workflow — it is purely compensatory.
+on:
+  schedule:
+    # Every 3 hours, offset from the top of the hour to dodge runner-pool
+    # congestion. Frequency chosen to stay under the observed hours-scale
+    # cache lifetime.
+    - cron: "23 */3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-caches
+
+env:
+  # Keep in sync with NODE_VERSION in pipeline.yml.
+  NODE_VERSION: 24
+
+jobs:
+  warm:
+    # Must run on Blacksmith runners: their runners store Actions caches in
+    # Blacksmith's own cache backend, which is the store the pipeline jobs
+    # restore from. A GitHub-hosted warmer would write to GitHub's store and
+    # warm nothing.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+    name: warm (mode${{ matrix.deploy-mode }})
+    env:
+      # Mirror the tests-web job env so turbo task hashes match.
+      NODE_ENV: test
+    strategy:
+      matrix:
+        deploy-mode: ["", "-azure", "-redis-cluster"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.4.0
+      - name: Use Node.js ${{ env.NODE_VERSION }} with pnpm cache
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # zizmor: ignore[cache-poisoning] scheduled cache warmer for test-job dependency caches only; runs on main, no released artifacts are built or published from this cached state
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+      - name: install dependencies
+        run: |
+          pnpm install
+      - name: Load default env
+        # Must stay byte-identical to the tests-web "Load default env" step in
+        # pipeline.yml: turbo hashes the whole .env (turbo.json
+        # globalDependencies), so any drift makes the warmed build hashes
+        # useless to tests-web.
+        run: |
+          cp .env.dev${{ matrix.deploy-mode }}.example .env
+          grep -v -e '^LANGFUSE_S3_BATCH_EXPORT_ENABLED=' -e '^NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=' .env.dev${{ matrix.deploy-mode }}.example > .env
+          echo "LANGFUSE_INGESTION_QUEUE_DELAY_MS=1" >> .env
+          echo "LANGFUSE_CACHE_PROMPT_ENABLED=false" >> .env
+          echo "LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS=1" >> .env
+          echo "LANGFUSE_TRACE_DELETE_DELAY_MS=1" >> .env
+          echo "LANGFUSE_TRACE_DELETE_CONCURRENCY=100" >> .env
+          echo "ADMIN_API_KEY=admin-api-key" >> .env
+          echo "LANGFUSE_EE_LICENSE_KEY=langfuse_ee_test" >> .env
+          echo "LANGFUSE_SKIP_EVALUATOR_MODEL_CALL_VALIDATION=true" >> .env
+          echo "LANGFUSE_ENABLE_SCORES_V3_API=true" >> .env
+      - name: Setup Turbo cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # zizmor: ignore[cache-poisoning] scheduled cache warmer for test-job turbo caches only; runs on main, publish jobs rebuild artifacts and do not restore this cache
+        with:
+          path: .turbo
+          # Same key shape as the tests-web "Setup Turbo cache" step so branch
+          # runs restore these archives via their restore-keys prefix.
+          key: ${{ runner.os }}-turbo-mode${{ matrix.deploy-mode == '' && '-default' || matrix.deploy-mode }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-mode${{ matrix.deploy-mode == '' && '-default' || matrix.deploy-mode }}-
+      - name: Build
+        # dev containers / Postgres are not needed: the build task only
+        # depends on db:generate, which is offline.
+        run: pnpm run build
+        env:
+          NODE_OPTIONS: --max_old_space_size=8192
+          # TypeScript is checked explicitly in the lint job; skip duplicate
+          # Next.js type checks to keep the warmer cheap (mirrors tests-web).
+          NEXT_IGNORE_BUILD_ERRORS: "true"
+      - name: Prune stale turbo cache entries
+        # Each run saves the restored archive plus new entries, so the cache
+        # grows without bound unless old entries are dropped before the save.
+        run: find .turbo/cache -type f -mtime +3 -delete 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Adds a scheduled workflow (`warm-caches.yml`, every 3h + `workflow_dispatch`) that runs on `main` on Blacksmith runners and re-saves the pnpm store cache and the three mode-scoped turbo caches. Cross-branch cache reuse flows exclusively through main-scoped caches, and full main pipeline runs are sparse (pre-job skips trees the merge queue already tested; none on weekends) — which was fine while cache retention was days.
- Since the Blacksmith cache-store resets of Jul 2–3, saved caches vanish within ~a day (contradicting their documented 7-day LRU eviction), so most branch runs find nothing restorable and pay a cold pnpm install (+15–20s/job) plus a cold turbo build (~+2min on the tests-web critical path). Measured on identical commits: a warm rerun completes in 316s vs 454s cold. This workflow keeps the main-scope pool warm until Blacksmith fixes retention; it is purely compensatory and can be dropped to daily or deleted afterwards.

## Linear

- None

## Major Decisions

- The warmer mirrors the tests-web job's `.env` construction byte-for-byte and reuses its exact cache-key shapes — turbo hashes the whole `.env` (`globalDependencies`), so any drift would make the warmed archives useless to tests-web. A comment marks the copy-sync requirement.
- No dev containers/Postgres: `build` only depends on `db:generate`, which is offline — keeps the warmer at ~5min/job.
- Runs on Blacksmith runners deliberately: their runners store Actions caches in Blacksmith's backend, which is what pipeline jobs restore from; a GitHub-hosted warmer would warm the wrong store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a new scheduled workflow (`warm-caches.yml`) that runs every 3 hours on Blacksmith runners to re-save the pnpm store and three mode-scoped turbo caches, working around an observed Blacksmith cache-store regression (caches vanishing within ~1 day instead of the documented 7-day LRU). The workflow is correctly scoped to `main`, uses the same runner type as the pipeline, and mirrors the `tests-web` env construction byte-for-byte to ensure turbo task hashes match.

- The `Load default env` step and turbo cache key shapes are exact copies of `tests-web` in `pipeline.yml`, which is critical for cache hit alignment since turbo hashes the full `.env`.
- The `concurrency` group (without `cancel-in-progress`) and the `workflow_dispatch` trigger are well-suited to the compensatory-until-fixed intent described in the PR.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the workflow is additive and purely compensatory. The single issue (missing fail-fast: false) would leave some modes un-warmed on a transient failure but does not break any existing jobs.

The env construction and cache key shapes are correctly mirrored from tests-web. The one gap — fail-fast defaults to true, so a failure in any one matrix deploy-mode cancels the other two before they can save their caches — partially defeats the warmer's purpose on flaky runs.

.github/workflows/warm-caches.yml — specifically the strategy block missing fail-fast: false.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant S as Scheduler (every 3h)
    participant W as warm-caches.yml (main)
    participant BC as Blacksmith Cache Store
    participant PR as Branch / PR Runs

    S->>W: Trigger (schedule / workflow_dispatch)
    Note over W: 3 parallel matrix jobs (default / -azure / -redis-cluster)
    W->>W: checkout + pnpm install
    W->>BC: Save pnpm store cache
    W->>W: Load default env (byte-identical to tests-web)
    W->>W: pnpm run build (turbo)
    W->>W: "Prune stale .turbo entries (>3 days)"
    W->>BC: "Save turbo cache (mode-scoped key @ main SHA)"
    PR->>BC: Restore pnpm cache (restore-key matches main)
    PR->>BC: Restore turbo cache (restore-key prefix matches main)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant S as Scheduler (every 3h)
    participant W as warm-caches.yml (main)
    participant BC as Blacksmith Cache Store
    participant PR as Branch / PR Runs

    S->>W: Trigger (schedule / workflow_dispatch)
    Note over W: 3 parallel matrix jobs (default / -azure / -redis-cluster)
    W->>W: checkout + pnpm install
    W->>BC: Save pnpm store cache
    W->>W: Load default env (byte-identical to tests-web)
    W->>W: pnpm run build (turbo)
    W->>W: "Prune stale .turbo entries (>3 days)"
    W->>BC: "Save turbo cache (mode-scoped key @ main SHA)"
    PR->>BC: Restore pnpm cache (restore-key matches main)
    PR->>BC: Restore turbo cache (restore-key prefix matches main)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/warm-caches.yml:46-48
Missing `fail-fast: false` on the matrix strategy means a transient build failure in any one deploy-mode will cancel the remaining matrix jobs before they can save their caches. Since the entire point of this workflow is to warm all three mode-scoped turbo archives, a flaky `-azure` or `-redis-cluster` run would silently leave the other modes cold until the next scheduled tick 3 hours later.

```suggestion
    strategy:
      fail-fast: false
      matrix:
        deploy-mode: ["", "-azure", "-redis-cluster"]
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: warm main-scoped pnpm and turbo cach..."](https://github.com/langfuse/langfuse/commit/797719754f333025328010f6872e194754216c0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42114524)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->