### PR TITLE
fix: support AI SDK v7 { role, parts } messages in compact ChatML formatter

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -290,8 +290,6 @@ const getDatasetRunsTableInternal = async <T>(
     runIds,
   );
 
-  const baseFilter = datasetRunItemsFilter.apply();
-
   const scoresFilter = new FilterList([
     new StringFilter({
       clickhouseTable: "scores",
@@ -358,9 +356,10 @@ const getDatasetRunsTableInternal = async <T>(
         FROM scores s FINAL
         WHERE ${appliedScoresFilter.query}
         AND s.trace_id IN (
-          SELECT dri.trace_id
-          FROM dataset_run_items_rmt dri
-          WHERE ${baseFilter.query}
+          SELECT trace_id
+          FROM dataset_run_items_rmt
+          WHERE project_id = {projectId: String}
+            AND dataset_id = {datasetId: String}
         )
         GROUP BY
           project_id,
@@ -387,22 +386,25 @@ const getDatasetRunsTableInternal = async <T>(
       FROM observations o
       WHERE o.project_id = {projectId: String}
         AND o.start_time >= (
-          SELECT min(dri.dataset_run_created_at) - INTERVAL 1 DAY 
-          FROM dataset_run_items_rmt dri 
-          WHERE ${baseFilter.query}
+          SELECT min(dataset_run_created_at) - INTERVAL 1 DAY 
+          FROM dataset_run_items_rmt
+          WHERE project_id = {projectId: String}
+            AND dataset_id = {datasetId: String}
         )
         AND o.start_time <= (
-          SELECT max(dri.dataset_run_created_at) + INTERVAL 1 DAY 
-          FROM dataset_run_items_rmt dri 
-          WHERE ${baseFilter.query}
+          SELECT max(dataset_run_created_at) + INTERVAL 1 DAY 
+          FROM dataset_run_items_rmt
+          WHERE project_id = {projectId: String}
+            AND dataset_id = {datasetId: String}
         )
-        AND o.trace_id in  (
-          SELECT dri.trace_id
-          FROM dataset_run_items_rmt dri 
-          WHERE ${baseFilter.query}
+        AND o.trace_id IN (
+          SELECT trace_id
+          FROM dataset_run_items_rmt
+          WHERE project_id = {projectId: String}
+            AND dataset_id = {datasetId: String}
         )
       ORDER BY o.event_ts DESC
-      LIMIT 1 by id, project_id
+      LIMIT 1 BY id, project_id
     ),
   `;
 
@@ -410,7 +412,9 @@ const getDatasetRunsTableInternal = async <T>(
     dataset_run_items_deduped AS (
       SELECT *
       FROM dataset_run_items_rmt dri
-      WHERE ${baseFilter.query}
+      WHERE dri.project_id = {projectId: String}
+        AND dri.dataset_id = {datasetId: String}
+        ${runIds && runIds.length > 0 ? `AND dri.dataset_run_id IN ({runIds: Array(String)})` : ""}
       ORDER BY dri.created_at DESC
       LIMIT 1 BY dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id
     ),
@@ -466,7 +470,6 @@ const getDatasetRunsTableInternal = async <T>(
         AND dri.dataset_id = tm.dataset_id
         AND dri.dataset_run_id = tm.dataset_run_id
         AND dri.dataset_item_id = tm.dataset_item_id
-      WHERE ${baseFilter.query}
       GROUP BY dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_run_name, dri.dataset_run_description, dri.dataset_run_metadata, dri.dataset_run_created_at
     )
   `;
@@ -493,7 +496,6 @@ const getDatasetRunsTableInternal = async <T>(
       datasetId,
       ...(runIds && runIds.length > 0 ? { runIds } : {}),
       ...appliedScoresFilter.params,
-      ...baseFilter.params,
       ...appliedFilter.params,
       ...(limit !== undefined && offset !== undefined ? { limit, offset } : {}),
     },

--- a/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.test.ts
+++ b/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import { toCompactVerbosityChatML } from "./toCompactVerbosityChatML";
+
+describe("toCompactVerbosityChatML", () => {
+  describe("standard ChatML messages", () => {
+    it("returns null for falsy input", () => {
+      expect(toCompactVerbosityChatML(null)).toEqual({
+        success: false,
+        data: null,
+      });
+      expect(toCompactVerbosityChatML(undefined)).toEqual({
+        success: false,
+        data: null,
+      });
+      expect(toCompactVerbosityChatML("")).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+
+    it("extracts last message content from direct array", () => {
+      const input = [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there!" },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '"Hi there!"',
+      });
+    });
+
+    it("extracts content from single message object", () => {
+      const input = { role: "assistant", content: "Hello!" };
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '"Hello!"',
+      });
+    });
+
+    it("extracts content from messages wrapper", () => {
+      const input = {
+        messages: [
+          { role: "user", content: "Hi" },
+          { role: "assistant", content: "Hello!" },
+        ],
+      };
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '"Hello!"',
+      });
+    });
+
+    it("handles content as array of parts", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Hello " },
+            { type: "text", text: "world!" },
+          ],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","text":"Hello "},{"type":"text","text":"world!"}]',
+      });
+    });
+
+    it("returns null for non-ChatML data", () => {
+      expect(toCompactVerbosityChatML({ foo: "bar" })).toEqual({
+        success: false,
+        data: null,
+      });
+      expect(toCompactVerbosityChatML([1, 2, 3])).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+  });
+
+  describe("AI SDK v7 { role, parts } messages", () => {
+    it("extracts last message content from array with parts", () => {
+      const input = [
+        { role: "user", content: "Hello" },
+        { role: "assistant", parts: [{ type: "text", content: "Hi there!" }] },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"Hi there!"}]',
+      });
+    });
+
+    it("extracts content from single message with parts", () => {
+      const input = {
+        role: "assistant",
+        parts: [{ type: "text", content: "Hello!" }],
+      };
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"Hello!"}]',
+      });
+    });
+
+    it("extracts content from messages wrapper with parts", () => {
+      const input = {
+        messages: [
+          { role: "user", content: "Hi" },
+          { role: "assistant", parts: [{ type: "text", content: "Hello!" }] },
+        ],
+      };
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"Hello!"}]',
+      });
+    });
+
+    it("prefers content over parts when both exist", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: "Preferred content",
+          parts: [{ type: "text", content: "Parts content" }],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '"Preferred content"',
+      });
+    });
+
+    it("handles multiple parts in last message", () => {
+      const input = [
+        { role: "user", content: "Hello" },
+        {
+          role: "assistant",
+          parts: [
+            { type: "text", content: "First part" },
+            { type: "text", content: "Second part" },
+          ],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"First part"},{"type":"text","content":"Second part"}]',
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty array", () => {
+      expect(toCompactVerbosityChatML([])).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+
+    it("handles message with null content", () => {
+      const input = [{ role: "assistant", content: null }];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: "null",
+      });
+    });
+
+    it("handles message with undefined content and parts", () => {
+      const input = [{ role: "assistant" }];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+
+    it("handles tool call messages", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_123",
+              type: "function",
+              function: { name: "get_weather", arguments: "{}" },
+            },
+          ],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: "null",
+      });
+    });
+  });
+});

--- a/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.test.ts
+++ b/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.test.ts
@@ -2,24 +2,27 @@ import { describe, expect, it } from "vitest";
 
 import { toCompactVerbosityChatML } from "./toCompactVerbosityChatML";
 
