### PR TITLE
fix(web): keep date-range filter when tables use external filter state

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/src/features/filters/config/observations-config";
 import { DEFAULT_SIDEBAR_IMPLICIT_ENVIRONMENT_CONFIG } from "@/src/features/filters/constants/internal-environments";
 import { transformFiltersForBackend } from "@/src/features/filters/lib/filter-transform";
+import { resolveTableFilterState } from "@/src/components/table/utils/resolveTableFilterState";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import {
@@ -535,8 +536,11 @@ export default function ObservationsTable({
     modelIdFilter,
   );
 
-  // Use external filter state if provided, otherwise use combined filter state
-  const filterState = externalFilterState || combinedFilterState;
+  const filterState = resolveTableFilterState({
+    externalFilterState,
+    dateRangeFilter,
+    combinedFilterState,
+  });
 
   const backendFilterState = transformFiltersForBackend(
     filterState,

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -55,6 +55,7 @@ import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
 import { type ScoreAggregate } from "@langfuse/shared";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
+import { resolveTableFilterState } from "@/src/components/table/utils/resolveTableFilterState";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
 import { BreakdownTooltip } from "@/src/components/trace/components/_shared/BreakdownToolTip";
@@ -395,8 +396,11 @@ export default function TracesTable({
     dateRangeFilter,
   );
 
-  // Use external filter state if provided, otherwise use combined filter state
-  const filterState = externalFilterState || combinedFilterState;
+  const filterState = resolveTableFilterState({
+    externalFilterState,
+    dateRangeFilter,
+    combinedFilterState,
+  });
 
   const [paginationState, setPaginationState] = usePaginationState(0, 50, {
     page: "pageIndex",

--- a/web/src/components/table/utils/resolveTableFilterState.clienttest.ts
+++ b/web/src/components/table/utils/resolveTableFilterState.clienttest.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { type FilterState } from "@langfuse/shared";
+import { resolveTableFilterState } from "./resolveTableFilterState";
+
+const dateRangeFilter: FilterState = [
+  {
+    column: "startTime",
+    type: "datetime",
+    operator: ">=",
+    value: new Date("2026-07-08T00:00:00.000Z"),
+  },
+];
+
+const externalFilterState: FilterState = [
+  {
+    column: "type",
+    type: "stringOptions",
+    operator: "any of",
+    value: ["GENERATION"],
+  },
+];
+
+const combinedFilterState: FilterState = [
+  {
+    column: "name",
+    type: "string",
+    operator: "=",
+    value: "my-observation",
+  },
+  ...dateRangeFilter,
+];
+
+describe("resolveTableFilterState", () => {
+  it("keeps the date-range filter when external filters are provided", () => {
+    // Regression: external filters (eval preview) used to replace the whole
+    // combined filter state including the date range, producing unbounded
+    // full-history ClickHouse queries.
+    const result = resolveTableFilterState({
+      externalFilterState,
+      dateRangeFilter,
+      combinedFilterState,
+    });
+
+    expect(result).toEqual([...externalFilterState, ...dateRangeFilter]);
+  });
+
+  it("keeps external filters with an empty date-range filter", () => {
+    const result = resolveTableFilterState({
+      externalFilterState,
+      dateRangeFilter: [],
+      combinedFilterState,
+    });
+
+    expect(result).toEqual(externalFilterState);
+  });
+
+  it("returns the combined filter state when no external filters are provided", () => {
+    const result = resolveTableFilterState({
+      externalFilterState: undefined,
+      dateRangeFilter,
+      combinedFilterState,
+    });
+
+    expect(result).toEqual(combinedFilterState);
+  });
+});

--- a/web/src/components/table/utils/resolveTableFilterState.ts
+++ b/web/src/components/table/utils/resolveTableFilterState.ts
@@ -1,0 +1,24 @@
+import { type FilterState } from "@langfuse/shared";
+
+/**
+ * Resolves the effective filter state for tables that can be controlled
+ * externally (e.g. the eval preview tables pass `externalFilterState` plus
+ * `externalDateRange`). External filters replace the user-managed table
+ * filters, but the active date-range filter must still apply: dropping it
+ * makes the backend query unbounded over the project's full history, which
+ * can exhaust ClickHouse memory (MEMORY_LIMIT_EXCEEDED in
+ * MergingSortedTransform) on large projects.
+ */
+export function resolveTableFilterState({
+  externalFilterState,
+  dateRangeFilter,
+  combinedFilterState,
+}: {
+  externalFilterState?: FilterState;
+  dateRangeFilter: FilterState;
+  combinedFilterState: FilterState;
+}): FilterState {
+  return externalFilterState
+    ? externalFilterState.concat(dateRangeFilter)
+    : combinedFilterState;
+}

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -5,6 +5,7 @@ import {
   DataTableControls,
 } from "@/src/components/table/data-table-controls";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
+import { resolveTableFilterState } from "@/src/components/table/utils/resolveTableFilterState";
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
@@ -605,8 +606,11 @@ export default function ObservationsEventsTable({
     .concat(userIdFilter)
     .concat(sessionIdFilter);
 
-  // Use external filter state if provided, otherwise use combined filter state
-  const filterState = externalFilterState || combinedFilterState;
+  const filterState = resolveTableFilterState({
+    externalFilterState,
+    dateRangeFilter,
+    combinedFilterState,
+  });
 
   // Use the custom hook for observations data fetching
   const {


### PR DESCRIPTION
## What does this PR do?
Fixes #14946

The evaluator setup preview ("Sample over the last 24 hours that match filters")
was running **unbounded** ClickHouse queries over a project's entire observation
and trace history, which can exhaust ClickHouse memory on large self-hosted
projects:

Code: 241. (total) memory limit exceeded: would use 15.41 GiB ...
While executing MergingSortedTransform. (MEMORY_LIMIT_EXCEEDED)
(comment: {"operation_name":"getObservationsTableInternal"})

**Root cause.** `ObservationsTable`, `TracesTable` and the v4 `EventsTable` all did:

    const filterState = externalFilterState || combinedFilterState;

When the eval preview passes `externalFilterState`, this replaces the whole
combined state — including the 24h `dateRangeFilter`, which only lives inside
`combinedFilterState`. So the `externalDateRange={last1Day}` the preview also
passes is dropped, and both `generations.all` and `generations.countAll` scan
and sort the full history.

**Fix.** A small shared `resolveTableFilterState` helper merges the active
date-range filter into external filters instead of replacing it. All three
tables use it, so the preview queries stay bounded to the selected window.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Evidence

Measured on a local seed project with 70,854 GENERATION observations, running the
exact pre-fix vs post-fix query shapes and reading `system.query_log`:

| Metric | Before (unbounded) | After (24h bounded) | Improvement |
| --- | --- | --- | --- |
| Rows read | 78.98 K | 5.10 K | ~15× fewer |
| Bytes read | 9.81 MiB | 658.61 KiB | ~15× less |
| Peak memory | 22.14 MiB | 386.14 KiB | ~57× less |
| Duration | 21 ms | 3 ms | ~7× faster |

Peak memory scales with rows fed into `MergingSortedTransform` (materialized
`ColumnString`) — precisely the allocation the production OOM failed on, so the
saving grows with project size.

Verified end-to-end in a browser against local Docker: the `generations.all` /
`generations.countAll` payloads now carry `startTime >=` (now − 24h), and the
executed ClickHouse query includes `o.start_time >= ...` in its WHERE clause.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Added a regression test (`resolveTableFilterState.clienttest.ts`) proving the
  date-range filter survives when external filters are present.
- `pnpm run lint` passes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an unbounded ClickHouse query issue in the evaluator preview tables (`ObservationsTable`, `TracesTable`, `EventsTable`). When those tables were rendered with `externalFilterState` (the evaluator's filter criteria), the date-range filter was silently dropped, causing queries to scan the entire project history and trigger `MEMORY_LIMIT_EXCEEDED` on large instances.

- Introduces a `resolveTableFilterState` helper that merges the active `dateRangeFilter` into the external filter state instead of letting it replace the full combined state. All three tables are updated to use it.
- Adds a focused unit test (`resolveTableFilterState.clienttest.ts`) that covers the regression scenario plus edge cases (empty date range, no external filter).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to how date-range filters are merged when external filter state is present, and all callers always supply both externalFilterState and externalDateRange together.

The helper is a pure function with three well-chosen test cases covering the regression and both branches. Verification in the calling files shows dateRangeFilter is always derived from externalDateRange ?? tableDateRange, so appending it to externalFilterState gives exactly the bounded query that was intended.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant EvalForm as inner-evaluator-form
    participant Table as ObservationsTable / TracesTable / EventsTable
    participant Helper as resolveTableFilterState
    participant Backend as ClickHouse (via tRPC)

    EvalForm->>Table: externalFilterState (eval criteria) + externalDateRange (last1Day)
    Table->>Table: "dateRange = externalDateRange ?? tableDateRange"
    Table->>Table: "dateRangeFilter = toStartTimeFilterState(dateRange)"
    Table->>Helper: "resolveTableFilterState({ externalFilterState, dateRangeFilter, combinedFilterState })"
    alt externalFilterState provided
        Helper-->>Table: externalFilterState.concat(dateRangeFilter)
    else no externalFilterState
        Helper-->>Table: combinedFilterState (already includes dateRangeFilter)
    end
    Table->>Backend: "filter = [...externalFilterState, dateRangeFilter]"
    Backend-->>Table: bounded results (last 24 h only)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant EvalForm as inner-evaluator-form
    participant Table as ObservationsTable / TracesTable / EventsTable
    participant Helper as resolveTableFilterState
    participant Backend as ClickHouse (via tRPC)

    EvalForm->>Table: externalFilterState (eval criteria) + externalDateRange (last1Day)
    Table->>Table: "dateRange = externalDateRange ?? tableDateRange"
    Table->>Table: "dateRangeFilter = toStartTimeFilterState(dateRange)"
    Table->>Helper: "resolveTableFilterState({ externalFilterState, dateRangeFilter, combinedFilterState })"
    alt externalFilterState provided
        Helper-->>Table: externalFilterState.concat(dateRangeFilter)
    else no externalFilterState
        Helper-->>Table: combinedFilterState (already includes dateRangeFilter)
    end
    Table->>Backend: "filter = [...externalFilterState, dateRangeFilter]"
    Backend-->>Table: bounded results (last 24 h only)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): keep date-range filter when ta..."](https://github.com/langfuse/langfuse/commit/868719411a4dda1140f8b96b64ba4c6cc0388c29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43018313)</sub>

<!-- /greptile_comment -->