### PR TITLE
chore(worker): add metric counting score ingestion updates

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -632,6 +632,17 @@ export class IngestionService {
       return;
     }
 
+    // Update = merging new events with a pre-existing record, found either in
+    // ClickHouse or as earlier event-log files for the same score id.
+    if (
+      scoreRecords.length > 0 &&
+      (clickhouseScoreRecord || scoreRecords.length > 1)
+    ) {
+      recordIncrement("langfuse.ingestion.score_update", 1, {
+        store: clickhouseScoreRecord ? "clickhouse" : "event_log",
+      });
+    }
+
     const finalScoreRecord: ScoreRecordInsertType =
       await this.mergeScoreRecords({
         clickhouseScoreRecord,


### PR DESCRIPTION
## What does this PR do?

Adds a `langfuse.ingestion.score_update` counter that increments whenever incoming score events merge with a pre-existing record, i.e. the scores API was used to update an existing score rather than create a new one.

An update is counted when a valid incoming event finds either:
- an existing ClickHouse row for the same score id (`store: clickhouse`), or
- more than one event-log file for the same score id (`store: event_log`) — this covers projects on the skip-ClickHouse-read path and fast successive writes that the ClickHouse lookup cannot see yet, which the existing `langfuse.ingestion.lookup.hit` metric misses.

Update *rate* can be derived against `langfuse.ingestion.clickhouse_read_for_update{table:scores}`, which fires once per score ingestion job.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Documentation update

## How should this be tested?

- `pnpm turbo run lint typecheck --filter=worker` passes
- `worker/src/services/IngestionService/tests/IngestionService.integration.test.ts` score tests (26) pass locally

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `langfuse.ingestion.score_update` metric counter that fires whenever a score ingestion is classified as an **update** (i.e., merging into a pre-existing record) rather than a net-new create.

- A metric is emitted with a `store` tag of `"clickhouse"` when a pre-existing record was fetched from ClickHouse, or `"event_log"` when multiple events for the same score ID arrive in the same batch without a prior ClickHouse hit.
- The metric is placed consistently alongside the existing `langfuse.ingestion.lookup.hit` counter in `processScoreEventList`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a small, additive observability change that has no impact on the score ingestion data path — it only calls recordIncrement after existing logic and before mergeScoreRecords, so a bug here would at worst produce a missing or mislabeled metric.

The new metric condition correctly handles all cases: empty score-record sets (all events failed validation), single-event creates, ClickHouse-backed updates, and event-log-only merges. The store tag assignment mirrors the existing lookup.hit pattern. No new imports or structural changes were introduced.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processScoreEventList] --> B{scoreEventList empty?}
    B -- Yes --> C[return early]
    B -- No --> D[Fetch clickhouseScoreRecord + map scoreEvents to scoreRecords]
    D --> E{clickhouseScoreRecord?}
    E -- Yes --> F[recordIncrement lookup.hit store=clickhouse]
    E -- No --> G[skip lookup.hit]
    F --> H
    G --> H{scoreRecords.length > 0 AND clickhouseScoreRecord OR scoreRecords.length > 1}
    H -- Yes, CH record exists --> I[recordIncrement score_update store=clickhouse]
    H -- Yes, multiple event-log records --> J[recordIncrement score_update store=event_log]
    H -- No --> K[no update metric]
    I --> L[mergeScoreRecords write to ClickHouse]
    J --> L
    K --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[processScoreEventList] --> B{scoreEventList empty?}
    B -- Yes --> C[return early]
    B -- No --> D[Fetch clickhouseScoreRecord + map scoreEvents to scoreRecords]
    D --> E{clickhouseScoreRecord?}
    E -- Yes --> F[recordIncrement lookup.hit store=clickhouse]
    E -- No --> G[skip lookup.hit]
    F --> H
    G --> H{scoreRecords.length > 0 AND clickhouseScoreRecord OR scoreRecords.length > 1}
    H -- Yes, CH record exists --> I[recordIncrement score_update store=clickhouse]
    H -- Yes, multiple event-log records --> J[recordIncrement score_update store=event_log]
    H -- No --> K[no update metric]
    I --> L[mergeScoreRecords write to ClickHouse]
    J --> L
    K --> L
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): add metric counting score..."](https://github.com/langfuse/langfuse/commit/aea5bf96072e5214a9bebe5b0f83e997fa08bb4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42684390)</sub>

<!-- /greptile_comment -->