### PR TITLE
chore: pipeline blob storage cleanup deletes and batch tombstone inserts

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -281,6 +281,13 @@ const EnvSchema = z.object({
   LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG: z
     .enum(["true", "false"])
     .default("true"),
+  // Max concurrent S3 deleteFiles requests the blob-storage cleanup consumer
+  // keeps in flight. Bounds memory and backpressures the ClickHouse ref stream.
+  LANGFUSE_BLOB_STORAGE_DELETE_S3_CONCURRENCY: z.coerce
+    .number()
+    .min(1)
+    .max(20)
+    .default(5),
 
   // V4 write mode. Mirrors worker/src/env.ts so the web package can gate
   // public API routes that rely on the legacy traces/observations tables.

--- a/packages/shared/src/server/data-deletion/ingestionFileDeletion.ts
+++ b/packages/shared/src/server/data-deletion/ingestionFileDeletion.ts
@@ -1,3 +1,4 @@
+import { Readable } from "stream";
 import {
   getBlobStorageByProjectId,
   getBlobStorageByProjectIdAndEntityIds,
@@ -9,12 +10,39 @@ import { logger } from "../logger";
 import { env } from "../../env";
 import { clickhouseClient } from "../clickhouse/client";
 import { buildClickHouseLogComment } from "../clickhouse/queryTags";
-import { getS3EventStorageClient } from "../s3";
+import { getS3EventStorageClient, S3_DELETE_OBJECTS_CHUNK_SIZE } from "../s3";
 
-export const deleteIngestionEventsFromS3AndClickhouseForScores = async (p: {
-  projectId: string;
-  scoreIds: string[];
-}) => {
+// Derive the default from the S3 DeleteObjects chunk size so a full chunk is
+// exactly one S3 API request (plus its internal retries) and the two can't
+// drift.
+const DEFAULT_S3_CHUNK_SIZE = S3_DELETE_OBJECTS_CHUNK_SIZE;
+// ClickHouse best practice batches inserts at 10k–100k rows; small tombstone
+// inserts create part-count pressure on blob_storage_file_log.
+const DEFAULT_TOMBSTONE_FLUSH_SIZE = 10_000;
+
+/**
+ * Tuning knobs for the blob-storage cleanup pipeline. All optional; defaults are
+ * production values. Tests inject tiny values to exercise chunking, batching, and
+ * the concurrency bound cheaply.
+ */
+type BlobCleanupPipelineOptions = {
+  // Refs per S3 deleteFiles call. Default matches the StorageService internal
+  // DeleteObjectsCommand chunk (900) so one dispatch is exactly one S3 request.
+  s3ChunkSize?: number;
+  // Max concurrent deleteFiles calls in flight; backpressures the ClickHouse ref
+  // stream and bounds resident memory. Defaults to the shared env knob.
+  s3Concurrency?: number;
+  // Refs buffered before a single tombstone insert. Larger batches mean fewer,
+  // bigger inserts (ClickHouse best practice; less part-count pressure).
+  tombstoneFlushSize?: number;
+};
+
+export const deleteIngestionEventsFromS3AndClickhouseForScores = async (
+  p: {
+    projectId: string;
+    scoreIds: string[];
+  } & BlobCleanupPipelineOptions,
+) => {
   const stream = getBlobStorageByProjectIdAndEntityIds(
     p.projectId,
     "score",
@@ -24,15 +52,20 @@ export const deleteIngestionEventsFromS3AndClickhouseForScores = async (p: {
   return removeIngestionEventsFromS3AndDeleteClickhouseRefs({
     projectId: p.projectId,
     stream,
+    s3ChunkSize: p.s3ChunkSize,
+    s3Concurrency: p.s3Concurrency,
+    tombstoneFlushSize: p.tombstoneFlushSize,
   });
 };
 
 export const removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces =
-  async (p: {
-    projectId: string;
-    traceIds: string[];
-    includeEventsTable?: boolean;
-  }) => {
+  async (
+    p: {
+      projectId: string;
+      traceIds: string[];
+      includeEventsTable?: boolean;
+    } & BlobCleanupPipelineOptions,
+  ) => {
     const stream = getBlobStorageByProjectIdAndTraceIds(
       p.projectId,
       p.traceIds,
@@ -42,12 +75,16 @@ export const removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces =
     return removeIngestionEventsFromS3AndDeleteClickhouseRefs({
       projectId: p.projectId,
       stream: stream,
+      s3ChunkSize: p.s3ChunkSize,
+      s3Concurrency: p.s3Concurrency,
+      tombstoneFlushSize: p.tombstoneFlushSize,
     });
   };
 
 export const removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject = (
   projectId: string,
   cutOffDate: Date | undefined,
+  options?: BlobCleanupPipelineOptions,
 ) => {
   const stream = cutOffDate
     ? getBlobStorageByProjectIdBeforeDate(projectId, cutOffDate)
@@ -56,49 +93,100 @@ export const removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject = (
   return removeIngestionEventsFromS3AndDeleteClickhouseRefs({
     projectId: projectId,
     stream: stream,
+    s3ChunkSize: options?.s3ChunkSize,
+    s3Concurrency: options?.s3Concurrency,
+    tombstoneFlushSize: options?.tombstoneFlushSize,
   });
 };
 
-async function removeIngestionEventsFromS3AndDeleteClickhouseRefs(p: {
-  projectId: string;
-  stream: AsyncGenerator<BlobStorageFileRefRecordReadType>;
-}) {
+/**
+ * Groups `source` into arrays of at most `size` elements, in order. The final
+ * group may be smaller than `size`.
+ */
+async function* chunk<T>(
+  source: AsyncIterable<T>,
+  size: number,
+): AsyncGenerator<T[]> {
+  let batch: T[] = [];
+  for await (const item of source) {
+    batch.push(item);
+    if (batch.length >= size) {
+      yield batch;
+      batch = [];
+    }
+  }
+  if (batch.length > 0) yield batch;
+}
+
+async function removeIngestionEventsFromS3AndDeleteClickhouseRefs(
+  p: {
+    projectId: string;
+    stream: AsyncGenerator<BlobStorageFileRefRecordReadType>;
+  } & BlobCleanupPipelineOptions,
+) {
   const { projectId, stream } = p;
+  const s3ChunkSize = p.s3ChunkSize ?? DEFAULT_S3_CHUNK_SIZE;
+  const s3Concurrency =
+    p.s3Concurrency ?? env.LANGFUSE_BLOB_STORAGE_DELETE_S3_CONCURRENCY;
+  const tombstoneFlushSize =
+    p.tombstoneFlushSize ?? DEFAULT_TOMBSTONE_FLUSH_SIZE;
 
-  let batch = 0;
-
-  let blobStorageRefs: BlobStorageFileRefRecordReadType[] = [];
   const eventStorageClient = getS3EventStorageClient(
     env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
   );
-  for await (const eventLog of stream) {
-    blobStorageRefs.push(eventLog);
-    if (blobStorageRefs.length > 500) {
-      // Delete the current batch and reset the list
-      await eventStorageClient.deleteFiles(
-        blobStorageRefs.map((r) => r.bucket_path),
-      );
 
-      // soft delete the blob storage references in clickhouse
-      await softDeleteInClickhouse(blobStorageRefs, {
-        projectId,
-      });
-      batch++;
+  let pendingTombstones: BlobStorageFileRefRecordReadType[] = [];
+  let dispatchedBatches = 0;
+  let flushes = 0;
+
+  const flushTombstones = async () => {
+    if (pendingTombstones.length === 0) {
+      return;
+    }
+    const toFlush = pendingTombstones;
+    pendingTombstones = [];
+    await softDeleteInClickhouse(toFlush, { projectId });
+    flushes++;
+    logger.info(
+      `Tombstoned ${toFlush.length} blob storage refs (flush ${flushes}) for project ${projectId}`,
+    );
+  };
+
+  // Cleanup is at-least-once: a ref reaches `pendingTombstones` only when the
+  // `.map` stage yields it, i.e. strictly after its chunk's `deleteFiles` call
+  // resolved -- so a ref can never be hidden from retry discovery while its S3
+  // object still exists (the one direction that would leak permanently). If a
+  // delete or a flush throws, the error propagates straight out of the loop and
+  // any refs deleted-but-not-yet-tombstoned simply stay FINAL-visible for the
+  // next retry to rediscover and re-delete idempotently -- no failure-path
+  // bookkeeping needed. (`Readable.map`'s typings report `Readable`/`any` for
+  // the mapped async iterator; the cast only restores the loop variable's real
+  // type, it doesn't relax the function's signature.)
+  const mapped = Readable.from(chunk(stream, s3ChunkSize)).map(
+    async (refs: BlobStorageFileRefRecordReadType[]) => {
+      dispatchedBatches++;
       logger.info(
-        `Deleted batch ${batch} of size ${blobStorageRefs.length} for ${projectId} of deleting s3 refs`,
+        `Dispatched S3 delete batch ${dispatchedBatches} of ${refs.length} refs for project ${projectId}`,
       );
-      blobStorageRefs = [];
+      // deleteFiles already retries 3x internally; a rejection here is terminal.
+      await eventStorageClient.deleteFiles(refs.map((r) => r.bucket_path));
+      return refs;
+    },
+    { concurrency: s3Concurrency },
+  );
+
+  for await (const deletedRefs of mapped as AsyncIterable<
+    BlobStorageFileRefRecordReadType[]
+  >) {
+    pendingTombstones.push(...deletedRefs);
+    if (pendingTombstones.length >= tombstoneFlushSize) {
+      await flushTombstones();
     }
   }
-  // Delete any remaining files
-  await eventStorageClient.deleteFiles(
-    blobStorageRefs.map((r) => r.bucket_path),
-  );
-  await softDeleteInClickhouse(blobStorageRefs, {
-    projectId,
-  });
+
+  await flushTombstones();
   logger.info(
-    `Deleted last batch ${batch} of size ${blobStorageRefs.length} for ${projectId} of deleting s3 refs`,
+    `Completed blob storage cleanup for project ${projectId}: ${dispatchedBatches} S3 delete batches, ${flushes} tombstone flushes`,
   );
 }
 

--- a/packages/shared/src/server/data-deletion/ingestionFileDeletion.ts
+++ b/packages/shared/src/server/data-deletion/ingestionFileDeletion.ts
@@ -125,7 +125,13 @@ async function removeIngestionEventsFromS3AndDeleteClickhouseRefs(
   } & BlobCleanupPipelineOptions,
 ) {
   const { projectId, stream } = p;
-  const s3ChunkSize = p.s3ChunkSize ?? DEFAULT_S3_CHUNK_SIZE;
+  // Cap at the S3 DeleteObjects chunk size: deleteFiles re-chunks internally at
+  // that limit, so a larger value would turn one dispatch into several S3
+  // requests and inflate the real in-flight request count past s3Concurrency.
+  const s3ChunkSize = Math.min(
+    p.s3ChunkSize ?? DEFAULT_S3_CHUNK_SIZE,
+    S3_DELETE_OBJECTS_CHUNK_SIZE,
+  );
   const s3Concurrency =
     p.s3Concurrency ?? env.LANGFUSE_BLOB_STORAGE_DELETE_S3_CONCURRENCY;
   const tombstoneFlushSize =
@@ -155,13 +161,10 @@ async function removeIngestionEventsFromS3AndDeleteClickhouseRefs(
   // Cleanup is at-least-once: a ref reaches `pendingTombstones` only when the
   // `.map` stage yields it, i.e. strictly after its chunk's `deleteFiles` call
   // resolved -- so a ref can never be hidden from retry discovery while its S3
-  // object still exists (the one direction that would leak permanently). If a
-  // delete or a flush throws, the error propagates straight out of the loop and
-  // any refs deleted-but-not-yet-tombstoned simply stay FINAL-visible for the
-  // next retry to rediscover and re-delete idempotently -- no failure-path
-  // bookkeeping needed. (`Readable.map`'s typings report `Readable`/`any` for
-  // the mapped async iterator; the cast only restores the loop variable's real
-  // type, it doesn't relax the function's signature.)
+  // object still exists (the one direction that would leak permanently).
+  // (`Readable.map`'s typings report `Readable`/`any` for the mapped async
+  // iterator; the cast only restores the loop variable's real type, it doesn't
+  // relax the function's signature.)
   const mapped = Readable.from(chunk(stream, s3ChunkSize)).map(
     async (refs: BlobStorageFileRefRecordReadType[]) => {
       dispatchedBatches++;
@@ -175,16 +178,27 @@ async function removeIngestionEventsFromS3AndDeleteClickhouseRefs(
     { concurrency: s3Concurrency },
   );
 
-  for await (const deletedRefs of mapped as AsyncIterable<
-    BlobStorageFileRefRecordReadType[]
-  >) {
-    pendingTombstones.push(...deletedRefs);
-    if (pendingTombstones.length >= tombstoneFlushSize) {
-      await flushTombstones();
+  try {
+    for await (const deletedRefs of mapped as AsyncIterable<
+      BlobStorageFileRefRecordReadType[]
+    >) {
+      pendingTombstones.push(...deletedRefs);
+      if (pendingTombstones.length >= tombstoneFlushSize) {
+        await flushTombstones();
+      }
     }
+  } finally {
+    // Tombstone whatever has been deleted but not yet flushed -- the final
+    // partial batch on success, or the already-succeeded chunks on error --
+    // so a retry resumes past them instead of redoing their deletes. Runs on
+    // both paths; flushTombstones() no-ops when the buffer is empty, so it
+    // never double-inserts. A throw here on the error path replaces the
+    // original error, which is acceptable: both outcomes just mean "retry",
+    // and every un-tombstoned ref stays FINAL-visible and idempotently
+    // re-deletable regardless.
+    await flushTombstones();
   }
 
-  await flushTombstones();
   logger.info(
     `Completed blob storage cleanup for project ${projectId}: ${dispatchedBatches} S3 delete batches, ${flushes} tombstone flushes`,
   );

--- a/packages/shared/src/server/s3/index.ts
+++ b/packages/shared/src/server/s3/index.ts
@@ -4,6 +4,8 @@ import {
   StorageServiceFactory,
 } from "../services/StorageService";
 
+export { S3_DELETE_OBJECTS_CHUNK_SIZE } from "../services/StorageService";
+
 let s3MediaStorageClient: StorageService;
 let s3EventStorageClient: StorageService;
 

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -271,6 +271,11 @@ export interface StorageService {
   deleteFiles(paths: string[]): Promise<void>;
 }
 
+// Keys per S3 DeleteObjects request. The API hard limit is 1000; 900 leaves a
+// margin. Exported so callers that batch their own deletes can size a batch to
+// exactly one request instead of duplicating the number.
+export const S3_DELETE_OBJECTS_CHUNK_SIZE = 900;
+
 export class StorageServiceFactory {
   /**
    * Get an instance of the StorageService
@@ -925,7 +930,7 @@ class S3StorageService implements StorageService {
   }
 
   async deleteFilesNonRetrying(paths: string[]): Promise<void> {
-    const chunkSize = 900;
+    const chunkSize = S3_DELETE_OBJECTS_CHUNK_SIZE;
     const chunks = [];
 
     for (let i = 0; i < paths.length; i += chunkSize) {

--- a/worker/src/__tests__/ingestionFileDeletion.test.ts
+++ b/worker/src/__tests__/ingestionFileDeletion.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import waitForExpect from "wait-for-expect";
+import {
+  clickhouseClient,
+  createOrgProjectAndApiKey,
+  getBlobStorageByProjectId,
+  getS3EventStorageClient,
+  removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
+  StorageService,
+  StorageServiceFactory,
+} from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+import { env } from "../env";
+
+type SeededRef = { entityId: string; bucketPath: string };
+
+describe("ingestion file deletion pipeline", () => {
+  let eventStorageService: StorageService;
+
+  beforeAll(() => {
+    eventStorageService = StorageServiceFactory.getInstance({
+      accessKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY,
+      bucketName: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+      endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
+      forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Seeds `count` blob storage refs for a project: uploads a matching S3 object
+   * for each ref (so real deletes have something to remove) and inserts the log
+   * rows. Returns the refs so tests can reason about individual bucket paths.
+   */
+  const seedRefs = async (
+    projectId: string,
+    count: number,
+    opts?: { uploadFiles?: boolean },
+  ): Promise<SeededRef[]> => {
+    const refs: SeededRef[] = Array.from({ length: count }, () => {
+      const entityId = randomUUID();
+      return {
+        entityId,
+        bucketPath: `${projectId}/traces/${entityId}-trace.json`,
+      };
+    });
+
+    if (opts?.uploadFiles !== false) {
+      await Promise.all(
+        refs.map((r) =>
+          eventStorageService.uploadFile({
+            fileName: r.bucketPath,
+            fileType: "application/json",
+            data: JSON.stringify({ hello: "world" }),
+          }),
+        ),
+      );
+    }
+
+    await clickhouseClient().insert({
+      table: "blob_storage_file_log",
+      format: "JSONEachRow",
+      values: refs.map((r) => ({
+        id: randomUUID(),
+        project_id: projectId,
+        entity_type: "trace",
+        entity_id: r.entityId,
+        event_id: randomUUID(),
+        bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+        bucket_path: r.bucketPath,
+        created_at: new Date().getTime(),
+        updated_at: new Date().getTime(),
+      })),
+    });
+
+    return refs;
+  };
+
+  /** Collects the bucket paths still visible under FINAL (i.e. not tombstoned). */
+  const visibleBucketPaths = async (projectId: string): Promise<string[]> => {
+    const paths: string[] = [];
+    for await (const ref of getBlobStorageByProjectId(projectId)) {
+      paths.push(ref.bucket_path);
+    }
+    return paths;
+  };
+
+  it("deletes every S3 object, tombstones every ref, and batches tombstone flushes independently of the S3 chunk size", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const refs = await seedRefs(projectId, 13);
+
+    const eventStorageClient = getS3EventStorageClient(
+      env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+    );
+    const deleteFilesSpy = vi.spyOn(eventStorageClient, "deleteFiles");
+    // Count only the tombstone inserts issued by the consumer (seeding already
+    // happened above, before the spy was installed).
+    const insertSpy = vi.spyOn(clickhouseClient(), "insert");
+
+    // chunk 3 => ceil(13/3) = 5 S3 deletes; flush 5 with concurrency 1 (so
+    // completion order is deterministic) => flushes at buffer sizes 6, 6, 1 = 3
+    // tombstone inserts. The batching is driven by the flush threshold, NOT by
+    // the S3 chunk count (which would be 5 under the old one-insert-per-chunk
+    // shape).
+    await removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject(
+      projectId,
+      undefined,
+      { s3ChunkSize: 3, s3Concurrency: 1, tombstoneFlushSize: 5 },
+    );
+
+    // Every ref tombstoned (invisible under FINAL).
+    expect(await visibleBucketPaths(projectId)).toHaveLength(0);
+
+    // Every S3 object removed.
+    const files = await eventStorageService.listFiles(projectId);
+    expect(files).toHaveLength(0);
+
+    // Exactly one S3 delete per chunk.
+    expect(deleteFilesSpy).toHaveBeenCalledTimes(5);
+    for (const call of deleteFilesSpy.mock.calls) {
+      expect((call[0] as string[]).length).toBeLessThanOrEqual(3);
+    }
+
+    // Tombstone inserts are batched by the flush threshold, not by S3 chunk.
+    expect(insertSpy).toHaveBeenCalledTimes(3);
+    expect(insertSpy.mock.calls.length).toBeLessThan(
+      deleteFilesSpy.mock.calls.length,
+    );
+
+    // Sanity: all seeded paths were passed to some delete call.
+    const deletedPaths = new Set(
+      deleteFilesSpy.mock.calls.flatMap((call) => call[0] as string[]),
+    );
+    for (const ref of refs) {
+      expect(deletedPaths.has(ref.bucketPath)).toBe(true);
+    }
+  });
+
+  it("rethrows on a failed chunk, tombstones only the chunks that succeeded, and leaves the failed chunk retry-able", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    await seedRefs(projectId, 13);
+
+    const eventStorageClient = getS3EventStorageClient(
+      env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+    );
+    const realDeleteFiles =
+      eventStorageClient.deleteFiles.bind(eventStorageClient);
+
+    let callIndex = 0;
+    const succeededPaths: string[] = [];
+    let failedPaths: string[] = [];
+    // Concurrency 1 => strictly sequential dispatch, so the 3rd chunk (index 2)
+    // fails only after chunks 0 and 1 fully resolved. Fail-fast then abandons
+    // the remaining chunks.
+    vi.spyOn(eventStorageClient, "deleteFiles").mockImplementation(
+      async (paths: string[]) => {
+        const idx = callIndex++;
+        if (idx === 2) {
+          failedPaths = [...paths];
+          throw new Error("Simulated S3 delete failure");
+        }
+        await realDeleteFiles(paths);
+        succeededPaths.push(...paths);
+      },
+    );
+
+    await expect(
+      removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject(
+        projectId,
+        undefined,
+        { s3ChunkSize: 3, s3Concurrency: 1, tombstoneFlushSize: 5 },
+      ),
+    ).rejects.toThrow("Simulated S3 delete failure");
+
+    // Chunks 0 and 1 succeeded (6 refs); chunk 2 failed (3 refs); chunks 3 and 4
+    // were never dispatched (fail-fast) => 7 refs remain visible.
+    expect(succeededPaths).toHaveLength(6);
+    expect(failedPaths).toHaveLength(3);
+
+    const visible = new Set(await visibleBucketPaths(projectId));
+
+    // Succeeded chunks tombstoned so a retry does not redo their S3 work.
+    for (const path of succeededPaths) {
+      expect(visible.has(path)).toBe(false);
+    }
+    // Failed chunk stays visible for a retry (its refs were never tombstoned).
+    for (const path of failedPaths) {
+      expect(visible.has(path)).toBe(true);
+    }
+    // 13 total - 6 succeeded = 7 still visible (3 failed + 4 never dispatched).
+    expect(visible.size).toBe(7);
+  });
+
+  it("never exceeds the configured concurrency while dispatching, and resumes as deletes settle", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    // No S3 objects needed: deleteFiles is fully mocked with deferred promises.
+    await seedRefs(projectId, 5, { uploadFiles: false });
+
+    const eventStorageClient = getS3EventStorageClient(
+      env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+    );
+
+    let activeDeletes = 0;
+    let maxActiveDeletes = 0;
+    const resolvers: Array<() => void> = [];
+    const deleteFilesSpy = vi
+      .spyOn(eventStorageClient, "deleteFiles")
+      .mockImplementation(() => {
+        activeDeletes++;
+        maxActiveDeletes = Math.max(maxActiveDeletes, activeDeletes);
+        return new Promise<void>((resolve) => {
+          resolvers.push(() => {
+            activeDeletes--;
+            resolve();
+          });
+        });
+      });
+
+    // chunk 1 => one delete per ref (5 chunks); concurrency 2; huge flush so no
+    // tombstone flush interferes mid-stream.
+    const runPromise =
+      removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject(
+        projectId,
+        undefined,
+        { s3ChunkSize: 1, s3Concurrency: 2, tombstoneFlushSize: 100 },
+      );
+
+    // Pool saturates at exactly 2 and then blocks: no third dispatch yet.
+    await waitForExpect(() => {
+      expect(deleteFilesSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(activeDeletes).toBe(2);
+    expect(maxActiveDeletes).toBe(2);
+    expect(deleteFilesSpy).toHaveBeenCalledTimes(2);
+
+    // Settle one delete => exactly one more dispatch proceeds, bound still holds.
+    resolvers[0]();
+    await waitForExpect(() => {
+      expect(deleteFilesSpy).toHaveBeenCalledTimes(3);
+    });
+    expect(maxActiveDeletes).toBe(2);
+
+    // Drain the rest so the pipeline completes; keep resolving new deferreds as
+    // they are dispatched (event-loop driven, no fixed delays).
+    let settled = false;
+    runPromise.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    let nextResolverIndex = 1;
+    const pump = () => {
+      while (nextResolverIndex < resolvers.length) {
+        resolvers[nextResolverIndex++]();
+      }
+      if (!settled) setImmediate(pump);
+    };
+    pump();
+
+    await runPromise;
+
+    // The bound was never breached across the whole run, and every chunk ran.
+    expect(maxActiveDeletes).toBe(2);
+    expect(deleteFilesSpy).toHaveBeenCalledTimes(5);
+    expect(await visibleBucketPaths(projectId)).toHaveLength(0);
+  });
+});

--- a/worker/src/__tests__/ingestionFileDeletion.test.ts
+++ b/worker/src/__tests__/ingestionFileDeletion.test.ts
@@ -196,6 +196,62 @@ describe("ingestion file deletion pipeline", () => {
     expect(visible.size).toBe(7);
   });
 
+  it("checkpoints already-deleted chunks on failure even when the flush threshold was never reached", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    await seedRefs(projectId, 13);
+
+    const eventStorageClient = getS3EventStorageClient(
+      env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+    );
+    const realDeleteFiles =
+      eventStorageClient.deleteFiles.bind(eventStorageClient);
+
+    let callIndex = 0;
+    const succeededPaths: string[] = [];
+    let failedPaths: string[] = [];
+    vi.spyOn(eventStorageClient, "deleteFiles").mockImplementation(
+      async (paths: string[]) => {
+        const idx = callIndex++;
+        if (idx === 2) {
+          failedPaths = [...paths];
+          throw new Error("Simulated S3 delete failure");
+        }
+        await realDeleteFiles(paths);
+        succeededPaths.push(...paths);
+      },
+    );
+
+    await expect(
+      removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject(
+        projectId,
+        undefined,
+        // tombstoneFlushSize (100) far exceeds the 6 refs the succeeding chunks
+        // produce, so the in-loop flush never fires: the ONLY thing that can
+        // tombstone them before the error propagates is the finally-flush. This
+        // pins that fail-path checkpoint against regressing back to "no error
+        // handling", which would leave all 6 visible and redone on retry.
+        { s3ChunkSize: 3, s3Concurrency: 1, tombstoneFlushSize: 100 },
+      ),
+    ).rejects.toThrow("Simulated S3 delete failure");
+
+    expect(succeededPaths).toHaveLength(6);
+    expect(failedPaths).toHaveLength(3);
+
+    const visible = new Set(await visibleBucketPaths(projectId));
+
+    // The finally-flush checkpointed the succeeded chunks despite never hitting
+    // the flush threshold, so a retry does not redo their S3 deletes.
+    for (const path of succeededPaths) {
+      expect(visible.has(path)).toBe(false);
+    }
+    // The failed chunk was never tombstoned -- it stays retry-able.
+    for (const path of failedPaths) {
+      expect(visible.has(path)).toBe(true);
+    }
+    // 6 checkpointed => 7 still visible (3 failed + 4 never dispatched).
+    expect(visible.size).toBe(7);
+  });
+
   it("never exceeds the configured concurrency while dispatching, and resumes as deletes settle", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
     // No S3 objects needed: deleteFiles is fully mocked with deferred promises.


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the blob-storage cleanup pipeline to support concurrent S3 batch deletes and decoupled ClickHouse tombstone flushing. The existing sequential 500-ref loop is replaced with a `Readable.map`-based pipeline that dispatches up to `LANGFUSE_BLOB_STORAGE_DELETE_S3_CONCURRENCY` (default 5) concurrent `DeleteObjects` requests, while tombstone inserts are batched independently at 10 000 refs to reduce ClickHouse part-count pressure.

- **`ingestionFileDeletion.ts`**: Introduces a generic `chunk()` async generator, uses `Readable.from().map({ concurrency })` for parallelism, and decouples tombstone flush size from S3 chunk size. The at-least-once ordering guarantee (S3 delete strictly before tombstone) is preserved — a ref is added to `pendingTombstones` only after its `deleteFiles` resolves.
- **`StorageService.ts` / `s3/index.ts`**: Extracts the internal S3 chunk limit (900) into an exported constant so the outer pipeline can align with it without duplicating the magic number.
- **`env.ts`**: Adds the `LANGFUSE_BLOB_STORAGE_DELETE_S3_CONCURRENCY` env var (1–20, default 5).
- **New integration tests**: Cover correct chunk batching, failure propagation with at-least-once semantics, and the concurrency bound via deferred-promise mocks.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The pipeline correctly preserves the S3-delete-before-tombstone ordering, and the at-least-once retry guarantee holds across the failure paths exercised by the new tests.

The core logic is sound and well-tested. Two minor issues: un-flushed tombstones in `pendingTombstones` can be silently dropped when the `for await` loop exits via an error (no `try/finally`), causing unnecessary re-processing on the next retry; and passing `s3ChunkSize > 900` to `BlobCleanupPipelineOptions` silently multiplies the actual S3 API call count beyond what `s3Concurrency` suggests. Neither condition is reachable in production today (the env var only controls concurrency, not chunk size), but the first is worth hardening.

packages/shared/src/server/data-deletion/ingestionFileDeletion.ts — the `removeIngestionEventsFromS3AndDeleteClickhouseRefs` function's `for await` loop and the `BlobCleanupPipelineOptions` type.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CH as ClickHouse (ref stream)
    participant CK as chunk() generator
    participant RM as Readable.map (concurrency N)
    participant S3 as S3 DeleteObjects
    participant TB as flushTombstones()
    participant CH2 as ClickHouse (tombstone insert)

    CH->>CK: stream BlobStorageFileRefRecordReadType
    CK->>RM: batch[] of s3ChunkSize refs
    Note over RM: up to s3Concurrency batches in-flight
    RM->>S3: deleteFiles(batch[0].bucket_paths)
    RM->>S3: deleteFiles(batch[1].bucket_paths)
    S3-->>RM: ok (or error propagate)
    RM-->>TB: deletedRefs[] (in dispatch order)
    TB->>TB: accumulate pendingTombstones
    alt "pendingTombstones.length >= tombstoneFlushSize"
        TB->>CH2: "INSERT tombstones (is_deleted=1)"
        CH2-->>TB: ok
    end
    Note over TB: final flush after stream exhausted
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CH as ClickHouse (ref stream)
    participant CK as chunk() generator
    participant RM as Readable.map (concurrency N)
    participant S3 as S3 DeleteObjects
    participant TB as flushTombstones()
    participant CH2 as ClickHouse (tombstone insert)

    CH->>CK: stream BlobStorageFileRefRecordReadType
    CK->>RM: batch[] of s3ChunkSize refs
    Note over RM: up to s3Concurrency batches in-flight
    RM->>S3: deleteFiles(batch[0].bucket_paths)
    RM->>S3: deleteFiles(batch[1].bucket_paths)
    S3-->>RM: ok (or error propagate)
    RM-->>TB: deletedRefs[] (in dispatch order)
    TB->>TB: accumulate pendingTombstones
    alt "pendingTombstones.length >= tombstoneFlushSize"
        TB->>CH2: "INSERT tombstones (is_deleted=1)"
        CH2-->>TB: ok
    end
    Note over TB: final flush after stream exhausted
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/data-deletion/ingestionFileDeletion.ts:165-185
**`pendingTombstones` silently dropped on mid-loop error**

When the `for await` loop exits due to an error thrown by the mapped stream, any refs already accumulated in `pendingTombstones` (S3-deleted but not yet flushed) are never tombstoned — there is no `try/finally` guarding `flushTombstones()`. In the concrete case where `tombstoneFlushSize` is large (e.g. the default 10 000) and a delete error fires before the first flush threshold is reached, all refs processed so far remain ClickHouse-visible and get re-processed on the next retry run. Because S3 `DeleteObjects` with `Quiet: true` treats deleting a non-existent key as a no-op this is functionally safe (at-least-once), but the retry will redundantly re-issue S3 API calls for every un-tombstoned ref. With a large `tombstoneFlushSize` and small `s3ChunkSize` the "retry blast" could be significant. Wrapping the loop in `try/finally { await flushTombstones(); }` would limit the number of refs that need re-processing without breaking the at-least-once guarantee.

### Issue 2 of 2
packages/shared/src/server/data-deletion/ingestionFileDeletion.ts:121-136
**Double-chunking when `s3ChunkSize` exceeds 900**

The outer `chunk(stream, s3ChunkSize)` function groups refs into batches that are then passed verbatim to `deleteFiles`. Internally, `deleteFiles` → `deleteFilesNonRetrying` re-chunks by `S3_DELETE_OBJECTS_CHUNK_SIZE` (900). At the default `s3ChunkSize = 900` the two are perfectly aligned and each `deleteFiles` call is exactly one `DeleteObjects` API request. However, if a caller passes `s3ChunkSize > 900`, each dispatch silently becomes multiple S3 API calls, which means the actual in-flight S3 request count is `s3Concurrency × ceil(s3ChunkSize / 900)` — potentially far higher than the `s3Concurrency` bound suggests. Since `s3ChunkSize` is not validated at the point it is accepted in `BlobCleanupPipelineOptions`, this contract is invisible to callers.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(worker): pipeline blob storage clea..."](https://github.com/langfuse/langfuse/commit/0100f427f001737c6f389d29a6b7c95e703f171f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42862582)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->