### PR TITLE
fix(evals): fail closed on internal eval targets at eval execution time

### DIFF
--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -79,6 +79,7 @@ import {
   completeEvalExecution,
   type EvalExecutionResult,
 } from "./evalCompletion";
+import { isEvalTargetEnvironmentAllowed } from "./isEvalTargetEnvironmentAllowed";
 import {
   type EvalExecutionDeps,
   createProductionEvalExecutionDeps,
@@ -1135,6 +1136,41 @@ export const evaluate = async ({
     `Extracted ${extractedVariables.length} variables for job ${event.jobExecutionId}`,
   );
 
+  const environment =
+    getEnvironmentFromVariables(extractedVariables) ??
+    DEFAULT_TRACE_ENVIRONMENT;
+
+  // Final fail-closed loop safeguard: never execute an eval whose target
+  // lives in an internal Langfuse environment, regardless of which scheduling
+  // path created the job. See isEvalTargetEnvironmentAllowed. The environment
+  // is derived from the extracted trace/observation variables; mappings
+  // without any tracing-data variable fall back to the default environment
+  // and rely on the scheduling-time guards.
+  if (!isEvalTargetEnvironmentAllowed(environment)) {
+    logger.warn(
+      "Cancelling eval job targeting an internal Langfuse environment",
+      {
+        jobExecutionId: event.jobExecutionId,
+        projectId: event.projectId,
+        environment,
+        traceId: job.jobInputTraceId,
+      },
+    );
+    recordIncrement(
+      "langfuse.evaluation-execution.internal_target_blocked",
+      1,
+      {
+        source: "trace-eval",
+      },
+    );
+    await prisma.jobExecution.update({
+      where: { id: job.id, projectId: event.projectId },
+      data: { status: JobExecutionStatus.CANCELLED, endTime: new Date() },
+    });
+
+    return;
+  }
+
   // Execute the shared LLM-as-a-judge evaluation
   await executeLLMAsJudgeEvaluation({
     projectId: event.projectId,
@@ -1143,9 +1179,7 @@ export const evaluate = async ({
     config,
     template: template as EvalTemplateLlmAsAJudge,
     extractedVariables,
-    environment:
-      getEnvironmentFromVariables(extractedVariables) ??
-      DEFAULT_TRACE_ENVIRONMENT,
+    environment,
   });
 };
 

--- a/worker/src/features/evaluation/isEvalTargetEnvironmentAllowed.test.ts
+++ b/worker/src/features/evaluation/isEvalTargetEnvironmentAllowed.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { isEvalTargetEnvironmentAllowed } from "./isEvalTargetEnvironmentAllowed";
+
+describe("isEvalTargetEnvironmentAllowed", () => {
+  it("allows user environments", () => {
+    expect(isEvalTargetEnvironmentAllowed("default")).toBe(true);
+    expect(isEvalTargetEnvironmentAllowed("production")).toBe(true);
+  });
+
+  it("allows missing environments (defaulted downstream)", () => {
+    expect(isEvalTargetEnvironmentAllowed(undefined)).toBe(true);
+    expect(isEvalTargetEnvironmentAllowed(null)).toBe(true);
+  });
+
+  it("blocks eval-on-eval targets across all internal environments", () => {
+    for (const environment of [
+      "langfuse-llm-as-a-judge",
+      "langfuse-code-eval",
+      "langfuse-natural-language-filter",
+      "langfuse-in-app-agent",
+      "langfuse",
+    ]) {
+      expect(isEvalTargetEnvironmentAllowed(environment)).toBe(false);
+    }
+  });
+
+  it("allows the sanctioned prompt-experiment targets", () => {
+    expect(isEvalTargetEnvironmentAllowed("langfuse-prompt-experiment")).toBe(
+      true,
+    );
+  });
+});

--- a/worker/src/features/evaluation/isEvalTargetEnvironmentAllowed.ts
+++ b/worker/src/features/evaluation/isEvalTargetEnvironmentAllowed.ts
@@ -1,0 +1,34 @@
+import { LangfuseInternalTraceEnvironment } from "@langfuse/shared/src/server";
+
+/**
+ * Final, fail-closed loop safeguard at eval EXECUTION time.
+ *
+ * Internal Langfuse executions (LLM-as-a-judge, code evals, natural-language
+ * filters) write their telemetry into reserved `langfuse-*` environments. An
+ * eval whose TARGET lives in such an environment is an eval-of-an-eval: it
+ * would spawn another internal execution, whose telemetry could be evaluated
+ * again — an infinite loop with per-cycle LLM cost.
+ *
+ * Scheduling-time guards exist per entry point (trace-upsert in
+ * createEvalJobs, the OTel queue's observation-eval guard), but every new
+ * ingestion mode or scheduling path must remember to add one. This check runs
+ * where all paths converge — the eval executors, right before any LLM/code
+ * execution — so a missing upstream guard degrades to wasted queue churn, not
+ * recursion.
+ *
+ * Single sanctioned exception: prompt-experiment outputs. Users attach
+ * evaluators to dataset runs, so their run items (environment
+ * `langfuse-prompt-experiment`) are legitimate eval targets. This cannot
+ * re-open a loop: experiments are only ever created by explicit user actions
+ * (never by ingestion), and the evals they trigger execute in
+ * `langfuse-llm-as-a-judge`, which stays blocked here.
+ */
+export function isEvalTargetEnvironmentAllowed(
+  environment: string | null | undefined,
+): boolean {
+  if (!environment?.startsWith("langfuse")) {
+    return true;
+  }
+
+  return environment === LangfuseInternalTraceEnvironment.PromptExperiments;
+}

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
@@ -810,4 +810,79 @@ describe("processObservationEval", () => {
       ).rejects.toThrow();
     });
   });
