### PR TITLE
feat(blobstorage): write run-completion manifest per export run (LFE-10843)

### DIFF
--- a/worker/src/__tests__/blobExportManifest.unit.test.ts
+++ b/worker/src/__tests__/blobExportManifest.unit.test.ts
@@ -72,7 +72,6 @@ describe("blob export manifest builders (LFE-10843)", () => {
     expect(manifest.createdAt).toBe("2026-07-10T10:00:05.000Z");
     expect(manifest.tables).toEqual(["scores", "traces", "observations"]);
     expect(manifest.files).toHaveLength(3);
-    // Round-trips through JSON without surprises.
     expect(JSON.parse(JSON.stringify(manifest))).toEqual(manifest);
   });
 

--- a/worker/src/__tests__/blobExportManifest.unit.test.ts
+++ b/worker/src/__tests__/blobExportManifest.unit.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  BLOB_EXPORT_MANIFEST_VERSION,
+  buildBlobExportManifest,
+  buildBlobExportManifestKey,
+  formatBlobExportTimestamp,
+  type BlobExportManifestFile,
+} from "../features/blobstorage/manifest";
+
+const file = (
+  overrides: Partial<BlobExportManifestFile> = {},
+): BlobExportManifestFile => ({
+  key: "proj/traces/2026-07-10T10-00-00.jsonl",
+  table: "traces",
+  fileType: "JSONL",
+  format: "jsonl-raw",
+  compressed: false,
+  contentType: "application/x-ndjson; charset=utf-8",
+  sizeBytes: 42,
+  rowCount: 3,
+  ...overrides,
+});
+
+describe("blob export manifest builders (LFE-10843)", () => {
+  it("strips colons from the timestamp stem and truncates to seconds", () => {
+    expect(
+      formatBlobExportTimestamp(new Date("2026-07-10T10:20:30.123Z")),
+    ).toBe("2026-07-10T10-20-30");
+  });
+
+  it("builds the manifest key under the project's manifests/ prefix", () => {
+    expect(
+      buildBlobExportManifestKey({
+        prefix: "team/",
+        projectId: "proj",
+        maxTimestamp: new Date("2026-07-10T10:20:30Z"),
+      }),
+    ).toBe("team/proj/manifests/2026-07-10T10-20-30.json");
+  });
+
+  it("treats an absent prefix as empty", () => {
+    expect(
+      buildBlobExportManifestKey({
+        projectId: "proj",
+        maxTimestamp: new Date("2026-07-10T10:20:30Z"),
+      }),
+    ).toBe("proj/manifests/2026-07-10T10-20-30.json");
+  });
+
+  it("assembles the manifest payload with version, window, and distinct tables", () => {
+    const manifest = buildBlobExportManifest({
+      projectId: "proj",
+      exportSource: "TRACES_OBSERVATIONS",
+      minTimestamp: new Date("2026-07-10T09:00:00Z"),
+      maxTimestamp: new Date("2026-07-10T10:00:00Z"),
+      createdAt: new Date("2026-07-10T10:00:05Z"),
+      files: [
+        file({ table: "scores", key: "proj/scores/x.jsonl" }),
+        file({ table: "traces", key: "proj/traces/x.jsonl" }),
+        file({ table: "observations", key: "proj/observations/x.jsonl" }),
+      ],
+    });
+
+    expect(manifest.version).toBe(BLOB_EXPORT_MANIFEST_VERSION);
+    expect(manifest.projectId).toBe("proj");
+    expect(manifest.exportSource).toBe("TRACES_OBSERVATIONS");
+    expect(manifest.window).toEqual({
+      minTimestamp: "2026-07-10T09:00:00.000Z",
+      maxTimestamp: "2026-07-10T10:00:00.000Z",
+    });
+    expect(manifest.maxTimestamp).toBe(manifest.window.maxTimestamp);
+    expect(manifest.createdAt).toBe("2026-07-10T10:00:05.000Z");
+    expect(manifest.tables).toEqual(["scores", "traces", "observations"]);
+    expect(manifest.files).toHaveLength(3);
+    // Round-trips through JSON without surprises.
+    expect(JSON.parse(JSON.stringify(manifest))).toEqual(manifest);
+  });
+
+  it("deduplicates tables while preserving first-seen order", () => {
+    const manifest = buildBlobExportManifest({
+      projectId: "proj",
+      exportSource: "EVENTS",
+      minTimestamp: new Date("2026-07-10T09:00:00Z"),
+      maxTimestamp: new Date("2026-07-10T10:00:00Z"),
+      createdAt: new Date("2026-07-10T10:00:05Z"),
+      files: [
+        file({ table: "observations_v2" }),
+        file({ table: "observations_v2", key: "proj/observations_v2/y.jsonl" }),
+      ],
+    });
+    expect(manifest.tables).toEqual(["observations_v2"]);
+  });
+});

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -636,7 +636,6 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       }
 
       const files = await s3StorageService.listFiles(s3Prefix);
-      // Exclude the run-completion manifest (LFE-10843) from the table-file count.
       const projectFiles = files.filter(
         (f) => f.file.includes(projectId) && !f.file.includes("/manifests/"),
       );
@@ -644,8 +643,6 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       // Should have 4 files (traces, observations, scores, events)
       expect(projectFiles).toHaveLength(4);
 
-      // The run manifest lists all 4 files, the export window, and per-file
-      // format; its presence is the run's commit point.
       const manifestFile = files.find((f) => f.file.includes("/manifests/"));
       expect(manifestFile).toBeDefined();
       const manifest = JSON.parse(
@@ -1067,7 +1064,6 @@ describe("BlobStorageIntegrationProcessingJob", () => {
 
         // Get files for this file type
         const files = await s3StorageService.listFiles(prefix);
-        // Exclude the run-completion manifest (LFE-10843) from the table-file count.
         const projectFiles = files.filter(
           (f) =>
             f.file.includes(projectId) &&
@@ -1669,7 +1665,6 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         } as Job);
 
         const files = await s3StorageService.listFiles(s3Prefix);
-        // Exclude the JSON run manifest (LFE-10843) from the extension check.
         const projectFiles = files.filter(
           (f) => f.file.includes(projectId) && !f.file.includes("/manifests/"),
         );
@@ -1724,7 +1719,6 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         } as Job);
 
         const files = await s3StorageService.listFiles(s3Prefix);
-        // Exclude the JSON run manifest (LFE-10843) from the extension check.
         const projectFiles = files.filter(
           (f) => f.file.includes(projectId) && !f.file.includes("/manifests/"),
         );
@@ -1789,7 +1783,6 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         } as Job);
 
         const files = await s3StorageService.listFiles(s3Prefix);
-        // Exclude the JSON run manifest (LFE-10843) from the extension check.
         const projectFiles = files.filter(
           (f) => f.file.includes(projectId) && !f.file.includes("/manifests/"),
         );
