### PR TITLE
feat(support): gate Sev-1/Sev-2 to Enterprise and confirm Sev-1 requests

### DIFF
--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -178,6 +178,56 @@ async function main() {
     },
   });
 
+  // Enterprise org to exercise Enterprise-gated flows locally (e.g. Sev-1 /
+  // Sev-2 support requests are Enterprise-only).
+  const enterpriseOrgId = "seed-enterprise-org-id";
+  const enterpriseProjectId = "3b1f5a62-7c4e-4d09-9c8b-1f2a3d4e5f6a";
+  await prisma.organization.upsert({
+    where: { id: enterpriseOrgId },
+    update: {
+      name: "Seed Enterprise Org",
+      cloudConfig: {
+        plan: "Enterprise",
+      },
+    },
+    create: {
+      id: enterpriseOrgId,
+      name: "Seed Enterprise Org",
+      aiFeaturesEnabled: true,
+      cloudConfig: {
+        plan: "Enterprise",
+      },
+    },
+  });
+
+  await prisma.project.upsert({
+    where: { id: enterpriseProjectId },
+    update: {
+      name: "enterprise-app",
+      orgId: enterpriseOrgId,
+    },
+    create: {
+      id: enterpriseProjectId,
+      name: "enterprise-app",
+      orgId: enterpriseOrgId,
+    },
+  });
+
+  await prisma.organizationMembership.upsert({
+    where: {
+      orgId_userId: {
+        userId: user.id,
+        orgId: enterpriseOrgId,
+      },
+    },
+    create: {
+      userId: user.id,
+      orgId: enterpriseOrgId,
+      role: "OWNER",
+    },
+    update: {},
+  });
+
   const summaryPrompt = await prisma.prompt.upsert({
     where: {
       projectId_name_version: {

--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -178,56 +178,6 @@ async function main() {
     },
   });
 
-  // Enterprise org to exercise Enterprise-gated flows locally (e.g. Sev-1 /
-  // Sev-2 support requests are Enterprise-only).
-  const enterpriseOrgId = "seed-enterprise-org-id";
-  const enterpriseProjectId = "3b1f5a62-7c4e-4d09-9c8b-1f2a3d4e5f6a";
-  await prisma.organization.upsert({
-    where: { id: enterpriseOrgId },
-    update: {
-      name: "Seed Enterprise Org",
-      cloudConfig: {
-        plan: "Enterprise",
-      },
-    },
-    create: {
-      id: enterpriseOrgId,
-      name: "Seed Enterprise Org",
-      aiFeaturesEnabled: true,
-      cloudConfig: {
-        plan: "Enterprise",
-      },
-    },
-  });
-
-  await prisma.project.upsert({
-    where: { id: enterpriseProjectId },
-    update: {
-      name: "enterprise-app",
-      orgId: enterpriseOrgId,
-    },
-    create: {
-      id: enterpriseProjectId,
-      name: "enterprise-app",
-      orgId: enterpriseOrgId,
-    },
-  });
-
-  await prisma.organizationMembership.upsert({
-    where: {
-      orgId_userId: {
-        userId: user.id,
-        orgId: enterpriseOrgId,
-      },
-    },
-    create: {
-      userId: user.id,
-      orgId: enterpriseOrgId,
-      role: "OWNER",
-    },
-    update: {},
-  });
-
   const summaryPrompt = await prisma.prompt.upsert({
     where: {
       projectId_name_version: {

--- a/web/src/__tests__/supportCaseSeverity.clienttest.ts
+++ b/web/src/__tests__/supportCaseSeverity.clienttest.ts
@@ -13,32 +13,33 @@ import {
   SEVERITY_2,
   SEVERITY_3,
   isSeverityAllowedForPlan,
-  highestSupportPlan,
 } from "@/src/features/support-chat/formConstants";
 
-const HIGH_TIER = "cloud:enterprise"; // may raise Sev-1, Sev-2, Sev-3
-const MID_TIER = "cloud:pro"; // may raise Sev-2, Sev-3
-const LOW_TIER = "cloud:hobby"; // may raise Sev-3 only
-const CORE = "cloud:core"; // may raise Sev-3 only
+const ENTERPRISE = "cloud:enterprise"; // may raise Sev-1, Sev-2, Sev-3
+const SELF_HOSTED_ENTERPRISE = "self-hosted:enterprise"; // same as ENTERPRISE
+const TEAM = "cloud:team"; // may raise Sev-3 only
+const PRO = "cloud:pro"; // may raise Sev-3 only
+const LOW_TIER = "cloud:hobby"; // no case severity at all
+const CORE = "cloud:core"; // no case severity at all
 
 describe("mapToPylonCaseSeverity", () => {
-  it("maps Severity 1 to Sev-1 only on high-tier plans", () => {
+  it("maps Severity 1 to Sev-1 only on Enterprise plans", () => {
     expect(
-      mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: HIGH_TIER }),
+      mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: ENTERPRISE }),
+    ).toBe("Sev-1");
+    expect(
+      mapToPylonCaseSeverity({
+        severity: SEVERITY_1,
+        plan: SELF_HOSTED_ENTERPRISE,
+      }),
     ).toBe("Sev-1");
   });
 
-  it("downgrades Severity 1 to Sev-2 for Pro-tier plans", () => {
-    expect(
-      mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: MID_TIER }),
-    ).toBe("Sev-2");
-  });
-
-  it("downgrades Severity 1 to Sev-3 for Hobby/Core plans", () => {
-    expect(
-      mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: LOW_TIER }),
-    ).toBe("Sev-3");
-    expect(mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: CORE })).toBe(
+  it("downgrades Severity 1 to Sev-3 for non-Enterprise paid plans", () => {
+    expect(mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: TEAM })).toBe(
+      "Sev-3",
+    );
+    expect(mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: PRO })).toBe(
       "Sev-3",
     );
   });
