### PR TITLE
fix(instrumentation): preserve OTel baggage across startNewTrace

### DIFF
--- a/packages/shared/src/server/instrumentation/index.test.ts
+++ b/packages/shared/src/server/instrumentation/index.test.ts
@@ -1,0 +1,59 @@
+import { context } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { normalizeClickHouseQueryTags } from "../clickhouse/queryTags";
+import { contextWithLangfuseProps } from "../headerPropagation";
+import { instrumentAsync, instrumentSync } from ".";
+
+describe("instrumentation baggage propagation", () => {
+  // Baggage only propagates through context.with once a manager is registered.
+  const contextManager = new AsyncLocalStorageContextManager();
+
+  beforeAll(() => {
+    contextManager.enable();
+    context.setGlobalContextManager(contextManager);
+  });
+
+  afterAll(() => {
+    context.disable();
+  });
+
+  it("instrumentAsync keeps worker surface/route across startNewTrace", async () => {
+    const workerContext = contextWithLangfuseProps({
+      projectId: "project-1",
+      clickhouse: { surface: "worker", route: "langfuse.queue.monitor" },
+    });
+
+    const tags = await context.with(workerContext, () =>
+      instrumentAsync(
+        { name: "process monitor", startNewTrace: true },
+        async () => normalizeClickHouseQueryTags(),
+      ),
+    );
+
+    expect(tags).toMatchObject({
+      surface: "worker",
+      route: "langfuse.queue.monitor",
+      projectId: "project-1",
+    });
+  });
+
+  it("instrumentSync keeps worker surface/route across startNewTrace", () => {
+    const workerContext = contextWithLangfuseProps({
+      projectId: "project-1",
+      clickhouse: { surface: "worker", route: "langfuse.queue.monitor" },
+    });
+
+    const tags = context.with(workerContext, () =>
+      instrumentSync({ name: "process monitor", startNewTrace: true }, () =>
+        normalizeClickHouseQueryTags(),
+      ),
+    );
+
+    expect(tags).toMatchObject({
+      surface: "worker",
+      route: "langfuse.queue.monitor",
+      projectId: "project-1",
+    });
+  });
+});

