### PR TITLE
fix(datasets): show empty state for filtered run compare

### DIFF
--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -70,13 +70,15 @@ function DatasetCompareRunsTableInternal(props: {
     page: "pageIndex",
     limit: "pageSize",
   });
+  const activeRunFilters = convertToColumnFilterList();
+  const hasActiveRunFilters = activeRunFilters.length > 0;
 
   const datasetItemsWithRunData = api.datasets.datasetItemsWithRunData.useQuery(
     {
       projectId: props.projectId,
       datasetId: props.datasetId,
       runIds: props.runIds,
-      filterByRun: convertToColumnFilterList(),
+      filterByRun: activeRunFilters,
       page: paginationState.pageIndex,
       limit: paginationState.pageSize,
     },
@@ -86,7 +88,7 @@ function DatasetCompareRunsTableInternal(props: {
     projectId: props.projectId,
     datasetId: props.datasetId,
     runIds: props.runIds,
-    filterByRun: convertToColumnFilterList(),
+    filterByRun: activeRunFilters,
   });
 
   const totalCount = totalCountQuery.data?.totalCount ?? null;
@@ -264,7 +266,7 @@ function DatasetCompareRunsTableInternal(props: {
       <FilteredRunPills
         projectId={props.projectId}
         datasetId={props.datasetId}
-        filteredRuns={convertToColumnFilterList()}
+        filteredRuns={activeRunFilters}
         className="px-2 pb-2"
       />
       <DataTable
@@ -298,6 +300,16 @@ function DatasetCompareRunsTableInternal(props: {
           m: "h-64",
           l: "h-96",
         }}
+        noResultsMessage={
+          hasActiveRunFilters ? (
+            <div className="text-muted-foreground flex flex-col items-center gap-1 text-sm">
+              <span>No dataset run items match the current filters.</span>
+              <span className="text-xs">
+                Adjust or clear filters to compare items again.
+              </span>
+            </div>
+          ) : undefined
+        }
         peekView={peekConfig}
       />
       <TablePeekViewTraceDetail {...peekConfig} projectId={props.projectId} />

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1942,6 +1942,10 @@ export const datasetRouter = createTRPCRouter({
         offset: page * limit,
       });
 
+      if (datasetItemIds.length === 0) {
+        return { data: [] };
+      }
+
       // Step 2: Given dataset item ids, lookup dataset run items in clickhouse
       // Note: for each unique dataset item id and dataset run id combination, we will retrieve a dataset run item
       const datasetRunItems = await getDatasetRunItemsWithoutIOByItemIds({


### PR DESCRIPTION
## Summary
- Shows an explicit empty state when dataset run compare filters match no run items
- Reuses the decoded compare filters for the table query, count query, filter pills, and empty-state condition

## Linear
- https://linear.app/langfuse/issue/LFE-7580/bug-if-no-dataset-run-item-matches-the-filters-the-screen-looks-broken

## Impacted packages
- `web`

## Verification
- `eslint src/features/datasets/components/DatasetCompareRunsTable.tsx --max-warnings 0 --no-cache`
- `prettier --check web/src/features/datasets/components/DatasetCompareRunsTable.tsx`
- `git diff --check`

Browser review not run locally because the flow needs an authenticated app with seeded dataset-run compare data.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a UX bug where the dataset run compare table showed a broken-looking blank screen when active filters matched no items. It now displays a descriptive empty state in that case.

- `convertToColumnFilterList()` is now called once per render (stored in `activeRunFilters`) instead of three separate times, and the cached result is reused for the data query, count query, filter pills, and the new empty-state condition.
- A `noResultsMessage` JSX node is conditionally passed to `DataTable` when `hasActiveRunFilters` is true, showing a user-friendly message with guidance to adjust or clear filters.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is minimal and correctly scoped to the empty-state rendering path.

The refactor to cache convertToColumnFilterList() once per render is a straight improvement with no behavioral change: tRPC's structural query-key comparison means a new array reference with identical content does not trigger extra fetches. The noResultsMessage is correctly gated by data.isLoading || !data.data inside DataTable, so the filter-hint message only appears after data has actually loaded and returned zero rows. No existing logic is modified.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Render DatasetCompareRunsTableInternal] --> B[convertToColumnFilterList]
    B --> C{activeRunFilters}
    C --> D[hasActiveRunFilters = length > 0]
    C --> E[datasetItemsWithRunData query\nfilterByRun: activeRunFilters]
    C --> F[runItemCompareCount query\nfilterByRun: activeRunFilters]
    C --> G[FilteredRunPills\nfilteredRuns: activeRunFilters]
    E --> H{Query result}
    H -->|isLoading| I[DataTable: skeleton rows]
    H -->|data loaded, rows > 0| J[DataTable: render rows]
    H -->|data loaded, rows = 0| K{hasActiveRunFilters?}
    K -->|true| L[noResultsMessage:\n'No dataset run items match filters']
    K -->|false| M[Default: 'No results.']
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Render DatasetCompareRunsTableInternal] --> B[convertToColumnFilterList]
    B --> C{activeRunFilters}
    C --> D[hasActiveRunFilters = length > 0]
    C --> E[datasetItemsWithRunData query\nfilterByRun: activeRunFilters]
    C --> F[runItemCompareCount query\nfilterByRun: activeRunFilters]
    C --> G[FilteredRunPills\nfilteredRuns: activeRunFilters]
    E --> H{Query result}
    H -->|isLoading| I[DataTable: skeleton rows]
    H -->|data loaded, rows > 0| J[DataTable: render rows]
    H -->|data loaded, rows = 0| K{hasActiveRunFilters?}
    K -->|true| L[noResultsMessage:\n'No dataset run items match filters']
    K -->|false| M[Default: 'No results.']
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(datasets): show empty state for filt..."](https://github.com/langfuse/langfuse/commit/a706b8ad4bb5ff4fefa8766fbff14a3816a3dee3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42726670)</sub>

<!-- /greptile_comment -->