### PR TITLE
feat(agents): add posthog-instrumentation skill (LFE-10785)

### DIFF
--- a/.agents/skills/posthog-instrumentation/SKILL.md
+++ b/.agents/skills/posthog-instrumentation/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: posthog-instrumentation
+description: |
+  Instrument Langfuse with PostHog product analytics, and decide whether new
+  frontend work should be instrumented. Use when (1) adding a meaningful user
+  action to the frontend — a button, onClick/onSubmit handler, form, dialog,
+  toggle, tRPC mutation call, or a new feature surface in `web/**` — pause and
+  propose instrumentation before finishing; (2) asked to instrument a feature,
+  add analytics or usage tracking, or answer "how do people use X"; (3) adding
+  or reviewing `capture()` events, `usePostHogClientCapture`, or any code that
+  touches `posthog`.
+---
+
+# PostHog Instrumentation
+
+**One idea:** every event exists to answer a **question** ("how do people
+filter?", "v3 vs v4?"), and it captures **shape/metadata — NEVER raw values.**
+If you cannot name the question an event answers, do not add it. If a property
+could contain user content, that is a bug.
+
+## Propose instrumentation when adding a frontend action
+
+When adding a meaningful user action to `web/**`, decide explicitly whether it
+should emit an event — do not skip the question silently.
+
+- **Meaningful:** a new feature surface, a funnel step (open → configure →
+  submit), an adoption signal the team would act on, a mode/view switch that
+  segments behavior.
+- **Not meaningful:** styling, refactors, hover states, programmatic state
+  changes, anything autocapture-grade. Capture the critical path, not
+  everything — event bloat is an anti-pattern.
+- If meaningful: write a one-line tracking plan (question → event → props →
+  key dimension) and include it in the plan or PR description. If deliberately
+  not instrumenting, say so in one sentence.
+
+## The Langfuse pattern (match it exactly)
+
+- **Hook:** `usePostHogClientCapture()` → `capture(eventName, props?)`
+  ([`usePostHogClientCapture.ts`](../../../web/src/features/posthog-analytics/usePostHogClientCapture.ts)).
+  The component calls the hook's `capture` — it never imports or touches
+  `posthog` directly. The only client-side exceptions are app-shell
+  infrastructure in `_app.tsx` (`$pageview`, `identify`, `register`).
+- **Names = `resource:action`, snake_case action.** Enforced by the typed
+  registry — the `events` object + `EventName` type in that file. **New events
+  MUST be added to the registry or they will not typecheck** (e.g.
+  `saved_views:view_selected`, `table:filter_builder_open`). Names are static
+  strings only — never interpolate (a `page_view_${name}` explodes into
+  un-analyzable definitions). Event names cannot be renamed after they exist —
+  version instead (`…_v2`).
+- **Props: camelCase, metadata-only.** IDs of enums / counts / booleans /
+  lengths — never content. Property naming: `objectAdjective` (`filterType`,
+  `valueCount`), `is`/`has` prefix for booleans (`isV4`, `hasFreeText`),
+  `Date`/`Timestamp` suffix for times.
+- **Global dimensions** ride as a **super property** registered once in
+  [`_app.tsx`](../../../web/src/pages/_app.tsx) (e.g. `v4BetaEnabled` via
+  `posthog.register`, removed on sign-out via `posthog.unregister`) so they
+  attach to every event. Also put a per-event copy on events where the value
+  at the moment of the action matters (Rule 4). For org/project-level
+  segmentation, PostHog group analytics is the documented mechanism — see
+  [references/posthog-code-patterns.md](references/posthog-code-patterns.md) §4.
+- **Server-side events are separate.** A few server paths capture via
+  `ServerPosthog` (e.g. `cloud_signup_complete`, playground analytics) with
+  event names distinct from any frontend event — keep it that way; reusing a
+  name across client and server double-counts.
+
+## The 6 rules (each earned the hard way on LFE-10781 / PR #14929)
+
+1. **PRIVACY is rule #1 — metadata only, never raw values.** Safe: `type`,
+   `column`, `operator`, `key` (a field _name_, not a value), counts
+   (`valueCount`, `conditionCount`), lengths (`queryLength` = char count, NOT
+   the text), enums (`trigger`, `reason`), `tableName`, booleans. **Never:**
+   the raw filter `value`, search text, the AI prompt, userId/sessionId,
+   metadata content, tag names.
+   ⚠ _Real leak:_ `table:filter_builder_close` sent `{ filter: filterState }`
+   — the whole filter including values → PII in PostHog. Fixed to
+   `{ filterCount }` in #14929. **Grep any event you touch for a raw value.**
+   💡 _How PostHog itself keeps PII out_ (see
+   [references/posthog-code-patterns.md](references/posthog-code-patterns.md) §2):
+   not SDK denylists — the **payload only accepts metadata**. Encode
+   "counts/lengths/booleans/enums only" into parameter **types** (raw content
+   → a type error) and shared `sanitize*()` helpers for complex objects.
+   Reserve a client-side `before_send` hook for _last-mile secrets_ (tokens in
+   URLs/share links) and for disabling capture on publicly-embedded views —
+   a backstop, not the primary defense.
+
+2. **Instrument the INTENT seam, not the low-level setter.** Capture in the
+   per-action function the user triggered (`updateFilter`, `updateOperator`,
+   `commit`), NOT the shared state setter (`setFilterState`) — the setter also
+   fires on programmatic restores (saved views, URL nav, defaults) →
+   double-count / phantom events. Find the function that maps 1:1 to "the user
+   did X".
+
+3. **Fire once per action — dedup.** Guard no-op triggers (a blur with no
+   change must NOT emit). When one emitting handler nests another (e.g. an
+   operator toggle that internally calls updateFilter), use a suppress-ref so
+   it emits once. Beware stale refs in external-sync effects that commit via
+   the raw setter and leave a baseline count stale → the next edit mis-fires.
+
+4. **Carry the key segmentation DIMENSION on every event — and make sure it is
+   actually populated.** For Langfuse the headline dimension is **v3 vs v4
+   (fast mode)** — filtering (and much else) behaves very differently across
+   them. Put `isV4` on every relevant event, derived from the surface **at the
+   moment of the action** (v4 events table / grammar search bar → true;
+   v3/legacy → false; shared components → from the table/view context).
+   ⚠ _Real P1:_ a component-level `isV4`/`tableName` prop that defaults to
+   `"unknown"`/`false` is worthless if callers do not forward it — **forward
+   it from EVERY call site and verify the emitted event carries the real
+   value, not the default.** The super property is a global backstop, not the
+   only source.
+
+5. **Cover every sub-path of a surface.** A "filter applied" event that only
+   fires for some facet kinds is a silent hole. ⚠ _Real gap:_ keyed-facet
+   handlers (metadata / scores) called the setter directly and emitted nothing
+   — on exactly the surfaces we most wanted data. **Enumerate a surface's
+   actions and confirm each emits.**
+
+6. **VERIFY LIVE — intercept the real capture calls; do not assume.** Spy on
+   `window.posthog.capture` (or the network POST to the PostHog ingest
+   endpoint) with Playwright and assert: (a) the action fires the event
+   **exactly once** (no double-count, no blur-refire); (b) the **key dimension
+   is present and correct** (contrast a v4 surface vs a v3 surface → `isV4`
+   true vs false); (c) **PRIVACY — dump every payload and confirm NO raw value
+   / search text / prompt / id appears.** A green typecheck ≠ correct
+   analytics; the dimension-populated and privacy checks catch the real bugs.
+
+## Workflow
+
+1. **Tracking plan first (tiny).** Write the question(s) → the events + props
+   that answer them → the key dimension. A short table beats scattered
+   `capture()` calls. (This IS the PR description.)
+2. **Register** the events in the `events` object (typed).
+3. **Wire** `capture()` at the intent seams (Rule 2), with dedup (3), the
+   dimension (4), full coverage (5), metadata-only (1).
+4. **Verify live** (6) — once + dimension + privacy.
+5. **PR** with the taxonomy table + an explicit "metadata-only, no raw values"
+   note. Fix any pre-existing leaks you pass.
+
+## Anti-patterns
+
+- Raw values / PII in props (Rule 1).
+- Wrong-seam double-count (Rule 2).
+- A dimension that silently defaults to `"unknown"` (Rule 4).
+- Coverage gaps (Rule 5).
+- Event bloat / events that map to no question.
+- Inconsistent naming — stick to `resource:action` snake_case; do not drift to
+  spaces or rename existing events.
+- Raw `posthog.capture` in a component instead of the typed hook.
+- Trusting a typecheck as verification (Rule 6).
+
+## References
+
+- [references/posthog-best-practices.md](references/posthog-best-practices.md)
+  — PostHog's official doctrine (naming, taxonomy, property scopes, PII,
+  tracking-plan governance), cited to their docs. Read when designing a new
+  taxonomy or debating naming/scope.
+- [references/posthog-code-patterns.md](references/posthog-code-patterns.md)
+  — how PostHog instruments its OWN frontend (central registry module,
+  sanitize-at-call-site PII firewall, super properties + groups, FE-vs-server
+  naming), cited to their product code. Read when hardening the pattern or
+  adding global dimensions.
+- **Worked example:** LFE-10781 / PR #14929 — a filter/search-bar taxonomy,
+  the `isV4` dimension, and three review fixes (unforwarded dimension,
+  coverage gap, stale-ref misfire) are the canonical case study.

