### PR TITLE
feat(web): add copy-session-id button to session detail header

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -645,6 +645,7 @@ const LoadedSessionEventsPage: React.FC<{
   const router = useRouter();
   const { setDetailPageList, detailPagelists } = useDetailPageLists();
   const userSession = useSession();
+  const capture = usePostHogClientCapture();
   const parentRef = useRef<HTMLDivElement>(null);
   const defaultPresetAppliedRef = useRef(false);
 
@@ -1120,6 +1121,11 @@ const LoadedSessionEventsPage: React.FC<{
                 isPublic={session.public}
                 key="publish"
                 size="icon-xs"
+              />
+              <CopySessionIdButton
+                key="copy-id"
+                sessionId={sessionId}
+                capture={capture}
               />
             </div>
           ),

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -19,7 +19,7 @@ import { Button } from "@/src/components/ui/button";
 import { CommentDrawerButton } from "@/src/features/comments/CommentDrawerButton";
 import { useSession } from "next-auth/react";
 import { CheckIcon, CopyIcon, Download, ExternalLinkIcon } from "lucide-react";
-import { copyTextToClipboard } from "@/src/utils/clipboard";
+import { useCopyToClipboard } from "@/src/hooks/useCopyToClipboard";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import Page from "@/src/components/layouts/page";
 import {
@@ -218,23 +218,7 @@ const CopySessionIdButton: React.FC<{
   sessionId: string;
   capture: ReturnType<typeof usePostHogClientCapture>;
 }> = ({ sessionId, capture }) => {
-  const [copied, setCopied] = useState(false);
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(
-    () => () => {
-      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
-    },
-    [],
-  );
-
-  const handleCopy = useCallback(() => {
-    copyTextToClipboard(sessionId);
-    capture("session_detail:copy_session_id_click");
-    setCopied(true);
-    if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
-    copyTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
-  }, [sessionId, capture]);
+  const { copy, isCopied } = useCopyToClipboard();
 
   return (
     <Button
@@ -242,9 +226,12 @@ const CopySessionIdButton: React.FC<{
       size="icon-xs"
       title="Copy session ID"
       aria-label="Copy session ID"
-      onClick={handleCopy}
+      onClick={async () => {
+        capture("session_detail:copy_session_id_click");
+        await copy(sessionId);
+      }}
     >
-      {copied ? (
+      {isCopied ? (
         <CheckIcon className="text-muted-green h-4 w-4" />
       ) : (
         <CopyIcon className="h-4 w-4" />

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -216,8 +216,8 @@ const SessionScores = ({
 };
 const CopySessionIdButton: React.FC<{
   sessionId: string;
-  capture: ReturnType<typeof usePostHogClientCapture>;
-}> = ({ sessionId, capture }) => {
+}> = ({ sessionId }) => {
+  const capture = usePostHogClientCapture();
   const { copy, isCopied } = useCopyToClipboard();
 
   return (
@@ -409,11 +409,7 @@ export const SessionPage: React.FC<{
                 key="publish"
                 size="icon-xs"
               />
-              <CopySessionIdButton
-                key="copy-id"
-                sessionId={sessionId}
-                capture={capture}
-              />
+              <CopySessionIdButton key="copy-id" sessionId={sessionId} />
             </div>
           ),
           actionButtonsRight: (
@@ -645,7 +641,6 @@ const LoadedSessionEventsPage: React.FC<{
   const router = useRouter();
   const { setDetailPageList, detailPagelists } = useDetailPageLists();
   const userSession = useSession();
-  const capture = usePostHogClientCapture();
   const parentRef = useRef<HTMLDivElement>(null);
   const defaultPresetAppliedRef = useRef(false);
 
@@ -1122,11 +1117,7 @@ const LoadedSessionEventsPage: React.FC<{
                 key="publish"
                 size="icon-xs"
               />
-              <CopySessionIdButton
-                key="copy-id"
-                sessionId={sessionId}
-                capture={capture}
-              />
+              <CopySessionIdButton key="copy-id" sessionId={sessionId} />
             </div>
           ),
           actionButtonsRight: (

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -18,7 +18,8 @@ import { AnnotateDrawer } from "@/src/features/scores/components/AnnotateDrawer"
 import { Button } from "@/src/components/ui/button";
 import { CommentDrawerButton } from "@/src/features/comments/CommentDrawerButton";
 import { useSession } from "next-auth/react";
-import { Download, ExternalLinkIcon } from "lucide-react";
+import { CheckIcon, CopyIcon, Download, ExternalLinkIcon } from "lucide-react";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import Page from "@/src/components/layouts/page";
 import {
@@ -213,6 +214,45 @@ const SessionScores = ({
     </div>
   );
 };
+const CopySessionIdButton: React.FC<{
+  sessionId: string;
+  capture: ReturnType<typeof usePostHogClientCapture>;
+}> = ({ sessionId, capture }) => {
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    },
+    [],
+  );
+
+  const handleCopy = useCallback(() => {
+    copyTextToClipboard(sessionId);
+    capture("session_detail:copy_session_id_click");
+    setCopied(true);
+    if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    copyTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
+  }, [sessionId, capture]);
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      title="Copy session ID"
+      aria-label="Copy session ID"
+      onClick={handleCopy}
+    >
+      {copied ? (
+        <CheckIcon className="text-muted-green h-4 w-4" />
+      ) : (
+        <CopyIcon className="h-4 w-4" />
+      )}
+    </Button>
+  );
+};
+
 export const SessionPage: React.FC<{
   sessionId: string;
   projectId: string;
@@ -381,6 +421,11 @@ export const SessionPage: React.FC<{
                 isPublic={session.data?.public ?? false}
                 key="publish"
                 size="icon-xs"
+              />
+              <CopySessionIdButton
+                key="copy-id"
+                sessionId={sessionId}
+                capture={capture}
               />
             </div>
           ),

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -108,7 +108,11 @@ export const events = {
     "duplicate_button_click",
     "duplicate_form_submit",
   ],
-  session_detail: ["publish_button_click", "download_button_click"],
+  session_detail: [
+    "publish_button_click",
+    "download_button_click",
+    "copy_session_id_click",
+  ],
   eval_config: [
     "new_form_submit",
     "new_form_open",


### PR DESCRIPTION
## Summary

Adds a **copy-session-id** button to the session detail header, next to the star and publish buttons. Clicking it copies the session ID to the clipboard and briefly swaps the copy icon for a green check as confirmation.

## Changes

- `web/src/components/session/index.tsx`: new `CopySessionIdButton` (ghost `icon-xs`) in the header's left action group. Copies `sessionId` via `copyTextToClipboard`, fires a PostHog capture, and shows a 1.5s check-icon confirmation. Timeout is cleared on unmount.
- `web/src/features/posthog-analytics/usePostHogClientCapture.ts`: registers the new `session_detail:copy_session_id_click` analytics event.

## Notes

The session detail page renders the session ID as its title and there is no separate session "name" field, so copying the ID is the meaningful action here.

## Test plan

- Seeded a chat session locally (`pnpm run seed -- session-shapes --shape chat`) and opened the session detail page.
- Verified the button appears in the header, copies the correct session ID, and the icon flips to a green check for ~1.5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a copy-session-ID button to the session detail page header. It introduces a new `CopySessionIdButton` component with a 1.5s check-icon confirmation state, proper timeout cleanup on unmount, and a corresponding PostHog analytics event.

- The new `CopySessionIdButton` component handles the clipboard write via the existing `copyTextToClipboard` utility, mirrors the visual confirmation pattern used by `CopyIdsPopover`, and registers a new `session_detail:copy_session_id_click` analytics event.
- The `capture` function is threaded into the component as a prop (typed as `ReturnType<typeof usePostHogClientCapture>`) rather than calling the hook directly inside `CopySessionIdButton`; the component is self-contained enough that the prop is unnecessary and adds coupling.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Small, additive UI change that copies text to clipboard with visual feedback — no data mutation, no auth path, no server calls. Safe to merge.

The new component follows the established clipboard+check-icon pattern used by CopyIdsPopover in the same codebase. Timeout cleanup on unmount is handled correctly. The only note is that the capture function is passed as a prop rather than called directly inside the component, which is a style preference rather than a defect.

No files require special attention. The single style suggestion is in web/src/components/session/index.tsx.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor User
    participant Button as CopySessionIdButton
    participant Clipboard as copyTextToClipboard
    participant PostHog as usePostHogClientCapture
    participant Timer as setTimeout

    User->>Button: click
    Button->>Clipboard: copyTextToClipboard(sessionId)
    Button->>PostHog: capture("session_detail:copy_session_id_click")
    Button->>Button: setCopied(true)
    Button->>Timer: "setTimeout(()=>setCopied(false), 1500)"
    Note over Button: shows CheckIcon (green)
    Timer-->>Button: fires after 1500ms
    Button->>Button: setCopied(false)
    Note over Button: reverts to CopyIcon

    Note over Button,Timer: On unmount: clearTimeout cleans up pending timer
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor User
    participant Button as CopySessionIdButton
    participant Clipboard as copyTextToClipboard
    participant PostHog as usePostHogClientCapture
    participant Timer as setTimeout

    User->>Button: click
    Button->>Clipboard: copyTextToClipboard(sessionId)
    Button->>PostHog: capture("session_detail:copy_session_id_click")
    Button->>Button: setCopied(true)
    Button->>Timer: "setTimeout(()=>setCopied(false), 1500)"
    Note over Button: shows CheckIcon (green)
    Timer-->>Button: fires after 1500ms
    Button->>Button: setCopied(false)
    Note over Button: reverts to CopyIcon

    Note over Button,Timer: On unmount: clearTimeout cleans up pending timer
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/session/index.tsx:217-237
The `capture` prop is typed as `ReturnType<typeof usePostHogClientCapture>` and passed from the parent, but `CopySessionIdButton` is a full React component that can call hooks itself. Calling `usePostHogClientCapture()` directly inside the component removes this coupling, makes the component self-contained, and eliminates `capture` from the `useCallback` dep array.

```suggestion
const CopySessionIdButton: React.FC<{
  sessionId: string;
}> = ({ sessionId }) => {
  const capture = usePostHogClientCapture();
  const [copied, setCopied] = useState(false);
  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

  useEffect(
    () => () => {
      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
    },
    [],
  );

  const handleCopy = useCallback(() => {
    copyTextToClipboard(sessionId);
    capture("session_detail:copy_session_id_click");
    setCopied(true);
    if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
    copyTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
  }, [sessionId, capture]);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): add copy-session-id button to..."](https://github.com/langfuse/langfuse/commit/9da0e3e15c966c626a9943010c48882f1805db1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43331039)</sub>

<!-- /greptile_comment -->