### PR TITLE
chore(deps): cleanup deps time excludes

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,37 +9,7 @@ minimumReleaseAge: 7200
 # the exclusions are temporary so that we can set the 5 day limit without downgrading packages.
 # this list is version-specific
 minimumReleaseAgeExclude:
-  - undici@7.28.0
-  - "form-data@2.5.6||4.0.6"
-  - esbuild@0.28.1
-  - "@esbuild/aix-ppc64@0.28.1"
-  - "@esbuild/android-arm@0.28.1"
-  - "@esbuild/android-arm64@0.28.1"
-  - "@esbuild/android-x64@0.28.1"
-  - "@esbuild/darwin-arm64@0.28.1"
-  - "@esbuild/darwin-x64@0.28.1"
-  - "@esbuild/freebsd-arm64@0.28.1"
-  - "@esbuild/freebsd-x64@0.28.1"
-  - "@esbuild/linux-arm@0.28.1"
-  - "@esbuild/linux-arm64@0.28.1"
-  - "@esbuild/linux-ia32@0.28.1"
-  - "@esbuild/linux-loong64@0.28.1"
-  - "@esbuild/linux-mips64el@0.28.1"
-  - "@esbuild/linux-ppc64@0.28.1"
-  - "@esbuild/linux-riscv64@0.28.1"
-  - "@esbuild/linux-s390x@0.28.1"
-  - "@esbuild/linux-x64@0.28.1"
-  - "@esbuild/netbsd-arm64@0.28.1"
-  - "@esbuild/netbsd-x64@0.28.1"
-  - "@esbuild/openbsd-arm64@0.28.1"
-  - "@esbuild/openbsd-x64@0.28.1"
-  - "@esbuild/openharmony-arm64@0.28.1"
-  - "@esbuild/sunos-x64@0.28.1"
-  - "@esbuild/win32-arm64@0.28.1"
-  - "@esbuild/win32-ia32@0.28.1"
-  - "@esbuild/win32-x64@0.28.1"
-  - eslint-plugin-tailwindcss@4.0.2
-  - '@clickhouse/client@1.23.1'
+  - "@clickhouse/client@1.23.1"
 allowBuilds:
   "@prisma/client": true
   "@prisma/engines": true


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes version-specific `minimumReleaseAgeExclude` entries that are no longer needed because those package versions have now surpassed the 5-day minimum release age window. Only the still-fresh `@clickhouse/client@1.23.1` exclusion is retained.

- Removes 33 stale exclusion entries covering `undici`, `form-data`, `esbuild` (and all platform-specific binaries), and `eslint-plugin-tailwindcss` — all of which are now older than the 7200-minute (5-day) minimumReleaseAge threshold.
- Retains the `@clickhouse/client@1.23.1` exclusion, which presumably still falls within the 5-day window.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a housekeeping-only change to the workspace config with no functional impact on application code.

The change removes 33 temporary version exclusions from minimumReleaseAgeExclude that were pinned to specific, now-aged package versions. All removed packages (undici, form-data, esbuild and its platform variants, eslint-plugin-tailwindcss) have been available long enough to clear the 5-day supply-chain hold. The one remaining exclusion (@clickhouse/client@1.23.1) is intentionally kept. No application logic, migrations, or build configuration is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm dependency update candidate] --> B{Age >= minimumReleaseAge\n7200 minutes / 5 days?}
    B -- Yes --> C[Allow update]
    B -- No --> D{Package in\nminimumReleaseAgeExclude?}
    D -- Yes --> C
    D -- No --> E[Block update\nsupply-chain safety hold]

    subgraph "After this PR"
        F["Only @clickhouse/client@1.23.1\nis excluded (still fresh)"]
    end

    subgraph "Before this PR"
        G["33 entries excluded:\nundici, form-data,\nesbuild + all platforms,\neslint-plugin-tailwindcss,\n@clickhouse/client"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pnpm dependency update candidate] --> B{Age >= minimumReleaseAge\n7200 minutes / 5 days?}
    B -- Yes --> C[Allow update]
    B -- No --> D{Package in\nminimumReleaseAgeExclude?}
    D -- Yes --> C
    D -- No --> E[Block update\nsupply-chain safety hold]

    subgraph "After this PR"
        F["Only @clickhouse/client@1.23.1\nis excluded (still fresh)"]
    end

    subgraph "Before this PR"
        G["33 entries excluded:\nundici, form-data,\nesbuild + all platforms,\neslint-plugin-tailwindcss,\n@clickhouse/client"]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): cleanup deps time excludes"](https://github.com/langfuse/langfuse/commit/62456f33066679eea844e6dc0fda20d2439e5fd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42754679)</sub>

<!-- /greptile_comment -->