--- a/.agents/skills/posthog-instrumentation/references/posthog-best-practices.md
+++ b/.agents/skills/posthog-instrumentation/references/posthog-best-practices.md
@@ -1,0 +1,94 @@
+# PostHog's own instrumentation best practices (from their docs)
+
+Synthesized from PostHog's published docs (repo `PostHog/posthog.com`; repo-relative paths below map to
+`posthog.com/docs/…` URLs). Richest source: `contents/docs/product-analytics/best-practices.mdx`.
+These GROUND the rules in `../SKILL.md`. **Where PostHog and the Langfuse house pattern differ, the SKILL
+wins** (it is Langfuse-specific); everything below is the "why" plus the general doctrine.
+
+## 1. Naming — `category:object_action`, lowercase, snake_case, present-tense verbs
+
+`best-practices.mdx` §3: "use the **category:object_action** framework" → `signup_flow:pricing_page_view`;
+"Only use lowercase letters"; "Use present-tense verbs (submit/create, not submitted/created)"; "Use snake
+case"; keep a **fixed allow-list of verbs** (click/submit/create/view/add/invite/update/delete/remove/
+start/end/cancel/fail/generate/send). Property names: **`object_adjective`** (`user_id`, `item_price`),
+**`is_`/`has_`** for booleans, **`_date`/`_timestamp`** suffix for times.
+→ **Langfuse's `resource:action` snake_case convention is this scheme.** Match the property-naming rules
+too (camelCase variants: `isV4`, `hasFreeText`).
+_(Caveat: PostHog's own docs are inconsistent — `getting-started/send-events.mdx` shows space-separated
+`user signed up`; the snake_case best-practices scheme is the canonical one. Standardize on snake_case.)_
+
+## 2. Static names only — no interpolation
+
+`best-practices.mdx` §6: names must be **fixed strings, never generated dynamically** —
+`page_viewed_${pageName}` explodes into thousands of undefilterable definitions (and can get property
+definitions rate-limited). → **Langfuse's typed `events` registry enforces this by construction.**
+Variable data goes in property _values_, never the name. §5: version instead of renaming
+(`registration_v2:…`) — **event names cannot be changed after creation.**
+
+## 3. Capture the critical path, not everything
+
+`getting-hogpilled.mdx`: define a **North Star metric → metrics tree → funnel**, then "capture just enough
+event data to measure the critical path… add more later." `best-practices.mdx` §1: instrument **growth
+events first** (autocapture alone misses a reliable `user_signed_up`). → Anti-bloat: every event answers a
+question (the SKILL's "one idea"). `activation.mdx`: activation events can be composite / a quantity.
+
+## 4. Autocapture + explicit custom events
+
+`getting-started/send-events.mdx`: start with autocapture for coverage, **add custom events for
+high-value, stable actions** (sign-ups, purchases, feature use) — custom is "far more reliable" since
+autocapture drifts when button text/DOM changes; tune autocapture if noisy. `autocapture.mdx`:
+interaction/navigation/clipboard/heatmap/dead-click types + per-SDK support. → Langfuse instrumentation is
+deliberately **custom events** (the actions are semantic, not DOM-stable).
+
+## 5. Property scopes — event / person / super
+
+`libraries/js/usage.mdx` (Super properties): `posthog.register(...)` sets props **auto-attached to every
+subsequent `capture`** (NOT a person/group prop) — `register_once` for first-touch, `unregister` to
+remove. This is **the documented "global dimension on every event" mechanism** → validates Langfuse's
+`v4BetaEnabled` super property in `web/src/pages/_app.tsx`. `person-properties.mdx`: `$set`/`$set_once` on
+the profile (cohorts/flags); 512KB/person; `$set` = last _ingested_ value (ordering caveat).
+`send-events.mdx`: "always include more properties than you might need." Group properties = a 4th (B2B)
+scope.
+
+## 6. PII / privacy — layered, consent-first
+
+`privacy/gdpr-compliance.mdx`: "don't collect, store or use any personal data without a good reason."
+Layered controls: EU hosting → IP toggle → autocapture masking (only `name`/`id`/`class` on inputs; **no
+form values**; skips password fields) → `ph-no-capture` class → **client-side `before_send` sanitization
+(can `return null` to drop an event)** → before-storage transformations (hash PII, anonymize IP, drop
+events) → opt-out. `libraries/js/config.mdx`: **`property_denylist`** = "properties that should never be
+sent with `capture`"; `mask_all_text`; `before_send`. (`sanitize_properties` is not a separate option —
+it is done via `before_send`.)
+→ **Actionable for Langfuse:** beyond "reviewers must be careful," a **client-side backstop** is
+available — a `property_denylist` for obviously-sensitive keys and/or a `before_send` that strips/asserts
+no `value`/content field on filter/search events. That would have caught the `filter_builder_close`
+raw-value leak at the SDK layer. Defense-in-depth, not a replacement for SKILL Rule 1 (and see
+`posthog-code-patterns.md` §2 for why types-at-the-call-site is the primary mechanism).
+
+## 7. Avoid double-counting + `distinct_id` hygiene
+
+`send-events.mdx`: "use different event names for your backend and frontend events to avoid duplicate
+counting" (`user created` backend vs `user signed up` frontend). `data/events.mdx`: dedup =
+`uuid`+`event`+`timestamp`+`distinct_id`. `best-practices.mdx` §4: don't use catch-all `distinct_id`s
+(`"system"`), keep casing consistent, link anon↔identified. §7-8: prefer backend for accuracy; events can
+arrive out of order. → Langfuse's client double-count risk is the wrong-seam one (SKILL Rule 2); server
+events already use distinct names (`cloud_signup_complete`) — keep it that way.
+
+## 8. Plan + govern — tracking plan, schema management, event states
+
+`getting-hogpilled.mdx` + `next-steps.mdx`: **write a tracking plan up front** (North Star → events).
+`schema-management.mdx`: define events/typed property groups before capture, `posthog-cli exp schema pull`
+generates typed clients, commit `posthog.json`; "Define events upfront", "Start with your most important
+events". `data/events.mdx`: Data Management page — descriptions, tags, owners, **Verified / Hidden**
+states (Hidden = soft-retire an old event). → Validates the SKILL's "tracking-plan-first" workflow; the
+typed `events` registry is Langfuse's lightweight equivalent of schema management.
+
+## Sources (repo-relative in `PostHog/posthog.com`; → posthog.com/docs/…)
+
+`contents/docs/product-analytics/best-practices.mdx` · `contents/docs/new-to-posthog/getting-hogpilled.mdx`
+· `contents/docs/getting-started/send-events.mdx` · `contents/docs/product-analytics/autocapture.mdx` ·
+`contents/docs/libraries/js/usage.mdx` · `contents/docs/product-analytics/person-properties.mdx` ·
+`contents/docs/privacy/{gdpr-compliance,data-collection,data-storage}.mdx` ·
+`contents/docs/product-analytics/privacy.mdx` · `contents/docs/libraries/js/config.mdx` ·
+`contents/docs/product-analytics/schema-management.mdx` · `contents/docs/data/events.mdx` ·
+`contents/docs/new-to-posthog/activation.mdx`.

