### PR TITLE
refactor(blobstorage): split settings into container + disposable form layers

### DIFF
--- a/web/src/features/blobstorage-integration/README.md
+++ b/web/src/features/blobstorage-integration/README.md
@@ -6,14 +6,14 @@ computed at read time by `deriveSyncStatus.ts`.
 
 ## DB fields (the state vector)
 
-| Field | Type | Written by |
-|---|---|---|
-| `enabled` | boolean | Web (save), Worker (catch — disables on a final-attempt customer-fault) |
-| `lastError` | string \| null | Worker (catch / success) |
-| `lastSyncAt` | Date \| null | Worker (success) |
-| `nextSyncAt` | Date \| null | Worker (success / empty-window), Web (save) |
-| `runStartedAt` | Date \| null | Worker (start / end), Web (save clears it) |
-| `lastFailureNotificationSentAt` | Date \| null | Worker (cooldown claim before the "failed" email), Web (save with enabled clears it) |
+| Field                           | Type           | Written by                                                                           |
+| ------------------------------- | -------------- | ------------------------------------------------------------------------------------ |
+| `enabled`                       | boolean        | Web (save), Worker (catch — disables on a final-attempt customer-fault)              |
+| `lastError`                     | string \| null | Worker (catch / success)                                                             |
+| `lastSyncAt`                    | Date \| null   | Worker (success)                                                                     |
+| `nextSyncAt`                    | Date \| null   | Worker (success / empty-window), Web (save)                                          |
+| `runStartedAt`                  | Date \| null   | Worker (start / end), Web (save clears it)                                           |
+| `lastFailureNotificationSentAt` | Date \| null   | Worker (cooldown claim before the "failed" email), Web (save with enabled clears it) |
 
 ## Derived states (precedence top-to-bottom)
 
@@ -73,25 +73,25 @@ up_to_date  ← fallthrough
 
 ## Transition detail
 
