### PR TITLE
feat(web): enable Select Observations entry point in dataset onboarding

### DIFF
--- a/web/src/components/onboarding/DatasetItemsOnboarding.tsx
+++ b/web/src/components/onboarding/DatasetItemsOnboarding.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { SplashScreen } from "@/src/components/ui/splash-screen";
 import { Braces, Code, ListTree, Upload } from "lucide-react";
-import DocPopup from "@/src/components/layouts/doc-popup";
 import Link from "next/link";
 import {
   Dialog,
@@ -22,11 +21,6 @@ interface DatasetItemEntryPointRowProps {
   description: string;
   onClick?: () => void;
   hasAccess?: boolean;
-  comingSoon?: boolean;
-  docPopup?: {
-    description: string;
-    href: string;
-  };
 }
 
 const DatasetItemEntryPointRow = ({
@@ -35,10 +29,8 @@ const DatasetItemEntryPointRow = ({
   description,
   onClick,
   hasAccess = true,
-  comingSoon = false,
-  docPopup,
 }: DatasetItemEntryPointRowProps) => {
-  const disabled = !hasAccess || comingSoon;
+  const disabled = !hasAccess;
   return (
     <div
       role="button"
@@ -70,12 +62,7 @@ const DatasetItemEntryPointRow = ({
       <div className="flex items-center">{icon}</div>
       <div className="flex flex-1 flex-col gap-1">
         <h3 className="font-semibold">{title}</h3>
-        <div className="flex items-center gap-1">
-          <p className="text-muted-foreground text-sm">{description}</p>
-          {docPopup && (
-            <DocPopup description={docPopup.description} href={docPopup.href} />
-          )}
-        </div>
+        <p className="text-muted-foreground text-sm">{description}</p>
       </div>
     </div>
   );
@@ -165,17 +152,16 @@ export const DatasetItemsOnboarding = ({
           />
         </Link>
 
-        <DatasetItemEntryPointRow
-          icon={<ListTree className="h-5 w-5" />}
-          title="Select Traces"
-          description="Coming soon!"
-          comingSoon
-          docPopup={{
-            description:
-              "Creating items from production data is supported on single trace level. Click to view docs for more details.",
-            href: "https://langfuse.com/docs/evaluation/experiments/datasets#create-items-from-production-data",
-          }}
-        />
+        <Link href={`/project/${projectId}/observations`}>
+          <DatasetItemEntryPointRow
+            icon={<ListTree className="h-5 w-5" />}
+            title="Select Observations"
+            description="Select observations in the observations table and use a batch action to add them to your dataset"
+            onClick={() => {
+              capture("dataset_item:select_observations_button_click");
+            }}
+          />
+        </Link>
       </div>
     </SplashScreen>
   );

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -155,6 +155,7 @@ export const events = {
     "new_from_trace_form_open",
     "upload_csv_button_click",
     "upload_csv_form_submit",
+    "select_observations_button_click",
     "delete",
   ],
   dataset_run: [


### PR DESCRIPTION
## Summary
- Replaces the disabled "Select Traces" row (showing "Coming soon!" with a docs popup) on the empty "Add items to your dataset" screen with an enabled "Select Observations" row.
- New description: "Select observations in the observations table and use a batch action to add them to your dataset".
- Clicking the row now navigates to the project's Observations page (`/project/[projectId]/observations`), where users can select rows and use the existing "Add to dataset" batch action.
- Removed the now-unused `comingSoon`/`docPopup` props from the internal `DatasetItemEntryPointRow` component since no row uses them anymore.
- Registered the new `dataset_item:select_observations_button_click` PostHog event name.

## Test plan
- [x] `pnpm --filter web run typecheck`
- [x] `npx eslint` on changed files (0 warnings)
- [x] Verified in a real browser: onboarding screen shows the enabled "Select Observations" row with correct copy, and clicking it navigates to the project's Observations page which loads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the disabled "Select Traces" ("Coming soon!") entry point in the dataset onboarding screen with an enabled "Select Observations" row that navigates users to the project's Observations page. It also cleans up the now-unused `comingSoon` and `docPopup` props from the `DatasetItemEntryPointRow` component and registers the new PostHog event.

- **UI change**: The "Select Traces (Coming Soon)" row is replaced by an active "Select Observations" row that links to `/project/[projectId]/observations`, using a consistent `<Link>` wrapper pattern already established by the "Add via Code" row.
- **Component cleanup**: `comingSoon`, `docPopup`, and the `DocPopup` import are removed from `DatasetItemEntryPointRow` since no rows use them anymore, simplifying the disabled logic to just `!hasAccess`.
- **Analytics**: `select_observations_button_click` is added to the `dataset_item` event list in `usePostHogClientCapture.ts`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change enables a previously disabled navigation entry point, removes dead code, and follows existing patterns in the file.

The new 'Select Observations' row mirrors the 'Add via Code' row pattern exactly (Link wrapper + DatasetItemEntryPointRow, no RBAC gate needed since the destination page has its own access control). The dead comingSoon/docPopup props and DocPopup import are cleanly removed, and the PostHog event is correctly registered in the events list.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Onboarding as DatasetItemsOnboarding
    participant NextLink as Next.js Link
    participant PostHog
    participant Observations as ObservationsPage

    User->>Onboarding: Clicks "Select Observations" row
    Onboarding->>PostHog: capture("dataset_item:select_observations_button_click")
    Onboarding->>NextLink: Click event bubbles up
    NextLink->>Observations: Navigate to /project/[projectId]/observations
    Note over Observations: User selects rows and uses "Add to dataset" batch action
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Onboarding as DatasetItemsOnboarding
    participant NextLink as Next.js Link
    participant PostHog
    participant Observations as ObservationsPage

    User->>Onboarding: Clicks "Select Observations" row
    Onboarding->>PostHog: capture("dataset_item:select_observations_button_click")
    Onboarding->>NextLink: Click event bubbles up
    NextLink->>Observations: Navigate to /project/[projectId]/observations
    Note over Observations: User selects rows and uses "Add to dataset" batch action
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): enable Select Observations en..."](https://github.com/langfuse/langfuse/commit/6f501ca87569c27a081723b051c03e23bd257ffe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42305576)</sub>

<!-- /greptile_comment -->