--- a/.agents/skills/posthog-instrumentation/references/posthog-code-patterns.md
+++ b/.agents/skills/posthog-instrumentation/references/posthog-code-patterns.md
@@ -1,0 +1,113 @@
+# How PostHog instruments its OWN frontend (from their product code)
+
+Real code patterns from the PostHog product monorepo (`PostHog/posthog`, React + Kea,
+`frontend/src/`). Complements the docs (`posthog-best-practices.md`). Where PostHog's _practice_ beats
+its _docs_, the practice wins.
+
+## 1. ONE module owns every event — `eventUsageLogic`
+
+`frontend/src/lib/utils/eventUsageLogic.ts` — a single Kea logic with **267 `posthog.capture(` calls**
+(the next-densest file has 17). Two-part shape: `actions({ reportX: (…) => payload })` **types every
+event**; `listeners({ reportX })` is the _only_ place that calls `posthog.capture(name, props)`. A
+component calls `reportInsightViewed(...)` — it **never names the event string or touches `posthog`**.
+~165 consumers via `useActions(eventUsageLogic)`. A few domain satellites follow the same shape
+(onboarding/session-recording event logics). → **Langfuse's typed `usePostHogClientCapture` registry is
+the same instinct.** The borrow is _discipline_: every event string + property shape in ONE reviewable
+module; forbid raw `posthog.capture` at component call sites (a lint rule is a candidate hardening) so
+nothing leaks the pattern.
+
+## 2. PII firewall = metadata-only payloads + `sanitize*` helpers AT THE CALL SITE — NOT SDK denylists
+
+**Key correction to the docs' framing:** PostHog carries **ZERO** `property_denylist` /
+`sanitize_properties` / `mask_all_text` in its SDK init (`frontend/src/loadPostHogJS.tsx`). Raw content
+never becomes a property because the **action payload only accepts metadata**. Examples from
+`eventUsageLogic.ts`:
+
+- `sanitizeQuery` — "returns properties that don't contain sensitive data": emits `query_kind`,
+  `series_length`, `event_entity_count`, `has_properties` (bool), `display` — never the filter values.
+- `sanitizeInsight` strips `result` before send.
+- `reportPersonDetailViewed` → `properties_count`, `has_email` (bool), `has_name` (bool) — a rich
+  profile with **no property value**.
+- `name_length`/`tags_count`/`searchLength`/`resultsCount` everywhere — counts/lengths, never content.
+- `objectClean(...)` drops undefined before send.
+
+→ **For Langfuse:** encode "counts/lengths/booleans/enums only" into the typed registry's **parameter
+types** so passing raw content is a **type error**; add shared `sanitize*(query|filter|…)` helpers for
+complex objects. This is stronger than a runtime denylist. (Keep `before_send` only for _last-mile
+secrets_ — §6.)
+
+## 3. Naming — Langfuse's `resource:action` snake_case is BETTER; keep it
+
+Empirically PostHog is **inconsistent**: of 781 distinct event names, ~80% are space-separated lowercase
+(`"insight viewed"`, `"viewed dashboard"`), ~19% snake_case (newer areas: `ai_query_prompted`,
+`error_tracking_issues_sorted`), **0 use a colon scheme.** The one thing they get right is
+**resource-first ordering** (grouping by leading word). Names can't be renamed → they froze
+`'viewed dashboard'` for back-compat. → **Langfuse's `resource:action` snake_case delivers
+resource-grouping explicitly and machine-parseably. Don't drift to spaces. Version instead of rename
+(`…_v2`).**
+
+## 4. Global dimensions once via super properties + GROUPS (not per-event)
+
+Stamped at login/preflight, not on every capture:
+
+- `frontend/src/scenes/userLogic.ts`: `posthog.register({ is_demo_project })` (super prop) +
+  `posthog.group('project', uuid, {...})` + `posthog.group('organization', id, {...})` +
+  `posthog.group('customer', …)`; person props via `posthog.people.set({ email: anonymize?null:email,
+realm })`.
+- `frontend/src/scenes/PreflightCheck/preflightLogic.tsx`: `posthog.register({ realm, commit_sha, … })`
+  — **`commit_sha` on every event.**
+- `frontend/src/scenes/billing/billingLogic.tsx`: dynamic per-product usage super-props.
+- `frontend/src/taxonomy/taxonomy.tsx` `CLOUD_INTERNAL_POSTHOG_PROPERTY_KEYS` — a catalog of the
+  internal dimensions.
+
+→ **For Langfuse (multi-tenant org→project):** group analytics
+(`posthog.group('organization'|'project', …)`) + `register` version/edition/`v4BetaEnabled` **once** is
+the scalable shape, instead of repeating global dims per event. Keep a catalog. NOTE: `isV4`/fast-mode
+is _per-action surface state_ → it stays a **per-event** prop (the user-global v4-beta flag can also be
+a super prop, but the per-event value reflects the surface at the action).
+
+## 5. Distinct names prevent double-counting; split FE vs server by context
+
+From `products/notebooks/plan/notebooks_observability_gaps.md` (an internal instrumentation-design
+review — the closest thing PostHog has to a playbook): server-side capture at the creation **choke
+point** = source of truth for counts; **distinct event names structurally prevent double-counting**
+("rename the frontend capture to `notebook created (client)`"); keep the FE event for context the
+server can't see (`$session_id` replay linkage, `$current_url` surface attribution, flag enrollment,
+funnel continuity); a stable id (`short_id`) as idempotency key. → Langfuse already keeps server events
+(`ServerPosthog`: `cloud_signup_complete`, playground analytics, telemetry) on distinct names — never
+reuse an event name across FE and server.
+
+## 6. `before_send` + replay opt-out for last-mile secrets; kill tracking on embedded/shared views
+
+`frontend/src/loadPostHogJS.tsx` exposes a `before_send` hook; `frontend/src/exporter/index.tsx` sets
+`apiKey=undefined` on shared/embedded dashboards (**don't log customers' end-users**) and, on the public
+interview page, a `before_send` strips a secret token from `$current_url`/`$referrer` + a
+`maskCapturedNetworkRequestFn` scrubs it from replay. Replay opt-out via
+`session_recording.blockSelector: '.ph-replay-block'`; staff impersonation →
+`opt_out_capturing_by_default`. → **For Langfuse:** `before_send` is for _secrets that shouldn't be
+captured even in principle_ (tokens in URLs/share links) + disabling capture on publicly-embeddable
+views (e.g. public traces) — NOT the primary PII mechanism (that's §2).
+
+## 7. Ergonomic seam
+
+Component → `const { reportX } = useActions(eventUsageLogic)` → call `reportX(...)` in the handler.
+**No `posthog-js/react` `usePostHog()` hook is used in their app** (raw `posthog-js` singleton wrapped
+in Kea). Direct `posthog.capture` in a `.tsx` exists only for lib-level infra widgets (Spinner,
+toolbar). → Langfuse's `usePostHogClientCapture()` hook is the equivalent seam (Langfuse isn't Kea) —
+the rule is the same: **the component calls a typed verb; it never names the event or touches
+`posthog`.**
+
+## 8. Notable: PostHog has NO dedicated "how to add events" doc
+
+Guidance is scattered (`.cursor/rules/react-typescript.mdc` forces the Kea-first "events are data"
+pattern; their `AGENTS.md` has a naming casing rule + a Celery capture gotcha). → **A dedicated Langfuse
+instrumentation skill is MORE disciplined than PostHog's own setup** — a genuine improvement, not just a
+copy.
+
+## Cite (repo-relative in `PostHog/posthog`)
+
+`frontend/src/lib/utils/eventUsageLogic.ts` · `frontend/src/loadPostHogJS.tsx` ·
+`frontend/src/exporter/index.tsx` ·
+`frontend/src/scenes/{userLogic.ts,PreflightCheck/preflightLogic.tsx,billing/billingLogic.tsx}` ·
+`frontend/src/taxonomy/taxonomy.tsx` · `.cursor/rules/react-typescript.mdc` ·
+`products/notebooks/plan/notebooks_observability_gaps.md`.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -68,12 +68,16 @@ Use root [AGENTS.md](../AGENTS.md) for monorepo-level rules.
   [`web/.agents/skills/vercel-composition-patterns/SKILL.md`](.agents/skills/vercel-composition-patterns/SKILL.md)
 - React/Next.js performance and rendering best practices:
   [`web/.agents/skills/vercel-react-best-practices/SKILL.md`](.agents/skills/vercel-react-best-practices/SKILL.md)
