### PR TITLE
fix: forward prompt tool config to dataset experiments (#14904)

### DIFF
--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -7,6 +7,7 @@ import { createExperimentJobClickhouse } from "../features/experiments/experimen
 import {
   createDatasetItem,
   createOrgProjectAndApiKey,
+  fetchLLMCompletion,
   logger,
 } from "@langfuse/shared/src/server";
 
@@ -573,5 +574,103 @@ describe("experiment processing integration", () => {
     //     }),
     //   }),
     // );
+  });
+});
+
+describe("experiment tool config (#14904)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("passes prompt tool config through to fetchLLMCompletion", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const datasetId = randomUUID();
+    const runId = randomUUID();
+    const promptId = randomUUID();
+
+    const toolDefinition = {
+      name: "get_weather",
+      description: "Get the current weather for a city",
+      parameters: {
+        type: "object",
+        properties: { city: { type: "string", description: "City name" } },
+        required: ["city"],
+      },
+    };
+
+    // Chat prompt whose config carries a tool definition (LLMToolDefinition shape).
+    await prisma.prompt.create({
+      data: {
+        id: promptId,
+        projectId,
+        name: "Weather Prompt",
+        prompt: [
+          {
+            role: "system",
+            content: "You are a weather assistant. Call the get_weather tool.",
+          },
+          { role: "user", content: "What is the weather in {{city}}?" },
+        ],
+        type: "chat",
+        version: 1,
+        createdBy: "test-user",
+        config: { tools: [toolDefinition], tool_choice: "auto" },
+      },
+    });
+
+    await prisma.dataset.create({
+      data: { id: datasetId, projectId, name: "Tool Config Dataset" },
+    });
+
+    await prisma.datasetRuns.create({
+      data: {
+        id: runId,
+        name: "Tool Config Run",
+        projectId,
+        datasetId,
+        metadata: {
+          prompt_id: promptId,
+          provider: "openai",
+          model: "gpt-3.5-turbo",
+          model_params: { temperature: 0 },
+        },
+      },
+    });
+
+    await createDatasetItem({
+      projectId,
+      datasetId,
+      input: { city: "Paris" },
+    });
+
+    await prisma.llmApiKeys.create({
+      data: {
+        id: randomUUID(),
+        projectId,
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        displaySecretKey: "test-key",
+        secretKey: encrypt("test-key"),
+      },
+    });
+
+    const result = await createExperimentJobClickhouse({
+      event: { projectId, datasetId, runId },
+    });
+
+    expect(result).toEqual({ success: true });
+
+    // The LLM invocation must receive the tool config defined on the prompt.
+    expect(vi.mocked(fetchLLMCompletion)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: expect.arrayContaining([
+          expect.objectContaining({ name: "get_weather" }),
+        ]),
+      }),
+    );
   });
 });

--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -764,4 +764,83 @@ describe("experiment tool config (#14904)", () => {
     expect(call).toBeDefined();
     expect(call).not.toHaveProperty("tools");
   });
+
+  test("warns when prompt tool_choice cannot be forwarded", async () => {
+    const mockLogger = vi.mocked(logger);
+    const { projectId } = await createOrgProjectAndApiKey();
+    const datasetId = randomUUID();
+    const runId = randomUUID();
+    const promptId = randomUUID();
+
+    await prisma.prompt.create({
+      data: {
+        id: promptId,
+        projectId,
+        name: "Weather Prompt",
+        prompt: [{ role: "user", content: "Weather in {{city}}?" }],
+        type: "chat",
+        version: 1,
+        createdBy: "test-user",
+        config: {
+          tools: [
+            {
+              name: "get_weather",
+              description: "Get the current weather for a city",
+              parameters: {
+                type: "object",
+                properties: { city: { type: "string" } },
+                required: ["city"],
+              },
+            },
+          ],
+          tool_choice: "required",
+        },
+      },
+    });
+
+    await prisma.dataset.create({
+      data: { id: datasetId, projectId, name: "Tool Choice Dataset" },
+    });
+
+    await prisma.datasetRuns.create({
+      data: {
+        id: runId,
+        name: "Tool Choice Run",
+        projectId,
+        datasetId,
+        metadata: {
+          prompt_id: promptId,
+          provider: "openai",
+          model: "gpt-3.5-turbo",
+          model_params: { temperature: 0 },
+        },
+      },
+    });
+
+    await createDatasetItem({ projectId, datasetId, input: { city: "Paris" } });
+
+    await prisma.llmApiKeys.create({
+      data: {
+        id: randomUUID(),
+        projectId,
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        displaySecretKey: "test-key",
+        secretKey: encrypt("test-key"),
+      },
+    });
+
+    const result = await createExperimentJobClickhouse({
+      event: { projectId, datasetId, runId },
+    });
+
+    expect(result).toEqual({ success: true });
+    // Tools are still forwarded, but the unsupported tool_choice is flagged.
+    expect(vi.mocked(fetchLLMCompletion)).toHaveBeenCalledWith(
+      expect.objectContaining({ tools: expect.any(Array) }),
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("tool_choice"),
+    );
+  });
 });

