### PR TITLE
fix: re-enable observations time-filter pruning for UI traffic (startTime vs "Start Time")

### DIFF
--- a/packages/shared/src/server/repositories/observations.test.ts
+++ b/packages/shared/src/server/repositories/observations.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockQueryClickhouse = vi.hoisted(() => vi.fn());
+const mockShouldSkipObservationsFinal = vi.hoisted(() => vi.fn());
+let charCounter = 0;
+
+vi.mock("./clickhouse", () => ({
+  queryClickhouse: mockQueryClickhouse,
+  commandClickhouse: vi.fn(),
+  queryClickhouseStream: vi.fn(),
+  upsertClickhouse: vi.fn(),
+  parseClickhouseUTCDateTimeFormat: vi.fn(),
+  // Return unique names per call so filter parameter variables don't collide
+  clickhouseCompliantRandomCharacters: vi.fn(() => `x${++charCounter}`),
+}));
+
+vi.mock("../queries/clickhouse-sql/query-options", () => ({
+  shouldSkipObservationsFinal: mockShouldSkipObservationsFinal,
+}));
+
+import { getObservationsTableCount } from "./observations";
+import { type FilterState } from "../../types";
+
+/**
+ * Regression coverage for the observations-table time-filter pruning.
+ *
+ * The traces-join time pruning (`t.timestamp > {tracesTimestampFilter} -
+ * INTERVAL 2 DAY`) only fires when the repository recognises a lower-bound
+ * start-time filter. The UI date-range picker sends the column id `startTime`,
+ * while worker batch export sends the display name `Start Time`. A regression
+ * matched only the display name, so all standard UI traffic joined the traces
+ * table without the time bound and scanned the full table.
+ */
+describe("getObservationsTableInternal — traces-join time pruning", () => {
+  const PRUNING_CLAUSE =
+    /t\.timestamp > \{tracesTimestampFilter: DateTime64\(3\)\} - INTERVAL 2 DAY/;
+
+  const traceNameFilter = {
+    column: "traceName",
+    type: "stringOptions" as const,
+    operator: "any of" as const,
+    value: ["my-trace"],
+  };
+
+  const startTimeLowerBound = (column: "startTime" | "Start Time") => ({
+    column,
+    type: "datetime" as const,
+    operator: ">=" as const,
+    value: new Date("2026-07-04T00:00:00.000Z"),
+  });
+
+  beforeEach(() => {
+    charCounter = 0;
+    vi.clearAllMocks();
+    mockQueryClickhouse.mockResolvedValue([{ count: "0" }]);
+    mockShouldSkipObservationsFinal.mockResolvedValue(false);
+  });
+
+  it("prunes the traces join when the UI sends the `startTime` column id", async () => {
+    const filter: FilterState = [
+      traceNameFilter,
+      startTimeLowerBound("startTime"),
+    ];
+
+    await getObservationsTableCount({ projectId: "proj-1", filter });
+
+    expect(mockQueryClickhouse).toHaveBeenCalledOnce();
+    const { query, params } = mockQueryClickhouse.mock.calls[0][0];
+    expect(query).toMatch(PRUNING_CLAUSE);
+    expect(params).toHaveProperty("tracesTimestampFilter");
+  });
+
+  it("prunes the traces join when the export sends the `Start Time` display name", async () => {
+    const filter: FilterState = [
+      traceNameFilter,
+      startTimeLowerBound("Start Time"),
+    ];
+
+    await getObservationsTableCount({ projectId: "proj-1", filter });
+
+    expect(mockQueryClickhouse).toHaveBeenCalledOnce();
+    const { query, params } = mockQueryClickhouse.mock.calls[0][0];
+    expect(query).toMatch(PRUNING_CLAUSE);
+    expect(params).toHaveProperty("tracesTimestampFilter");
+  });
+
+  it("does not emit the pruning clause when the traces table is not joined", async () => {
+    // No trace-level filter and no trace ordering → no LEFT JOIN traces, so
+    // there is nothing to prune even though a start-time bound is present.
+    const filter: FilterState = [startTimeLowerBound("startTime")];
+
+    await getObservationsTableCount({ projectId: "proj-1", filter });
+
+    expect(mockQueryClickhouse).toHaveBeenCalledOnce();
+    const { query } = mockQueryClickhouse.mock.calls[0][0];
+    expect(query).not.toMatch(/LEFT JOIN traces/);
+    expect(query).not.toMatch(PRUNING_CLAUSE);
+  });
+});

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -677,9 +677,15 @@ const getObservationsTableInternal = async <T>(
     ? `${select}, o.input, o.output, o.metadata`
     : select;
 
+  // Accept both the display name ("Start Time") and the column id ("startTime").
+  // The UI date-range picker sends the column id, while worker batch export sends
+  // the display name; matching only the display name silently disabled the
+  // traces-join time pruning and the scores CTE timestamp lower bound below for
+  // all standard UI traffic.
   const timeFilter = filter.find(
     (f) =>
-      f.column === "Start Time" && (f.operator === ">=" || f.operator === ">"),
+      (f.column === "Start Time" || f.column === "startTime") &&
+      (f.operator === ">=" || f.operator === ">"),
   );
 
   const scoresFilter = new FilterList([


### PR DESCRIPTION
## Problem

For all standard Observations-table UI traffic, the traces-join time pruning in
`getObservationsTableInternal` was silently dead. When the user adds a
trace-level filter (e.g. Trace Name) or orders by a trace column, the query
does `LEFT JOIN traces`, but the time bound that should prune the join
(`t.timestamp > {tracesTimestampFilter} - INTERVAL 2 DAY`) was never emitted.

Root cause: the `timeFilter` lookup matched the filter column with the literal
display name `"Start Time"` only. The UI date-range picker sends the column id
`"startTime"` (and `transformFiltersForBackend` does not rewrite it), so
`timeFilter` was always `undefined` for UI requests. As a consequence:

- the traces-join time bound was never applied, and
- the scores CTE timestamp lower bound was skipped.

Only worker batch export (which sends `"Start Time"`) ever benefited from the
pruning. This is a performance issue, not a correctness one — the row-level
`o.start_time >= / <=` data filter is applied through a separate code path
(`createFilterFromFilterState`, which matches both the column id and the display
name), so results were always correct; only the join scan was unbounded.

## Evidence (reproduced on production)

Verified end-to-end on production ClickHouse by observing the SQL that the
Observations table actually issues, and running an A/B where the **only**
difference is the filter column name.

### 1. UI operation that triggers the traces join

In the Langfuse UI, on the Observations(Generations) table I applied:

- **Trace Name** filter → `any of ["multi_agent Request"]`
  (a trace-level column, so the query must `LEFT JOIN traces`)
- **Environment** filter → `none of [...]`
- **Date range** → `2026-07-04 … 2026-07-07` (the time-range picker, which emits
  `column: "startTime"`)
- Ordered by **Start Time** DESC

This is the exact path that should benefit from the traces-join time pruning.

### 2. Baseline: capture the issued SQL from `system.query_log`

The main list query starts with a `scores_agg` CTE, so I matched it by a marker
unique to `getObservationsTableInternal` (`tool_definitions_count`) rather than
the `FROM` clause, and exposed "joined traces?" / "pruning present?" as computed
columns (matching both `INTERVAL 2 DAY` and its normalized form
`toIntervalDay(2)`):

```sql
SELECT
  event_time,
  read_rows,
  query_duration_ms,
  positionCaseInsensitive(query, 'LEFT JOIN traces') > 0 AS joined_traces,
  positionCaseInsensitive(query, 'INTERVAL 2 DAY') > 0
    OR positionCaseInsensitive(query, 'toIntervalDay(2)') > 0 AS has_trace_pruning,
  substring(query, 1, 3000) AS q
FROM system.query_log
WHERE type = 'QueryFinish'
  AND event_time > now() - INTERVAL 30 MINUTE
  AND query ILIKE '%tool_definitions_count%'
  AND query NOT ILIKE '%system.query_log%'
ORDER BY event_time DESC;
```

The captured query confirmed the bug: it did `LEFT JOIN traces AS t FINAL`
(`joined_traces = 1`) but its `WHERE` contained only the observation-side bound
`o.start_time >= … AND o.start_time <= …` — **no** `t.timestamp > … - INTERVAL
2 DAY` (`has_trace_pruning = 0`). It read ~1.2M rows.

### 3. A/B: flip only the filter column name and re-issue

I copied the `generations.all` tRPC request as cURL from the browser (keeping all
auth headers) and changed **only** the two datetime filters' `column` from
`startTime` to `Start Time` in the URL-encoded `input` payload — leaving
`orderBy.column` as `startTime` so the `toDate(start_time)` ordering
optimization stays identical and the comparison is clean. Re-sending that
request and re-running the query_log query above produced a query with
`has_trace_pruning = 1` (the `t.timestamp` bound now present) that read ~9× fewer
rows.

### 4. Result (same node, back-to-back)

| Filter column sent | `has_trace_pruning` | `read_rows` | `query_duration_ms` |
| ------------------ | ------------------- | ----------- | ------------------- |
| `startTime` (what the UI sends today) | 0 | ~1,198,700 | ~1,513–1,843 |
| `Start Time` (behaviour after this fix) | 1 | 131,000 | 764 |

≈ **89% fewer rows read (~9×)** and roughly **2× faster** on this project. The
row-level `o.start_time` bounds are present in both cases, so results are
identical — this is purely the traces-join scan being bounded again.


## Fix

Match both the display name and the column id when locating the lower-bound
start-time filter:

```ts
const timeFilter = filter.find(
  (f) =>
    (f.column === "Start Time" || f.column === "startTime") &&
    (f.operator === ">=" || f.operator === ">"),
);
```

This mirrors the defensive dual-matching already used across the web frontend,
and is analogous to how the traces UI-table service matches the lowered filter
by ClickHouse field name.

## Behaviour change to be aware of

Re-enabling the pruning restores the intended assumption documented in the
query ("a trace has to have been within the last 2 days to be relevant"): with
the join now time-bounded, orphan observations whose corresponding trace has a
`timestamp` more than 2 days before the start-time lower bound (or has no
matching trace at all) will be excluded from trace-joined queries. This is the
original intended trade-off that was silently lost when the frontend switched
from display names to column ids; it only affects trace-joined queries.

## Tests

Added `packages/shared/src/server/repositories/observations.test.ts`, which
mocks `queryClickhouse` and asserts on the generated SQL:

- pruning clause is emitted when the UI sends the `startTime` column id
  (fails before this fix),
- pruning clause is emitted for the `Start Time` display name (parity),
- no pruning clause when the traces table is not joined.

## Verification

- `pnpm --filter @langfuse/shared run test src/server/repositories/observations.test.ts` → 3 passed
- `pnpm --filter @langfuse/shared run lint` → pass
- `pnpm --filter @langfuse/shared run typecheck` → pass

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a silent performance regression in `getObservationsTableInternal` where the traces-join time-pruning clause was never applied for standard UI traffic. The UI date-range picker sends `"startTime"` (column id) while the filter lookup only matched `"Start Time"` (display name), leaving the `LEFT JOIN traces` unbounded for all UI requests.

- **`observations.ts`**: Adds `|| f.column === "startTime"` to the `timeFilter.find()` predicate so the traces-join bound (`t.timestamp > {tracesTimestampFilter} - INTERVAL 2 DAY`) and the scores CTE timestamp lower bound are emitted for UI traffic, matching the existing behaviour for batch-export workers.
- **`observations.test.ts`**: New regression test mocks `queryClickhouse` and asserts the pruning clause is present for both column id and display name variants, and absent when the traces table is not joined.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change re-enables a time-bound on the traces JOIN that was already the intended behaviour; row-level correctness is unaffected.

The fix is a one-condition addition to an existing find() predicate. It restores documented intended behaviour with no change to row-level filter results. Three new unit tests reproduce the pre-fix failure and verify both column-name variants. The only observable difference is that trace-joined count/list queries will now scan fewer rows from the traces table, which is the desired outcome.

No files require special attention. The two changed files are self-contained; observations.ts change is one expression, and the test file is entirely new.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[UI date-range filter\ncolumn: 'startTime'] --> B{timeFilter.find}
    C[Batch export filter\ncolumn: 'Start Time'] --> B

    B -->|Before fix: only 'Start Time' matched| D1[timeFilter = undefined]
    B -->|After fix: both match| D2[timeFilter = filter entry]

    D1 --> E1[Traces join: unbounded scan\nno t.timestamp pruning]
    D1 --> E2[Scores CTE: no timestamp lower bound]

    D2 --> F1{traceTableFilter or orderByTraces?}
    F1 -->|Yes| G1[AND t.timestamp > tracesTimestampFilter - INTERVAL 2 DAY]
    F1 -->|No| G2[No pruning clause - traces not joined]
    D2 --> H1[scores WHERE timestamp >= timeFilter.value]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[UI date-range filter\ncolumn: 'startTime'] --> B{timeFilter.find}
    C[Batch export filter\ncolumn: 'Start Time'] --> B

    B -->|Before fix: only 'Start Time' matched| D1[timeFilter = undefined]
    B -->|After fix: both match| D2[timeFilter = filter entry]

    D1 --> E1[Traces join: unbounded scan\nno t.timestamp pruning]
    D1 --> E2[Scores CTE: no timestamp lower bound]

    D2 --> F1{traceTableFilter or orderByTraces?}
    F1 -->|Yes| G1[AND t.timestamp > tracesTimestampFilter - INTERVAL 2 DAY]
    F1 -->|No| G2[No pruning clause - traces not joined]
    D2 --> H1[scores WHERE timestamp >= timeFilter.value]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(observations): match startTime colum..."](https://github.com/langfuse/langfuse/commit/f7e9cc3420c4a9a1e709a2295883e1d22e1a195d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42637099)</sub>

<!-- /greptile_comment -->