+- PostHog product analytics — when and how to instrument user actions:
+  [`../.agents/skills/posthog-instrumentation/SKILL.md`](../.agents/skills/posthog-instrumentation/SKILL.md)
 
 Read these package-local skills before substantial frontend refactors when the
 task involves component composition, reusable component APIs, rendering
 performance, virtualized lists, local feature stores, bundle size,
 React/Next.js performance patterns, or browser-based signoff of user-visible
-changes.
+changes. When adding a meaningful user action (button, handler, form,
+mutation, feature surface), read the PostHog instrumentation skill and decide
+explicitly whether the action should emit an analytics event.
 
 ## Web Conventions
 
@@ -206,7 +210,10 @@ changes.
 1. Prefer `src/features/<feature>/*` for feature-local code.
 2. Put broadly reusable components in `src/components/*`.
 3. Keep server logic near feature server folders when possible.
-4. Review the affected user flow in a real browser with the Playwright MCP
+4. For meaningful user actions (buttons, form submits, mode switches), decide
+   explicitly whether to instrument them with PostHog. Use
+   `../.agents/skills/posthog-instrumentation/SKILL.md`.
+5. Review the affected user flow in a real browser with the Playwright MCP
    server before signoff. Use
    `../.agents/skills/frontend-browser-review/SKILL.md`.
 


