### PR TITLE
fix(redirect): strip ASCII control characters in stripBasePath

### DIFF
--- a/web/src/__tests__/redirect.clienttest.ts
+++ b/web/src/__tests__/redirect.clienttest.ts
@@ -290,6 +290,27 @@ describe("stripBasePath", () => {
       expect(stripBasePath("/apps/apps/dashboard")).toBe("/apps/dashboard");
     });
 
+    it("strips ASCII control characters from the path", () => {
+      // Newline (header-injection vector)
+      expect(stripBasePath("/apps\n/dashboard")).toBe("/dashboard");
+      // CRLF
+      expect(stripBasePath("/apps\r\n/dashboard")).toBe("/dashboard");
+      // Null byte (path-extension confusion)
+      expect(stripBasePath("/apps\u0000/dashboard")).toBe("/dashboard");
+      // DEL (0x7F)
+      expect(stripBasePath("/apps\u007F/dashboard")).toBe("/dashboard");
+      // Multiple control chars in one path
+      expect(stripBasePath("/apps\n\r\u0000/dashboard")).toBe("/dashboard");
+    });
+
+    it("does NOT strip Unicode bidi-formatting characters outside the C0 range", () => {
+      // U+202E (RTL-override) is intentionally out of scope for this fix;
+      // it lives at 0x202E, beyond the 0x00-0x1F / 0x7F regex scope. The
+      // result still has a leading "/" so it survives the path-vs-leading-
+      // slash guard; downstream code decides whether to display it.
+      expect(stripBasePath("/apps\u202E/dashboard")).toBe("/\u202E/dashboard");
+    });
+
     it("leaves paths without basePath untouched", () => {
       expect(stripBasePath("/no-base")).toBe("/no-base");
     });

--- a/web/src/utils/redirect.ts
+++ b/web/src/utils/redirect.ts
@@ -81,6 +81,10 @@ export function stripBasePath(path: string): string {
     return path;
   }
 
-  const stripped = path.slice(basePath.length) || "/";
+  // Strip ASCII control characters (0x00-0x1F, 0x7F) before further
+  // processing. See getSafeRedirectPath for the rationale.
+  const cleaned = path.replace(/[\x00-\x1F\x7F]/g, "");
+
+  const stripped = cleaned.slice(basePath.length) || "/";
   return stripped.startsWith("/") ? stripped : `/${stripped}`;
 }


### PR DESCRIPTION
## What does this PR do?

Closes langfuse/langfuse#15013.

