### PR TITLE
feat(telemetry): report predominant ingested SDK version from events_core

### DIFF
--- a/packages/shared/src/server/ingestion/ingestionAttribution.test.ts
+++ b/packages/shared/src/server/ingestion/ingestionAttribution.test.ts
@@ -5,6 +5,7 @@ import {
   classifyIngestionSdkVersion,
   createIngestionAttribution,
   createUnknownSdkIngestionAttribution,
+  summarizeIngestionSdkUsage,
   UNKNOWN_INGESTION_SDK_VALUE,
 } from "./ingestionAttribution";
 
@@ -145,4 +146,59 @@ describe("ingestion attribution", () => {
       );
     },
   );
+});
+
+describe("summarizeIngestionSdkUsage", () => {
+  it("aggregates per canonical SDK and picks the predominant version", () => {
+    expect(
+      summarizeIngestionSdkUsage([
+        { sdkName: "python", sdkVersion: "3.4.0", count: 10 },
+        { sdkName: "langfuse-python", sdkVersion: "3.4.0", count: 5 },
+        { sdkName: "python", sdkVersion: "2.60.0", count: 8 },
+        { sdkName: "@langfuse/tracing", sdkVersion: "5.1.2", count: 3 },
+        { sdkName: "langfuse-js", sdkVersion: "5.1.2", count: 2 },
+        { sdkName: "@langfuse/openai", sdkVersion: "4.0.0", count: 4 },
+      ]),
+    ).toEqual({
+      python: { predominantVersion: "3.4.0", eventCount: 23 },
+      javascript: { predominantVersion: "5.1.2", eventCount: 9 },
+    });
+  });
+
+  it("folds pre-release suffixes into their base version", () => {
+    expect(
+      summarizeIngestionSdkUsage([
+        { sdkName: "python", sdkVersion: "3.4.0-rc.1", count: 3 },
+        { sdkName: "python", sdkVersion: "3.4.0", count: 3 },
+        { sdkName: "python", sdkVersion: "3.3.0", count: 5 },
+      ]),
+    ).toEqual({
+      python: { predominantVersion: "3.4.0", eventCount: 11 },
+    });
+  });
+
+  it("drops unknown and unsupported SDK rows", () => {
+    expect(
+      summarizeIngestionSdkUsage([
+        {
+          sdkName: UNKNOWN_INGESTION_SDK_VALUE,
+          sdkVersion: "1.0.0",
+          count: 100,
+        },
+        {
+          sdkName: "python",
+          sdkVersion: UNKNOWN_INGESTION_SDK_VALUE,
+          count: 100,
+        },
+        { sdkName: "ruby", sdkVersion: "1.0.0", count: 100 },
+        { sdkName: "python", sdkVersion: "3.4.0", count: 1 },
+      ]),
+    ).toEqual({
+      python: { predominantVersion: "3.4.0", eventCount: 1 },
+    });
+  });
+
+  it("returns an empty summary for no rows", () => {
+    expect(summarizeIngestionSdkUsage([])).toEqual({});
+  });
 });

--- a/packages/shared/src/server/ingestion/ingestionAttribution.ts
+++ b/packages/shared/src/server/ingestion/ingestionAttribution.ts
@@ -158,6 +158,59 @@ export const classifyIngestionSdkVersion = (params: {
   };
 };
 
