### PR TITLE
feat(blobstorage): drift banner + stale-feedback guards for settings form

### DIFF
--- a/web/src/features/blobstorage-integration/README.md
+++ b/web/src/features/blobstorage-integration/README.md
@@ -158,9 +158,16 @@ changes (project switch, create, delete) remount the form; same-entity
 refetches (5s status poll, post-save invalidation) keep the key stable
 and therefore can never wipe or leak a draft. Consequence, by design:
 clean fields do not live-update from background refetches while the
-form is mounted. Field-group components receive the typed `control`
-prop and subscribe to individual fields with `useWatch`; there is no
-local Zustand store and no feature `useEffect`.
+form is mounted. Instead, a refetched `updatedAt` differing from the
+mounted snapshot (someone else saved) surfaces a non-destructive
+drift banner whose explicit "Reload form" click bumps a key epoch;
+the user's own save adopts the bumped `updatedAt` silently and
+remounts from the saved row. Mutation callbacks compare their
+fired-with projectId against the live prop and skip toasts when
+stale (container survives client-side project switches). Field-group
+components receive the typed `control` prop and subscribe to
+individual fields with `useWatch`; there is no local Zustand store
+and no feature `useEffect`.
 
 **Performance boundaries**: a keystroke or select change rerenders only
 the field-group component watching that field. The form layer reads no

--- a/web/src/features/blobstorage-integration/README.md
+++ b/web/src/features/blobstorage-integration/README.md
@@ -158,11 +158,16 @@ changes (project switch, create, delete) remount the form; same-entity
 refetches (5s status poll, post-save invalidation) keep the key stable
 and therefore can never wipe or leak a draft. Consequence, by design:
 clean fields do not live-update from background refetches while the
-form is mounted. Instead, a refetched `updatedAt` differing from the
-mounted snapshot (someone else saved) surfaces a non-destructive
-drift banner whose explicit "Reload form" click bumps a key epoch;
-the user's own save adopts the bumped `updatedAt` silently and
-remounts from the saved row. Mutation callbacks compare their
+form is mounted. Instead, a refetch whose **user-configurable field
+values** differ from the mounted snapshot (someone else saved)
+surfaces a non-destructive drift banner whose explicit "Reload form"
+click bumps a key epoch. Drift deliberately does NOT key on
+`updatedAt`: Prisma's `@updatedAt` bumps on every worker status write
+(runStartedAt, lastSyncAt, …) exactly while the 5s poll is active, so
+timestamps would banner on every sync. `updatedAt` is used only to
+recognize the user's own save (the mutation's returned value; any
+refetch at-or-after it adopts silently and remounts from the saved
+row). Mutation callbacks compare their
 fired-with projectId against the live prop and skip toasts when
 stale (container survives client-side project switches). Field-group
 components receive the typed `control` prop and subscribe to

--- a/web/src/features/blobstorage-integration/README.md
+++ b/web/src/features/blobstorage-integration/README.md
@@ -165,9 +165,11 @@ click bumps a key epoch. Drift deliberately does NOT key on
 `updatedAt`: Prisma's `@updatedAt` bumps on every worker status write
 (runStartedAt, lastSyncAt, …) exactly while the 5s poll is active, so
 timestamps would banner on every sync. `updatedAt` is used only to
