### PR TITLE
ci: unpin pnpm version in cache warmer

### DIFF
--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -44,15 +44,20 @@ jobs:
       # Mirror the tests-web job env so turbo task hashes match.
       NODE_ENV: test
     strategy:
+      # One mode failing must not cancel the other warmers — a partially
+      # warmed pool still helps.
+      fail-fast: false
       matrix:
         deploy-mode: ["", "-azure", "-redis-cluster"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      # No pinned version on purpose: the action reads "packageManager" from
+      # package.json, so pnpm bumps that update pipeline.yml cannot strand
+      # this satellite workflow on a mismatched pin (which hard-fails the
+      # action, as the 2026-07-06 11.4.0→11.10.0 bump did).
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 11.4.0
       - name: Use Node.js ${{ env.NODE_VERSION }} with pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # zizmor: ignore[cache-poisoning] scheduled cache warmer for test-job dependency caches only; runs on main, no released artifacts are built or published from this cached state
         with:


### PR DESCRIPTION
## Summary

- The first scheduled run of the cache warmer ([28816154865](https://github.com/langfuse/langfuse/actions/runs/28816154865)) failed: its pinned pnpm `11.4.0` raced the `11.10.0` bump (#14806) that merged minutes before #14820, and `pnpm/action-setup` hard-fails when the pinned version disagrees with `packageManager` in `package.json`. Fail-fast then cancelled the two sibling mode jobs.
- Drop the pin so the action follows `packageManager` — future pnpm bumps that update `pipeline.yml` can no longer strand this satellite workflow — and set `fail-fast: false` so one mode's failure keeps the other warmers running (a partially warmed pool still helps).

## Linear

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a scheduled cache-warmer workflow that broke when `pnpm` was bumped from `11.4.0` to `11.10.0` in `package.json`, because the hard-pinned version in `warm-caches.yml` no longer matched and `pnpm/action-setup` hard-fails on a mismatch. The fix drops the explicit `version:` pin so the action falls back to reading `packageManager` from `package.json`, and adds `fail-fast: false` so a single matrix mode's failure no longer cancels the other warmers.

- **Removes `version: 11.4.0` pin** from `pnpm/action-setup`, relying on `packageManager` in `package.json` so future pnpm bumps cannot strand this satellite workflow.
- **Adds `fail-fast: false`** to the matrix strategy so the three deploy-mode warmers (`""`, `-azure`, `-redis-cluster`) run independently — a partial cache warm is still useful even if one mode fails.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are minimal, well-explained, and directly fix a race condition between a pinned pnpm version and a recent package.json bump.

Removing the hardcoded pnpm version pin and adding fail-fast: false are both low-risk, targeted fixes. The action commit is still pinned to a specific hash for supply-chain safety. Dropping the version: field is the documented way to delegate to packageManager in package.json, which means the warmer stays in sync with the rest of the pipeline automatically going forward. No logic, security, or correctness issues were found.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pnpm/action-setup runs\n(no version: pin)"] --> B{"packageManager\nin package.json?"}
    B -- "Yes\ne.g. pnpm@11.10.0" --> C["Install that pnpm version"]
    B -- "No" --> D["Use action default\n(latest stable)"]
    C --> E["matrix: deploy-mode=''\nwarm cache"]
    C --> F["matrix: deploy-mode='-azure'\nwarm cache"]
    C --> G["matrix: deploy-mode='-redis-cluster'\nwarm cache"]
    E -- "fail-fast: false" --> H{"One mode fails?"}
    F -- "fail-fast: false" --> H
    G -- "fail-fast: false" --> H
    H -- "Yes" --> I["Other modes continue\nPartial cache still helps"]
    H -- "No" --> J["All three caches warmed"]
    style I fill:#f9f,stroke:#333
    style J fill:#9f9,stroke:#333
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["pnpm/action-setup runs\n(no version: pin)"] --> B{"packageManager\nin package.json?"}
    B -- "Yes\ne.g. pnpm@11.10.0" --> C["Install that pnpm version"]
    B -- "No" --> D["Use action default\n(latest stable)"]
    C --> E["matrix: deploy-mode=''\nwarm cache"]
    C --> F["matrix: deploy-mode='-azure'\nwarm cache"]
    C --> G["matrix: deploy-mode='-redis-cluster'\nwarm cache"]
    E -- "fail-fast: false" --> H{"One mode fails?"}
    F -- "fail-fast: false" --> H
    G -- "fail-fast: false" --> H
    H -- "Yes" --> I["Other modes continue\nPartial cache still helps"]
    H -- "No" --> J["All three caches warmed"]
    style I fill:#f9f,stroke:#333
    style J fill:#9f9,stroke:#333
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: unpin pnpm version in cache warmer"](https://github.com/langfuse/langfuse/commit/fd93c4451fcbc46b8019aeb75d617bfb83f3e4ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42181536)</sub>

<!-- /greptile_comment -->