### PR TITLE
fix(web): avoid job configurations to reference old templates

### DIFF
--- a/web/src/__tests__/server/eval-template-output-definition.servertest.ts
+++ b/web/src/__tests__/server/eval-template-output-definition.servertest.ts
@@ -10,6 +10,7 @@ describe("CreateEvalTemplateInputSchema", () => {
   const baseInput = {
     name: "Accuracy evaluator",
     projectId: "project-1",
+    intent: "new" as const,
     prompt: "Judge {{output}} against {{expected_output}}",
     provider: null,
     model: null,

--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -900,6 +900,98 @@ describe("evals trpc", () => {
     });
   });
 
+  describe("evals.updateAllDatasetEvalJobStatusByTemplateId", () => {
+    it("toggles experiment-target evaluator configs for the dataset", async () => {
+      const { project, caller } = await prepare();
+      const datasetId = `dataset-${project.id}`;
+      const otherDatasetId = `other-dataset-${project.id}`;
+      // CODE template so the reactivation preflight passes without an LLM connection
+      const template = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: `toggle-template-${project.id}`,
+          version: 1,
+          type: EvalTemplateType.CODE,
+          prompt: null,
+          outputDefinition: undefined,
+          sourceCode:
+            'function evaluate() { return { scores: [{ name: "toggle-score", value: 1 }] }; }',
+          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        },
+      });
+      const experimentDatasetFilter = (id: string) => [
+        {
+          type: "stringOptions",
+          value: [id],
+          column: "experimentDatasetId",
+          operator: "any of",
+        },
+      ];
+      const experimentConfig = await prisma.jobConfiguration.create({
+        data: {
+          projectId: project.id,
+          jobType: "EVAL",
+          evalTemplateId: template.id,
+          scoreName: "experiment-toggle-score",
+          filter: experimentDatasetFilter(datasetId),
+          targetObject: EvalTargetObject.EXPERIMENT,
+          variableMapping: [],
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+        },
+      });
+      const otherDatasetConfig = await prisma.jobConfiguration.create({
+        data: {
+          projectId: project.id,
+          jobType: "EVAL",
+          evalTemplateId: template.id,
+          scoreName: "other-dataset-score",
+          filter: experimentDatasetFilter(otherDatasetId),
+          targetObject: EvalTargetObject.EXPERIMENT,
+          variableMapping: [],
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+        },
+      });
+
+      await caller.evals.updateAllDatasetEvalJobStatusByTemplateId({
+        projectId: project.id,
+        evalTemplateId: template.id,
+        datasetId,
+        newStatus: "INACTIVE",
+      });
+
+      await expect(
+        prisma.jobConfiguration.findUniqueOrThrow({
+          where: { id: experimentConfig.id },
+          select: { status: true },
+        }),
+      ).resolves.toEqual({ status: "INACTIVE" });
+      await expect(
+        prisma.jobConfiguration.findUniqueOrThrow({
+          where: { id: otherDatasetConfig.id },
+          select: { status: true },
+        }),
+      ).resolves.toEqual({ status: "ACTIVE" });
+
+      await caller.evals.updateAllDatasetEvalJobStatusByTemplateId({
+        projectId: project.id,
+        evalTemplateId: template.id,
+        datasetId,
+        newStatus: "ACTIVE",
+      });
+
+      await expect(
+        prisma.jobConfiguration.findUniqueOrThrow({
+          where: { id: experimentConfig.id },
+          select: { status: true },
+        }),
+      ).resolves.toEqual({ status: "ACTIVE" });
+    });
+  });
+
   describe("evals.updateConfig", () => {
     it("updates experiment code evaluator configs without a matching observation", async () => {
       const { project, caller } = await prepare();

--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -528,7 +528,8 @@ describe("evals trpc", () => {
           sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
         }),
       ).rejects.toThrow(
-        `An evaluator named "${existingTemplate.name}" already exists in this project. Open it to create a new version.`,
+        // the existing template is LLM_AS_JUDGE while the attempt is CODE
+        `An evaluator named "${existingTemplate.name}" already exists in this project with a different type. Use a different name.`,
       );
 
       await expect(

--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -43,6 +43,7 @@ import {
   EvalTargetObject,
   EvaluatorBlockReason,
 } from "@langfuse/shared";
+import { CODE_EVAL_TEMPLATE_VARIABLES } from "@/src/features/evals/utils/code-eval-template-utils";
 import type { Session } from "next-auth";
 
 beforeEach(() => {
@@ -445,7 +446,102 @@ describe("evals trpc", () => {
     });
   });
 
+  describe("evals.latestTemplates", () => {
+    it("should return only the latest template per project/name/type family", async () => {
+      const { project, caller } = await prepare();
+
+      const staleLlmTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: `latest-family-template-${project.id}`,
+          version: 1,
+          prompt: "Score this response",
+          outputDefinition: createNumericEvalOutputDefinition({
+            reasoningDescription: "Why",
+            scoreDescription: "How good",
+          }),
+        },
+      });
+
+      const latestLlmTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: staleLlmTemplate.name,
+          version: 2,
+          prompt: "Score this response again",
+          outputDefinition: createNumericEvalOutputDefinition({
+            reasoningDescription: "Why",
+            scoreDescription: "How good",
+          }),
+        },
+      });
+
+      const codeTemplateWithSameName = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: staleLlmTemplate.name,
+          version: 3,
+          type: EvalTemplateType.CODE,
+          prompt: null,
+          outputDefinition: undefined,
+          sourceCode:
+            'function evaluate() { return { scores: [{ name: "code-score", value: 1 }] }; }',
+          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        },
+      });
+
+      const response = await caller.evals.latestTemplates({
+        projectId: project.id,
+      });
+      const returnedIds = response.templates.map((template) => template.id);
+
+      expect(returnedIds).toContain(latestLlmTemplate.id);
+      expect(returnedIds).toContain(codeTemplateWithSameName.id);
+      expect(returnedIds).not.toContain(staleLlmTemplate.id);
+    });
+  });
+
   describe("evals.createTemplate", () => {
+    it("rejects new evaluators when the project already has the same template name", async () => {
+      const { project, caller } = await prepare();
+      const existingTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: `taken-template-name-${project.id}`,
+          version: 1,
+          prompt: "Score this response",
+          outputDefinition: createNumericEvalOutputDefinition({
+            reasoningDescription: "Why",
+            scoreDescription: "How good",
+          }),
+        },
+      });
+
+      await expect(
+        caller.evals.createTemplate({
+          projectId: project.id,
+          name: existingTemplate.name,
+          intent: "new",
+          type: EvalTemplateType.CODE,
+          sourceCode:
+            'function evaluate() { return { scores: [{ name: "code-score", value: 1 }] }; }',
+          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        }),
+      ).rejects.toThrow(
+        `An evaluator named "${existingTemplate.name}" already exists in this project. Open it to create a new version.`,
+      );
+
+      await expect(
+        prisma.evalTemplate.findMany({
+          where: {
+            projectId: project.id,
+            name: existingTemplate.name,
+          },
+          select: { id: true },
+        }),
+      ).resolves.toEqual([{ id: existingTemplate.id }]);
+    });
+
     it("rejects Python code evaluators for the insecure-local dispatcher", async () => {
       const { project, caller } = await prepare();
 
@@ -453,6 +549,7 @@ describe("evals trpc", () => {
         caller.evals.createTemplate({
           projectId: project.id,
           name: `python-code-template-${project.id}`,
+          intent: "new",
           type: EvalTemplateType.CODE,
           sourceCode:
             'def evaluate(ctx):\n    return { "scores": [{ "name": "python-score", "value": 1 }] }',
@@ -465,6 +562,164 @@ describe("evals trpc", () => {
   });
 
   describe("evals.createJob", () => {
+    it("keeps evaluator configs on latest template versions", async () => {
+      const { project, caller } = await prepare();
+      runCodeEvalTestForJobConfigMock.mockResolvedValue(null);
+      const mapping = CODE_EVAL_TEMPLATE_VARIABLES.map((templateVariable) => ({
+        templateVariable,
+        selectedColumnId: templateVariable,
+        jsonSelector: null,
+      }));
+
+      const staleTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: `code-versioning-template-${project.id}`,
+          version: 1,
+          type: EvalTemplateType.CODE,
+          prompt: null,
+          outputDefinition: undefined,
+          sourceCode:
+            'function evaluate() { return { scores: [{ name: "versioning-score", value: 1 }] }; }',
+          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        },
+      });
+      const latestTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: staleTemplate.name,
+          version: 2,
+          type: EvalTemplateType.CODE,
+          prompt: null,
+          outputDefinition: undefined,
+          sourceCode:
+            'function evaluate() { return { scores: [{ name: "versioning-score", value: 2 }] }; }',
+          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        },
+      });
+
+      const createdFromStaleId = await caller.evals.createJob({
+        projectId: project.id,
+        evalTemplateId: staleTemplate.id,
+        scoreName: "stale-template-score",
+        target: EvalTargetObject.EXPERIMENT,
+        filter: [],
+        mapping,
+        sampling: 1,
+        delay: 0,
+        timeScope: ["NEW"],
+      });
+
+      await expect(
+        prisma.jobConfiguration.findUnique({
+          where: { id: createdFromStaleId.id },
+          select: { evalTemplateId: true },
+        }),
+      ).resolves.toEqual({ evalTemplateId: latestTemplate.id });
+
+      const configToRetarget = await prisma.jobConfiguration.create({
+        data: {
+          projectId: project.id,
+          jobType: "EVAL",
+          evalTemplateId: staleTemplate.id,
+          scoreName: "retargeted-template-score",
+          filter: [],
+          targetObject: EvalTargetObject.EXPERIMENT,
+          variableMapping: mapping,
+          sampling: 1,
+          delay: 0,
+          status: "INACTIVE",
+          timeScope: ["NEW"],
+        },
+      });
+
+      const newVersion = await caller.evals.createTemplate({
+        projectId: project.id,
+        name: staleTemplate.name,
+        intent: "new-version",
+        sourceTemplateId: staleTemplate.id,
+        type: EvalTemplateType.CODE,
+        sourceCode:
+          'function evaluate() { return { scores: [{ name: "versioning-score", value: 3 }] }; }',
+        sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+      });
+
+      expect(newVersion.updatedConfigCount).toBe(2);
+      expect(newVersion.template.version).toBe(3);
+      await expect(
+        prisma.jobConfiguration.findUnique({
+          where: { id: configToRetarget.id },
+          select: { evalTemplateId: true, variableMapping: true },
+        }),
+      ).resolves.toEqual({
+        evalTemplateId: newVersion.template.id,
+        variableMapping: mapping,
+      });
+    });
+
+    it("rejects stale template resolution when the latest version needs new variable mappings", async () => {
+      const { project, caller } = await prepare();
+
+      const staleTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: `llm-versioning-template-${project.id}`,
+          version: 1,
+          prompt: "Score {{query}}",
+          vars: ["query"],
+          outputDefinition: createNumericEvalOutputDefinition({
+            reasoningDescription: "Why",
+            scoreDescription: "How good",
+          }),
+        },
+      });
+      const latestTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: staleTemplate.name,
+          version: 2,
+          prompt: "Score {{query}} with {{context}}",
+          vars: ["query", "context"],
+          outputDefinition: createNumericEvalOutputDefinition({
+            reasoningDescription: "Why",
+            scoreDescription: "How good",
+          }),
+        },
+      });
+
+      await expect(
+        caller.evals.createJob({
+          projectId: project.id,
+          evalTemplateId: staleTemplate.id,
+          scoreName: "stale-template-missing-mapping-score",
+          target: EvalTargetObject.EXPERIMENT,
+          filter: [],
+          mapping: [
+            {
+              templateVariable: "query",
+              selectedColumnId: "query",
+              jsonSelector: null,
+            },
+          ],
+          sampling: 1,
+          delay: 0,
+          timeScope: ["NEW"],
+        }),
+      ).rejects.toThrow(
+        `Evaluator template "${staleTemplate.name}" changed while this form was open`,
+      );
+
+      await expect(
+        prisma.jobConfiguration.findFirst({
+          where: {
+            projectId: project.id,
+            scoreName: "stale-template-missing-mapping-score",
+            evalTemplateId: latestTemplate.id,
+          },
+        }),
+      ).resolves.toBeNull();
+    });
+
     it("saves experiment code evaluator configs without a matching observation", async () => {
       const { project, caller } = await prepare();
       runCodeEvalTestForJobConfigMock.mockResolvedValueOnce(null);

--- a/web/src/features/batch-actions/components/RunEvaluationDialog/CreateEvaluatorDialog.tsx
+++ b/web/src/features/batch-actions/components/RunEvaluationDialog/CreateEvaluatorDialog.tsx
@@ -35,7 +35,7 @@ export function CreateEvaluatorDialog(props: CreateEvaluatorDialogProps) {
   const [templateId, setTemplateId] = useState<string | null>(null);
   const utils = api.useUtils();
 
-  const templatesQuery = api.evals.allTemplates.useQuery(
+  const templatesQuery = api.evals.latestTemplates.useQuery(
     {
       projectId,
       limit: 500,

--- a/web/src/features/evals/components/eval-templates-table.tsx
+++ b/web/src/features/evals/components/eval-templates-table.tsx
@@ -35,7 +35,6 @@ import { DeleteEvalTemplateDialog } from "@/src/features/evals/components/delete
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { EvalTemplateForm } from "@/src/features/evals/components/template-form";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
-import { EvalReferencedEvaluators } from "@/src/features/evals/types";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { type RouterInput } from "@/src/utils/types";
 import {
@@ -71,6 +70,11 @@ export type EvalsTemplateRow = {
   usageCount?: number;
   actions?: string;
 } & TemplateValidationInput;
+
+type CloneCreateTemplateInput = Extract<
+  RouterInput["evals"]["createTemplate"],
+  { intent: "clone" }
+>;
 
 const getMaintainerLabel = (maintainer: string) =>
   maintainer.replace(/ maintained$/, "");
@@ -252,9 +256,8 @@ export default function EvalsTemplateTable({
   const [cloneTemplateId, setCloneTemplateId] = useState<string | null>(null);
   const [showReferenceUpdateDialog, setShowReferenceUpdateDialog] =
     useState(false);
-  const [pendingCloneSubmission, setPendingCloneSubmission] = useState<
-    RouterInput["evals"]["createTemplate"] | null
-  >(null);
+  const [pendingCloneSubmission, setPendingCloneSubmission] =
+    useState<CloneCreateTemplateInput | null>(null);
 
   const utils = api.useUtils();
   const templates = api.evals.templateNames.useQuery({
@@ -327,6 +330,15 @@ export default function EvalsTemplateTable({
       showErrorToast("Error cloning evaluator", error.message);
     },
   });
+
+  const submitPendingClone = (retargetUsingJobConfigs: boolean) => {
+    if (!pendingCloneSubmission) return;
+
+    createEvalTemplateMutation.mutate({
+      ...pendingCloneSubmission,
+      retargetUsingJobConfigs,
+    });
+  };
 
   useEffect(() => {
     if (templates.isSuccess) {
@@ -687,10 +699,8 @@ export default function EvalsTemplateTable({
                 cloneTemplate.data &&
                 !cloneTemplate.data.projectId
               ) {
-                setPendingCloneSubmission({
-                  ...template,
-                  cloneSourceId: cloneTemplateId,
-                });
+                if (template.intent !== "clone") return true;
+                setPendingCloneSubmission(template);
                 setShowReferenceUpdateDialog(true);
                 return false; // Prevent immediate submission
               }
@@ -715,9 +725,7 @@ export default function EvalsTemplateTable({
         onOpenChange={(open) => {
           if (!open && pendingCloneSubmission) {
             // If dialog is closed without a decision, default to not updating references
-            pendingCloneSubmission.referencedEvaluators =
-              EvalReferencedEvaluators.PERSIST;
-            createEvalTemplateMutation.mutate(pendingCloneSubmission);
+            submitPendingClone(false);
           }
           setShowReferenceUpdateDialog(open);
         }}
@@ -738,24 +746,14 @@ export default function EvalsTemplateTable({
             <Button
               variant="outline"
               onClick={() => {
-                if (pendingCloneSubmission) {
-                  // Submit with PERSIST option
-                  pendingCloneSubmission.referencedEvaluators =
-                    EvalReferencedEvaluators.PERSIST;
-                  createEvalTemplateMutation.mutate(pendingCloneSubmission);
-                }
+                submitPendingClone(false);
               }}
             >
               No, keep as is
             </Button>
             <Button
               onClick={() => {
-                if (pendingCloneSubmission) {
-                  // Submit with UPDATE option
-                  pendingCloneSubmission.referencedEvaluators =
-                    EvalReferencedEvaluators.UPDATE;
-                  createEvalTemplateMutation.mutate(pendingCloneSubmission);
-                }
+                submitPendingClone(true);
               }}
             >
               Yes, update all references

--- a/web/src/features/evals/components/evaluator-selector.tsx
+++ b/web/src/features/evals/components/evaluator-selector.tsx
@@ -117,47 +117,22 @@ export function EvaluatorSelector({
     shouldShowEvalTemplate(template, codeEvalCapabilities),
   );
 
-  // Group templates by name and whether they are managed by Langfuse
-  const groupedTemplates = visibleEvalTemplates.reduce(
-    (acc, template) => {
-      const group = template.projectId ? "custom" : "langfuse";
-      if (!acc[group][template.name]) {
-        acc[group][template.name] = [];
-      }
-      acc[group][template.name].push(template);
-      return acc;
-    },
-    {
-      langfuse: {} as Record<string, EvalTemplate[]>,
-      custom: {} as Record<string, EvalTemplate[]>,
-    },
-  );
-
-  // Ensure per-name arrays are sorted by createdAt ascending so last is latest
-  const sortByCreatedAt = (arr: EvalTemplate[]) =>
-    arr.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
-  Object.values(groupedTemplates.custom).forEach(sortByCreatedAt);
-  Object.values(groupedTemplates.langfuse).forEach(sortByCreatedAt);
-
-  // Filter templates based on search
+  // latestTemplates already returns one row per evaluator family.
+  const matchesSearch = (template: EvalTemplate) =>
+    template.name.toLowerCase().includes(search.toLowerCase());
   const filteredTemplates = {
-    langfuse: Object.entries(groupedTemplates.langfuse)
-      .filter(([name]) => name.toLowerCase().includes(search.toLowerCase()))
-      .sort(([nameA, templatesA], [nameB, templatesB]) => {
-        // Get partners
-        const partnerA = templatesA[0]?.partner;
-        const partnerB = templatesB[0]?.partner;
-
+    langfuse: visibleEvalTemplates
+      .filter((template) => !template.projectId && matchesSearch(template))
+      .sort((templateA, templateB) => {
         // No partner comes before partner
-        if (!partnerA && partnerB) return -1;
-        if (partnerA && !partnerB) return 1;
+        if (!templateA.partner && templateB.partner) return -1;
+        if (templateA.partner && !templateB.partner) return 1;
 
-        // Sort by name within each group
-        return nameA.localeCompare(nameB);
+        return templateA.name.localeCompare(templateB.name);
       }),
-    custom: Object.entries(groupedTemplates.custom)
-      .filter(([name]) => name.toLowerCase().includes(search.toLowerCase()))
-      .sort(([a], [b]) => a.localeCompare(b)),
+    custom: visibleEvalTemplates
+      .filter((template) => template.projectId && matchesSearch(template))
+      .sort((a, b) => a.name.localeCompare(b.name)),
   };
 
   // Check if we have results
@@ -186,37 +161,33 @@ export function EvaluatorSelector({
         {filteredTemplates.custom.length > 0 && (
           <>
             <InputCommandGroup heading="Custom evaluators">
-              {filteredTemplates.custom.map(([name, templateData]) => {
-                const latestVersion = templateData[templateData.length - 1];
-                const isInvalid = isTemplateInvalid(latestVersion);
+              {filteredTemplates.custom.map((template) => {
+                const isInvalid = isTemplateInvalid(template);
 
                 return (
                   <InputCommandItem
-                    key={`custom-${name}`}
+                    key={`custom-${template.id}`}
                     disabled={isInvalid}
                     onSelect={() => {
                       onTemplateSelect(
-                        latestVersion.id,
-                        name,
-                        latestVersion.version,
+                        template.id,
+                        template.name,
+                        template.version,
                       );
                     }}
                     className={cn(
-                      templateData.some((t) => t.id === selectedTemplateId) &&
-                        "bg-secondary",
+                      template.id === selectedTemplateId && "bg-secondary",
                     )}
                   >
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <div className="flex min-w-0 items-center">
-                          <span className="truncate" title={name}>
-                            {name}
+                          <span className="truncate" title={template.name}>
+                            {template.name}
                           </span>
-                          {latestVersion.type === EvalTemplateType.CODE ? (
+                          {template.type === EvalTemplateType.CODE ? (
                             <CodeTemplateLanguageIcon
-                              sourceCodeLanguage={
-                                latestVersion.sourceCodeLanguage
-                              }
+                              sourceCodeLanguage={template.sourceCodeLanguage}
                             />
                           ) : null}
                         </div>
@@ -225,9 +196,7 @@ export function EvaluatorSelector({
                         side="right"
                         className="max-h-[70dvh] w-[720px] max-w-[calc(100vw-3rem)] overflow-y-auto"
                       >
-                        <TemplatePreviewTooltipContent
-                          template={latestVersion}
-                        />
+                        <TemplatePreviewTooltipContent template={template} />
                       </TooltipContent>
                     </Tooltip>
                     {isInvalid && (
@@ -248,7 +217,7 @@ export function EvaluatorSelector({
                         </TooltipContent>
                       </Tooltip>
                     )}
-                    {templateData.some((t) => t.id === selectedTemplateId) && (
+                    {template.id === selectedTemplateId && (
                       <CheckIcon className="ml-auto h-4 w-4" />
                     )}
                   </InputCommandItem>
@@ -262,37 +231,33 @@ export function EvaluatorSelector({
         {filteredTemplates.langfuse.length > 0 && (
           <>
             <InputCommandGroup heading="Langfuse managed evaluators">
-              {filteredTemplates.langfuse.map(([name, templateData]) => {
-                const latestVersion = templateData[templateData.length - 1];
-                const isInvalid = isTemplateInvalid(latestVersion);
+              {filteredTemplates.langfuse.map((template) => {
+                const isInvalid = isTemplateInvalid(template);
 
                 return (
                   <InputCommandItem
-                    key={`langfuse-${name}`}
+                    key={`langfuse-${template.id}`}
                     disabled={isInvalid}
                     onSelect={() => {
                       onTemplateSelect(
-                        latestVersion.id,
-                        name,
-                        latestVersion.version,
+                        template.id,
+                        template.name,
+                        template.version,
                       );
                     }}
                     className={cn(
-                      templateData.some((t) => t.id === selectedTemplateId) &&
-                        "bg-secondary",
+                      template.id === selectedTemplateId && "bg-secondary",
                     )}
                   >
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <div className="mr-1 flex min-w-0 items-center">
-                          <span className="truncate" title={name}>
-                            {name}
+                          <span className="truncate" title={template.name}>
+                            {template.name}
                           </span>
-                          {latestVersion.type === EvalTemplateType.CODE ? (
+                          {template.type === EvalTemplateType.CODE ? (
                             <CodeTemplateLanguageIcon
-                              sourceCodeLanguage={
-                                latestVersion.sourceCodeLanguage
-                              }
+                              sourceCodeLanguage={template.sourceCodeLanguage}
                             />
                           ) : null}
                         </div>
@@ -301,14 +266,10 @@ export function EvaluatorSelector({
                         side="right"
                         className="max-h-[70dvh] w-[720px] max-w-[calc(100vw-3rem)] overflow-y-auto"
                       >
-                        <TemplatePreviewTooltipContent
-                          template={latestVersion}
-                        />
+                        <TemplatePreviewTooltipContent template={template} />
                       </TooltipContent>
                     </Tooltip>
-                    <MaintainerTooltip
-                      maintainer={getMaintainer(latestVersion)}
-                    />
+                    <MaintainerTooltip maintainer={getMaintainer(template)} />
                     {isInvalid && (
                       <Tooltip>
                         <TooltipTrigger asChild>
@@ -327,7 +288,7 @@ export function EvaluatorSelector({
                         </TooltipContent>
                       </Tooltip>
                     )}
-                    {templateData.some((t) => t.id === selectedTemplateId) && (
+                    {template.id === selectedTemplateId && (
                       <CheckIcon className="ml-auto h-4 w-4" />
                     )}
                   </InputCommandItem>

--- a/web/src/features/evals/components/select-evaluator-list.tsx
+++ b/web/src/features/evals/components/select-evaluator-list.tsx
@@ -61,7 +61,7 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
   };
 
   // Fetch templates
-  const templates = api.evals.allTemplates.useQuery(
+  const templates = api.evals.latestTemplates.useQuery(
     {
       projectId,
     },
@@ -244,7 +244,7 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
                     setIsCreateTemplateOpen(false);
                     setCustomEvaluatorType(null);
                     setUseLlmCreateWizard(false);
-                    utils.evals.allTemplates.invalidate();
+                    utils.evals.latestTemplates.invalidate();
                     if (newTemplate) {
                       handleSelectEvaluator(newTemplate);
                     }
@@ -265,7 +265,7 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
                 }
                 setIsCreateTemplateOpen(false);
                 setCustomEvaluatorType(null);
-                utils.evals.allTemplates.invalidate();
+                utils.evals.latestTemplates.invalidate();
                 if (newTemplate) {
                   handleSelectEvaluator(newTemplate);
                 }

--- a/web/src/features/evals/components/template-form.tsx
+++ b/web/src/features/evals/components/template-form.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import Link from "next/link";
 import { useFieldArray, useForm } from "react-hook-form";
 import { z } from "zod";
 import { Input } from "@/src/components/ui/input";
@@ -37,7 +38,6 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { getFinalModelParams } from "@/src/utils/getFinalModelParams";
 import { useModelParams } from "@/src/features/playground/page/hooks/useModelParams";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
-import { EvalReferencedEvaluators } from "@/src/features/evals/types";
 import {
   getDefaultOutputDefinitionFormValues,
   shouldReplaceDefaultOutputDefinitionField,
@@ -361,13 +361,9 @@ export const InnerEvalTemplateForm = (props: {
 
   const utils = api.useUtils();
   const createEvalTemplateMutation = api.evals.createTemplate.useMutation({
-    onSuccess: () => {
+    onSuccess: (data) => {
       utils.models.invalidate();
-      if (
-        form.getValues("referencedEvaluators") ===
-          EvalReferencedEvaluators.UPDATE &&
-        props.existingEvalTemplateId
-      ) {
+      if (data.updatedConfigCount > 0) {
         showSuccessToast({
           title: "Updated evaluators",
           description:
@@ -378,27 +374,49 @@ export const InnerEvalTemplateForm = (props: {
     onError: (error) => setFormError(error.message),
   });
 
-  const evaluatorsByTemplateNameQuery =
-    api.evals.jobConfigsByTemplateName.useQuery(
-      {
-        projectId: props.projectId,
-        evalTemplateName: props.existingEvalTemplateName as string,
-      },
-      {
-        enabled: !!props.existingEvalTemplateName,
-      },
-    );
-
-  useEffect(() => {
-    if (evaluatorsByTemplateNameQuery.data) {
-      form.setValue(
-        "referencedEvaluators",
-        Boolean(evaluatorsByTemplateNameQuery.data.evaluators.length)
-          ? EvalReferencedEvaluators.UPDATE
-          : EvalReferencedEvaluators.PERSIST,
-      );
+  const isNewTemplate = !props.existingEvalTemplateId && !props.cloneSourceId;
+  const existingTemplatesQuery = api.evals.allTemplates.useQuery(
+    { projectId: props.projectId },
+    {
+      enabled: isNewTemplate,
+    },
+  );
+  // keep the latest version per name so the error message links to the current template
+  const existingTemplateByName = new Map<
+    string,
+    { id: string; version: number }
+  >();
+  for (const template of existingTemplatesQuery.data?.templates ?? []) {
+    if (template.projectId !== props.projectId) continue;
+    const existing = existingTemplateByName.get(template.name);
+    if (!existing || template.version > existing.version) {
+      existingTemplateByName.set(template.name, {
+        id: template.id,
+        version: template.version,
+      });
     }
-  }, [evaluatorsByTemplateNameQuery.data, form]);
+  }
+  const getExistingTemplateForName = (name: string) =>
+    isNewTemplate ? existingTemplateByName.get(name.trim()) : undefined;
+
+  const getCreateTemplateIntent = () => {
+    if (props.existingEvalTemplateId) {
+      return {
+        intent: "new-version" as const,
+        sourceTemplateId: props.existingEvalTemplateId,
+      };
+    }
+
+    if (props.cloneSourceId) {
+      return {
+        intent: "clone" as const,
+        cloneSourceId: props.cloneSourceId,
+        retargetUsingJobConfigs: false,
+      };
+    }
+
+    return { intent: "new" as const };
+  };
 
   async function submitEvalTemplate(
     evalTemplate: RouterInput["evals"]["createTemplate"],
@@ -411,13 +429,15 @@ export const InnerEvalTemplateForm = (props: {
     await createEvalTemplateMutation
       .mutateAsync(evalTemplate)
       .then((res) => {
-        props.onFormSuccess?.(res);
+        props.onFormSuccess?.(res.template);
         form.reset();
         props.setIsEditing?.(false);
         if (props.preventRedirect) {
           return;
         }
-        router.push(`/project/${props.projectId}/evals/templates/${res.id}`);
+        router.push(
+          `/project/${props.projectId}/evals/templates/${res.template.id}`,
+        );
       })
       .catch((error) => {
         if ("message" in error && typeof error.message === "string") {
@@ -435,6 +455,15 @@ export const InnerEvalTemplateForm = (props: {
         ? "eval_templates:update_form_submit"
         : "eval_templates:new_form_submit",
     );
+
+    if (getExistingTemplateForName(values.name)) {
+      form.setError("name", {
+        type: "validate",
+        message:
+          "Template with this name already exists. Edit this template or delete it to create a new template with this name.",
+      });
+      return;
+    }
 
     if (values.type === EvalTemplateType.CODE) {
       const submittedSourceCodeLanguage =
@@ -459,8 +488,7 @@ export const InnerEvalTemplateForm = (props: {
         projectId: props.projectId,
         sourceCode: formattedSourceCode,
         sourceCodeLanguage: submittedSourceCodeLanguage,
-        referencedEvaluators: values.referencedEvaluators,
-        cloneSourceId: props.cloneSourceId ?? undefined,
+        ...getCreateTemplateIntent(),
       } satisfies RouterInput["evals"]["createTemplate"];
 
       await submitEvalTemplate(evalTemplate);
@@ -500,8 +528,7 @@ export const InnerEvalTemplateForm = (props: {
         : getFinalModelParams(modelParams),
       vars: extractedVariables ?? [],
       outputDefinition,
-      referencedEvaluators: values.referencedEvaluators,
-      cloneSourceId: props.cloneSourceId ?? undefined,
+      ...getCreateTemplateIntent(),
     } satisfies RouterInput["evals"]["createTemplate"];
 
     // Only validate model if not using default
@@ -538,17 +565,34 @@ export const InnerEvalTemplateForm = (props: {
             <FormField
               control={form.control}
               name="name"
-              render={({ field }) => (
-                <>
+              render={({ field }) => {
+                const existingTemplate = getExistingTemplateForName(
+                  field.value,
+                );
+                return (
                   <FormItem>
                     <FormLabel>Name</FormLabel>
                     <FormControl>
                       <Input {...field} placeholder="Select a name" />
                     </FormControl>
+                    {existingTemplate && (
+                      <p className="text-destructive text-sm font-medium">
+                        Template with this name already exists.{" "}
+                        <Link
+                          href={`/project/${props.projectId}/evals/templates/${existingTemplate.id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline"
+                        >
+                          Edit this template
+                        </Link>{" "}
+                        or delete it to create a new template with this name.
+                      </p>
+                    )}
                     <FormMessage />
                   </FormItem>
-                </>
-              )}
+                );
+              }}
             />
           </div>
           <div className="col-span-1 row-span-1 lg:col-span-0"></div>

--- a/web/src/features/evals/components/template-selector.tsx
+++ b/web/src/features/evals/components/template-selector.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/src/components/ui/input-command";
 import { cn } from "@/src/utils/tailwind";
 import { Button } from "@/src/components/ui/button";
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
 import Link from "next/link";
 import { useExperimentEvaluatorSelection } from "@/src/features/experiments/hooks/useExperimentEvaluatorSelection";
 import { useTemplatesValidation } from "@/src/features/evals/hooks/useTemplatesValidation";
@@ -40,18 +40,15 @@ import { MaintainerTooltip } from "@/src/features/evals/components/maintainer-to
 import { env } from "@/src/env.mjs";
 import { useIsCodeEvalEnabled } from "@/src/features/evals/hooks/useIsCodeEvalEnabled";
 import { shouldShowEvalTemplate } from "@/src/features/evals/utils/code-eval-template-utils";
+import { getEvalTemplateFamilyKey } from "@/src/features/evals/utils/eval-template-family";
 
 type TemplateSelectorProps = {
   projectId: string;
   datasetId: string;
   evalTemplates: EvalTemplate[];
   disabled?: boolean;
-  activeTemplateIds?: string[];
-  inactiveTemplateIds?: string[];
-  evaluatorTargetObjects?: Record<string, string>;
   onConfigureTemplate?: (templateId: string) => void;
   onSelectEvaluator?: (templateId: string) => void;
-  onEvaluatorToggled?: () => void;
   className?: string;
 };
 
@@ -59,12 +56,8 @@ export const TemplateSelector = ({
   projectId,
   datasetId,
   evalTemplates,
-  activeTemplateIds,
-  inactiveTemplateIds,
-  evaluatorTargetObjects,
   onConfigureTemplate,
   onSelectEvaluator,
-  onEvaluatorToggled,
   className,
   disabled = false,
 }: TemplateSelectorProps) => {
@@ -75,60 +68,63 @@ export const TemplateSelector = ({
     shouldShowEvalTemplate(template, codeEvalCapabilities),
   );
   const {
-    activeTemplates,
+    existingEvaluators,
     isTemplateActive,
     isTemplateInactive,
     handleRowClick,
   } = useExperimentEvaluatorSelection({
     projectId: projectId,
     datasetId: datasetId,
-    initialActiveTemplateIds: activeTemplateIds,
-    initialInactiveTemplateIds: inactiveTemplateIds,
     onSelectEvaluator,
-    onEvaluatorToggled,
   });
+  const activeEvaluators = Object.values(existingEvaluators).filter(
+    (evaluator) => evaluator.isActive,
+  );
 
   // Validation for templates requiring default model
   const { isTemplateValid, hasDefaultModel } = useTemplatesValidation({
     projectId: projectId,
-    selectedTemplateIds: activeTemplates,
+    selectedTemplateIds: activeEvaluators.map(
+      (evaluator) => evaluator.evalTemplateId,
+    ),
   });
 
-  // Group templates by name and whether they are managed by Langfuse
+  // latestTemplates already returns one row per evaluator family.
   const groupedTemplates = visibleEvalTemplates.reduce(
     (acc, template) => {
       const group = template.projectId ? "custom" : "langfuse";
-      if (!acc[group][template.name]) {
-        acc[group][template.name] = [];
-      }
-      acc[group][template.name].push(template);
+      acc[group][getEvalTemplateFamilyKey(template)] = template;
       return acc;
     },
     {
-      langfuse: {} as Record<string, EvalTemplate[]>,
-      custom: {} as Record<string, EvalTemplate[]>,
+      langfuse: {} as Record<string, EvalTemplate>,
+      custom: {} as Record<string, EvalTemplate>,
     },
   );
 
   // Filter templates based on search
   const filteredTemplates = {
     langfuse: Object.entries(groupedTemplates.langfuse)
-      .filter(([name]) => name.toLowerCase().includes(search.toLowerCase()))
-      .sort(([nameA, templatesA], [nameB, templatesB]) => {
+      .filter(([, template]) =>
+        template.name.toLowerCase().includes(search.toLowerCase()),
+      )
+      .sort(([, templateA], [, templateB]) => {
         // Get partners
-        const partnerA = templatesA[0]?.partner;
-        const partnerB = templatesB[0]?.partner;
+        const partnerA = templateA.partner;
+        const partnerB = templateB.partner;
 
         // No partner comes before partner
         if (!partnerA && partnerB) return -1;
         if (partnerA && !partnerB) return 1;
 
         // Sort by name within each group
-        return nameA.localeCompare(nameB);
+        return templateA.name.localeCompare(templateB.name);
       }),
     custom: Object.entries(groupedTemplates.custom)
-      .filter(([name]) => name.toLowerCase().includes(search.toLowerCase()))
-      .sort(([a], [b]) => a.localeCompare(b)),
+      .filter(([, template]) =>
+        template.name.toLowerCase().includes(search.toLowerCase()),
+      )
+      .sort(([, a], [, b]) => a.name.localeCompare(b.name)),
   };
 
   const hasResults =
@@ -136,7 +132,7 @@ export const TemplateSelector = ({
     filteredTemplates.custom.length > 0;
 
   // Handle cog button click - configure template
-  const handleConfigureTemplate = (e: React.MouseEvent, templateId: string) => {
+  const handleConfigureTemplate = (e: MouseEvent, templateId: string) => {
     e.stopPropagation();
 
     // Check if this template requires a default model
@@ -155,8 +151,8 @@ export const TemplateSelector = ({
   });
 
   const triggerLabel =
-    activeTemplates.length > 0
-      ? `${activeTemplates.length} active evaluators`
+    activeEvaluators.length > 0
+      ? `${activeEvaluators.length} active evaluators`
       : "Select evaluators";
 
   return (
@@ -206,23 +202,19 @@ export const TemplateSelector = ({
                       heading="Custom evaluators"
                       className="max-h-full"
                     >
-                      {filteredTemplates.custom.map(([name, templateData]) => {
-                        const latestTemplate =
-                          templateData[templateData.length - 1];
-                        const isActive = isTemplateActive(latestTemplate.id);
-                        const isInactive = isTemplateInactive(
-                          latestTemplate.id,
-                        );
-                        const isInvalid = isTemplateInvalid(latestTemplate);
+                      {filteredTemplates.custom.map(([familyKey, template]) => {
+                        const isActive = isTemplateActive(familyKey);
+                        const isInactive = isTemplateInactive(familyKey);
+                        const isInvalid = isTemplateInvalid(template);
                         const isLegacy =
-                          evaluatorTargetObjects?.[latestTemplate.id] ===
+                          existingEvaluators[familyKey]?.targetObject ===
                           "dataset";
 
                         return (
                           <InputCommandItem
-                            key={`custom-${name}`}
+                            key={`custom-${familyKey}`}
                             onSelect={() => {
-                              handleRowClick(latestTemplate.id);
+                              handleRowClick(template.id, familyKey);
                             }}
                             disabled={isInvalid || disabled}
                           >
@@ -231,7 +223,7 @@ export const TemplateSelector = ({
                             ) : (
                               <div className="mr-2 h-4 w-4" />
                             )}
-                            {name}
+                            {template.name}
                             {isLegacy && (
                               <Badge variant="outline" className="ml-2 text-xs">
                                 legacy
@@ -269,7 +261,11 @@ export const TemplateSelector = ({
                                 variant="ghost"
                                 size="icon-xs"
                                 onClick={(e) =>
-                                  handleConfigureTemplate(e, latestTemplate.id)
+                                  handleConfigureTemplate(
+                                    e,
+                                    existingEvaluators[familyKey]
+                                      ?.evalTemplateId ?? template.id,
+                                  )
                                 }
                                 className="ml-auto"
                                 title={
@@ -297,21 +293,19 @@ export const TemplateSelector = ({
                     heading="Langfuse managed evaluators"
                     className="max-h-full min-h-0"
                   >
-                    {filteredTemplates.langfuse.map(([name, templateData]) => {
-                      const latestTemplate =
-                        templateData[templateData.length - 1];
-                      const isActive = isTemplateActive(latestTemplate.id);
-                      const isInactive = isTemplateInactive(latestTemplate.id);
-                      const isInvalid = isTemplateInvalid(latestTemplate);
+                    {filteredTemplates.langfuse.map(([familyKey, template]) => {
+                      const isActive = isTemplateActive(familyKey);
+                      const isInactive = isTemplateInactive(familyKey);
+                      const isInvalid = isTemplateInvalid(template);
                       const isLegacy =
-                        evaluatorTargetObjects?.[latestTemplate.id] ===
+                        existingEvaluators[familyKey]?.targetObject ===
                         "dataset";
 
                       return (
                         <InputCommandItem
-                          key={`langfuse-${name}`}
+                          key={`langfuse-${familyKey}`}
                           onSelect={() => {
-                            handleRowClick(latestTemplate.id);
+                            handleRowClick(template.id, familyKey);
                           }}
                           disabled={isInvalid || disabled}
                         >
@@ -320,9 +314,9 @@ export const TemplateSelector = ({
                           ) : (
                             <div className="mr-2 h-4 w-4" />
                           )}
-                          <div className="mr-1">{name}</div>
+                          <div className="mr-1">{template.name}</div>
                           <MaintainerTooltip
-                            maintainer={getMaintainer(latestTemplate)}
+                            maintainer={getMaintainer(template)}
                           />
                           {isLegacy && (
                             <Badge variant="outline" className="ml-2 text-xs">
@@ -362,7 +356,11 @@ export const TemplateSelector = ({
                               size="icon-xs"
                               className="ml-auto"
                               onClick={(e) =>
-                                handleConfigureTemplate(e, latestTemplate.id)
+                                handleConfigureTemplate(
+                                  e,
+                                  existingEvaluators[familyKey]
+                                    ?.evalTemplateId ?? template.id,
+                                )
                               }
                               title={
                                 isInvalid

--- a/web/src/features/evals/hooks/useTemplatesValidation.ts
+++ b/web/src/features/evals/hooks/useTemplatesValidation.ts
@@ -26,7 +26,7 @@ export function useTemplatesValidation({
     );
 
   // Fetch all templates
-  const { data: templatesData } = api.evals.allTemplates.useQuery(
+  const { data: templatesData } = api.evals.latestTemplates.useQuery(
     { projectId },
     { enabled: !!projectId },
   );

--- a/web/src/features/evals/pages/new-evaluator.tsx
+++ b/web/src/features/evals/pages/new-evaluator.tsx
@@ -54,7 +54,7 @@ export default function NewEvaluatorPage() {
     scope: "evalTemplate:CUD",
   });
 
-  const evalTemplates = api.evals.allTemplates.useQuery(
+  const evalTemplates = api.evals.latestTemplates.useQuery(
     {
       projectId,
       limit: 500,

--- a/web/src/features/evals/pages/new-evaluator.tsx
+++ b/web/src/features/evals/pages/new-evaluator.tsx
@@ -65,11 +65,26 @@ export default function NewEvaluatorPage() {
     },
   );
 
-  const currentTemplate = evalTemplates.data?.templates
-    .filter((template) =>
-      shouldShowEvalTemplate(template, codeEvalCapabilities),
-    )
-    .find((t) => t.id === evaluatorId);
+  // resolve by id (not via the latest-only list) so deep links to older
+  // template versions keep working and trigger the "use updated" banner
+  const currentTemplateQuery = api.evals.templateById.useQuery(
+    { projectId, id: evaluatorId as string },
+    { enabled: hasAccess && !!evaluatorId },
+  );
+  const currentTemplate =
+    currentTemplateQuery.data &&
+    shouldShowEvalTemplate(currentTemplateQuery.data, codeEvalCapabilities)
+      ? currentTemplateQuery.data
+      : undefined;
+
+  // deep links may reference an older version that the latest-only list
+  // does not contain; include it so the form can still render it
+  const latestEvalTemplates = evalTemplates.data?.templates ?? [];
+  const formEvalTemplates =
+    currentTemplate &&
+    !latestEvalTemplates.some((template) => template.id === currentTemplate.id)
+      ? [...latestEvalTemplates, currentTemplate]
+      : latestEvalTemplates;
 
   const templatesForCurrentName = api.evals.allTemplatesForName.useQuery(
     {
@@ -260,7 +275,7 @@ export default function NewEvaluatorPage() {
             <RunEvaluatorForm
               projectId={projectId}
               evaluatorId={evaluatorId}
-              evalTemplates={evalTemplates.data?.templates ?? []}
+              evalTemplates={formEvalTemplates}
             />
           </div>
         )

--- a/web/src/features/evals/server/evalTemplateCreation.ts
+++ b/web/src/features/evals/server/evalTemplateCreation.ts
@@ -13,35 +13,43 @@ import {
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import { assertUnreachable } from "@/src/utils/types";
-import { EvalReferencedEvaluators } from "@/src/features/evals/types";
 import {
   isCodeEvalEnabled,
   isCodeEvalSourceCodeLanguageSupported,
 } from "@/src/features/evals/server/isCodeEvalEnabled";
 
-const CreateEvalTemplateBaseInputSchema = z.object({
-  name: z.string().min(1),
-  projectId: z.string(),
-  cloneSourceId: z.string().optional(),
-  referencedEvaluators: z
-    .enum(EvalReferencedEvaluators)
-    .optional()
-    .default(EvalReferencedEvaluators.PERSIST),
+const CreateEvalTemplateIntentSchema = z.discriminatedUnion("intent", [
+  z.object({ intent: z.literal("new") }),
+  z.object({
+    intent: z.literal("new-version"),
+    sourceTemplateId: z.string(),
+  }),
+  z.object({
+    intent: z.literal("clone"),
+    cloneSourceId: z.string(),
+    retargetUsingJobConfigs: z.boolean(),
+  }),
+]);
+
+const CreateEvalTemplateBaseInputSchema = z
+  .object({
+    name: z.string().min(1),
+    projectId: z.string(),
+  })
+  .and(CreateEvalTemplateIntentSchema);
+
+const CreateLlmAsJudgeEvalTemplateInputSchema = z.object({
+  type: z.literal(EvalTemplateType.LLM_AS_JUDGE),
+  prompt: z.string(),
+  provider: z.string().nullish(),
+  model: z.string().nullish(),
+  modelParams: ZodModelConfig.nullish(),
+  vars: z.array(z.string()),
+  outputDefinition: PersistedEvalOutputDefinitionSchema,
 });
 
-const CreateLlmAsJudgeEvalTemplateInputSchema =
-  CreateEvalTemplateBaseInputSchema.extend({
-    type: z.literal(EvalTemplateType.LLM_AS_JUDGE),
-    prompt: z.string(),
-    provider: z.string().nullish(),
-    model: z.string().nullish(),
-    modelParams: ZodModelConfig.nullish(),
-    vars: z.array(z.string()),
-    outputDefinition: PersistedEvalOutputDefinitionSchema,
-  });
-
-const CreateLegacyLlmAsJudgeEvalTemplateInputSchema =
-  CreateEvalTemplateBaseInputSchema.extend({
+const CreateLegacyLlmAsJudgeEvalTemplateInputSchema = z
+  .object({
     type: z.undefined().optional(),
     prompt: z.string(),
     provider: z.string().nullish(),
@@ -49,43 +57,47 @@ const CreateLegacyLlmAsJudgeEvalTemplateInputSchema =
     modelParams: ZodModelConfig.nullish(),
     vars: z.array(z.string()),
     outputDefinition: PersistedEvalOutputDefinitionSchema,
-  }).transform((input) => ({
+  })
+  .transform((input) => ({
     ...input,
     type: EvalTemplateType.LLM_AS_JUDGE,
   }));
 
-const CreateCodeEvalTemplateInputSchema =
-  CreateEvalTemplateBaseInputSchema.extend({
-    type: z.literal(EvalTemplateType.CODE),
-    sourceCode: z
-      .string()
-      .min(1)
-      .refine(
-        (sourceCode) =>
-          Buffer.byteLength(sourceCode, "utf8") <= CODE_EVAL_SOURCE_MAX_BYTES,
-        {
-          message: `Source code must be ${CODE_EVAL_SOURCE_MAX_BYTES} bytes or less`,
-        },
-      ),
-    sourceCodeLanguage: z.enum([
-      EvalTemplateSourceCodeLanguage.PYTHON,
-      EvalTemplateSourceCodeLanguage.TYPESCRIPT,
-    ]),
-  });
+const CreateCodeEvalTemplateInputSchema = z.object({
+  type: z.literal(EvalTemplateType.CODE),
+  sourceCode: z
+    .string()
+    .min(1)
+    .refine(
+      (sourceCode) =>
+        Buffer.byteLength(sourceCode, "utf8") <= CODE_EVAL_SOURCE_MAX_BYTES,
+      {
+        message: `Source code must be ${CODE_EVAL_SOURCE_MAX_BYTES} bytes or less`,
+      },
+    ),
+  sourceCodeLanguage: z.enum([
+    EvalTemplateSourceCodeLanguage.PYTHON,
+    EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+  ]),
+});
 
 const CreateTypedEvalTemplateInputSchema = z.discriminatedUnion("type", [
   CreateLlmAsJudgeEvalTemplateInputSchema,
   CreateCodeEvalTemplateInputSchema,
 ]);
 
-export const CreateEvalTemplateInputSchema = z.union([
-  CreateTypedEvalTemplateInputSchema,
-  CreateLegacyLlmAsJudgeEvalTemplateInputSchema,
-]);
+export const CreateEvalTemplateInputSchema =
+  CreateEvalTemplateBaseInputSchema.and(
+    z.union([
+      CreateTypedEvalTemplateInputSchema,
+      CreateLegacyLlmAsJudgeEvalTemplateInputSchema,
+    ]),
+  );
 
 type CreateEvalTemplateInput = z.infer<typeof CreateEvalTemplateInputSchema>;
-type CreateLlmAsJudgeEvalTemplateInput = z.infer<
-  typeof CreateLlmAsJudgeEvalTemplateInputSchema
+type CreateLlmAsJudgeEvalTemplateInput = Extract<
+  CreateEvalTemplateInput,
+  { type: typeof EvalTemplateType.LLM_AS_JUDGE }
 >;
 
 async function validateLlmAsJudgeTemplateModel(

--- a/web/src/features/evals/server/evaluatorUpgrade.ts
+++ b/web/src/features/evals/server/evaluatorUpgrade.ts
@@ -1,9 +1,21 @@
 import {
   EvalTargetObject,
+  EvalTemplateType,
   InternalServerError,
+  LangfuseConflictError,
   observationVariableMappingList,
   variableMappingList,
 } from "@langfuse/shared";
+import { CODE_EVAL_TEMPLATE_VARIABLES } from "@/src/features/evals/utils/code-eval-template-utils";
+
+// accepts both stored templates and createTemplate inputs (CODE inputs carry no vars)
+export const getEvalTemplateVariables = (template: {
+  type: EvalTemplateType;
+  vars?: string[];
+}) =>
+  template.type === EvalTemplateType.CODE
+    ? [...CODE_EVAL_TEMPLATE_VARIABLES]
+    : (template.vars ?? []);
 
 export function prepareVariableMappingForEvaluatorUpgrade(params: {
   targetObject: string;
@@ -36,3 +48,31 @@ export function prepareVariableMappingForEvaluatorUpgrade(params: {
     missingVariables,
   };
 }
+
+export const prepareConfigsForTemplateUpgrade = (params: {
+  configs: {
+    id: string;
+    scoreName: string;
+    targetObject: string;
+    variableMapping: unknown;
+  }[];
+  nextVariables: string[];
+}) =>
+  params.configs.map((config) => {
+    const preparedMapping = prepareVariableMappingForEvaluatorUpgrade({
+      targetObject: config.targetObject,
+      variableMapping: config.variableMapping,
+      nextVariables: params.nextVariables,
+    });
+
+    if (preparedMapping.missingVariables.length > 0) {
+      throw new LangfuseConflictError(
+        `Creating a new evaluator version would invalidate the evaluator "${config.scoreName}" because it is missing mappings for new evaluator variables: ${preparedMapping.missingVariables.join(", ")}. Remove the new variable(s) from the template, or delete the evaluator "${config.scoreName}" and recreate it with a complete mapping.`,
+      );
+    }
+
+    return {
+      id: config.id,
+      variableMapping: preparedMapping.variableMapping,
+    };
+  });

--- a/web/src/features/evals/server/evaluatorUpgrade.ts
+++ b/web/src/features/evals/server/evaluatorUpgrade.ts
@@ -1,0 +1,38 @@
+import {
+  EvalTargetObject,
+  InternalServerError,
+  observationVariableMappingList,
+  variableMappingList,
+} from "@langfuse/shared";
+
+export function prepareVariableMappingForEvaluatorUpgrade(params: {
+  targetObject: string;
+  variableMapping: unknown;
+  nextVariables: string[];
+}) {
+  const mappingSchema =
+    params.targetObject === EvalTargetObject.EVENT ||
+    params.targetObject === EvalTargetObject.EXPERIMENT
+      ? observationVariableMappingList
+      : variableMappingList;
+  const mappingParseResult = mappingSchema.safeParse(params.variableMapping);
+
+  if (!mappingParseResult.success) {
+    throw new InternalServerError("Evaluation rule mapping is corrupted");
+  }
+
+  const migratedVariableMapping = mappingParseResult.data.filter((mapping) =>
+    params.nextVariables.includes(mapping.templateVariable),
+  );
+  const mappedVariables = new Set(
+    migratedVariableMapping.map((mapping) => mapping.templateVariable),
+  );
+  const missingVariables = params.nextVariables.filter(
+    (variable) => !mappedVariables.has(variable),
+  );
+
+  return {
+    variableMapping: migratedVariableMapping,
+    missingVariables,
+  };
+}

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -27,6 +27,8 @@ import {
   EvalTargetObjectSchema,
   validateEvaluatorFiltersForTarget,
   InvalidRequestError,
+  LangfuseConflictError,
+  LangfuseNotFoundError,
   EvalTemplateType,
   type EvalTemplateSourceCodeLanguage,
 } from "@langfuse/shared";
@@ -44,7 +46,6 @@ import {
   invalidateProjectEvalConfigCaches,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
-import { EvalReferencedEvaluators } from "@/src/features/evals/types";
 import { EvaluatorStatus } from "../types";
 import { traceException } from "@langfuse/shared/src/server";
 import { assertUnreachable, isNotNullOrUndefined } from "@/src/utils/types";
@@ -88,6 +89,7 @@ import {
   isCodeEvalEnabled,
   isCodeEvalSourceCodeLanguageSupported,
 } from "@/src/features/evals/server/isCodeEvalEnabled";
+import { prepareVariableMappingForEvaluatorUpgrade } from "@/src/features/evals/server/evaluatorUpgrade";
 export { CreateEvalTemplateInputSchema } from "@/src/features/evals/server/evalTemplateCreation";
 
 // Filter columns that used to be backed by the Postgres `traces` and
@@ -302,6 +304,49 @@ const validateVariableMappingForTarget = ({
 
   return result.data;
 };
+
+const getEvalTemplateInputVariables = (
+  input: z.infer<typeof CreateEvalTemplateInputSchema>,
+) =>
+  input.type === EvalTemplateType.CODE
+    ? [...CODE_EVAL_TEMPLATE_VARIABLES]
+    : input.vars;
+
+const getEvalTemplateVariables = (template: {
+  type: EvalTemplateType;
+  vars: string[];
+}) =>
+  template.type === EvalTemplateType.CODE
+    ? [...CODE_EVAL_TEMPLATE_VARIABLES]
+    : template.vars;
+
+const prepareConfigsForTemplateUpgrade = (params: {
+  configs: {
+    id: string;
+    scoreName: string;
+    targetObject: string;
+    variableMapping: unknown;
+  }[];
+  nextVariables: string[];
+}) =>
+  params.configs.map((config) => {
+    const preparedMapping = prepareVariableMappingForEvaluatorUpgrade({
+      targetObject: config.targetObject,
+      variableMapping: config.variableMapping,
+      nextVariables: params.nextVariables,
+    });
+
+    if (preparedMapping.missingVariables.length > 0) {
+      throw new LangfuseConflictError(
+        `Creating a new evaluator version would invalidate the evaluator "${config.scoreName}" because it is missing mappings for new evaluator variables: ${preparedMapping.missingVariables.join(", ")}. Remove the new variable(s) from the template, or delete the evaluator "${config.scoreName}" and recreate it with a complete mapping.`,
+      );
+    }
+
+    return {
+      id: config.id,
+      variableMapping: preparedMapping.variableMapping,
+    };
+  });
 
 const validateEvalTemplateCanRun = async ({
   prisma,
@@ -830,6 +875,7 @@ export const evalRouter = createTRPCRouter({
           ...(input.id ? { id: input.id } : undefined),
           ...getCodeEvalTemplateWhere(),
         },
+        orderBy: [{ name: "asc" }, { version: "asc" }],
         ...(input.limit && input.page
           ? { take: input.limit, skip: input.page * input.limit }
           : undefined),
@@ -845,6 +891,53 @@ export const evalRouter = createTRPCRouter({
       return {
         templates: templates,
         totalCount: count,
+      };
+    }),
+
+  latestTemplates: protectedProjectProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        limit: z.number().optional(),
+        page: z.number().optional(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "evalTemplate:read",
+      });
+
+      // distinct keeps the first row per family under this orderBy, i.e. the
+      // latest version (dedupe happens in the Prisma engine, not in SQL)
+      const latestTemplates = await ctx.prisma.evalTemplate.findMany({
+        where: {
+          OR: [{ projectId: input.projectId }, { projectId: null }],
+          ...getCodeEvalTemplateWhere(),
+        },
+        orderBy: [
+          { name: "asc" },
+          { type: "asc" },
+          { projectId: { sort: "asc", nulls: "first" } },
+          { version: "desc" },
+          { createdAt: "desc" },
+          { id: "desc" },
+        ],
+        distinct: ["projectId", "name", "type"],
+      });
+
+      const start =
+        input.limit !== undefined && input.page !== undefined
+          ? input.page * input.limit
+          : undefined;
+
+      return {
+        templates:
+          start !== undefined && input.limit !== undefined
+            ? latestTemplates.slice(start, start + input.limit)
+            : latestTemplates,
+        totalCount: latestTemplates.length,
       };
     }),
 
@@ -947,7 +1040,7 @@ export const evalRouter = createTRPCRouter({
         scope: "evalJob:CUD",
       });
 
-      const evalTemplate = await ctx.prisma.evalTemplate.findUnique({
+      const evalTemplate = await ctx.prisma.evalTemplate.findFirst({
         where: {
           id: input.evalTemplateId,
           OR: [{ projectId: input.projectId }, { projectId: null }],
@@ -960,9 +1053,25 @@ export const evalRouter = createTRPCRouter({
         );
         throw new Error("Template not found");
       }
-      if (evalTemplate.type === EvalTemplateType.CODE) {
+      const latestEvalTemplate = await ctx.prisma.evalTemplate.findFirst({
+        where: {
+          projectId: evalTemplate.projectId,
+          name: evalTemplate.name,
+          type: evalTemplate.type,
+        },
+        orderBy: [{ version: "desc" }, { createdAt: "desc" }, { id: "desc" }],
+      });
+      const resolvedEvalTemplate = latestEvalTemplate ?? evalTemplate;
+
+      if (resolvedEvalTemplate.id !== evalTemplate.id) {
+        logger.info(
+          `Resolved stale evaluator template ${evalTemplate.id} to latest version ${resolvedEvalTemplate.id} for project ${input.projectId}`,
+        );
+      }
+
+      if (resolvedEvalTemplate.type === EvalTemplateType.CODE) {
         assertCodeEvalTemplateCanRun({
-          sourceCodeLanguage: evalTemplate.sourceCodeLanguage,
+          sourceCodeLanguage: resolvedEvalTemplate.sourceCodeLanguage,
         });
       }
 
@@ -970,6 +1079,25 @@ export const evalRouter = createTRPCRouter({
         targetObject: input.target,
         mapping: input.mapping,
       });
+      const variableMappingForResolvedTemplate = (() => {
+        if (resolvedEvalTemplate.id === evalTemplate.id) {
+          return variableMappingForTarget;
+        }
+
+        const preparedMapping = prepareVariableMappingForEvaluatorUpgrade({
+          targetObject: input.target,
+          variableMapping: variableMappingForTarget,
+          nextVariables: getEvalTemplateVariables(resolvedEvalTemplate),
+        });
+
+        if (preparedMapping.missingVariables.length > 0) {
+          throw new LangfuseConflictError(
+            `Evaluator template "${evalTemplate.name}" changed while this form was open. Reload the page and configure the latest version before creating this evaluator. Missing mappings: ${preparedMapping.missingVariables.join(", ")}.`,
+          );
+        }
+
+        return preparedMapping.variableMapping;
+      })();
       const filterValidation = validateEvaluatorFiltersForTarget({
         targetObject: input.target,
         filter: input.filter ?? [],
@@ -982,14 +1110,14 @@ export const evalRouter = createTRPCRouter({
       }
       const validatedFilter = filterValidation.validatedFilters;
 
-      if (evalTemplate.type === EvalTemplateType.CODE) {
+      if (resolvedEvalTemplate.type === EvalTemplateType.CODE) {
         await assertCodeEvalJobConfigCanRunForTRPC({
           prisma: ctx.prisma,
           orgId: ctx.session.orgId,
           projectId: input.projectId,
-          evalTemplateId: input.evalTemplateId,
+          evalTemplateId: resolvedEvalTemplate.id,
           target: input.target,
-          mapping: variableMappingForTarget,
+          mapping: variableMappingForResolvedTemplate,
           scoreName: input.scoreName,
           filter: validatedFilter ?? [],
         });
@@ -1008,11 +1136,11 @@ export const evalRouter = createTRPCRouter({
           id: jobId,
           projectId: input.projectId,
           jobType: "EVAL",
-          evalTemplateId: input.evalTemplateId,
+          evalTemplateId: resolvedEvalTemplate.id,
           scoreName: input.scoreName,
           targetObject: input.target,
           filter: validatedFilter ?? [],
-          variableMapping: variableMappingForTarget,
+          variableMapping: variableMappingForResolvedTemplate,
           sampling: input.sampling,
           delay: input.delay,
           status: input.status,
@@ -1117,46 +1245,132 @@ export const evalRouter = createTRPCRouter({
 
       await validateEvalTemplateCreation(input);
 
-      /**
-       * CREATION OF PROJECT-LEVEL TEMPLATE
-       *
-       * Option 1: Create a new project-level template
-       * - Find existing project-level templates, templates are unique by [name, projectId]
-       * - If a template already exists, we will create a new version of the template
-       * - Otherwise, we will create a new template with version 1
-       *
-       * Option 2: Clone a langfuse managed template
-       * - Find the langfuse managed template
-       * - Clone the langfuse managed template by creating a new project-level template from the cloned langfuse managed template
-       */
-
-      // find all versions of the project-level template, should return null if input.cloneSourceId is provided
-      return ctx.prisma.$transaction(async (tx) => {
-        const templates = await tx.evalTemplate.findMany({
+      const result = await ctx.prisma.$transaction(async (tx) => {
+        const nextVariables = getEvalTemplateInputVariables(input);
+        const existingProjectTemplatesByName = await tx.evalTemplate.findMany({
           where: {
             projectId: input.projectId,
             name: input.name,
-            type: input.type,
           },
-          orderBy: [{ version: "desc" }],
+          orderBy: [{ version: "desc" }, { createdAt: "desc" }, { id: "desc" }],
           select: {
             id: true,
-            version: true,
+            name: true,
             type: true,
+            version: true,
           },
         });
+        const existingProjectTemplates = existingProjectTemplatesByName.filter(
+          (template) => template.type === input.type,
+        );
 
-        // find the latest user managed template, should be null if input.cloneSourceId is provided
-        const latestTemplate = Boolean(templates.length)
-          ? templates[0]
-          : undefined;
+        let templateIdsWhoseConfigsShouldMove: string[] = [];
+
+        switch (input.intent) {
+          case "new": {
+            if (existingProjectTemplatesByName.length > 0) {
+              throw new LangfuseConflictError(
+                `An evaluator named "${input.name}" already exists in this project. Open it to create a new version.`,
+              );
+            }
+            break;
+          }
+          case "new-version": {
+            const sourceTemplate = existingProjectTemplates.find(
+              (template) => template.id === input.sourceTemplateId,
+            );
+
+            if (!sourceTemplate) {
+              throw new LangfuseNotFoundError("Evaluator not found");
+            }
+
+            templateIdsWhoseConfigsShouldMove = existingProjectTemplates.map(
+              (template) => template.id,
+            );
+            break;
+          }
+          case "clone": {
+            const cloneSourceTemplate = await tx.evalTemplate.findFirst({
+              where: {
+                id: input.cloneSourceId,
+                projectId: null,
+              },
+            });
+
+            if (!cloneSourceTemplate) {
+              throw new LangfuseNotFoundError(
+                "Langfuse managed template not found",
+              );
+            }
+            if (cloneSourceTemplate.type !== input.type) {
+              throw new InvalidRequestError(
+                "Evaluator type cannot be changed.",
+              );
+            }
+            if (existingProjectTemplatesByName.length > 0) {
+              throw new LangfuseConflictError(
+                `An evaluator named "${input.name}" already exists in this project. Open it to create a new version.`,
+              );
+            }
+
+            if (input.retargetUsingJobConfigs) {
+              // Clone retargeting is opt-in from the dialog: move this project's
+              // configs that currently point at the managed source family to the
+              // newly cloned project template.
+              const cloneSourceTemplateList = await tx.evalTemplate.findMany({
+                where: {
+                  projectId: null,
+                  name: cloneSourceTemplate.name,
+                  type: cloneSourceTemplate.type,
+                },
+                select: {
+                  id: true,
+                },
+              });
+              templateIdsWhoseConfigsShouldMove = cloneSourceTemplateList.map(
+                (template) => template.id,
+              );
+            }
+            break;
+          }
+          default:
+            assertUnreachable(input);
+        }
+
+        const configsToUpgrade =
+          templateIdsWhoseConfigsShouldMove.length > 0
+            ? await tx.jobConfiguration.findMany({
+                where: {
+                  projectId: input.projectId,
+                  evalTemplateId: {
+                    in: templateIdsWhoseConfigsShouldMove,
+                  },
+                  evalTemplate: {
+                    is: {
+                      type: input.type,
+                    },
+                  },
+                },
+                select: {
+                  id: true,
+                  scoreName: true,
+                  targetObject: true,
+                  variableMapping: true,
+                },
+              })
+            : [];
+        const upgradedConfigs = prepareConfigsForTemplateUpgrade({
+          configs: configsToUpgrade,
+          nextVariables,
+        });
+
+        const latestTemplate = existingProjectTemplatesByName[0];
         const baseTemplateData = {
           version: (latestTemplate?.version ?? 0) + 1,
           name: input.name,
           projectId: input.projectId,
         };
 
-        // Create a new project-level template either by cloning a langfuse managed template or by creating a new project-level template
         const evalTemplate = await (async () => {
           switch (input.type) {
             case EvalTemplateType.CODE:
@@ -1196,88 +1410,22 @@ export const evalRouter = createTRPCRouter({
           }
         })();
 
-        /**
-         * END OF CREATION OF PROJECT-LEVEL TEMPLATE
-         * - Net new project-level template has been created, or
-         * - New version of existing project-level template has been created
-         */
-
-        /**
-         * UPDATE OF JOB CONFIGS REFERENCING THE NEW/UPDATED TEMPLATE
-         */
-        if (input.referencedEvaluators === EvalReferencedEvaluators.UPDATE) {
-          /**
-           * Option 2: Clone a langfuse managed template
-           *
-           * - Find the langfuse managed template
-           * - Create a new project-level template from the cloned langfuse managed template
-           * - Update all job configs that had referenced the langfuse managed template to now reference the cloned project-level template
-           */
-          if (input.cloneSourceId) {
-            // find the langfuse managed template to clone
-            const cloneSourceTemplate = await tx.evalTemplate.findUnique({
-              where: {
-                id: input.cloneSourceId,
-                projectId: null,
-              },
-            });
-
-            if (!cloneSourceTemplate) {
-              throw new TRPCError({
-                code: "NOT_FOUND",
-                message: "Langfuse managed template not found",
-              });
-            }
-            if (cloneSourceTemplate.type !== input.type) {
-              throw new TRPCError({
-                code: "BAD_REQUEST",
-                message: "Evaluator type cannot be changed.",
-              });
-            }
-
-            // find all versions of the langfuse managed template
-            const cloneSourceTemplateList = await tx.evalTemplate.findMany({
-              where: {
-                projectId: null,
-                name: cloneSourceTemplate.name,
-                type: cloneSourceTemplate.type,
-              },
-            });
-
-            if (Boolean(cloneSourceTemplateList.length)) {
-              // update all job configs that had referenced any version of the langfuse managed template to now reference the cloned user managed template
-              await tx.jobConfiguration.updateMany({
+        if (upgradedConfigs.length > 0) {
+          await Promise.all(
+            upgradedConfigs.map((config) =>
+              tx.jobConfiguration.update({
                 where: {
-                  evalTemplateId: {
-                    in: cloneSourceTemplateList.map((t) => t.id),
-                  },
+                  id: config.id,
                   projectId: input.projectId,
                 },
-                data: { evalTemplateId: evalTemplate.id },
-              });
-            }
-            /**
-             * Option 1: Create a new project-level template
-             *
-             * - Use previously found versions of the project-level template
-             * - Update all job configs that had referenced any version of the project-level template to now reference the new project-level template
-             */
-          } else if (Boolean(templates.length)) {
-            await tx.jobConfiguration.updateMany({
-              where: {
-                evalTemplateId: { in: templates.map((t) => t.id) },
-                projectId: input.projectId,
-              },
-              data: {
-                evalTemplateId: evalTemplate.id,
-              },
-            });
-          }
+                data: {
+                  evalTemplateId: evalTemplate.id,
+                  variableMapping: config.variableMapping,
+                },
+              }),
+            ),
+          );
         }
-
-        /**
-         * END OF UPDATE OF JOB CONFIGS REFERENCING THE NEW/UPDATED TEMPLATE
-         */
 
         await auditLog({
           session: ctx.session,
@@ -1286,8 +1434,17 @@ export const evalRouter = createTRPCRouter({
           action: "create",
         });
 
-        return evalTemplate;
+        return {
+          template: evalTemplate,
+          updatedConfigCount: upgradedConfigs.length,
+        };
       });
+
+      if (result.updatedConfigCount > 0) {
+        await invalidateProjectEvalConfigCaches(input.projectId);
+      }
+
+      return result;
     }),
 
   updateAllDatasetEvalJobStatusByTemplateId: protectedProjectProcedure

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -1224,15 +1224,22 @@ export const evalRouter = createTRPCRouter({
         const existingProjectTemplates = existingProjectTemplatesByName.filter(
           (template) => template.type === input.type,
         );
+        // "open it to create a new version" is a dead end when the name is
+        // taken by a template of a different type (type cannot change)
+        const throwTemplateNameConflict = () => {
+          throw new LangfuseConflictError(
+            existingProjectTemplates.length > 0
+              ? `An evaluator named "${input.name}" already exists in this project. Open it to create a new version.`
+              : `An evaluator named "${input.name}" already exists in this project with a different type. Use a different name.`,
+          );
+        };
 
         let templateIdsWhoseConfigsShouldMove: string[] = [];
 
         switch (input.intent) {
           case "new": {
             if (existingProjectTemplatesByName.length > 0) {
-              throw new LangfuseConflictError(
-                `An evaluator named "${input.name}" already exists in this project. Open it to create a new version.`,
-              );
+              throwTemplateNameConflict();
             }
             break;
           }
@@ -1269,9 +1276,7 @@ export const evalRouter = createTRPCRouter({
               );
             }
             if (existingProjectTemplatesByName.length > 0) {
-              throw new LangfuseConflictError(
-                `An evaluator named "${input.name}" already exists in this project. Open it to create a new version.`,
-              );
+              throwTemplateNameConflict();
             }
 
             if (input.retargetUsingJobConfigs) {

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -1437,7 +1437,11 @@ export const evalRouter = createTRPCRouter({
           where: {
             projectId: projectId,
             evalTemplateId: evalTemplateId,
-            targetObject: EvalTargetObject.DATASET,
+            // the experiment selector creates EXPERIMENT-target configs; DATASET
+            // is the legacy shape — the toggle must reach both
+            targetObject: {
+              in: [EvalTargetObject.DATASET, EvalTargetObject.EXPERIMENT],
+            },
             ...(newStatus === JobConfigState.ACTIVE
               ? {
                   OR: [

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -89,7 +89,11 @@ import {
   isCodeEvalEnabled,
   isCodeEvalSourceCodeLanguageSupported,
 } from "@/src/features/evals/server/isCodeEvalEnabled";
-import { prepareVariableMappingForEvaluatorUpgrade } from "@/src/features/evals/server/evaluatorUpgrade";
+import {
+  getEvalTemplateVariables,
+  prepareConfigsForTemplateUpgrade,
+  prepareVariableMappingForEvaluatorUpgrade,
+} from "@/src/features/evals/server/evaluatorUpgrade";
 export { CreateEvalTemplateInputSchema } from "@/src/features/evals/server/evalTemplateCreation";
 
 // Filter columns that used to be backed by the Postgres `traces` and
@@ -304,49 +308,6 @@ const validateVariableMappingForTarget = ({
 
   return result.data;
 };
-
-const getEvalTemplateInputVariables = (
-  input: z.infer<typeof CreateEvalTemplateInputSchema>,
-) =>
-  input.type === EvalTemplateType.CODE
-    ? [...CODE_EVAL_TEMPLATE_VARIABLES]
-    : input.vars;
-
-const getEvalTemplateVariables = (template: {
-  type: EvalTemplateType;
-  vars: string[];
-}) =>
-  template.type === EvalTemplateType.CODE
-    ? [...CODE_EVAL_TEMPLATE_VARIABLES]
-    : template.vars;
-
-const prepareConfigsForTemplateUpgrade = (params: {
-  configs: {
-    id: string;
-    scoreName: string;
-    targetObject: string;
-    variableMapping: unknown;
-  }[];
-  nextVariables: string[];
-}) =>
-  params.configs.map((config) => {
-    const preparedMapping = prepareVariableMappingForEvaluatorUpgrade({
-      targetObject: config.targetObject,
-      variableMapping: config.variableMapping,
-      nextVariables: params.nextVariables,
-    });
-
-    if (preparedMapping.missingVariables.length > 0) {
-      throw new LangfuseConflictError(
-        `Creating a new evaluator version would invalidate the evaluator "${config.scoreName}" because it is missing mappings for new evaluator variables: ${preparedMapping.missingVariables.join(", ")}. Remove the new variable(s) from the template, or delete the evaluator "${config.scoreName}" and recreate it with a complete mapping.`,
-      );
-    }
-
-    return {
-      id: config.id,
-      variableMapping: preparedMapping.variableMapping,
-    };
-  });
 
 const validateEvalTemplateCanRun = async ({
   prisma,
@@ -1246,7 +1207,7 @@ export const evalRouter = createTRPCRouter({
       await validateEvalTemplateCreation(input);
 
       const result = await ctx.prisma.$transaction(async (tx) => {
-        const nextVariables = getEvalTemplateInputVariables(input);
+        const nextVariables = getEvalTemplateVariables(input);
         const existingProjectTemplatesByName = await tx.evalTemplate.findMany({
           where: {
             projectId: input.projectId,

--- a/web/src/features/evals/server/unstable-public-api/evaluator-service.ts
+++ b/web/src/features/evals/server/unstable-public-api/evaluator-service.ts
@@ -1,10 +1,4 @@
-import {
-  EvalTargetObject,
-  extractVariables,
-  InternalServerError,
-  observationVariableMappingList,
-  variableMappingList,
-} from "@langfuse/shared";
+import { extractVariables } from "@langfuse/shared";
 import {
   invalidateProjectEvalConfigCaches,
   type ApiAccessScope,
@@ -37,48 +31,7 @@ import {
 import { assertEvaluatorDefinitionCanRunForPublicApi } from "./validation";
 import { createUnstablePublicApiError } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 import type { StoredPublicEvaluatorTemplate } from "./types";
-
-function prepareVariableMappingForEvaluatorUpgrade(params: {
-  scoreName: string;
-  targetObject: string;
-  variableMapping: unknown;
-  nextVariables: string[];
-}) {
-  const mappingSchema =
-    params.targetObject === EvalTargetObject.EVENT ||
-    params.targetObject === EvalTargetObject.EXPERIMENT
-      ? observationVariableMappingList
-      : variableMappingList;
-  const mappingParseResult = mappingSchema.safeParse(params.variableMapping);
-
-  if (!mappingParseResult.success) {
-    throw new InternalServerError("Evaluation rule mapping is corrupted");
-  }
-
-  const migratedVariableMapping = mappingParseResult.data.filter((mapping) =>
-    params.nextVariables.includes(mapping.templateVariable),
-  );
-  const mappedVariables = new Set(
-    migratedVariableMapping.map((mapping) => mapping.templateVariable),
-  );
-  const missingVariables = params.nextVariables.filter(
-    (variable) => !mappedVariables.has(variable),
-  );
-
-  if (missingVariables.length > 0) {
-    throw createUnstablePublicApiError({
-      httpCode: 409,
-      code: "conflict",
-      message: `Creating a new evaluator version would invalidate the evaluation rule "${params.scoreName}" because it is missing mappings for new evaluator variables: ${missingVariables.join(", ")}.`,
-      details: {
-        field: "mapping",
-        variables: missingVariables,
-      },
-    });
-  }
-
-  return migratedVariableMapping;
-}
+import { prepareVariableMappingForEvaluatorUpgrade } from "@/src/features/evals/server/evaluatorUpgrade";
 
 function assertCodeEvaluatorDefinitionCanRunForPublicApi(
   input: Extract<
@@ -251,15 +204,30 @@ export async function createPublicEvaluator(params: {
                 },
               })
             : [];
-        const upgradedConfigs = configsToUpgrade.map((config) => ({
-          id: config.id,
-          variableMapping: prepareVariableMappingForEvaluatorUpgrade({
-            scoreName: config.scoreName,
+        const upgradedConfigs = configsToUpgrade.map((config) => {
+          const preparedMapping = prepareVariableMappingForEvaluatorUpgrade({
             targetObject: config.targetObject,
             variableMapping: config.variableMapping,
             nextVariables,
-          }),
-        }));
+          });
+
+          if (preparedMapping.missingVariables.length > 0) {
+            throw createUnstablePublicApiError({
+              httpCode: 409,
+              code: "conflict",
+              message: `Creating a new evaluator version would invalidate the evaluation rule "${config.scoreName}" because it is missing mappings for new evaluator variables: ${preparedMapping.missingVariables.join(", ")}.`,
+              details: {
+                field: "mapping",
+                variables: preparedMapping.missingVariables,
+              },
+            });
+          }
+
+          return {
+            id: config.id,
+            variableMapping: preparedMapping.variableMapping,
+          };
+        });
         const latestProjectTemplate = existingProjectTemplates[0];
 
         const template = await tx.evalTemplate.create({

--- a/web/src/features/evals/types.ts
+++ b/web/src/features/evals/types.ts
@@ -1,11 +1,6 @@
 import { z } from "zod";
 import { JobConfigState, type JobConfiguration } from "@langfuse/shared";
 
-export enum EvalReferencedEvaluators {
-  UPDATE = "update",
-  PERSIST = "persist",
-}
-
 export const EvaluatorStatus = JobConfigState;
 export const EvaluatorStatusSchema = z.enum(EvaluatorStatus);
 export type EvaluatorStatusType = z.infer<typeof EvaluatorStatusSchema>;

--- a/web/src/features/evals/utils/eval-template-family.ts
+++ b/web/src/features/evals/utils/eval-template-family.ts
@@ -1,0 +1,5 @@
+import { type EvalTemplate } from "@langfuse/shared";
+
+export const getEvalTemplateFamilyKey = (
+  template: Pick<EvalTemplate, "projectId" | "name" | "type">,
+) => `${template.projectId ?? "langfuse"}:${template.type}:${template.name}`;

--- a/web/src/features/evals/utils/template-form-schema.ts
+++ b/web/src/features/evals/utils/template-form-schema.ts
@@ -9,7 +9,6 @@ import {
   ScoreDataTypeEnum,
   ZodModelConfig,
 } from "@langfuse/shared";
-import { EvalReferencedEvaluators } from "@/src/features/evals/types";
 
 const selectedModelSchema = z.object({
   provider: z.string().min(1, "Select a provider"),
@@ -58,10 +57,6 @@ export const templateFormSchema = z
     reasoningDescription: z.string().optional(),
     categories: z.array(categoricalOptionSchema).default([]),
     shouldAllowMultipleMatches: z.boolean().default(false),
-    referencedEvaluators: z
-      .enum(EvalReferencedEvaluators)
-      .optional()
-      .default(EvalReferencedEvaluators.PERSIST),
     shouldUseDefaultModel: z.boolean().default(true),
   })
   .superRefine((value, ctx) => {

--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -28,6 +28,7 @@ import { useEvaluatorDefaults } from "@/src/features/experiments/hooks/useEvalua
 import { useExperimentEvaluatorData } from "@/src/features/experiments/hooks/useExperimentEvaluatorData";
 import { useExperimentNameValidation } from "@/src/features/experiments/hooks/useExperimentNameValidation";
 import { useExperimentPromptData } from "@/src/features/experiments/hooks/useExperimentPromptData";
+import { getExistingEvaluators } from "@/src/features/experiments/hooks/useExperimentEvaluatorSelection";
 import { getFinalModelParams } from "@/src/utils/getFinalModelParams";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { Skeleton } from "@/src/components/ui/skeleton";
@@ -148,7 +149,7 @@ export const MultiStepExperimentForm = ({
     },
   );
 
-  const evalTemplates = api.evals.allTemplates.useQuery(
+  const evalTemplates = api.evals.latestTemplates.useQuery(
     { projectId },
     {
       enabled: hasEvalReadAccess,
@@ -158,9 +159,6 @@ export const MultiStepExperimentForm = ({
   const { createDefaultEvaluator } = useEvaluatorDefaults();
 
   const {
-    activeEvaluators,
-    pausedEvaluators,
-    evaluatorTargetObjects,
     selectedEvaluatorData,
     showEvaluatorForm,
     handleConfigureEvaluator,
@@ -323,10 +321,11 @@ export const MultiStepExperimentForm = ({
   }, [experimentName, form]);
 
   // Get evaluator names for review step
-  const activeEvaluatorNames =
-    evalTemplates.data?.templates
-      .filter((t) => activeEvaluators.includes(t.id))
-      .map((t) => t.name) ?? [];
+  const activeEvaluatorNames = Object.values(
+    getExistingEvaluators(evaluators.data, datasetId),
+  )
+    .filter((evaluator) => evaluator.isActive)
+    .map((evaluator) => evaluator.templateName);
 
   // Get dataset info for review step
   const selectedDataset = datasets.data?.find((d) => d.id === datasetId);
@@ -408,9 +407,6 @@ export const MultiStepExperimentForm = ({
     },
   };
   const evaluatorState = {
-    activeEvaluators,
-    pausedEvaluators,
-    evaluatorTargetObjects,
     evalTemplates: evalTemplates.data?.templates ?? [],
     activeEvaluatorNames,
     selectedEvaluatorData,
@@ -419,7 +415,6 @@ export const MultiStepExperimentForm = ({
     handleCloseEvaluatorForm,
     handleEvaluatorSuccess,
     handleSelectEvaluator,
-    handleEvaluatorToggled: () => evaluators.refetch(),
     preprocessFormValues,
   };
   const permissions = { hasEvalReadAccess, hasEvalWriteAccess };

--- a/web/src/features/experiments/components/steps/EvaluatorsStep.tsx
+++ b/web/src/features/experiments/components/steps/EvaluatorsStep.tsx
@@ -19,16 +19,12 @@ export const EvaluatorsStep: React.FC<EvaluatorsStepProps> = ({
 }) => {
   const {
     evalTemplates,
-    activeEvaluators,
-    pausedEvaluators,
-    evaluatorTargetObjects,
     selectedEvaluatorData,
     showEvaluatorForm,
     handleConfigureEvaluator,
     handleSelectEvaluator,
     handleCloseEvaluatorForm,
     handleEvaluatorSuccess,
-    handleEvaluatorToggled,
     preprocessFormValues,
   } = evaluatorState;
   const { hasEvalReadAccess, hasEvalWriteAccess } = permissions;
@@ -48,10 +44,6 @@ export const EvaluatorsStep: React.FC<EvaluatorsStepProps> = ({
             evalTemplates={evalTemplates}
             onConfigureTemplate={handleConfigureEvaluator}
             onSelectEvaluator={handleSelectEvaluator}
-            onEvaluatorToggled={handleEvaluatorToggled}
-            activeTemplateIds={activeEvaluators}
-            inactiveTemplateIds={pausedEvaluators}
-            evaluatorTargetObjects={evaluatorTargetObjects}
             disabled={!hasEvalWriteAccess}
           />
         ) : (

--- a/web/src/features/experiments/hooks/useExperimentEvaluatorData.ts
+++ b/web/src/features/experiments/hooks/useExperimentEvaluatorData.ts
@@ -1,61 +1,7 @@
-import { useState, useCallback, useMemo } from "react";
-import {
-  type EvalTemplate,
-  EvalTemplateType,
-  isJobConfigExecutable,
-  JobConfigState,
-} from "@langfuse/shared";
+import { useState, useCallback } from "react";
+import { type EvalTemplate, EvalTemplateType } from "@langfuse/shared";
 import { type RouterOutputs } from "@/src/utils/api";
 import { type PartialConfig } from "@/src/features/evals/types";
-
-const partitionEvaluators = (
-  evaluators: RouterOutputs["evals"]["jobConfigsByTarget"] | undefined,
-  datasetId: string,
-): {
-  activeEvaluators: string[];
-  pausedEvaluators: string[];
-  evaluatorTargetObjects: Record<string, string>;
-} => {
-  const filteredEvaluators =
-    evaluators?.filter(({ filter }) => {
-      if (filter?.length === 0) return true;
-      return filter?.some(
-        ({ type, value }) =>
-          type === "stringOptions" && value.includes(datasetId),
-      );
-    }) || [];
-
-  const activeEvaluators = filteredEvaluators.filter((evaluator) =>
-    isJobConfigExecutable({
-      status: evaluator.status,
-      blockedAt: evaluator.blockedAt,
-    }),
-  );
-  const pausedEvaluators = filteredEvaluators.filter(
-    (evaluator) =>
-      evaluator.status === JobConfigState.ACTIVE &&
-      evaluator.blockedAt !== null,
-  );
-
-  const activeIds = activeEvaluators.map(
-    (evaluator) => evaluator.evalTemplateId,
-  );
-  const pausedIds = pausedEvaluators.map(
-    (evaluator) => evaluator.evalTemplateId,
-  );
-
-  // Build a map of template ID to target object for displaying legacy badges
-  const evaluatorTargetObjects: Record<string, string> = {};
-  for (const evaluator of filteredEvaluators) {
-    evaluatorTargetObjects[evaluator.evalTemplateId] = evaluator.targetObject;
-  }
-
-  return {
-    activeEvaluators: activeIds,
-    pausedEvaluators: pausedIds,
-    evaluatorTargetObjects,
-  };
-};
 
 interface UseExperimentEvaluatorDataProps {
   datasetId: string;
@@ -176,18 +122,10 @@ export function useExperimentEvaluatorData({
     [prepareEvaluatorData],
   );
 
-  const { activeEvaluators, pausedEvaluators, evaluatorTargetObjects } =
-    useMemo(() => {
-      return partitionEvaluators(evaluatorsData, datasetId);
-    }, [evaluatorsData, datasetId]);
-
   return {
     // State
     selectedEvaluatorData,
     showEvaluatorForm,
-    activeEvaluators,
-    pausedEvaluators,
-    evaluatorTargetObjects,
 
     // Handlers
     handleConfigureEvaluator,

--- a/web/src/features/experiments/hooks/useExperimentEvaluatorSelection.ts
+++ b/web/src/features/experiments/hooks/useExperimentEvaluatorSelection.ts
@@ -1,112 +1,113 @@
-import { api } from "@/src/utils/api";
-import { useState, useCallback, useEffect } from "react";
+import { api, type RouterOutputs } from "@/src/utils/api";
+import { useMemo } from "react";
+import { isJobConfigExecutable } from "@langfuse/shared";
+import { getEvalTemplateFamilyKey } from "@/src/features/evals/utils/eval-template-family";
 
-type TemplateSelectionHookProps = {
-  projectId: string;
-  datasetId: string;
-  initialActiveTemplateIds?: string[];
-  initialInactiveTemplateIds?: string[];
-  onSelectEvaluator?: (templateId: string) => void;
-  onEvaluatorToggled?: () => void;
+/**
+ * One entry per evaluator family that already has a job config for this
+ * dataset. A non-executable config (deactivated or blocked) renders as
+ * "paused"; an active config wins if a family has several configs.
+ */
+export const getExistingEvaluators = (
+  jobConfigs: RouterOutputs["evals"]["jobConfigsByTarget"] | undefined,
+  datasetId: string,
+) => {
+  const result: Record<
+    string,
+    {
+      evalTemplateId: string;
+      targetObject: string;
+      templateName: string;
+      isActive: boolean;
+    }
+  > = {};
+
+  for (const jobConfig of jobConfigs ?? []) {
+    const matchesDataset =
+      jobConfig.filter?.length === 0 ||
+      jobConfig.filter?.some(
+        ({ type, value }) =>
+          type === "stringOptions" && value.includes(datasetId),
+      );
+    if (!matchesDataset || !jobConfig.evalTemplate) continue;
+
+    const familyKey = getEvalTemplateFamilyKey(jobConfig.evalTemplate);
+    const isActive = isJobConfigExecutable({
+      status: jobConfig.status,
+      blockedAt: jobConfig.blockedAt,
+    });
+    if (result[familyKey]?.isActive && !isActive) continue;
+
+    result[familyKey] = {
+      evalTemplateId: jobConfig.evalTemplate.id,
+      targetObject: jobConfig.targetObject,
+      templateName: jobConfig.evalTemplate.name,
+      isActive,
+    };
+  }
+
+  return result;
 };
 
 /**
- * Hook to manage the entire template selection state and lifecycle
- * Handles both pending templates (awaiting configuration) and confirmed selections
+ * Owns the existing-evaluator state for the template selector: fetches the
+ * dataset's job configs, derives per-family selection state, and toggles
+ * existing configs. Selecting a family without a config is delegated to
+ * `onSelectEvaluator` (opens the create form).
  */
 export function useExperimentEvaluatorSelection({
   projectId,
   datasetId,
-  initialActiveTemplateIds = [],
-  initialInactiveTemplateIds = [],
   onSelectEvaluator,
-  onEvaluatorToggled,
-}: TemplateSelectionHookProps) {
-  // Track confirmed selections
-  const [activeTemplates, setActiveTemplates] = useState<string[]>(
-    initialActiveTemplateIds,
+}: {
+  projectId: string;
+  datasetId: string;
+  onSelectEvaluator?: (templateId: string) => void;
+}) {
+  const utils = api.useUtils();
+  const jobConfigs = api.evals.jobConfigsByTarget.useQuery(
+    { projectId, targetObject: ["dataset", "experiment"] },
+    { enabled: !!datasetId },
   );
 
-  const [inactiveTemplates, setInactiveTemplates] = useState<string[]>(
-    initialInactiveTemplateIds,
+  const existingEvaluators = useMemo(
+    () => getExistingEvaluators(jobConfigs.data, datasetId),
+    [jobConfigs.data, datasetId],
   );
-  // Keep the active templates in sync with the initialActiveTemplateIds prop
-  useEffect(() => {
-    setActiveTemplates(initialActiveTemplateIds);
-  }, [initialActiveTemplateIds]);
-
-  // Keep the inactive templates in sync with the initialInactiveTemplateIds prop
-  useEffect(() => {
-    setInactiveTemplates(initialInactiveTemplateIds);
-  }, [initialInactiveTemplateIds]);
 
   const updateStatus =
     api.evals.updateAllDatasetEvalJobStatusByTemplateId.useMutation({
-      onSuccess: (_, variables) => {
-        if (variables.newStatus === "INACTIVE") {
-          setActiveTemplates((prev) =>
-            prev.filter((id) => id !== variables.evalTemplateId),
-          );
-          setInactiveTemplates((prev) => [...prev, variables.evalTemplateId]);
-        } else {
-          setActiveTemplates((prev) => [...prev, variables.evalTemplateId]);
-          setInactiveTemplates((prev) =>
-            prev.filter((id) => id !== variables.evalTemplateId),
-          );
-        }
-
-        // Notify parent to refetch evaluators
-        onEvaluatorToggled?.();
-      },
+      // Refreshes every consumer of the query, incl. the parent forms.
+      onSuccess: () => utils.evals.jobConfigsByTarget.invalidate(),
     });
 
-  const setTemplateSelected = useCallback(
-    (templateId: string) => {
-      templateId;
-      // Notify parent that a template was marked as pending
-      if (onSelectEvaluator) {
-        onSelectEvaluator(templateId);
-      }
-    },
-    [onSelectEvaluator],
-  );
+  const isTemplateActive = (familyKey: string) =>
+    Boolean(existingEvaluators[familyKey]?.isActive);
 
-  // Selection status methods
-  const isTemplateActive = useCallback(
-    (templateId: string) => {
-      return activeTemplates.includes(templateId);
-    },
-    [activeTemplates],
-  );
+  const isTemplateInactive = (familyKey: string) => {
+    const evaluator = existingEvaluators[familyKey];
+    return Boolean(evaluator && !evaluator.isActive);
+  };
 
-  const isTemplateInactive = useCallback(
-    (templateId: string) => inactiveTemplates.includes(templateId),
-    [inactiveTemplates],
-  );
+  const handleRowClick = (templateId: string, familyKey: string) => {
+    const existingEvaluator = existingEvaluators[familyKey];
 
-  const handleRowClick = (templateId: string) => {
-    if (isTemplateActive(templateId)) {
-      updateStatus.mutate({
-        projectId,
-        evalTemplateId: templateId,
-        datasetId,
-        newStatus: "INACTIVE",
-      });
-    } else if (isTemplateInactive(templateId)) {
-      updateStatus.mutate({
-        projectId: projectId,
-        evalTemplateId: templateId,
-        datasetId,
-        newStatus: "ACTIVE",
-      });
-    } else {
-      setTemplateSelected(templateId);
+    if (!existingEvaluator) {
+      onSelectEvaluator?.(templateId);
+      return;
     }
+
+    updateStatus.mutate({
+      projectId,
+      evalTemplateId: existingEvaluator.evalTemplateId,
+      datasetId,
+      newStatus: existingEvaluator.isActive ? "INACTIVE" : "ACTIVE",
+    });
   };
 
   return {
     // State
-    activeTemplates,
+    existingEvaluators,
 
     // Action
     handleRowClick,

--- a/web/src/features/experiments/types/stepProps.ts
+++ b/web/src/features/experiments/types/stepProps.ts
@@ -77,9 +77,6 @@ export type DatasetState = {
 };
 
 export type EvaluatorState = {
-  activeEvaluators: string[];
-  pausedEvaluators: string[];
-  evaluatorTargetObjects: Record<string, string>;
   evalTemplates: EvalTemplate[];
   activeEvaluatorNames: string[];
   selectedEvaluatorData: EvaluatorData | null;
@@ -88,7 +85,6 @@ export type EvaluatorState = {
   handleCloseEvaluatorForm: () => void;
   handleEvaluatorSuccess: () => void;
   handleSelectEvaluator: (templateId: string) => void;
-  handleEvaluatorToggled: () => void;
   preprocessFormValues: (values: any) => any;
 };
 

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/experiments/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/experiments/index.tsx
@@ -115,7 +115,7 @@ export default function Dataset() {
     scope: "evalJob:CUD",
   });
 
-  const evalTemplates = api.evals.allTemplates.useQuery({
+  const evalTemplates = api.evals.latestTemplates.useQuery({
     projectId,
   });
 
@@ -129,9 +129,6 @@ export default function Dataset() {
   const { createDefaultEvaluator } = useEvaluatorDefaults();
 
   const {
-    activeEvaluators,
-    pausedEvaluators,
-    evaluatorTargetObjects,
     selectedEvaluatorData,
     showEvaluatorForm,
     handleConfigureEvaluator,
@@ -200,9 +197,6 @@ export default function Dataset() {
                     evalTemplates={evalTemplates.data?.templates ?? []}
                     onConfigureTemplate={handleConfigureEvaluator}
                     onSelectEvaluator={handleSelectEvaluator}
-                    activeTemplateIds={activeEvaluators}
-                    inactiveTemplateIds={pausedEvaluators}
-                    evaluatorTargetObjects={evaluatorTargetObjects}
                     disabled={!hasEvalWriteAccess}
                   />
                 </div>
@@ -280,9 +274,6 @@ export default function Dataset() {
                   evalTemplates={evalTemplates.data?.templates ?? []}
                   onConfigureTemplate={handleConfigureEvaluator}
                   onSelectEvaluator={handleSelectEvaluator}
-                  activeTemplateIds={activeEvaluators}
-                  inactiveTemplateIds={pausedEvaluators}
-                  evaluatorTargetObjects={evaluatorTargetObjects}
                   disabled={!hasEvalWriteAccess}
                 />
               </div>


### PR DESCRIPTION
## Summary

- Production analysis showed evaluators silently pinned to stale template versions, actively produced by three UI paths: creating a template with an existing name silently bumped the family version *without* updating referencing evaluators (the update-flag defaulted client-side and two paths bypassed it), the template selectors consumed an unordered template list and assumed the last row per name was the latest version, and deactivated evaluators rendered as unchecked rows after reload, minting duplicate configs on re-selection.
- `evals.createTemplate` now takes an explicit intent — `new` (rejects duplicate names, with live inline validation + link to the existing template), `new-version` (**always** updates referencing evaluators, including inactive ones), or `clone` (retargeting stays an explicit dialog choice). The `EvalReferencedEvaluators` PERSIST/UPDATE flag is removed; the update decision is enforced server-side instead of via client-side form defaults.
- Updates are protected by the variable-mapping guard shared with the public API: a new version that would leave a referencing evaluator without mappings fails closed with an actionable error, and the sweep now rewrites `variableMapping` alongside the template pointer (the old tRPC path only repointed — a latent bug).
- `evals.createJob` resolves the referenced template to its family's latest version at insert time, so stale client state can't create evaluators born on old versions.
- New `evals.latestTemplates` endpoint (one row per `(project, name, type)` family) feeds the selectors; selector state is keyed by family instead of version id, and existing-evaluator state (active/paused) is derived from server data — deactivated evaluators now survive reloads as "Paused" with a working reactivation path.

## Linear

- None

## Major Decisions

- **No more PERSIST**: referencing evaluators always follow the family's latest version; deliberate pinning survives only as the clone dialog's "keep as is". Rationale: every silent-pinning path found in prod data was accidental, and the mapping guard makes the sweep safe.
- **Enforcement moved server-side**: the old client-computed default had two structural bypasses (new-template-with-existing-name never ran the check; fast submits raced it). Intent is now part of the API contract via a discriminated union.

## Review Focus

- `router.ts` `createTemplate` transaction: intent switch, sweep scope (includes INACTIVE configs — intentional), and the mapping rewrite.
- `createJob`'s silent latest-resolution has a known edge we deferred: a form opened against an old version can submit a mapping that misses variables added in the latest version — the guard isn't applied on this path yet (follow-up).
- Behavior change worth a product eye: deactivated evaluators now show as "Paused" in the experiment selector after reload (previously unchecked → duplicate-creation trap).
- `latestTemplates` uses Prisma's engine-side `distinct` (all versions fetched app-side, deduped there) — fine at current table sizes, `nativeDistinct` is the escape hatch if it ever matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a set of related bugs where evaluators could silently stay pinned to stale template versions: the `createTemplate` mutation now requires an explicit `intent` discriminated union (`new` / `new-version` / `clone`), the new `latestTemplates` endpoint feeds all selectors with exactly one row per family, and `createJob` resolves the submitted template ID to the family's latest version at insert time.

- **Server side (`router.ts`)**: the `createTemplate` transaction enforces the intent contract, sweeps referencing job configs (including INACTIVE ones) to the new template while rewriting `variableMapping`, and guards against missing-variable regressions. The `createJob` path now silently upgrades a stale `evalTemplateId` to the latest family version and applies the same mapping guard.
- **Client side**: selector state is now derived entirely from the `jobConfigsByTarget` query (keyed by family rather than version id), removing the client-side active/paused arrays and the duplicate-creation trap for deactivated evaluators.
- **Minor issues**: the version counter in `createTemplate` reads `existingProjectTemplatesByName[0]` (cross-type) rather than the type-filtered list, which can produce non-sequential version numbers for projects that pre-date the new name-uniqueness constraint; the `\"new\"` intent also fires its conflict error on cross-type name matches with a misleading message.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the transaction and mapping guard are correct, and the stale-resolution path in createJob does the right thing.

The core logic — transaction ordering, variable-mapping guard, family-key deduplication, and cache invalidation — is all correct and well-tested. The two flagged issues affect only projects with legacy same-name cross-type templates (blocked by the new intent going forward) or the wording of an error message; neither causes data loss or incorrect evaluator execution.

web/src/features/evals/server/router.ts around the version counter (line 1367) and the 'new' intent conflict check (line 1272); web/src/features/evals/components/template-form.tsx for the allTemplates vs latestTemplates query choice.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Client UI
    participant tRPC as tRPC Router
    participant DB as Database

    Note over UI,DB: createTemplate — new-version intent
    UI->>tRPC: "createTemplate({intent:"new-version", sourceTemplateId, ...})"
    tRPC->>DB: findMany(name, projectId) — cross-type
    DB-->>tRPC: existingProjectTemplatesByName[]
    tRPC->>tRPC: filter by type → existingProjectTemplates[]
    tRPC->>DB: findMany(jobConfiguration WHERE evalTemplateId IN [...])
    DB-->>tRPC: configsToUpgrade[]
    tRPC->>tRPC: prepareConfigsForTemplateUpgrade() — throws on missing vars
    tRPC->>DB: "evalTemplate.create(version = existingProjectTemplatesByName[0].version + 1)"
    DB-->>tRPC: newTemplate
    tRPC->>DB: "jobConfiguration.update(evalTemplateId = newTemplate.id, variableMapping)"
    tRPC-->>UI: "{template, updatedConfigCount}"

    Note over UI,DB: createJob — stale template resolution
    UI->>tRPC: "createJob({evalTemplateId: staleId, mapping})"
    tRPC->>DB: "findFirst(id = staleId)"
    DB-->>tRPC: evalTemplate (stale)
    tRPC->>DB: findFirst(projectId, name, type ORDER BY version DESC)
    DB-->>tRPC: latestEvalTemplate
    tRPC->>tRPC: prepareVariableMappingForEvaluatorUpgrade() — throws on missing vars
    tRPC->>DB: "jobConfiguration.create(evalTemplateId = latestTemplate.id)"
    tRPC-->>UI: "{id}"

    Note over UI,DB: latestTemplates — selector feed
    UI->>tRPC: "latestTemplates({projectId, limit, page})"
    tRPC->>DB: "findMany(distinct=[projectId,name,type] ORDER BY version DESC)"
    DB-->>tRPC: all templates (app-side dedup)
    tRPC->>tRPC: "slice(page*limit, page*limit+limit)"
    tRPC-->>UI: "{templates[], totalCount}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Client UI
    participant tRPC as tRPC Router
    participant DB as Database

    Note over UI,DB: createTemplate — new-version intent
    UI->>tRPC: "createTemplate({intent:"new-version", sourceTemplateId, ...})"
    tRPC->>DB: findMany(name, projectId) — cross-type
    DB-->>tRPC: existingProjectTemplatesByName[]
    tRPC->>tRPC: filter by type → existingProjectTemplates[]
    tRPC->>DB: findMany(jobConfiguration WHERE evalTemplateId IN [...])
    DB-->>tRPC: configsToUpgrade[]
    tRPC->>tRPC: prepareConfigsForTemplateUpgrade() — throws on missing vars
    tRPC->>DB: "evalTemplate.create(version = existingProjectTemplatesByName[0].version + 1)"
    DB-->>tRPC: newTemplate
    tRPC->>DB: "jobConfiguration.update(evalTemplateId = newTemplate.id, variableMapping)"
    tRPC-->>UI: "{template, updatedConfigCount}"

    Note over UI,DB: createJob — stale template resolution
    UI->>tRPC: "createJob({evalTemplateId: staleId, mapping})"
    tRPC->>DB: "findFirst(id = staleId)"
    DB-->>tRPC: evalTemplate (stale)
    tRPC->>DB: findFirst(projectId, name, type ORDER BY version DESC)
    DB-->>tRPC: latestEvalTemplate
    tRPC->>tRPC: prepareVariableMappingForEvaluatorUpgrade() — throws on missing vars
    tRPC->>DB: "jobConfiguration.create(evalTemplateId = latestTemplate.id)"
    tRPC-->>UI: "{id}"

    Note over UI,DB: latestTemplates — selector feed
    UI->>tRPC: "latestTemplates({projectId, limit, page})"
    tRPC->>DB: "findMany(distinct=[projectId,name,type] ORDER BY version DESC)"
    DB-->>tRPC: all templates (app-side dedup)
    tRPC->>tRPC: "slice(page*limit, page*limit+limit)"
    tRPC-->>UI: "{templates[], totalCount}"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/features/evals/server/router.ts:1367-1369
**Version counter spans across template types**

`existingProjectTemplatesByName` is fetched without a type filter, so `existingProjectTemplatesByName[0]` (the row with the highest version across _all_ types for this name) drives the version number of the new template. For any project that already contains, say, an LLM "foo" at v3 and a CODE "foo" at v1, creating a "new-version" for the CODE family would generate v4 — skipping v2 and v3 for that type family. This is a latent issue for projects that pre-date the "new" intent (which now prevents same-name cross-type templates going forward). Using `existingProjectTemplates[0]` (already filtered to the correct type) would correctly produce the next sequential version within the family.

```suggestion
        const latestTemplate = existingProjectTemplates[0] ?? existingProjectTemplatesByName[0];
        const baseTemplateData = {
          version: (latestTemplate?.version ?? 0) + 1,
```

### Issue 2 of 3
web/src/features/evals/components/template-form.tsx:378-383
**Inline validation fetches all template versions instead of the latest per family**

`api.evals.allTemplates` returns every version of every template for the project; the code then manually iterates all of them to build the name → latest-version map. `api.evals.latestTemplates` already returns exactly one row per family and would serve the same purpose at lower cost, especially for projects with many template versions.

```suggestion
  const existingTemplatesQuery = api.evals.latestTemplates.useQuery(
    { projectId: props.projectId },
    {
      enabled: isNewTemplate,
    },
  );
```

### Issue 3 of 3
web/src/features/evals/server/router.ts:1272-1277
**`"new"` intent blocks cross-type same-name creation with misleading guidance**

`existingProjectTemplatesByName` is cross-type, so the conflict error fires even when the existing template has a _different_ type (e.g. LLM "foo" exists, user tries to create CODE "foo"). The message then says "Open it to create a new version", but following that link leads to the LLM template — and there is no UI path from there to create a CODE template of the same name. Projects pre-dating this PR that already have same-name, cross-type templates would hit this dead end. Scoping the check to `existingProjectTemplates` (already filtered by `input.type`) would only block genuine same-family conflicts, which is what the message describes; a separate check can still reject the truly novel cross-type case if that restriction is intended.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): keep evaluators on latest eva..."](https://github.com/langfuse/langfuse/commit/24b730c1ecc7ad41bf6ecc310f52764160fb51f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42689121)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->