### PR TITLE
feat(analytics): instrument filter/search-bar usage with PostHog (LFE-10781)

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -1183,6 +1183,10 @@ const LoadedSessionEventsPage: React.FC<{
               onChange={queryFilter.setFilterState}
               columnsWithCustomSelect={filterColumnsWithCustomSelect}
               label="Filter observations"
+              // Analytics (LFE-10781): session-detail observation refinement is a
+              // v3/legacy surface (the v4 events table filters via the grammar bar).
+              tableName="session-detail"
+              isV4={false}
             />
 
             {/* Separator */}

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -9,7 +9,7 @@ import {
   type ColumnDefinition,
   type OrderByState,
   type TableViewPresetState,
-  type TableViewPresetTableName,
+  TableViewPresetTableName,
   type TracingSearchType,
 } from "@langfuse/shared";
 import {
@@ -469,6 +469,16 @@ export function DataTableToolbar<TData, TValue>({
             onChange={setFilterState}
             columnsWithCustomSelect={columnsWithCustomSelect}
             filterWithAI={filterWithAI}
+            // Analytics (LFE-10781): the table's own identity, so popover
+            // filters:applied events aren't mislabeled "unknown". The v4 events
+            // table filters via the grammar bar (it omits filterColumnDefinition
+            // here, so this popover is a v3/legacy surface); derive isV4 from the
+            // ObservationsEvents view for consistency + future-proofing.
+            tableName={viewConfig?.tableName ?? "unknown"}
+            isV4={
+              viewConfig?.tableName ===
+              TableViewPresetTableName.ObservationsEvents
+            }
           />
         )}
 

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -147,6 +147,11 @@ interface DataTableToolbarProps<TData, TValue> {
   };
   orderByState?: OrderByState;
   viewConfig?: TableViewConfig;
+  /** Analytics table identity (LFE-10781) for the popover filter builder's
+   * `filters:applied`/`filters:cleared` events. Tables with a `viewConfig`
+   * already supply it via `viewConfig.tableName`; tables WITHOUT one (users,
+   * dataset runs/items) must pass this so the event isn't labeled "unknown". */
+  tableName?: string;
   filterWithAI?: boolean;
   className?: string;
   rowClassName?: string;
@@ -219,6 +224,7 @@ export function DataTableToolbar<TData, TValue>({
   rowClassName,
   orderByState,
   viewConfig,
+  tableName,
   filterWithAI = false,
   viewModeToggle,
   leadingControls,
@@ -470,11 +476,13 @@ export function DataTableToolbar<TData, TValue>({
             columnsWithCustomSelect={columnsWithCustomSelect}
             filterWithAI={filterWithAI}
             // Analytics (LFE-10781): the table's own identity, so popover
-            // filters:applied events aren't mislabeled "unknown". The v4 events
-            // table filters via the grammar bar (it omits filterColumnDefinition
-            // here, so this popover is a v3/legacy surface); derive isV4 from the
+            // filters:applied/cleared events aren't mislabeled "unknown". Prefer
+            // an explicit `tableName` (tables without a viewConfig — users,
+            // dataset runs/items), else the view's table. The v4 events table
+            // filters via the grammar bar (it omits filterColumnDefinition here,
+            // so this popover is a v3/legacy surface); derive isV4 from the
             // ObservationsEvents view for consistency + future-proofing.
-            tableName={viewConfig?.tableName ?? "unknown"}
+            tableName={tableName ?? viewConfig?.tableName ?? "unknown"}
             isV4={
               viewConfig?.tableName ===
               TableViewPresetTableName.ObservationsEvents

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -144,7 +144,13 @@ interface TableViewPresetsDrawerProps {
        * shared-link visit where the view is intentionally not applied). */
       appliedViewId: string | null;
       handleSetViewId: (viewId: string | null) => void;
-      applyViewState: (viewData: TableViewPresetState) => void;
+      applyViewState: (
+        viewData: TableViewPresetState,
+        meta?: {
+          trigger: "select" | "permalink" | "default" | "system_preset";
+          viewId?: string | null;
+        },
+      ) => void;
     };
   };
   currentState: {
@@ -267,7 +273,7 @@ export function TableViewPresetsDrawer({
     });
 
     handleSetViewId(view.id);
-    applyViewState(view);
+    applyViewState(view, { trigger: "select", viewId: view.id });
   };
 
   const handleSelectSystemFilterPreset = useCallback(
@@ -277,7 +283,10 @@ export function TableViewPresetsDrawer({
         presetId: preset.id,
       });
       handleSetViewId(preset.id);
-      applyViewState(buildSystemFilterPresetState(preset));
+      applyViewState(buildSystemFilterPresetState(preset), {
+        trigger: "system_preset",
+        viewId: preset.id,
+      });
     },
     [capture, tableName, handleSetViewId, applyViewState],
   );

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -20,6 +20,18 @@ import { validateOrderBy, validateFilters } from "../validation";
 import { isSystemPresetId } from "../components/data-table-view-presets-drawer";
 import type { FilterStateMigration } from "@/src/features/filters/lib/filter-config";
 
+/** How a saved view / preset apply was initiated — the `trigger` analytics
+ * dimension on `saved_views:applied` (LFE-10781). */
+export type SavedViewApplyMeta = {
+  trigger: "select" | "permalink" | "default" | "system_preset";
+  viewId?: string | null;
+};
+
+export type ApplyViewStateFn = (
+  viewData: TableViewPresetState,
+  meta?: SavedViewApplyMeta,
+) => void;
+
 interface TableStateUpdaters {
   setColumnOrder: (columnOrder: string[]) => void;
   setColumnVisibility: (columnVisibility: VisibilityState) => void;
@@ -254,9 +266,19 @@ export function useTableViewManager({
     setSelectedViewId,
   ]);
 
+  // v4 fast-mode surface iff this manager drives the events table. Drives the
+  // `isV4` dimension on `saved_views:applied` (LFE-10781).
+  const isV4 = tableName === TableViewPresetTableName.ObservationsEvents;
+
   // Method to apply state from a view
   const applyViewState = useCallback(
-    (viewData: TableViewPresetState) => {
+    (
+      viewData: TableViewPresetState,
+      meta?: {
+        trigger: "select" | "permalink" | "default" | "system_preset";
+        viewId?: string | null;
+      },
+    ) => {
       // lock table
       setIsLoading(true);
 
@@ -364,8 +386,25 @@ export function useTableViewManager({
       // synchronous and the URL becomes the source of truth for the applied
       // filters on the same render. Unlock deterministically here instead.
       setIsLoading(false);
+
+      // Analytics (LFE-10781): a saved view / preset was applied. METADATA ONLY
+      // — we send the view id + filter COUNT, never the filter values. Fires for
+      // every apply path, including the programmatic default/session restore the
+      // drawer's own captures miss. `trigger` classifies the entry point.
+      if (meta) {
+        capture("saved_views:applied", {
+          tableName,
+          viewId: meta.viewId ?? null,
+          trigger: meta.trigger,
+          filterCount: validFilters.length,
+          isV4,
+        });
+      }
     },
     [
+      capture,
+      tableName,
+      isV4,
       setColumnOrder,
       setColumnVisibility,
       validationContext,
@@ -431,7 +470,14 @@ export function useTableViewManager({
       name: selectedViewData.name,
     });
 
-    applyViewState(selectedViewData);
+    // This single programmatic-restore effect covers URL permalinks, session
+    // restore, and the resolved default view. Classify as "default" when the
+    // applied view is the resolved default, else treat as a "permalink"
+    // (deep-link / session-restore) entry (LFE-10781).
+    applyViewState(selectedViewData, {
+      trigger: requestedViewId === defaultViewId ? "default" : "permalink",
+      viewId: requestedViewId,
+    });
     if (storedViewId !== requestedViewId) {
       setStoredViewId(requestedViewId);
     }
@@ -449,6 +495,7 @@ export function useTableViewManager({
     applyViewState,
     storedViewId,
     setStoredViewId,
+    defaultViewId,
   ]);
 
   useEffect(() => {

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -465,6 +465,14 @@ export function useTableViewManager({
       return;
     }
 
+    // Wait for the default-view query to resolve before applying, so the
+    // trigger is classified correctly. `getDefault` and `getById` race with no
+    // ordering; if `getById` wins (cold cache, a bookmark of the default view,
+    // session-restore), `defaultViewId` is still undefined here and a
+    // default-view restore would be mislabeled `permalink` — permanently, since
+    // the `isInitializedRef` guard makes this a one-shot (LFE-10781 review).
+    if (isDefaultLoading) return;
+
     // Track permalink visit
     capture("saved_views:permalink_visit", {
       tableName,
@@ -498,6 +506,7 @@ export function useTableViewManager({
     storedViewId,
     setStoredViewId,
     defaultViewId,
+    isDefaultLoading,
   ]);
 
   useEffect(() => {

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -21,9 +21,17 @@ import { isSystemPresetId } from "../components/data-table-view-presets-drawer";
 import type { FilterStateMigration } from "@/src/features/filters/lib/filter-config";
 
 /** How a saved view / preset apply was initiated — the `trigger` analytics
- * dimension on `saved_views:applied` (LFE-10781). */
+ * dimension on `saved_views:applied` (LFE-10781). `system_preset_cleared` is a
+ * v4 category-chip toggle-off (applies the cleared/default state). */
+export type SavedViewApplyTrigger =
+  | "select"
+  | "permalink"
+  | "default"
+  | "system_preset"
+  | "system_preset_cleared";
+
 export type SavedViewApplyMeta = {
-  trigger: "select" | "permalink" | "default" | "system_preset";
+  trigger: SavedViewApplyTrigger;
   viewId?: string | null;
 };
 
@@ -272,13 +280,7 @@ export function useTableViewManager({
 
   // Method to apply state from a view
   const applyViewState = useCallback(
-    (
-      viewData: TableViewPresetState,
-      meta?: {
-        trigger: "select" | "permalink" | "default" | "system_preset";
-        viewId?: string | null;
-      },
-    ) => {
+    (viewData: TableViewPresetState, meta?: SavedViewApplyMeta) => {
       // lock table
       setIsLoading(true);
 

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -392,6 +392,7 @@ export function DatasetItemsTable({
     <>
       <DataTableToolbar
         columns={columns}
+        tableName="dataset-items"
         filterColumnDefinition={datasetItemFilterColumns}
         filterState={filterState}
         setFilterState={setFilterStateWithDebounce}

--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -144,6 +144,10 @@ function RunAggregateHeader({
           onChange={(filters: FilterState) =>
             debouncedUpdateRunFilters(runId, filters)
           }
+          // Analytics (LFE-10781): per-run filtering in the dataset-run compare
+          // view — a v3/legacy surface (not the v4 events table).
+          tableName="dataset-runs-compare"
+          isV4={false}
         />
         <BaselineToggle runId={runId} />
       </div>

--- a/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
@@ -279,6 +279,7 @@ export function DatasetRunItemsByRunTable(props: {
     <>
       <DataTableToolbar
         columns={columns}
+        tableName="dataset-run-items"
         filterColumnDefinition={transformedFilterOptions}
         filterState={userFilterState}
         setFilterState={setFilterState}

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -708,6 +708,7 @@ export function DatasetRunsTable(props: {
           >
             <DataTableToolbar
               columns={columns}
+              tableName="dataset-runs"
               filterColumnDefinition={transformedFilterOptions}
               filterState={userFilterState}
               setFilterState={setFilterState}
@@ -773,6 +774,7 @@ export function DatasetRunsTable(props: {
         <>
           <DataTableToolbar
             columns={columns}
+            tableName="dataset-runs"
             filterColumnDefinition={transformedFilterOptions}
             filterState={userFilterState}
             setFilterState={setFilterState}

--- a/web/src/features/events/components/CategoryPresetChips.tsx
+++ b/web/src/features/events/components/CategoryPresetChips.tsx
@@ -63,8 +63,21 @@ type CategoryPresetChipsProps = {
   activeViewId: string | null;
   /** Sets `?viewId` (deep-link/provenance); pass null to deselect. */
   onApplyView: (viewId: string | null) => void;
-  /** Applies the preset's filters/orderBy to the live table. */
-  applyViewState: (viewData: TableViewPresetState) => void;
+  /** Applies the preset's filters/orderBy to the live table. Accepts the
+   * analytics `meta` (LFE-10781) so chip applies/toggle-offs emit
+   * `saved_views:applied` — the capture is gated on `meta` being passed. */
+  applyViewState: (
+    viewData: TableViewPresetState,
+    meta?: {
+      trigger:
+        | "select"
+        | "permalink"
+        | "default"
+        | "system_preset"
+        | "system_preset_cleared";
+      viewId?: string | null;
+    },
+  ) => void;
   /**
    * Non-destructive preview of a preset's filters in the search bar while
    * hovering/focusing its row; pass null to restore. No-op when the search bar
@@ -285,8 +298,18 @@ export function CategoryPresetChips({
                         const next = isPresetActive ? null : preset.id;
                         outcomeRef.current = next ? "applied" : "cleared";
                         onApplyView(next);
+                        // Pass analytics meta so the chip apply / toggle-off
+                        // emits `saved_views:applied` (LFE-10781): applying a
+                        // preset is a "system_preset" trigger; toggling it off
+                        // applies the cleared/default state.
                         applyViewState(
                           next ? preset.state : CLEARED_VIEW_STATE,
+                          {
+                            trigger: next
+                              ? "system_preset"
+                              : "system_preset_cleared",
+                            viewId: next,
+                          },
                         );
                         capture("saved_views:category_chip_apply", {
                           category,

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -444,6 +444,8 @@ export default function ObservationsEventsTable({
       loading: isFilterOptionsPending,
       loadingColumns,
       implicitDefaultConfig: DEFAULT_SIDEBAR_IMPLICIT_ENVIRONMENT_CONFIG,
+      // v4 fast-mode surface — drives `isV4` on filters:* analytics (LFE-10781).
+      isV4: true,
     };
 
     if (peekContext) {
@@ -541,6 +543,7 @@ export default function ObservationsEventsTable({
     applyFilters: searchBarApplyFilters,
   } = useEventsSearchBar({
     projectId,
+    tableName: eventsFilterConfig.tableName,
     enabled: searchBarMode,
     filterState: queryFilter.explicitFilterState,
     searchQuery,
@@ -1700,6 +1703,7 @@ export default function ObservationsEventsTable({
             {searchBarMode && (
               <EventsSearchBarRow
                 projectId={projectId}
+                tableName={eventsFilterConfig.tableName}
                 store={searchBarStore}
                 commit={searchBarCommit}
                 observed={observedOptions}

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -88,6 +88,8 @@ export function PopoverFilterBuilder({
   filterWithAI = false,
   buttonType = "default",
   label = "Filters",
+  tableName = "unknown",
+  isV4 = false,
 }: {
   /** Which column field to persist in filter.column: 'id' for stable refs, 'name' for legacy compatibility */
   columns: ColumnDefinitionWithAlert[];
@@ -101,10 +103,18 @@ export function PopoverFilterBuilder({
   buttonType?: "default" | "icon";
   /** Trigger button label. Defaults to "Filters"; override to clarify scope. */
   label?: string;
+  /** Table this builder filters — the `tableName` analytics dimension. */
+  tableName?: string;
+  /** Whether this builder sits on a v4 (fast-mode) surface — `isV4` dimension. */
+  isV4?: boolean;
 }) {
   const capture = usePostHogClientCapture();
   const [wipFilterState, _setWipFilterState] =
     useState<WipFilterState>(filterState);
+  // Count of already-applied (valid) filters, so `setWipFilterState` can emit
+  // `filters:applied` only when a filter is newly completed — not on every
+  // keystroke of an in-progress edit. Seeded from the incoming applied state.
+  const prevValidCountRef = useRef(filterState.length);
 
   // Sync wipFilterState when filterState prop changes externally
   // (e.g., when a saved view preset is applied)
@@ -152,6 +162,27 @@ export function PopoverFilterBuilder({
       const newState = state instanceof Function ? state(prev) : state;
       const validFilters = getValidFilters(newState);
       onChange(validFilters);
+      // Analytics (LFE-10781): emit `filters:applied` only when a filter is
+      // newly completed (valid count grew), so an in-progress edit does not
+      // fire per keystroke. METADATA ONLY — we report the last valid filter's
+      // shape + counts, never a raw value.
+      if (validFilters.length > prevValidCountRef.current) {
+        const applied = validFilters[validFilters.length - 1];
+        if (applied) {
+          capture("filters:applied", {
+            surface: "filter_builder",
+            tableName,
+            column: applied.column,
+            filterType: applied.type,
+            operator: applied.operator,
+            ...("key" in applied && applied.key ? { key: applied.key } : {}),
+            valueCount: Array.isArray(applied.value) ? applied.value.length : 1,
+            conditionCount: validFilters.length,
+            isV4,
+          });
+        }
+      }
+      prevValidCountRef.current = validFilters.length;
       return newState;
     });
   };
@@ -167,8 +198,11 @@ export function PopoverFilterBuilder({
           if (open && filterState.length === 0) addNewFilter();
           // Discard all wip filters when closing popover
           if (!open) {
+            // METADATA ONLY (LFE-10781): previously sent the full `filterState`,
+            // which leaked raw filter VALUES (user ids, metadata content, free
+            // text = PII) into PostHog. Send only the applied-filter count.
             capture("table:filter_builder_close", {
-              filter: filterState,
+              filterCount: filterState.length,
             });
             setWipFilterState(filterState);
           }

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -131,7 +131,15 @@ export function PopoverFilterBuilder({
         (f) => !singleFilter.safeParse(f).success,
       );
       // Don't sync if user is actively editing (has invalid WIP filters)
-      return hasWipFilters ? currentWip : filterState;
+      if (hasWipFilters) return currentWip;
+      // Synced from external state (saved view applied, URL nav, clear-all): the
+      // commit bypasses the wrapped `setWipFilterState`, so re-baseline the
+      // applied-count ref here too (LFE-10781). Otherwise a stale count makes the
+      // next wrapper edit — including popover close — mis-fire `filters:applied`.
+      // `filterState` is already-valid (typed FilterState), so its length is the
+      // valid count.
+      prevValidCountRef.current = filterState.length;
+      return filterState;
     });
   }, [filterState]);
 

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -171,6 +171,13 @@ export function PopoverFilterBuilder({
       const validFilters = getValidFilters(newState);
       onChange(validFilters);
       const prevCount = prevValidCountRef.current;
+      // A row was actually removed (clear-all X → []; or a single row X). This
+      // is the ONLY thing that counts as a clear: a valid count that drops
+      // because a row went transiently invalid mid-edit (changing a row's column
+      // sets value:undefined → fails safeParse) keeps the SAME row count and
+      // must NOT emit `filters:cleared` — the user is refining, not clearing
+      // (LFE-10781 review).
+      const rowsRemoved = newState.length < prev.length;
       // Analytics (LFE-10781). METADATA ONLY — we report the changed filter's
       // shape + counts, never a raw value. Count semantics match the sidebar:
       // `conditionCount` = TOTAL applied conditions across ALL columns;
@@ -195,9 +202,9 @@ export function PopoverFilterBuilder({
             isV4,
           });
         }
-      } else if (validFilters.length < prevCount) {
-        // A shrink — the clear-all X buttons (setWipFilterState([])) or removing
-        // a row. Mirrors the sidebar's clearAll → `filters:cleared`.
+      } else if (validFilters.length < prevCount && rowsRemoved) {
+        // A real clear — the clear-all X buttons (setWipFilterState([])) or
+        // removing a row. NOT a transient mid-column-change invalid shrink.
         capture("filters:cleared", {
           surface: "filter_builder",
           tableName,

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -170,11 +170,14 @@ export function PopoverFilterBuilder({
       const newState = state instanceof Function ? state(prev) : state;
       const validFilters = getValidFilters(newState);
       onChange(validFilters);
-      // Analytics (LFE-10781): emit `filters:applied` only when a filter is
-      // newly completed (valid count grew), so an in-progress edit does not
-      // fire per keystroke. METADATA ONLY — we report the last valid filter's
-      // shape + counts, never a raw value.
-      if (validFilters.length > prevValidCountRef.current) {
+      const prevCount = prevValidCountRef.current;
+      // Analytics (LFE-10781). METADATA ONLY — we report the changed filter's
+      // shape + counts, never a raw value. Count semantics match the sidebar:
+      // `conditionCount` = TOTAL applied conditions across ALL columns;
+      // `columnConditionCount` = rows for the changed column.
+      if (validFilters.length > prevCount) {
+        // A filter was newly completed (valid count grew) — an in-progress edit
+        // does not fire per keystroke.
         const applied = validFilters[validFilters.length - 1];
         if (applied) {
           capture("filters:applied", {
@@ -186,9 +189,21 @@ export function PopoverFilterBuilder({
             ...("key" in applied && applied.key ? { key: applied.key } : {}),
             valueCount: Array.isArray(applied.value) ? applied.value.length : 1,
             conditionCount: validFilters.length,
+            columnConditionCount: validFilters.filter(
+              (f) => f.column === applied.column,
+            ).length,
             isV4,
           });
         }
+      } else if (validFilters.length < prevCount) {
+        // A shrink — the clear-all X buttons (setWipFilterState([])) or removing
+        // a row. Mirrors the sidebar's clearAll → `filters:cleared`.
+        capture("filters:cleared", {
+          surface: "filter_builder",
+          tableName,
+          clearedCount: prevCount - validFilters.length,
+          isV4,
+        });
       }
       prevValidCountRef.current = validFilters.length;
       return newState;

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useCallback, useMemo, useEffect, useState } from "react";
+import { useCallback, useMemo, useEffect, useRef, useState } from "react";
 import {
   StringParam,
   useQueryParam,
@@ -34,6 +34,7 @@ import { useKeyedSessionStorageState } from "./useKeyedSessionStorageState";
 import useSessionStorage from "@/src/components/useSessionStorage";
 import type { FilterConfig, FilterStateMigration } from "../lib/filter-config";
 import type { PeekTableStateContextValue } from "@/src/components/table/peek/contexts/PeekTableStateContext";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 /**
  * Decodes filters from URL query string and normalizes display names to column IDs.
@@ -373,6 +374,14 @@ type BaseUseSidebarFilterStateOptions = {
    * columns that are not server-enumerated (e.g. metadata).
    */
   loadingColumns?: ReadonlySet<string>;
+  /**
+   * Whether this sidebar is rendered on a v4 (fast-mode / events-table) surface.
+   * Drives the `isV4` dimension on the `filters:*` analytics events so we can
+   * split filtering behaviour by v3-legacy vs v4-fast-mode. Defaults to false;
+   * the v4 events table passes `true`. (The `v4BetaEnabled` super property set
+   * in `_app.tsx` still segments every event globally as a backstop.)
+   */
+  isV4?: boolean;
 };
 
 export type UseSidebarFilterStateOptions =
@@ -505,6 +514,8 @@ export function useSidebarFilterState(
   hookOptions: UseSidebarFilterStateOptions = DEFAULT_HOOK_OPTIONS,
 ) {
   const { loading, loadingColumns, implicitDefaultConfig } = hookOptions;
+  const isV4Surface = hookOptions.isV4 ?? false;
+  const capture = usePostHogClientCapture();
   const stateLocationType = hookOptions.stateLocation;
   const peekContext =
     stateLocationType === "peekContext" ? hookOptions.context : undefined;
@@ -887,8 +898,52 @@ export function useSidebarFilterState(
     setStoredFiltersQuery,
   ]);
 
+  // When true, the applied-filter capture inside `updateFilter` is suppressed —
+  // set by `updateOperator`, which funnels through `updateFilter` but must emit
+  // `filters:facet_operator_toggled` instead of a duplicate `filters:applied`.
+  const suppressAppliedCaptureRef = useRef(false);
+
+  // Emit `filters:applied` for a single facet interaction. METADATA ONLY: we
+  // derive shape (type/operator/key/counts) from the RESULTING filters for the
+  // column and never send the raw filter value (PII). Skips emission when the
+  // column ends up with no filter (a deselect-to-empty is a clear, not an
+  // apply). `conditionCount` counts the rows the column produced (a numeric
+  // range is 2: >= and <=); `valueCount` counts selected options.
+  const emitFilterApplied = useCallback(
+    (
+      surface: "sidebar" | "filter_builder",
+      column: string,
+      next: FilterState,
+    ) => {
+      const colFilters = next.filter((f) => f.column === column);
+      if (colFilters.length === 0) return;
+      const primary = colFilters[0];
+      capture("filters:applied", {
+        surface,
+        tableName: config.tableName,
+        column,
+        filterType: primary.type,
+        operator: primary.operator,
+        ...("key" in primary && primary.key ? { key: primary.key } : {}),
+        valueCount: Array.isArray(primary.value) ? primary.value.length : 1,
+        conditionCount: colFilters.length,
+        isV4: isV4Surface,
+      });
+    },
+    [capture, config.tableName, isV4Surface],
+  );
+
   const clearAll = () => {
+    const clearedCount = explicitFilterState.length;
     setFilterState([]);
+    if (clearedCount > 0) {
+      capture("filters:cleared", {
+        surface: "sidebar",
+        tableName: config.tableName,
+        clearedCount,
+        isV4: isV4Surface,
+      });
+    }
   };
 
   // Generic apply selection logic
@@ -1086,8 +1141,11 @@ export function useSidebarFilterState(
 
       const next = applySelection(withoutTextFilters, column, values, operator);
       setFilterState(next);
+      if (!suppressAppliedCaptureRef.current) {
+        emitFilterApplied("sidebar", column, next);
+      }
     },
-    [filterState, applySelection, setFilterState],
+    [filterState, applySelection, setFilterState, emitFilterApplied],
   );
 
   const updateFilterOnly = useCallback(
@@ -1131,13 +1189,57 @@ export function useSidebarFilterState(
     ],
   );
 
+  const emitOperatorToggled = useCallback(
+    (
+      column: string,
+      fromOperator: string | undefined,
+      toOperator: "any of" | "all of" | "none of",
+      valueCount: number,
+    ) => {
+      capture("filters:facet_operator_toggled", {
+        surface: "sidebar",
+        tableName: config.tableName,
+        column,
+        fromOperator,
+        toOperator,
+        valueCount,
+        isV4: isV4Surface,
+      });
+    },
+    [capture, config.tableName, isV4Surface],
+  );
+
+  // Runs `updateFilter` without the `filters:applied` capture, so the operator
+  // toggle emits exactly one `filters:facet_operator_toggled` (not both events).
+  const applyOperatorChange = useCallback(
+    (
+      column: string,
+      values: string[],
+      operator: "any of" | "all of" | "none of",
+    ) => {
+      suppressAppliedCaptureRef.current = true;
+      try {
+        updateFilter(column, values, operator);
+      } finally {
+        suppressAppliedCaptureRef.current = false;
+      }
+    },
+    [updateFilter],
+  );
+
   const updateOperator = useCallback(
     (column: string, newOperator: "any of" | "all of" | "none of") => {
       // Find the existing filter for this column
       const existingFilter = filterState.find((f) => f.column === column);
+      const fromOperator =
+        existingFilter?.type === "arrayOptions" ||
+        existingFilter?.type === "stringOptions"
+          ? existingFilter.operator
+          : undefined;
       if (!existingFilter) {
         // Without selected values there is no valid persisted filter yet.
-        updateFilter(column, [], newOperator);
+        applyOperatorChange(column, [], newOperator);
+        emitOperatorToggled(column, fromOperator, newOperator, 0);
         return;
       }
 
@@ -1171,9 +1273,15 @@ export function useSidebarFilterState(
       }
 
       // Update the filter with the new operator
-      updateFilter(column, currentValues, newOperator);
+      applyOperatorChange(column, currentValues, newOperator);
+      emitOperatorToggled(
+        column,
+        fromOperator,
+        newOperator,
+        currentValues.length,
+      );
     },
-    [filterState, updateFilter, options],
+    [filterState, applyOperatorChange, emitOperatorToggled, options],
   );
 
   const updateNumericFilter = useCallback(
@@ -1211,8 +1319,9 @@ export function useSidebarFilterState(
 
       const next: FilterState = [...withoutNumeric, ...filters];
       setFilterState(next);
+      emitFilterApplied("sidebar", column, next);
     },
-    [filterState, setFilterState],
+    [filterState, setFilterState, emitFilterApplied],
   );
 
   const updateStringFilter = useCallback(
@@ -1234,9 +1343,10 @@ export function useSidebarFilterState(
           },
         ];
         setFilterState(next);
+        emitFilterApplied("sidebar", column, next);
       }
     },
-    [filterState, setFilterState],
+    [filterState, setFilterState, emitFilterApplied],
   );
 
   // Text filter management for categorical filters
@@ -1270,8 +1380,9 @@ export function useSidebarFilterState(
 
       const next: FilterState = [...withoutCheckboxFilters, newFilter];
       setFilterState(next);
+      emitFilterApplied("sidebar", column, next);
     },
-    [filterState, setFilterState],
+    [filterState, setFilterState, emitFilterApplied],
   );
 
   const removeTextFilter = useCallback(

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -1591,6 +1591,8 @@ export function useSidebarFilterState(
               ];
 
               setFilterState(newFilters);
+              // Analytics (LFE-10781): keyed metadata/category-score facet apply.
+              emitFilterApplied("sidebar", facet.column, newFilters);
             },
             onReset: () => {
               // Remove all categoryOptions filters for this column
@@ -1698,6 +1700,8 @@ export function useSidebarFilterState(
               ];
 
               setFilterState(newFilters);
+              // Analytics (LFE-10781): keyed numeric-score facet apply.
+              emitFilterApplied("sidebar", facet.column, newFilters);
             },
             onReset: () => {
               // Remove all numberObject filters for this column
@@ -1856,6 +1860,8 @@ export function useSidebarFilterState(
               ];
 
               setFilterState(newFilters);
+              // Analytics (LFE-10781): keyed metadata/string-score facet apply.
+              emitFilterApplied("sidebar", facet.column, newFilters);
             },
             onReset: () => {
               // Remove all stringObject filters for this column
@@ -2166,6 +2172,7 @@ export function useSidebarFilterState(
     removeTextFilter,
     expandedState,
     setFilterState,
+    emitFilterApplied,
     managedEnvironmentColumn,
     managedEnvironmentPolicyConfig.hiddenEnvironments,
   ]);

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -907,8 +907,11 @@ export function useSidebarFilterState(
   // derive shape (type/operator/key/counts) from the RESULTING filters for the
   // column and never send the raw filter value (PII). Skips emission when the
   // column ends up with no filter (a deselect-to-empty is a clear, not an
-  // apply). `conditionCount` counts the rows the column produced (a numeric
-  // range is 2: >= and <=); `valueCount` counts selected options.
+  // apply). Count semantics are aligned with the popover builder (LFE-10781
+  // review): `conditionCount` = TOTAL applied conditions across ALL columns
+  // (whole-filter complexity); `columnConditionCount` = rows this column
+  // produced (a numeric range is 2: >= and <=); `valueCount` = selected options
+  // in the primary condition.
   const emitFilterApplied = useCallback(
     (
       surface: "sidebar" | "filter_builder",
@@ -926,7 +929,8 @@ export function useSidebarFilterState(
         operator: primary.operator,
         ...("key" in primary && primary.key ? { key: primary.key } : {}),
         valueCount: Array.isArray(primary.value) ? primary.value.length : 1,
-        conditionCount: colFilters.length,
+        conditionCount: next.length,
+        columnConditionCount: colFilters.length,
         isV4: isV4Surface,
       });
     },

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -911,16 +911,34 @@ export function useSidebarFilterState(
   // review): `conditionCount` = TOTAL applied conditions across ALL columns
   // (whole-filter complexity); `columnConditionCount` = rows this column
   // produced (a numeric range is 2: >= and <=); `valueCount` = selected options
-  // in the primary condition.
+  // in the attributed condition.
+  //
+  // `prev` (the pre-change state) lets us attribute the event to the row the
+  // user JUST added/changed rather than the oldest one on the column — critical
+  // for keyed facets (metadata / scores) that hold several rows per column
+  // (adding `metadata.env` on top of `metadata.user_id` must report `env`, not
+  // `user_id`). We pick the entry absent from `prev` (added or value-changed);
+  // failing that, the last (appended) entry. The identity used to match rows
+  // includes the raw value but is only ever compared locally — it is NEVER put
+  // on the event payload.
   const emitFilterApplied = useCallback(
     (
       surface: "sidebar" | "filter_builder",
       column: string,
       next: FilterState,
+      prev?: FilterState,
     ) => {
       const colFilters = next.filter((f) => f.column === column);
       if (colFilters.length === 0) return;
-      const primary = colFilters[0];
+      const identity = (f: FilterState[number]): string =>
+        `${"key" in f ? f.key : ""} ${f.operator} ${JSON.stringify(
+          "value" in f ? f.value : null,
+        )}`;
+      const prevIdentities = new Set(
+        (prev ?? []).filter((f) => f.column === column).map((f) => identity(f)),
+      );
+      const changed = colFilters.find((f) => !prevIdentities.has(identity(f)));
+      const primary = changed ?? colFilters[colFilters.length - 1];
       capture("filters:applied", {
         surface,
         tableName: config.tableName,
@@ -1596,7 +1614,12 @@ export function useSidebarFilterState(
 
               setFilterState(newFilters);
               // Analytics (LFE-10781): keyed metadata/category-score facet apply.
-              emitFilterApplied("sidebar", facet.column, newFilters);
+              emitFilterApplied(
+                "sidebar",
+                facet.column,
+                newFilters,
+                filterState,
+              );
             },
             onReset: () => {
               // Remove all categoryOptions filters for this column
@@ -1705,7 +1728,12 @@ export function useSidebarFilterState(
 
               setFilterState(newFilters);
               // Analytics (LFE-10781): keyed numeric-score facet apply.
-              emitFilterApplied("sidebar", facet.column, newFilters);
+              emitFilterApplied(
+                "sidebar",
+                facet.column,
+                newFilters,
+                filterState,
+              );
             },
             onReset: () => {
               // Remove all numberObject filters for this column
@@ -1865,7 +1893,12 @@ export function useSidebarFilterState(
 
               setFilterState(newFilters);
               // Analytics (LFE-10781): keyed metadata/string-score facet apply.
-              emitFilterApplied("sidebar", facet.column, newFilters);
+              emitFilterApplied(
+                "sidebar",
+                facet.column,
+                newFilters,
+                filterState,
+              );
             },
             onReset: () => {
               // Remove all stringObject filters for this column

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -259,6 +259,7 @@ export const events = {
     "cleared",
     "facet_operator_toggled",
     "search_submitted",
+    "search_error",
     "ai_generate_requested",
     "ai_generate_applied",
     "ai_generate_failed",

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -63,6 +63,7 @@ export const events = {
     // A bookmarked/stored system-preset id that the catalog retired — the
     // user was shown the one-time notice and landed on the default view.
     "retired_view_redirect",
+    "applied",
   ],
   score: [
     "create",
@@ -249,6 +250,19 @@ export const events = {
   cmd_k_menu: ["opened", "search_entered", "navigated"],
   spend_alert: ["created", "updated", "deleted"],
   sidebar: ["book_a_call_clicked", "v4_beta_toggled"],
+  // Filter/search-bar usage analytics (LFE-10781). METADATA ONLY — payloads
+  // never carry a raw filter value, search text, or AI prompt (PII). Only
+  // type/column/operator/key(field-name)/counts/lengths/booleans/enums.
+  // `isV4` on every event reflects fast-mode (v4 events table) at action time.
+  filters: [
+    "applied",
+    "cleared",
+    "facet_operator_toggled",
+    "search_submitted",
+    "ai_generate_requested",
+    "ai_generate_applied",
+    "ai_generate_failed",
+  ],
 } as const;
 
 // type that represents all possible event names, e.g. "traces:bookmark"

--- a/web/src/features/search-bar/components/EventsSearchBarRow.tsx
+++ b/web/src/features/search-bar/components/EventsSearchBarRow.tsx
@@ -27,9 +27,11 @@ import { ComposerWithPreview } from "@/src/features/search-bar/components/Compos
 import { SearchBarAiPrompt } from "@/src/features/search-bar/components/SearchBarAiPrompt";
 import { SearchBarStoreProvider } from "@/src/features/search-bar/store/SearchBarStoreProvider";
 import type { SearchBarStore } from "@/src/features/search-bar/store/searchBarStore";
+import type { SearchCommitTrigger } from "@/src/features/search-bar/hooks/useEventsSearchBar";
 
 export function EventsSearchBarRow({
   projectId,
+  tableName,
   store,
   commit,
   observed,
@@ -40,8 +42,10 @@ export function EventsSearchBarRow({
   aiScoreNames,
 }: {
   projectId: string;
+  /** Table this bar filters — threaded to AI-prompt analytics (LFE-10781). */
+  tableName: string;
   store: SearchBarStore;
-  commit: () => string | null;
+  commit: (trigger?: SearchCommitTrigger) => string | null;
   observed: ObservedOptions | undefined;
   /** Columns whose lazy fetch terminally errored — value-stage loading settles to
    *  empty (per column) instead of pinning, matching the sidebar's settled-error
@@ -86,6 +90,7 @@ export function EventsSearchBarRow({
       {aiOpen && aiAvailable ? (
         <SearchBarAiPrompt
           projectId={projectId}
+          tableName={tableName}
           store={store}
           dataContext={aiDataContext}
           scoreNames={aiScoreNames}

--- a/web/src/features/search-bar/components/SearchBarAiPrompt.tsx
+++ b/web/src/features/search-bar/components/SearchBarAiPrompt.tsx
@@ -25,6 +25,7 @@ import type { ObservedScoreNames } from "@/src/features/search-bar/lib/observed-
 import type { SearchBarStore } from "@/src/features/search-bar/store/searchBarStore";
 import { api } from "@/src/utils/api";
 import { cn } from "@/src/utils/tailwind";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 // "No such score X" note for score filters the server dropped because their
 // name matches no observed score (exactly or normalized).
@@ -37,6 +38,7 @@ function unknownScoresMessage(names: string[]): string {
 
 export function SearchBarAiPrompt({
   projectId,
+  tableName,
   store,
   dataContext,
   scoreNames,
@@ -44,6 +46,8 @@ export function SearchBarAiPrompt({
   onExit,
 }: {
   projectId: string;
+  /** Table this bar filters — the `tableName` analytics dimension. */
+  tableName: string;
   /** The bar store; its `draft` is read as the live refine context. */
   store: SearchBarStore;
   /** Observed values + metadata keys + result count, so the model maps to the
@@ -58,6 +62,7 @@ export function SearchBarAiPrompt({
   /** Leave AI mode and restore the grammar composer. */
   onExit: () => void;
 }) {
+  const capture = usePostHogClientCapture();
   const [value, setValue] = React.useState("");
   const [error, setError] = React.useState<string | null>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -107,11 +112,20 @@ export function SearchBarAiPrompt({
     // The sidebar/saved-view selector stay mounted and can change the filters
     // mid-request; the model returns the COMPLETE set based on this snapshot.
     const refine = store.getState().draft.trim();
+    const refineMode = refine.length > 0;
+    // Analytics (LFE-10781): METADATA ONLY — `promptLength` is a CHAR COUNT, the
+    // prompt text itself is never sent. Ask-AI is a v4-only surface (isV4 true).
+    capture("filters:ai_generate_requested", {
+      tableName,
+      refineMode,
+      promptLength: prompt.length,
+      isV4: true,
+    });
     try {
       const result = await generateFilter.mutateAsync({
         projectId,
         prompt,
-        currentQuery: refine.length > 0 ? refine : undefined,
+        currentQuery: refineMode ? refine : undefined,
         dataContext,
         scoreNames,
       });
@@ -123,10 +137,22 @@ export function SearchBarAiPrompt({
       // so mergeWithSkipped won't preserve it). Bail and let the user retry
       // against the updated filters instead.
       if (store.getState().draft.trim() !== refine) {
+        capture("filters:ai_generate_failed", {
+          tableName,
+          refineMode,
+          reason: "stale",
+          isV4: true,
+        });
         setError("Filters changed while generating — try again.");
         return;
       }
       if (result.filters.length === 0) {
+        capture("filters:ai_generate_failed", {
+          tableName,
+          refineMode,
+          reason: "empty",
+          isV4: true,
+        });
         // A dropped unknown score name explains the empty result better than
         // the generic rephrase hint ("no such score X" beats a dead filter).
         setError(
@@ -136,6 +162,12 @@ export function SearchBarAiPrompt({
         );
         return;
       }
+      capture("filters:ai_generate_applied", {
+        tableName,
+        refineMode,
+        generatedFilterCount: result.filters.length,
+        isV4: true,
+      });
       onApply(result.filters as FilterState);
       if (result.unknownScoreNames.length > 0) {
         // Partial apply: the rest of the filters went through, so exit as
@@ -154,6 +186,12 @@ export function SearchBarAiPrompt({
       // an unhelpful "we have been notified" string anyway. The auth/precondition
       // cases are unreachable behind the cloud + aiFeaturesEnabled gate. Show one
       // generic, actionable message instead.
+      capture("filters:ai_generate_failed", {
+        tableName,
+        refineMode,
+        reason: "error",
+        isV4: true,
+      });
       setError("Couldn't reach the AI service. Please try again.");
     }
   };

--- a/web/src/features/search-bar/components/SearchComposer.tsx
+++ b/web/src/features/search-bar/components/SearchComposer.tsx
@@ -707,7 +707,9 @@ export function SearchComposer({
       // it reveals the invalid draft and returns null. On success it returns the
       // CANONICAL committed text in its RESTING form (trailing space when
       // non-empty) — the same text the resetTo effect re-derives.
-      const committedText = commitToFilterState();
+      const committedText = commitToFilterState(
+        advanceToTrailingSpace ? "enter" : "blur",
+      );
       if (committedText === null) return;
       setHighlightedOptionId(null);
       // Close the undo-coalesce window at the commit boundary, mirroring undo()/
@@ -756,7 +758,7 @@ export function SearchComposer({
   // (the `commit` path above) or blur. writeDraft ran synchronously, so the
   // freshly-set draftValid is current here.
   const commitStructuredEdit = React.useCallback(() => {
-    if (storeApi.getState().draftValid) commitToFilterState();
+    if (storeApi.getState().draftValid) commitToFilterState("pick");
   }, [storeApi, commitToFilterState]);
 
   const pickOption = React.useCallback(
@@ -776,7 +778,7 @@ export function SearchComposer({
         // reveal the red invalid state instead of silently no-op'ing (e.g. a
         // recent stored before a grammar tightening, or a since-retyped score).
         const state = storeApi.getState();
-        if (state.draftValid) commitToFilterState();
+        if (state.draftValid) commitToFilterState("pick");
         else state.actions.revealInvalid();
         setAutocompleteOpen(false);
         return;

--- a/web/src/features/search-bar/hooks/useEventsSearchBar.clienttest.tsx
+++ b/web/src/features/search-bar/hooks/useEventsSearchBar.clienttest.tsx
@@ -19,6 +19,7 @@ function setup(
   const { result } = renderHook(() =>
     useEventsSearchBar({
       projectId: "p",
+      tableName: "observations",
       enabled: true,
       filterState: [],
       searchQuery: "refund",

--- a/web/src/features/search-bar/hooks/useEventsSearchBar.ts
+++ b/web/src/features/search-bar/hooks/useEventsSearchBar.ts
@@ -31,6 +31,10 @@ import {
   createSearchBarStore,
   type SearchBarStore,
 } from "@/src/features/search-bar/store/searchBarStore";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+
+/** How a search-bar commit was triggered — the `trigger` analytics dimension. */
+export type SearchCommitTrigger = "enter" | "blur" | "pick";
 
 /** Order-independent scope-set equality (scopes are unique). */
 function sameScopes(a: TracingSearchType[], b: TracingSearchType[]): boolean {
@@ -61,6 +65,7 @@ function filterIdentity(f: FilterState[number]): string {
 
 export function useEventsSearchBar({
   projectId,
+  tableName,
   enabled,
   filterState,
   searchQuery,
@@ -71,6 +76,8 @@ export function useEventsSearchBar({
   setSearchType,
 }: {
   projectId: string;
+  /** Table this bar filters — the `tableName` analytics dimension. */
+  tableName: string;
   enabled: boolean;
   /** The user's explicit facet filters (sidebar `explicitFilterState`). */
   filterState: FilterState;
@@ -83,9 +90,11 @@ export function useEventsSearchBar({
   setSearchType: (type: TracingSearchType[]) => void;
 }): {
   store: SearchBarStore;
-  commit: () => string | null;
+  commit: (trigger?: SearchCommitTrigger) => string | null;
   applyFilters: (filters: FilterState) => void;
 } {
+  const capture = usePostHogClientCapture();
+
   // Latest observed options, read inside commit and by the store's draft
   // validation so both route `scores.<name>` by the same observed score type.
   const observedRef = useRef(observed);
@@ -171,44 +180,72 @@ export function useEventsSearchBar({
     [mergeWithSkipped],
   );
 
-  const commit = useCallback((): string | null => {
-    const result = planCommit(
-      store.getState().draft,
-      scoreTypeContextFromObserved(observedRef.current),
-    );
-    if (result.status === "invalid") {
-      store.getState().actions.revealInvalid();
-      return null;
-    }
-    const { setFilterState, setSearchQuery, setSearchType } = applyRef.current;
-    // Re-attach the filters the grammar can't represent so the commit never
-    // drops them (no-silent-drop contract; shared with the AI apply path).
-    const committedFilters = mergeWithSkipped(result.filters);
-    setFilterState(committedFilters);
-    setSearchQuery(result.searchQuery);
-    // Only write searchType when it actually changed. planCommit coerces a
-    // draft with no scope token to the default (`["id","content"]` — ids+names
-    // +input+output); the bar's default deliberately differs from the legacy
-    // toolbar's `["id"]`, so it IS written to the URL (that's how the content
-    // lane persists). The guard just avoids a redundant rewrite when unchanged.
-    if (!sameScopes(result.searchType, searchTypeRef.current)) {
-      setSearchType(result.searchType);
-    }
-    if (result.canonical.length > 0) {
-      recordRecentSearch(projectId, result.canonical);
-    }
-    // Return the CANONICAL committed text in its RESTING form (trailing space) —
-    // exactly what the resetTo effect re-derives on the next render (same
-    // filters + searchQuery/searchType). The composer drops the caret after it,
-    // so the echo string-compares equal and the space survives even when the
-    // commit reorders the query (e.g. `refund level:ERROR` → `level:ERROR refund`).
-    return restingDraft(
-      filterStateToQueryText(committedFilters, {
-        searchQuery: result.searchQuery,
-        searchType: result.searchType,
-      }).text,
-    );
-  }, [store, projectId, mergeWithSkipped]);
+  // The committed text at the last render — the dedup baseline so a blur that
+  // changed nothing does not emit a phantom `filters:search_submitted`.
+  const committedTextRef = useRef(committedText);
+  committedTextRef.current = committedText;
+
+  const commit = useCallback(
+    (trigger: SearchCommitTrigger = "enter"): string | null => {
+      const result = planCommit(
+        store.getState().draft,
+        scoreTypeContextFromObserved(observedRef.current),
+      );
+      if (result.status === "invalid") {
+        store.getState().actions.revealInvalid();
+        return null;
+      }
+      const { setFilterState, setSearchQuery, setSearchType } =
+        applyRef.current;
+      // Re-attach the filters the grammar can't represent so the commit never
+      // drops them (no-silent-drop contract; shared with the AI apply path).
+      const committedFilters = mergeWithSkipped(result.filters);
+      setFilterState(committedFilters);
+      setSearchQuery(result.searchQuery);
+      // Only write searchType when it actually changed. planCommit coerces a
+      // draft with no scope token to the default (`["id","content"]` — ids+names
+      // +input+output); the bar's default deliberately differs from the legacy
+      // toolbar's `["id"]`, so it IS written to the URL (that's how the content
+      // lane persists). The guard just avoids a redundant rewrite when unchanged.
+      if (!sameScopes(result.searchType, searchTypeRef.current)) {
+        setSearchType(result.searchType);
+      }
+      if (result.canonical.length > 0) {
+        recordRecentSearch(projectId, result.canonical);
+      }
+      // Return the CANONICAL committed text in its RESTING form (trailing space) —
+      // exactly what the resetTo effect re-derives on the next render (same
+      // filters + searchQuery/searchType). The composer drops the caret after it,
+      // so the echo string-compares equal and the space survives even when the
+      // commit reorders the query (e.g. `refund level:ERROR` → `level:ERROR refund`).
+      const committed = restingDraft(
+        filterStateToQueryText(committedFilters, {
+          searchQuery: result.searchQuery,
+          searchType: result.searchType,
+        }).text,
+      );
+
+      // Analytics (LFE-10781). METADATA ONLY — `queryLength` is a CHAR COUNT, we
+      // never send the query text itself. A blur that produced no change is a
+      // no-op (the resting draft re-settling), so it does not emit; an explicit
+      // enter/pick always counts even when re-submitting the same query. The
+      // grammar bar is a v4-only surface, so isV4 is always true.
+      if (trigger !== "blur" || committed !== committedTextRef.current) {
+        capture("filters:search_submitted", {
+          tableName,
+          filterCount: committedFilters.length,
+          hasFreeText: (result.searchQuery ?? "").trim().length > 0,
+          searchType: result.searchType,
+          queryLength: committed.trim().length,
+          trigger,
+          isV4: true,
+        });
+      }
+
+      return committed;
+    },
+    [store, projectId, tableName, mergeWithSkipped, capture],
+  );
 
   return { store, commit, applyFilters };
 }

--- a/web/src/features/search-bar/hooks/useEventsSearchBar.ts
+++ b/web/src/features/search-bar/hooks/useEventsSearchBar.ts
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { FilterState, TracingSearchType } from "@langfuse/shared";
 
 import {
+  classifySearchError,
   DEFAULT_SEARCH_TYPE,
   planCommit,
 } from "@/src/features/search-bar/lib/commit";
@@ -185,16 +186,50 @@ export function useEventsSearchBar({
   const committedTextRef = useRef(committedText);
   committedTextRef.current = committedText;
 
+  // The draft that last emitted a `filters:search_error`, so a blur that
+  // re-fails the SAME input does not double-emit (an explicit enter/pick retry
+  // still counts — a repeated attempt is signal).
+  const lastErrorTextRef = useRef<string | null>(null);
+
   const commit = useCallback(
     (trigger: SearchCommitTrigger = "enter"): string | null => {
+      const draftText = store.getState().draft;
       const result = planCommit(
-        store.getState().draft,
+        draftText,
         scoreTypeContextFromObserved(observedRef.current),
       );
       if (result.status === "invalid") {
         store.getState().actions.revealInvalid();
+        // Analytics (LFE-10781): a non-empty typed query was rejected (a UI
+        // error). METADATA ONLY — `orAttempted`/`reason` come from the AST shape
+        // + static diagnostic messages, `queryLength` is a char count; the query
+        // TEXT is never sent. The grammar bar is v4-only, so isV4 is always true.
+        // `orAttempted:true` (an OR between conditions — the parked cross-field
+        // OR, LFE-10421) is the headline demand signal. Fires once per failed
+        // commit: a blur that re-fails the same input is deduped.
+        const trimmed = draftText.trim();
+        const isBlurRefail =
+          trigger === "blur" && draftText === lastErrorTextRef.current;
+        if (trimmed.length > 0 && !isBlurRefail) {
+          const { orAttempted, reason } = classifySearchError(
+            result.ast,
+            result.diagnostics,
+          );
+          capture("filters:search_error", {
+            tableName,
+            orAttempted,
+            reason,
+            queryLength: trimmed.length,
+            trigger,
+            isV4: true,
+          });
+        }
+        lastErrorTextRef.current = draftText;
         return null;
       }
+      // A valid commit clears the error-dedup baseline so a later re-failure of
+      // the same text still emits.
+      lastErrorTextRef.current = null;
       const { setFilterState, setSearchQuery, setSearchType } =
         applyRef.current;
       // Re-attach the filters the grammar can't represent so the commit never

--- a/web/src/features/search-bar/lib/adapter.ts
+++ b/web/src/features/search-bar/lib/adapter.ts
@@ -33,6 +33,15 @@ import {
 } from "./fields";
 import { quoteIfNeeded } from "./quoting";
 
+/**
+ * Emitted when a top-level OR between conditions can't collapse to a same-field
+ * any-of (the PARKED cross-field-OR feature, LFE-10421). Exported so the
+ * analytics error classifier can match this exact cause without brittle string
+ * fragments (LFE-10781 `filters:search_error` → reason `unsupported_or`).
+ */
+export const OR_NOT_SUPPORTED_MESSAGE =
+  "OR is not supported yet, filters combine with AND. Use field:(a OR b) for any-of values";
+
 export type SingleEventsFilter = FilterState[number];
 
 export type AstToFilterStateResult = {
@@ -207,9 +216,7 @@ function lowerTopLevel(
         lowerFilterNode(collapsed, negated, ctx);
         return;
       }
-      ctx.errors.push(
-        "OR is not supported yet, filters combine with AND. Use field:(a OR b) for any-of values",
-      );
+      ctx.errors.push(OR_NOT_SUPPORTED_MESSAGE);
       return;
     }
     case "filter":

--- a/web/src/features/search-bar/lib/commit.ts
+++ b/web/src/features/search-bar/lib/commit.ts
@@ -9,7 +9,12 @@
 
 import type { FilterState, TracingSearchType } from "@langfuse/shared";
 
-import { astToFilterState, type ScoreTypeContext } from "./adapter";
+import type { ASTNode } from "./ast";
+import {
+  astToFilterState,
+  OR_NOT_SUPPORTED_MESSAGE,
+  type ScoreTypeContext,
+} from "./adapter";
 import { serialize, type Diagnostic } from "./langQ";
 import { validateQuery } from "./validate";
 
@@ -29,7 +34,7 @@ export type CommitResult =
       /** Canonical serialization of the committed query (for recent searches). */
       canonical: string;
     }
-  | { status: "invalid"; diagnostics: Diagnostic[] };
+  | { status: "invalid"; diagnostics: Diagnostic[]; ast: ASTNode | null };
 
 /**
  * Validate and lower `draftText`. `committed` carries everything the table
@@ -44,7 +49,7 @@ export function planCommit(
 ): CommitResult {
   const res = validateQuery(draftText.trim(), scoreTypes);
   if (!res.valid) {
-    return { status: "invalid", diagnostics: res.diagnostics };
+    return { status: "invalid", diagnostics: res.diagnostics, ast: res.ast };
   }
   const { filters, searchQuery, searchType, errors } = astToFilterState(
     res.ast,
@@ -63,6 +68,7 @@ export function planCommit(
         severity: "error" as const,
         message,
       })),
+      ast: res.ast,
     };
   }
   return {
@@ -72,4 +78,78 @@ export function planCommit(
     searchType: searchType ?? DEFAULT_SEARCH_TYPE,
     canonical: serialize(res.ast),
   };
+}
+
+// ---- Analytics: classify a rejected commit (LFE-10781 `filters:search_error`) ----
+
+/** Why a non-empty typed query failed to become a valid applied filter. */
+export type SearchErrorReason =
+  | "unsupported_or"
+  | "parse_error"
+  | "unknown_field"
+  | "bad_operator"
+  | "unknown";
+
+/**
+ * True when the query uses an OR token BETWEEN conditions/sections — a top-level
+ * `or` node (the unsupported, PARKED cross-field OR, LFE-10421). This is the
+ * headline demand signal ("did the user try to OR two different conditions?").
+ *
+ * The supported within-a-single-field `field:(a OR b)` parses as ONE `filter`
+ * node with `valueOp: "or"` — never an `or` node — so it is correctly NOT
+ * flagged. An `or` node nested inside an AND/paren group or a NOT is still a
+ * between-conditions OR, so we recurse through those; a `filter`'s within-field
+ * OR lives in `valueOp`, so we never descend into it.
+ */
+export function queryUsesTopLevelOr(ast: ASTNode | null): boolean {
+  if (ast === null) return false;
+  switch (ast.kind) {
+    case "or":
+      return true;
+    case "and":
+      return ast.children.some(queryUsesTopLevelOr);
+    case "not":
+      return queryUsesTopLevelOr(ast.child);
+    case "filter":
+    case "text":
+      return false;
+  }
+}
+
+/**
+ * Metadata-only classification of a rejected commit for `filters:search_error`.
+ * `orAttempted` is structural (an `or` node in the AST); `reason` buckets by the
+ * error cause the grammar/adapter distinguishes. NEVER reads raw values — only
+ * the AST shape and diagnostic MESSAGES (which are static, value-free strings).
+ */
+export function classifySearchError(
+  ast: ASTNode | null,
+  diagnostics: Diagnostic[],
+): { orAttempted: boolean; reason: SearchErrorReason } {
+  const orAttempted = queryUsesTopLevelOr(ast);
+  const errors = diagnostics.filter((d) => d.severity === "error");
+  const has = (re: RegExp) => errors.some((d) => re.test(d.message));
+
+  let reason: SearchErrorReason;
+  if (errors.some((d) => d.message === OR_NOT_SUPPORTED_MESSAGE)) {
+    reason = "unsupported_or";
+  } else if (has(/^Unknown field\b/)) {
+    reason = "unknown_field";
+  } else if (
+    has(
+      /\bdoes not support\b|\bis not supported\b|\bare not supported\b|\bnot representable\b|\bonly applies\b|\bonly works\b|\bsupports a single\b|\bis an? (number|datetime|boolean|text|array) field\b|\bAND grouping\b|\ball-of groups\b/,
+    )
+  ) {
+    reason = "bad_operator";
+  } else if (
+    ast === null ||
+    has(
+      /\bUnclosed\b|\bMissing (value|grouped)\b|\bMissing value\b|\bEmpty value\b|\bNested groups\b|\bIncomplete field\b/,
+    )
+  ) {
+    reason = "parse_error";
+  } else {
+    reason = "unknown";
+  }
+  return { orAttempted, reason };
 }

--- a/web/src/features/search-bar/store/SearchBarStoreProvider.tsx
+++ b/web/src/features/search-bar/store/SearchBarStoreProvider.tsx
@@ -5,13 +5,15 @@ import {
   type SearchBarStore,
   type SearchBarStoreState,
 } from "@/src/features/search-bar/store/searchBarStore";
+import { type SearchCommitTrigger } from "@/src/features/search-bar/hooks/useEventsSearchBar";
 
 type SearchBarContextValue = {
   store: SearchBarStore;
   /** Apply the current draft to the table's filter state (single source of
    * truth). Returns the canonical committed text on success, or null (and
-   * reveals diagnostics) when the draft is invalid. */
-  commit: () => string | null;
+   * reveals diagnostics) when the draft is invalid. `trigger` records how the
+   * commit was initiated for analytics. */
+  commit: (trigger?: SearchCommitTrigger) => string | null;
 };
 
 const SearchBarContext = createContext<SearchBarContextValue | null>(null);
@@ -23,7 +25,7 @@ export function SearchBarStoreProvider({
 }: {
   children: ReactNode;
   store: SearchBarStore;
-  commit: () => string | null;
+  commit: (trigger?: SearchCommitTrigger) => string | null;
 }) {
   const value = useMemo(() => ({ store, commit }), [store, commit]);
   return (
@@ -51,6 +53,8 @@ export function useSearchBarStore<TValue>(
   return useStore(useSearchBarContext().store, selector);
 }
 
-export function useSearchBarCommit(): () => string | null {
+export function useSearchBarCommit(): (
+  trigger?: SearchCommitTrigger,
+) => string | null {
   return useSearchBarContext().commit;
 }

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -610,6 +610,10 @@ export default function DashboardDetail() {
                 columns={filterColumns}
                 filterState={currentFilters}
                 onChange={setCurrentFilters}
+                // Analytics (LFE-10781): custom dashboard filter — a v3/legacy
+                // surface (not the v4 events table).
+                tableName="dashboard"
+                isV4={false}
               />
             </>
           ),

--- a/web/src/pages/project/[projectId]/index.tsx
+++ b/web/src/pages/project/[projectId]/index.tsx
@@ -283,6 +283,10 @@ export default function Dashboard() {
                 columns={filterColumns}
                 filterState={userFilterState}
                 onChange={useDebounce(setUserFilterState)}
+                // Analytics (LFE-10781): project-home dashboard filter — a
+                // v3/legacy surface (not the v4 events table).
+                tableName="home-dashboard"
+                isV4={false}
               />
             </>
           ),

--- a/web/src/pages/project/[projectId]/users/index.tsx
+++ b/web/src/pages/project/[projectId]/users/index.tsx
@@ -431,6 +431,7 @@ const UsersTable = ({
         />
       )}
       <DataTableToolbar
+        tableName="users"
         filterColumnDefinition={usersTableCols}
         filterState={userFilterState}
         setFilterState={useDebounce(setUserFilterState)}


### PR DESCRIPTION
## TL;DR
The primary filter surfaces — sidebar facets, the grammar search bar, and Ask-AI — had **zero product analytics**. We can't see how people filter, and we especially can't compare **v3 vs v4 (fast mode)** filtering behaviour. This adds a metadata-only `filters:*` event taxonomy (plus `saved_views:applied`), with **`isV4` on every event** so we can split by fast-mode, and fixes an existing PII leak. **No raw filter values, search text, or AI prompts are ever sent.**

## Why
Filtering is the workhorse of the product and the headline of the v4 story ("tremendous difference in filtering"), yet we've been flying blind on it. We couldn't answer basic questions: which facets get used, how often people clear vs refine, whether the search bar or the sidebar is the real entry point, how Ask-AI performs, or — the big one — whether v4 fast-mode filtering actually changes behaviour vs the v3 legacy tables.

## What
A new `filters` resource in the typed PostHog event registry, wired at each existing capture seam with minimal, localized insertions (no refactors). Every event carries **`isV4`** reflecting fast-mode at the moment of the action, and a `tableName`.

| Event | Fires when | Key props (metadata-only) |
| --- | --- | --- |
| `filters:applied` | sidebar facet / popover builder applies a filter | `surface, tableName, column, filterType, operator, key?, valueCount, conditionCount, isV4` |
| `filters:cleared` | clear-all | `surface, tableName, clearedCount, isV4` |
| `filters:facet_operator_toggled` | any-of / all-of / none-of toggle | `surface, tableName, column, fromOperator, toOperator, valueCount, isV4` |
| `filters:search_submitted` | grammar bar commit (enter/blur/pick) | `tableName, filterCount, hasFreeText, searchType, queryLength, trigger, isV4` |
| `filters:ai_generate_requested` / `_applied` / `_failed` | Ask-AI submit / success / fail | `tableName, refineMode, promptLength` / `generatedFilterCount` / `reason, isV4` |
| `saved_views:applied` | a view/preset is applied (incl. programmatic default) | `tableName, viewId, trigger, filterCount, isV4` |

**The `isV4` dimension.** The v4 events table + grammar bar + Ask-AI are inherently v4 (`true`). The sidebar and popover builder are shared across v3/v4, so they derive it from the surface — the events table opts in (`true`), legacy tables default `false`. Saved views derive it from the `ObservationsEvents` table. As a global backstop, the `v4BetaEnabled` super property already registered in `_app.tsx` segments every event regardless.

**Leak fix.** `table:filter_builder_close` previously sent `{ filter: filterState }` — the **full filter state including raw values** (user ids, metadata content, free text). Changed to `{ filterCount }`.

<details>
<summary>Privacy, dedup mechanics, and live verification</summary>

**Privacy (hard rule).** No payload carries a raw filter value, search text, or AI prompt. Only: type, column, operator, `key` (field NAME), counts, lengths, booleans, `tableName`, `isV4`, and trigger/reason/searchType enums. `queryLength`/`promptLength` are **character counts**, never the string.

**No double-counting.** `filters:applied` is emitted inside `updateFilter` (the funnel for all facet applies). The operator toggle routes through `updateFilter` too, so it sets a suppression flag and emits `facet_operator_toggled` alone. `setFilterState` is deliberately **not** instrumented, so programmatic view/URL restores don't inflate counts. The search bar dedupes blur no-ops by comparing the committed text to the current baseline.

**Verified live** (Playwright against the seeded demo project, capturing the exact `capture()` payloads):
- Applying a sidebar facet → `filters:applied` fires **once** (`isV4:true` on the v4 events table).
- Clear-all → `filters:cleared`.
- Search submit → `filters:search_submitted` once on Enter; **a blur with no change does not emit** a second event; `queryLength` was `8` for "checkout" (a count, not the text).
- The same facet on the **v3 sessions** table emitted `isV4:false` — confirming the dimension.
- **Privacy assertion passed:** every captured payload contained only metadata — no raw values or search text.

Not exercised live (self-hosted local has no Cloud AI features, and the demo project's facets didn't surface an arrayOptions operator toggle): Ask-AI events and the operator-toggle event. These follow the same metadata-only pattern and are covered by types/unit tests.
</details>

## Result
Full visibility into filter usage, segmentable by v3 vs v4 fast mode, with a privacy-safe payload and one PII leak closed. Lint + typecheck clean; existing filter/search-bar/table client tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR instruments the primary filter surfaces (sidebar facets, grammar search bar, Ask-AI, saved views) with PostHog analytics, adding a new `filters:*` event taxonomy plus `saved_views:applied`, each carrying an `isV4` flag so v3-legacy vs v4-fast-mode filtering behaviour can be split in analysis. It also closes a PII leak where `table:filter_builder_close` was sending the full raw filter state (including user-typed values) to PostHog — replaced with a plain `filterCount`.

- **New analytics events** — `filters:applied`, `filters:cleared`, `filters:facet_operator_toggled`, `filters:search_submitted`, `filters:ai_generate_*`, and `saved_views:applied` — are wired at each interaction seam; all payloads are metadata-only (counts, types, enums, lengths) with no raw values.
- **Double-fire prevention** — a `suppressAppliedCaptureRef` flag ensures operator-toggle events emit exactly one `facet_operator_toggled` instead of also firing `filters:applied`, and the search-bar dedupes blur no-ops against the committed-text baseline.
- **PII leak fix** — `table:filter_builder_close` now sends `{ filterCount }` instead of `{ filter: filterState }`, removing the raw filter value exposure.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are additive analytics instrumentation with no mutations to core filter or table logic, plus a PII-leak fix that is strictly an improvement.

The PII fix and new event taxonomy are well-structured. One gap exists in `filter-builder.tsx`: when an external change (saved view apply, sidebar clear-all) updates `filterState` while the popover is open, the `useEffect` that syncs `wipFilterState` calls the raw `_setWipFilterState` setter and never refreshes `prevValidCountRef`. This leaves the ref at the old high-water mark, silently suppressing `filters:applied` events until the user's new valid-filter count exceeds the stale baseline. It only affects analytics completeness, not product behaviour, but it is a real instrumentation miss.

`web/src/features/filters/components/filter-builder.tsx` — the `prevValidCountRef` sync gap described above.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant SB as Sidebar (useSidebarFilterState)
    participant FB as Filter Builder (PopoverFilterBuilder)
    participant SC as SearchComposer
    participant SH as useEventsSearchBar
    participant AI as SearchBarAiPrompt
    participant TVM as useTableViewManager
    participant PH as PostHog

    U->>SB: Toggle facet value
    SB->>SB: updateFilter / updateNumericFilter / updateStringFilter
    SB->>PH: "filters:applied {surface, tableName, column, filterType, operator, valueCount, conditionCount, isV4}"

    U->>SB: Toggle operator (any-of / all-of / none-of)
    SB->>SB: applyOperatorChange (suppresses filters:applied)
    SB->>PH: "filters:facet_operator_toggled {surface, tableName, column, fromOperator, toOperator, valueCount, isV4}"

    U->>SB: Clear all filters
    SB->>PH: "filters:cleared {surface, tableName, clearedCount, isV4}"

    U->>FB: Complete a filter row in popover
    FB->>FB: setWipFilterState (validCount grows)
    FB->>PH: "filters:applied {surface:filter_builder, tableName, column, filterType, operator, valueCount, conditionCount, isV4}"

    U->>SC: Enter / pick / blur search bar
    SC->>SH: commit(trigger)
    SH->>PH: "filters:search_submitted {tableName, filterCount, hasFreeText, searchType, queryLength, trigger, isV4:true}"

    U->>AI: Submit AI prompt
    AI->>PH: "filters:ai_generate_requested {tableName, refineMode, promptLength, isV4:true}"
    AI->>AI: generateFilter.mutateAsync(...)
    alt success
        AI->>PH: "filters:ai_generate_applied {tableName, refineMode, generatedFilterCount, isV4:true}"
    else failure
        AI->>PH: "filters:ai_generate_failed {tableName, refineMode, reason, isV4:true}"
    end

    U->>TVM: Select / apply a saved view
    TVM->>PH: "saved_views:applied {tableName, viewId, trigger, filterCount, isV4}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant SB as Sidebar (useSidebarFilterState)
    participant FB as Filter Builder (PopoverFilterBuilder)
    participant SC as SearchComposer
    participant SH as useEventsSearchBar
    participant AI as SearchBarAiPrompt
    participant TVM as useTableViewManager
    participant PH as PostHog

    U->>SB: Toggle facet value
    SB->>SB: updateFilter / updateNumericFilter / updateStringFilter
    SB->>PH: "filters:applied {surface, tableName, column, filterType, operator, valueCount, conditionCount, isV4}"

    U->>SB: Toggle operator (any-of / all-of / none-of)
    SB->>SB: applyOperatorChange (suppresses filters:applied)
    SB->>PH: "filters:facet_operator_toggled {surface, tableName, column, fromOperator, toOperator, valueCount, isV4}"

    U->>SB: Clear all filters
    SB->>PH: "filters:cleared {surface, tableName, clearedCount, isV4}"

    U->>FB: Complete a filter row in popover
    FB->>FB: setWipFilterState (validCount grows)
    FB->>PH: "filters:applied {surface:filter_builder, tableName, column, filterType, operator, valueCount, conditionCount, isV4}"

    U->>SC: Enter / pick / blur search bar
    SC->>SH: commit(trigger)
    SH->>PH: "filters:search_submitted {tableName, filterCount, hasFreeText, searchType, queryLength, trigger, isV4:true}"

    U->>AI: Submit AI prompt
    AI->>PH: "filters:ai_generate_requested {tableName, refineMode, promptLength, isV4:true}"
    AI->>AI: generateFilter.mutateAsync(...)
    alt success
        AI->>PH: "filters:ai_generate_applied {tableName, refineMode, generatedFilterCount, isV4:true}"
    else failure
        AI->>PH: "filters:ai_generate_failed {tableName, refineMode, reason, isV4:true}"
    end

    U->>TVM: Select / apply a saved view
    TVM->>PH: "saved_views:applied {tableName, viewId, trigger, filterCount, isV4}"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/filters/components/filter-builder.tsx:122-136
`prevValidCountRef` is not updated when `filterState` changes externally. The `useEffect` that syncs `wipFilterState` calls the raw `_setWipFilterState` setter, so `prevValidCountRef.current` is never refreshed. If a saved view or sidebar clear resets `filterState` to a shorter list while the popover is open, `prevValidCountRef.current` retains its old (higher) value. Any filter the user then adds whose total count doesn't exceed that stale high-water mark will fail the `validFilters.length > prevValidCountRef.current` guard and the `filters:applied` event will be silently dropped.

```suggestion
  const prevFilterStateRef = useRef(filterState);
  useEffect(() => {
    // Only sync if filterState actually changed (reference comparison is fine here
    // since filterState comes from URL parsing which creates new arrays)
    if (prevFilterStateRef.current === filterState) return;
    prevFilterStateRef.current = filterState;

    _setWipFilterState((currentWip) => {
      const hasWipFilters = currentWip.some(
        (f) => !singleFilter.safeParse(f).success,
      );
      // Don't sync if user is actively editing (has invalid WIP filters)
      if (hasWipFilters) return currentWip;
      // Reset the baseline so the first new filter the user adds after an
      // external change (saved-view apply, sidebar clear) still fires
      // `filters:applied` instead of comparing against the stale old count.
      prevValidCountRef.current = filterState.length;
      return filterState;
    });
  }, [filterState]);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(analytics): instrument filter/searc..."](https://github.com/langfuse/langfuse/commit/4e9c8ee64061c2a296e0296c7814ebbbf73ea3cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42973203)</sub>

<!-- /greptile_comment -->