### PR TITLE
chore: improve error handling in batch deletion

### DIFF
--- a/worker/src/__tests__/batchTraceDeletionCleaner.test.ts
+++ b/worker/src/__tests__/batchTraceDeletionCleaner.test.ts
@@ -1,28 +1,57 @@
-import { expect, describe, it, beforeEach, afterEach } from "vitest";
+import { expect, describe, it, beforeEach, afterEach, vi } from "vitest";
 import { randomUUID } from "crypto";
 import { prisma } from "@langfuse/shared/src/db";
-import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import { logger } from "@langfuse/shared/src/server";
 import { BatchTraceDeletionCleaner } from "../features/batch-trace-deletion-cleaner";
+import * as clickhouseTraceDelete from "../features/traces/processClickhouseTraceDelete";
+import * as postgresTraceDelete from "../features/traces/processPostgresTraceDelete";
 
 describe("BatchTraceDeletionCleaner", () => {
   let cleaner: BatchTraceDeletionCleaner;
   let projectId1: string;
   let projectId2: string;
+  let orgIds: string[];
+  let projectIds: string[];
+
+  const createTestProject = async () => {
+    const org = await prisma.organization.create({
+      data: {
+        id: randomUUID(),
+        name: randomUUID(),
+      },
+    });
+    const project = await prisma.project.create({
+      data: {
+        id: randomUUID(),
+        name: randomUUID(),
+        orgId: org.id,
+      },
+    });
+    orgIds.push(org.id);
+    projectIds.push(project.id);
+    return project.id;
+  };
 
   beforeEach(async () => {
-    const result1 = await createOrgProjectAndApiKey();
-    projectId1 = result1.projectId;
-
-    const result2 = await createOrgProjectAndApiKey();
-    projectId2 = result2.projectId;
+    orgIds = [];
+    projectIds = [];
+    projectId1 = await createTestProject();
+    projectId2 = await createTestProject();
 
     cleaner = new BatchTraceDeletionCleaner();
   });
 
   afterEach(async () => {
-    cleaner.stop();
+    cleaner?.stop();
+    vi.restoreAllMocks();
     await prisma.pendingDeletion.deleteMany({
-      where: { projectId: { in: [projectId1, projectId2] } },
+      where: { projectId: { in: projectIds } },
+    });
+    await prisma.project.deleteMany({
+      where: { id: { in: projectIds } },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: orgIds } },
     });
   });
 
@@ -83,6 +112,86 @@ describe("BatchTraceDeletionCleaner", () => {
       // Already-deleted trace should remain unchanged
       const alreadyDeleted = deletions.find((d) => d.objectId === deletedTrace);
       expect(alreadyDeleted?.isDeleted).toBe(true);
+    });
+
+    it("should leave failed trace deletions pending for a later retry", async () => {
+      const traceIds = Array.from({ length: 3 }, () => randomUUID());
+
+      await prisma.pendingDeletion.createMany({
+        data: traceIds.map((id) => ({
+          projectId: projectId1,
+          object: "trace",
+          objectId: id,
+          isDeleted: false,
+        })),
+      });
+
+      const processClickhouseTraceDeleteSpy = vi
+        .spyOn(clickhouseTraceDelete, "processClickhouseTraceDelete")
+        .mockRejectedValueOnce(new Error("ClickHouse timeout"));
+
+      await expect((cleaner as any).processProject(projectId1)).resolves.toBe(
+        false,
+      );
+
+      expect(processClickhouseTraceDeleteSpy).toHaveBeenCalledTimes(1);
+
+      const deletions = await prisma.pendingDeletion.findMany({
+        where: { projectId: projectId1 },
+      });
+      expect(deletions.every((d) => !d.isDeleted)).toBe(true);
+
+      await expect((cleaner as any).processProject(projectId1)).resolves.toBe(
+        true,
+      );
+
+      const retriedDeletions = await prisma.pendingDeletion.findMany({
+        where: { projectId: projectId1 },
+      });
+      expect(processClickhouseTraceDeleteSpy).toHaveBeenCalledTimes(2);
+      expect(retriedDeletions.every((d) => d.isDeleted)).toBe(true);
+    });
+
+    it("should log all failed deletion backends in a single failed run", async () => {
+      const traceIds = Array.from({ length: 3 }, () => randomUUID());
+
+      await prisma.pendingDeletion.createMany({
+        data: traceIds.map((id) => ({
+          projectId: projectId1,
+          object: "trace",
+          objectId: id,
+          isDeleted: false,
+        })),
+      });
+
+      vi.spyOn(
+        postgresTraceDelete,
+        "processPostgresTraceDelete",
+      ).mockRejectedValueOnce(new Error("Postgres timeout"));
+      vi.spyOn(
+        clickhouseTraceDelete,
+        "processClickhouseTraceDelete",
+      ).mockRejectedValueOnce(new Error("ClickHouse timeout"));
+      const loggerWarnSpy = vi.spyOn(logger, "warn");
+
+      await expect((cleaner as any).processProject(projectId1)).resolves.toBe(
+        false,
+      );
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        "BatchTraceDeletionCleaner: Trace deletion failed, will retry later",
+        expect.objectContaining({
+          failures: [
+            { backend: "postgres", errorName: "Error" },
+            { backend: "clickhouse", errorName: "Error" },
+          ],
+        }),
+      );
+
+      const deletions = await prisma.pendingDeletion.findMany({
+        where: { projectId: projectId1 },
+      });
+      expect(deletions.every((d) => !d.isDeleted)).toBe(true);
     });
   });
 

