### PR TITLE
fix(dashboard): smaller ex-home panel defaults + widgets adapt to panel height (LFE-10813)

### DIFF
--- a/packages/shared/src/domain/home-dashboard.ts
+++ b/packages/shared/src/domain/home-dashboard.ts
@@ -60,7 +60,7 @@ export const LANGFUSE_HOME_DASHBOARD_DEFINITION: DashboardDefinition = {
     // minimum heights. Cards adapt to their tile (charts stretch to absorb
     // extra height; a too-short tile scrolls internally), so sizes below
     // target a comfortable content fit at typical ~1300–1500px grid widths
-    // rather than the worst case. Below 1025px the grid stacks. (LFE-10813)
+    // rather than the worst case. Below 1024px the grid stacks. (LFE-10813)
     // Row 1: overview tables
     placement("home-traces", 0, 0, 4, 5),
     placement("home-model-costs", 4, 0, 4, 5),

--- a/packages/shared/src/domain/home-dashboard.ts
+++ b/packages/shared/src/domain/home-dashboard.ts
@@ -56,28 +56,29 @@ const placement = (
 export const LANGFUSE_HOME_DASHBOARD_DEFINITION: DashboardDefinition = {
   widgets: [
     // Grid rows are 16:9-proportional to column width (see DashboardGrid), so
-    // row heights shrink with the viewport while the Home cards have fixed
-    // intrinsic minimum heights (headline metrics, tabs, min-h chart floors).
-    // Sizes below fit the densest card down to ~1240px viewports; below that
-    // the preset tile scrolls internally, and below 1025px the grid stacks.
+    // tiles grow with the viewport while the Home cards' content has fixed
+    // minimum heights. Cards adapt to their tile (charts stretch to absorb
+    // extra height; a too-short tile scrolls internally), so sizes below
+    // target a comfortable content fit at typical ~1300–1500px grid widths
+    // rather than the worst case. Below 1025px the grid stacks. (LFE-10813)
     // Row 1: overview tables
-    placement("home-traces", 0, 0, 4, 6),
-    placement("home-model-costs", 4, 0, 4, 6),
-    placement("home-scores-table", 8, 0, 4, 6),
+    placement("home-traces", 0, 0, 4, 5),
+    placement("home-model-costs", 4, 0, 4, 5),
+    placement("home-scores-table", 8, 0, 4, 5),
     // Row 2: traffic + usage time series (tabbed cards with headline metrics
     // have the largest intrinsic height)
-    placement("home-traces-obs-time-series", 0, 6, 6, 8),
-    placement("home-model-usage", 6, 6, 6, 8),
+    placement("home-traces-obs-time-series", 0, 5, 6, 6),
+    placement("home-model-usage", 6, 5, 6, 6),
     // Row 3: users + scores over time
-    placement("home-users", 0, 14, 6, 7),
-    placement("home-chart-scores", 6, 14, 6, 7),
+    placement("home-users", 0, 11, 6, 6),
+    placement("home-chart-scores", 6, 11, 6, 6),
     // Row 4: latency percentile tables
-    placement("home-latency-table-traces", 0, 21, 4, 6),
-    placement("home-latency-table-generations", 4, 21, 4, 6),
-    placement("home-latency-table-observations", 8, 21, 4, 6),
+    placement("home-latency-table-traces", 0, 17, 4, 5),
+    placement("home-latency-table-generations", 4, 17, 4, 5),
+    placement("home-latency-table-observations", 8, 17, 4, 5),
     // Row 5+: full-width analytics
-    placement("home-generation-latency", 0, 27, 12, 8),
-    placement("home-score-analytics", 0, 35, 12, 7),
+    placement("home-generation-latency", 0, 22, 12, 6),
+    placement("home-score-analytics", 0, 28, 12, 6),
   ],
 };
 
@@ -89,5 +90,5 @@ export const LANGFUSE_HOME_DASHBOARD = {
   definition: LANGFUSE_HOME_DASHBOARD_DEFINITION,
   filters: [],
   createdAt: "2026-07-06T00:00:00.000Z",
-  updatedAt: "2026-07-06T13:00:00.000Z",
+  updatedAt: "2026-07-09T00:00:00.000Z",
 };

--- a/web/src/features/dashboard/components/ChartScores.tsx
+++ b/web/src/features/dashboard/components/ChartScores.tsx
@@ -118,7 +118,11 @@ export function ChartScores(props: {
       isLoading={props.isLoading || scores.isPending}
     >
       {!isEmptyTimeSeries({ data: extractedScores }) ? (
-        <div className="h-80 w-full shrink-0">
+        // The height is the flex basis (floor); grow lets the chart absorb
+        // extra tile height. On grid (lg) screens the floor is smaller so
+        // tiles fit narrow viewports — grow recovers the height above the
+        // grid's rowHeight floor. (LFE-10813)
+        <div className="h-80 w-full shrink-0 grow lg:h-56">
           <Chart
             chartType="LINE_TIME_SERIES"
             data={chartData}
@@ -132,7 +136,7 @@ export function ChartScores(props: {
           isLoading={props.isLoading || scores.isPending}
           description="Scores evaluate LLM quality and can be created manually or using the SDK."
           href="https://langfuse.com/docs/evaluation/overview"
-          className="h-full"
+          className="h-auto grow"
         />
       )}
     </DashboardCard>

--- a/web/src/features/dashboard/components/LatencyChart.tsx
+++ b/web/src/features/dashboard/components/LatencyChart.tsx
@@ -177,7 +177,11 @@ export const GenerationLatencyChart = ({
             content: (
               <>
                 {!isEmptyTimeSeries({ data: item.data }) ? (
-                  <div className="h-80 w-full shrink-0">
+                  // The height is the flex basis (floor); grow lets the chart absorb
+                  // extra tile height. On grid (lg) screens the floor is smaller so
+                  // tiles fit narrow viewports — grow recovers the height above the
+                  // grid's rowHeight floor. (LFE-10813)
+                  <div className="h-80 w-full shrink-0 grow lg:h-56">
                     <DashboardLineTimeSeriesChart
                       data={item.data}
                       label="Latency"
@@ -189,6 +193,7 @@ export const GenerationLatencyChart = ({
                 ) : (
                   <NoDataOrLoading
                     isLoading={isLoading || latencies.isPending}
+                    className="h-auto grow"
                   />
                 )}
               </>

--- a/web/src/features/dashboard/components/ModelUsageChart.tsx
+++ b/web/src/features/dashboard/components/ModelUsageChart.tsx
@@ -387,9 +387,14 @@ export const ModelUsageChart = ({
                 queryResult.isPending ? (
                   <NoDataOrLoading
                     isLoading={isLoading || queryResult.isPending}
+                    className="h-auto grow"
                   />
                 ) : (
-                  <div className="h-80 w-full shrink-0">
+                  // The height is the flex basis (floor); grow lets the chart absorb
+                  // extra tile height. On grid (lg) screens the floor is smaller so
+                  // tiles fit narrow viewports — grow recovers the height above the
+                  // grid's rowHeight floor. (LFE-10813)
+                  <div className="h-80 w-full shrink-0 grow lg:h-56">
                     <DashboardLineTimeSeriesChart
                       data={item.data}
                       label={item.chartMetricLabel}

--- a/web/src/features/dashboard/components/TabsComponent.tsx
+++ b/web/src/features/dashboard/components/TabsComponent.tsx
@@ -13,7 +13,9 @@ export const TabComponent = ({ tabs }: TabComponentProps) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const capture = usePostHogClientCapture();
   return (
-    <div>
+    // Grows inside the card's flex column so tab content (charts) can absorb
+    // extra tile height on dashboards. (LFE-10813)
+    <div className="flex grow flex-col">
       <div className="sm:hidden">
         <label htmlFor="tabs" className="sr-only">
           Select a tab
@@ -59,7 +61,9 @@ export const TabComponent = ({ tabs }: TabComponentProps) => {
           </nav>
         </div>
       </div>
-      <div className="mt-4 flex flex-col">{tabs[selectedIndex]?.content}</div>
+      <div className="mt-4 flex grow flex-col">
+        {tabs[selectedIndex]?.content}
+      </div>
     </div>
   );
 };

--- a/web/src/features/dashboard/components/TracesBarListChart.tsx
+++ b/web/src/features/dashboard/components/TracesBarListChart.tsx
@@ -134,8 +134,11 @@ export const TracesBarListChart = ({
           description="Total traces tracked"
         />
         {adjustedData.length > 0 ? (
+          // The computed height is the flex basis (floor); grow lets the chart
+          // absorb extra tile height on dashboards — bar thickness stays
+          // capped, only the spacing stretches. (LFE-10813)
           <div
-            className="mt-4 w-full"
+            className="mt-4 w-full shrink-0 grow"
             style={{
               minHeight: 200,
               height: Math.max(
@@ -170,6 +173,7 @@ export const TracesBarListChart = ({
             isLoading={isLoading || traces.isPending || totalTraces.isPending}
             description="Traces contain details about LLM applications and can be created using the SDK."
             href="https://langfuse.com/docs/get-started"
+            className="h-auto grow"
           />
         )}
         <ExpandListButton

--- a/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
+++ b/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
@@ -207,7 +207,11 @@ export const TracesAndObservationsTimeSeriesChart = ({
                   }
                 />
                 {!isEmptyTimeSeries({ data: item.data }) ? (
-                  <div className="h-80 w-full shrink-0">
+                  // The height is the flex basis (floor); grow lets the chart absorb
+                  // extra tile height. On grid (lg) screens the floor is smaller so
+                  // tiles fit narrow viewports — grow recovers the height above the
+                  // grid's rowHeight floor. (LFE-10813)
+                  <div className="h-80 w-full shrink-0 grow lg:h-56">
                     <DashboardLineTimeSeriesChart
                       data={item.data}
                       label={item.chartMetricLabel}
@@ -228,6 +232,7 @@ export const TracesAndObservationsTimeSeriesChart = ({
                     }
                     description="Traces contain details about LLM applications and can be created using the SDK."
                     href="https://langfuse.com/docs/observability/overview"
+                    className="h-auto grow"
                   />
                 )}
               </>

--- a/web/src/features/dashboard/components/UserChart.tsx
+++ b/web/src/features/dashboard/components/UserChart.tsx
@@ -159,7 +159,10 @@ export const UserChart = ({
     0,
   );
 
-  const BAR_ROW_HEIGHT = 36;
+  // Slightly tighter rows than TracesBarListChart: this card also stacks tabs
+  // and an expand button, and grow stretches the spacing back out whenever the
+  // tile offers more height. (LFE-10813)
+  const BAR_ROW_HEIGHT = 32;
   const CHART_AXIS_PADDING = 32;
 
   const data = [
@@ -200,13 +203,17 @@ export const UserChart = ({
             content: (
               <>
                 {item.data.length > 0 ? (
-                  <div className="flex flex-col">
+                  <div className="flex grow flex-col">
                     <TotalMetric
                       metric={item.totalMetric}
                       description={item.metricDescription}
                     />
+                    {/* The computed height is the flex basis (floor); grow
+                        lets the chart absorb extra tile height on dashboards —
+                        bar thickness stays capped, only the spacing
+                        stretches. (LFE-10813) */}
                     <div
-                      className="mt-4 w-full"
+                      className="mt-4 w-full shrink-0 grow"
                       style={{
                         minHeight: 200,
                         height: Math.max(
@@ -240,6 +247,7 @@ export const UserChart = ({
                     isLoading={isLoading || user.isPending}
                     description="Consumption per user is tracked by passing their ids on traces."
                     href="https://langfuse.com/docs/observability/features/users"
+                    className="h-auto grow"
                   />
                 )}
               </>

--- a/web/src/features/dashboard/components/cards/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/cards/DashboardTable.tsx
@@ -91,7 +91,12 @@ export const DashboardTable = ({
           ) : null}
         </div>
       ) : (
-        <NoDataOrLoading isLoading={isLoading} {...noDataProps} />
+        // Fills leftover tile height inside the card's flex column. (LFE-10813)
+        <NoDataOrLoading
+          isLoading={isLoading}
+          {...noDataProps}
+          className="h-auto grow"
+        />
       )}
     </>
   );

--- a/web/src/features/widgets/components/DashboardGrid.tsx
+++ b/web/src/features/widgets/components/DashboardGrid.tsx
@@ -107,8 +107,11 @@ export function DashboardGrid({
   const rowHeight =
     width !== null ? Math.max(MIN_ROW_HEIGHT, ((width / 12) * 9) / 16) : 150;
 
-  // Detect if screen is medium or smaller (1024px and below)
-  const isSmallScreen = useMediaQuery("(max-width: 1024px)");
+  // Detect if screen is medium or smaller (below 1024px). Exact complement of
+  // Tailwind's `lg:` breakpoint: widget content uses `lg:` variants for its
+  // grid-mode sizing (e.g. smaller chart flex bases that rely on grow), so the
+  // stacked layout must never overlap them. (LFE-10813)
+  const isSmallScreen = useMediaQuery("(max-width: 1023.98px)");
 
   // Convert WidgetPlacement to react-grid-layout format
   const layout = widgets.map((w) => ({

--- a/web/src/features/widgets/components/DashboardGrid.tsx
+++ b/web/src/features/widgets/components/DashboardGrid.tsx
@@ -99,8 +99,13 @@ export function DashboardGrid({
   readOnly?: boolean;
 }) {
   const { containerRef, width } = useDebouncedContainerWidth(200);
-  // Rows stay 16:9-proportional to column width
-  const rowHeight = width !== null ? ((width / 12) * 9) / 16 : 150;
+  // Rows stay 16:9-proportional to column width, with a floor so tiles keep a
+  // usable height on narrow screens — below the floor, widget content (chart
+  // floors, table rows) no longer fits and tiles scroll internally; the grid
+  // grows vertically instead. (LFE-10813)
+  const MIN_ROW_HEIGHT = 58;
+  const rowHeight =
+    width !== null ? Math.max(MIN_ROW_HEIGHT, ((width / 12) * 9) / 16) : 150;
 
   // Detect if screen is medium or smaller (1024px and below)
   const isSmallScreen = useMediaQuery("(max-width: 1024px)");


### PR DESCRIPTION
## TL;DR

The ex-home preset panels on the curated Home dashboard defaulted far too tall on wide screens, with big dead zones inside the cards. This shrinks their default sizes **and** makes the cards adapt to whatever height their panel has — charts stretch to fill, nothing scrolls internally at any common viewport width.

## Why

Follow-up to Home-as-dashboard (LFE-10693, #14824). The dashboard grid's rows are 16:9-proportional to container width, so tiles grow with the monitor — but the ex-home cards render fixed-height content (320px chart areas, count-based bar lists, content-sized tables). The preset sizes were chosen to fit the densest card at narrow widths, which made wide screens balloon: a chart row rendered ~780px tall around ~500px of content, leaving a dead zone below every chart.

## What

1. **Smaller defaults** — every placement in the curated Home definition drops 1–2 grid rows (`6/8/7/6/8/7 → 5/6/6/5/6/6`); `updatedAt` bumped so the worker upsert overwrites the existing row.
2. **Cards adapt to panel height** — chart areas keep their height as a flex *basis* and `grow` to absorb extra tile height (matching how generic query widgets fill their tiles). `TabComponent` passes the flex chain through; bar-list charts stretch spacing while bar thickness stays capped at 28px; empty states fill leftover space.
3. **Grid rowHeight floor (58px)** — on narrow screens, rows stop shrinking below usable heights; the grid grows vertically instead of forcing internal scrollbars in tiles. Applies to all dashboards, binds only below ~1450px viewports.

## Result

- Wide screens: noticeably shorter rows, charts fill their panels edge-to-edge, no dead zones.
- Manually resizing a preset panel taller now stretches the widget instead of leaving blank space.
- Narrow laptops: all 12 Home cards fit with zero internal scroll (previously the densest cards started scrolling below ~1240px).

<details>
<summary>Mechanism & verification</summary>

### Mechanism

- Preset tiles render the card with `min-h-full` inside an `overflow-y-auto` wrapper: the card always stretches to at least the tile, and scrolls only when intrinsic content genuinely exceeds it (e.g. "Show all" expansions — preserved).
- Chart slots: `h-80 → h-80 shrink-0 grow lg:h-56`. The height is the flex basis (floor); `grow` distributes extra tile height to the chart. On grid (`lg`) screens the basis is lowered to 224px so tiles fit narrow viewports — `grow` recovers 320px+ everywhere the tile allows. Below the `lg` breakpoint the grid stacks and cards stay content-sized with the full 320px chart, unchanged.
- Bar lists keep their computed per-row height as basis; `HorizontalBarChart` caps `maxBarSize` at 28, so growing only widens spacing.
- `UserChart` bar rows tightened 36 → 32px (that card stacks tabs + metric + expand, the densest); `grow` stretches spacing back out wherever the tile offers more room.
- `MIN_ROW_HEIGHT = 58` in `DashboardGrid` chosen so the densest Home card fits at the stack breakpoint; generic widget tiles just get slightly taller than pure 16:9 below ~1450px viewports.

### Verification

- Playwright against local dev, measuring `scrollHeight - clientHeight` per tile: **all 12 cards fit with 0px internal overflow at 1120 / 1280 / 1440 / 2000 / 2560px** viewports.
- Screenshots at 2000px and 1280px: charts fill to the card bottom; "Show all" expansion grows content to 808px inside a 354px tile and scrolls (previous behavior preserved).
- Stacked mode (<1025px): cards content-sized, charts at full 320px basis, unchanged.
- Generic (query-widget) dashboards spot-checked at 1280px — rows marginally taller from the floor, everything renders normally.
- Worker upsert verified live: bumped `updatedAt` triggers `Upserted dashboard Langfuse Home (langfuse-home-dashboard)`.
- `pnpm run lint` — Tasks: 8 successful, 8 total; web typecheck clean; `home-dashboard.test.ts` — Tests 3 passed (3).

</details>

Related: LFE-10693 (#14824), LFE-10576 (#14848).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR shrinks the default grid placements on the curated Home dashboard (1–2 fewer rows per tile) and threads a flex-grow chain through the chart cards so charts fill their tiles instead of leaving dead zones on wide screens. It also adds a `MIN_ROW_HEIGHT = 58` floor to `DashboardGrid` so tiles stay usable on narrow viewports without internal scrollbars.

- **Smaller defaults**: all 11 preset tiles drop 1–2 grid rows; `updatedAt` is bumped to trigger the worker upsert.
- **Chart flex-grow**: chart containers gain `shrink-0 grow lg:h-56` (floor + stretch); `TabComponent`, bar-list charts, and `NoDataOrLoading` empty states propagate the grow chain through the card hierarchy.
- **Row height floor**: `DashboardGrid` enforces `MIN_ROW_HEIGHT = 58px` so the 16:9 formula never shrinks rows below a usable size on narrow viewports.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. Changes are visual-only and constrained to the Home dashboard's preset chart cards. Existing Show all expansion behavior and the grid layout on typical desktop widths are unaffected.

At exactly 1024px viewport width (iPad landscape), the JS stacked-layout trigger and Tailwind lg: prefix both fire simultaneously. grow cannot recover the height reduction there because preset cards are height auto in the stacked layout, leaving charts at 224px instead of 320px at that one specific width. The rest of the changes — the grid placements, the MIN_ROW_HEIGHT floor, and the flex-grow chain — look correct and well-reasoned.

web/src/features/widgets/components/DashboardGrid.tsx — the useMediaQuery breakpoint overlaps with Tailwind lg: at exactly 1024px.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Viewport width] --> B{width > 1024px?}
    B -- No --> C[Stacked flex layout\npreset cards: height auto]
    B -- Yes --> D[Grid layout\nrowHeight = max 58px, 16:9 x colWidth]
    C --> E{CSS lg: applies?\nmin-width 1024px}
    E -- Yes, at 1024px --> F[chart: h-56 224px\ngrow has no parent height\nto fill stays 224px]
    E -- No, below 1024px --> G[chart: h-80 320px\ngrow has no parent height\nto fill stays 320px]
    D --> H[tile height = rowHeight x y_size minus margins]
    H --> I[DashboardCard flex col\nflex-1 on CardContent]
    I --> J[TabComponent flex grow flex-col\npasses grow to content pane]
    J --> K{has data?}
    K -- Yes --> L[chart div h-80 shrink-0 grow lg:h-56\nflex-grow absorbs remaining tile height]
    K -- No --> M[NoDataOrLoading h-auto grow\nfills remaining tile height]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Viewport width] --> B{width > 1024px?}
    B -- No --> C[Stacked flex layout\npreset cards: height auto]
    B -- Yes --> D[Grid layout\nrowHeight = max 58px, 16:9 x colWidth]
    C --> E{CSS lg: applies?\nmin-width 1024px}
    E -- Yes, at 1024px --> F[chart: h-56 224px\ngrow has no parent height\nto fill stays 224px]
    E -- No, below 1024px --> G[chart: h-80 320px\ngrow has no parent height\nto fill stays 320px]
    D --> H[tile height = rowHeight x y_size minus margins]
    H --> I[DashboardCard flex col\nflex-1 on CardContent]
    I --> J[TabComponent flex grow flex-col\npasses grow to content pane]
    J --> K{has data?}
    K -- Yes --> L[chart div h-80 shrink-0 grow lg:h-56\nflex-grow absorbs remaining tile height]
    K -- No --> M[NoDataOrLoading h-auto grow\nfills remaining tile height]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/widgets/components/DashboardGrid.tsx:111
**Breakpoint overlap at exactly 1024px**

`useMediaQuery("(max-width: 1024px)")` is inclusive of 1024px, so the stacked flex layout is active there. Tailwind `lg:` (`min-width: 1024px`) is also inclusive of 1024px, so `lg:h-56` on the chart divs reduces chart heights from 320px (h-80) to 224px at that exact width. `grow` is ineffective in the stacked layout (preset cards are `height: auto`), so the reduction is not recovered. The result is that at 1024px (iPad landscape) charts render 28% shorter than at 1023px, with no flex stretching to compensate. Shifting the JS query to `(max-width: 1023px)` or using `lg:h-56` only inside the grid container would eliminate the overlap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): smaller ex-home panel de..."](https://github.com/langfuse/langfuse/commit/abeb2ff3ef8e36f961c475fbeabccd12e517386d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43041059)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->