### PR TITLE
fix(table-views): make preset deletion idempotent

### DIFF
--- a/web/src/__tests__/server/table-view-presets-trpc.servertest.ts
+++ b/web/src/__tests__/server/table-view-presets-trpc.servertest.ts
@@ -1,0 +1,103 @@
+/** @jest-environment node */
+
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { TableViewPresetTableName } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import type { Session } from "next-auth";
+import { randomUUID } from "node:crypto";
+
+const prepare = async () => {
+  const { project, org } = await createOrgProjectAndApiKey();
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: `table-view-user-${randomUUID()}`,
+      canCreateOrganizations: true,
+      name: "Table View Test User",
+      organizations: [
+        {
+          id: org.id,
+          name: org.name,
+          role: "OWNER",
+          plan: "cloud:hobby",
+          cloudConfig: undefined,
+          metadata: {},
+          projects: [
+            {
+              id: project.id,
+              role: "ADMIN",
+              retentionDays: 30,
+              deletedAt: null,
+              name: project.name,
+              metadata: {},
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+      },
+      admin: false,
+    },
+    environment: {
+      enableExperimentalFeatures: false,
+      selfHostedInstancePlan: "cloud:hobby",
+    },
+  };
+
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+  return {
+    caller: appRouter.createCaller({ ...ctx, prisma }),
+    projectId: project.id,
+  };
+};
+
+describe("table view presets tRPC", () => {
+  it("deletes an already-deleted preset idempotently", async () => {
+    const { caller, projectId } = await prepare();
+    const preset = await prisma.tableViewPreset.create({
+      data: {
+        projectId,
+        name: `view-${randomUUID()}`,
+        tableName: TableViewPresetTableName.ObservationsEvents,
+        createdBy: null,
+        updatedBy: null,
+        filters: [],
+        columnOrder: [],
+        columnVisibility: {},
+        searchQuery: null,
+        orderBy: null,
+      },
+    });
+    await prisma.defaultView.create({
+      data: {
+        projectId,
+        userId: null,
+        viewName: TableViewPresetTableName.ObservationsEvents,
+        viewId: preset.id,
+      },
+    });
+
+    const input = {
+      projectId,
+      tableViewPresetsId: preset.id,
+    };
+
+    await expect(caller.TableViewPresets.delete(input)).resolves.toEqual({
+      success: true,
+    });
+    await expect(caller.TableViewPresets.delete(input)).resolves.toEqual({
+      success: true,
+    });
+
+    await expect(
+      prisma.tableViewPreset.count({ where: { id: preset.id, projectId } }),
+    ).resolves.toBe(0);
+    await expect(
+      prisma.defaultView.count({ where: { viewId: preset.id, projectId } }),
+    ).resolves.toBe(0);
+  });
+});

--- a/web/src/__tests__/server/table-view-presets-trpc.servertest.ts
+++ b/web/src/__tests__/server/table-view-presets-trpc.servertest.ts
@@ -86,12 +86,12 @@ describe("table view presets tRPC", () => {
       tableViewPresetsId: preset.id,
     };
 
-    await expect(caller.TableViewPresets.delete(input)).resolves.toEqual({
-      success: true,
-    });
-    await expect(caller.TableViewPresets.delete(input)).resolves.toEqual({
-      success: true,
-    });
+    await expect(
+      caller.TableViewPresets.delete(input),
+    ).resolves.toBeUndefined();
+    await expect(
+      caller.TableViewPresets.delete(input),
+    ).resolves.toBeUndefined();
 
     await expect(
       prisma.tableViewPreset.count({ where: { id: preset.id, projectId } }),
@@ -130,7 +130,7 @@ describe("table view presets tRPC", () => {
         projectId,
         tableViewPresetsId: systemPresetId,
       }),
-    ).resolves.toEqual({ success: true });
+    ).resolves.toBeUndefined();
 
     await expect(
       prisma.defaultView.count({
@@ -156,7 +156,7 @@ describe("table view presets tRPC", () => {
         projectId,
         tableViewPresetsId: missingPresetId,
       }),
-    ).resolves.toEqual({ success: true });
+    ).resolves.toBeUndefined();
 
     await expect(
       prisma.defaultView.count({

--- a/web/src/__tests__/server/table-view-presets-trpc.servertest.ts
+++ b/web/src/__tests__/server/table-view-presets-trpc.servertest.ts
@@ -100,4 +100,68 @@ describe("table view presets tRPC", () => {
       prisma.defaultView.count({ where: { viewId: preset.id, projectId } }),
     ).resolves.toBe(0);
   });
+
+  it("preserves defaults for system preset ids", async () => {
+    const { caller, projectId } = await prepare();
+    const user = await prisma.user.create({
+      data: { email: `system-default-${randomUUID()}@example.com` },
+    });
+    const systemPresetId = "__langfuse_errors_only";
+
+    await prisma.defaultView.createMany({
+      data: [
+        {
+          projectId,
+          userId: null,
+          viewName: TableViewPresetTableName.ObservationsEvents,
+          viewId: systemPresetId,
+        },
+        {
+          projectId,
+          userId: user.id,
+          viewName: TableViewPresetTableName.ObservationsEvents,
+          viewId: systemPresetId,
+        },
+      ],
+    });
+
+    await expect(
+      caller.TableViewPresets.delete({
+        projectId,
+        tableViewPresetsId: systemPresetId,
+      }),
+    ).resolves.toEqual({ success: true });
+
+    await expect(
+      prisma.defaultView.count({
+        where: { projectId, viewId: systemPresetId },
+      }),
+    ).resolves.toBe(2);
+  });
+
+  it("cleans dangling defaults for a missing user preset", async () => {
+    const { caller, projectId } = await prepare();
+    const missingPresetId = `missing-preset-${randomUUID()}`;
+    await prisma.defaultView.create({
+      data: {
+        projectId,
+        userId: null,
+        viewName: TableViewPresetTableName.ObservationsEvents,
+        viewId: missingPresetId,
+      },
+    });
+
+    await expect(
+      caller.TableViewPresets.delete({
+        projectId,
+        tableViewPresetsId: missingPresetId,
+      }),
+    ).resolves.toEqual({ success: true });
+
+    await expect(
+      prisma.defaultView.count({
+        where: { projectId, viewId: missingPresetId },
+      }),
+    ).resolves.toBe(0);
+  });
 });

--- a/web/src/server/api/routers/tableViewPresets.ts
+++ b/web/src/server/api/routers/tableViewPresets.ts
@@ -114,7 +114,7 @@ export const TableViewPresetsRouter = createTRPCRouter({
       // System presets are frontend-defined and have no table_view_presets row.
       // Treat their deletion as an idempotent no-op without clearing defaults.
       if (isSystemTableViewPresetId(input.tableViewPresetsId)) {
-        return { success: true };
+        return;
       }
 
       // Keep deletion idempotent so stale clients can safely repeat it.
@@ -134,10 +134,6 @@ export const TableViewPresetsRouter = createTRPCRouter({
           },
         });
       });
-
-      return {
-        success: true,
-      };
     }),
 
   getByTableName: protectedProjectProcedure

