### PR TITLE
feat(agents): fold React-without-useEffect principles into frontend skill (LFE-10842)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -7,6 +7,10 @@ evaluating, and debugging AI applications.
 
 - Read the minimal local context required for the task.
 - Keep changes scoped and avoid unrelated refactors.
+- If you are about to write a `useEffect` — or sync fetched data into state, or
+  wire form initial values from loaded data — read
+  `.agents/skills/frontend-large-feature-architecture/SKILL.md` first. Most
+  such effects should not exist.
 - For bug fixes, write the failing test first, confirm it fails, then fix the
   bug. If the bug depends on a data shape, pause and ask: can
   `pnpm run seed` prefill that shape locally? If not, consider extending a

--- a/.agents/skills/frontend-large-feature-architecture/SKILL.md
+++ b/.agents/skills/frontend-large-feature-architecture/SKILL.md
@@ -35,11 +35,14 @@ UI is a pure function of state. Do not use `useEffect` to derive, prepare, or
 sync data:
 
 - Derived values are computed in render (`const title = data?.name ?? ""`),
-  never mirrored into state by an effect.
+  never mirrored into state by an effect. Client state that refers to server
+  data stores only the user's intent (an id) and derives the effective value
+  by merging with query data in render.
 - When loaded data seeds editable state, split the component: an outer
-  data-preparer/controller fetches and renders a `<Spinner />` while loading;
-  the inner component receives the loaded value as an `initialValue` prop and
-  seeds `useState(initialValue)`. Do not render UI before its data is ready.
+  data-preparer/controller fetches and renders a loading state (prefer a
+  skeleton; `<Spinner />` as minimal fallback); the inner component receives
+  the loaded value as an `initialValue` prop and seeds `useState(initialValue)`.
+  Do not render UI before its data is ready.
 - Define a form only where all initial values are already prepared; if data is
   still loading, the form lives deeper in the tree.
 - Complex actions live outside React as plain functions using the store or

--- a/.agents/skills/frontend-large-feature-architecture/SKILL.md
+++ b/.agents/skills/frontend-large-feature-architecture/SKILL.md
@@ -4,7 +4,9 @@ description: |
   Use when building, changing, or refactoring large Langfuse frontend features,
   virtualized lists, large tables, controller components, local feature state,
   Zustand stores, row selection, high-frequency UI state, or
-  rendering-performance issues.
+  rendering-performance issues. Also read BEFORE writing any useEffect
+  (especially one that syncs fetched data into state), wiring form
+  initialValues/defaultValues from loaded data, or adding useCallback/useMemo.
 ---
 
 # Frontend Large Feature Architecture
@@ -27,6 +29,29 @@ boundaries, not the normal way to derive state.
 For the full rules, read
 [`references/big-feature-rules.md`](references/big-feature-rules.md).
 
+## React Without useEffect
+
+UI is a pure function of state. Do not use `useEffect` to derive, prepare, or
+sync data:
+
+- Derived values are computed in render (`const title = data?.name ?? ""`),
+  never mirrored into state by an effect.
+- When loaded data seeds editable state, split the component: an outer
+  data-preparer/controller fetches and renders a `<Spinner />` while loading;
+  the inner component receives the loaded value as an `initialValue` prop and
+  seeds `useState(initialValue)`. Do not render UI before its data is ready.
+- Define a form only where all initial values are already prepared; if data is
+  still loading, the form lives deeper in the tree.
+- Complex actions live outside React as plain functions using the store or
+  query client — not inside components, not behind effects.
+- `useCallback`/`useMemo` are premature optimization; fix re-render problems by
+  splitting components, not memoizing.
+- `useEffect` is legitimate only for DOM/browser API integration: no (or
+  minimal) dependencies, one concern, and a cleanup function.
+
+For the golden example and full reasoning, read
+[`references/react-without-useeffect.md`](references/react-without-useeffect.md).
+
 ## Required Model
 
 - The page/view owns lifecycle and creates feature-scoped dependencies.
