### PR TITLE
fix(audit-log): Include userId in in-app agent api-key audit logs

### DIFF
--- a/web/src/__tests__/server/audit-log-in-app-agent.servertest.ts
+++ b/web/src/__tests__/server/audit-log-in-app-agent.servertest.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from "crypto";
+import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { prisma, AuditLogRecordType } from "../../../../packages/shared/src/db";
+import { createAndAddApiKeysToDb } from "../../../../packages/shared/src/server/auth/apiKeys";
+import { createOrgProjectAndApiKey } from "../../../../packages/shared/src/server/test-utils/org-factory";
+
+describe("in-app agent audit logging", () => {
+  it("stores the creator on in-app-agent MCP keys", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const user = await prisma.user.create({
+      data: {
+        email: `${randomUUID()}@test.com`,
+        name: "In-app Agent User",
+      },
+    });
+
+    const mcpApiKey = await createAndAddApiKeysToDb({
+      prisma,
+      entityId: projectId,
+      scope: "PROJECT",
+      note: "In-app agent MCP session",
+      isInAppAgentKey: true,
+      createdByUserId: user.id,
+    });
+
+    const persistedApiKey = await prisma.apiKey.findUniqueOrThrow({
+      where: { id: mcpApiKey.id },
+      select: {
+        createdByUserId: true,
+        isInAppAgentKey: true,
+      },
+    });
+
+    expect(persistedApiKey).toEqual({
+      createdByUserId: user.id,
+      isInAppAgentKey: true,
+    });
+  });
+
+  it("stores the creator user id on audit logs written by in-app agent API keys", async () => {
+    const { orgId, projectId } = await createOrgProjectAndApiKey();
+    const user = await prisma.user.create({
+      data: {
+        email: `${randomUUID()}@test.com`,
+        name: "Audit User",
+      },
+    });
+
+    const mcpApiKey = await createAndAddApiKeysToDb({
+      prisma,
+      entityId: projectId,
+      scope: "PROJECT",
+      note: "In-app agent MCP session",
+      isInAppAgentKey: true,
+      createdByUserId: user.id,
+    });
+
+    const resourceId = randomUUID();
+    await auditLog({
+      action: "create",
+      resourceType: "job",
+      resourceId,
+      orgId,
+      projectId,
+      apiKeyId: mcpApiKey.id,
+    });
+
+    const persistedAuditLog = await prisma.auditLog.findFirstOrThrow({
+      where: {
+        apiKeyId: mcpApiKey.id,
+        resourceId,
+      },
+      select: {
+        type: true,
+        apiKeyId: true,
+        userId: true,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    expect(persistedAuditLog).toEqual({
+      type: AuditLogRecordType.API_KEY,
+      apiKeyId: mcpApiKey.id,
+      userId: user.id,
+    });
+  });
+});

--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -379,7 +379,7 @@ describe("MCP public API tools", () => {
     ).resolves.toBe(assignmentAuditLogCount + 1);
 
     const auditLogCreateSpy = vi
-      .spyOn(prisma.auditLog, "create")
+      .spyOn(prisma, "$transaction")
       .mockRejectedValueOnce(new Error("audit failed"));
 
     try {

--- a/web/src/features/audit-logs/auditLog.ts
+++ b/web/src/features/audit-logs/auditLog.ts
@@ -83,40 +83,72 @@ type AuditLog = {
 );
 
 export async function auditLog(log: AuditLog, prisma?: typeof _prisma) {
-  const meta =
-    "session" in log
-      ? {
-          userId: log.session.user.id,
-          orgId: log.session.orgId,
-          userOrgRole: log.session.orgRole,
-          projectId: log.session.projectId,
-          userProjectRole: log.session.projectRole,
-          type: AuditLogRecordType.USER,
-        }
-      : "userId" in log
-        ? {
-            userId: log.userId,
-            orgId: log.orgId,
-            userOrgRole: log.orgRole,
-            projectId: log.projectId,
-            userProjectRole: log.projectRole,
-            type: AuditLogRecordType.USER,
-          }
-        : {
-            apiKeyId: log.apiKeyId,
-            orgId: log.orgId,
-            projectId: log.projectId,
-            type: AuditLogRecordType.API_KEY,
-          };
+  const db = prisma ?? _prisma;
+  const shared = {
+    resourceType: log.resourceType,
+    resourceId: log.resourceId,
+    action: log.action,
+    before: log.before ? JSON.stringify(log.before) : undefined,
+    after: log.after ? JSON.stringify(log.after) : undefined,
+  };
 
-  await (prisma ?? _prisma).auditLog.create({
-    data: {
-      ...meta,
-      resourceType: log.resourceType,
-      resourceId: log.resourceId,
-      action: log.action,
-      before: log.before ? JSON.stringify(log.before) : undefined,
-      after: log.after ? JSON.stringify(log.after) : undefined,
-    },
-  });
+  if ("apiKeyId" in log) {
+    await db.$transaction(async (tx) => {
+      const apiKey = await tx.apiKey.findUnique({
+        where: { id: log.apiKeyId },
+        select: {
+          isInAppAgentKey: true,
+          createdByUserId: true,
+        },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          apiKeyId: log.apiKeyId,
+          userId:
+            apiKey?.isInAppAgentKey === true
+              ? (apiKey.createdByUserId ?? undefined)
+              : undefined,
+          orgId: log.orgId,
+          projectId: log.projectId,
+          type: AuditLogRecordType.API_KEY,
+          ...shared,
+        },
+      });
+    });
+
+    return;
+  }
+
+  if ("session" in log) {
+    await db.auditLog.create({
+      data: {
+        userId: log.session.user.id,
+        orgId: log.session.orgId,
+        userOrgRole: log.session.orgRole,
+        projectId: log.session.projectId,
+        userProjectRole: log.session.projectRole,
+        type: AuditLogRecordType.USER,
+        ...shared,
+      },
+    });
+
+    return;
+  }
+
+  if ("userId" in log) {
+    await db.auditLog.create({
+      data: {
+        userId: log.userId,
+        orgId: log.orgId,
+        userOrgRole: log.orgRole,
+        projectId: log.projectId,
+        userProjectRole: log.projectRole,
+        type: AuditLogRecordType.USER,
+        ...shared,
+      },
+    });
+
+    return;
+  }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enriches audit logs created via API key authentication so that in-app-agent MCP session keys carry the originating user's ID, enabling clearer attribution in the audit trail.

- The `auditLog` function is refactored into three explicit early-return branches; the `apiKeyId` branch now fetches the key row and populates `userId` from `createdByUserId` when `isInAppAgentKey` is `true`.
- A new server test file verifies both that the `createdByUserId` is stored on the key and that it propagates to the audit log record; the existing MCP tool test is updated to spy on `$transaction` instead of `auditLog.create`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the API-key audit-log path and does not touch session or userId paths.

The logic is correct: `createdByUserId` is read and conditionally set as `userId` only for in-app-agent keys, and the null-to-undefined conversion is handled properly. Tests cover both the key-creation and audit-log propagation cases.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant auditLog
    participant DB

    alt apiKeyId path (new)
        Caller->>auditLog: "auditLog({ apiKeyId, ... })"
        auditLog->>DB: $transaction start
        DB-->>auditLog: tx
        auditLog->>DB: "tx.apiKey.findUnique({ id: apiKeyId })"
        DB-->>auditLog: "{ isInAppAgentKey, createdByUserId }"
        note over auditLog: if isInAppAgentKey, userId = createdByUserId
        auditLog->>DB: "tx.auditLog.create({ ..., userId? })"
        DB-->>auditLog: created
        auditLog->>DB: $transaction commit
        auditLog-->>Caller: done
    else session path (unchanged)
        Caller->>auditLog: "auditLog({ session, ... })"
        auditLog->>DB: "auditLog.create({ userId: session.user.id, ... })"
        DB-->>auditLog: created
        auditLog-->>Caller: done
    else userId path (unchanged)
        Caller->>auditLog: "auditLog({ userId, ... })"
        auditLog->>DB: "auditLog.create({ userId, ... })"
        DB-->>auditLog: created
        auditLog-->>Caller: done
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant auditLog
    participant DB

    alt apiKeyId path (new)
        Caller->>auditLog: "auditLog({ apiKeyId, ... })"
        auditLog->>DB: $transaction start
        DB-->>auditLog: tx
        auditLog->>DB: "tx.apiKey.findUnique({ id: apiKeyId })"
        DB-->>auditLog: "{ isInAppAgentKey, createdByUserId }"
        note over auditLog: if isInAppAgentKey, userId = createdByUserId
        auditLog->>DB: "tx.auditLog.create({ ..., userId? })"
        DB-->>auditLog: created
        auditLog->>DB: $transaction commit
        auditLog-->>Caller: done
    else session path (unchanged)
        Caller->>auditLog: "auditLog({ session, ... })"
        auditLog->>DB: "auditLog.create({ userId: session.user.id, ... })"
        DB-->>auditLog: created
        auditLog-->>Caller: done
    else userId path (unchanged)
        Caller->>auditLog: "auditLog({ userId, ... })"
        auditLog->>DB: "auditLog.create({ userId, ... })"
        DB-->>auditLog: created
        auditLog-->>Caller: done
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(audit-log): Include userId in in-app..."](https://github.com/langfuse/langfuse/commit/31f6d99288f4d49a96ded70dc3a5c1044b324387) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42957438)</sub>

<!-- /greptile_comment -->