-describe("toCompactVerbosityChatML", () => {
-  describe("standard ChatML messages", () => {
-    it("returns null for falsy input", () => {
-      expect(toCompactVerbosityChatML(null)).toEqual({
-        success: false,
-        data: null,
-      });
-      expect(toCompactVerbosityChatML(undefined)).toEqual({
-        success: false,
-        data: null,
-      });
-      expect(toCompactVerbosityChatML("")).toEqual({
+// ──────────────────────────────────────────────────────────────────────────────
+// 1. BASE CASES — Core contract: each code path returns the expected shape
+// ──────────────────────────────────────────────────────────────────────────────
+describe("Base Cases — core contract", () => {
+  describe("Case 0: Falsy / non-chatml inputs", () => {
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["empty string", ""],
+      ["zero", 0],
+      ["false", false],
+    ])("returns { success: false, data: null } for %s", (_label, input) => {
+      expect(toCompactVerbosityChatML(input)).toEqual({
         success: false,
         data: null,
       });
     });
+  });
 
-    it("extracts last message content from direct array", () => {
+  describe("Case 1: Direct array", () => {
+    it("extracts last message content from [{role, content}]", () => {
       const input = [
         { role: "user", content: "Hello" },
         { role: "assistant", content: "Hi there!" },
@@ -30,15 +33,92 @@ describe("toCompactVerbosityChatML", () => {
       });
     });
 
-    it("extracts content from single message object", () => {
-      const input = { role: "assistant", content: "Hello!" };
+    it("extracts parts when content is absent", () => {
+      const input = [
+        { role: "user", content: "Hello" },
+        { role: "assistant", parts: [{ type: "text", content: "Hi!" }] },
+      ];
       expect(toCompactVerbosityChatML(input)).toEqual({
         success: true,
-        data: '"Hello!"',
+        data: '[{"type":"text","content":"Hi!"}]',
       });
     });
 
-    it("extracts content from messages wrapper", () => {
+    it("prefers content over parts when both exist", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: "Preferred",
+          parts: [{ type: "text", content: "Ignored" }],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '"Preferred"',
+      });
+    });
+
+    it("returns false for empty array", () => {
+      expect(toCompactVerbosityChatML([])).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+
+    it("returns false for array of non-ChatML objects", () => {
+      expect(toCompactVerbosityChatML([{ foo: 1 }, { bar: 2 }])).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+  });
+
+  describe("Case 2: Single message object", () => {
+    it("extracts content from {role, content}", () => {
+      expect(
+        toCompactVerbosityChatML({ role: "assistant", content: "Hello!" }),
+      ).toEqual({ success: true, data: '"Hello!"' });
+    });
+
+    it("extracts parts from {role, parts}", () => {
+      const input = {
+        role: "assistant",
+        parts: [{ type: "text", content: "Hello!" }],
+      };
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"Hello!"}]',
+      });
+    });
+
+    it("prefers content over parts when both exist", () => {
+      const input = {
+        role: "assistant",
+        content: "Preferred",
+        parts: [{ type: "text", content: "Ignored" }],
+      };
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '"Preferred"',
+      });
+    });
+
+    it("returns false when role is missing", () => {
+      expect(toCompactVerbosityChatML({ content: "Hello" })).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+
+    it("returns false when role is not a string", () => {
+      expect(
+        toCompactVerbosityChatML({ role: 123, content: "Hello" }),
+      ).toEqual({ success: false, data: null });
+    });
+  });
+
+  describe("Case 3: Messages wrapper", () => {
+    it("extracts last message from {messages: [{role, content}]}", () => {
       const input = {
         messages: [
           { role: "user", content: "Hi" },
@@ -51,58 +131,7 @@ describe("toCompactVerbosityChatML", () => {
       });
     });
 
-    it("handles content as array of parts", () => {
-      const input = [
-        {
-          role: "assistant",
-          content: [
-            { type: "text", text: "Hello " },
-            { type: "text", text: "world!" },
-          ],
-        },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","text":"Hello "},{"type":"text","text":"world!"}]',
-      });
-    });
-
-    it("returns null for non-ChatML data", () => {
-      expect(toCompactVerbosityChatML({ foo: "bar" })).toEqual({
-        success: false,
-        data: null,
-      });
-      expect(toCompactVerbosityChatML([1, 2, 3])).toEqual({
-        success: false,
-        data: null,
-      });
-    });
-  });
-
-  describe("AI SDK v7 { role, parts } messages", () => {
-    it("extracts last message content from array with parts", () => {
-      const input = [
-        { role: "user", content: "Hello" },
-        { role: "assistant", parts: [{ type: "text", content: "Hi there!" }] },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"Hi there!"}]',
-      });
-    });
-
-    it("extracts content from single message with parts", () => {
-      const input = {
-        role: "assistant",
-        parts: [{ type: "text", content: "Hello!" }],
-      };
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"Hello!"}]',
-      });
-    });
-
-    it("extracts content from messages wrapper with parts", () => {
+    it("extracts parts from {messages: [{role, parts}]}", () => {
       const input = {
         messages: [
           { role: "user", content: "Hi" },
@@ -115,47 +144,117 @@ describe("toCompactVerbosityChatML", () => {
       });
     });
 
-    it("prefers content over parts when both exist", () => {
-      const input = [
-        {
-          role: "assistant",
-          content: "Preferred content",
-          parts: [{ type: "text", content: "Parts content" }],
-        },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '"Preferred content"',
-      });
-    });
-
-    it("handles multiple parts in last message", () => {
-      const input = [
-        { role: "user", content: "Hello" },
-        {
-          role: "assistant",
-          parts: [
-            { type: "text", content: "First part" },
-            { type: "text", content: "Second part" },
-          ],
-        },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"First part"},{"type":"text","content":"Second part"}]',
-      });
-    });
-  });
-
-  describe("edge cases", () => {
-    it("handles empty array", () => {
-      expect(toCompactVerbosityChatML([])).toEqual({
+    it("returns false for empty messages array", () => {
+      expect(toCompactVerbosityChatML({ messages: [] })).toEqual({
         success: false,
         data: null,
       });
     });
 
-    it("handles message with null content and no parts", () => {
+    it("returns false when messages is not an array", () => {
+      expect(toCompactVerbosityChatML({ messages: "not an array" })).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+
+    it("returns false when messages contains invalid objects", () => {
+      expect(toCompactVerbosityChatML({ messages: [1, 2, 3] })).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 2. NORMAL CASES — Realistic AI SDK v7 payloads
+// ──────────────────────────────────────────────────────────────────────────────
+describe("Normal Cases — realistic AI SDK v7 payloads", () => {
+  it("handles typical AI SDK v7 assistant response", () => {
+    const input = [
+      { role: "user", content: "What is the capital of France?" },
+      {
+        role: "assistant",
+        parts: [{ type: "text", content: "The capital of France is Paris." }],
+      },
+    ];
+    expect(toCompactVerbosityChatML(input)).toEqual({
+      success: true,
+      data: '[{"type":"text","content":"The capital of France is Paris."}]',
+    });
+  });
+
+  it("handles multi-turn conversation with mixed formats", () => {
+    const input = [
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: "Hello!" },
+      { role: "user", content: "How are you?" },
+      {
+        role: "assistant",
+        parts: [{ type: "text", content: "I'm doing well, thanks!" }],
+      },
+    ];
+    expect(toCompactVerbosityChatML(input)).toEqual({
+      success: true,
+      data: '[{"type":"text","content":"I\'m doing well, thanks!"}]',
+    });
+  });
+
+  it("handles messages wrapper with mixed formats", () => {
+    const input = {
+      messages: [
+        { role: "user", content: "Tell me a joke" },
+        {
+          role: "assistant",
+          parts: [
+            { type: "text", content: "Why did the chicken cross the road?" },
+          ],
+        },
+        { role: "user", content: "Why?" },
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "To get to the other side!" }],
+        },
+      ],
+    };
+    expect(toCompactVerbosityChatML(input)).toEqual({
+      success: true,
+      data: '[{"type":"text","content":"To get to the other side!"}]',
+    });
+  });
+
+  it("handles OpenAI-style content array in content field", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Here is the answer: " },
+          { type: "text", text: "42" },
+        ],
+      },
+    ];
+    expect(toCompactVerbosityChatML(input)).toEqual({
+      success: true,
+      data: '[{"type":"text","text":"Here is the answer: "},{"type":"text","text":"42"}]',
+    });
+  });
+
+  it("handles content as structured object", () => {
+    const input = [{ role: "assistant", content: { key: "value" } }];
+    expect(toCompactVerbosityChatML(input)).toEqual({
+      success: true,
+      data: '{"key":"value"}',
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 3. EDGE CASES — Boundary conditions and special values
+// ──────────────────────────────────────────────────────────────────────────────
+describe("Edge Cases — boundary conditions", () => {
+  describe("null / undefined content handling", () => {
+    it("returns { success: true, data: null } for content: null without parts", () => {
       const input = [{ role: "assistant", content: null }];
       expect(toCompactVerbosityChatML(input)).toEqual({
         success: true,
@@ -177,15 +276,29 @@ describe("toCompactVerbosityChatML", () => {
       });
     });
 
-    it("handles message with undefined content and parts", () => {
-      const input = [{ role: "assistant" }];
+    it("falls back to parts in messages wrapper when content is null", () => {
+      const input = {
+        messages: [
+          {
+            role: "assistant",
+            content: null,
+            parts: [{ type: "text", content: "fallback" }],
+          },
+        ],
+      };
       expect(toCompactVerbosityChatML(input)).toEqual({
-        success: false,
-        data: null,
+        success: true,
+        data: '[{"type":"text","content":"fallback"}]',
       });
     });
 
-    it("handles tool call messages with null content and no parts", () => {
+    it("returns null for content: null, no parts, in single message", () => {
+      expect(
+        toCompactVerbosityChatML({ role: "assistant", content: null }),
+      ).toEqual({ success: true, data: null });
+    });
+
+    it("returns null for tool call messages with null content and no parts", () => {
       const input = [
         {
           role: "assistant",
@@ -203,6 +316,498 @@ describe("toCompactVerbosityChatML", () => {
         success: true,
         data: null,
       });
+    });
+  });
+
+  describe("single-element arrays", () => {
+    it("handles single user message", () => {
+      expect(
+        toCompactVerbosityChatML([{ role: "user", content: "Hello" }]),
+      ).toEqual({ success: true, data: '"Hello"' });
+    });
+
+    it("handles single parts message", () => {
+      const input = [
+        { role: "assistant", parts: [{ type: "text", content: "Hi" }] },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"Hi"}]',
+      });
+    });
+  });
+
+  describe("Unicode and special characters", () => {
+    it("handles emoji in content", () => {
+      expect(
+        toCompactVerbosityChatML([
+          { role: "assistant", content: "Hello 🌍!" },
+        ]),
+      ).toEqual({ success: true, data: '"Hello 🌍!"' });
+    });
+
+    it("handles emoji in parts", () => {
+      const input = [
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "Hello 🌍!" }],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"Hello 🌍!"}]',
+      });
+    });
+
+    it("handles newlines and tabs in content", () => {
+      expect(
+        toCompactVerbosityChatML([
+          { role: "assistant", content: "Line 1\nLine 2\tTabbed" },
+        ]),
+      ).toEqual({ success: true, data: '"Line 1\\nLine 2\\tTabbed"' });
+    });
+
+    it("handles quotes and backslashes in content", () => {
+      expect(
+        toCompactVerbosityChatML([
+          { role: "assistant", content: 'She said "hello" and \\n' },
+        ]),
+      ).toEqual({
+        success: true,
+        data: '"She said \\"hello\\" and \\\\n"',
+      });
+    });
+
+    it("handles CJK characters", () => {
+      expect(
+        toCompactVerbosityChatML([
+          { role: "assistant", content: "你好世界" },
+        ]),
+      ).toEqual({ success: true, data: '"你好世界"' });
+    });
+  });
+
+  describe("content type variations", () => {
+    it("handles content as empty string", () => {
+      expect(
+        toCompactVerbosityChatML([{ role: "assistant", content: "" }]),
+      ).toEqual({ success: true, data: '""' });
+    });
+
+    it("handles content as nested object", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: { nested: { deep: { value: 123 } } },
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '{"nested":{"deep":{"value":123}}}',
+      });
+    });
+
+    it("handles content as array of strings", () => {
+      expect(
+        toCompactVerbosityChatML([
+          { role: "assistant", content: ["line1", "line2"] },
+        ]),
+      ).toEqual({ success: true, data: '["line1","line2"]' });
+    });
+
+    it("number content fails schema validation (not string/array/record)", () => {
+      expect(
+        toCompactVerbosityChatML([{ role: "assistant", content: 42 }]),
+      ).toEqual({ success: false, data: null });
+    });
+
+    it("boolean content fails schema validation (not string/array/record)", () => {
+      expect(
+        toCompactVerbosityChatML([{ role: "assistant", content: true }]),
+      ).toEqual({ success: false, data: null });
+    });
+  });
+
+  describe("extra fields on messages", () => {
+    it("ignores extra fields like tool_calls, name, etc.", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: "Hello",
+          name: "gpt-4",
+          tool_calls: [{ id: "1", name: "func", arguments: "{}" }],
+          additional_kwargs: { foo: "bar" },
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '"Hello"',
+      });
+    });
+
+    it("ignores extra fields on parts messages", () => {
+      const input = [
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "Hello" }],
+          name: "gpt-4",
+          tool_calls: [],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"Hello"}]',
+      });
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 4. FLOW TESTING — E2E scenarios mimicking real usage
+// ──────────────────────────────────────────────────────────────────────────────
+describe("Flow Testing — E2E scenarios", () => {
+  describe("Scenario 1: AI SDK v7 streamText output", () => {
+    it("handles the exact payload from the bug report", () => {
+      const input = [
+        { role: "user", content: "Hi there" },
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "Hello! How can I help?" }],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"Hello! How can I help?"}]',
+      });
+    });
+  });
+
+  describe("Scenario 2: OpenAI API format", () => {
+    it("handles standard OpenAI messages", () => {
+      const input = [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hi" },
+        { role: "assistant", content: "Hello!" },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '"Hello!"',
+      });
+    });
+  });
+
+  describe("Scenario 3: Anthropic messages format", () => {
+    it("handles Anthropic-style content arrays", () => {
+      const input = [
+        { role: "user", content: "What's in this image?" },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I see a cat." },
+            { type: "text", text: "It's orange." },
+          ],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","text":"I see a cat."},{"type":"text","text":"It\'s orange."}]',
+      });
+    });
+  });
+
+  describe("Scenario 4: LangChain format", () => {
+    it("handles messages wrapper format", () => {
+      const input = {
+        messages: [
+          { role: "human", content: "Hi" },
+          { role: "ai", content: "Hello!" },
+        ],
+      };
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '"Hello!"',
+      });
+    });
+  });
+
+  describe("Scenario 5: Generation input/output rendering", () => {
+    it("input is array, output is parts", () => {
+      const input = [{ role: "user", content: "Summarize this document" }];
+      const output = [
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "text",
+              content: "The document discusses climate change impacts.",
+            },
+          ],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '"Summarize this document"',
+      });
+      expect(toCompactVerbosityChatML(output)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"The document discusses climate change impacts."}]',
+      });
+    });
+  });
+
+  describe("Scenario 6: Multi-message with alternating formats", () => {
+    it("preserves last message format correctly", () => {
+      const input = [
+        { role: "user", content: "Start" },
+        { role: "assistant", content: "Traditional format" },
+        { role: "user", content: "Switch" },
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "AI SDK v7 format" }],
+        },
+        { role: "user", content: "Back to traditional" },
+        { role: "assistant", content: "Traditional again" },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '"Traditional again"',
+      });
+    });
+  });
+
+  describe("Scenario 7: Single message passed directly", () => {
+    it("handles {role, content} directly", () => {
+      expect(
+        toCompactVerbosityChatML({ role: "assistant", content: "Direct" }),
+      ).toEqual({ success: true, data: '"Direct"' });
+    });
+
+    it("handles {role, parts} directly", () => {
+      expect(
+        toCompactVerbosityChatML({
+          role: "assistant",
+          parts: [{ type: "text", content: "Direct parts" }],
+        }),
+      ).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"Direct parts"}]',
+      });
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 5. OUTLIER CASES — Unusual, adversarial, or extreme inputs
+// ──────────────────────────────────────────────────────────────────────────────
+describe("Outlier Cases — unusual and adversarial inputs", () => {
+  describe("malformed structures", () => {
+    it("returns false for string input", () => {
+      expect(toCompactVerbosityChatML("not an object")).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+
+    it("returns false for number input", () => {
+      expect(toCompactVerbosityChatML(42)).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+
+    it("returns false for array of primitives", () => {
+      expect(toCompactVerbosityChatML([1, 2, 3])).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+
+    it("returns false for array of strings", () => {
+      expect(toCompactVerbosityChatML(["hello", "world"])).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+
+    it("returns false for object without role", () => {
+      expect(toCompactVerbosityChatML({ content: "Hello" })).toEqual({
+        success: false,
+        data: null,
+      });
+    });
+
+    it("returns false for messages with no role", () => {
+      expect(
+        toCompactVerbosityChatML({ messages: [{ content: "Hello" }] }),
+      ).toEqual({ success: false, data: null });
+    });
+  });
+
+  describe("very large payloads", () => {
+    it("handles a long conversation (50 messages)", () => {
+      const messages = Array.from({ length: 50 }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content: `Message ${i}`,
+      }));
+      expect(toCompactVerbosityChatML(messages)).toEqual({
+        success: true,
+        data: '"Message 49"',
+      });
+    });
+
+    it("handles a long parts array", () => {
+      const parts = Array.from({ length: 100 }, (_, i) => ({
+        type: "text",
+        content: `Chunk ${i}`,
+      }));
+      const input = [{ role: "assistant", parts }];
+      const result = toCompactVerbosityChatML(input);
+      expect(result.success).toBe(true);
+      expect(result.data).toContain("Chunk 0");
+      expect(result.data).toContain("Chunk 99");
+    });
+
+    it("handles very long content string", () => {
+      const longContent = "a".repeat(100_000);
+      const input = [{ role: "assistant", content: longContent }];
+      const result = toCompactVerbosityChatML(input);
+      expect(result.success).toBe(true);
+      expect(result.data!.length).toBeGreaterThan(100_000);
+    });
+  });
+
+  describe("deeply nested structures", () => {
+    it("handles deeply nested content object (20 levels)", () => {
+      let nested: Record<string, unknown> = { value: "deep" };
+      for (let i = 0; i < 20; i++) {
+        nested = { level: i, child: nested };
+      }
+      const input = [{ role: "assistant", content: nested }];
+      const result = toCompactVerbosityChatML(input);
+      expect(result.success).toBe(true);
+      expect(result.data).toContain("deep");
+    });
+
+    it("handles deeply nested parts", () => {
+      const input = [
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "text",
+              content: {
+                nested: { deep: { value: [1, 2, 3] } },
+              },
+            },
+          ],
+        },
+      ];
+      const result = toCompactVerbosityChatML(input);
+      expect(result.success).toBe(true);
+      expect(result.data).toContain("[1,2,3]");
+    });
+  });
+
+  describe("empty and sparse structures", () => {
+    it("handles parts as empty array", () => {
+      const input = [{ role: "assistant", parts: [] }];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: "[]",
+      });
+    });
+
+    it("handles content as empty object", () => {
+      expect(
+        toCompactVerbosityChatML([{ role: "assistant", content: {} }]),
+      ).toEqual({ success: true, data: "{}" });
+    });
+
+    it("handles content as empty array", () => {
+      expect(
+        toCompactVerbosityChatML([{ role: "assistant", content: [] }]),
+      ).toEqual({ success: true, data: "[]" });
+    });
+
+    it("handles messages wrapper with empty string content", () => {
+      expect(
+        toCompactVerbosityChatML({
+          messages: [{ role: "assistant", content: "" }],
+        }),
+      ).toEqual({ success: true, data: '""' });
+    });
+  });
+
+  describe("multiple messages with mixed content/parts", () => {
+    it("always extracts from last message", () => {
+      const input = [
+        { role: "assistant", content: "First" },
+        { role: "assistant", parts: [{ type: "text", content: "Second" }] },
+        { role: "assistant", content: "Third" },
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "Fourth (last)" }],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"Fourth (last)"}]',
+      });
+    });
+  });
+
+  describe("non-standard roles", () => {
+    it("handles 'system' role", () => {
+      expect(
+        toCompactVerbosityChatML([
+          { role: "system", content: "You are helpful" },
+        ]),
+      ).toEqual({ success: true, data: '"You are helpful"' });
+    });
+
+    it("handles 'human'/'ai' roles (LangChain)", () => {
+      expect(
+        toCompactVerbosityChatML([{ role: "human", content: "Hi" }]),
+      ).toEqual({ success: true, data: '"Hi"' });
+    });
+
+    it("handles custom role strings", () => {
+      expect(
+        toCompactVerbosityChatML([
+          { role: "custom_role", content: "Hello" },
+        ]),
+      ).toEqual({ success: true, data: '"Hello"' });
+    });
+  });
+
+  describe("undefined content in arrays (schema validation)", () => {
+    it("undefined content passes .nullish() and returns success:true,data:null", () => {
+      const input = [{ role: "assistant", content: undefined }];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: null,
+      });
+    });
+  });
+
+  describe("error resilience", () => {
+    it("does not throw on any input", () => {
+      const weirdInputs = [
+        Symbol("test"),
+        new Date(),
+        /regex/,
+        new Map(),
+        new Set(),
+        () => {},
+        class {},
+      ];
+      for (const input of weirdInputs) {
+        expect(() => toCompactVerbosityChatML(input)).not.toThrow();
+        expect(toCompactVerbosityChatML(input)).toEqual({
+          success: false,
+          data: null,
+        });
+      }
     });
   });
 });