-| From | Trigger | Writes | To |
-|---|---|---|---|
-| **any** | User saves with `enabled=false` | `runStartedAt=null` | **disabled** |
-| **any** | User saves with `enabled=true` | `runStartedAt=null`; `nextSyncAt=now` if errored or mode changed | **idle**, **queued**, **up_to_date**, or stays **error** (`lastError` is not cleared by save) |
-| **disabled** | User saves `enabled=true` | (as above) | **idle**, **queued**, **up_to_date**, or stays **error** |
-| **idle** | Scheduler finds `lastSyncAt=null` | Enqueues BullMQ job (no DB write) | stays **idle** |
-| **queued** | Scheduler finds `nextSyncAt<=now` | Enqueues BullMQ job (no DB write) | stays **queued** |
-| **idle/queued** | Worker starts job | `runStartedAt=now` | **running** |
-| **running** | Worker: integration disabled | `runStartedAt=null` | **disabled** |
-| **running** | Worker: empty time window | `runStartedAt=null`, `nextSyncAt=now+frequency`, `lastError=null` | **up_to_date** (or **idle** if never synced) |
-| **running** | Worker: export succeeds, caught up | `lastSyncAt=max`, `nextSyncAt=max+freq`, `lastError=null`, `runStartedAt=null` | **up_to_date** |
-| **running** | Worker: export succeeds, not caught up | `lastSyncAt=max`, `nextSyncAt=now`, `lastError=null`, `runStartedAt=null` + re-enqueues job | **queued** (immediately) |
-| **running** | Worker: export fails (retries left) | `lastError=msg`, `lastErrorAt=now`, `runStartedAt=null` (no email — a later retry may succeed) | **error** |
-| **running** | Worker: export fails, retries exhausted | `lastError=msg`, `lastErrorAt=now`, `runStartedAt=null` (+ cooldown-gated "failed" email) | **error** |
-| **running** | Worker: retries exhausted on a customer-config/credential failure | `lastError=msg`, `lastErrorAt=now`, `runStartedAt=null`, `enabled=false` (+ one-time "disabled" email, no cooldown) | **disabled** |
-| **error** | User saves (enabled, same mode) | `runStartedAt=null`, `nextSyncAt=now` | stays **error** (`lastError` preserved; scheduler re-enqueues via `nextSyncAt`) |
-| **error** | User clicks Run Now | Enqueues manual job (no DB write) | stays **error** until worker clears `lastError` (success or empty-window) |
-| **running** | Stale `runStartedAt` > 2h | (no write — derived only) | falls through to **queued**, **idle**, or **up_to_date** |
-| **up_to_date** | Clock passes `nextSyncAt` | (no write — derived only) | **queued** |
+| From            | Trigger                                                           | Writes                                                                                                              | To                                                                                            |
+| --------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **any**         | User saves with `enabled=false`                                   | `runStartedAt=null`                                                                                                 | **disabled**                                                                                  |
+| **any**         | User saves with `enabled=true`                                    | `runStartedAt=null`; `nextSyncAt=now` if errored or mode changed                                                    | **idle**, **queued**, **up_to_date**, or stays **error** (`lastError` is not cleared by save) |
+| **disabled**    | User saves `enabled=true`                                         | (as above)                                                                                                          | **idle**, **queued**, **up_to_date**, or stays **error**                                      |
+| **idle**        | Scheduler finds `lastSyncAt=null`                                 | Enqueues BullMQ job (no DB write)                                                                                   | stays **idle**                                                                                |
+| **queued**      | Scheduler finds `nextSyncAt<=now`                                 | Enqueues BullMQ job (no DB write)                                                                                   | stays **queued**                                                                              |
+| **idle/queued** | Worker starts job                                                 | `runStartedAt=now`                                                                                                  | **running**                                                                                   |
+| **running**     | Worker: integration disabled                                      | `runStartedAt=null`                                                                                                 | **disabled**                                                                                  |
+| **running**     | Worker: empty time window                                         | `runStartedAt=null`, `nextSyncAt=now+frequency`, `lastError=null`                                                   | **up_to_date** (or **idle** if never synced)                                                  |
+| **running**     | Worker: export succeeds, caught up                                | `lastSyncAt=max`, `nextSyncAt=max+freq`, `lastError=null`, `runStartedAt=null`                                      | **up_to_date**                                                                                |
+| **running**     | Worker: export succeeds, not caught up                            | `lastSyncAt=max`, `nextSyncAt=now`, `lastError=null`, `runStartedAt=null` + re-enqueues job                         | **queued** (immediately)                                                                      |
+| **running**     | Worker: export fails (retries left)                               | `lastError=msg`, `lastErrorAt=now`, `runStartedAt=null` (no email — a later retry may succeed)                      | **error**                                                                                     |
+| **running**     | Worker: export fails, retries exhausted                           | `lastError=msg`, `lastErrorAt=now`, `runStartedAt=null` (+ cooldown-gated "failed" email)                           | **error**                                                                                     |
+| **running**     | Worker: retries exhausted on a customer-config/credential failure | `lastError=msg`, `lastErrorAt=now`, `runStartedAt=null`, `enabled=false` (+ one-time "disabled" email, no cooldown) | **disabled**                                                                                  |
+| **error**       | User saves (enabled, same mode)                                   | `runStartedAt=null`, `nextSyncAt=now`                                                                               | stays **error** (`lastError` preserved; scheduler re-enqueues via `nextSyncAt`)               |
+| **error**       | User clicks Run Now                                               | Enqueues manual job (no DB write)                                                                                   | stays **error** until worker clears `lastError` (success or empty-window)                     |
+| **running**     | Stale `runStartedAt` > 2h                                         | (no write — derived only)                                                                                           | falls through to **queued**, **idle**, or **up_to_date**                                      |
+| **up_to_date**  | Clock passes `nextSyncAt`                                         | (no write — derived only)                                                                                           | **queued**                                                                                    |
 
 ## Safety valve
 
@@ -109,15 +109,15 @@ worker picks up the job and sets `runStartedAt`.
 
 ## Key files
 
-| File | Role |
-|---|---|
-| `deriveSyncStatus.ts` | Derives display status from DB fields |
-| `types.ts` | Form zod schema, `BlobStorageSyncStatus` type |
-| `exportSource.ts` | Export-source availability/options helpers (pure) |
-| `service.ts` | Upsert logic (web save path) |
-| `blobstorage-integration-router.ts` | tRPC router (save, runNow) |
-| `worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts` | Worker job handler |
-| `worker/src/features/blobstorage/handleBlobStorageIntegrationSchedule.ts` | Scheduler (enqueues due jobs) |
+| File                                                                        | Role                                              |
+| --------------------------------------------------------------------------- | ------------------------------------------------- |
+| `deriveSyncStatus.ts`                                                       | Derives display status from DB fields             |
+| `types.ts`                                                                  | Form zod schema, `BlobStorageSyncStatus` type     |
+| `exportSource.ts`                                                           | Export-source availability/options helpers (pure) |
+| `service.ts`                                                                | Upsert logic (web save path)                      |
+| `blobstorage-integration-router.ts`                                         | tRPC router (save, runNow)                        |
+| `worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts` | Worker job handler                                |
+| `worker/src/features/blobstorage/handleBlobStorageIntegrationSchedule.ts`   | Scheduler (enqueues due jobs)                     |
 
 ## UI Owner Map
 
@@ -132,27 +132,37 @@ feature components below.
 
 **Structure** (`components/`):
 
