### PR TITLE
chore: metrics v2 hourly quotas

### DIFF
--- a/packages/shared/src/interfaces/rate-limits.ts
+++ b/packages/shared/src/interfaces/rate-limits.ts
@@ -7,7 +7,7 @@ export const RateLimitResource = z.enum([
   "public-api",
   "public-api-legacy",
   "public-api-metrics",
-  "public-api-metrics-v2",
+  "public-api-v2-metrics",
   "public-api-daily-metrics-legacy",
   "prompts",
   "legacy-ingestion",

--- a/web/src/__tests__/server/rate-limit.servertest.ts
+++ b/web/src/__tests__/server/rate-limit.servertest.ts
@@ -389,11 +389,11 @@ describe("RateLimitService", () => {
 
   it("should apply public-api-metrics-v2 rate limits by cloud plan", async () => {
     const cases = [
-      { plan: "cloud:hobby" as const, points: 100 },
-      { plan: "cloud:core" as const, points: 2000 },
-      { plan: "cloud:pro" as const, points: 10_000 },
-      { plan: "cloud:team" as const, points: 10_000 },
-      { plan: "cloud:enterprise" as const, points: 10_000 },
+      { plan: "cloud:hobby" as const, points: 100, durationInSec: 86400 },
+      { plan: "cloud:core" as const, points: 100, durationInSec: 3600 },
+      { plan: "cloud:pro" as const, points: 500, durationInSec: 3600 },
+      { plan: "cloud:team" as const, points: 500, durationInSec: 3600 },
+      { plan: "cloud:enterprise" as const, points: 500, durationInSec: 3600 },
     ];
 
     const rateLimitService = RateLimitService.getInstance(redis);
@@ -426,6 +426,14 @@ describe("RateLimitService", () => {
         isFirstInDuration: true,
       });
       expect(result?.isRateLimited()).toBe(false);
+
+      const ttlInSec = await redis.ttl(
+        `${RATE_LIMIT_REDIS_KEY_PREFIX}:public-api-metrics-v2:${orgId}`,
+      );
+
+      expect(ttlInSec).toBeGreaterThan(0);
+      expect(ttlInSec).toBeLessThanOrEqual(testCase.durationInSec);
+      expect(ttlInSec).toBeGreaterThan(testCase.durationInSec - 60);
     }
   });
 

--- a/web/src/__tests__/server/rate-limit.servertest.ts
+++ b/web/src/__tests__/server/rate-limit.servertest.ts
@@ -387,7 +387,7 @@ describe("RateLimitService", () => {
     }
   });
 
-  it("should apply public-api-metrics-v2 rate limits by cloud plan", async () => {
+  it("should apply public-api-v2-metrics rate limits by cloud plan", async () => {
     const cases = [
       { plan: "cloud:hobby" as const, points: 100, durationInSec: 86400 },
       { plan: "cloud:core" as const, points: 100, durationInSec: 3600 },
@@ -399,9 +399,9 @@ describe("RateLimitService", () => {
     const rateLimitService = RateLimitService.getInstance(redis);
 
     for (const testCase of cases) {
-      await redis.del(
-        `${RATE_LIMIT_REDIS_KEY_PREFIX}:public-api-metrics-v2:${orgId}`,
-      );
+      const activeKey = `${RATE_LIMIT_REDIS_KEY_PREFIX}:public-api-v2-metrics:${orgId}`;
+
+      await redis.del(activeKey);
 
       const scope = {
         orgId: orgId,
@@ -413,12 +413,12 @@ describe("RateLimitService", () => {
 
       const result = await rateLimitService.rateLimitRequest(
         scope,
-        "public-api-metrics-v2",
+        "public-api-v2-metrics",
       );
 
       expect(result?.res).toEqual({
         scope: scope,
-        resource: "public-api-metrics-v2",
+        resource: "public-api-v2-metrics",
         points: testCase.points,
         remainingPoints: testCase.points - 1,
         msBeforeNext: expect.any(Number),
@@ -427,9 +427,7 @@ describe("RateLimitService", () => {
       });
       expect(result?.isRateLimited()).toBe(false);
 
-      const ttlInSec = await redis.ttl(
-        `${RATE_LIMIT_REDIS_KEY_PREFIX}:public-api-metrics-v2:${orgId}`,
-      );
+      const ttlInSec = await redis.ttl(activeKey);
 
       expect(ttlInSec).toBeGreaterThan(0);
       expect(ttlInSec).toBeLessThanOrEqual(testCase.durationInSec);

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -401,8 +401,8 @@ const getPlanBasedRateLimitConfig = (
         case "public-api-metrics-v2":
           return {
             resource: "public-api-metrics-v2",
-            points: 2000,
-            durationInSec: 86400, // 2000 requests per day
+            points: 100,
+            durationInSec: 3600, // 100 requests per hour
           };
         case "public-api-daily-metrics-legacy":
           return {
@@ -488,8 +488,8 @@ const getPlanBasedRateLimitConfig = (
         case "public-api-metrics-v2":
           return {
             resource: "public-api-metrics-v2",
-            points: 10_000,
-            durationInSec: 86400, // 10000 requests per day
+            points: 500,
+            durationInSec: 3600, // 500 requests per hour
           };
         case "public-api-daily-metrics-legacy":
           return {

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -307,9 +307,9 @@ const getPlanBasedRateLimitConfig = (
             points: 100,
             durationInSec: 86400, // 100 requests per day
           };
-        case "public-api-metrics-v2":
+        case "public-api-v2-metrics":
           return {
-            resource: "public-api-metrics-v2",
+            resource,
             points: 100,
             durationInSec: 86400, // 100 requests per day
           };
@@ -398,9 +398,9 @@ const getPlanBasedRateLimitConfig = (
             points: 2000, // temporary: using pro limit
             durationInSec: 86400, // 2000 requests per day
           };
-        case "public-api-metrics-v2":
+        case "public-api-v2-metrics":
           return {
-            resource: "public-api-metrics-v2",
+            resource,
             points: 100,
             durationInSec: 3600, // 100 requests per hour
           };
@@ -485,9 +485,9 @@ const getPlanBasedRateLimitConfig = (
             points: 2000,
             durationInSec: 86400, // 2000 requests per day
           };
-        case "public-api-metrics-v2":
+        case "public-api-v2-metrics":
           return {
-            resource: "public-api-metrics-v2",
+            resource,
             points: 500,
             durationInSec: 3600, // 500 requests per hour
           };

--- a/web/src/pages/api/public/v2/metrics.ts
+++ b/web/src/pages/api/public/v2/metrics.ts
@@ -14,7 +14,7 @@ const DEFAULT_ROW_LIMIT = 100;
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Metrics V2",
-    rateLimitResource: "public-api-metrics-v2",
+    rateLimitResource: "public-api-v2-metrics",
     querySchema: GetMetricsV2Query,
     responseSchema: GetMetricsV2Response,
     fn: async ({ query, auth }) => {


### PR DESCRIPTION
## Summary
- Update `public-api-metrics-v2` plan limits to use hourly quotas instead of daily quotas
- Align cloud plan limits with the new 100/hour and 500/hour thresholds
- Extend server coverage to verify TTL behavior matches the configured window

## Testing
- Updated rate-limit server tests to assert both quota values and Redis TTL duration
- Not run (not requested)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates the `public-api-metrics-v2` rate limit configuration from daily to hourly windows for `cloud:core` (2000/day → 100/hour) and `cloud:pro`/`cloud:team`/`cloud:enterprise` (10,000/day → 500/hour). The `cloud:hobby` plan is deliberately left on its existing daily window (100/day).

- **`RateLimitService.ts`**: Two `switch` branches updated with new `points` and `durationInSec` values; no other resources are affected.
- **`rate-limit.servertest.ts`**: Test cases augmented with `durationInSec` per plan and new Redis TTL assertions to verify the window is being persisted correctly in the rate-limiter key.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — two isolated numeric constant changes with matching test updates and Redis TTL verification.

The change is narrowly scoped to two switch-case blocks in the rate-limit config function. The hobby plan is intentionally kept on its existing daily window, which the updated test explicitly documents. The new TTL assertions confirm that rate-limiter-flexible actually persists the configured window to Redis, adding meaningful coverage. No auth paths, no data mutations, and no schema changes are involved.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming API Request] --> B{Cloud Plan?}
    B --> C[cloud:hobby]
    B --> D[cloud:core]
    B --> E[cloud:pro / team / enterprise]
    B --> F[oss / self-hosted]

    C --> C1["public-api-metrics-v2\n100 pts / 86400s (daily)\n**UNCHANGED**"]
    D --> D1["public-api-metrics-v2\n~~2000 pts / 86400s~~\n→ 100 pts / 3600s (hourly)"]
    E --> E1["public-api-metrics-v2\n~~10000 pts / 86400s~~\n→ 500 pts / 3600s (hourly)"]
    F --> F1["No rate limit applied"]

    C1 --> G[RateLimiterRedis.consume orgId]
    D1 --> G
    E1 --> G
    G --> H{Points remaining?}
    H -- Yes --> I[200 OK]
    H -- No --> J[429 Too Many Requests]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming API Request] --> B{Cloud Plan?}
    B --> C[cloud:hobby]
    B --> D[cloud:core]
    B --> E[cloud:pro / team / enterprise]
    B --> F[oss / self-hosted]

    C --> C1["public-api-metrics-v2\n100 pts / 86400s (daily)\n**UNCHANGED**"]
    D --> D1["public-api-metrics-v2\n~~2000 pts / 86400s~~\n→ 100 pts / 3600s (hourly)"]
    E --> E1["public-api-metrics-v2\n~~10000 pts / 86400s~~\n→ 500 pts / 3600s (hourly)"]
    F --> F1["No rate limit applied"]

    C1 --> G[RateLimiterRedis.consume orgId]
    D1 --> G
    E1 --> G
    G --> H{Points remaining?}
    H -- Yes --> I[200 OK]
    H -- No --> J[429 Too Many Requests]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix public API metrics v2 rate limits"](https://github.com/langfuse/langfuse/commit/03712d7cc26a560aa20a4e7a414005e079dae6d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42352331)</sub>

<!-- /greptile_comment -->