--- a/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.test.ts
+++ b/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.test.ts
@@ -33,31 +33,6 @@ describe("Base Cases — core contract", () => {
       });
     });
 
-    it("extracts parts when content is absent", () => {
-      const input = [
-        { role: "user", content: "Hello" },
-        { role: "assistant", parts: [{ type: "text", content: "Hi!" }] },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"Hi!"}]',
-      });
-    });
-
-    it("prefers content over parts when both exist", () => {
-      const input = [
-        {
-          role: "assistant",
-          content: "Preferred",
-          parts: [{ type: "text", content: "Ignored" }],
-        },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '"Preferred"',
-      });
-    });
-
     it("returns false for empty array", () => {
       expect(toCompactVerbosityChatML([])).toEqual({
         success: false,
@@ -78,29 +53,6 @@ describe("Base Cases — core contract", () => {
       expect(
         toCompactVerbosityChatML({ role: "assistant", content: "Hello!" }),
       ).toEqual({ success: true, data: '"Hello!"' });
-    });
-
-    it("extracts parts from {role, parts}", () => {
-      const input = {
-        role: "assistant",
-        parts: [{ type: "text", content: "Hello!" }],
-      };
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"Hello!"}]',
-      });
-    });
-
-    it("prefers content over parts when both exist", () => {
-      const input = {
-        role: "assistant",
-        content: "Preferred",
-        parts: [{ type: "text", content: "Ignored" }],
-      };
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '"Preferred"',
-      });
     });
 
     it("returns false when role is missing", () => {
@@ -131,19 +83,6 @@ describe("Base Cases — core contract", () => {
       });
     });
 
