### PR TITLE
chore(web): Disable unused tailwind color palettes

### DIFF
--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -10,6 +10,19 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme inline {
+  /* Disable unused built-in Tailwind color palettes. */
+  --color-lime-*: initial;
+  --color-cyan-*: initial;
+  --color-sky-*: initial;
+  --color-fuchsia-*: initial;
+  --color-rose-*: initial;
+  --color-neutral-*: initial;
+  --color-stone-*: initial;
+  --color-slate-*: initial;
+
+  /* TODO: Disable the remaining default palettes: red, orange, amber, yellow,
+     green, emerald, teal, blue, indigo, violet, purple, pink, gray, zinc. */
+
   --spacing-banner-offset: var(--banner-offset);
   --spacing-screen-with-banner: calc(100svh - var(--banner-offset));
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables eleven Tailwind color palettes (`lime`, `cyan`, `sky`, `fuchsia`, `rose`, `neutral`, `stone`, `mauve`, `olive`, `mist`, `taupe`) in `globals.css` by setting their theme variables to `initial`, preventing Tailwind CSS v4 from generating the corresponding utility classes and CSS custom properties, which reduces the CSS output bundle size.

- The wildcard `--color-<palette>-*: initial` approach is the correct Tailwind v4 mechanism for unregistering built-in color scales, and no usage of these color names was found anywhere in `web/src`.
- Four of the disabled palettes (`mauve`, `olive`, `mist`, `taupe`) are not part of Tailwind v4's built-in color set, so those entries are effectively no-ops; they may be vestigial or anticipatory.
- A `TODO` comment documents the remaining standard palettes still to be removed in a follow-up.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This change is safe to merge — it removes unused color palettes from the Tailwind theme configuration with no source-level usage found.

The disabled palettes have no usage in web/src. The four additional entries (mauve, olive, mist, taupe) are not Tailwind v4 built-ins, making those resets no-ops. The only external consideration is the two @source-referenced packages (@ferrucc-io/emoji-picker and streamdown), which are scanned for Tailwind class names — but these packages are unlikely to reference raw Tailwind color palette utilities, and the author appears to have verified usage before making this change.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["globals.css @theme inline"] --> B{Color palette defined?}
    B -- "lime, cyan, sky, fuchsia, rose\nneutral, stone → initial" --> C["❌ Variable unregistered\n(no CSS custom props generated)"]
    B -- "mauve, olive, mist, taupe → initial" --> D["⚠️ No-op\n(not a Tailwind v4 built-in)"]
    B -- "red, orange, amber, yellow,\ngreen, emerald, teal, blue,\nindigo, violet, purple, pink,\nslate, gray, zinc (TODO)" --> E["✅ CSS custom props generated\neg. --color-blue-500"]
    C --> F["Tailwind does not emit utility classes\neg. bg-cyan-400 not in output CSS"]
    E --> G["Utility classes available\neg. bg-blue-500"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["globals.css @theme inline"] --> B{Color palette defined?}
    B -- "lime, cyan, sky, fuchsia, rose\nneutral, stone → initial" --> C["❌ Variable unregistered\n(no CSS custom props generated)"]
    B -- "mauve, olive, mist, taupe → initial" --> D["⚠️ No-op\n(not a Tailwind v4 built-in)"]
    B -- "red, orange, amber, yellow,\ngreen, emerald, teal, blue,\nindigo, violet, purple, pink,\nslate, gray, zinc (TODO)" --> E["✅ CSS custom props generated\neg. --color-blue-500"]
    C --> F["Tailwind does not emit utility classes\neg. bg-cyan-400 not in output CSS"]
    E --> G["Utility classes available\neg. bg-blue-500"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(web): Disable unused tailwind colo..."](https://github.com/langfuse/langfuse/commit/cf2d4ba9b93a4d3b128de51fbd4945188372212f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43300783)</sub>

<!-- /greptile_comment -->