### PR TITLE
feat(public-api): expose isRootObservation on Observations v2 API

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -252,6 +252,13 @@ types:
       sessionId:
         type: optional<nullable<string>>
         docs: The session ID associated with the observation
+      isRootObservation:
+        type: optional<boolean>
+        docs: |
+          Whether the observation is a root of its trace. True when the observation has no parent,
+          or when it is an app root whose OpenTelemetry parent span was never ingested into Langfuse
+          (e.g. filtered out by the SDK span processor). Use this instead of relying on
+          `parentObservationId` being null to discover trace roots.
 
       # Time fields (field group: time)
       completionStartTime:

--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -17,7 +17,7 @@ service:
         ## Field Selection
         Use the `fields` parameter to control which observation fields are returned:
         - `core` - Always included: id, traceId, startTime, endTime, projectId, parentObservationId, type
-        - `basic` - name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId
+        - `basic` - name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId, isRootObservation
         - `time` - completionStartTime, createdAt, updatedAt
         - `io` - input, output
         - `metadata` - metadata (truncated to 200 chars by default, use `expandMetadata` to get full values)
@@ -130,6 +130,10 @@ service:
               - `version` (string) - Version tag
               - `userId` (string) - User ID
               - `sessionId` (string) - Session ID
+
+              ### Trace-Tree Position
+              - `isRootObservation` (boolean) - True for trace roots: observations without a parent, plus app roots whose OpenTelemetry parent span was never ingested (e.g. filtered out by the SDK span processor). Use this to list one root per trace even when `parentObservationId` is a dangling reference.
+              - `hasParentObservation` (boolean) - True when the observation carries a non-empty `parentObservationId`. Note: an app root can have both `hasParentObservation = true` (dangling parent) and `isRootObservation = true`.
 
               ### Trace-Related Fields
               - `traceName` (string) - Name of the parent trace

--- a/packages/shared/src/domain/observations.ts
+++ b/packages/shared/src/domain/observations.ts
@@ -121,6 +121,9 @@ export const EventsObservationSchema = ObservationSchema.extend({
   tags: z.array(z.string()).nullable().optional(),
   bookmarked: z.boolean().optional(),
   public: z.boolean().optional(),
+  // True when the observation is a trace root: no parent, or an app root
+  // whose OTel parent span was never ingested (is_app_root).
+  isRootObservation: z.boolean().optional(),
 });
 
 export type EventsObservation = z.infer<typeof EventsObservationSchema>;

--- a/packages/shared/src/eventsTable.ts
+++ b/packages/shared/src/eventsTable.ts
@@ -417,6 +417,7 @@ const OBSERVATION_MCP_ALLOWED_EVENTS_TABLE_FILTER_COLUMN_IDS = [
   "metadata",
   "traceTags",
   "hasParentObservation",
+  "isRootObservation",
 ] as const satisfies readonly EventsTableColumnId[];
 
 export type ObservationMcpAllowedEventsTableFilterColumn =

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -2,6 +2,7 @@ import {
   OBSERVATION_FIELD_GROUPS_PUBLIC_API,
   ObservationFieldGroupPublicApi,
 } from "../../../domain/observation-field-groups";
+import { eventsTableIsRootObservationSql } from "../../../eventsTable";
 import { OBSERVATIONS_TO_TRACE_INTERVAL } from "../../repositories/constants";
 import { FilterList, StringFilter } from "./clickhouse-filter";
 