--- a/web/src/server/api/routers/tableViewPresets.ts
+++ b/web/src/server/api/routers/tableViewPresets.ts
@@ -16,6 +16,7 @@ import {
   ClearDefaultViewInput,
   DefaultViewAssignmentsSchema,
   TableViewPresetsNamesCreatorListSchema,
+  isSystemTableViewPresetId,
 } from "@langfuse/shared/src/server";
 import {
   LangfuseConflictError,
@@ -109,6 +110,12 @@ export const TableViewPresetsRouter = createTRPCRouter({
         projectId: input.projectId,
         scope: "TableViewPresets:CUD",
       });
+
+      // System presets are frontend-defined and have no table_view_presets row.
+      // Treat their deletion as an idempotent no-op without clearing defaults.
+      if (isSystemTableViewPresetId(input.tableViewPresetsId)) {
+        return { success: true };
+      }
 
       // Keep deletion idempotent so stale clients can safely repeat it.
       await ctx.prisma.$transaction(async (tx) => {

--- a/web/src/server/api/routers/tableViewPresets.ts
+++ b/web/src/server/api/routers/tableViewPresets.ts
@@ -110,11 +110,9 @@ export const TableViewPresetsRouter = createTRPCRouter({
         scope: "TableViewPresets:CUD",
       });
 
-      // Use transaction to ensure atomicity
-      // Delete view first (validates it exists), then cleanup defaults
+      // Keep deletion idempotent so stale clients can safely repeat it.
       await ctx.prisma.$transaction(async (tx) => {
-        // Delete the view preset (will throw if not found)
-        await tx.tableViewPreset.delete({
+        await tx.tableViewPreset.deleteMany({
           where: {
             id: input.tableViewPresetsId,
             projectId: input.projectId,
@@ -123,7 +121,10 @@ export const TableViewPresetsRouter = createTRPCRouter({
 
         // Cleanup any default view references
         await tx.defaultView.deleteMany({
-          where: { viewId: input.tableViewPresetsId },
+          where: {
+            viewId: input.tableViewPresetsId,
+            projectId: input.projectId,
+          },
         });
       });
 


### PR DESCRIPTION
## Summary

- make saved-view deletion succeed when the preset is already absent
- keep preset and default-reference cleanup atomic and project-scoped
- add a tRPC regression covering repeated deletion and default cleanup
- preserve project and user defaults when a system preset id is submitted
- return no delete payload; callers use mutation resolution/rejection

## Impacted packages

- web

## Verification

- `pnpm --filter web run test src/__tests__/server/table-view-presets-trpc.servertest.ts` — `Tests 3 passed (3)`
- `pnpm --filter web run typecheck` — exited successfully
- `pnpm run lint` — `Tasks: 7 successful, 7 total`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the `TableViewPresets.delete` tRPC mutation idempotent by switching from `tableViewPreset.delete` (throws on missing record) to `deleteMany` (silent no-op), and tightens the `defaultView` cleanup to be project-scoped by adding `projectId` to that `deleteMany` where clause. A regression test verifies both behaviors.

- **Idempotent deletion**: switching to `deleteMany` means repeated or stale-client calls return `{ success: true }` rather than a Prisma `P2025` error, which is the correct behavior for a delete endpoint.
- **Project-scoped cleanup**: adding `projectId: input.projectId` to the `defaultView.deleteMany` where clause ensures the cleanup is bounded to the caller's project, aligning cleanup semantics with the authorization check above it.
- **Test coverage**: the new server test creates a preset and project-level default view, deletes twice, and asserts both records are gone after the first call.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change narrows a single mutation's behavior in a backward-compatible, more correct direction without touching any other code paths.

Both mutations now correctly handle the already-deleted case without throwing, the projectId scoping on the defaultView cleanup closes a latent cross-project cleanup gap, and the new server test exercises the exact regression scenario. The transaction is preserved for atomicity. No auth logic was altered and no data-loss risk is introduced.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant tRPC as tRPC delete mutation
    participant Auth as throwIfNoProjectAccess
    participant DB as Prisma Transaction

    Client->>tRPC: "TableViewPresets.delete({ projectId, tableViewPresetsId })"
    tRPC->>Auth: check TableViewPresets:CUD scope
    Auth-->>tRPC: ok (or throws)

    tRPC->>DB: BEGIN transaction
    DB->>DB: "tableViewPreset.deleteMany WHERE id=? AND projectId=?"
    DB->>DB: "defaultView.deleteMany WHERE viewId=? AND projectId=?"
    DB-->>tRPC: COMMIT

    tRPC-->>Client: "{ success: true }"

    note over Client,DB: Second call (stale client retry)
    Client->>tRPC: "TableViewPresets.delete({ projectId, tableViewPresetsId })"
    tRPC->>Auth: check TableViewPresets:CUD scope
    Auth-->>tRPC: ok
    tRPC->>DB: BEGIN transaction
    DB->>DB: tableViewPreset.deleteMany → 0 rows deleted
    DB->>DB: defaultView.deleteMany → 0 rows deleted
    DB-->>tRPC: COMMIT
    tRPC-->>Client: "{ success: true }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant tRPC as tRPC delete mutation
    participant Auth as throwIfNoProjectAccess
    participant DB as Prisma Transaction

    Client->>tRPC: "TableViewPresets.delete({ projectId, tableViewPresetsId })"
    tRPC->>Auth: check TableViewPresets:CUD scope
    Auth-->>tRPC: ok (or throws)

    tRPC->>DB: BEGIN transaction
    DB->>DB: "tableViewPreset.deleteMany WHERE id=? AND projectId=?"
    DB->>DB: "defaultView.deleteMany WHERE viewId=? AND projectId=?"
    DB-->>tRPC: COMMIT

    tRPC-->>Client: "{ success: true }"

    note over Client,DB: Second call (stale client retry)
    Client->>tRPC: "TableViewPresets.delete({ projectId, tableViewPresetsId })"
    tRPC->>Auth: check TableViewPresets:CUD scope
    Auth-->>tRPC: ok
    tRPC->>DB: BEGIN transaction
    DB->>DB: tableViewPreset.deleteMany → 0 rows deleted
    DB->>DB: defaultView.deleteMany → 0 rows deleted
    DB-->>tRPC: COMMIT
    tRPC-->>Client: "{ success: true }"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(table-views): make preset deletion i..."](https://github.com/langfuse/langfuse/commit/f375588c21c373c48adc80711afddf3d8b67f033) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43318278)</sub>

<!-- /greptile_comment -->

