### PR TITLE
feat(agents): trace model price audit runs in Langfuse via Claude Code hook

### DIFF
--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -179,7 +179,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: langfuse/Claude-Observability-Plugin
-          ref: ea5eca1dfa26dcb552e2892dde99bcd749eb7253
+          ref: 9ad0076a7a24e8673ac6e7ac6f7b658b18826bb6
           path: .github/actions/claude-observability-plugin
           fetch-depth: 1
           persist-credentials: false
@@ -190,7 +190,7 @@ jobs:
         with:
           version: "0.11.2"
 
-      - name: Validate Claude observability secrets
+      - name: Check Claude observability secrets and pre-warm hook
         if: steps.validate-inputs.outputs.dry_run_mode == 'disabled'
         env:
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
@@ -199,15 +199,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          missing=0
+          missing=()
           for secret_name in LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY LANGFUSE_BASE_URL; do
             if [ -z "${!secret_name:-}" ]; then
-              echo "::error::Required Claude observability secret is not set: ${secret_name}"
-              missing=1
+              missing+=("$secret_name")
             fi
           done
 
-          exit "$missing"
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::warning::Langfuse tracing is disabled for this run because these secrets are not set: ${missing[*]}. The audit runs normally without traces; set them in the repository secrets to enable tracing."
+            exit 0
+          fi
+
+          # Pre-warm the uv cache so the first Stop hook does not spend its timeout budget resolving dependencies.
+          uv run --quiet --script .github/actions/claude-observability-plugin/hooks/langfuse_hook.py < /dev/null || true
 
       - name: Run Claude price audit
         id: claude-audit
@@ -305,7 +310,6 @@ jobs:
             --model ${{ steps.validate-inputs.outputs.claude_model }}
             --max-turns ${{ steps.validate-inputs.outputs.max_turns }}
             --max-budget-usd ${{ steps.validate-inputs.outputs.max_budget_usd }}
-            --no-session-persistence
             --allowedTools "Read(/.github/workflows/model-price-audit.yml),Read(/worker/src/constants/default-model-prices.json),Read(/packages/shared/src/server/llm/types.ts),Read(/.agents/skills/add-model-price/SKILL.md),Read(/.agents/skills/add-model-price/references/*.md),Edit(/.github/workflows/model-price-audit.yml),Edit(/worker/src/constants/default-model-prices.json),Edit(/packages/shared/src/server/llm/types.ts),Edit(/.agents/skills/add-model-price/references/*.md),Write(/.agents/skills/add-model-price/references/*.md),WebFetch(domain:platform.claude.com),WebFetch(domain:docs.anthropic.com),WebFetch(domain:developers.openai.com),WebFetch(domain:ai.google.dev),WebFetch(domain:cloud.google.com),WebFetch(domain:aws.amazon.com),WebFetch(domain:azure.microsoft.com),Bash(date -u +%Y-%m-%dT00:00:00.000Z),Bash(node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs),Bash(node .agents/skills/add-model-price/scripts/test-match-pattern.mjs:*)"
             --json-schema '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string"},"changedModels":{"type":"array","items":{"type":"string"}},"skillReferenceUpdates":{"type":"array","items":{"type":"string"}},"workflowUpdates":{"type":"array","items":{"type":"string"}},"unresolvedFindings":{"type":"array","items":{"type":"string"}},"validation":{"type":"array","items":{"type":"string"}}},"required":["summary","changedModels","skillReferenceUpdates","workflowUpdates","unresolvedFindings","validation"]}'
 

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -167,6 +167,48 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Exclude local Claude observability plugin checkout from audit diff
+        if: steps.validate-inputs.outputs.dry_run_mode == 'disabled'
+        run: |
+          set -euo pipefail
+
+          echo ".github/actions/claude-observability-plugin/" >> .git/info/exclude
+
+      - name: Checkout Claude observability plugin
+        if: steps.validate-inputs.outputs.dry_run_mode == 'disabled'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: langfuse/Claude-Observability-Plugin
+          ref: ea5eca1dfa26dcb552e2892dde99bcd749eb7253
+          path: .github/actions/claude-observability-plugin
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install uv
+        if: steps.validate-inputs.outputs.dry_run_mode == 'disabled'
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.2"
+
+      - name: Validate Claude observability secrets
+        if: steps.validate-inputs.outputs.dry_run_mode == 'disabled'
+        env:
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for secret_name in LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY LANGFUSE_BASE_URL; do
+            if [ -z "${!secret_name:-}" ]; then
+              echo "::error::Required Claude observability secret is not set: ${secret_name}"
+              missing=1
+            fi
+          done
+
+          exit "$missing"
+
       - name: Run Claude price audit
         id: claude-audit
         if: steps.validate-inputs.outputs.dry_run_mode == 'disabled'
@@ -178,6 +220,41 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
           github_token: ${{ github.token }}
           display_report: "true"
