### PR TITLE
fix(web): honor date-range window in eval preview tables

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -537,8 +537,13 @@ export default function ObservationsTable({
     modelIdFilter,
   );
 
-  // Use external filter state if provided, otherwise use combined filter state
-  const filterState = externalFilterState || combinedFilterState;
+  // Use external filter state if provided, otherwise use combined filter
+  // state. Even with an external filter, still apply the date-range bound so
+  // callers that pass an externalDateRange (e.g. the eval preview's "last 24
+  // hours" window) have it honored for the row query, not just score columns.
+  const filterState = externalFilterState
+    ? externalFilterState.concat(dateRangeFilter)
+    : combinedFilterState;
 
   const backendFilterState = transformFiltersForBackend(
     filterState,

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -398,8 +398,13 @@ export default function TracesTable({
     dateRangeFilter,
   );
 
-  // Use external filter state if provided, otherwise use combined filter state
-  const filterState = externalFilterState || combinedFilterState;
+  // Use external filter state if provided, otherwise use combined filter
+  // state. Even with an external filter, still apply the date-range bound so
+  // callers that pass an externalDateRange (e.g. the eval preview's "last 24
+  // hours" window) have it honored for the row query, not just score columns.
+  const filterState = externalFilterState
+    ? externalFilterState.concat(dateRangeFilter)
+    : combinedFilterState;
 
   const [paginationState, setPaginationState] = usePaginationState(0, 50, {
     page: "pageIndex",

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -615,8 +615,13 @@ export default function ObservationsEventsTable({
     .concat(userIdFilter)
     .concat(sessionIdFilter);
 
-  // Use external filter state if provided, otherwise use combined filter state
-  const filterState = externalFilterState || combinedFilterState;
+  // Use external filter state if provided, otherwise use combined filter
+  // state. Even with an external filter, still apply the date-range bound so
+  // callers that pass an externalDateRange (e.g. the eval preview's "last 24
+  // hours" window) have it honored for the row query, not just score columns.
+  const filterState = externalFilterState
+    ? externalFilterState.concat(dateRangeFilter)
+    : combinedFilterState;
 
   // Use the custom hook for observations data fetching
   const {


### PR DESCRIPTION
## Problem

Reported via support (Slack, HIPAA cloud): the evaluator config preview labeled **"Sample over the last 24 hours that match filters"** surfaces events far older than 24h — a customer saw traces up to ~2 weeks old.

## Root cause

The preview passes both `externalFilterState` (the evaluator's filters) and `externalDateRange` (last 24h) to the Events / Traces / Observations tables. All three tables collapsed the filter with:

```ts
const filterState = externalFilterState || combinedFilterState;
```

The 24h `startTime` bound (`dateRangeFilter`) is only concatenated into `combinedFilterState`. Because an array is always truthy — **even `[]`** — `externalFilterState` always wins and the 24h bound is discarded. The eval form always passes a defined filter array (`form.watch("filter") ?? EMPTY_FILTER_STATE`), so the window was dropped **unconditionally**, regardless of whether the evaluator had filters.

Nothing downstream re-adds a lower time bound: the tRPC `events.all` handler and `getEventList` pass the filter straight through, and the ClickHouse row query applies only the filters it's given (the 30-day default lookback exists only for `filterOptions` dropdowns). So the row query ran unbounded — `ORDER BY startTime DESC LIMIT 10` — returning the most-recent matching events regardless of age. `externalDateRange` was still applied to the score columns' `fromTimestamp`, which is why it looked half-working.

This is display-only: the evaluator's actual sampling is unaffected.

## Fix

Apply `dateRangeFilter` to the external filter state too, so the row query honors the caller-provided window:

```ts
const filterState = externalFilterState
  ? externalFilterState.concat(dateRangeFilter)
  : combinedFilterState;
```

Applied to all three preview tables (`EventsTable.tsx`, `traces.tsx`, `observations.tsx`), which share the identical bug.

## Blast radius

The **only** caller anywhere that passes `externalFilterState` is the eval form (`inner-evaluator-form.tsx`), and it always passes `externalDateRange` alongside it. Every other consumer (traces page, observations pages, users, prompts, models) uses the in-table controls and hits the unchanged `: combinedFilterState` branch, so no other view changes.

## Verification

- `turbo run lint` — `Tasks: 8 successful, 8 total` (via pre-commit hook).
- Typecheck: change is a `.concat` of two `FilterState` arrays (type-safe by construction); the three changed files introduce no new type errors. (Full-package `typecheck` currently reports pre-existing errors in unrelated files from stale local build artifacts after the recent pull — same set present on a clean tree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a display bug in the evaluator config's preview tables where the "last 24 hours" date window was silently discarded. The `externalFilterState || combinedFilterState` expression always evaluated to `externalFilterState` even when it was an empty array `[]`, since arrays are truthy — causing the `dateRangeFilter` (which is part of `combinedFilterState` but not the external path) to be dropped for the row query entirely.

- The fix is applied consistently to all three preview tables (`TracesTable`, `ObservationsTable`, `EventsTable`) by concatenating `dateRangeFilter` onto `externalFilterState` when it is present, so the 24h bound is honored in the row query rather than only in score-column `fromTimestamp` logic.
- The blast radius is narrow: the only caller passing `externalFilterState` is `inner-evaluator-form.tsx`, which always co-passes `externalDateRange`, so the normal table views (no `externalFilterState`) are unaffected and hit the unchanged `combinedFilterState` branch.
- The evaluator's actual sampling is not affected — this is display-only in the preview UI.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrowly scoped to the eval preview path and does not touch any data-mutating logic or the evaluator's actual sampling pipeline.

All three table components receive an identical, symmetric fix. The dateRangeFilter is already computed correctly from externalDateRange before the ternary, so concatenating it onto externalFilterState adds the 24h bound exactly once with no duplication risk. The combinedFilterState branch (used by every other consumer) is untouched. The only caller that can reach the external-filter branch is inner-evaluator-form.tsx, which always supplies both externalFilterState and externalDateRange together.

No files require special attention. All three changed files apply the same minimal, targeted fix.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Form as inner-evaluator-form.tsx
    participant Table as TracesTable / ObservationsTable / EventsTable
    participant tRPC as tRPC handler
    participant CH as ClickHouse

    Form->>Table: "externalFilterState=[] (or user filters), externalDateRange={from: now-24h}"

    Note over Table: dateRangeFilter derived from externalDateRange (startTime >= now-24h)

    alt BEFORE fix (bug)
        Table->>Table: "filterState = externalFilterState OR combinedFilterState"
        Note over Table: [] is truthy, picks externalFilterState, dateRangeFilter DROPPED
        Table->>tRPC: "filter = externalFilterState (no date bound)"
        tRPC->>CH: ORDER BY startTime DESC LIMIT 10 (unbounded)
        CH-->>Form: rows up to weeks old
    end

    alt AFTER fix
        Table->>Table: "filterState = externalFilterState.concat(dateRangeFilter)"
        Table->>tRPC: "filter = externalFilterState + [startTime >= now-24h]"
        tRPC->>CH: "WHERE startTime >= now-24h ORDER BY startTime DESC LIMIT 10"
        CH-->>Form: rows from last 24h only
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Form as inner-evaluator-form.tsx
    participant Table as TracesTable / ObservationsTable / EventsTable
    participant tRPC as tRPC handler
    participant CH as ClickHouse

    Form->>Table: "externalFilterState=[] (or user filters), externalDateRange={from: now-24h}"

    Note over Table: dateRangeFilter derived from externalDateRange (startTime >= now-24h)

    alt BEFORE fix (bug)
        Table->>Table: "filterState = externalFilterState OR combinedFilterState"
        Note over Table: [] is truthy, picks externalFilterState, dateRangeFilter DROPPED
        Table->>tRPC: "filter = externalFilterState (no date bound)"
        tRPC->>CH: ORDER BY startTime DESC LIMIT 10 (unbounded)
        CH-->>Form: rows up to weeks old
    end

    alt AFTER fix
        Table->>Table: "filterState = externalFilterState.concat(dateRangeFilter)"
        Table->>tRPC: "filter = externalFilterState + [startTime >= now-24h]"
        tRPC->>CH: "WHERE startTime >= now-24h ORDER BY startTime DESC LIMIT 10"
        CH-->>Form: rows from last 24h only
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): honor date-range window in eva..."](https://github.com/langfuse/langfuse/commit/1f0e208c3d400f64421ad36cadf2ae011966bebb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43293309)</sub>

<!-- /greptile_comment -->