### PR TITLE
fix(agent): Track loading state of individual events

### DIFF
--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -55,7 +55,12 @@ export function ControlledInAppAgentWindow(
 
   const drawerMessages = useMemo(
     () =>
-      getDrawerMessages({ error, isRunning, messages, pendingToolApprovals }),
+      getDrawerMessages({
+        error,
+        isRunning,
+        messages,
+        pendingToolApprovals,
+      }),
     [error, isRunning, messages, pendingToolApprovals],
   );
 

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -10,7 +10,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from "react";
-import { HttpAgent } from "@ag-ui/client";
+import { EventType, HttpAgent } from "@ag-ui/client";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { z } from "zod";
@@ -22,6 +22,7 @@ import {
   createInAppAgentMessageId,
   createInAppAgentRunId,
 } from "@/src/ee/features/in-app-agent/ids";
+import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
 import {
   AgUiMessageSchema,
   type AgUiMessage,
@@ -43,6 +44,7 @@ import {
   getInAppAgentError,
   isInAppAgentRateLimited,
 } from "@/src/ee/features/in-app-agent/components/utils/utils";
+import { type InAppAiAgentMessage } from "@/src/ee/features/in-app-agent/components/utils/utils";
 
 const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";
@@ -91,8 +93,6 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
   rejectToolCall: async () => undefined,
   submitFeedback: async () => undefined,
 };
-
-type InAppAiAgentMessage = AgUiMessage;
 
 type InAppAiAgentFeedbackByConversationId = Record<
   string,
@@ -219,7 +219,7 @@ function InAppAiAgentProviderInner({
       `${FEEDBACK_STORAGE_KEY_PREFIX}:${projectId}`,
       {},
     );
-  const [messages, setMessages] = useState<InAppAiAgentMessage[]>([]);
+  const [messages, setMessages] = useState<AgUiMessage[]>([]);
   const [pendingToolApprovals, setPendingToolApprovals] = useState<
     InAppAgentPendingToolApproval[]
   >([]);
@@ -227,6 +227,9 @@ function InAppAiAgentProviderInner({
   const [isRunning, setIsRunning] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [loadingEventIds, setLoadingEventIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const [error, setError] = useState<InAppAgentError | null>(null);
   const agentRef = useRef<HttpAgent | null>(null);
   const activeRunIdRef = useRef<string | null>(null);
@@ -265,16 +268,41 @@ function InAppAiAgentProviderInner({
   );
   const hasMoreConversations = conversationListQuery.hasNextPage === true;
   const isLoadingMoreConversations = conversationListQuery.isFetchingNextPage;
-  const messagesWithFeedback = useMemo(
-    () =>
-      mergeMessagesWithFeedback(
-        messages,
-        selectedConversationId
-          ? feedbackByConversationId[selectedConversationId]
-          : undefined,
-      ),
-    [feedbackByConversationId, messages, selectedConversationId],
-  );
+  const messagesWithUiState = useMemo(() => {
+    const messagesWithFeedback = mergeMessagesWithFeedback(
+      messages,
+      selectedConversationId
+        ? feedbackByConversationId[selectedConversationId]
+        : undefined,
+    );
+
+    return messagesWithFeedback.map((message) => {
+      if (message.role === "reasoning") {
+        return { ...message, isLoading: loadingEventIds.has(message.id) };
+      }
+
+      if (message.role !== "assistant") {
+        return message;
+      }
+
+      return {
+        ...message,
+        isLoading:
+          loadingEventIds.has(message.id) ||
+          (message.toolCalls?.some(
+            (toolCall) =>
+              toolCall.function.name !== IN_APP_AGENT_REDIRECT_TOOL_NAME &&
+              loadingEventIds.has(toolCall.id),
+          ) ??
+            false),
+      };
+    });
+  }, [
+    feedbackByConversationId,
+    loadingEventIds,
+    messages,
+    selectedConversationId,
+  ]);
   const fetchNextConversationsPage = conversationListQuery.fetchNextPage;
   const loadMoreConversations = useCallback(() => {
     if (!hasMoreConversations || isLoadingMoreConversations) {
@@ -325,24 +353,51 @@ function InAppAiAgentProviderInner({
     },
     [],
   );
+  const updateLoadingEvent = useCallback(
+    (eventId: string, isLoading: boolean) => {
+      setLoadingEventIds((currentIds) => {
+        if (currentIds.has(eventId) === isLoading) {
+          return currentIds;
+        }
 
-  const resetAgent = useCallback((options?: { preserveAgent?: boolean }) => {
-    if (options?.preserveAgent) {
-      return;
-    }
-
-    if (agentRef.current?.isRunning) {
-      intentionalAbortRef.current = true;
-    }
-
-    subscriptionRef.current?.unsubscribe();
-    subscriptionRef.current = null;
-    agentRef.current?.abortRun();
-    agentRef.current = null;
-    activeRunIdRef.current = null;
-    pendingToolApprovalsRef.current = [];
-    setPendingToolApprovals([]);
+        const nextIds = new Set(currentIds);
+        if (isLoading) {
+          nextIds.add(eventId);
+        } else {
+          nextIds.delete(eventId);
+        }
+        return nextIds;
+      });
+    },
+    [],
+  );
+  const clearLoadingEvents = useCallback(() => {
+    setLoadingEventIds((currentIds) =>
+      currentIds.size > 0 ? new Set() : currentIds,
+    );
   }, []);
+
+  const resetAgent = useCallback(
+    (options?: { preserveAgent?: boolean }) => {
+      if (options?.preserveAgent) {
+        return;
+      }
+
+      if (agentRef.current?.isRunning) {
+        intentionalAbortRef.current = true;
+      }
+
+      subscriptionRef.current?.unsubscribe();
+      subscriptionRef.current = null;
+      agentRef.current?.abortRun();
+      agentRef.current = null;
+      activeRunIdRef.current = null;
+      pendingToolApprovalsRef.current = [];
+      setPendingToolApprovals([]);
+      clearLoadingEvents();
+    },
+    [clearLoadingEvents],
+  );
 
   // Hydrate local state from the selected persisted conversation once it loads.
   useEffect(() => {
@@ -460,6 +515,42 @@ function InAppAiAgentProviderInner({
             activeRunIdRef.current = payload.event.runId;
           }
         },
+        onEvent: ({ event }) => {
+          if (
+            event.type === EventType.REASONING_MESSAGE_START ||
+            event.type === EventType.TEXT_MESSAGE_START
+          ) {
+            updateLoadingEvent(event.messageId, true);
+            return;
+          }
+
+          if (
+            event.type === EventType.REASONING_MESSAGE_END ||
+            event.type === EventType.TEXT_MESSAGE_END
+          ) {
+            updateLoadingEvent(event.messageId, false);
+            return;
+          }
+
+          if (event.type === EventType.TOOL_CALL_START) {
+            updateLoadingEvent(event.toolCallId, true);
+            return;
+          }
+
+          // TOOL_CALL_END only finishes argument streaming. The tool remains
+          // active until its result arrives.
+          if (event.type === EventType.TOOL_CALL_RESULT) {
+            updateLoadingEvent(event.toolCallId, false);
+            return;
+          }
+
+          if (
+            event.type === EventType.RUN_FINISHED ||
+            event.type === EventType.RUN_ERROR
+          ) {
+            clearLoadingEvents();
+          }
+        },
         onCustomEvent: ({ event }) => {
           const approvalRequest = parseInAppAgentInterruptEvent(event);
 
@@ -521,13 +612,13 @@ function InAppAiAgentProviderInner({
         },
       });
     },
-    [updatePendingToolApprovals],
+    [clearLoadingEvents, updateLoadingEvent, updatePendingToolApprovals],
   );
 
   const getOrCreateAgent = useCallback(
     (
       conversationId: string,
-      initialMessages: InAppAiAgentMessage[],
+      initialMessages: AgUiMessage[],
       isNewConversation: boolean,
     ) => {
       if (agentRef.current?.threadId === conversationId) {
@@ -565,6 +656,7 @@ function InAppAiAgentProviderInner({
       conversationId: string,
       runParameters?: Parameters<HttpAgent["runAgent"]>[0],
     ) => {
+      clearLoadingEvents();
       setIsRunning(true);
       return agent
         .runAgent({
@@ -598,6 +690,7 @@ function InAppAiAgentProviderInner({
         })
         .finally(() => {
           const runId = activeRunIdRef.current;
+          clearLoadingEvents();
           setIsRunning(false);
           setMessages(
             attachActiveRunIdToAssistantMessages(
@@ -617,6 +710,7 @@ function InAppAiAgentProviderInner({
     },
     [
       projectId,
+      clearLoadingEvents,
       releaseSubmitLock,
       session.data?.user?.name,
       utils.inAppAgent.getConversation,
@@ -968,7 +1062,7 @@ function InAppAiAgentProviderInner({
       pendingToolApprovals,
       isSelectedConversationHydrating,
       error,
-      messages: messagesWithFeedback,
+      messages: messagesWithUiState,
       conversations,
       hasMoreConversations,
       isLoadingMoreConversations,
@@ -994,7 +1088,7 @@ function InAppAiAgentProviderInner({
       isSubmitting,
       deleteConversation,
       loadMoreConversations,
-      messagesWithFeedback,
+      messagesWithUiState,
       open,
       pendingToolApprovals,
       rejectToolCall,
@@ -1014,18 +1108,16 @@ function InAppAiAgentProviderInner({
   );
 }
 
-function isAgentConversationMessage(
-  message: unknown,
-): message is InAppAiAgentMessage {
+function isAgentConversationMessage(message: unknown): message is AgUiMessage {
   const result = AgUiMessageSchema.safeParse(message);
 
   return result.success;
 }
 
 function getHydratedMessages(
-  localMessages: InAppAiAgentMessage[],
+  localMessages: AgUiMessage[],
   storedMessages: readonly unknown[] | undefined,
-): InAppAiAgentMessage[] {
+): AgUiMessage[] {
   if (localMessages.length > 0) {
     return localMessages;
   }
@@ -1034,9 +1126,9 @@ function getHydratedMessages(
 }
 
 function mergeMessagesWithFeedback(
-  messages: InAppAiAgentMessage[],
+  messages: AgUiMessage[],
   feedbackByMessageId: Record<string, InAppAgentMessageFeedback> | undefined,
-): InAppAiAgentMessage[] {
+): AgUiMessage[] {
   if (!feedbackByMessageId || Object.keys(feedbackByMessageId).length === 0) {
     return messages;
   }
@@ -1056,9 +1148,9 @@ function mergeMessagesWithFeedback(
 }
 
 function attachActiveRunIdToAssistantMessages(
-  messages: InAppAiAgentMessage[],
+  messages: AgUiMessage[],
   runId: string | null,
-): InAppAiAgentMessage[] {
+): AgUiMessage[] {
   if (!runId) {
     return messages;
   }

--- a/web/src/ee/features/in-app-agent/components/utils/utils.clienttest.ts
+++ b/web/src/ee/features/in-app-agent/components/utils/utils.clienttest.ts
@@ -4,6 +4,7 @@ import {
   getDrawerMessages,
   getInAppAgentError,
   isInAppAgentRateLimited,
+  type InAppAiAgentMessage,
 } from "./utils";
 
 describe("getInAppAgentError", () => {
@@ -302,8 +303,9 @@ describe("getDrawerMessages", () => {
           id: "reasoning-1",
           role: "reasoning",
           content: "Checking recent traces before querying metrics.",
+          isLoading: true,
         },
-      ] satisfies AgUiMessage[],
+      ] satisfies InAppAiAgentMessage[],
     });
 
     expect(mappedMessages).toMatchObject([
@@ -368,7 +370,7 @@ describe("getDrawerMessages", () => {
     expect(mappedMessages).toHaveLength(2);
   });
 
-  it("keeps reasoning open while later tool calls run before the assistant response", () => {
+  it("completes reasoning while a later tool call runs before the assistant response", () => {
     const mappedMessages = getDrawerMessages({
       error: null,
       isRunning: true,
@@ -382,11 +384,13 @@ describe("getDrawerMessages", () => {
           id: "reasoning-1",
           role: "reasoning",
           content: "Looking for error-level traces first.",
+          isLoading: false,
         },
         {
           id: "assistant-1",
           role: "assistant",
           content: "",
+          isLoading: true,
           toolCalls: [
             {
               id: "tool-call-1",
@@ -398,7 +402,7 @@ describe("getDrawerMessages", () => {
             },
           ],
         },
-      ] satisfies AgUiMessage[],
+      ] satisfies InAppAiAgentMessage[],
     });
 
     expect(mappedMessages).toMatchObject([
@@ -411,7 +415,7 @@ describe("getDrawerMessages", () => {
         content: {
           type: "reasoning",
           text: "Looking for error-level traces first.",
-          isStreaming: true,
+          isStreaming: false,
         },
       },
       {
@@ -424,7 +428,7 @@ describe("getDrawerMessages", () => {
     ]);
   });
 
-  it("keeps only the latest reasoning block streaming in a multi-step tool loop", () => {
+  it("keeps only the active tool loading in a multi-step tool loop", () => {
     const mappedMessages = getDrawerMessages({
       error: null,
       isRunning: true,
@@ -438,11 +442,13 @@ describe("getDrawerMessages", () => {
           id: "reasoning-1",
           role: "reasoning",
           content: "Looking for error-level traces first.",
+          isLoading: false,
         },
         {
           id: "assistant-1",
           role: "assistant",
           content: "",
+          isLoading: false,
           toolCalls: [
             {
               id: "tool-call-1",
@@ -464,11 +470,13 @@ describe("getDrawerMessages", () => {
           id: "reasoning-2",
           role: "reasoning",
           content: "The metrics query failed, retrying with a smaller window.",
+          isLoading: false,
         },
         {
           id: "assistant-2",
           role: "assistant",
           content: "",
+          isLoading: true,
           toolCalls: [
             {
               id: "tool-call-2",
@@ -480,7 +488,7 @@ describe("getDrawerMessages", () => {
             },
           ],
         },
-      ] satisfies AgUiMessage[],
+      ] satisfies InAppAiAgentMessage[],
     });
 
     expect(mappedMessages).toMatchObject([
@@ -497,18 +505,91 @@ describe("getDrawerMessages", () => {
       },
       {
         id: "tools-assistant-1",
-        content: { type: "toolGroup" },
+        content: { type: "toolGroup", isLoading: false },
       },
       {
         id: "reasoning-2",
         content: {
           type: "reasoning",
-          isStreaming: true,
+          isStreaming: false,
         },
       },
       {
         id: "tools-assistant-2",
-        content: { type: "toolGroup" },
+        content: { type: "toolGroup", isLoading: true },
+      },
+    ]);
+  });
+
+  it("keeps a tool group loading while any grouped tool call is active", () => {
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        content: "Compare trace and observation metrics",
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "tool-call-1",
+            type: "function",
+            function: {
+              name: "langfuse_queryMetrics",
+              arguments: JSON.stringify({ view: "traces" }),
+            },
+          },
+          {
+            id: "tool-call-2",
+            type: "function",
+            function: {
+              name: "langfuse_queryMetrics",
+              arguments: JSON.stringify({ view: "observations" }),
+            },
+          },
+        ],
+      },
+      {
+        id: "tool-result-1",
+        role: "tool",
+        toolCallId: "tool-call-1",
+        content: JSON.stringify({ count: 10 }),
+      },
+    ] satisfies AgUiMessage[];
+
+    const activeMessages = getDrawerMessages({
+      error: null,
+      isRunning: true,
+      messages: messages.map((message) =>
+        message.id === "assistant-1"
+          ? { ...message, isLoading: true }
+          : message,
+      ),
+    });
+    const completedMessages = getDrawerMessages({
+      error: null,
+      isRunning: true,
+      messages: messages.map((message) =>
+        message.id === "assistant-1"
+          ? { ...message, isLoading: false }
+          : message,
+      ),
+    });
+
+    expect(activeMessages).toMatchObject([
+      { id: "user-1" },
+      {
+        id: "tools-assistant-1",
+        content: { type: "toolGroup", isLoading: true },
+      },
+    ]);
+    expect(completedMessages).toMatchObject([
+      { id: "user-1" },
+      {
+        id: "tools-assistant-1",
+        content: { type: "toolGroup", isLoading: false },
       },
     ]);
   });
@@ -529,6 +610,7 @@ describe("getDrawerMessages", () => {
           id: "reasoning-empty",
           role: "reasoning",
           content: "",
+          isLoading: false,
         },
         {
           id: "assistant-1",
@@ -544,8 +626,9 @@ describe("getDrawerMessages", () => {
           id: "reasoning-live",
           role: "reasoning",
           content: "",
+          isLoading: true,
         },
-      ] satisfies AgUiMessage[],
+      ] satisfies InAppAiAgentMessage[],
     });
 
     expect(mappedMessages).toMatchObject([
@@ -700,6 +783,7 @@ describe("getDrawerMessages", () => {
           id: "assistant-1",
           role: "assistant",
           content: "",
+          isLoading: false,
           toolCalls: [
             {
               id: "tool-call-1",
@@ -721,7 +805,7 @@ describe("getDrawerMessages", () => {
           content: toolError,
           error: toolError,
         },
-      ] satisfies AgUiMessage[],
+      ] satisfies InAppAiAgentMessage[],
       pendingToolApprovals: [
         {
           id: "tool-call-1",
@@ -750,7 +834,7 @@ describe("getDrawerMessages", () => {
         role: "assistant",
         content: {
           type: "toolGroup",
-          isLoading: true,
+          isLoading: false,
           tools: [
             {
               type: "tool",

--- a/web/src/ee/features/in-app-agent/components/utils/utils.ts
+++ b/web/src/ee/features/in-app-agent/components/utils/utils.ts
@@ -18,6 +18,12 @@ export type InAppAgentError =
   | { type: "generic"; message: string }
   | { type: "rate_limit"; retryAt: number };
 
+const InAppAiAgentMessageSchema = AgUiMessageSchema.and(
+  z.object({ isLoading: z.boolean().optional() }),
+);
+
+export type InAppAiAgentMessage = z.infer<typeof InAppAiAgentMessageSchema>;
+
 export type InAppAgentToolCallContent = {
   type: "tool";
   name: string;
@@ -177,7 +183,7 @@ export function getDrawerMessages({
   messages: unknown;
   pendingToolApprovals?: readonly InAppAgentPendingToolApproval[];
 }): InAppAgentWindowMessage[] {
-  const parsedMessages = z.array(AgUiMessageSchema).parse(messages);
+  const parsedMessages = z.array(InAppAiAgentMessageSchema).parse(messages);
   const toolResults = getToolResultsByToolCallId(parsedMessages);
   const resolvedToolCallIds = new Set(toolResults.keys());
   const pendingApprovalsByToolCallId = new Map(
@@ -188,6 +194,7 @@ export function getDrawerMessages({
   const mappedMessages: InAppAgentWindowMessage[] = [];
   let pendingTools: InAppAgentToolCallContent[] = [];
   let pendingToolGroupId: string | null = null;
+  let pendingToolGroupIsLoading = false;
   let pendingSources: InAppAgentMessageSource[] = [];
   const flushPendingTools = () => {
     if (pendingTools.length === 0) {
@@ -197,10 +204,15 @@ export function getDrawerMessages({
     mappedMessages.push({
       id: pendingToolGroupId ?? "tools-pending",
       role: "assistant",
-      content: { type: "toolGroup", tools: pendingTools },
+      content: {
+        type: "toolGroup",
+        tools: pendingTools,
+        isLoading: pendingToolGroupIsLoading,
+      },
     });
     pendingTools = [];
     pendingToolGroupId = null;
+    pendingToolGroupIsLoading = false;
   };
 
   parsedMessages.forEach((message, index) => {
@@ -252,10 +264,7 @@ export function getDrawerMessages({
     if (message.role === "reasoning") {
       flushPendingTools();
 
-      const isStreaming =
-        isRunning &&
-        !error &&
-        !hasLaterConversationMessageAfter(parsedMessages, index);
+      const isStreaming = isRunning && !error && message.isLoading === true;
 
       // Adaptive thinking can emit a reasoning start/end pair without any
       // content; a completed empty block has nothing to disclose, so only a
@@ -332,6 +341,11 @@ export function getDrawerMessages({
           ) ?? [])
         : [];
     const docsSources = extractLangfuseDocsSources(toolContent);
+    const isToolGroupLoading =
+      isRunning &&
+      !error &&
+      message.role === "assistant" &&
+      message.isLoading === true;
 
     if (role === "assistant" && toolContent.length > 0 && !text.trim()) {
       if (docsSources.length > 0) {
@@ -340,6 +354,7 @@ export function getDrawerMessages({
 
       pendingToolGroupId ??= `tools-${message.id}`;
       pendingTools.push(...toolContent);
+      pendingToolGroupIsLoading ||= isToolGroupLoading;
       return;
     }
 
@@ -385,7 +400,11 @@ export function getDrawerMessages({
       mappedMessages.push({
         id: `${message.id}-tools`,
         role,
-        content: { type: "toolGroup", tools: toolContent },
+        content: {
+          type: "toolGroup",
+          tools: toolContent,
+          isLoading: isToolGroupLoading,
+        },
       });
     }
   });
@@ -441,14 +460,7 @@ export function getDrawerMessages({
     latestAssistantMessage?.content.type !== "redirectAction"
   ) {
     if (latestAssistantMessage?.content.type === "toolGroup") {
-      return mappedMessages.map((message, index) =>
-        index === latestAssistantMessageIndex
-          ? {
-              ...message,
-              content: { ...latestAssistantMessage.content, isLoading: true },
-            }
-          : message,
-      );
+      return mappedMessages;
     }
 
     const hasAssistantAnswer = mappedMessages.some(
@@ -469,31 +481,6 @@ export function getDrawerMessages({
   }
 
   return mappedMessages;
-}
-
-// A reasoning block stays live while the model is still acting on it — the
-// tool calls and tool results it triggered keep it open. It only collapses
-// once the model has visibly moved on: a newer reasoning block, an assistant
-// message with text, or a new user turn.
-function hasLaterConversationMessageAfter(
-  messages: readonly AgUiMessage[],
-  currentIndex: number,
-) {
-  return messages.some((message, messageIndex) => {
-    if (messageIndex <= currentIndex) {
-      return false;
-    }
-
-    if (message.role === "reasoning" || message.role === "user") {
-      return true;
-    }
-
-    return (
-      message.role === "assistant" &&
-      typeof message.content === "string" &&
-      message.content.trim().length > 0
-    );
-  });
 }
 
 function stringifyToolArgs(args: unknown) {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces position-based heuristics for streaming/loading indicators with event-driven tracking per individual message and tool call. A new `loadingEventIds` state (a `ReadonlySet<string>`) is populated by `onEvent` handlers that listen to `*_START` / `*_END` / `TOOL_CALL_START` / `TOOL_CALL_RESULT` events, and the resulting `isLoading` flag is merged into each message before being passed to `getDrawerMessages`.

- Introduces `updateLoadingEvent` and `clearLoadingEvents` helpers that update the loading set immutably, with early-exit guards to avoid spurious re-renders.
- Removes the fragile `hasLaterConversationMessageAfter` position scan and the blanket "mark the latest toolGroup as loading" logic in `getDrawerMessages`; both are replaced by explicit `message.isLoading` checks.
- Exports `InAppAiAgentMessage` (= `AgUiMessage & { isLoading?: boolean }`) from `utils.ts` and updates test fixtures accordingly.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is well-scoped to UI loading indicators with no data persistence or auth implications.

The event-driven loading state is correctly wired: all cleanup paths (run start, .finally(), RUN_FINISHED, RUN_ERROR, resetAgent) call clearLoadingEvents, the updateLoadingEvent helper avoids spurious re-renders, and tests cover merged tool groups, reasoning completion, and multi-step loops. No logic regressions were found.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Server as Agent Server
    participant onEvent as onEvent handler
    participant loadingIds as loadingEventIds (state)
    participant uiState as messagesWithUiState (memo)
    participant drawer as getDrawerMessages

    Server->>onEvent: "REASONING_MESSAGE_START {messageId}"
    onEvent->>loadingIds: updateLoadingEvent(messageId, true)
    loadingIds-->>uiState: "re-compute (reasoning.isLoading=true)"
    uiState-->>drawer: "reasoning {isLoading:true} → isStreaming:true"

    Server->>onEvent: "REASONING_MESSAGE_END {messageId}"
    onEvent->>loadingIds: updateLoadingEvent(messageId, false)
    loadingIds-->>uiState: "re-compute (reasoning.isLoading=false)"
    uiState-->>drawer: "reasoning {isLoading:false} → isStreaming:false"

    Server->>onEvent: "TOOL_CALL_START {toolCallId}"
    onEvent->>loadingIds: updateLoadingEvent(toolCallId, true)
    loadingIds-->>uiState: "re-compute (assistant.isLoading=true via toolCall)"
    uiState-->>drawer: "toolGroup {isLoading:true}"

    Server->>onEvent: "TOOL_CALL_RESULT {toolCallId}"
    onEvent->>loadingIds: updateLoadingEvent(toolCallId, false)
    loadingIds-->>uiState: "re-compute (assistant.isLoading=false)"
    uiState-->>drawer: "toolGroup {isLoading:false}"

    Server->>onEvent: RUN_FINISHED
    onEvent->>loadingIds: clearLoadingEvents()
    Note over loadingIds: Safety net – clears any orphaned IDs
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Server as Agent Server
    participant onEvent as onEvent handler
    participant loadingIds as loadingEventIds (state)
    participant uiState as messagesWithUiState (memo)
    participant drawer as getDrawerMessages

    Server->>onEvent: "REASONING_MESSAGE_START {messageId}"
    onEvent->>loadingIds: updateLoadingEvent(messageId, true)
    loadingIds-->>uiState: "re-compute (reasoning.isLoading=true)"
    uiState-->>drawer: "reasoning {isLoading:true} → isStreaming:true"

    Server->>onEvent: "REASONING_MESSAGE_END {messageId}"
    onEvent->>loadingIds: updateLoadingEvent(messageId, false)
    loadingIds-->>uiState: "re-compute (reasoning.isLoading=false)"
    uiState-->>drawer: "reasoning {isLoading:false} → isStreaming:false"

    Server->>onEvent: "TOOL_CALL_START {toolCallId}"
    onEvent->>loadingIds: updateLoadingEvent(toolCallId, true)
    loadingIds-->>uiState: "re-compute (assistant.isLoading=true via toolCall)"
    uiState-->>drawer: "toolGroup {isLoading:true}"

    Server->>onEvent: "TOOL_CALL_RESULT {toolCallId}"
    onEvent->>loadingIds: updateLoadingEvent(toolCallId, false)
    loadingIds-->>uiState: "re-compute (assistant.isLoading=false)"
    uiState-->>drawer: "toolGroup {isLoading:false}"

    Server->>onEvent: RUN_FINISHED
    onEvent->>loadingIds: clearLoadingEvents()
    Note over loadingIds: Safety net – clears any orphaned IDs
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agent): Track loading state of indiv..."](https://github.com/langfuse/langfuse/commit/40395154c4cde4dbb0a5b1e4e789fd0f59817156) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43329197)</sub>

<!-- /greptile_comment -->