@@ -42,8 +67,10 @@ For the full rules, read
 - Shared `src/components/*` exports should stay context-free or receive
   explicit props. Put view-scoped Zustand consumers in `src/features/*`.
 - Large feature folders should have a concise `README.md` owner map.
-- Migrate real features through small PRs that improve one state boundary,
-  action workflow, data-preparation seam, or render boundary.
+- Migrate real features toward this model whenever you touch them: improve
+  state boundaries, action workflows, data-preparation seams, and render
+  boundaries. Hundreds of legacy cases remain — do not preserve a legacy shape
+  just to keep a change small.
 
 ## Local Store Default
 
@@ -61,6 +88,10 @@ The component wires hooks and passes dependencies; the action owns the workflow.
 
 - For the core big-feature rules and migration reality, read
   [`references/big-feature-rules.md`](references/big-feature-rules.md).
+- For the React-without-useEffect model — derived values, gating render on
+  loaded data, `initialValue` props, forms, actions outside React, and why not
+  to memoize — read
+  [`references/react-without-useeffect.md`](references/react-without-useeffect.md).
 - For virtualized lists, translated DOM, row measurement, and scroll rerenders,
   read [`references/virtualized-lists.md`](references/virtualized-lists.md).
 - For local feature stores and splitting large components, read

--- a/.agents/skills/frontend-large-feature-architecture/agents/openai.yaml
+++ b/.agents/skills/frontend-large-feature-architecture/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Frontend Feature Architecture"
   short_description: "Build, change, or refactor React features"
-  default_prompt: "Use $frontend-large-feature-architecture to build, change, or refactor this large frontend surface with clear state ownership, stable subscriptions, and view-only render boundaries."
+  default_prompt: "Use $frontend-large-feature-architecture to build, change, or refactor this large frontend surface with clear state ownership, effect-free data flow, stable subscriptions, and view-only render boundaries."
 
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/frontend-large-feature-architecture/references/big-feature-rules.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/big-feature-rules.md
@@ -44,30 +44,25 @@ changing responsibilities and waking too much UI.
    pure data preparation, a store action, or an explicit event handler.
 9. Do not copy existing large Langfuse feature components as examples. Treat
    them as legacy unless they follow this skill.
-10. Prefer small reliable PRs over a large rewrite. Each PR should improve one
-    state boundary, action workflow, data-preparation seam, or render boundary,
-    then update the feature README or migration note with the next slice.
+10. Follow the golden example in `react-without-useeffect.md`: gate render on
+    loaded data, seed state from `initialValue` props, and derive values in
+    render instead of syncing them with effects. When a change improves a
+    feature boundary, update the feature README or migration note with what
+    changed and the next slice.
 
 ## Migration Reality
 
 Most large frontend features are not yet in the ideal shape. Traces,
 observations, experiments, prompts, evals, datasets, and session views all have
-some controller-heavy surfaces. Do not copy an existing large component just
-because it works today. Treat it as a migration candidate and move it one
-state/action/data-preparation boundary at a time.
+controller-heavy surfaces, and there are hundreds of cases still to fix —
+including hundreds of `useEffect` calls that derive or sync state. Do not copy
+an existing large component just because it works today; treat it as a
+migration candidate. Do not scale ambition down either: broad, coherent
+improvements are welcome as long as each changed boundary is deliberate.
 
-For the step-by-step path, read `controller-migration.md`.
-
-## Small PR Policy
-
-A good big-feature PR is intentionally incomplete. It should change one
-semantic interaction and keep behavior stable: one selection boundary, one
-action workflow, one pure data-preparation helper, or one render boundary.
-
-Do not bundle file reorganization, state extraction, visual changes, and
-behavior fixes in the same PR unless the user explicitly asks for that scope.
-When a reorganization is needed, prefer a rename-only PR first or a later
-follow-up PR.
+The golden example — gate render on loaded data, seed state from props, keep
+actions outside React — is in `react-without-useeffect.md`. For the
+step-by-step controller path, read `controller-migration.md`.
 
 ## Effects And Actions
 

