### PR TITLE
feat(clickhouse): add ingested_sdks to analytics export views

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0036_add_ingested_sdks_to_analytics_scores.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0036_add_ingested_sdks_to_analytics_scores.down.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE VIEW analytics_scores ON CLUSTER default AS
+SELECT
+    project_id,
+    toStartOfHour(timestamp) AS hour,
+    uniq(id) AS countScores,
+    max(source = 'ANNOTATION') AS hasAnnotation,
+    max(source = 'API') AS hasApi,
+    max(source = 'EVAL') AS hasEval,
+    max(observation_id IS NOT NULL) AS hasObservationScore,
+    max(session_id IS NOT NULL) AS hasSessionScore,
+    max(dataset_run_id IS NOT NULL) AS hasDatasetRunScore,
+    max(data_type = 'BOOLEAN') AS hasBoolScore,
+    max(data_type = 'NUMERIC') AS hasNumericScore,
+    max(data_type = 'CATEGORICAL') AS hasCategoricalScore,
+    max(comment IS NOT NULL) AS hasComment
+FROM
+    scores
+WHERE toStartOfHour(timestamp) <= toStartOfHour(subtractHours(now(), 1))
+GROUP BY
+    project_id,
+    hour;

--- a/packages/shared/clickhouse/migrations/clustered/0036_add_ingested_sdks_to_analytics_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0036_add_ingested_sdks_to_analytics_scores.up.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE VIEW analytics_scores ON CLUSTER default AS
+SELECT
+    project_id,
+    toStartOfHour(timestamp) AS hour,
+    uniq(id) AS countScores,
+    max(source = 'ANNOTATION') AS hasAnnotation,
+    max(source = 'API') AS hasApi,
+    max(source = 'EVAL') AS hasEval,
+    max(observation_id IS NOT NULL) AS hasObservationScore,
+    max(session_id IS NOT NULL) AS hasSessionScore,
+    max(dataset_run_id IS NOT NULL) AS hasDatasetRunScore,
+    max(data_type = 'BOOLEAN') AS hasBoolScore,
+    max(data_type = 'NUMERIC') AS hasNumericScore,
+    max(data_type = 'CATEGORICAL') AS hasCategoricalScore,
+    max(comment IS NOT NULL) AS hasComment,
+    sumMap(map(concat(if(ingestion_sdk_name = '', 'unknown', ingestion_sdk_name), '@', if(ingestion_sdk_version = '', 'unknown', ingestion_sdk_version)), toUInt64(1))) AS ingested_sdks
+FROM
+    scores
+WHERE toStartOfHour(timestamp) <= toStartOfHour(subtractHours(now(), 1))
+GROUP BY
+    project_id,
+    hour;

--- a/packages/shared/clickhouse/migrations/unclustered/0036_add_ingested_sdks_to_analytics_scores.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0036_add_ingested_sdks_to_analytics_scores.down.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE VIEW analytics_scores AS
+SELECT
+    project_id,
+    toStartOfHour(timestamp) AS hour,
+    uniq(id) AS countScores,
+    max(source = 'ANNOTATION') AS hasAnnotation,
+    max(source = 'API') AS hasApi,
+    max(source = 'EVAL') AS hasEval,
+    max(observation_id IS NOT NULL) AS hasObservationScore,
+    max(session_id IS NOT NULL) AS hasSessionScore,
+    max(dataset_run_id IS NOT NULL) AS hasDatasetRunScore,
+    max(data_type = 'BOOLEAN') AS hasBoolScore,
+    max(data_type = 'NUMERIC') AS hasNumericScore,
+    max(data_type = 'CATEGORICAL') AS hasCategoricalScore,
+    max(comment IS NOT NULL) AS hasComment
+FROM
+    scores
+WHERE toStartOfHour(timestamp) <= toStartOfHour(subtractHours(now(), 1))
+GROUP BY
+    project_id,
+    hour;

