### PR TITLE
chore(in-app agent): Improve 'thinking' chunks instrumentation

### DIFF
--- a/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
@@ -689,10 +689,21 @@ describe("InAppAgentInstrumentation", () => {
     );
   });
 
-  it("records reasoning text in agent generation metadata", () => {
+  it("records reasoning as thinking parts on the assistant output messages", () => {
     const instrumentation = createInstrumentation();
+    const toolCall = {
+      id: "tool-1",
+      name: "listObservations",
+      arguments: '{"limit":10}',
+      type: "function",
+    };
+    const toolOutput = { traces: [{ id: "trace-1" }] };
 
     instrumentation.recordEvents([
+      {
+        type: EventType.REASONING_MESSAGE_START,
+        messageId: "reasoning-1",
+      },
       {
         type: EventType.REASONING_MESSAGE_CONTENT,
         messageId: "reasoning-1",
@@ -702,6 +713,42 @@ describe("InAppAgentInstrumentation", () => {
         type: EventType.REASONING_MESSAGE_CHUNK,
         messageId: "reasoning-1",
         delta: "filters",
+      },
+      {
+        type: EventType.REASONING_MESSAGE_END,
+        messageId: "reasoning-1",
+      },
+      {
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tool-1",
+        toolCallName: "listObservations",
+      },
+      {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: "tool-1",
+        delta: '{"limit":10}',
+      },
+      {
+        type: EventType.TOOL_CALL_END,
+        toolCallId: "tool-1",
+      },
+      {
+        type: EventType.TOOL_CALL_RESULT,
+        toolCallId: "tool-1",
+        content: JSON.stringify(toolOutput),
+      },
+      {
+        type: EventType.REASONING_MESSAGE_START,
+        messageId: "reasoning-2",
+      },
+      {
+        type: EventType.REASONING_MESSAGE_CONTENT,
+        messageId: "reasoning-2",
+        delta: "Drafting the answer",
+      },
+      {
+        type: EventType.REASONING_MESSAGE_END,
+        messageId: "reasoning-2",
       },
       {
         type: EventType.TEXT_MESSAGE_CONTENT,
@@ -717,11 +764,58 @@ describe("InAppAgentInstrumentation", () => {
         name: "agent-turn",
         input: expectedAgentRunInput,
         output: {
-          messages: [{ role: "assistant", content: "Done" }],
+          messages: [
+            {
+              role: "assistant",
+              content: "",
+              thinking: [{ type: "thinking", content: "Checking filters" }],
+              tool_calls: [toolCall],
+            },
+            { role: "tool", tool_call_id: "tool-1", content: toolOutput },
+            {
+              role: "assistant",
+              content: "Done",
+              thinking: [{ type: "thinking", content: "Drafting the answer" }],
+            },
+          ],
           text: "Done",
+          tool_calls: [toolCall],
         },
         completionStartTime: expect.any(Date),
-        metadata: expect.objectContaining({ reasoning: "Checking filters" }),
+      }),
+    );
+    const updateArg = mocks.agentGeneration.update.mock.calls.at(-1)?.[0] as {
+      metadata?: Record<string, unknown>;
+    };
+    expect(updateArg.metadata).not.toHaveProperty("reasoning");
+  });
+
+  it("records reasoning without a following assistant message as its own thinking message", () => {
+    const instrumentation = createInstrumentation();
+
+    instrumentation.recordEvents([
+      {
+        type: EventType.REASONING_MESSAGE_CONTENT,
+        messageId: "reasoning-1",
+        delta: "Checking filters",
+      },
+      {
+        type: EventType.RUN_FINISHED,
+      },
+    ]);
+
+    expect(mocks.agentGeneration.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "agent-turn",
+        output: {
+          messages: [
+            {
+              role: "assistant",
+              content: "",
+              thinking: [{ type: "thinking", content: "Checking filters" }],
+            },
+          ],
+        },
       }),
     );
   });

--- a/web/src/ee/features/in-app-agent/server/instrumentation.ts
+++ b/web/src/ee/features/in-app-agent/server/instrumentation.ts
@@ -64,10 +64,18 @@ type AgentRunSkillDefinition = {
   name: string;
   description?: string;
 };
+// Matches the ChatML thinking content part
+// (packages/shared/src/utils/IORepresentation/chatML/types.ts) so the trace UI
+// renders reasoning as collapsible "Thinking" blocks.
+type AgentRunThinkingPart = {
+  type: "thinking";
+  content: string;
+};
 type AgentRunChatMessage = {
   role: string;
   name?: string;
   content?: unknown;
+  thinking?: AgentRunThinkingPart[];
   tool_calls?: AgentRunToolCall[];
   tool_call_id?: string;
 };
@@ -140,7 +148,8 @@ export class InAppAgentInstrumentation {
   private readonly agentRunOutputMessages: AgentRunChatMessage[] = [];
   private readonly agentRunToolCalls: AgentRunToolCall[] = [];
   private output = "";
-  private reasoning = "";
+  private currentReasoning = "";
+  private pendingThinking: AgentRunThinkingPart[] = [];
   private completionStartTime?: Date;
   private ended = false;
 
@@ -274,6 +283,7 @@ export class InAppAgentInstrumentation {
 
     const message = error instanceof Error ? error.message : String(error);
     this.endOpenToolSpans({ error: message }, message);
+    this.flushTrailingThinking();
     this.agentRun.update({
       name: IN_APP_AGENT_TURN_NAME,
       input: this.agentRunInput,
@@ -285,7 +295,6 @@ export class InAppAgentInstrumentation {
       statusMessage: message,
       metadata: {
         ...this.metadata,
-        ...(this.reasoning ? { reasoning: this.reasoning } : {}),
         error: message,
       },
       ...(this.prompt
@@ -310,9 +319,9 @@ export class InAppAgentInstrumentation {
     }
 
     this.endOpenToolSpans(params?.aborted ? { aborted: true } : undefined);
+    this.flushTrailingThinking();
     const metadata = {
       ...this.metadata,
-      ...(this.reasoning ? { reasoning: this.reasoning } : {}),
       ...(params?.aborted ? { aborted: true } : {}),
       ...(params?.result ? { result: params.result } : {}),
     };
@@ -362,8 +371,16 @@ export class InAppAgentInstrumentation {
       event.type === EventType.REASONING_MESSAGE_CONTENT
     ) {
       if (typeof event.delta === "string") {
-        this.reasoning += event.delta;
+        this.currentReasoning += event.delta;
       }
+      return;
+    }
+
+    if (
+      event.type === EventType.REASONING_MESSAGE_START ||
+      event.type === EventType.REASONING_MESSAGE_END
+    ) {
+      this.flushCurrentReasoning();
       return;
     }
 
@@ -416,8 +433,6 @@ export class InAppAgentInstrumentation {
       event.type === EventType.STEP_FINISHED ||
       event.type === EventType.TOOL_CALL_CHUNK ||
       event.type === EventType.REASONING_START ||
-      event.type === EventType.REASONING_MESSAGE_START ||
-      event.type === EventType.REASONING_MESSAGE_END ||
       event.type === EventType.REASONING_END ||
       event.type === EventType.REASONING_ENCRYPTED_VALUE ||
       // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -582,12 +597,56 @@ export class InAppAgentInstrumentation {
     }
   }
 
+  // Reasoning that no assistant message followed (e.g. aborted or errored
+  // turns) still gets recorded as its own thinking-only assistant message.
+  private flushTrailingThinking() {
+    const thinking = this.takePendingThinking();
+    if (!thinking) {
+      return;
+    }
+
+    this.agentRunOutputMessages.push({
+      role: "assistant",
+      content: "",
+      thinking,
+    });
+  }
+
+  private flushCurrentReasoning() {
+    if (!this.currentReasoning) {
+      return;
+    }
+
+    this.pendingThinking.push({
+      type: "thinking",
+      content: this.currentReasoning,
+    });
+    this.currentReasoning = "";
+  }
+
+  // Reasoning always precedes the assistant action it produced, so pending
+  // thinking parts attach to the next assistant output message.
+  private takePendingThinking(): AgentRunThinkingPart[] | undefined {
+    this.flushCurrentReasoning();
+
+    if (this.pendingThinking.length === 0) {
+      return undefined;
+    }
+
+    return this.pendingThinking.splice(0);
+  }
+
   private recordAssistantText(delta: string) {
     this.output += delta;
     this.completionStartTime ??= new Date();
 
+    const thinking = this.takePendingThinking();
     const lastMessage = this.agentRunOutputMessages.at(-1);
-    if (lastMessage?.role === "assistant" && !lastMessage.tool_calls?.length) {
+    if (
+      !thinking &&
+      lastMessage?.role === "assistant" &&
+      !lastMessage.tool_calls?.length
+    ) {
       lastMessage.content = `${typeof lastMessage.content === "string" ? lastMessage.content : ""}${delta}`;
       return;
     }
@@ -595,6 +654,7 @@ export class InAppAgentInstrumentation {
     this.agentRunOutputMessages.push({
       role: "assistant",
       content: delta,
+      ...(thinking ? { thinking } : {}),
     });
   }
 
@@ -616,10 +676,12 @@ export class InAppAgentInstrumentation {
       type: "function",
     };
 
+    const thinking = this.takePendingThinking();
     this.agentRunToolCalls.push(toolCall);
     this.agentRunOutputMessages.push({
       role: "assistant",
       content: "",
+      ...(thinking ? { thinking } : {}),
       tool_calls: [toolCall],
     });
 


### PR DESCRIPTION
Add Proper instrumentation of thinking chunks (before we only added them into metadata.reasoning as one big text blob)
<img width="946" height="906" alt="Screenshot 2026-07-10 at 14 57 32" src="https://github.com/user-attachments/assets/10c2680a-78f4-4dde-90d6-2cce8a4e0bf6" />

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the previous approach of accumulating all reasoning text into a single `metadata.reasoning` string blob with proper structured instrumentation: each reasoning block is now captured as an `AgentRunThinkingPart` object attached to the assistant output message that follows it, matching the ChatML `thinking` content-part shape used by the trace UI for collapsible "Thinking" blocks.

- Introduces `currentReasoning` / `pendingThinking` state to buffer and flush reasoning chunks, attaching them to the next assistant or tool-call message via `takePendingThinking()`.
- Adds `flushTrailingThinking()` to handle reasoning that is never followed by an assistant action (aborted or errored turns), creating a standalone thinking-only assistant message.
- Test suite is expanded with a full multi-turn tool-call + reasoning scenario and a standalone trailing-thinking edge case.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The new thinking-chunk instrumentation is well-scoped, handles all lifecycle edge cases (missing START/END events, aborted/errored turns, tool calls completing in either order), and is backed by two focused test cases.

The state machine is simple and correct: `currentReasoning` accumulates text, `flushCurrentReasoning()` moves it into `pendingThinking`, and `takePendingThinking()` drains that buffer onto the next assistant message. The dual call to `flushCurrentReasoning()` on both REASONING_MESSAGE_START and REASONING_MESSAGE_END is intentional defensive programming. The metadata `reasoning` key removal is verified by an explicit assertion in the test. No data is dropped in error or abort paths — `endOpenToolSpans` → `recordToolCall` → `takePendingThinking` runs before `flushTrailingThinking`, so thinking always attaches to the closest action.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Agent as AG-UI Event Stream
    participant Inst as InAppAgentInstrumentation
    participant PM as pendingThinking[]
    participant Msgs as agentRunOutputMessages[]

    Agent->>Inst: REASONING_MESSAGE_START
    Note over Inst: flushCurrentReasoning() — defensive no-op if empty

    Agent->>Inst: REASONING_MESSAGE_CONTENT (delta)
    Inst->>Inst: "currentReasoning += delta"

    Agent->>Inst: REASONING_MESSAGE_END
    Inst->>PM: "push {type:"thinking", content: currentReasoning}"
    Note over Inst: currentReasoning = ""

    Agent->>Inst: TOOL_CALL_START / TOOL_CALL_ARGS / TOOL_CALL_END
    Agent->>Inst: TOOL_CALL_RESULT
    Inst->>PM: takePendingThinking()
    PM-->>Inst: "[{type:"thinking", ...}]"
    Inst->>Msgs: "push {role:"assistant", content:"", thinking:[...], tool_calls:[...]}"
    Inst->>Msgs: "push {role:"tool", tool_call_id:..., content:...}"

    Agent->>Inst: REASONING_MESSAGE_CONTENT (delta)
    Inst->>Inst: "currentReasoning += delta"
    Agent->>Inst: REASONING_MESSAGE_END
    Inst->>PM: "push {type:"thinking", content: currentReasoning}"

    Agent->>Inst: TEXT_MESSAGE_CONTENT (delta)
    Inst->>PM: takePendingThinking()
    PM-->>Inst: "[{type:"thinking", ...}]"
    Inst->>Msgs: "push {role:"assistant", content:delta, thinking:[...]}"

    Agent->>Inst: RUN_FINISHED
    Inst->>Inst: flushTrailingThinking() — no-op (PM empty)
    Inst->>Inst: agentRun.update(output)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Agent as AG-UI Event Stream
    participant Inst as InAppAgentInstrumentation
    participant PM as pendingThinking[]
    participant Msgs as agentRunOutputMessages[]

    Agent->>Inst: REASONING_MESSAGE_START
    Note over Inst: flushCurrentReasoning() — defensive no-op if empty

    Agent->>Inst: REASONING_MESSAGE_CONTENT (delta)
    Inst->>Inst: "currentReasoning += delta"

    Agent->>Inst: REASONING_MESSAGE_END
    Inst->>PM: "push {type:"thinking", content: currentReasoning}"
    Note over Inst: currentReasoning = ""

    Agent->>Inst: TOOL_CALL_START / TOOL_CALL_ARGS / TOOL_CALL_END
    Agent->>Inst: TOOL_CALL_RESULT
    Inst->>PM: takePendingThinking()
    PM-->>Inst: "[{type:"thinking", ...}]"
    Inst->>Msgs: "push {role:"assistant", content:"", thinking:[...], tool_calls:[...]}"
    Inst->>Msgs: "push {role:"tool", tool_call_id:..., content:...}"

    Agent->>Inst: REASONING_MESSAGE_CONTENT (delta)
    Inst->>Inst: "currentReasoning += delta"
    Agent->>Inst: REASONING_MESSAGE_END
    Inst->>PM: "push {type:"thinking", content: currentReasoning}"

    Agent->>Inst: TEXT_MESSAGE_CONTENT (delta)
    Inst->>PM: takePendingThinking()
    PM-->>Inst: "[{type:"thinking", ...}]"
    Inst->>Msgs: "push {role:"assistant", content:delta, thinking:[...]}"

    Agent->>Inst: RUN_FINISHED
    Inst->>Inst: flushTrailingThinking() — no-op (PM empty)
    Inst->>Inst: agentRun.update(output)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(in-app agent): Improve &#39;thinking&#39; ..."](https://github.com/langfuse/langfuse/commit/b4a34e353bb14ae9a4060b2530c151cd28ee7703) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43286616)</sub>

<!-- /greptile_comment -->