### PR TITLE
fix(docker): disable pnpm verify-deps-before-run in image builds

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -52,6 +52,13 @@ COPY --from=pruner /app/out/json/ .
 
 RUN pnpm install --frozen-lockfile
 
+# pnpm 11 defaults verify-deps-before-run to "install", so every `pnpm run`
+# spawned by turbo re-checks node_modules via file mtimes. Cached install
+# layers make those mtimes look stale, and the concurrent auto-installs race
+# in the hoisting step (ENOENT unlink in node_modules/.pnpm/node_modules).
+# The frozen-lockfile install above is authoritative; skip the check.
+ENV pnpm_config_verify_deps_before_run=false
+
 ENV DOCKER_BUILD 1
 ENV NEXT_MANUAL_SIG_HANDLE true
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -37,6 +37,13 @@ COPY --from=pruner /app/out/json/ .
 
 RUN pnpm install --frozen-lockfile
 
+# pnpm 11 defaults verify-deps-before-run to "install", so every `pnpm run`
+# spawned by turbo re-checks node_modules via file mtimes. Cached install
+# layers make those mtimes look stale, and the concurrent auto-installs race
+# in the hoisting step (ENOENT unlink in node_modules/.pnpm/node_modules).
+# The frozen-lockfile install above is authoritative; skip the check.
+ENV pnpm_config_verify_deps_before_run=false
+
 # pass public variables in build step
 ARG NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
 ARG NEXT_PUBLIC_DEMO_ORG_ID


### PR DESCRIPTION
## Problem

Release/CI Docker image builds fail intermittently in the `turbo run build` layer:

```
@langfuse/shared:db:generate: [ENOENT] ENOENT: no such file or directory, unlink '/app/node_modules/.pnpm/node_modules/@inquirer/confirm'
    at async symlinkHoistedDependency (.../pnpm/11.10.0/dist/pnpm.mjs:181359:3)
...
    at async runDepsStatusCheck (.../pnpm.mjs:249406:7)
```

## Root cause

pnpm 11 defaults `verify-deps-before-run` to `"install"` (pnpm.mjs:148823 in 11.10.0; same in 11.4.0). Every `pnpm run <script>` — i.e. every turbo task inside the image — first runs a deps-status check and, if node_modules looks out of sync, **silently spawns a full `pnpm install`**.

The staleness check is mtime-based (workspace manifests, lockfile, and the `patches/next-auth*.patch` files are compared against the `lastValidatedTimestamp` in `node_modules/.pnpm-workspace-state-v1.json`). In our Dockerfile flow (`pnpm install --frozen-lockfile` on the pruned `out/json` layer, then `COPY out/full`), a cached install layer combined with re-run source layers makes those mtimes look newer than the recorded install → the check fails even though nothing changed.

When two turbo tasks hit this concurrently, both spawn `pnpm install` into the same `/app/node_modules` (the `✓ Lockfile passes supply-chain policies (verified 5s ago)` line in the failure log is the second install observing the first one's verification). They race in the hoisting step over `node_modules/.pnpm/node_modules/@inquirer/confirm` (the lockfile has both 5.1.21 and 6.1.1 competing for that hoist slot) — one unlinks the symlink, the other's unlink gets ENOENT → exit 254 → `db:generate` fails.

## Fix

Set `pnpm_config_verify_deps_before_run=false` in the builder stages of both `web/Dockerfile` and `worker/Dockerfile`, right after `pnpm install --frozen-lockfile`. In an immutable image the frozen-lockfile install is authoritative, so the pre-script re-check is pure downside. pnpm reads exactly this env var (pnpm.mjs:149421), and `turbo.json` uses `envMode: "loose"`, so it reaches every `pnpm run` child.

## Impacted packages

- `web` (Dockerfile only)
- `worker` (Dockerfile only)

No application code or lockfile changes.

## Verification

Reproduced and verified against the exact pnpm build from the failure (corepack pnpm 11.10.0) in a scratch project:

- Workspace-manifest change + `pnpm run hi` → spawns full auto-install first (same log shape as the CI failure, including the supply-chain line).
- Same setup with `pnpm_config_verify_deps_before_run=false` → **no auto-install**, script runs directly.
- Control: `npm_config_verify_deps_before_run=false` does **not** suppress it — only the `pnpm_config_` form is honored for this setting, which is what this PR sets.

Skipped: a full local `docker build` of the web/worker images (multi-GB, ~10+ min); the CI docker-build smoke job on this PR exercises the changed layers directly. Repo lint/tests skipped as no package source changed (pre-commit prettier passed: `All matched files use Prettier code style!`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `ENV pnpm_config_verify_deps_before_run=false` to the `builder` stage of both `web/Dockerfile` and `worker/Dockerfile`, disabling pnpm 11's default behavior of re-verifying `node_modules` integrity before every `pnpm run` invocation.

- The env var is placed immediately after `pnpm install --frozen-lockfile` in each builder stage, ensuring turbo's concurrent `pnpm run` calls never trigger a racing background reinstall over the already-correct frozen install.
- The fix is correctly scoped to the `builder` stages only; both `runner` stages descend from `runtime-base` (not from `builder`), so the env var does not leak into production images.
- The worker's `prod-deps` stage (`FROM builder AS prod-deps`) inherits the flag, but `pnpm deploy` is not a `pnpm run` invocation and is unaffected by `verify-deps-before-run`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — two-line env var additions in builder stages only, no application code or lockfile touched.

The fix is minimal and targeted: a single env var that maps exactly to the pnpm internal setting responsible for the race. The frozen-lockfile install that precedes it guarantees correctness, so disabling the redundant re-check has no downside. Both runner stages inherit from runtime-base rather than builder, so the env var cannot escape into the shipped image. The prod-deps stage in the worker Dockerfile inherits it, but pnpm deploy does not invoke the verify-deps-before-run path.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docker): disable pnpm verify-deps-be..."](https://github.com/langfuse/langfuse/commit/5767b81b368428ab3a81720ed80f87485064077e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42683058)</sub>

<!-- /greptile_comment -->