### PR TITLE
fix(blobstorage): hide no-op trace_context group and single-option export source selector

### DIFF
--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -144,5 +144,8 @@ export const EXPORT_FIELD_GROUP_OPTIONS = OBSERVATION_FIELD_GROUPS_FULL.map(
     legacyDescription: legacyDescriptionForGroup(value),
     parquetDescription: parquetDescriptionForGroup(value),
     legacyParquetDescription: legacyParquetDescriptionForGroup(value),
+    // Groups without legacy columns (trace_context) are a no-op for
+    // legacy-only exports; the UI hides them for that source.
+    includedInLegacyExport: legacyFieldsForGroup(value).length > 0,
   }),
 );

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -150,4 +150,12 @@ describe("EXPORT_FIELD_GROUP_OPTIONS — parquet description", () => {
       "Not included in the legacy observations export",
     );
   });
+
+  it("flags groups without legacy observation columns so the UI can hide them for legacy-only exports", () => {
+    for (const option of EXPORT_FIELD_GROUP_OPTIONS) {
+      expect(option.includedInLegacyExport).toBe(
+        option.value !== "trace_context",
+      );
+    }
+  });
 });

--- a/web/src/features/blobstorage-integration/exportSource.clienttest.ts
+++ b/web/src/features/blobstorage-integration/exportSource.clienttest.ts
@@ -4,6 +4,7 @@ import {
   getExportSourceFormValue,
   getExportSourceOptions,
   isExportSourceSelectable,
+  shouldHideExportSourceSelector,
 } from "./exportSource";
 
 const cloudPreCutoff = {
@@ -175,5 +176,54 @@ describe("getExportSourceOptions", () => {
         (o) => o.value === AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
       )?.unavailable,
     ).toBe(false);
+  });
+});
+
+describe("shouldHideExportSourceSelector", () => {
+  it("hides the selector when there is exactly one selectable source", () => {
+    // Post-cutoff Cloud project: EVENTS only.
+    expect(
+      shouldHideExportSourceSelector(
+        getExportSourceOptions(undefined, cloudPostCutoff),
+      ),
+    ).toBe(true);
+    // Rolled-back self-hosted with a persisted legacy source: legacy only.
+    expect(
+      shouldHideExportSourceSelector(
+        getExportSourceOptions(
+          AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+          selfHostedRolledBack,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps the selector when there is a real choice", () => {
+    expect(
+      shouldHideExportSourceSelector(
+        getExportSourceOptions(undefined, cloudPreCutoff),
+      ),
+    ).toBe(false);
+    // Stale persisted enriched source alongside the legacy fallback.
+    expect(
+      shouldHideExportSourceSelector(
+        getExportSourceOptions(
+          AnalyticsIntegrationExportSource.EVENTS,
+          selfHostedRolledBack,
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps the selector when the sole option is the stale persisted source", () => {
+    // The unavailable-source alert points at the selector; hiding it here
+    // would strand the user with a blocked save and nothing to change.
+    const options = getExportSourceOptions(
+      AnalyticsIntegrationExportSource.EVENTS,
+      { eventsExportAvailable: false, forceEventsExport: true },
+    );
+    expect(options).toHaveLength(1);
+    expect(options[0].unavailable).toBe(true);
+    expect(shouldHideExportSourceSelector(options)).toBe(false);
   });
 });

--- a/web/src/features/blobstorage-integration/exportSource.ts
+++ b/web/src/features/blobstorage-integration/exportSource.ts
@@ -41,6 +41,16 @@ export type SelectableExportSourceOption = ExportSourceOption & {
   unavailable: boolean;
 };
 
+// A single selectable option carries no decision, so the selector is hidden
+// (post-cutoff Cloud projects never see it). When the sole option is the
+// stale persisted source, keep the selector: the unavailable-source alert
+// refers to it and hiding it would strand the user with a blocked save.
+export function shouldHideExportSourceSelector(
+  options: SelectableExportSourceOption[],
+): boolean {
+  return options.length === 1 && !options[0].unavailable;
+}
+
 // Selectable sources, plus the persisted one (marked unavailable) when it is
 // no longer selectable, so the conflict is visible rather than silently rewritten.
 export function getExportSourceOptions(

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -63,6 +63,7 @@ import {
   getExportSourceFormValue,
   getExportSourceOptions,
   isExportSourceSelectable,
+  shouldHideExportSourceSelector,
 } from "@/src/features/blobstorage-integration/exportSource";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProject } from "@/src/features/projects/hooks";
@@ -387,7 +388,10 @@ const BlobStorageIntegrationSettingsForm = ({
     state?.exportSource,
     availability,
   );
-  // Visible but locked when there is only one selectable option.
+  // No decision to make → no selector. Only the degenerate single-option
+  // state (stale persisted source) stays visible, locked, so the
+  // unavailable-source alert below has something to refer to.
+  const hideExportSource = shouldHideExportSourceSelector(exportSourceOptions);
   const exportSourceLocked = exportSourceOptions.length === 1;
   const exportSourceUnavailable =
     watchedExportSource != null &&
@@ -778,75 +782,77 @@ const BlobStorageIntegrationSettingsForm = ({
           )}
         />
 
-        <FormField
-          control={blobStorageForm.control}
-          name="exportSource"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel className="flex items-center gap-1.5 pt-2">
-                Export Source
-                <Tooltip>
-                  <TooltipTrigger>
-                    <Info className="text-muted-foreground h-3.5 w-3.5" />
-                  </TooltipTrigger>
-                  <TooltipContent
-                    side="bottom"
-                    className="max-w-[350px] space-y-2 p-3"
-                  >
-                    {exportSourceOptions.map((option) => (
-                      <div key={option.value} className="space-y-0.5">
-                        <div className="font-medium">{option.label}</div>
-                        <div className="text-muted-foreground text-xs">
-                          {option.description}
-                        </div>
-                      </div>
-                    ))}
-                    <div className="border-t pt-2">
-                      <a
-                        href="https://langfuse.com/docs/integrations/export-sources"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-muted-foreground hover:text-primary inline-flex items-center gap-1 text-xs hover:underline"
-                      >
-                        For further information see
-                        <ExternalLink className="h-3 w-3" />
-                      </a>
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              </FormLabel>
-              <Select
-                onValueChange={field.onChange}
-                value={field.value}
-                disabled={exportSourceLocked}
-              >
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select data to export" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  {exportSourceOptions.map((option) => (
-                    <SelectItem
-                      key={option.value}
-                      value={option.value}
-                      disabled={option.unavailable}
+        {!hideExportSource && (
+          <FormField
+            control={blobStorageForm.control}
+            name="exportSource"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="flex items-center gap-1.5 pt-2">
+                  Export Source
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <Info className="text-muted-foreground h-3.5 w-3.5" />
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="bottom"
+                      className="max-w-[350px] space-y-2 p-3"
                     >
-                      {option.unavailable
-                        ? `${option.label} (not available on this deployment)`
-                        : option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <FormDescription>
-                Choose which data sources to export to blob storage. Scores are
-                always included.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+                      {exportSourceOptions.map((option) => (
+                        <div key={option.value} className="space-y-0.5">
+                          <div className="font-medium">{option.label}</div>
+                          <div className="text-muted-foreground text-xs">
+                            {option.description}
+                          </div>
+                        </div>
+                      ))}
+                      <div className="border-t pt-2">
+                        <a
+                          href="https://langfuse.com/docs/integrations/export-sources"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-muted-foreground hover:text-primary inline-flex items-center gap-1 text-xs hover:underline"
+                        >
+                          For further information see
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                </FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value}
+                  disabled={exportSourceLocked}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select data to export" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {exportSourceOptions.map((option) => (
+                      <SelectItem
+                        key={option.value}
+                        value={option.value}
+                        disabled={option.unavailable}
+                      >
+                        {option.unavailable
+                          ? `${option.label} (not available on this deployment)`
+                          : option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription>
+                  Choose which data sources to export to blob storage. Scores
+                  are always included.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
 
         {exportSourceUnavailable && (
           <Alert variant="destructive">

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -875,11 +875,19 @@ const BlobStorageIntegrationSettingsForm = ({
                 size, or privacy-sensitive groups (e.g. Metadata) to avoid
                 storing user data.
                 {includesLegacyExport
-                  ? " Traces and scores are always exported in full. Fields that only exist on the enriched observations (e.g. Trace Context) are omitted from the legacy observations export."
+                  ? isLegacyOnlyExport
+                    ? " Traces and scores are always exported in full. Field groups that only exist on the enriched observations (e.g. Trace Context) are not available for this export source."
+                    : " Traces and scores are always exported in full. Fields that only exist on the enriched observations (e.g. Trace Context) are omitted from the legacy observations export."
                   : " Scores are always exported in full."}
               </FormDescription>
               <div className="mt-2 space-y-2">
-                {EXPORT_FIELD_GROUP_OPTIONS.map((option) => {
+                {EXPORT_FIELD_GROUP_OPTIONS.filter(
+                  // Hide no-op groups (no legacy columns) for legacy-only
+                  // exports; a saved selection is kept and applies again if
+                  // the source is migrated to enriched observations.
+                  (option) =>
+                    !isLegacyOnlyExport || option.includedInLegacyExport,
+                ).map((option) => {
                   const isCore = option.value === "core";
                   return (
                     <div key={option.value} className="flex items-start gap-2">


### PR DESCRIPTION
## What does this PR do?

Two UX fixes on the blob storage integration settings page, one commit each:

1. **Hide the Trace Context field group for legacy-only exports.** The `trace_context` group has no columns on the legacy `observations` table, so selecting it for a `TRACES_OBSERVATIONS` export is a silent no-op — the worker's column list (`LEGACY_OBSERVATION_EXPORT_FIELDS`) simply never matches it. The checkbox list now hides groups without legacy columns when the legacy-only source is selected, driven by a new `includedInLegacyExport` flag on `EXPORT_FIELD_GROUP_OPTIONS` that is derived from the legacy export contract rather than hardcoded. A persisted `trace_context` selection is kept in the form value and in the DB, so it applies again if the integration is later migrated to enriched observations. The mixed source (`TRACES_OBSERVATIONS_EVENTS`) still shows the group, since it also writes `observations_v2`.

2. **Hide the Export Source selector when only one source is selectable.** Post-cutoff Cloud projects and forced-enriched deployments used to see a disabled single-option dropdown; the docs describe these projects as not seeing the selector at all. The selector is now hidden when it carries no decision (`shouldHideExportSourceSelector`). The one exception is the degenerate state where the sole option is the persisted-but-no-longer-available source: there the selector stays visible (locked) because the unavailable-source alert refers to it.

Both flows were reviewed in a real browser (legacy / mixed / enriched sources, locked and unlocked selector states).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Two focused UX fixes on the blob storage integration settings page: hiding the `trace_context` field group when it is a no-op for legacy-only exports, and collapsing the Export Source selector when there is only one meaningful option.

- `includedInLegacyExport` is derived directly from `LEGACY_OBSERVATION_EXPORT_FIELDS` membership, keeping the UI contract in sync with the worker's column list without any hardcoding.
- `shouldHideExportSourceSelector` correctly preserves the selector in the degenerate case (sole option is the stale persisted/unavailable source) so the blocking alert below it still has a UI element to refer to.
- Persisted `trace_context` selections are preserved in the form value and database when hidden, ensuring they re-apply if the integration is later migrated to enriched observations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted UX-only fixes with no changes to data persistence, server logic, or export behavior.

Both changes are purely presentational: the export source selector and trace_context checkbox are hidden based on conditions already computed from existing form state. The includedInLegacyExport flag is derived from LEGACY_OBSERVATION_EXPORT_FIELDS rather than hardcoded, so it stays in sync with the worker contract automatically. The edge case where the selector must stay visible (sole unavailable option) is correctly handled and directly tested. Persisted selections are preserved in the form and database even when hidden. No server-side logic, schema, or data paths are touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[exportSourceOptions from getExportSourceOptions] --> B{options.length === 1}
    B -- No --> C[Show selector enabled]
    B -- Yes --> D{options 0 .unavailable}
    D -- No --> E[hideExportSource = true - Selector hidden]
    D -- Yes --> F[hideExportSource = false - Selector shown locked - Alert visible]

    E --> G{watchedExportSource}
    G -- TRACES_OBSERVATIONS --> H[isLegacyOnlyExport = true]
    G -- Other --> I[isLegacyOnlyExport = false]

    H --> J[Filter EXPORT_FIELD_GROUP_OPTIONS - Hide trace_context group]
    I --> K[Show all EXPORT_FIELD_GROUP_OPTIONS]

    C --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[exportSourceOptions from getExportSourceOptions] --> B{options.length === 1}
    B -- No --> C[Show selector enabled]
    B -- Yes --> D{options 0 .unavailable}
    D -- No --> E[hideExportSource = true - Selector hidden]
    D -- Yes --> F[hideExportSource = false - Selector shown locked - Alert visible]

    E --> G{watchedExportSource}
    G -- TRACES_OBSERVATIONS --> H[isLegacyOnlyExport = true]
    G -- Other --> I[isLegacyOnlyExport = false]

    H --> J[Filter EXPORT_FIELD_GROUP_OPTIONS - Hide trace_context group]
    I --> K[Show all EXPORT_FIELD_GROUP_OPTIONS]

    C --> G
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blobstorage): hide export source sel..."](https://github.com/langfuse/langfuse/commit/221b06a319fcb02bfdcd3846ab700c54008b93e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42343639)</sub>

<!-- /greptile_comment -->