### PR TITLE
chore(worker): warn on inconsistent provided usage_details totals (LFE-10743)

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -239,6 +239,14 @@ export class IngestionService {
     const input = this.stringify(eventData.input);
     const output = this.stringify(eventData.output);
 
+    // Runs outside the modelName gate below so model-less events with provided
+    // usage are still checked.
+    this.warnOnUsageTotalMismatch(
+      eventData.providedUsageDetails ?? {},
+      { id: eventData.spanId, project_id: eventData.projectId },
+      "events",
+    );
+
     // Perform lookups for prompt and model/usage enrichment
     const [prompt, generationUsage] = await Promise.all([
       // Lookup prompt by name and version
@@ -875,6 +883,20 @@ export class IngestionService {
       mergedObservationRecord.tool_call_names = normalizedTools.toolCallNames;
     }
 
+    // Only check when the incoming events carry usage themselves — partial
+    // updates merge stale usage back in from ClickHouse and must not re-fire.
+    if (
+      observationRecords.some(
+        (record) => Object.keys(record.provided_usage_details ?? {}).length > 0,
+      )
+    ) {
+      this.warnOnUsageTotalMismatch(
+        mergedObservationRecord.provided_usage_details ?? {},
+        mergedObservationRecord,
+        "legacy",
+      );
+    }
+
     const generationUsage = await this.getGenerationUsage({
       projectId,
       observationRecord: mergedObservationRecord,
@@ -1182,12 +1204,7 @@ export class IngestionService {
   private async getUsageUnits(
     observationRecord: Pick<
       ObservationRecordInsertType,
-      | "provided_usage_details"
-      | "level"
-      | "input"
-      | "output"
-      | "id"
-      | "project_id"
+      "provided_usage_details" | "level" | "input" | "output" | "id"
     >,
     model: Model | null | undefined,
   ): Promise<
@@ -1196,21 +1213,9 @@ export class IngestionService {
       "usage_details" | "provided_usage_details"
     >
   > {
-    // Convert all values to numbers to handle cases where ClickHouse returns UInt64 as strings.
-    // This prevents string concatenation bugs like "100" + "200" = "100200" instead of 300.
-    const providedUsageDetails: Record<string, number> = {};
-    for (const [key, value] of Object.entries(
+    const providedUsageDetails = IngestionService.normalizeProvidedUsageDetails(
       observationRecord.provided_usage_details,
-    )) {
-      if (value != null) {
-        const numValue = Number(value);
-        if (!isNaN(numValue) && numValue >= 0) {
-          providedUsageDetails[key] = numValue;
-        }
-      }
-    }
-
-    this.warnOnUsageTotalMismatch(providedUsageDetails, observationRecord);
+    );
 
     if (
       // Manual tokenisation when no user provided usage and generation has not status ERROR
@@ -1324,6 +1329,23 @@ export class IngestionService {
     };
   }
 
+  // Convert all values to numbers to handle cases where ClickHouse returns UInt64 as strings.
+  // This prevents string concatenation bugs like "100" + "200" = "100200" instead of 300.
+  private static normalizeProvidedUsageDetails(
+    providedUsageDetails: Record<string, unknown>,
+  ): Record<string, number> {
+    const normalized: Record<string, number> = {};
+    for (const [key, value] of Object.entries(providedUsageDetails)) {
+      if (value != null) {
+        const numValue = Number(value);
+        if (!isNaN(numValue) && numValue >= 0) {
+          normalized[key] = numValue;
+        }
+      }
+    }
+    return normalized;
+  }
+
   private static lastUsageTotalMismatchLogAt = 0;
   private static readonly USAGE_TOTAL_MISMATCH_TOLERANCE = 0.01;
   private static readonly USAGE_TOTAL_MISMATCH_LOG_INTERVAL_MS = 60_000;
@@ -1334,11 +1356,19 @@ export class IngestionService {
    * an inclusive `input` alongside cache buckets while providing a smaller
    * `total`. Warn only — buckets can be genuinely additive (e.g. Bedrock cache
    * writes), so auto-correcting could corrupt valid payloads.
+   *
+   * Called once per write path (`legacy` merge path, `events` direct path);
+   * dual-write mode fires both, so the metric carries a write_path tag to keep
+   * the counts reconcilable.
    */
   private warnOnUsageTotalMismatch(
-    providedUsageDetails: Record<string, number>,
+    rawProvidedUsageDetails: Record<string, unknown>,
     observationRecord: Pick<ObservationRecordInsertType, "id" | "project_id">,
+    writePath: "legacy" | "events",
   ): void {
+    const providedUsageDetails = IngestionService.normalizeProvidedUsageDetails(
+      rawProvidedUsageDetails,
+    );
     const providedTotal = providedUsageDetails.total;
     if (providedTotal == null) return;
 
@@ -1351,7 +1381,9 @@ export class IngestionService {
     );
     if (bucketSum <= providedTotal + tolerance) return;
 
-    recordIncrement("langfuse.ingestion.usage_details.total_mismatch");
+    recordIncrement("langfuse.ingestion.usage_details.total_mismatch", 1, {
+      write_path: writePath,
+    });
 
     const now = Date.now();
     if (
@@ -1369,6 +1401,7 @@ export class IngestionService {
         providedTotal,
         bucketSum,
         providedUsageDetails,
+        writePath,
       },
     );
   }

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1182,7 +1182,12 @@ export class IngestionService {
   private async getUsageUnits(
     observationRecord: Pick<
       ObservationRecordInsertType,
-      "provided_usage_details" | "level" | "input" | "output" | "id"
+      | "provided_usage_details"
+      | "level"
+      | "input"
+      | "output"
+      | "id"
+      | "project_id"
     >,
     model: Model | null | undefined,
   ): Promise<
@@ -1204,6 +1209,8 @@ export class IngestionService {
         }
       }
     }
+
+    this.warnOnUsageTotalMismatch(providedUsageDetails, observationRecord);
 
     if (
       // Manual tokenisation when no user provided usage and generation has not status ERROR
@@ -1315,6 +1322,55 @@ export class IngestionService {
       usage_details: usageDetails,
       provided_usage_details: providedUsageDetails,
     };
+  }
+
+  private static lastUsageTotalMismatchLogAt = 0;
+  private static readonly USAGE_TOTAL_MISMATCH_TOLERANCE = 0.01;
+  private static readonly USAGE_TOTAL_MISMATCH_LOG_INTERVAL_MS = 60_000;
+
+  /**
+   * Detects the double-count class from
+   * https://github.com/langfuse/langfuse/issues/10592: instrumentors that send
+   * an inclusive `input` alongside cache buckets while providing a smaller
+   * `total`. Warn only — buckets can be genuinely additive (e.g. Bedrock cache
+   * writes), so auto-correcting could corrupt valid payloads.
+   */
+  private warnOnUsageTotalMismatch(
+    providedUsageDetails: Record<string, number>,
+    observationRecord: Pick<ObservationRecordInsertType, "id" | "project_id">,
+  ): void {
+    const providedTotal = providedUsageDetails.total;
+    if (providedTotal == null) return;
+
+    const bucketSum = Object.entries(providedUsageDetails)
+      .filter(([key]) => key !== "total")
+      .reduce((sum, [, value]) => sum + value, 0);
+    const tolerance = Math.max(
+      1,
+      providedTotal * IngestionService.USAGE_TOTAL_MISMATCH_TOLERANCE,
+    );
+    if (bucketSum <= providedTotal + tolerance) return;
+
+    recordIncrement("langfuse.ingestion.usage_details.total_mismatch");
+
+    const now = Date.now();
+    if (
+      now - IngestionService.lastUsageTotalMismatchLogAt <
+      IngestionService.USAGE_TOTAL_MISMATCH_LOG_INTERVAL_MS
+    ) {
+      return;
+    }
+    IngestionService.lastUsageTotalMismatchLogAt = now;
+    logger.warn(
+      "Sum of provided non-total usage_details buckets exceeds provided total; the instrumentor may be sending an inclusive input alongside cache buckets",
+      {
+        projectId: observationRecord.project_id,
+        observationId: observationRecord.id,
+        providedTotal,
+        bucketSum,
+        providedUsageDetails,
+      },
+    );
   }
 
   static calculateUsageCosts(

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Price } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
-import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import { createOrgProjectAndApiKey, logger } from "@langfuse/shared/src/server";
 
 import { IngestionService } from "../../IngestionService";
 import * as clickhouseWriteExports from "../../ClickhouseWriter";
@@ -1367,6 +1367,108 @@ describe("Token Cost Calculation", () => {
 
       expect(generation.usage_details.input).toBe(100);
       expect(generation.usage_details.total).toBe(100);
+    });
+  });
+
+  describe("usage details total consistency guard", () => {
+    // Detects the double-count class from https://github.com/langfuse/langfuse/issues/10592:
+    // instrumentors sending an inclusive `input` alongside cache buckets while also
+    // providing a smaller `total`.
+
+    it("should warn when provided non-total buckets sum to more than the provided total", async () => {
+      (IngestionService as any).lastUsageTotalMismatchLogAt = 0;
+      const warnSpy = vi.spyOn(logger, "warn");
+      const generationId = uuidv4();
+
+      const eventRecord = await (mockIngestionService as any).createEventRecord(
+        {
+          projectId,
+          spanId: generationId,
+          startTime: new Date().toISOString(),
+          modelName,
+          // Inclusive input alongside cache buckets: 100 + 80 + 50 > 150
+          providedUsageDetails: {
+            input: 100,
+            cache_read_input_tokens: 80,
+            output: 50,
+            total: 150,
+          },
+        },
+        "testfile.txt",
+      );
+
+      const mismatchWarnings = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("exceeds provided total"),
+      );
+      expect(mismatchWarnings).toHaveLength(1);
+      expect(mismatchWarnings[0][1]).toMatchObject({
+        projectId,
+        observationId: generationId,
+        providedTotal: 150,
+        bucketSum: 230,
+      });
+
+      // Warn only — the provided values must be written unchanged
+      expect(eventRecord.usage_details).toEqual({
+        input: 100,
+        cache_read_input_tokens: 80,
+        output: 50,
+        total: 150,
+      });
+    });
+
+    it("should not warn when provided buckets are consistent with the provided total", async () => {
+      (IngestionService as any).lastUsageTotalMismatchLogAt = 0;
+      const warnSpy = vi.spyOn(logger, "warn");
+      const generationId = uuidv4();
+
+      await (mockIngestionService as any).createEventRecord(
+        {
+          projectId,
+          spanId: generationId,
+          startTime: new Date().toISOString(),
+          modelName,
+          // Exclusive input: 20 + 80 + 50 === 150
+          providedUsageDetails: {
+            input: 20,
+            cache_read_input_tokens: 80,
+            output: 50,
+            total: 150,
+          },
+        },
+        "testfile.txt",
+      );
+
+      const mismatchWarnings = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("exceeds provided total"),
+      );
+      expect(mismatchWarnings).toHaveLength(0);
+    });
+
+    it("should not warn when no total is provided", async () => {
+      (IngestionService as any).lastUsageTotalMismatchLogAt = 0;
+      const warnSpy = vi.spyOn(logger, "warn");
+      const generationId = uuidv4();
+
+      await (mockIngestionService as any).createEventRecord(
+        {
+          projectId,
+          spanId: generationId,
+          startTime: new Date().toISOString(),
+          modelName,
+          providedUsageDetails: {
+            input: 100,
+            cache_read_input_tokens: 80,
+            output: 50,
+          },
+        },
+        "testfile.txt",
+      );
+
+      const mismatchWarnings = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("exceeds provided total"),
+      );
+      expect(mismatchWarnings).toHaveLength(0);
     });
   });
 });

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -1406,6 +1406,7 @@ describe("Token Cost Calculation", () => {
         observationId: generationId,
         providedTotal: 150,
         bucketSum: 230,
+        writePath: "events",
       });
 
       // Warn only — the provided values must be written unchanged
@@ -1464,6 +1465,140 @@ describe("Token Cost Calculation", () => {
         },
         "testfile.txt",
       );
+
+      const mismatchWarnings = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("exceeds provided total"),
+      );
+      expect(mismatchWarnings).toHaveLength(0);
+    });
+
+    it("should warn on the direct event path even when no model is provided", async () => {
+      (IngestionService as any).lastUsageTotalMismatchLogAt = 0;
+      const warnSpy = vi.spyOn(logger, "warn");
+      const generationId = uuidv4();
+
+      await (mockIngestionService as any).createEventRecord(
+        {
+          projectId,
+          spanId: generationId,
+          startTime: new Date().toISOString(),
+          providedUsageDetails: {
+            input: 100,
+            cache_read_input_tokens: 80,
+            output: 50,
+            total: 150,
+          },
+        },
+        "testfile.txt",
+      );
+
+      const mismatchWarnings = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("exceeds provided total"),
+      );
+      expect(mismatchWarnings).toHaveLength(1);
+      expect(mismatchWarnings[0][1]).toMatchObject({
+        projectId,
+        observationId: generationId,
+      });
+    });
+
+    it("should log the warning at most once per rate-limit interval", async () => {
+      (IngestionService as any).lastUsageTotalMismatchLogAt = 0;
+      const warnSpy = vi.spyOn(logger, "warn");
+
+      for (const spanId of [uuidv4(), uuidv4()]) {
+        await (mockIngestionService as any).createEventRecord(
+          {
+            projectId,
+            spanId,
+            startTime: new Date().toISOString(),
+            modelName,
+            providedUsageDetails: {
+              input: 100,
+              cache_read_input_tokens: 80,
+              output: 50,
+              total: 150,
+            },
+          },
+          "testfile.txt",
+        );
+      }
+
+      const mismatchWarnings = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("exceeds provided total"),
+      );
+      expect(mismatchWarnings).toHaveLength(1);
+    });
+
+    it("should warn on the legacy merge path when incoming events carry inconsistent usage", async () => {
+      (IngestionService as any).lastUsageTotalMismatchLogAt = 0;
+      const warnSpy = vi.spyOn(logger, "warn");
+      const generationId = uuidv4();
+
+      const events = [
+        {
+          id: uuidv4(),
+          type: "generation-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: generationId,
+            startTime: new Date().toISOString(),
+            model: modelName,
+            usageDetails: {
+              input: 100,
+              cache_read_input_tokens: 80,
+              output: 50,
+              total: 150,
+            },
+          },
+        },
+      ];
+
+      await (mockIngestionService as any).processObservationEventList({
+        projectId,
+        entityId: generationId,
+        createdAtTimestamp: new Date(),
+        observationEventList: events,
+      });
+
+      const mismatchWarnings = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("exceeds provided total"),
+      );
+      expect(mismatchWarnings).toHaveLength(1);
+      expect(mismatchWarnings[0][1]).toMatchObject({
+        projectId,
+        observationId: generationId,
+        writePath: "legacy",
+      });
+    });
+
+    it("should not warn on the legacy merge path when incoming events carry no usage", async () => {
+      (IngestionService as any).lastUsageTotalMismatchLogAt = 0;
+      const warnSpy = vi.spyOn(logger, "warn");
+      const generationId = uuidv4();
+
+      // Partial update without usage: the guard must not fire even if merged
+      // state contains usage (here there is none, but the gate is on the
+      // incoming events).
+      const events = [
+        {
+          id: uuidv4(),
+          type: "generation-update",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: generationId,
+            startTime: new Date().toISOString(),
+            output: "updated output",
+          },
+        },
+      ];
+
+      await (mockIngestionService as any).processObservationEventList({
+        projectId,
+        entityId: generationId,
+        createdAtTimestamp: new Date(),
+        observationEventList: events,
+      });
 
       const mismatchWarnings = warnSpy.mock.calls.filter(([message]) =>
         String(message).includes("exceeds provided total"),


### PR DESCRIPTION
## What does this PR do?

Adds a cheap consistency check at ingestion for provided `usage_details`: when a `total` is present and the sum of the non-total buckets exceeds it (beyond a small tolerance), the instrumentor is almost certainly sending an inclusive `input` alongside cache buckets — the signature of the double-count class in #10592.

On a hit, the guard:

- increments the `langfuse.ingestion.usage_details.total_mismatch` metric on every occurrence (to size the problem in prod), and
- emits a structured warning log with project id, observation id, provided total, and bucket sum — rate-limited to once per minute per process.

It deliberately **warns without auto-correcting**: some buckets are genuinely additive (e.g. Bedrock cache writes), so silently rewriting customer payloads could corrupt correct data. Auto-normalization can be a follow-up once warning volume is understood.

The check lives in `IngestionService.getUsageUnits()`, which both the legacy (`mergeAndWrite`) and the v4 direct (`createEventRecord`) paths call — so it also covers the OTel `langfuse.observation.usage_details` pass-through without a second check in `OtelIngestionProcessor`.

Tests: inclusive input + total fires (and the record is written unchanged); consistent buckets stay silent; missing total stays silent.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have checked that my changes generate no new warnings (`npm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a lightweight consistency check in `IngestionService.getUsageUnits()` that fires whenever the sum of non-`total` buckets in a user-provided `usage_details` object exceeds the provided `total` by more than a small tolerance. The check increments a metric on every violation and emits a rate-limited (once/minute per process) structured warning log with project ID, observation ID, the provided total, and the computed bucket sum.

- `warnOnUsageTotalMismatch` is a new instance method backed by three static fields (`lastUsageTotalMismatchLogAt`, `USAGE_TOTAL_MISMATCH_TOLERANCE`, `USAGE_TOTAL_MISMATCH_LOG_INTERVAL_MS`) — the metric always increments on a mismatch, while the `logger.warn` call is rate-limited to avoid log flooding in production.
- Three new unit tests cover: mismatch fires + record written unchanged, consistent buckets are silent, missing total is silent. Each test manually resets the static timestamp to bypass rate limiting.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is warn-only, never modifies the stored record, and the metric fires unconditionally before any rate-limit guard.

The implementation is straightforward and the logic is sound. The only gap is a missing test for the rate-limit suppression path; the production behavior itself is correct.

The test file would benefit from a case that verifies the second mismatch within the 60-second window is suppressed.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as mergeAndWrite / createEventRecord
    participant GU as getUsageUnits()
    participant WM as warnOnUsageTotalMismatch()
    participant M as recordIncrement (metric)
    participant L as logger.warn (rate-limited)

    Caller->>GU: observationRecord (with provided_usage_details, project_id)
    GU->>GU: normalize provided_usage_details → numbers
    GU->>WM: providedUsageDetails, observationRecord
    WM->>WM: check if total key is present
    alt no total key
        WM-->>GU: return (silent)
    else total present
        WM->>WM: compute bucketSum (all non-total keys)
        WM->>WM: "tolerance = max(1, total × 1%)"
        alt bucketSum ≤ total + tolerance
            WM-->>GU: return (silent)
        else "bucketSum > total + tolerance (mismatch)"
            WM->>M: recordIncrement(langfuse.ingestion.usage_details.total_mismatch)
            WM->>WM: check rate-limit window (60s)
            alt within rate-limit window
                WM-->>GU: return (metric only)
            else outside window
                WM->>WM: update lastUsageTotalMismatchLogAt
                WM->>L: logger.warn(projectId, observationId, providedTotal, bucketSum)
                WM-->>GU: return
            end
        end
    end
    GU-->>Caller: usage_details unchanged (warn-only)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as mergeAndWrite / createEventRecord
    participant GU as getUsageUnits()
    participant WM as warnOnUsageTotalMismatch()
    participant M as recordIncrement (metric)
    participant L as logger.warn (rate-limited)

    Caller->>GU: observationRecord (with provided_usage_details, project_id)
    GU->>GU: normalize provided_usage_details → numbers
    GU->>WM: providedUsageDetails, observationRecord
    WM->>WM: check if total key is present
    alt no total key
        WM-->>GU: return (silent)
    else total present
        WM->>WM: compute bucketSum (all non-total keys)
        WM->>WM: "tolerance = max(1, total × 1%)"
        alt bucketSum ≤ total + tolerance
            WM-->>GU: return (silent)
        else "bucketSum > total + tolerance (mismatch)"
            WM->>M: recordIncrement(langfuse.ingestion.usage_details.total_mismatch)
            WM->>WM: check rate-limit window (60s)
            alt within rate-limit window
                WM-->>GU: return (metric only)
            else outside window
                WM->>WM: update lastUsageTotalMismatchLogAt
                WM->>L: logger.warn(projectId, observationId, providedTotal, bucketSum)
                WM-->>GU: return
            end
        end
    end
    GU-->>Caller: usage_details unchanged (warn-only)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts:1371-1372
**Rate-limit suppression is not tested**

Each test resets `lastUsageTotalMismatchLogAt = 0` to force the log through, but no test exercises the opposite: a second mismatch call made while the timestamp is still within the 60-second window. If the rate-limit guard was accidentally removed or its condition inverted, the existing tests would still pass. Adding a case that calls the method twice in quick succession and asserts that only one `warn` appears would close that gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): warn on inconsistent prov..."](https://github.com/langfuse/langfuse/commit/d439db5daf08782e526dfb0f7a9a49e147703e43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42656921)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->