@@ -1802,9 +1795,8 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     );
   });
 
-  // LFE-10843: every successful run writes a structured manifest as its last
-  // object (commit point). Uses the non-enriched TRACES_OBSERVATIONS source so
-  // it runs on every CI leg, independent of the V4-preview opt-in.
+  // Uses the non-enriched TRACES_OBSERVATIONS source so it runs on every CI
+  // leg, independent of the V4-preview opt-in.
   describe("run-completion manifest (LFE-10843)", () => {
     maybeIt(
       "writes a manifest listing every file, the window, and per-file format",
@@ -1878,7 +1870,6 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         );
         expect(tableFiles).toHaveLength(3); // scores, traces, observations
 
-        // Manifest key: {prefix}{projectId}/manifests/{maxTimestamp}.json
         const manifestFile = files.find((f) => f.file.includes("/manifests/"));
         expect(manifestFile).toBeDefined();
         expect(manifestFile!.file).toContain(
@@ -1896,13 +1887,10 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           new Set(["scores", "traces", "observations"]),
         );
 
-        // Files list matches exactly the uploaded table objects.
         expect(
           new Set(manifest.files.map((f: { key: string }) => f.key)),
         ).toEqual(new Set(tableFiles.map((f) => f.file)));
 
-        // Per-file format for a text export: uncompressed JSONL with a counted
-        // row count.
         const tracesEntry = manifest.files.find(
           (f: { table: string }) => f.table === "traces",
         );
@@ -1912,7 +1900,6 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         expect(tracesEntry.rowCount).toBe(1);
         expect(typeof tracesEntry.sizeBytes).toBe("number");
 
-        // Window is populated and maxTimestamp mirrors the window bound.
         expect(typeof manifest.window.minTimestamp).toBe("string");
         expect(manifest.maxTimestamp).toBe(manifest.window.maxTimestamp);
         expect(typeof manifest.createdAt).toBe("string");
@@ -2265,7 +2252,6 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       } as Job);
 
       const files = await s3StorageService.listFiles(s3Prefix);
-      // Exclude the JSON run manifest (LFE-10843) from the parquet-only checks.
       const projectFiles = files.filter(
         (f) => f.file.includes(projectId) && !f.file.includes("/manifests/"),
       );
@@ -2277,8 +2263,6 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         expect(f.file).not.toContain(".gz");
       }
 
-      // The parquet run manifest reports rowCount: null (binary stream, no
-      // per-row count) and PARQUET file type for every listed file (LFE-10843).
       const manifestFile = files.find((f) => f.file.includes("/manifests/"));
       expect(manifestFile).toBeDefined();
       const manifest = JSON.parse(

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -636,10 +636,32 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       }
 
       const files = await s3StorageService.listFiles(s3Prefix);
-      const projectFiles = files.filter((f) => f.file.includes(projectId));
+      // Exclude the run-completion manifest (LFE-10843) from the table-file count.
+      const projectFiles = files.filter(
+        (f) => f.file.includes(projectId) && !f.file.includes("/manifests/"),
+      );
 
       // Should have 4 files (traces, observations, scores, events)
       expect(projectFiles).toHaveLength(4);
+
+      // The run manifest lists all 4 files, the export window, and per-file
+      // format; its presence is the run's commit point.
+      const manifestFile = files.find((f) => f.file.includes("/manifests/"));
+      expect(manifestFile).toBeDefined();
+      const manifest = JSON.parse(
+        await s3StorageService.download(manifestFile!.file),
+      );
+      expect(manifest.version).toBe(1);
+      expect(manifest.projectId).toBe(projectId);
+      expect(manifest.exportSource).toBe("TRACES_OBSERVATIONS_EVENTS");
+      expect(new Set(manifest.tables)).toEqual(
+        new Set(["traces", "observations", "scores", "observations_v2"]),
+      );
+      expect(manifest.files).toHaveLength(4);
+      expect(
+        new Set(manifest.files.map((f: { key: string }) => f.key)),
+      ).toEqual(new Set(projectFiles.map((f) => f.file)));
+      expect(manifest.window.maxTimestamp).toBe(manifest.maxTimestamp);
 
       // Check file paths follow the expected pattern
       const traceFile = projectFiles.find((f) => f.file.includes("/traces/"));
@@ -1045,8 +1067,12 @@ describe("BlobStorageIntegrationProcessingJob", () => {
 
         // Get files for this file type
         const files = await s3StorageService.listFiles(prefix);
+        // Exclude the run-completion manifest (LFE-10843) from the table-file count.
         const projectFiles = files.filter(
-          (f) => f.file.includes(projectId) && f.file.includes(fileTypePrefix),
+          (f) =>
+            f.file.includes(projectId) &&
+            f.file.includes(fileTypePrefix) &&
+            !f.file.includes("/manifests/"),
         );
 
         // Should have 4 files (traces, observations, scores, events)
@@ -1643,7 +1669,10 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         } as Job);
 
         const files = await s3StorageService.listFiles(s3Prefix);
-        const projectFiles = files.filter((f) => f.file.includes(projectId));
+        // Exclude the JSON run manifest (LFE-10843) from the extension check.
+        const projectFiles = files.filter(
+          (f) => f.file.includes(projectId) && !f.file.includes("/manifests/"),
+        );
 
         expect(projectFiles.length).toBeGreaterThan(0);
         expect(projectFiles.every((f) => f.file.endsWith(".csv.gz"))).toBe(
@@ -1695,7 +1724,10 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         } as Job);
 
         const files = await s3StorageService.listFiles(s3Prefix);
-        const projectFiles = files.filter((f) => f.file.includes(projectId));
+        // Exclude the JSON run manifest (LFE-10843) from the extension check.
+        const projectFiles = files.filter(
+          (f) => f.file.includes(projectId) && !f.file.includes("/manifests/"),
+        );
 
         expect(projectFiles.length).toBeGreaterThan(0);
         expect(
@@ -1757,12 +1789,133 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         } as Job);
 
         const files = await s3StorageService.listFiles(s3Prefix);
-        const projectFiles = files.filter((f) => f.file.includes(projectId));
+        // Exclude the JSON run manifest (LFE-10843) from the extension check.
+        const projectFiles = files.filter(
+          (f) => f.file.includes(projectId) && !f.file.includes("/manifests/"),
+        );
 
         expect(projectFiles.length).toBeGreaterThan(0);
         expect(projectFiles.every((f) => f.file.endsWith(".jsonl.gz"))).toBe(
           true,
         );
