### PR TITLE
fix(otel): link prompts only on generation observations

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto";
 import {
   ForbiddenError,
   ObservationLevel,
+  ObservationType,
   ObservationTypeDomain,
 } from "../../";
 import {
@@ -400,6 +401,17 @@ export class OtelIngestionProcessor {
                     ? normalizedTools.toolCallNames
                     : undefined;
 
+                const observationType =
+                  observationTypeMapper.mapToObservationType(
+                    spanAttributes,
+                    resourceAttributes,
+                    scopeSpan?.scope,
+                    span.name,
+                  );
+                // Prompts can only be linked to GENERATION observations
+                const canLinkPrompt =
+                  observationType === ObservationType.GENERATION;
+
                 events.push({
                   projectId: this.projectId,
                   traceId,
@@ -407,12 +419,7 @@ export class OtelIngestionProcessor {
                   parentSpanId,
 
                   name,
-                  type: observationTypeMapper.mapToObservationType(
-                    spanAttributes,
-                    resourceAttributes,
-                    scopeSpan?.scope,
-                    span.name,
-                  ),
+                  type: observationType,
                   environment: this.extractEnvironment(
                     spanAttributes,
                     resourceAttributes,
@@ -442,21 +449,23 @@ export class OtelIngestionProcessor {
                     span.status?.message ??
                     null,
 
-                  promptName:
-                    spanAttributes?.[
-                      LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME
-                    ] ??
-                    spanAttributes["langfuse.prompt.name"] ??
-                    this.parseLangfusePromptFromAISDK(spanAttributes)?.name ??
-                    null,
-                  promptVersion:
-                    spanAttributes?.[
-                      LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
-                    ] ??
-                    spanAttributes["langfuse.prompt.version"] ??
-                    this.parseLangfusePromptFromAISDK(spanAttributes)
-                      ?.version ??
-                    null,
+                  promptName: canLinkPrompt
+                    ? (spanAttributes?.[
+                        LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME
+                      ] ??
+                      spanAttributes["langfuse.prompt.name"] ??
+                      this.parseLangfusePromptFromAISDK(spanAttributes)?.name ??
+                      null)
+                    : null,
+                  promptVersion: canLinkPrompt
+                    ? (spanAttributes?.[
+                        LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+                      ] ??
+                      spanAttributes["langfuse.prompt.version"] ??
+                      this.parseLangfusePromptFromAISDK(spanAttributes)
+                        ?.version ??
+                      null)
+                    : null,
 
                   modelParameters: this.extractModelParameters(
                     spanAttributes,
@@ -1026,6 +1035,15 @@ export class OtelIngestionProcessor {
     // model-call spans — skip model/usage/cost for them.
     const isAiSdkAgentSpan = this.isAiSdkAgentOperation(attributes);
 
+    const mappedObservationType = observationTypeMapper.mapToObservationType(
+      attributes,
+      resourceAttributes,
+      scopeSpan?.scope,
+      span.name,
+    );
+    // Prompts can only be linked to GENERATION observations
+    const canLinkPrompt = mappedObservationType === ObservationType.GENERATION;
+
     const observation = {
       id: this.parseId(span.spanId?.data ?? span.spanId),
       traceId,
@@ -1060,16 +1078,20 @@ export class OtelIngestionProcessor {
         instrumentationScopeName,
       ) as any,
       model: isAiSdkAgentSpan ? undefined : this.extractModelName(attributes),
-      promptName:
-        attributes?.[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME] ??
-        attributes["langfuse.prompt.name"] ??
-        this.parseLangfusePromptFromAISDK(attributes)?.name ??
-        null,
-      promptVersion:
-        attributes?.[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION] ??
-        attributes["langfuse.prompt.version"] ??
-        this.parseLangfusePromptFromAISDK(attributes)?.version ??
-        null,
+      promptName: canLinkPrompt
+        ? (attributes?.[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME] ??
+          attributes["langfuse.prompt.name"] ??
+          this.parseLangfusePromptFromAISDK(attributes)?.name ??
+          null)
+        : null,
+      promptVersion: canLinkPrompt
+        ? (attributes?.[
+            LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+          ] ??
+          attributes["langfuse.prompt.version"] ??
+          this.parseLangfusePromptFromAISDK(attributes)?.version ??
+          null)
+        : null,
       usageDetails: isAiSdkAgentSpan
         ? {}
         : this.extractUsageDetails(
@@ -1084,12 +1106,6 @@ export class OtelIngestionProcessor {
       output,
     };
 
-    const mappedObservationType = observationTypeMapper.mapToObservationType(
-      attributes,
-      resourceAttributes,
-      scopeSpan?.scope,
-      span.name,
-    );
     const observationType =
       mappedObservationType && typeof mappedObservationType === "string"
         ? mappedObservationType.toLowerCase()

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -2966,13 +2966,13 @@ describe("OTel Resource Span Mapping", () => {
         },
       ],
       [
-        "should extract promptName on observation from langfuse.prompt.name",
+        "should not extract promptName from langfuse.prompt.name on non-generation observation",
         {
           entity: "observation",
           otelAttributeKey: "langfuse.prompt.name",
           otelAttributeValue: { stringValue: "test" },
           entityAttributeKey: "promptName",
-          entityAttributeValue: "test",
+          entityAttributeValue: null,
         },
       ],
       [
@@ -3878,6 +3878,111 @@ describe("OTel Resource Span Mapping", () => {
         ).toEqual(spec.entityAttributeValue);
       },
     );
+
+    describe("prompt linking gated to GENERATION observations", () => {
+      const buildResourceSpan = (attributes: Record<string, any>[]) => ({
+        scopeSpans: [
+          {
+            spans: [
+              {
+                ...defaultSpanProps,
+                attributes,
+              },
+            ],
+          },
+        ],
+      });
+
+      const promptAttributes = [
+        {
+          key: "langfuse.observation.prompt.name",
+          value: { stringValue: "my-prompt" },
+        },
+        {
+          key: "langfuse.observation.prompt.version",
+          value: { intValue: { low: 1, high: 0, unsigned: false } },
+        },
+      ];
+
+      it.each([["agent"], ["tool"], ["span"]])(
+        "should not map prompt attributes on %s observations",
+        async (observationType: string) => {
+          const resourceSpan = buildResourceSpan([
+            {
+              key: "langfuse.observation.type",
+              value: { stringValue: observationType },
+            },
+            ...promptAttributes,
+          ]);
+
+          const events = await convertOtelSpanToIngestionEvent(
+            resourceSpan,
+            new Set(),
+          );
+          const observation = events.find((e) => e.type !== "trace-create");
+          expect(observation?.type).toBe(`${observationType}-create`);
+          expect(observation?.body.promptName).toBeNull();
+          expect(observation?.body.promptVersion).toBeNull();
+
+          const processor = createTestOtelProcessor();
+          const eventInputs = processor.processToEvent([resourceSpan]);
+          expect(eventInputs).toHaveLength(1);
+          expect(eventInputs[0].promptName).toBeNull();
+          expect(eventInputs[0].promptVersion).toBeNull();
+        },
+      );
+
+      it("should map prompt attributes on generation observations", async () => {
+        const resourceSpan = buildResourceSpan([
+          {
+            key: "langfuse.observation.type",
+            value: { stringValue: "generation" },
+          },
+          ...promptAttributes,
+        ]);
+
+        const events = await convertOtelSpanToIngestionEvent(
+          resourceSpan,
+          new Set(),
+        );
+        const observation = events.find((e) => e.type !== "trace-create");
+        expect(observation?.type).toBe("generation-create");
+        expect(observation?.body.promptName).toBe("my-prompt");
+        expect(observation?.body.promptVersion).toBe(1);
+
+        const processor = createTestOtelProcessor();
+        const eventInputs = processor.processToEvent([resourceSpan]);
+        expect(eventInputs).toHaveLength(1);
+        expect(eventInputs[0].promptName).toBe("my-prompt");
+        expect(eventInputs[0].promptVersion).toBe(1);
+      });
+
+      it("should map legacy langfuse.prompt.name attributes on generation observations", async () => {
+        const resourceSpan = buildResourceSpan([
+          {
+            key: "gen_ai.request.model",
+            value: { stringValue: "gpt-4o" },
+          },
+          {
+            key: "langfuse.prompt.name",
+            value: { stringValue: "my-prompt" },
+          },
+          {
+            key: "langfuse.prompt.version",
+            value: { intValue: { low: 2, high: 0, unsigned: false } },
+          },
+        ]);
+
+        const events = await convertOtelSpanToIngestionEvent(
+          resourceSpan,
+          new Set(),
+        );
+        const observation = events.find((e) => e.type !== "trace-create");
+        expect(observation?.type).toBe("generation-create");
+        expect(observation?.body.promptName).toBe("my-prompt");
+        expect(observation?.body.promptVersion).toBe(2);
+      });
+    });
 
     // Regression: OTLP/JSON exporters (e.g. the OpenTelemetry PHP SDK) send
     // int64 resource attributes as decimal strings (intValue: "7") rather than


### PR DESCRIPTION
## Problem

OTel ingestion maps prompt-linking attributes (`langfuse.observation.prompt.name` / `.version`, legacy `langfuse.prompt.name` / `.version`, and the AI SDK `langfusePrompt` telemetry metadata) onto **every** span, regardless of the observation type the span maps to. Downstream, `IngestionService` resolves these fields to a real `prompt_id` unconditionally, so AGENT, TOOL, SPAN, etc. observations end up linked to prompts.

This becomes a real issue as SDKs start propagating prompt attributes to all spans within a context (e.g. the Python SDK): only generations should end up linked to the prompt. Prompt version metrics already filter on GENERATION, but the Linked Generations tab would surface AGENT/TOOL/etc. observations.

## Change

Gate prompt linking to `GENERATION` observations at the OTel mapping layer (`packages/shared/src/server/otel/OtelIngestionProcessor.ts`), at both mapping sites:

- `processToEvent` path: the mapped observation type is hoisted into a local const and `promptName` / `promptVersion` are only populated when the type is `ObservationType.GENERATION`, otherwise `null`.
- `processToIngestionEvents` path (observation event body): the existing `mapToObservationType` call is hoisted above the observation construction and the same gating is applied.

`IngestionService` and UI are unchanged — non-generation observations simply never carry prompt fields anymore.

## Tests

Added to `web/src/__tests__/server/api/otel/otelMapping.servertest.ts`:

- `langfuse.observation.prompt.name` / `.version` on spans mapped to `agent`, `tool`, and `span` types → `promptName` / `promptVersion` are `null` on both the event input and the ingestion event body.
- Same attributes on a `generation` span → mapped as before.
- Legacy `langfuse.prompt.name` / `.version` on a span inferred as GENERATION (via `gen_ai.request.model`) → mapped as before.
- Updated the existing parameterized case for bare `langfuse.prompt.name` (span maps to SPAN by default) to expect `null`.

## Checks run

- `vitest run web/src/__tests__/server/api/otel/otelMapping.servertest.ts` → 221 passed, 1 skipped (pre-existing skip)
- Worker OTel tests (`otelToObservationForEval`, `otelMetadataProcessing`, `otelFlueMapping`) → 34 passed
- `tsc --noEmit` on `@langfuse/shared` → clean
- ESLint + Prettier on both touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gates OTel prompt linking (`promptName` / `promptVersion`) to `GENERATION` observations only, preventing agent, tool, and span observations from being incorrectly associated with prompts when SDKs propagate prompt attributes across an entire trace context.

- **`processToEvent` path**: `mapToObservationType` is hoisted out of the `events.push()` call, a `canLinkPrompt` flag is derived from the result, and `promptName`/`promptVersion` are set only when `canLinkPrompt` is true — covering all three attribute sources (new-style, legacy, and AI SDK).
- **`processToIngestionEvents` path**: Same hoist-and-gate pattern applied to the `observation` object construction; the downstream event-type string derivation is unchanged.
- New parameterised tests cover all three non-generation types (agent, tool, span) and validate that generation observations still receive prompt data; the legacy `langfuse.prompt.name` test expectation is corrected from `"test"` to `null` for a non-generation span.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is narrowly scoped to setting promptName/promptVersion to null for non-GENERATION observations; IngestionService and the UI are untouched, and the gating is consistent across both OTel ingestion code paths.

Both processToEvent and processToIngestionEvents paths are updated symmetrically, mapToObservationType is called exactly once per path (no performance regression), and the guard covers all three prompt-attribute sources. The new tests exercise non-generation types in both paths, the generation happy-path, and the legacy attribute name. No unintended side-effects are visible.

No files require special attention. The AI SDK langfusePrompt attribute source is gated by the same canLinkPrompt check as the other two sources but lacks its own explicit test for non-generation spans; this is a minor gap that does not affect correctness.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OTel Span Received] --> B{Path}
    B -->|processToEvent| C[mapToObservationType]
    B -->|processToIngestionEvents| D[mapToObservationType - hoisted]

    C --> E{observationType == GENERATION?}
    D --> F{mappedObservationType == GENERATION?}

    E -->|Yes - canLinkPrompt=true| G[Read promptName/promptVersion\nfrom span attributes]
    E -->|No - canLinkPrompt=false| H[promptName = null\npromptVersion = null]

    F -->|Yes - canLinkPrompt=true| I[Read promptName/promptVersion\nfrom span attributes]
    F -->|No - canLinkPrompt=false| J[promptName = null\npromptVersion = null]

    G --> K[events.push with type=observationType]
    H --> K
    I --> L[observation object → IngestionEvent]
    J --> L

    K --> M[IngestionService resolves prompt_id\nonly for GENERATIONs]
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[OTel Span Received] --> B{Path}
    B -->|processToEvent| C[mapToObservationType]
    B -->|processToIngestionEvents| D[mapToObservationType - hoisted]

    C --> E{observationType == GENERATION?}
    D --> F{mappedObservationType == GENERATION?}

    E -->|Yes - canLinkPrompt=true| G[Read promptName/promptVersion\nfrom span attributes]
    E -->|No - canLinkPrompt=false| H[promptName = null\npromptVersion = null]

    F -->|Yes - canLinkPrompt=true| I[Read promptName/promptVersion\nfrom span attributes]
    F -->|No - canLinkPrompt=false| J[promptName = null\npromptVersion = null]

    G --> K[events.push with type=observationType]
    H --> K
    I --> L[observation object → IngestionEvent]
    J --> L

    K --> M[IngestionService resolves prompt_id\nonly for GENERATIONs]
    L --> M
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): link prompts only on generati..."](https://github.com/langfuse/langfuse/commit/ceb2fe165881880fadc568ec6a444dd7567b8b28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43257097)</sub>

<!-- /greptile_comment -->