### PR TITLE
fix(events): honor Fast Preview ordering in every event stream

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -839,6 +839,7 @@ abstract class BaseEventsQueryBuilder<
 > extends AbstractCTEQueryBuilder {
   protected selectFields: Set<string> = new Set();
   protected projectId: string | NoProjectIdType;
+  private qualifyClauses: string[] = [];
 
   constructor(
     protected fields: TFields,
@@ -867,6 +868,17 @@ abstract class BaseEventsQueryBuilder<
     });
     if (orderByClause) {
       this.orderByClause = orderByClause;
+    }
+    return this;
+  }
+
+  /** Add a QUALIFY condition for window-function results. */
+  qualifyRaw(condition: string, params?: Record<string, any>): this {
+    if (condition.trim()) {
+      this.qualifyClauses.push(condition);
+    }
+    if (params) {
+      this.params = { ...this.params, ...params };
     }
     return this;
   }
@@ -965,6 +977,10 @@ abstract class BaseEventsQueryBuilder<
     const havingSection = this.buildHavingSection();
     if (havingSection) {
       parts.push(havingSection);
+    }
+
+    if (this.qualifyClauses.length > 0) {
+      parts.push(`QUALIFY ${this.qualifyClauses.join("\n  AND ")}`);
     }
 
     // ORDER BY

--- a/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   buildEventsBlobExportStreamQuery,
   buildEventsStreamQuery,
+  getEventsOrderByEntries,
 } from "./events-stream-query";
 
 const projectId = "project-characterization";
@@ -34,6 +35,14 @@ const buildSelection = ({ filter }: { filter: FilterCondition[] }) => {
   return { ...selection, ...built };
 };
 
