### PR TITLE
fix(monitors): populate trace/observation name filter suggestions (LFE-10659)

### DIFF
--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -746,48 +746,6 @@ describe("Clickhouse Events Repository Test", () => {
         expect(Number(range?.max)).toBeCloseTo(1, 3);
       });
     });
-
-    it("uses the monitor window to scope monitor filter option queries", async () => {
-      const uniqueProjectId = randomUUID();
-      const traceId = randomUUID();
-      const now = Date.now();
-      const recentLevel = "WARNING";
-      const oldLevel = "ERROR";
-
-      await createEventsCh([
-        createEvent({
-          id: randomUUID(),
-          span_id: randomUUID(),
-          project_id: uniqueProjectId,
-          trace_id: traceId,
-          type: "SPAN",
-          name: "recent-monitor-filter-option-event",
-          level: recentLevel,
-          start_time: (now - 60 * 1000) * 1000,
-        }),
-        createEvent({
-          id: randomUUID(),
-          span_id: randomUUID(),
-          project_id: uniqueProjectId,
-          trace_id: traceId,
-          type: "SPAN",
-          name: "old-monitor-filter-option-event",
-          level: oldLevel,
-          start_time: (now - 10 * 60 * 1000) * 1000,
-        }),
-      ]);
-
-      await waitForExpect(async () => {
-        const options = await getEventFilterOptions({
-          projectId: uniqueProjectId,
-          monitorWindow: "5m",
-        });
-        const levels = options.level.map((level) => level.value);
-
-        expect(levels).toContain(recentLevel);
-        expect(levels).not.toContain(oldLevel);
-      });
-    });
   });
 
   maybe("events filter option repository helpers", () => {

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -11,7 +11,6 @@ import {
   paginationZod,
   timeFilter,
 } from "@langfuse/shared";
-import { MonitorWindowSchema } from "@langfuse/shared/monitors";
 import {
   toDomainArrayWithStringifiedMetadata,
   toDomainWithStringifiedMetadata,
@@ -58,7 +57,6 @@ export type GetAllEventsInput = z.infer<typeof GetAllEventsInput>;
 const GetEventFilterOptionsInput = zodSchema.object({
   projectId: zodSchema.string(),
   startTimeFilter: zodSchema.array(timeFilter).optional(),
-  monitorWindow: MonitorWindowSchema.optional(),
   isRootObservation: zodSchema.boolean().optional(),
   hasParentObservation: zodSchema.boolean().optional(),
   columns: zodSchema
@@ -170,7 +168,6 @@ export const eventsRouter = createTRPCRouter({
           return getEventFilterOptions({
             projectId: input.projectId,
             startTimeFilter: input.startTimeFilter,
-            monitorWindow: input.monitorWindow,
             isRootObservation:
               input.isRootObservation ??
               (input.hasParentObservation !== undefined

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -22,11 +22,6 @@ import {
   type EventFilterOptionColumn,
 } from "@langfuse/shared/src/server";
 import { type timeFilter, type FilterState } from "@langfuse/shared";
-import {
-  monitorEvaluationOffsetMs,
-  type MonitorWindow,
-  windowToMs,
-} from "@langfuse/shared/monitors";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
 
 type TimeFilter = z.infer<typeof timeFilter>;
@@ -82,7 +77,6 @@ interface GetObservationsCountParams {
 interface GetObservationsFilterOptionsParams {
   projectId: string;
   startTimeFilter?: TimeFilter[];
-  monitorWindow?: MonitorWindow;
   isRootObservation?: boolean;
   hasParentObservation?: boolean;
   observationType?: string;
@@ -155,29 +149,6 @@ const getDefaultEventFilterOptionsStartTimeFilter = (): TimeFilter[] => [
   },
 ];
 
-const getMonitorWindowStartTimeFilter = (
-  monitorWindow: MonitorWindow,
-): TimeFilter[] => {
-  const windowMs = Number(windowToMs(monitorWindow));
-  const to = new Date(Date.now() - monitorEvaluationOffsetMs);
-  const from = new Date(to.getTime() - windowMs);
-
-  return [
-    {
-      column: "startTime",
-      type: "datetime",
-      operator: ">=",
-      value: from,
-    },
-    {
-      column: "startTime",
-      type: "datetime",
-      operator: "<=",
-      value: to,
-    },
-  ];
-};
-
 const ensureStartTimeFilterForEventFilterOptions = <
   TParams extends GetObservationsFilterOptionsParams,
 >(
@@ -185,16 +156,6 @@ const ensureStartTimeFilterForEventFilterOptions = <
 ): TParams => {
   if (hasEventFilterOptionsLowerBoundStartTimeFilter(params.startTimeFilter)) {
     return params;
-  }
-
-  if (params.monitorWindow) {
-    return {
-      ...params,
-      startTimeFilter: [
-        ...getMonitorWindowStartTimeFilter(params.monitorWindow),
-        ...(params.startTimeFilter ?? []),
-      ],
-    };
   }
 
   logger.warn(

--- a/web/src/features/monitors/components/MonitorChartPreview.tsx
+++ b/web/src/features/monitors/components/MonitorChartPreview.tsx
@@ -21,9 +21,7 @@ import {
 } from "@langfuse/shared/monitors";
 
 import { renderChartSubtitle } from "../helpers/renderMonitorLabels";
-
-/** previewBucketCount is the number of complete window buckets the preview renders. */
-const previewBucketCount = 20;
+import { getMonitorPreviewRange } from "../helpers/monitorTimeRanges";
 
 /** MonitorChartPreview renders the live time-series preview with alert/warning threshold bands for a monitor draft. */
 export const MonitorChartPreview = ({
@@ -49,12 +47,10 @@ export const MonitorChartPreview = ({
 }) => {
   /** bucketRange spans 20 complete window buckets ending at the last floored boundary. */
   const { fromTimestamp, toTimestamp } = useMemo(() => {
-    const ms = Number(windowToMs(window));
-    const to = Math.floor(Date.now() / ms) * ms;
-    const from = to - previewBucketCount * ms;
+    const { from, to } = getMonitorPreviewRange(window, Date.now());
     return {
-      toTimestamp: new Date(to).toISOString(),
-      fromTimestamp: new Date(from).toISOString(),
+      toTimestamp: to.toISOString(),
+      fromTimestamp: from.toISOString(),
     };
   }, [window]);
 

--- a/web/src/features/monitors/components/MonitorForm.clienttest.ts
+++ b/web/src/features/monitors/components/MonitorForm.clienttest.ts
@@ -140,6 +140,28 @@ describe("buildFilterColumnsParams", () => {
     expect(values.length).toBeGreaterThan(0);
   });
 
+  it("maps filterOptions.name into a searchable Observation Name stringOptions column", () => {
+    const params = buildFilterColumnsParams({
+      view: "observations",
+      filterOptions: {
+        name: [{ value: "generation-alpha" }, { value: "generation-beta" }],
+      } as Parameters<typeof buildFilterColumnsParams>[0]["filterOptions"],
+      datasets: undefined,
+    });
+    const column = getWidgetFilterColumns(params).find(
+      (c) => c.id === "observationName",
+    );
+    expect(column?.type).toBe("stringOptions");
+    const values =
+      column?.type === "stringOptions"
+        ? column.options.map((o) => o.value)
+        : [];
+    expect(values).toEqual(["generation-alpha", "generation-beta"]);
+    expect(getWidgetColumnsWithCustomSelect(params)).toContain(
+      "observationName",
+    );
+  });
+
   it("keeps Type/Level as non-searchable columns (they rely on complete option lists)", () => {
     // Confirms the fix must be complete enum lists: Type/Level are NOT custom
     // (searchable/free-text) selects, so an empty option list is a hard dead-end.

--- a/web/src/features/monitors/components/MonitorForm.tsx
+++ b/web/src/features/monitors/components/MonitorForm.tsx
@@ -80,11 +80,13 @@ import {
   ObservationTypeDomain,
   viewDeclarations,
   type FilterState,
+  type TimeFilter,
 } from "@langfuse/shared";
 
 import TagManager from "@/src/features/tag/components/TagManager";
 
 import { MonitorChartPreview } from "./MonitorChartPreview";
+import { getMonitorFilterOptionsLookbackFrom } from "../helpers/monitorTimeRanges";
 import { MonitorAutomationsPanel } from "./MonitorAutomationsPanel";
 import { MonitorSeverityBadge } from "./MonitorSeverityBadge";
 import { Badge } from "@/src/components/ui/badge";
@@ -181,6 +183,7 @@ const buildFilterColumnsParams = ({
     viewVersion: "v2" as const,
     environmentOptions: filterOptions?.environment ?? [],
     nameOptions: normalizeSingleValueOptions(filterOptions?.traceName),
+    observationNameOptions: normalizeSingleValueOptions(filterOptions?.name),
     tagsOptions: filterOptions?.traceTags ?? [],
     modelOptions: filterOptions?.providedModelName ?? [],
     toolNamesOptions: filterOptions?.toolNames ?? [],
@@ -312,6 +315,19 @@ export const MonitorForm = ({
   const watched = useWatch({ control: form.control });
   const monitorWindow = (watched.window ?? "5m") as MonitorWindow;
 
+  /** filterOptionsStartTimeFilter lower-bounds discovery at max(20×window, 7d) so even a small monitor window still yields value suggestions. */
+  const filterOptionsStartTimeFilter = useMemo<TimeFilter[]>(
+    () => [
+      {
+        column: "startTime",
+        type: "datetime",
+        operator: ">=",
+        value: getMonitorFilterOptionsLookbackFrom(monitorWindow, Date.now()),
+      },
+    ],
+    [monitorWindow],
+  );
+
   // Push the live name up to the host (e.g. the edit page header) so the page
   // title can mirror it as the user types instead of waiting for save.
   useEffect(() => {
@@ -322,7 +338,7 @@ export const MonitorForm = ({
   const eventsFilterOptions = api.events.filterOptions.useQuery(
     {
       projectId,
-      monitorWindow,
+      startTimeFilter: filterOptionsStartTimeFilter,
     },
     {
       trpc: { context: { skipBatch: true } },

--- a/web/src/features/monitors/helpers/monitorTimeRanges.clienttest.ts
+++ b/web/src/features/monitors/helpers/monitorTimeRanges.clienttest.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { windowToMs } from "@langfuse/shared/monitors";
+
+import {
+  getMonitorFilterOptionsLookbackFrom,
+  getMonitorPreviewRange,
+  monitorPreviewBucketCount,
+} from "./monitorTimeRanges";
+
+const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+
+describe("getMonitorPreviewRange", () => {
+  it("spans 20 window buckets ending at the last floored boundary", () => {
+    const bucketMs = Number(windowToMs("5m"));
+    const now = 1_700_000_123_456;
+    const range = getMonitorPreviewRange("5m", now);
+    expect(range.bucketMs).toBe(bucketMs);
+    expect(range.to.getTime()).toBe(Math.floor(now / bucketMs) * bucketMs);
+    expect(range.to.getTime() - range.from.getTime()).toBe(
+      monitorPreviewBucketCount * bucketMs,
+    );
+  });
+
+  it("returns the same bucketed `to` for two instants inside one window bucket", () => {
+    const bucketMs = Number(windowToMs("5m"));
+    const boundary = Math.floor(1_700_000_123_456 / bucketMs) * bucketMs;
+    const early = getMonitorPreviewRange("5m", boundary + 1);
+    const late = getMonitorPreviewRange("5m", boundary + bucketMs - 1);
+    expect(early.to.getTime()).toBe(boundary);
+    expect(late.to.getTime()).toBe(boundary);
+  });
+});
+
+describe("getMonitorFilterOptionsLookbackFrom", () => {
+  it("floors the lookback at 7d for a small window whose 20-bucket span is shorter", () => {
+    const now = 1_700_000_123_456;
+    const { to } = getMonitorPreviewRange("5m", now);
+    const from = getMonitorFilterOptionsLookbackFrom("5m", now);
+    expect(to.getTime() - from.getTime()).toBe(sevenDaysMs);
+  });
+
+  it("uses the full 20-bucket span for a large window that exceeds 7d", () => {
+    const now = 1_700_000_123_456;
+    const { to, bucketMs } = getMonitorPreviewRange("1d", now);
+    const from = getMonitorFilterOptionsLookbackFrom("1d", now);
+    expect(to.getTime() - from.getTime()).toBe(
+      monitorPreviewBucketCount * bucketMs,
+    );
+  });
+});

--- a/web/src/features/monitors/helpers/monitorTimeRanges.ts
+++ b/web/src/features/monitors/helpers/monitorTimeRanges.ts
@@ -1,0 +1,38 @@
+import { type MonitorWindow, windowToMs } from "@langfuse/shared/monitors";
+
+/** monitorPreviewBucketCount is the number of complete window buckets the preview renders. */
+export const monitorPreviewBucketCount = 20;
+
+/** monitorFilterOptionsLookbackFloorMs is the 7d floor guaranteeing non-empty filter suggestions for small windows. */
+const monitorFilterOptionsLookbackFloorMs = 7 * 24 * 60 * 60 * 1000;
+
+/** getMonitorPreviewRange returns the 20-bucket preview span ending at the last floored window boundary. */
+export const getMonitorPreviewRange = (
+  window: MonitorWindow,
+  now: number,
+): MonitorPreviewRange => {
+  const bucketMs = Number(windowToMs(window));
+  const to = Math.floor(now / bucketMs) * bucketMs;
+  const from = to - monitorPreviewBucketCount * bucketMs;
+  return { from: new Date(from), to: new Date(to), bucketMs };
+};
+
+/** getMonitorFilterOptionsLookbackFrom returns the discovery lower bound: the preview `to` minus max(20×window, 7d). */
+export const getMonitorFilterOptionsLookbackFrom = (
+  window: MonitorWindow,
+  now: number,
+): Date => {
+  const { to, bucketMs } = getMonitorPreviewRange(window, now);
+  const spanMs = Math.max(
+    monitorPreviewBucketCount * bucketMs,
+    monitorFilterOptionsLookbackFloorMs,
+  );
+  return new Date(to.getTime() - spanMs);
+};
+
+/** MonitorPreviewRange is the bucketed [from, to] preview span plus the per-bucket width. */
+type MonitorPreviewRange = {
+  from: Date;
+  to: Date;
+  bucketMs: number;
+};

--- a/web/src/features/widgets/components/WidgetForm.observationNameOptions.clienttest.tsx
+++ b/web/src/features/widgets/components/WidgetForm.observationNameOptions.clienttest.tsx
@@ -1,0 +1,106 @@
+import { render } from "@testing-library/react";
+
+// Hoisted so the vi.mock factory can reference them.
+const { generationsFilterOptionsUseQuery, noopQuery } = vi.hoisted(() => ({
+  generationsFilterOptionsUseQuery: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isSuccess: false,
+  })),
+  noopQuery: () => ({
+    data: undefined,
+    isLoading: false,
+    isSuccess: false,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    traces: { filterOptions: { useQuery: noopQuery } },
+    generations: {
+      filterOptions: { useQuery: generationsFilterOptionsUseQuery },
+    },
+    events: { filterOptions: { useQuery: noopQuery } },
+    projects: { environmentFilterOptions: { useQuery: noopQuery } },
+    datasets: { allDatasetMeta: { useQuery: noopQuery } },
+    dashboard: { executeQuery: { useQuery: noopQuery } },
+  },
+}));
+
+// Force the v1 path, which sources the observation-name picker from generations.
+vi.mock("@/src/features/events/hooks/useV4Beta", () => ({
+  useV4Beta: () => ({ isBetaEnabled: false }),
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    query: {},
+    asPath: "/",
+    push: vi.fn(),
+    replace: vi.fn(),
+    isReady: true,
+  }),
+}));
+
+vi.mock("use-query-params", () => ({
+  StringParam: {},
+  useQueryParams: () => [{ dateRange: undefined }, vi.fn()],
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: null, status: "unauthenticated" }),
+}));
+
+import { WidgetForm } from "./WidgetForm";
+
+describe("WidgetForm v1 observation-name options", () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    Element.prototype.scrollIntoView = vi.fn();
+    Element.prototype.hasPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+  });
+
+  it("v1 observations view queries observation names across ALL types", () => {
+    // The six filter-option queries fire at the top of the component body; a
+    // downstream child (filter builder / chart) may crash after, which is
+    // irrelevant to what input the query under test received.
+    try {
+      render(
+        <WidgetForm
+          projectId="p1"
+          onSave={vi.fn()}
+          initialValues={{
+            name: "w",
+            description: "",
+            view: "observations",
+            measure: "count",
+            aggregation: "count",
+            dimension: "none",
+            chartType: "LINE_TIME_SERIES",
+            filters: [],
+          }}
+        />,
+      );
+    } catch {
+      // Ignore downstream render failures; see comment above.
+    }
+
+    expect(generationsFilterOptionsUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ observationType: "ALL" }),
+      expect.anything(),
+    );
+  });
+});

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -681,6 +681,7 @@ export function WidgetForm({
     {
       projectId,
       startTimeFilter: getDateRangeFilter("startTime", dateRange),
+      observationType: "ALL",
     },
     {
       trpc: {

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -754,6 +754,10 @@ export function WidgetForm({
     viewVersion === "v2"
       ? normalizeSingleValueOptions(eventsFilterOptions.data?.traceName)
       : normalizeSingleValueOptions(traceFilterOptions.data?.name);
+  const observationNameOptions =
+    viewVersion === "v2"
+      ? normalizeSingleValueOptions(eventsFilterOptions.data?.name)
+      : normalizeSingleValueOptions(generationsFilterOptions.data?.name);
   const tagsOptions =
     viewVersion === "v2"
       ? eventsFilterOptions.data?.traceTags || []
@@ -789,6 +793,7 @@ export function WidgetForm({
     viewVersion,
     environmentOptions,
     nameOptions,
+    observationNameOptions,
     tagsOptions,
     modelOptions,
     toolNamesOptions,
@@ -803,6 +808,7 @@ export function WidgetForm({
     viewVersion,
     environmentOptions,
     nameOptions,
+    observationNameOptions,
     tagsOptions,
     modelOptions,
     toolNamesOptions,
@@ -822,6 +828,7 @@ export function WidgetForm({
       viewVersion,
       environmentOptions,
       nameOptions,
+      observationNameOptions,
       tagsOptions,
       modelOptions,
       toolNamesOptions,

--- a/web/src/features/widgets/components/widgetFilterColumns.ts
+++ b/web/src/features/widgets/components/widgetFilterColumns.ts
@@ -11,6 +11,7 @@ type GetWidgetFilterColumnsParams = {
   viewVersion: ViewVersion;
   environmentOptions: SingleValueOption[];
   nameOptions: SingleValueOption[];
+  observationNameOptions: SingleValueOption[];
   tagsOptions: SingleValueOption[];
   modelOptions: SingleValueOption[];
   toolNamesOptions: SingleValueOption[];
@@ -31,6 +32,7 @@ const getWidgetFilterColumnSpecs = ({
   viewVersion,
   environmentOptions,
   nameOptions,
+  observationNameOptions,
   tagsOptions,
   modelOptions,
   toolNamesOptions,
@@ -129,9 +131,11 @@ const getWidgetFilterColumnSpecs = ({
       column: {
         name: "Observation Name",
         id: "observationName",
-        type: "string",
+        type: "stringOptions",
+        options: observationNameOptions,
         internal: "internalValue",
       },
+      customSelect: true,
     });
   }
 
@@ -152,9 +156,11 @@ const getWidgetFilterColumnSpecs = ({
         column: {
           name: "Observation Name",
           id: "observationName",
-          type: "string",
+          type: "stringOptions",
+          options: observationNameOptions,
           internal: "internalValue",
         },
+        customSelect: true,
       },
     );
   }


### PR DESCRIPTION
## Summary

When configuring a Monitor's target filter, the value-suggestion dropdowns for Trace Name (plus env/model/tags) were empty and Observation Name had no picker at all, so there was nothing to pick from.

To achieve this we:
- Widened the monitor filter-option lookback to `max(20×window, 7d)` so short eval windows still surface suggestions — previously discovery was scoped to the monitor's ~5-minute eval window, which is almost always empty.
- Gave Observation Name a real value picker (an "any of / none of" multi-select) in both monitors and widgets, fed by the name options the backend already returns.
- Extracted a shared `monitorTimeRanges` helper so the chart preview and the filter-option lookback share one bucketing primitive instead of drifting apart.
- Removed the now-dead `monitorWindow` server parameter in favor of an explicit client-sent start-time bound.

**Note**: The chart preview range stays `20×window` and is never floored to 7d — the 7d floor is discovery-only, since a 7d span at 5m granularity would blow the chart's row limit. The `string → stringOptions` change on Observation Name is backward-compatible; existing saved filters keep working and no migration is needed.

Fixes [LFE-10659](https://linear.app/langfuse/issue/LFE-10659)
Related to [LFE-10616](https://linear.app/langfuse/issue/LFE-10616)

## Verification

- [x] `pnpm run lint` — `Tasks: 8 successful, 8 total`
- [x] `pnpm --filter web run typecheck` — exit 0, no errors
- [x] `pnpm --filter web run test-client monitorTimeRanges` — `Tests 4 passed (4)`
- [x] `pnpm --filter web run test-client MonitorForm` — `Tests 13 passed (13)`
- [x] `pnpm --filter web run test-client MonitorChartPreview` — `Tests 4 passed (4)`
- [x] `pnpm --filter web run test event-repository` — `Tests 66 passed (66)`
- [x] Browser review — Trace Name picker populated with 482 options, Observation Name picker with 889

## Test plan

- [ ] Create a monitor with the default 5-minute window and confirm the Trace Name dropdown suggests values.
- [ ] In the same form, confirm Observation Name is a searchable "any of" picker (not free text) and suggests values.
- [ ] Confirm the monitor chart preview still renders correctly.
- [ ] In the widget form, confirm Observation Name is now a picker and previously saved widget filters still apply.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes empty filter-suggestion dropdowns in Monitor forms by widening the discovery lookback to `max(20×window, 7d)` instead of the monitor's narrow eval window, and adds a proper value-picker for Observation Name in both monitors and widgets.

- **`monitorTimeRanges.ts`** extracts `getMonitorPreviewRange` and `getMonitorFilterOptionsLookbackFrom` as shared helpers; `MonitorChartPreview` delegates to the former, and `MonitorForm` uses the latter to build the `startTimeFilter` it now sends explicitly instead of the dead `monitorWindow` server parameter.
- **`widgetFilterColumns.ts`** promotes Observation Name from `type: \"string\"` (free-text) to `type: \"stringOptions\"` with `customSelect: true`; `WidgetForm` and `MonitorForm` both plumb in `observationNameOptions` populated from the events filter-options endpoint.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the changes are isolated to filter-option discovery and UI column definitions and the core monitor evaluation path is untouched.

The lookback and preview helpers are clean and well-tested. The only open questions are the stale Date.now() anchor in the useMemo (harmless at a 7-day floor but conceptually impure) and whether existing saved monitors with a free-text Observation Name filter survive the string to stringOptions column-type promotion without silent data loss or broken rendering.

widgetFilterColumns.ts — the string-to-stringOptions type change on Observation Name is the only path where pre-existing user data (saved filter state) could be affected.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Form as MonitorForm / WidgetForm
    participant Helper as monitorTimeRanges.ts
    participant tRPC as events.filterOptions (tRPC)
    participant Server as eventsService
    participant CH as ClickHouse

    Form->>Helper: getMonitorFilterOptionsLookbackFrom(window, now)
    Helper-->>Form: Date (max(20xwindow, 7d) ago)

    Form->>tRPC: "filterOptions({ projectId, startTimeFilter })"
    tRPC->>Server: ensureStartTimeFilterForEventFilterOptions(params)
    Note over Server: params has startTimeFilter, early return
    Server->>CH: "query events WHERE startTime >= from"
    CH-->>Server: name[], traceName[], environment[]
    Server-->>tRPC: EventFilterOptions
    tRPC-->>Form: name, traceName, environment

    Form->>Form: "observationNameOptions = normalizeSingleValueOptions(data.name)"
    Form->>Form: Render Observation Name as stringOptions picker
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Form as MonitorForm / WidgetForm
    participant Helper as monitorTimeRanges.ts
    participant tRPC as events.filterOptions (tRPC)
    participant Server as eventsService
    participant CH as ClickHouse

    Form->>Helper: getMonitorFilterOptionsLookbackFrom(window, now)
    Helper-->>Form: Date (max(20xwindow, 7d) ago)

    Form->>tRPC: "filterOptions({ projectId, startTimeFilter })"
    tRPC->>Server: ensureStartTimeFilterForEventFilterOptions(params)
    Note over Server: params has startTimeFilter, early return
    Server->>CH: "query events WHERE startTime >= from"
    CH-->>Server: name[], traceName[], environment[]
    Server-->>tRPC: EventFilterOptions
    tRPC-->>Form: name, traceName, environment

    Form->>Form: "observationNameOptions = normalizeSingleValueOptions(data.name)"
    Form->>Form: Render Observation Name as stringOptions picker
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/monitors/components/MonitorForm.tsx:318-329
`Date.now()` is evaluated once when `monitorWindow` first renders (or changes), so the lookback anchor is frozen for the lifetime of the form unless the user explicitly switches windows. With a 7-day floor this is inconsequential today, but it means the filter never "rolls forward" on its own. Including a coarser time quantization keeps the memo stable while still refreshing the anchor when it meaningfully drifts — e.g., rounding to the nearest hour so the key re-hashes only when the hour turns, not every render.

```suggestion
  /** filterOptionsStartTimeFilter lower-bounds discovery at max(20×window, 7d) so even a small monitor window still yields value suggestions.
   * Date.now() is quantized to the nearest hour so the query key stays stable within a window
   * and naturally refreshes when the hour turns rather than staying frozen from mount time. */
  const filterOptionsStartTimeFilter = useMemo<TimeFilter[]>(() => {
    const quantizedNow = Math.floor(Date.now() / (60 * 60 * 1000)) * (60 * 60 * 1000);
    return [
      {
        column: "startTime",
        type: "datetime",
        operator: ">=",
        value: getMonitorFilterOptionsLookbackFrom(monitorWindow, quantizedNow),
      },
    ];
  }, [monitorWindow]);
```

### Issue 2 of 2
web/src/features/widgets/components/widgetFilterColumns.ts:131-139
**Backward compat of saved string-typed Observation Name filters**

A monitor or widget saved before this PR may have an Observation Name filter stored as `{ type: "string", operator: "contains", value: "foo" }`. The column definition now declares `type: "stringOptions"`, whose valid operators are "any of" / "none of". If the filter-rendering layer checks the column definition type when deciding how to display a loaded filter (rather than using the stored filter's own `type`), those saved filters would either render incorrectly or be silently dropped. The PR description claims backward compatibility but doesn't call out the mechanism — could you confirm whether the filter panel reads the stored filter type or the column-definition type when hydrating existing entries?

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(monitors): populate trace/observatio..."](https://github.com/langfuse/langfuse/commit/23438366e83491abd264a2fd3de4b50b34436534) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42450107)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->