### PR TITLE
fix(clickhouse): avoid atomic view replacement in migration

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0036_add_ingested_sdks_to_analytics_scores.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0036_add_ingested_sdks_to_analytics_scores.down.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE VIEW analytics_scores ON CLUSTER default AS
+DROP VIEW IF EXISTS analytics_scores ON CLUSTER default;
+CREATE VIEW analytics_scores ON CLUSTER default AS
 SELECT
     project_id,
     toStartOfHour(timestamp) AS hour,

--- a/packages/shared/clickhouse/migrations/clustered/0036_add_ingested_sdks_to_analytics_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0036_add_ingested_sdks_to_analytics_scores.up.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE VIEW analytics_scores ON CLUSTER default AS
+DROP VIEW IF EXISTS analytics_scores ON CLUSTER default;
+CREATE VIEW analytics_scores ON CLUSTER default AS
 SELECT
     project_id,
     toStartOfHour(timestamp) AS hour,

--- a/packages/shared/clickhouse/migrations/unclustered/0036_add_ingested_sdks_to_analytics_scores.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0036_add_ingested_sdks_to_analytics_scores.down.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE VIEW analytics_scores AS
+DROP VIEW IF EXISTS analytics_scores;
+CREATE VIEW analytics_scores AS
 SELECT
     project_id,
     toStartOfHour(timestamp) AS hour,

--- a/packages/shared/clickhouse/migrations/unclustered/0036_add_ingested_sdks_to_analytics_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0036_add_ingested_sdks_to_analytics_scores.up.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE VIEW analytics_scores AS
+DROP VIEW IF EXISTS analytics_scores;
+CREATE VIEW analytics_scores AS
 SELECT
     project_id,
     toStartOfHour(timestamp) AS hour,

--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -686,10 +686,11 @@ SETTINGS enable_full_text_index = 1;
 -- PROD ROLLOUT: unlike analytics_scores (managed via numbered migrations),
 -- this view is NOT migration-managed because events_core only exists in
 -- cloud environments (see header note). Any change here must be applied
--- manually as CREATE OR REPLACE VIEW in every cloud region (eu, us, hipaa,
--- jp) and recorded in the migrations doc linked in the header — otherwise
--- the DWH S3 export silently misses the new columns.
-CREATE OR REPLACE VIEW analytics_events_core AS
+-- manually as DROP VIEW IF EXISTS followed by CREATE VIEW in every cloud
+-- region (eu, us, hipaa, jp) and recorded in the migrations doc linked in the
+-- header — otherwise the DWH S3 export silently misses the new columns.
+DROP VIEW IF EXISTS analytics_events_core;
+CREATE VIEW analytics_events_core AS
 SELECT
   project_id,
   toStartOfHour(start_time) AS hour,


### PR DESCRIPTION
## What does this PR do?

  Fixes #14906.

  Replaces `CREATE OR REPLACE VIEW` in the ClickHouse `0036_add_ingested_sdks_to_analytics_scores` migration with explicit `DROP
  VIEW IF EXISTS` + `CREATE VIEW`.

  This avoids ClickHouse atomic view replacement behavior, which can fail on NFS-backed filesystems such as Amazon EFS.

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Mandatory Tasks

  - [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

  ## Test plan

  - `git diff --check`
  - Verified the affected `0036` clustered/unclustered up/down migrations no longer use `CREATE OR REPLACE VIEW`.

  I did not run the full Langfuse test suite because this is a ClickHouse migration-only change and the full local stack requires Docker/Postgres/Redis/ClickHouse setup.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a ClickHouse migration failure on NFS-backed filesystems (Amazon EFS) by replacing `CREATE OR REPLACE VIEW` with explicit `DROP VIEW IF EXISTS` + `CREATE VIEW` in all four variants (clustered/unclustered, up/down) of migration `0036`. ClickHouse's atomic view replacement relies on filesystem-level atomic rename operations, which EFS does not support reliably.

- All four migration files (clustered up/down, unclustered up/down) are updated consistently, and no other migration files in the directory retain `CREATE OR REPLACE VIEW`.
- The down migration correctly recreates the pre-0036 view definition (without the `ingested_sdks` column), which is the appropriate rollback state.
- The two-step DROP + CREATE introduces a brief window where `analytics_scores` does not exist, which is an inherent tradeoff of this approach — queries against the view during migration execution will fail transiently.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted fix touching only four SQL migration files, with no logic changes beyond swapping a one-liner for the equivalent two-step DROP+CREATE.

All four migration variants are updated consistently, no other migration files retain CREATE OR REPLACE VIEW, and the down migrations correctly recover the pre-0036 view schema. The brief unavailability window between DROP and CREATE is an accepted, documented tradeoff of this approach.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant M as Migration Runner
    participant CH as ClickHouse

    rect rgb(255, 220, 220)
        Note over M,CH: Before (CREATE OR REPLACE VIEW — fails on EFS)
        M->>CH: CREATE OR REPLACE VIEW analytics_scores ...
        CH-->>M: ❌ Error: atomic rename fails on NFS/EFS
    end

    rect rgb(220, 255, 220)
        Note over M,CH: After (DROP + CREATE — works on EFS)
        M->>CH: DROP VIEW IF EXISTS analytics_scores [ON CLUSTER default]
        CH-->>M: ✅ OK (view removed)
        Note over CH: ⚠️ Brief window: view unavailable
        M->>CH: CREATE VIEW analytics_scores [ON CLUSTER default] AS SELECT ...
        CH-->>M: ✅ OK (view created)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant M as Migration Runner
    participant CH as ClickHouse

    rect rgb(255, 220, 220)
        Note over M,CH: Before (CREATE OR REPLACE VIEW — fails on EFS)
        M->>CH: CREATE OR REPLACE VIEW analytics_scores ...
        CH-->>M: ❌ Error: atomic rename fails on NFS/EFS
    end

    rect rgb(220, 255, 220)
        Note over M,CH: After (DROP + CREATE — works on EFS)
        M->>CH: DROP VIEW IF EXISTS analytics_scores [ON CLUSTER default]
        CH-->>M: ✅ OK (view removed)
        Note over CH: ⚠️ Brief window: view unavailable
        M->>CH: CREATE VIEW analytics_scores [ON CLUSTER default] AS SELECT ...
        CH-->>M: ✅ OK (view created)
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(clickhouse): avoid atomic view repla..."](https://github.com/langfuse/langfuse/commit/f301bb528f5ca6944bd04afae3c1a87390f9b92e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43036396)</sub>

<!-- /greptile_comment -->