### PR TITLE
fix: remediate scoped security findings

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -141,7 +141,7 @@
     "lossless-json": "^4.1.1",
     "lru-cache": "^11.2.7",
     "next-auth": "^4.24.14",
-    "nodemailer": "^8.0.11",
+    "nodemailer": "9.0.1",
     "oci-common": "^2.125.0",
     "oci-objectstorage": "^2.125.0",
     "safe-regex2": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,8 @@ overrides:
   '@ai-sdk/provider-utils-v5': npm:@ai-sdk/provider-utils@4.0.27
   '@copilotkit/runtime@0.0.0-mme-ag-ui-0-0-46-20260227141603>@ag-ui/langgraph': 0.0.29
   '@anthropic-ai/vertex-sdk>@anthropic-ai/sdk': 0.104.1
-  next-auth>nodemailer: ^8.0.11
+  next-auth>nodemailer: 9.0.1
+  nodemailer@<=9.0.0: 9.0.1
 
 patchedDependencies:
   next-auth@4.24.14: 298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d
@@ -292,10 +293,10 @@ importers:
         version: 11.2.7
       next-auth:
         specifier: ^4.24.14
-        version: 4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@8.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@9.0.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nodemailer:
-        specifier: ^8.0.11
-        version: 8.0.11
+        specifier: 9.0.1
+        version: 9.0.1
       oci-common:
         specifier: ^2.125.0
         version: 2.127.0
