### PR TITLE
feat(evals): add opt-in safe JSONPath filter expressions for variable…

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -189,6 +189,14 @@ const EnvSchema = z.object({
     .int()
     .positive()
     .default(2_000),
+  // Opt-in to filter/script JSONPath expressions (e.g. `$[?(@.role=='user')]`)
+  // in eval variable mapping. Disabled by default so hosted deployments stay
+  // locked down; when enabled, expressions run through jsonpath-plus' sandboxed
+  // `eval: 'safe'` engine (jsep-based, no eval()/Function) rather than being
+  // rejected outright.
+  LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS: z
+    .enum(["true", "false"])
+    .default("false"),
   LANGFUSE_TRACE_UPSERT_QUEUE_SHARD_COUNT: z.coerce
     .number()
     .positive()

--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -1,4 +1,5 @@
 import { JSONPath } from "jsonpath-plus";
+import { env } from "../../env";
 import { parseJsonPrioritised } from "../../utils/json";
 
 /**
@@ -63,7 +64,15 @@ function parseJsonDefault(selectedColumn: unknown, jsonSelector: string) {
   const result = JSONPath({
     path: jsonSelector,
     json: selectedColumn as any, // JSONPath accepts unknown but types are strict
-    eval: false,
+    // Filter/script expressions (e.g. `$[?(@.role=='user')]`) require an
+    // evaluator. Default deployments keep these disabled (`eval: false`); when
+    // opted in, use jsonpath-plus' sandboxed `'safe'` engine (jsep-based, no
+    // eval()/Function) so untrusted expressions can select array elements by
+    // content without arbitrary code execution.
+    eval:
+      env.LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS === "true"
+        ? "safe"
+        : false,
   });
 
   if (!Array.isArray(result) || result.length === 0) {

--- a/web/src/features/evals/server/unstable-public-api/validation.ts
+++ b/web/src/features/evals/server/unstable-public-api/validation.ts
@@ -3,6 +3,7 @@ import {
   observationEvalFilterColumns,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
+import { env } from "@langfuse/shared/src/env";
 import { JSONPath } from "jsonpath-plus";
 import type {
   PublicEvaluationRuleFilterType,
@@ -284,7 +285,15 @@ function validateJsonPath(params: {
     JSONPath({
       path: jsonPath,
       json: {},
-      eval: false,
+      // Keep validation in lockstep with extraction (see
+      // packages/shared/src/features/evals/utilities.ts): filter/script
+      // expressions are only accepted when opted in, using jsonpath-plus'
+      // sandboxed `'safe'` engine. Otherwise they are rejected here so invalid
+      // mappings fail fast, and valid ones are not rejected at validation time.
+      eval:
+        env.LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS === "true"
+          ? "safe"
+          : false,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";

--- a/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
+++ b/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+// Import from source (not the built `@langfuse/shared` entry) so the `env`
+// singleton mutated below is the same instance the extraction reads, mirroring
+// the env-override pattern in secureLlmFetch.test.ts / fetchLLMCompletionTimeout.test.ts.
 import {
   extractValueFromObjectAsString,
   extractValueFromObject,
-} from "@langfuse/shared";
+} from "../../../../../packages/shared/src/features/evals/utilities";
+import { env } from "../../../../../packages/shared/src/env";
 
 describe("extractValueFromObject", () => {
   describe("JSONPath slice expressions returning multiple elements", () => {
@@ -179,6 +183,96 @@ describe("extractValueFromObject", () => {
       const result = extractValueFromObject(obj, "data", "$.id");
       expect(result.value).toBe("107505301260286111");
       expect(result.error).toBeNull();
+    });
+  });
+
+  describe("JSONPath filter/script expressions (LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS)", () => {
+    const originalFlag = env.LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS;
+
+    afterEach(() => {
+      env.LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS = originalFlag;
+    });
+
+    const conversation = () =>
+      JSON.stringify([
+        { role: "user", content: "first question" },
+        { role: "assistant", content: "answer" },
+        { role: "user", content: "follow-up question" },
+      ]);
+
+    describe("flag enabled", () => {
+      it("selects array elements by content for $[?(@.role=='user')]", () => {
+        env.LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS = "true";
+
+        const result = extractValueFromObject(
+          { data: conversation() },
+          "data",
+          "$[?(@.role=='user')]",
+        );
+
+        expect(result.error).toBeNull();
+        expect(result.value).toEqual([
+          { role: "user", content: "first question" },
+          { role: "user", content: "follow-up question" },
+        ]);
+      });
+
+      it("unwraps a single filtered match", () => {
+        env.LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS = "true";
+
+        const result = extractValueFromObject(
+          { data: conversation() },
+          "data",
+          "$[?(@.role=='assistant')]",
+        );
+
+        expect(result.error).toBeNull();
+        expect(result.value).toEqual({ role: "assistant", content: "answer" });
+      });
+
+      it("still resolves plain selectors unchanged when enabled", () => {
+        env.LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS = "true";
+
+        const result = extractValueFromObject(
+          { data: JSON.stringify({ name: "Alice" }) },
+          "data",
+          "$.name",
+        );
+
+        expect(result.error).toBeNull();
+        expect(result.value).toBe("Alice");
+      });
+    });
+
+    describe("flag disabled (default)", () => {
+      it("rejects $[?(@.role=='user')] and leaves the raw value untouched", () => {
+        env.LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS = "false";
+
+        const data = conversation();
+        const result = extractValueFromObject(
+          { data },
+          "data",
+          "$[?(@.role=='user')]",
+        );
+
+        expect(result.error).not.toBeNull();
+        expect(result.error?.message).toMatch(/[Ee]val/);
+        // Extraction falls back to the raw original value on error.
+        expect(result.value).toBe(data);
+      });
+
+      it("keeps plain selectors working when disabled", () => {
+        env.LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS = "false";
+
+        const result = extractValueFromObject(
+          { data: JSON.stringify({ name: "Alice" }) },
+          "data",
+          "$.name",
+        );
+
+        expect(result.error).toBeNull();
+        expect(result.value).toBe("Alice");
+      });
     });
   });
 


### PR DESCRIPTION
## What does this PR do?

Eval variable mapping extracts values with `jsonpath-plus` using `eval: false`, which rejects JSONPath filter/script expressions such as `$[?(@.role=='user')]` with `Eval [?(expr)] prevented in JSONPath expression`. As a result, self-hosted users can only select array elements **by position** (e.g. `$[0]`, `$[1:]`), never **by content** — so it is impossible to map, for example, "all user messages" from a conversation into an evaluator variable.

`jsonpath-plus` 10.x (pinned `10.3.0` in this repo) ships an `eval: 'safe'` mode: a sandboxed, [jsep](https://github.com/EricSmekens/jsep)-based evaluator that does **not** use `eval()`/`Function` and is intended for untrusted expressions (added after CVE-2024-21534). This PR exposes that mode behind a new, **default-off** environment flag so Langfuse Cloud / hosted deployments stay locked down while self-hosters can opt in.

### Changes

- **`packages/shared/src/env.ts`** — add `LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS` as `z.enum(['true','false']).default('false')`, following the existing feature-flag patterns.
- **`packages/shared/src/features/evals/utilities.ts`** (`parseJsonDefault`) — pass `eval: 'safe'` when the flag is enabled, otherwise `eval: false` as today.
- **`web/src/features/evals/server/unstable-public-api/validation.ts`** — the mapping validation used `eval: false` to validate JSONPath; it now respects the same flag so valid filter mappings are not rejected at validation time (kept in lockstep with extraction).

### Security rationale

- **Default behavior is unchanged.** With the flag off (the default), filter/script expressions are rejected exactly as today.
- When opted in, expressions run **only** through `jsonpath-plus`' sandboxed `'safe'` evaluator — no `eval()`/`Function`, no arbitrary code execution.

### Scope

Limited to **evals variable mapping**. Other JSONPath usages — `packages/shared/src/utils/mediaReferences.ts` and `packages/shared/src/features/batchAction/applyFieldMapping.ts` — are intentionally left untouched.

### Tests

Extends the existing `extractValueFromObject` suite:

- **Flag on:** `$[?(@.role=='user')]` selects array elements by content; a single filtered match is unwrapped; plain selectors still resolve unchanged.
- **Flag off (default):** filter expressions are rejected and the raw value is preserved (behavior unchanged); plain selectors keep working.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces an opt-in environment flag (`LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS`) that enables `jsonpath-plus`' sandboxed `eval: 'safe'` (jsep-based, no `eval()`/`Function`) for filter expressions in eval variable mapping. The default remains `eval: false`, keeping hosted deployments unaffected.

- Adds the flag to `packages/shared/src/env.ts` following existing `z.enum(["true","false"])` patterns, then threads it into both the extraction path (`utilities.ts`) and the API validation path (`validation.ts`) so they stay in lockstep.
- Extends the `extractValueFromObject` test suite with flag-on/flag-off coverage, using direct source imports to share the same `env` singleton as the code under test.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The feature is off by default and the existing code path is completely unchanged. When opted in, expressions run through jsonpath-plus' jsep-based sandbox with no eval()/Function. Safe to merge as-is.

The extraction and validation paths are kept in lockstep, imports are correctly placed at module top, and the test suite covers both flag states. The only gap is a minor test fragility where originalFlag is captured at describe-block load time rather than in a beforeEach.

worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts — the env-singleton mutation pattern works today but is worth a second look if test isolation assumptions ever change.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts:190-194
**`originalFlag` captured at describe-body evaluation time, not inside a hook**

`originalFlag` is assigned when the `describe` block's body runs (file load time), before any test lifecycle. If a future test in the _same file_ (or a `globalSetup`) mutates `env.LANGFUSE_ENABLE_JSONPATH_FILTER_EXPRESSIONS` before this describe block's first test, `originalFlag` would capture the mutated value and `afterEach` would restore to the wrong state. A `beforeEach` (or `beforeAll`) that reads the current value is slightly more defensive and follows the same "capture + restore" pattern already used elsewhere.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): add opt-in safe JSONPath fi..."](https://github.com/langfuse/langfuse/commit/ade65d4434dcaa431e82c32d54ed5113b4c01811) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42437242)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->