### PR TITLE
chore(otel): log SDK, version, instrumentation scopes, and span count on OTEL conversion failures (LFE-10869)

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -3186,10 +3186,6 @@ export class OtelIngestionProcessor {
   }
 
   /**
-   * Count the total number of spans across all resource spans.
-   * Returns -1 if an error occurs during counting to avoid throwing exceptions.
-   */
-  /**
    * Attribution context for conversion failure logs so a Datadog log line
    * answers which SDK/version/instrumentation produced a malformed batch and
    * how many spans were lost. Must never throw.
@@ -3235,6 +3231,10 @@ export class OtelIngestionProcessor {
     }
   }
 
+  /**
+   * Count the total number of spans across all resource spans.
+   * Returns -1 if an error occurs during counting to avoid throwing exceptions.
+   */
   private getTotalSpanCount(resourceSpans: ResourceSpan[]): number {
     try {
       if (!Array.isArray(resourceSpans)) {

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -51,6 +51,12 @@ export interface OtelIngestionProcessorConfig {
    * schema strips.
    */
   isLangfuseInternal?: boolean;
+  /**
+   * S3 key of the raw OTLP payload this batch was replayed from. Only set on
+   * the queue-consumer side; included in conversion failure logs so a single
+   * log line points at the replayable payload.
+   */
+  fileKey?: string;
 }
 
 interface CreateTraceEventParams {
@@ -166,6 +172,7 @@ export class OtelIngestionProcessor {
   private readonly sdkVersion: string;
   private readonly ingestionVersion?: string;
   private readonly isLangfuseInternal?: boolean;
+  private readonly fileKey?: string;
 
   constructor(config: OtelIngestionProcessorConfig) {
     this.projectId = config.projectId;
@@ -180,6 +187,7 @@ export class OtelIngestionProcessor {
     // only used as a write-path hint, not as SDK attribution.
     this.ingestionVersion = config.ingestionVersion;
     this.isLangfuseInternal = config.isLangfuseInternal;
+    this.fileKey = config.fileKey;
   }
 
   /**
@@ -540,7 +548,10 @@ export class OtelIngestionProcessor {
             return events;
           });
       } catch (error) {
-        logger.error("Error processing OTEL spans to events:", error);
+        logger.error("Error processing OTEL spans to events:", {
+          error,
+          ...this.getConversionFailureLogContext(resourceSpans),
+        });
         traceException(error, span);
         throw error;
       }
@@ -617,7 +628,10 @@ export class OtelIngestionProcessor {
           }
 
           // Log error but don't throw to avoid breaking the ingestion pipeline
-          logger.error("Error processing OTEL spans:", error);
+          logger.error("Error processing OTEL spans:", {
+            error,
+            ...this.getConversionFailureLogContext(resourceSpans),
+          });
           traceException(error, span);
 
           return [];
@@ -3175,6 +3189,52 @@ export class OtelIngestionProcessor {
    * Count the total number of spans across all resource spans.
    * Returns -1 if an error occurs during counting to avoid throwing exceptions.
    */
+  /**
+   * Attribution context for conversion failure logs so a Datadog log line
+   * answers which SDK/version/instrumentation produced a malformed batch and
+   * how many spans were lost. Must never throw.
+   */
+  private getConversionFailureLogContext(
+    resourceSpans: ResourceSpan[],
+  ): Record<string, unknown> {
+    return {
+      projectId: this.projectId,
+      sdkName: this.sdkName,
+      sdkVersion: this.sdkVersion,
+      fileKey: this.fileKey,
+      spanCount: this.getTotalSpanCount(resourceSpans),
+      instrumentationScopes: this.getInstrumentationScopes(resourceSpans),
+    };
+  }
+
+  private getInstrumentationScopes(
+    resourceSpans: ResourceSpan[],
+    limit = 10,
+  ): string[] {
+    try {
+      if (!Array.isArray(resourceSpans)) {
+        return [];
+      }
+
+      const scopes = new Set<string>();
+      for (const resourceSpan of resourceSpans) {
+        for (const scopeSpan of resourceSpan?.scopeSpans ?? []) {
+          const name = scopeSpan?.scope?.name;
+          if (name) {
+            scopes.add(name);
+            if (scopes.size >= limit) {
+              return [...scopes];
+            }
+          }
+        }
+      }
+      return [...scopes];
+    } catch (error) {
+      logger.warn("Failed to collect instrumentation scopes:", error);
+      return [];
+    }
+  }
+
   private getTotalSpanCount(resourceSpans: ResourceSpan[]): number {
     try {
       if (!Array.isArray(resourceSpans)) {

--- a/worker/src/queues/__tests__/otelConversionFailureLogging.test.ts
+++ b/worker/src/queues/__tests__/otelConversionFailureLogging.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests that OTEL conversion failures log structured attribution context
+ * (SDK name/version, instrumentation scopes, span count, project id, file key)
+ * so a single Datadog log line answers which SDK produced a malformed batch
+ * and how many spans were lost.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { logger, OtelIngestionProcessor } from "@langfuse/shared/src/server";
+
+const FILE_KEY = "events/otel/test-project/2026/07/13/batch.json";
+
+const createProcessor = () =>
+  new OtelIngestionProcessor({
+    projectId: "test-project",
+    publicKey: "test-public-key",
+    sdkName: "python",
+    sdkVersion: "3.2.1",
+    fileKey: FILE_KEY,
+  });
+
+const expectedContext = {
+  projectId: "test-project",
+  sdkName: "python",
+  sdkVersion: "3.2.1",
+  fileKey: FILE_KEY,
+  spanCount: 1,
+  instrumentationScopes: ["opentelemetry.instrumentation.openai"],
+};
+
+// Crash site: convertValueToPlainJavascript reads `value.stringValue` on undefined
+const batchWithAttributeWithoutValue = [
+  {
+    scopeSpans: [
+      {
+        scope: { name: "opentelemetry.instrumentation.openai" },
+        spans: [
+          {
+            traceId: "0123456789abcdef0123456789abcdef",
+            spanId: "0123456789abcdef",
+            name: "chat openai",
+            attributes: [{ key: "gen_ai.system" }],
+            startTimeUnixNano: "1752384000000000000",
+            endTimeUnixNano: "1752384001000000000",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+// Crash site: parseId calls Buffer.from(undefined) when traceId is missing
+const batchWithSpanWithoutTraceId = [
+  {
+    scopeSpans: [
+      {
+        scope: { name: "opentelemetry.instrumentation.openai" },
+        spans: [
+          {
+            spanId: "0123456789abcdef",
+            name: "chat openai",
+            attributes: [],
+            startTimeUnixNano: "1752384000000000000",
+            endTimeUnixNano: "1752384001000000000",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+describe("OtelIngestionProcessor conversion failure logging", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs attribution context when processToIngestionEvents fails on an attribute without value", async () => {
+    const errorSpy = vi.spyOn(logger, "error");
+
+    const result = await createProcessor().processToIngestionEvents(
+      batchWithAttributeWithoutValue,
+    );
+
+    expect(result).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Error processing OTEL spans:",
+      expect.objectContaining({
+        ...expectedContext,
+        error: expect.any(Error),
+      }),
+    );
+  });
+
+  it("logs attribution context when processToIngestionEvents fails on a span without traceId", async () => {
+    const errorSpy = vi.spyOn(logger, "error");
+
+    const result = await createProcessor().processToIngestionEvents(
+      batchWithSpanWithoutTraceId,
+    );
+
+    expect(result).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Error processing OTEL spans:",
+      expect.objectContaining({
+        ...expectedContext,
+        error: expect.any(Error),
+      }),
+    );
+  });
+
+  it("logs attribution context when processToEvent fails on a span without traceId", () => {
+    const errorSpy = vi.spyOn(logger, "error");
+
+    expect(() =>
+      createProcessor().processToEvent(batchWithSpanWithoutTraceId),
+    ).toThrow();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Error processing OTEL spans to events:",
+      expect.objectContaining({
+        ...expectedContext,
+        error: expect.any(Error),
+      }),
+    );
+  });
+});

--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -314,6 +314,7 @@ export const otelIngestionQueueProcessorBuilder = (
         publicKey: attribution.ingestionApiKey,
         sdkName: attribution.ingestionSdkName,
         sdkVersion: attribution.ingestionSdkVersion,
+        fileKey,
       });
       const events: IngestionEventType[] =
         await processor.processToIngestionEvents(parsedSpans);


### PR DESCRIPTION
## What does this PR do?

When the worker fails to convert an OTLP batch, the error logs (`"Error processing OTEL spans:"` / `"Error processing OTEL spans to events:"`) only carried the bare error. From Datadog we could not tell which SDK, which version, or which instrumentation scope produced the malformed payload, nor how many spans were lost — distinguishing an SDK regression from a single tenant sending broken payloads required downloading raw payloads from S3.

Both catch blocks in `OtelIngestionProcessor` now log a structured context object alongside the error:

- `sdkName`, `sdkVersion` (from the `x-langfuse-sdk-*` header attribution already held by the processor)
- `projectId` (explicit, not only via propagated log context)
- `spanCount` (via the existing `getTotalSpanCount`)
- `instrumentationScopes` — distinct `scopeSpan.scope.name` values, bounded to the first 10
- `fileKey` — S3 key of the raw payload (new optional constructor field, passed by the queue consumer), so a single log line points at the replayable payload

No behavior change to conversion or retries; the context builder never throws.

Resolves LFE-10869.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have added tests that prove my fix is effective or that my feature works — unit tests reproduce both production crash shapes (attribute without `value`, span without `traceId`) and assert the logged context
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves observability for OTEL conversion failures by enriching error log lines with structured attribution context: SDK name/version, project ID, a file key pointing at the replayable S3 payload, total span count, and a deduplicated list of instrumentation scope names (capped at 10). The `fileKey` is threaded from the queue consumer through to the new `getConversionFailureLogContext` helper, and three focused unit tests cover the two crash paths that motivated the change.

- `OtelIngestionProcessor` gains `getConversionFailureLogContext` and `getInstrumentationScopes` helpers, both guarded against throwing, and both error log sites are enriched with the new context.
- `otelIngestionQueue.ts` passes the pre-existing `fileKey` variable into the processor constructor — a one-line addition.
- A new test file validates that both `processToIngestionEvents` and `processToEvent` log the full structured context on failure.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are additive and observability-only, with no logic modifications to the conversion or ingestion path.

The only finding is a misplaced JSDoc block caused by inserting the new methods between the old comment and its method, leaving `getTotalSpanCount` undocumented. This does not affect runtime behaviour but will confuse tooling and future readers.

The double-comment block around `getConversionFailureLogContext` / `getTotalSpanCount` in `OtelIngestionProcessor.ts` needs a one-line cleanup.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Q as otelIngestionQueue
    participant P as OtelIngestionProcessor
    participant L as logger

    Q->>P: "new OtelIngestionProcessor({ projectId, sdkName, sdkVersion, fileKey })"
    Q->>P: processToIngestionEvents(parsedSpans)
    alt conversion succeeds
        P-->>Q: IngestionEventType[]
    else conversion fails
        P->>P: getConversionFailureLogContext(resourceSpans)
        P->>P: getTotalSpanCount(resourceSpans)
        P->>P: getInstrumentationScopes(resourceSpans)
        P->>L: logger.error(error + projectId + sdkName + sdkVersion + fileKey + spanCount + scopes)
        P-->>Q: []
    end
    Q->>P: processToEvent(resourceSpans)
    alt conversion fails
        P->>P: getConversionFailureLogContext(resourceSpans)
        P->>L: logger.error(error + ...context)
        P->>Q: throws
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Q as otelIngestionQueue
    participant P as OtelIngestionProcessor
    participant L as logger

    Q->>P: "new OtelIngestionProcessor({ projectId, sdkName, sdkVersion, fileKey })"
    Q->>P: processToIngestionEvents(parsedSpans)
    alt conversion succeeds
        P-->>Q: IngestionEventType[]
    else conversion fails
        P->>P: getConversionFailureLogContext(resourceSpans)
        P->>P: getTotalSpanCount(resourceSpans)
        P->>P: getInstrumentationScopes(resourceSpans)
        P->>L: logger.error(error + projectId + sdkName + sdkVersion + fileKey + spanCount + scopes)
        P-->>Q: []
    end
    Q->>P: processToEvent(resourceSpans)
    alt conversion fails
        P->>P: getConversionFailureLogContext(resourceSpans)
        P->>L: logger.error(error + ...context)
        P->>Q: throws
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/otel/OtelIngestionProcessor.ts:3188-3197
The JSDoc comment that originally documented `getTotalSpanCount` (lines 3188–3191) is now sitting directly above `getConversionFailureLogContext` because the new methods were inserted between that comment and its intended method. In TypeScript/TSDoc tooling, the first doc-comment block is associated with `getConversionFailureLogContext`, so `getTotalSpanCount` ends up undocumented and the comment above `getConversionFailureLogContext` is misleading.

```suggestion
  /**
   * Attribution context for conversion failure logs so a Datadog log line
   * answers which SDK/version/instrumentation produced a malformed batch and
   * how many spans were lost. Must never throw.
   */
  private getConversionFailureLogContext(
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(otel): log SDK, version, scopes, a..."](https://github.com/langfuse/langfuse/commit/cd15f6674928849550a796859f447601917ebf1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43761904)</sub>

<!-- /greptile_comment -->