### PR TITLE
fix(shared): cap token detail sub-counts at the parent count (#14987)

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -141,8 +141,13 @@ const OpenAICompletionUsageSchema = z
     if (prompt_tokens_details) {
       for (const [key, value] of Object.entries(prompt_tokens_details)) {
         if (value !== null && value !== undefined) {
-          result[`input_${key}`] = value;
-          result.input = Math.max(result.input - (value ?? 0), 0);
+          // Cap each sub-count at the remaining parent budget so the detail
+          // buckets plus the residual always sum back to the parent and never
+          // go negative, even when a provider reports a sub-count larger than
+          // its parent (e.g. a details entry exceeding prompt_tokens).
+          const capped = Math.min(value, result.input);
+          result[`input_${key}`] = capped;
+          result.input -= capped;
         }
       }
     }
@@ -150,8 +155,13 @@ const OpenAICompletionUsageSchema = z
     if (completion_tokens_details) {
       for (const [key, value] of Object.entries(completion_tokens_details)) {
         if (value !== null && value !== undefined) {
-          result[`output_${key}`] = value;
-          result.output = Math.max(result.output - (value ?? 0), 0);
+          // Cap each sub-count at the remaining parent budget so the detail
+          // buckets plus the residual always sum back to the parent and never
+          // go negative, even when a provider reports a sub-count larger than
+          // its parent (e.g. reasoning_tokens exceeding completion_tokens).
+          const capped = Math.min(value, result.output);
+          result[`output_${key}`] = capped;
+          result.output -= capped;
         }
       }
     }
@@ -196,8 +206,13 @@ const OpenAIResponseUsageSchema = z
     if (input_tokens_details) {
       for (const [key, value] of Object.entries(input_tokens_details)) {
         if (value !== null && value !== undefined) {
-          result[`input_${key}`] = value;
-          result.input = Math.max(result.input - (value ?? 0), 0);
+          // Cap each sub-count at the remaining parent budget so the detail
+          // buckets plus the residual always sum back to the parent and never
+          // go negative, even when a provider reports a sub-count larger than
+          // its parent (e.g. a details entry exceeding prompt_tokens).
+          const capped = Math.min(value, result.input);
+          result[`input_${key}`] = capped;
+          result.input -= capped;
         }
       }
     }
@@ -205,8 +220,13 @@ const OpenAIResponseUsageSchema = z
     if (output_tokens_details) {
       for (const [key, value] of Object.entries(output_tokens_details)) {
         if (value !== null && value !== undefined) {
-          result[`output_${key}`] = value;
-          result.output = Math.max(result.output - (value ?? 0), 0);
+          // Cap each sub-count at the remaining parent budget so the detail
+          // buckets plus the residual always sum back to the parent and never
+          // go negative, even when a provider reports a sub-count larger than
+          // its parent (e.g. reasoning_tokens exceeding completion_tokens).
+          const capped = Math.min(value, result.output);
+          result[`output_${key}`] = capped;
+          result.output -= capped;
         }
       }
     }

--- a/packages/shared/src/server/ingestion/usage-details.test.ts
+++ b/packages/shared/src/server/ingestion/usage-details.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+
+import { UsageDetails } from "./types";
+
+/**
+ * Regression tests for issue #14987: when a provider reports a token
+ * sub-count that is larger than its parent (e.g. `reasoning_tokens` >
+ * `completion_tokens`), the detail bucket must be capped at the remaining
+ * parent budget so the buckets plus the residual still sum back to the
+ * parent count and never go negative.
+ */
+describe("UsageDetails token-detail capping", () => {
+  it("caps completion detail buckets that exceed completion_tokens (#14987)", () => {
+    const result = UsageDetails.parse({
+      prompt_tokens: 1640,
+      completion_tokens: 102,
+      total_tokens: 1742,
+      completion_tokens_details: { reasoning_tokens: 109 },
+    }) as Record<string, number>;
+
+    // bucket capped to the parent, residual clamped to 0
+    expect(result.output_reasoning_tokens).toBe(102);
+    expect(result.output).toBe(0);
+    // invariant: residual + buckets === parent completion_tokens
+    expect(result.output + result.output_reasoning_tokens).toBe(102);
+  });
+
+  it("caps prompt detail buckets that exceed prompt_tokens", () => {
+    const result = UsageDetails.parse({
+      prompt_tokens: 50,
+      completion_tokens: 10,
+      total_tokens: 60,
+      prompt_tokens_details: { cached_tokens: 80 },
+    }) as Record<string, number>;
+
+    expect(result.input_cached_tokens).toBe(50);
+    expect(result.input).toBe(0);
+    expect(result.input + result.input_cached_tokens).toBe(50);
+  });
+
+  it("caps Responses-API output detail buckets that exceed output_tokens", () => {
+    const result = UsageDetails.parse({
+      input_tokens: 1640,
+      output_tokens: 102,
+      total_tokens: 1742,
+      output_tokens_details: { reasoning_tokens: 109 },
+    }) as Record<string, number>;
+
+    expect(result.output_reasoning_tokens).toBe(102);
+    expect(result.output).toBe(0);
+    expect(result.output + result.output_reasoning_tokens).toBe(102);
+  });
+
+  it("leaves well-formed sub-counts untouched", () => {
+    const result = UsageDetails.parse({
+      prompt_tokens: 100,
+      completion_tokens: 100,
+      total_tokens: 200,
+      completion_tokens_details: { reasoning_tokens: 40 },
+    }) as Record<string, number>;
+
+    // residual is the remaining, bucket keeps its reported value
+    expect(result.output_reasoning_tokens).toBe(40);
+    expect(result.output).toBe(60);
+    expect(result.output + result.output_reasoning_tokens).toBe(100);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #14987.

When a provider reports a token **sub-count larger than its parent** (e.g. `reasoning_tokens: 109` with `completion_tokens: 102`), the usage transform in `packages/shared/src/server/ingestion/types.ts` stored the full sub-count but clamped the parent residual to `0` with `Math.max(...)`. The detail buckets then no longer summed back to the parent, so:

- the trace view's **Output** (a sum of every `output*` key) showed **109 instead of 102**, and
- `input + output` no longer equalled `total`.

This caps each sub-count at the *remaining parent budget* instead, so the buckets plus the residual always sum back to the parent and stay non-negative. Applied symmetrically to both the Completion and Responses usage schemas, on the input and output sides.

### Proof (issue's reported numbers: input 1640, output 102, total 1742, `reasoning_tokens` 109)

| | stored `output` (residual) | stored `output_reasoning_tokens` | UI-displayed Output | `input + output == total`? |
|---|---|---|---|---|
| **before** | 0 | 109 | **109** ❌ | 1640 + 109 ≠ 1742 ❌ |
| **after** | 0 | 102 | **102** ✅ | 1640 + 102 = 1742 ✅ |

### A note on the design choice

The input data is internally inconsistent (a sub-count exceeding its parent), so there's a judgement call. I chose to **cap** rather than allow a negative residual, because negative token counts flow downstream into cost/storage. The existing code already clamped the residual to `0`, so this keeps that non-negativity guarantee while additionally preserving "buckets sum back to the parent." Happy to switch to the negative-residual approach if you'd prefer sub-counts preserved verbatim.

I noticed the issue is triage-assigned to @hassiebp — glad to hand this off or adjust the approach; there was no PR yet so I put one up.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] I have self-reviewed the code.
- [x] I have commented the non-obvious part (why sub-counts are capped).
- [x] I have added unit tests that prove the fix (overflow + well-formed cases) in `packages/shared/src/server/ingestion/usage-details.test.ts`.

> Note: I validated the transform math with a standalone reproduction of the before/after (table above) but could not run the full monorepo test suite locally (it requires Node 24 + a `pnpm install` I couldn't complete on this machine), so I'm relying on CI to run the added vitest cases. I traced the existing `IngestionService` integration cases by hand — their sub-counts are all within their parents, so capping leaves them unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a display bug where a provider reporting a token sub-count larger than its parent (e.g. `reasoning_tokens: 109` with `completion_tokens: 102`) caused the UI "Output" total to show the raw sub-count rather than the parent count, and broke the `input + output == total` invariant.

- **Core fix (`types.ts`):** Both `OpenAICompletionUsageSchema` and `OpenAIResponseUsageSchema` now cap each detail bucket at the remaining parent budget (`Math.min(value, remaining)`) and decrement the residual by the capped value, guaranteeing buckets plus residual always sum to the parent.
- **Tests (`usage-details.test.ts`):** Four cases cover single-bucket overflow (completion, prompt, Responses-API), and the well-formed base case. A multi-bucket scenario where individual sub-counts are in-range but their sum exceeds the parent is not yet tested, though the progressive-capping logic handles it correctly by design.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the capping logic is correct, the invariant is preserved, and the fix is applied consistently to all four detail-processing paths.

The transform logic is straightforward and demonstrably correct for the reported scenario. The only gap is a missing test for the multi-bucket collective-overflow edge case, where the progressive budget drain silently caps the second sub-count. That case is handled correctly by the current code, but leaving it undocumented in tests makes future changes riskier.

The test file could benefit from one additional case covering multiple sub-counts whose sum exceeds the parent.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Provider usage payload\n(e.g. completion_tokens: 102,\nreasoning_tokens: 109)"] --> B["OpenAICompletionUsageSchema / OpenAIResponseUsageSchema\n.transform()"]
    B --> C["result.output = completion_tokens\nresult.input = prompt_tokens\nresult.total = total_tokens"]
    C --> D{"completion_tokens_details\nnot null?"}
    D -- No --> G["Return result"]
    D -- Yes --> E["For each sub-count key/value"]
    E --> F["capped = Math.min(value, result.output)\nresult[output_key] = capped\nresult.output -= capped"]
    F --> E
    E -- done --> G
    G --> H["Stored flat map:\noutput = 0\noutput_reasoning_tokens = 102\ntotal = 1742\ninput = 1640"]
    H --> I["UI sums all output_* keys\n= 0 + 102 = 102 ✅\ninput + output_sum = 1742 ✅"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Provider usage payload\n(e.g. completion_tokens: 102,\nreasoning_tokens: 109)"] --> B["OpenAICompletionUsageSchema / OpenAIResponseUsageSchema\n.transform()"]
    B --> C["result.output = completion_tokens\nresult.input = prompt_tokens\nresult.total = total_tokens"]
    C --> D{"completion_tokens_details\nnot null?"}
    D -- No --> G["Return result"]
    D -- Yes --> E["For each sub-count key/value"]
    E --> F["capped = Math.min(value, result.output)\nresult[output_key] = capped\nresult.output -= capped"]
    F --> E
    E -- done --> G
    G --> H["Stored flat map:\noutput = 0\noutput_reasoning_tokens = 102\ntotal = 1742\ninput = 1640"]
    H --> I["UI sums all output_* keys\n= 0 + 102 = 102 ✅\ninput + output_sum = 1742 ✅"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/ingestion/usage-details.test.ts:12-25
**Missing multi-bucket collective-overflow test**

The current tests each send a single sub-count that exceeds its parent. A subtler case arises when two sub-counts individually fit within the parent but their sum exceeds it — e.g., `completion_tokens: 100`, `reasoning_tokens: 70`, `audio_tokens: 70`. The loop progressively drains the remaining budget (`output` → 30 after the first bucket, then caps the second at 30), so the result is `output_reasoning_tokens=70, output_audio_tokens=30, output=0` rather than `audio_tokens=70`. This is the correct and intended behavior, but it is order-dependent (whichever key `Object.entries()` yields first consumes budget first) and worth a test to document the contract and protect against future refactors.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): cap token detail sub-counts..."](https://github.com/langfuse/langfuse/commit/dce1ab3259dbe6f151d734a9310f6daced5cfe2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43600517)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->