--- a/worker/src/features/batch-trace-deletion-cleaner/index.ts
+++ b/worker/src/features/batch-trace-deletion-cleaner/index.ts
@@ -19,6 +19,15 @@ interface ProjectWorkload {
   pendingCount: number;
 }
 
+type TraceDeletionBackend = "postgres" | "clickhouse";
+type TraceDeletionFailure = {
+  backend: TraceDeletionBackend;
+  errorName: string;
+};
+
+const getErrorName = (error: unknown) =>
+  error instanceof Error ? error.name : typeof error;
+
 /**
  * BatchTraceDeletionCleaner handles periodic deletion of traces from pending_deletions.
  *
@@ -80,8 +89,10 @@ export class BatchTraceDeletionCleaner extends PeriodicExclusiveRunner {
             pendingCount: workload.pendingCount,
           });
 
-          await this.processProject(workload.projectId);
-          recordIncrement(`${METRIC_PREFIX}.projects_processed`, 1);
+          const processed = await this.processProject(workload.projectId);
+          if (processed) {
+            recordIncrement(`${METRIC_PREFIX}.projects_processed`, 1);
+          }
         } else {
           logger.info(`${this.name}: No pending trace deletions to process`);
         }
@@ -125,7 +136,7 @@ export class BatchTraceDeletionCleaner extends PeriodicExclusiveRunner {
     };
   }
 
-  private async processProject(projectId: string): Promise<void> {
+  private async processProject(projectId: string): Promise<boolean> {
     // Get trace IDs to delete (no orderBy for faster query)
     const pendingDeletions = await prisma.pendingDeletion.findMany({
       where: {
@@ -141,7 +152,7 @@ export class BatchTraceDeletionCleaner extends PeriodicExclusiveRunner {
       logger.info(`${this.name}: No traces to delete for project`, {
         projectId,
       });
-      return;
+      return true;
     }
 
     const traceIdsToDelete = pendingDeletions.map((d) => d.objectId);
@@ -151,11 +162,38 @@ export class BatchTraceDeletionCleaner extends PeriodicExclusiveRunner {
       count: traceIdsToDelete.length,
     });
 
-    // Delete from both Postgres and ClickHouse in parallel
-    await Promise.all([
+    const [postgresDeletion, clickhouseDeletion] = await Promise.allSettled([
       processPostgresTraceDelete(projectId, traceIdsToDelete),
       processClickhouseTraceDelete(projectId, traceIdsToDelete),
     ]);
+
+    const failures: TraceDeletionFailure[] = [
+      { backend: "postgres" as const, result: postgresDeletion },
+      { backend: "clickhouse" as const, result: clickhouseDeletion },
+    ].flatMap(({ backend, result }) => {
+      if (result.status === "rejected") {
+        traceException(result.reason);
+        return [
+          {
+            backend,
+            errorName: getErrorName(result.reason),
+          },
+        ];
+      }
+
+      return [];
+    });
+
+    if (failures.length > 0) {
+      recordIncrement(`${METRIC_PREFIX}.deletion_failures`, 1);
+      logger.warn(`${this.name}: Trace deletion failed, will retry later`, {
+        projectId,
+        count: traceIdsToDelete.length,
+        retryDelayMs: env.LANGFUSE_BATCH_TRACE_DELETION_CLEANER_INTERVAL_MS,
+        failures,
+      });
+      return false;
+    }
 
     // Mark traces as deleted
     await prisma.pendingDeletion.updateMany({
@@ -182,5 +220,7 @@ export class BatchTraceDeletionCleaner extends PeriodicExclusiveRunner {
       projectId,
       tracesDeleted: traceIdsToDelete.length,
     });
+
+    return true;
   }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves resilience of `BatchTraceDeletionCleaner` by catching errors inside `processProject`, logging them, and returning `false` instead of propagating the exception — enabling the cleaner to retry on the next scheduled interval rather than crashing.

- `processProject` is refactored to return `boolean`; the `projects_processed` metric is only incremented on success, and deletion errors emit `deletion_failures` without halting the runner.
- A new private `deleteAndMarkTraces` helper uses `Promise.allSettled` so both Postgres and ClickHouse deletions are always attempted before deciding whether to throw.
- Tests replace the `createOrgProjectAndApiKey` helper with direct Prisma calls and add a new retry-on-failure scenario using `vi.spyOn`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core retry logic is sound and the change is a clear improvement over propagating deletion errors; the main gap is that a dual-failure scenario silently drops the second error.

The retry-on-failure path is correct and well-tested. The only notable gap is in `deleteAndMarkTraces`: if both deletions reject, the second error is neither rethrown nor logged, so a dual-failure produces only half the observability signal. This is non-blocking but worth addressing before any debugging session where both sinks are down simultaneously.

The `deleteAndMarkTraces` method in `index.ts` around the `Promise.allSettled` handling deserves a second look for the silent second-error case.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[execute] --> B{Lock acquired?}
    B -- No --> C[deletion_failures++]
    B -- Yes --> D[getTopProjectWorkload]
    D --> E{workload?}
    E -- No --> F[Log: no work]
    E -- Yes --> G[processProject]
    G --> H[findMany pendingDeletions]
    H --> I{length == 0?}
    I -- Yes --> J[return true]
    I -- No --> K[deleteAndMarkTraces]
    K --> L[Promise.allSettled: postgres + clickhouse]
    L --> M{any rejected?}
    M -- Yes --> N[throw first rejection]
    M -- No --> O[updateMany isDeleted=true, traces_deleted++]
    O --> P[return true]
    N --> Q[catch in processProject, traceException, deletion_failures++, log warn]
    Q --> R[return false]
    J --> S{processed?}
    P --> S
    R --> S
    S -- true --> T[projects_processed++]
    S -- false --> U[no metric]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[execute] --> B{Lock acquired?}
    B -- No --> C[deletion_failures++]
    B -- Yes --> D[getTopProjectWorkload]
    D --> E{workload?}
    E -- No --> F[Log: no work]
    E -- Yes --> G[processProject]
    G --> H[findMany pendingDeletions]
    H --> I{length == 0?}
    I -- Yes --> J[return true]
    I -- No --> K[deleteAndMarkTraces]
    K --> L[Promise.allSettled: postgres + clickhouse]
    L --> M{any rejected?}
    M -- Yes --> N[throw first rejection]
    M -- No --> O[updateMany isDeleted=true, traces_deleted++]
    O --> P[return true]
    N --> Q[catch in processProject, traceException, deletion_failures++, log warn]
    Q --> R[return false]
    J --> S{processed?}
    P --> S
    R --> S
    S -- true --> T[projects_processed++]
    S -- false --> U[no metric]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/batch-trace-deletion-cleaner/index.ts:186-191
**Second rejection silently discarded**

When both `processPostgresTraceDelete` and `processClickhouseTraceDelete` fail, `Array.find` returns only the first rejected result. The second rejection's reason is never thrown, logged, or counted — it disappears completely. One `deletion_failures` metric is emitted instead of two, and the second error is invisible to any observability tooling.

### Issue 2 of 2
worker/src/__tests__/batchTraceDeletionCleaner.test.ts:143-153
**Second `processProject` call invokes real ClickHouse**

`mockRejectedValueOnce` exhausts after the first invocation, so the second call to `processProject` runs the real `processClickhouseTraceDelete` against whatever ClickHouse instance is available in CI. If ClickHouse is unreachable or returns a non-idempotent error on the re-attempt, the test will fail unexpectedly. The describe block is labelled "unit" but `processPostgresTraceDelete` is also unspied, making this effectively an integration test. Mocking or spying both functions for the full scenario would remove the environmental dependency.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: improve error handling in batch d..."](https://github.com/langfuse/langfuse/commit/88af336ba08a0bf63d883707572873115d7a60d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42343229)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->