### PR TITLE
fix(events): show "select all across pages" banner on v4 events table (LFE-10733)

### DIFF
--- a/web/src/components/table/data-table-toolbar.clienttest.tsx
+++ b/web/src/components/table/data-table-toolbar.clienttest.tsx
@@ -1,0 +1,182 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import {
+  DataTableToolbar,
+  type MultiSelect,
+} from "@/src/components/table/data-table-toolbar";
+
+const baseMultiSelect = (overrides: Partial<MultiSelect>): MultiSelect => ({
+  selectAll: false,
+  setSelectAll: vi.fn(),
+  selectedRowIds: [],
+  setRowSelection: vi.fn(),
+  pageSize: 50,
+  pageIndex: 0,
+  totalCount: null,
+  ...overrides,
+});
+
+const selectedIds = (count: number) =>
+  Array.from({ length: count }, (_, i) => `row-${i}`);
+
+describe("DataTableToolbar select-all banner gate", () => {
+  describe("exact-count tables (v3)", () => {
+    it("shows the exact-count banner when the full first page is selected", () => {
+      render(
+        <DataTableToolbar
+          columns={[]}
+          multiSelect={baseMultiSelect({
+            totalCount: 500,
+            selectedRowIds: selectedIds(50),
+          })}
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", {
+          name: "Select all 500 items across 10 pages",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows no banner while the count is unknown and no more-pages signal is provided", () => {
+      render(
+        <DataTableToolbar
+          columns={[]}
+          multiSelect={baseMultiSelect({
+            totalCount: null,
+            selectedRowIds: selectedIds(50),
+          })}
+        />,
+      );
+
+      expect(
+        screen.queryByText(/items on this page are selected/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows no banner when all rows fit on one page", () => {
+      render(
+        <DataTableToolbar
+          columns={[]}
+          multiSelect={baseMultiSelect({
+            totalCount: 30,
+            selectedRowIds: selectedIds(30),
+          })}
+        />,
+      );
+
+      expect(
+        screen.queryByText(/items on this page are selected/),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("count-unknown tables with a more-pages signal (v4 events)", () => {
+    it("shows the banner and flips select-all when the full first page is selected", () => {
+      const setSelectAll = vi.fn();
+      render(
+        <DataTableToolbar
+          columns={[]}
+          multiSelect={baseMultiSelect({
+            totalCount: null,
+            hasNextPage: true,
+            selectedRowIds: selectedIds(50),
+            setSelectAll,
+          })}
+        />,
+      );
+
+      const selectAllButton = screen.getByRole("button", {
+        name: "Select all matching items",
+      });
+      fireEvent.click(selectAllButton);
+      expect(setSelectAll).toHaveBeenCalledWith(true);
+    });
+
+    it("keeps the banner visible while the lazy count is loading after select-all", () => {
+      render(
+        <DataTableToolbar
+          columns={[]}
+          multiSelect={baseMultiSelect({
+            selectAll: true,
+            totalCount: null,
+            hasNextPage: true,
+            selectedRowIds: selectedIds(50),
+          })}
+        />,
+      );
+
+      expect(screen.getByText(/items are selected/)).toBeInTheDocument();
+    });
+
+    it("shows the exact count once the lazy count resolves after select-all", () => {
+      render(
+        <DataTableToolbar
+          columns={[]}
+          multiSelect={baseMultiSelect({
+            selectAll: true,
+            totalCount: 823,
+            hasNextPage: true,
+            selectedRowIds: selectedIds(50),
+          })}
+        />,
+      );
+
+      expect(screen.getByText("823")).toBeInTheDocument();
+      expect(screen.getByText(/items are selected/)).toBeInTheDocument();
+    });
+
+    it("shows no banner on the last page (no more matching rows)", () => {
+      render(
+        <DataTableToolbar
+          columns={[]}
+          multiSelect={baseMultiSelect({
+            totalCount: null,
+            hasNextPage: false,
+            selectedRowIds: selectedIds(50),
+          })}
+        />,
+      );
+
+      expect(
+        screen.queryByText(/items on this page are selected/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows no banner when the page is only partially selected", () => {
+      render(
+        <DataTableToolbar
+          columns={[]}
+          multiSelect={baseMultiSelect({
+            totalCount: null,
+            hasNextPage: true,
+            selectedRowIds: selectedIds(10),
+          })}
+        />,
+      );
+
+      expect(
+        screen.queryByText(/items on this page are selected/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows no banner beyond the first page", () => {
+      render(
+        <DataTableToolbar
+          columns={[]}
+          multiSelect={baseMultiSelect({
+            totalCount: null,
+            hasNextPage: true,
+            pageIndex: 1,
+            selectedRowIds: selectedIds(50),
+          })}
+        />,
+      );
+
+      expect(
+        screen.queryByText(/items on this page are selected/),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -66,6 +66,10 @@ export interface MultiSelect {
   pageSize: number;
   pageIndex: number;
   totalCount: number | null;
+  // Tables that only compute totalCount lazily (e.g. v4 events, where counting
+  // is expensive and runs once select-all is active) pass this keyset-pagination
+  // signal instead, so the select-all banner can show while the count is unknown.
+  hasNextPage?: boolean;
   // When the displayed row count does not equal the number of affected entities
   // (e.g. datasets where a folder row expands to many datasets on delete), the
   // select-all banner drops the precise number and says "matching" instead.
@@ -224,12 +228,14 @@ export function DataTableToolbar<TData, TValue>({
   );
   const allVisibleRowsSelected = Boolean(
     multiSelect &&
-    multiSelect.totalCount !== null &&
-    multiSelect.totalCount > multiSelect.pageSize &&
     multiSelect.pageIndex === 0 &&
     multiSelect.selectedRowIds.length > 0 &&
-    multiSelect.selectedRowIds.length ===
-      Math.min(multiSelect.pageSize, multiSelect.totalCount),
+    (multiSelect.totalCount !== null
+      ? multiSelect.totalCount > multiSelect.pageSize &&
+        multiSelect.selectedRowIds.length ===
+          Math.min(multiSelect.pageSize, multiSelect.totalCount)
+      : multiSelect.hasNextPage === true &&
+        multiSelect.selectedRowIds.length === multiSelect.pageSize),
   );
 
   const submitSearch = (query: string) => {

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1709,6 +1709,10 @@ export default function ObservationsEventsTable({
                 selectedRowIds: selectedObservationIds,
                 setRowSelection: setSelectedRows,
                 totalCount,
+                // totalCount stays null until select-all triggers the lazy
+                // count query; hasNextPage lets the select-all banner show
+                // without an eager count over the events table.
+                hasNextPage: hasMore,
                 pageSize: paginationState.limit,
                 pageIndex: paginationState.page - 1,
               }}


### PR DESCRIPTION
## TL;DR
On the v4 events/observations table, selecting the whole visible page never offered "Select all across pages" — bulk actions were capped at the current page. One gate in the shared toolbar deadlocked against v4's lazy count; this PR relaxes that gate behind a new opt-in signal, keeping the expensive count off the hot path and leaving v3 tables byte-for-byte unchanged.

## Why
v3 tables show *"All 50 items on this page are selected. Select all 823 items across 17 pages."* The v4 events table wires up all the same machinery (banner, `useSelectAll`, batch actions with `isBatchAction`), but the count is intentionally lazy — `events.countAll` only runs once select-all is already active, because counting over the events table is expensive. The shared toolbar gate required `totalCount !== null` before rendering the banner — the only control that activates select-all. Chicken-and-egg: the banner that triggers the count waited on the count, so it never rendered.

## What
- `MultiSelect` (shared toolbar contract) gains an optional `hasNextPage` — a keyset-pagination "more matching rows exist" signal for tables that compute `totalCount` lazily.
- The banner gate now has a count-unknown branch: when `totalCount === null`, accept `hasNextPage === true` + a fully selected first page. The exact-count branch is the same conjunction as before, so tables that don't pass `hasNextPage` (all v3 tables) behave identically.
- `EventsTable` passes `hasNextPage: hasMore` (already available from its keyset list query).
- No banner or backend changes: the banner already had count-unknown copy ("Select all matching items"), and the exact count still resolves lazily after the click.

## Result
- v4 events table: select the visible page → *"All 50 items on this page are selected. **Select all matching items**"* → click → *"All 606 items are selected."* (count resolves lazily) → bulk action applies to **all** matching rows.
- v3 tables: unchanged exact-count banner.

<details>
<summary>Verification</summary>

- New client test `data-table-toolbar.clienttest.tsx` (9 cases): written failing-first against the old gate (`Tests  2 failed | 7 passed`), green after the fix (`Tests  9 passed (9)`). Covers the v3 exact-count paths (banner shown, no banner while count is null without the signal, no banner on a single page) and the v4 count-unknown paths (banner + `setSelectAll(true)` on click, banner persists while the lazy count loads, exact copy once it resolves, no banner on last page / partial selection / page > 1).
- Browser (dev server, seeded project with 3.2k v4 events):
  - v4 `/observations`: full-page select → banner appeared with "Select all matching items"; click → "All 606 items are selected." (606 = count within the active 1-day time range, fetched only after the click); ran **Add to Annotation Queue** with select-all on → exactly 606 queue items created (verified in Postgres), matching the banner count across all 13 pages.
  - v3 no-regression (v4 beta off): traces table → *"Select all 156 items across 4 pages"*; observations table → *"Select all 1,085 items across 22 pages"* — both unchanged.
- `pnpm --filter web run lint` clean, `pnpm --filter web run typecheck` clean.

</details>

Fixes LFE-10733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a chicken-and-egg deadlock in the v4 events table where the "Select all across pages" banner never appeared because its gate required `totalCount !== null`, yet the count query only runs after select-all is activated. The fix adds an optional `hasNextPage` field to the `MultiSelect` interface so keyset-pagination tables can signal "more rows exist" without triggering an expensive eager count.

- **`data-table-toolbar.tsx`**: `allVisibleRowsSelected` now has two branches — the existing exact-count branch (unchanged, v3 tables) and a new count-unknown branch (`totalCount === null && hasNextPage === true && selectedRowIds.length === pageSize`) for lazy-count tables.
- **`EventsTable.tsx`**: Passes `hasNextPage: hasMore` (already returned by the list query) into the `multiSelect` prop so the toolbar can use the new signal.
- **`data-table-toolbar.clienttest.tsx`**: Nine new tests covering both code paths, including the banner lifecycle from pre-select through lazy-count resolution.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is backward-compatible — all three gating conditions on the new branch (page 0, full-page selection, explicit `hasNextPage === true`) must hold simultaneously, so v3 tables that never pass `hasNextPage` are entirely unaffected.

The fix is a narrow, targeted change to a single boolean gate. The v3 exact-count path is structurally unchanged; the new v4 branch adds a strict conjunction that cannot fire on existing callers. Nine new tests written in failing-first order cover both paths including the banner lifecycle through lazy-count resolution, partial selection, last-page, and multi-page scenarios. `hasMore` is sourced directly from the list query already in use, so no new data dependencies are introduced.

No files require special attention. The banner component (`data-table-select-all-banner.tsx`) already handled `totalCount === null` gracefully before this PR, so no changes were needed there.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant EventsTable
    participant DataTableToolbar
    participant SelectAllBanner
    participant CountQuery

    User->>EventsTable: select all rows on page 1
    EventsTable->>DataTableToolbar: "multiSelect { totalCount: null, hasNextPage: true, selectedRowIds: [50 ids] }"
    Note over DataTableToolbar: allVisibleRowsSelected check<br/>totalCount===null → use hasNextPage branch<br/>hasNextPage===true && selected===pageSize → true
    DataTableToolbar->>SelectAllBanner: render (totalCount null → "Select all matching items")
    User->>SelectAllBanner: click "Select all matching items"
    SelectAllBanner->>EventsTable: setSelectAll(true)
    EventsTable->>CountQuery: trigger lazy countAll query
    EventsTable->>DataTableToolbar: "multiSelect { selectAll: true, totalCount: null, hasNextPage: true }"
    DataTableToolbar->>SelectAllBanner: render ("All matching items are selected.")
    CountQuery-->>EventsTable: "totalCount = 606"
    EventsTable->>DataTableToolbar: "multiSelect { selectAll: true, totalCount: 606, hasNextPage: true }"
    Note over DataTableToolbar: allVisibleRowsSelected check<br/>totalCount!==null → use exact-count branch<br/>606 > 50 && 50===min(50,606) → true
    DataTableToolbar->>SelectAllBanner: render ("All 606 items are selected.")
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant EventsTable
    participant DataTableToolbar
    participant SelectAllBanner
    participant CountQuery

    User->>EventsTable: select all rows on page 1
    EventsTable->>DataTableToolbar: "multiSelect { totalCount: null, hasNextPage: true, selectedRowIds: [50 ids] }"
    Note over DataTableToolbar: allVisibleRowsSelected check<br/>totalCount===null → use hasNextPage branch<br/>hasNextPage===true && selected===pageSize → true
    DataTableToolbar->>SelectAllBanner: render (totalCount null → "Select all matching items")
    User->>SelectAllBanner: click "Select all matching items"
    SelectAllBanner->>EventsTable: setSelectAll(true)
    EventsTable->>CountQuery: trigger lazy countAll query
    EventsTable->>DataTableToolbar: "multiSelect { selectAll: true, totalCount: null, hasNextPage: true }"
    DataTableToolbar->>SelectAllBanner: render ("All matching items are selected.")
    CountQuery-->>EventsTable: "totalCount = 606"
    EventsTable->>DataTableToolbar: "multiSelect { selectAll: true, totalCount: 606, hasNextPage: true }"
    Note over DataTableToolbar: allVisibleRowsSelected check<br/>totalCount!==null → use exact-count branch<br/>606 > 50 && 50===min(50,606) → true
    DataTableToolbar->>SelectAllBanner: render ("All 606 items are selected.")
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(events): show select-all-across-page..."](https://github.com/langfuse/langfuse/commit/28d2756620642a07d1839f40a89ae103079b1777) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42447523)</sub>

<!-- /greptile_comment -->