### PR TITLE
docs: add TokenLab OpenAI-compatible tracing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,23 @@ def main():
 main()
 ```
 
+For OpenAI-compatible providers, create the SDK client with the provider's base URL and keep the Langfuse integration in
+place. For example, TokenLab:
+
+```python filename="main.py"
+import os
+
+from langfuse.openai import openai
+
+openai.api_key = os.environ["TOKENLAB_API_KEY"]
+openai.base_url = "https://api.tokenlab.sh/v1"
+
+response = openai.chat.completions.create(
+    model="claude-sonnet-5",
+    messages=[{"role": "user", "content": "What is Langfuse?"}],
+)
+```
+
 ### 3️⃣ See traces in Langfuse
 
 See your language model calls and other application logic in Langfuse.

--- a/README.md
+++ b/README.md
@@ -207,21 +207,28 @@ def main():
 main()
 ```
 
-For OpenAI-compatible providers, create the SDK client with the provider's base URL and keep the Langfuse integration in
-place. For example, TokenLab:
+For OpenAI-compatible providers, create the Langfuse-wrapped SDK client with the provider's base URL. For example,
+TokenLab:
 
 ```python filename="main.py"
 import os
 
-from langfuse.openai import openai
+from langfuse import observe
+from langfuse.openai import OpenAI
 
-openai.api_key = os.environ["TOKENLAB_API_KEY"]
-openai.base_url = "https://api.tokenlab.sh/v1"
-
-response = openai.chat.completions.create(
-    model="claude-sonnet-5",
-    messages=[{"role": "user", "content": "What is Langfuse?"}],
+client = OpenAI(
+    api_key=os.environ["TOKENLAB_API_KEY"],
+    base_url="https://api.tokenlab.sh/v1",
 )
+
+@observe()
+def main():
+    return client.chat.completions.create(
+        model="claude-sonnet-5",  # TokenLab catalog model ID
+        messages=[{"role": "user", "content": "What is Langfuse?"}],
+    ).choices[0].message.content
+
+main()
 ```
 
 ### 3️⃣ See traces in Langfuse


### PR DESCRIPTION
## Summary
- Show Langfuse's OpenAI integration with a TokenLab base_url.
- Keep the change docs-only and scoped to the project's existing OpenAI-compatible configuration surface.

## Validation
- git diff --check

---

Supersedes #14909. The previous PR was closed while fixing contributor commit metadata; this replacement branch preserves the same scoped diff with commits authored by `hedging8563 <45883076+hedging8563@users.noreply.github.com>`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This docs-only PR adds a short TokenLab OpenAI-compatible tracing example to `README.md`, immediately after the existing OpenAI quickstart snippet. The new block shows how to point the Langfuse-patched `openai` module at a third-party base URL.

- The introductory sentence says \"create the SDK client with the provider's base URL\" but the code uses module-level attribute assignment (`openai.base_url = ...`) rather than instantiating a client, creating a mismatch between prose and implementation.
- The snippet drops the `@observe()` decorator pattern used in every surrounding example, so a reader copying it verbatim will produce no Langfuse traces.
- The model name `claude-sonnet-5` does not match any known Anthropic or TokenLab naming convention and could not be verified; if it is a TokenLab-specific alias, that should be called out explicitly.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Docs-only change with no runtime impact; the main risk is that readers copy an incomplete or misleading example.

The change touches only README.md and introduces no code paths. The three issues found are all in documentation and none affect the application itself. A reader who copies the snippet may get no tracing output and may need to debug the model name, but no data is at risk.

README.md — the new TokenLab snippet between lines 210–225 should be reviewed against the actual TokenLab API docs to confirm the model name and to align the code style with the surrounding examples.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as User Application
    participant LF as langfuse.openai (wrapper)
    participant TL as TokenLab API (OpenAI-compatible)
    participant LFC as Langfuse Cloud

    App->>LF: openai.chat.completions.create(model, messages)
    Note over LF: Intercepts call, records trace start
    LF->>TL: POST /v1/chat/completions (with TOKENLAB_API_KEY + custom base_url)
    TL-->>LF: LLM response
    Note over LF: Records token usage, latency, model metadata
    LF-->>App: response object
    LF--)LFC: Async flush — trace + spans
    LFC-->>LF: 200 OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as User Application
    participant LF as langfuse.openai (wrapper)
    participant TL as TokenLab API (OpenAI-compatible)
    participant LFC as Langfuse Cloud

    App->>LF: openai.chat.completions.create(model, messages)
    Note over LF: Intercepts call, records trace start
    LF->>TL: POST /v1/chat/completions (with TOKENLAB_API_KEY + custom base_url)
    TL-->>LF: LLM response
    Note over LF: Records token usage, latency, model metadata
    LF-->>App: response object
    LF--)LFC: Async flush — trace + spans
    LFC-->>LF: 200 OK
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
README.md:210-225
**Description/code mismatch — text says "create the SDK client" but code uses module-level assignment**

The introductory sentence reads "create the SDK client with the provider's base URL", which implies the instantiation pattern (`client = OpenAI(api_key=..., base_url=...)`). The code snippet instead sets `openai.base_url` and `openai.api_key` as module-level attributes — a different (and in `openai>=1.0`, less idiomatic) approach. Either update the prose to accurately describe the module-level pattern, or change the snippet to instantiate a client, e.g. `client = openai.OpenAI(api_key=os.environ["TOKENLAB_API_KEY"], base_url="https://api.tokenlab.sh/v1")`, which is the pattern the Langfuse docs themselves use for custom base URLs.

### Issue 2 of 3
README.md:213-225
**Example omits `@observe()` tracing pattern used throughout the README**

Every other code snippet in this section wraps calls with `@observe()` from `langfuse` to produce the traces that are the whole point of using Langfuse. This new snippet drops that decorator entirely, so a reader who copies it will get no tracing output and may conclude the integration is broken. Adding at least a minimal `@observe()`-decorated function, consistent with the preceding snippet, would make the example self-contained and demonstrably correct.

### Issue 3 of 3
README.md:222
**Unverifiable model identifier — `claude-sonnet-5` does not match any known naming convention**

Standard Anthropic model identifiers use the format `claude-<version>-<variant>-<date>` (e.g. `claude-3-5-sonnet-20241022`). `claude-sonnet-5` does not match that pattern and could not be verified as a valid TokenLab model alias during this review. If this is a real TokenLab model name, a brief inline note would help readers understand it is TokenLab-specific; if it was chosen arbitrarily as a placeholder, it should be replaced with a confirmed working value to avoid confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add TokenLab OpenAI-compatible tra..."](https://github.com/langfuse/langfuse/commit/58d6fc89e8844a720d3fd0eee27a39054d6e403b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42937926)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->