### PR TITLE
fix(v4): populate environment filter options from events tables in non-legacy write modes

### DIFF
--- a/packages/shared/src/server/repositories/environments.ts
+++ b/packages/shared/src/server/repositories/environments.ts
@@ -1,4 +1,5 @@
 import { LISTABLE_SCORE_TYPES } from "../../domain/scores";
+import { env } from "../../env";
 import { queryClickhouse } from "./clickhouse";
 
 export type EnvironmentFilterProps = {
@@ -11,38 +12,61 @@ export const getEnvironmentsForProject = async (
 ): Promise<{ environment: string }[]> => {
   const { projectId, fromTimestamp } = props;
 
-  const query = `
-    (
-      SELECT distinct environment
-      FROM traces
-      WHERE project_id = {projectId: String}
-      ${fromTimestamp ? "AND timestamp >= {fromTimestamp: DateTime64(3)}" : ""}
-    ) UNION ALL (
-      SELECT distinct environment
-      FROM observations
-      WHERE project_id = {projectId: String}
-      ${fromTimestamp ? "AND start_time >= {fromTimestamp: DateTime64(3)}" : ""}
-    ) UNION ALL (
+  // In dual and events_only write modes all tracing data lands in the events
+  // tables: a single events_core scan covers traces and observations and is
+  // the only populated source under events_only. Scores keep their own table
+  // in every write mode. The events read may be routed to a dedicated
+  // ClickHouse service (CLICKHOUSE_EVENTS_READ_ONLY_URL), so it cannot share
+  // a query with the scores read.
+  const tracingEnvironmentsPromise =
+    env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "legacy"
+      ? queryClickhouse<{ environment: string }>({
+          query: `
+            (
+              SELECT distinct environment
+              FROM traces
+              WHERE project_id = {projectId: String}
+              ${fromTimestamp ? "AND timestamp >= {fromTimestamp: DateTime64(3)}" : ""}
+            ) UNION ALL (
+              SELECT distinct environment
+              FROM observations
+              WHERE project_id = {projectId: String}
+              ${fromTimestamp ? "AND start_time >= {fromTimestamp: DateTime64(3)}" : ""}
+            )
+          `,
+          params: { projectId, fromTimestamp },
+          tags: { projectId },
+          preferredClickhouseService: "ReadOnly",
+        })
+      : queryClickhouse<{ environment: string }>({
+          query: `
+            SELECT distinct environment
+            FROM events_core
+            WHERE project_id = {projectId: String}
+            ${fromTimestamp ? "AND start_time >= {fromTimestamp: DateTime64(3)}" : ""}
+          `,
+          params: { projectId, fromTimestamp },
+          tags: { projectId },
+          preferredClickhouseService: "EventsReadOnly",
+        });
+
+  const scoreEnvironmentsPromise = queryClickhouse<{ environment: string }>({
+    query: `
       SELECT distinct environment
       FROM scores
       WHERE project_id = {projectId: String}
       AND data_type IN ({dataTypes: Array(String)})
       ${fromTimestamp ? "AND timestamp >= {fromTimestamp: DateTime64(3)}" : ""}
-    )
-  `;
-
-  const results = await queryClickhouse<{
-    environment: string;
-  }>({
-    query,
-    params: {
-      projectId,
-      fromTimestamp,
-      dataTypes: LISTABLE_SCORE_TYPES,
-    },
+    `,
+    params: { projectId, fromTimestamp, dataTypes: LISTABLE_SCORE_TYPES },
     tags: { projectId },
     preferredClickhouseService: "ReadOnly",
   });
+
+  const results = (
+    await Promise.all([tracingEnvironmentsPromise, scoreEnvironmentsPromise])
+  ).flat();
+
   // Always add default environment to list
   results.push({ environment: "default" });
 