### PR DESCRIPTION
## TL;DR

Adds a repo-owned agent skill, `.agents/skills/posthog-instrumentation`, that does two things: it **proposes itself whenever an agent adds a meaningful user action to the frontend** (button, handler, form, mutation, new surface), and it **teaches exactly how to instrument Langfuse with PostHog** — the typed registry pattern, naming, privacy rules, and live verification. Follow-up instrumentation work (LFE-10786) builds on it.

## Why

PR #14929 (LFE-10781, filter/search-bar instrumentation) surfaced a set of hard-won lessons — a real PII leak (`filter_builder_close` sending the whole filter state), a segmentation dimension that silently defaulted to `"unknown"`, coverage gaps on exactly the surfaces we most wanted data from, and double-fire seams. None of that knowledge lived anywhere an agent (or new contributor) would find it before writing the next `capture()` call.

## What

- **`SKILL.md`** — the how-to: a "should this action be instrumented?" decision step, the Langfuse pattern (typed `usePostHogClientCapture` registry, `resource:action` snake_case, metadata-only camelCase props, `v4BetaEnabled` super property, distinct server-side names), six rules distilled from #14929 (privacy first · intent seam · fire once · carry + verify the key dimension · cover every sub-path · verify live by intercepting real `capture()` calls), a workflow, and anti-patterns.
- **`references/posthog-best-practices.md`** — PostHog's own published doctrine (naming framework, static names, critical-path capture, property scopes, layered PII controls, tracking-plan governance), cited to their docs.
- **`references/posthog-code-patterns.md`** — how PostHog instruments its *own* frontend (one registry module owning all events, sanitize-at-call-site PII firewall instead of SDK denylists, super properties + group analytics, distinct FE/server event names), cited to their product code.
- **`web/AGENTS.md`** — surfaces the skill in Package-Local Skills and adds an instrumentation-decision step to the add-frontend-feature playbook, so agents that discover guidance via AGENTS.md (not skill descriptions) hit it too.