--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -51,12 +51,18 @@ export type SpanCtx = {
 
 type AsyncCallbackFn<T> = (span: opentelemetry.Span) => Promise<T>;
 
+/** instrumentAsync runs an async callback inside a fresh OTel span. */
 export async function instrumentAsync<T>(
   ctx: SpanCtx,
   callback: AsyncCallbackFn<T>,
 ): Promise<T> {
   const activeContext = ctx.startNewTrace
-    ? opentelemetry.ROOT_CONTEXT
+    ? // Sever the parent trace but carry baggage onto the new root.
+      opentelemetry.propagation.setBaggage(
+        opentelemetry.ROOT_CONTEXT,
+        opentelemetry.propagation.getBaggage(opentelemetry.context.active()) ??
+          opentelemetry.propagation.createBaggage(),
+      )
     : ctx.traceContext
       ? opentelemetry.propagation.extract(
           opentelemetry.context.active(),
@@ -95,12 +101,18 @@ export async function instrumentAsync<T>(
 
 type SyncCallbackFn<T> = (span: opentelemetry.Span) => T;
 
+/** instrumentSync runs a callback inside a fresh OTel span. */
 export function instrumentSync<T>(
   ctx: SpanCtx,
   callback: SyncCallbackFn<T>,
 ): T {
   const activeContext = ctx.startNewTrace
-    ? opentelemetry.ROOT_CONTEXT
+    ? // Sever the parent trace but carry baggage onto the new root.
+      opentelemetry.propagation.setBaggage(
+        opentelemetry.ROOT_CONTEXT,
+        opentelemetry.propagation.getBaggage(opentelemetry.context.active()) ??
+          opentelemetry.propagation.createBaggage(),
+      )
     : ctx.traceContext
       ? opentelemetry.propagation.extract(
           opentelemetry.context.active(),


### PR DESCRIPTION
## Summary

Worker processors that open with `startNewTrace: true` — the monitor queue and eight others — emit ClickHouse queries tagged `surface: "unknown"`, because severing the parent trace also discarded the OTel baggage that carries `surface`/`route`.

To achieve this we:
- Carried the active baggage onto the new root context in `instrumentAsync` and `instrumentSync`, so `startNewTrace` severs the parent trace without dropping the baggage.
- Restored `surface: "worker"` / `route: "langfuse.queue.<name>"` (plus `projectId` and the `langfuse.*` span attributes) on `log_comment` for every `startNewTrace` processor.

**Note**: `llm/ai-sdk/telemetry.ts` intentionally detaches LLM spans onto a bare `ROOT_CONTEXT` and is left untouched.

## Verification

- [x] `turbo run lint` — `Tasks: 8 successful, 8 total`
- [x] `@langfuse/shared` baggage regression test — `Tests 2 passed (2)`
- [x] worker `monitorProcessorScalarQuery.test.ts` (real query path) — `Tests 1 passed (1)`
- [x] web `api-auth-span.servertest.ts` — `Tests 2 passed (2)`

## Test plan

- [ ] Run a monitor evaluation and confirm its ClickHouse `system.query_log` `log_comment` carries `surface: "worker"` and `route: "langfuse.queue.monitor"`.
- [ ] Spot-check another `startNewTrace` processor (e.g. data retention) and confirm its queries tag `surface: "worker"` rather than `"unknown"`.
- [ ] Confirm processors without `startNewTrace` still tag correctly (no regression).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes worker processors that use `startNewTrace: true` emitting ClickHouse queries tagged `surface: \"unknown\"` by preserving OTel baggage when severing the parent trace. Previously the code replaced the active context with bare `ROOT_CONTEXT`, which stripped baggage entries; the fix grafts the current baggage onto `ROOT_CONTEXT` before starting the new span.

- In `instrumentAsync` and `instrumentSync`, the `startNewTrace` branch now reads the active baggage via `getBaggage(context.active())` and re-attaches it to `ROOT_CONTEXT` via `setBaggage`, so that `normalizeClickHouseQueryTags` can still read `surface`, `route`, and `projectId` inside the new trace.
- New tests in `index.test.ts` register an `AsyncLocalStorageContextManager` and assert that both the async and sync paths forward baggage entries through a `startNewTrace` boundary.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a targeted, well-tested fix to a single branching condition in both instrument helpers; the logic and OTel API usage are correct, and new tests exercise the exact regression path.

The baggage-grafting approach is correct: setBaggage(ROOT_CONTEXT, existingBaggage) preserves entries while startActiveSpan's context-with call makes them visible to context.active() inside the callback. The ?? createBaggage() fallback is functionally harmless but slightly opaque. The test's afterAll installs a global context manager without fully restoring the prior state, which could affect sibling test files sharing a Vitest worker. Neither concern introduces incorrect runtime behavior.

The test file (index.test.ts) modifies global OTel context manager state without restoring it; worth reviewing test isolation if the Vitest configuration runs this suite in a shared worker.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/shared/src/server/instrumentation/index.ts:54-71
When no active baggage exists (`getBaggage` returns `undefined`), the `?? createBaggage()` fallback attaches an empty `Baggage` object to `ROOT_CONTEXT` instead of returning `ROOT_CONTEXT` unchanged. Both are functionally equivalent, but the conditional form makes the "nothing to propagate" path explicit and avoids allocating a no-op `Baggage` instance.

```suggestion
/** instrumentAsync runs an async callback inside a fresh OTel span. */
export async function instrumentAsync<T>(
  ctx: SpanCtx,
  callback: AsyncCallbackFn<T>,
): Promise<T> {
  const existingBaggage = opentelemetry.propagation.getBaggage(
    opentelemetry.context.active(),
  );
  const activeContext = ctx.startNewTrace
    ? // Sever the parent trace but carry baggage onto the new root.
      existingBaggage
      ? opentelemetry.propagation.setBaggage(
          opentelemetry.ROOT_CONTEXT,
          existingBaggage,
        )
      : opentelemetry.ROOT_CONTEXT
    : ctx.traceContext
      ? opentelemetry.propagation.extract(
          opentelemetry.context.active(),
          ctx.traceContext,
        )
      : opentelemetry.context.active();
```

### Issue 2 of 3
packages/shared/src/server/instrumentation/index.ts:109-130
The sync path has the same `?? createBaggage()` fallback. Applying the same conditional approach here for consistency.

```suggestion
  const existingBaggage = opentelemetry.propagation.getBaggage(
    opentelemetry.context.active(),
  );
  const activeContext = ctx.startNewTrace
    ? // Sever the parent trace but carry baggage onto the new root.
      existingBaggage
      ? opentelemetry.propagation.setBaggage(
          opentelemetry.ROOT_CONTEXT,
          existingBaggage,
        )
      : opentelemetry.ROOT_CONTEXT
    : ctx.traceContext
      ? opentelemetry.propagation.extract(
          opentelemetry.context.active(),
          ctx.traceContext,
        )
      : opentelemetry.context.active();

  return getTracer(ctx.traceScope ?? callback.name).startActiveSpan(
    ctx.name,
    {
      root: ctx.startNewTrace || (!ctx.traceContext && ctx.rootSpan),
      kind: ctx.spanKind,
    },
    activeContext,
    (span) => {
```

### Issue 3 of 3
packages/shared/src/server/instrumentation/index.test.ts:12-17
**Global context manager not restored after tests**

`context.setGlobalContextManager(contextManager)` installs a process-wide singleton. `context.disable()` disables propagation but does not unregister the manager or restore the prior state. If this suite shares a Vitest worker with other tests that rely on the default no-op context manager, they may observe unexpected context propagation after this file runs. Consider restoring the prior manager or running this suite in isolation (`--pool=forks` / a dedicated worker).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(instrumentation): preserve OTel bagg..."](https://github.com/langfuse/langfuse/commit/0f0e6bafc8b7e5133672452d36279687c45a0bb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43042492)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->