@@ -113,6 +114,8 @@ const EVENTS_FIELDS = {
   environment: 'e.environment as "environment"',
   type: "e.type as type",
   parentObservationId: 'e.parent_span_id as "parent_observation_id"',
+  // App-root observations (dangling parent, is_app_root=true) count as roots
+  isRootObservation: `toBool(${eventsTableIsRootObservationSql}) as "is_root_observation"`,
   name: "e.name as name",
   level: "e.level as level",
   statusMessage: 'e.status_message as "status_message"',
@@ -375,6 +378,7 @@ const FIELD_SETS = {
     "public",
     "userId",
     "sessionId",
+    "isRootObservation",
   ],
   time: ["completionStartTime", "createdAt", "updatedAt"],
   model: ["providedModelName", "internalModelId", "modelParameters"],

--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -124,6 +124,7 @@ export const eventsObservationRecordReadSchema =
     tags: z.array(z.string()).optional(),
     bookmarked: z.boolean().optional(),
     public: z.boolean().optional(),
+    is_root_observation: z.boolean().optional(),
   });
 export type EventsObservationRecordReadType = z.infer<
   typeof eventsObservationRecordReadSchema

--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -420,6 +420,9 @@ export function convertEventsObservation(
       tags: record.tags ?? null,
       bookmarked: record.bookmarked!,
       public: record.public!,
+      ...(record.is_root_observation !== undefined && {
+        isRootObservation: record.is_root_observation,
+      }),
     };
   }
 
@@ -437,6 +440,9 @@ export function convertEventsObservation(
     ...(record.tags !== undefined && { tags: record.tags }),
     ...(record.bookmarked !== undefined && { bookmarked: record.bookmarked }),
     ...(record.public !== undefined && { public: record.public }),
+    ...(record.is_root_observation !== undefined && {
+      isRootObservation: record.is_root_observation,
+    }),
   };
 }
 

