### PR TITLE
feat(events): enable select-all batch delete on v4 events table

### DIFF
--- a/packages/shared/src/features/batchAction/types.ts
+++ b/packages/shared/src/features/batchAction/types.ts
@@ -37,8 +37,9 @@ export const BatchActionQuerySchema = z.object({
   searchQuery: z.string().optional(),
   searchType: z.array(TracingSearchType).optional(),
   pathPrefix: z.string().optional(),
-  // Dispatch-time snapshot of the user's v4 beta flag; routes the sessions
-  // read stream to the events table instead of the legacy traces path.
+  // Routes worker reads to the events table instead of the legacy tables.
+  // The v4 events view declares it and the server validates the declaration;
+  // otherwise createBatchActionJob snapshots the user's v4 beta flag.
   useEventsTable: z.boolean().optional(),
 });
 

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -105,6 +105,10 @@ const buildOrderByClause = (
 const EVENTS_FIELDS = {
   // Aggregates
   count: "count(*) as count",
+  // uniq() is the approximate distinct aggregate (HLL-based, bounded memory);
+  // uniqExact would build an unbounded hash set when the filtered set spans
+  // millions of traces.
+  uniqueTraceCount: 'uniq(e.trace_id) as "unique_trace_count"',
 
   // Identity & basic fields
   id: "e.span_id as id",
@@ -203,6 +207,7 @@ const EVENTS_FIELDS = {
 const FIELD_SETS = {
   // Aggregates
   count: ["count"],
+  countWithUniqueTraces: ["count", "uniqueTraceCount"],
 
   // List query field sets (for getObservationsWithModelDataFromEventsTable)
   base: [

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -480,6 +480,28 @@ export const getObservationsCountFromEventsTable = async (
   return Number(count[0].count);
 };
 
+/**
+ * Row count plus approximate distinct trace count over the same filtered set,
+ * computed in a single ClickHouse pass. Powers the events-table select-all
+ * batch-delete confirmation ("N items spanning M unique traces").
+ */
+export const getObservationsCountsFromEventsTable = async (
+  opts: ObservationTableQuery,
+): Promise<{ totalCount: number; uniqueTraceCount: number }> => {
+  const counts = await getObservationsFromEventsTableInternal<{
+    count: string;
+    unique_trace_count: string;
+  }>({
+    ...opts,
+    select: "count-with-unique-traces",
+  });
+
+  return {
+    totalCount: Number(counts[0].count),
+    uniqueTraceCount: Number(counts[0].unique_trace_count),
+  };
+};
+
 export const getObservationsWithModelDataFromEventsTable = async (
   opts: ObservationTableQuery,
 ): Promise<FullEventsObservations> => {
@@ -560,7 +582,11 @@ export const getTraceDeleteCursorPageFromEvents = async (props: {
 
 async function getObservationsFromEventsTableInternal<T>(
   opts: ObservationTableQuery & {
-    select: "count" | "rows" | "trace-delete-cursor";
+    select:
+      | "count"
+      | "count-with-unique-traces"
+      | "rows"
+      | "trace-delete-cursor";
     selectToolData?: boolean;
     cursor?: PublicApiObservationsQuery["cursor"];
     preferredClickhouseService?: PreferredClickhouseService;
@@ -624,6 +650,8 @@ async function getObservationsFromEventsTableInternal<T>(
 
   if (opts.select === "count") {
     queryBuilder.selectFieldSet("count");
+  } else if (opts.select === "count-with-unique-traces") {
+    queryBuilder.selectFieldSet("countWithUniqueTraces");
   } else if (opts.select === "trace-delete-cursor") {
     queryBuilder.selectRaw(
       "e.span_id AS id",

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -4,6 +4,7 @@ import {
   getObservationsForTraceFromEventsTable,
   getObservationsWithModelDataFromEventsTable,
   getObservationsCountFromEventsTable,
+  getObservationsCountsFromEventsTable,
   getObservationByIdFromEventsTable,
   getObservationsFromEventsTableForPublicApi,
   getObservationsCountFromEventsTableForPublicApi,
@@ -463,6 +464,95 @@ describe("Clickhouse Events Repository Test", () => {
 
       expect(count).toBe(5);
       expect(observations.length).toBe(5);
+    });
+  });
+
+  maybe("getObservationsCountsFromEventsTable", () => {
+    it("should return zero counts for non-existent project", async () => {
+      const nonExistentProjectId = randomUUID();
+
+      const counts = await getObservationsCountsFromEventsTable({
+        projectId: nonExistentProjectId,
+        filter: [],
+      });
+
+      expect(counts).toEqual({ totalCount: 0, uniqueTraceCount: 0 });
+    });
+
+    it("should return total event count and unique trace count in one query", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceIds = [randomUUID(), randomUUID(), randomUUID()];
+      // 6 events across 3 distinct traces (2 events per trace)
+      const events = traceIds.flatMap((traceId, traceIndex) =>
+        Array.from({ length: 2 }, (_, i) =>
+          createEvent({
+            id: randomUUID(),
+            span_id: randomUUID(),
+            project_id: uniqueProjectId,
+            trace_id: traceId,
+            type: "SPAN",
+            name: `counts-test-${traceIndex}-${i}`,
+          }),
+        ),
+      );
+
+      await createEventsCh(events);
+
+      const counts = await getObservationsCountsFromEventsTable({
+        projectId: uniqueProjectId,
+        filter: [],
+      });
+
+      expect(counts.totalCount).toBe(6);
+      expect(counts.uniqueTraceCount).toBe(3);
+    });
+
+    it("should apply filters to both counts", async () => {
+      const uniqueProjectId = randomUUID();
+      const matchingTraceId = randomUUID();
+      const otherTraceId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: matchingTraceId,
+          type: "SPAN",
+          name: "counts-filter-match",
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: matchingTraceId,
+          type: "SPAN",
+          name: "counts-filter-match",
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: otherTraceId,
+          type: "SPAN",
+          name: "counts-filter-other",
+        }),
+      ]);
+
+      const counts = await getObservationsCountsFromEventsTable({
+        projectId: uniqueProjectId,
+        filter: [
+          {
+            type: "string",
+            column: "name",
+            operator: "=",
+            value: "counts-filter-match",
+          },
+        ],
+      });
+
+      expect(counts.totalCount).toBe(2);
+      expect(counts.uniqueTraceCount).toBe(1);
     });
   });
 

--- a/web/src/__tests__/server/traces-batch-delete-trpc.servertest.ts
+++ b/web/src/__tests__/server/traces-batch-delete-trpc.servertest.ts
@@ -16,12 +16,14 @@ vi.mock("@langfuse/shared/src/server", async () => {
 
 import type { Session } from "next-auth";
 import { randomUUID } from "crypto";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { env } from "@/src/env.mjs";
 import { prisma } from "@langfuse/shared/src/db";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import {
   ActionId,
+  AnnotationQueueObjectType,
   BatchExportTableName,
   BatchActionStatus,
   createTraceDeleteBatchActionConfig,
@@ -310,5 +312,165 @@ describe("traces.deleteMany batch action", () => {
       }),
     ).resolves.toBe(true);
     expect(mockGetBatchActionJobState).not.toHaveBeenCalled();
+  });
+
+  it("rejects batch deletes with comment filters without creating a batch action", async () => {
+    const { projectId, caller } = await createCaller();
+    const batchActionId = `${projectId}-traces-trace-delete`;
+
+    await expect(
+      caller.traces.deleteMany({
+        projectId,
+        traceIds: [randomUUID()],
+        isBatchAction: true,
+        query: {
+          filter: [
+            {
+              column: "commentCount",
+              operator: ">=" as const,
+              value: 1,
+              type: "number" as const,
+            },
+          ],
+          orderBy: { column: "timestamp", order: "DESC" as const },
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message:
+        "Batch deletion does not support comment filters. Remove the comment filter and try again.",
+    });
+
+    await expect(
+      prisma.batchAction.findUnique({ where: { id: batchActionId } }),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects deletes with an empty traceIds array even for batch actions", async () => {
+    // An empty selection while select-all is armed signals a client-side
+    // consistency issue; the server contract requires at least one traceId
+    // for every delete and must fail loudly rather than absorb it.
+    const { projectId, caller } = await createCaller();
+    const batchActionId = `${projectId}-traces-trace-delete`;
+
+    await expect(
+      caller.traces.deleteMany({
+        projectId,
+        traceIds: [],
+        isBatchAction: true,
+        query: traceDeleteQuery(`delete-user-${randomUUID()}`),
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Minimum 1 traceId is required."),
+    });
+
+    await expect(
+      prisma.batchAction.findUnique({ where: { id: batchActionId } }),
+    ).resolves.toBeNull();
+  });
+
+  describe("with legacy IO search disabled", () => {
+    const mutableEnv = env as unknown as {
+      LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH: "true" | "false";
+    };
+    const originalLegacyIoSearchDisabled =
+      mutableEnv.LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH;
+
+    afterEach(() => {
+      mutableEnv.LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH =
+        originalLegacyIoSearchDisabled;
+    });
+
+    const ioSearchQuery = (userId: string) => ({
+      ...traceDeleteQuery(userId),
+      searchQuery: "some full-text query",
+      searchType: ["id" as const, "content" as const],
+    });
+
+    it("allows v4 (events-backed) batch deletes with full-text search", async () => {
+      mutableEnv.LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH = "true";
+      const { projectId, caller } = await createCaller({
+        v4BetaEnabled: true,
+      });
+      const batchActionId = `${projectId}-traces-trace-delete`;
+
+      await caller.traces.deleteMany({
+        projectId,
+        traceIds: [randomUUID()],
+        isBatchAction: true,
+        query: ioSearchQuery(`delete-user-${randomUUID()}`),
+      });
+
+      const batchAction = await prisma.batchAction.findUniqueOrThrow({
+        where: { id: batchActionId },
+      });
+      expect(batchAction.status).toBe(BatchActionStatus.Queued);
+      expect(batchAction.query).toMatchObject({
+        useEventsTable: true,
+        searchQuery: "some full-text query",
+        searchType: ["id", "content"],
+      });
+      expect(
+        TraceDeleteBatchActionConfigSchema.parse(batchAction.config),
+      ).toMatchObject({ source: "events" });
+    });
+
+    it("still rejects non-TraceDelete batch actions with full-text search for v4 users", async () => {
+      // Only TraceDelete's worker path honors useEventsTable; other batch
+      // actions (here: trace add-to-annotation-queue) read from the legacy
+      // traces table and must keep the strict legacy IO-search guard even
+      // when the dispatching user is v4-flagged.
+      mutableEnv.LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH = "true";
+      const { projectId, caller } = await createCaller({
+        v4BetaEnabled: true,
+      });
+
+      await expect(
+        caller.annotationQueueItems.createMany({
+          projectId,
+          queueId: randomUUID(),
+          objectIds: [randomUUID()],
+          objectType: AnnotationQueueObjectType.TRACE,
+          isBatchAction: true,
+          query: ioSearchQuery(`queue-user-${randomUUID()}`),
+        }),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        // Literal owned by the module-private LEGACY_IO_SEARCH_BATCH_JOB_ERROR_MESSAGE
+        // in web/src/features/traces/server/legacyIoSearch.ts.
+        message:
+          "Input/output search is disabled for legacy tracing tables on this instance. Switch to ID, name, or user ID search before creating a batch job.",
+      });
+
+      expect(mockAddBatchAction).not.toHaveBeenCalled();
+    });
+
+    it("still rejects legacy (traces-backed) batch deletes with full-text search", async () => {
+      mutableEnv.LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH = "true";
+      const { projectId, caller } = await createCaller({
+        v4BetaEnabled: false,
+      });
+      const batchActionId = `${projectId}-traces-trace-delete`;
+
+      await expect(
+        caller.traces.deleteMany({
+          projectId,
+          traceIds: [randomUUID()],
+          isBatchAction: true,
+          query: ioSearchQuery(`delete-user-${randomUUID()}`),
+        }),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        // Literal owned by the module-private LEGACY_IO_SEARCH_BATCH_JOB_ERROR_MESSAGE
+        // in web/src/features/traces/server/legacyIoSearch.ts.
+        message:
+          "Input/output search is disabled for legacy tracing tables on this instance. Switch to ID, name, or user ID search before creating a batch job.",
+      });
+
+      await expect(
+        prisma.batchAction.findUnique({ where: { id: batchActionId } }),
+      ).resolves.toBeNull();
+    });
   });
 });

--- a/web/src/__tests__/server/traces-batch-delete-trpc.servertest.ts
+++ b/web/src/__tests__/server/traces-batch-delete-trpc.servertest.ts
@@ -134,29 +134,6 @@ describe("traces.deleteMany batch action", () => {
     expect(mockAddBatchAction).not.toHaveBeenCalled();
   });
 
-  it("snapshots v4 beta state into an events-backed config", async () => {
-    const { projectId, caller } = await createCaller({ v4BetaEnabled: true });
-    const batchActionId = `${projectId}-traces-trace-delete`;
-
-    await caller.traces.deleteMany({
-      projectId,
-      traceIds: [randomUUID()],
-      isBatchAction: true,
-      query: traceDeleteQuery(`delete-user-${randomUUID()}`),
-    });
-
-    const batchAction = await prisma.batchAction.findUniqueOrThrow({
-      where: { id: batchActionId },
-    });
-    expect(batchAction.query).toMatchObject({ useEventsTable: true });
-    expect(
-      TraceDeleteBatchActionConfigSchema.parse(batchAction.config),
-    ).toMatchObject({
-      source: "events",
-      inFlightBatch: null,
-    });
-  });
-
   it("does not overwrite an active trace-delete BatchAction row", async () => {
     const { projectId, session, caller } = await createCaller();
     const batchActionId = `${projectId}-traces-trace-delete`;
@@ -370,7 +347,7 @@ describe("traces.deleteMany batch action", () => {
     ).resolves.toBeNull();
   });
 
-  describe("events-view dispatches (query.useEventsTable declared)", () => {
+  describe("events-surface declarations (query.useEventsTable)", () => {
     const mutableEnv = env as unknown as {
       LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN: "true" | "false";
     };
@@ -444,13 +421,13 @@ describe("traces.deleteMany batch action", () => {
       ).resolves.toBeNull();
     });
 
-    it("keeps the traces-backed config for non-beta users who do not declare the events view", async () => {
-      // The v3 traces table dispatches without a declaration; the session
-      // snapshot alone decides the source even when the preview surface is
-      // enabled instance-wide.
-      mutableEnv.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+    it("ignores a client-sent useEventsTable: false and routes on the session snapshot", async () => {
+      // Only validated useEventsTable: true declarations are honored —
+      // legacy and stale clients can't be trusted to set the flag correctly,
+      // so a client-sent false is ignored and the session's v4 beta flag
+      // snapshot decides the source: a beta user stays events-backed.
       const { projectId, caller } = await createCaller({
-        v4BetaEnabled: false,
+        v4BetaEnabled: true,
       });
       const batchActionId = `${projectId}-traces-trace-delete`;
 
@@ -458,15 +435,57 @@ describe("traces.deleteMany batch action", () => {
         projectId,
         traceIds: [randomUUID()],
         isBatchAction: true,
-        query: traceDeleteQuery(`delete-user-${randomUUID()}`),
+        query: {
+          ...traceDeleteQuery(`delete-user-${randomUUID()}`),
+          useEventsTable: false,
+        },
       });
 
       const batchAction = await prisma.batchAction.findUniqueOrThrow({
         where: { id: batchActionId },
       });
-      expect(batchAction.query).toMatchObject({ useEventsTable: false });
+      expect(batchAction.query).toMatchObject({ useEventsTable: true });
       expect(
         TraceDeleteBatchActionConfigSchema.parse(batchAction.config),
+      ).toMatchObject({ source: "events", inFlightBatch: null });
+    });
+
+    it("falls back to the session flag when the client declares no surface", async () => {
+      // Dispatches without query.useEventsTable (stale clients mid-deploy,
+      // out-of-tree callers) route on the session's v4 beta flag alone; the
+      // instance-wide preview opt-in is irrelevant without a declaration.
+      mutableEnv.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+
+      const beta = await createCaller({ v4BetaEnabled: true });
+      await beta.caller.traces.deleteMany({
+        projectId: beta.projectId,
+        traceIds: [randomUUID()],
+        isBatchAction: true,
+        query: traceDeleteQuery(`delete-user-${randomUUID()}`),
+      });
+
+      const betaBatchAction = await prisma.batchAction.findUniqueOrThrow({
+        where: { id: `${beta.projectId}-traces-trace-delete` },
+      });
+      expect(betaBatchAction.query).toMatchObject({ useEventsTable: true });
+      expect(
+        TraceDeleteBatchActionConfigSchema.parse(betaBatchAction.config),
+      ).toMatchObject({ source: "events", inFlightBatch: null });
+
+      const nonBeta = await createCaller({ v4BetaEnabled: false });
+      await nonBeta.caller.traces.deleteMany({
+        projectId: nonBeta.projectId,
+        traceIds: [randomUUID()],
+        isBatchAction: true,
+        query: traceDeleteQuery(`delete-user-${randomUUID()}`),
+      });
+
+      const nonBetaBatchAction = await prisma.batchAction.findUniqueOrThrow({
+        where: { id: `${nonBeta.projectId}-traces-trace-delete` },
+      });
+      expect(nonBetaBatchAction.query).toMatchObject({ useEventsTable: false });
+      expect(
+        TraceDeleteBatchActionConfigSchema.parse(nonBetaBatchAction.config),
       ).toMatchObject({ source: "traces" });
     });
   });
@@ -488,6 +507,11 @@ describe("traces.deleteMany batch action", () => {
       searchQuery: "some full-text query",
       searchType: ["id" as const, "content" as const],
     });
+
+    // Literal owned by the module-private LEGACY_IO_SEARCH_BATCH_JOB_ERROR_MESSAGE
+    // in web/src/features/traces/server/legacyIoSearch.ts.
+    const legacyIoSearchErrorMessage =
+      "Input/output search is disabled for legacy tracing tables on this instance. Switch to ID, name, or user ID search before creating a batch job.";
 
     it("allows v4 (events-backed) batch deletes with full-text search", async () => {
       mutableEnv.LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH = "true";
@@ -538,10 +562,7 @@ describe("traces.deleteMany batch action", () => {
         }),
       ).rejects.toMatchObject({
         code: "BAD_REQUEST",
-        // Literal owned by the module-private LEGACY_IO_SEARCH_BATCH_JOB_ERROR_MESSAGE
-        // in web/src/features/traces/server/legacyIoSearch.ts.
-        message:
-          "Input/output search is disabled for legacy tracing tables on this instance. Switch to ID, name, or user ID search before creating a batch job.",
+        message: legacyIoSearchErrorMessage,
       });
 
       expect(mockAddBatchAction).not.toHaveBeenCalled();
@@ -563,10 +584,7 @@ describe("traces.deleteMany batch action", () => {
         }),
       ).rejects.toMatchObject({
         code: "BAD_REQUEST",
-        // Literal owned by the module-private LEGACY_IO_SEARCH_BATCH_JOB_ERROR_MESSAGE
-        // in web/src/features/traces/server/legacyIoSearch.ts.
-        message:
-          "Input/output search is disabled for legacy tracing tables on this instance. Switch to ID, name, or user ID search before creating a batch job.",
+        message: legacyIoSearchErrorMessage,
       });
 
       await expect(

--- a/web/src/__tests__/server/traces-batch-delete-trpc.servertest.ts
+++ b/web/src/__tests__/server/traces-batch-delete-trpc.servertest.ts
@@ -370,6 +370,107 @@ describe("traces.deleteMany batch action", () => {
     ).resolves.toBeNull();
   });
 
+  describe("events-view dispatches (query.useEventsTable declared)", () => {
+    const mutableEnv = env as unknown as {
+      LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN: "true" | "false";
+    };
+    const originalPreviewOptIn =
+      mutableEnv.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+
+    afterEach(() => {
+      mutableEnv.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
+        originalPreviewOptIn;
+    });
+
+    it("creates an events-backed config for non-beta users when the events preview surface is enabled", async () => {
+      // The events view is reachable without the per-user v4 beta flag when
+      // the instance-wide preview opt-in is set; a dispatch from it must keep
+      // reading from the events table so the persisted events-view filters
+      // stay valid for the worker.
+      mutableEnv.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const { projectId, caller } = await createCaller({
+        v4BetaEnabled: false,
+      });
+      const batchActionId = `${projectId}-traces-trace-delete`;
+
+      await caller.traces.deleteMany({
+        projectId,
+        traceIds: [randomUUID()],
+        isBatchAction: true,
+        query: {
+          ...traceDeleteQuery(`delete-user-${randomUUID()}`),
+          useEventsTable: true,
+        },
+      });
+
+      const batchAction = await prisma.batchAction.findUniqueOrThrow({
+        where: { id: batchActionId },
+      });
+      expect(batchAction.query).toMatchObject({ useEventsTable: true });
+      expect(
+        TraceDeleteBatchActionConfigSchema.parse(batchAction.config),
+      ).toMatchObject({
+        source: "events",
+        inFlightBatch: null,
+      });
+      expect(mockAddBatchAction).not.toHaveBeenCalled();
+    });
+
+    it("rejects the declaration when neither the beta flag nor the preview surface is enabled", async () => {
+      mutableEnv.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { projectId, caller } = await createCaller({
+        v4BetaEnabled: false,
+      });
+      const batchActionId = `${projectId}-traces-trace-delete`;
+
+      await expect(
+        caller.traces.deleteMany({
+          projectId,
+          traceIds: [randomUUID()],
+          isBatchAction: true,
+          query: {
+            ...traceDeleteQuery(`delete-user-${randomUUID()}`),
+            useEventsTable: true,
+          },
+        }),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        message:
+          "Events-backed batch deletion is not available for this user on this instance.",
+      });
+
+      await expect(
+        prisma.batchAction.findUnique({ where: { id: batchActionId } }),
+      ).resolves.toBeNull();
+    });
+
+    it("keeps the traces-backed config for non-beta users who do not declare the events view", async () => {
+      // The v3 traces table dispatches without a declaration; the session
+      // snapshot alone decides the source even when the preview surface is
+      // enabled instance-wide.
+      mutableEnv.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const { projectId, caller } = await createCaller({
+        v4BetaEnabled: false,
+      });
+      const batchActionId = `${projectId}-traces-trace-delete`;
+
+      await caller.traces.deleteMany({
+        projectId,
+        traceIds: [randomUUID()],
+        isBatchAction: true,
+        query: traceDeleteQuery(`delete-user-${randomUUID()}`),
+      });
+
+      const batchAction = await prisma.batchAction.findUniqueOrThrow({
+        where: { id: batchActionId },
+      });
+      expect(batchAction.query).toMatchObject({ useEventsTable: false });
+      expect(
+        TraceDeleteBatchActionConfigSchema.parse(batchAction.config),
+      ).toMatchObject({ source: "traces" });
+    });
+  });
+
   describe("with legacy IO search disabled", () => {
     const mutableEnv = env as unknown as {
       LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH: "true" | "false";

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -591,6 +591,15 @@ export default function TracesTable({
     compactNumberFormatter(Object.keys(selectedRows).length)
   );
 
+  // Select-all deletes persist the raw filterState into the batch action, but
+  // comment filters resolve via Postgres at read time and the server rejects
+  // such dispatches, so disable the action up front with a clear reason.
+  // Column ids mirror the traces.deleteMany guard in
+  // web/src/server/api/routers/traces.ts.
+  const hasCommentFilter = filterState.some(
+    (f) => f.column === "commentCount" || f.column === "commentContent",
+  );
+
   const tableActions: TableAction[] = [
     ...(hasTraceDeletionEntitlement
       ? [
@@ -599,6 +608,9 @@ export default function TracesTable({
             type: BatchActionType.Delete,
             label: "Delete Traces",
             description: `This action permanently deletes ${displayCount} traces and cannot be undone. Trace deletion happens asynchronously and may take up to 24 hours.`,
+            disabled: selectAll && hasCommentFilter,
+            disabledReason:
+              "Batch deletion does not support comment filters. Remove the comment filter to delete.",
             accessCheck: {
               scope: "traces:delete",
               entitlement: "trace-deletion",

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -39,7 +39,11 @@ import {
 import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
 import { cn } from "@/src/utils/tailwind";
 import { LevelColors } from "@/src/components/level-colors";
-import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
+import {
+  compactNumberFormatter,
+  numberFormatter,
+  usdFormatter,
+} from "@/src/utils/numbers";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
@@ -612,6 +616,7 @@ export default function ObservationsEventsTable({
   const {
     observations,
     totalCount,
+    uniqueTraceCount,
     isTotalCountLoading,
     isTotalCountError,
     hasMore,
@@ -745,15 +750,54 @@ export default function ObservationsEventsTable({
   }, [observations.rows, selectedRows]);
 
   const handleDeleteTraces = async ({ projectId }: { projectId: string }) => {
-    if (selectedTraceIds.length === 0) return;
+    // Select-all deletes are dispatched even if a background refetch drained
+    // the visible-page selection to [] while the dialog was open: the server
+    // requires at least one traceId regardless, so such a dispatch fails
+    // loudly (as in the v3 traces table) — an empty selection while
+    // select-all is armed signals a consistency issue, not a no-op.
+    if (!selectAll && selectedTraceIds.length === 0) return;
 
     await traceDeleteMutation.mutateAsync({
       projectId,
       traceIds: selectedTraceIds,
-      isBatchAction: false,
+      query: {
+        filter: filterState,
+        orderBy: orderByState,
+        searchQuery: searchQuery || undefined,
+        searchType,
+      },
+      isBatchAction: selectAll,
     });
     setSelectedRows({});
   };
+
+  // Confirmation counts for "Delete Traces": page selection counts directly;
+  // select-all counts resolve lazily ("..." while loading) and the distinct
+  // trace count is a ClickHouse `uniq` approximation, hence the "~".
+  const selectedVisibleRowCount = (observations.rows ?? []).filter(
+    (observation) => selectedRows[observation.id],
+  ).length;
+  const selectedItemCount = selectAll ? totalCount : selectedVisibleRowCount;
+  const itemCountDisplay =
+    selectedItemCount !== null
+      ? compactNumberFormatter(selectedItemCount)
+      : "...";
+  const selectedUniqueTraceCount = selectAll
+    ? uniqueTraceCount
+    : selectedTraceIds.length;
+  const traceCountDisplay =
+    selectedUniqueTraceCount !== null
+      ? `${selectAll ? "~" : ""}${compactNumberFormatter(selectedUniqueTraceCount)}`
+      : "...";
+
+  // Select-all deletes persist the raw filterState into the batch action, but
+  // comment filters (commentCount/commentContent) resolve via Postgres at read
+  // time and the worker cannot translate them into a ClickHouse query — the
+  // server blocks such dispatches, so disable the action up front with a
+  // clear reason.
+  const hasCommentFilter = filterState.some(
+    (f) => f.column === "commentCount" || f.column === "commentContent",
+  );
 
   const isSelectAllCountUnavailable = isTotalCountLoading || isTotalCountError;
   const selectAllCountUnavailableReason = isTotalCountLoading
@@ -768,12 +812,27 @@ export default function ObservationsEventsTable({
             id: ActionId.TraceDelete,
             type: BatchActionType.Delete,
             label: "Delete Traces",
-            description:
-              "This permanently deletes all observations within this trace(s), as well as the trace(s), even if you only have single observations selected. This action cannot be undone. Trace deletion happens asynchronously and may take up to 24 hours.",
-            disabled: selectAll || selectedTraceIds.length === 0,
-            disabledReason: selectAll
-              ? "Delete traces is only available for observations selected on the current page."
-              : "Selected observations are missing trace IDs.",
+            description: `${itemCountDisplay} ${selectedItemCount === 1 ? "item is" : "items are"} selected, spanning ${traceCountDisplay} unique ${selectedUniqueTraceCount === 1 ? "trace" : "traces"}. A trace is always deleted as a whole — if at least one of its observations is selected, all of its observations are deleted with it. This action cannot be undone. Trace deletion happens asynchronously and may take up to 24 hours.`,
+            // Select-all is not gated on the visible-page selection; if that
+            // selection drained to empty, dispatch fails loudly with the
+            // server's min-1 traceIds rejection (as in the v3 traces table).
+            // Page selection needs concrete trace IDs.
+            disabled: selectAll
+              ? hasCommentFilter
+              : selectedTraceIds.length === 0,
+            disabledReason:
+              selectAll && hasCommentFilter
+                ? "Batch deletion does not support comment filters. Remove the comment filter to delete."
+                : "Selected observations are missing trace IDs.",
+            // The server keys every trace-delete batch row under the traces
+            // table (row id `${projectId}-traces-trace-delete`), whichever
+            // view dispatched it — the events-vs-traces read routing travels
+            // in the job's config.source, not in the table name. The shared
+            // key allows only one active trace deletion per project across
+            // the v3 and v4 views, and pointing the in-progress poll at it
+            // lets this dialog see a deletion started from either view. This
+            // must stay Traces at least as long as the v3 view exists.
+            tableName: BatchExportTableName.Traces,
             accessCheck: {
               scope: "traces:delete",
               entitlement: "trace-deletion",

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -765,6 +765,10 @@ export default function ObservationsEventsTable({
         orderBy: orderByState,
         searchQuery: searchQuery || undefined,
         searchType,
+        // Declare the dispatching surface: these are events-view filters, so
+        // the worker must read them from the events table. The server
+        // validates the declaration (beta flag or instance preview opt-in).
+        useEventsTable: true,
       },
       isBatchAction: selectAll,
     });

--- a/web/src/features/events/hooks/useEventsTableData.ts
+++ b/web/src/features/events/hooks/useEventsTableData.ts
@@ -174,6 +174,11 @@ export function useEventsTableData({
   const totalCount = selectAll
     ? (totalCountQuery.data?.totalCount ?? null)
     : null;
+  // Approximate distinct trace_id count over the same filtered set, computed
+  // alongside totalCount; shares its loading/error state below.
+  const uniqueTraceCount = selectAll
+    ? (totalCountQuery.data?.uniqueTraceCount ?? null)
+    : null;
   const isTotalCountLoading =
     selectAll && totalCount === null && totalCountQuery.isFetching;
   const isTotalCountError =
@@ -233,6 +238,7 @@ export function useEventsTableData({
     observations: joinedData,
     dataUpdatedAt: observations.dataUpdatedAt,
     totalCount,
+    uniqueTraceCount,
     isTotalCountLoading,
     isTotalCountError,
     hasMore,

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -134,7 +134,7 @@ export const eventsRouter = createTRPCRouter({
       });
 
       if (hasNoMatches) {
-        return { totalCount: 0 };
+        return { totalCount: 0, uniqueTraceCount: 0 };
       }
 
       return instrumentAsync(

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -6,7 +6,7 @@ import {
   filterAndValidateDbScoreList,
 } from "@langfuse/shared";
 import {
-  getObservationsCountFromEventsTable,
+  getObservationsCountsFromEventsTable,
   getObservationsWithModelDataFromEventsTable,
   getCategoricalScoresGroupedByName,
   getEventsFilterOptionsForColumns,
@@ -324,7 +324,8 @@ export async function getEventList(params: GetObservationsListParams) {
 }
 
 /**
- * Get total count of events matching filters
+ * Get total count of events matching filters, plus the approximate number of
+ * unique traces they span (single ClickHouse pass).
  */
 export async function getEventCount(params: GetObservationsCountParams) {
   const queryOpts = {
@@ -337,9 +338,10 @@ export async function getEventCount(params: GetObservationsCountParams) {
     offset: 0,
   };
 
-  const totalCount = await getObservationsCountFromEventsTable(queryOpts);
+  const { totalCount, uniqueTraceCount } =
+    await getObservationsCountsFromEventsTable(queryOpts);
 
-  return { totalCount };
+  return { totalCount, uniqueTraceCount };
 }
 
 type EventFilterOptionRow = Awaited<

--- a/web/src/features/table/components/TableActionDialog.tsx
+++ b/web/src/features/table/components/TableActionDialog.tsx
@@ -59,7 +59,10 @@ export function TableActionDialog({
   const isInProgress = api.table.getIsBatchActionInProgress.useQuery(
     {
       projectId,
-      tableName,
+      // Batch action rows are keyed by (projectId, actionId, tableName); an
+      // action that registers under a different table than the hosting view
+      // overrides the poll target via action.tableName.
+      tableName: action.tableName ?? tableName,
       actionId: action.id,
     },
     {

--- a/web/src/features/table/components/TableActionMenu.tsx
+++ b/web/src/features/table/components/TableActionMenu.tsx
@@ -45,22 +45,31 @@ export function TableActionMenu({
   onClearSelection,
   onCustomAction,
 }: TableActionMenuProps) {
-  const [selectedAction, setSelectedAction] = useState<TableAction | null>(
-    null,
-  );
+  const [selectedActionId, setSelectedActionId] = useState<
+    TableAction["id"] | null
+  >(null);
   const [isDialogOpen, setDialogOpen] = useState(false);
+
+  // Derive the action from props on every render (ids are unique within one
+  // menu) so the dialog shows live data — e.g. descriptions embedding lazily
+  // resolved select-all counts — instead of a snapshot frozen at click time.
+  // If the action disappears from `actions` while open, the dialog unmounts.
+  const selectedAction =
+    selectedActionId !== null
+      ? actions.find((action) => action.id === selectedActionId)
+      : undefined;
 
   const handleActionSelect = (action: TableAction) => {
     if ("customDialog" in action && action.customDialog) {
       onCustomAction?.(action.id);
       return;
     }
-    setSelectedAction(action);
+    setSelectedActionId(action.id);
     setDialogOpen(true);
   };
 
   const handleClose = () => {
-    setSelectedAction(null);
+    setSelectedActionId(null);
     setDialogOpen(false);
   };
 

--- a/web/src/features/table/components/TableActionMenu.tsx
+++ b/web/src/features/table/components/TableActionMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { X, Trash } from "lucide-react";
 import { Plus } from "lucide-react";
@@ -72,6 +72,16 @@ export function TableActionMenu({
     setSelectedActionId(null);
     setDialogOpen(false);
   };
+
+  // If the selected action leaves `actions` while its dialog is open, the
+  // dialog unmounts without firing onClose; reset the open/selected state so
+  // the dialog cannot reappear without a click if the action returns.
+  useEffect(() => {
+    if (selectedActionId !== null && selectedAction === undefined) {
+      setSelectedActionId(null);
+      setDialogOpen(false);
+    }
+  }, [selectedActionId, selectedAction]);
 
   return (
     <>

--- a/web/src/features/table/server/createBatchActionJob.ts
+++ b/web/src/features/table/server/createBatchActionJob.ts
@@ -40,11 +40,9 @@ type CreateBatchActionJob = {
   };
   query: BatchActionQuery;
   targetId?: string;
-  // When defined, replaces the session snapshot as the worker's read-table
-  // routing. Callers must validate the value before passing it (see
-  // traces.deleteMany: the events view declares its surface and the server
-  // checks the beta flag / preview opt-in). Leave undefined everywhere else
-  // so the session snapshot keeps overriding client-sent values.
+  // Call-site decision on whether this action reads from the events table
+  // (see traces.deleteMany). When unset, it is inferred from the user's v4
+  // beta flag below.
   useEventsTableOverride?: boolean;
 };
 
@@ -66,11 +64,9 @@ export const createBatchActionJob = async ({
   targetId,
   useEventsTableOverride,
 }: CreateBatchActionJob) => {
-  // Snapshot the user's v4 beta flag so the worker reads from the same data
-  // source as the UI table; overrides any client-sent value. A caller may
-  // replace the snapshot with a validated override (e.g. the events view is
-  // reachable without the beta flag on preview instances, and its dispatches
-  // must stay events-backed so the persisted filters match the read table).
+  // Whether the action reads from the events table is determined at the
+  // call site (useEventsTableOverride) or inferred from the user's v4 beta
+  // flag; the decision is snapshotted into the query at dispatch time.
   const queryWithSnapshot: BatchActionQuery = {
     ...query,
     useEventsTable:

--- a/web/src/features/table/server/createBatchActionJob.ts
+++ b/web/src/features/table/server/createBatchActionJob.ts
@@ -40,6 +40,12 @@ type CreateBatchActionJob = {
   };
   query: BatchActionQuery;
   targetId?: string;
+  // When defined, replaces the session snapshot as the worker's read-table
+  // routing. Callers must validate the value before passing it (see
+  // traces.deleteMany: the events view declares its surface and the server
+  // checks the beta flag / preview opt-in). Leave undefined everywhere else
+  // so the session snapshot keeps overriding client-sent values.
+  useEventsTableOverride?: boolean;
 };
 
 const ACTIVE_BATCH_ACTION_STATUSES = [
@@ -58,12 +64,17 @@ export const createBatchActionJob = async ({
   session,
   query,
   targetId,
+  useEventsTableOverride,
 }: CreateBatchActionJob) => {
   // Snapshot the user's v4 beta flag so the worker reads from the same data
-  // source as the UI table; overrides any client-sent value.
+  // source as the UI table; overrides any client-sent value. A caller may
+  // replace the snapshot with a validated override (e.g. the events view is
+  // reachable without the beta flag on preview instances, and its dispatches
+  // must stay events-backed so the persisted filters match the read table).
   const queryWithSnapshot: BatchActionQuery = {
     ...query,
-    useEventsTable: session.user.v4BetaEnabled ?? false,
+    useEventsTable:
+      useEventsTableOverride ?? session.user.v4BetaEnabled ?? false,
   };
 
   assertLegacyTracingIoSearchCanCreateBatchJob({

--- a/web/src/features/table/server/createBatchActionJob.ts
+++ b/web/src/features/table/server/createBatchActionJob.ts
@@ -59,18 +59,26 @@ export const createBatchActionJob = async ({
   query,
   targetId,
 }: CreateBatchActionJob) => {
-  assertLegacyTracingIoSearchCanCreateBatchJob({
-    searchQuery: query.searchQuery,
-    searchType: query.searchType,
-    tableName,
-  });
-
   // Snapshot the user's v4 beta flag so the worker reads from the same data
   // source as the UI table; overrides any client-sent value.
   const queryWithSnapshot: BatchActionQuery = {
     ...query,
     useEventsTable: session.user.v4BetaEnabled ?? false,
   };
+
+  assertLegacyTracingIoSearchCanCreateBatchJob({
+    searchQuery: queryWithSnapshot.searchQuery,
+    searchType: queryWithSnapshot.searchType,
+    tableName,
+    // Only TraceDelete's worker path honors useEventsTable (config.source
+    // "events" -> getTraceDeleteCursorPageFromEvents). Every other action
+    // reads from the legacy tables regardless of the flag, so it must keep
+    // the strict legacy IO-search guard.
+    useEventsTable:
+      actionId === ActionId.TraceDelete
+        ? queryWithSnapshot.useEventsTable
+        : undefined,
+  });
 
   const batchActionId = generateBatchActionId(projectId, actionId, tableName);
 

--- a/web/src/features/table/types.ts
+++ b/web/src/features/table/types.ts
@@ -1,6 +1,10 @@
 import { type Entitlement } from "@/src/features/entitlements/constants/entitlements";
 import { type ProjectScope } from "@/src/features/rbac/constants/projectAccessRights";
-import { type BatchActionType, type ActionId } from "@langfuse/shared";
+import {
+  type BatchActionType,
+  type ActionId,
+  type BatchExportTableName,
+} from "@langfuse/shared";
 import { type ReactElement } from "react";
 
 type BaseTableAction = {
@@ -10,6 +14,11 @@ type BaseTableAction = {
   icon?: ReactElement<any>;
   disabled?: boolean;
   disabledReason?: string;
+  // Batch action rows are registered per (projectId, actionId, tableName).
+  // When an action dispatches under a different table than the hosting view
+  // (e.g. TraceDelete from the events view registers under "traces"), set
+  // this so the in-progress poll targets the table the job is stored under.
+  tableName?: BatchExportTableName;
   accessCheck: {
     scope: ProjectScope;
     entitlement?: Entitlement;

--- a/web/src/features/traces/server/legacyIoSearch.ts
+++ b/web/src/features/traces/server/legacyIoSearch.ts
@@ -62,9 +62,18 @@ export const assertLegacyTracingIoSearchCanCreateBatchJob = ({
   searchQuery,
   searchType,
   tableName,
+  useEventsTable,
 }: LegacyTracingSearch & {
   tableName: BatchTableNames;
+  // Dispatch-time snapshot of the user's v4 beta flag. Callers must only set
+  // this for jobs whose worker path actually runs the stored query against
+  // the events table (currently only TraceDelete via config.source "events");
+  // such jobs are exempt from the legacy IO-search restriction just like
+  // tableName "events". Leave it unset for every other action — their worker
+  // paths ignore the flag and still run the legacy full-text IO scan.
+  useEventsTable?: boolean;
 }) => {
+  if (useEventsTable) return;
   if (!isLegacyTracingIoSearchDisabled()) return;
   if (!hasSearchQuery(searchQuery)) return;
   if (!hasLegacyTracingIoSearch(searchType)) return;

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -487,6 +487,29 @@ export const traceRouter = createTRPCRouter({
               "Batch deletion does not support comment filters. Remove the comment filter and try again.",
           });
         }
+
+        // The events view declares its surface via query.useEventsTable so
+        // the worker reads the persisted events-view filters from the events
+        // table (their columns do not exist, or mean something else, in the
+        // traces table). The declaration is only honored when the events
+        // surface is actually available: per-user v4 beta flag, or the
+        // instance-wide preview opt-in that exposes the events view to
+        // non-beta users. Without a declaration (v3 traces table), the
+        // session snapshot in createBatchActionJob decides the source.
+        const declaresEventsTable = input.query.useEventsTable === true;
+        if (declaresEventsTable) {
+          const eventsSurfaceAvailable =
+            ctx.session.user.v4BetaEnabled === true ||
+            env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
+          if (!eventsSurfaceAvailable) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "Events-backed batch deletion is not available for this user on this instance.",
+            });
+          }
+        }
+
         await createBatchActionJob({
           projectId: input.projectId,
           actionId: ActionId.TraceDelete,
@@ -494,6 +517,7 @@ export const traceRouter = createTRPCRouter({
           tableName: BatchExportTableName.Traces,
           session: ctx.session,
           query: input.query,
+          useEventsTableOverride: declaresEventsTable ? true : undefined,
         });
       } else {
         await Promise.all(

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -488,14 +488,12 @@ export const traceRouter = createTRPCRouter({
           });
         }
 
-        // The events view declares its surface via query.useEventsTable so
-        // the worker reads the persisted events-view filters from the events
-        // table (their columns do not exist, or mean something else, in the
-        // traces table). The declaration is only honored when the events
-        // surface is actually available: per-user v4 beta flag, or the
-        // instance-wide preview opt-in that exposes the events view to
-        // non-beta users. Without a declaration (v3 traces table), the
-        // session snapshot in createBatchActionJob decides the source.
+        // Decide here whether this delete reads from the events table: the
+        // v4 events view sets query.useEventsTable: true, which we honor
+        // after checking the events view is actually available to this user
+        // (v4 beta flag, or the instance-wide preview opt-in). In every
+        // other case createBatchActionJob infers the choice from the user's
+        // v4 beta flag.
         const declaresEventsTable = input.query.useEventsTable === true;
         if (declaresEventsTable) {
           const eventsSurfaceAvailable =

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -471,6 +471,22 @@ export const traceRouter = createTRPCRouter({
       });
 
       if (input.isBatchAction && input.query) {
+        // Comment filters (commentCount/commentContent in both the v3 traces
+        // and v4 events views) resolve via Postgres lookups at read time
+        // (applyCommentFilters); when the worker translates the stored
+        // filters into ClickHouse SQL, these columns map to a nonexistent
+        // "comments" table and would deterministically fail every batch, so
+        // reject them at dispatch.
+        const hasCommentFilter = (input.query.filter ?? []).some(
+          (f) => f.column === "commentCount" || f.column === "commentContent",
+        );
+        if (hasCommentFilter) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Batch deletion does not support comment filters. Remove the comment filter and try again.",
+          });
+        }
         await createBatchActionJob({
           projectId: input.projectId,
           actionId: ActionId.TraceDelete,


### PR DESCRIPTION
## What does this PR do?

Enables "select all across pages" batch deletion on the v4 "Fast (Preview)" events table. The Delete Traces button was disabled after select-all ("Delete traces is only available for observations selected on the current page") — a leftover from before #14776 landed the durable, events-aware batch-delete backend. The action now stays enabled, shows a confirmation dialog with item and unique-trace counts, and routes through the existing batch action (`config.source: "events"`, processed by the `TraceDeleteBatchActionRunner`).

Key changes:

- `EventsTable` dispatches `traces.deleteMany` with the live view query (`filter`/`orderBy`/`searchQuery`/`searchType`) and `isBatchAction: selectAll`, mirroring the v3 traces table.
- New confirmation copy: "N items are selected, spanning ~M unique traces. A trace is always deleted as a whole — if at least one of its observations is selected, all of its observations are deleted with it. …". The unique-trace count comes from a new `count-with-unique-traces` select variant behind `events.countAll` (`count(*)` + `uniq(trace_id)` in a single ClickHouse pass).
- In-progress poll fix: TraceDelete batch rows register under tableName `traces`, but the events view polled under `observations`, so its dialog never detected an active deletion. Added an optional per-action `tableName` override on `TableAction`, set only on this action.
- `TableActionMenu` now derives the clicked action from props at render instead of freezing it in state, so dialog copy that embeds lazily loaded select-all counts resolves in place.
- Scoped the legacy IO-search exemption to TraceDelete only: other batch actions keep the strict `LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH` guard because their worker paths still read the legacy tables.
- Comment filters (resolved via Postgres at read time, untranslatable to a ClickHouse delete query) now fail fast on batch deletes: server-side BAD_REQUEST at dispatch plus a disabled action with an explanatory tooltip in both the v3 and v4 views.

Impacted packages: `web`, `@langfuse/shared`.

Reviewer notes:

- The delete dispatch deliberately keeps tableName `Traces`: it is the durable row's identity and the runner's work-queue key, which enforces a single active trace deletion per project across both views; the events-vs-traces read routing travels in `config.source`.
- Browser-verified end to end on seeded data: two select-all deletes (1,100 events / 100 traces and 912 / 456) completed with `config.source: "events"` and exact scope in ClickHouse; the in-progress guard blocked a concurrent dispatch; comment-filter tooltips verified in both views.

Verification commands executed:

- `pnpm --filter web run test src/__tests__/server/traces-batch-delete-trpc.servertest.ts` → `Tests  10 passed (10)`
- `pnpm --filter web run test src/__tests__/server/repositories/event-repository.servertest.ts` → `Tests  69 passed (69)`
- `pnpm --filter worker run test src/__tests__/traceBatchDeleteBatchAction.test.ts` → `Tests  7 passed (7)`
- `pnpm run typecheck` → `Tasks:    8 successful, 8 total`
- `pnpm run lint` → `Tasks:    8 successful, 8 total`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables \"select-all\" batch deletion on the v4 events table by wiring the `EventsTable` `handleDeleteTraces` handler to dispatch `traces.deleteMany` with the live query when `selectAll` is true, mirroring the v3 traces table. It also fixes an in-progress poll bug (events view previously polled under `observations`, missing deletions started under `traces`) and adds a server-side guard rejecting batch deletes that include comment filters.

- **New `count-with-unique-traces` ClickHouse query variant**: runs `count(*) + uniq(trace_id)` in a single pass to power the \"N items spanning ~M unique traces\" confirmation copy.
- **`TableActionMenu` live-action derivation**: the dialog now derives the clicked action from current props on each render instead of freezing it at click time, so lazily-loaded select-all counts resolve in place.
- **Comment-filter guard**: server rejects batch delete dispatches with `commentCount`/`commentContent` filters (BAD_REQUEST), and both the v3 and v4 views disable the action up front with an explanatory tooltip.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the batch delete path is well-guarded on both client and server, and the in-progress poll fix is correct.

The core flow — dispatching a select-all batch delete from the events view, routing it through the existing TraceDeleteBatchActionRunner with config.source 'events', and polling for progress under the traces table — is implemented correctly and mirrors the v3 traces table. The comment-filter guard is enforced at both the UI and server layers. The two findings are both non-blocking: one is a misleading disabledReason string that is never shown to users, and the other is a theoretical edge case in TableActionMenu where a mid-dialog entitlement flip could leave isDialogOpen stale.

web/src/features/table/components/TableActionMenu.tsx — the new live-derivation pattern has a minor state-coherence edge case worth a second look.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant EventsTable
    participant TableActionMenu
    participant TableActionDialog
    participant TRPC as traces.deleteMany
    participant CreateBatch as createBatchActionJob
    participant CH as ClickHouse

    User->>EventsTable: Select all rows
    EventsTable->>TRPC: events.countAll (enabled: selectAll)
    TRPC->>CH: "count(*) + uniq(trace_id)"
    CH-->>TRPC: "{totalCount, uniqueTraceCount}"
    TRPC-->>EventsTable: "{totalCount, uniqueTraceCount}"

    Note over EventsTable: Builds tableActions with live description

    User->>TableActionMenu: Click Delete Traces
    TableActionMenu->>TableActionDialog: "open(action.id), action.tableName = Traces"
    TableActionDialog->>TRPC: table.getIsBatchActionInProgress(tableName: Traces)
    TRPC-->>TableActionDialog: inProgress status

    User->>TableActionDialog: Confirm
    TableActionDialog->>EventsTable: handleDeleteTraces()
    EventsTable->>TRPC: "traces.deleteMany({isBatchAction: true, query, traceIds})"
    TRPC->>TRPC: Validate no comment filters
    TRPC->>CreateBatch: createBatchActionJob(tableName: Traces, config.source: events)
    CreateBatch-->>TRPC: BatchAction queued
    TRPC-->>EventsTable: success
    EventsTable->>EventsTable: "setSelectedRows({})"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant EventsTable
    participant TableActionMenu
    participant TableActionDialog
    participant TRPC as traces.deleteMany
    participant CreateBatch as createBatchActionJob
    participant CH as ClickHouse

    User->>EventsTable: Select all rows
    EventsTable->>TRPC: events.countAll (enabled: selectAll)
    TRPC->>CH: "count(*) + uniq(trace_id)"
    CH-->>TRPC: "{totalCount, uniqueTraceCount}"
    TRPC-->>EventsTable: "{totalCount, uniqueTraceCount}"

    Note over EventsTable: Builds tableActions with live description

    User->>TableActionMenu: Click Delete Traces
    TableActionMenu->>TableActionDialog: "open(action.id), action.tableName = Traces"
    TableActionDialog->>TRPC: table.getIsBatchActionInProgress(tableName: Traces)
    TRPC-->>TableActionDialog: inProgress status

    User->>TableActionDialog: Confirm
    TableActionDialog->>EventsTable: handleDeleteTraces()
    EventsTable->>TRPC: "traces.deleteMany({isBatchAction: true, query, traceIds})"
    TRPC->>TRPC: Validate no comment filters
    TRPC->>CreateBatch: createBatchActionJob(tableName: Traces, config.source: events)
    CreateBatch-->>TRPC: BatchAction queued
    TRPC-->>EventsTable: success
    EventsTable->>EventsTable: "setSelectedRows({})"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/events/components/EventsTable.tsx:823-826
The `disabledReason` fallback is "Selected observations are missing trace IDs." even when the action is enabled (`selectAll=true`, no comment filter). This is never shown to users (the tooltip only renders when `disabled === true`), but the stale string is misleading to future readers. Consider using `undefined` when neither disabled condition applies.

```suggestion
            disabledReason:
              selectAll && hasCommentFilter
                ? "Batch deletion does not support comment filters. Remove the comment filter to delete."
                : !selectAll && selectedTraceIds.length === 0
                  ? "Selected observations are missing trace IDs."
                  : undefined,
```

### Issue 2 of 2
web/src/features/table/components/TableActionMenu.tsx:56-60
**Stale `isDialogOpen` when action disappears mid-dialog**

`selectedAction` becoming `undefined` (e.g. `hasTraceDeletionEntitlement` momentarily flips) unmounts `<TableActionDialog>` but leaves `isDialogOpen === true` in state. If the action later reappears in `actions`, the dialog would reopen without any user click because `isOpen={true}` is still set. Calling `handleClose()` in the unmount path (or resetting both pieces of state together) would prevent this.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(events): enable select-all batch de..."](https://github.com/langfuse/langfuse/commit/f5b3efc96f6d3f86147209f8ab09c83d3069bfe2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42995567)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->