--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -673,4 +673,95 @@ describe("experiment tool config (#14904)", () => {
       }),
     );
   });
+
+  test("does not forward tools when a structured output schema is set", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const datasetId = randomUUID();
+    const runId = randomUUID();
+    const promptId = randomUUID();
+
+    await prisma.prompt.create({
+      data: {
+        id: promptId,
+        projectId,
+        name: "Weather Prompt",
+        prompt: [
+          {
+            role: "system",
+            content: "You are a weather assistant. Call the get_weather tool.",
+          },
+          { role: "user", content: "What is the weather in {{city}}?" },
+        ],
+        type: "chat",
+        version: 1,
+        createdBy: "test-user",
+        config: {
+          tools: [
+            {
+              name: "get_weather",
+              description: "Get the current weather for a city",
+              parameters: {
+                type: "object",
+                properties: { city: { type: "string" } },
+                required: ["city"],
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    await prisma.dataset.create({
+      data: { id: datasetId, projectId, name: "Tool Config Dataset" },
+    });
+
+    // Structured output schema on the run metadata conflicts with prompt tools;
+    // fetchLLMCompletion cannot use both, so tools must be dropped. (#14904)
+    await prisma.datasetRuns.create({
+      data: {
+        id: runId,
+        name: "Structured Output Run",
+        projectId,
+        datasetId,
+        metadata: {
+          prompt_id: promptId,
+          provider: "openai",
+          model: "gpt-3.5-turbo",
+          model_params: { temperature: 0 },
+          structured_output_schema: {
+            type: "object",
+            properties: { answer: { type: "string" } },
+            required: ["answer"],
+          },
+        },
+      },
+    });
+
+    await createDatasetItem({
+      projectId,
+      datasetId,
+      input: { city: "Paris" },
+    });
+
+    await prisma.llmApiKeys.create({
+      data: {
+        id: randomUUID(),
+        projectId,
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        displaySecretKey: "test-key",
+        secretKey: encrypt("test-key"),
+      },
+    });
+
+    const result = await createExperimentJobClickhouse({
+      event: { projectId, datasetId, runId },
+    });
+
+    expect(result).toEqual({ success: true });
+
+    const call = vi.mocked(fetchLLMCompletion).mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call).not.toHaveProperty("tools");
+  });
 });

--- a/worker/src/features/experiments/experimentServiceClickhouse.ts
+++ b/worker/src/features/experiments/experimentServiceClickhouse.ts
@@ -218,6 +218,8 @@ async function processLLMCall(
       ...config.model_params,
     },
     structuredOutputSchema: config.structuredOutputSchema,
+    // Forward tool config defined on the prompt (GitHub #14904)
+    ...(config.tools.length > 0 ? { tools: config.tools } : {}),
     traceSinkParams,
   }).catch(); // catch errors and do not retry
 

--- a/worker/src/features/experiments/utils.ts
+++ b/worker/src/features/experiments/utils.ts
@@ -20,6 +20,7 @@ import {
   ExperimentCreateEventSchema,
   ExperimentMetadataSchema,
   LLMApiKeySchema,
+  LLMToolDefinitionSchema,
   PromptContentSchema,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
@@ -223,6 +224,14 @@ export async function validateAndSetupExperiment(
 
   const allVariables = [...extractedVariables, ...placeholderNames];
 
+  // Tool config lives on the prompt's free-form `config` JSON. Extract and
+  // validate it here so it can be forwarded to the LLM call; invalid or absent
+  // configs fall back to no tools. (GitHub #14904)
+  const promptToolsResult = z
+    .object({ tools: z.array(LLMToolDefinitionSchema) })
+    .safeParse(prompt.config);
+  const tools = promptToolsResult.success ? promptToolsResult.data.tools : [];
+
   return {
     datasetRun,
     prompt,
@@ -231,6 +240,7 @@ export async function validateAndSetupExperiment(
     provider,
     model,
     model_params,
+    tools,
     structuredOutputSchema: validatedRunMetadata.data.structured_output_schema,
     experimentName: validatedRunMetadata.data.experiment_name,
     experimentRunName: validatedRunMetadata.data.experiment_run_name,

--- a/worker/src/features/experiments/utils.ts
+++ b/worker/src/features/experiments/utils.ts
@@ -228,7 +228,10 @@ export async function validateAndSetupExperiment(
   // validate it here so it can be forwarded to the LLM call; invalid or absent
   // configs fall back to no tools. (GitHub #14904)
   const promptToolsResult = z
-    .object({ tools: z.array(LLMToolDefinitionSchema) })
+    .object({
+      tools: z.array(LLMToolDefinitionSchema),
+      tool_choice: z.unknown().optional(),
+    })
     .safeParse(prompt.config);
   const promptTools = promptToolsResult.success
     ? promptToolsResult.data.tools
@@ -246,6 +249,24 @@ export async function validateAndSetupExperiment(
     );
   }
   const tools = hasStructuredOutput ? [] : promptTools;
+
+  // fetchLLMCompletion does not accept tool_choice yet, so a non-default value
+  // set on the prompt (e.g. "required"/"none") has no effect in experiments.
+  // Warn so it is discoverable instead of silently dropped. (GitHub #14904)
+  const promptToolChoice = promptToolsResult.success
+    ? promptToolsResult.data.tool_choice
+    : undefined;
+  if (
+    tools.length > 0 &&
+    promptToolChoice !== undefined &&
+    promptToolChoice !== "auto"
+  ) {
+    logger.warn(
+      `Experiment run ${runId}: prompt tool_choice ${JSON.stringify(
+        promptToolChoice,
+      )} is not applied; experiments do not forward tool_choice.`,
+    );
+  }
 
   return {
     datasetRun,

--- a/worker/src/features/experiments/utils.ts
+++ b/worker/src/features/experiments/utils.ts
@@ -230,7 +230,22 @@ export async function validateAndSetupExperiment(
   const promptToolsResult = z
     .object({ tools: z.array(LLMToolDefinitionSchema) })
     .safeParse(prompt.config);
-  const tools = promptToolsResult.success ? promptToolsResult.data.tools : [];
+  const promptTools = promptToolsResult.success
+    ? promptToolsResult.data.tools
+    : [];
+
+  // fetchLLMCompletion cannot combine tools with a structured-output schema:
+  // the structured-output branch short-circuits before tools are applied. Drop
+  // tools when a schema is set and warn, rather than ignoring them silently.
+  const hasStructuredOutput = Boolean(
+    validatedRunMetadata.data.structured_output_schema,
+  );
+  if (promptTools.length > 0 && hasStructuredOutput) {
+    logger.warn(
+      `Experiment run ${runId}: ignoring prompt tools because a structured output schema is set; fetchLLMCompletion cannot use both.`,
+    );
+  }
+  const tools = hasStructuredOutput ? [] : promptTools;
 
   return {
     datasetRun,


### PR DESCRIPTION
## Problem

Fixes #14904. Tool definitions configured on a prompt (in the prompt's `config` JSON) were never passed to the LLM invocation when running an in-app dataset experiment. The model ran with no tools, so it could not make tool calls — it only produced plausible-looking text.

Confirmed on a real run: with a prompt whose config defines a `get_weather` tool (param `city`), the experiment generation's request contained no tool schema and the model returned the text `get_weather(location="Paris")` — inventing the `location` arg because it never received the `city` schema.

## Root cause

Tool config was dropped at the worker layer: `processLLMCall` called `fetchLLMCompletion` (which accepts `tools`) without ever forwarding the prompt's tools.

## Fix

- `validateAndSetupExperiment` extracts and validates `prompt.config.tools` against `LLMToolDefinitionSchema` (absent/invalid config → no tools).
- `processLLMCall` forwards `tools` to `fetchLLMCompletion` when present.

Scoped to the worker: no `ExperimentMetadata` schema change (the prompt is already pinned by `prompt_id`) and no public API contract change (`experimentMetadata` is an opaque `map<string, unknown>` in Fern), so no regeneration needed.

## Tests

Added a worker test that seeds a chat prompt with a tool in its config, runs the experiment handler, and asserts `fetchLLMCompletion` receives the `tools`. Confirmed it fails without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where tool definitions stored in a prompt's `config` JSON were never forwarded to the LLM during in-app dataset experiments, causing models to receive no tool schema and hallucinate tool calls as plain text.

- **`utils.ts`**: `validateAndSetupExperiment` now parses `prompt.config.tools` against `LLMToolDefinitionSchema` and returns a `tools` array (empty on parse failure), making it available to downstream callers.
- **`experimentServiceClickhouse.ts`**: `processLLMCall` conditionally spreads `tools` into the `fetchLLMCompletion` call when the array is non-empty.
- **Test**: A new integration test seeds a prompt with a `get_weather` tool, runs the experiment handler, and asserts the mock `fetchLLMCompletion` receives the expected tools array — confirmed to fail without the fix.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core fix is correct and well-tested; the two edge cases (structuredOutputSchema + tools conflict, tool_choice being ignored) are non-critical and pre-date this PR.

The fix correctly threads tools through the extraction and forwarding layers, is gated by Zod validation with a safe fallback, and is covered by a new integration test. Two gaps exist: when structuredOutputSchema and tools are both set the tools are silently skipped inside fetchLLMCompletion, and tool_choice from the prompt config is never forwarded since fetchLLMCompletion has no such parameter. Neither path causes data loss or errors.

No files require critical attention. The two comments on experimentServiceClickhouse.ts and utils.ts describe limitations worth a follow-up but don't block the fix.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W as Worker
    participant V as validateAndSetupExperiment (utils.ts)
    participant P as prisma (prompt.config)
    participant L as processLLMCall (experimentServiceClickhouse.ts)
    participant F as fetchLLMCompletion

    W->>V: createExperimentJobClickhouse(event)
    V->>P: fetchPrompt(prompt_id, projectId)
    P-->>V: prompt (with config.tools)
    V->>V: "z.object({tools}).safeParse(prompt.config)"
    V-->>W: "PromptExperimentConfig { tools: [...] | [] }"
    W->>L: "processItem -> processLLMCall(config)"
    L->>L: replaceVariablesInPrompt(...)
    L->>F: "fetchLLMCompletion({ ..., tools: config.tools })"
    F-->>L: "ToolCallResponse | string"
    L-->>W: "{ success: true }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W as Worker
    participant V as validateAndSetupExperiment (utils.ts)
    participant P as prisma (prompt.config)
    participant L as processLLMCall (experimentServiceClickhouse.ts)
    participant F as fetchLLMCompletion

    W->>V: createExperimentJobClickhouse(event)
    V->>P: fetchPrompt(prompt_id, projectId)
    P-->>V: prompt (with config.tools)
    V->>V: "z.object({tools}).safeParse(prompt.config)"
    V-->>W: "PromptExperimentConfig { tools: [...] | [] }"
    W->>L: "processItem -> processLLMCall(config)"
    L->>L: replaceVariablesInPrompt(...)
    L->>F: "fetchLLMCompletion({ ..., tools: config.tools })"
    F-->>L: "ToolCallResponse | string"
    L-->>W: "{ success: true }"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/experiments/experimentServiceClickhouse.ts:220-223
**`structuredOutputSchema` silently suppresses tools**

When both `config.structuredOutputSchema` and `config.tools` are set, `fetchLLMCompletion` enters the structured-output branch first (line ~735) and returns before ever reaching the tools branch, so all tool definitions are silently ignored. A user who adds a structured-output schema to an experiment that also has prompt tools will observe no tool calls with no error or log entry. Since the experiment run's `metadata` can carry `structured_output_schema` independently of the prompt's `config.tools`, the two can co-exist in practice today.

### Issue 2 of 2
worker/src/features/experiments/utils.ts:230-233
**`tool_choice` from prompt config is silently dropped**

The parser only extracts `tools` from `prompt.config`; the sibling `tool_choice` field (present in the test fixture as `"auto"`) is discarded. `fetchLLMCompletion` has no `tool_choice` parameter today, but users who set `tool_choice: "required"` or `"none"` in the prompt editor will see no effect in experiments. At minimum, a log warning would make the behavior discoverable, and the `FetchLLMCompletionParams` type could be extended to forward it when `fetchLLMCompletion` gains support.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: forward prompt tool config to datas..."](https://github.com/langfuse/langfuse/commit/1045353e00a06ecffdf64f6e20c668641a2ce333) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43170387)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->