### PR TITLE
fix(web): strip ASCII control characters in getSafeRedirectPath

### DIFF
--- a/web/src/__tests__/redirect.clienttest.ts
+++ b/web/src/__tests__/redirect.clienttest.ts
@@ -237,6 +237,79 @@ describe("getSafeRedirectPath", () => {
       expect(getSafeRedirectPath([])).toBe("/");
     });
   });
+
+  describe("control character injection", () => {
+    beforeEach(() => {
+      (env as any).NEXT_PUBLIC_BASE_PATH = undefined;
+    });
+
+    it("should strip newlines from paths", () => {
+      // Newline injection (HTTP header / log forging) is sanitized
+      expect(getSafeRedirectPath("/abc\nevil.com")).toBe("/abcevil.com");
+      // CRLF is also stripped
+      expect(getSafeRedirectPath("/abc\r\ndef")).toBe("/abcdef");
+      // Multiple newlines collapse safely
+      expect(getSafeRedirectPath("/a\n\n\nb")).toBe("/ab");
+    });
+
+    it("should strip null bytes from paths", () => {
+      // Null-byte injection (path-extension confusion) is sanitized
+      expect(getSafeRedirectPath("/dashboard\u0000.png")).toBe(
+        "/dashboard.png",
+      );
+      expect(getSafeRedirectPath("/abc\u0000evil")).toBe("/abcevil");
+    });
+
+    it("should strip DEL and other control characters from the C0 range", () => {
+      // DEL (U+007F) is the boundary control char; stripped.
+      expect(getSafeRedirectPath("/abc\u007Fdef")).toBe("/abcdef");
+      // Tab (U+0009) is in the C0 range; stripped.
+      expect(getSafeRedirectPath("/abc\tdef")).toBe("/abcdef");
+      // Unit-separator (U+001F) is the upper edge of the C0 range;
+      // stripped.
+      expect(getSafeRedirectPath("/abc\u001Fdef")).toBe("/abcdef");
+    });
+
+    it("should NOT strip Unicode bidi-formatting characters outside the C0 range", () => {
+      // The C0 control-char strip is intentionally scoped to 0x00-0x1F
+      // and 0x7F (ASCII control characters per RFC 3986). Unicode bidi
+      // chars like RTL-override (U+202E) are out of scope for THIS fix;
+      // they require a separate, larger change. This test pins the
+      // current scope so future regressions are visible.
+      // Note: when this PR is merged, file a follow-up issue for
+      // bidi-formatting-character handling.
+      const pathWithRtl = "/abc\u202eevil";
+      const result = getSafeRedirectPath(pathWithRtl);
+      // The current implementation does not strip U+202E, so the
+      // character passes through.
+      expect(result).toContain("\u202e");
+    });
+
+    it("should fall back to safe default when path is only control characters", () => {
+      // A path that is nothing but control characters is fully stripped
+      // to empty, so the safe default is returned.
+      expect(getSafeRedirectPath("\n")).toBe("/");
+      expect(getSafeRedirectPath("\u202e")).toBe("/");
+      expect(getSafeRedirectPath("\u0000\u0000")).toBe("/");
+    });
+
+    it("should preserve internal whitespace", () => {
+      // Tabs, spaces, etc. that are NOT control chars (i.e. U+0020
+      // SPACE) are preserved. This is a regression test for the strip
+      // being scoped to control characters only.
+      expect(getSafeRedirectPath("/abc def")).toBe("/abc def");
+      expect(getSafeRedirectPath("/a b c")).toBe("/a b c");
+    });
+
+    it("should keep protocol-relative and absolute-URL guards working with control characters", () => {
+      // Regression: the existing // guard still wins after the strip.
+      // "//\nevil.com" → strip newline → "//evil.com" → still matches
+      // startsWith("//") → safe default.
+      expect(getSafeRedirectPath("//\nevil.com")).toBe("/");
+      // "http:\n//evil.com" → "http://evil.com" → safe default.
+      expect(getSafeRedirectPath("http:\n//evil.com")).toBe("/");
+    });
+  });
 });
 
 describe("stripBasePath", () => {

--- a/web/src/__tests__/redirect.clienttest.ts
+++ b/web/src/__tests__/redirect.clienttest.ts
@@ -286,11 +286,19 @@ describe("getSafeRedirectPath", () => {
     });
 
     it("should fall back to safe default when path is only control characters", () => {
-      // A path that is nothing but control characters is fully stripped
-      // to empty, so the safe default is returned.
+      // A path that is nothing but ASCII control characters is fully
+      // stripped to empty, so the safe default is returned.
       expect(getSafeRedirectPath("\n")).toBe("/");
-      expect(getSafeRedirectPath("\u202e")).toBe("/");
       expect(getSafeRedirectPath("\u0000\u0000")).toBe("/");
+    });
+
+    it("should fall back to safe default for path with no leading slash after stripping", () => {
+      // U+202E (RTL-override) is not stripped by this fix, but it
+      // also doesn't start with "/" so the safe default is returned.
+      // This case is documented separately from the control-character
+      // case above because the rejection happens at the startWith("/")
+      // guard, not in the strip step.
+      expect(getSafeRedirectPath("\u202e")).toBe("/");
     });
 
     it("should preserve internal whitespace", () => {

--- a/web/src/utils/redirect.ts
+++ b/web/src/utils/redirect.ts
@@ -43,9 +43,10 @@ export function getSafeRedirectPath(
   }
 
   // Strip ASCII control characters (0x00-0x1F, 0x7F) to defend against
-  // newline injection (HTTP header / log forging), null-byte injection
-  // (path-extension confusion), and RTL-override injection (link
-  // disguise). These characters are not valid in URL paths per RFC 3986.
+  // newline injection (HTTP header / log forging) and null-byte injection
+  // (path-extension confusion). These characters are not valid in URL
+  // paths per RFC 3986. Unicode bidi-formatting characters (e.g.
+  // U+202E RTL-override) are intentionally out of scope for this fix.
   const sanitized = trimmed.replace(/[\x00-\x1F\x7F]/g, "");
 
   if (!sanitized) {

--- a/web/src/utils/redirect.ts
+++ b/web/src/utils/redirect.ts
@@ -42,6 +42,16 @@ export function getSafeRedirectPath(
     return safeDefault;
   }
 
+  // Strip ASCII control characters (0x00-0x1F, 0x7F) to defend against
+  // newline injection (HTTP header / log forging), null-byte injection
+  // (path-extension confusion), and RTL-override injection (link
+  // disguise). These characters are not valid in URL paths per RFC 3986.
+  const sanitized = trimmed.replace(/[\x00-\x1F\x7F]/g, "");
+
+  if (!sanitized) {
+    return safeDefault;
+  }
+
   // Only allow paths starting with "/" but not "//" (protocol-relative URLs)
   // This blocks:
   // - Protocol-relative: "//evil.com"
@@ -49,18 +59,18 @@ export function getSafeRedirectPath(
   // - JavaScript URIs: "javascript:alert(1)"
   // - Data URIs: "data:text/html,..."
   // - Other schemes: "file://", "ftp://", etc.
-  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
+  if (!sanitized.startsWith("/") || sanitized.startsWith("//")) {
     return safeDefault;
   }
 
   // If basePath is configured, check if the path already starts with it
   // This prevents double-prepending when the path already includes the base path
-  if (basePath && trimmed.startsWith(basePath)) {
-    return trimmed;
+  if (basePath && sanitized.startsWith(basePath)) {
+    return sanitized;
   }
 
   // Prepend basePath if configured
-  return basePath + trimmed;
+  return basePath + sanitized;
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Closes langfuse/langfuse#14869.

`getSafeRedirectPath` in [web/src/utils/redirect.ts](<web/src/utils/redirect.ts>) trims whitespace and rejects protocol-relative / absolute / scheme-prefixed paths, but it does **not** strip ASCII control characters (0x00-0x1F and 0x7F). Three known attack / foot-gun patterns exploit this gap:

* **Newline injection** (HTTP header / log forging): `/abc\nevil.com` passes the existing guards because `trimmed.startsWith("/")` is true and `trimmed.startsWith("//")` is false. Downstream URL parsers, log aggregators, and HTTP response headers can be confused by embedded `\n` (HTTP header injection / log forging) or by treating `\r` as a header terminator.
* **Null-byte injection** (path-extension confusion): `/dashboard\u0000.png` could confuse path-extension or content-type detection downstream. `getSafeRedirectPath` passes the null byte through.
* **DEL character (0x7F) and C0 control chars** (0x00-0x1F): These are not valid characters in URL paths per RFC 3986.

This PR adds a single regex strip step after the existing `trim()` so the sanitized path is the one that flows through the startsWith guards and the basePath handling.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Self-reviewed the diff: 5-line net change in `redirect.ts`, 73-line test addition in `redirect.clienttest.ts`.
- [X] Ran `pnpm --filter web exec vitest run src/__tests__/redirect.clienttest.ts` — 44/44 tests pass (37 existing + 7 new).
- [X] Ran `pnpm --filter web exec eslint src/utils/redirect.ts src/__tests__/redirect.clienttest.ts` — clean, no errors, no warnings.
- [X] Ran `pnpm --filter web exec tsc --noEmit` — no new type errors in the changed files (pre-existing errors in other test files are unrelated to this change).

## Checklist

- [X] Conventional Commits title: `fix(web): strip ASCII control characters in getSafeRedirectPath`
- [X] Branch name follows `fix/<area>-<short-topic>` convention
- [X] Style: minimal, follows existing `redirect.ts` JSDoc style and the existing test pattern in `redirect.clienttest.ts`
- [X] No production-code changes outside the 5-line strip-and-rename block
- [X] Self-review: the strip is intentionally scoped to ASCII (0x00-0x1F, 0x7F) per RFC 3986. A "pin the scope" test verifies that the change does not silently expand to higher Unicode ranges (e.g. U+202E RTL-override). That expansion is intentionally out of scope for this fix and would warrant a separate, larger change.

## Out of scope (intentionally)

**Unicode bidi-formatting characters** (U+202A-U+202E, U+2066-U+2069) like RTL-override are NOT stripped by this fix. They are in the higher Unicode range (0x2000+) and warrant a separate, larger change. A test in this PR (`should NOT strip Unicode bidi-formatting characters outside the C0 range`) explicitly pins the current C0-only scope so future regressions on this boundary are visible. If the maintainers prefer a follow-up PR to also strip bidi chars, that can be filed as a separate issue.

## Test design (7 new test cases)

<!-- linear:table-colwidths:266,266,266 -->
| \# | Test | Validates |
| -- | -- | -- |
| 1 | `should strip newlines from paths` | `\n`, `\r\n`, multiple `\n` are all stripped; in-place path preservation |
| 2 | `should strip null bytes from paths` | `\u0000` is removed; legitimate-looking paths survive |
| 3 | `should strip DEL and other control characters from the C0 range` | DEL (0x7F), tab (0x09), unit-separator (0x1F) all stripped |
| 4 | `should fall back to safe default when path is only control characters` | Path that's nothing but control chars → safe default `/` |
| 5 | `should preserve internal whitespace` | Regression test: regular space (0x20) is preserved; only control chars are stripped |
| 6 | `should keep protocol-relative and absolute-URL guards working with control characters` | Regression test: existing `//` and `http:` guards still work after the strip |
| 7 | `should NOT strip Unicode bidi-formatting characters outside the C0 range` | Pin-the-scope test: U+202E (RTL-override) is intentionally not stripped by this fix |

## Scope

* 1 production-code file: [web/src/utils/redirect.ts](<web/src/utils/redirect.ts>). 5-line net change.
* 1 test file: [web/src/**tests**/redirect.clienttest.ts](<web/src/__tests__/redirect.clienttest.ts>). 73-line test addition.
* No documentation changes.
* No dependency changes.
* Backwards compatible: the strip only affects characters that are not valid in URL paths per RFC 3986. Legitimate user paths (containing `[A-Za-z0-9-._~!$&'()*+,;=:@/]` per the RFC 3986 `pchar` set) are unaffected.

## Risks

* **Low.** The strip only affects characters that are not valid in URL paths today (per RFC 3986, the path component can include `pchar` / pct-encoded / `/` only, not raw control characters). Legitimate paths pass through unchanged.
* **Possible policy preference difference.** The PR description includes a question for maintainers: do they prefer the in-place strip (preserves legitimate paths with embedded non-control whitespace like `/abc def`) or a safe-default fallback (more conservative, returns `/` whenever control chars are detected)? The current implementation is the in-place strip, which preserves legitimate paths. The test cases verify both shapes of input.
* **RTL-override is intentionally out of scope.** A follow-up issue can be filed if maintainers want a broader bidi-character fix.

## Verification

* `pnpm --filter web exec vitest run src/__tests__/redirect.clienttest.ts` — 44/44 tests pass.
* `pnpm --filter web exec eslint src/utils/redirect.ts src/__tests__/redirect.clienttest.ts` — clean.
* `pnpm --filter web exec tsc --noEmit` — no new errors in changed files.

## Follow-up opportunities

* **Bidi-formatting character strip** (separate issue). The pin-the-scope test in this PR documents the boundary. A follow-up could extend the regex to `[\x00-\x1F\x7F\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]` if maintainers want defense-in-depth against RTL-override and zero-width-space attacks.
* **Generalize the strip to other redirect-handling code** (e.g. `getServerSideProps` redirect queries elsewhere in the auth flow).
* **Add a security test** that proves an HTTP response containing a path with embedded `\r\n` does not result in header injection.

<details><summary>Greptile Summary</summary>

This PR adds a control-character strip (`[\x00-\x1F\x7F]`) inside `getSafeRedirectPath` to close a gap where newline, null-byte, and DEL characters could pass through the existing validation guards despite being invalid in URL paths per RFC 3986. The strip is applied after `trim()` and before the protocol-relative/absolute-URL checks, with an explicit empty-result guard.

* `web/src/utils/redirect.ts`: Introduces `const sanitized = trimmed.replace(/[\x00-\x1F\x7F]/g, "")` and updates all downstream references from `trimmed` to `sanitized`, keeping the existing logic otherwise unchanged.
* `web/src/__tests__/redirect.clienttest.ts`: Adds 7 focused test cases covering newline, null-byte, DEL, C0-range edge cases, the empty-after-strip fallback, whitespace preservation, and regression checks that the existing `//` and scheme guards still fire correctly after the strip.

</details>

<details><summary>Confidence Score: 5/5</summary>

Safe to merge — the strip is narrowly scoped to characters that are never valid in URL paths, leaves all legitimate redirect paths unchanged, and the existing protocol/scheme guards still fire correctly after the strip.

The change is a minimal, well-bounded sanitization step. All references to trimmed below the new strip are correctly updated to sanitized, the empty-result guard handles the edge case, and the ordering (trim → strip → guards) is logically sound. Test coverage for the new code path is thorough.

No files require special attention.

</details>

<details><summary>Flowchart</summary>

[%%{init: {'theme': 'neutral'}}%% flowchart TD A< />targetPath input< /> --> B{empty / null / not string?} B -- yes --> Z< />return safeDefault< /> B -- no --> C< />trim whitespace< /> C --> D{trimmed empty?} D -- yes --> Z D -- no --> E< />"strip ASCII control chars< />n< />< />x00-< />x1F< />x7F< /> → ''"< /> E --> F{sanitized empty?} F -- yes --> Z F -- no --> G{starts with '/'?} G -- no --> Z G -- yes --> H{starts with '//'?} H -- yes --> Z H -- no --> I{basePath configured AND< />nsanitized starts with basePath?} I -- yes --> J< />return sanitized< /> I -- no --> K< />return basePath + sanitized< />](<#gh-light-mode-only>) [%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%% flowchart TD A< />targetPath input< /> --> B{empty / null / not string?} B -- yes --> Z< />return safeDefault< /> B -- no --> C< />trim whitespace< /> C --> D{trimmed empty?} D -- yes --> Z D -- no --> E< />"strip ASCII control chars< />n< />< />x00-< />x1F< />x7F< /> → ''"< /> E --> F{sanitized empty?} F -- yes --> Z F -- no --> G{starts with '/'?} G -- no --> Z G -- yes --> H{starts with '//'?} H -- yes --> Z H -- no --> I{basePath configured AND< />nsanitized starts with basePath?} I -- yes --> J< />return sanitized< /> I -- no --> K< />return basePath + sanitized< />](<#gh-dark-mode-only>)

</details>

Reviews (2): Last reviewed commit: ["test(redirect): address Greptile P1+P2 r..."](<https://github.com/langfuse/langfuse/commit/ab8fd5f8dc0495ed9178d2d4f710147eaccf6095>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=42617390>)