### PR TITLE
chore(vitest): Enable "silent: passed-only" by default

### DIFF
--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    silent: "passed-only",
     dir: "./src",
     include: ["**/*.test.ts"],
     pool: "forks",

--- a/web/vitest.config.mts
+++ b/web/vitest.config.mts
@@ -68,7 +68,7 @@ export default defineConfig({
     reporters: process.env.CI
       ? ["default", new VitestCiReporter()]
       : ["default"],
-    silent: process.env.CI ? "passed-only" : false,
+    silent: "passed-only",
     globals: true,
     retry: process.env.CI ? 3 : 0,
     // Servertests are DB-roundtrip bound, so hundreds cross the default 300ms

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     reporters: process.env.CI
       ? ["default", new VitestCiReporter()]
       : ["default"],
-    silent: process.env.CI ? "passed-only" : false,
+    silent: "passed-only",
     retry: process.env.CI ? 3 : 0,
     // Worker tests are DB-roundtrip bound, so many cross the default 300ms
     // slow threshold on CI and the default reporter prints a line for each.


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables `silent: "passed-only"` in all three Vitest configs unconditionally, so passing tests suppress console output both locally and in CI. Previously, `web` and `worker` only activated silent mode in CI, and `packages/shared` had no silent setting at all.

- **`web` and `worker`**: The conditional `process.env.CI ? "passed-only" : false` is replaced with the always-on `"passed-only"` value, reducing console noise during local development.
- **`packages/shared`**: `silent: "passed-only"` is added as a new option where previously no silencing was configured.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are limited to Vitest reporter configuration and have no impact on production code or test correctness.

All three changes are identical in intent: console output from passing tests is suppressed everywhere. Failing tests continue to show their full output, so no debugging signal is lost. The only behavioral difference from the old setup is that developers running tests locally will no longer see console.log output from tests that pass.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[vitest run] --> B{Test result?}
    B -- Passed --> C["silent: passed-only\nConsole output suppressed"]
    B -- Failed --> D["Console output shown\n(unchanged)"]
    C --> E[Reporter: default output only]
    D --> F[Reporter: default + full logs]
    style C fill:#c8e6c9,stroke:#4caf50
    style D fill:#ffcdd2,stroke:#f44336
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[vitest run] --> B{Test result?}
    B -- Passed --> C["silent: passed-only\nConsole output suppressed"]
    B -- Failed --> D["Console output shown\n(unchanged)"]
    C --> E[Reporter: default output only]
    D --> F[Reporter: default + full logs]
    style C fill:#c8e6c9,stroke:#4caf50
    style D fill:#ffcdd2,stroke:#f44336
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(vitest): Enable &quot;silent: passed-on..."](https://github.com/langfuse/langfuse/commit/44cab3eaf3a8fbbc60e4e9a738b4616d8d7ebfff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43286181)</sub>

<!-- /greptile_comment -->