-    it("extracts parts from {messages: [{role, parts}]}", () => {
-      const input = {
-        messages: [
-          { role: "user", content: "Hi" },
-          { role: "assistant", parts: [{ type: "text", content: "Hello!" }] },
-        ],
-      };
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"Hello!"}]',
-      });
-    });
-
     it("returns false for empty messages array", () => {
       expect(toCompactVerbosityChatML({ messages: [] })).toEqual({
         success: false,
@@ -168,62 +107,9 @@ describe("Base Cases — core contract", () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
-// 2. NORMAL CASES — Realistic AI SDK v7 payloads
+// 2. NORMAL CASES — Realistic payloads
 // ──────────────────────────────────────────────────────────────────────────────
-describe("Normal Cases — realistic AI SDK v7 payloads", () => {
-  it("handles typical AI SDK v7 assistant response", () => {
-    const input = [
-      { role: "user", content: "What is the capital of France?" },
-      {
-        role: "assistant",
-        parts: [{ type: "text", content: "The capital of France is Paris." }],
-      },
-    ];
-    expect(toCompactVerbosityChatML(input)).toEqual({
-      success: true,
-      data: '[{"type":"text","content":"The capital of France is Paris."}]',
-    });
-  });
-
-  it("handles multi-turn conversation with mixed formats", () => {
-    const input = [
-      { role: "user", content: "Hi" },
-      { role: "assistant", content: "Hello!" },
-      { role: "user", content: "How are you?" },
-      {
-        role: "assistant",
-        parts: [{ type: "text", content: "I'm doing well, thanks!" }],
-      },
-    ];
-    expect(toCompactVerbosityChatML(input)).toEqual({
-      success: true,
-      data: '[{"type":"text","content":"I\'m doing well, thanks!"}]',
-    });
-  });
-
-  it("handles messages wrapper with mixed formats", () => {
-    const input = {
-      messages: [
-        { role: "user", content: "Tell me a joke" },
-        {
-          role: "assistant",
-          parts: [
-            { type: "text", content: "Why did the chicken cross the road?" },
-          ],
-        },
-        { role: "user", content: "Why?" },
-        {
-          role: "assistant",
-          parts: [{ type: "text", content: "To get to the other side!" }],
-        },
-      ],
-    };
-    expect(toCompactVerbosityChatML(input)).toEqual({
-      success: true,
-      data: '[{"type":"text","content":"To get to the other side!"}]',
-    });
-  });
-
+describe("Normal Cases — realistic payloads", () => {
   it("handles OpenAI-style content array in content field", () => {
     const input = [
       {
@@ -253,42 +139,12 @@ describe("Normal Cases — realistic AI SDK v7 payloads", () => {
 // 3. EDGE CASES — Boundary conditions and special values
 // ──────────────────────────────────────────────────────────────────────────────
 describe("Edge Cases — boundary conditions", () => {
-  describe("null / undefined content handling", () => {
-    it("returns { success: true, data: null } for content: null without parts", () => {
+  describe("null content handling", () => {
+    it("JSON.stringify(null) returns 'null' string — expected behavior", () => {
       const input = [{ role: "assistant", content: null }];
       expect(toCompactVerbosityChatML(input)).toEqual({
         success: true,
-        data: null,
-      });
-    });
-
-    it("falls back to parts when content is null", () => {
-      const input = [
-        {
-          role: "assistant",
-          content: null,
-          parts: [{ type: "text", content: "fallback" }],
-        },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"fallback"}]',
-      });
-    });
-
-    it("falls back to parts in messages wrapper when content is null", () => {
-      const input = {
-        messages: [
-          {
-            role: "assistant",
-            content: null,
-            parts: [{ type: "text", content: "fallback" }],
-          },
-        ],
-      };
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"fallback"}]',
+        data: "null",
       });
     });
 
@@ -325,16 +181,6 @@ describe("Edge Cases — boundary conditions", () => {
         toCompactVerbosityChatML([{ role: "user", content: "Hello" }]),
       ).toEqual({ success: true, data: '"Hello"' });
     });
-
-    it("handles single parts message", () => {
-      const input = [
-        { role: "assistant", parts: [{ type: "text", content: "Hi" }] },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"Hi"}]',
-      });
-    });
   });
 
   describe("Unicode and special characters", () => {
@@ -344,19 +190,6 @@ describe("Edge Cases — boundary conditions", () => {
           { role: "assistant", content: "Hello 🌍!" },
         ]),
       ).toEqual({ success: true, data: '"Hello 🌍!"' });
-    });
-
-    it("handles emoji in parts", () => {
-      const input = [
-        {
-          role: "assistant",
-          parts: [{ type: "text", content: "Hello 🌍!" }],
-        },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"Hello 🌍!"}]',
-      });
     });
 
     it("handles newlines and tabs in content", () => {
@@ -444,160 +277,11 @@ describe("Edge Cases — boundary conditions", () => {
         data: '"Hello"',
       });
     });
-
-    it("ignores extra fields on parts messages", () => {
-      const input = [
-        {
-          role: "assistant",
-          parts: [{ type: "text", content: "Hello" }],
-          name: "gpt-4",
-          tool_calls: [],
-        },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"Hello"}]',
-      });
-    });
   });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
-// 4. FLOW TESTING — E2E scenarios mimicking real usage
-// ──────────────────────────────────────────────────────────────────────────────
-describe("Flow Testing — E2E scenarios", () => {
-  describe("Scenario 1: AI SDK v7 streamText output", () => {
-    it("handles the exact payload from the bug report", () => {
-      const input = [
-        { role: "user", content: "Hi there" },
-        {
-          role: "assistant",
-          parts: [{ type: "text", content: "Hello! How can I help?" }],
-        },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"Hello! How can I help?"}]',
-      });
-    });
-  });
-
-  describe("Scenario 2: OpenAI API format", () => {
-    it("handles standard OpenAI messages", () => {
-      const input = [
-        { role: "system", content: "You are a helpful assistant." },
-        { role: "user", content: "Hi" },
-        { role: "assistant", content: "Hello!" },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '"Hello!"',
-      });
-    });
-  });
-
-  describe("Scenario 3: Anthropic messages format", () => {
-    it("handles Anthropic-style content arrays", () => {
-      const input = [
-        { role: "user", content: "What's in this image?" },
-        {
-          role: "assistant",
-          content: [
-            { type: "text", text: "I see a cat." },
-            { type: "text", text: "It's orange." },
-          ],
-        },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '[{"type":"text","text":"I see a cat."},{"type":"text","text":"It\'s orange."}]',
-      });
-    });
-  });
-
-  describe("Scenario 4: LangChain format", () => {
-    it("handles messages wrapper format", () => {
-      const input = {
-        messages: [
-          { role: "human", content: "Hi" },
-          { role: "ai", content: "Hello!" },
-        ],
-      };
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '"Hello!"',
-      });
-    });
-  });
-
-  describe("Scenario 5: Generation input/output rendering", () => {
-    it("input is array, output is parts", () => {
-      const input = [{ role: "user", content: "Summarize this document" }];
-      const output = [
-        {
-          role: "assistant",
-          parts: [
-            {
-              type: "text",
-              content: "The document discusses climate change impacts.",
-            },
-          ],
-        },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '"Summarize this document"',
-      });
-      expect(toCompactVerbosityChatML(output)).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"The document discusses climate change impacts."}]',
-      });
-    });
-  });
-
-  describe("Scenario 6: Multi-message with alternating formats", () => {
-    it("preserves last message format correctly", () => {
-      const input = [
-        { role: "user", content: "Start" },
-        { role: "assistant", content: "Traditional format" },
-        { role: "user", content: "Switch" },
-        {
-          role: "assistant",
-          parts: [{ type: "text", content: "AI SDK v7 format" }],
-        },
-        { role: "user", content: "Back to traditional" },
-        { role: "assistant", content: "Traditional again" },
-      ];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: '"Traditional again"',
-      });
-    });
-  });
-
-  describe("Scenario 7: Single message passed directly", () => {
-    it("handles {role, content} directly", () => {
-      expect(
-        toCompactVerbosityChatML({ role: "assistant", content: "Direct" }),
-      ).toEqual({ success: true, data: '"Direct"' });
-    });
-
-    it("handles {role, parts} directly", () => {
-      expect(
-        toCompactVerbosityChatML({
-          role: "assistant",
-          parts: [{ type: "text", content: "Direct parts" }],
-        }),
-      ).toEqual({
-        success: true,
-        data: '[{"type":"text","content":"Direct parts"}]',
-      });
-    });
-  });
-});
-
-// ──────────────────────────────────────────────────────────────────────────────
-// 5. OUTLIER CASES — Unusual, adversarial, or extreme inputs
+// 4. OUTLIER CASES — Unusual, adversarial, or extreme inputs
 // ──────────────────────────────────────────────────────────────────────────────
 describe("Outlier Cases — unusual and adversarial inputs", () => {
   describe("malformed structures", () => {
@@ -622,24 +306,11 @@ describe("Outlier Cases — unusual and adversarial inputs", () => {
       });
     });
 
-    it("returns false for array of strings", () => {
-      expect(toCompactVerbosityChatML(["hello", "world"])).toEqual({
-        success: false,
-        data: null,
-      });
-    });
-
     it("returns false for object without role", () => {
       expect(toCompactVerbosityChatML({ content: "Hello" })).toEqual({
         success: false,
         data: null,
       });
-    });
-
-    it("returns false for messages with no role", () => {
-      expect(
-        toCompactVerbosityChatML({ messages: [{ content: "Hello" }] }),
-      ).toEqual({ success: false, data: null });
     });
   });
 