+
+  describe("internal target loop safeguard", () => {
+    const setupExecutableJob = (environment: string) => {
+      const job = createMockJobExecution({
+        id: jobExecutionId,
+        projectId,
+        status: JobExecutionStatus.PENDING,
+        jobConfigurationId: "config-123",
+        jobInputTraceId: "trace-abc",
+        jobInputObservationId: "obs-xyz",
+      });
+      const template = createMockEvalTemplate({
+        id: "template-456",
+        projectId,
+        prompt: "Evaluate: {{output}}",
+      });
+      const config = createMockJobConfiguration({
+        id: "config-123",
+        projectId,
+        evalTemplateId: "template-456",
+        variableMapping: [
+          { templateVariable: "output", selectedColumnId: "output" },
+        ],
+        evalTemplate: template,
+      });
+      const observation = createTestObservation({
+        span_id: "obs-xyz",
+        project_id: projectId,
+        trace_id: "trace-abc",
+        environment,
+        output: '{"response": "test output"}',
+      });
+
+      (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
+      (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(config);
+
+      return createMockProcessorDeps({
+        downloadObservationFromS3: vi
+          .fn()
+          .mockResolvedValue(JSON.stringify(observation)),
+      });
+    };
+
+    it("cancels jobs targeting internal observations instead of executing (eval-on-eval loop guard)", async () => {
+      const deps = setupExecutableJob("langfuse-llm-as-a-judge");
+
+      await processObservationEval({
+        event: baseEvent,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
+        deps,
+      });
+
+      expect(runLLMAsJudgeEvaluation).not.toHaveBeenCalled();
+      expect(executeCodeBasedEvaluation).not.toHaveBeenCalled();
+      expect(prisma.jobExecution.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: JobExecutionStatus.CANCELLED,
+          }),
+        }),
+      );
+    });
+
+    it("executes evals on sanctioned prompt-experiment targets", async () => {
+      const deps = setupExecutableJob("langfuse-prompt-experiment");
+
+      await processObservationEval({
+        event: baseEvent,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
+        deps,
+      });
+
+      expect(runLLMAsJudgeEvaluation).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
+++ b/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
@@ -4,8 +4,10 @@ import {
   ObservationEvalExecutionEventSchema,
   extractObservationVariables,
   logger,
+  recordIncrement,
   type ExtractedVariable,
 } from "@langfuse/shared/src/server";
+import { isEvalTargetEnvironmentAllowed } from "../isEvalTargetEnvironmentAllowed";
 import {
   observationForEvalSchema,
   observationVariableMappingList,
@@ -203,6 +205,34 @@ export async function processObservationEval(
   logger.debug(
     `Downloaded observation data for job ${job.id}: span_id=${observationData.span_id}`,
   );
+
+  // Final fail-closed loop safeguard: never execute an eval whose target
+  // lives in an internal Langfuse environment, regardless of which scheduling
+  // path created the job. See isEvalTargetEnvironmentAllowed.
+  if (!isEvalTargetEnvironmentAllowed(observationData.environment)) {
+    logger.warn(
+      "Cancelling eval job targeting an internal Langfuse environment",
+      {
+        jobExecutionId: event.jobExecutionId,
+        projectId: event.projectId,
+        environment: observationData.environment,
+        observationId: observationData.span_id,
+      },
+    );
+    recordIncrement(
+      "langfuse.evaluation-execution.internal_target_blocked",
+      1,
+      {
+        source: "observation-eval",
+      },
+    );
+    await prisma.jobExecution.update({
+      where: { id: job.id, projectId: event.projectId },
+      data: { status: JobExecutionStatus.CANCELLED, endTime: new Date() },
+    });
+
+    return;
+  }
 
   // Extract variables from observation
   const parsedVariableMapping = observationVariableMappingList.parse(


### PR DESCRIPTION
## Problem

Protection against eval-on-eval infinite loops (eval → internal trace → eval → …) currently lives at the **scheduling edges**: the trace-upsert guard in `createEvalJobs` and the OTel ingestion queue's observation-eval guard. Every new ingestion mode (dual write, direct v4 write, OTel) or scheduling entry point must remember to add its own guard — the defense is O(paths). A recent loop-safety audit found two such holes introduced within one week on the AI SDK engine branch (an unguarded observation-eval path and an environment-stripping bug that bypassed the trace-upsert guard).

## Fix

Add the final, fail-closed safeguard at the point where **every scheduling path converges**: the eval executors, immediately before any LLM or code execution.

- New `isEvalTargetEnvironmentAllowed` predicate: blocks all internal `langfuse-*` target environments, with one sanctioned exception — `langfuse-prompt-experiment` (users attach evaluators to dataset runs; experiments are only created by explicit user actions and the evals they trigger execute in `langfuse-llm-as-a-judge`, which stays blocked, so the exception cannot re-open a loop).
- `processObservationEval` checks the observation's environment (already loaded from S3).
- `evaluate` (trace/dataset path) checks the environment already derived from extracted tracing-data variables.
- Blocked jobs are marked `CANCELLED` with a structured warning and a `langfuse.evaluation-execution.internal_target_blocked` metric — a missing upstream guard now degrades to queue churn instead of recursion.

No extra database lookups: both executors already hold the target environment.

**Known limitation (documented in code):** on the trace path, a variable mapping with no trace/observation variable yields the default environment, so that pathological case relies on the scheduling-time guards.

## Impacted packages

- `worker`

## Verification

- `pnpm --filter worker run test src/features/evaluation` → Tests 322 passed | 5 skipped (327) — includes new predicate suite and two executor guard tests (written failing-first)
- `pnpm --filter worker run typecheck` → pass
- `pnpm --filter worker run lint` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a fail-closed loop safeguard at eval execution time to prevent eval-on-eval infinite recursion, complementing the existing per-entry-point scheduling-time guards. Both the trace/dataset LLM-as-a-judge executor (`evaluate`) and the observation eval executor (`processObservationEval`) now check `isEvalTargetEnvironmentAllowed` immediately before any LLM or code execution, cancelling jobs targeting internal `langfuse-*` environments and recording a metric.

- A new `isEvalTargetEnvironmentAllowed` predicate blocks all `langfuse-*` environments except the explicitly sanctioned `langfuse-prompt-experiment`, with well-tested null/undefined passthrough for environments not yet set.
- Both executors cancel the job with `JobExecutionStatus.CANCELLED`, emit a structured warning log, and record a `langfuse.evaluation-execution.internal_target_blocked` metric; the PR acknowledges a documented limitation where dataset-only variable mappings fall back to `DEFAULT_TRACE_ENVIRONMENT` and thus depend on the existing scheduling-time guards.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change adds a defensive guard and cannot break existing happy-path eval execution; the only risk is an overly broad block if the langfuse-* namespace is not reserved at creation time.

The core logic is correct and well-tested. The two observations worth a second look are: (1) the `evaluate` function only guards the LLM-as-a-judge trace/dataset path — if any other eval type (code-based, natural-language-filter) can reach a separate trace/dataset executor, that path would be unprotected; and (2) the `langfuse-*` prefix heuristic silently cancels any user environment starting with those characters, which is safe only if that namespace is enforced at environment creation time.

worker/src/features/evaluation/evalService.ts — confirm no other trace/dataset eval executors exist that bypass the guard
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Eval Job Triggered] --> B{Scheduling-time guard}
    B -->|blocked| Z1[Job not created]
    B -->|passes| C{Which executor?}

    C --> D[evaluate - trace/dataset]
    C --> E[processObservationEval]

    D --> D1[extractVariablesFromTracingData]
    D1 --> D2[getEnvironmentFromVariables]
    D2 --> D3{isEvalTargetEnvironmentAllowed?}
    D3 -->|NO - langfuse-star blocked| D4[CANCELLED + metric]
    D3 -->|YES| D5[executeLLMAsJudgeEvaluation]

    E --> E1[downloadObservationFromS3]
    E1 --> E2[parse observationData]
    E2 --> E3{isEvalTargetEnvironmentAllowed?}
    E3 -->|NO - langfuse-star blocked| E4[CANCELLED + metric]
    E3 -->|YES| E5{EvalTemplateType?}
    E5 --> E6[runLLMAsJudgeEvaluation]
    E5 --> E7[executeCodeBasedEvaluation]

    style D4 fill:#f88,stroke:#c00
    style E4 fill:#f88,stroke:#c00
    style D5 fill:#8f8,stroke:#080
    style E6 fill:#8f8,stroke:#080
    style E7 fill:#8f8,stroke:#080
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Eval Job Triggered] --> B{Scheduling-time guard}
    B -->|blocked| Z1[Job not created]
    B -->|passes| C{Which executor?}

    C --> D[evaluate - trace/dataset]
    C --> E[processObservationEval]

    D --> D1[extractVariablesFromTracingData]
    D1 --> D2[getEnvironmentFromVariables]
    D2 --> D3{isEvalTargetEnvironmentAllowed?}
    D3 -->|NO - langfuse-star blocked| D4[CANCELLED + metric]
    D3 -->|YES| D5[executeLLMAsJudgeEvaluation]

    E --> E1[downloadObservationFromS3]
    E1 --> E2[parse observationData]
    E2 --> E3{isEvalTargetEnvironmentAllowed?}
    E3 -->|NO - langfuse-star blocked| E4[CANCELLED + metric]
    E3 -->|YES| E5{EvalTemplateType?}
    E5 --> E6[runLLMAsJudgeEvaluation]
    E5 --> E7[executeCodeBasedEvaluation]

    style D4 fill:#f88,stroke:#c00
    style E4 fill:#f88,stroke:#c00
    style D5 fill:#8f8,stroke:#080
    style E6 fill:#8f8,stroke:#080
    style E7 fill:#8f8,stroke:#080
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/evaluation/evalService.ts:1139-1172
**`evaluate` only guards the LLM-as-a-judge path**

The safeguard in `evaluate` is placed just before `executeLLMAsJudgeEvaluation`, but `evaluate` appears to be exclusively the LLM-as-a-judge trace/dataset executor. If code-based or natural-language-filter evaluations can be triggered on the trace/dataset path through a separate executor function that doesn't share this code path, those jobs would be unprotected at execution time. The `processObservationEval` switch statement (line 273) covers multiple `EvalTemplateType`s, so it's worth confirming there is no equivalent trace/dataset-path executor for code evals that would also need this guard.

### Issue 2 of 2
worker/src/features/evaluation/isEvalTargetEnvironmentAllowed.ts:26-34
**`langfuse-*` prefix is not validated at environment creation time**

The function assumes `langfuse-*` is a reserved namespace, but if the application does not currently validate and reject user-created environments with a `langfuse-` prefix, a legitimate user environment named e.g. `langfuse-staging` would be silently cancelled with a CANCELLED status. The user would see their eval jobs cancelled with no visible indication that the environment name is the cause. It's worth confirming this namespace is enforced elsewhere, or at minimum surfacing the cancellation reason in the job's status/log output.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): fail closed on internal eval..."](https://github.com/langfuse/langfuse/commit/ce8669f313b3e3b532caf099aa5223b340bd15a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42340041)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->