--- a/packages/shared/clickhouse/migrations/unclustered/0036_add_ingested_sdks_to_analytics_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0036_add_ingested_sdks_to_analytics_scores.up.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE VIEW analytics_scores AS
+SELECT
+    project_id,
+    toStartOfHour(timestamp) AS hour,
+    uniq(id) AS countScores,
+    max(source = 'ANNOTATION') AS hasAnnotation,
+    max(source = 'API') AS hasApi,
+    max(source = 'EVAL') AS hasEval,
+    max(observation_id IS NOT NULL) AS hasObservationScore,
+    max(session_id IS NOT NULL) AS hasSessionScore,
+    max(dataset_run_id IS NOT NULL) AS hasDatasetRunScore,
+    max(data_type = 'BOOLEAN') AS hasBoolScore,
+    max(data_type = 'NUMERIC') AS hasNumericScore,
+    max(data_type = 'CATEGORICAL') AS hasCategoricalScore,
+    max(comment IS NOT NULL) AS hasComment,
+    sumMap(map(concat(if(ingestion_sdk_name = '', 'unknown', ingestion_sdk_name), '@', if(ingestion_sdk_version = '', 'unknown', ingestion_sdk_version)), toUInt64(1))) AS ingested_sdks
+FROM
+    scores
+WHERE toStartOfHour(timestamp) <= toStartOfHour(subtractHours(now(), 1))
+GROUP BY
+    project_id,
+    hour;

--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -530,6 +530,43 @@ SELECT
     byteSize(*) AS total_size
 FROM traces;
 
+CREATE VIEW analytics_events_core AS
+SELECT
+  project_id,
+  toStartOfHour(start_time) AS hour,
+  sumMap(map(type, toUInt64(1))) AS count_types,
+  uniq(trace_id) AS count_traces,
+  uniq(span_id) AS count_spans,
+  uniqIf(trace_name, trace_name != '') AS count_trace_names,
+  max(user_id != '') AS has_users,
+  uniqIf(user_id, user_id != '') AS count_users,
+  max(session_id != '') AS has_sessions,
+  uniqIf(session_id, session_id != '') AS count_sessions,
+  max(if(environment != 'default', 1, 0)) AS has_environments,
+  uniq(environment) as count_environments,
+  max(length(tags) > 0) AS has_tags,
+  uniqArray(tags) AS count_unique_tags,
+  max(level != 'DEFAULT') AS has_level,
+  max(provided_model_name != '') AS has_provided_model_name,
+  uniqIf(provided_model_name, provided_model_name != '') AS count_models,
+  max(length(provided_usage_details) > 0) AS has_provided_usage_details,
+  max(length(provided_cost_details) > 0) AS has_provided_cost_details,
+  max(prompt_name != '') AS has_prompt_name,
+  max(length(tool_definitions) > 0) AS has_tool_definitions,
+  max(length(tool_calls) > 0) AS has_tool_calls,
+  uniqArray(metadata_names) AS count_unique_metadata_names,
+  max(experiment_name != '') AS has_experiment_names,
+  uniqIf(experiment_name, experiment_name != '') AS count_unique_experiment_names,
+  sum(event_bytes) AS sum_event_bytes,
+  sumMap(map(if(source = '', '-', source), toUInt64(1))) AS count_sources,
+  uniqIf(service_name, service_name != '') as count_service_names,
+  sumMap(map(if(scope_name = '', '-', concat(scope_name, '-', scope_version)), toUInt64(1))) AS count_scopes,
+  sumMap(map(if(telemetry_sdk_language = '', '-', telemetry_sdk_language), toUInt64(1))) AS count_telemetry_sdk_languages,
+  sumMap(map(if(telemetry_sdk_name = '', '-', concat(telemetry_sdk_language, '-', telemetry_sdk_name, '-', telemetry_sdk_version)), toUInt64(1))) AS count_sdk_telemetry_sdks
+FROM events_core
+WHERE toStartOfHour(start_time) <= toStartOfHour(subtractHours(now(), 1))
+GROUP BY project_id, hour;
+
 -- Apply dev-table migrations for ingestion attribution.
 ALTER TABLE observations_batch_staging
   ADD COLUMN IF NOT EXISTS ingestion_api_key String DEFAULT ''
@@ -642,6 +679,7 @@ SELECT
 FROM events_full
 SETTINGS enable_full_text_index = 1;
 
+-- Append-only re-definition of analytics_events_core adding ingested_sdks.
 -- Must stay after the ingestion attribution ALTERs above: the view reads
 -- ingestion_sdk_name/ingestion_sdk_version from events_core.
 --
@@ -651,7 +689,7 @@ SETTINGS enable_full_text_index = 1;
 -- manually as CREATE OR REPLACE VIEW in every cloud region (eu, us, hipaa,
 -- jp) and recorded in the migrations doc linked in the header — otherwise
 -- the DWH S3 export silently misses the new columns.
-CREATE VIEW analytics_events_core AS
+CREATE OR REPLACE VIEW analytics_events_core AS
 SELECT
   project_id,
   toStartOfHour(start_time) AS hour,

--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -530,44 +530,6 @@ SELECT
     byteSize(*) AS total_size
 FROM traces;
 
