### PR TITLE
fix(evals): stop offering new trace-level evals to v4-toggle cohort on Cloud

### DIFF
--- a/web/src/features/evals/hooks/useEvalCapabilities.ts
+++ b/web/src/features/evals/hooks/useEvalCapabilities.ts
@@ -49,27 +49,24 @@ export function useEvalCapabilities(
   const hasLegacyEvals = (evalCounts.data?.legacyConfigCount ?? 0) > 0;
 
   // The legacy eval experience depends on whether the deployment still writes
-  // the legacy tables and on the user's rollout cohort. Use === true / explicit
-  // mode checks so we default to hidden while the session is loading, which
-  // prevents a flash of legacy options.
+  // the legacy tables. Use explicit mode checks so we default to hidden while
+  // the session is loading, which prevents a flash of legacy options.
   const { isLangfuseCloud } = useLangfuseCloudRegion();
-  const canToggleV4 = session?.user?.canToggleV4 === true;
   const v4WriteMode = session?.environment?.v4WriteMode;
 
   // Whether a *new* config may use the legacy experience (independent of
   // hasLegacyEvals, which always keeps legacy visible so existing legacy
   // evaluators stay manageable):
   // - events_only: legacy tables are no longer written → no new legacy evals.
-  // - dual: self-hosted deployments always allow legacy; on Cloud only cohorts
-  //   that can still toggle V4 (orgs created before the rollout cutoff).
+  // - dual: self-hosted deployments always allow legacy; on Cloud, new legacy
+  //   evals are only available via hasLegacyEvals (projects that already have
+  //   legacy evaluators) — being able to toggle V4 is not enough.
   // - legacy: legacy is the only experience.
   const modeAllowsNewLegacy =
     v4WriteMode === "events_only"
       ? false
       : v4WriteMode === "dual"
-        ? isLangfuseCloud
-          ? canToggleV4
-          : true
+        ? !isLangfuseCloud
         : v4WriteMode === "legacy"; // legacy → true; undefined (loading) → false
 
   return {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens Cloud-side access to new trace-level (legacy) evaluator creation by removing the `canToggleV4` cohort check from `useEvalCapabilities`. On Cloud in `dual` write mode, `modeAllowsNewLegacy` now always evaluates to `false`; new legacy evals are only reachable via the `hasLegacyEvals` path (projects that already have existing legacy evaluators).

- **Removed `canToggleV4` guard**: Previously, Cloud users in the v4-toggle cohort (`session?.user?.canToggleV4 === true`) could still create new trace-level evals in `dual` mode. The simplified expression `!isLangfuseCloud` replaces the nested cohort ternary and blocks new legacy evals for all Cloud users regardless of cohort.
- **Self-hosted behavior preserved**: `!isLangfuseCloud` evaluates to `true` on self-hosted deployments, so the `dual`-mode allowance there is unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a targeted, narrow logic simplification that removes one cohort gate and does not alter any data-writing path.

The only change is swapping `isLangfuseCloud ? canToggleV4 : true` for `!isLangfuseCloud` in a pure boolean expression. All four `v4WriteMode` branches produce the same results except for Cloud + `dual`, where new legacy evals are now blocked for everyone, including the former v4-toggle cohort. Existing legacy-eval management (via `hasLegacyEvals`) is completely unaffected, and self-hosted behavior is unchanged.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useEvalCapabilities called] --> B{v4WriteMode?}
    B -->|events_only| C[modeAllowsNewLegacy = false]
    B -->|legacy| D[modeAllowsNewLegacy = true]
    B -->|undefined / loading| E[modeAllowsNewLegacy = false]
    B -->|dual| F{isLangfuseCloud?}
    F -->|true - Cloud| G[modeAllowsNewLegacy = false]
    F -->|false - Self-hosted| H[modeAllowsNewLegacy = true]
    C --> I{allowLegacy}
    D --> I
    E --> I
    G --> I
    H --> I
    I -->|modeAllowsNewLegacy OR hasLegacyEvals AND NOT isCodeEvalConfig| J[allowLegacy = true]
    I -->|neither condition met| K[allowLegacy = false]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[useEvalCapabilities called] --> B{v4WriteMode?}
    B -->|events_only| C[modeAllowsNewLegacy = false]
    B -->|legacy| D[modeAllowsNewLegacy = true]
    B -->|undefined / loading| E[modeAllowsNewLegacy = false]
    B -->|dual| F{isLangfuseCloud?}
    F -->|true - Cloud| G[modeAllowsNewLegacy = false]
    F -->|false - Self-hosted| H[modeAllowsNewLegacy = true]
    C --> I{allowLegacy}
    D --> I
    E --> I
    G --> I
    H --> I
    I -->|modeAllowsNewLegacy OR hasLegacyEvals AND NOT isCodeEvalConfig| J[allowLegacy = true]
    I -->|neither condition met| K[allowLegacy = false]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): stop offering new trace-leve..."](https://github.com/langfuse/langfuse/commit/fed3b1cae96726337642bcc3b20e9df22ac37d43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42966738)</sub>

<!-- /greptile_comment -->