--- a/.agents/skills/frontend-large-feature-architecture/references/controller-migration.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/controller-migration.md
@@ -7,8 +7,9 @@ actions, and expensive rendering.
 The target is clear ownership, not "everything in a store." Start from the
 ownership baseline in `big-feature-rules.md`.
 
-Most existing features are not there yet. Migrate in narrow slices and keep
-behavior stable.
+Most existing features are not there yet, and there are hundreds of cases
+still to fix. Be explicit about which boundaries each change improves and what
+behavior changes on purpose.
 
 ## Realistic Migration Strategy
 
@@ -18,15 +19,16 @@ change safer than the previous one.
 For each migration PR, write down:
 
 - the current controller problem being targeted
-- the single state/action/data-preparation/render boundary being improved
-- what behavior must remain unchanged
+- the state/action/data-preparation/render boundaries being improved
+- what behavior changes on purpose and what must remain unchanged — a UI
+  simplification such as gating render behind a spinner is often the right
+  call (see `react-without-useeffect.md`)
 - what instrumentation or tests prove the slice worked
 - what still remains spread across the feature
-- the next recommended atomic slice
+- the next recommended slice
 
-This is how large features become managed features without review-hostile
-rewrites. The feature README is the living owner map; update it in place as the
-feature moves forward.
+This is how large features become managed features. The feature README is the
+living owner map; update it in place as the feature moves forward.
 
 ## Step-by-Step Path
 
@@ -39,12 +41,12 @@ feature moves forward.
    selection, scroll, filter change, drawer open, form step change, or
    saved-view change. Measure what rerenders, remounts, refetches, or
    recalculates.
-4. **Choose one boundary.** Start with the smallest high-value boundary:
-   selection, lazy-row state, batch action workflow, filter-target mapping,
-   column/view state, wizard step state, or pure data preparation. Do not
-   migrate everything at once.
+4. **Choose a boundary.** Start with a high-value boundary: selection,
+   lazy-row state, batch action workflow, filter-target mapping, column/view
+   state, wizard step state, or pure data preparation. Work boundary by
+   boundary, even when one change improves several.
 5. **Choose the lightest tool.** A pure helper or action extraction may be the
-   right first PR. Add a local store only when selective subscriptions or
+   right first move. Add a local store only when selective subscriptions or
    per-mount persistence are needed.
 6. **Create a local store instance when needed.** Use lazy `useState` in the
    page/view:
@@ -109,7 +111,7 @@ migration, not proof that the whole surface is healthy.
   data derivation.
 - Complex workflows can be called without rendering the page.
 - The feature README tells the next developer what has improved, what remains
-  spread, and what the next small PR should target.
+  spread, and what the next improvement should target.
 
 Avoid:
 

--- a/.agents/skills/frontend-large-feature-architecture/references/feature-readmes.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/feature-readmes.md
@@ -69,21 +69,18 @@ Use an update-in-place style rather than a changelog. For example:
   batch action workflow into an action file; split route/query glue from view
   components.
 
-This makes small PRs reviewable while keeping the feature migration plan
-visible. Do not wait for a perfect reorganization before documenting the
+This keeps each improvement reviewable while keeping the feature migration
+plan visible. Do not wait for a perfect reorganization before documenting the
 current state.
 
-## PR-Scale Guidance
+## Matching Updates To The Change
 
-Feature README updates should match the PR size:
+Feature README updates should match what actually changed:
 
-- For a small state/action extraction, add or update only the relevant
+- For a state/action extraction, add or update only the relevant
   migration-state bullets.
 - For a new feature folder structure, include the owner map and external
   consumers before moving logic into the folder.
-- For a rename-only PR, document intended structure but avoid changing behavior.
-- For behavior PRs, avoid unrelated file moves unless they are required for the
-  boundary being improved.
 
 The README should help the next contributor avoid falling back into the same
 large component, not argue that the migration is complete.

