### PR TITLE
perf(worker): skip metadata on eval trace prefetch unless filtered on

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -540,7 +540,9 @@ export const getTraceByIdFromTracesTable = async ({
         : renderingProps.truncated
           ? `leftUTF8(output, ${env.LANGFUSE_SERVER_SIDE_IO_CHAR_LIMIT})`
           : "output";
-      const metadataColumn = excludeMetadata ? "'{}'" : "metadata";
+      // map() (not a '{}' string literal) so the excluded column keeps the
+      // Map type and converts to an empty object in the domain model.
+      const metadataColumn = excludeMetadata ? "map()" : "metadata";
 
       const query = `
         SELECT

--- a/web/src/__tests__/server/repositories/trace-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/trace-repository.servertest.ts
@@ -4,6 +4,7 @@ import {
 } from "@langfuse/shared/src/server";
 import {
   getTraceById,
+  getTraceByIdFromTracesTable,
   getTracesBySessionId,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
@@ -135,6 +136,37 @@ describe("Clickhouse Traces Repository Test", () => {
       new Date(trace.updated_at).getTime(),
       -2, // Up to 50ms precision
     );
+  });
+
+  it("should return empty metadata and IO when excluded from the fetch", async () => {
+    const traceId = v4();
+
+    const trace = createTrace({
+      id: traceId,
+      project_id: projectId,
+      metadata: { key: "value" },
+      input: "some input",
+      output: "some output",
+      timestamp: Date.now(),
+    });
+
+    await createTracesCh([trace]);
+
+    const result = await getTraceByIdFromTracesTable({
+      traceId,
+      projectId,
+      timestamp: new Date(trace.timestamp),
+      excludeInputOutput: true,
+      excludeMetadata: true,
+    });
+    expect(result).not.toBeNull();
+    if (!result) {
+      return;
+    }
+    expect(result.id).toEqual(trace.id);
+    expect(result.metadata).toEqual({});
+    expect(result.input).toBeNull();
+    expect(result.output).toBeNull();
   });
 
   it("should retrieve traces by session ID", async () => {

--- a/worker/src/__tests__/evalService.filtering.test.ts
+++ b/worker/src/__tests__/evalService.filtering.test.ts
@@ -701,4 +701,60 @@ describe("test eval filtering", () => {
     // Both configs should produce a job — the metadata filter should match
     expect(jobs.length).toBe(2);
   }, 10_000);
+
+  test("evaluates non-metadata filters in memory when metadata is excluded from the cached trace fetch", async ({
+    expect,
+    projectId,
+    traceId1,
+    upsertTrace,
+    configureJob,
+    getJobs,
+  }) => {
+    // The trace carries metadata, but no config filters on it, so the cached
+    // trace fetch drops the metadata column entirely.
+    await upsertTrace({
+      id: traceId1,
+      name: "important-trace",
+      metadata: { tier: "premium" },
+    });
+
+    // Two configs so configs.length > 1 triggers the cached trace path.
+    await configureJob({
+      scoreName: "name-match",
+      filter: [
+        {
+          type: "string",
+          value: "important-trace",
+          column: "Name",
+          operator: "=",
+        },
+      ],
+    });
+    await configureJob({
+      scoreName: "name-mismatch",
+      filter: [
+        {
+          type: "string",
+          value: "other-trace",
+          column: "Name",
+          operator: "=",
+        },
+      ],
+    });
+
+    await createEvalJobs({
+      event: { projectId, traceId: traceId1 },
+      jobTimestamp: new Date(),
+    });
+
+    const jobs = await getJobs();
+    // In-memory evaluation on the metadata-less trace must still discriminate
+    // between the two name filters.
+    expect(jobs.length).toBe(1);
+    expect(jobs[0].jobInputTraceId).toBe(traceId1);
+    const matchingConfig = await prisma.jobConfiguration.findFirst({
+      where: { projectId, scoreName: "name-match" },
+    });
+    expect(jobs[0].jobConfigurationId).toBe(matchingConfig?.id);
+  }, 10_000);
 });

--- a/worker/src/__tests__/traceFilterUtils.test.ts
+++ b/worker/src/__tests__/traceFilterUtils.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { type FilterState } from "@langfuse/shared";
+import { inMemoryFilterRequiresMetadata } from "../features/evaluation/traceFilterUtils";
+
+describe("inMemoryFilterRequiresMetadata", () => {
+  it("returns false for an empty filter", () => {
+    expect(inMemoryFilterRequiresMetadata([])).toBe(false);
+  });
+
+  it("returns false when only non-metadata in-memory columns are referenced", () => {
+    const filter: FilterState = [
+      { type: "string", column: "Name", operator: "=", value: "checkout" },
+      {
+        type: "arrayOptions",
+        column: "Tags",
+        operator: "any of",
+        value: ["prod"],
+      },
+    ];
+    expect(inMemoryFilterRequiresMetadata(filter)).toBe(false);
+  });
+
+  it("returns true when a condition references metadata", () => {
+    const filter: FilterState = [
+      {
+        type: "stringObject",
+        column: "metadata",
+        key: "tier",
+        operator: "=",
+        value: "premium",
+      },
+    ];
+    expect(inMemoryFilterRequiresMetadata(filter)).toBe(true);
+  });
+
+  it("returns true when metadata is referenced by its UI table name", () => {
+    const filter: FilterState = [
+      {
+        type: "stringObject",
+        column: "Metadata",
+        key: "tier",
+        operator: "=",
+        value: "premium",
+      },
+    ];
+    expect(inMemoryFilterRequiresMetadata(filter)).toBe(true);
+  });
+
+  it("returns false when the filter requires a database lookup", () => {
+    // A Level condition cannot be evaluated in memory, so the whole filter
+    // goes to the database and the cached trace's metadata is never read.
+    const filter: FilterState = [
+      {
+        type: "stringObject",
+        column: "metadata",
+        key: "tier",
+        operator: "=",
+        value: "premium",
+      },
+      { type: "string", column: "Level", operator: "=", value: "ERROR" },
+    ];
+    expect(inMemoryFilterRequiresMetadata(filter)).toBe(false);
+  });
+
+  it("returns true for unknown columns", () => {
+    const filter: FilterState = [
+      {
+        type: "string",
+        column: "not-a-real-column",
+        operator: "=",
+        value: "x",
+      },
+    ];
+    expect(inMemoryFilterRequiresMetadata(filter)).toBe(true);
+  });
+});

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -36,6 +36,7 @@ import {
   type CodeEvalScoreWithName,
 } from "@langfuse/shared/src/server";
 import {
+  inMemoryFilterRequiresMetadata,
   mapTraceFilterColumn,
   requiresDatabaseLookup,
 } from "./traceFilterUtils";
@@ -258,6 +259,21 @@ export const createEvalJobs = async ({
   recordIncrement("langfuse.evaluation-execution.config_count", configs.length);
   if (configs.length > 1) {
     try {
+      // Metadata is the heaviest column on this fetch. Skip it unless a
+      // trace-target config's filter reads it during in-memory evaluation;
+      // keep it for unparseable filters so a metadata filter never evaluates
+      // against an empty object.
+      const cachedTraceNeedsMetadata = configs.some((config) => {
+        if (config.targetObject !== EvalTargetObject.TRACE) {
+          return false;
+        }
+        const parsedFilter = z.array(singleFilter).safeParse(config.filter);
+        return (
+          !parsedFilter.success ||
+          inMemoryFilterRequiresMetadata(parsedFilter.data)
+        );
+      });
+
       // Fetch trace data and store it. If observation data is required, we'll make a separate lookup.
       // Those fields are used rarely, though.
       // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -271,11 +287,12 @@ export const createEvalJobs = async ({
               ? new Date(event.timestamp)
               : new Date(jobTimestamp),
         excludeInputOutput: true,
-        excludeMetadata: false, // Metadata needed for in-memory filter evaluation
+        excludeMetadata: !cachedTraceNeedsMetadata,
       });
 
       recordIncrement("langfuse.evaluation-execution.trace_cache_fetch", 1, {
         found: Boolean(cachedTrace).toString(),
+        withMetadata: cachedTraceNeedsMetadata.toString(),
       });
       logger.debug("Fetched trace for evaluation optimization", {
         traceId: event.traceId,

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -261,7 +261,7 @@ export const createEvalJobs = async ({
     try {
       // Metadata is the heaviest column on this fetch. Skip it unless a
       // trace-target config's filter reads it during in-memory evaluation;
-      // keep it for unparseable filters so a metadata filter never evaluates
+      // keep it for unparsable filters so a metadata filter never evaluates
       // against an empty object.
       const cachedTraceNeedsMetadata = configs.some((config) => {
         if (config.targetObject !== EvalTargetObject.TRACE) {

--- a/worker/src/features/evaluation/traceFilterUtils.ts
+++ b/worker/src/features/evaluation/traceFilterUtils.ts
@@ -100,6 +100,26 @@ export function mapTraceFilterColumn(
 }
 
 /**
+ * Whether in-memory evaluation of this trace filter reads the metadata field.
+ * False when the filter never runs in memory (it requires a database lookup)
+ * or references no metadata column. Unknown columns report true so the cached
+ * trace fetch never drops a column a filter might need.
+ */
+export function inMemoryFilterRequiresMetadata(filter: FilterState): boolean {
+  try {
+    if (requiresDatabaseLookup(filter)) {
+      return false;
+    }
+    return filter.some(
+      (condition) =>
+        getInMemoryTraceFilterColumn(condition.column) === "metadata",
+    );
+  } catch {
+    return true;
+  }
+}
+
+/**
  * Determines if a filter requires a database lookup.
  * We make the decision based on whether the filter only selects for allow-listed columns
  */


### PR DESCRIPTION
createEvalJobs fetches the trace once per event (projects with >1 active evaluator) purely for in-memory filter evaluation. Metadata was the last heavy column read unconditionally, but it only matters when a trace-target config filters on it — detect that from the prefetched configs and set excludeMetadata dynamically. Unparseable filters, unknown columns, and filters that fall back to a database lookup keep the column so a metadata filter can never evaluate against an empty object.

Also fix the excludeMetadata placeholder in the traces repository: the '{}' string literal parsed into a garbage object in the domain model; map() converts to a clean {} (matches the events-table variant).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a targeted ClickHouse metadata-skipping optimization to the eval prefetch path: instead of always fetching the heavy `metadata` column when `configs.length > 1`, it now derives at config-parse time whether any trace-target filter actually reads metadata during in-memory evaluation. It also fixes a pre-existing bug where `excludeMetadata` substituted `'{}'` (a string literal that was silently coerced to a garbage Map) with `map()`, which returns a correctly-typed empty ClickHouse Map.

- **New `inMemoryFilterRequiresMetadata` helper** inspects parsed `FilterState` to determine if metadata is needed; unknown columns, parse failures, and unparseable filters conservatively return `true` so metadata is never missing when a filter could read it.
- **`map()` replaces `'{}'`** in the SQL projection for excluded metadata, fixing a type-mismatch bug in the domain model conversion that existed before this PR.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The metadata-exclusion logic is conservative at every decision point and the map() fix corrects a pre-existing type mismatch with no user-facing regression risk.

The new inMemoryFilterRequiresMetadata helper defaults to true (keep metadata) on any unknown column, parse failure, or exception, so the optimization can never cause a metadata filter to evaluate against an empty object. The map() fix resolves a silent type mismatch that was previously returning garbage data on excluded metadata reads. All changed paths are covered by both unit and integration tests.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W as Worker (createEvalJobs)
    participant TFU as traceFilterUtils
    participant CH as ClickHouse
    participant PG as Postgres (DB lookup)

    W->>W: "configs.length > 1?"
    alt Yes — batch optimisation path
        loop for each trace-target config
            W->>TFU: z.array(singleFilter).safeParse(config.filter)
            alt parse fails
                TFU-->>W: "cachedTraceNeedsMetadata = true"
            else parse succeeds
                W->>TFU: inMemoryFilterRequiresMetadata(parsedFilter)
                TFU->>TFU: requiresDatabaseLookup(filter)?
                alt requires DB lookup
                    TFU-->>W: false (metadata not needed for cache)
                else in-memory only
                    TFU->>TFU: "any condition.column === metadata?"
                    TFU-->>W: true/false
                end
            end
        end
        W->>CH: "getTraceById(excludeMetadata=!cachedTraceNeedsMetadata)"
        CH-->>W: cachedTrace (with or without metadata)
    end

    loop for each config
        W->>TFU: requiresDatabaseLookup(traceFilter)?
        alt false — in-memory evaluation
            W->>W: InMemoryFilterService.evaluateFilter(cachedTrace, traceFilter)
        else true — DB lookup needed
            W->>PG: checkTraceExistsAndGetTimestamp(filter)
            PG-->>W: exists, timestamp
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W as Worker (createEvalJobs)
    participant TFU as traceFilterUtils
    participant CH as ClickHouse
    participant PG as Postgres (DB lookup)

    W->>W: "configs.length > 1?"
    alt Yes — batch optimisation path
        loop for each trace-target config
            W->>TFU: z.array(singleFilter).safeParse(config.filter)
            alt parse fails
                TFU-->>W: "cachedTraceNeedsMetadata = true"
            else parse succeeds
                W->>TFU: inMemoryFilterRequiresMetadata(parsedFilter)
                TFU->>TFU: requiresDatabaseLookup(filter)?
                alt requires DB lookup
                    TFU-->>W: false (metadata not needed for cache)
                else in-memory only
                    TFU->>TFU: "any condition.column === metadata?"
                    TFU-->>W: true/false
                end
            end
        end
        W->>CH: "getTraceById(excludeMetadata=!cachedTraceNeedsMetadata)"
        CH-->>W: cachedTrace (with or without metadata)
    end

    loop for each config
        W->>TFU: requiresDatabaseLookup(traceFilter)?
        alt false — in-memory evaluation
            W->>W: InMemoryFilterService.evaluateFilter(cachedTrace, traceFilter)
        else true — DB lookup needed
            W->>PG: checkTraceExistsAndGetTimestamp(filter)
            PG-->>W: exists, timestamp
        end
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(worker): skip metadata on eval trac..."](https://github.com/langfuse/langfuse/commit/5d8cdda0b92c090867b19352d9294b2260b6d6e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42782026)</sub>

<!-- /greptile_comment -->