## Result

Adding a frontend action now comes with a built-in nudge to make an explicit instrument-or-not decision, and instrumentation PRs get a single canonical playbook that would have prevented every finding on #14929.

<details>
<summary>Mechanics + verification</summary>

- Skill lives at the canonical `.agents/skills/` location; `pnpm run agents:sync` projects it into `.claude/skills/` (gitignored symlink), verified with `pnpm run agents:check` — both pass.
- Self-proposing is description-driven (the skill description carries the frontend-action triggers), same mechanism as sibling skills; no hook added — description-first, per the shared agent-setup model.
- The description trigger was validated in-session: after sync, the harness surfaced the skill automatically.
- Claims grounded against the current codebase: 118 files consume `usePostHogClientCapture`; client-side raw `posthog.capture` exists only in `_app.tsx` app-shell infra; server-side captures (`ServerPosthog`) already use distinct event names.
- Pre-commit verification: `prettier --check` clean, `turbo run lint` — `Tasks: 8 successful, 8 total`.
- Docs-only change (markdown + AGENTS.md); no runtime code touched, so no browser/test verification applies.

</details>

Related: LFE-10781 / #14929 (the seed lessons) · LFE-10786 (first consumer of this skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a repo-owned agent skill (`posthog-instrumentation`) under `.agents/skills/` that teaches agents when and how to instrument Langfuse actions with PostHog, and updates `web/AGENTS.md` to surface it at frontend-feature authoring time. No runtime code is changed.