-| File | Role |
-|---|---|
-| `BlobStorageIntegrationForm.tsx` | Form shell: availability + schema, `useForm`, mutations, submit, action buttons |
-| `formValues.ts` | Pure `buildBlobStorageFormValues()` + shared `BlobStorageFormControl` type |
-| `StorageProviderFields.tsx` | Provider select + provider-dependent connection fields |
-| `ExportScheduleFields.tsx` | Frequency, file type, export mode, custom start date |
-| `ExportSourceField.tsx` | Source selector + blocked-save alert (LFE-10296) |
-| `ExportFieldGroupsField.tsx` | Field-group checkboxes |
-| `GzipCompressionField.tsx` | Gzip toggle; self-hides for Parquet |
-| `BlobStorageStatusSection.tsx` | Status header, last-error alert, sync card |
+| File                                  | Role                                                                                                                                     |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `BlobStorageIntegrationContainer.tsx` | State layer: availability derivation, the four mutations, entity-action buttons (Validate / Run Now / Reset), loading gate, identity key |
+| `BlobStorageIntegrationForm.tsx`      | Disposable draft layer: `useForm` + schema, fields, Save; no tRPC                                                                        |
+| `formValues.ts`                       | Pure `buildBlobStorageFormValues()` + shared `BlobStorageFormControl` type                                                               |
+| `StorageProviderFields.tsx`           | Provider select + provider-dependent connection fields                                                                                   |
+| `ExportScheduleFields.tsx`            | Frequency, file type, export mode, custom start date                                                                                     |
+| `ExportSourceField.tsx`               | Source selector + blocked-save alert (LFE-10296)                                                                                         |
+| `ExportFieldGroupsField.tsx`          | Field-group checkboxes                                                                                                                   |
+| `GzipCompressionField.tsx`            | Gzip toggle; self-hides for Parquet                                                                                                      |
+| `BlobStorageStatusSection.tsx`        | Status header, last-error alert, sync card                                                                                               |
 
 **External consumers**: none — the components are only mounted by the
 settings page above.
 
-**State ownership**: server state lives in the tRPC query (page); form
-state lives in react-hook-form, created in the form shell and re-synced
-from server state via the reactive `values` option with
-`keepDirtyValues` (no reset effect). Field-group components receive the
-typed `control` prop and subscribe to individual fields with `useWatch`;
-there is no local Zustand store and no feature `useEffect`.
+**State ownership — draft-lifetime model**: server state lives in the
+tRPC query (page). Form state is a **disposable draft scoped to one
+entity identity**: the container mounts `BlobStorageIntegrationForm`
+keyed on `projectId` + config existence, only after the query and
+project have resolved. Initial values flow in once via `defaultValues`;
+edits flow out only via `onSubmit`. There is no reset path at all — no
+reactive `values`, no `resetOptions`, no reset `useEffect`. Identity
+changes (project switch, create, delete) remount the form; same-entity
+refetches (5s status poll, post-save invalidation) keep the key stable
+and therefore can never wipe or leak a draft. Consequence, by design:
+clean fields do not live-update from background refetches while the
+form is mounted. Field-group components receive the typed `control`
+prop and subscribe to individual fields with `useWatch`; there is no
+local Zustand store and no feature `useEffect`.
 
 **Performance boundaries**: a keystroke or select change rerenders only
