### PR TITLE
fix(v4): allow public traces to be seen by authed users

### DIFF
--- a/web/src/components/trace/api/usePrefetchObservation.ts
+++ b/web/src/components/trace/api/usePrefetchObservation.ts
@@ -26,6 +26,7 @@ export function usePrefetchObservation({
       utils.events.batchIO.prefetch(
         {
           projectId,
+          traceId, // Must match useLogViewObservationIO for cache hit
           observations: [{ id: observationId, traceId }],
           minStartTime: startTime,
           maxStartTime: startTime,

--- a/web/src/components/trace/components/TraceLogView/useLogViewObservationIO.ts
+++ b/web/src/components/trace/components/TraceLogView/useLogViewObservationIO.ts
@@ -54,8 +54,6 @@ export function useLogViewObservationIO({
   const eventsQuery = api.events.batchIO.useQuery(
     {
       projectId,
-      // Top-level traceId enables trace-level auth (public traces) in the
-      // protectedGetTraceProcedure middleware.
       traceId,
       observations: [{ id: observationId, traceId }],
       minStartTime: startTime,

--- a/web/src/components/trace/components/TraceLogView/useLogViewObservationIO.ts
+++ b/web/src/components/trace/components/TraceLogView/useLogViewObservationIO.ts
@@ -54,6 +54,9 @@ export function useLogViewObservationIO({
   const eventsQuery = api.events.batchIO.useQuery(
     {
       projectId,
+      // Top-level traceId enables trace-level auth (public traces) in the
+      // protectedGetTraceProcedure middleware.
+      traceId,
       observations: [{ id: observationId, traceId }],
       minStartTime: startTime,
       maxStartTime: startTime,

--- a/web/src/features/events/hooks/useEventsTableData.ts
+++ b/web/src/features/events/hooks/useEventsTableData.ts
@@ -124,7 +124,6 @@ export function useEventsTableData({
     enabled: observations.isSuccess && batchIOPayload !== null,
     refetchOnWindowFocus: false,
     staleTime: 0,
-    traceId: batchIOPayload?.traceId,
   });
 
   // Extract error information for display (only from observations.all, not batchIO)

--- a/web/src/features/events/hooks/useEventsTableData.ts
+++ b/web/src/features/events/hooks/useEventsTableData.ts
@@ -124,6 +124,7 @@ export function useEventsTableData({
     enabled: observations.isSuccess && batchIOPayload !== null,
     refetchOnWindowFocus: false,
     staleTime: 0,
+    traceId: batchIOPayload?.traceId,
   });
 
   // Extract error information for display (only from observations.all, not batchIO)

--- a/web/src/features/events/hooks/useEventsTraceData.ts
+++ b/web/src/features/events/hooks/useEventsTraceData.ts
@@ -105,8 +105,6 @@ export function useEventsTraceData(
   const rootIOQuery = api.events.batchIO.useQuery(
     {
       projectId,
-      // Top-level traceId enables trace-level auth (public traces) in the
-      // protectedGetTraceProcedure middleware.
       traceId,
       observations: primaryObservation
         ? [{ id: primaryObservation.id, traceId }]

--- a/web/src/features/events/hooks/useEventsTraceData.ts
+++ b/web/src/features/events/hooks/useEventsTraceData.ts
@@ -105,6 +105,9 @@ export function useEventsTraceData(
   const rootIOQuery = api.events.batchIO.useQuery(
     {
       projectId,
+      // Top-level traceId enables trace-level auth (public traces) in the
+      // protectedGetTraceProcedure middleware.
+      traceId,
       observations: primaryObservation
         ? [{ id: primaryObservation.id, traceId }]
         : [],

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -79,6 +79,7 @@ export const BatchIOInput = zodSchema.object({
   minStartTime: zodSchema.date(),
   maxStartTime: zodSchema.date(),
   truncated: zodSchema.boolean().optional(), // Defaults to true for performance
+  traceId: zodSchema.string().optional(),
 });
 
 export type BatchIOInput = z.infer<typeof BatchIOInput>;
@@ -178,7 +179,7 @@ export const eventsRouter = createTRPCRouter({
         },
       );
     }),
-  batchIO: protectedProjectProcedure
+  batchIO: protectedGetTraceProcedure
     .input(BatchIOInput)
     .query(async ({ input, ctx }) => {
       return instrumentAsync(

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -79,6 +79,7 @@ export const BatchIOInput = zodSchema.object({
   minStartTime: zodSchema.date(),
   maxStartTime: zodSchema.date(),
   truncated: zodSchema.boolean().optional(), // Defaults to true for performance
+  // Opts into trace-level auth (public traces) in protectedGetTraceProcedure
   traceId: zodSchema.string().optional(),
 });
 
@@ -181,16 +182,22 @@ export const eventsRouter = createTRPCRouter({
     }),
   batchIO: protectedGetTraceProcedure
     .input(BatchIOInput)
-    .query(async ({ input, ctx }) => {
+    .query(async ({ input }) => {
       return instrumentAsync(
         { name: "get-event-batch-io-trpc" },
         async (span) => {
           span.setAttribute("project_id", input.projectId);
           span.setAttribute("observation_count", input.observations.length);
 
+          // the middleware only authorized access to input.traceId (which may
+          // merely be public) — never fetch other traces' observations through it
+          const observations = input.traceId
+            ? input.observations.filter((o) => o.traceId === input.traceId)
+            : input.observations;
+
           const batchIO = await getEventBatchIO({
-            projectId: ctx.session.projectId,
-            observations: input.observations,
+            projectId: input.projectId,
+            observations,
             minStartTime: input.minStartTime,
             maxStartTime: input.maxStartTime,
             truncated: input.truncated,

--- a/web/src/hooks/useParsedObservation.ts
+++ b/web/src/hooks/useParsedObservation.ts
@@ -225,8 +225,6 @@ export function useParsedObservation({
   const eventsQuery = api.events.batchIO.useQuery(
     {
       projectId,
-      // Top-level traceId enables trace-level auth (public traces) in the
-      // protectedGetTraceProcedure middleware.
       traceId,
       observations: [{ id: observationId, traceId }],
       minStartTime: startTime ?? new Date(0),

--- a/web/src/hooks/useParsedObservation.ts
+++ b/web/src/hooks/useParsedObservation.ts
@@ -225,6 +225,9 @@ export function useParsedObservation({
   const eventsQuery = api.events.batchIO.useQuery(
     {
       projectId,
+      // Top-level traceId enables trace-level auth (public traces) in the
+      // protectedGetTraceProcedure middleware.
+      traceId,
       observations: [{ id: observationId, traceId }],
       minStartTime: startTime ?? new Date(0),
       maxStartTime: startTime ?? new Date(),

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -356,6 +356,12 @@ export const traceRouter = createTRPCRouter({
       }),
     )
     .query(async ({ ctx }) => {
+      if (!ctx.trace) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Trace not found",
+        });
+      }
       return {
         ...ctx.trace,
         input: ctx.trace.input as string,

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -469,10 +469,11 @@ export const protectedOrganizationProcedure = withOtelTracingProcedure
  * Protect trace-level getter routes.
  * - Users need to be member of the project to access the trace.
  * - Alternatively, the trace needs to be public.
+ * - Without a traceId, falls back to the project-membership check (trace: null).
  */
 
 const inputTraceSchema = z.object({
-  traceId: z.string(),
+  traceId: z.string().optional(),
   projectId: z.string(),
   timestamp: z.date().nullish(),
   fromTimestamp: z.date().nullish(),
@@ -499,19 +500,21 @@ const enforceTraceAccess = t.middleware(async (opts) => {
   const fromTimestamp = result.data.fromTimestamp;
   const verbosity = result.data.verbosity;
 
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const clickhouseTrace = await getTraceById({
-    traceId,
-    projectId,
-    timestamp: timestamp ?? undefined,
-    fromTimestamp: fromTimestamp ?? undefined,
-    renderingProps: {
-      truncated: verbosity === "truncated",
-      shouldJsonParse: false, // we do not want to parse the input/output for tRPC
-    },
-  });
+  const clickhouseTrace = traceId
+    ? // eslint-disable-next-line @typescript-eslint/no-deprecated
+      await getTraceById({
+        traceId,
+        projectId,
+        timestamp: timestamp ?? undefined,
+        fromTimestamp: fromTimestamp ?? undefined,
+        renderingProps: {
+          truncated: verbosity === "truncated",
+          shouldJsonParse: false, // we do not want to parse the input/output for tRPC
+        },
+      })
+    : null;
 
-  if (!clickhouseTrace) {
+  if (traceId && !clickhouseTrace) {
     logger.error(`Trace with id ${traceId} not found for project ${projectId}`);
     throw new TRPCError({
       code: "NOT_FOUND",
@@ -519,17 +522,19 @@ const enforceTraceAccess = t.middleware(async (opts) => {
     });
   }
 
-  const trace = {
-    ...clickhouseTrace,
-    input: parseIO(clickhouseTrace.input, verbosity),
-    output: parseIO(clickhouseTrace.output, verbosity),
-  };
+  const trace = clickhouseTrace
+    ? {
+        ...clickhouseTrace,
+        input: parseIO(clickhouseTrace.input, verbosity),
+        output: parseIO(clickhouseTrace.output, verbosity),
+      }
+    : null;
 
   const sessionProject = ctx.session?.user?.organizations
     .flatMap((org) => org.projects)
     .find(({ id }) => id === projectId);
 
-  const traceSession = !!trace.sessionId
+  const traceSession = !!trace?.sessionId
     ? await ctx.prisma.traceSession.findFirst({
         where: {
           id: trace.sessionId,
@@ -544,7 +549,7 @@ const enforceTraceAccess = t.middleware(async (opts) => {
   const isSessionPublic = traceSession?.public === true;
 
   if (
-    !trace.public &&
+    !trace?.public &&
     !sessionProject &&
     !isSessionPublic &&
     ctx.session?.user?.admin !== true


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends `protectedGetTraceProcedure` to support an optional `traceId` so that authenticated users can view public traces without needing project membership. The `batchIO` endpoint is migrated from `protectedProjectProcedure` to this more flexible middleware, and all four client-side callers are updated to pass `traceId` to match the new cache key.

- `enforceTraceAccess` middleware now treats `traceId` as optional; without it, access falls back to a pure project-membership check (`trace === null`), preserving backward compatibility.
- `batchIO` adds a server-side observation filter (`o.traceId === input.traceId`) that limits public-trace users to only the authorized trace's observations, preventing cross-trace observation hopping through the batch endpoint.
- `traces.byId` gains a defensive `!ctx.trace` guard; this is redundant for that specific route (which always requires a non-null `traceId`), but protects against future callers that may omit `traceId`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The auth logic is sound — the middleware correctly gates unauthenticated callers behind the public-trace check, and the observation filter prevents cross-trace data leakage on the public path.

The change is well-scoped and the security model is consistent: public-trace users are limited to the single authorized trace's observations, and the fallback to project-membership when traceId is absent preserves the existing access model. Only minor style observations were found — no functional defects were identified.

No files require special attention, though eventsRouter.ts (the observation filter asymmetry) and traces.ts (the unreachable guard) could benefit from a clarifying comment.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Client calls batchIO] --> B{traceId provided?}
    B -- Yes --> C[enforceTraceAccess: fetch trace by traceId+projectId]
    B -- No --> D[enforceTraceAccess: skip trace fetch, trace = null]

    C --> E{Trace found?}
    E -- No --> F[Throw NOT_FOUND]
    E -- Yes --> G{Access check}

    D --> H{sessionProject member?}
    H -- No --> I[Throw UNAUTHORIZED]
    H -- Yes --> J[Access granted, observations unfiltered]

    G --> K{trace.public OR sessionProject OR admin?}
    K -- No --> L[Throw UNAUTHORIZED]
    K -- Yes --> M[Access granted]

    M --> N[Filter: observations where o.traceId === input.traceId]
    N --> O[getEventBatchIO projectId=input.projectId]
    J --> O
    O --> P[Return IO data]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Client calls batchIO] --> B{traceId provided?}
    B -- Yes --> C[enforceTraceAccess: fetch trace by traceId+projectId]
    B -- No --> D[enforceTraceAccess: skip trace fetch, trace = null]

    C --> E{Trace found?}
    E -- No --> F[Throw NOT_FOUND]
    E -- Yes --> G{Access check}

    D --> H{sessionProject member?}
    H -- No --> I[Throw UNAUTHORIZED]
    H -- Yes --> J[Access granted, observations unfiltered]

    G --> K{trace.public OR sessionProject OR admin?}
    K -- No --> L[Throw UNAUTHORIZED]
    K -- Yes --> M[Access granted]

    M --> N[Filter: observations where o.traceId === input.traceId]
    N --> O[getEventBatchIO projectId=input.projectId]
    J --> O
    O --> P[Return IO data]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/events/server/eventsRouter.ts:183-209
**Observation filter only applied on the public-trace path**

When `input.traceId` is absent (project-member path), `input.observations` is passed through to `getEventBatchIO` completely unfiltered. This is intentional and safe because `getEventBatchIO` is always scoped to `input.projectId`, so cross-project leakage is impossible. It is worth adding a short inline comment to make the asymmetry explicit for the next reader — otherwise it looks like the filter was accidentally omitted for the no-`traceId` case.

### Issue 2 of 2
web/src/server/api/routers/traces.ts:358-364
**Unreachable guard in `byId`**

`byId` declares `traceId: z.string()` as required in its own input schema. The `enforceTraceAccess` middleware therefore always either resolves `ctx.trace` or throws `NOT_FOUND` before this handler runs — so `ctx.trace` can never be `null` here in practice. The guard is harmless, but if it is kept, a brief comment explaining that it is purely defensive (guarding against future `traceId`-optional callers) would prevent confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/langfuse/langfuse/commit/1bac1f17310e539225571912f8164d3dd7784f4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42770609)</sub>

<!-- /greptile_comment -->