### PR TITLE
fix(trace): comfortable info-favoring default + persistent split for full-page trace view (LFE-10729)

### DIFF
--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -23,51 +23,51 @@ import { useViewPreferences } from "@/src/components/trace/contexts/ViewPreferen
 import { useSelection } from "@/src/components/trace/contexts/SelectionContext";
 import { resolveEffectiveWidthFraction } from "@/src/components/table/peek/store/peekPanelStore";
 
-// v2: the default split gives the trace (tree/timeline) the central space with a
-// slimmer detail panel. Bumped so a stale saved layout doesn't mask it. Used by
-// the full-page trace view; the peek uses its own id/storage/default (below).
-const RESIZABLE_PANEL_GROUP_ID = "trace-layout-v2";
-// Peek gets a distinct group so its computed-percentage default and localStorage
-// persistence don't leak into the full-page view (which stays share-based, per
-// tab). Same panels, different layout scope (LFE-10601).
+// Full-page trace view's layout group. v3: the full-page view gets the same
+// computed info-favoring default + localStorage persistence as the peek
+// (LFE-10729); bumped from v2 so stale saved layouts from the old 60/40-share
+// era don't mask the new default.
+const RESIZABLE_PANEL_GROUP_ID = "trace-layout-v3";
+// Peek keeps a distinct group id so the two surfaces remember their sizes
+// independently — a split dragged in a ~50vw peek is rarely right for a
+// full-page trace, and vice versa. Same panels, different layout scope
+// (LFE-10601).
 const PEEK_RESIZABLE_PANEL_GROUP_ID = "trace-layout-peek-v1";
 const RESIZABLE_PANEL_HANDLE_ID = "trace-layout-handle";
 const RESIZABLE_PANEL_NAVIGATION_ID = "trace-layout-panel-navigation";
 const RESIZABLE_PANEL_PREVIEW_ID = "trace-layout-panel-preview";
 
-// Full-page default (unchanged): a share-based split — tree gets the majority.
-const FULL_NAVIGATION_DEFAULT_SIZE = "60%";
-const FULL_DETAIL_DEFAULT_SIZE = "40%";
-
-// Peek default split (LFE-10601). We size the tree/timeline (the index) to a
-// comfortable band and give the *rest* to the detail panel (the content), so on
-// a wide peek the extra width flows to info, not the tree — killing the old
-// "very wide tree, cramped info" that the 60/40 share produced on big screens.
+// Default split (LFE-10601 peek, LFE-10729 full-page). We size the
+// tree/timeline (the index) to a comfortable band and give the *rest* to the
+// detail panel (the content), so on a wide container the extra width flows to
+// info, not the tree — killing the old "very wide tree, cramped info" that the
+// 60/40 share produced on big screens.
 //
 // We express this as an explicit *percentage* layout computed from the known
-// peek width, NOT as a px `defaultSize`. The library converts a px defaultSize
-// to a percentage against whatever group width it happens to measure first,
-// which on a peek is a transient mid-open value — so the resolved ratio (and
-// thus what gets persisted) was non-deterministic. A percentage is
-// width-independent, so the default is stable across opens.
-const PEEK_INFO_COMFORTABLE_TARGET_PX = 560; // info wants ~this to read JSON/scores
-const PEEK_NAV_COMFORTABLE_MIN_PX = 340; // tree's comfortable floor (> the 260 hard min)
-const PEEK_NAV_COMFORTABLE_MAX_PX = 460; // never default the tree wider than this
+// container width, NOT as a px `defaultSize`. The library converts a px
+// defaultSize to a percentage against whatever group width it happens to
+// measure first, which on a peek is a transient mid-open value — so the
+// resolved ratio (and thus what gets persisted) was non-deterministic. A
+// percentage is width-independent, so the default is stable across opens.
+const INFO_COMFORTABLE_TARGET_PX = 560; // info wants ~this to read JSON/scores
+const NAV_COMFORTABLE_MIN_PX = 340; // tree's comfortable floor (> the 260 hard min)
+const NAV_COMFORTABLE_MAX_PX = 460; // never default the tree wider than this
 