-the field-group component watching that field. The form shell reads no
-field values, so it only rerenders on mutation/loading state changes.
+the field-group component watching that field. The form layer reads no
+field values and holds no async state; mutation pending-state lives in
+the container.

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -1,0 +1,174 @@
+import { useMemo } from "react";
+import { Button } from "@/src/components/ui/button";
+import { Skeleton } from "@/src/components/ui/skeleton";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { api } from "@/src/utils/api";
+import {
+  isLegacyBlobExportAllowed,
+  isLegacyBlobExporter,
+  type BlobStorageIntegration,
+} from "@langfuse/shared";
+import {
+  parquetEnabledFromTuning,
+  type BlobStorageIntegrationFormSchema,
+} from "@/src/features/blobstorage-integration/types";
+import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
+import { useQueryProject } from "@/src/features/projects/hooks";
+import { buildBlobStorageFormValues } from "@/src/features/blobstorage-integration/components/formValues";
+import { BlobStorageIntegrationForm } from "@/src/features/blobstorage-integration/components/BlobStorageIntegrationForm";
+
+// State layer. Owns everything async and entity-scoped: availability
+// derivation, the four mutations, and the entity-action buttons. The form
+// below it is a disposable draft: it is not mounted until every input has
+// resolved, and it is remounted (via key) whenever the entity identity
+// changes — project switch, create, delete. Background refetches of the
+// same entity (status poll, post-save invalidation) keep the key stable so
+// they can never touch a draft in progress.
+export const BlobStorageIntegrationContainer = ({
+  config,
+  projectId,
+  isLoading,
+  isEnrichedExportAvailable,
+}: {
+  config: Partial<BlobStorageIntegration> | null;
+  projectId: string;
+  isLoading: boolean;
+  isEnrichedExportAvailable: boolean;
+}) => {
+  const capture = usePostHogClientCapture();
+  const { isLangfuseCloud } = useLangfuseCloudRegion();
+  const { project } = useQueryProject();
+
+  const isPostCutoffCloud =
+    project?.createdAt != null &&
+    !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
+  const eventsExportAvailable = isEnrichedExportAvailable;
+  // Integration-level cutoff (Cloud only): a row predating the exporter cutoff
+  // keeps legacy options; a new or post-cutoff row is locked to EVENTS.
+  const isLegacyExporter = isLegacyBlobExporter(
+    config?.createdAt ? new Date(config.createdAt) : null,
+    isLangfuseCloud,
+  );
+  const forceEventsExport =
+    isPostCutoffCloud || (eventsExportAvailable && !isLegacyExporter);
+  const availability = useMemo(
+    () => ({ eventsExportAvailable, forceEventsExport }),
+    [eventsExportAvailable, forceEventsExport],
+  );
+
+  const utils = api.useUtils();
+  const mut = api.blobStorageIntegration.update.useMutation({
+    onSuccess: () => {
+      utils.blobStorageIntegration.invalidate();
+    },
+    onError: (error) => {
+      showErrorToast("Failed to save integration", error.message);
+    },
+  });
+  const mutDelete = api.blobStorageIntegration.delete.useMutation({
+    onSuccess: () => {
+      utils.blobStorageIntegration.invalidate();
+    },
+  });
+  const mutRunNow = api.blobStorageIntegration.runNow.useMutation({
+    onSuccess: () => {
+      utils.blobStorageIntegration.invalidate();
+    },
+  });
+  const mutValidate = api.blobStorageIntegration.validate.useMutation({
+    onSuccess: (data) => {
+      showSuccessToast({
+        title: data.message,
+        description: `Test file: ${data.testFileName}`,
+      });
+    },
+    onError: (error) => {
+      showErrorToast("Validation failed", error.message);
+    },
+  });
+
+  // The form is never mounted before its inputs resolve, so there is no
+  // mid-flight reset to protect a draft from.
+  if (isLoading || !project) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-full" />
+      </div>
+    );
+  }
+
+  const handleSubmit = (values: BlobStorageIntegrationFormSchema) => {
+    capture("integrations:blob_storage_form_submitted");
+    mut.mutate({
+      projectId,
+      ...values,
+    });
+  };
+
+  return (
+    <BlobStorageIntegrationForm
+      // Draft lifetime = entity identity. Deliberately NOT updatedAt:
+      // exists→exists refetches (5s status poll, post-update refetch) must
+      // not remount, so mid-save typing survives. Delete flips
+      // configured→new and remounts blank; create flips new→configured and
+      // remounts from the saved row (clearing stale dirty flags).
+      key={`${projectId}:${config ? "configured" : "new"}`}
+      initialValues={buildBlobStorageFormValues(
+        config ?? undefined,
+        availability,
+      )}
+      availability={availability}
+      persistedExportSource={config?.exportSource}
+      isParquetOverride={parquetEnabledFromTuning(config?.exportTuning)}
+      isSaving={mut.isPending}
+      onSubmit={handleSubmit}
+    >
+      <Button
+        variant="secondary"
+        loading={mutValidate.isPending}
+        disabled={!config}
+        title="Test your saved configuration by uploading a small test file to your storage"
+        onClick={() => {
+          mutValidate.mutate({ projectId });
+        }}
+      >
+        Validate
+      </Button>
+      <Button
+        variant="secondary"
+        loading={mutRunNow.isPending}
+        disabled={!config?.enabled}
+        title="Trigger an immediate export of all data since the last sync"
+        onClick={() => {
+          if (
+            confirm(
+              "Are you sure you want to run the blob storage export now? This will export all data since the last sync.",
+            )
+          )
+            mutRunNow.mutate({ projectId });
+        }}
+      >
+        Run Now
+      </Button>
+      <Button
+        variant="ghost"
+        loading={mutDelete.isPending}
+        disabled={!config}
+        onClick={() => {
+          if (
+            confirm(
+              "Are you sure you want to reset the Blob Storage integration for this project?",
+            )
+          )
+            mutDelete.mutate({ projectId });
+        }}
+      >
+        Reset
+      </Button>
+    </BlobStorageIntegrationForm>
+  );
+};

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  BlobStorageIntegrationFileType,
+  BlobStorageIntegrationType,
+  type BlobStorageIntegration,
+} from "@langfuse/shared";
+import { TooltipProvider } from "@/src/components/ui/tooltip";
+import { BlobStorageIntegrationForm } from "./BlobStorageIntegrationForm";
+import {
+  buildBlobStorageFormValues,
+  type BlobStorageFormValues,
+} from "./formValues";
+import { type ExportSourceAvailability } from "@/src/features/blobstorage-integration/exportSource";
+
+// EVENTS-only deployment: single selectable source, selector hidden —
+// keeps the rendered tree small and the submit payload valid.
+const availability: ExportSourceAvailability = {
+  eventsExportAvailable: true,
+  forceEventsExport: true,
+};
+
+const savedConfig: Partial<BlobStorageIntegration> = {
+  type: BlobStorageIntegrationType.S3,
+  bucketName: "seed-bucket",
+  region: "us-east-1",
+  accessKeyId: "AKIA-SEED",
+  fileType: BlobStorageIntegrationFileType.JSONL,
+  enabled: true,
+};
+
+const ui = (
+  key: string,
+  initialValues: BlobStorageFormValues,
+  onSubmit: (values: unknown) => void = () => {},
+) => (
+  <TooltipProvider>
+    <BlobStorageIntegrationForm
+      key={key}
+      initialValues={initialValues}
+      availability={availability}
+      persistedExportSource={null}
+      isParquetOverride={false}
+      isSaving={false}
+      onSubmit={onSubmit}
+    />
+  </TooltipProvider>
+);
+
+const bucketInput = () =>
+  screen.getByLabelText("Bucket Name") as HTMLInputElement;
+
+describe("BlobStorageIntegrationForm draft lifetime (keyed remount)", () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    Element.prototype.scrollIntoView = vi.fn();
+    Element.prototype.hasPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+  });
+
+  it("delete flow: dirty configured form + key flip to 'new' renders blank defaults", () => {
+    const { rerender } = render(
+      ui(
+        "p1:configured",
+        buildBlobStorageFormValues(savedConfig, availability),
+      ),
+    );
+    fireEvent.change(bucketInput(), { target: { value: "edited-bucket" } });
+    expect(bucketInput()).toHaveValue("edited-bucket");
+
+    // Container behavior after delete: config becomes null → key flips.
+    rerender(ui("p1:new", buildBlobStorageFormValues(undefined, availability)));
+
+    expect(bucketInput()).toHaveValue("");
+    expect(screen.getByLabelText("Region")).toHaveValue("auto");
+  });
+
+  it("project switch: key change discards unsaved input from the previous project", () => {
+    const { rerender } = render(
+      ui("p1:new", buildBlobStorageFormValues(undefined, availability)),
+    );
+    fireEvent.change(bucketInput(), {
+      target: { value: "project-a-secret-bucket" },
+    });
+    fireEvent.change(screen.getByLabelText(/Access Key ID/), {
+      target: { value: "AKIA-PROJECT-A" },
+    });
+
+    rerender(ui("p2:new", buildBlobStorageFormValues(undefined, availability)));
+
+    expect(bucketInput()).toHaveValue("");
+    expect(screen.getByLabelText(/Access Key ID/)).toHaveValue("");
+  });
+
+  it("post-create: key flip to 'configured' initializes from the saved config", () => {
+    const { rerender } = render(
+      ui("p1:new", buildBlobStorageFormValues(undefined, availability)),
+    );
+    fireEvent.change(bucketInput(), { target: { value: "typed-before-save" } });
+
+    rerender(
+      ui(
+        "p1:configured",
+        buildBlobStorageFormValues(savedConfig, availability),
+      ),
+    );
+
+    expect(bucketInput()).toHaveValue("seed-bucket");
+    expect(screen.getByLabelText("Region")).toHaveValue("us-east-1");
+  });
+
+  it("same key: rerender with new initialValues does NOT touch the mounted draft", () => {
+    // Container behavior during the 5s status poll: same entity refetches
+    // keep the key stable, so a draft in progress is never wiped.
+    const { rerender } = render(
+      ui(
+        "p1:configured",
+        buildBlobStorageFormValues(savedConfig, availability),
+      ),
+    );
+    fireEvent.change(bucketInput(), { target: { value: "mid-save-typing" } });
+
+    rerender(
+      ui(
+        "p1:configured",
+        buildBlobStorageFormValues(
+          { ...savedConfig, bucketName: "refetched-bucket" },
+          availability,
+        ),
+      ),
+    );
+
+    expect(bucketInput()).toHaveValue("mid-save-typing");
+  });
+
+  it("submit passes the draft values through unchanged", async () => {
+    const onSubmit = vi.fn();
+    render(
+      ui(
+        "p1:new",
+        buildBlobStorageFormValues(undefined, availability),
+        onSubmit,
+      ),
+    );
+    fireEvent.change(bucketInput(), { target: { value: "my-new-bucket" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: BlobStorageIntegrationType.S3,
+        bucketName: "my-new-bucket",
+        region: "auto",
+        exportFrequency: "daily",
+        fileType: BlobStorageIntegrationFileType.PARQUET,
+        enabled: false,
+      }),
+      expect.anything(),
+    );
+  });
+});

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/src/components/ui/button";
@@ -11,64 +11,55 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
-import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
-import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import { api } from "@/src/utils/api";
-import {
-  isLegacyBlobExportAllowed,
-  isLegacyBlobExporter,
-  type BlobStorageIntegration,
-} from "@langfuse/shared";
+import { type AnalyticsIntegrationExportSource } from "@langfuse/shared";
 import {
   blobStorageIntegrationFormSchema,
-  parquetEnabledFromTuning,
   type BlobStorageIntegrationFormSchema,
 } from "@/src/features/blobstorage-integration/types";