--- a/.agents/skills/frontend-large-feature-architecture/references/react-without-useeffect.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/react-without-useeffect.md
@@ -1,0 +1,131 @@
+# React Without useEffect
+
+UI is a pure function of state. Almost every `useEffect` that derives,
+prepares, or syncs data should not exist. The codebase has hundreds of them
+(over 350 `useEffect` call sites in `web/src` at the time of writing), and
+agents reach for `useEffect` by default because their training data is full
+of it. Do not.
+This file is the golden example and the target shape. Treat every
+data-derivation effect you touch as a migration candidate.
+
+## Mental Model: State → Frame
+
+Think of React as a game engine: the UI is a frame, rendered from state by a
+pure function. Since React 18, rendering is not atomic — a render can be
+interrupted, resumed, and spread across ticks, and you have close to zero
+control over the timing. A `useEffect` side effect fires against that
+interruptible render, which makes it a race condition by construction:
+impure, timing-dependent, and untestable.
+
+Keep render pure. Logic belongs where execution is synchronous and owned:
+event handlers, named actions, or plain derived values.
+
+## The #1 Anti-Pattern: Effects That Derive Or Prepare Data
+
+Real case, `web/src/features/monitors/pages/EditMonitorPage.tsx`:
+
+```tsx
+const [liveName, setLiveName] = useState("");
+useEffect(() => {
+  setLiveName(data?.name ?? "");
+}, [data?.name]);
+```
+
+An effect mirrors fetched data into local state. Now there are two sources of
+truth, a timing window between them, and a race: if the user edits the name
+before the query settles, the effect clobbers their input.
+
+Two fixes, depending on what the value is:
+
+- **Purely derived value** (never edited locally): compute it in render. No
+  state, no effect: `const title = data?.name ?? ""`.
+- **Loaded data seeding editable state** (this case): use the golden split
+  below.
+
+## The Golden Example: Split The Component, Gate Render On Load
+
+Split into two components. The outer one is a data preparer + controller: it
+fetches and renders a `<Spinner />` while loading. The inner one receives the
+loaded value as an `initialValue` prop and seeds `useState(initialValue)` —
+the value is guaranteed present and stable, and no effect can clobber it.
+
+```tsx
+// Outer: data preparer + controller. Do not render UI before its data is ready.
+function EditMonitorPage() {
+  const { data, isPending } = api.monitors.get.useQuery({ projectId, id });
+  if (isPending) return <Spinner />;
+  if (!data) return <ErrorPage title="Monitor not found" />;
+  return <EditMonitorForm key={data.id} initialMonitor={data} />;
+}
+
+// Inner: mounts only once data exists. Seeds state exactly once.
+function EditMonitorForm({ initialMonitor }: { initialMonitor: Monitor }) {
+  const [liveName, setLiveName] = useState(initialMonitor.name);
+  // ...
+}
+```
+
+This kills the whole class of typing-before-load races: there is no moment
+where the form exists without its data. The `key` remounts the inner component
+when the entity identity changes, so the seed stays honest.
+
+## Forms
+
+Only define a form where all initial values are already prepared. If data is
+still loading, the form lives deeper in the tree: a `DataPreparerAndController`
+fetches, shows a spinner, then passes `initialValues` and `onSubmit` to a pure
+`FormComponent` that only renders fields and submits.
+
+Real case, `web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx`:
+`useForm` is created at the top of the dialog with create-mode defaults, then a
+"populate form when in edit mode" effect calls `form.reset(...)` once the
+existing tool is available. The fix is structural, not a better effect: decide
+the `defaultValues` (create vs. edit) before rendering the form component, and
+render the form only when they are ready. The reset effect disappears.
+
+## Big Actions Live Outside React
+
+`queryClient` (React Query) and vanilla Zustand store instances are reachable
+outside the component tree — nothing forces a workflow through a hook or an
+effect. In the same dialog, `prettifyJson` and `handleDelete` are trapped
+inside the component because they close over form state and mutation hooks.
+Restructure so the dependencies live outside (the store, or a small passed-in
+dependency object), and the action becomes a plain, testable function.
+
+See `big-feature-rules.md` (Effects And Actions) and `local-feature-state.md`
+(Independent Actions) for the action shape.
+
+## When useEffect Is Legitimate
+
+An effect is for reaching things that exist outside React's render: the DOM
+and browser APIs. `document.addEventListener`/`removeEventListener`,
+observers, imperative third-party APIs, Web Audio (which also requires a user
+gesture). A healthy effect has: no dependencies (or minimal stable ones), one
+concern, and a cleanup function.
+
+## useCallback And useMemo Are Premature Optimization
+
+`useCallback` is `useMemo` for a function. Do not memoize before a confirmed,
+measured performance problem. Fix performance by splitting components and
+correcting re-render boundaries — splitting is itself a form of memoization.
+Needing memoization everywhere means the component re-renders too often, which
+means a state boundary is wrong. Fix the boundary.
+
+## Prefer UI Solutions Over Code Solutions
+
+Many frontend problems have UI solutions, not code solutions. A spinner plus
+gated rendering deletes more complexity than a clever behavior-preserving
+refactor. Do not fear changing behavior to simplify: rendering a spinner where
+the page previously showed a half-ready form is an improvement, not a
+regression. This is also why "write a characterization test, then refactor
+preserving behavior" rarely fits large frontend refactors — the target
+behavior is often the simpler one, not the current one.
+
+## The Vision
+
+Fetched data flows one way: query → prepared data → render, gated on
+readiness. State is seeded from props, edited by handlers, and never mirrored
+by effects. Actions are plain functions outside the tree. Effects that remain
+are thin DOM/browser integrations with cleanup. Hundreds of cases do not yet
+look like this — when you touch one, move it toward this shape rather than
+extending the effect.