`getSafeRedirectPath` in [web/src/utils/redirect.ts](<web/src/utils/redirect.ts>) was hardened in [PR #14870](<https://github.com/Harsh23Kashyap/langfuse/pull/14870>) to strip ASCII control characters (0x00-0x1F and 0x7F) before downstream URL handling. The sibling function `stripBasePath` in the same file did not get the same treatment.

This PR adds the same strip to `stripBasePath`, mirroring the existing fix.

`stripBasePath` is called on user-influenced paths in four production callers:

* [web/src/components/layouts/app-layout/hooks/useAuthGuard.ts:93,112](<web/src/components/layouts/app-layout/hooks/useAuthGuard.ts>) — strips `asPath` / `redirectUrl` before they become `?targetPath=` query params in the sign-in redirect.
* [web/src/components/trace/TracePage.tsx:73](<web/src/components/trace/TracePage.tsx>) — strips `router.asPath` before display.
* [web/src/components/error-page.tsx:29](<web/src/components/error-page.tsx>) — strips `router.asPath` before display.
* [web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx:108](<web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx>) — strips `parsedUrl.pathname` before display.

The `useAuthGuard.ts` flow is the highest-stakes: `stripBasePath(rawPath)` produces a value that is `encodeURIComponent`-encoded into a `?targetPath=...` query parameter. If `rawPath` contains `\r\n` (CRLF), a sufficiently old or non-strict downstream URL parser may decode it back to a literal CRLF in the redirect Location header, enabling HTTP response splitting or open-redirect through legacy URL handling.

The fix is symmetric with the existing `getSafeRedirectPath` strip and shares the same RFC 3986 justification (these characters are not valid in URL paths). Unicode bidi-formatting characters (e.g. U+202E RTL-override) are intentionally out of scope; a test pins this boundary explicitly.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Self-reviewed the diff: 6-line net change in production code (`web/src/utils/redirect.ts`) + 21-line test addition (`web/src/__tests__/redirect.clienttest.ts`).
- [X] Ran `pnpm --filter web exec vitest run src/__tests__/redirect.clienttest.ts` -> all tests in the file pass (the file currently has 29 `it` blocks; new tests added 2).
- [X] Ran `pnpm --filter web exec eslint src/utils/redirect.ts src/__tests__/redirect.clienttest.ts` -> clean, no errors, no warnings.
- [X] Ran `pnpm --filter web exec tsc --noEmit` -> no new errors in changed files (pre-existing errors in unrelated files such as `aggregateScores.clienttest.ts` and `mergeScoresWithCache.clienttest.ts` are not introduced by this change).

## Checklist

- [X] Conventional Commits title: `fix(redirect): strip ASCII control characters in stripBasePath`.
- [X] Branch name follows `fix/<area>-<short-topic>` convention.
- [X] Style: minimal, follows existing `getSafeRedirectPath` strip in the same file (PR langfuse/langfuse#14870). Same regex scope (`[\x00-\x1F\x7F]`).
- [X] No production-code changes outside the two-file diff.
- [X] Self-review: the strip is intentionally scoped to ASCII control characters (matches PR langfuse/langfuse#14870's scope for consistency). A separate test (`should NOT strip Unicode bidi-formatting characters outside the C0 range`) pins the boundary.

## Out of scope (intentionally)

**Unicode bidi-formatting characters** (U+202A-U+202E, U+2066-U+2069) like RTL-override are NOT stripped by this fix. They are in the higher Unicode range (0x2000+) and warrant a separate, larger change. The new `should NOT strip Unicode bidi-formatting characters outside the C0 range` test pins this scope boundary. This matches the same scoping decision in PR langfuse/langfuse#14870 for `getSafeRedirectPath`.

## Scope

* 1 production-code file: [web/src/utils/redirect.ts](<web/src/utils/redirect.ts>) — 6-line addition inside the existing `stripBasePath` function.
* 1 test file: [web/src/**tests**/redirect.clienttest.ts](<web/src/__tests__/redirect.clienttest.ts>) — 21-line addition: 2 new `it` blocks inside the existing `describe("with basePath configured", ...)` block.
* No documentation changes.
* No new dependencies.
* Backwards compatible: every URL path in existence today is already control-character-free per RFC 3986, so the strip only affects the attack-surface cases.

## Risks

* **Low.** The strip only affects characters that are not valid in URL paths per RFC 3986. Legitimate user paths (containing only `pchar` per the RFC) are unaffected.
* The fix mirrors the existing strip in `getSafeRedirectPath` (already merged in PR langfuse/langfuse#14870) — both functions in the same file now have a consistent control-character policy.
* No backwards compatibility risk: every URL path in existence today is already control-character-free by spec.

## Verification

* `pnpm --filter web exec vitest run src/__tests__/redirect.clienttest.ts` -> all tests in the file pass.
* `pnpm --filter web exec eslint src/utils/redirect.ts src/__tests__/redirect.clienttest.ts` -> clean.
* `pnpm --filter web exec tsc --noEmit` -> no new errors in changed files.
* Manually verified against the test cases:
  * `stripBasePath("/apps\n/dashboard")` returns `"/dashboard"` (newline stripped).
  * `stripBasePath("/apps\r\n/dashboard")` returns `"/dashboard"` (CRLF stripped).
  * `stripBasePath("/apps\u0000/dashboard")` returns `"/dashboard"` (null byte stripped).
  * `stripBasePath("/apps\u007F/dashboard")` returns `"/dashboard"` (DEL stripped).
  * `stripBasePath("/apps\n\r\u0000/dashboard")` returns `"/dashboard"` (multiple stripped).
  * `stripBasePath("/apps\u202E/dashboard")` returns `"/\u202E/dashboard"` (RTL-override preserved, boundary pinned).

## Follow-up opportunities

* If maintainers want defense-in-depth against bidi characters, a separate follow-up PR can extend the regex to include the bidi ranges.
* A separate test case for `stripBasePath` with a `basePath` longer than the path (which currently returns `path` due to the `!path.startsWith(basePath)` guard) could pin that edge case if it's not already covered.

<details><summary>Greptile Summary</summary>

This PR adds ASCII control-character stripping (`[\x00-\x1F\x7F]`) to `stripBasePath` in `web/src/utils/redirect.ts`, mirroring the equivalent guard already present in `getSafeRedirectPath` (added in PR langfuse/langfuse#14870). Two new test cases in the existing `"with basePath configured"` describe block cover both the strip behavior and the intentional bidi-character boundary.

* **Production change**: a single `path.replace(/[\x00-\x1F\x7F]/g, "")` step inserted inside `stripBasePath`, applied after the `startsWith(basePath)` guard and before the slice — correct for the matched case.
* **Test additions**: one test exercises five control-character variants (newline, CRLF, null byte, DEL, mixed); a second pins the U+202E (RTL-override) non-stripping boundary, explicitly documenting the out-of-scope decision.

</details>

<details><summary>Confidence Score: 5/5</summary>

Safe to merge — the change is a minimal, targeted sanitization that only affects characters invalid in URL paths by spec, and its logic is correct for the code path it touches.

The fix is a six-line, symmetric addition that mirrors an already-merged guard in the same file. The regex and placement are correct. The two early-return paths that skip the new strip were noted and acknowledged in the prior review thread and are intentionally deferred.

No files require special attention.

</details>

<details><summary>Flowchart</summary>

[%%{init: {'theme': 'neutral'}}%% flowchart TD A\["stripBasePath(path)"\] --> B{"basePath empty?"} B -- yes --> C\["return path OR slash\\n(no strip - early exit)"\] B -- no --> D{"path empty?"} D -- yes --> E\["return slash"\] D -- no --> F{"path starts with basePath?"} F -- no --> G\["return path\\n(no strip - early exit)"\] F -- yes --> H\["cleaned = path.replace control chars NEW"\] H --> I\["stripped = cleaned.slice basePath.length OR slash"\] I --> J{"stripped starts with slash?"} J -- yes --> K\["return stripped"\] J -- no --> L\["return slash + stripped"\]](<#gh-light-mode-only>) [%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%% flowchart TD A\["stripBasePath(path)"\] --> B{"basePath empty?"} B -- yes --> C\["return path OR slash\\n(no strip - early exit)"\] B -- no --> D{"path empty?"} D -- yes --> E\["return slash"\] D -- no --> F{"path starts with basePath?"} F -- no --> G\["return path\\n(no strip - early exit)"\] F -- yes --> H\["cleaned = path.replace control chars NEW"\] H --> I\["stripped = cleaned.slice basePath.length OR slash"\] I --> J{"stripped starts with slash?"} J -- yes --> K\["return stripped"\] J -- no --> L\["return slash + stripped"\]](<#gh-dark-mode-only>)

</details>

Reviews (2): Last reviewed commit: ["fix(redirect): strip ASCII control chara..."](<https://github.com/langfuse/langfuse/commit/3ffa84dc1cd84396a05cf1cf1d38006733b82ca2>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=43641358>)