--- a/web/src/__tests__/server/repositories/environment-repository-events-only.servertest.ts
+++ b/web/src/__tests__/server/repositories/environment-repository-events-only.servertest.ts
@@ -1,0 +1,125 @@
+/**
+ * Events-only write-mode routing for getEnvironmentsForProject.
+ *
+ * In events_only mode tracing data is written ONLY to the events tables; the
+ * legacy traces/observations tables stay empty. The environment filter options
+ * must read events_core, otherwise the dropdown only shows environments that
+ * appear on scores (which keep their own table in every write mode).
+ *
+ * The write mode is read from the parsed env at module load, so it is forced
+ * via process.env BEFORE any module is imported. Split into its own file
+ * because the env is process-wide; the legacy-mode tests live in
+ * environment-repository.servertest.ts.
+ */
+import { vi } from "vitest";
+
+// The events tables are created only by the ClickHouse dev-tables setup (CI's
+// "Setup Dev Tables" step), which runs in the default deploy-mode where
+// .env.dev.example enables the v4 preview opt-in. The -azure and
+// -redis-cluster CI runs skip that setup, so the events tables are absent and
+// the reads below would error. Capture the ORIGINAL opt-in flag BEFORE the
+// override forces it on.
+const eventsTableAvailable = vi.hoisted(() => {
+  const enabled =
+    process.env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
+  process.env.LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
+  // events_only requires the preview opt-in (web read paths gate on it, and
+  // worker/web env validation enforces the pairing).
+  process.env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+  return enabled;
+});
+
+import {
+  createEvent,
+  createEventsCh,
+  createTraceScore,
+  createScoresCh,
+  getEnvironmentsForProject,
+} from "@langfuse/shared/src/server";
+import { env } from "@langfuse/shared/src/env";
+import { randomUUID } from "crypto";
+
+// Skip on environments without the events dev tables (azure / redis-cluster
+// CI). Mirrors the gating used across the other events-table server tests.
+const maybe = eventsTableAvailable ? describe : describe.skip;
+
+// At least one always-running test so the file does not hang on the redis
+// connections opened by the shared server imports when the events-table tests
+// below are skipped via `maybe`.
+describe("environment repository (events_only write mode) liveness", () => {
+  it("should not hang when the events table is unavailable", () => {});
+});
+
+maybe("environment repository (events_only write mode)", () => {
+  // Sanity check that the forced write mode reached the parsed shared env that
+  // getEnvironmentsForProject routes on. If this ever regresses, the
+  // assertions below would silently read the (empty) legacy tables.
+  it("forces events_only write mode", () => {
+    expect(env.LANGFUSE_MIGRATION_V4_WRITE_MODE).toBe("events_only");
+  });
+
+  it("should return environments from the events table and scores", async () => {
+    const projectId = randomUUID();
+    const eventEnvironment = randomUUID();
+    const scoreEnvironment = randomUUID();
+
+    // events_only deployments write tracing data exclusively to the events
+    // tables (events_core is populated from events_full via MV).
+    await createEventsCh([
+      createEvent({
+        project_id: projectId,
+        environment: eventEnvironment,
+      }),
+    ]);
+    await createScoresCh([
+      createTraceScore({
+        project_id: projectId,
+        environment: scoreEnvironment,
+      }),
+    ]);
+
+    const environments = await getEnvironmentsForProject({ projectId });
+
+    expect(environments).toEqual(
+      expect.arrayContaining([
+        { environment: eventEnvironment },
+        { environment: scoreEnvironment },
+        { environment: "default" },
+      ]),
+    );
+    expect(environments).toHaveLength(3);
+  });
+
+  it("should respect fromTimestamp on the events table read", async () => {
+    const projectId = randomUUID();
+    const oldEnvironment = randomUUID();
+    const recentEnvironment = randomUUID();
+    const now = Date.now();
+
+    await createEventsCh([
+      createEvent({
+        project_id: projectId,
+        environment: oldEnvironment,
+        start_time: (now - 10 * 24 * 60 * 60 * 1000) * 1000, // micros
+      }),
+      createEvent({
+        project_id: projectId,
+        environment: recentEnvironment,
+        start_time: now * 1000, // micros
+      }),
+    ]);
+
+    const environments = await getEnvironmentsForProject({
+      projectId,
+      fromTimestamp: new Date(now - 24 * 60 * 60 * 1000),
+    });
+
+    expect(environments).toEqual(
+      expect.arrayContaining([
+        { environment: recentEnvironment },
+        { environment: "default" },
+      ]),
+    );
+    expect(environments).toHaveLength(2);
+  });
+});