--- a/.agents/skills/frontend-large-feature-architecture/references/react-without-useeffect.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/react-without-useeffect.md
@@ -11,11 +11,13 @@ data-derivation effect you touch as a migration candidate.
 ## Mental Model: State → Frame
 
 Think of React as a game engine: the UI is a frame, rendered from state by a
-pure function. Since React 18, rendering is not atomic — a render can be
-interrupted, resumed, and spread across ticks, and you have close to zero
-control over the timing. A `useEffect` side effect fires against that
-interruptible render, which makes it a race condition by construction:
-impure, timing-dependent, and untestable.
+pure function. An effect that writes state breaks that model mechanically:
+React commits and paints a frame from incomplete state, the effect fires
+after paint, and a second render repairs the frame. Between those frames the
+user can act and async results can land, so the repair step races real input —
+this is where "the effect reset my form" bugs come from. Concurrent rendering
+(React 18+) makes the timing even less predictable, but the model was already
+broken: two renders and a repair step where one pure render should be.
 
 Keep render pure. Logic belongs where execution is synchronous and owned:
 event handlers, named actions, or plain derived values.
@@ -45,9 +47,11 @@ Two fixes, depending on what the value is:
 ## The Golden Example: Split The Component, Gate Render On Load
 
 Split into two components. The outer one is a data preparer + controller: it