-import { isExportSourceSelectable } from "@/src/features/blobstorage-integration/exportSource";
-import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
-import { useQueryProject } from "@/src/features/projects/hooks";
-import { buildBlobStorageFormValues } from "@/src/features/blobstorage-integration/components/formValues";
+import {
+  isExportSourceSelectable,
+  type ExportSourceAvailability,
+} from "@/src/features/blobstorage-integration/exportSource";
+import { type BlobStorageFormValues } from "@/src/features/blobstorage-integration/components/formValues";
 import { StorageProviderFields } from "@/src/features/blobstorage-integration/components/StorageProviderFields";
 import { ExportScheduleFields } from "@/src/features/blobstorage-integration/components/ExportScheduleFields";
 import { ExportSourceField } from "@/src/features/blobstorage-integration/components/ExportSourceField";
 import { ExportFieldGroupsField } from "@/src/features/blobstorage-integration/components/ExportFieldGroupsField";
 import { GzipCompressionField } from "@/src/features/blobstorage-integration/components/GzipCompressionField";
 
+// Disposable draft layer. The container mounts one instance per entity
+// identity (project + config existence, via React key) after all async
+// inputs have resolved. Initial state flows in once through defaultValues;
+// edits flow out only through onSubmit. There is deliberately no reset
+// logic and no tRPC access here — a stale draft is discarded by remount,
+// never patched in place.
 export const BlobStorageIntegrationForm = ({
-  state,
-  projectId,
-  isLoading,
-  isEnrichedExportAvailable,
+  initialValues,
+  availability,
+  persistedExportSource,
+  isParquetOverride,
+  isSaving,
+  onSubmit,
+  children,
 }: {
-  state?: Partial<BlobStorageIntegration>;
-  projectId: string;
-  isLoading: boolean;
-  isEnrichedExportAvailable: boolean;
+  initialValues: BlobStorageFormValues;
+  availability: ExportSourceAvailability;
+  persistedExportSource: AnalyticsIntegrationExportSource | null | undefined;
+  // Internal `exportTuning.parquet` override (no write path); reflected
+  // read-only since the worker forces Parquet over the persisted fileType
+  // + gzip.
+  isParquetOverride: boolean;
+  isSaving: boolean;
+  onSubmit: (values: BlobStorageIntegrationFormSchema) => void;
+  // Entity-scoped action buttons (Validate / Run Now / Reset) rendered by
+  // the container next to Save — they act on the persisted entity, not on
+  // this draft.
+  children?: ReactNode;
 }) => {
-  const capture = usePostHogClientCapture();
-  const { isLangfuseCloud } = useLangfuseCloudRegion();
-  const { project } = useQueryProject();
-
-  const isPostCutoffCloud =
-    project?.createdAt != null &&
-    !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
-  const eventsExportAvailable = isEnrichedExportAvailable;
-  // Integration-level cutoff (Cloud only): a row predating the exporter cutoff
-  // keeps legacy options; a new or post-cutoff row is locked to EVENTS.
-  const isLegacyExporter = isLegacyBlobExporter(
-    state?.createdAt ? new Date(state.createdAt) : null,
-    isLangfuseCloud,
-  );
-  const forceEventsExport =
-    isPostCutoffCloud || (eventsExportAvailable && !isLegacyExporter);
-  const availability = useMemo(
-    () => ({ eventsExportAvailable, forceEventsExport }),
-    [eventsExportAvailable, forceEventsExport],
-  );
-
   // Block the save when the persisted source is no longer selectable rather
-  // than silently rewriting it (LFE-10296).
+  // than silently rewriting it (LFE-10296). Availability is fixed for the
+  // lifetime of this mount: it derives from the project and config identity,
+  // and any identity change remounts the form via the container key.
   const formSchema = useMemo(
     () =>
       blobStorageIntegrationFormSchema.superRefine((data, ctx) => {
@@ -84,63 +75,10 @@ export const BlobStorageIntegrationForm = ({
     [availability],
   );
 
-  // Reactive `values` re-syncs the form whenever the persisted integration or
-  // the deployment availability changes, keeping unsaved edits — no manual
-  // reset effect needed.
-  const formValues = useMemo(
-    () => buildBlobStorageFormValues(state, availability),
-    [state, availability],
-  );
   const blobStorageForm = useForm({
     resolver: zodResolver(formSchema),
-    values: formValues,
-    resetOptions: { keepDirtyValues: true },
-    disabled: isLoading,
+    defaultValues: initialValues,
   });
-
-  // Internal `exportTuning.parquet` override (no write path); reflected
-  // read-only since the worker forces Parquet over the persisted fileType
-  // + gzip.
-  const isParquetOverride = parquetEnabledFromTuning(state?.exportTuning);
-
-  const utils = api.useUtils();
-  const mut = api.blobStorageIntegration.update.useMutation({
-    onSuccess: () => {
-      utils.blobStorageIntegration.invalidate();
-    },
-    onError: (error) => {
-      showErrorToast("Failed to save integration", error.message);
-    },
-  });
-  const mutDelete = api.blobStorageIntegration.delete.useMutation({
-    onSuccess: () => {
-      utils.blobStorageIntegration.invalidate();
-    },
-  });
-  const mutRunNow = api.blobStorageIntegration.runNow.useMutation({
-    onSuccess: () => {
-      utils.blobStorageIntegration.invalidate();
-    },
-  });
-  const mutValidate = api.blobStorageIntegration.validate.useMutation({
-    onSuccess: (data) => {
-      showSuccessToast({
-        title: data.message,
-        description: `Test file: ${data.testFileName}`,
-      });
-    },
-    onError: (error) => {
-      showErrorToast("Validation failed", error.message);
-    },
-  });
-
-  async function onSubmit(values: BlobStorageIntegrationFormSchema) {
-    capture("integrations:blob_storage_form_submitted");
-    mut.mutate({
-      projectId,
-      ...values,
-    });
-  }
 
   const control = blobStorageForm.control;
 
@@ -157,7 +95,7 @@ export const BlobStorageIntegrationForm = ({
         />
         <ExportSourceField
           control={control}
-          persistedExportSource={state?.exportSource}
+          persistedExportSource={persistedExportSource}
           availability={availability}
         />
         <ExportFieldGroupsField
@@ -189,54 +127,12 @@ export const BlobStorageIntegrationForm = ({
       </form>
       <div className="mt-8 flex gap-2">
         <Button
-          loading={mut.isPending}
+          loading={isSaving}
           onClick={blobStorageForm.handleSubmit(onSubmit)}
-          disabled={isLoading}
         >
           Save
         </Button>
-        <Button
-          variant="secondary"
-          loading={mutValidate.isPending}
-          disabled={isLoading || !state}
-          title="Test your saved configuration by uploading a small test file to your storage"
-          onClick={() => {
-            mutValidate.mutate({ projectId });
-          }}
-        >
-          Validate
-        </Button>
-        <Button
-          variant="secondary"
-          loading={mutRunNow.isPending}
-          disabled={isLoading || !state?.enabled}
-          title="Trigger an immediate export of all data since the last sync"
-          onClick={() => {
-            if (
-              confirm(
-                "Are you sure you want to run the blob storage export now? This will export all data since the last sync.",
-              )
-            )
-              mutRunNow.mutate({ projectId });
-          }}
-        >
-          Run Now
-        </Button>
-        <Button
-          variant="ghost"
-          loading={mutDelete.isPending}
-          disabled={isLoading || !state}
-          onClick={() => {
-            if (
-              confirm(
-                "Are you sure you want to reset the Blob Storage integration for this project?",
-              )
-            )
-              mutDelete.mutate({ projectId });
-          }}
-        >
-          Reset
-        </Button>
+        {children}
       </div>
     </Form>
   );

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -9,7 +9,7 @@ import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAcces
 import { api, type RouterOutputs } from "@/src/utils/api";
 import { deriveSyncStatus } from "@/src/features/blobstorage-integration/deriveSyncStatus";
 import { type BlobStorageSyncStatus } from "@/src/features/blobstorage-integration/types";
-import { BlobStorageIntegrationForm } from "@/src/features/blobstorage-integration/components/BlobStorageIntegrationForm";
+import { BlobStorageIntegrationContainer } from "@/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer";
 import { BlobStorageStatusSection } from "@/src/features/blobstorage-integration/components/BlobStorageStatusSection";
 
 const syncStatusToBadge: Record<BlobStorageSyncStatus, string> = {
@@ -106,8 +106,8 @@ export default function BlobStorageIntegrationSettings() {
         <>
           <Header title="Configuration" className="mt-8" />
           <Card className="p-3">
-            <BlobStorageIntegrationForm
-              state={state.data?.config || undefined}
+            <BlobStorageIntegrationContainer
+              config={state.data?.config ?? null}
               projectId={projectId}
               isLoading={state.isLoading}
               isEnrichedExportAvailable={


### PR DESCRIPTION
## What does this PR do?

Stacked on #14964. Restructures the blob storage settings into a **state layer** and a **disposable form layer**, fixing two draft-leak regressions the previous slice introduced by replacing the guarded reset with an unconditional `keepDirtyValues` re-sync.

**Draft-lifetime model**: draft state lives exactly as long as one entity identity. `BlobStorageIntegrationContainer` owns the async inputs (project, cloud region, availability derivation), all four mutations, and the entity-action buttons (Validate / Run Now / Reset); it gates rendering behind a skeleton until inputs resolve, then mounts `BlobStorageIntegrationForm` with `key = projectId + (configured|new)`. The form takes `initialValues` once via `defaultValues` and emits values only through `onSubmit` — no reactive `values`, no `resetOptions`, no reset `useEffect`, no tRPC imports.

Fixed regressions:
- **Delete flow**: Reset → delete → refetch previously re-populated the blank form from retained dirty values, so one Save could silently re-create the deleted integration. Now delete flips the key `configured → new` and the form remounts blank, guaranteed one layer up.
- **Cross-project carryover**: unsaved credentials typed under project A survived a client-side project switch and could be saved under project B. Now the key includes `projectId`, so the draft is discarded on switch.

Declared behavior deltas (by design):
- Clean fields no longer live-update from background refetches while the form is mounted; the form is a draft scoped to the entity identity it was opened for. Same-entity refetches (5s running/queued status poll, post-save invalidation) keep the key stable and never touch the draft — mid-save typing survives, and validation errors persist across refetches instead of being partially re-synced.
- Post-create, the form remounts from the saved row, which also clears react-hook-form's retained dirty flags.
- The form is not rendered until the integration query and project have resolved (skeleton placeholder), replacing the "keepDirtyValues protects half-typed input during async load" mechanism — there is no mid-flight reset at all.

Not addressed here (tracked separately): stale async feedback after a project switch (a Validate fired under project A resolving after a switch shows its toast on project B) — the container survives the switch, so this redesign does not change it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How should this be tested?

- New component tests for the form layer (`BlobStorageIntegrationForm.clienttest.tsx`): delete-flow key flip → blank form; project-switch key change → no carryover; post-create remount from saved config; same-key rerender leaves a draft untouched; submit payload passthrough. `pnpm --filter web run test-client src/features/blobstorage-integration` — `Tests 43 passed (43)` (5 new component tests; the other 38 are pre-existing pure-helper tests).
- `pnpm turbo run lint typecheck --filter=web` — `Tasks: 6 successful, 6 total`.
- Manual browser verification (local seed data): typed an unsaved bucket name under `llm-app`, switched projects via breadcrumb → field blank on the target project; created an integration on a scratch project → Status section + form remounted from the saved row; dirtied the form and clicked Reset → integration deleted and every field returned to blank defaults; Validate/Run Now/Reset disabled without a config; JSONL ↔ Parquet gzip-toggle and custom-date reveal still work.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My changes require a change to the documentation
- [ ] I have updated the documentation accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR splits the monolithic `BlobStorageIntegrationForm` component into two layers: a stateful `BlobStorageIntegrationContainer` (owns the four tRPC mutations, availability derivation, and entity-scoped action buttons) and a pure `BlobStorageIntegrationForm` (disposable draft with `defaultValues`, no tRPC). The key architectural shift is replacing the reactive `values` + `keepDirtyValues` reset strategy with key-based remounting scoped to entity identity (`projectId:configured|new`).

- **Container layer** gates form mounting behind `isLoading || !project`, ensuring `defaultValues` are always fully resolved before the form renders, and keeps the key stable across same-entity background refetches so in-progress drafts are never wiped.
- **New client test file** covers all four key draft-lifetime scenarios: delete flow, project switch, post-create reinit, and same-key stability during polling.
- README is updated to reflect the new component ownership model and the disposable-draft state contract.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a clean structural split with no new logic introduced and all edge cases documented and tested.

The refactor moves code between files without changing observable behavior: mutations, toasts, confirm dialogs, and availability derivation are identical to the original; only their location changed. The new key-based draft lifetime is a well-understood React pattern, the README explains the contract precisely, and five client tests verify the four critical remount/stability scenarios. No regressions were found in the diff.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(blobstorage): split settings in..."](https://github.com/langfuse/langfuse/commit/709873d03f21ecd97eb804e6d09ffc0a84c8ca61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43287198)</sub>

<!-- /greptile_comment -->