--- a/web/src/__tests__/server/repositories/environment-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/environment-repository.servertest.ts
@@ -1,11 +1,30 @@
+/**
+ * Legacy write-mode coverage for getEnvironmentsForProject: reads come from
+ * the legacy traces/observations tables. The write mode is read from the
+ * parsed env at module load, so it is forced via process.env BEFORE any module
+ * is imported — the dev/CI default is dual, which would route the read to the
+ * events tables instead. The events_only tests live in
+ * environment-repository-events-only.servertest.ts.
+ */
+import { vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+});
+
 import {
   createTracesCh,
   createTrace,
   getEnvironmentsForProject,
 } from "@langfuse/shared/src/server";
+import { env } from "@langfuse/shared/src/env";
 import { randomUUID } from "crypto";
 
 describe("Clickhouse Project Repository Test", () => {
+  it("forces legacy write mode", () => {
+    expect(env.LANGFUSE_MIGRATION_V4_WRITE_MODE).toBe("legacy");
+  });
+
   it("should return default if no environments are found", async () => {
     const projectId = randomUUID();
     const environments = await getEnvironmentsForProject({ projectId });


### PR DESCRIPTION
getEnvironmentsForProject only read the legacy traces/observations tables, so deployments with LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only saw only score environments (plus default) in every environment filter dropdown.

In dual and events_only write modes all tracing data lands in the events tables, so the traces+observations union is replaced by a single events_core scan (routed via the EventsReadOnly ClickHouse service). The scores read stays on its own query because the events read may target a dedicated ClickHouse service. Legacy mode is unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `getEnvironmentsForProject` only read the legacy `traces`/`observations` tables, causing deployments with `LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only` (or `dual`) to show only score-derived environments in every environment filter dropdown.

- **Core fix** (`environments.ts`): Adds a write-mode branch — `legacy` keeps the existing `traces + observations + scores` UNION ALL, while `dual`/`events_only` replaces the tracing half with a single `events_core` scan routed via `EventsReadOnly`, with scores kept in a separate parallel query because the events read may target a dedicated ClickHouse cluster.
- **Tests**: Two test files provide isolated coverage — one forces `legacy` mode (existing tests updated with env-hoisting), and a new file forces `events_only` mode with tests for both the combined tracing+score result set and the `fromTimestamp` filter on `events_core`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the write-mode branch correctly routes dual/events_only reads to events_core and the fix is well-isolated from the legacy path.

The core logic change in environments.ts is small and correct: dual and events_only deployments now read environments from events_core, which is always populated in those modes, while legacy deployments are entirely unchanged. The score query is correctly kept separate because it may target a different ClickHouse cluster. Tests provide coverage for events_only mode with proper env hoisting, including the fromTimestamp filter path. The one gap is that score environments in legacy mode are not explicitly tested after the refactor to a parallel promise, though the score query itself is identical to what existed before.

All changed files look correct. The new test file is conditional on events tables being available, which is expected CI behavior.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getEnvironmentsForProject] --> B{LANGFUSE_MIGRATION_V4_WRITE_MODE}

    B -- legacy --> C[Query: traces UNION ALL observations\npreferredClickhouseService: ReadOnly]
    B -- dual or events_only --> D[Query: events_core\npreferredClickhouseService: EventsReadOnly]

    E[Query: scores\npreferredClickhouseService: ReadOnly]

    C --> F[Promise.all]
    D --> F
    E --> F

    F --> G[Flatten results]
    G --> H[Push 'default' environment]
    H --> I[Deduplicate via Set]
    I --> J[Return environments list]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[getEnvironmentsForProject] --> B{LANGFUSE_MIGRATION_V4_WRITE_MODE}

    B -- legacy --> C[Query: traces UNION ALL observations\npreferredClickhouseService: ReadOnly]
    B -- dual or events_only --> D[Query: events_core\npreferredClickhouseService: EventsReadOnly]

    E[Query: scores\npreferredClickhouseService: ReadOnly]

    C --> F[Promise.all]
    D --> F
    E --> F

    F --> G[Flatten results]
    G --> H[Push 'default' environment]
    H --> I[Deduplicate via Set]
    I --> J[Return environments list]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): populate environment filter opt..."](https://github.com/langfuse/langfuse/commit/90d7bd8e382c85af8df0d27779e0e665d555a448) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43250074)</sub>

<!-- /greptile_comment -->