### PR TITLE
docs(experiments): explain baseline runs in compare panel

### DIFF
--- a/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
+++ b/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
@@ -4,11 +4,20 @@ import { Button } from "@/src/components/ui/button";
 import { ExperimentComparisonSelector } from "./ExperimentComparisonSelector";
 import { ExperimentBaselineControls } from "./ExperimentBaselineControls";
 import Link from "next/link";
+import { ExternalLink, InfoIcon } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 import { ExperimentMetadataSection } from "./ExperimentMetadataSection";
 import {
   ExperimentOverviewField,
   ExperimentOverviewSectionHeading,
 } from "./ExperimentOverviewField";
+
+const EXPERIMENT_BASELINE_DOCS_URL =
+  "https://langfuse.com/docs/evaluation/dataset-runs";
 
 const isSafeHttpUrl = (value: string | undefined) => {
   if (!value) return false;
@@ -93,7 +102,33 @@ export function ExperimentOverviewPanel({
 
         <div>
           <ExperimentOverviewSectionHeading>
-            Baseline
+            <span className="inline-flex items-center gap-1.5">
+              Baseline
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="What is a baseline experiment?"
+                    className="text-muted-foreground hover:text-primary"
+                  >
+                    <InfoIcon className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-[280px]">
+                  The baseline is the reference experiment run used to compare
+                  all other selected runs.
+                </TooltipContent>
+              </Tooltip>
+              <Link
+                href={EXPERIMENT_BASELINE_DOCS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Open experiment baseline documentation"
+                className="text-muted-foreground hover:text-primary"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </Link>
+            </span>
           </ExperimentOverviewSectionHeading>
           <ExperimentBaselineControls
             projectId={projectId}


### PR DESCRIPTION
## Summary
- Adds a concise info tooltip next to the experiment results baseline selector
- Adds a docs link from the baseline label to the dataset runs documentation

## Linear
- https://linear.app/langfuse/issue/LFE-9194/docs-explain-baseline-experiment-run

## Impacted packages
- `web`

## Verification
- `eslint src/features/experiments/components/ExperimentOverviewPanel.tsx --max-warnings 0 --no-cache`
- `prettier --check web/src/features/experiments/components/ExperimentOverviewPanel.tsx`
- `git diff --check`

Browser review not run locally because the flow needs an authenticated app with seeded experiment results data.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a small UX improvement to the experiment compare panel's "Baseline" section heading: an info tooltip explaining what a baseline is, and an external link to the dataset runs documentation.

- Adds an `InfoIcon` tooltip with a concise description of the baseline concept next to the "Baseline" heading.
- Adds an `ExternalLink` icon that opens the Langfuse dataset-runs docs in a new tab, with proper `rel="noopener noreferrer"` and `aria-label` for accessibility.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to adding an info tooltip and external docs link to a UI section heading, with no logic changes.

The change is purely additive UI: a tooltip describing the baseline concept and an external link to the dataset-runs docs page. The global TooltipProvider in _app.tsx covers the new Tooltip usage. Imports are correctly placed at the top, the docs URL is a named constant, the external link has proper security attributes, and both interactive elements carry accessibility labels. No existing behavior is altered.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor User
    participant BaselineHeading as Baseline Heading
    participant Tooltip as InfoIcon Tooltip
    participant ExternalLink as ExternalLink Icon
    participant DocsPage as langfuse.com/docs

    User->>BaselineHeading: Views "Baseline" section
    User->>Tooltip: Hovers over InfoIcon
    Tooltip-->>User: Shows "The baseline is the reference experiment run used to compare all other selected runs."
    User->>ExternalLink: Clicks ExternalLink icon
    ExternalLink->>DocsPage: Opens /docs/evaluation/dataset-runs in new tab
    DocsPage-->>User: Shows dataset runs documentation
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor User
    participant BaselineHeading as Baseline Heading
    participant Tooltip as InfoIcon Tooltip
    participant ExternalLink as ExternalLink Icon
    participant DocsPage as langfuse.com/docs

    User->>BaselineHeading: Views "Baseline" section
    User->>Tooltip: Hovers over InfoIcon
    Tooltip-->>User: Shows "The baseline is the reference experiment run used to compare all other selected runs."
    User->>ExternalLink: Clicks ExternalLink icon
    ExternalLink->>DocsPage: Opens /docs/evaluation/dataset-runs in new tab
    DocsPage-->>User: Shows dataset runs documentation
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(experiments): explain baseline runs..."](https://github.com/langfuse/langfuse/commit/e90cadc3fb8c760e4bc40eb53c696b65a63cc5c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42726922)</sub>

<!-- /greptile_comment -->