-CREATE VIEW analytics_events_core AS
-SELECT
-  project_id,
-  toStartOfHour(start_time) AS hour,
-  sumMap(map(type, toUInt64(1))) AS count_types,
-  uniq(trace_id) AS count_traces,
-  uniq(span_id) AS count_spans,
-  uniqIf(trace_name, trace_name != '') AS count_trace_names,
-  max(user_id != '') AS has_users,
-  uniqIf(user_id, user_id != '') AS count_users,
-  max(session_id != '') AS has_sessions,
-  uniqIf(session_id, session_id != '') AS count_sessions,
-  max(if(environment != 'default', 1, 0)) AS has_environments,
-  uniq(environment) as count_environments,
-  max(length(tags) > 0) AS has_tags,
-  uniqArray(tags) AS count_unique_tags,
-  max(level != 'DEFAULT') AS has_level,
-  max(provided_model_name != '') AS has_provided_model_name,
-  uniqIf(provided_model_name, provided_model_name != '') AS count_models,
-  max(length(provided_usage_details) > 0) AS has_provided_usage_details,
-  max(length(provided_cost_details) > 0) AS has_provided_cost_details,
-  max(prompt_name != '') AS has_prompt_name,
-  max(length(tool_definitions) > 0) AS has_tool_definitions,
-  max(length(tool_calls) > 0) AS has_tool_calls,
-  uniqArray(metadata_names) AS count_unique_metadata_names,
-  max(experiment_name != '') AS has_experiment_names,
-  uniqIf(experiment_name, experiment_name != '') AS count_unique_experiment_names,
-  sum(event_bytes) AS sum_event_bytes,
-  sumMap(map(if(source = '', '-', source), toUInt64(1))) AS count_sources,
-  uniqIf(service_name, service_name != '') as count_service_names,
-  sumMap(map(if(scope_name = '', '-', concat(scope_name, '-', scope_version)), toUInt64(1))) AS count_scopes,
-  sumMap(map(if(telemetry_sdk_language = '', '-', telemetry_sdk_language), toUInt64(1))) AS count_telemetry_sdk_languages,
-  sumMap(map(if(telemetry_sdk_name = '', '-', concat(telemetry_sdk_language, '-', telemetry_sdk_name, '-', telemetry_sdk_version)), toUInt64(1))) AS count_sdk_telemetry_sdks,
-  sumMap(map(concat(if(ingestion_sdk_name = '', 'unknown', ingestion_sdk_name), '@', if(ingestion_sdk_version = '', 'unknown', ingestion_sdk_version)), toUInt64(1))) AS ingested_sdks
-FROM events_core
-WHERE toStartOfHour(start_time) <= toStartOfHour(subtractHours(now(), 1))
-GROUP BY project_id, hour;
-
 -- Apply dev-table migrations for ingestion attribution.
 ALTER TABLE observations_batch_staging
   ADD COLUMN IF NOT EXISTS ingestion_api_key String DEFAULT ''
@@ -679,6 +641,53 @@ SELECT
     ingestion_sdk_version
 FROM events_full
 SETTINGS enable_full_text_index = 1;
