### PR TITLE
fix(otel): treat gen_ai.usage.input_cached_tokens as cache-read alias (LFE-10765)

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2581,13 +2581,15 @@ export class OtelIngestionProcessor {
       rawUsageDetails["cache_read_tokens"] ??
       rawUsageDetails["details.cache_read_tokens"] ??
       rawUsageDetails["details.cache_read_input_tokens"] ??
-      rawUsageDetails["prompt_details.cache_read"];
+      rawUsageDetails["prompt_details.cache_read"] ??
+      rawUsageDetails["input_cached_tokens"];
     const cacheCreationTokens =
       rawUsageDetails["cache_creation.input_tokens"] ??
       rawUsageDetails["cache_write_tokens"] ??
       rawUsageDetails["details.cache_write_tokens"] ??
       rawUsageDetails["details.cache_creation_input_tokens"] ??
-      rawUsageDetails["prompt_details.cache_write"];
+      rawUsageDetails["prompt_details.cache_write"] ??
+      rawUsageDetails["input_cache_creation"];
 
     const normalizedUsageDetails = Object.entries(rawUsageDetails).reduce(
       (acc: Record<string, number>, [key, value]) => {
@@ -2606,11 +2608,13 @@ export class OtelIngestionProcessor {
             "details.cache_read_tokens",
             "details.cache_read_input_tokens",
             "prompt_details.cache_read",
+            "input_cached_tokens",
             "cache_creation.input_tokens",
             "cache_write_tokens",
             "details.cache_write_tokens",
             "details.cache_creation_input_tokens",
             "prompt_details.cache_write",
+            "input_cache_creation",
           ].includes(key)
         ) {
           return acc;

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -2266,6 +2266,101 @@ describe("OTel Resource Span Mapping", () => {
       ).toBeUndefined();
     });
 
+    it("should subtract gen_ai.usage.input_cached_tokens / input_cache_creation from inclusive input tokens", async () => {
+      // Integrators reading the Langfuse docs emit Langfuse's canonical usage
+      // keys through the gen_ai.usage.* namespace. They must be treated as
+      // cache aliases like gen_ai.usage.cache_read.input_tokens, otherwise the
+      // inclusive input stays unreduced and cached tokens count twice
+      // (github.com/langfuse/langfuse/issues/12306).
+      const traceId = "abcdef1234567890abcdef1234567892";
+
+      const langfuseKeysSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "telemetry.sdk.language",
+              value: { stringValue: "python" },
+            },
+            {
+              key: "service.name",
+              value: { stringValue: "test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "custom-instrumentation",
+              version: "1.0.0",
+              attributes: [],
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("80854cd6bd218bf7", "hex"),
+                name: "langfuse-usage-keys-cache-test",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "gen_ai.usage.input_tokens",
+                    value: {
+                      intValue: { low: 50000, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "gen_ai.usage.output_tokens",
+                    value: { intValue: { low: 200, high: 0, unsigned: false } },
+                  },
+                  {
+                    key: "gen_ai.usage.input_cached_tokens",
+                    value: {
+                      intValue: { low: 40000, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "gen_ai.usage.input_cache_creation",
+                    value: {
+                      intValue: { low: 5000, high: 0, unsigned: false },
+                    },
+                  },
+                ],
+                events: [],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        langfuseKeysSpan,
+        new Set(),
+      );
+
+      const observationEvent = events.find((e) => e.type === "span-create");
+
+      expect(observationEvent).toBeDefined();
+      // input must be the uncached remainder: 50000 - 40000 - 5000 = 5000
+      expect(observationEvent?.body.usageDetails.input).toBe(5000);
+      expect(observationEvent?.body.usageDetails.output).toBe(200);
+      expect(observationEvent?.body.usageDetails.input_cached_tokens).toBe(
+        40000,
+      );
+      expect(observationEvent?.body.usageDetails.input_cache_creation).toBe(
+        5000,
+      );
+    });
+
     it("should prepend gen_ai.system_instructions to pydantic_ai.all_messages input when system message is absent", async () => {
       const traceId = "9d7aa9a729def1eadc0b2063ca4ebeb4";
 


### PR DESCRIPTION
## What does this PR do?

The generic OTel usage normalizer (`extractGenericGenAiUsageDetails`) subtracts cache tokens from the inclusive `gen_ai.usage.input_tokens` only for a fixed alias list — and `input_cached_tokens` was not on it. An attribute `gen_ai.usage.input_cached_tokens` passed through verbatim while `input` stayed inclusive, so cached tokens were counted twice in display and inferred cost. This is especially bad because `input_cached_tokens` is Langfuse's own canonical usage key: integrators who read the Langfuse docs and emit it through the `gen_ai.usage.*` namespace got double-counted, while the official OTel key `gen_ai.usage.cache_read.input_tokens` worked correctly.

This PR adds `input_cached_tokens` to the cache-read alias list and `input_cache_creation` to the cache-creation alias list, and excludes both from pass-through (they are re-emitted as the canonical keys, same as the existing aliases). Includes a regression test: span with inclusive `gen_ai.usage.input_tokens` + `gen_ai.usage.input_cached_tokens` / `input_cache_creation` → stored `input` is the uncached remainder.

Fixes double counting reported in a post-fix comment on #12306.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have checked if my changes generate no new warnings (`npm run lint`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR treats `gen_ai.usage.input_cached_tokens` and `gen_ai.usage.input_cache_creation` as canonical aliases for cache-read and cache-write tokens, so integrators who follow Langfuse's own documentation naming don't end up with cached tokens double-counted in the inclusive `input` field.

- `input_cached_tokens` and `input_cache_creation` are appended as last-resort fallbacks in the `cacheReadTokens` / `cacheCreationTokens` resolution chains, and both keys are added to the exclusion list in `normalizedUsageDetails` to prevent the raw values from also appearing as extra entries.
- A new integration test verifies the full path: `input_tokens=50000`, `input_cached_tokens=40000`, `input_cache_creation=5000` → `input=5000`, and the canonical keys are re-surfaced under their normalized names.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both new keys are added consistently to the alias chain and the exclusion list, and the test validates the exact arithmetic end-to-end.

The change is small and symmetric: two keys are added in parallel to the existing alias patterns for cache-read and cache-write tokens, and both are excluded from double-counting in normalizedUsageDetails. The accompanying test covers the full input/output/cache arithmetic and confirms the canonical keys appear in the final usageDetails object. No pre-existing aliases or edge cases appear to be disrupted.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["OTEL span attributes\ngen_ai.usage.*"] --> B["Strip prefix\ngen_ai.usage. → rawUsageDetails key"]
    B --> C{"key == 'input_cached_tokens'?"}
    C -- Yes --> D["Resolve as cacheReadTokens\n(last fallback in ?? chain)"]
    C -- No --> E{"key == 'input_cache_creation'?"}
    E -- Yes --> F["Resolve as cacheCreationTokens\n(last fallback in ?? chain)"]
    E -- No --> G["Regular key handling"]
    D --> H["Exclude from normalizedUsageDetails\n(skip block)"]
    F --> H
    H --> I["Compute input = max(inputTokens - cacheRead - cacheCreation, 0)"]
    I --> J["normalizedUsageDetails.input_cached_tokens = cacheReadTokens"]
    I --> K["normalizedUsageDetails.input_cache_creation = cacheCreationTokens"]
    J --> L["Return normalizedUsageDetails"]
    K --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["OTEL span attributes\ngen_ai.usage.*"] --> B["Strip prefix\ngen_ai.usage. → rawUsageDetails key"]
    B --> C{"key == 'input_cached_tokens'?"}
    C -- Yes --> D["Resolve as cacheReadTokens\n(last fallback in ?? chain)"]
    C -- No --> E{"key == 'input_cache_creation'?"}
    E -- Yes --> F["Resolve as cacheCreationTokens\n(last fallback in ?? chain)"]
    E -- No --> G["Regular key handling"]
    D --> H["Exclude from normalizedUsageDetails\n(skip block)"]
    F --> H
    H --> I["Compute input = max(inputTokens - cacheRead - cacheCreation, 0)"]
    I --> J["normalizedUsageDetails.input_cached_tokens = cacheReadTokens"]
    I --> K["normalizedUsageDetails.input_cache_creation = cacheCreationTokens"]
    J --> L["Return normalizedUsageDetails"]
    K --> L
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): treat gen\_ai.usage.input\_cach..."](https://github.com/langfuse/langfuse/commit/e9b6949e4444885c544bb8d995eadb6774acddeb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42761026)</sub>

<!-- /greptile_comment -->