+      },
+    );
+  });
+
+  // LFE-10843: every successful run writes a structured manifest as its last
+  // object (commit point). Uses the non-enriched TRACES_OBSERVATIONS source so
+  // it runs on every CI leg, independent of the V4-preview opt-in.
+  describe("run-completion manifest (LFE-10843)", () => {
+    maybeIt(
+      "writes a manifest listing every file, the window, and per-file format",
+      async () => {
+        const { projectId } = await createOrgProjectAndApiKey();
+        s3Prefix = `${projectId}/`;
+        const now = new Date();
+        const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+        const dataTime = now.getTime() - 40 * 60 * 1000;
+
+        await prisma.blobStorageIntegration.create({
+          data: {
+            projectId,
+            type: BlobStorageIntegrationType.S3,
+            bucketName,
+            prefix: s3Prefix,
+            accessKeyId: minioAccessKeyId,
+            secretAccessKey: encrypt(minioAccessKeySecret),
+            region: region ? region : "auto",
+            endpoint: minioEndpoint,
+            forcePathStyle:
+              env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+            enabled: true,
+            exportFrequency: "hourly",
+            exportSource: "TRACES_OBSERVATIONS",
+            fileType: BlobStorageIntegrationFileType.JSONL,
+            compressed: false,
+            lastSyncAt: oneHourAgo,
+          },
+        });
+
+        const traceId = randomUUID();
+        await Promise.all([
+          createTracesCh([
+            createTrace({
+              id: traceId,
+              project_id: projectId,
+              timestamp: dataTime,
+              name: "Manifest Trace",
+            }),
+          ]),
+          createObservationsCh([
+            createObservation({
+              id: randomUUID(),
+              trace_id: traceId,
+              project_id: projectId,
+              start_time: dataTime,
+              end_time: dataTime + 5000,
+              name: "Manifest Observation",
+            }),
+          ]),
+          createScoresCh([
+            createTraceScore({
+              id: randomUUID(),
+              trace_id: traceId,
+              project_id: projectId,
+              timestamp: dataTime,
+              name: "Manifest Score",
+              value: 0.5,
+            }),
+          ]),
+        ]);
+
+        await handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+        } as Job);
+
+        const files = await s3StorageService.listFiles(s3Prefix);
+        const tableFiles = files.filter(
+          (f) => f.file.includes(projectId) && !f.file.includes("/manifests/"),
+        );
+        expect(tableFiles).toHaveLength(3); // scores, traces, observations
+
+        // Manifest key: {prefix}{projectId}/manifests/{maxTimestamp}.json
+        const manifestFile = files.find((f) => f.file.includes("/manifests/"));
+        expect(manifestFile).toBeDefined();
+        expect(manifestFile!.file).toContain(
+          `${s3Prefix}${projectId}/manifests/`,
+        );
+        expect(manifestFile!.file.endsWith(".json")).toBe(true);
+
+        const manifest = JSON.parse(
+          await s3StorageService.download(manifestFile!.file),
+        );
+        expect(manifest.version).toBe(1);
+        expect(manifest.projectId).toBe(projectId);
+        expect(manifest.exportSource).toBe("TRACES_OBSERVATIONS");
+        expect(new Set(manifest.tables)).toEqual(
+          new Set(["scores", "traces", "observations"]),
+        );
+
+        // Files list matches exactly the uploaded table objects.
+        expect(
+          new Set(manifest.files.map((f: { key: string }) => f.key)),
+        ).toEqual(new Set(tableFiles.map((f) => f.file)));
+
+        // Per-file format for a text export: uncompressed JSONL with a counted
+        // row count.
+        const tracesEntry = manifest.files.find(
+          (f: { table: string }) => f.table === "traces",
+        );
+        expect(tracesEntry.fileType).toBe("JSONL");
+        expect(tracesEntry.format).toBe("jsonl-raw");
+        expect(tracesEntry.compressed).toBe(false);
+        expect(tracesEntry.rowCount).toBe(1);
+        expect(typeof tracesEntry.sizeBytes).toBe("number");
+
+        // Window is populated and maxTimestamp mirrors the window bound.
+        expect(typeof manifest.window.minTimestamp).toBe("string");
+        expect(manifest.maxTimestamp).toBe(manifest.window.maxTimestamp);
+        expect(typeof manifest.createdAt).toBe("string");
       },
     );
   });
@@ -2112,13 +2265,31 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       } as Job);
 
       const files = await s3StorageService.listFiles(s3Prefix);
-      const projectFiles = files.filter((f) => f.file.includes(projectId));
+      // Exclude the JSON run manifest (LFE-10843) from the parquet-only checks.
+      const projectFiles = files.filter(
+        (f) => f.file.includes(projectId) && !f.file.includes("/manifests/"),
+      );
 
       // traces, observations, scores, observations_v2 (events).
       expect(projectFiles).toHaveLength(4);
       for (const f of projectFiles) {
         expect(f.file.endsWith(".parquet")).toBe(true);
         expect(f.file).not.toContain(".gz");
+      }
+
+      // The parquet run manifest reports rowCount: null (binary stream, no
+      // per-row count) and PARQUET file type for every listed file (LFE-10843).
+      const manifestFile = files.find((f) => f.file.includes("/manifests/"));
+      expect(manifestFile).toBeDefined();
+      const manifest = JSON.parse(
+        await s3StorageService.download(manifestFile!.file),
+      );
+      expect(manifest.files).toHaveLength(4);
+      for (const f of manifest.files) {
+        expect(f.fileType).toBe("PARQUET");
+        expect(f.format).toBe("parquet");
+        expect(f.compressed).toBe(false);
+        expect(f.rowCount).toBeNull();
       }
 
       // Every object is a valid Parquet file (magic at both ends).

--- a/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
+++ b/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
@@ -34,6 +34,8 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
           }
           return undefined;
         }),
+        // Run-completion manifest write (LFE-10843); string body, no stream.
+        uploadFile: vi.fn(async () => undefined),
       }),
     },
     getTracesForBlobStorageExport: () => empty(),

--- a/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
+++ b/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
@@ -34,7 +34,7 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
           }
           return undefined;
         }),
-        // Run-completion manifest write (LFE-10843); string body, no stream.
+        // Manifest write; string body, no stream to drain.
         uploadFile: vi.fn(async () => undefined),
       }),
     },

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -318,8 +318,7 @@ const createRawJsonlNewlineTransform = (): Transform =>
     },
   });
 
