### PR TITLE
fix(web): Remove usages of slate- color classes

### DIFF
--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -46,7 +46,7 @@ const CommandDialog = ({
       <DialogContent
         className={cn(
           commandDialogSurfaceClass,
-          "top-[calc(var(--banner-offset)+clamp(4rem,14dvh,8rem))] translate-y-0 overflow-hidden border p-0 shadow-2xl dark:border-slate-700/70 dark:shadow-[0_32px_96px_-28px_rgb(0_0_0/0.95),0_16px_40px_-24px_rgb(0_0_0/0.9),0_0_0_1px_rgb(148_163_184/0.1)]",
+          "dark:border-border-contrast/70 top-[calc(var(--banner-offset)+clamp(4rem,14dvh,8rem))] translate-y-0 overflow-hidden border p-0 shadow-2xl dark:shadow-[0_32px_96px_-28px_rgb(0_0_0/0.95),0_16px_40px_-24px_rgb(0_0_0/0.9),0_0_0_1px_rgb(148_163_184/0.1)]",
         )}
         closeOnInteractionOutside
         overlayMode="invisible"

--- a/web/src/components/ui/input-command.tsx
+++ b/web/src/components/ui/input-command.tsx
@@ -22,7 +22,7 @@ const InputCommand = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "flex h-full w-full flex-col overflow-hidden rounded-md bg-white text-slate-950 dark:bg-slate-950 dark:text-slate-50",
+      "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
       className,
     )}
     {...props}
@@ -40,7 +40,7 @@ const InputCommandDialog = ({
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
         <DialogBody>
-          <InputCommand className="[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-slate-500 dark:**:[[cmdk-group-heading]]:text-slate-400 **:[[cmdk-group]]:px-2 **:[[cmdk-input]]:h-12 **:[[cmdk-item]]:px-2 **:[[cmdk-item]]:py-3">
+          <InputCommand className="**:[[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group]]:px-2 **:[[cmdk-input]]:h-12 **:[[cmdk-item]]:px-2 **:[[cmdk-item]]:py-3">
             {children}
           </InputCommand>
         </DialogBody>
@@ -67,7 +67,7 @@ const InputCommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-8 w-full rounded border-transparent bg-transparent py-3 text-sm outline-hidden placeholder:text-slate-500 focus:border-0 focus:border-none focus:border-transparent focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-slate-400",
+        "placeholder:text-foreground-tertiary flex h-8 w-full rounded border-transparent bg-transparent py-3 text-sm outline-hidden focus:border-0 focus:border-none focus:border-transparent focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}
@@ -110,7 +110,7 @@ const InputCommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      "overflow-hidden p-1 text-slate-950 dark:text-slate-50 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-slate-500 dark:**:[[cmdk-group-heading]]:text-slate-400",
+      "text-foreground **:[[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium",
       className,
     )}
     {...props}
@@ -125,7 +125,7 @@ const InputCommandSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 h-px bg-slate-200 dark:bg-slate-800", className)}
+    className={cn("bg-border -mx-1 h-px", className)}
     {...props}
   />
 ));
@@ -138,7 +138,7 @@ const InputCommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none aria-selected:bg-slate-100 aria-selected:text-slate-900 dark:aria-selected:bg-slate-800 dark:aria-selected:text-slate-50",
+      "aria-selected:bg-accent aria-selected:text-accent-foreground relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none",
       className,
     )}
     {...props}

