### PR TITLE
fix(ui): align Tokens per second with outputTokensPerSecond

### DIFF
--- a/packages/shared/src/eventsTable.ts
+++ b/packages/shared/src/eventsTable.ts
@@ -207,8 +207,9 @@ const eventsTableColsDefinition = [
     name: "Tokens per second",
     id: "tokensPerSecond",
     type: "number",
+    // Align with Metrics `outputTokensPerSecond`: exclude time-to-first-token.
     internal:
-      "(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, usage_details))) / (date_diff('millisecond', start_time, end_time) / 1000))",
+      "(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, usage_details))) / nullIf(date_diff('millisecond', e.completion_start_time, e.end_time) / 1000, 0))",
     nullable: true,
   },
   {

--- a/packages/shared/src/observationsTable.ts
+++ b/packages/shared/src/observationsTable.ts
@@ -92,7 +92,9 @@ export const observationsTableCols: ColumnDefinition[] = [
     name: "Tokens per second",
     id: "tokensPerSecond",
     type: "number",
-    internal: 'o."completion_tokens" / "latency"',
+    // Align with Metrics `outputTokensPerSecond`: exclude time-to-first-token.
+    internal:
+      'o."completion_tokens" / NULLIF(EXTRACT(EPOCH FROM (o."end_time" - o."completion_start_time")), 0)',
     nullable: true,
   },
   {

--- a/packages/shared/src/server/tableMappings/mapEventsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapEventsTable.ts
@@ -75,8 +75,10 @@ export const eventsTableNativeUiColumnDefinitions: UiColumnMappings = [
     uiTableName: "Tokens per second",
     uiTableId: "tokensPerSecond",
     clickhouseTableName: "events_proto",
+    // Align with Metrics `outputTokensPerSecond`: output tokens over the
+    // generation window (completion_start_time → end_time), excluding TTFT.
     clickhouseSelect:
-      "(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, usage_details))) / (date_diff('millisecond', start_time, end_time) / 1000))",
+      "(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, usage_details))) / nullIf(date_diff('millisecond', e.completion_start_time, e.end_time) / 1000, 0))",
   },
   {
     uiTableName: "Input Cost ($)",

--- a/packages/shared/src/server/tableMappings/mapObservationsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapObservationsTable.ts
@@ -115,8 +115,10 @@ export const observationsTableUiColumnDefinitions: UiColumnMappings = [
     uiTableName: "Tokens per second",
     uiTableId: "tokensPerSecond",
     clickhouseTableName: "observations",
+    // Align with Metrics `outputTokensPerSecond`: output tokens over the
+    // generation window (completion_start_time → end_time), excluding TTFT.
     clickhouseSelect:
-      "(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, usage_details))) / (date_diff('millisecond', start_time, end_time) / 1000))",
+      "(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, usage_details))) / nullIf(date_diff('millisecond', completion_start_time, end_time) / 1000, 0))",
   },
   {
     uiTableName: "Input Cost ($)",

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -51,7 +51,11 @@ import {
 } from "@langfuse/shared";
 import { cn } from "@/src/utils/tailwind";
 import { LevelColors } from "@/src/components/level-colors";
-import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
+import {
+  getOutputTokensPerSecond,
+  numberFormatter,
+  usdFormatter,
+} from "@/src/utils/numbers";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import { MemoizedIOTableCell } from "../../ui/IOTableCell";
@@ -1142,18 +1146,20 @@ export default function ObservationsTable({
           size: 200,
           cell: ({ row }) => {
             const latency: number | undefined = row.getValue("latency");
-            const usage: {
-              promptTokens: number;
-              completionTokens: number;
-              totalTokens: number;
-            } = row.getValue("usage");
-            return latency !== undefined &&
-              (usage.completionTokens !== 0 || usage.totalTokens !== 0) ? (
-              <span>
-                {usage.completionTokens && latency
-                  ? Number((usage.completionTokens / latency).toFixed(1))
-                  : undefined}
-              </span>
+            const timeToFirstToken: number | undefined =
+              row.getValue("timeToFirstToken");
+            const usage = row.getValue("usage") as {
+              inputUsage: number;
+              outputUsage: number;
+              totalUsage: number;
+            };
+            const tokensPerSecond = getOutputTokensPerSecond(
+              usage.outputUsage,
+              latency,
+              timeToFirstToken,
+            );
+            return tokensPerSecond !== undefined ? (
+              <span>{tokensPerSecond}</span>
             ) : undefined;
           },
           defaultHidden: true,

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -41,6 +41,7 @@ import { cn } from "@/src/utils/tailwind";
 import { LevelColors } from "@/src/components/level-colors";
 import {
   compactNumberFormatter,
+  getOutputTokensPerSecond,
   numberFormatter,
   usdFormatter,
 } from "@/src/utils/numbers";
@@ -1249,18 +1250,20 @@ export default function ObservationsEventsTable({
           size: 200,
           cell: ({ row }) => {
             const latency: number | undefined = row.getValue("latency");
+            const timeToFirstToken: number | undefined =
+              row.getValue("timeToFirstToken");
             const usage = row.getValue("usage") as {
               inputUsage: number;
               outputUsage: number;
               totalUsage: number;
             };
-            return latency !== undefined &&
-              (usage.outputUsage !== 0 || usage.totalUsage !== 0) ? (
-              <span>
-                {usage.outputUsage && latency
-                  ? Number((usage.outputUsage / latency).toFixed(1))
-                  : undefined}
-              </span>
+            const tokensPerSecond = getOutputTokensPerSecond(
+              usage.outputUsage,
+              latency,
+              timeToFirstToken,
+            );
+            return tokensPerSecond !== undefined ? (
+              <span>{tokensPerSecond}</span>
             ) : undefined;
           },
           defaultHidden: true,

--- a/web/src/utils/numbers.clienttest.ts
+++ b/web/src/utils/numbers.clienttest.ts
@@ -1,0 +1,22 @@
+import { getOutputTokensPerSecond } from "@/src/utils/numbers";
+
+describe("getOutputTokensPerSecond", () => {
+  it("divides output tokens by the generation window", () => {
+    // latency 10s, TTFT 2s → generation window 8s
+    expect(getOutputTokensPerSecond(80, 10, 2)).toBe(10);
+  });
+
+  it("returns undefined when time-to-first-token is missing", () => {
+    expect(getOutputTokensPerSecond(80, 10, null)).toBeUndefined();
+    expect(getOutputTokensPerSecond(80, 10, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when generation window is non-positive", () => {
+    expect(getOutputTokensPerSecond(80, 2, 2)).toBeUndefined();
+    expect(getOutputTokensPerSecond(80, 1, 2)).toBeUndefined();
+  });
+
+  it("returns undefined when output usage is zero", () => {
+    expect(getOutputTokensPerSecond(0, 10, 2)).toBeUndefined();
+  });
+});

--- a/web/src/utils/numbers.ts
+++ b/web/src/utils/numbers.ts
@@ -97,6 +97,27 @@ export const formatTokenCounts = (
     : `${numberFormatter(inputUsage ?? 0, 0)} → ${numberFormatter(outputUsage ?? 0, 0)} (∑ ${numberFormatter(totalUsage ?? 0, 0)})`;
 };
 
+/**
+ * Output tokens / generation window (completion start → end).
+ * Matches Metrics `outputTokensPerSecond`: excludes time-to-first-token.
+ */
+export const getOutputTokensPerSecond = (
+  outputUsage?: number | null,
+  latency?: number | null,
+  timeToFirstToken?: number | null,
+): number | undefined => {
+  if (!outputUsage || latency == null || timeToFirstToken == null) {
+    return undefined;
+  }
+
+  const generationSeconds = latency - timeToFirstToken;
+  if (generationSeconds <= 0) {
+    return undefined;
+  }
+
+  return Number((outputUsage / generationSeconds).toFixed(1));
+};
+
 export function randomIntFromInterval(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }


### PR DESCRIPTION
## Summary
- Generations table Tokens per second still read `completionTokens` after #9468 migrated usage fields to `outputUsage`, so the column stayed blank.
- Align table display + sort/filter SQL with Metrics/Dashboard `outputTokensPerSecond`: `outputTokens / (end - completion_start)` (excludes TTFT).
- Shared helper `getOutputTokensPerSecond` used by Generations and Events tables; add unit tests.

Fixes #14913

## Formula
```text
outputUsage / (latency - timeToFirstToken)
# equivalent to output / (end_time - completion_start_time)
```
Rows without `completion_start_time` / TTFT render blank (same as Dashboard).

Note: Metrics also exposes a differently named measure `tokensPerSecond` = `totalTokens / (end - start)`. This PR does **not** change that; the table column aligns with `outputTokensPerSecond`.

## Related
- Closes the leftover from #9468 (Input/Output/Total Tokens migrated; Tokens per second cell was missed)
- Continues the Generations-table metric from #3511
- Related product context: org discussions [#8877](https://github.com/orgs/langfuse/discussions/8877) (TPS monitoring), [#5782](https://github.com/orgs/langfuse/discussions/5782) / #5813 (streaming latency metrics), [#964](https://github.com/orgs/langfuse/discussions/964) (TTFT + Tokens/s)

## Test plan
- [ ] Generations table: enable Tokens per second; rows with Output Tokens + TTFT show a value
- [ ] Same row without TTFT stays blank
- [ ] Events table Tokens per second matches the same formula
- [ ] Sorting by Tokens per second uses generation-window SQL
- [ ] Dashboard Avg Output Tokens Per Second widget unchanged
- [ ] `getOutputTokensPerSecond` unit tests pass