+
+-- Must stay after the ingestion attribution ALTERs above: the view reads
+-- ingestion_sdk_name/ingestion_sdk_version from events_core.
+--
+-- PROD ROLLOUT: unlike analytics_scores (managed via numbered migrations),
+-- this view is NOT migration-managed because events_core only exists in
+-- cloud environments (see header note). Any change here must be applied
+-- manually as CREATE OR REPLACE VIEW in every cloud region (eu, us, hipaa,
+-- jp) and recorded in the migrations doc linked in the header — otherwise
+-- the DWH S3 export silently misses the new columns.
+CREATE VIEW analytics_events_core AS
+SELECT
+  project_id,
+  toStartOfHour(start_time) AS hour,
+  sumMap(map(type, toUInt64(1))) AS count_types,
+  uniq(trace_id) AS count_traces,
+  uniq(span_id) AS count_spans,
+  uniqIf(trace_name, trace_name != '') AS count_trace_names,
+  max(user_id != '') AS has_users,
+  uniqIf(user_id, user_id != '') AS count_users,
+  max(session_id != '') AS has_sessions,
+  uniqIf(session_id, session_id != '') AS count_sessions,
+  max(if(environment != 'default', 1, 0)) AS has_environments,
+  uniq(environment) as count_environments,
+  max(length(tags) > 0) AS has_tags,
+  uniqArray(tags) AS count_unique_tags,
+  max(level != 'DEFAULT') AS has_level,
+  max(provided_model_name != '') AS has_provided_model_name,
+  uniqIf(provided_model_name, provided_model_name != '') AS count_models,
+  max(length(provided_usage_details) > 0) AS has_provided_usage_details,
+  max(length(provided_cost_details) > 0) AS has_provided_cost_details,
+  max(prompt_name != '') AS has_prompt_name,
+  max(length(tool_definitions) > 0) AS has_tool_definitions,
+  max(length(tool_calls) > 0) AS has_tool_calls,
+  uniqArray(metadata_names) AS count_unique_metadata_names,
+  max(experiment_name != '') AS has_experiment_names,
+  uniqIf(experiment_name, experiment_name != '') AS count_unique_experiment_names,
+  sum(event_bytes) AS sum_event_bytes,
+  sumMap(map(if(source = '', '-', source), toUInt64(1))) AS count_sources,
+  uniqIf(service_name, service_name != '') as count_service_names,
+  sumMap(map(if(scope_name = '', '-', concat(scope_name, '-', scope_version)), toUInt64(1))) AS count_scopes,
+  sumMap(map(if(telemetry_sdk_language = '', '-', telemetry_sdk_language), toUInt64(1))) AS count_telemetry_sdk_languages,
+  sumMap(map(if(telemetry_sdk_name = '', '-', concat(telemetry_sdk_language, '-', telemetry_sdk_name, '-', telemetry_sdk_version)), toUInt64(1))) AS count_sdk_telemetry_sdks,
+  sumMap(map(concat(if(ingestion_sdk_name = '', 'unknown', ingestion_sdk_name), '@', if(ingestion_sdk_version = '', 'unknown', ingestion_sdk_version)), toUInt64(1))) AS ingested_sdks
+FROM events_core
+WHERE toStartOfHour(start_time) <= toStartOfHour(subtractHours(now(), 1))
+GROUP BY project_id, hour;
 
 EOF
 

--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -562,7 +562,8 @@ SELECT
   uniqIf(service_name, service_name != '') as count_service_names,
   sumMap(map(if(scope_name = '', '-', concat(scope_name, '-', scope_version)), toUInt64(1))) AS count_scopes,
   sumMap(map(if(telemetry_sdk_language = '', '-', telemetry_sdk_language), toUInt64(1))) AS count_telemetry_sdk_languages,
-  sumMap(map(if(telemetry_sdk_name = '', '-', concat(telemetry_sdk_language, '-', telemetry_sdk_name, '-', telemetry_sdk_version)), toUInt64(1))) AS count_sdk_telemetry_sdks
+  sumMap(map(if(telemetry_sdk_name = '', '-', concat(telemetry_sdk_language, '-', telemetry_sdk_name, '-', telemetry_sdk_version)), toUInt64(1))) AS count_sdk_telemetry_sdks,
+  sumMap(map(concat(if(ingestion_sdk_name = '', 'unknown', ingestion_sdk_name), '@', if(ingestion_sdk_version = '', 'unknown', ingestion_sdk_version)), toUInt64(1))) AS ingested_sdks
 FROM events_core
 WHERE toStartOfHour(start_time) <= toStartOfHour(subtractHours(now(), 1))
 GROUP BY project_id, hour;


### PR DESCRIPTION
## Summary

Adds an `ingested_sdks` column — `Map(String, UInt64)` of `"<sdk-name>@<sdk-version>" → row count`, e.g. `{'python@4.2.1': 554, 'javascript@5.1.3': 14}` — to the ClickHouse analytics views that are exported to the internal DWH, so we can build dashboards on SDK upgrade cycles. Built on the ingestion attribution columns introduced in #14593.