-// Tree/info split (as a nav-panel percentage) for a peek of `peekWidthPx`: give
-// info its comfortable target, hand the remainder to the tree clamped to its
-// comfortable band. Returns undefined when the width is unknown (SSR).
-function computePeekNavPercent(peekWidthPx: number): number | undefined {
-  if (!(peekWidthPx > 0)) return undefined;
+// Tree/info split (as a nav-panel percentage) for a container of
+// `containerWidthPx`: give info its comfortable target, hand the remainder to
+// the tree clamped to its comfortable band. Returns undefined when the width is
+// unknown (SSR).
+function computeNavPercent(containerWidthPx: number): number | undefined {
+  if (!(containerWidthPx > 0)) return undefined;
   const navPx = Math.min(
-    PEEK_NAV_COMFORTABLE_MAX_PX,
+    NAV_COMFORTABLE_MAX_PX,
     Math.max(
-      PEEK_NAV_COMFORTABLE_MIN_PX,
-      peekWidthPx - PEEK_INFO_COMFORTABLE_TARGET_PX,
+      NAV_COMFORTABLE_MIN_PX,
+      containerWidthPx - INFO_COMFORTABLE_TARGET_PX,
     ),
   );
   // Keep it a sane share; the panels' own min/collapse constraints do the rest.
-  return Math.min(90, Math.max(10, (navPx / peekWidthPx) * 100));
+  return Math.min(90, Math.max(10, (navPx / containerWidthPx) * 100));
 }
 
 // Min widths of the two collapsible panels (kept here so the Panel props and the
@@ -126,8 +126,8 @@ function collapsedShareMaxForWidth(groupWidthPx: number): number {
   const boundaryPx = (COLLAPSED_PANEL_PX + NAVIGATION_PANEL_MIN_PX) / 2;
   return (boundaryPx / groupWidthPx) * 100;
 }
-// Full-page fallback (its container width isn't known at seed time): the boundary
-// as a share of the narrowest both-open width, matching the prior heuristic.
+// Fallback when the container width isn't known (SSR): the boundary as a share
+// of the narrowest both-open width, matching the prior heuristic.
 const COLLAPSED_LAYOUT_SHARE_MAX_PCT = collapsedShareMaxForWidth(
   BOTH_PANELS_MIN_WIDTH_PX,
 );
@@ -155,12 +155,6 @@ interface TraceLayoutDesktopContext {
   isDetailPanelCollapsed: boolean;
   setIsDetailPanelCollapsed: (collapsed: boolean) => void;
   expandDetailPanel: () => void;
-  // Fallback panel sizes (peek is driven by the computed-percentage
-  // `defaultLayout`; these apply only when it's absent, e.g. the full-page view
-  // or SSR). Detail is `undefined` when nav carries the sole default so it
-  // auto-fills the remainder.
-  navigationDefaultSize: string;
-  detailDefaultSize: string | undefined;
 }
 
 const LayoutContext = createContext<TraceLayoutDesktopContext | null>(null);
@@ -192,59 +186,50 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
   const isTimelineView = viewMode === "timeline";
 
   // Get annotation mode + peek mode from context. Peek scopes the layout to its
-  // own group so its px-anchored default + cross-session persistence stay out of
-  // the full-page view (LFE-10601).
+  // own group so a split dragged there doesn't leak into the full-page view and
+  // vice versa (LFE-10601).
   const { isAnnotationMode, isPeekMode } = useViewPreferences();
 
   const groupId = isPeekMode
     ? PEEK_RESIZABLE_PANEL_GROUP_ID
     : RESIZABLE_PANEL_GROUP_ID;
-  // Unify the peek's persistence with its outer width: both live in
-  // localStorage, so a resized tree/info ratio sticks across tabs and reloads
-  // instead of resetting per tab (the old sessionStorage behavior). The
-  // full-page view keeps its per-tab sessionStorage. Guarded so SSR / DOM-less
-  // tests fall back to a no-op store instead of throwing on the bare global.
+  // Both views persist their split in localStorage (like the peek's outer
+  // width), so a resized tree/info ratio sticks across tabs and reloads instead
+  // of resetting per tab (the peek's old sessionStorage behavior, fixed in
+  // LFE-10601; the full-page's in LFE-10729). Guarded so SSR / DOM-less tests
+  // fall back to a no-op store instead of throwing on the bare global.
   const storage =
-    typeof window === "undefined"
-      ? NOOP_LAYOUT_STORAGE
-      : isPeekMode
-        ? window.localStorage
-        : window.sessionStorage;
+    typeof window === "undefined" ? NOOP_LAYOUT_STORAGE : window.localStorage;
 
-  // Peek drives its split via an explicit percentage `defaultLayout` (below);
-  // the panel `defaultSize`s are the SSR/fallback only. Full-page keeps its
-  // share-based 60/40. Detail has no default so it fills the remainder there.
-  const navigationDefaultSize = FULL_NAVIGATION_DEFAULT_SIZE;
-  const detailDefaultSize = isPeekMode ? undefined : FULL_DETAIL_DEFAULT_SIZE;
-
-  // The width the peek actually opens at. When expanded (a shared/reloaded
+  // The width the trace container actually opens at, driving the computed
+  // default split. Peek: the drawer width — when expanded (a shared/reloaded
   // `?peekView=expanded` link) the panel renders at ~viewport width, NOT the
   // widget fraction — so we must size the split against that, or a first-open
-  // expanded peek on a big screen re-creates the wide-tree bug. The sidebar
-  // offset is ignored (the nav is width-capped at these sizes, so the small
-  // difference doesn't move the split). 0 outside peek / during SSR. Mount-time
-  // default only (a saved layout wins after first open), so it doesn't track
-  // viewport changes.
+  // expanded peek on a big screen re-creates the wide-tree bug. Full-page: the
+  // viewport. Sidebar offsets are ignored in both (the nav is width-capped at
+  // these sizes, so the small overestimate only makes the tree slightly
+  // narrower, still within its comfortable band). 0 during SSR. Mount-time
+  // default only (a saved layout wins after the first resize), so it doesn't
+  // track viewport changes.
   const [peekView] = useQueryParam("peekView", StringParam);
   const isPeekExpanded = isPeekMode && peekView === "expanded";
-  const peekWidthPx = useMemo(() => {
-    if (!isPeekMode || typeof window === "undefined") return 0;
-    return isPeekExpanded
-      ? window.innerWidth
-      : resolveEffectiveWidthFraction() * window.innerWidth;
+  const containerWidthPx = useMemo(() => {
+    if (typeof window === "undefined") return 0;
+    if (!isPeekMode || isPeekExpanded) return window.innerWidth;
+    return resolveEffectiveWidthFraction() * window.innerWidth;
   }, [isPeekMode, isPeekExpanded]);
 
-  // Deterministic peek default split, computed from `peekWidthPx`. Only used on
+  // Deterministic default split, computed from `containerWidthPx`. Only used on
   // first open (no saved layout); memoized so the Group sees a stable prop.
-  // Undefined for the full-page view and during SSR.
-  const peekDefaultLayout = useMemo(() => {
-    const navPercent = computePeekNavPercent(peekWidthPx);
+  // Undefined during SSR.
+  const computedDefaultLayout = useMemo(() => {
+    const navPercent = computeNavPercent(containerWidthPx);
     if (navPercent === undefined) return undefined;
     return {
       [RESIZABLE_PANEL_NAVIGATION_ID]: navPercent,
       [RESIZABLE_PANEL_PREVIEW_ID]: 100 - navPercent,
     };
-  }, [peekWidthPx]);
+  }, [containerWidthPx]);
 
   // Restored layout for this group. Read before the collapse flags so we can
   // seed them from what the library is about to restore on mount — otherwise the
@@ -258,12 +243,11 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
     storage,
   });
 
-  // Collapse-seed threshold: width-aware for the peek (whose width we know), so
-  // a small-share-but-open nav on a wide peek isn't mis-seeded as collapsed;
-  // fixed fallback for the full-page view (its width isn't known here).
+  // Collapse-seed threshold: width-aware, so a small-share-but-open nav on a
+  // wide container isn't mis-seeded as collapsed; fixed fallback during SSR.
   const collapseSeedMaxSharePct =
-    isPeekMode && peekWidthPx > 0
-      ? collapsedShareMaxForWidth(peekWidthPx)
+    containerWidthPx > 0
+      ? collapsedShareMaxForWidth(containerWidthPx)
       : COLLAPSED_LAYOUT_SHARE_MAX_PCT;
 
   const [isNavigationPanelCollapsed, setIsNavigationPanelCollapsed] = useState(
@@ -481,8 +465,6 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
     isDetailPanelCollapsed,
     setIsDetailPanelCollapsed,
     expandDetailPanel,
-    navigationDefaultSize,
-    detailDefaultSize,
   };
 
   return (
@@ -499,7 +481,7 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
           orientation="horizontal"
           id={groupId}
           groupRef={groupRef}
-          defaultLayout={defaultLayout ?? peekDefaultLayout}
+          defaultLayout={defaultLayout ?? computedDefaultLayout}
           onLayoutChanged={isAnnotationMode ? undefined : onLayoutChanged}
           className={bothPanelsOpen ? undefined : "min-w-0"}
           style={
@@ -525,8 +507,7 @@ TraceLayoutDesktop.NavigationPanel = function Navigation({
 }: {
   children: ReactNode;
 }) {
-  const { setIsNavigationPanelCollapsed, panelRef, navigationDefaultSize } =
-    useLayoutContext();
+  const { setIsNavigationPanelCollapsed, panelRef } = useLayoutContext();
 
   return (
     <Panel
@@ -535,7 +516,10 @@ TraceLayoutDesktop.NavigationPanel = function Navigation({
       collapsible={true}
       collapsedSize="40px"
       minSize={`${NAVIGATION_PANEL_MIN_PX}px`}
-      defaultSize={navigationDefaultSize}
+      // SSR/no-width fallback only — the computed percentage `defaultLayout`
+      // on the Group drives the real default split. Detail carries no default
+      // so it fills the remainder.
+      defaultSize="40%"
       onResize={() => {
         setIsNavigationPanelCollapsed(panelRef.current?.isCollapsed() ?? false);
       }}
@@ -569,7 +553,6 @@ TraceLayoutDesktop.DetailPanel = function Detail({
     setIsDetailPanelCollapsed,
     isDetailPanelCollapsed,
     expandDetailPanel,
-    detailDefaultSize,
   } = useLayoutContext();
 
   return (
@@ -581,7 +564,6 @@ TraceLayoutDesktop.DetailPanel = function Detail({
     <Panel
       id={RESIZABLE_PANEL_PREVIEW_ID}
       panelRef={detailPanelRef}
-      defaultSize={detailDefaultSize}
       collapsible={true}
       collapsedSize="40px"
       minSize={`${DETAIL_PANEL_MIN_PX}px`}

--- a/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
+++ b/web/src/components/trace/components/_layout/TraceLayoutDesktop.tsx
@@ -198,8 +198,18 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
   // of resetting per tab (the peek's old sessionStorage behavior, fixed in
   // LFE-10601; the full-page's in LFE-10729). Guarded so SSR / DOM-less tests
   // fall back to a no-op store instead of throwing on the bare global.
+  //
+  // Annotation mode is an opinionated workspace — nav on its rail, detail
+  // full-width — that never SAVES a layout (onLayoutChanged below), so it must
+  // not INHERIT one either: it shares the full-page group id, and a full-page
+  // session that parked the detail panel on its 40px rail would otherwise open
+  // annotation with BOTH panels collapsed (trace-level queue items have no
+  // selection to auto-expand the detail panel). No-op storage keeps it on the
+  // computed default.
   const storage =
-    typeof window === "undefined" ? NOOP_LAYOUT_STORAGE : window.localStorage;
+    typeof window === "undefined" || isAnnotationMode
+      ? NOOP_LAYOUT_STORAGE
+      : window.localStorage;
 
   // The width the trace container actually opens at, driving the computed
   // default split. Peek: the drawer width — when expanded (a shared/reloaded

--- a/web/src/components/trace/components/_layout/TracePanelNavigationHeader.tsx
+++ b/web/src/components/trace/components/_layout/TracePanelNavigationHeader.tsx
@@ -165,6 +165,16 @@ function TracePanelNavigationHeaderExpanded({
 
   return (
     <Command className="flex h-auto shrink-0 flex-col gap-1 overflow-hidden rounded-none border-b">
+      {/* Responsive toolbar via container queries on this row's own width —
+          no JS measurement. The breakpoints are tuned to the row's actual
+          content minimums (all fixed-size icon buttons + the search input's
+          min-width, so the sums are font-independent): with playback controls
+          present the row needs ~434px with switcher labels, ~352px icons-only,
+          ~292px with the minor tools folded into "…". Hence: labels < 440px →
+          hidden; tools < 360px → folded; search < 300px → narrower min-width
+          (covers dragging to the 260px panel min). If you ADD anything to this
+          row, re-measure and retune all three — stale thresholds show up as a
+          clipped switcher at default widths (LFE-10729). */}
       <div className="@container/navheader flex flex-row items-center justify-between pr-2 pl-1">
         {/* Panel Toggle Button; special p-0.5 offset to pixel align with closed
             version. Hidden while the detail panel is closed (nothing useful to
@@ -185,7 +195,7 @@ function TracePanelNavigationHeaderExpanded({
           <CommandInput
             showBorder={false}
             placeholder="Search"
-            className="h-7 min-w-20 border-0 pr-0 focus:ring-0"
+            className="h-7 min-w-20 border-0 pr-0 focus:ring-0 @max-[300px]/navheader:min-w-10"
             value={searchInputValue}
             onValueChange={setSearchInputValue}
             onKeyDown={handleSearchKeyDown}
@@ -193,7 +203,7 @@ function TracePanelNavigationHeaderExpanded({
         </div>
         <div className="flex shrink-0 flex-row items-center gap-0.5">
           {/* Minor tools — inline when the panel is wide enough. */}
-          <div className="hidden flex-row items-center gap-0.5 @min-[380px]/navheader:flex">
+          <div className="hidden flex-row items-center gap-0.5 @min-[360px]/navheader:flex">
             <Button
               onClick={handleToggleTreeNodes}
               variant="ghost"
@@ -236,7 +246,7 @@ function TracePanelNavigationHeaderExpanded({
                 size="icon"
                 title="More"
                 aria-label="More options"
-                className="h-7 w-7 @min-[380px]/navheader:hidden"
+                className="h-7 w-7 @min-[360px]/navheader:hidden"
               >
                 <MoreHorizontal className="h-3.5 w-3.5" />
               </Button>
@@ -334,7 +344,7 @@ function ViewModeSegment({
       )}
     >
       <Icon className="h-3.5 w-3.5 shrink-0" />
-      <span className="@max-[360px]/navheader:hidden">{label}</span>
+      <span className="@max-[440px]/navheader:hidden">{label}</span>
     </button>
   );
 }


### PR DESCRIPTION
## TL;DR

The standalone full-page trace view now opens with the info panel as the larger panel (tree clamped to a comfortable 340–460px band) and remembers a dragged split across reloads and tabs — the same computed-default + localStorage machinery the peek view got in LFE-10601 (#14716, #14766). The nav-header's responsive breakpoints are retuned so the Tree/Timeline switcher no longer clips at the new default widths.

## Why

LFE-10601 fixed the peek view, but the full-page trace page kept its old defaults: a fixed 60/40 share (tree wider than the info panel, ballooning on wide monitors) and per-tab `sessionStorage` (a dragged split silently reset in every new tab). Users read the info panel — the tree is the index — so the default had it backwards, and the "my layout keeps resetting" complaints were the sessionStorage scoping.

The new tree default (340–460px) also exposed a stale set of nav-header container-query breakpoints: they predate the playback transport in that row, so at 380–434px everything stayed inline but no longer fit, clipping the Tree/Timeline switcher — the old 60% default was simply too wide to ever land there.

## What

Layout (`TraceLayoutDesktop.tsx`):

- Generalized the peek's `computePeekNavPercent` → `computeNavPercent` and drive the full-page default from the viewport width: the tree gets a clamped comfortable band (340–460px), the info panel gets everything else.
- Full-page split now persists in `localStorage` (was `sessionStorage`), matching the peek.
- Bumped the full-page group id `trace-layout-v2` → `trace-layout-v3` so stale saved 60/40 layouts don't mask the new default.
- Made the collapse-seed threshold width-aware for the full-page too (previously peek-only), so a persisted open-but-small-share tree on a wide monitor isn't mis-seeded as collapsed on restore.

Nav header (`TracePanelNavigationHeader.tsx`):

- Retuned the container-query breakpoints to the row's measured content minimums: switcher labels hidden < 440px (row needs ~434px with them), minor tools fold into "…" < 360px (icons-only needs ~352px), and the search input's min-width narrows < 300px so the row still fits at the 260px panel minimum. Arithmetic documented inline so the next toolbar addition retunes instead of clipping.

Peek behavior and annotation mode (nav starts collapsed, no layout saving) are unchanged.

## Result

Verified in the browser at 2560/1920/1440/1100px viewports:

| Viewport | Tree (default) | Info (default) |
|---|---|---|
| 2560px | 427px | 1948px |
| 1440px | 401px | 854px |
| 1100px | 383px | 532px |

Drag → reload → new tab all restore the chosen split from localStorage; the peek still opens at its LFE-10601 computed default under its own `trace-layout-peek-v1` key; annotation queues still start with the tree collapsed and persist nothing. Header verified at tree widths 280/340/396/420/480px: no overflow in any band — labels ≥440px, icons-only 360–440px, tools folded <360px.

<details>
<summary>Engineering detail</summary>

- The default is expressed as a computed *percentage* `defaultLayout` (not a px `defaultSize`) for the same reason as the peek: the library resolves px defaults against whatever group width it first measures, which is non-deterministic mid-mount (see #14716).
- The full-page container width is approximated by `window.innerWidth` (sidebar offset ignored) — the tree is width-capped, so the overestimate only makes the tree slightly narrower, still inside its comfortable band. Same trade-off the peek makes with its drawer width.
- The `navigationDefaultSize`/`detailDefaultSize` context plumbing is gone: both views are driven by the computed layout, so the panel `defaultSize` is a static SSR-only fallback (nav 40%, detail fills the remainder).
- Collapse-state seeding on restore uses the width-aware boundary for both views now; the fixed `COLLAPSED_LAYOUT_SHARE_MAX_PCT` remains only as the SSR fallback. Without this, a 400px open tree saved on a 2560px monitor (≈16% share) would be mis-seeded as collapsed on reload.
- The nav-header breakpoints are pure CSS container queries (no JS measurement); all elements in the row are fixed-size icon buttons or min-width-bounded inputs, so the content minimums are font-independent and the thresholds deterministic across browsers.
- Lint (`Tasks: 8 successful, 8 total`) and web typecheck pass.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)