@@ -470,7 +471,7 @@ importers:
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@8.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 1.0.7(@prisma/client@6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@9.0.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -716,7 +717,7 @@ importers:
         version: 16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^4.24.14
-        version: 4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@8.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@9.0.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-query-params:
         specifier: ^5.1.0
         version: 5.1.0(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(use-query-params@2.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -9419,7 +9420,7 @@ packages:
     peerDependencies:
       '@auth/core': 0.34.3
       next: ^12.2.5 || ^13 || ^14 || ^15 || ^16
-      nodemailer: ^8.0.11
+      nodemailer: 9.0.1
       react: ^17.0.2 || ^18 || ^19
       react-dom: ^17.0.2 || ^18 || ^19
     peerDependenciesMeta:
@@ -9527,8 +9528,8 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
-  nodemailer@8.0.11:
-    resolution: {integrity: sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==}
+  nodemailer@9.0.1:
+    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
     engines: {node: '>=6.0.0'}
 
   npm-run-path@6.0.0:
@@ -14384,10 +14385,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@8.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@9.0.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@prisma/client': 6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2)
-      next-auth: 4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@8.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-auth: 4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@9.0.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   '@next/env@16.0.0': {}
 
@@ -21453,7 +21454,7 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  next-auth@4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@8.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next-auth@4.24.14(patch_hash=298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@9.0.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@babel/runtime': 7.29.2
       '@panva/hkdf': 1.2.1
@@ -21468,7 +21469,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       uuid: 8.3.2
     optionalDependencies:
-      nodemailer: 8.0.11
+      nodemailer: 9.0.1
 
   next-query-params@5.1.0(next@16.2.9(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(use-query-params@2.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
@@ -21572,7 +21573,7 @@ snapshots:
 
   node-releases@2.0.37: {}
 
-  nodemailer@8.0.11: {}
+  nodemailer@9.0.1: {}
 
   npm-run-path@6.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,7 @@ overrides:
   "@ai-sdk/provider-utils@<=4.0.26": 4.0.27
   "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@4.0.27"
   "@copilotkit/runtime@0.0.0-mme-ag-ui-0-0-46-20260227141603>@ag-ui/langgraph": 0.0.29
+  
   # Keep Anthropic's Vertex client on an SDK version that emits Vertex rawPredict URLs.
   # Remove once @langchain/anthropic allows the same SDK range.
   # Check: https://www.npmjs.com/package/@langchain/anthropic?activeTab=dependencies
@@ -54,7 +55,8 @@ overrides:
   # nodemailer imports (we pass a custom sendVerificationRequest); without this
   # pnpm auto-installs a second, unused nodemailer@7 instance for web.
   # Remove once next-auth allows nodemailer ^8.
-  "next-auth>nodemailer": "^8.0.11"
+  "next-auth>nodemailer": "9.0.1"
+  "nodemailer@<=9.0.0": "9.0.1"
 patchedDependencies:
   next-auth@4.24.14: patches/next-auth@4.24.14.patch
 publicHoistPattern:

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -3,3 +3,5 @@
 
 *storybook.log
 storybook-static
+
+.env

--- a/web/src/components/ui/chart.tsx
+++ b/web/src/components/ui/chart.tsx
@@ -89,29 +89,54 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
     return null;
   }
 
-  return (
-    <style
-      dangerouslySetInnerHTML={{
-        __html: Object.entries(THEMES)
-          .map(
-            ([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
-${colorConfig
-  .map(([key, itemConfig]) => {
-    const color =
-      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
-      itemConfig.color;
-    const safeKey = key.replace(/[^\p{L}\p{N}_ .()-]/gu, "_");
-    return color ? `  --color-${safeKey}: ${color};` : null;
-  })
-  .join("\n")}
-}
-`,
-          )
-          .join("\n"),
-      }}
-    />
-  );
+  const sanitizeCssVariableName = (value: string) =>
+    value.replace(/[^a-zA-Z0-9_-]/g, "_");
+
+  const escapeCssAttributeValue = (value: string) =>
+    value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "");
+
+  const isSafeCssColorValue = (value: string) => {
+    const trimmedValue = value.trim();
+
+    return (
+      /^#[0-9a-fA-F]{3,8}$/.test(trimmedValue) ||
+      /^(rgb|rgba|hsl|hsla|oklch|lab|lch)\([a-zA-Z0-9\s,.%/+()-]+\)$/.test(
+        trimmedValue,
+      ) ||
+      /^var\(--[a-zA-Z0-9_-]+\)$/.test(trimmedValue) ||
+      /^[a-zA-Z]+$/.test(trimmedValue)
+    );
+  };
+
+  const safeChartId = escapeCssAttributeValue(id);
+
+  const chartCss = Object.entries(THEMES)
+    .map(([theme, prefix]) => {
+      const cssVariables = colorConfig
+        .map(([key, itemConfig]) => {
+          const color =
+            itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+            itemConfig.color;
+
+          if (!color || !isSafeCssColorValue(color)) {
+            return null;
+          }
+
+          const safeKey = sanitizeCssVariableName(key);
+
+          return `  --color-${safeKey}: ${color.trim()};`;
+        })
+        .filter(Boolean)
+        .join("\n");
+
+      return `
+${prefix} [data-chart="${safeChartId}"] {
+${cssVariables}
+}`;
+    })
+    .join("\n");
+
+  return <style>{chartCss}</style>;
 };
 
 type ChartTooltipProps = React.ComponentProps<typeof RechartsPrimitive.Tooltip>;

--- a/worker/src/utils/RedisLock.ts
+++ b/worker/src/utils/RedisLock.ts
@@ -98,7 +98,7 @@ export class RedisLock {
         String(this.ttlSeconds),
       );
 
-      if (result === 1) {
+      if (Number(result) === 1) {
         logger.debug(
           `[${this.name}] Extended lock with TTL ${this.ttlSeconds}s`,
         );
@@ -220,7 +220,7 @@ export class RedisLock {
         this.lockKey,
         this.lockValue,
       );
-      if (result === 1) {
+      if (Number(result) === 1) {
         logger.debug(`[${this.name}] Released lock`);
         return true;
       }


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses several scoped security findings: it sanitizes CSS injection in `ChartStyle` by replacing `dangerouslySetInnerHTML` with validated string children, upgrades `nodemailer` from v8 to a pinned v9.0.1 to fix a known vulnerability, adds `.env` to the `web` gitignore, and fixes a type-unsafe Redis eval result comparison in `RedisLock`.

- **`chart.tsx`**: `dangerouslySetInnerHTML` replaced with sanitized `<style>` children using three new helpers (`sanitizeCssVariableName`, `escapeCssAttributeValue`, `isSafeCssColorValue`). The whitelist-based color validator silently rejects valid `color()` functional notation (CSS Color Level 4) and `var()` with fallback values; `escapeCssAttributeValue` also omits escaping of `<`, which could matter if chart IDs ever contain `</style>` in an SSR context.
- **`RedisLock.ts`**: `result === 1` changed to `Number(result) === 1` in both `extend()` and `release()` — fixes a real type mismatch where some Redis client builds return the Lua integer result as a string, causing `release()` to always return `false`.
- **`nodemailer` upgrade**: Pinned to 9.0.1 with a workspace override that also forces any sub-9 transitive copies to upgrade. nodemailer v9 tightens TLS certificate validation for HTTPS-based transports (OAuth2 endpoints, attachment URLs), which is a potential breaking change for non-standard transport configurations.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge with awareness of two edge cases: the color validator will silently drop valid `color()` CSS values, and the chart-ID escaper leaves `<` unhandled.

The RedisLock fix is unambiguously correct. The nodemailer upgrade is sound for standard SMTP paths. The chart sanitization is a meaningful improvement over unguarded `dangerouslySetInnerHTML`, but two gaps remain: `isSafeCssColorValue` silently rejects CSS Color Level 4 `color()` notation causing invisible chart colors, and `escapeCssAttributeValue` does not escape `<`, leaving a narrow SSR tag-injection path open if chart IDs are ever user-derived.

`web/src/components/ui/chart.tsx` — both the color validator whitelist and the attribute-value escaper are worth a second look before shipping to SSR environments or applications with user-controlled chart IDs.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **`chart.tsx` — potential `</style>` injection in SSR**: `escapeCssAttributeValue` escapes `\"`, `\\`, and `
` but not `<`. A chart `id` containing `</style>` could break out of the style tag in server-side-rendered HTML. Risk is conditional on user-controlled chart IDs.
- **`web/.gitignore`** — `.env` added, reducing the risk of accidental credential commits.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ChartContainer receives id prop"] --> B["chartId = 'chart-' + id or useId()"]
    B --> C["ChartStyle receives chartId + config"]
    C --> D{"colorConfig.length > 0?"}
    D -- No --> E["return null"]
    D -- Yes --> F["escapeCssAttributeValue(chartId)"]
    F --> G["For each THEME x colorConfig entry"]
    G --> H["Get color from theme or .color"]
    H --> I{"isSafeCssColorValue(color)?"}
    I -- No --> J["return null (silently dropped)"]
    I -- Yes --> K["sanitizeCssVariableName(key)"]
    K --> L["Build CSS variable string"]
    L --> M["Join all variables"]
    M --> N["Return style element with CSS text children"]
    N --> O["Browser parses as CSS scoped to data-chart selector"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["ChartContainer receives id prop"] --> B["chartId = 'chart-' + id or useId()"]
    B --> C["ChartStyle receives chartId + config"]
    C --> D{"colorConfig.length > 0?"}
    D -- No --> E["return null"]
    D -- Yes --> F["escapeCssAttributeValue(chartId)"]
    F --> G["For each THEME x colorConfig entry"]
    G --> H["Get color from theme or .color"]
    H --> I{"isSafeCssColorValue(color)?"}
    I -- No --> J["return null (silently dropped)"]
    I -- Yes --> K["sanitizeCssVariableName(key)"]
    K --> L["Build CSS variable string"]
    L --> M["Join all variables"]
    M --> N["Return style element with CSS text children"]
    N --> O["Browser parses as CSS scoped to data-chart selector"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/components/ui/chart.tsx:95-96
**`escapeCssAttributeValue` does not escape `<`**

`escapeCssAttributeValue` escapes `\`, `"`, and `\n` but omits `<`. A chart `id` containing the sequence `</style>` would close the style element prematurely in server-side-rendered HTML output, since React SSR serialises `<style>` children as raw text. If the `id` prop is ever derived from user-supplied data (e.g. a dynamically-generated chart name), this allows injecting arbitrary HTML after the broken style tag. Adding `.replace(/</g, "\\3C ")` (CSS-escape for `<`) or filtering `<`/`>` entirely would close this path.

### Issue 2 of 3
web/src/components/ui/chart.tsx:101-108
**`isSafeCssColorValue` drops valid CSS Color Level 4 `color()` values and `var()` with fallbacks**

The whitelist regex covers `rgb`, `rgba`, `hsl`, `hsla`, `oklch`, `lab`, and `lch` but omits the `color()` functional notation (`color(display-p3 0.5 0.5 0.5)`) which is increasingly common in Tailwind v4 and modern design tokens. It also rejects `var(--token, fallback)` (any `var()` containing a comma). Both cases are silently dropped, rendering the chart with no color instead of the configured value.

```suggestion
    return (
      /^#[0-9a-fA-F]{3,8}$/.test(trimmedValue) ||
      /^(rgb|rgba|hsl|hsla|oklch|lab|lch|color)\([a-zA-Z0-9\s,.%/+()-]+\)$/.test(
        trimmedValue,
      ) ||
      /^var\(--[a-zA-Z0-9_-]+(?:,\s*[a-zA-Z0-9\s#%(),._/-]+)?\)$/.test(
        trimmedValue,
      ) ||
      /^[a-zA-Z]+$/.test(trimmedValue)
    );
```

### Issue 3 of 3
packages/shared/package.json:144
**nodemailer v9 introduces stricter TLS validation**

nodemailer v9.0.0 changed HTTPS requests (used for attachment URLs, OAuth2 token endpoints, and HTTP/HTTPS proxy CONNECT) to strictly validate TLS certificates by default. Any email transport configured with an OAuth2 token endpoint behind a self-signed or hostname-mismatched certificate will start failing with this upgrade, requiring an explicit `tls: { rejectUnauthorized: false }` opt-out. Standard SMTP-only transports are unaffected, but it is worth verifying that the project's production email transport configuration does not rely on the previously lenient behaviour.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remediate scoped security findings"](https://github.com/langfuse/langfuse/commit/a64d5e3787b04fdc0fc4dd7f19088a591a756c11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42885566)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->