### PR TITLE
fix(otel): map input/output from gen_ai.client.inference.operation.details span events

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1676,6 +1676,30 @@ export class OtelIngestionProcessor {
       }
     }
 
+    // OpenTelemetry GenAI semconv v1.37+ records prompts and completions on a
+    // gen_ai.client.inference.operation.details span event instead of span
+    // attributes (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/)
+    const operationDetailsEvents = events.filter(
+      (event: Record<string, unknown>) =>
+        event.name === "gen_ai.client.inference.operation.details",
+    );
+    for (const event of operationDetailsEvents) {
+      const eventAttributes: Record<string, unknown> =
+        event.attributes?.reduce(
+          (acc: Record<string, unknown>, attr: any) => {
+            acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+            return acc;
+          },
+          {} as Record<string, unknown>,
+        ) ?? {};
+
+      const genAiInputOutput =
+        this.extractOpenTelemetryGenAiInputAndOutput(eventAttributes);
+      if (genAiInputOutput) {
+        return { ...genAiInputOutput, filteredAttributes };
+      }
+    }
+
     const inputEvents = events.filter(
       (event: Record<string, unknown>) =>
         event.name === "gen_ai.system.message" ||

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -4478,6 +4478,156 @@ describe("OTel Resource Span Mapping", () => {
       );
     });
 
