### PR TITLE
fix(agent): Adjust layers so that assistant is rendered above panels

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -129,8 +129,10 @@ explicitly whether the action should emit an analytics event.
   z-index.** The app renders inside `#__next`, isolated into one stacking
   context (`globals.css`), so its z-indexes can't escape; overlays go in layers
   that sit outside it and always win. `LAYER_ORDER` is
-  `["agent", "modal", "popover", "tooltip", "toast"]` — containers declared in
-  `_document.tsx`, ordered by that array (later = on top), carrying NO z-index.
+  `["panel", "agent", "modal", "popover", "tooltip", "toast"]` — containers declared
+  in `_document.tsx`, ordered by that array (later = on top), carrying NO z-index.
+  `panel` is for docked side surfaces like Sheet, Drawer, and the table peek;
+  `modal` is for true blocking Dialog and AlertDialog surfaces.
   **THE RULE (see `src/components/ui/layer.tsx` JSDoc — source of truth): every
   overlay portals through a layer container; never let a Radix/Vaul `*.Portal`
   fall back to `<body>`.** Radix/Vaul primitives route via their `*.Portal`'s

--- a/web/src/components/design-system/OverlayLayers.mdx
+++ b/web/src/components/design-system/OverlayLayers.mdx
@@ -1,6 +1,9 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Design System/Overlay Layers" parameters={{ layout: "fullscreen" }} />
+<Meta
+  title="Design System/Overlay Layers"
+  parameters={{ layout: "fullscreen" }}
+/>
 
 # Overlay Layers
 
@@ -40,23 +43,40 @@ itself an isolated stacking context.
   </thead>
   <tbody>
     <tr>
-      <td><code>agent</code></td>
+      <td>
+        <code>panel</code>
+      </td>
+      <td>
+        <code>Sheet</code>, <code>Drawer</code>, and the table peek
+      </td>
+      <td>
+        docked side surfaces; above the page but below the assistant and true
+        modals
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>agent</code>
+      </td>
       <td>the in-app assistant window</td>
       <td>
-        persistent and draggable; floats above the page but below every
-        transient overlay
+        persistent and draggable; floats above app panels but below every true
+        modal/transient overlay
       </td>
     </tr>
     <tr>
-      <td><code>modal</code></td>
       <td>
-        <code>Dialog</code>, <code>AlertDialog</code>, <code>Sheet</code>{" "}
-        including the table peek, <code>Drawer</code>
+        <code>modal</code>
       </td>
-      <td>blocking surfaces, above the page and the assistant</td>
+      <td>
+        <code>Dialog</code> and <code>AlertDialog</code>
+      </td>
+      <td>true blocking surfaces, above app panels and the assistant</td>
     </tr>
     <tr>
-      <td><code>popover</code></td>
+      <td>
+        <code>popover</code>
+      </td>
       <td>
         <code>Popover</code>, <code>DropdownMenu</code>, <code>Select</code>,{" "}
         <code>HoverCard</code>
@@ -67,12 +87,18 @@ itself an isolated stacking context.
       </td>
     </tr>
     <tr>
-      <td><code>tooltip</code></td>
-      <td><code>Tooltip</code> and bespoke anchored tooltips</td>
+      <td>
+        <code>tooltip</code>
+      </td>
+      <td>
+        <code>Tooltip</code> and bespoke anchored tooltips
+      </td>
       <td>hints stay above their trigger, even inside a modal</td>
     </tr>
     <tr>
