### PR TITLE
fix(assistant): fix error bubble bottom spacing (LFE-10704)

### DIFF
--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -436,7 +436,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
         >
           <div
             className={cn(
-              "flex h-full w-full flex-col py-4",
+              "flex min-h-full w-full flex-col py-4",
               isExpanded && "mx-auto max-w-3xl",
               isExpanded ? "px-0" : "px-3",
             )}


### PR DESCRIPTION
## Summary
- The in-app assistant's error bubble had inconsistent spacing: ~16px above it but ~0px below it before the input box, because the message-list wrapper used `h-full`, which pins its height to the scroll viewport. Once messages overflow that height (the normal case once a conversation is long), the wrapper's own trailing bottom padding collapses instead of trailing after the last item.
- Switched the wrapper to `min-h-full` so it still centers the empty "Welcome" state when there are no messages, but grows to fit overflowing content, restoring the trailing padding.

## Test plan
- [x] Reproduced the bug in Storybook (`InAppAgentWindow` → `Error` story) with enough messages to overflow the panel; measured the gap below the error bubble collapsing to ~0px vs. ~16px above.
- [x] Applied the fix and confirmed via Storybook that the gap above and below the error bubble are now both ~16px.
- [x] Verified the `Empty` story (no messages) still centers the welcome state correctly.
- [x] `pnpm run lint` passes on the changed file.

Linear: LFE-10704

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a bottom-spacing bug in the in-app assistant's message list by replacing `h-full` with `min-h-full` on the wrapper div, allowing the container to grow beyond the scroll-viewport height so the trailing `py-4` padding is no longer collapsed when messages overflow.

- Changes `h-full` → `min-h-full` on the message-list wrapper so the container can grow past the viewport, restoring the ~16px bottom gap after the last message.
- The empty/welcome state still centers correctly because `min-h-full` keeps the parent at 100% viewport height when content is shorter than the viewport.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line Tailwind class swap with a clearly correct fix and no side effects on other components.

The change swaps `h-full` for `min-h-full` on a single wrapper div. The fix precisely addresses why trailing padding collapsed when messages overflowed the viewport, and the empty-state centering is unaffected because `min-h-full` still gives the wrapper 100% viewport height when content is shorter. No logic, data flow, or API surface is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Scroll Viewport<br/>fixed height] --> B[Wrapper div]
    B -->|h-full — OLD| C[Height locked to viewport]
    B -->|min-h-full — NEW| D[Height ≥ viewport, grows with content]
    C --> E[trailing py-4 collapses\nwhen messages overflow]
    D --> F[trailing py-4 preserved\nregardless of content length]
    D --> G[empty welcome state\nstill centered ✓]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Scroll Viewport<br/>fixed height] --> B[Wrapper div]
    B -->|h-full — OLD| C[Height locked to viewport]
    B -->|min-h-full — NEW| D[Height ≥ viewport, grows with content]
    C --> E[trailing py-4 collapses\nwhen messages overflow]
    D --> F[trailing py-4 preserved\nregardless of content length]
    D --> G[empty welcome state\nstill centered ✓]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(assistant): fix error bubble bottom ..."](https://github.com/langfuse/langfuse/commit/f89d326f08f6dedd7d36aeb3fe46c3efdafcb3ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42318158)</sub>

<!-- /greptile_comment -->