-// Shared connection config for every object written by a run (table files and
-// the run-completion manifest). KMS SSE is not supported for this integration.
+// KMS SSE is not supported for this integration.
 type BlobStorageConnectionConfig = {
   bucketName: string;
   endpoint: string | null;
@@ -452,8 +451,6 @@ const processBlobStorageExport = async (config: {
       // Outside the try so the catch can distinguish a real upload success from
       // a failure.
       let uploadSucceeded = false;
-      // Populated at the upload boundary; returned to the caller so the run can
-      // list every file in its completion manifest (LFE-10843).
       let manifestFile: BlobExportManifestFile | undefined;
       let heartbeat: ReturnType<typeof setInterval> | undefined;
 
@@ -489,8 +486,6 @@ const processBlobStorageExport = async (config: {
             ? "passthrough"
             : "standard";
 
-        // Shared stem with the run manifest key, so a run's files and its
-        // manifest sort together under the project prefix.
         const timestamp = formatBlobExportTimestamp(config.maxTimestamp);
         // Parquet: fixed `.parquet` extension (no `.gz`) and Parquet content type.
         const extension = parquetEligible
@@ -807,9 +802,8 @@ const processBlobStorageExport = async (config: {
             ? BlobExportFormat.PARQUET
             : resolveBlobExportFormat(config.fileType, config.compressed);
 
-          // Record this file for the run manifest. rowCount is null on the
-          // parquet path (binary stream has no per-row boundaries, so
-          // sourceStats.rows stays 0 and would misreport as an empty file).
+          // rowCount null on parquet: sourceStats.rows stays 0 for the binary
+          // stream and would misreport as an empty file.
           manifestFile = {
             key: filePath,
             table: config.table,
@@ -1069,8 +1063,7 @@ const processBlobStorageExport = async (config: {
         span.setAttribute("blob.eventLoopDelay.meanMs", Math.round(meanMs));
       }
 
-      // Only reached on the success path (the catch above rethrows), so the
-      // entry is always populated here.
+      // Always populated on the success path (the catch above rethrows).
       if (!manifestFile) {
         throw new Error(
           `[BLOB INTEGRATION] Missing manifest entry after a successful ${config.table} export for project ${config.projectId}`,
@@ -1081,9 +1074,8 @@ const processBlobStorageExport = async (config: {
   );
 };
 
-// Writes the run-completion manifest (LFE-10843). The manifest is a small JSON
-// body, so it uses the single-shot uploadFile (string body) rather than the
-// buffered multipart path the table streams use.
+// Small JSON body, so single-shot uploadFile instead of the buffered multipart
+// path the table streams use.
 const writeBlobExportManifest = async (params: {
   connection: BlobStorageConnectionConfig;
   prefix?: string;
@@ -1111,7 +1103,7 @@ const writeBlobExportManifest = async (params: {
   await storageService.uploadFile({
     fileName: key,
     fileType: "application/json; charset=utf-8",
-    // Trailing newline keeps the object POSIX-line friendly for shell tooling.
+    // Trailing newline for POSIX-friendly shell tooling.
     data: JSON.stringify(manifest, null, 2) + "\n",
   });
 
@@ -1325,7 +1317,6 @@ export const handleBlobStorageIntegrationProjectJob = async (
       );
     }
 
-    // Files written by this run, collected for the completion manifest below.
     let runFiles: BlobExportManifestFile[];
     if (isTraceOnlyProject) {
       // Only process traces table for projects in the trace-only list (legacy behavior)
@@ -1375,13 +1366,9 @@ export const handleBlobStorageIntegrationProjectJob = async (
       runFiles = await Promise.all(processPromises);
     }
 
-    // Write the run-completion manifest as the LAST object of the run — its
-    // presence is the run's commit point. Strictly after every table upload
-    // succeeded (the awaits above), so consumers subscribing to native
-    // object-created events on the `manifests/` prefix get a run-level
-    // completion signal and can verify they can read every listed file
-    // (LFE-10843). A failure here throws into the catch below, so lastSyncAt is
-    // not advanced and the run retries — table files are simply overwritten.
+    // The manifest is the run's commit point: written strictly after every
+    // table upload succeeded. A failure here fails the run, so lastSyncAt does
+    // not advance and the retry idempotently overwrites the table files.
     await writeBlobExportManifest({
       connection: executionConfig,
       prefix: blobStorageIntegration.prefix || undefined,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -351,13 +351,8 @@ const processBlobStorageExport = async (config: {
   projectId: string;
   minTimestamp: Date;
   maxTimestamp: Date;
-  bucketName: string;
-  endpoint: string | null;
-  region: string;
-  accessKeyId: string | undefined;
-  secretAccessKey: string | undefined;
+  storageService: StorageService;
   prefix?: string;
-  forcePathStyle?: boolean;
   type: BlobStorageIntegrationType;
   table: "traces" | "observations" | "scores" | "observations_v2"; // observations_v2 is the events table
   fileType: BlobStorageIntegrationFileType;
@@ -383,7 +378,7 @@ const processBlobStorageExport = async (config: {
     `[BLOB INTEGRATION] Processing ${config.table} export for project ${config.projectId}`,
   );
 
-  const storageService = createBlobStorageService(config);
+  const storageService = config.storageService;
 
   return await instrumentAsync(
     {
@@ -451,7 +446,6 @@ const processBlobStorageExport = async (config: {
       // Outside the try so the catch can distinguish a real upload success from
       // a failure.
       let uploadSucceeded = false;
-      let manifestFile: BlobExportManifestFile | undefined;
       let heartbeat: ReturnType<typeof setInterval> | undefined;
 
       // Per-stage errors so the catch can name the originating cause instead of
@@ -804,7 +798,7 @@ const processBlobStorageExport = async (config: {
 
           // rowCount null on parquet: sourceStats.rows stays 0 for the binary
           // stream and would misreport as an empty file.
-          manifestFile = {
+          const manifestFile: BlobExportManifestFile = {
             key: filePath,
             table: config.table,
             fileType: parquetEligible
@@ -882,6 +876,8 @@ const processBlobStorageExport = async (config: {
                 ? ` gzipLevel=${gzipStats.level} compressedBytes=${compressedCounter.bytes}`
                 : ""),
           );
+
+          return manifestFile;
         } finally {
           span.setAttribute("blob.rows", sourceStats.rows);
           // Same chReadMs / uploadWaitMs derivation as the success path above.
@@ -1062,14 +1058,6 @@ const processBlobStorageExport = async (config: {
         span.setAttribute("blob.eventLoopDelay.p99Ms", Math.round(p99Ms));
         span.setAttribute("blob.eventLoopDelay.meanMs", Math.round(meanMs));
       }
-
-      // Always populated on the success path (the catch above rethrows).
-      if (!manifestFile) {
-        throw new Error(
-          `[BLOB INTEGRATION] Missing manifest entry after a successful ${config.table} export for project ${config.projectId}`,
-        );
-      }
-      return manifestFile;
     },
   );
 };
@@ -1077,7 +1065,7 @@ const processBlobStorageExport = async (config: {
 // Small JSON body, so single-shot uploadFile instead of the buffered multipart
 // path the table streams use.
 const writeBlobExportManifest = async (params: {
-  connection: BlobStorageConnectionConfig;
+  storageService: StorageService;
   prefix?: string;
   projectId: string;
   exportSource: string;
@@ -1099,8 +1087,7 @@ const writeBlobExportManifest = async (params: {
     maxTimestamp: params.maxTimestamp,
   });
 
-  const storageService = createBlobStorageService(params.connection);
-  await storageService.uploadFile({
+  await params.storageService.uploadFile({
     fileName: key,
     fileType: "application/json; charset=utf-8",
     // Trailing newline for POSIX-friendly shell tooling.
@@ -1259,10 +1246,8 @@ export const handleBlobStorageIntegrationProjectJob = async (
       );
     }
 
-    const executionConfig = {
-      projectId,
-      minTimestamp,
-      maxTimestamp,
+    // One client per run, shared by all table uploads and the manifest write.
+    const storageService = createBlobStorageService({
       bucketName: blobStorageIntegration.bucketName,
       endpoint: blobStorageIntegration.endpoint,
       region: blobStorageIntegration.region || "auto",
@@ -1270,8 +1255,16 @@ export const handleBlobStorageIntegrationProjectJob = async (
       secretAccessKey: blobStorageIntegration.secretAccessKey
         ? decrypt(blobStorageIntegration.secretAccessKey)
         : undefined,
-      prefix: blobStorageIntegration.prefix || undefined,
       forcePathStyle: blobStorageIntegration.forcePathStyle || undefined,
+      type: blobStorageIntegration.type,
+    });
+
+    const executionConfig = {
+      projectId,
+      minTimestamp,
+      maxTimestamp,
+      storageService,
+      prefix: blobStorageIntegration.prefix || undefined,
       type: blobStorageIntegration.type,
       fileType: blobStorageIntegration.fileType,
       compressed: blobStorageIntegration.compressed,
@@ -1370,7 +1363,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
     // table upload succeeded. A failure here fails the run, so lastSyncAt does
     // not advance and the retry idempotently overwrites the table files.
     await writeBlobExportManifest({
-      connection: executionConfig,
+      storageService,
       prefix: blobStorageIntegration.prefix || undefined,
       projectId,
       exportSource: blobStorageIntegration.exportSource,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -68,6 +68,12 @@ import { randomUUID } from "crypto";
 import { SpanKind } from "@opentelemetry/api";
 import { env, v4AllowPreviewOptIn } from "../../env";
 import { recordExportVolume } from "../../services/exportVolumeMetric";
+import {
+  buildBlobExportManifest,
+  buildBlobExportManifestKey,
+  formatBlobExportTimestamp,
+  type BlobExportManifestFile,
+} from "./manifest";
 
 export const BlobExportFormat = {
   JSON_RAW: "json-raw",
@@ -312,6 +318,36 @@ const createRawJsonlNewlineTransform = (): Transform =>
     },
   });
 
+// Shared connection config for every object written by a run (table files and
+// the run-completion manifest). KMS SSE is not supported for this integration.
+type BlobStorageConnectionConfig = {
+  bucketName: string;
+  endpoint: string | null;
+  region: string;
+  accessKeyId: string | undefined;
+  secretAccessKey: string | undefined;
+  forcePathStyle?: boolean;
+  type: BlobStorageIntegrationType;
+};
+
+const createBlobStorageService = (
+  config: BlobStorageConnectionConfig,
+): StorageService =>
+  StorageServiceFactory.getInstance({
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    bucketName: config.bucketName,
+    endpoint: config.endpoint ?? undefined,
+    region: config.region,
+    forcePathStyle: config.forcePathStyle ?? false,
+    awsSse: undefined,
+    awsSseKmsKeyId: undefined,
+    useAzureBlob: config.type === BlobStorageIntegrationType.AZURE_BLOB_STORAGE,
+    useGoogleCloudStorage: false, // Not supported in blob storage integration
+    useOCIObjectStorage: false, // Not supported in blob storage integration
+    connectionValidation: blobStorageEndpointConnectionValidationOptions(),
+  });
+
 const processBlobStorageExport = async (config: {
   projectId: string;
   minTimestamp: Date;
@@ -348,24 +384,9 @@ const processBlobStorageExport = async (config: {
     `[BLOB INTEGRATION] Processing ${config.table} export for project ${config.projectId}`,
   );
 
-  // Initialize the storage service
-  // KMS SSE is not supported for this integration.
-  const storageService: StorageService = StorageServiceFactory.getInstance({
-    accessKeyId: config.accessKeyId,
-    secretAccessKey: config.secretAccessKey,
-    bucketName: config.bucketName,
-    endpoint: config.endpoint ?? undefined,
-    region: config.region,
-    forcePathStyle: config.forcePathStyle ?? false,
-    awsSse: undefined,
-    awsSseKmsKeyId: undefined,
-    useAzureBlob: config.type === BlobStorageIntegrationType.AZURE_BLOB_STORAGE,
-    useGoogleCloudStorage: false, // Not supported in blob storage integration
-    useOCIObjectStorage: false, // Not supported in blob storage integration
-    connectionValidation: blobStorageEndpointConnectionValidationOptions(),
-  });
+  const storageService = createBlobStorageService(config);
 
-  await instrumentAsync(
+  return await instrumentAsync(
     {
       name: `blob-export-table`,
       spanKind: SpanKind.INTERNAL,
@@ -431,6 +452,9 @@ const processBlobStorageExport = async (config: {
       // Outside the try so the catch can distinguish a real upload success from
       // a failure.
       let uploadSucceeded = false;
+      // Populated at the upload boundary; returned to the caller so the run can
+      // list every file in its completion manifest (LFE-10843).
+      let manifestFile: BlobExportManifestFile | undefined;
       let heartbeat: ReturnType<typeof setInterval> | undefined;
 
       // Per-stage errors so the catch can name the originating cause instead of
@@ -465,10 +489,9 @@ const processBlobStorageExport = async (config: {
             ? "passthrough"
             : "standard";
 
-        const timestamp = config.maxTimestamp
-          .toISOString()
-          .replace(/:/g, "-")
-          .substring(0, 19);
+        // Shared stem with the run manifest key, so a run's files and its
+        // manifest sort together under the project prefix.
+        const timestamp = formatBlobExportTimestamp(config.maxTimestamp);
         // Parquet: fixed `.parquet` extension (no `.gz`) and Parquet content type.
         const extension = parquetEligible
           ? "parquet"
@@ -783,6 +806,24 @@ const processBlobStorageExport = async (config: {
           const exportFormat = parquetEligible
             ? BlobExportFormat.PARQUET
             : resolveBlobExportFormat(config.fileType, config.compressed);
+
+          // Record this file for the run manifest. rowCount is null on the
+          // parquet path (binary stream has no per-row boundaries, so
+          // sourceStats.rows stays 0 and would misreport as an empty file).
+          manifestFile = {
+            key: filePath,
+            table: config.table,
+            fileType: parquetEligible
+              ? BlobStorageIntegrationFileType.PARQUET
+              : config.fileType,
+            format: exportFormat,
+            compressed: parquetEligible ? false : config.compressed,
+            contentType: uploadContentType,
+            sizeBytes: compressedCounter
+              ? compressedCounter.bytes
+              : serializedCounter.bytes,
+            rowCount: parquetEligible ? null : sourceStats.rows,
+          };
           // Unified export-volume metric: the actual uploaded volume per
           // source (post-gzip size for compressed formats, raw/parquet size
           // otherwise). destination_type (S3 / S3_COMPATIBLE / AZURE_*) splits
@@ -1027,7 +1068,56 @@ const processBlobStorageExport = async (config: {
         span.setAttribute("blob.eventLoopDelay.p99Ms", Math.round(p99Ms));
         span.setAttribute("blob.eventLoopDelay.meanMs", Math.round(meanMs));
       }
+
+      // Only reached on the success path (the catch above rethrows), so the
+      // entry is always populated here.
+      if (!manifestFile) {
+        throw new Error(
+          `[BLOB INTEGRATION] Missing manifest entry after a successful ${config.table} export for project ${config.projectId}`,
+        );
+      }
+      return manifestFile;
     },
+  );
+};
+
+// Writes the run-completion manifest (LFE-10843). The manifest is a small JSON
+// body, so it uses the single-shot uploadFile (string body) rather than the
+// buffered multipart path the table streams use.
+const writeBlobExportManifest = async (params: {
+  connection: BlobStorageConnectionConfig;
+  prefix?: string;
+  projectId: string;
+  exportSource: string;
+  minTimestamp: Date;
+  maxTimestamp: Date;
+  files: BlobExportManifestFile[];
+}): Promise<void> => {
+  const manifest = buildBlobExportManifest({
+    projectId: params.projectId,
+    exportSource: params.exportSource,
+    minTimestamp: params.minTimestamp,
+    maxTimestamp: params.maxTimestamp,
+    createdAt: new Date(),
+    files: params.files,
+  });
+  const key = buildBlobExportManifestKey({
+    prefix: params.prefix,
+    projectId: params.projectId,
+    maxTimestamp: params.maxTimestamp,
+  });
+
+  const storageService = createBlobStorageService(params.connection);
+  await storageService.uploadFile({
+    fileName: key,
+    fileType: "application/json; charset=utf-8",
+    // Trailing newline keeps the object POSIX-line friendly for shell tooling.
+    data: JSON.stringify(manifest, null, 2) + "\n",
+  });
+
+  logger.info(
+    `[BLOB INTEGRATION] Wrote run manifest for project ${params.projectId}: ` +
+      `key=${key} files=${manifest.files.length} tables=${manifest.tables.join(",")}`,
   );
 };
 
@@ -1235,15 +1325,19 @@ export const handleBlobStorageIntegrationProjectJob = async (
       );
     }
 
+    // Files written by this run, collected for the completion manifest below.
+    let runFiles: BlobExportManifestFile[];
     if (isTraceOnlyProject) {
       // Only process traces table for projects in the trace-only list (legacy behavior)
       logger.info(
         `[BLOB INTEGRATION] Project ${projectId} is configured for trace-only export via env var, skipping observations, scores, and events`,
       );
-      await processBlobStorageExport({ ...executionConfig, table: "traces" });
+      runFiles = [
+        await processBlobStorageExport({ ...executionConfig, table: "traces" }),
+      ];
     } else {
       // Process tables based on exportSource setting
-      const processPromises: Promise<void>[] = [];
+      const processPromises: Promise<BlobExportManifestFile>[] = [];
 
       // Always include scores
       processPromises.push(
@@ -1278,8 +1372,25 @@ export const handleBlobStorageIntegrationProjectJob = async (
         );
       }
 
-      await Promise.all(processPromises);
+      runFiles = await Promise.all(processPromises);
     }
+
+    // Write the run-completion manifest as the LAST object of the run — its
+    // presence is the run's commit point. Strictly after every table upload
+    // succeeded (the awaits above), so consumers subscribing to native
+    // object-created events on the `manifests/` prefix get a run-level
+    // completion signal and can verify they can read every listed file
+    // (LFE-10843). A failure here throws into the catch below, so lastSyncAt is
+    // not advanced and the run retries — table files are simply overwritten.
+    await writeBlobExportManifest({
+      connection: executionConfig,
+      prefix: blobStorageIntegration.prefix || undefined,
+      projectId,
+      exportSource: blobStorageIntegration.exportSource,
+      minTimestamp,
+      maxTimestamp,
+      files: runFiles,
+    });
 
     // Determine if we've caught up with present-day data
     const caughtUp = maxTimestamp.getTime() >= uncappedMaxTimestamp.getTime();

--- a/worker/src/features/blobstorage/manifest.ts
+++ b/worker/src/features/blobstorage/manifest.ts
@@ -1,0 +1,95 @@
+// LFE-10843: run-completion manifest for blob storage exports.
+//
+// An export run writes up to 4 table files (scores / traces / observations /
+// observations_v2, depending on exportSource) with no per-run marker. Consumers
+// subscribing to native object-created events (S3 Event Notifications, Azure
+// Event Grid, B2, MinIO) can see each file land but cannot tell when a run is
+// complete, since the file count varies by exportSource.
+//
+// The manifest is a structured JSON object (S3-Inventory / Cost-&-Usage-Report
+// convention, not an empty _SUCCESS marker) written as the LAST object of a
+// successful run — its presence is the run's commit point. It lists every file
+// written, the export window, and per-file format so consumers can verify they
+// can read the full run and react with a single prefix-filtered subscription on
+// the `manifests/` key.
+
+/**
+ * Manifest schema version. Bump on any breaking change to the payload shape so
+ * consumers can gate on it. Additive fields do not require a bump.
+ */
+export const BLOB_EXPORT_MANIFEST_VERSION = 1;
+
+export type BlobExportManifestFile = {
+  /** Full object key including the integration prefix. */
+  key: string;
+  /** ClickHouse source table: scores | traces | observations | observations_v2. */
+  table: string;
+  /** Effective file type: JSON | CSV | JSONL | PARQUET. */
+  fileType: string;
+  /** Serialization format including compression, e.g. jsonl-gzip, parquet. */
+  format: string;
+  compressed: boolean;
+  contentType: string;
+  /** Bytes uploaded (post-gzip size for compressed formats). */
+  sizeBytes: number;
+  /** Rows written, or null when not counted (parquet is a binary stream). */
+  rowCount: number | null;
+};
+
+export type BlobExportManifest = {
+  version: number;
+  projectId: string;
+  /** Integration export source, e.g. TRACES_OBSERVATIONS_EVENTS. */
+  exportSource: string;
+  /** Export window [minTimestamp, maxTimestamp) in ISO-8601. */
+  window: { minTimestamp: string; maxTimestamp: string };
+  /** Run commit timestamp (equals window.maxTimestamp); also the manifest key stem. */
+  maxTimestamp: string;
+  /** When the manifest was written (ISO-8601). */
+  createdAt: string;
+  /** Distinct tables included in this run, in write order. */
+  tables: string[];
+  files: BlobExportManifestFile[];
+};
+
+/**
+ * Timestamp stem shared by table file names and the manifest key, so a manifest
+ * and its run's files sort together. Colons are stripped for object-key safety.
+ */
+export const formatBlobExportTimestamp = (date: Date): string =>
+  date.toISOString().replace(/:/g, "-").substring(0, 19);
+
+/**
+ * Manifest object key: `{prefix}{projectId}/manifests/{maxTimestamp}.json`.
+ * Consumers set a native event subscription with a prefix filter on
+ * `{prefix}{projectId}/manifests/` to receive one event per completed run.
+ */
+export const buildBlobExportManifestKey = (params: {
+  prefix?: string;
+  projectId: string;
+  maxTimestamp: Date;
+}): string =>
+  `${params.prefix ?? ""}${params.projectId}/manifests/${formatBlobExportTimestamp(
+    params.maxTimestamp,
+  )}.json`;
+
+export const buildBlobExportManifest = (params: {
+  projectId: string;
+  exportSource: string;
+  minTimestamp: Date;
+  maxTimestamp: Date;
+  createdAt: Date;
+  files: BlobExportManifestFile[];
+}): BlobExportManifest => ({
+  version: BLOB_EXPORT_MANIFEST_VERSION,
+  projectId: params.projectId,
+  exportSource: params.exportSource,
+  window: {
+    minTimestamp: params.minTimestamp.toISOString(),
+    maxTimestamp: params.maxTimestamp.toISOString(),
+  },
+  maxTimestamp: params.maxTimestamp.toISOString(),
+  createdAt: params.createdAt.toISOString(),
+  tables: [...new Set(params.files.map((f) => f.table))],
+  files: params.files,
+});

--- a/worker/src/features/blobstorage/manifest.ts
+++ b/worker/src/features/blobstorage/manifest.ts
@@ -23,7 +23,10 @@ export type BlobExportManifest = {
   version: number;
   projectId: string;
   exportSource: string;
-  /** Export window [minTimestamp, maxTimestamp). */
+  /**
+   * Export window, both bounds inclusive — a row at exactly maxTimestamp also
+   * falls into the next run's window.
+   */
   window: { minTimestamp: string; maxTimestamp: string };
   /** Equals window.maxTimestamp; also the manifest key stem. */
   maxTimestamp: string;

--- a/worker/src/features/blobstorage/manifest.ts
+++ b/worker/src/features/blobstorage/manifest.ts
@@ -1,69 +1,42 @@
-// LFE-10843: run-completion manifest for blob storage exports.
-//
-// An export run writes up to 4 table files (scores / traces / observations /
-// observations_v2, depending on exportSource) with no per-run marker. Consumers
-// subscribing to native object-created events (S3 Event Notifications, Azure
-// Event Grid, B2, MinIO) can see each file land but cannot tell when a run is
-// complete, since the file count varies by exportSource.
-//
-// The manifest is a structured JSON object (S3-Inventory / Cost-&-Usage-Report
-// convention, not an empty _SUCCESS marker) written as the LAST object of a
-// successful run — its presence is the run's commit point. It lists every file
-// written, the export window, and per-file format so consumers can verify they
-// can read the full run and react with a single prefix-filtered subscription on
-// the `manifests/` key.
+// Run-completion manifest for blob storage exports (LFE-10843): written as the
+// last object of a successful run (the run's commit point), listing every file
+// written, the export window, and per-file format.
 
-/**
- * Manifest schema version. Bump on any breaking change to the payload shape so
- * consumers can gate on it. Additive fields do not require a bump.
- */
+/** Bump on breaking payload changes; additive fields do not require a bump. */
 export const BLOB_EXPORT_MANIFEST_VERSION = 1;
 
 export type BlobExportManifestFile = {
   /** Full object key including the integration prefix. */
   key: string;
-  /** ClickHouse source table: scores | traces | observations | observations_v2. */
   table: string;
-  /** Effective file type: JSON | CSV | JSONL | PARQUET. */
   fileType: string;
-  /** Serialization format including compression, e.g. jsonl-gzip, parquet. */
   format: string;
   compressed: boolean;
   contentType: string;
-  /** Bytes uploaded (post-gzip size for compressed formats). */
+  /** Post-gzip size for compressed formats. */
   sizeBytes: number;
-  /** Rows written, or null when not counted (parquet is a binary stream). */
+  /** Null when not counted (parquet is a binary stream). */
   rowCount: number | null;
 };
 
 export type BlobExportManifest = {
   version: number;
   projectId: string;
-  /** Integration export source, e.g. TRACES_OBSERVATIONS_EVENTS. */
   exportSource: string;
-  /** Export window [minTimestamp, maxTimestamp) in ISO-8601. */
+  /** Export window [minTimestamp, maxTimestamp). */
   window: { minTimestamp: string; maxTimestamp: string };
-  /** Run commit timestamp (equals window.maxTimestamp); also the manifest key stem. */
+  /** Equals window.maxTimestamp; also the manifest key stem. */
   maxTimestamp: string;
-  /** When the manifest was written (ISO-8601). */
   createdAt: string;
-  /** Distinct tables included in this run, in write order. */
   tables: string[];
   files: BlobExportManifestFile[];
 };
 
-/**
- * Timestamp stem shared by table file names and the manifest key, so a manifest
- * and its run's files sort together. Colons are stripped for object-key safety.
- */
+/** Shared with table file names so a run's files and manifest sort together. */
 export const formatBlobExportTimestamp = (date: Date): string =>
   date.toISOString().replace(/:/g, "-").substring(0, 19);
 
-/**
- * Manifest object key: `{prefix}{projectId}/manifests/{maxTimestamp}.json`.
- * Consumers set a native event subscription with a prefix filter on
- * `{prefix}{projectId}/manifests/` to receive one event per completed run.
- */
+/** `{prefix}{projectId}/manifests/{maxTimestamp}.json` — prefix-filterable per run. */
 export const buildBlobExportManifestKey = (params: {
   prefix?: string;
   projectId: string;


### PR DESCRIPTION
## What does this PR do?

Writes a structured **run-completion manifest** as the last object of each
successful blob storage export run (the run's commit point), addressing
LFE-10843.

An export run writes up to 4 table files (scores / traces / observations /
observations_v2, depending on `exportSource`) with no per-run marker. Native
object-created events (S3 Event Notifications, Azure Event Grid, B2, MinIO)
signal each file landing but can't signal **run completeness**, since the file
count varies by source. The manifest gives consumers a single, prefix-filterable
completion signal.

**Manifest** — `{prefix}{projectId}/manifests/{maxTimestamp}.json`:
- versioned schema (`version: 1`)
- every file written (full object keys) + per-file `fileType` / `format` /
  `compressed` / `sizeBytes` / `rowCount`
- export window (`minTimestamp`/`maxTimestamp`), `exportSource`, tables included

**Implementation:**
- New `worker/src/features/blobstorage/manifest.ts`: versioned schema + pure,
  unit-tested builders (manifest key, payload, shared timestamp stem).
- `processBlobStorageExport` returns a per-file manifest entry on success.
- Handler writes the manifest **strictly after** all table uploads succeed;
  a failed manifest write fails the run so BullMQ retries it (table files are
  idempotently overwritten). Written per catch-up chunk (one manifest per run).
- One storage client is created per run and shared by all table uploads and
  the manifest write (single-shot `uploadFile` for the small JSON body).

Docs (per-provider event-subscription recipes + manifest contract) are tracked
separately — this PR is the code change only.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Unit tests for the manifest builders (`blobExportManifest.unit.test.ts`)
- [x] Integration test asserting the manifest is written with the correct key,
      file list, window, and per-file format (text + parquet paths)
- [x] Existing file-count assertions updated to exclude the new manifest object
- [x] `pnpm turbo run lint --filter=worker` — 4 successful
- [x] `pnpm turbo run typecheck --filter=worker` — 4 successful
- [x] `pnpm --filter worker run test blobStorageIntegrationProcessing` — 26 passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a structured run-completion manifest to blob storage exports (LFE-10843). After all table files upload successfully, a small JSON object is written to `{prefix}{projectId}/manifests/{maxTimestamp}.json` as the final step — its presence signals that every listed file is available and the run is complete. Consumers can subscribe to native object-created events on the `manifests/` prefix to get a per-run completion signal.

- **`manifest.ts`** introduces the manifest schema, a versioned `BlobExportManifest` type, and pure builder functions (`buildBlobExportManifest`, `buildBlobExportManifestKey`, `formatBlobExportTimestamp`).
- **`handleBlobStorageIntegrationProjectJob.ts`** extracts `createBlobStorageService` as a shared helper, changes `processBlobStorageExport` to return a `BlobExportManifestFile`, and adds `writeBlobExportManifest` called strictly after all table uploads succeed.
- Tests cover manifest key construction, payload assembly, deduplication, and the end-to-end integration path for both JSONL and Parquet exports.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the manifest write is the last step and any failure there prevents lastSyncAt from advancing, guaranteeing a clean retry.

The core logic — returning a BlobExportManifestFile from each parallel table upload then writing a single manifest as the commit point — is correct and well-tested. One subtle pre-existing behavioural detail is now visible in the manifest: the scores table is always exported regardless of exportSource, so a consumer watching exportSource: EVENTS manifests will see scores alongside events. This is not a bug introduced here, but it is now part of the documented contract.

The main handler (handleBlobStorageIntegrationProjectJob.ts) is the most complex changed file — specifically the interplay between manifestFile population inside instrumentAsync and the return await instrumentAsync change that makes the return value flow correctly to the caller.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as handleBlobStorageIntegrationProjectJob
    participant Export as processBlobStorageExport (×N)
    participant Storage as StorageService (S3 / Azure / GCS)
    participant Manifest as writeBlobExportManifest

    Job->>Handler: execute(projectId)
    Handler->>Handler: resolve executionConfig (timestamps, creds, tuning)
    par parallel table uploads
        Handler->>Export: "table=scores"
        Export->>Storage: uploadFileBuffered(filePath)
        Storage-->>Export: OK
        Export-->>Handler: BlobExportManifestFile
    and
        Handler->>Export: "table=traces"
        Export->>Storage: uploadFileBuffered(filePath)
        Storage-->>Export: OK
        Export-->>Handler: BlobExportManifestFile
    and
        Handler->>Export: "table=observations / observations_v2"
        Export->>Storage: uploadFileBuffered(filePath)
        Storage-->>Export: OK
        Export-->>Handler: BlobExportManifestFile
    end
    Handler->>Manifest: "files=runFiles, maxTimestamp"
    Manifest->>Manifest: buildBlobExportManifest(files)
    Manifest->>Manifest: buildBlobExportManifestKey
    Manifest->>Storage: uploadFile(manifestKey, JSON body)
    Storage-->>Manifest: OK
    Manifest-->>Handler: void
    Handler->>Handler: advance lastSyncAt
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as handleBlobStorageIntegrationProjectJob
    participant Export as processBlobStorageExport (×N)
    participant Storage as StorageService (S3 / Azure / GCS)
    participant Manifest as writeBlobExportManifest

    Job->>Handler: execute(projectId)
    Handler->>Handler: resolve executionConfig (timestamps, creds, tuning)
    par parallel table uploads
        Handler->>Export: "table=scores"
        Export->>Storage: uploadFileBuffered(filePath)
        Storage-->>Export: OK
        Export-->>Handler: BlobExportManifestFile
    and
        Handler->>Export: "table=traces"
        Export->>Storage: uploadFileBuffered(filePath)
        Storage-->>Export: OK
        Export-->>Handler: BlobExportManifestFile
    and
        Handler->>Export: "table=observations / observations_v2"
        Export->>Storage: uploadFileBuffered(filePath)
        Storage-->>Export: OK
        Export-->>Handler: BlobExportManifestFile
    end
    Handler->>Manifest: "files=runFiles, maxTimestamp"
    Manifest->>Manifest: buildBlobExportManifest(files)
    Manifest->>Manifest: buildBlobExportManifestKey
    Manifest->>Storage: uploadFile(manifestKey, JSON body)
    Storage-->>Manifest: OK
    Manifest-->>Handler: void
    Handler->>Handler: advance lastSyncAt
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:1072-1079
**Unreachable guard / misleading defensive assertion**

The `!manifestFile` check is currently dead code: the catch block at line ~1017 unconditionally rethrows, so any failure before `manifestFile = {...}` is assigned propagates before reaching this line. In the success path `manifestFile` is always set immediately after `uploadSucceeded = true`. The only realistic scenario where this fires is if a future refactor introduces an early-return or a swallowed-exception path — but in that case the guard fires with `uploadSucceeded = true`, skipping the failure metric at line 1031 and producing a confusing internal error rather than a proper export failure. Consider either removing the guard (relying on TypeScript's type narrowing to enforce the invariant for callers) or positioning it as a static assertion so it is caught at compile time rather than at runtime.

### Issue 2 of 2
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:1127-1145
**Two separate `StorageService` instances created per manifest write**

`writeBlobExportManifest` calls `createBlobStorageService(params.connection)` internally, so each run creates one service instance per table file (inside `processBlobStorageExport`) plus a second instance specifically for the manifest. If `StorageServiceFactory.getInstance` establishes a new connection or TLS session per call, this is N+1 connections per run. Consider accepting an already-constructed `StorageService` in `writeBlobExportManifest` (the caller already has the config handy and could build one), or verifying that `StorageServiceFactory.getInstance` reuses an underlying transport for identical configs.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(blobstorage): write run-completion ..."](https://github.com/langfuse/langfuse/commit/1715bb6447e443adc974e0484bc89c2810edbf78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43329369)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