-      <td><code>toast</code></td>
+      <td>
+        <code>toast</code>
+      </td>
       <td>Sonner toasts</td>
       <td>last, so they always sit above everything by order alone</td>
     </tr>

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -161,9 +161,9 @@ export const InAppAiAgentButton = () => {
         >
           {(deleteConversationDialog) => (
             // The assistant window lives in the `agent` overlay layer — a
-            // <body>-level layer container that floats above page content but below
-            // every transient overlay (dropdowns, dialogs, popovers, tooltips,
-            // toasts) by DOM order alone. No z-index: layer ORDER stacks it (see
+            // <body>-level layer container that floats above page content and
+            // panel surfaces, but below true modals and transient overlays by DOM
+            // order alone. No z-index: layer ORDER stacks it (see
             // components/ui/layer.tsx). This replaces the old body portal + z-51,
             // which fought the nav-user dropdown's z-60 at <body> level.
             <Layer name="agent">

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -110,12 +110,12 @@ Drawer.displayName = "Drawer";
 
 const DrawerTrigger = DrawerPrimitive.Trigger;
 
-// Route the Vaul portal into the `modal` overlay layer (null until mounted →
+// Route the Vaul portal into the `panel` overlay layer (null until mounted →
 // falls back to <body>, SSR-parity). Layer order, not z-index, stacks it.
 const DrawerPortal = ({
   ...props
 }: React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Portal>) => {
-  const container = useLayerContainer("modal");
+  const container = useLayerContainer("panel");
   return <DrawerPrimitive.Portal container={container} {...props} />;
 };
 DrawerPortal.displayName = "DrawerPortal";

--- a/web/src/components/ui/layer.tsx
+++ b/web/src/components/ui/layer.tsx
@@ -25,12 +25,14 @@ import { createPortal } from "react-dom";
  * `@repo/no-overlay-zindex` lint rule guards the z-index half of this.
  *
  * The bands, low → high:
+ * - `panel`   — docked/side surfaces like Sheet, Drawer, and the table peek.
+ *   Above `#__next`, below the in-app assistant and true blocking modals.
  * - `agent`   — the in-app assistant window: a persistent, draggable/resizable
- *   panel that floats above page content but BELOW every transient overlay, so
- *   dropdowns, dialogs, popovers, tooltips and toasts (incl. ones opened from
- *   inside the window itself, e.g. its conversation-history menu) all paint
- *   above it. First (lowest) overlay rung — above `#__next`, below the rest.
- * - `modal`   — Dialog, AlertDialog, Sheet (incl. the table peek), Drawer.
+ *   panel that floats above page content and app panels but BELOW every true
+ *   modal/transient overlay, so dialogs, dropdowns, popovers, tooltips and
+ *   toasts (incl. ones opened from inside the window itself, e.g. its
+ *   conversation-history menu) all paint above it.
+ * - `modal`   — true blocking Dialog and AlertDialog surfaces.
  * - `popover` — Popover, DropdownMenu, Select, HoverCard. ABOVE `modal` so a
  *   Select/Popover/Dropdown opened *inside* a Dialog renders above it (matches
  *   the old "newest-opened wins" z-50 behaviour; the common in-form case).
@@ -39,6 +41,7 @@ import { createPortal } from "react-dom";
  *   (incl. a non-modal peek) by DOM order alone — no z-index needed.
  */
 export const LAYER_ORDER = [
+  "panel",
   "agent",
   "modal",
   "popover",

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -14,14 +14,15 @@ const SheetTrigger = SheetPrimitive.Trigger;
 
 const SheetClose = SheetPrimitive.Close;
 
-// Route the portal into the `modal` overlay layer (null until mounted →
+// Route the portal into the `panel` overlay layer (null until mounted →
 // falls back to <body>, SSR-parity). Layer order, not z-index, stacks it.
-// The non-modal table peek (modal={false}) portals here too; the `toast`
-// layer is ordered after `modal`, so toasts paint above the peek by DOM order.
+// The non-modal table peek (modal={false}) portals here too; the `agent`,
+// `modal`, and `toast` layers are ordered after `panel`, so they paint above
+// panel surfaces by DOM order.
 const SheetPortal = ({
   ...props
 }: React.ComponentPropsWithoutRef<typeof SheetPrimitive.Portal>) => {
-  const container = useLayerContainer("modal");
+  const container = useLayerContainer("panel");
   return <SheetPrimitive.Portal container={container} {...props} />;
 };
 SheetPortal.displayName = "SheetPortal";

--- a/web/src/features/search-bar/README.md
+++ b/web/src/features/search-bar/README.md
@@ -471,31 +471,6 @@ unused planners).
     operators, or leave it. Entangled with `tidyQueryText`/chip-removal (which
     strips redundant parens and would bail on a now-"invalid" paren) and
     removes documented top-level grouping — needs its own pass.
-- **Layer system**: the bar's in-flow overlays use a hardcoded local ladder (X
-  z-20 < autocomplete popover z-50, both drop into the table below the bar).
-  These are genuinely local — they live inside the app's isolated `#__next`
-  stacking context, can't escape it, and never need to beat a body-level
-  overlay, so their z-index is fine. The **error tooltip is the exception**:
-  when the popover is open it flips ABOVE the bar, into the page header's band,
-  where no in-flow z-index can win — `#page > main` is `overflow:hidden` (clips
-  anything above the bar) and the header is inside the isolated stacking
-  context. So that one tooltip renders through the `"tooltip"` `<Layer>`
-  (`components/ui/layer.tsx`), which puts it in a `<body>`-level overlay layer
-  that paints above the whole app by DOM ORDER — no z-index needed.
-- **The app-wide layer system** (`components/ui/layer.tsx`): `<Layer>` is now
-  part of the full overlay band, not a one-off seed. `LAYER_ORDER` is
-  `["agent", "modal", "popover", "tooltip", "toast"]` — five `<body>`-level
-  layers (declared in `_document.tsx`), each its own isolated stacking context,
-  stacked by DOM ORDER (later = on top), carrying NO z-index of their own. ALL
-  overlays route through it: Radix/Vaul primitives via their `*.Portal`'s
-  `container` (use `useLayerContainer`), and bespoke
-  imperatively-positioned content (like this bar's error tooltip) via `<Layer>`.
-  No overlay carries a magic z-index to "escape to the top" anymore; the
-  `@repo/no-overlay-zindex` lint rule enforces this — it bans high z-index on
-  the `ui/*` overlay wrappers, and app-wide on any overlay _content_ element
-  (e.g. a `*Content` you put a stray `z-50` on). When adding a search-bar
-  overlay that must escape clipping/stacking, reach for `<Layer>` (bespoke) or a
-  layer-routed Radix primitive — never a one-off portal + z-index.
 - Optional: extract `SearchComposer`'s contenteditable selection/`beforeinput`
   machinery into a `useContentEditableController` hook to fully separate the
   imperative integration from the React component.


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Introduces a new `panel` overlay layer (below `agent`) and moves `Sheet` and `Drawer` portals into it, so the AI assistant window now floats above side panels and drawers but remains below true blocking dialogs and transient overlays. The `_document.tsx` picks up the new layer automatically via `LAYER_ORDER`.

- **`layer.tsx`**: Adds `"panel"` as the first entry in `LAYER_ORDER`; updates the JSDoc to document the new 6-band hierarchy (`panel → agent → modal → popover → tooltip → toast`).
- **`sheet.tsx` / `drawer.tsx`**: Changes `useLayerContainer("modal")` to `useLayerContainer("panel")` so both surfaces render in the new lowest rung.
- **`OverlayLayers.mdx`** (not in the diff): The Storybook design-system documentation still shows `Sheet` and `Drawer` under the `modal` row and has no entry for the new `panel` layer — worth updating to keep the reference accurate.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The layer restructuring is internally consistent — `_document.tsx` derives containers from `LAYER_ORDER` automatically, so the new `panel` container is created without extra wiring. The only gap is that `OverlayLayers.mdx` was not updated to reflect the moved Sheet/Drawer components.

The functional changes are small, targeted, and correctly wired end-to-end. `dialog.tsx` and `alert-dialog.tsx` remain on `modal`, popovers/tooltips/toasts are untouched, and the agent layer sits exactly where the PR intends. The sole outstanding item is the Storybook docs table, which still lists `Sheet` and `Drawer` under `modal` and omits the `panel` layer entirely — a misleading reference for future contributors but no runtime impact.

web/src/components/design-system/OverlayLayers.mdx — the layer table is stale and needs a `panel` row added while removing Sheet/Drawer from the `modal` row.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph body["&lt;body&gt;"]
        next["#__next (app, isolation: isolate)"]
        subgraph overlay["data-overlay-root (DOM siblings after #__next)"]
            panel["panel layer\nSheet · Drawer · table peek\n(NEW — lowest rung)"]
            agent["agent layer\nAI assistant window"]
            modal["modal layer\nDialog · AlertDialog"]
            popover["popover layer\nPopover · DropdownMenu · Select · HoverCard"]
            tooltip["tooltip layer\nTooltip"]
            toast["toast layer\nSonner toasts"]
        end
    end

    panel -->|"below"| agent
    agent -->|"below"| modal
    modal -->|"below"| popover
    popover -->|"below"| tooltip
    tooltip -->|"below"| toast

    style panel fill:#c8e6c9,stroke:#388e3c
    style agent fill:#bbdefb,stroke:#1976d2
    style modal fill:#fff3e0,stroke:#e65100
    style popover fill:#f3e5f5,stroke:#6a1b9a
    style tooltip fill:#e8eaf6,stroke:#283593
    style toast fill:#fce4ec,stroke:#b71c1c
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph body["&lt;body&gt;"]
        next["#__next (app, isolation: isolate)"]
        subgraph overlay["data-overlay-root (DOM siblings after #__next)"]
            panel["panel layer\nSheet · Drawer · table peek\n(NEW — lowest rung)"]
            agent["agent layer\nAI assistant window"]
            modal["modal layer\nDialog · AlertDialog"]
            popover["popover layer\nPopover · DropdownMenu · Select · HoverCard"]
            tooltip["tooltip layer\nTooltip"]
            toast["toast layer\nSonner toasts"]
        end
    end

    panel -->|"below"| agent
    agent -->|"below"| modal
    modal -->|"below"| popover
    popover -->|"below"| tooltip
    tooltip -->|"below"| toast

    style panel fill:#c8e6c9,stroke:#388e3c
    style agent fill:#bbdefb,stroke:#1976d2
    style modal fill:#fff3e0,stroke:#e65100
    style popover fill:#f3e5f5,stroke:#6a1b9a
    style tooltip fill:#e8eaf6,stroke:#283593
    style toast fill:#fce4ec,stroke:#b71c1c
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Adjust layers so that assist..."](https://github.com/langfuse/langfuse/commit/310547b0feb7e798f8d793ee57600a32e6c981fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43019405)</sub>

<!-- /greptile_comment -->