+          settings: |
+            {
+              "env": {
+                "LANGFUSE_PUBLIC_KEY": "${{ secrets.LANGFUSE_PUBLIC_KEY }}",
+                "LANGFUSE_SECRET_KEY": "${{ secrets.LANGFUSE_SECRET_KEY }}",
+                "LANGFUSE_BASE_URL": "${{ secrets.LANGFUSE_BASE_URL }}",
+                "LANGFUSE_USER_ID": "${{ github.actor }}",
+                "CC_LANGFUSE_DEBUG": "false",
+                "CC_LANGFUSE_MAX_CHARS": "20000",
+                "CC_LANGFUSE_SKILL_TAGS": "true",
+                "CC_LANGFUSE_CAPTURE_SKILL_CONTENT": "false"
+              },
+              "hooks": {
+                "Stop": [
+                  {
+                    "hooks": [
+                      {
+                        "type": "command",
+                        "command": "uv run --quiet --script ${{ github.workspace }}/.github/actions/claude-observability-plugin/hooks/langfuse_hook.py"
+                      }
+                    ]
+                  }
+                ],
+                "SessionEnd": [
+                  {
+                    "hooks": [
+                      {
+                        "type": "command",
+                        "command": "uv run --quiet --script ${{ github.workspace }}/.github/actions/claude-observability-plugin/hooks/langfuse_hook.py"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
           prompt: |
             You are running Langfuse's scheduled default model price audit.
 

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -167,22 +167,20 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Exclude local Claude observability plugin checkout from audit diff
+      - name: Checkout Claude observability plugin
         if: steps.validate-inputs.outputs.dry_run_mode == 'disabled'
+        env:
+          PLUGIN_COMMIT: 9ad0076a7a24e8673ac6e7ac6f7b658b18826bb6
         run: |
           set -euo pipefail
 
-          echo ".github/actions/claude-observability-plugin/" >> .git/info/exclude
-
-      - name: Checkout Claude observability plugin
-        if: steps.validate-inputs.outputs.dry_run_mode == 'disabled'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: langfuse/Claude-Observability-Plugin
-          ref: 9ad0076a7a24e8673ac6e7ac6f7b658b18826bb6
-          path: .github/actions/claude-observability-plugin
-          fetch-depth: 1
-          persist-credentials: false
+          # Clone outside the workspace so the plugin files never show up in
+          # the audit diff that guards the allowed edit surface.
+          plugin_dir="$RUNNER_TEMP/claude-observability-plugin"
+          git clone --no-checkout --depth 1 \
+            https://github.com/langfuse/Claude-Observability-Plugin.git "$plugin_dir"
+          git -C "$plugin_dir" fetch --depth 1 origin "$PLUGIN_COMMIT"
+          git -C "$plugin_dir" checkout "$PLUGIN_COMMIT"
 
       - name: Install uv
         if: steps.validate-inputs.outputs.dry_run_mode == 'disabled'
@@ -212,7 +210,7 @@ jobs:
           fi
 
           # Pre-warm the uv cache so the first Stop hook does not spend its timeout budget resolving dependencies.
-          uv run --quiet --script .github/actions/claude-observability-plugin/hooks/langfuse_hook.py < /dev/null || true
+          uv run --quiet --script "$RUNNER_TEMP/claude-observability-plugin/hooks/langfuse_hook.py" < /dev/null || true
 
       - name: Run Claude price audit
         id: claude-audit
@@ -243,7 +241,7 @@ jobs:
                     "hooks": [
                       {
                         "type": "command",
-                        "command": "uv run --quiet --script ${{ github.workspace }}/.github/actions/claude-observability-plugin/hooks/langfuse_hook.py"
+                        "command": "uv run --quiet --script ${{ runner.temp }}/claude-observability-plugin/hooks/langfuse_hook.py"
                       }
                     ]
                   }
@@ -253,7 +251,7 @@ jobs:
                     "hooks": [
                       {
                         "type": "command",
-                        "command": "uv run --quiet --script ${{ github.workspace }}/.github/actions/claude-observability-plugin/hooks/langfuse_hook.py"
+                        "command": "uv run --quiet --script ${{ runner.temp }}/claude-observability-plugin/hooks/langfuse_hook.py"
                       }
                     ]
                   }


### PR DESCRIPTION
## What does this PR do?

Makes every real `model-price-audit` run visible in Langfuse as a trace (turns, generations with model/token/cost, tool calls), using the [Langfuse Claude Code observability plugin](https://github.com/langfuse/Claude-Observability-Plugin) as a Stop/SessionEnd hook.

Closes LFE-10633.

### How it works

1. A new step clones the observability plugin at a **pinned commit** into `RUNNER_TEMP` (outside the workspace, so the plugin files never appear in the audit diff that guards the allowed edit surface).
2. The `settings` input of `claude-code-action` registers the plugin's `langfuse_hook.py` as `Stop`/`SessionEnd` hook and injects the `LANGFUSE_*` secrets as env for the Claude process. After each agent turn, the hook reads the new transcript lines and ships them to Langfuse. The agent itself is unaffected by tracing.

### Notable decisions

- **Removed `--no-session-persistence`**: the flag suppresses the transcript file entirely (verified empirically), which would silently disable the hook.
- **Missing secrets warn instead of fail**: without `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` / `LANGFUSE_BASE_URL` the run emits a workflow warning and the audit proceeds untraced.
- **uv cache pre-warm**: the hook's script dependencies are resolved once up front so the first Stop hook stays well below the hook timeout.
- The Langfuse keys are visible to the audit agent's process env; exfiltration surface is minimal (no free-form Bash, WebFetch restricted to provider domains) and equivalent to the existing `CLAUDE_API_KEY` exposure.

### How to test

1. Add repo secrets `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL` (target project of your choice).
2. Dispatch the workflow with `claude_model=sonnet`, `max_turns=15`, `max_budget_usd=2`, `dry_run_mode=disabled` (dry runs skip Claude entirely, so they produce no traces).
3. Check the Langfuse project: expect one trace per agent turn, `userId` = triggering actor, generations with model/usage/cost.
