### PR TITLE
fix(datasets): render JSON-string metadata as expanded JSON in item editor (#14751)

### DIFF
--- a/web/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -24,7 +24,7 @@ import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { CodeMirrorEditor } from "@/src/components/editor";
 import { useMediaTagChips } from "@/src/components/editor/mediaTagWidget";
-import { type Prisma } from "@langfuse/shared";
+import { deepParseJson, type Prisma } from "@langfuse/shared";
 import { cn } from "@/src/utils/tailwind";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { DatasetSchemaHoverCard } from "./DatasetSchemaHoverCard";
@@ -57,10 +57,7 @@ import { Check, ChevronsUpDown } from "lucide-react";
 import { Badge } from "@/src/components/ui/badge";
 import { ScrollArea } from "@/src/components/ui/scroll-area";
 import { DialogBody, DialogFooter } from "@/src/components/ui/dialog";
-import {
-  isValidDatasetJson,
-  parseDatasetJson,
-} from "../utils/parseDatasetJson";
+import { isValidDatasetJson } from "../utils/parseDatasetJson";
 
 const formSchema = z.object({
   datasetIds: z.array(z.string()).min(1, "Select at least one dataset"),
@@ -105,17 +102,17 @@ type DatasetWithSchema = {
 const formatJsonValue = (value: Prisma.JsonValue | undefined): string => {
   if (value === undefined) return "";
 
-  if (typeof value === "string") {
-    try {
-      // Parse the string and re-stringify with proper formatting
-      const parsed = parseDatasetJson(value);
-      return JSON.stringify(parsed, null, 2);
-    } catch {
-      // If it's not valid JSON, stringify the string itself
-      return JSON.stringify(value, null, 2);
-    }
+  try {
+    // Expand nested JSON strings (#14751); clone since deepParseJson mutates.
+    const parsed = deepParseJson(
+      typeof value === "object" && value !== null
+        ? structuredClone(value)
+        : value,
+    );
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return JSON.stringify(value, null, 2);
   }
-  return JSON.stringify(value, null, 2);
 };
 
 export const NewDatasetItemForm = (props: {

--- a/web/src/features/datasets/utils/datasetItemUtils.clienttest.ts
+++ b/web/src/features/datasets/utils/datasetItemUtils.clienttest.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { stringifyDatasetItemData } from "./datasetItemUtils";
+
+describe("stringifyDatasetItemData", () => {
+  it("returns empty string for null/undefined", () => {
+    expect(stringifyDatasetItemData(null)).toBe("");
+    expect(stringifyDatasetItemData(undefined)).toBe("");
+  });
+
+  // #14751: OTLP-ingested metadata often holds JSON-string values. They must
+  // render as expanded JSON (like the trace viewer), not an escaped blob.
+  it("expands a nested JSON-string metadata value", () => {
+    const metadata = {
+      "my.tools": '{"AgentA":[{"name":"getX","args":{"id":"1"}}]}',
+    };
+
+    const result = stringifyDatasetItemData(metadata);
+
+    expect(result).not.toContain('\\"');
+    expect(JSON.parse(result)).toEqual({
+      "my.tools": { AgentA: [{ name: "getX", args: { id: "1" } }] },
+    });
+  });
+
+  it("expands a top-level JSON-string value", () => {
+    expect(stringifyDatasetItemData('{"answer":"London"}')).toBe(
+      JSON.stringify({ answer: "London" }, null, 2),
+    );
+  });
+
+  it("keeps a non-JSON string as a quoted string", () => {
+    expect(stringifyDatasetItemData("hello world")).toBe('"hello world"');
+  });
+
+  it("does not mutate the input object", () => {
+    const metadata = { nested: '{"a":1}' };
+    stringifyDatasetItemData(metadata);
+    expect(metadata.nested).toBe('{"a":1}');
+  });
+});

--- a/web/src/features/datasets/utils/datasetItemUtils.ts
+++ b/web/src/features/datasets/utils/datasetItemUtils.ts
@@ -1,5 +1,5 @@
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import type { Prisma } from "@langfuse/shared";
+import { deepParseJson, type Prisma } from "@langfuse/shared";
 
 /**
  * Converts a dataset item field value to a formatted JSON string.
@@ -9,7 +9,11 @@ export const stringifyDatasetItemData = (data: unknown): string => {
   if (!data) return "";
 
   try {
-    return JSON.stringify(data, null, 2);
+    // Expand nested JSON strings (#14751); clone since deepParseJson mutates.
+    const parsed = deepParseJson(
+      typeof data === "object" ? structuredClone(data) : data,
+    );
+    return JSON.stringify(parsed, null, 2);
   } catch {
     showErrorToast(
       "Failed to stringify data",


### PR DESCRIPTION
## What

The dataset-item editor showed JSON-string metadata as an escaped blob, like `"{\"tools\":[...]}"`. The trace viewer showed the same value as expanded, readable JSON. Values like this are common on OTLP-ingested traces, where non-primitive attributes get serialized to strings. In the editor the escaping made the value hard to read and near impossible to edit by hand.

Fixes #14751.

## Why it happened

Two paths build the string the editor shows, and both called `JSON.stringify` directly:

- `formatJsonValue` in `NewDatasetItemForm` (the "Add to dataset" form)
- `stringifyDatasetItemData` in `datasetItemUtils` (the edit dialog)

Neither unwrapped nested JSON strings, so a stringified value stayed escaped. The trace viewer already handles this by running values through `deepParseJson`.

## The fix

Both paths now run the value through the shared `deepParseJson` before formatting, so the editor matches the trace viewer. Objects are cloned first, because `deepParseJson` mutates its input in place and the value comes from shared React state.

## Behavior change to flag

The editor now saves the deep-parsed form. A metadata attribute stored as a JSON string gets written back as a real object the next time the item is saved. That is what the issue asks for, but a maintainer should confirm it is the wanted behavior.

## Testing

Added `datasetItemUtils.clienttest.ts` covering nested JSON strings, top-level JSON strings, plain strings, null, and the no-mutation guarantee. I could not run the full suite locally because of an unrelated `pnpm install` problem on my machine, so please let CI confirm.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the dataset item editor rendering JSON-string metadata as an escaped blob by routing both `formatJsonValue` (in `NewDatasetItemForm`) and `stringifyDatasetItemData` (in `datasetItemUtils`) through `deepParseJson` before formatting, matching what the trace viewer already does. A small test suite is added covering the key scenarios.

- `deepParseJson` is now applied (with a `structuredClone` guard) before `JSON.stringify` in both display paths, so OTLP-ingested metadata attributes stored as JSON strings are shown as readable, expanded JSON rather than escaped blobs.
- The change carries an acknowledged behavioral side-effect: saving a dataset item after viewing it will persist the deep-parsed (object) form of any previously-stringified metadata field, converting stored JSON strings to real objects.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The display fix is solid, but `stringifyDatasetItemData` silently drops valid falsy `Prisma.JsonValue` inputs (`0`, `false`, `""`) via the `!data` guard, and on save those values would be written back as deep-parsed objects — a combination that warrants a second look before merging.

The `!data` early-return in `stringifyDatasetItemData` was pre-existing but is now load-bearing for the `structuredClone` null-protection path. Any falsy `Prisma.JsonValue` — `0`, `false`, or empty string — gets silently serialized as `""` instead of the correct JSON representation, and if the user saves after viewing, that field would either be dropped or overwritten. The fix itself (deep-parsing nested strings) is correct and well-tested, and `NewDatasetItemForm.tsx` handles the same cases cleanly.

web/src/features/datasets/utils/datasetItemUtils.ts — the `!data` guard and the missing `null` check on `structuredClone`
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dataset Item Editor opens] --> B{Field value type?}
    B -->|Prisma.JsonValue - object/array| C[structuredClone value]
    B -->|Prisma.JsonValue - string / primitive| D[Use value as-is]
    C --> E[deepParseJson]
    D --> E
    E --> F{Contains nested JSON strings?}
    F -->|Yes - e.g. OTLP trace metadata| G[Recursively parse string values into objects]
    F -->|No| H[Return value unchanged]
    G --> I[JSON.stringify with 2-space indent]
    H --> I
    I --> J[Display in CodeMirror editor]
    J --> K{User saves item?}
    K -->|Yes| L[Saves deep-parsed form\nJSON strings become real objects]
    K -->|No| M[No data mutation]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Dataset Item Editor opens] --> B{Field value type?}
    B -->|Prisma.JsonValue - object/array| C[structuredClone value]
    B -->|Prisma.JsonValue - string / primitive| D[Use value as-is]
    C --> E[deepParseJson]
    D --> E
    E --> F{Contains nested JSON strings?}
    F -->|Yes - e.g. OTLP trace metadata| G[Recursively parse string values into objects]
    F -->|No| H[Return value unchanged]
    G --> I[JSON.stringify with 2-space indent]
    H --> I
    I --> J[Display in CodeMirror editor]
    J --> K{User saves item?}
    K -->|Yes| L[Saves deep-parsed form\nJSON strings become real objects]
    K -->|No| M[No data mutation]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/datasets/utils/datasetItemUtils.ts:13-15
The `typeof data === "object"` guard is `true` for `null` (standard JS quirk), so it would call `structuredClone(null)` when `data` is `null`. That call succeeds and returns `null`, so there's no runtime error here — `null` is already excluded by the `!data` early-return above — but the asymmetry with the parallel guard in `NewDatasetItemForm.tsx` (`typeof value === "object" && value !== null`) is a latent confusion risk if the early-return is ever adjusted.

```suggestion
    const parsed = deepParseJson(
      typeof data === "object" && data !== null ? structuredClone(data) : data,
    );
```

### Issue 2 of 2
web/src/features/datasets/utils/datasetItemUtils.ts:9
**Falsy-value short-circuit silently swallows valid data** — The `!data` guard returns `""` for any falsy value: `0`, `false`, and `""` are all valid `Prisma.JsonValue` entries that would be silently dropped instead of serialized. This is pre-existing behavior, but the new `deepParseJson` path now relies on this guard for null protection in `structuredClone`, making the coupling more load-bearing than it was before.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(datasets): render JSON-string metada..."](https://github.com/langfuse/langfuse/commit/2ede501ce7514104d63423dc37f55e735a18b8c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42852578)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->