### PR TITLE
perf(clickhouse): prune blob storage cleanup by primary key during trace deletion

### DIFF
--- a/packages/shared/src/server/data-deletion/ingestionFileDeletion.ts
+++ b/packages/shared/src/server/data-deletion/ingestionFileDeletion.ts
@@ -28,10 +28,15 @@ export const deleteIngestionEventsFromS3AndClickhouseForScores = async (p: {
 };
 
 export const removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces =
-  async (p: { projectId: string; traceIds: string[] }) => {
+  async (p: {
+    projectId: string;
+    traceIds: string[];
+    includeEventsTable?: boolean;
+  }) => {
     const stream = getBlobStorageByProjectIdAndTraceIds(
       p.projectId,
       p.traceIds,
+      { includeEventsTable: p.includeEventsTable ?? false },
     );
 
     return removeIngestionEventsFromS3AndDeleteClickhouseRefs({

--- a/packages/shared/src/server/repositories/blobStorageLog.ts
+++ b/packages/shared/src/server/repositories/blobStorageLog.ts
@@ -99,50 +99,73 @@ export const getBlobStorageByProjectIdAndEntityIds = (
 export const getBlobStorageByProjectIdAndTraceIds = (
   projectId: string,
   traceIds: string[],
+  opts?: { includeEventsTable?: boolean },
 ): AsyncGenerator<BlobStorageFileRefRecordReadType> => {
+  const includeEventsTable = opts?.includeEventsTable ?? false;
+
+  // In v4 events_only write mode spans live only in events_core, not in the
+  // observations table. Include an events_core branch so their blob refs are
+  // cleaned up too. Gated behind a flag because events_core is a dev/v4-only
+  // table (created by clickhouse/scripts/dev-tables.sh, not by migrations) and
+  // self-hosters on legacy write mode may not have it. When disabled the query
+  // must not reference events_core at all.
+  const filteredEventsCoreCte = includeEventsTable
+    ? `, filtered_events_core as (
+      select
+        span_id as entity_id,
+        'observation' as entity_type
+      from events_core
+      where project_id = {projectId: String}
+        and trace_id in ({traceIds: Array(String)})
+    )`
+    : "";
+  const filteredEventsCoreUnion = includeEventsTable
+    ? `
+      union all
+      select * from filtered_events_core`
+    : "";
+
+  // We filter the blob log with a tuple `(entity_type, entity_id) IN (subquery)`
+  // predicate rather than a JOIN. A prepared-set IN predicate on the leading
+  // primary-key columns participates in primary-index analysis, so ClickHouse
+  // can prune granules down to the target entities. A JOIN key does not, which
+  // forced a FINAL scan of the whole project's blob log. The trace entity ids
+  // are exactly the input traceIds, so we build them with arrayJoin instead of
+  // reading the traces table (which is both wasted work and, in events_only
+  // mode where the trace has no traces row, a coverage bug that leaked files).
   const query = `
     with filtered_traces as (
-      select distinct
-        id as entity_id,
-        project_id as project_id,
+      select
+        arrayJoin({traceIds: Array(String)}) as entity_id,
         'trace' as entity_type
-      from traces
-      where project_id = {projectId: String}
-        and id in ({traceIds: Array(String)})
     ), filtered_observations as (
-      select distinct
+      select
         id as entity_id,
-        project_id as project_id,
         'observation' as entity_type
       from observations
       where project_id = {projectId: String}
         and trace_id in ({traceIds: Array(String)})
     ), filtered_scores as (
-      select distinct
+      select
         id as entity_id,
-        project_id as project_id,
         'score' as entity_type
       from scores
       where project_id = {projectId: String}
         and trace_id in ({traceIds: Array(String)})
-    ), filtered_events as (
-      select *
-      from filtered_traces
+    )${filteredEventsCoreCte}, filtered_entities as (
+      select * from filtered_traces
       union all
-      select *
-      from filtered_observations
+      select * from filtered_observations
       union all
-      select *
-      from filtered_scores
+      select * from filtered_scores${filteredEventsCoreUnion}
     )
 
-    -- We use a semi join because we only use the 'filtered_events' as a filter.
-    -- There is no need to build the cartesian product (i.e. the combination) between the event log and the events.
     select el.*
     from blob_storage_file_log el FINAL
-    left semi join filtered_events fe
-    on el.project_id = fe.project_id and el.entity_id = fe.entity_id and el.entity_type = fe.entity_type
     where el.project_id = {projectId: String}
+      and (el.entity_type, el.entity_id) in (
+        select entity_type, entity_id from filtered_entities
+      )
   `;
 
   return queryClickhouseStream<BlobStorageFileRefRecordReadType>({

--- a/worker/src/__tests__/traceDeletion.test.ts
+++ b/worker/src/__tests__/traceDeletion.test.ts
@@ -1,6 +1,9 @@
 import { expect, describe, it, beforeAll, afterEach, vi } from "vitest";
+import waitForExpect from "wait-for-expect";
 import {
   clickhouseClient,
+  createEvent,
+  createEventsCh,
   createObservation,
   createObservationsCh,
   createOrgProjectAndApiKey,
@@ -12,6 +15,8 @@ import {
   getObservationsForTrace,
   getScoresForTraces,
   getTracesByIds,
+  queryClickhouse,
+  removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces,
   StorageService,
   StorageServiceFactory,
 } from "@langfuse/shared/src/server";
@@ -19,6 +24,7 @@ import { randomUUID } from "crypto";
 import { processClickhouseTraceDelete } from "../features/traces/processClickhouseTraceDelete";
 import { env } from "../env";
 import { prisma } from "@langfuse/shared/src/db";
+import { skipUnlessClickhouseTablesExist } from "./helpers/clickhouseTables";
 
 describe("trace deletion", () => {
   let eventStorageService: StorageService;
@@ -468,6 +474,245 @@ describe("trace deletion", () => {
     const eventLog = getBlobStorageByProjectId(projectId);
     for await (const _ of eventLog) {
       // Should never happen as the expect event log to be empty
+      expect(true).toBe(false);
+    }
+
+    const files = await eventStorageService.listFiles(projectId);
+    expect(files).toHaveLength(0);
+  });
+
+  it("should clean up a trace blob ref that has no row in the traces table", async () => {
+    // Setup: a blob ref for a trace whose `traces` row does not exist (e.g. a
+    // project in v4 events_only write mode where traces are not written to the
+    // legacy `traces` table). The old query joined against `traces`, so this
+    // ref was missed and the S3 file leaked.
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId = randomUUID();
+    const bucketPath = `${projectId}/traces/${traceId}-trace.json`;
+
+    await eventStorageService.uploadFile({
+      fileName: bucketPath,
+      fileType: "application/json",
+      data: JSON.stringify({ hello: "world" }),
+    });
+
+    await clickhouseClient().insert({
+      table: "blob_storage_file_log",
+      format: "JSONEachRow",
+      values: [
+        {
+          id: randomUUID(),
+          project_id: projectId,
+          entity_type: "trace",
+          entity_id: traceId,
+          event_id: randomUUID(),
+          bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+          bucket_path: bucketPath,
+          created_at: new Date().getTime(),
+          updated_at: new Date().getTime(),
+        },
+      ],
+    });
+
+    // When: no traces/observations/scores rows exist at all
+    await removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces({
+      projectId,
+      traceIds: [traceId],
+      includeEventsTable: false,
+    });
+
+    // Then: blob ref soft-deleted (invisible under FINAL) and S3 file gone
+    const eventLog = getBlobStorageByProjectId(projectId);
+    for await (const _ of eventLog) {
+      expect(true).toBe(false);
+    }
+
+    const files = await eventStorageService.listFiles(projectId);
+    expect(files).toHaveLength(0);
+  });
+
+  it("should clean up an events-only observation blob ref when includeEventsTable is true", async (ctx) => {
+    await skipUnlessClickhouseTablesExist(
+      ctx,
+      ["events_core"],
+      "events ClickHouse tables are not enabled",
+    );
+
+    // Setup: a span that exists only in the events pipeline (events_full →
+    // events_core via MV), with no row in the legacy `observations` table.
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId = randomUUID();
+    const spanId = randomUUID();
+    const eventTime = Date.now() * 1000; // micros
+
+    await createEventsCh([
+      createEvent({
+        id: spanId,
+        span_id: spanId,
+        trace_id: traceId,
+        project_id: projectId,
+        start_time: eventTime,
+        created_at: eventTime,
+        updated_at: eventTime,
+        event_ts: eventTime,
+      }),
+    ]);
+
+    // The events_core materialized view populates asynchronously; wait for the
+    // span to land before deleting so the query can prune to it.
+    await waitForExpect(async () => {
+      const rows = await queryClickhouse<{ count: string }>({
+        query: `
+          select count(*) as count
+          from events_core
+          where project_id = {projectId: String}
+            and trace_id in ({traceIds: Array(String)})
+        `,
+        params: { projectId, traceIds: [traceId] },
+      });
+      expect(Number(rows[0]?.count ?? 0)).toBe(1);
+    }, 20_000);
+
+    const bucketPath = `${projectId}/observation/${spanId}-observation.json`;
+    await eventStorageService.uploadFile({
+      fileName: bucketPath,
+      fileType: "application/json",
+      data: JSON.stringify({ hello: "world" }),
+    });
+
+    await clickhouseClient().insert({
+      table: "blob_storage_file_log",
+      format: "JSONEachRow",
+      values: [
+        {
+          id: randomUUID(),
+          project_id: projectId,
+          entity_type: "observation",
+          entity_id: spanId,
+          event_id: randomUUID(),
+          bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+          bucket_path: bucketPath,
+          created_at: new Date().getTime(),
+          updated_at: new Date().getTime(),
+        },
+      ],
+    });
+
+    // When
+    await removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces({
+      projectId,
+      traceIds: [traceId],
+      includeEventsTable: true,
+    });
+
+    // Then: blob ref soft-deleted and S3 file removed
+    const eventLog = getBlobStorageByProjectId(projectId);
+    for await (const _ of eventLog) {
+      expect(true).toBe(false);
+    }
+
+    const files = await eventStorageService.listFiles(projectId);
+    expect(files).toHaveLength(0);
+  });
+
+  it("should clean up legacy trace/observation/score blob refs with includeEventsTable false", async () => {
+    // Gating: with the events branch disabled, legacy data backed by the
+    // traces/observations/scores tables must be cleaned exactly as before.
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId = randomUUID();
+    const observationId = randomUUID();
+    const scoreId = randomUUID();
+
+    await createTracesCh([createTrace({ id: traceId, project_id: projectId })]);
+    await createObservationsCh([
+      createObservation({
+        id: observationId,
+        trace_id: traceId,
+        project_id: projectId,
+      }),
+    ]);
+    await createScoresCh([
+      createTraceScore({
+        id: scoreId,
+        trace_id: traceId,
+        project_id: projectId,
+      }),
+    ]);
+
+    const fileType = "application/json";
+    const data = JSON.stringify({ hello: "world" });
+
+    await Promise.all([
+      eventStorageService.uploadFile({
+        fileName: `${projectId}/traces/${traceId}-trace.json`,
+        fileType,
+        data,
+      }),
+      eventStorageService.uploadFile({
+        fileName: `${projectId}/observation/${observationId}-observation.json`,
+        fileType,
+        data,
+      }),
+      eventStorageService.uploadFile({
+        fileName: `${projectId}/score/${scoreId}-score.json`,
+        fileType,
+        data,
+      }),
+    ]);
+
+    await clickhouseClient().insert({
+      table: "blob_storage_file_log",
+      format: "JSONEachRow",
+      values: [
+        {
+          id: randomUUID(),
+          project_id: projectId,
+          entity_type: "trace",
+          entity_id: traceId,
+          event_id: randomUUID(),
+          bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+          bucket_path: `${projectId}/traces/${traceId}-trace.json`,
+          created_at: new Date().getTime(),
+          updated_at: new Date().getTime(),
+        },
+        {
+          id: randomUUID(),
+          project_id: projectId,
+          entity_type: "observation",
+          entity_id: observationId,
+          event_id: randomUUID(),
+          bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+          bucket_path: `${projectId}/observation/${observationId}-observation.json`,
+          created_at: new Date().getTime(),
+          updated_at: new Date().getTime(),
+        },
+        {
+          id: randomUUID(),
+          project_id: projectId,
+          entity_type: "score",
+          entity_id: scoreId,
+          event_id: randomUUID(),
+          bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+          bucket_path: `${projectId}/score/${scoreId}-score.json`,
+          created_at: new Date().getTime(),
+          updated_at: new Date().getTime(),
+        },
+      ],
+    });
+
+    // When
+    await removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces({
+      projectId,
+      traceIds: [traceId],
+      includeEventsTable: false,
+    });
+
+    // Then
+    const eventLog = getBlobStorageByProjectId(projectId);
+    for await (const _ of eventLog) {
       expect(true).toBe(false);
     }
 

--- a/worker/src/features/traces/processClickhouseTraceDelete.ts
+++ b/worker/src/features/traces/processClickhouseTraceDelete.ts
@@ -179,6 +179,7 @@ export const processClickhouseTraceDelete = async (
         ? removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces({
             projectId,
             traceIds,
+            includeEventsTable: v4WritesToEventsTable(env),
           })
         : Promise.resolve(),
       deleteTraces(projectId, traceIds),


### PR DESCRIPTION
getBlobStorageByProjectIdAndTraceIds FINAL-scanned the entire project's
blob_storage_file_log per batch because LEFT SEMI JOIN keys don't
participate in primary-index analysis. Replace the join with a
(entity_type, entity_id) tuple-IN predicate so the read prunes to the
target entities' granules (EXPLAIN: Granules 4/39 on a seeded log).

Also fixes v4 coverage: the trace CTE branch now uses the input trace
ids via arrayJoin instead of reading the traces table, and an optional
events_core branch (gated by the caller via v4WritesToEventsTable) maps
span ids for events-only projects — previously both leaked S3 files and
blob refs in events_only write mode.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces a `LEFT SEMI JOIN` in `getBlobStorageByProjectIdAndTraceIds` with a `(entity_type, entity_id) IN (subquery)` predicate so ClickHouse can prune primary-key granules during trace deletion. It also fixes two coverage gaps in v4 `events_only` write mode: the `filtered_traces` CTE now uses `arrayJoin` on the input IDs instead of joining the `traces` table (which has no rows in events-only mode), and an optional `filtered_events_core` branch (gated by `includeEventsTable`) recovers observation blob refs for spans that only exist in `events_core`.

- **Performance fix**: `IN (subquery)` on `(entity_type, entity_id)` participates in primary-index analysis; the old `LEFT SEMI JOIN` did not, causing a full-project `FINAL` scan per batch.
- **Bug fix (events_only)**: `arrayJoin` on the caller-supplied trace IDs removes the dependency on the `traces` table, so blob refs for traces with no `traces` row are no longer leaked.
- **New coverage**: The `filtered_events_core` CTE (off by default, toggled by `v4WritesToEventsTable`) maps span IDs from `events_core` to observation entity IDs, closing the blob-ref leak for events-only spans.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the query rewrite is well-motivated, the arrayJoin-based trace CTE correctly handles the events_only write mode, and the three new integration tests cover the regression cases.

The core correctness of the change is solid: switching from LEFT SEMI JOIN to a tuple IN predicate is a well-understood ClickHouse optimization and doesn't alter the result set for existing data. The arrayJoin fix for trace blob refs in events_only mode is also straightforward. The one open item is the events_core CTE, which could include NULL span_ids (trace-level events) in the IN subquery — harmless in practice but worth an explicit guard for clarity.

blobStorageLog.ts — specifically the events_core CTE in getBlobStorageByProjectIdAndTraceIds, where a span_id IS NOT NULL guard is missing.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Worker as processClickhouseTraceDelete
    participant Cleanup as removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces
    participant CH as ClickHouse (getBlobStorageByProjectIdAndTraceIds)
    participant S3 as S3 / Blob Storage
    participant Del as deleteTraces / deleteObservations / deleteScores / deleteEvents

    Worker->>Cleanup: "{projectId, traceIds, includeEventsTable: v4WritesToEventsTable}"
    Worker->>Del: (runs concurrently via Promise.all)

    Cleanup->>CH: Stream query (FINAL on blob_storage_file_log)
    Note over CH: WITH filtered_traces AS (arrayJoin traceIds)<br/>filtered_observations (from observations)<br/>filtered_scores (from scores)<br/>[optional] filtered_events_core (from events_core)<br/>WHERE (entity_type, entity_id) IN (filtered_entities)<br/>Primary-index prunes to target granules

    CH-->>Cleanup: Stream of BlobStorageFileRefRecordReadType

    loop per batch of 500
        Cleanup->>S3: deleteFiles(bucket_paths)
        Cleanup->>CH: "INSERT is_deleted=1 (soft-delete refs)"
    end

    Cleanup-->>Worker: done
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Worker as processClickhouseTraceDelete
    participant Cleanup as removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces
    participant CH as ClickHouse (getBlobStorageByProjectIdAndTraceIds)
    participant S3 as S3 / Blob Storage
    participant Del as deleteTraces / deleteObservations / deleteScores / deleteEvents

    Worker->>Cleanup: "{projectId, traceIds, includeEventsTable: v4WritesToEventsTable}"
    Worker->>Del: (runs concurrently via Promise.all)

    Cleanup->>CH: Stream query (FINAL on blob_storage_file_log)
    Note over CH: WITH filtered_traces AS (arrayJoin traceIds)<br/>filtered_observations (from observations)<br/>filtered_scores (from scores)<br/>[optional] filtered_events_core (from events_core)<br/>WHERE (entity_type, entity_id) IN (filtered_entities)<br/>Primary-index prunes to target granules

    CH-->>Cleanup: Stream of BlobStorageFileRefRecordReadType

    loop per batch of 500
        Cleanup->>S3: deleteFiles(bucket_paths)
        Cleanup->>CH: "INSERT is_deleted=1 (soft-delete refs)"
    end

    Cleanup-->>Worker: done
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/repositories/blobStorageLog.ts:114-119
The `filtered_events_core` CTE selects `span_id` from every event under those trace IDs without guarding against NULL. In `events_core`, trace-level events (not spans/observations) typically have a NULL `span_id`. A NULL value in the subquery won't produce a false-positive match — ClickHouse's tuple IN evaluates to NULL for NULL inputs, so no wrong blob ref is deleted — but it does place meaningless `('observation', NULL)` tuples in the set. Adding an explicit `IS NOT NULL` guard communicates intent clearly and avoids inflating the in-set for large trace batches.

```suggestion
      select
        span_id as entity_id,
        'observation' as entity_type
      from events_core
      where project_id = {projectId: String}
        and trace_id in ({traceIds: Array(String)})
        and span_id is not null
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(clickhouse): prune blob storage cle..."](https://github.com/langfuse/langfuse/commit/67bd9c0cfeb083f73af1784483f76a73a8ce34d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42710170)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->