-recognize the user's own save (the mutation's returned value; any
-refetch at-or-after it adopts silently and remounts from the saved
-row). Mutation callbacks compare their
+recognize the user's own save (the mutation's returned value; a
+refetch at-or-after it whose values match the save is adopted by
+rebaselining the snapshot only — never a remount, so typing that
+continued past Save survives; the explicit Reload click also clears
+the pending expectation). Mutation callbacks compare their
 fired-with projectId against the live prop and skip toasts when
 stale (container survives client-side project switches). Field-group
 components receive the typed `control` prop and subscribe to

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.clienttest.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.clienttest.tsx
@@ -215,7 +215,7 @@ describe("BlobStorageIntegrationContainer", () => {
     act(() => mutationOpts.update.onMutate?.({ projectId: "p1" }));
     act(() =>
       mutationOpts.update.onSuccess?.(
-        { updatedAt: savedAt },
+        savedConfig({ bucketName: "self-saved-bucket", updatedAt: savedAt }),
         { projectId: "p1" },
       ),
     );
@@ -252,10 +252,10 @@ describe("BlobStorageIntegrationContainer", () => {
     ).not.toBeInTheDocument(); // no flash while in flight
     expect(bucketInput()).toHaveValue("racy-bucket"); // draft untouched
 
-    // Mutation response arrives; its updatedAt matches → silent adoption.
+    // Mutation response arrives; its updatedAt and values match → adoption.
     act(() =>
       mutationOpts.update.onSuccess?.(
-        { updatedAt: savedAt },
+        savedConfig({ bucketName: "racy-bucket", updatedAt: savedAt }),
         { projectId: "p1" },
       ),
     );
@@ -277,7 +277,7 @@ describe("BlobStorageIntegrationContainer", () => {
     act(() => mutationOpts.update.onMutate?.({ projectId: "p1" }));
     act(() =>
       mutationOpts.update.onSuccess?.(
-        { updatedAt: savedAt },
+        savedConfig({ bucketName: "self-saved-bucket", updatedAt: savedAt }),
         { projectId: "p1" },
       ),
     );
@@ -307,10 +307,9 @@ describe("BlobStorageIntegrationContainer", () => {
 
     act(() => mutationOpts.update.onMutate?.({ projectId: "p1" }));
     act(() =>
-      mutationOpts.update.onSuccess?.(
-        { updatedAt: savedAt },
-        { projectId: "p1" },
-      ),
+      mutationOpts.update.onSuccess?.(savedConfig({ updatedAt: savedAt }), {
+        projectId: "p1",
+      }),
     );
 
     fireEvent.change(bucketInput(), { target: { value: "my-draft" } });
@@ -327,5 +326,55 @@ describe("BlobStorageIntegrationContainer", () => {
       screen.getByText("Configuration changed elsewhere"),
     ).toBeInTheDocument(); // still banners
     expect(bucketInput()).toHaveValue("my-draft"); // draft intact
+  });
+
+  it("first visit: availability resolving after the loading render does not banner", () => {
+    // While the query loads, the page passes isEnrichedExportAvailable=false
+    // (the ?? false fallback); once resolved it may flip to true, changing
+    // the exportSource default for a never-configured project. That
+    // transition must rebaseline, not read as drift.
+    const { rerender } = render(
+      ui({ isLoading: true, config: null, isEnrichedExportAvailable: false }),
+    );
+    rerender(
+      ui({ isLoading: false, config: null, isEnrichedExportAvailable: true }),
+    );
+
+    expect(
+      screen.queryByText("Configuration changed elsewhere"),
+    ).not.toBeInTheDocument();
+    expect(bucketInput()).toHaveValue(""); // blank new-config form
+  });
+
+  it("concurrent save landing inside the save→refetch window still banners", () => {
+    // User B's save reaches the server after A's save but before A's
+    // post-save refetch: the refetch carries B's values with a LATER
+    // updatedAt. Timestamp alone would adopt it silently; the value check
+    // must keep the banner.
+    const savedAt = new Date("2026-01-02T00:00:00Z");
+    const userBAt = new Date("2026-01-02T00:00:03Z");
+    const { rerender } = render(ui({ config: savedConfig() }));
+    fireEvent.change(bucketInput(), { target: { value: "user-a-bucket" } });
+
+    act(() => mutationOpts.update.onMutate?.({ projectId: "p1" }));
+    act(() =>
+      mutationOpts.update.onSuccess?.(
+        savedConfig({ bucketName: "user-a-bucket", updatedAt: savedAt }),
+        { projectId: "p1" },
+      ),
+    );
+    rerender(
+      ui({
+        config: savedConfig({
+          bucketName: "user-b-bucket",
+          updatedAt: userBAt,
+        }),
+      }),
+    );
+
+    expect(
+      screen.getByText("Configuration changed elsewhere"),
+    ).toBeInTheDocument();
+    expect(bucketInput()).toHaveValue("user-a-bucket"); // draft intact
   });
 });

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.clienttest.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.clienttest.tsx
@@ -207,7 +207,7 @@ describe("BlobStorageIntegrationContainer", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("own save: updatedAt bump after update success remounts without a banner", () => {
+  it("own save: adoption rebaselines without a banner AND without remounting — post-Save typing survives", () => {
     const savedAt = new Date("2026-01-02T00:00:00Z");
     const { rerender } = render(ui({ config: savedConfig() }));
     fireEvent.change(bucketInput(), { target: { value: "self-saved-bucket" } });
@@ -219,6 +219,10 @@ describe("BlobStorageIntegrationContainer", () => {
         { projectId: "p1" },
       ),
     );
+    // User keeps typing between Save resolving and the refetch landing.
+    fireEvent.change(bucketInput(), {
+      target: { value: "self-saved-bucket-postsave-edit" },
+    });
     rerender(
       ui({
         config: savedConfig({
@@ -231,7 +235,8 @@ describe("BlobStorageIntegrationContainer", () => {
     expect(
       screen.queryByText("Configuration changed elsewhere"),
     ).not.toBeInTheDocument();
-    expect(bucketInput()).toHaveValue("self-saved-bucket"); // remounted from saved row
+    // No remount: the post-Save keystrokes are still in the field.
+    expect(bucketInput()).toHaveValue("self-saved-bucket-postsave-edit");
   });
 
   it("own-save race: poll delivering the new updatedAt before onSuccess does not flash the banner", () => {
@@ -376,5 +381,57 @@ describe("BlobStorageIntegrationContainer", () => {
       screen.getByText("Configuration changed elsewhere"),
     ).toBeInTheDocument();
     expect(bucketInput()).toHaveValue("user-a-bucket"); // draft intact
+  });
+
+  it("reload clears the own-save expectation: a later external revert banners instead of adopting", () => {
+    // A saves V1; B's V2 lands inside A's save→refetch window → banner.
+    // A clicks Reload (acknowledging V2) and edits a fresh draft. B then
+    // reverts to V1 with a later updatedAt — matching A's stale
+    // expectation. It must banner, not silently adopt over A's new draft.
+    const savedAt = new Date("2026-01-02T00:00:00Z");
+    const userBAt = new Date("2026-01-02T00:00:03Z");
+    const revertAt = new Date("2026-01-02T00:05:00Z");
+    const { rerender } = render(ui({ config: savedConfig() }));
+    fireEvent.change(bucketInput(), { target: { value: "user-a-bucket" } });
+
+    act(() => mutationOpts.update.onMutate?.({ projectId: "p1" }));
+    act(() =>
+      mutationOpts.update.onSuccess?.(
+        savedConfig({ bucketName: "user-a-bucket", updatedAt: savedAt }),
+        { projectId: "p1" },
+      ),
+    );
+    rerender(
+      ui({
+        config: savedConfig({
+          bucketName: "user-b-bucket",
+          updatedAt: userBAt,
+        }),
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Reload form (discards unsaved edits)",
+      }),
+    );
+    expect(bucketInput()).toHaveValue("user-b-bucket"); // reloaded to B's row
+    fireEvent.change(bucketInput(), {
+      target: { value: "post-reload-draft" },
+    });
+
+    // B reverts to exactly A's earlier values, later timestamp.
+    rerender(
+      ui({
+        config: savedConfig({
+          bucketName: "user-a-bucket",
+          updatedAt: revertAt,
+        }),
+      }),
+    );
+
+    expect(
+      screen.getByText("Configuration changed elsewhere"),
+    ).toBeInTheDocument(); // not silently adopted
+    expect(bucketInput()).toHaveValue("post-reload-draft"); // draft intact
   });
 });

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.clienttest.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.clienttest.tsx
@@ -155,7 +155,29 @@ describe("BlobStorageIntegrationContainer", () => {
     expect(showSuccessToast).toHaveBeenCalledTimes(1); // no second toast
   });
 
-  it("drift banner: external updatedAt change shows the banner, keeps the draft, reload remounts", () => {
+  it("worker status write: updatedAt bump without config-field changes does NOT banner", () => {
+    // Prisma @updatedAt bumps on every worker write (runStartedAt,
+    // lastSyncAt, ...) while the 5s poll is active — must not read as drift.
+    const { rerender } = render(ui({ config: savedConfig() }));
+    fireEvent.change(bucketInput(), { target: { value: "my-draft" } });
+
+    rerender(
+      ui({
+        config: savedConfig({
+          updatedAt: new Date("2026-01-02T00:00:00Z"),
+          lastSyncAt: new Date("2026-01-02T00:00:00Z"),
+          runStartedAt: null,
+        }),
+      }),
+    );
+
+    expect(
+      screen.queryByText("Configuration changed elsewhere"),
+    ).not.toBeInTheDocument();
+    expect(bucketInput()).toHaveValue("my-draft"); // draft intact
+  });
+
+  it("drift banner: external config change shows the banner, keeps the draft, reload remounts", () => {
     const { rerender } = render(ui({ config: savedConfig() }));
     fireEvent.change(bucketInput(), { target: { value: "my-draft" } });
 
@@ -243,9 +265,44 @@ describe("BlobStorageIntegrationContainer", () => {
     expect(bucketInput()).toHaveValue("racy-bucket");
   });
 
-  it("leftover own-save expectation cannot swallow a different external edit", () => {
+  it("own save + worker bump: refetch with a LATER updatedAt still adopts silently", () => {
+    // Worker status writes can bump the row again between the save and its
+    // refetch; adoption is >= the expected updatedAt, so the user's own
+    // save never turns into a drift banner.
     const savedAt = new Date("2026-01-02T00:00:00Z");
-    const externalAt = new Date("2026-01-03T00:00:00Z");
+    const workerBumpAt = new Date("2026-01-02T00:00:05Z");
+    const { rerender } = render(ui({ config: savedConfig() }));
+    fireEvent.change(bucketInput(), { target: { value: "self-saved-bucket" } });
+
+    act(() => mutationOpts.update.onMutate?.({ projectId: "p1" }));
+    act(() =>
+      mutationOpts.update.onSuccess?.(
+        { updatedAt: savedAt },
+        { projectId: "p1" },
+      ),
+    );
+    rerender(
+      ui({
+        config: savedConfig({
+          bucketName: "self-saved-bucket",
+          updatedAt: workerBumpAt,
+          runStartedAt: new Date("2026-01-02T00:00:05Z"),
+        }),
+      }),
+    );
+
+    expect(
+      screen.queryByText("Configuration changed elsewhere"),
+    ).not.toBeInTheDocument();
+    expect(bucketInput()).toHaveValue("self-saved-bucket");
+  });
+
+  it("pre-save drift arriving after save success still banners (not adopted)", () => {
+    // Drift existed before the user saved; the drifted row (older
+    // updatedAt than the save) lands after onSuccess. It must not be
+    // silently adopted as the user's own save.
+    const driftAt = new Date("2026-01-01T12:00:00Z"); // before savedAt
+    const savedAt = new Date("2026-01-02T00:00:00Z");
     const { rerender } = render(ui({ config: savedConfig() }));
 
     act(() => mutationOpts.update.onMutate?.({ projectId: "p1" }));
@@ -256,14 +313,12 @@ describe("BlobStorageIntegrationContainer", () => {
       ),
     );
 
-    // The post-save refetch never delivered savedAt (e.g. it failed); the
-    // next thing to arrive is a concurrent edit with a DIFFERENT updatedAt.
     fireEvent.change(bucketInput(), { target: { value: "my-draft" } });
     rerender(
       ui({
         config: savedConfig({
           bucketName: "changed-elsewhere",
-          updatedAt: externalAt,
+          updatedAt: driftAt,
         }),
       }),
     );

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.clienttest.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.clienttest.tsx
@@ -10,6 +10,7 @@ const { mutationOpts } = vi.hoisted(() => ({
   mutationOpts: {} as Record<
     string,
     {
+      onMutate?: (variables: { projectId: string }) => void;
       onSuccess?: (data: unknown, variables: { projectId: string }) => void;
       onError?: (error: unknown, variables: { projectId: string }) => void;
     }
@@ -185,15 +186,22 @@ describe("BlobStorageIntegrationContainer", () => {
   });
 
   it("own save: updatedAt bump after update success remounts without a banner", () => {
+    const savedAt = new Date("2026-01-02T00:00:00Z");
     const { rerender } = render(ui({ config: savedConfig() }));
     fireEvent.change(bucketInput(), { target: { value: "self-saved-bucket" } });
 
-    act(() => mutationOpts.update.onSuccess?.({}, { projectId: "p1" }));
+    act(() => mutationOpts.update.onMutate?.({ projectId: "p1" }));
+    act(() =>
+      mutationOpts.update.onSuccess?.(
+        { updatedAt: savedAt },
+        { projectId: "p1" },
+      ),
+    );
     rerender(
       ui({
         config: savedConfig({
           bucketName: "self-saved-bucket",
-          updatedAt: new Date("2026-01-02T00:00:00Z"),
+          updatedAt: savedAt,
         }),
       }),
     );
@@ -202,5 +210,67 @@ describe("BlobStorageIntegrationContainer", () => {
       screen.queryByText("Configuration changed elsewhere"),
     ).not.toBeInTheDocument();
     expect(bucketInput()).toHaveValue("self-saved-bucket"); // remounted from saved row
+  });
+
+  it("own-save race: poll delivering the new updatedAt before onSuccess does not flash the banner", () => {
+    const savedAt = new Date("2026-01-02T00:00:00Z");
+    const { rerender } = render(ui({ config: savedConfig() }));
+    fireEvent.change(bucketInput(), { target: { value: "racy-bucket" } });
+
+    // Save request in flight; poll refetch lands first with the new row.
+    act(() => mutationOpts.update.onMutate?.({ projectId: "p1" }));
+    rerender(
+      ui({
+        config: savedConfig({ bucketName: "racy-bucket", updatedAt: savedAt }),
+      }),
+    );
+
+    expect(
+      screen.queryByText("Configuration changed elsewhere"),
+    ).not.toBeInTheDocument(); // no flash while in flight
+    expect(bucketInput()).toHaveValue("racy-bucket"); // draft untouched
+
+    // Mutation response arrives; its updatedAt matches → silent adoption.
+    act(() =>
+      mutationOpts.update.onSuccess?.(
+        { updatedAt: savedAt },
+        { projectId: "p1" },
+      ),
+    );
+    expect(
+      screen.queryByText("Configuration changed elsewhere"),
+    ).not.toBeInTheDocument();
+    expect(bucketInput()).toHaveValue("racy-bucket");
+  });
+
+  it("leftover own-save expectation cannot swallow a different external edit", () => {
+    const savedAt = new Date("2026-01-02T00:00:00Z");
+    const externalAt = new Date("2026-01-03T00:00:00Z");
+    const { rerender } = render(ui({ config: savedConfig() }));
+
+    act(() => mutationOpts.update.onMutate?.({ projectId: "p1" }));
+    act(() =>
+      mutationOpts.update.onSuccess?.(
+        { updatedAt: savedAt },
+        { projectId: "p1" },
+      ),
+    );
+
+    // The post-save refetch never delivered savedAt (e.g. it failed); the
+    // next thing to arrive is a concurrent edit with a DIFFERENT updatedAt.
+    fireEvent.change(bucketInput(), { target: { value: "my-draft" } });
+    rerender(
+      ui({
+        config: savedConfig({
+          bucketName: "changed-elsewhere",
+          updatedAt: externalAt,
+        }),
+      }),
+    );
+
+    expect(
+      screen.getByText("Configuration changed elsewhere"),
+    ).toBeInTheDocument(); // still banners
+    expect(bucketInput()).toHaveValue("my-draft"); // draft intact
   });
 });

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.clienttest.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.clienttest.tsx
@@ -1,0 +1,206 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  BlobStorageIntegrationFileType,
+  BlobStorageIntegrationType,
+  type BlobStorageIntegration,
+} from "@langfuse/shared";
+import { TooltipProvider } from "@/src/components/ui/tooltip";
+
+const { mutationOpts } = vi.hoisted(() => ({
+  mutationOpts: {} as Record<
+    string,
+    {
+      onSuccess?: (data: unknown, variables: { projectId: string }) => void;
+      onError?: (error: unknown, variables: { projectId: string }) => void;
+    }
+  >,
+}));
+
+vi.mock("@/src/utils/api", () => {
+  const makeUseMutation =
+    (name: string) => (opts: (typeof mutationOpts)[string]) => {
+      mutationOpts[name] = opts;
+      return { mutate: vi.fn(), isPending: false };
+    };
+  return {
+    api: {
+      useUtils: () => ({ blobStorageIntegration: { invalidate: vi.fn() } }),
+      blobStorageIntegration: {
+        update: { useMutation: makeUseMutation("update") },
+        delete: { useMutation: makeUseMutation("delete") },
+        runNow: { useMutation: makeUseMutation("runNow") },
+        validate: { useMutation: makeUseMutation("validate") },
+      },
+    },
+  };
+});
+
+vi.mock("@/src/features/notifications/showSuccessToast", () => ({
+  showSuccessToast: vi.fn(),
+}));
+vi.mock("@/src/features/notifications/showErrorToast", () => ({
+  showErrorToast: vi.fn(),
+}));
+vi.mock("@/src/features/projects/hooks", () => ({
+  useQueryProject: () => ({
+    project: { id: "p1", createdAt: new Date("2024-01-01T00:00:00Z") },
+  }),
+}));
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { BlobStorageIntegrationContainer } from "./BlobStorageIntegrationContainer";
+
+const savedConfig = (
+  overrides: Partial<BlobStorageIntegration> = {},
+): Partial<BlobStorageIntegration> => ({
+  type: BlobStorageIntegrationType.S3,
+  bucketName: "saved-bucket",
+  region: "us-east-1",
+  fileType: BlobStorageIntegrationFileType.PARQUET,
+  enabled: true,
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+  ...overrides,
+});
+
+type ContainerProps = Parameters<typeof BlobStorageIntegrationContainer>[0];
+
+const ui = (props: Partial<ContainerProps> = {}) => (
+  <TooltipProvider>
+    <BlobStorageIntegrationContainer
+      projectId="p1"
+      config={null}
+      isLoading={false}
+      isEnrichedExportAvailable={true}
+      {...props}
+    />
+  </TooltipProvider>
+);
+
+const bucketInput = () =>
+  screen.getByLabelText("Bucket Name") as HTMLInputElement;
+
+describe("BlobStorageIntegrationContainer", () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    Element.prototype.scrollIntoView = vi.fn();
+    Element.prototype.hasPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+  });
+
+  beforeEach(() => {
+    vi.mocked(showSuccessToast).mockClear();
+  });
+
+  it("loading gate: form is not mounted while the query is loading", () => {
+    render(ui({ isLoading: true }));
+    expect(screen.queryByText("Storage Provider")).not.toBeInTheDocument();
+  });
+
+  it("delete flow: dirty form remounts blank when config becomes null", () => {
+    const { rerender } = render(ui({ config: savedConfig() }));
+    fireEvent.change(bucketInput(), { target: { value: "edited-bucket" } });
+
+    rerender(ui({ config: null }));
+
+    expect(bucketInput()).toHaveValue("");
+  });
+
+  it("project switch: no value carryover across projectId change", () => {
+    const { rerender } = render(ui({ projectId: "p1" }));
+    fireEvent.change(bucketInput(), { target: { value: "project-a-draft" } });
+
+    rerender(ui({ projectId: "p2" }));
+
+    expect(bucketInput()).toHaveValue("");
+  });
+
+  it("post-create: new → configured remounts initialized from the saved config", () => {
+    const { rerender } = render(ui({ config: null }));
+    fireEvent.change(bucketInput(), { target: { value: "typed-before-save" } });
+
+    rerender(ui({ config: savedConfig() }));
+
+    expect(bucketInput()).toHaveValue("saved-bucket");
+  });
+
+  it("stale mutation guard: validate resolving after a project switch does not toast", () => {
+    const { rerender } = render(ui({ projectId: "p1" }));
+
+    act(() =>
+      mutationOpts.validate.onSuccess?.(
+        { message: "ok", testFileName: "f1" },
+        { projectId: "p1" },
+      ),
+    );
+    expect(showSuccessToast).toHaveBeenCalledTimes(1);
+
+    rerender(ui({ projectId: "p2" }));
+    act(() =>
+      mutationOpts.validate.onSuccess?.(
+        { message: "ok", testFileName: "f2" },
+        { projectId: "p1" },
+      ),
+    );
+    expect(showSuccessToast).toHaveBeenCalledTimes(1); // no second toast
+  });
+
+  it("drift banner: external updatedAt change shows the banner, keeps the draft, reload remounts", () => {
+    const { rerender } = render(ui({ config: savedConfig() }));
+    fireEvent.change(bucketInput(), { target: { value: "my-draft" } });
+
+    rerender(
+      ui({
+        config: savedConfig({
+          bucketName: "changed-elsewhere",
+          updatedAt: new Date("2026-01-02T00:00:00Z"),
+        }),
+      }),
+    );
+
+    expect(
+      screen.getByText("Configuration changed elsewhere"),
+    ).toBeInTheDocument();
+    expect(bucketInput()).toHaveValue("my-draft"); // draft intact
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Reload form (discards unsaved edits)",
+      }),
+    );
+
+    expect(bucketInput()).toHaveValue("changed-elsewhere");
+    expect(
+      screen.queryByText("Configuration changed elsewhere"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("own save: updatedAt bump after update success remounts without a banner", () => {
+    const { rerender } = render(ui({ config: savedConfig() }));
+    fireEvent.change(bucketInput(), { target: { value: "self-saved-bucket" } });
+
+    act(() => mutationOpts.update.onSuccess?.({}, { projectId: "p1" }));
+    rerender(
+      ui({
+        config: savedConfig({
+          bucketName: "self-saved-bucket",
+          updatedAt: new Date("2026-01-02T00:00:00Z"),
+        }),
+      }),
+    );
+
+    expect(
+      screen.queryByText("Configuration changed elsewhere"),
+    ).not.toBeInTheDocument();
+    expect(bucketInput()).toHaveValue("self-saved-bucket"); // remounted from saved row
+  });
+});

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import { useMemo, useRef, useState } from "react";
+import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { Button } from "@/src/components/ui/button";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
@@ -23,9 +24,10 @@ import { BlobStorageIntegrationForm } from "@/src/features/blobstorage-integrati
 // derivation, the four mutations, and the entity-action buttons. The form
 // below it is a disposable draft: it is not mounted until every input has
 // resolved, and it is remounted (via key) whenever the entity identity
-// changes — project switch, create, delete. Background refetches of the
-// same entity (status poll, post-save invalidation) keep the key stable so
-// they can never touch a draft in progress.
+// changes — project switch, create, delete — or the user explicitly reloads
+// after a concurrent edit. Background refetches of the same entity (status
+// poll, post-save invalidation) keep the key stable so they can never touch
+// a draft in progress.
 export const BlobStorageIntegrationContainer = ({
   config,
   projectId,
@@ -40,6 +42,12 @@ export const BlobStorageIntegrationContainer = ({
   const capture = usePostHogClientCapture();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const { project } = useQueryProject();
+
+  // The container survives a client-side project switch; mutation callbacks
+  // compare the projectId they were fired with against the live prop and
+  // skip UI feedback when they no longer match (stale resolution).
+  const projectIdRef = useRef(projectId);
+  projectIdRef.current = projectId;
 
   const isPostCutoffCloud =
     project?.createdAt != null &&
@@ -58,12 +66,63 @@ export const BlobStorageIntegrationContainer = ({
     [eventsExportAvailable, forceEventsExport],
   );
 
+  // Concurrent-edit drift detection. The form freezes a snapshot at mount;
+  // `snapshot` records which entity identity and updatedAt that snapshot was
+  // built from. A differing refetched updatedAt on the SAME identity means
+  // someone else saved — surface a banner, never discard the draft without
+  // an explicit click. `epoch` remounts the form on that click.
+  const identity = `${projectId}:${config ? "configured" : "new"}`;
+  const [snapshot, setSnapshot] = useState<{
+    identity: string;
+    updatedAt: Date | null;
+    epoch: number;
+  }>({ identity, updatedAt: config?.updatedAt ?? null, epoch: 0 });
+  // Set on own-save success so the resulting updatedAt bump is adopted
+  // (remount from the just-saved row, clearing dirty flags) instead of
+  // showing the banner against the user's own change.
+  const [pendingSelfSave, setPendingSelfSave] = useState(false);
+
+  // Render-phase state adjustment (React's derive-state-from-props pattern):
+  // identity changes rebaseline the snapshot before anything is compared.
+  if (snapshot.identity !== identity) {
+    setSnapshot({ identity, updatedAt: config?.updatedAt ?? null, epoch: 0 });
+    if (pendingSelfSave) setPendingSelfSave(false);
+  }
+
+  const configUpdatedAt = config?.updatedAt
+    ? new Date(config.updatedAt).getTime()
+    : null;
+  const snapshotUpdatedAt = snapshot.updatedAt
+    ? new Date(snapshot.updatedAt).getTime()
+    : null;
+  const updatedAtChanged =
+    snapshot.identity === identity &&
+    configUpdatedAt != null &&
+    snapshotUpdatedAt != null &&
+    configUpdatedAt !== snapshotUpdatedAt;
+
+  if (updatedAtChanged && pendingSelfSave) {
+    setSnapshot({
+      identity,
+      updatedAt: config?.updatedAt ?? null,
+      epoch: snapshot.epoch + 1,
+    });
+    setPendingSelfSave(false);
+  }
+  const hasDrift = updatedAtChanged && !pendingSelfSave;
+
   const utils = api.useUtils();
+  // invalidate() stays unguarded everywhere: the query cache is keyed per
+  // projectId, so refreshing the fired-for project in the background is
+  // correct even after a switch.
   const mut = api.blobStorageIntegration.update.useMutation({
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       utils.blobStorageIntegration.invalidate();
+      if (variables.projectId !== projectIdRef.current) return; // stale
+      setPendingSelfSave(true);
     },
-    onError: (error) => {
+    onError: (error, variables) => {
+      if (variables.projectId !== projectIdRef.current) return; // stale
       showErrorToast("Failed to save integration", error.message);
     },
   });
@@ -78,13 +137,15 @@ export const BlobStorageIntegrationContainer = ({
     },
   });
   const mutValidate = api.blobStorageIntegration.validate.useMutation({
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
+      if (variables.projectId !== projectIdRef.current) return; // stale
       showSuccessToast({
         title: data.message,
         description: `Test file: ${data.testFileName}`,
       });
     },
-    onError: (error) => {
+    onError: (error, variables) => {
+      if (variables.projectId !== projectIdRef.current) return; // stale
       showErrorToast("Validation failed", error.message);
     },
   });
@@ -110,65 +171,92 @@ export const BlobStorageIntegrationContainer = ({
   };
 
   return (
-    <BlobStorageIntegrationForm
-      // Draft lifetime = entity identity. Deliberately NOT updatedAt:
-      // exists→exists refetches (5s status poll, post-update refetch) must
-      // not remount, so mid-save typing survives. Delete flips
-      // configured→new and remounts blank; create flips new→configured and
-      // remounts from the saved row (clearing stale dirty flags).
-      key={`${projectId}:${config ? "configured" : "new"}`}
-      initialValues={buildBlobStorageFormValues(
-        config ?? undefined,
-        availability,
+    <>
+      {hasDrift && (
+        <Alert className="mb-4">
+          <AlertTitle>Configuration changed elsewhere</AlertTitle>
+          <AlertDescription>
+            The saved configuration was updated in another tab or by another
+            user. Your unsaved edits are kept until you reload.
+            <div className="mt-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() =>
+                  setSnapshot({
+                    identity,
+                    updatedAt: config?.updatedAt ?? null,
+                    epoch: snapshot.epoch + 1,
+                  })
+                }
+              >
+                Reload form (discards unsaved edits)
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
       )}
-      availability={availability}
-      persistedExportSource={config?.exportSource}
-      isParquetOverride={parquetEnabledFromTuning(config?.exportTuning)}
-      isSaving={mut.isPending}
-      onSubmit={handleSubmit}
-    >
-      <Button
-        variant="secondary"
-        loading={mutValidate.isPending}
-        disabled={!config}
-        title="Test your saved configuration by uploading a small test file to your storage"
-        onClick={() => {
-          mutValidate.mutate({ projectId });
-        }}
+      <BlobStorageIntegrationForm
+        // Draft lifetime = entity identity (+ explicit reload epoch).
+        // Deliberately NOT updatedAt: exists→exists refetches (5s status
+        // poll, post-update refetch) must not remount, so mid-save typing
+        // survives. Delete flips configured→new and remounts blank; create
+        // flips new→configured and remounts from the saved row (clearing
+        // stale dirty flags).
+        key={`${identity}:${snapshot.epoch}`}
+        initialValues={buildBlobStorageFormValues(
+          config ?? undefined,
+          availability,
+        )}
+        availability={availability}
+        persistedExportSource={config?.exportSource}
+        isParquetOverride={parquetEnabledFromTuning(config?.exportTuning)}
+        isSaving={mut.isPending}
+        onSubmit={handleSubmit}
       >
-        Validate
-      </Button>
-      <Button
-        variant="secondary"
-        loading={mutRunNow.isPending}
-        disabled={!config?.enabled}
-        title="Trigger an immediate export of all data since the last sync"
-        onClick={() => {
-          if (
-            confirm(
-              "Are you sure you want to run the blob storage export now? This will export all data since the last sync.",
+        <Button
+          variant="secondary"
+          loading={mutValidate.isPending}
+          disabled={!config}
+          title="Test your saved configuration by uploading a small test file to your storage"
+          onClick={() => {
+            mutValidate.mutate({ projectId });
+          }}
+        >
+          Validate
+        </Button>
+        <Button
+          variant="secondary"
+          loading={mutRunNow.isPending}
+          disabled={!config?.enabled}
+          title="Trigger an immediate export of all data since the last sync"
+          onClick={() => {
+            if (
+              confirm(
+                "Are you sure you want to run the blob storage export now? This will export all data since the last sync.",
+              )
             )
-          )
-            mutRunNow.mutate({ projectId });
-        }}
-      >
-        Run Now
-      </Button>
-      <Button
-        variant="ghost"
-        loading={mutDelete.isPending}
-        disabled={!config}
-        onClick={() => {
-          if (
-            confirm(
-              "Are you sure you want to reset the Blob Storage integration for this project?",
+              mutRunNow.mutate({ projectId });
+          }}
+        >
+          Run Now
+        </Button>
+        <Button
+          variant="ghost"
+          loading={mutDelete.isPending}
+          disabled={!config}
+          onClick={() => {
+            if (
+              confirm(
+                "Are you sure you want to reset the Blob Storage integration for this project?",
+              )
             )
-          )
-            mutDelete.mutate({ projectId });
-        }}
-      >
-        Reset
-      </Button>
-    </BlobStorageIntegrationForm>
+              mutDelete.mutate({ projectId });
+          }}
+        >
+          Reset
+        </Button>
+      </BlobStorageIntegrationForm>
+    </>
   );
 };

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -67,23 +67,46 @@ export const BlobStorageIntegrationContainer = ({
   );
 
   // Concurrent-edit drift detection. The form freezes a snapshot at mount;
-  // `snapshot` records which entity identity and updatedAt that snapshot was
-  // built from. A differing refetched updatedAt on the SAME identity means
-  // someone else saved — surface a banner, never discard the draft without
-  // an explicit click. `epoch` remounts the form on that click.
+  // `snapshot` records the entity identity and the user-configurable field
+  // values that snapshot was built from. Drift compares those FORM VALUES,
+  // not `updatedAt`: Prisma's @updatedAt bumps on every worker status write
+  // (runStartedAt, lastSyncAt, nextSyncAt, lastError — many times per sync,
+  // exactly while the 5s poll is active), so timestamps alone would banner
+  // on every active sync with no concurrent editor. A differing refetched
+  // value set on the SAME identity means someone else saved — surface a
+  // banner, never discard the draft without an explicit click. `epoch`
+  // remounts the form on that click.
   const identity = `${projectId}:${config ? "configured" : "new"}`;
+  const comparableConfigValues = (
+    c: Partial<BlobStorageIntegration> | null,
+  ) => {
+    const v = buildBlobStorageFormValues(c ?? undefined, availability);
+    // Field-group order is a persistence detail, not a config difference.
+    return JSON.stringify({
+      ...v,
+      exportFieldGroups: [...(v.exportFieldGroups ?? [])].sort(),
+    });
+  };
   const [snapshot, setSnapshot] = useState<{
     identity: string;
     updatedAt: Date | null;
+    values: string;
     epoch: number;
-  }>({ identity, updatedAt: config?.updatedAt ?? null, epoch: 0 });
+  }>({
+    identity,
+    updatedAt: config?.updatedAt ?? null,
+    values: comparableConfigValues(config),
+    epoch: 0,
+  });
   // Own-save tracking. `inFlight` is set from onMutate so a poll refetch
   // that races ahead of the mutation response cannot flash the banner for
-  // the user's own change. onSuccess records the exact updatedAt the save
-  // wrote, and ONLY that value is adopted silently (remount from the saved
-  // row, clearing dirty flags) — any other new updatedAt is a genuine
-  // concurrent edit and still banners, so a leftover expectation can never
-  // swallow an external edit.
+  // the user's own change. onSuccess records the updatedAt the save wrote;
+  // any refetch at or after it (>= — worker status writes may bump the row
+  // again before our refetch lands) is adopted silently: remount from the
+  // saved row, clearing dirty flags. A value change WITHOUT a pending
+  // expectation is a genuine concurrent edit and banners, so a leftover
+  // expectation cannot swallow an external edit that arrives after the
+  // post-save refetch has cleared it.
   const [selfSave, setSelfSave] = useState<{
     inFlight: boolean;
     expectedUpdatedAt: number | null;
@@ -92,7 +115,12 @@ export const BlobStorageIntegrationContainer = ({
   // Render-phase state adjustment (React's derive-state-from-props pattern):
   // identity changes rebaseline the snapshot before anything is compared.
   if (snapshot.identity !== identity) {
-    setSnapshot({ identity, updatedAt: config?.updatedAt ?? null, epoch: 0 });
+    setSnapshot({
+      identity,
+      updatedAt: config?.updatedAt ?? null,
+      values: comparableConfigValues(config),
+      epoch: 0,
+    });
     if (selfSave.inFlight || selfSave.expectedUpdatedAt != null)
       setSelfSave({ inFlight: false, expectedUpdatedAt: null });
   }
@@ -100,31 +128,25 @@ export const BlobStorageIntegrationContainer = ({
   const configUpdatedAt = config?.updatedAt
     ? new Date(config.updatedAt).getTime()
     : null;
-  const snapshotUpdatedAt = snapshot.updatedAt
-    ? new Date(snapshot.updatedAt).getTime()
-    : null;
-  const updatedAtChanged =
+  const valuesChanged =
     snapshot.identity === identity &&
-    configUpdatedAt != null &&
-    snapshotUpdatedAt != null &&
-    configUpdatedAt !== snapshotUpdatedAt;
-
-  if (
-    updatedAtChanged &&
+    comparableConfigValues(config) !== snapshot.values;
+  const adoptingSelfSave =
+    snapshot.identity === identity &&
     selfSave.expectedUpdatedAt != null &&
-    configUpdatedAt === selfSave.expectedUpdatedAt
-  ) {
+    configUpdatedAt != null &&
+    configUpdatedAt >= selfSave.expectedUpdatedAt;
+
+  if (adoptingSelfSave) {
     setSnapshot({
       identity,
       updatedAt: config?.updatedAt ?? null,
+      values: comparableConfigValues(config),
       epoch: snapshot.epoch + 1,
     });
     setSelfSave({ inFlight: false, expectedUpdatedAt: null });
   }
-  const hasDrift =
-    updatedAtChanged &&
-    !selfSave.inFlight &&
-    configUpdatedAt !== selfSave.expectedUpdatedAt;
+  const hasDrift = valuesChanged && !selfSave.inFlight && !adoptingSelfSave;
 
   const utils = api.useUtils();
   // invalidate() stays unguarded everywhere: the query cache is keyed per
@@ -213,6 +235,7 @@ export const BlobStorageIntegrationContainer = ({
                   setSnapshot({
                     identity,
                     updatedAt: config?.updatedAt ?? null,
+                    values: comparableConfigValues(config),
                     epoch: snapshot.epoch + 1,
                   })
                 }

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -77,16 +77,24 @@ export const BlobStorageIntegrationContainer = ({
     updatedAt: Date | null;
     epoch: number;
   }>({ identity, updatedAt: config?.updatedAt ?? null, epoch: 0 });
-  // Set on own-save success so the resulting updatedAt bump is adopted
-  // (remount from the just-saved row, clearing dirty flags) instead of
-  // showing the banner against the user's own change.
-  const [pendingSelfSave, setPendingSelfSave] = useState(false);
+  // Own-save tracking. `inFlight` is set from onMutate so a poll refetch
+  // that races ahead of the mutation response cannot flash the banner for
+  // the user's own change. onSuccess records the exact updatedAt the save
+  // wrote, and ONLY that value is adopted silently (remount from the saved
+  // row, clearing dirty flags) — any other new updatedAt is a genuine
+  // concurrent edit and still banners, so a leftover expectation can never
+  // swallow an external edit.
+  const [selfSave, setSelfSave] = useState<{
+    inFlight: boolean;
+    expectedUpdatedAt: number | null;
+  }>({ inFlight: false, expectedUpdatedAt: null });
 
   // Render-phase state adjustment (React's derive-state-from-props pattern):
   // identity changes rebaseline the snapshot before anything is compared.
   if (snapshot.identity !== identity) {
     setSnapshot({ identity, updatedAt: config?.updatedAt ?? null, epoch: 0 });
-    if (pendingSelfSave) setPendingSelfSave(false);
+    if (selfSave.inFlight || selfSave.expectedUpdatedAt != null)
+      setSelfSave({ inFlight: false, expectedUpdatedAt: null });
   }
 
   const configUpdatedAt = config?.updatedAt
@@ -101,27 +109,46 @@ export const BlobStorageIntegrationContainer = ({
     snapshotUpdatedAt != null &&
     configUpdatedAt !== snapshotUpdatedAt;
 
-  if (updatedAtChanged && pendingSelfSave) {
+  if (
+    updatedAtChanged &&
+    selfSave.expectedUpdatedAt != null &&
+    configUpdatedAt === selfSave.expectedUpdatedAt
+  ) {
     setSnapshot({
       identity,
       updatedAt: config?.updatedAt ?? null,
       epoch: snapshot.epoch + 1,
     });
-    setPendingSelfSave(false);
+    setSelfSave({ inFlight: false, expectedUpdatedAt: null });
   }
-  const hasDrift = updatedAtChanged && !pendingSelfSave;
+  const hasDrift =
+    updatedAtChanged &&
+    !selfSave.inFlight &&
+    configUpdatedAt !== selfSave.expectedUpdatedAt;
 
   const utils = api.useUtils();
   // invalidate() stays unguarded everywhere: the query cache is keyed per
   // projectId, so refreshing the fired-for project in the background is
   // correct even after a switch.
   const mut = api.blobStorageIntegration.update.useMutation({
-    onSuccess: (_data, variables) => {
+    onMutate: () => {
+      setSelfSave({ inFlight: true, expectedUpdatedAt: null });
+    },
+    onSuccess: (data, variables) => {
       utils.blobStorageIntegration.invalidate();
-      if (variables.projectId !== projectIdRef.current) return; // stale
-      setPendingSelfSave(true);
+      if (variables.projectId !== projectIdRef.current) {
+        setSelfSave({ inFlight: false, expectedUpdatedAt: null }); // stale
+        return;
+      }
+      setSelfSave({
+        inFlight: false,
+        expectedUpdatedAt: data?.updatedAt
+          ? new Date(data.updatedAt).getTime()
+          : null,
+      });
     },
     onError: (error, variables) => {
+      setSelfSave({ inFlight: false, expectedUpdatedAt: null });
       if (variables.projectId !== projectIdRef.current) return; // stale
       showErrorToast("Failed to save integration", error.message);
     },

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -76,15 +76,26 @@ export const BlobStorageIntegrationContainer = ({
   // value set on the SAME identity means someone else saved — surface a
   // banner, never discard the draft without an explicit click. `epoch`
   // remounts the form on that click.
-  const identity = `${projectId}:${config ? "configured" : "new"}`;
+  // The identity treats "inputs not yet resolved" as its own state: the
+  // snapshot taken during the loading render is baked against the fallback
+  // availability (isEnrichedExportAvailable defaults false while the query
+  // loads), which would otherwise read as drift on a never-configured
+  // project once availability resolves and flips the exportSource default.
+  const inputsResolved = !isLoading && project != null;
+  const identity = inputsResolved
+    ? `${projectId}:${config ? "configured" : "new"}`
+    : "unresolved";
   const comparableConfigValues = (
     c: Partial<BlobStorageIntegration> | null,
   ) => {
     const v = buildBlobStorageFormValues(c ?? undefined, availability);
-    // Field-group order is a persistence detail, not a config difference.
     return JSON.stringify({
       ...v,
+      // Field-group order is a persistence detail, not a config difference.
       exportFieldGroups: [...(v.exportFieldGroups ?? [])].sort(),
+      // Never part of the comparison: the GET omits it, while the mutation
+      // returns the encrypted value — the two sources must normalize equal.
+      secretAccessKey: null,
     });
   };
   const [snapshot, setSnapshot] = useState<{
@@ -100,17 +111,23 @@ export const BlobStorageIntegrationContainer = ({
   });
   // Own-save tracking. `inFlight` is set from onMutate so a poll refetch
   // that races ahead of the mutation response cannot flash the banner for
-  // the user's own change. onSuccess records the updatedAt the save wrote;
-  // any refetch at or after it (>= — worker status writes may bump the row
-  // again before our refetch lands) is adopted silently: remount from the
-  // saved row, clearing dirty flags. A value change WITHOUT a pending
-  // expectation is a genuine concurrent edit and banners, so a leftover
-  // expectation cannot swallow an external edit that arrives after the
-  // post-save refetch has cleared it.
+  // the user's own change. onSuccess records the updatedAt AND the values
+  // the save wrote; a refetch is adopted silently (remount from the saved
+  // row, clearing dirty flags) only when its timestamp is at-or-after the
+  // save's (>= — worker status writes may bump the row again before our
+  // refetch lands) AND its user-configurable values equal what the save
+  // wrote. A concurrent user's save landing inside the save→refetch window
+  // fails the value check and still banners.
   const [selfSave, setSelfSave] = useState<{
     inFlight: boolean;
     expectedUpdatedAt: number | null;
-  }>({ inFlight: false, expectedUpdatedAt: null });
+    expectedValues: string | null;
+  }>({ inFlight: false, expectedUpdatedAt: null, expectedValues: null });
+  const clearedSelfSave = {
+    inFlight: false,
+    expectedUpdatedAt: null,
+    expectedValues: null,
+  };
 
   // Render-phase state adjustment (React's derive-state-from-props pattern):
   // identity changes rebaseline the snapshot before anything is compared.
@@ -122,7 +139,7 @@ export const BlobStorageIntegrationContainer = ({
       epoch: 0,
     });
     if (selfSave.inFlight || selfSave.expectedUpdatedAt != null)
-      setSelfSave({ inFlight: false, expectedUpdatedAt: null });
+      setSelfSave(clearedSelfSave);
   }
 
   const configUpdatedAt = config?.updatedAt
@@ -135,7 +152,8 @@ export const BlobStorageIntegrationContainer = ({
     snapshot.identity === identity &&
     selfSave.expectedUpdatedAt != null &&
     configUpdatedAt != null &&
-    configUpdatedAt >= selfSave.expectedUpdatedAt;
+    configUpdatedAt >= selfSave.expectedUpdatedAt &&
+    comparableConfigValues(config) === selfSave.expectedValues;
 
   if (adoptingSelfSave) {
     setSnapshot({
@@ -144,7 +162,7 @@ export const BlobStorageIntegrationContainer = ({
       values: comparableConfigValues(config),
       epoch: snapshot.epoch + 1,
     });
-    setSelfSave({ inFlight: false, expectedUpdatedAt: null });
+    setSelfSave(clearedSelfSave);
   }
   const hasDrift = valuesChanged && !selfSave.inFlight && !adoptingSelfSave;
 
@@ -154,12 +172,16 @@ export const BlobStorageIntegrationContainer = ({
   // correct even after a switch.
   const mut = api.blobStorageIntegration.update.useMutation({
     onMutate: () => {
-      setSelfSave({ inFlight: true, expectedUpdatedAt: null });
+      setSelfSave({
+        inFlight: true,
+        expectedUpdatedAt: null,
+        expectedValues: null,
+      });
     },
     onSuccess: (data, variables) => {
       utils.blobStorageIntegration.invalidate();
       if (variables.projectId !== projectIdRef.current) {
-        setSelfSave({ inFlight: false, expectedUpdatedAt: null }); // stale
+        setSelfSave(clearedSelfSave); // stale
         return;
       }
       setSelfSave({
@@ -167,10 +189,11 @@ export const BlobStorageIntegrationContainer = ({
         expectedUpdatedAt: data?.updatedAt
           ? new Date(data.updatedAt).getTime()
           : null,
+        expectedValues: data ? comparableConfigValues(data) : null,
       });
     },
     onError: (error, variables) => {
-      setSelfSave({ inFlight: false, expectedUpdatedAt: null });
+      setSelfSave(clearedSelfSave);
       if (variables.projectId !== projectIdRef.current) return; // stale
       showErrorToast("Failed to save integration", error.message);
     },
@@ -201,7 +224,7 @@ export const BlobStorageIntegrationContainer = ({
 
   // The form is never mounted before its inputs resolve, so there is no
   // mid-flight reset to protect a draft from.
-  if (isLoading || !project) {
+  if (!inputsResolved) {
     return (
       <div className="space-y-3">
         <Skeleton className="h-9 w-full" />

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -112,12 +112,14 @@ export const BlobStorageIntegrationContainer = ({
   // Own-save tracking. `inFlight` is set from onMutate so a poll refetch
   // that races ahead of the mutation response cannot flash the banner for
   // the user's own change. onSuccess records the updatedAt AND the values
-  // the save wrote; a refetch is adopted silently (remount from the saved
-  // row, clearing dirty flags) only when its timestamp is at-or-after the
-  // save's (>= — worker status writes may bump the row again before our
-  // refetch lands) AND its user-configurable values equal what the save
-  // wrote. A concurrent user's save landing inside the save→refetch window
-  // fails the value check and still banners.
+  // the save wrote; a refetch is adopted silently only when its timestamp
+  // is at-or-after the save's (>= — worker status writes may bump the row
+  // again before our refetch lands) AND its user-configurable values equal
+  // what the save wrote. Adoption ONLY rebaselines the drift snapshot — it
+  // must never bump the epoch/remount, so anything the user typed between
+  // clicking Save and the refetch landing survives. A concurrent user's
+  // save landing inside the save→refetch window fails the value check and
+  // still banners.
   const [selfSave, setSelfSave] = useState<{
     inFlight: boolean;
     expectedUpdatedAt: number | null;
@@ -160,7 +162,7 @@ export const BlobStorageIntegrationContainer = ({
       identity,
       updatedAt: config?.updatedAt ?? null,
       values: comparableConfigValues(config),
-      epoch: snapshot.epoch + 1,
+      epoch: snapshot.epoch, // rebaseline only — a bump would remount and eat post-Save typing
     });
     setSelfSave(clearedSelfSave);
   }
@@ -254,14 +256,18 @@ export const BlobStorageIntegrationContainer = ({
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={() =>
+                onClick={() => {
                   setSnapshot({
                     identity,
                     updatedAt: config?.updatedAt ?? null,
                     values: comparableConfigValues(config),
                     epoch: snapshot.epoch + 1,
-                  })
-                }
+                  });
+                  // The explicit reload acknowledges the current server
+                  // state — any leftover own-save expectation is stale and
+                  // must not silently adopt a later external change.
+                  setSelfSave(clearedSelfSave);
+                }}
               >
                 Reload form (discards unsaved edits)
               </Button>

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import {
+  AnalyticsIntegrationExportSource,
+  BlobStorageExportMode,
   BlobStorageIntegrationFileType,
   BlobStorageIntegrationType,
   type BlobStorageIntegration,
@@ -163,5 +165,88 @@ describe("BlobStorageIntegrationForm draft lifetime (keyed remount)", () => {
       }),
       expect.anything(),
     );
+  });
+
+  it("provider switch to S3-compatible reveals endpoint and force-path-style fields", async () => {
+    render(ui("p1:new", buildBlobStorageFormValues(undefined, availability)));
+    expect(screen.queryByText("Endpoint URL")).not.toBeInTheDocument();
+    expect(screen.queryByText("Force Path Style")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("combobox")[0]);
+    fireEvent.click(
+      await screen.findByRole("option", { name: "S3 Compatible Storage" }),
+    );
+
+    expect(screen.getByText("Endpoint URL")).toBeInTheDocument();
+    expect(screen.getByText("Force Path Style")).toBeInTheDocument();
+  });
+
+  it("non-Parquet file type shows the gzip toggle; Parquet hides it", () => {
+    const { rerender } = render(
+      ui(
+        "a",
+        buildBlobStorageFormValues(
+          { fileType: BlobStorageIntegrationFileType.JSONL },
+          availability,
+        ),
+      ),
+    );
+    expect(screen.getByText("Gzip Compression")).toBeInTheDocument();
+
+    rerender(ui("b", buildBlobStorageFormValues(undefined, availability)));
+    expect(screen.queryByText("Gzip Compression")).not.toBeInTheDocument();
+  });
+
+  it("custom-date export mode reveals the start date field", () => {
+    render(
+      ui(
+        "a",
+        buildBlobStorageFormValues(
+          {
+            exportMode: BlobStorageExportMode.FROM_CUSTOM_DATE,
+            exportStartDate: new Date("2025-01-01T00:00:00Z"),
+          },
+          availability,
+        ),
+      ),
+    );
+    expect(screen.getByLabelText("Export Start Date")).toHaveValue(
+      "2025-01-01",
+    );
+  });
+
+  it("blocks save when the persisted export source is not selectable (LFE-10296)", async () => {
+    const blocked: ExportSourceAvailability = {
+      eventsExportAvailable: false,
+      forceEventsExport: false,
+    };
+    const onSubmit = vi.fn();
+    render(
+      <TooltipProvider>
+        <BlobStorageIntegrationForm
+          initialValues={buildBlobStorageFormValues(
+            {
+              exportSource: AnalyticsIntegrationExportSource.EVENTS,
+              bucketName: "valid-bucket",
+            },
+            blocked,
+          )}
+          availability={blocked}
+          persistedExportSource={AnalyticsIntegrationExportSource.EVENTS}
+          isParquetOverride={false}
+          isSaving={false}
+          onSubmit={onSubmit}
+        />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText(
+        "This export source is not available on this deployment. Select an available export source to save.",
+      ),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What does this PR do?

Stacked on #14977. Ships the three agreed follow-ups from the adversarial review of the blob storage settings refactor; the disposable form layer is untouched — everything lands in the container.

1. **Stale cross-project mutation feedback guarded.** The container survives a client-side project switch, so a mutation fired under project A that resolves after switching used to toast on project B's screen. Callbacks now compare the projectId they were fired with against the live prop and skip UI feedback when stale. Cache invalidation stays unguarded on purpose — it is keyed per projectId, so refreshing A's cache entry in the background remains correct.
2. **Real component test coverage.** Container-level tests with the tRPC boundary mocked (loading gate, delete-flow remount, project-switch isolation, post-create remount, stale-toast guard, drift banner, own-save suppression) plus form-level tests for conditional fields (provider switch, gzip toggle, custom start date) and the LFE-10296 blocked-save path. This addresses the review finding that the previously cited tests were pre-existing pure-helper tests that could not fail on component mistakes.
3. **Concurrent-edit drift banner (non-destructive).** The form freezes a snapshot at mount; the container records the user-configurable field values that snapshot was built from. A refetch whose form-bound values differ on the same entity identity (someone else saved) shows a banner — deliberately NOT keyed on `updatedAt`, which Prisma bumps on every worker status write (review finding; a timestamp signal would banner on every active sync) — the draft is kept intact until the user explicitly clicks "Reload form (discards unsaved edits)", which bumps a key epoch and remounts from the latest values. The user's own save is recognized via the mutation's returned `updatedAt` (marked in-flight from `onMutate` so racing poll responses can't flash the banner); any refetch at-or-after that value whose form-bound values match the save is adopted silently by rebaselining the drift snapshot only — the mounted draft is never remounted, so typing that continued past Save survives; the explicit Reload click clears any pending own-save expectation. Identity changes rebaseline the snapshot so the banner never fires against a stale baseline. Note: drift is detected on whatever refetch occurs (5s running/queued status poll, post-mutation invalidation) — the page intentionally does not poll otherwise.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How should this be tested?

- `pnpm --filter web run test-client src/features/blobstorage-integration` — `Tests 54 passed (54)` (16 component tests: 9 form + 7 container; 38 pre-existing helper tests).
- `pnpm turbo run lint typecheck --filter=web` — `Tasks: 6 successful, 6 total`.
- Manual browser verification on local seed data: saved an integration, forced queued status so the 5s poll runs, dirtied the bucket field, then bumped `bucket_name`/`updated_at` in Postgres to simulate another tab → banner appeared within one poll cycle with the draft intact; "Reload form" showed the external values and cleared the banner; a subsequent own save (with the poll still running) adopted silently with no banner and the form remounted from the saved row.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My changes require a change to the documentation
- [ ] I have updated the documentation accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds concurrent-edit drift detection and stale-mutation guards to `BlobStorageIntegrationContainer`. When a background refetch brings a newer `updatedAt` for the same entity, a non-destructive banner is surfaced and the user's draft is preserved until they explicitly reload. Mutation callbacks for the user's own save now set a `pendingSelfSave` flag so the resulting `updatedAt` bump silently remounts the form rather than triggering the banner.

- `BlobStorageIntegrationContainer.tsx`: introduces `snapshot`/`pendingSelfSave` state, render-phase derive-from-props rebaseline on identity change, `projectIdRef` stale-guard for `update` and `validate` mutation callbacks, epoch-keyed form remount, and the drift `Alert` UI.
- Two new test files cover the container's state machine (loading gate, project switch, delete, post-create, drift banner, own-save, stale mutation guard) and four additional form-level behaviors (S3-compatible field reveal, gzip toggle, custom-date export mode, blocked export-source validation).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the state machine correctly handles all main lifecycle events and is well-tested.

The drift detection design is sound and the test suite is thorough. Two narrow edge cases exist: the 5 s background poll could briefly flash the drift banner on the user's own save, and a stuck pendingSelfSave flag could silently absorb a later concurrent edit without surfacing the banner.

BlobStorageIntegrationContainer.tsx — specifically the pendingSelfSave / updatedAtChanged interaction and the render-phase state transitions.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx:104-112
**Narrow race: poll refetch can arrive before `onSuccess` sets `pendingSelfSave`**

`utils.blobStorageIntegration.invalidate()` is called on line 120, and `setPendingSelfSave(true)` is called immediately after — both in the same synchronous `onSuccess` callback. This is the safe common path. However, if the 5 s background poll fires AND resolves *after* the save completes on the server but *before* the mutation's `onSuccess` has been processed by React, the new `updatedAt` arrives while `pendingSelfSave` is still `false`, causing `hasDrift = true` and briefly flashing the drift banner — which then self-corrects once `onSuccess` does run and the epoch bumps. The banner should not appear for the user's own save.

### Issue 2 of 2
web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx:104-110
**`pendingSelfSave` stuck true can silently consume a concurrent edit**

If `setPendingSelfSave(true)` is set in `onSuccess` but the subsequent refetch (triggered by `invalidate()`) fails or returns the same `updatedAt` (e.g., optimistic caching), `pendingSelfSave` stays `true` indefinitely. In that state, the next external edit that arrives via the background poll (`updatedAtChanged = true`, `pendingSelfSave = true`) will satisfy the condition on line 104 and silently bump the epoch, remounting the form without ever showing the drift banner to the user. A timeout-based reset of `pendingSelfSave` (e.g., using a `useEffect` with a TTL) would close this window.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(blobstorage): drift banner + stale-..."](https://github.com/langfuse/langfuse/commit/3f74f05159fdcf9d32e3896731efc54312395927) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43290169)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