--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -234,6 +234,7 @@ const createObservationEvent = (params: {
   userId?: string;
   sessionId?: string;
   totalCost?: number;
+  isAppRoot?: boolean;
 }) => {
   const observationId = params.observationId ?? randomUUID();
   const startTime = params.startTime ?? new Date();
@@ -245,6 +246,7 @@ const createObservationEvent = (params: {
     span_id: observationId,
     trace_id: params.traceId ?? randomUUID(),
     parent_span_id: params.parentObservationId ?? null,
+    is_app_root: params.isAppRoot ?? false,
     project_id: params.projectId,
     name: params.name ?? `mcp-observation-${nanoid()}`,
     type: params.type ?? "GENERATION",
@@ -634,6 +636,7 @@ describe("MCP Read Tools", () => {
       ["providedModelName", "stringOptions", true],
       ["tags", "arrayOptions", false],
       ["hasParentObservation", "boolean", false],
+      ["isRootObservation", "boolean", false],
     ])(
       "should expose the %s column used by observation filter values",
       async (column, type, nullable) => {
@@ -781,6 +784,54 @@ describe("MCP Read Tools", () => {
           }),
         },
       ]);
+    });
+
+    it("should filter by isRootObservation including app roots with dangling parents", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const traceId = randomUUID();
+      const trueRoot = createObservationEvent({
+        projectId,
+        traceId,
+        name: `mcp-filter-true-root-${nanoid()}`,
+        parentObservationId: null,
+      });
+      // App root: OTel parent span was never ingested
+      const appRoot = createObservationEvent({
+        projectId,
+        traceId,
+        name: `mcp-filter-app-root-${nanoid()}`,
+        parentObservationId: randomUUID(),
+        isAppRoot: true,
+      });
+      const child = createObservationEvent({
+        projectId,
+        traceId,
+        name: `mcp-filter-child-${nanoid()}`,
+        parentObservationId: trueRoot.id,
+      });
+
+      await createEventsCh([trueRoot, appRoot, child]);
+
+      const result = (await handleListObservations(
+        {
+          filter: [
+            {
+              type: "boolean",
+              column: "isRootObservation",
+              operator: "=",
+              value: true,
+            },
+          ],
+          fields: ["id"],
+          limit: 100,
+        },
+        context,
+      )) as { data: Array<{ id: string }> };
+
+      const ids = result.data.map((row) => row.id);
+      expect(ids).toHaveLength(2);
+      expect(ids).toContain(trueRoot.id);
+      expect(ids).toContain(appRoot.id);
     });
 
     it("should list observations with compact default projection", async () => {
@@ -1939,6 +1990,46 @@ describe("MCP Read Tools", () => {
       expect(result.values).toEqual([
         expect.objectContaining({ value: false, count: 1 }),
         expect.objectContaining({ value: true, count: 1 }),
+      ]);
+    });
+
+    it("should return boolean values for isRootObservation counting app roots as roots", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+
+      await createEventsCh([
+        // True root: no parent
+        createObservationEvent({
+          projectId,
+          name: `mcp-filter-true-root-${nanoid()}`,
+          parentObservationId: null,
+        }),
+        // App root: dangling parent that was never ingested
+        createObservationEvent({
+          projectId,
+          name: `mcp-filter-app-root-${nanoid()}`,
+          parentObservationId: randomUUID(),
+          isAppRoot: true,
+        }),
+        // Non-root child
+        createObservationEvent({
+          projectId,
+          name: `mcp-filter-child-${nanoid()}`,
+          parentObservationId: randomUUID(),
+        }),
+      ]);
+
+      const result = (await handleGetObservationFilterValues(
+        { column: "isRootObservation", limit: 100 },
+        context,
+      )) as {
+        column: string;
+        values: Array<{ value: boolean; count?: number }>;
+      };
+
+      expect(result.column).toBe("isRootObservation");
+      expect(result.values).toEqual([
+        expect.objectContaining({ value: false, count: 1 }),
+        expect.objectContaining({ value: true, count: 2 }),
       ]);
     });
 

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -532,6 +532,102 @@ describe("/api/public/v2/observations API Endpoint", () => {
       expect(traceNameResponse.body.data.length).toBeGreaterThanOrEqual(1);
     });
 
+    it("should expose app-root observations as roots via isRootObservation filter and field (#14868)", async () => {
+      const traceId = randomUUID();
+      const trueRootId = randomUUID();
+      const appRootId = randomUUID();
+      const childId = randomUUID();
+      // Parent span that was never ingested (e.g. filtered out by LangfuseSpanProcessor)
+      const danglingParentId = randomUUID();
+      const timestamp = Date.now() * 1000;
+
+      await createEventsCh([
+        createEvent({
+          id: trueRootId,
+          span_id: trueRootId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "true-root",
+          parent_span_id: null,
+          is_app_root: false,
+          start_time: timestamp,
+        }),
+        createEvent({
+          id: appRootId,
+          span_id: appRootId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "app-root",
+          parent_span_id: danglingParentId,
+          is_app_root: true,
+          start_time: timestamp + 1,
+        }),
+        createEvent({
+          id: childId,
+          span_id: childId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "child",
+          parent_span_id: trueRootId,
+          is_app_root: false,
+          start_time: timestamp + 2,
+        }),
+      ]);
+
+      // Filter isRootObservation = true must return both the true root and
+      // the app root (dangling parent), but not the child.
+      const rootFilterParam = JSON.stringify([
+        {
+          type: "boolean",
+          column: "isRootObservation",
+          operator: "=",
+          value: true,
+        },
+      ]);
+      const rootResponse = await getObservations(
+        `/api/public/v2/observations?traceId=${traceId}&fields=basic&filter=${encodeURIComponent(rootFilterParam)}`,
+      );
+
+      expect(rootResponse.status).toBe(200);
+      const rootIds = rootResponse.body.data.map((obs: any) => obs.id);
+      expect(rootIds).toHaveLength(2);
+      expect(rootIds).toContain(trueRootId);
+      expect(rootIds).toContain(appRootId);
+
+      // The app root keeps its raw parentObservationId (no data loss).
+      const appRootObs = rootResponse.body.data.find(
+        (obs: any) => obs.id === appRootId,
+      );
+      expect(appRootObs?.parentObservationId).toBe(danglingParentId);
+
+      // Response exposes isRootObservation so consumers can distinguish
+      // app roots without relying on parentObservationId nullness.
+      expect(appRootObs?.isRootObservation).toBe(true);
+      const trueRootObs = rootResponse.body.data.find(
+        (obs: any) => obs.id === trueRootId,
+      );
+      expect(trueRootObs?.isRootObservation).toBe(true);
+
+      // Filter isRootObservation = false returns only the child.
+      const nonRootFilterParam = JSON.stringify([
+        {
+          type: "boolean",
+          column: "isRootObservation",
+          operator: "=",
+          value: false,
+        },
+      ]);
+      const nonRootResponse = await getObservations(
+        `/api/public/v2/observations?traceId=${traceId}&fields=basic&filter=${encodeURIComponent(nonRootFilterParam)}`,
+      );
+
+      expect(nonRootResponse.status).toBe(200);
+      expect(nonRootResponse.body.data.map((obs: any) => obs.id)).toEqual([
+        childId,
+      ]);
+      expect(nonRootResponse.body.data[0]?.isRootObservation).toBe(false);
+    });
+
     it("should support nested metadata field filtering with stringObject", async () => {
       const traceId = randomUUID();
       const observationId1 = randomUUID();
@@ -1054,6 +1150,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
       "public",
       "userId",
       "sessionId",
+      "isRootObservation",
       // time
       "completionStartTime",
       "createdAt",
@@ -1154,6 +1251,8 @@ describe("/api/public/v2/observations API Endpoint", () => {
       tags: ["tag-a", "tag-b"],
       release: "1.2.3",
       usagePricingTierName: "contract-tier",
+      // Fixture has no parent_span_id, so it is a trace root.
+      isRootObservation: true,
     };
 
     const fieldsForGroup: Record<string, readonly string[]> = {
@@ -1167,6 +1266,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
         "public",
         "userId",
         "sessionId",
+        "isRootObservation",
       ],
       time: ["completionStartTime", "createdAt", "updatedAt"],
       io: ["input", "output"],

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -458,6 +458,7 @@ export async function getEventFilterValuePage(
     column:
       | "traceTags"
       | "hasParentObservation"
+      | "isRootObservation"
       | "providedModelName"
       | "modelId"
       | "name"

--- a/web/src/features/mcp/features/observations/schema.ts
+++ b/web/src/features/mcp/features/observations/schema.ts
@@ -59,6 +59,11 @@ const OBSERVATION_MCP_FIELD_METADATA: Record<
   public: { type: "boolean" },
   userId: { type: "string", nullable: true, sensitive: true },
   sessionId: { type: "string", nullable: true, sensitive: true },
+  isRootObservation: {
+    type: "boolean",
+    description:
+      "True for trace roots: observations without a parent, plus app roots whose OpenTelemetry parent span was never ingested.",
+  },
   completionStartTime: { type: "datetime", nullable: true },
   createdAt: { type: "datetime" },
   updatedAt: { type: "datetime" },

--- a/web/src/features/mcp/features/observations/tools/getObservationFilterValues.ts
+++ b/web/src/features/mcp/features/observations/tools/getObservationFilterValues.ts
@@ -35,6 +35,7 @@ const OBSERVATION_MCP_FILTER_VALUE_COLUMNS = [
   "timeToFirstToken",
   "tags",
   "hasParentObservation",
+  "isRootObservation",
 ] as const satisfies readonly ObservationMcpFilterColumn[];
 
 const FilterValueColumnSchema = z.enum(OBSERVATION_MCP_FILTER_VALUE_COLUMNS);
@@ -89,8 +90,8 @@ const normalizeFilterOptions = (
 ): FilterOption[] => {
   const normalizeValue = (value: unknown): string | boolean | null => {
     if (typeof value === "string") {
-      // Special handling for the "hasParentObservation" column to convert "true"/"false" strings to boolean values.
-      if (column === "hasParentObservation") {
+      // Special handling for boolean columns to convert "true"/"false" strings to boolean values.
+      if (column === "hasParentObservation" || column === "isRootObservation") {
         if (value === "true") return true;
         if (value === "false") return false;
       }

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -178,6 +178,9 @@ export const transformDbToApiObservation = (
     bookmarked,
 
     public: _public,
+
+    // Exclude isRootObservation from V1; it is a V2 events-based field.
+    isRootObservation,
     ...rest
   } = observation as EventsObservation &
     ObservationPriceFields & {
@@ -363,6 +366,7 @@ const APIObservationV2 = z
     public: z.boolean().optional(),
     userId: z.string().nullable().optional(),
     sessionId: z.string().nullable().optional(),
+    isRootObservation: z.boolean().optional(),
 
     // Time fields (field group: time)
     completionStartTime: z.coerce.date().nullable().optional(),


### PR DESCRIPTION
## Problem

Closes #14868.

When an app-root observation's OpenTelemetry parent span is never exported to
Langfuse (e.g. a FastAPI server span filtered out by `LangfuseSpanProcessor`),
the SDK marks it `langfuse.internal.is_app_root` and Langfuse treats it as a
trace root internally. But `GET /api/public/v2/observations` still returns a
**non-null, dangling** `parentObservationId` for it, and the only public root
filter — `parentObservationId is null` — does not consult the app-root signal.
Consumers listing traces one-row-per-trace via the recommended v2 endpoint
never see these traces.

## Approach

Chose the issue's **Option 2** (expose the app-root signal) over Option 1
(null out `parentObservationId` on ingestion), because Option 1 destroys real
OTel parent data irreversibly, can't reliably decide "parent will never
arrive" at ingestion time given out-of-order spans, and doesn't help already
ingested data.

While implementing, it turned out the `isRootObservation` **filter was already
functional** — the internal column `(parent_span_id = '' OR is_app_root)` was
defined and already accepted by the v2 `filter` param. It was just
undocumented, untested at the public-API layer, missing from the response, and
not surfaced through the MCP observation tools. So this PR is mostly about
surfacing and documenting it.

## Changes

### Public API v2

- **Query builder** — add `is_root_observation` to `EVENTS_FIELDS` (reusing
  `eventsTableIsRootObservationSql`) and to the `basic` field group.
- **Read/domain/convert** — thread the field through the events read-record
  schema, `EventsObservationSchema`, and `convertEventsObservation`.
- **Response contract** — add `isRootObservation` to `APIObservationV2`;
  exclude it from the strict v1 `transformDbToApiObservation` (same pattern
  as `bookmarked`/`public`).
- **Fern** — document `isRootObservation` and `hasParentObservation`,
  including the dangling-parent semantics (an app root can have both
  `hasParentObservation = true` and `isRootObservation = true`).

### MCP observation tools

- **Filter allowlist** — add `isRootObservation` to
  `OBSERVATION_MCP_ALLOWED_EVENTS_TABLE_FILTER_COLUMNS`, so `listObservations`
  accepts it as a filter column and `getObservationFilterSchema` advertises it.
  Previously only `hasParentObservation` was allowed, which misses app roots
  with dangling parents.
- **Filter values** — add `isRootObservation` to the value-discovery column
  list in `getObservationFilterValues` (with boolean `true`/`false`
  normalization), and widen the `getEventFilterValuePage` column union
  accordingly.
- **Field metadata** — add the MCP observation field metadata entry (required
  by the typed field map).

## Usage

```
GET /api/public/v2/observations?filter=[{"type":"boolean","column":"isRootObservation","operator":"=","value":true}]
```
returns app roots (dangling parent) alongside true roots; each row's
`isRootObservation` distinguishes them without relying on
`parentObservationId` nullness. The same filter column is now usable from the
MCP `listObservations` / `getObservationFilterValues` tools.

## Tests

- **Targeted v2 test** — true root, app root (dangling parent + `is_app_root`),
  and child: asserts the filter both ways, that the raw `parentObservationId`
  is preserved, and that the response carries `isRootObservation`.
- **Field-group contract test** — added `isRootObservation` to the generic
  `basic`-group and non-core field lists so future placement/removal mistakes
  are caught.
- **MCP tests** — filter-schema exposure, filter-values boolean counts (app
  root counted as a root), and an end-to-end `listObservations` filter run.

## Verification

- `pnpm run lint` — `Tasks: 8 successful, 8 total`
- `pnpm run typecheck` — `Tasks: 8 successful, 8 total`
- `npx fern-api check` — `All checks passed`
- v2 observations API — `Tests 38 passed (38)`
- MCP read tools — `Tests 153 passed (153)`
- MCP public-api tools — `Tests 14 passed (14)`
- v1 observations regressions — list `Tests 24 passed (24)`, single `Tests 32 passed (32)`

> Fern SDK regeneration is left to the post-merge `sdk-api-spec` CI job (it
> runs with `FERN_TOKEN`); the definition was validated locally with
> `fern check`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exposes the pre-existing `isRootObservation` signal on the v2 observations API, enabling consumers to discover app-root observations (those whose OTel parent span was filtered out and never ingested) without relying on `parentObservationId` being null.

- **Query builder & schema**: `is_root_observation` is added to `EVENTS_FIELDS` (reusing `eventsTableIsRootObservationSql`), the `basic` field group, the ClickHouse read schema, and threaded through the converter, domain schema, and `APIObservationV2` Zod type.
- **API surface**: `isRootObservation` is deliberately excluded from the v1 `transformDbToApiObservation` transformer (same destructure-to-omit pattern used for `bookmarked`/`public`), documented in Fern, and added to the MCP field metadata and allowed filter columns.
- **Tests**: New regression tests cover the true-root, app-root (dangling parent + `is_app_root`), and child cases, asserting both filtering behaviour and the presence of `isRootObservation` in the response.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change adds a read-only, backward-compatible field to the v2 API; it does not mutate any stored data and cannot affect v1 callers.

The field is threaded consistently through every layer (SQL → read schema → converter → domain → API schema → docs), the underlying SQL expression was already tested and used for filtering before this PR, v1 callers are explicitly shielded by the destructure-to-omit pattern, and the new tests cover all three cases (true root, app root with dangling parent, child) with both filter directions.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant API as v2 Observations API
    participant QB as EventQueryBuilder
    participant CH as ClickHouse (events table)

    Client->>API: "GET /api/public/v2/observations?fields=basic&filter=[isRootObservation=true]"
    API->>QB: build query (FIELD_SETS.basic includes isRootObservation)
    QB->>CH: "SELECT ..., toBool(e.parent_span_id = '' OR e.is_app_root = true) AS is_root_observation"
    CH-->>QB: rows with is_root_observation
    QB-->>API: EventsObservationRecordReadType[]
    API->>API: convertEventsObservation() maps is_root_observation to isRootObservation
    API->>API: APIObservationV2 Zod parse
    API-->>Client: "{ data: [{ id, parentObservationId, isRootObservation: true, ... }] }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant API as v2 Observations API
    participant QB as EventQueryBuilder
    participant CH as ClickHouse (events table)

    Client->>API: "GET /api/public/v2/observations?fields=basic&filter=[isRootObservation=true]"
    API->>QB: build query (FIELD_SETS.basic includes isRootObservation)
    QB->>CH: "SELECT ..., toBool(e.parent_span_id = '' OR e.is_app_root = true) AS is_root_observation"
    CH-->>QB: rows with is_root_observation
    QB-->>API: EventsObservationRecordReadType[]
    API->>API: convertEventsObservation() maps is_root_observation to isRootObservation
    API->>API: APIObservationV2 Zod parse
    API-->>Client: "{ data: [{ id, parentObservationId, isRootObservation: true, ... }] }"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): expose isRootObservati..."](https://github.com/langfuse/langfuse/commit/6e998a9cb84a0940eecd06b1932f8e0c4c9db3b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42760430)</sub>

<!-- /greptile_comment -->