### PR TITLE
fix(tables): remove eager count query from legacy traces & observations tables

### DIFF
--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -171,6 +171,10 @@ export type FetchTracesTableProps = {
   orderBy?: OrderByState;
   limit?: number;
   page?: number;
+  // Overrides the offset derived from limit * page. Needed when limit is
+  // padded (e.g. limit + 1 to detect a next page) but the offset must still
+  // advance by the caller's page size.
+  offset?: number;
   clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
   tags?: Record<string, string>;
   traceDeleteCursor?: TraceDeleteBatchActionCursor | null;
@@ -215,6 +219,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
     orderBy,
     limit,
     page,
+    offset,
     searchQuery,
     searchType,
     clickhouseConfigs,
@@ -473,7 +478,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
       const limitClause =
         limit !== undefined && traceDeleteCursorOrder
           ? "LIMIT {limit: Int32}"
-          : limit !== undefined && page !== undefined
+          : limit !== undefined && (page !== undefined || offset !== undefined)
             ? "LIMIT {limit: Int32} OFFSET {offset: Int32}"
             : "";
 
@@ -509,7 +514,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
         query: query,
         params: {
           limit: limit,
-          offset: limit && page ? limit * page : 0,
+          offset: offset ?? (limit && page ? limit * page : 0),
           traceTimestamp: timeStampFilter?.value.getTime(),
           ...(traceDeleteCursor
             ? {
@@ -580,6 +585,7 @@ export const getTracesTable = async (p: {
   orderBy?: OrderByState;
   limit?: number;
   page?: number;
+  offset?: number;
   clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
 }) => {
   const {
@@ -590,6 +596,7 @@ export const getTracesTable = async (p: {
     orderBy,
     limit,
     page,
+    offset,
     clickhouseConfigs,
   } = p;
   const rows = await getTracesTableGeneric({
@@ -601,6 +608,7 @@ export const getTracesTable = async (p: {
     orderBy,
     limit,
     page,
+    offset,
     clickhouseConfigs,
   });
 

--- a/web/src/__tests__/server/observations-trpc.servertest.ts
+++ b/web/src/__tests__/server/observations-trpc.servertest.ts
@@ -200,6 +200,73 @@ describe("traces trpc", () => {
 
       expect(outputSearchResults.generations).toBeDefined();
     });
+
+    it("returns hasMore and paginates without overlap", async () => {
+      const traceId = randomUUID();
+      const generationName = `has-more-generation-${randomUUID()}`;
+
+      await createTracesCh([
+        createTrace({
+          id: traceId,
+          project_id: projectId,
+          name: "has-more-trace",
+        }),
+      ]);
+
+      await createObservationsCh(
+        Array(3)
+          .fill(0)
+          .map(() =>
+            createObservation({
+              id: randomUUID(),
+              project_id: projectId,
+              trace_id: traceId,
+              type: "GENERATION",
+              name: generationName,
+            }),
+          ),
+      );
+
+      const filter = [
+        {
+          column: "Name",
+          operator: "=" as const,
+          value: generationName,
+          type: "string" as const,
+        },
+      ];
+
+      const firstPage = await caller.generations.all({
+        projectId,
+        searchQuery: null,
+        searchType: ["id"],
+        filter,
+        orderBy: { column: "startTime", order: "DESC" },
+        limit: 2,
+        page: 0,
+      });
+
+      expect(firstPage.generations.length).toBe(2);
+      expect(firstPage.hasMore).toBe(true);
+
+      const secondPage = await caller.generations.all({
+        projectId,
+        searchQuery: null,
+        searchType: ["id"],
+        filter,
+        orderBy: { column: "startTime", order: "DESC" },
+        limit: 2,
+        page: 1,
+      });
+
+      expect(secondPage.generations.length).toBe(1);
+      expect(secondPage.hasMore).toBe(false);
+
+      const allIds = [...firstPage.generations, ...secondPage.generations].map(
+        (g) => g.id,
+      );
+      expect(new Set(allIds).size).toBe(3);
+    });
   });
 
   describe("generations.countAll", () => {

--- a/web/src/__tests__/server/traces-trpc.servertest.ts
+++ b/web/src/__tests__/server/traces-trpc.servertest.ts
@@ -333,6 +333,73 @@ describe("traces trpc", () => {
       expect(traces.traces.length).toBeGreaterThan(0);
       expect(traces.traces.some((t) => t.id === trace.id)).toBe(true);
     });
+
+    it("returns hasMore and paginates without overlap", async () => {
+      const tag = `has-more-${randomUUID()}`;
+      const seededTraces = Array(3)
+        .fill(0)
+        .map(() =>
+          createTrace({
+            project_id: projectId,
+            tags: [tag],
+          }),
+        );
+
+      await createTracesCh(seededTraces);
+
+      const filter = [
+        {
+          column: "timestamp",
+          type: "datetime" as const,
+          operator: ">=" as const,
+          value: new Date(new Date().getTime() - 1000).toISOString(),
+        },
+        {
+          column: "tags",
+          operator: "any of" as const,
+          value: [tag],
+          type: "arrayOptions" as const,
+        },
+      ];
+
+      const firstPage = await caller.traces.all({
+        projectId,
+        filter,
+        searchQuery: null,
+        searchType: ["id"],
+        page: 0,
+        limit: 2,
+        orderBy: {
+          column: "timestamp",
+          order: "DESC",
+        },
+      });
+
+      expect(firstPage.traces.length).toBe(2);
+      expect(firstPage.hasMore).toBe(true);
+
+      const secondPage = await caller.traces.all({
+        projectId,
+        filter,
+        searchQuery: null,
+        searchType: ["id"],
+        page: 1,
+        limit: 2,
+        orderBy: {
+          column: "timestamp",
+          order: "DESC",
+        },
+      });
+
+      expect(secondPage.traces.length).toBe(1);
+      expect(secondPage.hasMore).toBe(false);
+
+      const allIds = [...firstPage.traces, ...secondPage.traces].map(
+        (t) => t.id,
+      );
+      expect(new Set(allIds).size).toBe(3);
+      expect(allIds.sort()).toEqual(seededTraces.map((t) => t.id).sort());
+    });
   });
 
   describe("traces.countAll", () => {

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -100,6 +100,7 @@ import {
   type RefreshInterval,
   REFRESH_INTERVALS,
 } from "@/src/components/table/data-table-refresh-button";
+import { useStore } from "zustand";
 import {
   ObservationsTableStoreProvider,
   useObservationsTableStore,
@@ -562,10 +563,28 @@ export default function ObservationsTable({
   const generations = api.generations.all.useQuery(getAllPayload, {
     refetchOnWindowFocus: true,
   });
+  const selectAll = useStore(
+    observationsTableStore,
+    (state) => state.selectAll,
+  );
+  // Fetch the exact count only after the user selects all matching rows.
+  // The count query cannot early-stop in ClickHouse and is expensive,
+  // especially with full-text search filters.
   const totalCountQuery = api.generations.countAll.useQuery(getCountPayload, {
+    enabled: selectAll,
     refetchOnWindowFocus: true,
   });
-  const totalCount = totalCountQuery.data?.totalCount ?? null;
+  const totalCount = selectAll
+    ? (totalCountQuery.data?.totalCount ?? null)
+    : null;
+  const isTotalCountLoading =
+    selectAll && totalCount === null && totalCountQuery.isFetching;
+  const isTotalCountError =
+    selectAll &&
+    totalCount === null &&
+    totalCountQuery.isError &&
+    !totalCountQuery.isFetching;
+  const hasMore = generations.data?.hasMore ?? false;
 
   const addToQueueMutation = api.annotationQueueItems.createMany.useMutation({
     onSuccess: (data) => {
@@ -642,6 +661,12 @@ export default function ObservationsTable({
     actions.clearSelection();
   };
 
+  const isSelectAllCountUnavailable = isTotalCountLoading || isTotalCountError;
+  const selectAllCountUnavailableReason = isTotalCountLoading
+    ? "Counting selected observations."
+    : isTotalCountError
+      ? "Could not count selected observations. Clear selection and try again."
+      : undefined;
   const tableActions: TableAction[] = [
     {
       id: ActionId.ObservationAddToAnnotationQueue,
@@ -660,6 +685,10 @@ export default function ObservationsTable({
       label: "Add to Dataset",
       description: "Add selected observations to a dataset",
       customDialog: true,
+      // The dialog needs the exact count, which only loads lazily once
+      // select-all is active.
+      disabled: isSelectAllCountUnavailable,
+      disabledReason: selectAllCountUnavailableReason,
       accessCheck: {
         scope: "datasets:CUD",
       },
@@ -1444,6 +1473,7 @@ export default function ObservationsTable({
             searchType={searchType}
             tableActions={tableActions}
             totalCount={totalCount}
+            hasNextPage={hasMore}
             paginationState={paginationState}
           />
         )}
@@ -1484,6 +1514,9 @@ export default function ObservationsTable({
                   ? undefined
                   : {
                       totalCount,
+                      hasNextPage: hasMore,
+                      hideTotalCount: true,
+                      canJumpPages: false,
                       onChange: setPaginationState,
                       state: paginationState,
                     }
@@ -1570,6 +1603,7 @@ type ObservationsDataTableToolbarProps = Omit<
   searchType: TracingSearchType[];
   tableActions: TableAction[];
   totalCount: number | null;
+  hasNextPage: boolean;
 };
 
 function ObservationsDataTableToolbar({
@@ -1581,6 +1615,7 @@ function ObservationsDataTableToolbar({
   searchType,
   tableActions,
   totalCount,
+  hasNextPage,
   ...toolbarProps
 }: ObservationsDataTableToolbarProps) {
   const selectedObservationIds = useObservationsTableStore(
@@ -1630,6 +1665,10 @@ function ObservationsDataTableToolbar({
         selectedRowIds: selectedObservationIds,
         setRowSelection: actions.setRowSelection,
         totalCount,
+        // totalCount stays null until select-all triggers the lazy count
+        // query; hasNextPage lets the select-all banner show without an
+        // eager count over the observations table.
+        hasNextPage,
         ...paginationState,
       }}
     />

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -426,8 +426,11 @@ export default function TracesTable({
     orderBy: null,
   };
 
+  // Fetch the exact count only after the user selects all matching rows.
+  // The count query cannot early-stop in ClickHouse and is expensive,
+  // especially with full-text search filters.
   const totalCountQuery = api.traces.countAll.useQuery(tracesAllCountFilter, {
-    enabled: environmentFilterOptions.data !== undefined,
+    enabled: selectAll && environmentFilterOptions.data !== undefined,
   });
 
   const tracesAllQueryFilter = {
@@ -469,7 +472,10 @@ export default function TracesTable({
     [traces.data?.traces, traceMetrics.data],
   );
 
-  const totalCount = totalCountQuery.data?.totalCount ?? null;
+  const totalCount = selectAll
+    ? (totalCountQuery.data?.totalCount ?? null)
+    : null;
+  const hasMore = traces.data?.hasMore ?? false;
 
   useEffect(() => {
     if (traces.isSuccess) {
@@ -583,12 +589,12 @@ export default function TracesTable({
     setSelectedRows({});
   };
 
-  const displayCount = totalCountQuery.isPending ? (
-    <span className="inline-block font-mono">...</span>
-  ) : selectAll ? (
-    compactNumberFormatter(totalCountQuery.data?.totalCount)
-  ) : (
+  const displayCount = !selectAll ? (
     compactNumberFormatter(Object.keys(selectedRows).length)
+  ) : totalCount === null ? (
+    <span className="inline-block font-mono">...</span>
+  ) : (
+    compactNumberFormatter(totalCount)
   );
 
   const tableActions: TableAction[] = [
@@ -1495,6 +1501,10 @@ export default function TracesTable({
               selectedRowIds: selectedTraceIds,
               setRowSelection: setSelectedRows,
               totalCount,
+              // totalCount stays null until select-all triggers the lazy
+              // count query; hasNextPage lets the select-all banner show
+              // without an eager count over the traces table.
+              hasNextPage: hasMore,
               ...paginationState,
             }}
           />
@@ -1535,6 +1545,9 @@ export default function TracesTable({
                   ? undefined
                   : {
                       totalCount,
+                      hasNextPage: hasMore,
+                      hideTotalCount: true,
+                      canJumpPages: false,
                       onChange: setPaginationState,
                       state: paginationState,
                     }

--- a/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
+++ b/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
@@ -25,9 +25,15 @@ export async function getAllGenerations({
     searchType: input.searchType,
     selectIOAndMetadata: selectIOAndMetadata,
     offset: input.page * input.limit,
-    limit: input.limit,
+    // Fetch one extra row to derive hasMore so the UI can paginate without
+    // an eager countAll query (which cannot early-stop in ClickHouse).
+    limit: input.limit + 1,
   };
-  let generations = await getObservationsTableWithModelData(queryOpts);
+  const fetchedGenerations = await getObservationsTableWithModelData(queryOpts);
+  const hasMore = fetchedGenerations.length > input.limit;
+  const generations = hasMore
+    ? fetchedGenerations.slice(0, input.limit)
+    : fetchedGenerations;
 
   const scores = await getScoresForObservations({
     projectId: input.projectId,
@@ -55,5 +61,6 @@ export async function getAllGenerations({
 
   return {
     generations: fullGenerations,
+    hasMore,
   };
 }

--- a/web/src/server/api/routers/generations/getAllQueries.ts
+++ b/web/src/server/api/routers/generations/getAllQueries.ts
@@ -31,10 +31,10 @@ export const getAllQueries = {
       });
 
       if (hasNoMatches) {
-        return { generations: [] };
+        return { generations: [], hasMore: false };
       }
 
-      const { generations } = await getAllGenerations({
+      const { generations, hasMore } = await getAllGenerations({
         input: {
           ...input,
           filter: filterState,
@@ -43,7 +43,7 @@ export const getAllQueries = {
         },
         selectIOAndMetadata: false,
       });
-      return { generations };
+      return { generations, hasMore };
     }),
   countAll: protectedProjectProcedure
     .input(GenerationTableOptions)

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -143,10 +143,12 @@ export const traceRouter = createTRPCRouter({
       });
 
       if (hasNoMatches) {
-        return { traces: [] };
+        return { traces: [], hasMore: false };
       }
 
-      const traces = await getTracesTable({
+      // Fetch one extra row to derive hasMore so the UI can paginate without
+      // an eager countAll query (which cannot early-stop in ClickHouse).
+      const fetchedTraces = await getTracesTable({
         projectId: ctx.session.projectId,
         filter: filterState,
         searchQuery: search.searchQuery,
@@ -155,10 +157,14 @@ export const traceRouter = createTRPCRouter({
           orderBy: input.orderBy,
           expectedTimeColumn: "timestamp",
         }),
-        limit: input.limit,
-        page: input.page,
+        limit: input.limit + 1,
+        offset: input.page * input.limit,
       });
-      return { traces };
+      const hasMore = fetchedTraces.length > input.limit;
+      const traces = hasMore
+        ? fetchedTraces.slice(0, input.limit)
+        : fetchedTraces;
+      return { traces, hasMore };
     }),
   countAll: protectedProjectProcedure
     .input(TraceCountOptions)


### PR DESCRIPTION
## Problem

On the legacy **Traces** and **Observations** list views, opening the page fires
`traces.countAll` / `generations.countAll` eagerly, in parallel with the row
query, as soon as the environment filter options resolve. Both the count and the
rows query share the same filter payload including `searchQuery` / `searchType`.

The count query is expensive and — unlike the rows query — cannot early-stop:

- The count branch uses `uniqExact(t.id)` and must scan every trace in the
  filtered range. The router's `limit: 1` only caps returned rows; the aggregate
  is a single row anyway, so it does nothing for scan volume.
- With full-text search, the filter is an `ILIKE '%query%'` over `input`/`output`
  (plus an extra escaped-variant `ILIKE` for non-ASCII queries).
- The rows query, by contrast, is deliberately designed to early-stop:
  non-FINAL + `ORDER BY toDate(timestamp) DESC` + `LIMIT 1 BY` + `LIMIT 50` let
  ClickHouse read only the latest date from disk. The count query has no such
  shortcut.

Net effect: the same expensive ILIKE scan runs twice on every page load, and the
count one can't be short-circuited.

## Fix

This ports the pattern already shipped for the v4 events table in #14447 (and its
follow-up #14859) to the two legacy paths:

- **Rows query derives `hasMore`**: fetch `limit + 1` rows and return
  `hasMore = fetched.length > limit`, so pagination no longer needs a total count.
- **Count is deferred**: `countAll` is now gated behind `enabled: selectAll`, so it
  only runs once the user explicitly chooses "select all matching items". The
  exact count still resolves lazily and populates the select-all banner and batch
  action counts after the click.
- The shared `DataTable` already supports `totalCount: null` + `hasNextPage`
  keyset pagination, and the toolbar select-all banner already supports an unknown
  total ("Select all matching items"), so no shared-component changes were needed
  beyond wiring the props through.

### Changes

- `getTracesTable` gains an optional `offset` override. This is required because
  the router now pads `limit` to `limit + 1` to detect a next page, but the
  offset must still advance by the caller's real page size — otherwise page ≥ 1
  would be misaligned.
- `traces.all` and `generations.all` fetch `limit + 1`, slice back to `limit`,
  and return `{ …, hasMore }`. (For generations the slice happens before the
  per-row scores lookup, so the extra probe row costs no additional score query.)
- Frontend `traces.tsx` / `observations.tsx`: gate `countAll` on `selectAll`,
  switch `DataTable` pagination to `hasNextPage` + `hideTotalCount` +
  `canJumpPages: false`, and pass `hasNextPage` into `multiSelect` so the
  select-all banner shows while the count is unknown. In `observations.tsx`,
  "Add to Dataset" is disabled with a reason while the lazy count is loading or
  errored, since that dialog needs the exact total (matching the events-table
  behavior).

### Out of scope (intentionally unchanged)

- `useEvalTargetCount`'s `traces.countAll` — the eval wizard genuinely needs the
  total.
- Batch export paths.
- The v4 events table (already fixed in #14447 / #14859).

## Testing

**Server tests** (added):
- `traces.all` and `generations.all` now assert `hasMore` and that two
  consecutive pages contain no overlapping IDs — this specifically guards the new
  `offset` override.

**Browser verification** against a local instance seeded with ~30k traces and
~70k generations:

| Check | Before | After |
| --- | --- | --- |
| Requests on page load (Traces) | `traces.all` + `traces.countAll` | `traces.all` only, **zero** `countAll` |
| Requests on page load (Observations) | `generations.all` + `generations.countAll` | `generations.all` only, **zero** `countAll` |
| Pagination footer | "Page 1 of N" | "Page 1" (unknown total), next/prev work |
| Select-all banner before count | — | "Select all matching items" |
| After clicking select-all | count already present | `countAll` fires once, banner shows exact total (952 traces / 2,652 observations) |

Captured via the network panel: on both list pages the count query no longer
appears at load time and only fires after the select-all click.

**Local checks**: `pnpm run typecheck` (8/8) and `pnpm run lint` (8/8) pass.
Existing toolbar + selection-store client tests pass (20/20). Two pre-existing
failures in `traces-trpc.servertest.ts` (`default.events_full does not exist`)
reproduce on unmodified `main` and are unrelated to this change.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the eager `countAll` query fired on every page load for the legacy Traces and Observations tables by adopting the `limit + 1` / `hasMore` pagination pattern already in use for the v4 events table. The exact row count is now fetched lazily only when the user explicitly selects all matching rows.

- **Backend**: `traces.all` and `generations.all` fetch `limit + 1` rows, derive `hasMore`, and return both. `getTracesTable` gains an optional `offset` override so the real page-size offset is computed from the caller's original `limit`, not the padded one.
- **Frontend**: `countAll` is gated behind `selectAll`; `DataTable` receives `hasNextPage`/`hideTotalCount`/`canJumpPages: false`; the "Add to Dataset" action in Observations is disabled while the lazy count is in flight.
- **Tests**: New server tests assert `hasMore` values and verify two consecutive pages share no IDs, directly guarding the offset-override logic.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The offset-override math is correct for all page values including page 0, the score lookup correctly operates on the sliced (not padded) generation list, and the lazy-count gating mirrors the already-reviewed events-table pattern.

The change is well-scoped and the core pagination arithmetic (limit+1 / offset = page × original_limit) is verified by the new server tests. The only finding is a minor import-ordering style issue in observations.tsx where the `zustand` `useStore` import lands between internal `@/src` imports rather than with other third-party packages.

No files require special attention. The import placement in `observations.tsx` is a cosmetic nit.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant tRPC as tRPC Router
    participant CH as ClickHouse

    Note over Browser,CH: Before (eager count on every page load)
    Browser->>tRPC: "traces.all (limit=50, page=0)"
    Browser->>tRPC: traces.countAll (parallel, always enabled)
    tRPC->>CH: SELECT ... LIMIT 50 OFFSET 0
    tRPC->>CH: SELECT uniqExact(id) — full scan, no early-stop
    CH-->>tRPC: 50 rows
    CH-->>tRPC: totalCount (expensive)
    tRPC-->>Browser: "{ traces, totalCount }"

    Note over Browser,CH: After (lazy count, hasMore pagination)
    Browser->>tRPC: "traces.all (limit=51, offset=0)"
    tRPC->>CH: SELECT ... LIMIT 51 OFFSET 0
    CH-->>tRPC: up to 51 rows
    tRPC-->>Browser: "{ traces[0..49], hasMore=true/false }"
    Note over Browser: countAll NOT fired

    Note over Browser,CH: After — user clicks Select All
    Browser->>tRPC: traces.countAll (now enabled)
    tRPC->>CH: SELECT uniqExact(id) — full scan
    CH-->>tRPC: totalCount
    tRPC-->>Browser: "{ totalCount }"
    Note over Browser: banner shows exact total
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant tRPC as tRPC Router
    participant CH as ClickHouse

    Note over Browser,CH: Before (eager count on every page load)
    Browser->>tRPC: "traces.all (limit=50, page=0)"
    Browser->>tRPC: traces.countAll (parallel, always enabled)
    tRPC->>CH: SELECT ... LIMIT 50 OFFSET 0
    tRPC->>CH: SELECT uniqExact(id) — full scan, no early-stop
    CH-->>tRPC: 50 rows
    CH-->>tRPC: totalCount (expensive)
    tRPC-->>Browser: "{ traces, totalCount }"

    Note over Browser,CH: After (lazy count, hasMore pagination)
    Browser->>tRPC: "traces.all (limit=51, offset=0)"
    tRPC->>CH: SELECT ... LIMIT 51 OFFSET 0
    CH-->>tRPC: up to 51 rows
    tRPC-->>Browser: "{ traces[0..49], hasMore=true/false }"
    Note over Browser: countAll NOT fired

    Note over Browser,CH: After — user clicks Select All
    Browser->>tRPC: traces.countAll (now enabled)
    tRPC->>CH: SELECT uniqExact(id) — full scan
    CH-->>tRPC: totalCount
    tRPC-->>Browser: "{ totalCount }"
    Note over Browser: banner shows exact total
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/table/use-cases/observations.tsx:102-106
The `useStore` import from `zustand` (a third-party package) is inserted between two internal `@/src/...` imports rather than alongside the other external-package imports grouped at the top of the file. Conventional import ordering places third-party modules before workspace/internal paths.

```suggestion
} from "@/src/components/table/data-table-refresh-button";
import {
  ObservationsTableStoreProvider,
  useObservationsTableStore,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tables): remove eager count query fr..."](https://github.com/langfuse/langfuse/commit/ebf425a066a5200748a7e75673644ec4a29ad8e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42910070)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->