### PR TITLE
fix(events): apply score filters to every event stream

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts
@@ -8,7 +8,7 @@ import { createFilterFromFilterState } from "./factory";
 import { extractTimeFilter } from "./filter-utils";
 import {
   eventsScoresAggregation,
-  eventsTracesScoresAggregation,
+  eventsTracesScoresAggregationFromObservationStart,
 } from "./query-fragments";
 import { clickhouseSearchCondition } from "./search";
 
@@ -49,10 +49,6 @@ export type EventsObservationRowSelectionInput = {
   filter: FilterCondition[] | null;
   searchQuery?: string;
   searchType?: TracingSearchType[];
-  scoreFilterCapabilities: {
-    observation: boolean;
-    trace: boolean;
-  };
 };
 
 type ObservationScoreDependency = {
@@ -75,9 +71,10 @@ const buildObservationScoreFilterDependency: ObservationScoreDependencyFactory =
   });
 
 const buildBlobExportObservationScoreDependency: ObservationScoreDependencyFactory =
-  ({ projectId }) => ({
+  ({ projectId, startTimeFrom }) => ({
     cte: eventsScoresAggregation({
       projectId,
+      startTimeFrom,
       includeTupleEncoding: true,
     }),
     joinTable: "scores_agg s",
@@ -135,7 +132,6 @@ const buildEventsObservationRowSelectionInternal = (
     filter,
     searchQuery,
     searchType,
-    scoreFilterCapabilities,
   }: EventsObservationRowSelectionInput,
   observationScoreDependencyFactory?: ObservationScoreDependencyFactory,
 ): {
@@ -144,41 +140,25 @@ const buildEventsObservationRowSelectionInternal = (
   search: ReturnType<typeof eventSearchCondition>;
 } => {
   const filterGroups = groupEventsObservationFilters(filter);
-  const classifiedFilters = (filter ?? []).map((filterItem) => ({
-    filter: filterItem,
-    group: classifyFilter(filterItem),
-  }));
-
-  const effectiveFilters = classifiedFilters.flatMap(({ filter, group }) => {
-    if (group === "observationScores" && !scoreFilterCapabilities.observation) {
-      return [];
-    }
-    if (group === "traceScores" && !scoreFilterCapabilities.trace) return [];
-    return [filter];
-  });
 
   const eventsFilter = new FilterList(
     createFilterFromFilterState(
-      effectiveFilters,
+      filter ?? [],
       eventsTableUiColumnDefinitions,
       eventsTableCols,
     ),
   );
   const startTimeFrom = extractTimeFilter(eventsFilter);
-  const hasObservationScoreFilter =
-    scoreFilterCapabilities.observation &&
-    eventsFilter.some(
-      (filterItem) =>
-        filterItem.clickhouseTable === "scores" &&
-        filterItem.field.startsWith("s."),
-    );
-  const hasTraceScoreFilter =
-    scoreFilterCapabilities.trace &&
-    eventsFilter.some(
-      (filterItem) =>
-        filterItem.clickhouseTable === "scores" &&
-        filterItem.field.startsWith("ts."),
-    );
+  const hasObservationScoreFilter = eventsFilter.some(
+    (filterItem) =>
+      filterItem.clickhouseTable === "scores" &&
+      filterItem.field.startsWith("s."),
+  );
+  const hasTraceScoreFilter = eventsFilter.some(
+    (filterItem) =>
+      filterItem.clickhouseTable === "scores" &&
+      filterItem.field.startsWith("ts."),
+  );
   const queryBuilder = new EventsQueryBuilder({ projectId });
   const observationScoreDependency =
     observationScoreDependencyFactory?.({ projectId, startTimeFrom }) ??
@@ -204,7 +184,7 @@ const buildEventsObservationRowSelectionInternal = (
     .when(hasTraceScoreFilter, (builder) =>
       builder.withCTE(
         "trace_scores_agg",
-        eventsTracesScoresAggregation({
+        eventsTracesScoresAggregationFromObservationStart({
           projectId,
           startTimeFrom,
           hasScoreAggregationFilters: true,

--- a/packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts
@@ -1,10 +1,14 @@
 import { eventsTableCols } from "../../../eventsTable";
 import type { TracingSearchType } from "../../../interfaces/search";
+import { findUiColumnMapping } from "../../../tableDefinitions";
 import type { FilterCondition } from "../../../types";
 import { eventsTableUiColumnDefinitions } from "../../tableMappings/mapEventsTable";
 import { FilterList, filtersRequireEventsFull } from "./clickhouse-filter";
 import { EventsQueryBuilder } from "./event-query-builder";
-import { createFilterFromFilterState } from "./factory";
+import {
+  createFilterFromFilterState,
+  resolveLegacyScoreFilterColumn,
+} from "./factory";
 import { extractTimeFilter } from "./filter-utils";
 import {
   eventsScoresAggregation,
@@ -88,10 +92,13 @@ const buildBlobExportObservationScoreDependency: ObservationScoreDependencyFacto
   });
 
 const classifyFilter = (filter: FilterCondition): EventFilterGroup => {
-  const columnDefinition = eventsTableUiColumnDefinitions.find(
-    (column) =>
-      column.uiTableName === filter.column ||
-      column.uiTableId === filter.column,
+  const filterColumn = resolveLegacyScoreFilterColumn(
+    filter,
+    eventsTableUiColumnDefinitions,
+  );
+  const columnDefinition = findUiColumnMapping(
+    eventsTableUiColumnDefinitions,
+    filterColumn,
   );
 
   if (columnDefinition?.clickhouseTableName === "comments") {
@@ -138,6 +145,7 @@ const buildEventsObservationRowSelectionInternal = (
   queryBuilder: EventsQueryBuilder;
   filterGroups: EventsObservationFilterGroups;
   search: ReturnType<typeof eventSearchCondition>;
+  startTimeFrom: string | null;
 } => {
   const filterGroups = groupEventsObservationFilters(filter);
 
@@ -149,16 +157,8 @@ const buildEventsObservationRowSelectionInternal = (
     ),
   );
   const startTimeFrom = extractTimeFilter(eventsFilter);
-  const hasObservationScoreFilter = eventsFilter.some(
-    (filterItem) =>
-      filterItem.clickhouseTable === "scores" &&
-      filterItem.field.startsWith("s."),
-  );
-  const hasTraceScoreFilter = eventsFilter.some(
-    (filterItem) =>
-      filterItem.clickhouseTable === "scores" &&
-      filterItem.field.startsWith("ts."),
-  );
+  const hasObservationScoreFilter = filterGroups.observationScores.length > 0;
+  const hasTraceScoreFilter = filterGroups.traceScores.length > 0;
   const queryBuilder = new EventsQueryBuilder({ projectId });
   const observationScoreDependency =
     observationScoreDependencyFactory?.({ projectId, startTimeFrom }) ??
@@ -204,7 +204,7 @@ const buildEventsObservationRowSelectionInternal = (
 
   queryBuilder.applyFilters(eventsFilter).where(search);
 
-  return { queryBuilder, filterGroups, search };
+  return { queryBuilder, filterGroups, search, startTimeFrom };
 };
 
 export const buildEventsObservationRowSelection = (

--- a/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
@@ -112,7 +112,7 @@ describe("buildEventsStreamQuery", () => {
   });
 
   it("shares one bounded score dependency between filtering and projection", () => {
-    const { queryBuilder } = buildEventsBlobExportStreamQuery({
+    const { queryBuilder, startTimeFrom } = buildEventsBlobExportStreamQuery({
       projectId,
       filter: [
         {
@@ -131,8 +131,9 @@ describe("buildEventsStreamQuery", () => {
       ],
       rowLimit: 7,
     });
-    const { query } = queryBuilder.buildWithParams();
+    const { query, params } = queryBuilder.buildWithParams();
 
+    expect(startTimeFrom).toBe(params.startTimeFrom);
     expect(query.match(/\bscores_agg AS \(/g)).toHaveLength(1);
     expect(query).toContain("s.scores_avg as scores_avg");
     expect(query).toContain("s.score_categories as score_categories");
@@ -148,7 +149,7 @@ describe("buildEventsStreamQuery", () => {
   });
 
   it("applies score filters without exposing them as native event filters", () => {
-    const { queryBuilder, eventOnlyFilters } = buildEventsStreamQuery({
+    const { queryBuilder } = buildEventsStreamQuery({
       projectId,
       filter: [
         nativeFilter,
@@ -164,12 +165,11 @@ describe("buildEventsStreamQuery", () => {
     });
     const { params } = queryBuilder.selectFieldSet("eval").buildWithParams();
 
-    expect(eventOnlyFilters).toEqual([nativeFilter]);
     expect(Object.values(params)).toContain("quality");
   });
 
   it("keeps comment filters out of the legacy stream selection", () => {
-    const { queryBuilder, eventOnlyFilters } = buildEventsStreamQuery({
+    const { queryBuilder } = buildEventsStreamQuery({
       projectId,
       filter: [
         nativeFilter,
@@ -184,7 +184,6 @@ describe("buildEventsStreamQuery", () => {
     });
     const { params } = queryBuilder.selectFieldSet("eval").buildWithParams();
 
-    expect(eventOnlyFilters).toEqual([nativeFilter]);
     expect(Object.values(params)).not.toContain("comment-needle");
   });
 });
@@ -231,7 +230,7 @@ describe("buildEventsObservationRowSelection", () => {
   });
 
   it("does not invent score time bounds without an Events lower bound", () => {
-    const { query } = buildSelection({
+    const { query, startTimeFrom } = buildSelection({
       filter: [
         {
           type: "numberObject",
@@ -250,6 +249,7 @@ describe("buildEventsObservationRowSelection", () => {
       ],
     });
 
+    expect(startTimeFrom).toBeNull();
     expect(query).not.toContain("AND timestamp >=");
   });
 
@@ -257,6 +257,7 @@ describe("buildEventsObservationRowSelection", () => {
     ["scores_avg", "observationScores"],
     ["trace_scores_avg", "traceScores"],
     ["Scores", "observationScores"],
+    ["SCORES", "observationScores"],
     ["Scores (numeric)", "observationScores"],
     ["Trace Scores (numeric)", "traceScores"],
   ] as const)(

--- a/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
@@ -20,22 +20,10 @@ const nativeFilter: FilterCondition = {
 
 const normalizeSql = (query: string) => query.replace(/\s+/g, " ").trim();
 
-const buildSelection = ({
-  filter,
-  observationScores = true,
-  traceScores = true,
-}: {
-  filter: FilterCondition[];
-  observationScores?: boolean;
-  traceScores?: boolean;
-}) => {
+const buildSelection = ({ filter }: { filter: FilterCondition[] }) => {
   const selection = buildEventsObservationRowSelection({
     projectId,
     filter,
-    scoreFilterCapabilities: {
-      observation: observationScores,
-      trace: traceScores,
-    },
   });
 
   const built = selection.queryBuilder
@@ -123,7 +111,7 @@ describe("buildEventsStreamQuery", () => {
     expect(normalizeSql(query)).toContain("FROM events_core e");
   });
 
-  it("keeps the blob-export score projection and source together", () => {
+  it("shares one bounded score dependency between filtering and projection", () => {
     const { queryBuilder } = buildEventsBlobExportStreamQuery({
       projectId,
       filter: [
@@ -133,10 +121,17 @@ describe("buildEventsStreamQuery", () => {
           operator: ">=",
           value: new Date("2025-01-02T03:04:05.678Z"),
         },
+        {
+          type: "numberObject",
+          column: "scores_avg",
+          operator: ">",
+          key: "quality",
+          value: 0.5,
+        },
       ],
       rowLimit: 7,
     });
-    const { query, params } = queryBuilder.buildWithParams();
+    const { query } = queryBuilder.buildWithParams();
 
     expect(query.match(/\bscores_agg AS \(/g)).toHaveLength(1);
     expect(query).toContain("s.scores_avg as scores_avg");
@@ -147,10 +142,12 @@ describe("buildEventsStreamQuery", () => {
     expect(query).toContain(
       "ON s.trace_id = e.trace_id AND s.observation_id = e.span_id",
     );
-    expect(params).not.toHaveProperty("startTimeFrom");
+    expect(query).toContain(
+      "AND timestamp >= {startTimeFrom: DateTime64(3)} - INTERVAL 1 HOUR",
+    );
   });
 
-  it("keeps score filters out of the legacy stream selection", () => {
+  it("applies score filters without exposing them as native event filters", () => {
     const { queryBuilder, eventOnlyFilters } = buildEventsStreamQuery({
       projectId,
       filter: [
@@ -168,7 +165,7 @@ describe("buildEventsStreamQuery", () => {
     const { params } = queryBuilder.selectFieldSet("eval").buildWithParams();
 
     expect(eventOnlyFilters).toEqual([nativeFilter]);
-    expect(Object.values(params)).not.toContain("quality");
+    expect(Object.values(params)).toContain("quality");
   });
 
   it("keeps comment filters out of the legacy stream selection", () => {
@@ -193,6 +190,69 @@ describe("buildEventsStreamQuery", () => {
 });
 
 describe("buildEventsObservationRowSelection", () => {
+  it("routes score filters and bounds both score scans from Events time", () => {
+    const startTime = new Date("2025-01-02T03:04:05.678Z");
+    const { query, params, filterGroups } = buildSelection({
+      filter: [
+        {
+          type: "datetime",
+          column: "startTime",
+          operator: ">=",
+          value: startTime,
+        },
+        {
+          type: "numberObject",
+          column: "scores_avg",
+          operator: ">",
+          key: "observation-quality",
+          value: 0.5,
+        },
+        {
+          type: "numberObject",
+          column: "trace_scores_avg",
+          operator: ">",
+          key: "trace-quality",
+          value: 0.5,
+        },
+      ],
+    });
+
+    expect(filterGroups.events).toHaveLength(1);
+    expect(filterGroups.observationScores).toHaveLength(1);
+    expect(filterGroups.traceScores).toHaveLength(1);
+    expect(Object.values(params)).toContain("observation-quality");
+    expect(Object.values(params)).toContain("trace-quality");
+    expect(query).toContain(
+      "AND timestamp >= {startTimeFrom: DateTime64(3)} - INTERVAL 1 HOUR",
+    );
+    expect(query).toContain(
+      "AND timestamp >= {startTimeFrom: DateTime64(3)} - INTERVAL 2 DAY - INTERVAL 1 HOUR",
+    );
+  });
+
+  it("does not invent score time bounds without an Events lower bound", () => {
+    const { query } = buildSelection({
+      filter: [
+        {
+          type: "numberObject",
+          column: "scores_avg",
+          operator: ">",
+          key: "observation-quality",
+          value: 0.5,
+        },
+        {
+          type: "numberObject",
+          column: "trace_scores_avg",
+          operator: ">",
+          key: "trace-quality",
+          value: 0.5,
+        },
+      ],
+    });
+
+    expect(query).not.toContain("AND timestamp >=");
+  });
+
   it.each([
     ["scores_avg", "observationScores"],
     ["trace_scores_avg", "traceScores"],
@@ -213,36 +273,6 @@ describe("buildEventsObservationRowSelection", () => {
       expect(filterGroups[expectedGroup]).toHaveLength(1);
     },
   );
-
-  it("does not apply score predicates when score filtering is disabled", () => {
-    const { params, filterGroups } = buildSelection({
-      filter: [
-        {
-          type: "numberObject",
-          column: "scores_avg",
-          operator: ">",
-          key: "observation-score",
-          value: 0,
-        },
-        {
-          type: "numberObject",
-          column: "trace_scores_avg",
-          operator: ">",
-          key: "trace-score",
-          value: 0,
-        },
-      ],
-      observationScores: false,
-      traceScores: false,
-    });
-
-    expect(filterGroups.events).toHaveLength(0);
-    expect(filterGroups.observationScores).toHaveLength(1);
-    expect(filterGroups.traceScores).toHaveLength(1);
-
-    expect(Object.values(params)).not.toContain("observation-score");
-    expect(Object.values(params)).not.toContain("trace-score");
-  });
 
   it("does not silently discard unresolved comment filters", () => {
     expect(() =>

--- a/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.ts
@@ -18,7 +18,10 @@ export type EventsStreamQueryInput = {
 
 export type EventsStreamQuery = {
   queryBuilder: EventsQueryBuilder;
-  eventOnlyFilters: FilterCondition[];
+};
+
+export type EventsBlobExportStreamQuery = EventsStreamQuery & {
+  startTimeFrom: string | null;
 };
 
 /**
@@ -41,7 +44,7 @@ const buildEventsStreamQueryInternal = (
     rowLimit,
   }: EventsStreamQueryInput,
   buildRowSelection: typeof buildEventsObservationRowSelection,
-): EventsStreamQuery => {
+): EventsBlobExportStreamQuery => {
   const originalFilterGroups = groupEventsObservationFilters(filter);
   const filterConditions: FilterCondition[] = [
     ...originalFilterGroups.events,
@@ -57,7 +60,7 @@ const buildEventsStreamQueryInternal = (
     });
   }
 
-  const { queryBuilder } = buildRowSelection({
+  const { queryBuilder, startTimeFrom } = buildRowSelection({
     projectId,
     filter: filterConditions,
     searchQuery,
@@ -72,7 +75,7 @@ const buildEventsStreamQueryInternal = (
 
   return {
     queryBuilder,
-    eventOnlyFilters: originalFilterGroups.events,
+    startTimeFrom,
   };
 };
 
@@ -87,7 +90,7 @@ export const buildEventsStreamQuery = (
  */
 export const buildEventsBlobExportStreamQuery = (
   input: EventsStreamQueryInput,
-): EventsStreamQuery => {
+): EventsBlobExportStreamQuery => {
   const result = buildEventsStreamQueryInternal(
     input,
     buildEventsObservationRowSelectionForBlobExport,

--- a/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.ts
@@ -26,8 +26,10 @@ export type EventsStreamQuery = {
  *
  * The returned builder is intentionally unprojected so each consumer can
  * select its own row shape. Callers must add a field set or raw selection
- * before building the query. Score and comment filters are intentionally
- * excluded here to preserve the legacy stream behavior.
+ * before building the query.
+ *
+ * Score filters are applied by the shared row-selection planner. Unresolved
+ * comment filters remain excluded until the stream caller resolves them.
  */
 const buildEventsStreamQueryInternal = (
   {
@@ -41,7 +43,11 @@ const buildEventsStreamQueryInternal = (
   buildRowSelection: typeof buildEventsObservationRowSelection,
 ): EventsStreamQuery => {
   const originalFilterGroups = groupEventsObservationFilters(filter);
-  const filterConditions: FilterCondition[] = [...originalFilterGroups.events];
+  const filterConditions: FilterCondition[] = [
+    ...originalFilterGroups.events,
+    ...originalFilterGroups.observationScores,
+    ...originalFilterGroups.traceScores,
+  ];
   if (cutoffCreatedAt) {
     filterConditions.push({
       column: "startTime",
@@ -56,7 +62,6 @@ const buildEventsStreamQueryInternal = (
     filter: filterConditions,
     searchQuery,
     searchType,
-    scoreFilterCapabilities: { observation: false, trace: false },
   });
 
   queryBuilder

--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -40,7 +40,7 @@ const LEGACY_SCORE_FILTER_COLUMNS: Partial<
   booleanObject: "score_booleans",
 };
 
-const resolveLegacyScoreFilterColumn = (
+export const resolveLegacyScoreFilterColumn = (
   filter: EventsTableFilterState[number],
   columnMapping: UiColumnMappings,
 ): string => {

--- a/packages/shared/src/server/queries/clickhouse-sql/filter-utils.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/filter-utils.ts
@@ -11,15 +11,20 @@ export function extractTimeFilter(
   fieldName: "start_time" | "timestamp" = "start_time",
   prefix?: "e" | "t",
 ): string | null {
-  const timeFilter = filter.find(
-    (filterItem) =>
-      // For events tables, match any events_* prefix (events_proto, events_core, events_full)
+  const timeFilter = filter.find((filterItem) => {
+    // For events tables, match any events_* prefix (events_proto, events_core, events_full)
+    const normalizedField = filterItem.field.replaceAll('"', "");
+    const expectedField = prefix ? `${prefix}.${fieldName}` : fieldName;
+
+    return (
       (tableName === "events_proto"
         ? filterItem.clickhouseTable.startsWith("events_")
         : filterItem.clickhouseTable === tableName) &&
-      filterItem.field === (prefix ? `${prefix}.${fieldName}` : fieldName) &&
-      (filterItem.operator === ">=" || filterItem.operator === ">"),
-  );
+      (normalizedField === expectedField ||
+        (!prefix && normalizedField.endsWith(`.${fieldName}`))) &&
+      (filterItem.operator === ">=" || filterItem.operator === ">")
+    );
+  });
 
   return timeFilter
     ? convertDateToClickhouseDateTime((timeFilter as DateTimeFilter).value)

--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -11,6 +11,10 @@ import {
   type CTEWithSchema,
 } from "./event-query-builder";
 import { AGGREGATABLE_SCORE_TYPES } from "../../../domain/scores";
+import {
+  OBSERVATIONS_TO_TRACE_INTERVAL,
+  SCORE_TO_TRACE_OBSERVATIONS_INTERVAL,
+} from "../../repositories/constants";
 
 /**
  * Lightweight trace metadata query: one row per trace with name, user_id, tags.
@@ -90,6 +94,7 @@ interface BaseScoresParams {
 
 interface BaseScoresAggregationParams extends BaseScoresParams {
   hasScoreAggregationFilters?: boolean;
+  startTimeLookbackIntervals: readonly string[];
   /**
    * When true, adds an extra `score_categories_tuples` column with
    * `tuple(name, string_value, data_type)` encoding alongside the default concat-encoded
@@ -99,6 +104,14 @@ interface BaseScoresAggregationParams extends BaseScoresParams {
    */
   includeTupleEncoding?: boolean;
 }
+
+const scoreTimestampLowerBound = (
+  startTimeFrom: string | null | undefined,
+  lookbackIntervals: readonly string[],
+): string =>
+  startTimeFrom
+    ? `AND timestamp >= {startTimeFrom: DateTime64(3)}${lookbackIntervals.map((interval) => ` - ${interval}`).join("")}`
+    : "";
 
 /**
  * Unified score aggregation CTE builder for both observation-level and trace-level scores.
@@ -153,7 +166,7 @@ export const buildScoresAggregationCTE = (
         FROM scores FINAL
         WHERE project_id = {projectId: String}
           ${observationFilter}
-          ${params.startTimeFrom ? `AND timestamp >= {startTimeFrom: DateTime64(3)}` : ""}
+          ${scoreTimestampLowerBound(params.startTimeFrom, params.startTimeLookbackIntervals)}
         GROUP BY
           ${primaryKey},
           trace_id,
@@ -190,6 +203,7 @@ export const eventsScoresAggregation = (
   return buildScoresAggregationCTE({
     ...params,
     level: "observation",
+    startTimeLookbackIntervals: [SCORE_TO_TRACE_OBSERVATIONS_INTERVAL],
   });
 };
 
@@ -212,13 +226,15 @@ interface EventsTracesScoresAggregationParams {
  *
  * Returns a query and params object that can be passed directly to withCTE.
  */
-export const eventsTracesScoresAggregation = (
+const buildEventsTracesScoresAggregation = (
   params: EventsTracesScoresAggregationParams,
+  startTimeLookbackIntervals: readonly string[],
 ): { query: string; params: Record<string, any> } => {
   if (params.hasScoreAggregationFilters) {
     return buildScoresAggregationCTE({
       ...params,
       level: "trace",
+      startTimeLookbackIntervals,
     });
   }
 
@@ -239,7 +255,7 @@ export const eventsTracesScoresAggregation = (
     FROM scores
     WHERE project_id = {projectId: String}
       AND observation_id IS NULL
-      ${params.startTimeFrom ? `AND timestamp >= {startTimeFrom: DateTime64(3)}` : ""}
+      ${scoreTimestampLowerBound(params.startTimeFrom, startTimeLookbackIntervals)}
     GROUP BY
       trace_id,
       project_id
@@ -247,6 +263,25 @@ export const eventsTracesScoresAggregation = (
 
   return { query, params: queryParams };
 };
+
+export const eventsTracesScoresAggregation = (
+  params: EventsTracesScoresAggregationParams,
+): { query: string; params: Record<string, any> } =>
+  buildEventsTracesScoresAggregation(params, [
+    SCORE_TO_TRACE_OBSERVATIONS_INTERVAL,
+  ]);
+
+/**
+ * Trace-score aggregation for observation rows selected by event start time.
+ * The lower bound covers trace-to-observation skew before the score lookback.
+ */
+export const eventsTracesScoresAggregationFromObservationStart = (
+  params: EventsTracesScoresAggregationParams,
+): { query: string; params: Record<string, any> } =>
+  buildEventsTracesScoresAggregation(params, [
+    OBSERVATIONS_TO_TRACE_INTERVAL,
+    SCORE_TO_TRACE_OBSERVATIONS_INTERVAL,
+  ]);
 
 /**
  * Aggregates events directly by session_id in a single step.

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -660,7 +660,6 @@ async function getObservationsFromEventsTableInternal<T>(
     filter: baseFilter,
     searchQuery: opts.searchQuery,
     searchType: opts.searchType,
-    scoreFilterCapabilities: { observation: true, trace: true },
   });
 
   if (opts.select === "count") {

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2110,14 +2110,18 @@ export const getDistinctScoreNames = async (p: {
     isTimestampFilter,
     clickhouseConfigs,
   } = p;
-  const scoreTimestampFilter = filter?.find(isTimestampFilter);
+  const scoreTimestampFilter = filter?.find(
+    (filterItem): filterItem is TimeFilter =>
+      isTimestampFilter(filterItem) &&
+      (filterItem.operator === ">=" || filterItem.operator === ">"),
+  );
 
   const query = `    SELECT DISTINCT
       name
     FROM scores s
     WHERE s.project_id = {projectId: String}
     AND s.created_at <= {cutoffCreatedAt: DateTime64(3)}
-    ${scoreTimestampFilter ? `AND s.timestamp >= {filterTimestamp: DateTime64(3)}` : ""}
+    ${scoreTimestampFilter ? `AND s.timestamp >= {filterTimestamp: DateTime64(3)} - ${SCORE_TO_TRACE_OBSERVATIONS_INTERVAL}` : ""}
     AND s.data_type IN ({dataTypes: Array(String)})
   `;
 

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2096,32 +2096,56 @@ export const getScoreCountOfProjectsSinceCreationDate = async ({
   return Number(rows[0]?.count ?? 0);
 };
 
-export const getDistinctScoreNames = async (p: {
-  projectId: string;
-  cutoffCreatedAt: Date;
-  filter: FilterState;
-  isTimestampFilter: (filter: FilterCondition) => filter is TimeFilter;
-  clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
-}) => {
-  const {
-    projectId,
-    cutoffCreatedAt,
-    filter,
-    isTimestampFilter,
-    clickhouseConfigs,
-  } = p;
-  const scoreTimestampFilter = filter?.find(
+/**
+ * Reuses an already-planned ClickHouse lower bound when available. Callers
+ * without one can retain their view-specific timestamp-filter predicate.
+ */
+type DistinctScoreNamesTimestampSource =
+  | {
+      filter: FilterState;
+      isTimestampFilter: (filter: FilterCondition) => filter is TimeFilter;
+      startTimeFrom?: never;
+    }
+  | {
+      startTimeFrom: string | null;
+      filter?: never;
+      isTimestampFilter?: never;
+    };
+
+const getDistinctScoreNamesStartTimeFrom = (
+  source: DistinctScoreNamesTimestampSource,
+): string | null => {
+  if ("startTimeFrom" in source) {
+    return source.startTimeFrom ?? null;
+  }
+
+  const scoreTimestampFilter = source.filter.find(
     (filterItem): filterItem is TimeFilter =>
-      isTimestampFilter(filterItem) &&
+      source.isTimestampFilter(filterItem) &&
       (filterItem.operator === ">=" || filterItem.operator === ">"),
   );
+
+  return scoreTimestampFilter
+    ? convertDateToClickhouseDateTime(scoreTimestampFilter.value)
+    : null;
+};
+
+export const getDistinctScoreNames = async (
+  p: {
+    projectId: string;
+    cutoffCreatedAt: Date;
+    clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
+  } & DistinctScoreNamesTimestampSource,
+) => {
+  const { projectId, cutoffCreatedAt, clickhouseConfigs } = p;
+  const startTimeFrom = getDistinctScoreNamesStartTimeFrom(p);
 
   const query = `    SELECT DISTINCT
       name
     FROM scores s
     WHERE s.project_id = {projectId: String}
     AND s.created_at <= {cutoffCreatedAt: DateTime64(3)}
-    ${scoreTimestampFilter ? `AND s.timestamp >= {filterTimestamp: DateTime64(3)} - ${SCORE_TO_TRACE_OBSERVATIONS_INTERVAL}` : ""}
+    ${startTimeFrom ? `AND s.timestamp >= {filterTimestamp: DateTime64(3)} - ${SCORE_TO_TRACE_OBSERVATIONS_INTERVAL}` : ""}
     AND s.data_type IN ({dataTypes: Array(String)})
   `;
 
@@ -2131,11 +2155,9 @@ export const getDistinctScoreNames = async (p: {
       projectId,
       cutoffCreatedAt: convertDateToClickhouseDateTime(cutoffCreatedAt),
       dataTypes: LISTABLE_SCORE_TYPES,
-      ...(scoreTimestampFilter
+      ...(startTimeFrom
         ? {
-            filterTimestamp: convertDateToClickhouseDateTime(
-              scoreTimestampFilter.value,
-            ),
+            filterTimestamp: startTimeFrom,
           }
         : {}),
     },

--- a/worker/src/__tests__/event-stream-score-filters.test.ts
+++ b/worker/src/__tests__/event-stream-score-filters.test.ts
@@ -144,7 +144,7 @@ const createScoreSet = ({
 const scoreFilters: FilterCondition[] = [
   {
     type: "numberObject",
-    column: "scores_avg",
+    column: "SCORES",
     key: "observation-numeric",
     operator: ">",
     value: 0.5,
@@ -270,8 +270,8 @@ maybeDescribe("event stream score filters", () => {
       }),
     ]);
 
-    await createScoresCh(
-      variants.flatMap((variant) =>
+    await createScoresCh([
+      ...variants.flatMap((variant) =>
         createScoreSet({
           projectId,
           traceId: variant.traceId,
@@ -282,7 +282,16 @@ maybeDescribe("event stream score filters", () => {
           traceTimestamp: traceScoreTimestamp,
         }),
       ),
-    );
+      createTraceScore({
+        project_id: projectId,
+        trace_id: variants[0]!.traceId,
+        observation_id: variants[0]!.eventId,
+        name: "outside-score-lookback",
+        data_type: "NUMERIC",
+        value: 1,
+        timestamp: now - 61 * 60 * 1_000,
+      }),
+    ]);
 
     for (const { name, run } of streamAdapters) {
       const rows = await collectRows(
@@ -307,6 +316,7 @@ maybeDescribe("event stream score filters", () => {
         expect(rows[0]?.["observation-numeric"]).toEqual([0.9]);
         expect(rows[0]?.["observation:category"]).toEqual(["matching"]);
         expect(rows[0]).not.toHaveProperty("trace-numeric");
+        expect(rows[0]).not.toHaveProperty("outside-score-lookback");
       }
     }
   }, 30_000);

--- a/worker/src/__tests__/event-stream-score-filters.test.ts
+++ b/worker/src/__tests__/event-stream-score-filters.test.ts
@@ -1,0 +1,423 @@
+import type { FilterCondition } from "@langfuse/shared";
+import {
+  createEvent,
+  createEventsCh,
+  createScoresCh,
+  createTraceScore,
+  getEventsStreamForEval,
+} from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+import type { Readable } from "stream";
+import { describe, expect, it } from "vitest";
+import {
+  getEventsStream,
+  getEventsStreamForAnnotationQueue,
+  getEventsStreamForDataset,
+} from "../features/database-read-stream/event-stream";
+
+const maybeDescribe =
+  process.env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+    ? describe
+    : describe.skip;
+
+type StreamInput = {
+  projectId: string;
+  cutoffCreatedAt: Date;
+  filter: FilterCondition[];
+  rowLimit: number;
+};
+
+type StreamAdapter = {
+  name: string;
+  run: (input: StreamInput) => Promise<Readable>;
+};
+
+const streamAdapters: StreamAdapter[] = [
+  { name: "blob export", run: getEventsStream },
+  { name: "dataset", run: getEventsStreamForDataset },
+  { name: "annotation queue", run: getEventsStreamForAnnotationQueue },
+  { name: "evaluation", run: getEventsStreamForEval },
+];
+
+const collectRows = async (
+  stream: Readable,
+): Promise<Array<{ id: string; [key: string]: unknown }>> => {
+  const rows: Array<{ id: string; [key: string]: unknown }> = [];
+  for await (const row of stream) {
+    rows.push(row as { id: string; [key: string]: unknown });
+  }
+  return rows;
+};
+
+type ScoreValues = {
+  numericValue: number;
+  categoryValue: string;
+  booleanValue: boolean;
+};
+
+const createScoreSet = ({
+  projectId,
+  traceId,
+  observationId,
+  observationValues,
+  traceValues,
+  observationTimestamp,
+  traceTimestamp,
+}: {
+  projectId: string;
+  traceId: string;
+  observationId: string;
+  observationValues: ScoreValues;
+  traceValues: ScoreValues;
+  observationTimestamp?: number;
+  traceTimestamp?: number;
+}) => {
+  const observationTimestampField =
+    observationTimestamp === undefined
+      ? {}
+      : { timestamp: observationTimestamp };
+  const traceTimestampField =
+    traceTimestamp === undefined ? {} : { timestamp: traceTimestamp };
+
+  return [
+    createTraceScore({
+      project_id: projectId,
+      trace_id: traceId,
+      observation_id: observationId,
+      name: "observation-numeric",
+      data_type: "NUMERIC",
+      value: observationValues.numericValue,
+      ...observationTimestampField,
+    }),
+    createTraceScore({
+      project_id: projectId,
+      trace_id: traceId,
+      observation_id: observationId,
+      name: "observation:category",
+      data_type: "CATEGORICAL",
+      value: 0,
+      string_value: observationValues.categoryValue,
+      ...observationTimestampField,
+    }),
+    createTraceScore({
+      project_id: projectId,
+      trace_id: traceId,
+      observation_id: observationId,
+      name: "observation-boolean",
+      data_type: "BOOLEAN",
+      value: observationValues.booleanValue ? 1 : 0,
+      string_value: observationValues.booleanValue ? "True" : "False",
+      ...observationTimestampField,
+    }),
+    createTraceScore({
+      project_id: projectId,
+      trace_id: traceId,
+      observation_id: null,
+      name: "trace-numeric",
+      data_type: "NUMERIC",
+      value: traceValues.numericValue,
+      ...traceTimestampField,
+    }),
+    createTraceScore({
+      project_id: projectId,
+      trace_id: traceId,
+      observation_id: null,
+      name: "trace-category",
+      data_type: "CATEGORICAL",
+      value: 0,
+      string_value: traceValues.categoryValue,
+      ...traceTimestampField,
+    }),
+    createTraceScore({
+      project_id: projectId,
+      trace_id: traceId,
+      observation_id: null,
+      name: "trace-boolean",
+      data_type: "BOOLEAN",
+      value: traceValues.booleanValue ? 1 : 0,
+      string_value: traceValues.booleanValue ? "True" : "False",
+      ...traceTimestampField,
+    }),
+  ];
+};
+
+const scoreFilters: FilterCondition[] = [
+  {
+    type: "numberObject",
+    column: "scores_avg",
+    key: "observation-numeric",
+    operator: ">",
+    value: 0.5,
+  },
+  {
+    type: "categoryOptions",
+    column: "score_categories",
+    key: "observation:category",
+    operator: "any of",
+    value: ["matching"],
+  },
+  {
+    type: "booleanObject",
+    column: "score_booleans",
+    key: "observation-boolean",
+    operator: "=",
+    value: true,
+  },
+  {
+    type: "numberObject",
+    column: "trace_scores_avg",
+    key: "trace-numeric",
+    operator: ">",
+    value: 0.5,
+  },
+  {
+    type: "categoryOptions",
+    column: "trace_score_categories",
+    key: "trace-category",
+    operator: "any of",
+    value: ["matching"],
+  },
+  {
+    type: "booleanObject",
+    column: "trace_score_booleans",
+    key: "trace-boolean",
+    operator: "=",
+    value: true,
+  },
+];
+
+maybeDescribe("event stream score filters", () => {
+  it("applies observation and trace score filters to every stream", async () => {
+    const projectId = randomUUID();
+    const unscoredTraceId = randomUUID();
+    const unscoredEventId = randomUUID();
+    const now = Date.now();
+    const observationScoreTimestamp = now - 30 * 60 * 1_000;
+    const traceScoreTimestamp = now - (48 * 60 + 30) * 60 * 1_000;
+    const matchingValues: ScoreValues = {
+      numericValue: 0.9,
+      categoryValue: "matching",
+      booleanValue: true,
+    };
+    const variants = [
+      {
+        label: "matching-all-score-filters",
+        observationValues: matchingValues,
+        traceValues: matchingValues,
+        matches: true,
+      },
+      {
+        label: "observation-numeric-mismatch",
+        observationValues: { ...matchingValues, numericValue: 0.1 },
+        traceValues: matchingValues,
+      },
+      {
+        label: "observation-category-mismatch",
+        observationValues: {
+          ...matchingValues,
+          categoryValue: "not-matching",
+        },
+        traceValues: matchingValues,
+      },
+      {
+        label: "observation-boolean-mismatch",
+        observationValues: { ...matchingValues, booleanValue: false },
+        traceValues: matchingValues,
+      },
+      {
+        label: "trace-numeric-mismatch",
+        observationValues: matchingValues,
+        traceValues: { ...matchingValues, numericValue: 0.1 },
+      },
+      {
+        label: "trace-category-mismatch",
+        observationValues: matchingValues,
+        traceValues: { ...matchingValues, categoryValue: "not-matching" },
+      },
+      {
+        label: "trace-boolean-mismatch",
+        observationValues: matchingValues,
+        traceValues: { ...matchingValues, booleanValue: false },
+      },
+    ].map((variant, index) => ({
+      ...variant,
+      eventId: randomUUID(),
+      traceId: randomUUID(),
+      startTime: (now + index) * 1000,
+    }));
+    const matchingEventId = variants.find(
+      (variant) => variant.matches,
+    )!.eventId;
+
+    await createEventsCh([
+      ...variants.map((variant) =>
+        createEvent({
+          id: variant.eventId,
+          span_id: variant.eventId,
+          project_id: projectId,
+          trace_id: variant.traceId,
+          name: variant.label,
+          start_time: variant.startTime,
+        }),
+      ),
+      createEvent({
+        id: unscoredEventId,
+        span_id: unscoredEventId,
+        project_id: projectId,
+        trace_id: unscoredTraceId,
+        name: "missing-scores",
+        start_time: (now + 2) * 1000,
+      }),
+    ]);
+
+    await createScoresCh(
+      variants.flatMap((variant) =>
+        createScoreSet({
+          projectId,
+          traceId: variant.traceId,
+          observationId: variant.eventId,
+          observationValues: variant.observationValues,
+          traceValues: variant.traceValues,
+          observationTimestamp: observationScoreTimestamp,
+          traceTimestamp: traceScoreTimestamp,
+        }),
+      ),
+    );
+
+    for (const { name, run } of streamAdapters) {
+      const rows = await collectRows(
+        await run({
+          projectId,
+          cutoffCreatedAt: new Date(now + 60_000),
+          filter: [
+            {
+              type: "datetime",
+              column: "startTime",
+              operator: ">=",
+              value: new Date(now),
+            },
+            ...scoreFilters,
+          ],
+          rowLimit: 100,
+        }),
+      );
+
+      expect(rows.map((row) => row.id).sort(), name).toEqual([matchingEventId]);
+      if (name === "blob export") {
+        expect(rows[0]?.["observation-numeric"]).toEqual([0.9]);
+        expect(rows[0]?.["observation:category"]).toEqual(["matching"]);
+        expect(rows[0]).not.toHaveProperty("trace-numeric");
+      }
+    }
+  }, 30_000);
+
+  it("preserves negative score semantics for unscored rows", async () => {
+    const projectId = randomUUID();
+    const now = Date.now();
+    const allowedEventId = randomUUID();
+    const allowedTraceId = randomUUID();
+    const blockedEventId = randomUUID();
+    const blockedTraceId = randomUUID();
+    const unscoredEventId = randomUUID();
+
+    await createEventsCh([
+      createEvent({
+        id: allowedEventId,
+        span_id: allowedEventId,
+        project_id: projectId,
+        trace_id: allowedTraceId,
+        start_time: now * 1000,
+      }),
+      createEvent({
+        id: blockedEventId,
+        span_id: blockedEventId,
+        project_id: projectId,
+        trace_id: blockedTraceId,
+        start_time: (now + 1) * 1000,
+      }),
+      createEvent({
+        id: unscoredEventId,
+        span_id: unscoredEventId,
+        project_id: projectId,
+        trace_id: randomUUID(),
+        start_time: (now + 2) * 1000,
+      }),
+    ]);
+    await createScoresCh([
+      ...createScoreSet({
+        projectId,
+        traceId: allowedTraceId,
+        observationId: allowedEventId,
+        observationValues: {
+          numericValue: 0,
+          categoryValue: "allowed",
+          booleanValue: false,
+        },
+        traceValues: {
+          numericValue: 0,
+          categoryValue: "allowed",
+          booleanValue: false,
+        },
+      }),
+      ...createScoreSet({
+        projectId,
+        traceId: blockedTraceId,
+        observationId: blockedEventId,
+        observationValues: {
+          numericValue: 0,
+          categoryValue: "blocked",
+          booleanValue: true,
+        },
+        traceValues: {
+          numericValue: 0,
+          categoryValue: "blocked",
+          booleanValue: true,
+        },
+      }),
+    ]);
+
+    for (const { name, run } of streamAdapters) {
+      const rows = await collectRows(
+        await run({
+          projectId,
+          cutoffCreatedAt: new Date(now + 60_000),
+          rowLimit: 100,
+          filter: [
+            {
+              type: "categoryOptions",
+              column: "score_categories",
+              key: "observation:category",
+              operator: "none of",
+              value: ["blocked"],
+            },
+            {
+              type: "booleanObject",
+              column: "score_booleans",
+              key: "observation-boolean",
+              operator: "<>",
+              value: true,
+            },
+            {
+              type: "categoryOptions",
+              column: "trace_score_categories",
+              key: "trace-category",
+              operator: "none of",
+              value: ["blocked"],
+            },
+            {
+              type: "booleanObject",
+              column: "trace_score_booleans",
+              key: "trace-boolean",
+              operator: "<>",
+              value: true,
+            },
+          ],
+        }),
+      );
+
+      expect(rows.map((row) => row.id).sort(), name).toEqual(
+        [allowedEventId, unscoredEventId].sort(),
+      );
+    }
+  }, 30_000);
+});

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -10,7 +10,6 @@
 import {
   FilterCondition,
   type ScoreDataTypeType,
-  TimeFilter,
   TracingSearchType,
 } from "@langfuse/shared";
 import {
@@ -65,7 +64,7 @@ export const getEventsStream = async (props: {
     },
   };
 
-  const { queryBuilder, eventOnlyFilters } = buildEventsBlobExportStreamQuery({
+  const { queryBuilder, startTimeFrom } = buildEventsBlobExportStreamQuery({
     projectId,
     cutoffCreatedAt,
     filter,
@@ -79,13 +78,7 @@ export const getEventsStream = async (props: {
   const distinctScoreNames = await getDistinctScoreNames({
     projectId,
     cutoffCreatedAt,
-    filter: eventOnlyFilters,
-    isTimestampFilter: (
-      filterItem: FilterCondition,
-    ): filterItem is TimeFilter =>
-      (filterItem.column === "startTime" ||
-        filterItem.column === "Start Time") &&
-      filterItem.type === "datetime",
+    startTimeFrom,
     clickhouseConfigs,
   });
 

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -83,7 +83,9 @@ export const getEventsStream = async (props: {
     isTimestampFilter: (
       filterItem: FilterCondition,
     ): filterItem is TimeFilter =>
-      filterItem.column === "Start Time" && filterItem.type === "datetime",
+      (filterItem.column === "startTime" ||
+        filterItem.column === "Start Time") &&
+      filterItem.type === "datetime",
     clickhouseConfigs,
   });
 


### PR DESCRIPTION
## Summary

- Enable observation- and trace-score filters for blob export, dataset, annotation-queue, and evaluation streams.
- Reuse observation-score aggregation and conditionally join trace_scores_agg.
- Keep trace scores filter-only while preserving flattened observation-score fields and export field order.
- Preserve project and time pruning before score joins, including quoted Events time aliases.

## Stack

PR 3 of 5. Base: valeriy-codex/events-shared-row-selection.

## Coverage

Adds numeric, categorical, boolean, negative or missing-score, combined-scope, and legacy-alias regression coverage across every stream.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the `scoreFilterCapabilities` gate that previously disabled observation- and trace-score filtering for blob-export, dataset, annotation-queue, and eval streams, wiring score filters into all event streams via the shared `buildEventsObservationRowSelection` planner. It also tightens time-bounding of score CTEs with explicit lookback intervals and fixes a pre-existing correctness issue in `getDistinctScoreNames` where an upper-bound (`<=`) datetime filter could be misread as a lower bound.

- **Score filter plumbing for all streams**: `buildEventsStreamQueryInternal` now forwards `observationScores` and `traceScores` filter groups alongside event filters, letting the row-selection planner conditionally add `scores_agg` / `trace_scores_agg` CTEs and LEFT JOINs only when score filters are present.
- **Interval-based score time bounding**: A new `scoreTimestampLowerBound` helper and two `eventsTracesScoresAggregation` variants apply correct multi-interval lookbacks so the score scan is bounded without missing late-written scores.
- **`extractTimeFilter` and `getDistinctScoreNames` fixes**: Quote stripping and an `endsWith` fallback in `extractTimeFilter` handle aliased/quoted event-table fields, while `getDistinctScoreNames` is narrowed to `>= / >` operators and gains the 1-hour score lookback.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge. The removal of the scoreFilterCapabilities gate is the central behavioral change and is well-reasoned, tested, and scoped to the correct call sites.

All changes trace directly to the stated intent. Score filter plumbing is wired through filterConditions rather than silently discarded, the score CTE time bounds use the documented interval constants, and the extractTimeFilter quote-stripping and endsWith fallback is clearly motivated by aliased event-table field names. The scores.ts operator check is a genuine correctness improvement on a pre-existing misuse. Integration tests cover all four stream adapters across numeric, categorical, boolean, negative-semantics, and unscored-row cases.

No files require special attention. The integration test in worker/src/__tests__/event-stream-score-filters.test.ts is gated by LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN and won't run in CI unless that flag is set.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(events): apply score filters to even..."](https://github.com/langfuse/langfuse/commit/803725523870bcd9aca6959374784121c055f3fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44523625)</sub>

<!-- /greptile_comment -->