--- a/web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
+++ b/web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
@@ -125,7 +125,7 @@ export const CreateNewAnnotationQueueItem = ({
           {queues.data?.totalCount ? (
             <span className="relative mr-1 text-xs">
               <ChevronDown className="text-secondary-foreground h-3 w-3" />
-              <span className="absolute -top-1 left-2.5 flex h-3 min-w-3 items-center justify-center rounded-sm bg-slate-600 px-0.5 text-[8px] font-medium text-white shadow-xs">
+              <span className="bg-primary text-primary-foreground absolute -top-1 left-2.5 flex h-3 min-w-3 items-center justify-center rounded-sm px-0.5 text-[8px] font-medium shadow-xs">
                 {queues.data?.totalCount > 99 ? "99+" : queues.data?.totalCount}
               </span>
             </span>

--- a/web/src/features/experiments/components/table/types.ts
+++ b/web/src/features/experiments/components/table/types.ts
@@ -6,9 +6,8 @@ import { type ReactNode } from "react";
 export const EXPERIMENT_COLOR_STYLES = [
   {
     textClass: "text-dark-gray",
-    markerClass: "bg-slate-500 dark:bg-slate-400",
-    badgeClass:
-      "border-slate-400/80 bg-slate-100/70 text-slate-700 dark:border-slate-500/70 dark:bg-slate-900/60 dark:text-slate-300",
+    markerClass: "bg-muted-foreground",
+    badgeClass: "border-border-contrast/80 bg-muted/70 text-foreground/80",
   }, // Baseline - index 0
   {
     textClass: "text-blue-700 dark:text-blue-300",

--- a/web/src/features/monitors/components/MonitorForm.tsx
+++ b/web/src/features/monitors/components/MonitorForm.tsx
@@ -1037,7 +1037,7 @@ const NoDataField = ({
             Keep the previous
             <Badge
               variant="secondary"
-              className="w-20 justify-center bg-slate-500 py-1 text-slate-50 hover:bg-slate-500"
+              className="bg-muted-foreground text-background hover:bg-muted-foreground w-20 justify-center py-1"
             >
               SEVERITY
             </Badge>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces hardcoded `slate-*` Tailwind color classes with semantic design-token CSS variables across five UI files, improving theme adaptability. All referenced tokens (`border-contrast`, `foreground-tertiary`, `muted-foreground`, `popover`, `accent`, `primary`, `background`, etc.) are confirmed defined in `globals.css`.

- **`input-command.tsx`**: All six `slate-*` usages replaced with `bg-popover/text-popover-foreground`, `text-muted-foreground`, `placeholder:text-foreground-tertiary`, `bg-border`, and `aria-selected:bg-accent/text-accent-foreground`.
- **`types.ts` & `MonitorForm.tsx`**: Dark-mode split classes (`slate-N dark:slate-M`) collapsed into single CSS-variable-backed tokens; light/dark switching is now handled automatically by the variable.
- **`CreateNewAnnotationQueueItem.tsx`**: The count-badge changes from `bg-slate-600 text-white` to `bg-primary text-primary-foreground`, which in dark mode renders as a near-white badge with very dark text — a noticeable visual shift worth verifying in both themes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Straightforward theming refactor; all replacement tokens are verified in globals.css. One badge in CreateNewAnnotationQueueItem picks up a visually inverted appearance in dark mode that is worth checking against the design intent before merging.

All five files change only CSS class strings to semantic CSS-variable-backed tokens; no logic, no data flow, and no API surface changes. Every token referenced is confirmed defined in globals.css with proper light and dark values. The only open question is whether `bg-primary` is the right semantic choice for the count badge — in dark mode, primary is near-white, producing an inverted appearance relative to the original neutral gray style.

web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx — the count badge token choice should be verified visually in dark mode.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Tailwind class applied] --> B{Hardcoded slate-* class?}
    B -->|Yes - Before PR| C[Fixed color regardless of theme]
    B -->|No - After PR| D[Semantic CSS variable token]
    D --> E{Theme mode?}
    E -->|Light mode| F[CSS var resolves to light value]
    E -->|Dark mode| G[CSS var resolves to dark value]
    C --> H[Same color in both modes]
    F --> I[Correct themed color]
    G --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Tailwind class applied] --> B{Hardcoded slate-* class?}
    B -->|Yes - Before PR| C[Fixed color regardless of theme]
    B -->|No - After PR| D[Semantic CSS variable token]
    D --> E{Theme mode?}
    E -->|Light mode| F[CSS var resolves to light value]
    E -->|Dark mode| G[CSS var resolves to dark value]
    C --> H[Same color in both modes]
    F --> I[Correct themed color]
    G --> I
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx:128-130
**Primary token visually inverts badge in dark mode**

The original badge used `bg-slate-600 text-white` (medium-dark gray, light text) without any dark-mode override — so it was identical in both themes. With `bg-primary text-primary-foreground`, the dark-mode primary resolves to `hsl(0 0% 90%)` (near-white) with `hsl(0 0% 3.5%)` (near-black) text, producing a visually inverted badge compared to the original. If the intent is a neutral indicator, `bg-muted-foreground text-background` (consistent with the MonitorForm badge approach in this same PR) or `bg-secondary text-secondary-foreground` would better preserve the neutral gray style across themes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Remove usages of slate- color ..."](https://github.com/langfuse/langfuse/commit/e6fc891192d4b93f2501d77b9c783d2734f6a66f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43302976)</sub>

<!-- /greptile_comment -->