+const simplifyOrderEntries = (
+  entries: ReturnType<typeof getEventsOrderByEntries>,
+) =>
+  entries.map(({ column, direction }) => ({
+    column: column.replaceAll('"', "").replace(/^e\./, ""),
+    direction,
+  }));
+
 describe("buildEventsStreamQuery", () => {
   it("builds the common event-stream selection", () => {
     const { queryBuilder } = buildEventsStreamQuery({
@@ -52,12 +61,12 @@ describe("buildEventsStreamQuery", () => {
     expect(query).toContain("e.project_id = {projectId: String}");
     expect(query).toContain("e.is_deleted = 0");
 
+    const deduplicationIndex = query.lastIndexOf("QUALIFY ");
     const orderIndex = query.lastIndexOf("ORDER BY ");
-    const deduplicationIndex = query.lastIndexOf("LIMIT 1 BY ");
     const rowLimitIndex = query.lastIndexOf("LIMIT {");
-    expect(orderIndex).toBeGreaterThan(-1);
-    expect(orderIndex).toBeLessThan(deduplicationIndex);
-    expect(deduplicationIndex).toBeLessThan(rowLimitIndex);
+    expect(deduplicationIndex).toBeGreaterThan(-1);
+    expect(deduplicationIndex).toBeLessThan(orderIndex);
+    expect(orderIndex).toBeLessThan(rowLimitIndex);
 
     expect(params).toMatchObject({
       projectId,
@@ -168,6 +177,49 @@ describe("buildEventsStreamQuery", () => {
 
     expect(Object.values(params)).toContain("quality");
   });
+
+  it.each([
+    ["timestamp", "ASC"],
+    ["createdAt", "DESC"],
+    ["startTime", "ASC"],
+  ] as const)("normalizes the %s alias to start time %s", (column, order) => {
+    expect(
+      simplifyOrderEntries(getEventsOrderByEntries({ column, order })),
+    ).toEqual([
+      { column: "start_time", direction: order },
+      { column: "span_id", direction: order },
+    ]);
+  });
+
+  it.each(["ASC", "DESC"] as const)(
+    "uses the stable ID tie-breaker for non-time ordering in %s order",
+    (order) => {
+      expect(
+        simplifyOrderEntries(
+          getEventsOrderByEntries({ column: "name", order }),
+        ),
+      ).toEqual([
+        { column: "name", direction: order },
+        { column: "span_id", direction: order },
+      ]);
+    },
+  );
+
+  it("defaults to descending start time with a stable ID tie-breaker", () => {
+    expect(simplifyOrderEntries(getEventsOrderByEntries())).toEqual([
+      { column: "start_time", direction: "DESC" },
+      { column: "span_id", direction: "DESC" },
+    ]);
+  });
+
+  it.each(["positionInTrace", "scores_avg", "trace_scores_avg"])(
+    "rejects unsupported %s ordering for the general Events stream",
+    (column) => {
+      expect(() => getEventsOrderByEntries({ column, order: "ASC" })).toThrow(
+        InvalidRequestError,
+      );
+    },
+  );
 });
 
 describe("buildEventsObservationRowSelection", () => {

--- a/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.ts
@@ -1,10 +1,16 @@
 import type { FilterCondition } from "../../../types";
 import type { TracingSearchType } from "../../../interfaces/search";
-import type { EventsQueryBuilder } from "./event-query-builder";
+import {
+  type OrderByState,
+  normalizeOrderByForTable,
+} from "../../../interfaces/orderBy";
+import { eventsTableNativeUiColumnDefinitions } from "../../tableMappings/mapEventsTable";
+import type { EventsQueryBuilder, OrderByEntry } from "./event-query-builder";
 import {
   buildEventsObservationRowSelection,
   buildEventsObservationRowSelectionForBlobExport,
 } from "./events-observation-row-selection";
+import { orderByToEntries } from "./orderby-factory";
 
 export type EventsStreamQueryInput = {
   projectId: string;
@@ -12,6 +18,7 @@ export type EventsStreamQueryInput = {
   filter: FilterCondition[] | null;
   searchQuery?: string;
   searchType?: TracingSearchType[];
+  orderBy?: OrderByState;
   rowLimit: number;
 };
 
@@ -21,6 +28,29 @@ export type EventsStreamQuery = {
 
 export type EventsBlobExportStreamQuery = EventsStreamQuery & {
   startTimeFrom: string | null;
+};
+
+export const getEventsOrderByEntries = (
+  orderBy?: OrderByState,
+): OrderByEntry[] => {
+  const normalizedOrderBy = normalizeOrderByForTable({
+    orderBy: orderBy ?? null,
+    expectedTimeColumn: "startTime",
+  });
+  const mappedEntries = orderByToEntries(
+    normalizedOrderBy,
+    eventsTableNativeUiColumnDefinitions,
+  );
+  const entries =
+    mappedEntries.length > 0
+      ? mappedEntries
+      : [{ column: "e.start_time", direction: "DESC" as const }];
+
+  return entries.some(
+    (entry) => entry.column.replaceAll('"', "") === "e.span_id",
+  )
+    ? entries
+    : [...entries, { column: "e.span_id", direction: entries[0].direction }];
 };
 
 /**
@@ -40,6 +70,7 @@ const buildEventsStreamQueryInternal = (
     filter,
     searchQuery,
     searchType,
+    orderBy,
     rowLimit,
   }: EventsStreamQueryInput,
   buildRowSelection: typeof buildEventsObservationRowSelection,
@@ -61,10 +92,13 @@ const buildEventsStreamQueryInternal = (
     searchType,
   });
 
+  const orderByEntries = getEventsOrderByEntries(orderBy);
   queryBuilder
     .whereRaw("e.is_deleted = 0")
-    .orderByDefault()
-    .limitBy("e.span_id", "e.project_id")
+    .qualifyRaw(
+      "row_number() OVER (PARTITION BY e.project_id, e.span_id ORDER BY e.event_ts DESC) = 1",
+    )
+    .orderByColumns(orderByEntries)
     .limit(rowLimit);
 
   return {

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -93,6 +93,7 @@ export {
 export {
   buildEventsBlobExportStreamQuery,
   buildEventsStreamQuery,
+  getEventsOrderByEntries,
   type EventsStreamQuery,
   type EventsStreamQueryInput,
 } from "./clickhouse-sql/events-stream-query";

--- a/packages/shared/src/server/repositories/events-stream.ts
+++ b/packages/shared/src/server/repositories/events-stream.ts
@@ -1,4 +1,5 @@
 import { Readable } from "stream";
+import type { OrderByState } from "../../interfaces/orderBy";
 import type { FilterCondition } from "../../types";
 import type { TracingSearchType } from "../../interfaces/search";
 import { buildEventsStreamQuery } from "../queries";
@@ -14,6 +15,7 @@ export const getEventsStreamForEval = async (props: {
   filter: FilterCondition[] | null;
   searchQuery?: string;
   searchType?: TracingSearchType[];
+  orderBy?: OrderByState;
   rowLimit: number;
 }): Promise<Readable> => {
   const {
@@ -22,6 +24,7 @@ export const getEventsStreamForEval = async (props: {
     filter = [],
     searchQuery,
     searchType,
+    orderBy,
     rowLimit,
   } = props;
 
@@ -31,6 +34,7 @@ export const getEventsStreamForEval = async (props: {
     filter,
     searchQuery,
     searchType,
+    orderBy,
     rowLimit,
   });
   const { query, params: queryParams } = queryBuilder

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -49,6 +49,7 @@ import {
   type ApiColumnMapping,
   ObservationPriceFields,
 } from "../queries";
+import { getEventsOrderByEntries } from "../queries/clickhouse-sql/events-stream-query";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
 import type { EventsTableFilterState, FilterState } from "../../types";
 import type { TracingSearchType } from "../../interfaces/search";
@@ -718,10 +719,10 @@ async function getObservationsFromEventsTableInternal<T>(
     ...filter.filter((f) => f.type !== "positionInTrace"),
   ];
 
-  const orderByEntries = orderByToEntries(
-    [orderBy ?? null],
-    eventsTableUiColumnDefinitions,
-  );
+  const orderByEntries =
+    opts.select === "rows"
+      ? getEventsOrderByEntries(orderBy)
+      : orderByToEntries([orderBy ?? null], eventsTableUiColumnDefinitions);
 
   // Build filter list from baseFilter (without positionInTrace)
   // Build query using EventsQueryBuilder

--- a/web/src/features/events/hooks/useEventsTableData.clienttest.tsx
+++ b/web/src/features/events/hooks/useEventsTableData.clienttest.tsx
@@ -1,0 +1,99 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useEventsTableData } from "@/src/features/events/hooks/useEventsTableData";
+
+const { mockCreateMany } = vi.hoisted(() => ({
+  mockCreateMany: vi.fn(),
+}));
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    events: {
+      all: {
+        useQuery: () => ({
+          data: {
+            observations: [
+              {
+                id: "observation-1",
+                traceId: "trace-1",
+                startTime: new Date("2026-01-01T00:00:00.000Z"),
+              },
+            ],
+            hasMore: false,
+          },
+          dataUpdatedAt: 0,
+          error: null,
+          isError: false,
+          isLoading: false,
+          isPlaceholderData: false,
+          isSuccess: true,
+        }),
+      },
+      batchIO: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+      countAll: {
+        useQuery: () => ({
+          data: { totalCount: 1, uniqueTraceCount: 1 },
+          isError: false,
+          isFetching: false,
+        }),
+      },
+    },
+    annotationQueueItems: {
+      createMany: {
+        useMutation: () => ({ mutateAsync: mockCreateMany }),
+      },
+    },
+  },
+  sendAsPostOption: {},
+}));
+
+describe("useEventsTableData", () => {
+  it("persists the complete Events query for select-all annotation actions", async () => {
+    const filterState = [
+      {
+        type: "string" as const,
+        column: "name",
+        operator: "contains" as const,
+        value: "checkout",
+      },
+    ];
+    const orderByState = { column: "endTime", order: "ASC" as const };
+    const searchType = ["id", "content"] as const;
+
+    const { result } = renderHook(() =>
+      useEventsTableData({
+        projectId: "project-1",
+        filterState,
+        paginationState: { page: 0, limit: 50 },
+        orderByState,
+        searchQuery: "refund",
+        searchType: [...searchType],
+        selectedRows: { "observation-1": true },
+        selectAll: true,
+        setSelectedRows: vi.fn(),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleAddToAnnotationQueue({
+        projectId: "project-1",
+        targetId: "queue-1",
+      });
+    });
+
+    expect(mockCreateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isBatchAction: true,
+        query: {
+          filter: filterState,
+          orderBy: orderByState,
+          searchQuery: "refund",
+          searchType,
+        },
+      }),
+    );
+  });
+});

--- a/web/src/features/events/hooks/useEventsTableData.ts
+++ b/web/src/features/events/hooks/useEventsTableData.ts
@@ -266,6 +266,8 @@ export function useEventsTableData({
       query: {
         filter: filterState,
         orderBy: orderByState,
+        searchQuery: searchQuery ?? undefined,
+        searchType,
       },
     });
     setSelectedRows({});

--- a/worker/src/__tests__/event-stream-ordering.test.ts
+++ b/worker/src/__tests__/event-stream-ordering.test.ts
@@ -1,0 +1,201 @@
+import {
+  type FilterCondition,
+  type OrderByState,
+  normalizeOrderByForTable,
+} from "@langfuse/shared";
+import {
+  createEvent,
+  createEventsCh,
+  getEventsStreamForEval,
+  getObservationsWithModelDataFromEventsTable,
+} from "@langfuse/shared/src/server";
+import { randomUUID } from "node:crypto";
+import type { Readable } from "node:stream";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  getEventsStream,
+  getEventsStreamForAnnotationQueue,
+  getEventsStreamForDataset,
+} from "../features/database-read-stream/event-stream";
+
+const maybeDescribe =
+  process.env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+    ? describe
+    : describe.skip;
+
+type StreamInput = {
+  projectId: string;
+  cutoffCreatedAt: Date;
+  filter: FilterCondition[];
+  orderBy: OrderByState;
+  rowLimit: number;
+};
+
+const streamAdapters: Array<{
+  name: string;
+  run: (input: StreamInput) => Promise<Readable>;
+}> = [
+  { name: "blob export", run: getEventsStream },
+  { name: "dataset", run: getEventsStreamForDataset },
+  { name: "annotation queue", run: getEventsStreamForAnnotationQueue },
+  { name: "evaluation", run: getEventsStreamForEval },
+];
+
+const collectIds = async (stream: Readable): Promise<string[]> => {
+  const ids: string[] = [];
+  for await (const row of stream) {
+    ids.push((row as { id: string }).id);
+  }
+  return ids;
+};
+
+maybeDescribe("event stream ordering parity", () => {
+  const projectId = randomUUID();
+  const cutoffCreatedAt = new Date(Date.now() + 60_000);
+  const filter: FilterCondition[] = [];
+  const eventIds = [randomUUID(), randomUUID(), randomUUID()];
+
+  beforeAll(async () => {
+    const baseTime = Date.now() - 10_000;
+    await createEventsCh(
+      eventIds.map((eventId, index) =>
+        createEvent({
+          id: eventId,
+          span_id: eventId,
+          project_id: projectId,
+          trace_id: randomUUID(),
+          name: "same-ordering-key",
+          start_time: (baseTime + index * 1_000) * 1_000,
+        }),
+      ),
+    );
+  });
+
+  it.each(["ASC", "DESC"] as const)(
+    "selects the same first two event IDs as Fast Preview for timestamp %s",
+    async (direction) => {
+      const persistedOrderBy: OrderByState = {
+        column: "timestamp",
+        order: direction,
+      };
+      const fastPreviewOrderBy = normalizeOrderByForTable({
+        orderBy: persistedOrderBy,
+        expectedTimeColumn: "startTime",
+      });
+      const fastPreviewRows = await getObservationsWithModelDataFromEventsTable(
+        {
+          projectId,
+          filter,
+          orderBy: fastPreviewOrderBy,
+          limit: 2,
+          offset: 0,
+        },
+      );
+      const expectedIds = fastPreviewRows.map((row) => row.id);
+
+      expect(expectedIds).toEqual(
+        direction === "ASC"
+          ? eventIds.slice(0, 2)
+          : eventIds.slice(1).reverse(),
+      );
+
+      for (const adapter of streamAdapters) {
+        const actualIds = await collectIds(
+          await adapter.run({
+            projectId,
+            cutoffCreatedAt,
+            filter,
+            orderBy: persistedOrderBy,
+            rowLimit: 2,
+          }),
+        );
+
+        expect(actualIds, adapter.name).toEqual(expectedIds);
+      }
+    },
+    20_000,
+  );
+
+  it.each(["ASC", "DESC"] as const)(
+    "uses the same ID tie-breaker as Fast Preview for name %s",
+    async (direction) => {
+      const orderBy: OrderByState = { column: "name", order: direction };
+      const fastPreviewRows = await getObservationsWithModelDataFromEventsTable(
+        {
+          projectId,
+          filter,
+          orderBy,
+          limit: 2,
+          offset: 0,
+        },
+      );
+      const sortedIds = [...eventIds].sort();
+      const expectedIds = (
+        direction === "ASC" ? sortedIds : sortedIds.reverse()
+      ).slice(0, 2);
+
+      expect(fastPreviewRows.map((row) => row.id)).toEqual(expectedIds);
+
+      for (const adapter of streamAdapters) {
+        const actualIds = await collectIds(
+          await adapter.run({
+            projectId,
+            cutoffCreatedAt,
+            filter,
+            orderBy,
+            rowLimit: 2,
+          }),
+        );
+
+        expect(actualIds, adapter.name).toEqual(expectedIds);
+      }
+    },
+    20_000,
+  );
+
+  it("orders the newest physical event version by its current value", async () => {
+    const duplicateProjectId = randomUUID();
+    const duplicateId = randomUUID();
+    const controlId = randomUUID();
+    const traceId = randomUUID();
+    const startTime = (Date.now() - 10_000) * 1_000;
+    const event = (
+      id: string,
+      name: string,
+      output: string,
+      eventTsOffset: number,
+    ) =>
+      createEvent({
+        id,
+        span_id: id,
+        project_id: duplicateProjectId,
+        trace_id: traceId,
+        name,
+        output,
+        start_time: startTime,
+        event_ts: startTime + eventTsOffset,
+      });
+
+    await createEventsCh([
+      event(duplicateId, "a-stale", "stale", 1),
+      event(controlId, "m-control", "control", 2),
+    ]);
+    await createEventsCh([event(duplicateId, "z-current", "current", 3)]);
+
+    const rows: Array<{ id: string; output: unknown }> = [];
+    for await (const row of await getEventsStreamForDataset({
+      projectId: duplicateProjectId,
+      cutoffCreatedAt,
+      filter,
+      orderBy: { column: "name", order: "ASC" },
+      rowLimit: 2,
+    })) {
+      rows.push(row as { id: string; output: unknown });
+    }
+
+    expect(rows.map(({ id, output }) => ({ id, output }))).toEqual([
+      { id: controlId, output: "control" },
+      { id: duplicateId, output: "current" },
+    ]);
+  });
+});

--- a/worker/src/__tests__/handleBatchActionJob-comment-filters.unit.test.ts
+++ b/worker/src/__tests__/handleBatchActionJob-comment-filters.unit.test.ts
@@ -77,6 +77,7 @@ const idFilter = (value: string[]): FilterCondition[] => [
 ];
 const resolvedCommentFilter = idFilter(["observation-1"]);
 const emptySelectionFilter = idFilter([]);
+const eventOrderBy = { column: "name", order: "ASC" as const };
 const datasetConfig = {
   datasetId: "dataset-1",
   datasetName: "Dataset",
@@ -98,7 +99,7 @@ const createPayload = (
     actionId,
     tableName,
     cutoffCreatedAt: new Date(),
-    query: { filter: rawCommentFilter, orderBy: null },
+    query: { filter: rawCommentFilter, orderBy: eventOrderBy },
     targetId: "queue-1",
     batchActionId: "batch-action-1",
     config: datasetConfig,
@@ -126,6 +127,7 @@ describe("event batch-action comment filter wiring", () => {
       name: "Events annotation queue",
       payload: createPayload("observation-add-to-annotation-queue"),
       getStream: mocks.getEventsStreamForAnnotationQueue,
+      expectsOrderBy: true,
     },
     {
       name: "legacy Observations annotation queue",
@@ -134,6 +136,7 @@ describe("event batch-action comment filter wiring", () => {
         BatchTableNames.Observations,
       ),
       getStream: mocks.getObservationStream,
+      expectsOrderBy: false,
     },
     {
       name: "legacy Observations dataset",
@@ -142,21 +145,24 @@ describe("event batch-action comment filter wiring", () => {
         BatchTableNames.Observations,
       ),
       getStream: mocks.getObservationStream,
+      expectsOrderBy: false,
     },
     {
       name: "Events evaluation",
       payload: createPayload("observation-run-batched-evaluation"),
       getStream: mocks.getEventsStreamForEval,
+      expectsOrderBy: true,
     },
     {
       name: "Events dataset with no matches",
       payload: createPayload("observation-add-to-dataset"),
       getStream: mocks.getEventsStreamForDataset,
       noMatches: true,
+      expectsOrderBy: true,
     },
   ])(
     "resolves observation comments for $name",
-    async ({ payload, getStream, noMatches }) => {
+    async ({ payload, getStream, noMatches, expectsOrderBy }) => {
       if (noMatches) {
         mocks.applyCommentFilters.mockResolvedValue({
           filterState: [],
@@ -164,7 +170,6 @@ describe("event batch-action comment filter wiring", () => {
           matchingIds: [],
         });
       }
-
       await runBatchAction(payload);
 
       expect(mocks.applyCommentFilters).toHaveBeenCalledWith({
@@ -176,6 +181,7 @@ describe("event batch-action comment filter wiring", () => {
       expect(getStream).toHaveBeenCalledWith(
         expect.objectContaining({
           filter: noMatches ? emptySelectionFilter : resolvedCommentFilter,
+          ...(expectsOrderBy ? { orderBy: eventOrderBy } : {}),
         }),
       );
     },

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -249,7 +249,10 @@ export const handleBatchActionJob = async (
               orderBy: query.orderBy,
             })
           : tableName === BatchTableNames.Events
-            ? await getEventsStreamForAnnotationQueue(streamParams)
+            ? await getEventsStreamForAnnotationQueue({
+                ...streamParams,
+                orderBy: query.orderBy,
+              })
             : tableName === BatchTableNames.Observations
               ? await getObservationStream(streamParams)
               : await getDatabaseReadStreamPaginated({
@@ -430,7 +433,10 @@ export const handleBatchActionJob = async (
     };
     const dbReadStream =
       tableName === BatchTableNames.Events
-        ? await getEventsStreamForDataset(streamParams)
+        ? await getEventsStreamForDataset({
+            ...streamParams,
+            orderBy: query.orderBy,
+          })
         : await getObservationStream(streamParams);
 
     // Collect all observations
@@ -539,6 +545,7 @@ export const handleBatchActionJob = async (
       filter,
       searchQuery: query.searchQuery ?? undefined,
       searchType: query.searchType ?? ["id", "content"],
+      orderBy: query.orderBy,
       rowLimit: env.LANGFUSE_MAX_HISTORIC_EVAL_CREATION_LIMIT,
     });
 

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -9,6 +9,7 @@
 
 import {
   FilterCondition,
+  type OrderByState,
   type ScoreDataTypeType,
   TracingSearchType,
 } from "@langfuse/shared";
@@ -42,6 +43,7 @@ export const getEventsStream = async (props: {
   filter: FilterCondition[] | null;
   searchQuery?: string;
   searchType?: TracingSearchType[];
+  orderBy?: OrderByState;
   rowLimit?: number;
 }): Promise<Readable> => {
   const {
@@ -50,6 +52,7 @@ export const getEventsStream = async (props: {
     filter = [],
     searchQuery,
     searchType,
+    orderBy,
     rowLimit = env.BATCH_EXPORT_ROW_LIMIT,
   } = props;
 
@@ -70,6 +73,7 @@ export const getEventsStream = async (props: {
     filter,
     searchQuery,
     searchType,
+    orderBy,
     rowLimit,
   });
   const { query, params: queryParams } = queryBuilder.buildWithParams();
@@ -281,6 +285,7 @@ export const getEventsStreamForDataset = async (props: {
   filter: FilterCondition[] | null;
   searchQuery?: string;
   searchType?: TracingSearchType[];
+  orderBy?: OrderByState;
   rowLimit?: number;
 }): Promise<Readable> => {
   const {
@@ -289,6 +294,7 @@ export const getEventsStreamForDataset = async (props: {
     filter = [],
     searchQuery,
     searchType,
+    orderBy,
     rowLimit = env.BATCH_EXPORT_ROW_LIMIT,
   } = props;
 
@@ -298,6 +304,7 @@ export const getEventsStreamForDataset = async (props: {
     filter,
     searchQuery,
     searchType,
+    orderBy,
     rowLimit,
   });
   const { query, params: queryParams } = queryBuilder
@@ -354,6 +361,7 @@ export const getEventsStreamForAnnotationQueue = async (props: {
   filter: FilterCondition[] | null;
   searchQuery?: string;
   searchType?: TracingSearchType[];
+  orderBy?: OrderByState;
   rowLimit?: number;
 }): Promise<Readable> => {
   const {
@@ -362,6 +370,7 @@ export const getEventsStreamForAnnotationQueue = async (props: {
     filter = [],
     searchQuery,
     searchType,
+    orderBy,
     rowLimit = env.BATCH_EXPORT_ROW_LIMIT,
   } = props;
 
@@ -371,6 +380,7 @@ export const getEventsStreamForAnnotationQueue = async (props: {
     filter,
     searchQuery,
     searchType,
+    orderBy,
     rowLimit,
   });
   const { query, params: queryParams } = queryBuilder


### PR DESCRIPTION
## Summary

- Pass persisted orderBy into all four Events streams.
- Normalize time aliases and reuse Fast Preview column mapping.
- Preserve startTime DESC when ordering is absent.
- Apply ordering before deduplication and row limits.
- Add a stable span_id tie-breaker shared by Fast Preview and streams.
- Preserve annotation select-all search criteria.

## Stack

PR 5 of 5. Base: valeriy-codex/events-stream-comment-filters.

## Scope

positionInTrace remains session-only and is explicitly not advertised or enabled for general Events streams.

## Verification

The full stack passes lint, typecheck, targeted repository, stream, score, comment, batch-action, evaluation, and low-limit ordering tests. Fast Preview export and selection flows were also reviewed in the browser with seeded v4 data.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes event-stream ordering by threading the persisted `orderBy` state into all four event stream adapters (blob export, dataset, annotation queue, evaluation) and aligning them with the Fast Preview ordering via a shared `getEventsOrderByEntries` helper. It also fixes a select-all annotation-queue bug where `searchQuery` and `searchType` were dropped from the batch-action payload.

- `getEventsOrderByEntries` normalises time-column aliases (`timestamp`, `createdAt` → `startTime`), maps UI column names to ClickHouse columns, falls back to `start_time DESC` when no ordering is provided, and appends `span_id` as a stable tie-breaker — matching the Fast Preview behaviour.
- `handleBatchActionJob` now spreads `query.orderBy` into `getEventsStreamForAnnotationQueue` and `getEventsStreamForDataset`; `getEventsStreamForEval` receives it directly; the legacy Observations streams are intentionally excluded.
- `useEventsTableData` now includes `searchQuery` and `searchType` in the select-all annotation-queue mutation query, preserving the full user search criteria for batch actions.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge. The ordering fix is plumbed consistently through all four stream paths and the shared helper correctly normalises aliases, maps columns, and appends a stable tie-breaker.

The core logic — getEventsOrderByEntries, alias normalisation, tie-breaker, and the four stream wiring sites — is correct and covered by new unit and integration tests. The select-all annotation-queue payload fix is straightforward and also covered. A single subpath import in events.ts is the only finding.

No files require special attention. events.ts has the minor import style issue; all other changed files are clean.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    UI[Events Table UI] -->|orderBy + filter + searchQuery + searchType| Hook[useEventsTableData]
    Hook -->|selectAll action| AQMutation[Annotation Queue Mutation\nnow includes searchQuery + searchType]

    BatchJob[handleBatchActionJob] -->|query.orderBy| AQ[getEventsStreamForAnnotationQueue]
    BatchJob -->|query.orderBy| DS[getEventsStreamForDataset]
    BatchJob -->|query.orderBy| EV[getEventsStreamForEval]
    BatchJob -->|query.orderBy| BS[getEventsStream blob export]

    AQ --> QBuilder[buildEventsStreamQuery]
    DS --> QBuilder
    EV --> StreamRepo[getEventsStreamForEval events-stream.ts]
    BS --> QBuilder
    StreamRepo --> QBuilder

    QBuilder --> GEO[getEventsOrderByEntries]
    GEO -->|normalizeOrderByForTable| Normalize[timestamp/createdAt → startTime]
    Normalize --> Map[orderByToEntries ui column → CH column]
    Map --> Fallback{entries empty?}
    Fallback -->|yes| Default[e.start_time DESC]
    Fallback -->|no| UserOrder[user-specified order]
    Default --> TieBreaker[+e.span_id tie-breaker]
    UserOrder --> TieBreaker

    TieBreaker --> QB[QueryBuilder .orderByColumns .limitBy span_id .limit rowLimit]

    FP[Fast Preview getObservationsFromEventsTableInternal select=rows] -->|also uses getEventsOrderByEntries| GEO
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    UI[Events Table UI] -->|orderBy + filter + searchQuery + searchType| Hook[useEventsTableData]
    Hook -->|selectAll action| AQMutation[Annotation Queue Mutation\nnow includes searchQuery + searchType]

    BatchJob[handleBatchActionJob] -->|query.orderBy| AQ[getEventsStreamForAnnotationQueue]
    BatchJob -->|query.orderBy| DS[getEventsStreamForDataset]
    BatchJob -->|query.orderBy| EV[getEventsStreamForEval]
    BatchJob -->|query.orderBy| BS[getEventsStream blob export]

    AQ --> QBuilder[buildEventsStreamQuery]
    DS --> QBuilder
    EV --> StreamRepo[getEventsStreamForEval events-stream.ts]
    BS --> QBuilder
    StreamRepo --> QBuilder

    QBuilder --> GEO[getEventsOrderByEntries]
    GEO -->|normalizeOrderByForTable| Normalize[timestamp/createdAt → startTime]
    Normalize --> Map[orderByToEntries ui column → CH column]
    Map --> Fallback{entries empty?}
    Fallback -->|yes| Default[e.start_time DESC]
    Fallback -->|no| UserOrder[user-specified order]
    Default --> TieBreaker[+e.span_id tie-breaker]
    UserOrder --> TieBreaker

    TieBreaker --> QB[QueryBuilder .orderByColumns .limitBy span_id .limit rowLimit]

    FP[Fast Preview getObservationsFromEventsTableInternal select=rows] -->|also uses getEventsOrderByEntries| GEO
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/repositories/events.ts:52
The new import goes directly to the `clickhouse-sql` subpath while the surrounding file already uses `../queries` (the package index) for other symbols — and `getEventsOrderByEntries` was just added to that same index in `queries/index.ts`. Going through the index keeps the import graph consistent and avoids coupling `events.ts` to internal file layout.

```suggestion
import { getEventsOrderByEntries } from "../queries";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(events): honor Fast Preview ordering..."](https://github.com/langfuse/langfuse/commit/1544207f42f390b0c6b2e59bee0bf25aa82c7ae7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45089131)</sub>

<!-- /greptile_comment -->