### PR TITLE
fix(agent): Do not close open panels when toggling assistant

### DIFF
--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -24,7 +24,6 @@ import type { InAppAgentWindowConversation } from "@/src/ee/features/in-app-agen
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { AIFeaturesDisabledNotice } from "@/src/features/organizations/components/AIFeaturesDisabledNotice";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback";
 
 function DeleteConversationDialog({
@@ -78,7 +77,6 @@ export const InAppAiAgentButton = () => {
     setIsExpanded,
   } = useInAppAiAgent();
   const hasInAppAgentEntitlement = useHasEntitlement("in-app-agent");
-  const { setOpen: setSupportDrawerOpen } = useSupportDrawer();
   const buttonRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const previousPanelRectRef = useRef<DOMRect | null>(null);
@@ -128,12 +126,10 @@ export const InAppAiAgentButton = () => {
 
   const handleClick = () => {
     if (organization && !organization.aiFeaturesEnabled) {
-      setSupportDrawerOpen(false);
       setEnableDialogOpen(true);
       return;
     }
 
-    setSupportDrawerOpen(false);
     const willOpen = !open;
 
     if (willOpen) {
@@ -145,7 +141,12 @@ export const InAppAiAgentButton = () => {
 
   return (
     <>
-      <SidebarMenuButton ref={buttonRef} isActive={open} onClick={handleClick}>
+      <SidebarMenuButton
+        ref={buttonRef}
+        data-ignore-outside-interaction
+        isActive={open}
+        onClick={handleClick}
+      >
         <BotMessageSquare className="h-4 w-4" />
         Assistant
       </SidebarMenuButton>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a UX regression where clicking the AI assistant button would close any open panels (such as table peek panels or the support drawer) due to the button triggering the app's "outside interaction" detection logic. Two targeted changes address this: removing the explicit `setSupportDrawerOpen(false)` calls from `handleClick`, and adding the `data-ignore-outside-interaction` attribute to the `SidebarMenuButton`.

- **`data-ignore-outside-interaction` attribute**: Prevents the `shouldIgnoreOutsideInteraction` utility from treating clicks on the assistant button as "outside clicks," stopping panels that listen for outside interaction (e.g., peek panels) from closing when the assistant is toggled.
- **Removal of `setSupportDrawerOpen(false)` calls**: The assistant no longer force-closes the support drawer when clicked; both panels can now coexist.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is small, well-targeted, and consistent with how the rest of the codebase uses data-ignore-outside-interaction.

Both changes are minimal and correct. The data-ignore-outside-interaction attribute is already used on InAppAgentWindowShell for the same purpose, and SidebarMenuButton spreads all extra props onto the underlying DOM element, so the attribute is guaranteed to reach the browser. Removing the setSupportDrawerOpen(false) calls eliminates an unnecessary side-effect that was closing unrelated panels.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant AssistantButton as SidebarMenuButton<br/>(data-ignore-outside-interaction)
    participant OutsideInteraction as shouldIgnoreOutsideInteraction
    participant PeekPanel as Peek Panel / Open Panels

    User->>AssistantButton: click

    Note over AssistantButton,OutsideInteraction: BEFORE fix
    AssistantButton--xPeekPanel: setSupportDrawerOpen(false) closes panels
    AssistantButton--xPeekPanel: outside-click handler fires → closes panels

    Note over AssistantButton,OutsideInteraction: AFTER fix
    AssistantButton->>OutsideInteraction: click event bubbles up
    OutsideInteraction-->>PeekPanel: "closest([data-ignore-outside-interaction]) = found → ignore"
    PeekPanel-->>User: panels remain open ✓
    AssistantButton->>AssistantButton: handleClick() toggles open state only
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant AssistantButton as SidebarMenuButton<br/>(data-ignore-outside-interaction)
    participant OutsideInteraction as shouldIgnoreOutsideInteraction
    participant PeekPanel as Peek Panel / Open Panels

    User->>AssistantButton: click

    Note over AssistantButton,OutsideInteraction: BEFORE fix
    AssistantButton--xPeekPanel: setSupportDrawerOpen(false) closes panels
    AssistantButton--xPeekPanel: outside-click handler fires → closes panels

    Note over AssistantButton,OutsideInteraction: AFTER fix
    AssistantButton->>OutsideInteraction: click event bubbles up
    OutsideInteraction-->>PeekPanel: "closest([data-ignore-outside-interaction]) = found → ignore"
    PeekPanel-->>User: panels remain open ✓
    AssistantButton->>AssistantButton: handleClick() toggles open state only
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Do not close open panels whe..."](https://github.com/langfuse/langfuse/commit/008b8662dcc8aa853570c48987dcabee1e31ae4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43021410)</sub>

<!-- /greptile_comment -->