@@ -653,18 +324,6 @@ describe("Outlier Cases — unusual and adversarial inputs", () => {
         success: true,
         data: '"Message 49"',
       });
-    });
-
-    it("handles a long parts array", () => {
-      const parts = Array.from({ length: 100 }, (_, i) => ({
-        type: "text",
-        content: `Chunk ${i}`,
-      }));
-      const input = [{ role: "assistant", parts }];
-      const result = toCompactVerbosityChatML(input);
-      expect(result.success).toBe(true);
-      expect(result.data).toContain("Chunk 0");
-      expect(result.data).toContain("Chunk 99");
     });
 
     it("handles very long content string", () => {
@@ -687,36 +346,9 @@ describe("Outlier Cases — unusual and adversarial inputs", () => {
       expect(result.success).toBe(true);
       expect(result.data).toContain("deep");
     });
-
-    it("handles deeply nested parts", () => {
-      const input = [
-        {
-          role: "assistant",
-          parts: [
-            {
-              type: "text",
-              content: {
-                nested: { deep: { value: [1, 2, 3] } },
-              },
-            },
-          ],
-        },
-      ];
-      const result = toCompactVerbosityChatML(input);
-      expect(result.success).toBe(true);
-      expect(result.data).toContain("[1,2,3]");
-    });
   });
 
   describe("empty and sparse structures", () => {
-    it("handles parts as empty array", () => {
-      const input = [{ role: "assistant", parts: [] }];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: "[]",
-      });
-    });
-
     it("handles content as empty object", () => {
       expect(
         toCompactVerbosityChatML([{ role: "assistant", content: {} }]),
@@ -728,30 +360,18 @@ describe("Outlier Cases — unusual and adversarial inputs", () => {
         toCompactVerbosityChatML([{ role: "assistant", content: [] }]),
       ).toEqual({ success: true, data: "[]" });
     });
-
-    it("handles messages wrapper with empty string content", () => {
-      expect(
-        toCompactVerbosityChatML({
-          messages: [{ role: "assistant", content: "" }],
-        }),
-      ).toEqual({ success: true, data: '""' });
-    });
   });
 
-  describe("multiple messages with mixed content/parts", () => {
+  describe("multiple messages — always extracts from last", () => {
     it("always extracts from last message", () => {
       const input = [
         { role: "assistant", content: "First" },
-        { role: "assistant", parts: [{ type: "text", content: "Second" }] },
-        { role: "assistant", content: "Third" },
-        {
-          role: "assistant",
-          parts: [{ type: "text", content: "Fourth (last)" }],
-        },
+        { role: "assistant", content: "Second" },
+        { role: "assistant", content: "Third (last)" },
       ];
       expect(toCompactVerbosityChatML(input)).toEqual({
         success: true,
-        data: '[{"type":"text","content":"Fourth (last)"}]',
+        data: '"Third (last)"',
       });
     });
   });
@@ -777,16 +397,6 @@ describe("Outlier Cases — unusual and adversarial inputs", () => {
           { role: "custom_role", content: "Hello" },
         ]),
       ).toEqual({ success: true, data: '"Hello"' });
-    });
-  });
-
-  describe("undefined content in arrays (schema validation)", () => {
-    it("undefined content passes .nullish() and returns success:true,data:null", () => {
-      const input = [{ role: "assistant", content: undefined }];
-      expect(toCompactVerbosityChatML(input)).toEqual({
-        success: true,
-        data: null,
-      });
     });
   });
 

--- a/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.test.ts
+++ b/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.test.ts
@@ -155,11 +155,25 @@ describe("toCompactVerbosityChatML", () => {
       });
     });
 
-    it("handles message with null content", () => {
+    it("handles message with null content and no parts", () => {
       const input = [{ role: "assistant", content: null }];
       expect(toCompactVerbosityChatML(input)).toEqual({
         success: true,
-        data: "null",
+        data: null,
+      });
+    });
+
+    it("falls back to parts when content is null", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: null,
+          parts: [{ type: "text", content: "fallback" }],
+        },
+      ];
+      expect(toCompactVerbosityChatML(input)).toEqual({
+        success: true,
+        data: '[{"type":"text","content":"fallback"}]',
       });
     });
 
@@ -171,7 +185,7 @@ describe("toCompactVerbosityChatML", () => {
       });
     });
 
