### PR TITLE
fix(api): actionable error messages for frequent MCP tool failures

### DIFF
--- a/packages/shared/src/server/repositories/dataset-items.ts
+++ b/packages/shared/src/server/repositories/dataset-items.ts
@@ -5,6 +5,7 @@ import { datasetItemsFilterCols } from "./dataset-items-columns";
 import {
   InternalServerError,
   InvalidRequestError,
+  LangfuseConflictError,
   LangfuseNotFoundError,
 } from "../../errors";
 import { DatasetItemValidator } from "../services/DatasetService";
@@ -76,10 +77,13 @@ async function getDatasets(props: {
     },
   });
 
-  if (datasets.length !== props.datasetIds.length)
+  if (datasets.length !== props.datasetIds.length) {
+    const foundIds = new Set(datasets.map((dataset) => dataset.id));
+    const missingIds = props.datasetIds.filter((id) => !foundIds.has(id));
     throw new LangfuseNotFoundError(
-      `One or more datasets not found for project ${props.projectId}`,
+      `Dataset(s) not found for project ${props.projectId}: ${missingIds.join(", ")}. \`datasetId\` must be a dataset id, not a dataset name; if you have a name, list datasets to resolve it to an id first.`,
     );
+  }
 
   return datasets;
 }
@@ -315,8 +319,8 @@ export async function upsertDatasetItem(
       datasetItemId: props.datasetItemId,
     });
     if (!!existingItem && existingItem.datasetId !== dataset.id) {
-      throw new LangfuseNotFoundError(
-        `Dataset item with id ${props.datasetItemId} not found for project ${props.projectId}`,
+      throw new LangfuseConflictError(
+        `Dataset item id ${props.datasetItemId} already exists in another dataset (id ${existingItem.datasetId}) in this project; item ids are unique per project across datasets. Use a different id or target dataset ${existingItem.datasetId}.`,
       );
     }
   }
@@ -439,8 +443,8 @@ export async function upsertDatasetItem(
         });
 
         if (current && current.datasetId !== dataset.id) {
-          throw new LangfuseNotFoundError(
-            `Dataset item with id ${itemId} not found for project ${props.projectId}`,
+          throw new LangfuseConflictError(
+            `Dataset item id ${itemId} already exists in another dataset (id ${current.datasetId}) in this project; item ids are unique per project across datasets. Use a different id or target dataset ${current.datasetId}.`,
           );
         }
 

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -454,7 +454,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
   });
 
