### PR TITLE
fix(search-bar): Use `LANGFUSE_AWS_BEDROCK_SMALL_MODEL` for AI features

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -185,10 +185,8 @@ AWS_ACCESS_KEY_ID="A123456789"
 AWS_SECRET_ACCESS_KEY="SAK123456789"
 LANGFUSE_LLM_CONNECTION_BEDROCK_API_KEY="1234567890abcdef"
 LANGFUSE_AWS_BEDROCK_REGION="eu-west-1"
-# Model for AI features (e.g. the search-bar AI filter generator). Cloud/prod uses
-# `eu.anthropic.claude-opus-4-8`. Set that here to match prod exactly. Weak/old
-# models (e.g. `eu.anthropic.claude-3-haiku-20240307-v1:0`) degrade refine quality
-# — they tend to ignore the existing filters and replace instead of narrowing.
+# Default model for AI features. Search-bar filter generation prefers the small
+# model below and falls back to this model when the small model is not configured.
 LANGFUSE_AWS_BEDROCK_MODEL="eu.anthropic.claude-opus-4-8"
 LANGFUSE_AWS_BEDROCK_SMALL_MODEL="eu.anthropic.claude-haiku-4-5-20251001-v1:0"
 LANGFUSE_IN_APP_AGENT_AWS_PROFILE="playground"

--- a/web/src/features/search-bar/server/router.ts
+++ b/web/src/features/search-bar/server/router.ts
@@ -83,7 +83,11 @@ export const searchBarRouter = createTRPCRouter({
           });
         }
 
-        if (!env.LANGFUSE_AWS_BEDROCK_MODEL) {
+        const model =
+          env.LANGFUSE_AWS_BEDROCK_SMALL_MODEL ??
+          env.LANGFUSE_AWS_BEDROCK_MODEL;
+
+        if (!model) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
             message:
@@ -123,6 +127,7 @@ export const searchBarRouter = createTRPCRouter({
               type: ChatMessageType.PublicAPICreated,
             },
           ],
+          model,
           maxTokens: 2048,
           traceSinkParams: aiTelemetryEnabled
             ? getLangfuseAITraceSinkParams({


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the search-bar AI filter generation to prefer `LANGFUSE_AWS_BEDROCK_SMALL_MODEL` over `LANGFUSE_AWS_BEDROCK_MODEL`, with a fallback to the larger model when the small model env var isn't set.

- **`router.ts`**: The model selection is now `LANGFUSE_AWS_BEDROCK_SMALL_MODEL ?? LANGFUSE_AWS_BEDROCK_MODEL`, and the resolved value is passed explicitly to `fetchLangfuseAICompletion`. Previously the router only validated `LANGFUSE_AWS_BEDROCK_MODEL` and then relied on the function's internal default, meaning the small-model env var was silently ignored.
- **`.env.dev.example`**: Comment updated to describe the new two-tier model selection, with `LANGFUSE_AWS_BEDROCK_SMALL_MODEL` shown as the preferred target for this feature.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Straightforward and safe to merge — the change is a targeted model selection fix with a well-defined fallback path and no regressions on the existing validation or error-handling logic.

The router now correctly resolves the model from the small-model env var first, falls back to the large-model var, and passes the result explicitly to the completion function. The guard check, error messages, and all other paths are unchanged. The .env.dev.example comment accurately describes the new behavior.

No files require special attention. Note that natural-language-filters/server/router.ts still uses the old behavior (no small-model preference), but that appears intentional and is out of scope for this PR.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as searchBarRouter.generateFilter
    participant BedrockFn as fetchLangfuseAICompletion
    participant Bedrock as AWS Bedrock

    Client->>Router: mutation(prompt, projectId, ...)
    Router->>Router: Check cloud region guard
    Router->>Router: Check aiFeaturesEnabled
    Router->>Router: "model = LANGFUSE_AWS_BEDROCK_SMALL_MODEL ?? LANGFUSE_AWS_BEDROCK_MODEL"
    alt model is null
        Router-->>Client: TRPCError PRECONDITION_FAILED
    else model is set
        Router->>BedrockFn: "{ messages, model, maxTokens, traceSinkParams }"
        BedrockFn->>Bedrock: fetchLLMCompletion(model, messages)
        Bedrock-->>BedrockFn: completion string
        BedrockFn-->>Router: llmCompletion
        Router->>Router: parseGeneratedFilters(llmCompletion)
        Router-->>Client: "{ filters, queryText }"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as searchBarRouter.generateFilter
    participant BedrockFn as fetchLangfuseAICompletion
    participant Bedrock as AWS Bedrock

    Client->>Router: mutation(prompt, projectId, ...)
    Router->>Router: Check cloud region guard
    Router->>Router: Check aiFeaturesEnabled
    Router->>Router: "model = LANGFUSE_AWS_BEDROCK_SMALL_MODEL ?? LANGFUSE_AWS_BEDROCK_MODEL"
    alt model is null
        Router-->>Client: TRPCError PRECONDITION_FAILED
    else model is set
        Router->>BedrockFn: "{ messages, model, maxTokens, traceSinkParams }"
        BedrockFn->>Bedrock: fetchLLMCompletion(model, messages)
        Bedrock-->>BedrockFn: completion string
        BedrockFn-->>Router: llmCompletion
        Router->>Router: parseGeneratedFilters(llmCompletion)
        Router-->>Client: "{ filters, queryText }"
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search-bar): Use \`LANGFUSE\_AWS\_BEDRO..."](https://github.com/langfuse/langfuse/commit/9066c22e9b0bb050e430bce64943e198d71c59bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43283383)</sub>

<!-- /greptile_comment -->