### PR TITLE
chore(web): Setup eslint useEffect plugin for agent and design system

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -916,6 +916,9 @@ importers:
       eslint:
         specifier: ^9.39.2
         version: 9.39.4(jiti@2.7.0)
+      eslint-plugin-react-you-might-not-need-an-effect:
+        specifier: ^1.0.1
+        version: 1.0.1(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-storybook:
         specifier: 10.3.6
         version: 10.3.6(eslint@9.39.4(jiti@2.7.0))(storybook@10.3.6(@testing-library/dom@10.0.0)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.3)
@@ -7569,6 +7572,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react-you-might-not-need-an-effect@1.0.1:
+    resolution: {integrity: sha512-oOhQTYhor88Xp8RVytq25tvBfiAjU0r9SCDC51Qop+3Wg5BR1xGMAkM+/dV4MZbcMhdaU1L9bkv6LC95JmiTig==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      eslint: '>=8.40.0'
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
@@ -19020,6 +19029,11 @@ snapshots:
       zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-react-you-might-not-need-an-effect@1.0.1(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+      globals: 16.5.0
 
   eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)):
     dependencies:

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -1,4 +1,5 @@
 import { globalIgnores } from "eslint/config";
+import reactYouMightNotNeedAnEffect from "eslint-plugin-react-you-might-not-need-an-effect";
 import storybook from "eslint-plugin-storybook";
 import eslintPluginTailwindcss from "eslint-plugin-tailwindcss";
 
@@ -85,10 +86,12 @@ export default [
   },
 
   {
+    ...reactYouMightNotNeedAnEffect.configs.recommended,
     name: "langfuse/web/design-system-rules",
     files: ["src/components/design-system/**/*.{ts,tsx}"],
     ignores: ["src/components/design-system/**/*.stories.tsx"],
     rules: {
+      ...reactYouMightNotNeedAnEffect.configs.recommended.rules,
       // Design-system component APIs must use explicit variants instead of styling escape hatches.
       "@repo/no-style-props": "error",
 
@@ -107,9 +110,11 @@ export default [
 
   // We're using the in-app-agent directory as a testing ground for some new eslint-rules.
   {
+    ...reactYouMightNotNeedAnEffect.configs.recommended,
     name: "langfuse/web/in-app-agent",
     files: ["src/ee/features/in-app-agent/**/*.{ts,tsx}"],
     rules: {
+      ...reactYouMightNotNeedAnEffect.configs.recommended.rules,
       "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
       "@typescript-eslint/no-confusing-void-expression": "warn",
       "@typescript-eslint/no-non-null-assertion": "warn",

--- a/web/package.json
+++ b/web/package.json
@@ -200,6 +200,7 @@
     "dotenv-cli": "^7.4.2",
     "dotenv-expand": "^10.0.0",
     "eslint": "^9.39.2",
+    "eslint-plugin-react-you-might-not-need-an-effect": "^1.0.1",
     "eslint-plugin-storybook": "10.3.6",
     "eslint-plugin-tailwindcss": "4.0.2",
     "jsdom": "^26.1.0",

--- a/web/src/components/design-system/InlineEditText/InlineEditText.tsx
+++ b/web/src/components/design-system/InlineEditText/InlineEditText.tsx
@@ -29,14 +29,14 @@ export const InlineEditText = ({
 }: InlineEditTextProps) => {
   const [editing, setEditing] = React.useState(false);
   const [draft, setDraft] = React.useState(value);
-  const inputRef = React.useRef<HTMLInputElement>(null);
 
-  React.useEffect(() => {
-    if (editing) {
-      inputRef.current?.focus();
-      inputRef.current?.select();
-    }
-  }, [editing]);
+  // Keep the callback ref stable so typing does not reattach it and reselect the input.
+  const focusInput = React.useCallback((input: HTMLInputElement | null) => {
+    if (!input) return;
+
+    input.focus();
+    input.select();
+  }, []);
 
   const commit = () => {
     setEditing(false);
@@ -58,7 +58,7 @@ export const InlineEditText = ({
   if (editing) {
     return (
       <input
-        ref={inputRef}
+        ref={focusInput}
         value={draft}
         placeholder={placeholder}
         aria-label={ariaLabel ?? "Edit text"}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import {
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   BotMessageSquare,
   History,
@@ -285,16 +291,24 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     scrollViewportToBottom(viewportRef.current);
   }, [selectedConversationId]);
 
+  // Update after refs commit so setInputRef can compare the previous disabled state.
   useEffect(() => {
-    const wasInputDisabled = previousIsInputDisabledRef.current;
     previousIsInputDisabledRef.current = isInputDisabled;
-
-    if (!wasInputDisabled || isInputDisabled) {
-      return;
-    }
-
-    inputRef.current?.focus();
   }, [isInputDisabled]);
+
+  const setInputRef = useCallback(
+    (input: HTMLTextAreaElement | null) => {
+      inputRef.current = input;
+
+      const shouldRefocusInput =
+        previousIsInputDisabledRef.current && !isInputDisabled;
+
+      if (input && shouldRefocusInput) {
+        input.focus();
+      }
+    },
+    [isInputDisabled],
+  );
 
   useEffect(() => {
     const input = inputRef.current;
@@ -674,7 +688,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
           >
             <textarea
               autoFocus={!isExpanded}
-              ref={inputRef}
+              ref={setInputRef}
               value={input}
               onChange={(event) => {
                 setInput(event.target.value);

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -51,6 +51,7 @@ const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";
 const OPEN_STORAGE_KEY_PREFIX = "langfuse:in-app-ai-agent-open";
 const FEEDBACK_STORAGE_KEY_PREFIX = "langfuse:in-app-ai-agent-feedback";
+const EMPTY_MESSAGES: AgUiMessage[] = [];
 
 const MastraSuspendEventSchema = z.object({
   type: z.literal("mastra_suspend"),
@@ -212,9 +213,11 @@ function InAppAiAgentProviderInner({
   const utils = api.useUtils();
   const capture = usePostHogClientCapture();
   const session = useSession();
-  const [selectedConversationId, setSelectedConversationId] = useSessionStorage<
-    string | null
-  >(`${SELECTED_CONVERSATION_STORAGE_KEY_PREFIX}:${projectId}`, null);
+  const [_selectedConversationId, setSelectedConversationId] =
+    useSessionStorage<string | null>(
+      `${SELECTED_CONVERSATION_STORAGE_KEY_PREFIX}:${projectId}`,
+      null,
+    );
   const [feedbackByConversationId, setFeedbackByConversationId] =
     useSessionStorage<InAppAiAgentFeedbackByConversationId>(
       `${FEEDBACK_STORAGE_KEY_PREFIX}:${projectId}`,
@@ -251,15 +254,20 @@ function InAppAiAgentProviderInner({
   const conversationQuery = api.inAppAgent.getConversation.useQuery(
     {
       projectId,
-      conversationId: selectedConversationId ?? "",
+      conversationId: _selectedConversationId ?? "",
     },
     {
-      enabled: open && Boolean(selectedConversationId) && !isSubmitting,
+      enabled: open && Boolean(_selectedConversationId) && !isSubmitting,
     },
   );
   const deleteConversationMutation =
     api.inAppAgent.deleteConversation.useMutation();
   const feedbackMutation = api.inAppAgent.submitFeedback.useMutation();
+  const isSelectedConversationNotFound =
+    conversationQuery.error?.data?.code === "NOT_FOUND";
+  const selectedConversationId = isSelectedConversationNotFound
+    ? null
+    : _selectedConversationId;
 
   const conversations = useMemo(
     () =>
@@ -269,9 +277,35 @@ function InAppAiAgentProviderInner({
   );
   const hasMoreConversations = conversationListQuery.hasNextPage === true;
   const isLoadingMoreConversations = conversationListQuery.isFetchingNextPage;
+  const currentMessages = useMemo(() => {
+    if (isSelectedConversationNotFound) {
+      return EMPTY_MESSAGES;
+    }
+
+    const storedMessages =
+      conversationQuery.data?.conversation.id === selectedConversationId
+        ? conversationQuery.data.messages.filter(isAgentConversationMessage)
+        : undefined;
+
+    if (
+      !isRunning &&
+      storedMessages &&
+      messages.length <= storedMessages.length
+    ) {
+      return storedMessages;
+    }
+
+    return messages;
+  }, [
+    conversationQuery.data,
+    isRunning,
+    isSelectedConversationNotFound,
+    messages,
+    selectedConversationId,
+  ]);
   const messagesWithUiState = useMemo(() => {
     const messagesWithFeedback = mergeMessagesWithFeedback(
-      messages,
+      currentMessages,
       selectedConversationId
         ? feedbackByConversationId[selectedConversationId]
         : undefined,
@@ -300,8 +334,8 @@ function InAppAiAgentProviderInner({
     });
   }, [
     feedbackByConversationId,
+    currentMessages,
     loadingEventIds,
-    messages,
     selectedConversationId,
   ]);
   const fetchNextConversationsPage = conversationListQuery.fetchNextPage;
@@ -378,92 +412,20 @@ function InAppAiAgentProviderInner({
     );
   }, []);
 
-  const resetAgent = useCallback(
-    (options?: { preserveAgent?: boolean }) => {
-      if (options?.preserveAgent) {
-        return;
-      }
-
-      if (agentRef.current?.isRunning) {
-        intentionalAbortRef.current = true;
-      }
-
-      subscriptionRef.current?.unsubscribe();
-      subscriptionRef.current = null;
-      agentRef.current?.abortRun();
-      agentRef.current = null;
-      activeRunIdRef.current = null;
-      pendingToolApprovalsRef.current = [];
-      setPendingToolApprovals([]);
-      clearLoadingEvents();
-    },
-    [clearLoadingEvents],
-  );
-
-  // Hydrate local state from the selected persisted conversation once it loads.
-  useEffect(() => {
-    if (!selectedConversationId) {
-      if (!isRunning) {
-        resetAgent();
-        setMessages([]);
-      }
-      return;
+  const resetAgent = useCallback(() => {
+    if (agentRef.current?.isRunning) {
+      intentionalAbortRef.current = true;
     }
 
-    if (!conversationQuery.data || isRunning) {
-      return;
-    }
-
-    const storedMessages = conversationQuery.data.messages.filter(
-      isAgentConversationMessage,
-    );
-
-    if (messages.length > storedMessages.length) {
-      return;
-    }
-
-    const hasResumablePendingApproval =
-      pendingToolApprovalsRef.current.length > 0 &&
-      agentRef.current?.threadId === selectedConversationId;
-
-    resetAgent({ preserveAgent: hasResumablePendingApproval });
-    // TODO: Avoid replacing hydrated messages when only server-generated ids
-    // differ from optimistic client ids; this can cause a small post-run flicker.
-    setMessages(storedMessages);
-  }, [
-    conversationQuery.data,
-    isRunning,
-    messages.length,
-    resetAgent,
-    selectedConversationId,
-  ]);
-
-  // Clear local selection when the selected conversation cannot be loaded.
-  useEffect(() => {
-    if (!selectedConversationId || isRunning || !conversationQuery.error) {
-      return;
-    }
-
-    if (conversationQuery.error.data?.code !== "NOT_FOUND") {
-      console.error("Failed to load in-app agent conversation", {
-        error: conversationQuery.error,
-        projectId,
-        conversationId: selectedConversationId,
-      });
-      return;
-    }
-
-    resetAgent();
-    setMessages([]);
-    setSelectedConversationId(null);
-  }, [
-    conversationQuery.error,
-    isRunning,
-    projectId,
-    resetAgent,
-    selectedConversationId,
-    setSelectedConversationId,
-  ]);
+    subscriptionRef.current?.unsubscribe();
+    subscriptionRef.current = null;
+    agentRef.current?.abortRun();
+    agentRef.current = null;
+    activeRunIdRef.current = null;
+    pendingToolApprovalsRef.current = [];
+    setPendingToolApprovals([]);
+    clearLoadingEvents();
+  }, [clearLoadingEvents]);
 
   useEffect(() => {
     return () => {
@@ -721,7 +683,7 @@ function InAppAiAgentProviderInner({
 
   const selectConversation = useCallback(
     (conversationId: string | null) => {
-      if (isRunning || conversationId === selectedConversationId) {
+      if (isRunning || conversationId === _selectedConversationId) {
         return;
       }
 
@@ -732,7 +694,7 @@ function InAppAiAgentProviderInner({
       setMessages([]);
       setSelectedConversationId(conversationId);
     },
-    [isRunning, resetAgent, selectedConversationId, setSelectedConversationId],
+    [_selectedConversationId, isRunning, resetAgent, setSelectedConversationId],
   );
 
   const deleteConversation = useCallback(
@@ -1068,7 +1030,9 @@ function InAppAiAgentProviderInner({
       setIsExpanded,
       isRunning,
       isSubmitting,
-      pendingToolApprovals,
+      pendingToolApprovals: isSelectedConversationNotFound
+        ? []
+        : pendingToolApprovals,
       isSelectedConversationHydrating,
       error,
       messages: messagesWithUiState,
@@ -1095,6 +1059,7 @@ function InAppAiAgentProviderInner({
       isRunning,
       isSelectedConversationHydrating,
       isSubmitting,
+      isSelectedConversationNotFound,
       deleteConversation,
       loadMoreConversations,
       messagesWithUiState,

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -43,8 +43,9 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import {
   getInAppAgentError,
   isInAppAgentRateLimited,
+  type InAppAiAgentMessage,
 } from "@/src/ee/features/in-app-agent/components/utils/utils";
-import { type InAppAiAgentMessage } from "@/src/ee/features/in-app-agent/components/utils/utils";
+import { evaluateSetStateAction } from "@/src/utils/evaluate-set-state-action";
 
 const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";
@@ -933,11 +934,19 @@ function InAppAiAgentProviderInner({
     ],
   );
 
-  useEffect(() => {
-    if (!open) {
-      setIsExpanded(false);
-    }
-  }, [open]);
+  const setAgentOpen = useCallback<Dispatch<SetStateAction<boolean>>>(
+    (action) => {
+      const nextOpen = evaluateSetStateAction(action, open);
+
+      if (!nextOpen) {
+        // Collapse the drawer when closing
+        setIsExpanded(false);
+      }
+
+      setOpen(nextOpen);
+    },
+    [open, setOpen],
+  );
 
   const resumeToolApproval = useCallback(
     async (approvalId: string, approved: boolean) => {
@@ -1054,7 +1063,7 @@ function InAppAiAgentProviderInner({
     () => ({
       isAvailable: true,
       open,
-      setOpen,
+      setOpen: setAgentOpen,
       isExpanded,
       setIsExpanded,
       isRunning,
@@ -1092,10 +1101,10 @@ function InAppAiAgentProviderInner({
       open,
       pendingToolApprovals,
       rejectToolCall,
+      setAgentOpen,
       invalidateConversations,
       selectConversation,
       selectedConversationId,
-      setOpen,
       submit,
       submitFeedback,
     ],

--- a/web/src/utils/evaluate-set-state-action.ts
+++ b/web/src/utils/evaluate-set-state-action.ts
@@ -1,0 +1,12 @@
+import type { SetStateAction } from "react";
+
+export function evaluateSetStateAction<T>(
+  action: SetStateAction<T>,
+  previousState: T,
+) {
+  if (typeof action === "function") {
+    return (action as (previousState: T) => T)(previousState);
+  }
+
+  return action;
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `eslint-plugin-react-you-might-not-need-an-effect` to the ESLint config for the design-system and in-app-agent directories, then refactors existing code to comply with the new lint rules.

- **`InlineEditText.tsx`**: Replaces `useEffect` + `useRef` focus/select pattern with a stable callback ref (`useCallback(fn, [])`), avoiding unintended reselection while the user types.
- **`InAppAgentWindow.tsx`**: Splits the single `isInputDisabled` effect into a passive-update effect (for tracking previous state) and a `useCallback` callback ref (`setInputRef`) that focuses the textarea only when the input transitions from disabled to enabled.
- **`InAppAiAgentProvider.tsx`**: Removes two `useEffect` hooks that called `setState` for conversation hydration and NOT_FOUND error clearing, replacing them with a `useMemo`-derived `currentMessages` and an inline `selectedConversationId` derivation; also replaces `useEffect(() => setIsExpanded(false), [open])` with a wrapped `setAgentOpen` dispatcher.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are mechanical refactors driven by a new lint rule, touching only UI-layer event handling and derived state computation with no data mutations or API changes.

All three code changes correctly preserve prior behavior. The ref-ordering guarantee in InAppAgentWindow is standard React and correctly relied upon. No regressions apparent.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[isInputDisabled changes] --> B[setInputRef callback ref changes\nbecause isInputDisabled is a dep]
    B --> C[React calls old setInputRef null\ncleanup: inputRef.current = null]
    C --> D[React calls new setInputRef textarea]
    D --> E{previousIsInputDisabledRef.current\n AND NOT isInputDisabled?}
    E -- yes --> F[textarea.focus called\nre-enable focus]
    E -- no --> G[no focus]
    F --> H[useEffect runs:\npreviousIsInputDisabledRef.current = isInputDisabled]
    G --> H

    I[_selectedConversationId state] --> J{conversationQuery error\ncode === NOT_FOUND?}
    J -- yes --> K[selectedConversationId = null\ncurrentMessages = EMPTY_MESSAGES\npendingToolApprovals = empty array]
    J -- no --> L[selectedConversationId = _selectedConversationId\ncurrentMessages = useMemo logic]
    L --> M{isRunning OR storedMessages missing\nOR messages.length gt storedMessages?}
    M -- yes --> N[return live messages state]
    M -- no --> O[return storedMessages from query]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[isInputDisabled changes] --> B[setInputRef callback ref changes\nbecause isInputDisabled is a dep]
    B --> C[React calls old setInputRef null\ncleanup: inputRef.current = null]
    C --> D[React calls new setInputRef textarea]
    D --> E{previousIsInputDisabledRef.current\n AND NOT isInputDisabled?}
    E -- yes --> F[textarea.focus called\nre-enable focus]
    E -- no --> G[no focus]
    F --> H[useEffect runs:\npreviousIsInputDisabledRef.current = isInputDisabled]
    G --> H

    I[_selectedConversationId state] --> J{conversationQuery error\ncode === NOT_FOUND?}
    J -- yes --> K[selectedConversationId = null\ncurrentMessages = EMPTY_MESSAGES\npendingToolApprovals = empty array]
    J -- no --> L[selectedConversationId = _selectedConversationId\ncurrentMessages = useMemo logic]
    L --> M{isRunning OR storedMessages missing\nOR messages.length gt storedMessages?}
    M -- yes --> N[return live messages state]
    M -- no --> O[return storedMessages from query]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Refactor remaining useEffect hooks in \`I..."](https://github.com/langfuse/langfuse/commit/89f5c7ad6eca2c27c806ceda3b9ae5bb1aaf465f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43808935)</sub>

<!-- /greptile_comment -->