@@ -47,43 +48,63 @@ describe("mapToPylonCaseSeverity", () => {
     expect(mapToPylonCaseSeverity({ severity: SEVERITY_1 })).toBe("Sev-3");
   });
 
-  it("maps Severity 2 to Sev-2 for Pro tier and above", () => {
+  it("maps Severity 2 to Sev-2 only on Enterprise plans", () => {
     expect(
-      mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: HIGH_TIER }),
+      mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: ENTERPRISE }),
     ).toBe("Sev-2");
     expect(
-      mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: MID_TIER }),
+      mapToPylonCaseSeverity({
+        severity: SEVERITY_2,
+        plan: SELF_HOSTED_ENTERPRISE,
+      }),
     ).toBe("Sev-2");
   });
 
-  it("downgrades Severity 2 to Sev-3 for Hobby/Core plans", () => {
-    expect(
-      mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: LOW_TIER }),
-    ).toBe("Sev-3");
-    expect(mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: CORE })).toBe(
+  it("downgrades Severity 2 to Sev-3 for non-Enterprise paid plans", () => {
+    expect(mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: TEAM })).toBe(
+      "Sev-3",
+    );
+    expect(mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: PRO })).toBe(
       "Sev-3",
     );
   });
 
-  it("maps Severity 3 to Sev-3 regardless of plan", () => {
+  it("maps Severity 3 to Sev-3 for eligible plans and unknown plans", () => {
     expect(
-      mapToPylonCaseSeverity({ severity: SEVERITY_3, plan: HIGH_TIER }),
+      mapToPylonCaseSeverity({ severity: SEVERITY_3, plan: ENTERPRISE }),
     ).toBe("Sev-3");
     expect(mapToPylonCaseSeverity({ severity: SEVERITY_3 })).toBe("Sev-3");
+  });
+
+  it("returns no case severity for Hobby/Core plans regardless of selection", () => {
+    for (const severity of [SEVERITY_1, SEVERITY_2, SEVERITY_3]) {
+      expect(
+        mapToPylonCaseSeverity({ severity, plan: LOW_TIER }),
+      ).toBeUndefined();
+      expect(mapToPylonCaseSeverity({ severity, plan: CORE })).toBeUndefined();
+    }
   });
 });
 
 describe("isSeverityAllowedForPlan", () => {
-  it("allows Severity 1 only for high-tier plans", () => {
-    expect(isSeverityAllowedForPlan(SEVERITY_1, HIGH_TIER)).toBe(true);
-    expect(isSeverityAllowedForPlan(SEVERITY_1, MID_TIER)).toBe(false);
+  it("allows Severity 1 only for Enterprise plans", () => {
+    expect(isSeverityAllowedForPlan(SEVERITY_1, ENTERPRISE)).toBe(true);
+    expect(isSeverityAllowedForPlan(SEVERITY_1, SELF_HOSTED_ENTERPRISE)).toBe(
+      true,
+    );
+    expect(isSeverityAllowedForPlan(SEVERITY_1, TEAM)).toBe(false);
+    expect(isSeverityAllowedForPlan(SEVERITY_1, PRO)).toBe(false);
     expect(isSeverityAllowedForPlan(SEVERITY_1, LOW_TIER)).toBe(false);
     expect(isSeverityAllowedForPlan(SEVERITY_1, undefined)).toBe(false);
   });
 
-  it("allows Severity 2 for Pro tier and above but not Hobby/Core", () => {
-    expect(isSeverityAllowedForPlan(SEVERITY_2, HIGH_TIER)).toBe(true);
-    expect(isSeverityAllowedForPlan(SEVERITY_2, MID_TIER)).toBe(true);
+  it("allows Severity 2 only for Enterprise plans", () => {
+    expect(isSeverityAllowedForPlan(SEVERITY_2, ENTERPRISE)).toBe(true);
+    expect(isSeverityAllowedForPlan(SEVERITY_2, SELF_HOSTED_ENTERPRISE)).toBe(
+      true,
+    );
+    expect(isSeverityAllowedForPlan(SEVERITY_2, TEAM)).toBe(false);
+    expect(isSeverityAllowedForPlan(SEVERITY_2, PRO)).toBe(false);
     expect(isSeverityAllowedForPlan(SEVERITY_2, LOW_TIER)).toBe(false);
     expect(isSeverityAllowedForPlan(SEVERITY_2, CORE)).toBe(false);
     expect(isSeverityAllowedForPlan(SEVERITY_2, undefined)).toBe(false);
@@ -95,42 +116,14 @@ describe("isSeverityAllowedForPlan", () => {
   });
 });
 
-describe("highestSupportPlan", () => {
-  it("returns the plan granting the highest severity from a list", () => {
-    expect(highestSupportPlan(["cloud:hobby", "cloud:enterprise"])).toBe(
-      "cloud:enterprise",
-    );
-    expect(highestSupportPlan(["cloud:hobby", "cloud:pro"])).toBe("cloud:pro");
-  });
-
-  it("ignores undefined/empty entries", () => {
-    expect(highestSupportPlan([undefined, "cloud:team", undefined])).toBe(
-      "cloud:team",
-    );
-  });
-
-  it("returns a low-tier plan when that is all the user has", () => {
-    expect(highestSupportPlan(["cloud:hobby", "cloud:core"])).toBe(
-      "cloud:hobby",
-    );
-  });
-
-  it("returns undefined when there are no plans", () => {
-    expect(highestSupportPlan([])).toBeUndefined();
-    expect(highestSupportPlan([undefined])).toBeUndefined();
-  });
-
-  it("a Team/Enterprise member filing off-context can still raise Sev-1", () => {
-    // Regression: support form opened from a no-org page must not wrongly gate.
-    const best = highestSupportPlan(["cloud:hobby", "cloud:enterprise"]);
-    expect(isSeverityAllowedForPlan(SEVERITY_1, best)).toBe(true);
-  });
-});
-
 describe("mapCaseSeverityToPylonPriority", () => {
   it("derives Pylon priority from the effective case severity", () => {
     expect(mapCaseSeverityToPylonPriority("Sev-1")).toBe("urgent");
     expect(mapCaseSeverityToPylonPriority("Sev-2")).toBe("high");
     expect(mapCaseSeverityToPylonPriority("Sev-3")).toBe("low");
+  });
+
+  it("falls back to low priority when there is no case severity", () => {
+    expect(mapCaseSeverityToPylonPriority(undefined)).toBe("low");
   });
 });

--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -52,7 +52,7 @@ import {
 } from "@/src/components/ui/select";
 import { Textarea } from "@/src/components/ui/textarea";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import {
   Dropzone,
@@ -220,6 +220,20 @@ export function SupportFormSection({
     selectedTopic as any,
   );
 
+  // The drawer is globally mounted, so a severity selected under one org's
+  // plan can survive navigation to an org (or no-org page) that no longer
+  // allows it. Snap back to Severity 3 so the visible selection, the Sev-1
+  // confirm dialog, and the submitted value stay consistent with the plan.
+  const selectedSeverity = form.watch("severity");
+  useEffect(() => {
+    if (
+      selectedSeverity &&
+      !isSeverityAllowedForPlan(selectedSeverity, effectivePlan)
+    ) {
+      form.setValue("severity", SEVERITY_3);
+    }
+  }, [selectedSeverity, effectivePlan, form]);
+
   const createSupportThread = api.supportRouter.createSupportThread.useMutation(
     {
       onSuccess: (data) => {
@@ -299,9 +313,12 @@ export function SupportFormSection({
   };
 
   const submitForm = async (values: SupportFormInput) => {
-    const parsed: SupportFormValues = SupportFormSchema.parse(values);
-
     try {
+      // Parse inside the try so a failure surfaces via form.setError below
+      // instead of escaping as an unhandled rejection (the confirm dialog
+      // calls this outside react-hook-form's handleSubmit).
+      const parsed: SupportFormValues = SupportFormSchema.parse(values);
+
       setIsSubmittingLocal(true);
 
       // Validate files using centralized validation function

--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -13,7 +13,6 @@ import {
   type MessageType,
   SupportFormSchema,
   isSeverityAllowedForPlan,
-  highestSupportPlan,
 } from "./formConstants";
 
 import { api } from "@/src/utils/api";
@@ -30,6 +29,16 @@ import {
 } from "@/src/components/ui/form";
 import { RadioGroup } from "@/src/components/ui/radio-group";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/src/components/ui/alert-dialog";
+import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -43,7 +52,6 @@ import {
 } from "@/src/components/ui/select";
 import { Textarea } from "@/src/components/ui/textarea";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { useSession } from "next-auth/react";
 import { useMemo, useState } from "react";
 
 import {
@@ -171,18 +179,12 @@ export function SupportFormSection({
   onSuccess: () => void;
 }) {
   const { organization, project } = useQueryProjectOrOrganization();
-  const session = useSession();
 
   // The support drawer is mounted globally and reachable from pages without an
   // org/project in the URL (home, setup, onboarding, account settings), where
-  // `organization` is null. Fall back to the user's highest-tier org plan so
-  // severity eligibility reflects what the user actually has access to instead
-  // of being wrongly restricted. The server applies the same fallback.
-  const effectivePlan =
-    organization?.plan ??
-    highestSupportPlan(
-      (session.data?.user?.organizations ?? []).map((o) => o.plan),
-    );
+  // `organization` is null. Without an org context the plan is unknown, so
+  // Severity 1/2 are gated there. The server applies the same rule.
+  const effectivePlan = organization?.plan;
 
   // Tracks whether we've already warned about a short message
   const [warnedShortOnce, setWarnedShortOnce] = useState(false);
@@ -196,6 +198,10 @@ export function SupportFormSection({
 
   // Local submit guard to avoid flicker across multiple mutations
   const [isSubmittingLocal, setIsSubmittingLocal] = useState(false);
+
+  // Sev-1 pages the on-call team, so submission requires an explicit
+  // confirmation step.
+  const [sev1ConfirmOpen, setSev1ConfirmOpen] = useState(false);
 
   const form = useForm<SupportFormInput>({
     resolver: zodResolver(SupportFormSchema),
@@ -281,6 +287,19 @@ export function SupportFormSection({
       setWarnedShortOnce(true);
       return;
     }
+
+    // Sev-1 pages the on-call team — require explicit confirmation before
+    // submitting. The dialog's confirm action calls `submitForm` directly.
+    if (parsed.severity === SEVERITY_1) {
+      setSev1ConfirmOpen(true);
+      return;
+    }
+
+    await submitForm(values);
+  };
+
+  const submitForm = async (values: SupportFormInput) => {
+    const parsed: SupportFormValues = SupportFormSchema.parse(values);
 
     try {
       setIsSubmittingLocal(true);
@@ -393,8 +412,8 @@ export function SupportFormSection({
             )}
           />
 
-          {/* Priority (maps to Pylon case_severity). Severity 1 is gated to
-              Team / Enterprise plans. */}
+          {/* Priority (maps to Pylon case_severity). Severity 1 and 2 are
+              gated to Enterprise plans. */}
           <FormField
             control={form.control}
             name="severity"
@@ -428,8 +447,8 @@ export function SupportFormSection({
                             </TooltipTrigger>
                             <TooltipContent className="max-w-xs">
                               {s === SEVERITY_1
-                                ? "Severity 1 is available on the Team and Enterprise plans."
-                                : "Severity 2 is available on the Pro plan and above."}
+                                ? "Severity 1 is available on the Enterprise plan."
+                                : "Severity 2 is available on the Enterprise plan."}
                             </TooltipContent>
                           </Tooltip>
                         ),
@@ -672,6 +691,29 @@ export function SupportFormSection({
           )}
         </form>
       </Form>
+
+      {/* Confirmation gate before a Sev-1 request pages the on-call team. */}
+      <AlertDialog open={sev1ConfirmOpen} onOpenChange={setSev1ConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Confirm Severity 1 (Critical Business Impact)
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Please confirm that your issue has critical business impact. This
+              means it severely impacts your use of Langfuse in production, such
+              as loss of production data, ingestion issues, or prompt fetching
+              issues.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => submitForm(form.getValues())}>
+              Confirm &amp; Submit
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/web/src/features/support-chat/formConstants.ts
+++ b/web/src/features/support-chat/formConstants.ts
@@ -55,34 +55,33 @@ export const SEVERITY_2 = SeveritySchema.options[1];
 export const SEVERITY_3 = SeveritySchema.options[2];
 
 /**
- * Plans that may raise a Severity 1 (Sev-1) support request.
- * Mirrors the high-tier check in `mapToPylonCaseSeverity`.
+ * Plans that may raise Severity 1 (Sev-1) and Severity 2 (Sev-2) support
+ * requests — Enterprise only. All other plans (and free/unknown plans) are
+ * limited to Severity 3. Mirrors the check in `mapToPylonCaseSeverity`.
  */
-export const HIGH_TIER_SUPPORT_PLANS = [
-  "cloud:team",
+export const ENTERPRISE_SUPPORT_PLANS = [
   "cloud:enterprise",
   "self-hosted:enterprise",
 ] as const;
+
+/** Whether the given plan may raise Severity 1/2 support requests. */
+export const isEnterpriseSupportPlan = (plan?: string): boolean =>
+  !!plan && (ENTERPRISE_SUPPORT_PLANS as readonly string[]).includes(plan);
 
 /**
- * Plans that may raise a Severity 2 (Sev-2) support request — Pro tier and
- * above. Hobby/Core (and free/unknown plans) are limited to Severity 3.
+ * Plans whose support requests carry no Pylon `case_severity` at all: the
+ * field is omitted from the issue instead of defaulting to Sev-3. See
+ * `mapToPylonCaseSeverity`.
  */
-export const SEV2_SUPPORT_PLANS = [
-  "cloud:pro",
-  "cloud:team",
-  "cloud:enterprise",
-  "self-hosted:pro",
-  "self-hosted:enterprise",
+export const NO_CASE_SEVERITY_SUPPORT_PLANS = [
+  "cloud:hobby",
+  "cloud:core",
 ] as const;
 
-/** Whether the given plan may raise a Severity 1 support request. */
-export const isHighTierSupportPlan = (plan?: string): boolean =>
-  !!plan && (HIGH_TIER_SUPPORT_PLANS as readonly string[]).includes(plan);
-
-/** Whether the given plan may raise a Severity 2 support request. */
-export const canRaiseSeverity2 = (plan?: string): boolean =>
-  !!plan && (SEV2_SUPPORT_PLANS as readonly string[]).includes(plan);
+/** Whether support requests from the given plan carry no case severity. */
+export const isPlanWithoutCaseSeverity = (plan?: string): boolean =>
+  !!plan &&
+  (NO_CASE_SEVERITY_SUPPORT_PLANS as readonly string[]).includes(plan);
 
 /**
  * Whether a given severity level can be selected on the given plan. Used both
@@ -93,33 +92,9 @@ export const isSeverityAllowedForPlan = (
   severity: string,
   plan?: string,
 ): boolean => {
-  if (severity === SEVERITY_1) return isHighTierSupportPlan(plan);
-  if (severity === SEVERITY_2) return canRaiseSeverity2(plan);
+  if (severity === SEVERITY_1 || severity === SEVERITY_2)
+    return isEnterpriseSupportPlan(plan);
   return true; // Severity 3 is always available
-};
-
-/**
- * Picks the plan granting the highest support severity from a list. Used as a
- * fallback when no specific org/project is in context (e.g. the support form is
- * opened from a page without an org/project in the URL): eligibility should
- * reflect the best plan the user has access to rather than defaulting to none.
- */
-export const highestSupportPlan = (
-  plans: Array<string | undefined>,
-): string | undefined => {
-  const rank = (plan?: string) =>
-    isHighTierSupportPlan(plan) ? 3 : canRaiseSeverity2(plan) ? 2 : 1;
-  let best: string | undefined;
-  let bestRank = 0;
-  for (const plan of plans) {
-    if (!plan) continue;
-    const r = rank(plan);
-    if (r > bestRank) {
-      bestRank = r;
-      best = plan;
-    }
-  }
-  return best;
 };
 
 export const IntegrationTypeSchema = z.enum([

--- a/web/src/features/support-chat/pylon/pylonClient.ts
+++ b/web/src/features/support-chat/pylon/pylonClient.ts
@@ -1,7 +1,7 @@
 import { logger } from "@langfuse/shared/src/server";
 import {
-  isHighTierSupportPlan,
-  canRaiseSeverity2,
+  isEnterpriseSupportPlan,
+  isPlanWithoutCaseSeverity,
   SEVERITY_1,
   SEVERITY_2,
 } from "../formConstants";
@@ -180,7 +180,7 @@ export async function updatePylonAccountCustomFields(
  * consistent.
  */
 export function mapCaseSeverityToPylonPriority(
-  caseSeverity: "Sev-1" | "Sev-2" | "Sev-3",
+  caseSeverity: "Sev-1" | "Sev-2" | "Sev-3" | undefined,
 ): "urgent" | "high" | "low" {
   switch (caseSeverity) {
     case "Sev-1":
@@ -266,25 +266,28 @@ export function mapMessageTypeToPylonQuestionType(messageType: string): string {
  * Maps the user-selected severity level to the Pylon `case_severity` value,
  * capped by what the plan is eligible for.
  *
- * Severity 1 requires a high-tier plan (Team/Enterprise); Severity 2 requires
- * Pro tier or above. These options are disabled in the UI for ineligible plans,
- * but we also enforce it here as a server-side safeguard: a selection above the
- * plan's eligibility is downgraded to the highest level it can raise (a
- * Hobby/Core request therefore never exceeds Sev-3).
+ * Severity 1 and Severity 2 require an Enterprise plan. These options are
+ * disabled in the UI for ineligible plans, but we also enforce it here as a
+ * server-side safeguard: a selection above the plan's eligibility is
+ * downgraded to Sev-3 (a non-Enterprise request therefore never exceeds
+ * Sev-3).
+ *
+ * Hobby/Core requests carry no case severity at all: this returns undefined
+ * and the `case_severity` field is omitted from the Pylon issue.
  */
 export function mapToPylonCaseSeverity(params: {
   severity: string;
   plan?: string;
-}): "Sev-1" | "Sev-2" | "Sev-3" {
+}): "Sev-1" | "Sev-2" | "Sev-3" | undefined {
   const { severity, plan } = params;
 
-  if (severity === SEVERITY_1 && isHighTierSupportPlan(plan)) {
+  if (isPlanWithoutCaseSeverity(plan)) {
+    return undefined;
+  }
+  if (severity === SEVERITY_1 && isEnterpriseSupportPlan(plan)) {
     return "Sev-1";
   }
-  if (
-    (severity === SEVERITY_1 || severity === SEVERITY_2) &&
-    canRaiseSeverity2(plan)
-  ) {
+  if (severity === SEVERITY_2 && isEnterpriseSupportPlan(plan)) {
     return "Sev-2";
   }
   return "Sev-3";

--- a/web/src/features/support-chat/trpc/supportRouter.ts
+++ b/web/src/features/support-chat/trpc/supportRouter.ts
@@ -15,7 +15,6 @@ import {
   SeveritySchema,
   TopicSchema,
   TopicGroups,
-  highestSupportPlan,
 } from "../formConstants";
 
 import {
@@ -150,18 +149,13 @@ export const supportRouter = createTRPCRouter({
       }
 
       // When no specific org/project is in context (the support form is
-      // reachable from pages without org/project in the URL), fall back to the
-      // user's highest-tier org plan. This mirrors the client-side gating so a
-      // legitimate Team/Enterprise user is not silently downgraded.
-      if (!currentSupportRequestContext.plan) {
-        currentSupportRequestContext.plan = highestSupportPlan(
-          ctx.session.user.organizations.map((o) => o.plan),
-        );
-      }
+      // reachable from pages without org/project in the URL), the plan stays
+      // undefined and the request is capped to Sev-3. This mirrors the
+      // client-side gating.
 
-      // Resolve the Pylon case severity (Sev-1/2/3). Sev-1 is gated to
-      // high-tier plans inside mapToPylonCaseSeverity, so a Severity 1 selection
-      // from a non-high-tier plan is safely downgraded server-side.
+      // Resolve the Pylon case severity (Sev-1/2/3). Sev-1 and Sev-2 are
+      // gated to Enterprise plans inside mapToPylonCaseSeverity, so a
+      // selection from a non-Enterprise plan is safely downgraded server-side.
       const caseSeverity = mapToPylonCaseSeverity({
         severity: input.severity,
         plan: currentSupportRequestContext.plan,
@@ -229,10 +223,11 @@ export const supportRouter = createTRPCRouter({
                   ]
                 : []),
               { slug: "langfuse_metadata", value: pylonMetadata },
-              {
-                slug: "case_severity",
-                value: caseSeverity,
-              },
+              // Hobby/Core requests carry no case severity (undefined) — omit
+              // the field entirely instead of writing a default.
+              ...(caseSeverity
+                ? [{ slug: "case_severity", value: caseSeverity }]
+                : []),
             ],
           });
 


### PR DESCRIPTION
## What does this PR do?

Tightens how the support form's **Priority** selection maps to the Pylon `case_severity` field, and adds a confirmation step for Severity 1 requests. Follow-up to #14320.

**Plan gating (was: Sev-1 = Team+, Sev-2 = Pro+):**

| Plan | Selectable in UI | `case_severity` on the Pylon issue | Issue priority |
|---|---|---|---|
| Enterprise (cloud / self-hosted) | Sev-1, Sev-2, Sev-3 | as selected | urgent / high / low |
| Pro, Team, unknown / no org context | Sev-3 only | always `Sev-3` | low |
| Hobby, Core | Sev-3 only | **field omitted entirely** | low |

- Severity 1 and 2 are Enterprise-only. Other plans see both options greyed out with an explanatory hover tooltip, and `mapToPylonCaseSeverity` enforces the same rule server-side (ineligible selections are downgraded, defense-in-depth against hand-crafted tRPC calls).
- **Severity 1 confirmation dialog**: clicking Submit with Sev-1 selected opens an `AlertDialog` ("Please confirm that your issue has critical business impact…") before the thread is created. Cancel keeps the form state intact.
- **Removed the highest-plan fallback** (`highestSupportPlan`): severity eligibility now comes only from the org in URL/request context. An Enterprise member filing from a no-org page (home, setup, account settings) is capped at Sev-3 — previously their best org plan was used. Client and server behave identically.
- **Hobby/Core issues carry no `case_severity` at all**: the custom field is omitted from the Pylon payload instead of defaulting to Sev-3. The user's original selection is still recorded in `langfuse_metadata`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- `src/__tests__/supportCaseSeverity.clienttest.ts` updated to the new matrix: `✓ supportCaseSeverity.clienttest.ts (12 tests)`. The 31 other client-test failures in the full local run also fail on clean `origin/main` (pre-existing, unrelated).
- Pre-commit prettier + turbo lint: `Tasks: 8 successful, 8 total`.
- Browser-reviewed via Playwright against a locally created Enterprise org (not part of this PR): Team org shows Sev-1/Sev-2 greyed out with Enterprise tooltips; Enterprise org has both selectable; Sev-1 submit opens the confirmation dialog; Cancel closes it with zero `createSupportThread` calls; no-org pages gate both options even for an Enterprise member. Did not click "Confirm & Submit" locally (live Pylon key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens support-form priority gating to Enterprise-only for Sev-1 and Sev-2 (previously Team/Pro were also eligible), adds a confirmation `AlertDialog` before a Sev-1 request pages the on-call team, and removes the `highestSupportPlan` fallback so no-org-context pages are always capped at Sev-3.

- **Plan gating overhaul**: `ENTERPRISE_SUPPORT_PLANS` replaces the old tier lists; a new `NO_CASE_SEVERITY_SUPPORT_PLANS` constant causes Hobby/Core requests to omit the `case_severity` Pylon custom field entirely rather than defaulting to Sev-3. Server and client enforce the same rule.
- **Sev-1 confirmation dialog**: `onSubmit` intercepts Sev-1 selections and opens an `AlertDialog`; only `AlertDialogAction` proceeds to `submitForm`, keeping form state intact on cancel.
- **Seeder addition**: a hardcoded Enterprise org/project/membership is added to `seed-postgres.ts` so Enterprise-gated flows are reviewable locally.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the gating logic is correctly mirrored on both client and server, and the Sev-1 confirmation dialog works as described.

The core plan-gating and server-side downgrade logic are solid and well-tested. The one rough edge is `submitForm` being invoked as a floating promise from the dialog's `onClick`, with `SupportFormSchema.parse` sitting outside the try/catch — any exception there would be silently lost. In practice this can't happen (the same values were validated moments earlier in `onSubmit` and the modal blocks re-entry), but the pattern is fragile enough to be worth addressing.

web/src/features/support-chat/SupportFormSection.tsx — the `submitForm` / `AlertDialogAction` async wiring.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant SupportForm
    participant AlertDialog
    participant tRPC
    participant Pylon

    User->>SupportForm: Submit (Sev-1, Enterprise plan)
    SupportForm->>SupportForm: onSubmit() — validate short-message
    SupportForm->>AlertDialog: setSev1ConfirmOpen(true)
    AlertDialog-->>User: Show confirmation dialog

    alt User cancels
        User->>AlertDialog: Click Cancel
        AlertDialog-->>SupportForm: onOpenChange(false)
        SupportForm-->>User: Dialog closes, form state intact
    else User confirms
        User->>AlertDialog: Click Confirm and Submit
        AlertDialog->>SupportForm: onClick → submitForm(form.getValues())
        SupportForm->>SupportForm: SupportFormSchema.parse(values)
        SupportForm->>SupportForm: setIsSubmittingLocal(true)
        SupportForm->>tRPC: createSupportThread.mutateAsync()
        tRPC->>tRPC: mapToPylonCaseSeverity() Enterprise → Sev-1
        tRPC->>Pylon: createPylonIssue priority urgent case_severity Sev-1
        Pylon-->>tRPC: Issue created
        tRPC-->>SupportForm: pylonIssueFailed false
        SupportForm-->>User: Form reset, onSuccess()
    end

    Note over SupportForm,Pylon: Non-Enterprise: Sev-1/2 greyed out in UI, server downgrades to Sev-3. Hobby/Core: case_severity omitted from Pylon payload.
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant SupportForm
    participant AlertDialog
    participant tRPC
    participant Pylon

    User->>SupportForm: Submit (Sev-1, Enterprise plan)
    SupportForm->>SupportForm: onSubmit() — validate short-message
    SupportForm->>AlertDialog: setSev1ConfirmOpen(true)
    AlertDialog-->>User: Show confirmation dialog

    alt User cancels
        User->>AlertDialog: Click Cancel
        AlertDialog-->>SupportForm: onOpenChange(false)
        SupportForm-->>User: Dialog closes, form state intact
    else User confirms
        User->>AlertDialog: Click Confirm and Submit
        AlertDialog->>SupportForm: onClick → submitForm(form.getValues())
        SupportForm->>SupportForm: SupportFormSchema.parse(values)
        SupportForm->>SupportForm: setIsSubmittingLocal(true)
        SupportForm->>tRPC: createSupportThread.mutateAsync()
        tRPC->>tRPC: mapToPylonCaseSeverity() Enterprise → Sev-1
        tRPC->>Pylon: createPylonIssue priority urgent case_severity Sev-1
        Pylon-->>tRPC: Issue created
        tRPC-->>SupportForm: pylonIssueFailed false
        SupportForm-->>User: Form reset, onSuccess()
    end

    Note over SupportForm,Pylon: Non-Enterprise: Sev-1/2 greyed out in UI, server downgrades to Sev-3. Hobby/Core: case_severity omitted from Pylon payload.
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/support-chat/SupportFormSection.tsx:711
**Floating promise from dialog confirm action**

The `onClick` handler fires `submitForm` without awaiting it, leaving an unhandled promise. More importantly, `SupportFormSchema.parse(values)` inside `submitForm` sits *outside* the `try/catch` block (line 302). If it were to throw, the error would be silently swallowed — no `form.setError` call, no spinner reset, and no user-visible feedback. In this specific path (`form.getValues()` after the form already passed `onSubmit` validation) the parse won't realistically throw, but the pattern is fragile; moving the parse inside the `try/catch` would close the gap and also make it safe to `void` the promise explicitly.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(support): gate Sev-1/Sev-2 to Enter..."](https://github.com/langfuse/langfuse/commit/aeb282e09d12fd54dcd94c634c5adace3de65dac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42702223)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