- **`SKILL.md`** establishes a six-rule instrumentation playbook (privacy-first, intent seam, fire-once, segmentation dimension, full coverage, live verification) with Langfuse-specific patterns drawn from PR #14929 lessons.
- **`references/posthog-best-practices.md` and `references/posthog-code-patterns.md`** ground the rules in PostHog's published docs and their own product code, respectively.
- **`web/AGENTS.md`** adds a step-4 analytics decision gate to the add-frontend-feature workflow and lists the skill in Package-Local Skills so agents discover it before writing any meaningful user action.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change adding an agent skill and an AGENTS.md update; no runtime code touched.

All four changed files are Markdown. The skill content is accurate — event name examples were verified against the live usePostHogClientCapture.ts registry, relative paths resolve correctly from their locations, and the guidance faithfully reflects lessons from PR #14929. The web/AGENTS.md edits insert a new step 4 and renumber correctly. No functional risk.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent adds frontend action\nin web/**] --> B{Is it a meaningful\nuser action?}
    B -- "button / handler / form\nmutation / feature surface" --> C[Read posthog-instrumentation\nSKILL.md]
    B -- "styling / refactor\nhover / programmatic" --> Z[Skip — not meaningful]
    C --> D{Should this action\nbe instrumented?}
    D -- Yes --> E[Write tracking plan\nquestion → event → props → dimension]
    D -- No --> F[Document decision\nin PR description]
    E --> G[Register event in\nusePostHogClientCapture registry]
    G --> H[Wire capture at intent seam\nRule 2: not the setter]
    H --> I[Add isV4 + key dimension\nRule 4: fully populated]
    I --> J[Verify privacy\nRule 1: metadata only, no raw values]
    J --> K[Verify live\nRule 6: intercept real capture calls]
    K --> L[PR with taxonomy table\n+ metadata-only note]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Agent adds frontend action\nin web/**] --> B{Is it a meaningful\nuser action?}
    B -- "button / handler / form\nmutation / feature surface" --> C[Read posthog-instrumentation\nSKILL.md]
    B -- "styling / refactor\nhover / programmatic" --> Z[Skip — not meaningful]
    C --> D{Should this action\nbe instrumented?}
    D -- Yes --> E[Write tracking plan\nquestion → event → props → dimension]
    D -- No --> F[Document decision\nin PR description]
    E --> G[Register event in\nusePostHogClientCapture registry]
    G --> H[Wire capture at intent seam\nRule 2: not the setter]
    H --> I[Add isV4 + key dimension\nRule 4: fully populated]
    I --> J[Verify privacy\nRule 1: metadata only, no raw values]
    J --> K[Verify live\nRule 6: intercept real capture calls]
    K --> L[PR with taxonomy table\n+ metadata-only note]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agents): add posthog-instrumentatio..."](https://github.com/langfuse/langfuse/commit/07c65102dcd03f5522453db353ef192f40b74041) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42997804)</sub>

<!-- /greptile_comment -->