+export type IngestionSdkUsageRow = {
+  sdkName: string;
+  sdkVersion: string;
+  count: number;
+};
+
+export type IngestionSdkUsageSummary = Partial<
+  Record<
+    IngestionSdkCanonicalName,
+    { predominantVersion: string; eventCount: number }
+  >
+>;
+
+/**
+ * Collapses raw (sdkName, sdkVersion, count) rows into per-canonical-SDK
+ * usage: total event count plus the version that ingested the most events.
+ * Rows from non-Langfuse clients (unknown/unsupported SDK names or versions)
+ * are dropped; pre-release suffixes are folded into their base version.
+ */
+export const summarizeIngestionSdkUsage = (
+  rows: IngestionSdkUsageRow[],
+): IngestionSdkUsageSummary => {
+  const versionCounts = new Map<
+    IngestionSdkCanonicalName,
+    Map<string, number>
+  >();
+
+  for (const row of rows) {
+    const canonicalSdkName = normalizeIngestionSdkName(row.sdkName);
+    if (!canonicalSdkName) continue;
+
+    const version = extractBaseIngestionSdkVersion(row.sdkVersion);
+    if (!version || version === UNKNOWN_INGESTION_SDK_VALUE) continue;
+
+    const counts = versionCounts.get(canonicalSdkName) ?? new Map();
+    counts.set(version, (counts.get(version) ?? 0) + row.count);
+    versionCounts.set(canonicalSdkName, counts);
+  }
+
+  const summary: IngestionSdkUsageSummary = {};
+  for (const [canonicalSdkName, counts] of versionCounts) {
+    const [predominantVersion] = [...counts.entries()].sort(
+      (a, b) => b[1] - a[1] || b[0].localeCompare(a[0]),
+    )[0]!;
+    summary[canonicalSdkName] = {
+      predominantVersion,
+      eventCount: [...counts.values()].reduce((acc, curr) => acc + curr, 0),
+    };
+  }
+
+  return summary;
+};
+
 export const createIngestionAttribution = (params: {
   headers?: IngestionHeaderMap;
   authCheck: AuthHeaderValidVerificationResult;

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -91,7 +91,10 @@ import {
   EventsObservationRecordReadType,
   TraceRecordReadType,
 } from "./definitions";
-import { UNKNOWN_INGESTION_SDK_VALUE } from "../ingestion/ingestionAttribution";
+import {
+  type IngestionSdkUsageRow,
+  UNKNOWN_INGESTION_SDK_VALUE,
+} from "../ingestion/ingestionAttribution";
 import type { AnalyticsObservationEvent } from "../analytics-integrations/types";
 import {
   getObservationByIdFromObservationsTable,
@@ -3318,6 +3321,62 @@ export async function getLatestSdkVersionInfoFromEvents(params: {
     }),
   };
 }
+
+/**
+ * Aggregates Langfuse SDK ingestion attribution (name, version, event count)
+ * from events_core in the given creation interval. Returns null when the
+ * events_core table does not exist — the v4 events pipeline is not
+ * migration-managed yet, so most self-hosted deployments do not have it and
+ * callers must treat null as a no-op.
+ */
+export const getIngestionSdkUsageInCreationInterval = async ({
+  start,
+  end,
+}: {
+  start: Date;
+  end: Date;
+}): Promise<IngestionSdkUsageRow[] | null> => {
+  const tableExists = await queryClickhouse<{ result: number }>({
+    query: "EXISTS TABLE events_core",
+    tags: { route: "telemetry" },
+  });
+  if (Number(tableExists[0]?.result) !== 1) {
+    return null;
+  }
+
+  const rows = await queryClickhouse<{
+    sdk_name: string;
+    sdk_version: string;
+    count: string;
+  }>({
+    query: `
+      SELECT
+        ingestion_sdk_name AS sdk_name,
+        ingestion_sdk_version AS sdk_version,
+        count(*) AS count
+      FROM events_core
+      WHERE created_at >= {start: DateTime64(3)}
+        AND created_at < {end: DateTime64(3)}
+        AND ingestion_sdk_name != {unknown: String}
+        AND ingestion_sdk_version != {unknown: String}
+      GROUP BY sdk_name, sdk_version
+      ORDER BY count DESC
+      LIMIT 1000
+    `,
+    params: {
+      start: convertDateToClickhouseDateTime(start),
+      end: convertDateToClickhouseDateTime(end),
+      unknown: UNKNOWN_INGESTION_SDK_VALUE,
+    },
+    tags: { route: "telemetry" },
+  });
+
+  return rows.map((row) => ({
+    sdkName: row.sdk_name,
+    sdkVersion: row.sdk_version,
+    count: Number(row.count),
+  }));
+};
 
 export const getTracesIdentifierForSessionFromEvents = async (
   projectId: string,

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -11,6 +11,7 @@ import {
   updateEvents,
   getTraceByIdFromEventsTable,
   getObservationsBatchIOFromEventsTable,
+  getIngestionSdkUsageInCreationInterval,
   getLatestSdkVersionInfoFromEvents,
   getTracesIdentifierForSessionFromEvents,
   getEventsFilterOptionsForColumns,
@@ -3515,6 +3516,68 @@ describe("Clickhouse Events Repository Test", () => {
       expect(result.name).toBeUndefined();
       expect(result.version).toBeUndefined();
       expect(result.language).toBe("nodejs");
+    });
+  });
+
+  maybe("getIngestionSdkUsageInCreationInterval", () => {
+    it("aggregates SDK usage by name and version within the interval", async () => {
+      const now = Date.now();
+      // The query is instance-wide (no project filter), so isolate this
+      // test's rows via a unique version string
+      const uniqueVersion = `9.9.9+${randomUUID()}`;
+
+      await createEventsCh([
+        createEvent({
+          project_id: randomUUID(),
+          ingestion_sdk_name: "langfuse-python",
+          ingestion_sdk_version: uniqueVersion,
+        }),
+        createEvent({
+          project_id: randomUUID(),
+          ingestion_sdk_name: "langfuse-python",
+          ingestion_sdk_version: uniqueVersion,
+        }),
+      ]);
+
+      const rows = await getIngestionSdkUsageInCreationInterval({
+        start: new Date(now - 60 * 60 * 1000),
+        end: new Date(now + 60 * 60 * 1000),
+      });
+
+      expect(rows).not.toBeNull();
+      expect(rows).toContainEqual({
+        sdkName: "langfuse-python",
+        sdkVersion: uniqueVersion,
+        count: 2,
+      });
+      // 'unknown' sentinel rows (raw OTel clients) are excluded
+      for (const row of rows!) {
+        expect(row.sdkName).not.toBe("unknown");
+        expect(row.sdkVersion).not.toBe("unknown");
+      }
+    });
+
+    it("excludes events created outside the interval", async () => {
+      const now = Date.now();
+      const uniqueVersion = `9.9.9+${randomUUID()}`;
+
+      await createEventsCh([
+        createEvent({
+          project_id: randomUUID(),
+          ingestion_sdk_name: "langfuse-python",
+          ingestion_sdk_version: uniqueVersion,
+        }),
+      ]);
+
+      const rows = await getIngestionSdkUsageInCreationInterval({
+        start: new Date(now - 2 * 60 * 60 * 1000),
+        end: new Date(now - 60 * 60 * 1000),
+      });
+
+      expect(rows).not.toBeNull();
+      expect(
+        rows!.find((row) => row.sdkVersion === uniqueVersion),
+      ).toBeUndefined();
     });
   });
 

--- a/web/src/features/telemetry/index.ts
+++ b/web/src/features/telemetry/index.ts
@@ -4,10 +4,13 @@ import { Prisma, prisma } from "@langfuse/shared/src/db";
 import { v4 as uuidv4 } from "uuid";
 import {
   getDatasetRunItemCountsByProjectInCreationInterval,
+  getIngestionSdkUsageInCreationInterval,
   getObservationCountsByProjectInCreationInterval,
   getScoreCountsByProjectInCreationInterval,
   getTraceCountsByProjectInCreationInterval,
+  type IngestionSdkUsageSummary,
   logger,
+  summarizeIngestionSdkUsage,
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
 
@@ -237,6 +240,21 @@ async function posthogTelemetry({
       0,
     );
 
+    // Predominant ingested SDK (python/javascript) and version, from the v4
+    // events table; noop on deployments without events_core
+    let ingestionSdkUsage: IngestionSdkUsageSummary | null = null;
+    try {
+      const sdkUsageRows = await getIngestionSdkUsageInCreationInterval({
+        start: startTimeframe ?? new Date(0),
+        end: endTimeframe,
+      });
+      ingestionSdkUsage = sdkUsageRows
+        ? summarizeIngestionSdkUsage(sdkUsageRows)
+        : null;
+    } catch (error) {
+      logger.warn("Telemetry failed to read ingestion SDK usage", error);
+    }
+
     // Domains (no PII)
     const domains = await prisma.$queryRaw<Array<{ domain: string }>>`
       SELECT
@@ -267,11 +285,29 @@ async function posthogTelemetry({
         endTimeframe: endTimeframe.toISOString(),
         eeLicenseKey: env.LANGFUSE_EE_LICENSE_KEY,
         langfuseCloudRegion: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+        ...(ingestionSdkUsage?.python && {
+          pythonSdkPredominantVersion:
+            ingestionSdkUsage.python.predominantVersion,
+          pythonSdkEventCount: ingestionSdkUsage.python.eventCount,
+        }),
+        ...(ingestionSdkUsage?.javascript && {
+          javascriptSdkPredominantVersion:
+            ingestionSdkUsage.javascript.predominantVersion,
+          javascriptSdkEventCount: ingestionSdkUsage.javascript.eventCount,
+        }),
         $set: {
           environment: process.env.NODE_ENV,
           userDomains: domains,
           docker: true,
           langfuseVersion: VERSION,
+          ...(ingestionSdkUsage?.python && {
+            pythonSdkPredominantVersion:
+              ingestionSdkUsage.python.predominantVersion,
+          }),
+          ...(ingestionSdkUsage?.javascript && {
+            javascriptSdkPredominantVersion:
+              ingestionSdkUsage.javascript.predominantVersion,
+          }),
         },
       },
     });


### PR DESCRIPTION
## Summary

Adds the predominantly used Langfuse SDK (python/javascript) and its version to the self-hosted telemetry event, sourced exclusively from the v4 `events_core` table.

- `getIngestionSdkUsageInCreationInterval` (shared, events repository): checks `EXISTS TABLE events_core` first and returns `null` when the table is absent — deployments without the v4 events pipeline are a simple noop. Otherwise aggregates event counts by `ingestion_sdk_name`/`ingestion_sdk_version` over the telemetry interval (filtered on `created_at`, minmax-indexed), excluding `unknown` sentinel rows from raw OTel clients.
- `summarizeIngestionSdkUsage` (shared, ingestion attribution): pure helper that normalizes raw SDK names to canonical `python`/`javascript` (`langfuse-python`, `@langfuse/tracing`, `langfuse-js`, … collapse correctly), folds pre-release suffixes into base versions, and returns per-language `{ predominantVersion, eventCount }`.
- Telemetry job (`web/src/features/telemetry/index.ts`): captures `pythonSdkPredominantVersion`/`pythonSdkEventCount` and `javascriptSdkPredominantVersion`/`javascriptSdkEventCount` as event properties, with the predominant versions also in `$set`. The lookup is wrapped in its own try/catch so it can never break the rest of the telemetry event.

## Impacted packages

- `@langfuse/shared`
- `web`

## Verification

- `pnpm --filter @langfuse/shared run test src/server/ingestion/ingestionAttribution.test.ts` — `Tests  15 passed (15)` (4 new summarizer tests)
- `pnpm --filter web run test src/__tests__/server/repositories/event-repository.servertest.ts` — `Tests  74 passed (74)` (2 new tests for the interval query)
- `pnpm run lint` — `Tasks:    8 successful, 8 total`
- `pnpm run typecheck` — `Tasks:    8 successful, 8 total`
- Noop path verified against local ClickHouse: `EXISTS TABLE` on a missing table returns `{"result":0}` without erroring.

## Follow-up (outside this repo)

The telemetry docs page (langfuse.com/self-hosting/security/telemetry) documents the exact fields collected and should gain the four new SDK fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends self-hosted telemetry to report the predominant Langfuse SDK (Python/JavaScript) and its version, aggregated from the `events_core` ClickHouse table over the telemetry interval.

- **New repository function** (`getIngestionSdkUsageInCreationInterval`): guards with `EXISTS TABLE events_core` before querying, filtering unknown sentinels in SQL and returning `null` for deployments without the v4 events pipeline — making the feature a safe noop for most self-hosted users.
- **New aggregation helper** (`summarizeIngestionSdkUsage`): normalizes raw SDK names to canonical `python`/`javascript`, strips pre-release suffixes, and picks the version with the highest event count as predominant.
- **Telemetry integration**: the lookup is isolated in its own `try/catch`, spreading four new properties (`pythonSdkPredominantVersion`, `pythonSdkEventCount`, `javascriptSdkPredominantVersion`, `javascriptSdkEventCount`) into the PostHog event, with the version fields also set as persistent person properties via `$set`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the SDK lookup is fully isolated in a try/catch and degrades to a noop on deployments without events_core, so the existing telemetry path cannot be affected.

The implementation is well-structured and the isolation guarantees are solid. The one issue found is in the tie-breaking comparator for predominantVersion: it uses localeCompare (lexicographic string order) instead of semver ordering, which can report an older version as predominant when two versions have exactly equal event counts (e.g. '3.9.0' would beat '3.10.0'). This only affects reporting accuracy in a rare edge case and has no impact on application correctness.

ingestionAttribution.ts — the tie-breaking logic in summarizeIngestionSdkUsage deserves a second look.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant TJ as Telemetry Job (web)
    participant ER as events.ts (shared)
    participant CH as ClickHouse
    participant IA as ingestionAttribution.ts (shared)
    participant PH as PostHog

    TJ->>ER: "getIngestionSdkUsageInCreationInterval({start, end})"
    ER->>CH: EXISTS TABLE events_core
    CH-->>ER: result: 0 or 1
    alt table does not exist
        ER-->>TJ: null (noop)
    else table exists
        ER->>CH: "SELECT sdk_name, sdk_version, count(*) FROM events_core WHERE created_at IN [start,end] AND not unknown GROUP BY ... ORDER BY count DESC LIMIT 1000"
        CH-->>ER: rows[]
        ER-->>TJ: IngestionSdkUsageRow[]
        TJ->>IA: summarizeIngestionSdkUsage(rows)
        IA->>IA: normalizeIngestionSdkName (python/javascript)
        IA->>IA: extractBaseIngestionSdkVersion (strip pre-release)
        IA->>IA: aggregate counts, pick predominantVersion
        IA-->>TJ: "IngestionSdkUsageSummary {python, javascript}"
        TJ->>PH: capture telemetry event with SDK version and count fields
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant TJ as Telemetry Job (web)
    participant ER as events.ts (shared)
    participant CH as ClickHouse
    participant IA as ingestionAttribution.ts (shared)
    participant PH as PostHog

    TJ->>ER: "getIngestionSdkUsageInCreationInterval({start, end})"
    ER->>CH: EXISTS TABLE events_core
    CH-->>ER: result: 0 or 1
    alt table does not exist
        ER-->>TJ: null (noop)
    else table exists
        ER->>CH: "SELECT sdk_name, sdk_version, count(*) FROM events_core WHERE created_at IN [start,end] AND not unknown GROUP BY ... ORDER BY count DESC LIMIT 1000"
        CH-->>ER: rows[]
        ER-->>TJ: IngestionSdkUsageRow[]
        TJ->>IA: summarizeIngestionSdkUsage(rows)
        IA->>IA: normalizeIngestionSdkName (python/javascript)
        IA->>IA: extractBaseIngestionSdkVersion (strip pre-release)
        IA->>IA: aggregate counts, pick predominantVersion
        IA-->>TJ: "IngestionSdkUsageSummary {python, javascript}"
        TJ->>PH: capture telemetry event with SDK version and count fields
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/ingestion/ingestionAttribution.ts:202-204
**Lexicographic tiebreaker breaks semver ordering**

When two versions have exactly equal event counts, `localeCompare` is used as the tiebreaker. This performs a lexicographic/locale-aware string sort rather than semver ordering, so `"3.9.0"` sorts above `"3.10.0"` (since `'9' > '1'` in string order), causing the older version to be reported as predominant. Consider using a numeric component comparison for the tiebreaker, e.g. splitting on `'.'` and comparing each segment as a number.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(telemetry): report predominant inge..."](https://github.com/langfuse/langfuse/commit/7ec2b27baa48f2af5c12a4d6a1b4f3631442b52d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43278808)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->