### PR TITLE
fix(agent): Improve UX around rate-limiting

### DIFF
--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -682,7 +682,10 @@ describe("in-app agent public API route auth", () => {
 
       expect(response.status).toBe(429);
       await expect(response.json()).resolves.toEqual({
-        error: "Rate limit exceeded",
+        code: "rate_limited",
+        details: {
+          retryAfterSeconds: 60,
+        },
       });
       expect(response.headers.get("Retry-After")).toBe("60");
       expect(rateLimitMocks.rateLimitRequest).toHaveBeenCalledWith(

--- a/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../../../../../.storybook/preview";
-import { fn } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 import { InAppAgentToolCallCard } from "./InAppAgentToolCallCard";
 
 const meta = preview.meta({
@@ -82,5 +82,38 @@ export const ApprovalSubmitting = meta.story({
     },
     onApproveToolCall: fn(),
     onRejectToolCall: fn(),
+  },
+});
+
+export const ApprovalDisabled = meta.story({
+  args: {
+    isCompact: true,
+    isDisabled: true,
+    tool: {
+      type: "tool",
+      name: "langfuse_upsertDataset",
+      args: JSON.stringify(
+        {
+          name: "regression-examples",
+          description: "Examples used for release regression tests",
+        },
+        null,
+        2,
+      ),
+      approval: {
+        id: "approval-1",
+        status: "pending",
+      },
+    },
+    onApproveToolCall: fn(),
+    onRejectToolCall: fn(),
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByRole("button", { name: "Confirm" }),
+    ).toBeDisabled();
+    await expect(canvas.getByRole("button", { name: "Reject" })).toBeDisabled();
   },
 });

--- a/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.tsx
@@ -9,11 +9,13 @@ import { type InAppAgentToolCallContent } from "@/src/ee/features/in-app-agent/c
 export function InAppAgentToolCallCard({
   tool,
   isCompact = false,
+  isDisabled = false,
   onApproveToolCall,
   onRejectToolCall,
 }: {
   tool: InAppAgentToolCallContent;
   isCompact?: boolean;
+  isDisabled?: boolean;
   onApproveToolCall?: (approvalId: string) => Promise<void>;
   onRejectToolCall?: (approvalId: string) => Promise<void>;
 }) {
@@ -52,7 +54,9 @@ export function InAppAgentToolCallCard({
                 size="sm"
                 variant="outline-success"
                 className="h-7"
-                disabled={isApprovalSubmitting || !onApproveToolCall}
+                disabled={
+                  isDisabled || isApprovalSubmitting || !onApproveToolCall
+                }
                 onClick={() => {
                   if (isApprovalPending) {
                     onApproveToolCall?.(approval.id).catch(() => undefined);
@@ -71,7 +75,9 @@ export function InAppAgentToolCallCard({
                 size="sm"
                 variant="outline"
                 className="h-7"
-                disabled={isApprovalSubmitting || !onRejectToolCall}
+                disabled={
+                  isDisabled || isApprovalSubmitting || !onRejectToolCall
+                }
                 onClick={() => {
                   if (isApprovalPending) {
                     onRejectToolCall?.(approval.id).catch(() => undefined);

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -900,7 +900,6 @@ export const FeedbackControlsShowAfterTurnEnd = meta.story({
   name: "(Test) Feedback Controls Show After Turn End",
   args: {
     selectedConversationId: "conversation-1",
-    isInputDisabled: false,
     isAssistantTurnInProgress: false,
     onSubmitFeedback: fn(),
     messages: [
@@ -961,7 +960,10 @@ export const Connecting = meta.story({
 
 export const Error = meta.story({
   args: {
-    error: "Assistant is not enabled for this user",
+    error: {
+      type: "generic",
+      message: "Assistant is not enabled for this user",
+    },
     messages: [
       {
         id: "user-1",
@@ -972,6 +974,49 @@ export const Error = meta.story({
         },
       },
     ],
+  },
+});
+
+export const RateLimited = meta.story({
+  name: "(Test) Rate Limited",
+  args: {
+    error: null,
+    messages: [],
+  },
+  render: function Render(args) {
+    const [retryAt] = useState(() => Date.now() + 12_000);
+
+    return (
+      <StatefulInAppAgentWindow
+        {...args}
+        error={{ type: "rate_limit", retryAt }}
+      />
+    );
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvas.getByRole("alert");
+    const initialAlertText = alert.textContent;
+
+    await expect(alert).toHaveTextContent(
+      "You've reached the assistant request limit",
+    );
+    await expect(alert).toHaveTextContent("Try again in about");
+    await waitFor(() => expect(alert.textContent).not.toBe(initialAlertText), {
+      timeout: 2_000,
+    });
+    await expect(
+      canvas.getByRole("textbox", { name: "Ask the assistant a question" }),
+    ).toBeDisabled();
+    await expect(
+      canvas.getByRole("button", { name: "Get started with Langfuse" }),
+    ).toBeDisabled();
+    await expect(
+      canvas.getByRole("button", { name: "Start new conversation" }),
+    ).toBeEnabled();
+    await expect(
+      canvas.getByRole("button", { name: "Conversation history" }),
+    ).toBeEnabled();
   },
 });
 

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -26,6 +26,7 @@ import {
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
 import { cn } from "@/src/utils/tailwind";
+import { formatApproximateDuration } from "@/src/utils/dates";
 import {
   InAppAgentMessage,
   type InAppAgentMessageContent,
@@ -33,6 +34,10 @@ import {
 } from "./InAppAgentMessage";
 import type { InAppAgentMessageFeedbackValue } from "@/src/ee/features/in-app-agent/schema";
 import { InAppAgentToolCallCard } from "@/src/ee/features/in-app-agent/components/InAppAgentToolCallCard";
+import {
+  type InAppAgentError,
+  isInAppAgentRateLimited,
+} from "@/src/ee/features/in-app-agent/components/utils/utils";
 
 const AUTO_SCROLL_THRESHOLD_PX = 50;
 const SCROLL_DIRECTION_TOLERANCE_PX = 1;
@@ -88,7 +93,7 @@ type InAppAgentWindowCloseButtonProps =
 
 export type InAppAgentWindowProps = {
   conversations: InAppAgentWindowConversation[];
-  error: string | null;
+  error: InAppAgentError | null;
   hasMoreConversations: boolean;
   isAssistantTurnInProgress: boolean;
   isHeaderDragHandleEnabled?: boolean;
@@ -114,6 +119,70 @@ export type InAppAgentWindowProps = {
   selectedConversationId: string | undefined;
 } & InAppAgentWindowCloseButtonProps;
 
+function InAppAgentRateLimitError({
+  error,
+  isExpanded,
+}: {
+  error: Extract<InAppAgentError, { type: "rate_limit" }>;
+  isExpanded: boolean;
+}) {
+  const [secondsRemaining, setSecondsRemaining] = useState(() =>
+    Math.ceil((error.retryAt - Date.now()) / 1_000),
+  );
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      const secondsRemaining = Math.ceil((error.retryAt - Date.now()) / 1_000);
+      setSecondsRemaining(secondsRemaining);
+
+      if (secondsRemaining <= 1) {
+        window.clearInterval(interval);
+      }
+    }, 1_000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [error.retryAt]);
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "border-border bg-muted/60 text-foreground rounded-lg border px-2 py-1",
+        isExpanded ? "text-sm" : "text-xs",
+      )}
+    >
+      <div className="space-y-0.5">
+        <p className="font-medium">
+          You&apos;ve reached the assistant request limit
+        </p>
+        <p>Try again in about {formatApproximateDuration(secondsRemaining)}.</p>
+      </div>
+    </div>
+  );
+}
+
+function InAppAgentGenericError({
+  error,
+  isExpanded,
+}: {
+  error: Extract<InAppAgentError, { type: "generic" }>;
+  isExpanded: boolean;
+}) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "border-destructive/40 dark:bg-destructive dark:border-destructive-foreground/20 bg-destructive/10 dark:text-destructive-foreground text-destructive rounded-lg border px-2 py-1",
+        isExpanded ? "text-sm" : "text-xs",
+      )}
+    >
+      {error.message}
+    </div>
+  );
+}
+
 export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const {
     conversations,
@@ -122,7 +191,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     isAssistantTurnInProgress,
     isHeaderDragHandleEnabled = false,
     isExpanded,
-    isInputDisabled,
+    isInputDisabled: baseIsInputDisabled,
     isLoadingMoreConversations,
     messages,
     onDeleteConversation,
@@ -137,6 +206,8 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     onSubmitFeedback,
     selectedConversationId,
   } = props;
+  const isRateLimited = isInAppAgentRateLimited(error);
+  const isInputDisabled = baseIsInputDisabled || isRateLimited;
   const viewportRef = useRef<HTMLDivElement>(null);
   const isAutoScrollAttachedRef = useRef(true);
   const previousScrollTopRef = useRef(0);
@@ -273,7 +344,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 size="icon"
                 className="size-6 shrink-0"
                 onClick={onNewConversation}
-                disabled={isInputDisabled}
+                disabled={baseIsInputDisabled}
                 aria-label="Start new conversation"
               >
                 <Plus className="size-3" />
@@ -299,7 +370,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                     variant="ghost"
                     size="icon"
                     className="size-6 shrink-0"
-                    disabled={isInputDisabled}
+                    disabled={baseIsInputDisabled}
                     aria-label="Conversation history"
                   >
                     <History className="size-3" />
@@ -346,7 +417,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                         variant="ghost"
                         size="icon-xs"
                         className="text-muted-foreground hover:text-destructive -mr-1.5 shrink-0"
-                        disabled={isInputDisabled}
+                        disabled={baseIsInputDisabled}
                         aria-label="Delete conversation"
                         onClick={(event) => {
                           event.preventDefault();
@@ -525,7 +596,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                       role={message.role}
                       content={message.content}
                       isCompact={!isExpanded}
-                      isFeedbackDisabled={isInputDisabled}
+                      isFeedbackDisabled={baseIsInputDisabled}
                       onSubmitFeedback={
                         feedbackRunId
                           ? (params) =>
@@ -542,17 +613,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
               })}
             </ol>
 
-            {error ? (
-              <div
-                role="alert"
-                className={cn(
-                  "border-destructive/40 dark:bg-destructive dark:border-destructive-foreground/20 bg-destructive/10 dark:text-destructive-foreground text-destructive rounded-lg border px-2 py-1",
-                  isExpanded ? "text-sm" : "text-xs",
-                )}
-              >
-                {error}
-              </div>
-            ) : null}
+            {error?.type === "generic" && (
+              <InAppAgentGenericError error={error} isExpanded={isExpanded} />
+            )}
           </div>
         </div>
         {pendingToolCalls.length > 0 ? (
@@ -573,6 +636,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                   key={`${tool.approval?.id ?? tool.name}-${index}`}
                   tool={tool}
                   isCompact={!isExpanded}
+                  isDisabled={isRateLimited}
                   onApproveToolCall={onApproveToolCall}
                   onRejectToolCall={onRejectToolCall}
                 />
@@ -580,6 +644,11 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
             </div>
           </div>
         ) : null}
+        {error?.type === "rate_limit" && (
+          <div className="p-2">
+            <InAppAgentRateLimitError error={error} isExpanded={isExpanded} />
+          </div>
+        )}
         <div
           className={cn(
             "p-1.5",

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -30,6 +30,7 @@ import {
   type InAppAgentRuntimeState,
   type InAppAgentToolApprovalRequest,
 } from "@/src/ee/features/in-app-agent/schema";
+import type { InAppAgentError } from "@/src/ee/features/in-app-agent/components/utils/utils";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { api } from "@/src/utils/api";
@@ -38,6 +39,10 @@ import {
   createInAppAgentUserContext,
 } from "@/src/ee/features/in-app-agent/context";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import {
+  getInAppAgentError,
+  isInAppAgentRateLimited,
+} from "@/src/ee/features/in-app-agent/components/utils/utils";
 
 const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";
@@ -116,7 +121,7 @@ type InAppAiAgentContextType = {
   isSubmitting: boolean;
   pendingToolApprovals: InAppAgentPendingToolApproval[];
   isSelectedConversationHydrating: boolean;
-  error: string | null;
+  error: InAppAgentError | null;
   messages: InAppAiAgentMessage[];
   conversations: InAppAiAgentConversation[];
   hasMoreConversations: boolean;
@@ -222,7 +227,7 @@ function InAppAiAgentProviderInner({
   const [isRunning, setIsRunning] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<InAppAgentError | null>(null);
   const agentRef = useRef<HttpAgent | null>(null);
   const activeRunIdRef = useRef<string | null>(null);
   const intentionalAbortRef = useRef(false);
@@ -410,6 +415,34 @@ function InAppAiAgentProviderInner({
     };
   }, [resetAgent]);
 
+  const rateLimitRetryAt = error?.type === "rate_limit" ? error.retryAt : null;
+
+  useEffect(() => {
+    if (rateLimitRetryAt === null) {
+      return;
+    }
+
+    const timeout = window.setTimeout(
+      () => {
+        setError((currentError) => {
+          if (
+            currentError?.type !== "rate_limit" ||
+            currentError.retryAt !== rateLimitRetryAt
+          ) {
+            return currentError;
+          }
+
+          return null;
+        });
+      },
+      Math.max(0, rateLimitRetryAt - Date.now()),
+    );
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [rateLimitRetryAt]);
+
   const ensureSubscription = useCallback(
     (agent: HttpAgent) => {
       if (subscriptionRef.current) {
@@ -467,8 +500,7 @@ function InAppAiAgentProviderInner({
             return;
           }
 
-          const errorMessage = getAgentErrorMessage(event);
-          setError(errorMessage);
+          setError(getInAppAgentError(event));
           console.error("In-app agent drawer run error", event);
         },
         onMessagesChanged: ({ messages }) => {
@@ -560,8 +592,7 @@ function InAppAiAgentProviderInner({
             throw error;
           }
 
-          const errorMessage = getAgentErrorMessage(error);
-          setError(errorMessage);
+          setError(getInAppAgentError(error));
           console.error("In-app agent drawer error", error);
           return false;
         })
@@ -599,7 +630,9 @@ function InAppAiAgentProviderInner({
         return;
       }
 
-      setError(null);
+      setError((currentError) =>
+        isInAppAgentRateLimited(currentError) ? currentError : null,
+      );
       resetAgent();
       setMessages([]);
       setSelectedConversationId(conversationId);
@@ -667,6 +700,7 @@ function InAppAiAgentProviderInner({
       if (
         !content ||
         isRunning ||
+        isInAppAgentRateLimited(error) ||
         isSelectedConversationHydrating ||
         submitInFlightRef.current
       ) {
@@ -724,8 +758,7 @@ function InAppAiAgentProviderInner({
         runAgent(agent, conversationId);
         return true;
       } catch (error) {
-        const errorMessage = getAgentErrorMessage(error);
-        setError(errorMessage);
+        setError(getInAppAgentError(error));
         console.error("Failed to start in-app agent conversation", error);
         return false;
       } finally {
@@ -738,6 +771,7 @@ function InAppAiAgentProviderInner({
       conversationQuery.data,
       capture,
       ensureSubscription,
+      error,
       getOrCreateAgent,
       isSelectedConversationHydrating,
       isRunning,
@@ -817,7 +851,12 @@ function InAppAiAgentProviderInner({
         (approval) => approval.id === approvalId,
       );
 
-      if (!approval || !selectedConversationId || isRunning) {
+      if (
+        !approval ||
+        !selectedConversationId ||
+        isRunning ||
+        isInAppAgentRateLimited(error)
+      ) {
         return;
       }
 
@@ -877,7 +916,10 @@ function InAppAiAgentProviderInner({
               (currentApproval) => currentApproval.id !== approvalId,
             ),
           );
-          setError("This tool approval is no longer valid. Please try again.");
+          setError({
+            type: "generic",
+            message: "This tool approval is no longer valid. Please try again.",
+          });
           console.error("Failed to resume in-app agent tool call", error);
           return;
         }
@@ -889,12 +931,13 @@ function InAppAiAgentProviderInner({
               : currentApproval,
           ),
         );
-        setError(errorMessage);
+        setError(getInAppAgentError(error));
         console.error("Failed to resume in-app agent tool call", error);
       }
     },
     [
       ensureSubscription,
+      error,
       isRunning,
       pendingToolApprovals,
       runAgent,

--- a/web/src/ee/features/in-app-agent/components/utils/utils.clienttest.ts
+++ b/web/src/ee/features/in-app-agent/components/utils/utils.clienttest.ts
@@ -1,5 +1,70 @@
 import type { AgUiMessage } from "@/src/ee/features/in-app-agent/schema";
-import { extractLangfuseDocsSources, getDrawerMessages } from "./utils";
+import {
+  extractLangfuseDocsSources,
+  getDrawerMessages,
+  getInAppAgentError,
+  isInAppAgentRateLimited,
+} from "./utils";
+
+describe("getInAppAgentError", () => {
+  const now = new Date("2026-07-08T20:00:54.997Z").getTime();
+  const rateLimitError = {
+    message: "Rate limit exceeded",
+    code: "rate_limited",
+    details: {
+      retryAfterSeconds: 12,
+      limit: 30,
+      remaining: 0,
+      resetAt: "2026-07-08T20:01:06.997Z",
+    },
+  };
+
+  it("extracts a rate limit from a streamed MCP error", () => {
+    expect(
+      getInAppAgentError(
+        {
+          message: `Failed to initialize Langfuse MCP: Streamable HTTP error: Error POSTing to endpoint: ${JSON.stringify(rateLimitError)}`,
+        },
+        now,
+      ),
+    ).toEqual({
+      type: "rate_limit",
+      retryAt: now + 12_000,
+    });
+  });
+
+  it("extracts a rate limit from a direct HTTP error payload", () => {
+    expect(getInAppAgentError({ payload: rateLimitError }, now)).toEqual({
+      type: "rate_limit",
+      retryAt: now + 12_000,
+    });
+  });
+
+  it("checks rate limits against the current time", () => {
+    const error = getInAppAgentError({ payload: rateLimitError }, now);
+
+    expect(isInAppAgentRateLimited(error, now + 11_999)).toBe(true);
+    expect(isInAppAgentRateLimited(error, now + 12_000)).toBe(false);
+  });
+
+  it("preserves unrelated errors as generic errors", () => {
+    expect(
+      getInAppAgentError({ message: "Assistant connection failed" }, now),
+    ).toEqual({
+      type: "generic",
+      message: "Assistant connection failed",
+    });
+  });
+
+  it("does not classify malformed embedded JSON as a rate limit", () => {
+    const message = 'Failed to initialize Langfuse MCP: {"code":"rate_limited"';
+
+    expect(getInAppAgentError({ message }, now)).toEqual({
+      type: "generic",
+      message,
+    });
+  });
+});
 
 describe("extractLangfuseDocsSources", () => {
   it("extracts and deduplicates document sources from docs tool results", () => {

--- a/web/src/ee/features/in-app-agent/components/utils/utils.ts
+++ b/web/src/ee/features/in-app-agent/components/utils/utils.ts
@@ -7,11 +7,16 @@ import { stableJsonStringify } from "@/src/utils/json";
 import {
   AgUiMessageSchema,
   type AgUiMessage,
+  InAppAgentRateLimitErrorResponseSchema,
   type InAppAgentMessageSource,
   InAppAgentRedirectActionToolResultSchema,
   InAppAgentMessageSourceSchema,
 } from "@/src/ee/features/in-app-agent/schema";
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
+
+export type InAppAgentError =
+  | { type: "generic"; message: string }
+  | { type: "rate_limit"; retryAt: number };
 
 export type InAppAgentToolCallContent = {
   type: "tool";
@@ -24,6 +29,15 @@ export type InAppAgentToolCallContent = {
     status: "pending" | "submitting";
   };
 };
+
+const InAppAgentTransportErrorSchema = z.object({
+  message: z.string().optional(),
+  payload: z.unknown().optional(),
+});
+
+const InAppAgentLegacyErrorPayloadSchema = z.object({
+  error: z.string(),
+});
 
 const LangfuseDocsDocumentSchema = z.object({
   type: z.literal("document"),
@@ -75,6 +89,82 @@ const InkeepChoiceResultSchema = z.object({
     ),
   }),
 });
+
+export function getInAppAgentError(
+  error: unknown,
+  now = Date.now(),
+): InAppAgentError {
+  const parsedError = InAppAgentTransportErrorSchema.safeParse(error);
+  const payload = parsedError.success ? parsedError.data.payload : undefined;
+  const message = getErrorMessage(error);
+  const rateLimitError =
+    parseRateLimitError(payload) ??
+    parseRateLimitError(error) ??
+    parseEmbeddedRateLimitError(message);
+
+  if (rateLimitError) {
+    return {
+      type: "rate_limit",
+      retryAt: now + rateLimitError.details.retryAfterSeconds * 1_000,
+    };
+  }
+
+  return { type: "generic", message };
+}
+
+function parseRateLimitError(value: unknown) {
+  const parsed = InAppAgentRateLimitErrorResponseSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function isInAppAgentRateLimited(
+  error: InAppAgentError | null,
+  now = Date.now(),
+) {
+  return error?.type === "rate_limit" && error.retryAt > now;
+}
+
+function parseEmbeddedRateLimitError(message: string) {
+  const endIndex = message.lastIndexOf("}");
+  let startIndex = message.indexOf("{");
+
+  while (startIndex !== -1 && startIndex < endIndex) {
+    try {
+      const parsed = JSON.parse(
+        message.slice(startIndex, endIndex + 1),
+      ) as unknown;
+      const rateLimitError = parseRateLimitError(parsed);
+
+      if (rateLimitError) {
+        return rateLimitError;
+      }
+    } catch {
+      // The transport prefixes JSON with error context, so try the next object.
+    }
+
+    startIndex = message.indexOf("{", startIndex + 1);
+  }
+
+  return null;
+}
+
+function getErrorMessage(error: unknown) {
+  const parsedError = InAppAgentTransportErrorSchema.safeParse(error);
+  if (!parsedError.success) {
+    return "Assistant request failed. Please try again.";
+  }
+
+  const legacyPayload = InAppAgentLegacyErrorPayloadSchema.safeParse(
+    parsedError.data.payload,
+  );
+  if (legacyPayload.success) {
+    return legacyPayload.data.error;
+  }
+
+  return (
+    parsedError.data.message ?? "Assistant request failed. Please try again."
+  );
+}
 
 export function getDrawerMessages({
   error,

--- a/web/src/ee/features/in-app-agent/schema.ts
+++ b/web/src/ee/features/in-app-agent/schema.ts
@@ -47,6 +47,13 @@ export type InAppAgentMessageFeedback = z.infer<
   typeof InAppAgentMessageFeedbackSchema
 >;
 
+export const InAppAgentRateLimitErrorResponseSchema = z.object({
+  code: z.literal("rate_limited"),
+  details: z.object({
+    retryAfterSeconds: z.number().int().positive(),
+  }),
+});
+
 // Changes to this schema need to be backwards-compatible as messages with this are already persisted.
 export const InAppAgentRedirectActionToolResultSchema = z.object({
   type: z.literal("redirectAction"),

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -634,7 +634,12 @@ function createInAppAgentRateLimitResponse(rateLimitRes: RateLimitResult) {
   }
 
   return Response.json(
-    { error: "Rate limit exceeded" },
+    {
+      code: "rate_limited",
+      details: {
+        retryAfterSeconds: Math.ceil(rateLimitRes.msBeforeNext / 1_000),
+      },
+    },
     { status: 429, headers },
   );
 }

--- a/web/src/utils/dates.ts
+++ b/web/src/utils/dates.ts
@@ -46,6 +46,22 @@ export const formatIntervalSeconds = (seconds: number, scale = 2) => {
   return `${seconds.toFixed(scale)}s`;
 };
 
+export const formatApproximateDuration = (secondsRemaining: number) => {
+  const seconds = Math.max(1, secondsRemaining);
+
+  if (seconds < 60) {
+    return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  }
+
+  const minutes = Math.ceil(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+
+  const hours = Math.ceil(minutes / 60);
+  return `${hours} hour${hours === 1 ? "" : "s"}`;
+};
+
 export const getShortLocalTimezone = () => {
   return new Date()
     .toLocaleTimeString("en-us", { timeZoneName: "short" })


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upgrades the in-app agent rate-limiting experience by replacing the plain `"Rate limit exceeded"` error string with a structured `{ code: "rate_limited", details: { retryAfterSeconds } }` response, then parsing that on the client to show a live countdown and block the appropriate controls.

- **Server**: `createInAppAgentRateLimitResponse` now emits a structured JSON body (matching the new `InAppAgentRateLimitErrorResponseSchema`) and the existing `Retry-After` header.
- **Client error parsing**: `getInAppAgentError` classifies errors as `rate_limit` or `generic` using a three-tier strategy — direct payload match, top-level object match, and substring JSON extraction for transport-wrapped errors (`parseEmbeddedRateLimitError`).
- **UX controls**: the input, feedback, tool-approval buttons, and the "Get started" button are disabled while rate-limited; navigation buttons ("Start new conversation", "Conversation history") stay enabled. A countdown component auto-clears in the provider via `setTimeout` at the exact `retryAt` timestamp.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are UI and error-classification logic only, with no schema-breaking changes and solid guard rails throughout.

The server response change is additive (structured body replaces plain string, existing Retry-After header unchanged). The three-tier client-side parsing is well-tested, including the substring JSON extraction. The auto-clear setTimeout correctly guards stale-state overwrites with a functional updater, and all submit/approve paths check isInAppAgentRateLimited before acting. No data mutations, migrations, or auth-boundary changes are involved.

No files require special attention. The parsing logic in utils.ts and the countdown in InAppAgentWindow.tsx are the most nuanced changes but are well-exercised by the new unit tests and Storybook play tests.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant InAppAgentWindow
    participant InAppAiAgentProvider
    participant Server

    User->>InAppAgentWindow: Submit message
    InAppAiAgentProvider->>Server: POST /api/in-app-agent
    Server-->>InAppAiAgentProvider: "429 { code:"rate_limited", details:{ retryAfterSeconds:60 } }"
    InAppAiAgentProvider->>InAppAiAgentProvider: "getInAppAgentError() → { type:"rate_limit", retryAt }"
    InAppAiAgentProvider->>InAppAiAgentProvider: "setError({ type:"rate_limit", retryAt })"
    InAppAiAgentProvider->>InAppAiAgentProvider: setTimeout(clearError, retryAt - now)
    InAppAiAgentProvider-->>InAppAgentWindow: "error = { type:"rate_limit", retryAt }"
    InAppAgentWindow-->>User: "Show countdown banner, disable input & tool approvals"
    Note over InAppAgentWindow: Every 1s: update secondsRemaining display
    User->>InAppAgentWindow: Try to submit again
    InAppAiAgentProvider->>InAppAiAgentProvider: isInAppAgentRateLimited(error) → true, return early
    Note over InAppAiAgentProvider: After retryAt ms...
    InAppAiAgentProvider->>InAppAiAgentProvider: clearTimeout fires, setError(null)
    InAppAiAgentProvider-->>InAppAgentWindow: "error = null"
    InAppAgentWindow-->>User: Countdown gone, controls re-enabled
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant InAppAgentWindow
    participant InAppAiAgentProvider
    participant Server

    User->>InAppAgentWindow: Submit message
    InAppAiAgentProvider->>Server: POST /api/in-app-agent
    Server-->>InAppAiAgentProvider: "429 { code:"rate_limited", details:{ retryAfterSeconds:60 } }"
    InAppAiAgentProvider->>InAppAiAgentProvider: "getInAppAgentError() → { type:"rate_limit", retryAt }"
    InAppAiAgentProvider->>InAppAiAgentProvider: "setError({ type:"rate_limit", retryAt })"
    InAppAiAgentProvider->>InAppAiAgentProvider: setTimeout(clearError, retryAt - now)
    InAppAiAgentProvider-->>InAppAgentWindow: "error = { type:"rate_limit", retryAt }"
    InAppAgentWindow-->>User: "Show countdown banner, disable input & tool approvals"
    Note over InAppAgentWindow: Every 1s: update secondsRemaining display
    User->>InAppAgentWindow: Try to submit again
    InAppAiAgentProvider->>InAppAiAgentProvider: isInAppAgentRateLimited(error) → true, return early
    Note over InAppAiAgentProvider: After retryAt ms...
    InAppAiAgentProvider->>InAppAiAgentProvider: clearTimeout fires, setError(null)
    InAppAiAgentProvider-->>InAppAgentWindow: "error = null"
    InAppAgentWindow-->>User: Countdown gone, controls re-enabled
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Improve UX around rate-limit..."](https://github.com/langfuse/langfuse/commit/751b4f74528ce0d67d6f2b22d12b55b741f15d30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43763289)</sub>

<!-- /greptile_comment -->