### PR TITLE
chore(filters): trace more langfuse metadata

### DIFF
--- a/web/src/features/natural-language-filters/server/router.ts
+++ b/web/src/features/natural-language-filters/server/router.ts
@@ -134,6 +134,11 @@ export const naturalLanguageFilterRouter = createTRPCRouter({
                 userId: ctx.session.user.id,
                 metadata: {
                   langfuse_user_id: ctx.session.user.id,
+                  ...(ctx.session.user.email
+                    ? { langfuse_user_email: ctx.session.user.email }
+                    : {}),
+                  langfuse_user_project_role: ctx.session.projectRole,
+                  langfuse_cloud_region: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
                 },
                 prompt: promptResponse,
               })

--- a/web/src/features/search-bar/server/router.ts
+++ b/web/src/features/search-bar/server/router.ts
@@ -134,6 +134,11 @@ export const searchBarRouter = createTRPCRouter({
                 userId: ctx.session.user.id,
                 metadata: {
                   langfuse_user_id: ctx.session.user.id,
+                  ...(ctx.session.user.email
+                    ? { langfuse_user_email: ctx.session.user.email }
+                    : {}),
+                  langfuse_user_project_role: ctx.session.projectRole,
+                  langfuse_cloud_region: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
                   // Debugging context for prompt iteration: a trace alone should
                   // explain WHY the model produced what it did. refine_mode marks
                   // refine vs. from-scratch; current_query is the filters being


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds three additional metadata fields (`langfuse_user_email`, `langfuse_user_project_role`, `langfuse_cloud_region`) to the AI trace sink parameters in both the natural-language filter router and the search-bar filter router, to improve observability for internal debugging.

- Both routers now conditionally spread the user's email (only when present) and always include the user's project role and cloud region in the trace metadata object passed to `getLangfuseAITraceSinkParams`.
- The metadata enrichment is already gated behind the existing `aiTelemetryEnabled` org-level flag, so organizations that have opted out are unaffected.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a narrow, additive change to internal telemetry metadata; it touches no business logic, and the new fields are already gated behind the org-level aiTelemetryEnabled flag.

Both files receive identical, minimal additions: a conditional email spread and two constant metadata fields. No data flow, auth logic, or output paths are changed. The email field is correctly guarded with a conditional spread. The cloud region is always a non-null string at that point due to the early throw. Changes are symmetric and low risk.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as TRPC Router
    participant Guard as Auth & Feature Guards
    participant Bedrock as fetchLangfuseAICompletion
    participant Langfuse as Langfuse AI Trace Sink

    Client->>Router: mutation(input, ctx)
    Router->>Guard: throwIfNoProjectAccess
    Guard-->>Router: ok
    Router->>Router: check CLOUD_REGION, aiFeaturesEnabled, Bedrock config
    Router->>Bedrock: fetchLangfuseAICompletion with traceSinkParams
    note over Router,Bedrock: metadata now includes langfuse_user_email, langfuse_user_project_role, langfuse_cloud_region
    Bedrock->>Langfuse: trace (if aiTelemetryEnabled)
    Langfuse-->>Bedrock: ack
    Bedrock-->>Router: llmCompletion
    Router-->>Client: filters / queryText
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as TRPC Router
    participant Guard as Auth & Feature Guards
    participant Bedrock as fetchLangfuseAICompletion
    participant Langfuse as Langfuse AI Trace Sink

    Client->>Router: mutation(input, ctx)
    Router->>Guard: throwIfNoProjectAccess
    Guard-->>Router: ok
    Router->>Router: check CLOUD_REGION, aiFeaturesEnabled, Bedrock config
    Router->>Bedrock: fetchLangfuseAICompletion with traceSinkParams
    note over Router,Bedrock: metadata now includes langfuse_user_email, langfuse_user_project_role, langfuse_cloud_region
    Bedrock->>Langfuse: trace (if aiTelemetryEnabled)
    Langfuse-->>Bedrock: ack
    Bedrock-->>Router: llmCompletion
    Router-->>Client: filters / queryText
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(filters): trace more langfuse meta..."](https://github.com/langfuse/langfuse/commit/b0c5a1f42c7590f1c23905a02aa9faea3587bfe8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42352971)</sub>

<!-- /greptile_comment -->