-fetches and renders a `<Spinner />` while loading. The inner one receives the
-loaded value as an `initialValue` prop and seeds `useState(initialValue)` —
-the value is guaranteed present and stable, and no effect can clobber it.
+fetches and renders a loading state while the query is pending — prefer a
+skeleton that matches the final layout; a `<Spinner />` is the minimal
+fallback. The inner one receives the loaded value as an `initialValue` prop
+and seeds `useState(initialValue)` — the value is guaranteed present and
+stable, and no effect can clobber it.
 
 ```tsx
 // Outer: data preparer + controller. Do not render UI before its data is ready.
@@ -69,12 +73,30 @@ This kills the whole class of typing-before-load races: there is no moment
 where the form exists without its data. The `key` remounts the inner component
 when the entity identity changes, so the seed stays honest.
 
+## Derive Client State From Server State
+
+When client state refers to server data — a selected row, an active id, a
+chosen option — store only the user's intent (the id) and derive the effective
+value during render by merging it with the query data:
+
+```tsx
+const selectedId = useFeatureStore((s) => s.selectedId);
+const selected = rows.find((r) => r.id === selectedId) ?? null;
+```
+
+Do not write an effect that validates or copies server data into the client
+store on refetch. Deriving keeps one source of truth per fact — the store owns
+intent, the query owns data — and the merge stays correct through loading,
+refetch, and invalidation. Wrap the merge in `useMemo` only when it is
+measurably expensive. (Pattern:
+[Deriving Client State from Server State](https://tkdodo.eu/blog/deriving-client-state-from-server-state).)
+
 ## Forms
 
 Only define a form where all initial values are already prepared. If data is
 still loading, the form lives deeper in the tree: a `DataPreparerAndController`
-fetches, shows a spinner, then passes `initialValues` and `onSubmit` to a pure
-`FormComponent` that only renders fields and submits.
+fetches, shows a loading state, then passes `initialValues` and `onSubmit` to a
+pure `FormComponent` that only renders fields and submits.
 
 Real case, `web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx`:
 `useForm` is created at the top of the dialog with create-mode defaults, then a
@@ -111,12 +133,18 @@ correcting re-render boundaries — splitting is itself a form of memoization.
 Needing memoization everywhere means the component re-renders too often, which
 means a state boundary is wrong. Fix the boundary.
 
+The exception is referential stability as a correctness requirement: when a
+callback or object is a dependency of a legitimate integration effect or a
+data-fetching hook, memoize it — or hoist it outside the component — so the
+dependency does not change identity every render and loop the effect. That is
+correctness, not optimization.
+
 ## Prefer UI Solutions Over Code Solutions
 
-Many frontend problems have UI solutions, not code solutions. A spinner plus
-gated rendering deletes more complexity than a clever behavior-preserving
-refactor. Do not fear changing behavior to simplify: rendering a spinner where
-the page previously showed a half-ready form is an improvement, not a
+Many frontend problems have UI solutions, not code solutions. A loading state
+plus gated rendering deletes more complexity than a clever behavior-preserving
+refactor. Do not fear changing behavior to simplify: rendering a skeleton
+where the page previously showed a half-ready form is an improvement, not a
 regression. This is also why "write a characterization test, then refactor
 preserving behavior" rarely fits large frontend refactors — the target
 behavior is often the simpler one, not the current one.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -62,7 +62,8 @@ Use root [AGENTS.md](../AGENTS.md) for monorepo-level rules.
 
 - Shared browser-review workflow for user-visible frontend changes:
   [`../.agents/skills/frontend-browser-review/SKILL.md`](../.agents/skills/frontend-browser-review/SKILL.md)
-- Large frontend feature, virtualized-list, and local state architecture:
+- Large frontend feature, virtualized-list, local state, and React
+  effect-free data-flow architecture:
   [`../.agents/skills/frontend-large-feature-architecture/SKILL.md`](../.agents/skills/frontend-large-feature-architecture/SKILL.md)
 - React composition and component API design:
   [`web/.agents/skills/vercel-composition-patterns/SKILL.md`](.agents/skills/vercel-composition-patterns/SKILL.md)
@@ -75,9 +76,12 @@ Read these package-local skills before substantial frontend refactors when the
 task involves component composition, reusable component APIs, rendering
 performance, virtualized lists, local feature stores, bundle size,
 React/Next.js performance patterns, or browser-based signoff of user-visible
-changes. When adding a meaningful user action (button, handler, form,
-mutation, feature surface), read the PostHog instrumentation skill and decide
-explicitly whether the action should emit an analytics event.
+changes. If you are about to write a `useEffect` or wire form initial values
+from loaded data, read the frontend-large-feature-architecture skill first —
+most effects that derive or sync state should not exist. When adding a
+meaningful user action (button, handler, form, mutation, feature surface),
+read the PostHog instrumentation skill and decide explicitly whether the
+action should emit an analytics event.
 
 ## Web Conventions
 


### PR DESCRIPTION
## TL;DR

The `frontend-large-feature-architecture` skill now teaches the **"React without useEffect"** model from the internal React sharing session — centerpiece: **split a data-preparer/controller from an inner component seeded via `initialValue` props, and gate render on load** — and all "small PR" prescriptions are removed in favor of a golden example + vision.

## Why

Agents (and humans) reach for `useEffect` to derive or sync state by default — training data is full of it. `web/src` has **350+ `useEffect` call sites**, and most data-derivation effects are race conditions by construction: since React 18, rendering is interruptible, so an effect firing against a partial render clobbers user input (type into a form before its query settles and watch the effect reset it).

Separately, the skill mandated small, intentionally-incomplete PRs. That pace doesn't match how much of the frontend needs improving — the process prescription is gone; what matters is the target shape, not the diff size.

## What

- **New [`references/react-without-useeffect.md`](https://github.com/langfuse/langfuse/blob/feature/lfe-10842-improve-large-front-end-feature-skill/.agents/skills/frontend-large-feature-architecture/references/react-without-useeffect.md)** — mental model (UI = pure function of state, state → frame), the #1 anti-pattern (effects that derive/prepare data, with two real in-repo cases), the golden split + spinner-on-load pattern, forms defined only where initial values are ready, big actions outside React, when `useEffect` *is* legitimate, `useCallback`/`useMemo` as premature optimization, and preferring UI solutions over code solutions.
- **`SKILL.md`**: new "React Without useEffect" section with the headline rules, plus a widened `description:` trigger (useEffect / form initial values / memoization) so agents self-summon the skill.
- **PR-size language removed everywhere**: "Small PR Policy" deleted, Hard Rule #10 rewritten to point at the golden example, "Migration Reality" reframed as vision + "hundreds of cases still to fix"; small-PR phrasings in `feature-readmes.md` and `controller-migration.md` replaced.
- **Root `AGENTS.md` + `web/AGENTS.md`**: trigger line — if you're about to write a `useEffect`, read the skill first.

## Result

An agent about to write a data-syncing effect now gets intercepted twice: the AGENTS.md trigger line before it starts, and the skill description when the task mentions effects/forms. The skill then routes it to derive-in-render or the golden split instead.

<details>
<summary>Verification & mechanics</summary>

- `pnpm run agents:sync` + `pnpm run agents:check` — clean.
- `prettier --write` over all touched files — no changes needed; pre-commit `turbo run lint`: `Tasks: 7 successful, 7 total`.
- Skill frontmatter parses (harness re-loaded the updated description live).
- Both anti-pattern examples cited in the new reference are real, current code: `web/src/features/monitors/pages/EditMonitorPage.tsx` (effect mirrors `data?.name` into `liveName` state) and `web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx` (populate-form-on-edit `form.reset` effect; `prettifyJson`/`handleDelete` trapped in the component).
- Provider shims under `.claude/` etc. are generated locally and not committed, per the shared agent-setup model.

</details>

Related: #14940 (same author-a-repo-skill pattern, posthog-instrumentation). Ticket: [LFE-10842](https://linear.app/langfuse/issue/LFE-10842).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds well-reasoned "React without useEffect" guidance to the agent skill system. The core patterns — the golden split (outer controller → spinner gate → inner component with `initialValue`), derive-in-render, forms gated on data readiness, and actions outside React — are technically sound and directly address a real codebase problem (350+ `useEffect` call sites).

- **New reference doc** codifies the golden split pattern, two canonical in-repo anti-pattern examples, and guidance on keeping actions outside React.
- **Trigger lines** in `.agents/AGENTS.md` and `web/AGENTS.md` intercept an agent before it writes a data-syncing `useEffect`.
- **PR-size policy removed**: Hard Rule #10 and the "Small PR Policy" block replaced with a vision statement.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

All changes are documentation and agent-skill markdown files with no runtime code path — safe to merge.

The guidance is well-reasoned and the golden-split pattern is correct. Two small issues in the new reference doc hold it back from a clean pass: a missing blank line that causes two intended paragraphs to merge, and a `useCallback`/`useMemo` section that doesn't carve out the stable-reference correctness case — an agent following the guidance literally could strip `useCallback` wrappers needed as stable deps for the very DOM-integration effects the document endorses, producing infinite loops.

`references/react-without-useeffect.md` — both issues live there; the other changed files look correct.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent starts frontend task] --> B{About to write useEffect or wire form initialValues?}
    B -- No --> C[Proceed with task]
    B -- Yes --> D[Intercepted by AGENTS.md trigger line]
    D --> E[Read frontend-large-feature-architecture SKILL.md]
    E --> F{What kind of effect?}
    F -- Derived value, never edited --> G[Compute inline in render]
    F -- Loaded data seeds editable state --> H[Golden split: Outer controller + Spinner gate + Inner receives initialValue prop]
    F -- Form initial values --> I[Move form deeper: DataPreparer shows Spinner, FormComponent renders only when data ready]
    F -- Big action / workflow --> J[Move outside React: plain function using queryClient or Zustand store]
    F -- DOM / browser API integration --> K[Legitimate useEffect: no/minimal deps, one concern, cleanup fn]
    G --> L[No useEffect needed]
    H --> L
    I --> L
    J --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Agent starts frontend task] --> B{About to write useEffect or wire form initialValues?}
    B -- No --> C[Proceed with task]
    B -- Yes --> D[Intercepted by AGENTS.md trigger line]
    D --> E[Read frontend-large-feature-architecture SKILL.md]
    E --> F{What kind of effect?}
    F -- Derived value, never edited --> G[Compute inline in render]
    F -- Loaded data seeds editable state --> H[Golden split: Outer controller + Spinner gate + Inner receives initialValue prop]
    F -- Form initial values --> I[Move form deeper: DataPreparer shows Spinner, FormComponent renders only when data ready]
    F -- Big action / workflow --> J[Move outside React: plain function using queryClient or Zustand store]
    F -- DOM / browser API integration --> K[Legitimate useEffect: no/minimal deps, one concern, cleanup fn]
    G --> L[No useEffect needed]
    H --> L
    I --> L
    J --> L
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.agents/skills/frontend-large-feature-architecture/references/react-without-useeffect.md:8-9
**Missing blank line between paragraphs**

"Do not." ends the opening paragraph and "This file is the golden example…" starts a new thought, but there is no blank line between them. In Markdown, consecutive non-blank lines merge into one paragraph, so renderers (and agents reading the HTML output) will see a single run-on paragraph instead of the intended two-sentence break.

### Issue 2 of 2
.agents/skills/frontend-large-feature-architecture/references/react-without-useeffect.md:100-107
**`useCallback` guidance omits the stable-reference use case**

The section frames `useCallback`/`useMemo` purely as a performance optimization and instructs agents not to reach for them before a "confirmed, measured performance problem." This is correct for the render-churn case, but `useCallback` is also required for _correctness_ when the function is consumed as a dependency by a legitimate `useEffect` (DOM/browser integration) or a `useQuery`/`useSWR` hook — omitting it makes the dependency unstable, causing infinite refetch or effect loops. An agent that follows this guidance literally and strips `useCallback` wrappers from stable callback deps of the hooks the document does endorse as legitimate could introduce runtime regressions. Adding a one-line carve-out ("except when the callback is a dependency of a DOM-integration effect or data-fetching hook") would prevent that misapplication.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agents): fold React-without-useEffe..."](https://github.com/langfuse/langfuse/commit/2bd450ecb5dbb762927e70af0251122ba57c8418) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43325233)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->