### PR TITLE
refactor(agent): Enable more eslint rules

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -112,6 +112,7 @@ export default [
     rules: {
       "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
       "@typescript-eslint/no-confusing-void-expression": "warn",
+      "@typescript-eslint/no-meaningless-void-operator": "warn",
       "@typescript-eslint/no-invalid-void-type": "warn",
       "@typescript-eslint/no-unsafe-assignment": "warn",
       "@typescript-eslint/return-await": ["warn", "in-try-catch"],

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -110,6 +110,7 @@ export default [
     name: "langfuse/web/in-app-agent",
     files: ["src/ee/features/in-app-agent/**/*.{ts,tsx}"],
     rules: {
+      "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
       curly: ["error", "all"],
       "@repo/no-switch-statements": "error",
     },

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -112,6 +112,7 @@ export default [
     rules: {
       "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
       "@typescript-eslint/no-confusing-void-expression": "warn",
+      "@typescript-eslint/no-invalid-void-type": "warn",
       "@typescript-eslint/no-unsafe-assignment": "warn",
       "@typescript-eslint/return-await": ["warn", "in-try-catch"],
       curly: ["error", "all"],

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -112,6 +112,7 @@ export default [
     rules: {
       "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
       "@typescript-eslint/no-confusing-void-expression": "warn",
+      "@typescript-eslint/no-unsafe-assignment": "warn",
       "@typescript-eslint/return-await": ["warn", "in-try-catch"],
       curly: ["error", "all"],
       "@repo/no-switch-statements": "error",

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -110,6 +110,7 @@ export default [
     name: "langfuse/web/in-app-agent",
     files: ["src/ee/features/in-app-agent/**/*.{ts,tsx}"],
     rules: {
+      curly: ["error", "all"],
       "@repo/no-switch-statements": "error",
     },
   },

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -112,6 +112,7 @@ export default [
     rules: {
       "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
       "@typescript-eslint/no-confusing-void-expression": "warn",
+      "@typescript-eslint/return-await": ["warn", "in-try-catch"],
       curly: ["error", "all"],
       "@repo/no-switch-statements": "error",
     },

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -112,6 +112,7 @@ export default [
     rules: {
       "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
       "@typescript-eslint/no-confusing-void-expression": "warn",
+      "@typescript-eslint/no-non-null-assertion": "warn",
       "@typescript-eslint/no-meaningless-void-operator": "warn",
       "@typescript-eslint/no-invalid-void-type": "warn",
       "@typescript-eslint/no-unsafe-assignment": "warn",

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -111,6 +111,7 @@ export default [
     files: ["src/ee/features/in-app-agent/**/*.{ts,tsx}"],
     rules: {
       "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
+      "@typescript-eslint/no-confusing-void-expression": "warn",
       curly: ["error", "all"],
       "@repo/no-switch-statements": "error",
     },

--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -79,7 +79,9 @@ export function ControlledInAppAgentWindow(
       onOpenConversationHistory={invalidateConversations}
       onDeleteConversation={props.onDeleteConversation}
       onSelectConversation={selectConversation}
-      onNewConversation={() => selectConversation(null)}
+      onNewConversation={() => {
+        selectConversation(null);
+      }}
       onExpandedChange={props.onExpandedChange}
       onSubmit={submit}
       onApproveToolCall={approveToolCall}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -398,7 +398,9 @@ function MessageFeedbackControls({
           label="Good response"
           isSelected={selectedValue === "thumbs_up"}
           disabled={isDisabled}
-          onClick={() => handleSelectFeedback("thumbs_up")}
+          onClick={() => {
+            handleSelectFeedback("thumbs_up");
+          }}
         >
           <ThumbsUp
             className={cn(
@@ -412,7 +414,9 @@ function MessageFeedbackControls({
         label="Bad response"
         isSelected={selectedValue === "thumbs_down"}
         disabled={isDisabled}
-        onClick={() => handleSelectFeedback("thumbs_down")}
+        onClick={() => {
+          handleSelectFeedback("thumbs_down");
+        }}
       >
         <ThumbsDown
           className={cn(
@@ -427,7 +431,9 @@ function MessageFeedbackControls({
           className="text-muted-foreground hover:text-foreground ml-1 min-w-0 flex-1 truncate text-left text-xs disabled:cursor-not-allowed disabled:opacity-60"
           title={commentButtonText}
           disabled={isDisabled}
-          onClick={() => setIsCommentPopoverOpen(true)}
+          onClick={() => {
+            setIsCommentPopoverOpen(true);
+          }}
         >
           {commentButtonText}
         </button>
@@ -441,7 +447,9 @@ function MessageFeedbackControls({
           <div>
             <textarea
               value={comment}
-              onChange={(event) => setComment(event.target.value)}
+              onChange={(event) => {
+                setComment(event.target.value);
+              }}
               disabled={isDisabled}
               placeholder="Optional feedback comment"
               rows={3}
@@ -833,7 +841,9 @@ function getSelectedMarkdownFromSource(
   htmlContainer.append(range.cloneContents());
   htmlContainer
     .querySelectorAll("[data-in-app-agent-code-copy-button]")
-    .forEach((node) => node.remove());
+    .forEach((node) => {
+      node.remove();
+    });
 
   return {
     markdown: selectedMarkdown,

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -360,7 +360,9 @@ function StreamingInAppAgentWindow(args: InAppAgentWindowProps) {
       );
     }, 140);
 
-    return () => window.clearInterval(intervalId);
+    return () => {
+      window.clearInterval(intervalId);
+    };
   }, []);
 
   return (

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -189,9 +189,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
             currentInput.trim() === trimmedContent ? "" : currentInput,
           );
 
-          window.requestAnimationFrame(() =>
-            scrollViewportToBottom(viewportRef.current),
-          );
+          window.requestAnimationFrame(() => {
+            scrollViewportToBottom(viewportRef.current);
+          });
         }
       })
       .catch(() => undefined);
@@ -329,7 +329,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                         conversation.id === selectedConversationId &&
                           "bg-accent text-accent-foreground",
                       )}
-                      onSelect={() => onSelectConversation(conversation.id)}
+                      onSelect={() => {
+                        onSelectConversation(conversation.id);
+                      }}
                     >
                       <span
                         className="min-w-0 flex-1 truncate"
@@ -378,7 +380,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 size="icon"
                 className="size-6"
                 aria-label={isExpanded ? "Collapse window" : "Expand window"}
-                onClick={() => onExpandedChange(!isExpanded)}
+                onClick={() => {
+                  onExpandedChange(!isExpanded);
+                }}
               >
                 {isExpanded ? (
                   <Minimize2 className="size-3" />
@@ -467,7 +471,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                           : "rounded-xl px-2 py-1.5",
                       )}
                       disabled={isInputDisabled}
-                      onClick={() => submitInput(message)}
+                      onClick={() => {
+                        submitInput(message);
+                      }}
                     >
                       {label}
                     </button>
@@ -595,7 +601,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
               autoFocus={!isExpanded}
               ref={inputRef}
               value={input}
-              onChange={(event) => setInput(event.target.value)}
+              onChange={(event) => {
+                setInput(event.target.value);
+              }}
               onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
                 if (
                   event.key === "Enter" &&

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -417,8 +417,15 @@ function InAppAiAgentProviderInner({
       }
 
       subscriptionRef.current = agent.subscribe({
-        onRunStartedEvent: ({ event }) => {
-          activeRunIdRef.current = event.runId;
+        onRunStartedEvent: (payload: { event: unknown }) => {
+          if (
+            typeof payload.event === "object" &&
+            payload.event !== null &&
+            "runId" in payload.event &&
+            typeof payload.event.runId === "string"
+          ) {
+            activeRunIdRef.current = payload.event.runId;
+          }
         },
         onCustomEvent: ({ event }) => {
           const approvalRequest = parseInAppAgentInterruptEvent(event);

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -139,9 +139,9 @@ type InAppAiAgentContextType = {
 
 const InAppAiAgentContext = createContext<InAppAiAgentContextType | null>(null);
 
-export interface InAppAiAgentProviderProps extends PropsWithChildren {
+export type InAppAiAgentProviderProps = PropsWithChildren<{
   defaultOpen?: boolean;
-}
+}>;
 
 export function InAppAiAgentProvider({
   children,

--- a/web/src/ee/features/in-app-agent/schema.ts
+++ b/web/src/ee/features/in-app-agent/schema.ts
@@ -183,8 +183,8 @@ export type InAppAgentMessageSource = z.infer<
 const AgUiToolSchema = z.object({
   name: z.string(),
   description: z.string(),
-  parameters: z.any().optional(),
-  metadata: z.record(z.string(), z.any()).optional(),
+  parameters: z.unknown().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 const AgUiContextSchema = z.object({
@@ -196,11 +196,11 @@ export const AgUiRunAgentInputSchema = z.object({
   threadId: z.string(),
   runId: z.string(),
   parentRunId: z.string().optional(),
-  state: z.any().optional(),
+  state: z.unknown().optional(),
   messages: z.array(AgUiMessageSchema),
   tools: z.array(AgUiToolSchema),
   context: z.array(AgUiContextSchema),
-  forwardedProps: z.any().optional(),
+  forwardedProps: z.unknown().optional(),
 });
 
 export type AgUiRunAgentInput = z.infer<typeof AgUiRunAgentInputSchema>;

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -298,7 +298,9 @@ export async function createAgUiStream(params: {
               encoder.encode(`data: ${JSON.stringify(agUiEvent)}\n\n`),
             );
           })
-          .catch((error) => failStream(error, String(agUiEvent.type)));
+          .catch((error) => {
+            failStream(error, String(agUiEvent.type));
+          });
       };
 
       const handleStreamedRunError = () => {
@@ -356,7 +358,9 @@ export async function createAgUiStream(params: {
             closed = true;
             controller.close();
           })
-          .catch((error) => failStream(error))
+          .catch((error) => {
+            failStream(error);
+          })
           .finally(finish);
       };
 

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -211,15 +211,16 @@ export async function createAgUiStream(params: {
 
         for (const result of results) {
           if (result.status === "rejected") {
+            const error: unknown = result.reason;
             logger.error("Error in agent stream cleanup", {
-              error: result.reason,
+              error,
               runId: params.input.runId,
               threadId: params.input.threadId,
             });
           }
         }
       })
-      .catch((error) => {
+      .catch((error: unknown) => {
         logger.error("Error in agent stream cleanup", {
           error,
           runId: params.input.runId,
@@ -234,7 +235,7 @@ export async function createAgUiStream(params: {
   ) => {
     try {
       await callback?.();
-    } catch (error) {
+    } catch (error: unknown) {
       logger.error(errorContext, {
         error,
         runId: params.input.runId,
@@ -298,7 +299,7 @@ export async function createAgUiStream(params: {
               encoder.encode(`data: ${JSON.stringify(agUiEvent)}\n\n`),
             );
           })
-          .catch((error) => {
+          .catch((error: unknown) => {
             failStream(error, String(agUiEvent.type));
           });
       };
@@ -358,7 +359,7 @@ export async function createAgUiStream(params: {
             closed = true;
             controller.close();
           })
-          .catch((error) => {
+          .catch((error: unknown) => {
             failStream(error);
           })
           .finally(finish);
@@ -391,7 +392,7 @@ export async function createAgUiStream(params: {
             closed = true;
             controller.close();
           })
-          .catch((error) => {
+          .catch((error: unknown) => {
             closed = true;
             logger.error("Error while aborting agent stream", {
               error,
@@ -454,7 +455,7 @@ export async function createAgUiStream(params: {
         .then(async (initialAdapter) => {
           if (ending || closed || params.signal.aborted) {
             initialAdapter.interrupt();
-            initialAdapter.cleanup().catch((error) => {
+            initialAdapter.cleanup().catch((error: unknown) => {
               logger.error("Error in agent stream cleanup", {
                 error,
                 runId: params.input.runId,
@@ -510,7 +511,7 @@ export async function createAgUiStream(params: {
 
             if (ending || closed || params.signal.aborted) {
               currentAdapter.interrupt();
-              currentAdapter.cleanup().catch((error) => {
+              currentAdapter.cleanup().catch((error: unknown) => {
                 logger.error("Error in agent stream cleanup", {
                   error,
                   runId: params.input.runId,
@@ -573,7 +574,7 @@ export async function createAgUiStream(params: {
                 }
               }
             },
-            error(error) {
+            error(error: unknown) {
               if (ending || closed) {
                 return;
               }
@@ -629,7 +630,7 @@ export async function createAgUiStream(params: {
             },
           });
         })
-        .catch((error) => {
+        .catch((error: unknown) => {
           if (ending || closed) {
             return;
           }
@@ -673,7 +674,7 @@ export async function createAgUiStream(params: {
         .then(() => {
           closed = true;
         })
-        .catch((error) => {
+        .catch((error: unknown) => {
           closed = true;
           logger.error("Error while cancelling agent stream", {
             error,
@@ -826,8 +827,8 @@ async function createMastraAdapter(params: {
       interrupt: () => agent.abortRunStream(params.input.runId),
       cleanup: () => mcpClient.disconnect(),
     };
-  } catch (error) {
-    await mcpClient.disconnect().catch((disconnectError) => {
+  } catch (error: unknown) {
+    await mcpClient.disconnect().catch((disconnectError: unknown) => {
       logger.error("Error cleaning up failed agent initialization", {
         error: disconnectError,
         runId: params.input.runId,

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -732,7 +732,10 @@ async function cleanupInAppAgentMcpApiKey(params: {
   });
 }
 
-type SanitizedAgentInput = AgUiRunAgentInput &
+type SanitizedAgentInput = Omit<
+  AgUiRunAgentInput,
+  "messages" | "forwardedProps"
+> &
   (
     | {
         messages: [SanitizedUserMessage];
@@ -757,7 +760,7 @@ function sanitizeAgentInput(
   input: AgUiRunAgentInput,
   projectId: string,
 ): SanitizedAgentInput {
-  const forwardedProps = input.forwardedProps;
+  const forwardedProps: unknown = input.forwardedProps;
 
   if (
     forwardedProps !== undefined &&

--- a/web/src/ee/features/in-app-agent/server/instrumentation.ts
+++ b/web/src/ee/features/in-app-agent/server/instrumentation.ts
@@ -857,7 +857,7 @@ function normalizeToolOutput(output: unknown): unknown {
     return parsedOutput;
   }
 
-  const firstContent = parsedOutput.content[0];
+  const firstContent: unknown = parsedOutput.content[0];
 
   if (
     parsedOutput.content.length !== 1 ||

--- a/web/src/ee/features/in-app-agent/server/persistence.ts
+++ b/web/src/ee/features/in-app-agent/server/persistence.ts
@@ -713,10 +713,8 @@ export function createConversationMessageAccumulator(
       return true;
     }
 
-    messages[existingIndex] = mergeMessages(
-      messages[existingIndex]!,
-      parsed.data,
-    );
+    const existingMessage = messages[existingIndex];
+    messages[existingIndex] = mergeMessages(existingMessage, parsed.data);
 
     return true;
   };

--- a/web/src/ee/features/in-app-agent/server/persistence.ts
+++ b/web/src/ee/features/in-app-agent/server/persistence.ts
@@ -197,7 +197,7 @@ export async function finishRun(params: {
         errorMessage: params.errorMessage ?? null,
       },
     })
-    .catch((error) =>
+    .catch((error: unknown) =>
       logger.error("Failed to finish in-app agent run", {
         error,
         runId: params.runId,

--- a/web/src/ee/features/in-app-agent/server/skills.ts
+++ b/web/src/ee/features/in-app-agent/server/skills.ts
@@ -46,7 +46,7 @@ function parseSkillMarkdown(
 }
 
 function parseFrontmatter(frontmatter: string): Record<string, string> {
-  const parsed = parse(frontmatter);
+  const parsed: unknown = parse(frontmatter);
 
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("In-app agent skill frontmatter must be a YAML object.");


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables additional ESLint rules (`curly: all`, `no-non-null-assertion`, `no-unsafe-assignment`, `return-await`, `consistent-type-definitions`, etc.) for the `in-app-agent` module and fixes all resulting violations.

- **Curly braces**: All single-expression arrow-function bodies expanded to block form across five component files.
- **Type safety**: `z.any()` replaced with `z.unknown()` in schema definitions; `catch`/`.catch()` callbacks annotated with `error: unknown`; `SanitizedAgentInput` corrected from a raw intersection to `Omit<AgUiRunAgentInput, "messages" | "forwardedProps"> & …` to avoid the conflicting `messages` field types; `onRunStartedEvent` callback now guards `payload.event.runId` before assignment instead of relying on implicit `any`.
- **Type-definition style**: `interface InAppAiAgentProviderProps` converted to a `type` alias per `consistent-type-definitions`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are mechanical ESLint fixes with no altered runtime logic.

Every change is a direct, expected response to a newly enabled lint rule: brace expansion, unknown-typed catch blocks, z.any→z.unknown in schemas, and a correct Omit-based type fix. The only substantive logic change (adding a runtime type-guard around payload.event.runId) makes the code strictly safer than the original implicit-any access. No runtime behavior or data flow is altered.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ESLint rule enabled\n for in-app-agent] --> B{Rule type}
    B -->|curly: all| C[Expand arrow bodies\nto block form\n5 component files]
    B -->|no-unsafe-assignment| D[Annotate catch/\n.catch handlers\nas unknown]
    B -->|no-unsafe-assignment| E[onRunStartedEvent:\nruntime type guard\nfor payload.event.runId]
    B -->|no-non-null-assertion| F[persistence.ts:\nRemove messages array\nnon-null assertion]
    B -->|consistent-type-definitions| G[interface → type\nfor InAppAiAgentProviderProps]
    B -->|schema z.any→z.unknown| H[schema.ts:\nz.any → z.unknown\nfor parameters/metadata/state]
    B -->|Omit fix| I[handler.ts:\nSanitizedAgentInput uses\nOmit to remove conflicting\nmessages/forwardedProps]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ESLint rule enabled\n for in-app-agent] --> B{Rule type}
    B -->|curly: all| C[Expand arrow bodies\nto block form\n5 component files]
    B -->|no-unsafe-assignment| D[Annotate catch/\n.catch handlers\nas unknown]
    B -->|no-unsafe-assignment| E[onRunStartedEvent:\nruntime type guard\nfor payload.event.runId]
    B -->|no-non-null-assertion| F[persistence.ts:\nRemove messages array\nnon-null assertion]
    B -->|consistent-type-definitions| G[interface → type\nfor InAppAiAgentProviderProps]
    B -->|schema z.any→z.unknown| H[schema.ts:\nz.any → z.unknown\nfor parameters/metadata/state]
    B -->|Omit fix| I[handler.ts:\nSanitizedAgentInput uses\nOmit to remove conflicting\nmessages/forwardedProps]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(eslint): Enable no-non-null-assert..."](https://github.com/langfuse/langfuse/commit/e7180504aa922a6e5a77c8e787ef17be81e18dea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42400469)</sub>

<!-- /greptile_comment -->