### PR TITLE
fix(web): render blob storage export start date directly below export mode

### DIFF
--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -775,6 +775,43 @@ const BlobStorageIntegrationSettingsForm = ({
           )}
         />
 
+        {watchedExportMode === BlobStorageExportMode.FROM_CUSTOM_DATE && (
+          <FormField
+            control={blobStorageForm.control}
+            name="exportStartDate"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Export Start Date</FormLabel>
+                <FormControl>
+                  <Input
+                    type="date"
+                    max={(() => {
+                      const t = new Date();
+                      return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, "0")}-${String(t.getDate()).padStart(2, "0")}`;
+                    })()}
+                    value={
+                      field.value instanceof Date
+                        ? field.value.toISOString().split("T")[0]
+                        : ""
+                    }
+                    onChange={(e) => {
+                      const date = e.target.value
+                        ? new Date(e.target.value)
+                        : null;
+                      field.onChange(date);
+                    }}
+                    placeholder="Select start date"
+                  />
+                </FormControl>
+                <FormDescription>
+                  Data before this date will not be included in exports
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+
         {!hideExportSource && (
           <FormField
             control={blobStorageForm.control}
@@ -950,43 +987,6 @@ const BlobStorageIntegrationSettingsForm = ({
             </FormItem>
           )}
         />
-
-        {watchedExportMode === BlobStorageExportMode.FROM_CUSTOM_DATE && (
-          <FormField
-            control={blobStorageForm.control}
-            name="exportStartDate"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Export Start Date</FormLabel>
-                <FormControl>
-                  <Input
-                    type="date"
-                    max={(() => {
-                      const t = new Date();
-                      return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, "0")}-${String(t.getDate()).padStart(2, "0")}`;
-                    })()}
-                    value={
-                      field.value instanceof Date
-                        ? field.value.toISOString().split("T")[0]
-                        : ""
-                    }
-                    onChange={(e) => {
-                      const date = e.target.value
-                        ? new Date(e.target.value)
-                        : null;
-                      field.onChange(date);
-                    }}
-                    placeholder="Select start date"
-                  />
-                </FormControl>
-                <FormDescription>
-                  Data before this date will not be included in exports
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        )}
 
         {/* Parquet compresses internally — gzip does not apply. */}
         {!isParquetExport && (


### PR DESCRIPTION
The conditional Export Start Date field rendered below the Export Source selector and the Export Field Groups checkbox list, far from the Export Mode select whose "Custom date" option reveals it. Move it directly beneath Export Mode so the relationship is obvious. Pure JSX reorder, no logic changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reorders a single form field in the blob storage integration settings page. The `Export Start Date` input — which is only visible when the `FROM_CUSTOM_DATE` export mode is selected — is moved from its previous position after the Export Field Groups checkboxes to immediately after the Export Mode selector, making the conditional relationship between the two fields visually obvious.

- The `exportStartDate` `FormField` block (including its conditional `watchedExportMode` guard) is cut from the bottom of the form and pasted right after the Export Mode field, with no logic, validation, or state changes.
- The identical JSX block is removed from its original location near the compression settings.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Pure JSX reorder with no logic, validation, or state changes — safe to merge.

The only change is moving an existing, fully-guarded FormField block up in the render tree so it appears directly beneath the field that controls its visibility. The field's conditional logic, react-hook-form binding, validation, and change handlers are untouched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph BEFORE["Before (original order)"]
        A1[Export Mode selector] --> B1[Export Source selector]
        B1 --> C1[Export Field Groups checkboxes]
        C1 --> D1["Export Start Date\n(shown only if FROM_CUSTOM_DATE)"]
        D1 --> E1[Compression / other fields]
    end

    subgraph AFTER["After (this PR)"]
        A2[Export Mode selector] --> B2["Export Start Date\n(shown only if FROM_CUSTOM_DATE)"]
        B2 --> C2[Export Source selector]
        C2 --> D2[Export Field Groups checkboxes]
        D2 --> E2[Compression / other fields]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph BEFORE["Before (original order)"]
        A1[Export Mode selector] --> B1[Export Source selector]
        B1 --> C1[Export Field Groups checkboxes]
        C1 --> D1["Export Start Date\n(shown only if FROM_CUSTOM_DATE)"]
        D1 --> E1[Compression / other fields]
    end

    subgraph AFTER["After (this PR)"]
        A2[Export Mode selector] --> B2["Export Start Date\n(shown only if FROM_CUSTOM_DATE)"]
        B2 --> C2[Export Source selector]
        C2 --> D2[Export Field Groups checkboxes]
        D2 --> E2[Compression / other fields]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): render blob storage export sta..."](https://github.com/langfuse/langfuse/commit/75c8795c2589489a3cb232bcf4fc649bac7bd4d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42991664)</sub>

<!-- /greptile_comment -->