### PR TITLE
fix(agent): Improve reaction to denied tool calls

### DIFF
--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -310,6 +310,37 @@ describe("in-app agent public API route auth", () => {
     });
   });
 
+  it("does not create a mutating tool override for rejected approvals", async () => {
+    await withInAppAgentCloudEnv(async () => {
+      const { project, userId } = await setupInAppAgentProjectSession();
+      const conversationId = `conversation-${randomUUID()}`;
+      const forwardedProps = createResumeForwardedProps(false);
+      await seedPendingToolApproval({
+        projectId: project.id,
+        conversationId,
+        userId,
+        approvalRequest: forwardedProps.command.resume.approvalRequest,
+      });
+
+      const { response } = await callInAppAgentRoute({
+        projectId: project.id,
+        conversationId,
+        forwardedProps,
+      });
+
+      expect(response.status).toBe(200);
+      expect(agentMocks.createAgUiStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({
+            langfuseMcp: expect.objectContaining({
+              runOverride: undefined,
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
   it("rejects mutated resume forwarded props without consuming the pending approval", async () => {
     await withInAppAgentCloudEnv(async () => {
       const { project, userId } = await setupInAppAgentProjectSession();
@@ -483,6 +514,40 @@ describe("in-app agent public API route auth", () => {
         }),
       ).resolves.toBe(false);
       expect(agentMocks.createAgUiStream).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does not restore a rejected approval when stream initialization fails", async () => {
+    await withInAppAgentCloudEnv(async () => {
+      const { project, userId } = await setupInAppAgentProjectSession();
+      const conversationId = `conversation-${randomUUID()}`;
+      const forwardedProps = createResumeForwardedProps(false);
+      await seedPendingToolApproval({
+        projectId: project.id,
+        conversationId,
+        userId,
+        approvalRequest: forwardedProps.command.resume.approvalRequest,
+      });
+
+      agentMocks.createAgUiStream.mockRejectedValueOnce(
+        new Error("stream init failed"),
+      );
+
+      await expect(
+        callInAppAgentRoute({
+          projectId: project.id,
+          conversationId,
+          runId: "client-run-rejected-failed",
+          forwardedProps,
+        }),
+      ).rejects.toThrow("stream init failed");
+      await expect(
+        pendingToolApprovalExists({
+          projectId: project.id,
+          conversationId,
+          toolCallId: forwardedProps.command.resume.approvalRequest.toolCallId,
+        }),
+      ).resolves.toBe(false);
     });
   });
 
@@ -1004,11 +1069,11 @@ async function setupInAppAgentProjectSession() {
   return { org, project, userId };
 }
 
-function createResumeForwardedProps() {
+function createResumeForwardedProps(approved = true) {
   return {
     command: {
       resume: {
-        approved: true,
+        approved,
         approvalRequest: {
           type: "tool_approval_request" as const,
           toolCallId: `tool-call-${randomUUID()}`,

--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -1306,7 +1306,7 @@ describe("createAgUiStream", () => {
     );
   });
 
-  it("aborts rejected tools after streaming the rejected tool result", async () => {
+  it("continues after rejected tools and asks the user how to proceed", async () => {
     const { createAgUiStream } =
       await import("@/src/ee/features/in-app-agent/server/agent");
     const input = createToolApprovalResumeInput(false);
@@ -1314,6 +1314,25 @@ describe("createAgUiStream", () => {
     adapterEvents.items = [
       {
         type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+      {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId: "assistant-message-1",
+        role: "assistant",
+      },
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "assistant-message-1",
+        delta: "The action was not completed. How would you like to continue?",
+      },
+      {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: "assistant-message-1",
+      },
+      {
+        type: EventType.RUN_FINISHED,
         threadId: input.threadId,
         runId: input.runId,
       },
@@ -1339,7 +1358,6 @@ describe("createAgUiStream", () => {
           publicKey: "pk",
           secretKey: "sk",
           userAccess: defaultInAppAgentUserAccess,
-          runOverride: "run-override",
         },
         redirectAction: {
           projectId: "project-1",
@@ -1354,9 +1372,39 @@ describe("createAgUiStream", () => {
       streamedEvents.push(event);
     });
 
-    expect(adapterEvents.inputs).toEqual([]);
-    expect(vi.mocked(MCPClient)).not.toHaveBeenCalled();
-    expect(vi.mocked(Agent)).not.toHaveBeenCalled();
+    expect(adapterEvents.inputs).toEqual([
+      expect.objectContaining({
+        forwardedProps: {},
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            id: "tool-call-1-approval-tool-call",
+            role: "assistant",
+            toolCalls: [
+              expect.objectContaining({
+                id: "tool-call-1",
+              }),
+            ],
+          }),
+          expect.objectContaining({
+            id: "tool-call-1-approval-tool-result",
+            role: "tool",
+            toolCallId: "tool-call-1",
+            content: "Tool call was not approved by the user.",
+            error: "Tool call was not approved by the user.",
+          }),
+          expect.objectContaining({
+            id: "tool-call-1-approval-rejection-guidance",
+            role: "developer",
+            content: expect.stringContaining(
+              "ask the user how they would like to continue",
+            ),
+          }),
+        ]),
+      }),
+    ]);
+    expect(adapterEvents.createScoreConfigExecute).not.toHaveBeenCalled();
+    expect(vi.mocked(MCPClient)).toHaveBeenCalledOnce();
+    expect(vi.mocked(Agent)).toHaveBeenCalledOnce();
     expect(persistedEvents).toEqual([
       {
         type: EventType.RUN_STARTED,
@@ -1390,6 +1438,25 @@ describe("createAgUiStream", () => {
         content: "Tool call was not approved by the user.",
         role: "tool",
         error: "Tool call was not approved by the user.",
+      },
+      {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId: "assistant-message-1",
+        role: "assistant",
+      },
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "assistant-message-1",
+        delta: "The action was not completed. How would you like to continue?",
+      },
+      {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: "assistant-message-1",
+      },
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: input.threadId,
+        runId: input.runId,
       },
     ]);
     expect(streamedEvents).toEqual(persistedEvents);

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -454,6 +454,14 @@ function InAppAiAgentProviderInner({
             return nextApprovals;
           });
         },
+        onToolCallResultEvent: ({ event }) => {
+          updatePendingToolApprovals((currentApprovals) =>
+            currentApprovals.filter(
+              (approval) =>
+                approval.approvalRequest.toolCallId !== event.toolCallId,
+            ),
+          );
+        },
         onRunErrorEvent: ({ event }) => {
           if (intentionalAbortRef.current) {
             return;

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -15,10 +15,7 @@ import {
   type InAppAgentToolApprovalRequest,
   type ResumeForwardedProps,
 } from "@/src/ee/features/in-app-agent/schema";
-import {
-  createManualToolApprovalRunInput,
-  type ManualToolApprovalRunInput,
-} from "@/src/ee/features/in-app-agent/server/human-in-the-loop";
+import { createManualToolApprovalRunInput } from "@/src/ee/features/in-app-agent/server/human-in-the-loop";
 import type {
   InAppAgentPromptMetadata,
   InAppAgentTracingConfig,
@@ -337,27 +334,6 @@ export async function createAgUiStream(params: {
         return params.options.onError?.(new Error(streamedRunError));
       };
 
-      const completeManualToolApprovalRun = (
-        runInput: ManualToolApprovalRunInput,
-      ) => {
-        const terminalEvents = [
-          createRunStartedEvent(params.input),
-          ...runInput.syntheticEvents,
-        ];
-
-        instrumentation?.recordToolCallApproval(runInput.toolCallApproval);
-        instrumentation?.recordEvents(terminalEvents);
-        for (const syntheticEvent of terminalEvents) {
-          enqueueEvent(syntheticEvent);
-        }
-
-        closeController(() => {
-          instrumentation?.end({});
-          instrumentation?.flush();
-          return params.options.onComplete?.();
-        });
-      };
-
       const closeController = (
         terminalCallback?: () => void | Promise<void>,
       ) => {
@@ -440,32 +416,6 @@ export async function createAgUiStream(params: {
         | ResumeForwardedProps
         | undefined;
 
-      if (forwardedProps?.command?.resume?.approved === false) {
-        createManualToolApprovalRunInput({
-          input: params.input,
-          executeToolCall: async () => {
-            throw new Error("Rejected tool approvals must not execute tools.");
-          },
-        })
-          .then((runInput) => {
-            if (ending || closed || params.signal.aborted) {
-              abortStream();
-              return;
-            }
-
-            completeManualToolApprovalRun(runInput);
-          })
-          .catch((error) => {
-            if (ending || closed) {
-              return;
-            }
-
-            failStream(error);
-          });
-
-        return;
-      }
-
       createMastraAdapter({
         input: params.input,
         signal: params.signal,
@@ -501,11 +451,6 @@ export async function createAgUiStream(params: {
               params.options.onApprovedToolCallExecuted,
           });
           const pendingSyntheticEvents = [...runInput.syntheticEvents];
-
-          if (!runInput.shouldContinue) {
-            completeManualToolApprovalRun(runInput);
-            return;
-          }
 
           if (
             forwardedProps?.command?.resume?.approved === true &&
@@ -1200,15 +1145,6 @@ function normalizeAdapterEvent(
   }
 
   return [event];
-}
-
-function createRunStartedEvent(input: AgUiRunAgentInput): AgUiEvent {
-  return {
-    type: EventType.RUN_STARTED,
-    threadId: input.threadId,
-    runId: input.runId,
-    ...(input.parentRunId ? { parentRunId: input.parentRunId } : {}),
-  };
 }
 
 function createRunErrorEvent(

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -263,13 +263,19 @@ export default async function handler(request: Request) {
       ? sanitizedInput.forwardedProps.command.resume.approvalRequest
       : undefined;
 
+    const approvedResumeApprovalRequest =
+      isResumeAgentInput(sanitizedInput) &&
+      sanitizedInput.forwardedProps.command.resume.approved
+        ? sanitizedInput.forwardedProps.command.resume.approvalRequest
+        : undefined;
+
     return await withInAppAgentMcpApiKeyCleanup(
       {
         projectId,
         runId: sanitizedInput.runId,
         userId,
         toolName: getInAppAgentMcpRegistryToolName(
-          resumeApprovalRequest?.toolName,
+          approvedResumeApprovalRequest?.toolName,
         ),
       },
       async (mcpApiKey, runOverride, cleanupMcpApiKey) => {
@@ -281,7 +287,7 @@ export default async function handler(request: Request) {
         const restorePendingToolApprovalIfRetryable = () => {
           if (
             !pendingToolApprovalConsumed ||
-            !resumeApprovalRequest ||
+            !approvedResumeApprovalRequest ||
             approvedToolResultPersisted
           ) {
             return;
@@ -290,7 +296,7 @@ export default async function handler(request: Request) {
           return storePendingToolApproval({
             projectId,
             conversationId: conversation.id,
-            approvalRequest: resumeApprovalRequest,
+            approvalRequest: approvedResumeApprovalRequest,
           });
         };
 

--- a/web/src/ee/features/in-app-agent/server/human-in-the-loop.ts
+++ b/web/src/ee/features/in-app-agent/server/human-in-the-loop.ts
@@ -155,7 +155,6 @@ export function parseInAppAgentInterruptEvent(
 export type ManualToolApprovalRunInput = {
   input: AgUiRunAgentInput;
   syntheticEvents: AgUiEvent[];
-  shouldContinue: boolean;
   toolCallApproval?: {
     toolCallId: string;
     status: "approved" | "rejected";
@@ -172,14 +171,30 @@ export async function createManualToolApprovalRunInput(params: {
   const forwardedProps = getResumeForwardedProps(params.input);
 
   if (!forwardedProps) {
-    return { input: params.input, syntheticEvents: [], shouldContinue: true };
+    return { input: params.input, syntheticEvents: [] };
   }
 
   const { approved, approvalRequest } = forwardedProps.command.resume;
   if (!approved) {
+    const assistantMessage =
+      createManualToolCallAssistantMessage(approvalRequest);
+    const toolMessage: AgUiMessage = {
+      id: createManualToolResultMessageId(approvalRequest),
+      role: "tool",
+      content: MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
+      toolCallId: approvalRequest.toolCallId,
+      error: MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
+    };
+
     return {
       input: {
         ...params.input,
+        messages: [
+          ...params.input.messages,
+          assistantMessage,
+          toolMessage,
+          createToolRejectionGuidanceMessage(approvalRequest),
+        ],
         forwardedProps: {},
       },
       syntheticEvents: createManualToolApprovalEvents({
@@ -187,7 +202,6 @@ export async function createManualToolApprovalRunInput(params: {
         toolResultContent: MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
         toolError: MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
       }),
-      shouldContinue: false,
       toolCallApproval: {
         toolCallId: approvalRequest.toolCallId,
         status: "rejected",
@@ -235,11 +249,25 @@ export async function createManualToolApprovalRunInput(params: {
       forwardedProps: {},
     },
     syntheticEvents,
-    shouldContinue: true,
     toolCallApproval: {
       toolCallId: approvalRequest.toolCallId,
       status: "approved",
     },
+  };
+}
+
+function createToolRejectionGuidanceMessage(
+  approvalRequest: InAppAgentToolApprovalRequest,
+): AgUiMessage {
+  return {
+    id: `${approvalRequest.toolCallId}-approval-rejection-guidance`,
+    role: "developer",
+    content: [
+      `The user declined the proposed tool call ${approvalRequest.toolName}.`,
+      "The action was not completed.",
+      "Do not retry this tool call or attempt an equivalent action unless the user explicitly requests it.",
+      "Briefly acknowledge that the action was not completed and ask the user how they would like to continue.",
+    ].join("\n"),
   };
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes the agent's behaviour when a user denies a tool-call approval: instead of aborting the stream immediately with synthetic rejection events, the agent now continues, injects the rejection into the conversation history along with a developer-role guidance message, and lets the model acknowledge the denial and ask the user how to proceed.

- **`human-in-the-loop.ts`**: Removes `shouldContinue` from `ManualToolApprovalRunInput`; for rejected approvals the input messages are augmented with the assistant message, rejection tool-result, and a new `createToolRejectionGuidanceMessage` so the model receives full context.
- **`handler.ts`**: Introduces `approvedResumeApprovalRequest` (separate from `resumeApprovalRequest`) so the mutating MCP run-override is only created for *approved* resumes; rejected tool calls no longer get privileged MCP write access.
- **`InAppAiAgentProvider.tsx`**: Adds `onToolCallResultEvent` to immediately remove the pending approval from client state once the tool-call result event arrives, covering the rejection path that previously relied on stream termination to clean up UI state.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core changes are safe to merge: rejected tool calls no longer receive a mutating MCP run-override, and the agent now continues correctly after a rejection. The one issue worth a follow-up is a narrowed but real edge case in the restore-on-error path.

The architectural change is sound and the tests cover the main flows well. The only gap is that `restorePendingToolApprovalIfRetryable` in `handler.ts` still gates on `resumeApprovalRequest` (present for both approved and rejected resumes) rather than the new `approvedResumeApprovalRequest`. If MCP initialisation fails during the continuation run for a rejected tool, the previously-rejected pending approval gets restored in the DB, allowing the user to re-submit and potentially approve what they had declined. The window is a real infrastructure failure path (MCP outage during rejection continuation), but not an immediately exploitable flow.

web/src/ee/features/in-app-agent/server/handler.ts — specifically the `restorePendingToolApprovalIfRetryable` closure and its use of `resumeApprovalRequest` versus `approvedResumeApprovalRequest`.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Provider as InAppAiAgentProvider
    participant Handler as handler.ts
    participant Agent as agent.ts
    participant HITL as human-in-the-loop.ts
    participant Mastra as MastraAdapter/Agent

    User->>Provider: Reject tool approval
    Provider->>Handler: "POST /api/agent (approved=false)"
    Handler->>Handler: validatePendingToolApproval
    Handler->>Handler: consumeAndValidatePendingToolApproval
    Note over Handler: approvedResumeApprovalRequest=undefined
    Handler->>Agent: createAgUiStream(input, options)
    Agent->>Mastra: createMastraAdapter()
    Agent->>HITL: "createManualToolApprovalRunInput(approved=false)"
    HITL-->>Agent: messages with assistantMsg + toolResultMsg + guidanceMsg
    Agent->>Mastra: adapter.run(runInput)
    Mastra-->>Agent: RUN_STARTED event
    Agent->>Agent: emit synthetic rejection events
    Provider->>Provider: onToolCallResultEvent removes pendingApproval
    Mastra-->>Agent: TEXT_MESSAGE events
    Agent-->>Handler: stream events
    Handler-->>Provider: SSE stream
    Mastra-->>Agent: RUN_FINISHED
    Agent-->>Provider: RUN_FINISHED
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Provider as InAppAiAgentProvider
    participant Handler as handler.ts
    participant Agent as agent.ts
    participant HITL as human-in-the-loop.ts
    participant Mastra as MastraAdapter/Agent

    User->>Provider: Reject tool approval
    Provider->>Handler: "POST /api/agent (approved=false)"
    Handler->>Handler: validatePendingToolApproval
    Handler->>Handler: consumeAndValidatePendingToolApproval
    Note over Handler: approvedResumeApprovalRequest=undefined
    Handler->>Agent: createAgUiStream(input, options)
    Agent->>Mastra: createMastraAdapter()
    Agent->>HITL: "createManualToolApprovalRunInput(approved=false)"
    HITL-->>Agent: messages with assistantMsg + toolResultMsg + guidanceMsg
    Agent->>Mastra: adapter.run(runInput)
    Mastra-->>Agent: RUN_STARTED event
    Agent->>Agent: emit synthetic rejection events
    Provider->>Provider: onToolCallResultEvent removes pendingApproval
    Mastra-->>Agent: TEXT_MESSAGE events
    Agent-->>Handler: stream events
    Handler-->>Provider: SSE stream
    Mastra-->>Agent: RUN_FINISHED
    Agent-->>Provider: RUN_FINISHED
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/ee/features/in-app-agent/server/handler.ts:287-301
**Rejected approval eligible for restoration if continuation run fails**

`restorePendingToolApprovalIfRetryable` uses `resumeApprovalRequest` — which is non-null for *both* approved and rejected resumes — as its guard. Before this PR, rejected cases terminated immediately before MCP initialisation, so the restore window was essentially zero. Now the agent runs a full continuation turn, and if `createMastraAdapter` (or the subsequent agent run) throws before the rejection `TOOL_CALL_RESULT` synthetic event is persisted (`approvedToolResultPersisted = true`), `onError` will call `restorePendingToolApprovalIfRetryable`, which would re-insert the rejected approval into the DB. A user whose rejection was followed by an MCP outage would find their previously-rejected approval retrievable and could subsequently approve it. Using `approvedResumeApprovalRequest` (the new variable introduced two lines above) as the guard would limit restoration to genuinely approved-but-failed cases only.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Improve reaction to denied t..."](https://github.com/langfuse/langfuse/commit/6ffdb1bb7461ec8e4f09baa90df0a8ea604e1598) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43277347)</sub>

<!-- /greptile_comment -->