-  it("should return 404 when trying to update dataset item that exists in different dataset of the same project", async () => {
+  it("should return 409 when trying to update dataset item that exists in different dataset of the same project", async () => {
     const dataset = await prisma.dataset.create({
       data: {
         name: "dataset-name-1",
@@ -491,7 +491,10 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
       auth,
     );
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(409);
+    expect(JSON.stringify(response.body)).toContain(
+      `Dataset item id ${datasetItemId} already exists in another dataset (id ${dataset.id})`,
+    );
   });
 
   it("GET datasets (v1 & v2)", async () => {

--- a/web/src/__tests__/server/repositories/dataset-items-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/dataset-items-repository.servertest.ts
@@ -5,6 +5,7 @@ process.env.LANGFUSE_DATASET_SERVICE_WRITE_TO_VERSIONED_IMPLEMENTATION = "true";
 
 import crypto from "crypto";
 
+import { LangfuseConflictError } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   createDatasetItem,
@@ -964,6 +965,43 @@ describe("Dataset Items Repository - Versioning Tests", () => {
       // ExpectedOutput should be preserved
       expect(updated.expectedOutput).toEqual({ result: "output1" });
     });
+
+    it("should throw a conflict when item id exists in another dataset of the project", async () => {
+      const datasetAId = v4();
+      const datasetBId = v4();
+      const itemId = v4();
+      await prisma.dataset.create({
+        data: { id: datasetAId, name: v4(), projectId },
+      });
+      await prisma.dataset.create({
+        data: { id: datasetBId, name: v4(), projectId },
+      });
+
+      await upsertDatasetItem({
+        projectId,
+        datasetId: datasetAId,
+        datasetItemId: itemId,
+        input: { key: "value" },
+        normalizeOpts: {},
+        validateOpts: {},
+      });
+
+      const upsertIntoOtherDataset = upsertDatasetItem({
+        projectId,
+        datasetId: datasetBId,
+        datasetItemId: itemId,
+        input: { key: "other" },
+        normalizeOpts: {},
+        validateOpts: {},
+      });
+
+      await expect(upsertIntoOtherDataset).rejects.toThrow(
+        LangfuseConflictError,
+      );
+      await expect(upsertIntoOtherDataset).rejects.toThrow(
+        `Dataset item id ${itemId} already exists in another dataset (id ${datasetAId}) in this project; item ids are unique per project across datasets. Use a different id or target dataset ${datasetAId}.`,
+      );
+    });
   });
 
   describe("deleteDatasetItem()", () => {
@@ -1178,6 +1216,27 @@ describe("Dataset Items Repository - Versioning Tests", () => {
       // Should have 2 version timestamps (one per batch)
       const versions = await listDatasetVersions({ projectId, datasetId });
       expect(versions.length).toBe(2);
+    });
+
+    it("should name the missing dataset ids when a dataset does not exist", async () => {
+      const datasetId = v4();
+      await prisma.dataset.create({
+        data: { id: datasetId, name: v4(), projectId },
+      });
+      // agents commonly pass a dataset *name* where an id is expected
+      const nameShapedDatasetId = "my-dataset-name";
+
+      const createItems = createManyDatasetItems({
+        projectId,
+        items: [
+          { datasetId, input: { item: 1 } },
+          { datasetId: nameShapedDatasetId, input: { item: 2 } },
+        ],
+      });
+
+      await expect(createItems).rejects.toThrow(
+        `Dataset(s) not found for project ${projectId}: ${nameShapedDatasetId}. \`datasetId\` must be a dataset id, not a dataset name; if you have a name, list datasets to resolve it to an id first.`,
+      );
     });
   });
 

--- a/web/src/__tests__/server/repositories/dataset-items-stateful-upsert.servertest.ts
+++ b/web/src/__tests__/server/repositories/dataset-items-stateful-upsert.servertest.ts
@@ -1,0 +1,52 @@
+vi.hoisted(() => {
+  process.env.LANGFUSE_DATASET_SERVICE_READ_FROM_VERSIONED_IMPLEMENTATION =
+    "false";
+  process.env.LANGFUSE_DATASET_SERVICE_WRITE_TO_VERSIONED_IMPLEMENTATION =
+    "false";
+});
+
+import { LangfuseConflictError } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import { upsertDatasetItem } from "@langfuse/shared/src/server";
+import { v4 } from "uuid";
+
+const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+const createDataset = async () => {
+  const datasetId = v4();
+  await prisma.dataset.create({
+    data: { id: datasetId, name: v4(), projectId },
+  });
+  return datasetId;
+};
+
+describe("Dataset item stateful upsert", () => {
+  it("throws a conflict when item id exists in another dataset of the project", async () => {
+    const datasetAId = await createDataset();
+    const datasetBId = await createDataset();
+    const itemId = v4();
+
+    await upsertDatasetItem({
+      projectId,
+      datasetId: datasetAId,
+      datasetItemId: itemId,
+      input: { key: "value" },
+      normalizeOpts: {},
+      validateOpts: {},
+    });
+
+    const upsertIntoOtherDataset = upsertDatasetItem({
+      projectId,
+      datasetId: datasetBId,
+      datasetItemId: itemId,
+      input: { key: "other" },
+      normalizeOpts: {},
+      validateOpts: {},
+    });
+
+    await expect(upsertIntoOtherDataset).rejects.toThrow(LangfuseConflictError);
+    await expect(upsertIntoOtherDataset).rejects.toThrow(
+      `Dataset item id ${itemId} already exists in another dataset (id ${datasetAId}) in this project; item ids are unique per project across datasets. Use a different id or target dataset ${datasetAId}.`,
+    );
+  });
+});

--- a/web/src/__tests__/server/unit/evaluator-preflight.servertest.ts
+++ b/web/src/__tests__/server/unit/evaluator-preflight.servertest.ts
@@ -15,6 +15,7 @@ import {
 } from "@langfuse/shared";
 import {
   DefaultEvalModelService,
+  LLMCompletionError,
   testModelCall,
 } from "@langfuse/shared/src/server";
 import { getEvaluatorDefinitionPreflightError } from "@/src/features/evals/server/evaluator-preflight";
@@ -62,6 +63,25 @@ describe("evaluator preflight", () => {
       originalSkipFlag;
   });
 
+  it("points to the LLM connection settings when no valid model is configured", async () => {
+    mockFetchValidModelConfig.mockResolvedValue({
+      valid: false,
+      error: "No default model or custom model configured for project p1",
+    });
+
+    const result = await getEvaluatorDefinitionPreflightError({
+      projectId: "p1",
+      template: {
+        name: "Answer correctness",
+        outputDefinition: numericOutputDefinition,
+      },
+    });
+
+    expect(result).toBe(
+      `No valid LLM model found for evaluator "Answer correctness". No default model or custom model configured for project p1. Configure an LLM connection for this project under Settings → LLM Connections (/project/p1/settings/llm-connections) before creating llm_as_judge evaluators.`,
+    );
+  });
+
   it("skips the live provider call when the explicit test flag is enabled", async () => {
     process.env.LANGFUSE_SKIP_EVALUATOR_MODEL_CALL_VALIDATION = "true";
 
@@ -75,5 +95,61 @@ describe("evaluator preflight", () => {
 
     expect(result).toBeNull();
     expect(mockTestModelCall).not.toHaveBeenCalled();
+  });
+
+  describe("live provider call failures", () => {
+    // The preflight skips the provider call in test-like environments;
+    // stub these so the mocked testModelCall is actually reached.
+    beforeEach(() => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("DATABASE_URL", "postgresql://localhost:5432/postgres");
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("returns a clean model-not-found message when the provider responds with 404", async () => {
+      mockTestModelCall.mockRejectedValue(
+        new LLMCompletionError({
+          message:
+            '404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-3-sonnet-20240229"}}',
+          responseStatusCode: 404,
+        }),
+      );
+
+      const result = await getEvaluatorDefinitionPreflightError({
+        projectId: "project_test",
+        template: {
+          name: "Answer correctness",
+          outputDefinition: numericOutputDefinition,
+        },
+      });
+
+      expect(result).toBe(
+        `Model configuration not valid for evaluator "Answer correctness". The provider could not find model 'gpt-4.1-mini' — it may be retired, misspelled, or not available to your API key. Update the evaluator's model or the project's default evaluation model.`,
+      );
+    });
+
+    it("keeps the provider error message for non-404 failures", async () => {
+      mockTestModelCall.mockRejectedValue(
+        new LLMCompletionError({
+          message: "401 Incorrect API key provided",
+          responseStatusCode: 401,
+        }),
+      );
+
+      const result = await getEvaluatorDefinitionPreflightError({
+        projectId: "project_test",
+        template: {
+          name: "Answer correctness",
+          outputDefinition: numericOutputDefinition,
+        },
+      });
+
+      expect(result).toBe(
+        `Model configuration not valid for evaluator "Answer correctness". 401 Incorrect API key provided`,
+      );
+    });
   });
 });

--- a/web/src/features/evals/server/evaluator-preflight.ts
+++ b/web/src/features/evals/server/evaluator-preflight.ts
@@ -5,6 +5,7 @@ import {
 } from "@langfuse/shared";
 import {
   DefaultEvalModelService,
+  isLLMCompletionError,
   testModelCall,
 } from "@langfuse/shared/src/server";
 
@@ -33,7 +34,7 @@ export async function getEvaluatorDefinitionPreflightError(params: {
   );
 
   if (!modelConfig.valid) {
-    return `No valid LLM model found for evaluator "${params.template.name}". ${modelConfig.error}`;
+    return `No valid LLM model found for evaluator "${params.template.name}". ${modelConfig.error}. Configure an LLM connection for this project under Settings → LLM Connections (/project/${params.projectId}/settings/llm-connections) before creating llm_as_judge evaluators.`;
   }
 
   try {
@@ -63,6 +64,11 @@ export async function getEvaluatorDefinitionPreflightError(params: {
       structuredOutputSchema: compiledOutputDefinition.outputResultSchema,
     });
   } catch (err) {
+    // A provider 404 also covers typos, missing model access, and bad base
+    // URLs — not just retired models, so don't claim "retired" as fact.
+    if (isLLMCompletionError(err) && err.responseStatusCode === 404) {
+      return `Model configuration not valid for evaluator "${params.template.name}". The provider could not find model '${modelConfig.config.model}' — it may be retired, misspelled, or not available to your API key. Update the evaluator's model or the project's default evaluation model.`;
+    }
     const message = err instanceof Error ? err.message : "Unknown error";
     return `Model configuration not valid for evaluator "${params.template.name}". ${message}`;
   }

--- a/web/src/features/mcp/core/run-mcp-tool.ts
+++ b/web/src/features/mcp/core/run-mcp-tool.ts
@@ -1,5 +1,8 @@
+import { BaseError } from "@langfuse/shared";
 import { instrumentAsync } from "@langfuse/shared/src/server";
 import { SpanKind, type Span } from "@opentelemetry/api";
+
+import { UnstablePublicApiError } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 
 import type { ServerContext } from "../types";
 
@@ -31,6 +34,18 @@ export const runMcpTool = async <TResult>({
         ),
       });
 
-      return await fn(span);
+      try {
+        return await fn(span);
+      } catch (error) {
+        // Expose the error cause on the span so trace analyses can group by
+        // cause instead of a single error class name.
+        if (error instanceof BaseError) {
+          span.setAttribute("mcp.error.http_code", error.httpCode);
+        }
+        if (error instanceof UnstablePublicApiError) {
+          span.setAttribute("mcp.error.code", error.code);
+        }
+        throw error;
+      }
     },
   );

--- a/web/src/features/mcp/features/datasets/tools/upsertDatasetItem.ts
+++ b/web/src/features/mcp/features/datasets/tools/upsertDatasetItem.ts
@@ -7,7 +7,8 @@ import { PostDatasetItemMcpInput } from "../schema";
 
 export const [upsertDatasetItemTool, handleUpsertDatasetItem] = defineTool({
   name: "upsertDatasetItem",
-  description: "Upsert a dataset item (one example in a dataset) by dataset ID",
+  description:
+    "Upsert a dataset item (one example in a dataset) by dataset ID. Item IDs are unique per project across all datasets, so an ID used in one dataset cannot be reused in another.",
   baseSchema: PostDatasetItemMcpInput,
   inputSchema: PostDatasetItemMcpInput,
   handler: async (input, context) =>


### PR DESCRIPTION
## Summary

Improves the highest-frequency MCP tool invocation errors (from a 14d Datadog prod-us span analysis of `mcp.dataset_items.upsert`, `mcp.evaluators.upsert`, `mcp.evaluation_rules.create`). Agents were retrying blind because the error messages hid the actual cause:

- **Cross-dataset item-ID collision → 409 instead of misleading 404.** Dataset item ids are unique per project across datasets, so "Dataset item with id X not found" was only reachable when the id *did* exist — in another dataset (~95% of `dataset_items.upsert` errors). Now a `LangfuseConflictError` names the owning dataset and the uniqueness rule; the MCP tool description documents it too.
- **Dataset-not-found lists the missing ids** and hints that `datasetId` must be an id, not a name (raw spans showed dataset *names* passed as ids). Echoing the offending value lets agents self-correct; deliberately no name-fallback resolution.
- **Evaluator preflight provider 404 → clean "model not found" message** (retired/misspelled/no-access model) instead of raw provider JSON with a LangChain troubleshooting URL.
- **Missing LLM connection → remediation hint** pointing to Settings → LLM Connections (the majority cause behind `evaluators.upsert` failures across ~11 projects).
- **MCP error spans now carry `mcp.error.code` / `mcp.error.http_code`** so future Datadog analyses can group by cause instead of a single error class name.

All behavior changes are covered by failing-test-first tests (STATEFUL + VERSIONED dataset strategies, preflight unit tests, updated public API 409 expectation).

## Linear

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves actionability of MCP tool error messages by fixing three high-frequency failure modes: cross-dataset item-ID collisions now return 409 instead of a misleading 404, dataset-not-found errors now list the missing IDs and hint that names are not IDs, and evaluator preflight failures produce human-readable model-not-found and LLM-connection-missing messages. MCP error spans gain `mcp.error.http_code` and `mcp.error.code` attributes for better Datadog grouping.

- **Dataset item conflict**: `LangfuseNotFoundError` replaced with `LangfuseConflictError` (409) for the cross-dataset ID collision case in both the stateful and versioned upsert paths; the tool description and a new `getDatasets` error message are updated to match.
- **Evaluator preflight**: Provider 404 responses produce a targeted \"model may be retired/misspelled\" message; missing LLM connections append a direct link to `/project/{id}/settings/llm-connections`.
- **Observability**: `runMcpTool` wraps the inner `fn` call in a try/catch that stamps `mcp.error.http_code` (for all `BaseError`s) and `mcp.error.code` (for `UnstablePublicApiError`s) on the OTel span before re-throwing.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all three failure-mode fixes are correctly implemented and covered by new tests. The only issue is that new 409 conflict errors will produce an unintended warning log per occurrence.

The dataset-item conflict fix, evaluator preflight improvements, and span attribute additions all look correct and are well-tested. The one gap is that LangfuseConflictError has no dedicated branch in error-formatting.ts, causing every cross-dataset ID collision to log a logger.warn — something that does not happen for LangfuseNotFoundError in the same file. The agent still receives the right error message, but monitoring will accumulate warning noise from what are expected, self-correctable user inputs.

web/src/features/mcp/core/error-formatting.ts — needs a dedicated LangfuseConflictError branch (parallel to the existing LangfuseNotFoundError branch) to avoid warning logs for expected user errors.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Agent
    participant MCP Tool
    participant runMcpTool
    participant OTel Span
    participant createDatasetItemForApi
    participant upsertDatasetItem

    Agent->>MCP Tool: upsertDatasetItem(itemId, datasetBId)
    MCP Tool->>runMcpTool: fn(span)
    runMcpTool->>OTel Span: setAttributes(project, org, apiKey, datasetId)
    runMcpTool->>createDatasetItemForApi: create(itemId, datasetBId)
    createDatasetItemForApi->>upsertDatasetItem: itemId exists in datasetA?
    upsertDatasetItem-->>createDatasetItemForApi: LangfuseConflictError (409)
    createDatasetItemForApi-->>runMcpTool: throw LangfuseConflictError
    runMcpTool->>OTel Span: setAttribute(mcp.error.http_code, 409)
    runMcpTool-->>MCP Tool: re-throw LangfuseConflictError
    Note over MCP Tool: wrapErrorHandling catches → formatErrorForUser
    MCP Tool-->>Agent: McpError(InvalidRequest, "Dataset item id X already exists in another dataset...")
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Agent
    participant MCP Tool
    participant runMcpTool
    participant OTel Span
    participant createDatasetItemForApi
    participant upsertDatasetItem

    Agent->>MCP Tool: upsertDatasetItem(itemId, datasetBId)
    MCP Tool->>runMcpTool: fn(span)
    runMcpTool->>OTel Span: setAttributes(project, org, apiKey, datasetId)
    runMcpTool->>createDatasetItemForApi: create(itemId, datasetBId)
    createDatasetItemForApi->>upsertDatasetItem: itemId exists in datasetA?
    upsertDatasetItem-->>createDatasetItemForApi: LangfuseConflictError (409)
    createDatasetItemForApi-->>runMcpTool: throw LangfuseConflictError
    runMcpTool->>OTel Span: setAttribute(mcp.error.http_code, 409)
    runMcpTool-->>MCP Tool: re-throw LangfuseConflictError
    Note over MCP Tool: wrapErrorHandling catches → formatErrorForUser
    MCP Tool-->>Agent: McpError(InvalidRequest, "Dataset item id X already exists in another dataset...")
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): actionable error messages for ..."](https://github.com/langfuse/langfuse/commit/f7543f64daa4a54ba872bb9e104e08d27f0fde69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42316459)</sub>

<!-- /greptile_comment -->