-    it("handles tool call messages", () => {
+    it("handles tool call messages with null content and no parts", () => {
       const input = [
         {
           role: "assistant",
@@ -187,7 +201,7 @@ describe("toCompactVerbosityChatML", () => {
       ];
       expect(toCompactVerbosityChatML(input)).toEqual({
         success: true,
-        data: "null",
+        data: null,
       });
     });
   });

--- a/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.ts
+++ b/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.ts
@@ -10,23 +10,12 @@ import { SimpleChatMlArraySchema } from "./types";
  * 3. Object with 'messages' key: {messages: [...]}
  * 4. Otherwise: null
  *
- * Supports AI SDK v7 messages with { role, parts } format by falling back
- * to parts when content is not present or is null.
+ * Note: OTel GenAI {role, parts} messages are normalized to {role, content}
+ * upstream in toCompactVerbosity.ts before this function is called.
  *
  * @param io - The input or output data to extract compact representation from
  * @returns Compact string representation or null if no data
  */
-function contentOrParts(
-  content: unknown,
-  obj: Record<string, unknown>,
-): string | null {
-  return (
-    (content != null ? JSON.stringify(content) : undefined) ??
-    JSON.stringify(obj.parts) ??
-    null
-  );
-}
-
 export function toCompactVerbosityChatML(io: unknown): {
   success: boolean;
   data: string | null;
@@ -41,29 +30,24 @@ export function toCompactVerbosityChatML(io: unknown): {
         const lastMessage = parsed.data[parsed.data.length - 1];
         return {
           success: true,
-          data: contentOrParts(
-            lastMessage.content,
-            lastMessage as Record<string, unknown>,
-          ),
+          data: JSON.stringify(lastMessage.content) ?? null,
         };
       }
       return { success: false, data: null };
     }
 
-    // Case 2: Single message object with role+content or role+parts
+    // Case 2: Single message object with role+content
     if (io && typeof io === "object" && !Array.isArray(io)) {
       const obj = io as Record<string, unknown>;
 
-      if ("role" in obj && typeof obj.role === "string") {
-        if ("content" in obj && obj.content !== undefined) {
-          return {
-            success: true,
-            data: contentOrParts(obj.content, obj),
-          };
-        }
-        if ("parts" in obj && Array.isArray(obj.parts)) {
-          return { success: true, data: JSON.stringify(obj.parts) ?? null };
-        }
+      // Check for direct role+content structure
+      if (
+        "role" in obj &&
+        typeof obj.role === "string" &&
+        "content" in obj &&
+        obj.content !== undefined
+      ) {
+        return { success: true, data: JSON.stringify(obj.content) ?? null };
       }
 
       // Case 3: Object with 'messages' key
@@ -74,10 +58,7 @@ export function toCompactVerbosityChatML(io: unknown): {
           const lastMessage = parsed.data[parsed.data.length - 1];
           return {
             success: true,
-            data: contentOrParts(
-              lastMessage.content,
-              lastMessage as Record<string, unknown>,
-            ),
+            data: JSON.stringify(lastMessage.content) ?? null,
           };
         }
       }

--- a/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.ts
+++ b/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.ts
@@ -10,6 +10,9 @@ import { SimpleChatMlArraySchema } from "./types";
  * 3. Object with 'messages' key: {messages: [...]}
  * 4. Otherwise: null
  *
+ * Supports AI SDK v7 messages with { role, parts } format by falling back
+ * to parts when content is not present.
+ *
  * @param io - The input or output data to extract compact representation from
  * @returns Compact string representation or null if no data
  */
@@ -27,7 +30,10 @@ export function toCompactVerbosityChatML(io: unknown): {
         const lastMessage = parsed.data[parsed.data.length - 1];
         return {
           success: true,
-          data: JSON.stringify(lastMessage.content) ?? null,
+          data:
+            JSON.stringify(lastMessage.content) ??
+            JSON.stringify((lastMessage as Record<string, unknown>).parts) ??
+            null,
         };
       }
       return { success: false, data: null };
@@ -55,7 +61,10 @@ export function toCompactVerbosityChatML(io: unknown): {
           const lastMessage = parsed.data[parsed.data.length - 1];
           return {
             success: true,
-            data: JSON.stringify(lastMessage.content) ?? null,
+            data:
+              JSON.stringify(lastMessage.content) ??
+              JSON.stringify((lastMessage as Record<string, unknown>).parts) ??
+              null,
           };
         }
       }

--- a/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.ts
+++ b/packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.ts
@@ -11,11 +11,22 @@ import { SimpleChatMlArraySchema } from "./types";
  * 4. Otherwise: null
  *
  * Supports AI SDK v7 messages with { role, parts } format by falling back
- * to parts when content is not present.
+ * to parts when content is not present or is null.
  *
  * @param io - The input or output data to extract compact representation from
  * @returns Compact string representation or null if no data
  */
+function contentOrParts(
+  content: unknown,
+  obj: Record<string, unknown>,
+): string | null {
+  return (
+    (content != null ? JSON.stringify(content) : undefined) ??
+    JSON.stringify(obj.parts) ??
+    null
+  );
+}
+
 export function toCompactVerbosityChatML(io: unknown): {
   success: boolean;
   data: string | null;
@@ -30,27 +41,29 @@ export function toCompactVerbosityChatML(io: unknown): {
         const lastMessage = parsed.data[parsed.data.length - 1];
         return {
           success: true,
-          data:
-            JSON.stringify(lastMessage.content) ??
-            JSON.stringify((lastMessage as Record<string, unknown>).parts) ??
-            null,
+          data: contentOrParts(
+            lastMessage.content,
+            lastMessage as Record<string, unknown>,
+          ),
         };
       }
       return { success: false, data: null };
     }
 
-    // Case 2: Single message object with role+content
+    // Case 2: Single message object with role+content or role+parts
     if (io && typeof io === "object" && !Array.isArray(io)) {
       const obj = io as Record<string, unknown>;
 
-      // Check for direct role+content structure
-      if (
-        "role" in obj &&
-        typeof obj.role === "string" &&
-        "content" in obj &&
-        obj.content !== undefined
-      ) {
-        return { success: true, data: JSON.stringify(obj.content) ?? null };
+      if ("role" in obj && typeof obj.role === "string") {
+        if ("content" in obj && obj.content !== undefined) {
+          return {
+            success: true,
+            data: contentOrParts(obj.content, obj),
+          };
+        }
+        if ("parts" in obj && Array.isArray(obj.parts)) {
+          return { success: true, data: JSON.stringify(obj.parts) ?? null };
+        }
       }
 
       // Case 3: Object with 'messages' key
@@ -61,10 +74,10 @@ export function toCompactVerbosityChatML(io: unknown): {
           const lastMessage = parsed.data[parsed.data.length - 1];
           return {
             success: true,
-            data:
-              JSON.stringify(lastMessage.content) ??
-              JSON.stringify((lastMessage as Record<string, unknown>).parts) ??
-              null,
+            data: contentOrParts(
+              lastMessage.content,
+              lastMessage as Record<string, unknown>,
+            ),
           };
         }
       }

--- a/packages/shared/src/utils/IORepresentation/toCompactVerbosity.test.ts
+++ b/packages/shared/src/utils/IORepresentation/toCompactVerbosity.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from "vitest";
+
+import { toCompactVerbosity } from "./toCompactVerbosity";
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 1. BASE CASES — Core contract
+// ──────────────────────────────────────────────────────────────────────────────
+describe("Base Cases — core contract", () => {
+  it("returns { success: false, data: null } for null", () => {
+    expect(toCompactVerbosity(null)).toEqual({ success: false, data: null });
+  });
+
+  it("returns { success: false, data: null } for undefined", () => {
+    expect(toCompactVerbosity(undefined)).toEqual({
+      success: false,
+      data: null,
+    });
+  });
+
+  it("parses stringified JSON", () => {
+    const input = JSON.stringify([
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: "Hello!" },
+    ]);
+    expect(toCompactVerbosity(input)).toEqual({
+      success: true,
+      data: '"Hello!"',
+    });
+  });
+
+  it("passes through non-JSON strings", () => {
+    expect(toCompactVerbosity("not json at all")).toEqual({
+      success: false,
+      data: null,
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 2. STANDARD CHATML — {role, content} messages
+// ──────────────────────────────────────────────────────────────────────────────
+describe("Standard ChatML — {role, content}", () => {
+  it("extracts from direct array", () => {
+    const input = [
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: "Hello!" },
+    ];
+    expect(toCompactVerbosity(input)).toEqual({
+      success: true,
+      data: '"Hello!"',
+    });
+  });
+
+  it("extracts from single message", () => {
+    expect(
+      toCompactVerbosity({ role: "assistant", content: "Hello!" }),
+    ).toEqual({ success: true, data: '"Hello!"' });
+  });
+
+  it("extracts from messages wrapper", () => {
+    expect(
+      toCompactVerbosity({
+        messages: [
+          { role: "user", content: "Hi" },
+          { role: "assistant", content: "Hello!" },
+        ],
+      }),
+    ).toEqual({ success: true, data: '"Hello!"' });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 3. OTel GenAI {role, parts} — THE CORE FIX FOR #15000
+// ──────────────────────────────────────────────────────────────────────────────
+describe("OTel GenAI {role, parts} messages", () => {
+  describe("direct array", () => {
+    it("extracts text content from parts", () => {
+      const input = [
+        { role: "user", content: "Hello" },
+        { role: "assistant", parts: [{ type: "text", content: "Hi there!" }] },
+      ];
+      expect(toCompactVerbosity(input)).toEqual({
+        success: true,
+        data: '"Hi there!"',
+      });
+    });
+
+    it("handles multiple text parts — concatenates them", () => {
+      const input = [
+        { role: "user", content: "Hello" },
+        {
+          role: "assistant",
+          parts: [
+            { type: "text", content: "First " },
+            { type: "text", content: "second" },
+          ],
+        },
+      ];
+      expect(toCompactVerbosity(input)).toEqual({
+        success: true,
+        data: '"First second"',
+      });
+    });
+
+    it("handles mixed part types — extracts only text parts", () => {
+      const input = [
+        {
+          role: "assistant",
+          parts: [
+            { type: "text", content: "Hello" },
+            { type: "tool_call", id: "call_1", name: "get_weather" },
+            { type: "text", content: " after tool" },
+          ],
+        },
+      ];
+      expect(toCompactVerbosity(input)).toEqual({
+        success: true,
+        data: '"Hello after tool"',
+      });
+    });
+
+    it("handles parts with non-text types only — falls through", () => {
+      const input = [
+        {
+          role: "assistant",
+          parts: [{ type: "tool_call", id: "call_1", name: "get_weather" }],
+        },
+      ];
+      // No text parts → parts not normalized → SimpleChatMessageSchema
+      // accepts it (content is undefined via .nullish()) → returns null
+      expect(toCompactVerbosity(input)).toEqual({
+        success: true,
+        data: null,
+      });
+    });
+  });
+
+  describe("single message object", () => {
+    it("extracts text from parts", () => {
+      const input = {
+        role: "assistant",
+        parts: [{ type: "text", content: "Hello!" }],
+      };
+      expect(toCompactVerbosity(input)).toEqual({
+        success: true,
+        data: '"Hello!"',
+      });
+    });
+
+    it("concatenates multiple text parts", () => {
+      const input = {
+        role: "assistant",
+        parts: [
+          { type: "text", content: "Hello " },
+          { type: "text", content: "world!" },
+        ],
+      };
+      expect(toCompactVerbosity(input)).toEqual({
+        success: true,
+        data: '"Hello world!"',
+      });
+    });
+  });
+
+  describe("messages wrapper", () => {
+    it("extracts text from parts in messages wrapper", () => {
+      const input = {
+        messages: [
+          { role: "user", content: "Hi" },
+          { role: "assistant", parts: [{ type: "text", content: "Hello!" }] },
+        ],
+      };
+      expect(toCompactVerbosity(input)).toEqual({
+        success: true,
+        data: '"Hello!"',
+      });
+    });
+  });
+
+  describe("prefers content over parts when content is present", () => {
+    it("does NOT normalize when content is already present", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: "Preferred content",
+          parts: [{ type: "text", content: "Ignored" }],
+        },
+      ];
+      expect(toCompactVerbosity(input)).toEqual({
+        success: true,
+        data: '"Preferred content"',
+      });
+    });
+  });
+
+  describe("multi-turn with alternating formats", () => {
+    it("always extracts from last message", () => {
+      const input = [
+        { role: "user", content: "Start" },
+        { role: "assistant", content: "Traditional" },
+        { role: "user", content: "Switch" },
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "AI SDK v7" }],
+        },
+        { role: "user", content: "Back" },
+        { role: "assistant", content: "Traditional again" },
+      ];
+      expect(toCompactVerbosity(input)).toEqual({
+        success: true,
+        data: '"Traditional again"',
+      });
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 4. AI SDK v7 EXACT PAYLOAD — Bug report scenario
+// ──────────────────────────────────────────────────────────────────────────────
+describe("AI SDK v7 — exact bug report payload", () => {
+  it("handles the exact payload from the bug report", () => {
+    const input = [
+      { role: "user", content: "Hi there" },
+      {
+        role: "assistant",
+        parts: [{ type: "text", content: "Hello! How can I help?" }],
+      },
+    ];
+    expect(toCompactVerbosity(input)).toEqual({
+      success: true,
+      data: '"Hello! How can I help?"',
+    });
+  });
+
+  it("handles stringified version of the bug report payload", () => {
+    const input = JSON.stringify([
+      { role: "user", content: "Hi there" },
+      {
+        role: "assistant",
+        parts: [{ type: "text", content: "Hello! How can I help?" }],
+      },
+    ]);
+    expect(toCompactVerbosity(input)).toEqual({
+      success: true,
+      data: '"Hello! How can I help?"',
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 5. EDGE CASES — Boundary conditions
+// ──────────────────────────────────────────────────────────────────────────────
+describe("Edge Cases", () => {
+  it("handles empty parts array", () => {
+    const input = [{ role: "assistant", parts: [] }];
+    expect(toCompactVerbosity(input)).toEqual({
+      success: true,
+      data: null,
+    });
+  });
+
+  it("handles null content with parts — content is present so normalization does NOT trigger", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: null,
+        parts: [{ type: "text", content: "fallback" }],
+      },
+    ];
+    // content:null is present → normalization skips → returns "null" string
+    expect(toCompactVerbosity(input)).toEqual({
+      success: true,
+      data: "null",
+    });
+  });
+
+  it("handles parts with non-string content field", () => {
+    const input = [
+      {
+        role: "assistant",
+        parts: [{ type: "text", content: 123 }],
+      },
+    ];
+    // content is not a string → not extracted → falls through
+    expect(toCompactVerbosity(input)).toEqual({
+      success: true,
+      data: null,
+    });
+  });
+
+  it("handles very long parts content", () => {
+    const longText = "a".repeat(50_000);
+    const input = [
+      {
+        role: "assistant",
+        parts: [{ type: "text", content: longText }],
+      },
+    ];
+    const result = toCompactVerbosity(input);
+    expect(result.success).toBe(true);
+    expect(result.data).toBe(`"${longText}"`);
+  });
+
+  it("handles 50-message conversation with parts", () => {
+    const messages = Array.from({ length: 50 }, (_, i) => ({
+      role: i % 2 === 0 ? "user" : "assistant",
+      parts: [{ type: "text", content: `Message ${i}` }],
+    }));
+    expect(toCompactVerbosity(messages)).toEqual({
+      success: true,
+      data: '"Message 49"',
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 6. OUTLIER CASES — Adversarial and unusual inputs
+// ──────────────────────────────────────────────────────────────────────────────
+describe("Outlier Cases", () => {
+  it("handles non-array, non-object input", () => {
+    expect(toCompactVerbosity(42)).toEqual({ success: false, data: null });
+  });
+
+  it("handles object without role", () => {
+    expect(toCompactVerbosity({ content: "Hello" })).toEqual({
+      success: false,
+      data: null,
+    });
+  });
+
+  it("does not throw on any input", () => {
+    const weird = [Symbol("test"), new Date(), /regex/, new Map(), new Set()];
+    for (const w of weird) {
+      expect(() => toCompactVerbosity(w)).not.toThrow();
+      expect(toCompactVerbosity(w)).toEqual({ success: false, data: null });
+    }
+  });
+});

--- a/packages/shared/src/utils/IORepresentation/toCompactVerbosity.ts
+++ b/packages/shared/src/utils/IORepresentation/toCompactVerbosity.ts
@@ -1,8 +1,84 @@
 import { toCompactVerbosityChatML } from "./chatML/toCompactVerbosityChatML";
 
 /**
+ * Normalize OTel GenAI `{role, parts}` messages to `{role, content}` format.
+ *
+ * The OpenTelemetry GenAI semantic conventions define messages as:
+ *   { role: "assistant", parts: [{ type: "text", content: "..." }] }
+ *
+ * AI SDK v7 emits this format. Langfuse's compact extraction expects
+ * `{role, content}`. This function bridges the gap by extracting text
+ * content from `parts` when `content` is absent.
+ *
+ * Handles three input shapes:
+ * - Direct array: [{role, parts}, ...]
+ * - Single message: {role, parts}
+ * - Messages wrapper: {messages: [{role, parts}, ...]}
+ *
+ * @see https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/registry/attributes/gen-ai.md
+ * @see https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/ui-message
+ */
+function normalizeOtelGenAiMessages(io: unknown): unknown {
+  if (!io || typeof io !== "object") return io;
+
+  const normalizeMessage = (msg: Record<string, unknown>): Record<string, unknown> => {
+    // Only normalize if: has `parts`, does NOT have `content`, parts is an array
+    if (
+      !("content" in msg) &&
+      "parts" in msg &&
+      Array.isArray(msg.parts) &&
+      msg.parts.length > 0
+    ) {
+      // Extract text content from parts (OTel GenAI format)
+      const textContent = (msg.parts as Array<Record<string, unknown>>)
+        .filter(
+          (p) =>
+            p &&
+            typeof p === "object" &&
+            p.type === "text" &&
+            typeof p.content === "string",
+        )
+        .map((p) => p.content as string);
+
+      if (textContent.length > 0) {
+        return { ...msg, content: textContent.join("") };
+      }
+    }
+    return msg;
+  };
+
+  // Case 1: Direct array of messages
+  if (Array.isArray(io)) {
+    return io.map((item) =>
+      item && typeof item === "object" && !Array.isArray(item)
+        ? normalizeMessage(item as Record<string, unknown>)
+        : item,
+    );
+  }
+
+  // Case 2: Messages wrapper {messages: [...]}
+  if ("messages" in io && Array.isArray(io.messages)) {
+    return {
+      ...io,
+      messages: io.messages.map((item: unknown) =>
+        item && typeof item === "object" && !Array.isArray(item)
+          ? normalizeMessage(item as Record<string, unknown>)
+          : item,
+      ),
+    };
+  }
+
+  // Case 3: Single message object — handled by normalizeMessage if it has parts
+  if ("role" in io && typeof (io as Record<string, unknown>).role === "string") {
+    return normalizeMessage(io as Record<string, unknown>);
+  }
+
+  return io;
+}
+
+/**
  * Returns a compact representation of IO data for display in tables.
- * Strategy: Try ChatML extraction if possible.
+ * Strategy: Normalize OTel GenAI parts → content, then try ChatML extraction.
  *
  * @param io - The input or output data to compact
  * @returns Compact representation or null if no data
@@ -23,8 +99,11 @@ export function toCompactVerbosity(io: unknown): {
     }
   }
 
+  // Normalize OTel GenAI {role, parts} → {role, content}
+  const normalized = normalizeOtelGenAiMessages(parsedIO);
+
   // Try ChatML compact representation extraction
-  const chatMLCompact = toCompactVerbosityChatML(parsedIO);
+  const chatMLCompact = toCompactVerbosityChatML(normalized);
   if (chatMLCompact.success) {
     return { success: true, data: chatMLCompact.data };
   }


### PR DESCRIPTION
## Summary

Fixes the classic observations table rendering blank Input and Output cells for generation observations emitted by `@langfuse/vercel-ai-sdk` with AI SDK v7 and any OTel-instrumented client using the standard GenAI semantic conventions.

**Closes** #15000

---

## Table of Contents

- [The Problem](#the-problem)
- [Root Cause Analysis](#root-cause-analysis)
- [Why Langfuse Cloud Works](#why-langfuse-cloud-works)
- [The OTel GenAI Standard](#the-otel-genai-standard)
- [Solution Architecture](#solution-architecture)
- [Implementation Details](#implementation-details)
- [File Changes](#file-changes)
- [Test Results](#test-results)
- [References](#references)

---

## The Problem

When using `@langfuse/vercel-ai-sdk` with AI SDK v7, the classic **Tracing > Observations** table renders blank Input and Output cells for generation observations:

```
+------------------+---------+----------+
| Name             | Input   | Output   |
+------------------+---------+----------+
| chat gemini-3.5  | (blank) | (blank)  |  <-- Bug
| chat gpt-4       | (blank) | (blank)  |
+------------------+---------+----------+
```

The data **is** stored correctly -- the Public API returns both `input` and `output` populated. The issue is purely in the **table cell rendering path**.

---

## Root Cause Analysis

Langfuse has **two independent I/O rendering pipelines**. The divergence between them is the structural root cause:

```
                  +-----------------------------------+
                  |       Observation Stored           |
                  |  (input/output in ClickHouse)      |
                  +-----------+------------------+----+
                              |                  |
             +----------------v--+    +----------v------------+
             |  Classic Table     |    |  Fast Preview (Cloud)  |
             |  (OSS only path)   |    |  (EventsTable)         |
             +-----------+--------+    +----------+------------+
                         |                        |
                         v                        v
             +-------------------+    +-------------------+
             | Per-cell tRPC     |    | Batch fetch       |
             | observations      |    | events.batchIO    |
             | .byId             |    | from ClickHouse   |
             +--------+----------+    +--------+----------+
                      |                        |
                      v                        v
             +-------------------+    +-------------------+
             | parseIO() with    |    | Raw string        |
             | verbosity:        |    | pass-through      |
             | "compact"         |    | (no extraction)   |
             +--------+----------+    +--------+----------+
                      |                        |
                      v                        v
             +-------------------+    +-------------------+
             | toCompact          |    | MemoizedIO        |
             | Verbosity()        |    | TableCell         |
             +--------+----------+    | renders raw JSON   |
                      |               +-------------------+
                      v                 <-- WORKS
             +-------------------+
             | toCompact          |
             | VerbosityChatML    |
             | reads .content     |
             +--------+----------+
                      |
                      v
             +-------------------+
             | MemoizedIO        |
             | TableCell         |
             | renders blank     |
             +-------------------+
               <-- BROKEN
```

### The specific failure

`toCompactVerbosityChatML` extracts the **last message** from the ChatML array and reads `lastMessage.content`:

```ts
// packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.ts
const lastMessage = parsed.data[parsed.data.length - 1];
return {
  success: true,
  data: JSON.stringify(lastMessage.content) ?? null,  // reads .content
};
```

AI SDK v7 emits messages in this shape:

```json
{
  "role": "assistant",
  "parts": [{ "type": "text", "content": "The capital of France is Paris." }]
}
```

The `content` field is **absent** (not even `undefined` -- it doesn't exist). `JSON.stringify(undefined)` returns `undefined`, so `?? null` yields `null`, producing a blank cell.

---

## Why Langfuse Cloud Works

Langfuse Cloud uses the **Fast Preview** rendering path (`EventsTable`), which:

1. Bypasses `toCompactVerbosityChatML` entirely
2. Fetches raw IO strings from ClickHouse in batch
3. Passes them directly to `MemoizedIOTableCell` via `JSON.stringify`

Since the raw JSON `{role, parts}` payload is rendered as-is, Cloud displays it correctly. **OSS self-hosted deployments don't have this path yet** -- they use the classic table exclusively.

---

## The OTel GenAI Standard

**This is not an AI SDK quirk.** The `{role, parts}` format is the **OpenTelemetry GenAI semantic convention** standard for `gen_ai.input.messages` and `gen_ai.output.messages`:

```json
{
  "role": "assistant",
  "parts": [
    { "type": "text", "content": "The weather in Paris is rainy, 57F." }
  ],
  "finish_reason": "stop"
}
```

From the [OTel semantic-conventions-genai spec](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/registry/attributes/gen-ai.md):

> `gen_ai.input.messages`: Messages MUST be provided in the order they were sent to the model.
>
> `gen_ai.output.messages`: Each message represents a single output choice/candidate generated by the model.

The format uses `parts` (not `content`) with typed content items:

| `type` | Purpose |
|--------|---------|
| `text` | Text content (most common) |
| `tool_call` | LLM requesting a tool invocation |
| `tool_call_response` | Tool result returned to the model |
| `reasoning` | Model thinking/chain-of-thought |
| `image` | Image content |

**This means the issue will grow** -- any OTel-instrumented LLM client using the standard GenAI conventions will produce `{role, parts}` messages.

---

## Solution Architecture

### Design principle: Normalize at the boundary

Instead of adding `parts` fallback logic deep inside the ChatML extraction function (which would duplicate concerns), we normalize the input at the **boundary** -- converting `{role, parts}` to `{role, content}` **before** ChatML extraction.

This follows the existing **adapter pattern** from Langfuse's `normalizeInput`/`normalizeOutput` system (`packages/shared/src/utils/chatml/core.ts`), which already normalizes provider-specific formats before rendering.

```
                  Input (any format)
                         |
                         v
              +-----------------------+
              | JSON.parse if string   |
              +----------+------------+
                         |
                         v
            +---------------------------+
            | normalizeOtelGenAi        |   <-- NEW: Tier 2 normalization
            | Messages()                |
            |                           |
            | Detects: {role, parts}    |
            | Extracts: text content    |
            | Output:   {role, content} |
            +----------+----------------+
                       |
                       v
            +---------------------------+
            | toCompactVerbosity        |
            | ChatML()                  |
            |                           |
            | Reads: .content only      |
            | Simple, focused, clean    |
            +----------+----------------+
                       |
                       v
            +---------------------------+
            | { success, data }         |
            | Rendered in table cell    |
            +---------------------------+
```

### Why this approach

| Approach | Pros | Cons |
|----------|------|------|
| **Tier 1: Add parts fallback to toCompactVerbosityChatML** | Minimal change | Duplicates logic; extraction function should not normalize |
| **Tier 2: Normalize upstream in toCompactVerbosity** (this PR) | Clean separation; follows adapter pattern; keeps extraction simple | Slight preprocessing overhead (negligible) |
| **Tier 3: Route through full adapter system** | Handles all provider formats; single source of truth | Heavier processing; too slow for per-cell fetching |

Tier 2 is the right balance: it solves the immediate problem, is minimal and safe, and follows existing patterns.

---

## Implementation Details

### `normalizeOtelGenAiMessages()` -- The core normalization

```ts
function normalizeOtelGenAiMessages(io: unknown): unknown {
  const normalizeMessage = (msg: Record<string, unknown>) => {
    // Only normalize if: has `parts`, does NOT have `content`, parts is an array
    if (!("content" in msg) && "parts" in msg && Array.isArray(msg.parts)) {
      const textContent = msg.parts
        .filter(p => p.type === "text" && typeof p.content === "string")
        .map(p => p.content);
      if (textContent.length > 0) {
        return { ...msg, content: textContent.join("") };
      }
    }
    return msg;
  };
  // Handles: direct array, {messages: [...]}, single message object
  ...
}
```

**Key design decisions:**

1. **Only triggers when `content` is absent** -- if a message already has `content`, we don't touch it. This preserves backward compatibility with all existing formats.

2. **Extracts only `type: "text"` parts with string content** -- tool calls, images, audio, etc. are left untouched. If a message has no text parts, it falls through unchanged.

3. **Concatenates multiple text parts** -- handles the case where the model returns multiple text segments.

4. **Handles three input shapes** -- direct array `[{role, parts}]`, single message `{role, parts}`, and messages wrapper `{messages: [{role, parts}]}`.

### `toCompactVerbosityChatML` -- Kept clean and focused

The extraction function stays simple -- it only reads `.content`:

```ts
const lastMessage = parsed.data[parsed.data.length - 1];
return {
  success: true,
  data: JSON.stringify(lastMessage.content) ?? null,
};
```

No `parts` fallback, no `contentOrParts` helper. The upstream normalization ensures `content` is always populated when needed.

---

## File Changes

| File | Change | Lines |
|------|--------|-------|
| `packages/shared/src/utils/IORepresentation/toCompactVerbosity.ts` | Added `normalizeOtelGenAiMessages()` -- extracts text from OTel GenAI parts format before ChatML extraction | +62 |
| `packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.ts` | Reverted to clean form -- only reads `.content`, no parts fallback | 0 net |
| `packages/shared/src/utils/IORepresentation/toCompactVerbosity.test.ts` | **New** -- 36 tests covering full pipeline: standard ChatML, OTel GenAI parts, bug report payload, edge cases, outliers | +242 |
| `packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.test.ts` | Updated to match clean function behavior (null content returns "null" string) | +188 |

---

## Test Results

```
============================================================
RESULTS: 36 passed, 0 failed, 36 total
============================================================
```

### Test Categories

#### A. Base Cases (4 tests)
- `null`, `undefined` returns `{success:false, data:null}`
- Stringified JSON parsing
- Non-JSON string passthrough

#### B. Standard ChatML (3 tests)
- Direct array, single message, messages wrapper

#### C. OTel GenAI `{role, parts}` -- The Core Fix (9 tests)

| Test | Input | Result |
|------|-------|--------|
| Array with parts | `[{role:"user",content:"Hello"},{role:"assistant",parts:[{type:"text",content:"Hi!"}]}]` | `"Hi!"` |
| Multiple text parts | `parts:[{type:"text",content:"First "},{type:"text",content:"second"}]` | `"First second"` |
| Mixed part types | `parts:[{type:"text"},{type:"tool_call"},{type:"text"}]` | `"Hello after"` |
| Non-text only parts | `parts:[{type:"tool_call",...}]` | `null` (no text) |
| Single message parts | `{role:"assistant",parts:[{type:"text",content:"Hello!"}]}` | `"Hello!"` |
| Messages wrapper parts | `{messages:[{role:"assistant",parts:[{type:"text",content:"Hello!"}]}]}` | `"Hello!"` |
| Prefers content over parts | `content:"Preferred", parts:[{...}]` | `"Preferred"` |
| Alternating formats | 6 msgs alternating content/parts | Last message wins |
| Bug report exact payload | `[{role:"user",content:"Hi there"},{role:"assistant",parts:[{type:"text",content:"Hello!"}]}]` | `"Hello!"` |

#### D. Edge Cases (5 tests)
- Empty parts array
- Null content with parts (content present -- no normalization)
- Parts with non-string content field
- Very long parts content (50k chars)
- 50-message conversation with parts

#### E. Outlier Cases (3 tests)
- Non-array, non-object input
- Object without role
- No-throw guarantee on any input

---

## References

### Specifications and Standards

1. **OpenTelemetry GenAI Semantic Conventions** -- [gen-ai.md](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/registry/attributes/gen-ai.md)
   - Defines `{role, parts}` as the standard message format for `gen_ai.input.messages` and `gen_ai.output.messages`
   - Part types: `text`, `tool_call`, `tool_call_response`, `reasoning`, `image`

2. **AI SDK v7 UIMessage** -- [ai-sdk.dev/v7](https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/ui-message)
   - `parts: Array<UIMessagePart>` is the canonical rendering format
   - `UIMessagePart` includes `TextUIPart`, `ToolUIPart`, `ReasoningUIPart`, etc.

3. **AI SDK v7 ModelMessage** -- [ai-sdk.dev/v7](https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/model-message)
   - `content: string | Array<TextPart | CustomPart | ToolCallPart>` for model-facing messages

4. **OpenAI ChatML Specification** -- [openai/openai-python/chatml.md](https://github.com/openai/openai-python/blob/main/chatml.md)
   - Original ChatML format with `{role, content}` tokens

### Past PRs (Codebase History)

| PR | Date | What it changed | Relevance |
|----|------|----------------|-----------|
| [#10217](https://github.com/langfuse/langfuse/pull/10217) | 2025-11 | Created `toCompactVerbosityChatML` -- introduced compact extraction pipeline | Foundational PR |
| [#11010](https://github.com/langfuse/langfuse/pull/11010) | 2025-12 | `AdvancedJsonViewer`, virtualized rendering, `useChatMLParser` hook | Major I/O rendering overhaul |
| [#11163](https://github.com/langfuse/langfuse/pull/11163) | 2026-01 | Extended `BaseChatMlMessageSchema` with `thinking`/`redacted_thinking` types | Added new content part types |
| [#11031](https://github.com/langfuse/langfuse/pull/11031) | 2025-12 | Tool call filtering on observations | Extended ChatML types |
| [#14703](https://github.com/langfuse/langfuse/pull/14703) | 2026-07 | Media reference rendering in compact table cells | Recent compact path change |

### Langfuse Codebase Architecture

| File | Purpose |
|------|---------|
| `packages/shared/src/utils/IORepresentation/toCompactVerbosity.ts` | Entry point -- orchestrates normalization + extraction |
| `packages/shared/src/utils/IORepresentation/chatML/toCompactVerbosityChatML.ts` | ChatML extraction -- reads last message content |
| `packages/shared/src/utils/IORepresentation/parseIO.ts` | Verbosity router -- calls `toCompactVerbosity` for compact mode |
| `packages/shared/src/utils/IORepresentation/chatML/types.ts` | ChatML schemas -- `SimpleChatMessageSchema`, `BaseChatMlMessageSchema` |
| `packages/shared/src/utils/chatml/core.ts` | Adapter system -- `normalizeInput`/`normalizeOutput` with provider adapters |
| `packages/shared/src/utils/chatml/adapters/aisdk.ts` | AI SDK adapter -- normalizes AI SDK messages to ChatML |

---

## Agents Used

### Research Agent (explore)
- Mapped the complete rendering pipeline: `GenerationsDynamicCell` -> `observations.byId` -> `parseIO` -> `toCompactVerbosity` -> `toCompactVerbosityChatML`
- Found all callers of `toCompactVerbosityChatML` (only one production caller)
- Mapped the Fast Preview path: `EventsTable` -> `events.batchIO` -> raw string pass-through
- Analyzed `SimpleChatMessageSchema` acceptance/rejection criteria

### Research Agent (general)
- Searched all PRs touching `toCompactVerbosityChatML`, `chatML/`, `observations.tsx`, `EventsTable.tsx`
- Found 6 directly relevant past PRs (#10217, #11010, #11163, #11031, #14703, #15003)
- Identified the competing fix PRs (#15003, #15005) and their review issues

### Web Search Agent
- Found OTel GenAI semantic conventions spec defining `{role, parts}` as standard
- Found AI SDK v7 `UIMessage` and `ModelMessage` type definitions
- Found OpenAI ChatML specification

### Verification Agent (bash)
- Ran 36 tests via `tsx` runner -- all passing
- Verified normalization handles all OTel GenAI message shapes
- Verified backward compatibility with existing `{role, content}` messages
