### PR TITLE
chore(shared): document ms-aligned start_time assumption in v2 observations cursor (LFE-10405)

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1456,6 +1456,12 @@ function applyObservationsCursorFilter(
   cursor: PublicApiObservationsQuery["cursor"] | undefined,
   queryBuilder: EventsQueryBuilder,
 ): EventsQueryBuilder {
+  // The cursor carries start_time at millisecond precision (JS Date round-trip),
+  // while the column is DateTime64(6). This is lossless only because every
+  // ingestion path writes ms-aligned start_time values (OTel nanos are floored
+  // to ms). If ingestion ever preserves sub-millisecond precision, this bound
+  // floors to the boundary row's millisecond and permanently skips rows at page
+  // boundaries — carry the raw ClickHouse string through the cursor instead (LFE-10405).
   return queryBuilder.when(Boolean(cursor), (b) => {
     const currentCursor = cursor;
     if (!currentCursor) {


### PR DESCRIPTION
## What does this PR do?

Adds a comment at the v2 observations keyset-cursor comparison (`applyObservationsCursorFilter` in `packages/shared/src/server/repositories/events.ts`) documenting that the cursor's millisecond-precision `start_time` round-trip is lossless only because all ingestion paths write ms-aligned values into the `DateTime64(6)` column. If ingestion ever preserves sub-millisecond precision, the cursor bound would floor to the boundary row's millisecond and permanently skip rows at page boundaries.

The corresponding ticket (LFE-10405) was closed as not planned since the skip is unreachable today; this comment is the durable guard, placed where a future precision change would be made.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a documentation comment to `applyObservationsCursorFilter` in `events.ts` to explicitly record the millisecond-precision assumption baked into the v2 observations cursor. The comment explains why the JS `Date` round-trip is currently safe and what would break if ingestion ever begins preserving sub-millisecond timestamps.

- Adds a code comment describing the DateTime64(6) vs. ms-precision cursor mismatch and the OTel nanos floor-to-ms invariant that prevents pagination data loss today.
- References LFE-10405 and proposes carrying the raw ClickHouse timestamp string through the cursor as the long-term fix.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the only change is a code comment; no logic, schema, or behavior is altered.

The PR touches a single function and adds only comments. The comment accurately describes the DateTime64(6) vs. JS Date millisecond round-trip constraint and correctly identifies the failure mode (rows skipped at page boundaries) that would occur if the ms-alignment invariant were ever broken. No executable code changed.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant API
    participant applyObservationsCursorFilter
    participant ClickHouse

    Client->>API: "GET /observations?cursor={lastStartTime, lastTraceId, lastId}"
    API->>applyObservationsCursorFilter: cursor with lastStartTimeTo (JS Date, ms precision)
    Note over applyObservationsCursorFilter: cursor.lastStartTimeTo is a JS Date<br/>(millisecond precision only).<br/>ClickHouse column is DateTime64(6).<br/>Safe today because ingestion floors<br/>OTel nanos to ms on every write.
    applyObservationsCursorFilter->>ClickHouse: "WHERE e.start_time <= {lastStartTime: DateTime64(6)}<br/>AND (start_time, xxHash32(trace_id), span_id) < (lastStartTime, ...)"
    ClickHouse-->>API: next page rows (limit+1)
    API-->>Client: observations + next cursor
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant API
    participant applyObservationsCursorFilter
    participant ClickHouse

    Client->>API: "GET /observations?cursor={lastStartTime, lastTraceId, lastId}"
    API->>applyObservationsCursorFilter: cursor with lastStartTimeTo (JS Date, ms precision)
    Note over applyObservationsCursorFilter: cursor.lastStartTimeTo is a JS Date<br/>(millisecond precision only).<br/>ClickHouse column is DateTime64(6).<br/>Safe today because ingestion floors<br/>OTel nanos to ms on every write.
    applyObservationsCursorFilter->>ClickHouse: "WHERE e.start_time <= {lastStartTime: DateTime64(6)}<br/>AND (start_time, xxHash32(trace_id), span_id) < (lastStartTime, ...)"
    ClickHouse-->>API: next page rows (limit+1)
    API-->>Client: observations + next cursor
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(shared): document ms-aligned start..."](https://github.com/langfuse/langfuse/commit/c9b835ea77ae04f569407b9a5e86ef9e4973e9f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42969204)</sub>

<!-- /greptile_comment -->