+    // GenAI semantic conventions v1.37+ record prompts/completions on a
+    // gen_ai.client.inference.operation.details span event (e.g. Hindsight)
+    it("should extract input/output from gen_ai.client.inference.operation.details span event", async () => {
+      const inputMessages = JSON.stringify([
+        {
+          role: "user",
+          parts: [{ type: "text", content: "What is the capital of France?" }],
+        },
+      ]);
+      const outputMessages = JSON.stringify([
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "Paris" }],
+          finish_reason: "stop",
+        },
+      ]);
+
+      const resourceSpan = {
+        resource: {},
+        scopeSpans: [
+          {
+            spans: [
+              {
+                ...defaultSpanProps,
+                attributes: [
+                  {
+                    key: "gen_ai.operation.name",
+                    value: { stringValue: "chat" },
+                  },
+                  {
+                    key: "gen_ai.request.model",
+                    value: { stringValue: "gpt-4o-mini" },
+                  },
+                ],
+                events: [
+                  {
+                    timeUnixNano: {
+                      low: 1327691067,
+                      high: 404677085,
+                      unsigned: true,
+                    },
+                    name: "gen_ai.client.inference.operation.details",
+                    attributes: [
+                      {
+                        key: "gen_ai.input.messages",
+                        value: { stringValue: inputMessages },
+                      },
+                      {
+                        key: "gen_ai.output.messages",
+                        value: { stringValue: outputMessages },
+                      },
+                      {
+                        key: "gen_ai.system_instructions",
+                        value: { stringValue: "You are a helpful assistant." },
+                      },
+                      {
+                        key: "gen_ai.response.finish_reasons",
+                        value: { stringValue: JSON.stringify(["stop"]) },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const langfuseEvents = await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set(),
+      );
+
+      const observation = langfuseEvents.find(
+        (e) => e.type.endsWith("-create") && e.type !== "trace-create",
+      );
+
+      // Input contains the chat history with system instructions prepended
+      expect(observation?.body.input).toBeDefined();
+      const inputParsed =
+        typeof observation?.body.input === "string"
+          ? JSON.parse(observation.body.input)
+          : observation?.body.input;
+      expect(Array.isArray(inputParsed)).toBe(true);
+      expect(inputParsed[0]).toEqual({
+        role: "system",
+        content: "You are a helpful assistant.",
+      });
+      expect(inputParsed[1].role).toBe("user");
+      expect(inputParsed[1].parts[0].content).toBe(
+        "What is the capital of France?",
+      );
+
+      // Output contains the model response messages
+      expect(observation?.body.output).toBeDefined();
+      const outputParsed =
+        typeof observation?.body.output === "string"
+          ? JSON.parse(observation.body.output)
+          : observation?.body.output;
+      expect(Array.isArray(outputParsed)).toBe(true);
+      expect(outputParsed[0].role).toBe("assistant");
+      expect(outputParsed[0].parts[0].content).toBe("Paris");
+    });
+
+    it("should extract output from gen_ai.client.inference.operation.details span event without system instructions", async () => {
+      const outputMessages = JSON.stringify([
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "Hello!" }],
+          finish_reason: "stop",
+        },
+      ]);
+
+      const resourceSpan = {
+        resource: {},
+        scopeSpans: [
+          {
+            spans: [
+              {
+                ...defaultSpanProps,
+                events: [
+                  {
+                    name: "gen_ai.client.inference.operation.details",
+                    attributes: [
+                      {
+                        key: "gen_ai.output.messages",
+                        value: { stringValue: outputMessages },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const langfuseEvents = await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set(),
+      );
+
+      const observation = langfuseEvents.find(
+        (e) => e.type.endsWith("-create") && e.type !== "trace-create",
+      );
+
+      expect(observation?.body.input).toBeFalsy();
+      expect(observation?.body.output).toBe(outputMessages);
+    });
+
     it("should move gen_ai.tool.definitions from metadata to observation input", async () => {
       const traceId = "abcdef1234567890abcdef1234567892";
       const rootSpanId = "1234567890abcdeb";


### PR DESCRIPTION
## Summary

Resolves [LFE-8891](https://linear.app/langfuse/issue/LFE-8891) / #12657

GenAI semantic conventions v1.37+ moved prompts and completions from span attributes to an opt-in span event named `gen_ai.client.inference.operation.details`, which carries the content in the event attributes `gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions` ([spec](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-events.md#event-gen_aiclientinferenceoperationdetails)). Emitters like [Hindsight](https://github.com/vectorize-io/hindsight/blob/main/hindsight-api-slim/hindsight_api/tracing.py) attach this event to their LLM spans.

`OtelIngestionProcessor.extractInputAndOutput` only read the older event names (`gen_ai.{system,user,assistant,tool}.message`, `gen_ai.choice`, legacy `gen_ai.content.{prompt,completion}`) and the attribute-based `gen_ai.input.messages`/`gen_ai.output.messages`, so observations from v1.37+ event-based emitters showed `Input: null` / `Output: undefined` even though token counts and costs were tracked.

## Changes

- Extract input/output from `gen_ai.client.inference.operation.details` span events by converting the event attributes and reusing the existing `extractOpenTelemetryGenAiInputAndOutput` mapping (including `gen_ai.system_instructions` prepending as a system message).
- Added regression tests covering the event with and without system instructions.

## Test plan

- New failing-first tests in `web/src/__tests__/server/api/otel/otelMapping.servertest.ts`:
  - `should extract input/output from gen_ai.client.inference.operation.details span event`
  - `should extract output from gen_ai.client.inference.operation.details span event without system instructions`
- `pnpm --filter web run test src/__tests__/server/api/otel/otelMapping.servertest.ts` → `Tests  216 passed | 1 skipped (217)`
- `pnpm --filter worker run test src/queues/__tests__/otelToObservationForEval.test.ts` → `Tests  25 passed (25)`
- `pnpm run lint` → `Tasks: 8 successful, 8 total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds extraction of `input`/`output` from `gen_ai.client.inference.operation.details` span events, which carry prompts and completions in GenAI semantic conventions v1.37+. The new event-based path is inserted before the older individual-event and attribute-based paths in `extractInputAndOutput`, so spans from newer emitters (like Hindsight) are correctly handled without breaking the existing fallback chain.

- Adds a filter-and-reduce loop in `OtelIngestionProcessor.extractInputAndOutput` for `gen_ai.client.inference.operation.details` events, reusing the existing `extractOpenTelemetryGenAiInputAndOutput` helper (including `gen_ai.system_instructions` prepend logic).
- Two new regression tests cover the full message path with system instructions and the output-only path without them.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, falls through gracefully when the new event is absent, and is covered by targeted regression tests.

The new code path inserts cleanly into an existing priority chain, reuses a well-exercised helper, and cannot regress existing behaviour because it only activates for spans that carry the specific gen_ai.client.inference.operation.details event. The two new tests validate the key scenarios, including the system-instructions prepend edge case.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[extractInputAndOutput called] --> B{Langfuse attrs?}
    B -- yes --> Z[return]
    B -- no --> C{Genkit scope?}
    C -- yes --> Z
    C -- no --> D{Vercel AI SDK scope?}
    D -- yes --> Z
    D -- no --> E{Flue attrs?}
    E -- yes --> Z
    E -- no --> F{gen_ai.client.inference\n.operation.details event?}
    F -- yes, has input/output --> Z
    F -- no / null result --> G{Older gen_ai.*\nspan events?}
    G -- yes --> Z
    G -- no --> H{llm.input/output_messages\nattrs?}
    H -- yes --> Z
    H -- no --> I{gen_ai.input/output.messages\nspan attrs}
    I -- yes --> Z
    I -- no --> J[return null, null]

    style F fill:#d4edda,stroke:#28a745
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[extractInputAndOutput called] --> B{Langfuse attrs?}
    B -- yes --> Z[return]
    B -- no --> C{Genkit scope?}
    C -- yes --> Z
    C -- no --> D{Vercel AI SDK scope?}
    D -- yes --> Z
    D -- no --> E{Flue attrs?}
    E -- yes --> Z
    E -- no --> F{gen_ai.client.inference\n.operation.details event?}
    F -- yes, has input/output --> Z
    F -- no / null result --> G{Older gen_ai.*\nspan events?}
    G -- yes --> Z
    G -- no --> H{llm.input/output_messages\nattrs?}
    H -- yes --> Z
    H -- no --> I{gen_ai.input/output.messages\nspan attrs}
    I -- yes --> Z
    I -- no --> J[return null, null]

    style F fill:#d4edda,stroke:#28a745
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): map input/output from gen\_ai...."](https://github.com/langfuse/langfuse/commit/d4104dc64551d4f3e74b5573920ae672f7969d90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42974221)</sub>

<!-- /greptile_comment -->