### PR TITLE
chore: tighten project_failure.active_projects

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -302,7 +302,7 @@ const EnvSchema = z.object({
     .number()
     .int()
     .gt(60)
-    .default(3600), // 1 hour
+    .default(600), // 10 minutes
   LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED: z
     .enum(["true", "false"])
     .default("false"),

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -2,6 +2,8 @@ import { Cluster, Redis } from "ioredis";
 import { v4 } from "uuid";
 import { Decimal } from "decimal.js";
 import {
+  InvalidRequestError,
+  LangfuseNotFoundError,
   Model,
   ObservationLevel,
   PrismaClient,
@@ -534,6 +536,7 @@ export class IngestionService {
       minTimestamp === Infinity
         ? undefined
         : convertDateToClickhouseDateTime(new Date(minTimestamp));
+    const unexpectedScoreValidationErrors: unknown[] = [];
     const [clickhouseScoreRecord, scoreRecords] = await Promise.all([
       this.getClickhouseRecord({
         projectId,
@@ -587,6 +590,13 @@ export class IngestionService {
             };
             // Gracefully handle any score schema validation errors, skip the score insert and reject silently.
           } catch (error) {
+            if (
+              !(error instanceof InvalidRequestError) &&
+              !(error instanceof LangfuseNotFoundError)
+            ) {
+              unexpectedScoreValidationErrors.push(error);
+            }
+
             logger.info(
               `Failed to validate and enrich score body for project: ${projectId} and score: ${entityId}`,
               error,
@@ -606,6 +616,17 @@ export class IngestionService {
         store: "clickhouse",
         object: "score",
       });
+    }
+
+    if (
+      scoreRecords.length === 0 &&
+      !clickhouseScoreRecord &&
+      unexpectedScoreValidationErrors.length === 0
+    ) {
+      logger.warn(
+        `No valid score records found for project: ${projectId} and score: ${entityId}`,
+      );
+      return;
     }
 
     const finalScoreRecord: ScoreRecordInsertType =

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -618,11 +618,14 @@ export class IngestionService {
       });
     }
 
-    if (
-      scoreRecords.length === 0 &&
-      !clickhouseScoreRecord &&
-      unexpectedScoreValidationErrors.length === 0
-    ) {
+    if (unexpectedScoreValidationErrors.length > 0) {
+      throw new AggregateError(
+        unexpectedScoreValidationErrors,
+        `Unexpected error(s) validating score batch for project: ${projectId} and score: ${entityId}`,
+      );
+    }
+
+    if (scoreRecords.length === 0 && !clickhouseScoreRecord) {
       logger.warn(
         `No valid score records found for project: ${projectId} and score: ${entityId}`,
       );

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -3,6 +3,7 @@ import { IngestionService } from "../../IngestionService";
 import {
   convertDateToClickhouseDateTime,
   type ObservationEvent,
+  type ScoreEventType,
 } from "@langfuse/shared/src/server";
 import { TableName } from "../../ClickhouseWriter";
 
@@ -88,5 +89,105 @@ describe("IngestionService unit tests", () => {
     expect(observationRecord?.metadata).toEqual({
       attributes: JSON.stringify({ "custom.attribute": "keep-me" }),
     });
+  });
+
+  it("silently rejects score batches with no valid records", async () => {
+    const addToQueue = vi.fn();
+    const ingestionService = new IngestionService(
+      {} as any,
+      {} as any,
+      { addToQueue } as any,
+      {} as any,
+    );
+    const timestamp = "2024-10-12T12:13:14.123Z";
+    const scoreEventList: ScoreEventType[] = [
+      {
+        id: "event-id",
+        timestamp,
+        type: "score-create",
+        body: {
+          id: "score-id",
+          dataType: "NUMERIC",
+          name: "invalid-score",
+          value: "not-a-number",
+          source: "API",
+          traceId: "trace-id",
+          environment: "default",
+        },
+      },
+    ];
+
+    vi.spyOn(ingestionService as any, "getClickhouseRecord").mockResolvedValue(
+      null,
+    );
+
+    await expect(
+      (ingestionService as any).processScoreEventList({
+        projectId: "project-id",
+        entityId: "score-id",
+        createdAtTimestamp: new Date(timestamp),
+        scoreEventList,
+        attribution: {
+          ingestionApiKey: "pk-lf-unit-test",
+          ingestionSdkName: "langfuse-test",
+          ingestionSdkVersion: "0.0.0",
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(addToQueue).not.toHaveBeenCalled();
+  });
+
+  it("does not silently reject score batches with unexpected record errors", async () => {
+    const addToQueue = vi.fn();
+    const ingestionService = new IngestionService(
+      {} as any,
+      {} as any,
+      { addToQueue } as any,
+      {} as any,
+    );
+    const timestamp = "2024-10-12T12:13:14.123Z";
+    const scoreEventList: ScoreEventType[] = [
+      {
+        id: "event-id",
+        timestamp,
+        type: "score-create",
+        body: {
+          id: "score-id",
+          dataType: "NUMERIC",
+          name: "valid-score",
+          value: 1,
+          source: "API",
+          traceId: "trace-id",
+          environment: "default",
+        },
+      },
+    ];
+
+    vi.spyOn(ingestionService as any, "getClickhouseRecord").mockResolvedValue(
+      null,
+    );
+    vi.spyOn(
+      ingestionService as any,
+      "getMillisecondTimestamp",
+    ).mockImplementation(() => {
+      throw new Error("unexpected timestamp failure");
+    });
+
+    await expect(
+      (ingestionService as any).processScoreEventList({
+        projectId: "project-id",
+        entityId: "score-id",
+        createdAtTimestamp: new Date(timestamp),
+        scoreEventList,
+        attribution: {
+          ingestionApiKey: "pk-lf-unit-test",
+          ingestionSdkName: "langfuse-test",
+          ingestionSdkVersion: "0.0.0",
+        },
+      }),
+    ).rejects.toThrow("No records to merge");
+
+    expect(addToQueue).not.toHaveBeenCalled();
   });
 });

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -2,6 +2,7 @@ import { expect, describe, it, vi } from "vitest";
 import { IngestionService } from "../../IngestionService";
 import {
   convertDateToClickhouseDateTime,
+  createTraceScore,
   type ObservationEvent,
   type ScoreEventType,
 } from "@langfuse/shared/src/server";
@@ -186,7 +187,65 @@ describe("IngestionService unit tests", () => {
           ingestionSdkVersion: "0.0.0",
         },
       }),
-    ).rejects.toThrow("No records to merge");
+    ).rejects.toThrow("Unexpected error(s) validating score batch");
+
+    expect(addToQueue).not.toHaveBeenCalled();
+  });
+
+  it("propagates unexpected score errors even when a ClickHouse score exists", async () => {
+    const addToQueue = vi.fn();
+    const ingestionService = new IngestionService(
+      {} as any,
+      {} as any,
+      { addToQueue } as any,
+      {} as any,
+    );
+    const timestamp = "2024-10-12T12:13:14.123Z";
+    const scoreEventList: ScoreEventType[] = [
+      {
+        id: "event-id",
+        timestamp,
+        type: "score-update",
+        body: {
+          id: "score-id",
+          dataType: "NUMERIC",
+          name: "valid-score",
+          value: 1,
+          source: "API",
+          traceId: "trace-id",
+          environment: "default",
+        },
+      },
+    ];
+
+    vi.spyOn(ingestionService as any, "getClickhouseRecord").mockResolvedValue(
+      createTraceScore({
+        id: "score-id",
+        project_id: "project-id",
+        trace_id: "trace-id",
+        timestamp: new Date(timestamp).getTime(),
+      }),
+    );
+    vi.spyOn(
+      ingestionService as any,
+      "getMillisecondTimestamp",
+    ).mockImplementation(() => {
+      throw new Error("unexpected timestamp failure");
+    });
+
+    await expect(
+      (ingestionService as any).processScoreEventList({
+        projectId: "project-id",
+        entityId: "score-id",
+        createdAtTimestamp: new Date(timestamp),
+        scoreEventList,
+        attribution: {
+          ingestionApiKey: "pk-lf-unit-test",
+          ingestionSdkName: "langfuse-test",
+          ingestionSdkVersion: "0.0.0",
+        },
+      }),
+    ).rejects.toThrow("Unexpected error(s) validating score batch");
 
     expect(addToQueue).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens failure-tracking behavior in two ways: it reduces the default `LANGFUSE_INGEST_FAILURE_PROJECT_TTL_SECONDS` from 1 hour to 10 minutes, and it adds a smarter early-return guard in `processScoreEventList` that distinguishes between expected user-input validation errors (`InvalidRequestError`/`LangfuseNotFoundError`) and unexpected runtime errors before deciding whether to return silently or surface a failure.

- **`env.ts`**: Default TTL for `LANGFUSE_INGEST_FAILURE_PROJECT_TTL_SECONDS` reduced from 3600 s to 600 s; the `.gt(60)` constraint is still satisfied.
- **`IngestionService/index.ts`**: Unexpected validation errors are now tracked separately; a new guard prevents `mergeScoreRecords` from being called (and throwing "No records to merge") when every event in a batch failed with an expected user-input error and no prior Clickhouse record exists.
- **Tests**: Two new unit tests cover the silent-reject and unexpected-error-propagation branches.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the new guard correctly avoids calling mergeScoreRecords on an empty dataset when all failures are expected user-input errors, and the TTL reduction is intentional and within the validated range.

The logic change is narrow and well-tested. The only non-trivial concern is that unexpected runtime errors inside the catch block are still emitted at `info` level, making them indistinguishable from ordinary user-input rejections in logs — this could delay detection of novel failure modes in production, but does not cause incorrect data to be written or dropped.

worker/src/services/IngestionService/index.ts — specifically the catch block log level for unexpected errors
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processScoreEventList] --> B{scoreEventList empty?}
    B -- yes --> C[return early]
    B -- no --> D[sort events by time]
    D --> E[Promise.all: getClickhouseRecord + validate each event]
    E --> F{validateAndInflateScore succeeds?}
    F -- yes --> G[build ScoreRecord]
    F -- no: InvalidRequestError / LangfuseNotFoundError --> H[logger.info\nskip silently]
    F -- no: unexpected error --> I[push to unexpectedScoreValidationErrors\nlogger.info]
    G --> J[scoreRecords]
    H --> K[null → filtered out]
    I --> K
    J --> L{scoreRecords.length == 0\nAND no clickhouse record\nAND no unexpected errors?}
    L -- yes --> M[logger.warn\nreturn early NEW]
    L -- no --> N[mergeScoreRecords]
    N --> O{has records?}
    O -- yes --> P[addToQueue ClickHouse]
    O -- no --> Q[throw 'No records to merge']
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[processScoreEventList] --> B{scoreEventList empty?}
    B -- yes --> C[return early]
    B -- no --> D[sort events by time]
    D --> E[Promise.all: getClickhouseRecord + validate each event]
    E --> F{validateAndInflateScore succeeds?}
    F -- yes --> G[build ScoreRecord]
    F -- no: InvalidRequestError / LangfuseNotFoundError --> H[logger.info\nskip silently]
    F -- no: unexpected error --> I[push to unexpectedScoreValidationErrors\nlogger.info]
    G --> J[scoreRecords]
    H --> K[null → filtered out]
    I --> K
    J --> L{scoreRecords.length == 0\nAND no clickhouse record\nAND no unexpected errors?}
    L -- yes --> M[logger.warn\nreturn early NEW]
    L -- no --> N[mergeScoreRecords]
    N --> O{has records?}
    O -- yes --> P[addToQueue ClickHouse]
    O -- no --> Q[throw 'No records to merge']
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/services/IngestionService/index.ts:592-603
Unexpected errors are still logged at `info` level, making them harder to distinguish from ordinary validation noise in production. Since the PR now explicitly tracks `unexpectedScoreValidationErrors` as a distinct category, the log entry for those errors should use a higher severity (e.g. `logger.error` or `logger.warn`) so that unexpected runtime failures are visible in alerting and dashboards without having to increase log verbosity to `info`.

```suggestion
          } catch (error) {
            if (
              !(error instanceof InvalidRequestError) &&
              !(error instanceof LangfuseNotFoundError)
            ) {
              unexpectedScoreValidationErrors.push(error);
              logger.error(
                `Unexpected error validating score body for project: ${projectId} and score: ${entityId}`,
                error,
              );
            } else {
              logger.info(
                `Failed to validate and enrich score body for project: ${projectId} and score: ${entityId}`,
                error,
              );
            }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: tighten project\_failure.active\_pr..."](https://github.com/langfuse/langfuse/commit/268efddcf734bbf78d076859d8fc0814d6e496b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42394605)</sub>

<!-- /greptile_comment -->