### PR TITLE
fix(filters): route legacy score filters by type

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -32,6 +32,28 @@ export class QueryBuilderError extends Error {
   }
 }
 
+const resolveLegacyScoreFilterColumn = (
+  filter: EventsTableFilterState[number],
+  columnMapping: UiColumnMappings,
+): string => {
+  if (filter.column.toLowerCase() !== "scores") {
+    return filter.column;
+  }
+
+  const typedColumn =
+    filter.type === "categoryOptions"
+      ? "score_categories"
+      : filter.type === "numberObject"
+        ? "scores_avg"
+        : filter.type === "booleanObject"
+          ? "score_booleans"
+          : null;
+
+  return typedColumn && findUiColumnMapping(columnMapping, typedColumn)
+    ? typedColumn
+    : filter.column;
+};
+
 // This function ensures that the user only selects valid columns from the clickhouse schema.
 // The filter property in this column needs to be zod verified.
 // User input for values (e.g. project_id = <value>) are sent to Clickhouse as parameters to prevent SQL injection
@@ -45,8 +67,16 @@ export const createFilterFromFilterState = (
   );
 
   return applicableFilters.map((frontEndFilter) => {
+    const filterColumn = resolveLegacyScoreFilterColumn(
+      frontEndFilter,
+      columnMapping,
+    );
     // checks if the column exists in the clickhouse schema
-    const column = matchAndVerifyTracesUiColumn(frontEndFilter, columnMapping);
+    const column = matchAndVerifyTracesUiColumn(
+      frontEndFilter,
+      columnMapping,
+      filterColumn,
+    );
 
     if (columnDefinitions && frontEndFilter.type !== "null") {
       const colDef = columnDefinitions.find((c) => c.id === column.uiTableId);
@@ -199,14 +229,15 @@ const validateEventsTableMatchesFilter = (
 const matchAndVerifyTracesUiColumn = (
   filter: EventsTableFilterState[number],
   uiTableDefinitions: UiColumnMappings,
+  filterColumn = filter.column,
 ) => {
   // tries to match the column name to the clickhouse table name
-  const uiTable = findUiColumnMapping(uiTableDefinitions, filter.column);
+  const uiTable = findUiColumnMapping(uiTableDefinitions, filterColumn);
 
   if (!uiTable) {
-    const errorMessage = `Column ${filter.column} does not match a UI / CH table mapping.`;
+    const errorMessage = `Column ${filterColumn} does not match a UI / CH table mapping.`;
     logger.error(errorMessage, {
-      filterColumn: filter.column,
+      filterColumn,
       filterType: filter.type,
       availableColumns: uiTableDefinitions.map(
         (col) => col.uiTableId ?? col.uiTableName,

--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -32,6 +32,14 @@ export class QueryBuilderError extends Error {
   }
 }
 
+const LEGACY_SCORE_FILTER_COLUMNS: Partial<
+  Record<EventsTableFilterState[number]["type"], string>
+> = {
+  categoryOptions: "score_categories",
+  numberObject: "scores_avg",
+  booleanObject: "score_booleans",
+};
+
 const resolveLegacyScoreFilterColumn = (
   filter: EventsTableFilterState[number],
   columnMapping: UiColumnMappings,
@@ -40,18 +48,24 @@ const resolveLegacyScoreFilterColumn = (
     return filter.column;
   }
 
-  const typedColumn =
-    filter.type === "categoryOptions"
-      ? "score_categories"
-      : filter.type === "numberObject"
-        ? "scores_avg"
-        : filter.type === "booleanObject"
-          ? "score_booleans"
-          : null;
+  const typedColumn = LEGACY_SCORE_FILTER_COLUMNS[filter.type];
 
-  return typedColumn && findUiColumnMapping(columnMapping, typedColumn)
-    ? typedColumn
-    : filter.column;
+  if (!typedColumn) {
+    throw new InvalidRequestError(
+      `Invalid filter type '${filter.type}' for legacy score column '${filter.column}'. Expected one of 'categoryOptions', 'numberObject', or 'booleanObject'.`,
+    );
+  }
+
+  // The legacy scores mapping aliases only the numeric score aggregate.
+  // Categorical and boolean filters must resolve to their typed mappings.
+  if (
+    filter.type === "numberObject" &&
+    !findUiColumnMapping(columnMapping, typedColumn)
+  ) {
+    return filter.column;
+  }
+
+  return typedColumn;
 };
 
 // This function ensures that the user only selects valid columns from the clickhouse schema.

--- a/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
+++ b/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
@@ -48,6 +48,24 @@ describe("createFilterFromFilterState filter type validation", () => {
       clickhouseTableName: "scores",
       clickhouseSelect: "s.score_categories",
     },
+    scores: {
+      uiTableName: "Scores",
+      uiTableId: "scores",
+      clickhouseTableName: "scores",
+      clickhouseSelect: "s.scores_avg",
+    },
+    scores_avg: {
+      uiTableName: "Scores (numeric)",
+      uiTableId: "scores_avg",
+      clickhouseTableName: "scores",
+      clickhouseSelect: "s.scores_avg",
+    },
+    score_booleans: {
+      uiTableName: "Scores (boolean)",
+      uiTableId: "score_booleans",
+      clickhouseTableName: "scores",
+      clickhouseSelect: "s.score_booleans",
+    },
     eventInput: {
       uiTableName: "Input",
       uiTableId: "input",
@@ -122,6 +140,18 @@ describe("createFilterFromFilterState filter type validation", () => {
       type: "categoryOptions",
       internal: "s.score_categories",
       options: [],
+    },
+    {
+      name: "Scores (numeric)",
+      id: "scores_avg",
+      type: "numberObject",
+      internal: "s.scores_avg",
+    },
+    {
+      name: "Scores (boolean)",
+      id: "score_booleans",
+      type: "booleanObject",
+      internal: "s.score_booleans",
     },
     {
       name: "Input",
@@ -228,6 +258,47 @@ describe("createFilterFromFilterState filter type validation", () => {
       }),
     );
   });
+
+  it.each([
+    {
+      filter: {
+        type: "categoryOptions",
+        operator: "any of",
+        key: "attack_class",
+        value: ["Novel probe"],
+      },
+      expectedColumn: "s.score_categories",
+    },
+    {
+      filter: {
+        type: "numberObject",
+        operator: ">=",
+        key: "quality",
+        value: 0.5,
+      },
+      expectedColumn: "s.scores_avg",
+    },
+    {
+      filter: {
+        type: "booleanObject",
+        operator: "=",
+        key: "approved",
+        value: true,
+      },
+      expectedColumn: "s.score_booleans",
+    },
+  ] as const)(
+    "routes a legacy scores $filter.type filter to $expectedColumn",
+    ({ filter, expectedColumn }) => {
+      const [result] = createFilterFromFilterState(
+        [{ column: "scores", ...filter } as any],
+        Object.values(mappings),
+        columnDefinitions,
+      );
+
+      expect(result.apply().query).toContain(expectedColumn);
+    },
+  );
 
   it.each([
     {

--- a/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
+++ b/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
@@ -300,6 +300,73 @@ describe("createFilterFromFilterState filter type validation", () => {
     },
   );
 
+  it("falls back to the legacy scores mapping when the numeric mapping is unavailable", () => {
+    const filters = [
+      {
+        column: "scores",
+        type: "numberObject",
+        operator: ">=",
+        key: "quality",
+        value: 0.5,
+      },
+    ] satisfies EventsTableFilterState;
+
+    const [result] = createFilterFromFilterState(filters, [mappings.scores]);
+
+    expect(result.apply().query).toContain("s.scores_avg");
+  });
+
+  it.each([
+    {
+      type: "categoryOptions",
+      operator: "any of",
+      key: "attack_class",
+      value: ["Novel probe"],
+    },
+    {
+      type: "booleanObject",
+      operator: "=",
+      key: "approved",
+      value: true,
+    },
+  ] as const)(
+    "rejects a legacy scores $type filter when its typed mapping is unavailable",
+    (filter) => {
+      expect(() =>
+        createFilterFromFilterState(
+          [{ column: "scores", ...filter } as any],
+          [mappings.scores],
+          columnDefinitions,
+        ),
+      ).toThrow(InvalidRequestError);
+    },
+  );
+
+  it.each([
+    {
+      type: "stringOptions",
+      operator: "any of",
+      value: ["quality:good"],
+    },
+    {
+      type: "null",
+      operator: "is null",
+      value: "",
+    },
+  ] as const)("rejects an unsupported legacy scores $type filter", (filter) => {
+    expect(() =>
+      createFilterFromFilterState(
+        [{ column: "scores", ...filter } as any],
+        Object.values(mappings),
+        columnDefinitions,
+      ),
+    ).toThrow(
+      new InvalidRequestError(
+        `Invalid filter type '${filter.type}' for legacy score column 'scores'. Expected one of 'categoryOptions', 'numberObject', or 'booleanObject'.`,
+      ),
+    );
+  });
+
   it.each([
     {
       scenario: "matching filter type",


### PR DESCRIPTION
## Summary

- resolve persisted legacy `scores` filters to the typed score column before ClickHouse filter construction
- route categorical, numeric, and boolean filters to `score_categories`, `scores_avg`, and `score_booleans` respectively
- preserve numeric legacy fallback when `scores_avg` is unavailable and fail closed for other missing/unsupported typed mappings
- add regression coverage for all three legacy routes, numeric fallback, and fail-closed paths

## Impacted packages

- packages/shared
- web (regression coverage)
- worker (shared filter-factory consumer verification)

## ClickHouse review

This changes column resolution only. Per `query-join-filter-before`, `query-join-choose-algorithm`, `query-join-use-any`, `query-index-skipping-indices`, and `schema-pk-filter-on-orderby`, no JOIN, index, or query-plan change is required for this type mismatch.

## Verification

- `pnpm --filter @langfuse/shared run build` — `$ tsc`
- `pnpm --filter web run test src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts` — `Tests 29 passed (29)`
- `pnpm --filter worker run test src/__tests__/batchExport.test.ts` — `Tests 29 passed | 44 skipped (73)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes routing of persisted legacy `scores` filters to their typed ClickHouse columns by introducing `resolveLegacyScoreFilterColumn` in `factory.ts`, which inspects the filter's `type` field and redirects to `score_categories`, `scores_avg`, or `score_booleans` before column lookup. If the caller's mapping does not include the resolved typed column, the function gracefully falls back to the original `scores` column.

- The new `resolveLegacyScoreFilterColumn` function integrates cleanly into `createFilterFromFilterState` by passing the resolved column name as an optional third argument to `matchAndVerifyTracesUiColumn`, minimizing diff surface.
- Three parameterized regression tests verify the happy path for all supported filter types; test fixtures add `scores`, `scores_avg`, and `score_booleans` column mappings and definitions to the existing suite.
- Two gaps remain: there is no test for the documented fallback scenario (typed column absent from mapping), and filter types outside the three handled cases (e.g., `stringOptions` on a legacy `scores` column) fall through silently with no log warning.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the routing logic is correct for all three handled filter types and falls back safely for others.

The core remapping in resolveLegacyScoreFilterColumn is correct and integrates cleanly with the existing validation pipeline. Two gaps exist: the documented fallback path (typed column not in mapping) has no regression test, and filter types outside the three handled cases fall through to the legacy scores column silently — both are quality concerns rather than current breakage.

factory.ts (silent fallback for unhandled filter types) and the test file (missing fallback coverage)
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createFilterFromFilterState] --> B[resolveLegacyScoreFilterColumn]
    B --> C{column == scores?}
    C -- No --> D[return filter.column]
    C -- Yes --> E{filter.type}
    E -- categoryOptions --> F[typedColumn = score_categories]
    E -- numberObject --> G[typedColumn = scores_avg]
    E -- booleanObject --> H[typedColumn = score_booleans]
    E -- other --> I[typedColumn = null]
    F --> J{typed col in mapping?}
    G --> J
    H --> J
    I --> K[fallback: return filter.column]
    J -- Yes --> L[return typedColumn]
    J -- No --> K
    L --> M[matchAndVerifyTracesUiColumn]
    K --> M
    M --> N{uiTable found?}
    N -- No --> O[throw InvalidRequestError]
    N -- Yes --> P[type validation via columnDefinitions]
    P --> Q[Build ClickHouse filter]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[createFilterFromFilterState] --> B[resolveLegacyScoreFilterColumn]
    B --> C{column == scores?}
    C -- No --> D[return filter.column]
    C -- Yes --> E{filter.type}
    E -- categoryOptions --> F[typedColumn = score_categories]
    E -- numberObject --> G[typedColumn = scores_avg]
    E -- booleanObject --> H[typedColumn = score_booleans]
    E -- other --> I[typedColumn = null]
    F --> J{typed col in mapping?}
    G --> J
    H --> J
    I --> K[fallback: return filter.column]
    J -- Yes --> L[return typedColumn]
    J -- No --> K
    L --> M[matchAndVerifyTracesUiColumn]
    K --> M
    M --> N{uiTable found?}
    N -- No --> O[throw InvalidRequestError]
    N -- Yes --> P[type validation via columnDefinitions]
    P --> Q[Build ClickHouse filter]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/queries/clickhouse-sql/factory.ts:43-54
**Unhandled filter types on legacy "scores" column silently fall through**

Any filter type that is not `categoryOptions`, `numberObject`, or `booleanObject` (e.g., a persisted `stringOptions` or `null` filter on the legacy `scores` column) will produce `typedColumn = null` and fall back to the raw `"scores"` column. If a `scores` mapping exists in the caller's `columnMapping`, the filter proceeds against whatever `clickhouseSelect` that mapping exposes (often `s.scores_avg`) with no type mismatch error and no log warning. This can generate silently incorrect SQL for any legacy filter shape outside the three handled cases, and the fallback path has no observability signal to aid debugging.

### Issue 2 of 2
web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts:259-301
**Fallback path (typed column absent from mapping) is documented but untested**

The PR description explicitly notes that when a caller's `columnMapping` does not include the typed column (e.g., `scores_avg`), the resolver falls back to the original `"scores"` column. This path is exercised by `resolveLegacyScoreFilterColumn` but has no test. A regression in the `findUiColumnMapping` check on line 52 of factory.ts could silently break callers that only expose the legacy `scores` column without any test catching it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(filters): route legacy score filters..."](https://github.com/langfuse/langfuse/commit/fe6964a3609491baccf27eeb5d22368b52603d02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43319505)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->
