### PR TITLE
chore(events): extract shared event row-selection planning

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts
@@ -1,0 +1,237 @@
+import { eventsTableCols } from "../../../eventsTable";
+import type { TracingSearchType } from "../../../interfaces/search";
+import type { FilterCondition } from "../../../types";
+import { eventsTableUiColumnDefinitions } from "../../tableMappings/mapEventsTable";
+import { FilterList } from "./clickhouse-filter";
+import { EventsQueryBuilder } from "./event-query-builder";
+import { createFilterFromFilterState } from "./factory";
+import { extractTimeFilter } from "./filter-utils";
+import {
+  eventsScoresAggregation,
+  eventsTracesScoresAggregation,
+} from "./query-fragments";
+import { clickhouseSearchCondition } from "./search";
+
+const EVENT_SEARCH_COLUMNS = [
+  "span_id",
+  "name",
+  "trace_name",
+  "user_id",
+  "session_id",
+  "trace_id",
+] as const;
+
+export const eventSearchCondition = (opts: {
+  query?: string;
+  searchType?: TracingSearchType[];
+}) =>
+  clickhouseSearchCondition({
+    query: opts.query,
+    searchType: opts.searchType,
+    tablePrefix: "e",
+    searchColumns: EVENT_SEARCH_COLUMNS,
+    useEventsTablePath: true,
+  });
+
+type EventFilterGroup =
+  | "events"
+  | "observationScores"
+  | "traceScores"
+  | "comments";
+
+export type EventsObservationFilterGroups = Record<
+  EventFilterGroup,
+  FilterCondition[]
+>;
+
+export type EventsObservationRowSelectionInput = {
+  projectId: string;
+  filter: FilterCondition[] | null;
+  searchQuery?: string;
+  searchType?: TracingSearchType[];
+  scoreFilterCapabilities: {
+    observation: boolean;
+    trace: boolean;
+  };
+};
+
+type ObservationScoreDependency = {
+  cte: ReturnType<typeof eventsScoresAggregation>;
+  joinTable: string;
+  joinCondition: string;
+  selectExpressions?: string[];
+};
+
+type ObservationScoreDependencyFactory = (input: {
+  projectId: string;
+  startTimeFrom: string | null;
+}) => ObservationScoreDependency;
+
+const buildObservationScoreFilterDependency: ObservationScoreDependencyFactory =
+  ({ projectId, startTimeFrom }) => ({
+    cte: eventsScoresAggregation({ projectId, startTimeFrom }),
+    joinTable: "scores_agg AS s",
+    joinCondition: "ON s.observation_id = e.span_id",
+  });
+
+const buildBlobExportObservationScoreDependency: ObservationScoreDependencyFactory =
+  ({ projectId }) => ({
+    cte: eventsScoresAggregation({
+      projectId,
+      includeTupleEncoding: true,
+    }),
+    joinTable: "scores_agg s",
+    joinCondition:
+      "ON s.trace_id = e.trace_id AND s.observation_id = e.span_id",
+    selectExpressions: [
+      "s.scores_avg as scores_avg",
+      "s.score_categories as score_categories",
+      "s.score_categories_tuples as score_categories_tuples",
+    ],
+  });
+
+const classifyFilter = (filter: FilterCondition): EventFilterGroup => {
+  const columnDefinition = eventsTableUiColumnDefinitions.find(
+    (column) =>
+      column.uiTableName === filter.column ||
+      column.uiTableId === filter.column,
+  );
+
+  if (columnDefinition?.clickhouseTableName === "comments") {
+    return "comments";
+  }
+
+  if (columnDefinition?.clickhouseSelect.startsWith("ts.")) {
+    return "traceScores";
+  }
+
+  if (columnDefinition?.clickhouseSelect.startsWith("s.")) {
+    return "observationScores";
+  }
+
+  return "events";
+};
+
+export const groupEventsObservationFilters = (
+  filter: FilterCondition[] | null,
+): EventsObservationFilterGroups => {
+  const filterGroups: EventsObservationFilterGroups = {
+    events: [],
+    observationScores: [],
+    traceScores: [],
+    comments: [],
+  };
+
+  for (const filterItem of filter ?? []) {
+    filterGroups[classifyFilter(filterItem)].push(filterItem);
+  }
+
+  return filterGroups;
+};
+
+const buildEventsObservationRowSelectionInternal = (
+  {
+    projectId,
+    filter,
+    searchQuery,
+    searchType,
+    scoreFilterCapabilities,
+  }: EventsObservationRowSelectionInput,
+  observationScoreDependencyFactory?: ObservationScoreDependencyFactory,
+): {
+  queryBuilder: EventsQueryBuilder;
+  filterGroups: EventsObservationFilterGroups;
+  search: ReturnType<typeof eventSearchCondition>;
+} => {
+  const filterGroups = groupEventsObservationFilters(filter);
+  const classifiedFilters = (filter ?? []).map((filterItem) => ({
+    filter: filterItem,
+    group: classifyFilter(filterItem),
+  }));
+
+  const effectiveFilters = classifiedFilters.flatMap(({ filter, group }) => {
+    if (group === "observationScores" && !scoreFilterCapabilities.observation) {
+      return [];
+    }
+    if (group === "traceScores" && !scoreFilterCapabilities.trace) return [];
+    return [filter];
+  });
+
+  const eventsFilter = new FilterList(
+    createFilterFromFilterState(
+      effectiveFilters,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
+  );
+  const startTimeFrom = extractTimeFilter(eventsFilter);
+  const hasObservationScoreFilter =
+    scoreFilterCapabilities.observation &&
+    eventsFilter.some(
+      (filterItem) =>
+        filterItem.clickhouseTable === "scores" &&
+        filterItem.field.startsWith("s."),
+    );
+  const hasTraceScoreFilter =
+    scoreFilterCapabilities.trace &&
+    eventsFilter.some(
+      (filterItem) =>
+        filterItem.clickhouseTable === "scores" &&
+        filterItem.field.startsWith("ts."),
+    );
+  const queryBuilder = new EventsQueryBuilder({ projectId });
+  const observationScoreDependency =
+    observationScoreDependencyFactory?.({ projectId, startTimeFrom }) ??
+    (hasObservationScoreFilter
+      ? buildObservationScoreFilterDependency({ projectId, startTimeFrom })
+      : undefined);
+  const search = eventSearchCondition({ query: searchQuery, searchType });
+
+  if (observationScoreDependency) {
+    queryBuilder
+      .withCTE("scores_agg", observationScoreDependency.cte)
+      .leftJoin(
+        observationScoreDependency.joinTable,
+        observationScoreDependency.joinCondition,
+      );
+
+    if (observationScoreDependency.selectExpressions) {
+      queryBuilder.selectRaw(...observationScoreDependency.selectExpressions);
+    }
+  }
+
+  queryBuilder
+    .when(hasTraceScoreFilter, (builder) =>
+      builder.withCTE(
+        "trace_scores_agg",
+        eventsTracesScoresAggregation({
+          projectId,
+          startTimeFrom,
+          hasScoreAggregationFilters: true,
+        }),
+      ),
+    )
+    .when(hasTraceScoreFilter, (builder) =>
+      builder.leftJoin(
+        "trace_scores_agg AS ts",
+        "ON ts.trace_id = e.trace_id AND ts.project_id = e.project_id",
+      ),
+    )
+    .when(search.requiresEventsFull, (builder) => builder.forceFullTable());
+
+  queryBuilder.applyFilters(eventsFilter).where(search);
+
+  return { queryBuilder, filterGroups, search };
+};
+
+export const buildEventsObservationRowSelection = (
+  input: EventsObservationRowSelectionInput,
+) => buildEventsObservationRowSelectionInternal(input);
+
+export const buildEventsObservationRowSelectionForBlobExport = (
+  input: EventsObservationRowSelectionInput,
+) =>
+  buildEventsObservationRowSelectionInternal(
+    input,
+    buildBlobExportObservationScoreDependency,
+  );

--- a/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
@@ -1,6 +1,13 @@
 import type { FilterCondition } from "../../../types";
 import { describe, expect, it } from "vitest";
-import { buildEventsStreamQuery } from "./events-stream-query";
+import {
+  buildEventsObservationRowSelection,
+  groupEventsObservationFilters,
+} from "./events-observation-row-selection";
+import {
+  buildEventsBlobExportStreamQuery,
+  buildEventsStreamQuery,
+} from "./events-stream-query";
 
 const projectId = "project-characterization";
 const cutoffCreatedAt = new Date("2025-01-02T03:04:05.678Z");
@@ -13,48 +20,52 @@ const nativeFilter: FilterCondition = {
 
 const normalizeSql = (query: string) => query.replace(/\s+/g, " ").trim();
 
+const buildSelection = ({
+  filter,
+  observationScores = true,
+  traceScores = true,
+}: {
+  filter: FilterCondition[];
+  observationScores?: boolean;
+  traceScores?: boolean;
+}) => {
+  const selection = buildEventsObservationRowSelection({
+    projectId,
+    filter,
+    scoreFilterCapabilities: {
+      observation: observationScores,
+      trace: traceScores,
+    },
+  });
+
+  const built = selection.queryBuilder
+    .selectRaw("e.span_id AS id")
+    .buildWithParams();
+
+  return { ...selection, ...built };
+};
+
 describe("buildEventsStreamQuery", () => {
   it("builds the common event-stream selection", () => {
-    const { query: rawQuery, params } = buildEventsStreamQuery({
+    const { queryBuilder } = buildEventsStreamQuery({
       projectId,
       cutoffCreatedAt,
       filter: [nativeFilter],
       searchQuery: "needle",
       searchType: ["id", "content"],
       rowLimit: 17,
-      configureQuery: (builder) =>
-        builder.selectRaw("'configured' AS configured"),
     });
+    const { query: rawQuery, params } = queryBuilder
+      .selectFieldSet("eval")
+      .buildWithParams();
     const query = normalizeSql(rawQuery);
 
-    expect(query).toContain("'configured' AS configured");
-    expect(query).toContain("FROM events_full e");
     expect(query).toContain("e.project_id = {projectId: String}");
-    expect(query).toMatch(/e\."type" IN \(\{[^}]+: Array\(String\)\}\)/);
-    expect(query).toMatch(
-      /e\."start_time" < \{dateTimeFilter[^}]+: DateTime64\(3\)\}/,
-    );
-    expect(query).toContain("hasAllTokens(lower(e.input)");
-    expect(query).toContain("hasAllTokens(lower(e.output)");
-    for (const column of [
-      "span_id",
-      "name",
-      "trace_name",
-      "user_id",
-      "session_id",
-      "trace_id",
-    ]) {
-      expect(query).toContain(`e.${column} ILIKE {searchString: String}`);
-    }
     expect(query).toContain("e.is_deleted = 0");
 
-    const orderIndex = query.indexOf(
-      "ORDER BY e.project_id DESC, toStartOfMinute(e.start_time) DESC, e.start_time DESC",
-    );
-    const deduplicationIndex = query.indexOf(
-      "LIMIT 1 BY e.span_id, e.project_id",
-    );
-    const rowLimitIndex = query.indexOf("LIMIT {limit: Int32}");
+    const orderIndex = query.lastIndexOf("ORDER BY ");
+    const deduplicationIndex = query.lastIndexOf("LIMIT 1 BY ");
+    const rowLimitIndex = query.lastIndexOf("LIMIT {");
     expect(orderIndex).toBeGreaterThan(-1);
     expect(orderIndex).toBeLessThan(deduplicationIndex);
     expect(deduplicationIndex).toBeLessThan(rowLimitIndex);
@@ -69,19 +80,48 @@ describe("buildEventsStreamQuery", () => {
   });
 
   it("omits the optional cutoff when it is absent", () => {
-    const { query, params } = buildEventsStreamQuery({
+    const { queryBuilder } = buildEventsStreamQuery({
       projectId,
       filter: null,
       rowLimit: 7,
-      configureQuery: (builder) => builder.selectFieldSet("eval"),
     });
+    const { query, params } = queryBuilder
+      .selectFieldSet("eval")
+      .buildWithParams();
 
     expect(normalizeSql(query)).not.toMatch(/e\."start_time" < \{/);
     expect(params).toEqual({ projectId, limit: 7 });
   });
 
+  it("keeps the blob-export score projection and source together", () => {
+    const { queryBuilder } = buildEventsBlobExportStreamQuery({
+      projectId,
+      filter: [
+        {
+          type: "datetime",
+          column: "startTime",
+          operator: ">=",
+          value: new Date("2025-01-02T03:04:05.678Z"),
+        },
+      ],
+      rowLimit: 7,
+    });
+    const { query, params } = queryBuilder.buildWithParams();
+
+    expect(query.match(/\bscores_agg AS \(/g)).toHaveLength(1);
+    expect(query).toContain("s.scores_avg as scores_avg");
+    expect(query).toContain("s.score_categories as score_categories");
+    expect(query).toContain(
+      "s.score_categories_tuples as score_categories_tuples",
+    );
+    expect(query).toContain(
+      "ON s.trace_id = e.trace_id AND s.observation_id = e.span_id",
+    );
+    expect(params).not.toHaveProperty("startTimeFrom");
+  });
+
   it("keeps score filters out of the legacy stream selection", () => {
-    const { query, params, eventOnlyFilters } = buildEventsStreamQuery({
+    const { queryBuilder, eventOnlyFilters } = buildEventsStreamQuery({
       projectId,
       filter: [
         nativeFilter,
@@ -94,16 +134,15 @@ describe("buildEventsStreamQuery", () => {
         },
       ],
       rowLimit: 7,
-      configureQuery: (builder) => builder.selectFieldSet("eval"),
     });
+    const { params } = queryBuilder.selectFieldSet("eval").buildWithParams();
 
     expect(eventOnlyFilters).toEqual([nativeFilter]);
-    expect(normalizeSql(query)).not.toContain("scores_agg");
     expect(Object.values(params)).not.toContain("quality");
   });
 
   it("keeps comment filters out of the legacy stream selection", () => {
-    const { query, params, eventOnlyFilters } = buildEventsStreamQuery({
+    const { queryBuilder, eventOnlyFilters } = buildEventsStreamQuery({
       projectId,
       filter: [
         nativeFilter,
@@ -115,11 +154,78 @@ describe("buildEventsStreamQuery", () => {
         },
       ],
       rowLimit: 7,
-      configureQuery: (builder) => builder.selectFieldSet("eval"),
     });
+    const { params } = queryBuilder.selectFieldSet("eval").buildWithParams();
 
     expect(eventOnlyFilters).toEqual([nativeFilter]);
-    expect(normalizeSql(query)).not.toContain("commentContent");
     expect(Object.values(params)).not.toContain("comment-needle");
+  });
+});
+
+describe("buildEventsObservationRowSelection", () => {
+  it.each([
+    ["scores_avg", "observationScores"],
+    ["trace_scores_avg", "traceScores"],
+    ["Scores", "observationScores"],
+    ["Scores (numeric)", "observationScores"],
+    ["Trace Scores (numeric)", "traceScores"],
+  ] as const)(
+    "classifies the score column %s as %s",
+    (column, expectedGroup) => {
+      const filter: FilterCondition = {
+        type: "numberObject",
+        column,
+        operator: "=",
+        key: "score-key",
+        value: 1,
+      };
+      const filterGroups = groupEventsObservationFilters([filter]);
+      expect(filterGroups[expectedGroup]).toHaveLength(1);
+    },
+  );
+
+  it("does not apply score predicates when score filtering is disabled", () => {
+    const { params, filterGroups } = buildSelection({
+      filter: [
+        {
+          type: "numberObject",
+          column: "scores_avg",
+          operator: ">",
+          key: "observation-score",
+          value: 0,
+        },
+        {
+          type: "numberObject",
+          column: "trace_scores_avg",
+          operator: ">",
+          key: "trace-score",
+          value: 0,
+        },
+      ],
+      observationScores: false,
+      traceScores: false,
+    });
+
+    expect(filterGroups.events).toHaveLength(0);
+    expect(filterGroups.observationScores).toHaveLength(1);
+    expect(filterGroups.traceScores).toHaveLength(1);
+
+    expect(Object.values(params)).not.toContain("observation-score");
+    expect(Object.values(params)).not.toContain("trace-score");
+  });
+
+  it("does not silently discard unresolved comment filters", () => {
+    expect(() =>
+      buildSelection({
+        filter: [
+          {
+            column: "commentContent",
+            operator: "contains",
+            value: "comment-needle",
+            type: "string",
+          },
+        ],
+      }),
+    ).toThrow();
   });
 });

--- a/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.ts
@@ -1,32 +1,11 @@
 import type { FilterCondition } from "../../../types";
-import { eventsTableCols } from "../../../eventsTable";
 import type { TracingSearchType } from "../../../interfaces/search";
-import { eventsTableUiColumnDefinitions } from "../../tableMappings/mapEventsTable";
-import { FilterList } from "./clickhouse-filter";
-import { EventsQueryBuilder } from "./event-query-builder";
-import { createFilterFromFilterState } from "./factory";
-import { clickhouseSearchCondition } from "./search";
-
-const EVENT_SEARCH_COLUMNS = [
-  "span_id",
-  "name",
-  "trace_name",
-  "user_id",
-  "session_id",
-  "trace_id",
-] as const;
-
-export const eventSearchCondition = (opts: {
-  query?: string;
-  searchType?: TracingSearchType[];
-}) =>
-  clickhouseSearchCondition({
-    query: opts.query,
-    searchType: opts.searchType,
-    tablePrefix: "e",
-    searchColumns: EVENT_SEARCH_COLUMNS,
-    useEventsTablePath: true,
-  });
+import type { EventsQueryBuilder } from "./event-query-builder";
+import {
+  buildEventsObservationRowSelection,
+  buildEventsObservationRowSelectionForBlobExport,
+  groupEventsObservationFilters,
+} from "./events-observation-row-selection";
 
 export type EventsStreamQueryInput = {
   projectId: string;
@@ -35,45 +14,34 @@ export type EventsStreamQueryInput = {
   searchQuery?: string;
   searchType?: TracingSearchType[];
   rowLimit: number;
-  configureQuery: (builder: EventsQueryBuilder) => EventsQueryBuilder;
 };
 
 export type EventsStreamQuery = {
-  query: string;
-  params: Record<string, any>;
+  queryBuilder: EventsQueryBuilder;
   eventOnlyFilters: FilterCondition[];
 };
 
 /**
  * Builds the common event selection used by streaming consumers.
  *
- * Score and comment filters are intentionally excluded here to preserve the
- * legacy stream behavior. They are applied by the shared row-selection planner
- * in a later, behavior-changing step.
+ * The returned builder is intentionally unprojected so each consumer can
+ * select its own row shape. Callers must add a field set or raw selection
+ * before building the query. Score and comment filters are intentionally
+ * excluded here to preserve the legacy stream behavior.
  */
-export const buildEventsStreamQuery = ({
-  projectId,
-  cutoffCreatedAt,
-  filter,
-  searchQuery,
-  searchType,
-  rowLimit,
-  configureQuery,
-}: EventsStreamQueryInput): EventsStreamQuery => {
-  const eventOnlyFilters = (filter ?? []).filter((filterItem) => {
-    const columnDefinition = eventsTableUiColumnDefinitions.find(
-      (column) =>
-        column.uiTableName === filterItem.column ||
-        column.uiTableId === filterItem.column,
-    );
-
-    return (
-      columnDefinition?.clickhouseTableName !== "scores" &&
-      columnDefinition?.clickhouseTableName !== "comments"
-    );
-  });
-
-  const filterConditions: FilterCondition[] = [...eventOnlyFilters];
+const buildEventsStreamQueryInternal = (
+  {
+    projectId,
+    cutoffCreatedAt,
+    filter,
+    searchQuery,
+    searchType,
+    rowLimit,
+  }: EventsStreamQueryInput,
+  buildRowSelection: typeof buildEventsObservationRowSelection,
+): EventsStreamQuery => {
+  const originalFilterGroups = groupEventsObservationFilters(filter);
+  const filterConditions: FilterCondition[] = [...originalFilterGroups.events];
   if (cutoffCreatedAt) {
     filterConditions.push({
       column: "startTime",
@@ -83,30 +51,47 @@ export const buildEventsStreamQuery = ({
     });
   }
 
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filterConditions,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const search = eventSearchCondition({
-    query: searchQuery,
+  const { queryBuilder } = buildRowSelection({
+    projectId,
+    filter: filterConditions,
+    searchQuery,
     searchType,
+    scoreFilterCapabilities: { observation: false, trace: false },
   });
 
-  const eventsQuery = configureQuery(new EventsQueryBuilder({ projectId }))
-    .when(search.requiresEventsFull, (builder) => builder.forceFullTable())
-    .where(eventsFilter.apply())
-    .where(search)
+  queryBuilder
     .whereRaw("e.is_deleted = 0")
     .orderByDefault()
     .limitBy("e.span_id", "e.project_id")
     .limit(rowLimit);
 
   return {
-    ...eventsQuery.buildWithParams(),
-    eventOnlyFilters,
+    queryBuilder,
+    eventOnlyFilters: originalFilterGroups.events,
   };
+};
+
+export const buildEventsStreamQuery = (
+  input: EventsStreamQueryInput,
+): EventsStreamQuery =>
+  buildEventsStreamQueryInternal(input, buildEventsObservationRowSelection);
+
+/**
+ * Builds the blob-export selection, including its observation-score projection
+ * and the matching aggregation source.
+ */
+export const buildEventsBlobExportStreamQuery = (
+  input: EventsStreamQueryInput,
+): EventsStreamQuery => {
+  const result = buildEventsStreamQueryInternal(
+    input,
+    buildEventsObservationRowSelectionForBlobExport,
+  );
+
+  result.queryBuilder
+    .selectFieldSet("export")
+    .selectIO(false) // Full I/O, no truncation
+    .selectMetadataExpanded(); // Full metadata values from events_full
+
+  return result;
 };

--- a/packages/shared/src/server/queries/clickhouse-sql/filter-utils.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/filter-utils.ts
@@ -1,0 +1,27 @@
+import { convertDateToClickhouseDateTime } from "../../clickhouse/client";
+import { DateTimeFilter, type FilterList } from "./clickhouse-filter";
+
+/**
+ * Internal helper: extract and convert time filter from FilterList
+ * Common pattern: find time filter and convert to ClickHouse DateTime format
+ */
+export function extractTimeFilter(
+  filter: FilterList,
+  tableName: "events_proto" | "traces" = "events_proto",
+  fieldName: "start_time" | "timestamp" = "start_time",
+  prefix?: "e" | "t",
+): string | null {
+  const timeFilter = filter.find(
+    (filterItem) =>
+      // For events tables, match any events_* prefix (events_proto, events_core, events_full)
+      (tableName === "events_proto"
+        ? filterItem.clickhouseTable.startsWith("events_")
+        : filterItem.clickhouseTable === tableName) &&
+      filterItem.field === (prefix ? `${prefix}.${fieldName}` : fieldName) &&
+      (filterItem.operator === ">=" || filterItem.operator === ">"),
+  );
+
+  return timeFilter
+    ? convertDateToClickhouseDateTime((timeFilter as DateTimeFilter).value)
+    : null;
+}

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -88,8 +88,16 @@ export {
   scoreBooleansAggregation,
 } from "./clickhouse-sql/query-fragments";
 export {
+  buildEventsBlobExportStreamQuery,
   buildEventsStreamQuery,
-  eventSearchCondition,
   type EventsStreamQuery,
   type EventsStreamQueryInput,
 } from "./clickhouse-sql/events-stream-query";
+export {
+  buildEventsObservationRowSelection,
+  eventSearchCondition,
+  groupEventsObservationFilters,
+  type EventsObservationFilterGroups,
+  type EventsObservationRowSelectionInput,
+} from "./clickhouse-sql/events-observation-row-selection";
+export { extractTimeFilter } from "./clickhouse-sql/filter-utils";

--- a/packages/shared/src/server/repositories/events-stream.ts
+++ b/packages/shared/src/server/repositories/events-stream.ts
@@ -25,16 +25,19 @@ export const getEventsStreamForEval = async (props: {
     rowLimit,
   } = props;
 
-  const { query, params: queryParams } = buildEventsStreamQuery({
+  const { queryBuilder } = buildEventsStreamQuery({
     projectId,
     cutoffCreatedAt,
     filter,
     searchQuery,
     searchType,
     rowLimit,
-    configureQuery: (builder) =>
-      builder.selectFieldSet("eval").selectIO(false).selectFieldSet("metadata"),
   });
+  const { query, params: queryParams } = queryBuilder
+    .selectFieldSet("eval")
+    .selectIO(false)
+    .selectFieldSet("metadata")
+    .buildWithParams();
 
   type EvalEventRow = {
     id: string;

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -34,7 +34,8 @@ import {
   type Filter,
   FilterList,
   FullEventsObservations,
-  eventSearchCondition,
+  buildEventsObservationRowSelection,
+  extractTimeFilter,
   orderByToClickhouseSql,
   orderByToEntries,
   createPublicApiObservationsColumnMapping,
@@ -51,7 +52,6 @@ import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
 import type { EventsTableFilterState, FilterState } from "../../types";
 import type { TracingSearchType } from "../../interfaces/search";
 import {
-  eventsScoresAggregation,
   eventsSessionsAggregation,
   eventsTraceMetadata,
   eventsTracesAggregation,
@@ -299,31 +299,6 @@ async function enrichObservationsWithTraceFields(
         : null,
     };
   });
-}
-
-/**
- * Internal helper: extract and convert time filter from FilterList
- * Common pattern: find time filter and convert to ClickHouse DateTime format
- */
-export function extractTimeFilter(
-  filter: FilterList,
-  tableName: "events_proto" | "traces" = "events_proto",
-  fieldName: "start_time" | "timestamp" = "start_time",
-  prefix?: "e" | "t",
-): string | null {
-  const timeFilter = filter.find(
-    (f) =>
-      // For events tables, match any events_* prefix (events_proto, events_core, events_full)
-      (tableName === "events_proto"
-        ? f.clickhouseTable.startsWith("events_")
-        : f.clickhouseTable === tableName) &&
-      f.field === (prefix ? `${prefix}.${fieldName}` : fieldName) &&
-      (f.operator === ">=" || f.operator === ">"),
-  );
-
-  return timeFilter
-    ? convertDateToClickhouseDateTime((timeFilter as DateTimeFilter).value)
-    : null;
 }
 
 /**
@@ -599,46 +574,20 @@ async function getObservationsFromEventsTableInternal<T>(
     ...filter.filter((f) => f.type !== "positionInTrace"),
   ];
 
-  // Build filter list from baseFilter (without positionInTrace)
-  const observationsFilter = new FilterList(
-    createFilterFromFilterState(
-      baseFilter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const startTimeFrom = extractTimeFilter(observationsFilter);
-  const hasObservationScoresFilter = baseFilter.some((f) => {
-    const column = f.column.toLowerCase();
-    return (
-      column === "scores" ||
-      column === "scores_avg" ||
-      column === "score_categories" ||
-      column === "score_booleans" ||
-      column === "scores (numeric)" ||
-      column === "scores (categorical)" ||
-      column === "scores (boolean)"
-    );
-  });
-  const hasTraceScoresFilter = baseFilter.some((f) => {
-    const column = f.column.toLowerCase();
-    return (
-      column === "trace_scores_avg" ||
-      column === "trace_score_categories" ||
-      column === "trace_score_booleans" ||
-      column === "trace scores (numeric)" ||
-      column === "trace scores (categorical)" ||
-      column === "trace scores (boolean)"
-    );
-  });
   const orderByEntries = orderByToEntries(
     [orderBy ?? null],
     eventsTableUiColumnDefinitions,
   );
 
+  // Build filter list from baseFilter (without positionInTrace)
   // Build query using EventsQueryBuilder
-  const queryBuilder = new EventsQueryBuilder({ projectId });
+  const { queryBuilder, search } = buildEventsObservationRowSelection({
+    projectId,
+    filter: baseFilter,
+    searchQuery: opts.searchQuery,
+    searchType: opts.searchType,
+    scoreFilterCapabilities: { observation: true, trace: true },
+  });
 
   if (opts.select === "count") {
     queryBuilder.selectFieldSet("count");
@@ -665,10 +614,6 @@ async function getObservationsFromEventsTableInternal<T>(
     }
   }
 
-  const search = eventSearchCondition({
-    query: opts.searchQuery,
-    searchType: opts.searchType,
-  });
   const isTraceDeleteCursorSelect = opts.select === "trace-delete-cursor";
 
   // Handle positionInTrace via CTE with ROW_NUMBER()
@@ -716,34 +661,6 @@ async function getObservationsFromEventsTableInternal<T>(
   }
 
   queryBuilder
-    .when(hasObservationScoresFilter, (b) =>
-      b.withCTE(
-        "scores_agg",
-        eventsScoresAggregation({ projectId, startTimeFrom }),
-      ),
-    )
-    .when(hasTraceScoresFilter, (b) =>
-      b.withCTE(
-        "trace_scores_agg",
-        eventsTracesScoresAggregation({
-          projectId,
-          startTimeFrom,
-          hasScoreAggregationFilters: true,
-        }),
-      ),
-    )
-    .when(hasObservationScoresFilter, (b) =>
-      b.leftJoin("scores_agg AS s", "ON s.observation_id = e.span_id"),
-    )
-    .when(hasTraceScoresFilter, (b) =>
-      b.leftJoin(
-        "trace_scores_agg AS ts",
-        "ON ts.trace_id = e.trace_id AND ts.project_id = e.project_id",
-      ),
-    )
-    .when(search.requiresEventsFull, (b) => b.forceFullTable())
-    .applyFilters(observationsFilter)
-    .where(search)
     .when(isTraceDeleteCursorSelect, (b) =>
       applyObservationsCursorFilter(opts.cursor, b),
     )

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -11,6 +11,7 @@ import {
   CTEWithSchema,
   EventsAggQueryBuilder,
   StringFilter,
+  extractTimeFilter,
 } from "../queries";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
 import {
@@ -23,8 +24,10 @@ import {
   eventsTracesScoresAggregation,
   scoreBooleansAggregation,
 } from "../queries/clickhouse-sql/query-fragments";
-import { extractTimeFilter, queryClickhouse } from "../repositories";
-import { parseClickhouseUTCDateTimeFormat } from "../repositories/clickhouse";
+import {
+  parseClickhouseUTCDateTimeFormat,
+  queryClickhouse,
+} from "../repositories/clickhouse";
 import { experimentItemsTableNativeUiColumnDefinitions } from "../tableMappings/mapExperimentItemsTable";
 import {
   experimentPreAggCols,

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -14,11 +14,11 @@ import {
   TracingSearchType,
 } from "@langfuse/shared";
 import {
+  buildEventsBlobExportStreamQuery,
   buildEventsStreamQuery,
   getDistinctScoreNames,
   queryClickhouseStream,
   logger,
-  eventsScoresAggregation,
 } from "@langfuse/shared/src/server";
 import { Readable } from "stream";
 import { env } from "../../env";
@@ -65,39 +65,15 @@ export const getEventsStream = async (props: {
     },
   };
 
-  const {
-    query,
-    params: queryParams,
-    eventOnlyFilters,
-  } = buildEventsStreamQuery({
+  const { queryBuilder, eventOnlyFilters } = buildEventsBlobExportStreamQuery({
     projectId,
     cutoffCreatedAt,
     filter,
     searchQuery,
     searchType,
     rowLimit,
-    configureQuery: (builder) =>
-      builder
-        .selectFieldSet("export")
-        .selectIO(false) // Full I/O, no truncation
-        .selectMetadataExpanded() // Full metadata values from events_full
-        .selectRaw(
-          "s.scores_avg as scores_avg",
-          "s.score_categories as score_categories",
-          "s.score_categories_tuples as score_categories_tuples",
-        )
-        .withCTE(
-          "scores_agg",
-          eventsScoresAggregation({
-            projectId,
-            includeTupleEncoding: true,
-          }),
-        )
-        .leftJoin(
-          "scores_agg s",
-          "ON s.trace_id = e.trace_id AND s.observation_id = e.span_id",
-        ),
   });
+  const { query, params: queryParams } = queryBuilder.buildWithParams();
 
   // Get distinct score names for empty columns
   const distinctScoreNames = await getDistinctScoreNames({
@@ -321,16 +297,19 @@ export const getEventsStreamForDataset = async (props: {
     rowLimit = env.BATCH_EXPORT_ROW_LIMIT,
   } = props;
 
-  const { query, params: queryParams } = buildEventsStreamQuery({
+  const { queryBuilder } = buildEventsStreamQuery({
     projectId,
     cutoffCreatedAt,
     filter,
     searchQuery,
     searchType,
     rowLimit,
-    configureQuery: (builder) =>
-      builder.selectFieldSet("core").selectIO(false).selectFieldSet("metadata"),
   });
+  const { query, params: queryParams } = queryBuilder
+    .selectFieldSet("core")
+    .selectIO(false)
+    .selectFieldSet("metadata")
+    .buildWithParams();
 
   type DatasetEventRow = {
     id: string;
@@ -391,15 +370,17 @@ export const getEventsStreamForAnnotationQueue = async (props: {
     rowLimit = env.BATCH_EXPORT_ROW_LIMIT,
   } = props;
 
-  const { query, params: queryParams } = buildEventsStreamQuery({
+  const { queryBuilder } = buildEventsStreamQuery({
     projectId,
     cutoffCreatedAt,
     filter,
     searchQuery,
     searchType,
     rowLimit,
-    configureQuery: (builder) => builder.selectFieldSet("core"),
   });
+  const { query, params: queryParams } = queryBuilder
+    .selectFieldSet("core")
+    .buildWithParams();
 
   type AnnotationQueueEventRow = {
     id: string;


### PR DESCRIPTION
## Summary

- Extract shared native-filter, search, and score-dependency planning from Fast Preview.
- Infer observation versus trace score scope from mapped s.* and ts.* fields.
- Migrate Fast Preview and the consolidated stream constructor to the shared planner.

## Stack

PR 2 of 5. PR #14973 has merged; this PR is now based on main.

## Scope

No intended behavior change. Streams still disable score filters here. Comment preprocessing, ordering, cutoff, pagination, projections, and Session Detail position logic remain caller-owned. positionInTrace remains session-only and is not enabled for general Events streams.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts the shared filter-classification, score CTE/join setup, and search-condition planning from `getObservationsFromEventsTableInternal` and the stream constructor into a new `buildEventsObservationRowSelection` helper. It also lifts `extractTimeFilter` into a standalone `filter-utils.ts` module.

- **New planner (`events-observation-row-selection.ts`)**: classifies each `FilterCondition` by inspecting the mapped `clickhouseSelect` prefix (`s.*` → observation scores, `ts.*` → trace scores, `comments` table → comments, else events). This replaces a hardcoded string list and infers scope from the column mapping.
- **`buildEventsStreamQuery` migration**: passes `scoreFilterCapabilities: { observation: false, trace: false }` to preserve the legacy stream behavior of ignoring score predicates, and replaces `eventOnlyFilters` derivation with `groupEventsObservationFilters(filter).events`.
- **`event-stream.ts` migration**: removes the manually inlined `eventsScoresAggregation` CTE/join and delegates to `observationScoreProjection: { includeTupleEncoding: true }`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — pure refactoring with no intended behavior changes; all key query invariants are preserved.

The extraction is clean and behavioral equivalence is well-preserved across all three callers. The new classifyFilter approach via clickhouseSelect prefix is more robust than the old hardcoded string list. The only items worth watching are the implicit ordering contract between configureQuery and the score CTE additions, and the intentional suppression of startTimeFrom when observationScoreProjection is set.

events-observation-row-selection.ts — specifically the configureQuery execution order relative to score CTEs, and the observationScoreProjection / startTimeFrom interaction.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming FilterCondition list] --> B[groupEventsObservationFilters]
    B --> C{classifyFilter per item}
    C --> |clickhouseTableName = comments| D[comments group]
    C --> |clickhouseSelect starts with ts.| E[traceScores group]
    C --> |clickhouseSelect starts with s.| F[observationScores group]
    C --> |otherwise| G[events group]

    B --> H[buildEventsObservationRowSelection]

    H --> I{scoreFilterCapabilities}
    I --> |observation: false or true| J[effectiveFilters exclude/include obs scores]
    I --> |trace: false or true| K[effectiveFilters exclude/include trace scores]

    J & K --> L[createFilterFromFilterState eventsFilter]
    L --> M[extractTimeFilter startTimeFrom]

    H --> N{observationScoreProjection set?}
    N --> |yes| O[needsObservationScoreJoin = true, startTimeFrom = undefined]
    N --> |no| P[needsObservationScoreJoin = hasObservationScoreFilter]

    H --> Q[configureQuery callback]
    Q --> R[EventsQueryBuilder]
    O & P --> S{needsObservationScoreJoin}
    S --> |true| T[withCTE scores_agg + leftJoin]
    K --> U{hasTraceScoreFilter}
    U --> |true| V[withCTE trace_scores_agg + leftJoin]
    R --> T
    R --> V
    T & V --> W{filterApplication}
    W --> |optimized| X[applyFilters]
    W --> |raw| Y[where apply]
    X & Y --> Z[where search]
    Z --> AA[Return queryBuilder + filterGroups + search]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming FilterCondition list] --> B[groupEventsObservationFilters]
    B --> C{classifyFilter per item}
    C --> |clickhouseTableName = comments| D[comments group]
    C --> |clickhouseSelect starts with ts.| E[traceScores group]
    C --> |clickhouseSelect starts with s.| F[observationScores group]
    C --> |otherwise| G[events group]

    B --> H[buildEventsObservationRowSelection]

    H --> I{scoreFilterCapabilities}
    I --> |observation: false or true| J[effectiveFilters exclude/include obs scores]
    I --> |trace: false or true| K[effectiveFilters exclude/include trace scores]

    J & K --> L[createFilterFromFilterState eventsFilter]
    L --> M[extractTimeFilter startTimeFrom]

    H --> N{observationScoreProjection set?}
    N --> |yes| O[needsObservationScoreJoin = true, startTimeFrom = undefined]
    N --> |no| P[needsObservationScoreJoin = hasObservationScoreFilter]

    H --> Q[configureQuery callback]
    Q --> R[EventsQueryBuilder]
    O & P --> S{needsObservationScoreJoin}
    S --> |true| T[withCTE scores_agg + leftJoin]
    K --> U{hasTraceScoreFilter}
    U --> |true| V[withCTE trace_scores_agg + leftJoin]
    R --> T
    R --> V
    T & V --> W{filterApplication}
    W --> |optimized| X[applyFilters]
    W --> |raw| Y[where apply]
    X & Y --> Z[where search]
    Z --> AA[Return queryBuilder + filterGroups + search]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts:162-199
**Score CTEs built before `configureQuery` mutations are visible to it**

`configureQuery` is invoked first and returns the builder, then the planner chains `.when(needsObservationScoreJoin, ...)` onto the result. This means any builder state set inside `configureQuery` (field sets, the `qualifying_obs` CTE, etc.) is visible to the subsequent `.when()` calls, but the `scores_agg` / `trace_scores_agg` CTEs and their joins are **not yet present** when `configureQuery` runs. Currently no caller references those CTEs inside `configureQuery`, but if a future `configureQuery` tries to refer to `scores_agg` (e.g., to compute a derived expression before the main filter), it will produce a query that references the CTE before it is declared. A short doc-comment on the parameter stating that score CTEs are added after `configureQuery` returns would prevent misuse.

### Issue 2 of 4
packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts:164-174
**`observationScoreProjection` suppresses time-pruning silently**

When `observationScoreProjection` is provided, `startTimeFrom` is forced to `undefined`, so the `scores_agg` CTE scans scores for all time regardless of any time filter in the query. This matches the previous unconditional behavior in `event-stream.ts` and is correct for the export case. However, if a future caller passes both a tight time filter and an `observationScoreProjection` (e.g., a paginated preview that also needs tuple encoding), they will get an unexpectedly expensive scores scan with no time pruning. A comment explaining why the time bound is intentionally dropped here would clarify the trade-off.

### Issue 3 of 4
packages/shared/src/server/queries/clickhouse-sql/events-stream-query.ts:45-65
**`groupEventsObservationFilters` called twice for the same input**

`groupEventsObservationFilters(filter)` is called once here to capture `originalFilterGroups`, and then called a second time inside `buildEventsObservationRowSelection` (on the augmented `filterConditions`). The inner call's `filterGroups` result is unused. This is a minor redundancy; passing `originalFilterGroups.events` directly as the return value already avoids any real correctness problem, but the extra classification pass on the full list (including score conditions) happens needlessly on every invocation.

### Issue 4 of 4
packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts:261-281
**`classifyFilter` silently falls back to `"events"` for unknown columns**

If `filter.column` matches no entry in `eventsTableUiColumnDefinitions` (e.g., a stale session-cached column name or a future column not yet in the map), `columnDefinition` is `undefined`, all three guards are skipped, and the filter is classified as `"events"`. This means the filter will be compiled and sent to ClickHouse referencing a column that the events table mapping doesn't know about, likely producing a compile-time error in ClickHouse rather than a clear application-level message. The old explicit string-list approach had the same blind spot, but it's worth noting that there is no guard against unrecognised column names here either.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(events): extract shared row-select..."](https://github.com/langfuse/langfuse/commit/0724e365362043557045f4d585499b6dd7503757) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43315273)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->