- **`analytics_events_core`** ([dev-tables.sh](https://github.com/langfuse/langfuse/blob/main/packages/shared/clickhouse/scripts/dev-tables.sh)): new `sumMap` column keyed by `ingestion_sdk_name@ingestion_sdk_version`, with empty values normalized to `unknown` (consistent with the `unknown` defaults from #14593). Note: the prod view is not migration-managed and needs a manual `CREATE OR REPLACE VIEW` per region after merge.
- **`analytics_scores`** (migration `0036`, clustered + unclustered): `CREATE OR REPLACE VIEW` with the same `ingested_sdks` column appended; down migration restores the previous definition.

Per DWH guidance (schema evolution on the S3 imports), appending a `Map(String, UInt64)` column is backward compatible; existing column types are unchanged. Follow-up outside this repo: expose the column in the `ClickHouse/dwh-dbt` staging/mart models (incl. the Map cast applied to the other map columns in dwh-dbt#1072).

## Verification

Against local dev ClickHouse (67k scores, 108k events_core rows):

- `0036` up applied cleanly; `analytics_scores` returns e.g. `{'javascript@5.1.3':14,'python@4.2.1':554,'unknown@unknown':1}` per project/hour.
- Migration round-trip: down → `hasColumnInTable = 0`, up → `hasColumnInTable = 1`.
- Updated `analytics_events_core` definition created and queried successfully (local seed data carries no attribution on `events_core`, so keys aggregate to `unknown@unknown`).
- Pre-commit: prettier clean, `turbo run lint` — `Tasks: 8 successful, 8 total`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an `ingested_sdks Map(String, UInt64)` column — keyed by `"<sdk-name>@<sdk-version>"` — to two ClickHouse analytics export views to enable SDK-upgrade-cycle dashboards. The column is built with `sumMap` over the `ingestion_sdk_name`/`ingestion_sdk_version` attribution columns introduced in migration 0035.

- **`analytics_scores`** (migrations `0036`, clustered + unclustered): `CREATE OR REPLACE VIEW` with the new column added and a correct down migration that restores the previous definition.
- **`analytics_events_core`** (`dev-tables.sh` only): the same `sumMap` expression is appended, but there is no numbered migration for this view — production regions require a manual `CREATE OR REPLACE VIEW` after merge, which the PR description acknowledges.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the migration round-trip for analytics_scores is clean and backward-compatible; the only gap is the manual deployment step needed for analytics_events_core in production.

The four migration files are correct and consistent: the sumMap expression handles both empty-string and 'unknown' defaults defensively, the clustered/unclustered split follows established patterns, and the down migration faithfully restores the prior view. The analytics_events_core change only exists in dev-tables.sh with no numbered migration, so that view will not be updated in production automatically — it requires a manual CREATE OR REPLACE VIEW per region after merge. If that step is skipped, the two views exported to the DWH will be out of sync on this column.

packages/shared/clickhouse/scripts/dev-tables.sh — the analytics_events_core view change here has no corresponding migration file and needs a tracked manual deployment step for production regions.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Ingestion as Ingestion Pipeline
    participant scores as scores table
    participant events_core as events_core table
    participant analytics_scores as analytics_scores view (migration 0036)
    participant analytics_events_core as analytics_events_core view (dev-tables.sh)
    participant DWH as DWH S3 Export

    Ingestion->>scores: INSERT (ingestion_sdk_name, ingestion_sdk_version)
    Ingestion->>events_core: INSERT (ingestion_sdk_name, ingestion_sdk_version)

    analytics_scores->>scores: GROUP BY project_id, hour sumMap AS ingested_sdks
    analytics_events_core->>events_core: GROUP BY project_id, hour sumMap AS ingested_sdks

    analytics_scores->>DWH: export with ingested_sdks column (via migration)
    analytics_events_core->>DWH: export with ingested_sdks column (manual CREATE OR REPLACE VIEW required)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Ingestion as Ingestion Pipeline
    participant scores as scores table
    participant events_core as events_core table
    participant analytics_scores as analytics_scores view (migration 0036)
    participant analytics_events_core as analytics_events_core view (dev-tables.sh)
    participant DWH as DWH S3 Export

    Ingestion->>scores: INSERT (ingestion_sdk_name, ingestion_sdk_version)
    Ingestion->>events_core: INSERT (ingestion_sdk_name, ingestion_sdk_version)

    analytics_scores->>scores: GROUP BY project_id, hour sumMap AS ingested_sdks
    analytics_events_core->>events_core: GROUP BY project_id, hour sumMap AS ingested_sdks

    analytics_scores->>DWH: export with ingested_sdks column (via migration)
    analytics_events_core->>DWH: export with ingested_sdks column (manual CREATE OR REPLACE VIEW required)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/clickhouse/scripts/dev-tables.sh:566
**No migration file for `analytics_events_core`**

The `analytics_scores` view is updated via a proper numbered migration (`0036`), giving it an automatic up/down round-trip in every environment. The `analytics_events_core` change only lives in `dev-tables.sh`, so the prod view must be updated manually per region after merge. If that manual step is missed or run out of order, the DWH export for `events_core` will silently lack the `ingested_sdks` column while `analytics_scores` already carries it — diverging the two views that are supposed to be processed together downstream.

The PR description acknowledges this, but it is worth making the manual step as explicit as possible (e.g. a runbook entry or a TODO comment in the script) so it isn't dropped between merge and deploy.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(clickhouse): add ingested\_sdks to a..."](https://github.com/langfuse/langfuse/commit/859d4649a7fdba1185ca29d706652a1bd876a12f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42638428)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->