### PR TITLE
chore(blobstorage): remove Parquet export-tuning special-casing

### DIFF
--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
@@ -21,7 +21,6 @@ function resolved(
 ): ResolvedBlobExportTuning {
   return {
     rawPassthrough: false,
-    parquet: false,
     gzipLevel: undefined,
     partSizeBytes: DEFAULTS.partSizeBytes,
     maxConcurrentParts: undefined,
@@ -119,63 +118,6 @@ describe("resolveBlobExportTuning", () => {
           skipEnrichment: true,
         }),
       );
-      expect(warnings).toEqual([]);
-    });
-  });
-
-  describe("parquet (LFE-10463)", () => {
-    it("honors parquet=true", () => {
-      const { resolved: res, warnings } = resolveBlobExportTuning(
-        { parquet: true },
-        DEFAULTS,
-      );
-      expect(res).toEqual(resolved({ parquet: true }));
-      expect(warnings).toEqual([]);
-    });
-
-    it("honors parquet=false explicitly", () => {
-      const { resolved: res, warnings } = resolveBlobExportTuning(
-        { parquet: false },
-        DEFAULTS,
-      );
-      expect(res.parquet).toBe(false);
-      expect(warnings).toEqual([]);
-    });
-
-    it("defaults parquet to false when absent", () => {
-      expect(resolveBlobExportTuning({}, DEFAULTS).resolved.parquet).toBe(
-        false,
-      );
-    });
-
-    it("falls back to false and warns on a wrong-typed parquet", () => {
-      const { resolved: res, warnings } = resolveBlobExportTuning(
-        { parquet: "yes" },
-        DEFAULTS,
-      );
-      expect(res.parquet).toBe(false);
-      expect(warnings.some((w) => w.includes("expected a boolean"))).toBe(true);
-    });
-
-    it("takes precedence over rawPassthrough: parquet wins, rawPassthrough forced false, with a warning", () => {
-      const { resolved: res, warnings } = resolveBlobExportTuning(
-        { parquet: true, rawPassthrough: true },
-        DEFAULTS,
-      );
-      expect(res.parquet).toBe(true);
-      expect(res.rawPassthrough).toBe(false);
-      expect(warnings.some((w) => w.includes("parquet takes precedence"))).toBe(
-        true,
-      );
-    });
-
-    it("leaves rawPassthrough untouched when parquet is not set", () => {
-      const { resolved: res, warnings } = resolveBlobExportTuning(
-        { rawPassthrough: true },
-        DEFAULTS,
-      );
-      expect(res.parquet).toBe(false);
-      expect(res.rawPassthrough).toBe(true);
       expect(warnings).toEqual([]);
     });
   });
@@ -392,12 +334,6 @@ describe("BlobExportTuningSchema (write schema)", () => {
       BlobExportTuningSchema.safeParse({ rawPassthrough: true, gzipLevel: 6 })
         .success,
     ).toBe(true);
-  });
-
-  it("accepts parquet", () => {
-    expect(BlobExportTuningSchema.safeParse({ parquet: true }).success).toBe(
-      true,
-    );
   });
 
   it("rejects out-of-range values (writes reject; reads clamp)", () => {

--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
@@ -60,14 +60,6 @@ export const BlobExportTuningSchema = z.object({
   // >= RAW_PASSTHROUGH_MIN_CLICKHOUSE_VERSION (see above) for mid-stream failure
   // detection. Do not enable on older self-hosted ClickHouse.
   rawPassthrough: z.boolean().optional(),
-  // LFE-10463 Parquet export path: stream ClickHouse's native `FORMAT Parquet`
-  // bytes straight to upload, offloading columnar encoding + compression to
-  // ClickHouse query threads (no worker gzip). When set, produces `.parquet`
-  // files for all tables and overrides both `fileType` and `compressed`. Takes
-  // precedence over `rawPassthrough` (resolved below). Like rawPassthrough it
-  // relies on mid-stream exception tagging, so the same ClickHouse
-  // >= RAW_PASSTHROUGH_MIN_CLICKHOUSE_VERSION caveat applies on self-hosted.
-  parquet: z.boolean().optional(),
   // LFE-10402 gzip tuning: zlib deflate level for compressed exports. Lower
   // levels trade output size for markedly less worker CPU. Only honored when the
   // integration has compression enabled. zlib accepts 0 (store) through 9 (max);
@@ -107,9 +99,6 @@ export interface BlobExportTuningDefaults {
 
 export type ResolvedBlobExportTuning = {
   rawPassthrough: boolean;
-  // LFE-10463. When true the export uses ClickHouse-native `FORMAT Parquet`;
-  // forces `rawPassthrough` to false (parquet wins) — see resolver below.
-  parquet: boolean;
   // undefined => use the zlib default (6); a concrete 0-9 otherwise.
   gzipLevel: number | undefined;
   partSizeBytes: number;
@@ -251,7 +240,6 @@ export function resolveBlobExportTuning(
 
   const fallback: ResolvedBlobExportTuning = {
     rawPassthrough: false,
-    parquet: false,
     gzipLevel: undefined,
     partSizeBytes: defaults.partSizeBytes,
     maxConcurrentParts: undefined,
@@ -272,29 +260,15 @@ export function resolveBlobExportTuning(
 
   const obj = raw as Record<string, unknown>;
 
-  const parquet = resolveBoolean("parquet", obj.parquet, warnings);
-  let rawPassthrough = resolveBoolean(
+  const rawPassthrough = resolveBoolean(
     "rawPassthrough",
     obj.rawPassthrough,
     warnings,
   );
 
-  // LFE-10463: Parquet is a distinct execution path (ClickHouse-native
-  // `FORMAT Parquet`) that supersedes the JSONEachRow raw-passthrough path.
-  // Enabling both is a misconfiguration; honor parquet and disable
-  // rawPassthrough with a warning rather than letting the handler pick one
-  // silently.
-  if (parquet && rawPassthrough) {
-    rawPassthrough = false;
-    warnings.push(
-      "parquet and rawPassthrough are both enabled; parquet takes precedence, ignoring rawPassthrough",
-    );
-  }
-
   return {
     resolved: {
       rawPassthrough,
-      parquet,
       gzipLevel: resolveGzipLevel(obj.gzipLevel, warnings),
       partSizeBytes: resolveNumber(
         "partSizeBytes",

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -4,7 +4,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import {
   type BlobStorageIntegrationFormSchema,
   blobStorageIntegrationFormSchema,
-  parquetEnabledFromTuning,
 } from "@/src/features/blobstorage-integration/types";
 import {
   AnalyticsIntegrationExportSource,
@@ -86,22 +85,6 @@ describe("blob storage form — exportFieldGroups validation", () => {
     });
 
     expect(onSubmit).toHaveBeenCalledOnce();
-  });
-});
-
-describe("parquetEnabledFromTuning", () => {
-  it.each([
-    [{ parquet: true }, true],
-    [{ parquet: true, gzipLevel: 1 }, true],
-    [{ parquet: false }, false],
-    [{ gzipLevel: 1 }, false],
-    [{}, false],
-    [null, false],
-    [undefined, false],
-    ["parquet", false],
-    [["parquet"], false],
-  ])("%o → %s", (input, expected) => {
-    expect(parquetEnabledFromTuning(input)).toBe(expected);
   });
 });
 

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -10,10 +10,7 @@ import {
   isLegacyBlobExporter,
   type BlobStorageIntegration,
 } from "@langfuse/shared";
-import {
-  parquetEnabledFromTuning,
-  type BlobStorageIntegrationFormSchema,
-} from "@/src/features/blobstorage-integration/types";
+import { type BlobStorageIntegrationFormSchema } from "@/src/features/blobstorage-integration/types";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProject } from "@/src/features/projects/hooks";
 import { buildBlobStorageFormValues } from "@/src/features/blobstorage-integration/components/formValues";
@@ -123,7 +120,6 @@ export const BlobStorageIntegrationContainer = ({
       )}
       availability={availability}
       persistedExportSource={config?.exportSource}
-      isParquetOverride={parquetEnabledFromTuning(config?.exportTuning)}
       isSaving={mut.isPending}
       onSubmit={handleSubmit}
     >

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
@@ -39,7 +39,6 @@ const ui = (
       initialValues={initialValues}
       availability={availability}
       persistedExportSource={null}
-      isParquetOverride={false}
       isSaving={false}
       onSubmit={onSubmit}
     />

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.tsx
@@ -37,7 +37,6 @@ export const BlobStorageIntegrationForm = ({
   initialValues,
   availability,
   persistedExportSource,
-  isParquetOverride,
   isSaving,
   onSubmit,
   children,
@@ -45,10 +44,6 @@ export const BlobStorageIntegrationForm = ({
   initialValues: BlobStorageFormValues;
   availability: ExportSourceAvailability;
   persistedExportSource: AnalyticsIntegrationExportSource | null | undefined;
-  // Internal `exportTuning.parquet` override (no write path); reflected
-  // read-only since the worker forces Parquet over the persisted fileType
-  // + gzip.
-  isParquetOverride: boolean;
   isSaving: boolean;
   onSubmit: (values: BlobStorageIntegrationFormSchema) => void;
   // Entity-scoped action buttons (Validate / Run Now / Reset) rendered by
@@ -89,23 +84,14 @@ export const BlobStorageIntegrationForm = ({
         onSubmit={blobStorageForm.handleSubmit(onSubmit)}
       >
         <StorageProviderFields control={control} />
-        <ExportScheduleFields
-          control={control}
-          isParquetOverride={isParquetOverride}
-        />
+        <ExportScheduleFields control={control} />
         <ExportSourceField
           control={control}
           persistedExportSource={persistedExportSource}
           availability={availability}
         />
-        <ExportFieldGroupsField
-          control={control}
-          isParquetOverride={isParquetOverride}
-        />
-        <GzipCompressionField
-          control={control}
-          isParquetOverride={isParquetOverride}
-        />
+        <ExportFieldGroupsField control={control} />
+        <GzipCompressionField control={control} />
         <FormField
           control={control}
           name="enabled"

--- a/web/src/features/blobstorage-integration/components/ExportFieldGroupsField.tsx
+++ b/web/src/features/blobstorage-integration/components/ExportFieldGroupsField.tsx
@@ -19,10 +19,8 @@ import { type BlobStorageFormControl } from "@/src/features/blobstorage-integrat
 // selected export source and file type.
 export const ExportFieldGroupsField = ({
   control,
-  isParquetOverride,
 }: {
   control: BlobStorageFormControl;
-  isParquetOverride: boolean;
 }) => {
   const [watchedExportSource, watchedFileType] = useWatch({
     control,
@@ -30,7 +28,6 @@ export const ExportFieldGroupsField = ({
   });
   const { errors } = useFormState({ control, name: "exportFieldGroups" });
   const isParquetExport =
-    isParquetOverride ||
     watchedFileType === BlobStorageIntegrationFileType.PARQUET;
   // The legacy observations table contains fewer columns than the enriched
   // observations, so the per-group field lists differ for legacy-only exports.

--- a/web/src/features/blobstorage-integration/components/ExportScheduleFields.tsx
+++ b/web/src/features/blobstorage-integration/components/ExportScheduleFields.tsx
@@ -25,12 +25,8 @@ import { type BlobStorageFormControl } from "@/src/features/blobstorage-integrat
 // mode requires one).
 export const ExportScheduleFields = ({
   control,
-  isParquetOverride,
 }: {
   control: BlobStorageFormControl;
-  // Internal `exportTuning.parquet` override (no write path); reflected
-  // read-only since the worker forces Parquet over the persisted fileType.
-  isParquetOverride: boolean;
 }) => {
   const watchedExportMode = useWatch({ control, name: "exportMode" });
 
@@ -73,11 +69,7 @@ export const ExportScheduleFields = ({
           <FormItem>
             <FormLabel>File Type</FormLabel>
             <FormControl>
-              <Select
-                value={isParquetOverride ? "PARQUET" : field.value}
-                onValueChange={field.onChange}
-                disabled={isParquetOverride}
-              >
+              <Select value={field.value} onValueChange={field.onChange}>
                 <SelectTrigger>
                   <SelectValue placeholder="Select file type" />
                 </SelectTrigger>
@@ -90,11 +82,9 @@ export const ExportScheduleFields = ({
               </Select>
             </FormControl>
             <FormDescription>
-              {isParquetOverride
-                ? "Exporting as Apache Parquet — a columnar binary format encoded and compressed by ClickHouse. This is configured for your project and overrides the file type; gzip compression is not applicable."
-                : field.value === BlobStorageIntegrationFileType.PARQUET
-                  ? "Apache Parquet — a columnar binary format encoded and compressed by ClickHouse. Gzip compression does not apply."
-                  : "The file format for exported data."}
+              {field.value === BlobStorageIntegrationFileType.PARQUET
+                ? "Apache Parquet — a columnar binary format encoded and compressed by ClickHouse. Gzip compression does not apply."
+                : "The file format for exported data."}
             </FormDescription>
             <FormMessage />
           </FormItem>

--- a/web/src/features/blobstorage-integration/components/GzipCompressionField.tsx
+++ b/web/src/features/blobstorage-integration/components/GzipCompressionField.tsx
@@ -13,17 +13,12 @@ import { type BlobStorageFormControl } from "@/src/features/blobstorage-integrat
 
 export const GzipCompressionField = ({
   control,
-  isParquetOverride,
 }: {
   control: BlobStorageFormControl;
-  isParquetOverride: boolean;
 }) => {
   const watchedFileType = useWatch({ control, name: "fileType" });
   // Parquet compresses internally — gzip does not apply.
-  const isParquetExport =
-    isParquetOverride ||
-    watchedFileType === BlobStorageIntegrationFileType.PARQUET;
-  if (isParquetExport) return null;
+  if (watchedFileType === BlobStorageIntegrationFileType.PARQUET) return null;
 
   return (
     <FormField

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -52,17 +52,6 @@ export const blobStorageIntegrationFormSchemaBase = z.object({
   compressed: z.boolean().default(true),
 });
 
-// True when the internal, DB-set `exportTuning.parquet` override is on (no UI
-// write path). Mirrors the worker resolver: only `{ parquet: true }` counts.
-export function parquetEnabledFromTuning(exportTuning: unknown): boolean {
-  return (
-    typeof exportTuning === "object" &&
-    exportTuning !== null &&
-    !Array.isArray(exportTuning) &&
-    (exportTuning as Record<string, unknown>).parquet === true
-  );
-}
-
 export const blobStorageIntegrationFormSchema =
   blobStorageIntegrationFormSchemaBase
     .superRefine(validateAzureContainerName)

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -2016,7 +2016,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
   });
 
   maybeDescribe("Parquet export (LFE-10463)", () => {
-    // E2e: exportTuning.parquet runs the real handler → MinIO. Parquet magic is
+    // E2e: fileType=PARQUET runs the real handler → MinIO. Parquet magic is
     // ASCII, so it survives the string download at both ends of the body.
     const PARQUET_MAGIC = "PAR1";
 
@@ -2051,8 +2051,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           lastSyncAt: twoHoursAgo,
           // compressed must be ignored on the parquet path (no .gz suffix).
           compressed: true,
-          fileType: BlobStorageIntegrationFileType.JSONL,
-          exportTuning: { parquet: true },
+          fileType: BlobStorageIntegrationFileType.PARQUET,
         },
       });
 

--- a/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
+++ b/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
@@ -153,44 +153,9 @@ describe("handleBlobStorageIntegrationProjectJob tuning wiring", () => {
     }
   });
 
-  // LFE-10463: parquet tuning routes every table through the Parquet path,
-  // overriding fileType (CSV here) and the .gz suffix.
-  it("produces .parquet files with the parquet content type when parquet is enabled", async () => {
-    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue(
-      baseRow({ parquet: true }),
-    );
-
-    await handleBlobStorageIntegrationProjectJob(makeJob());
-
-    // exportSource TRACES_OBSERVATIONS → scores, traces, observations.
-    expect(uploadCalls.length).toBe(3);
-    for (const call of uploadCalls) {
-      expect(call.fileName.endsWith(".parquet")).toBe(true);
-      expect(call.fileName.endsWith(".gz")).toBe(false);
-      expect(call.fileType).toBe("application/vnd.apache.parquet");
-    }
-  });
-
-  it("ignores the compressed flag on the parquet path (no .gz suffix)", async () => {
-    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue({
-      ...baseRow({ parquet: true }),
-      compressed: true,
-      fileType: "JSONL",
-    });
-
-    await handleBlobStorageIntegrationProjectJob(makeJob());
-
-    expect(uploadCalls.length).toBe(3);
-    for (const call of uploadCalls) {
-      expect(call.fileName.endsWith(".parquet")).toBe(true);
-      expect(call.fileName).not.toContain(".gz");
-      expect(call.fileType).toBe("application/vnd.apache.parquet");
-    }
-  });
-
-  // First-class PARQUET fileType (no exportTuning.parquet) routes through the
-  // same Parquet path as the legacy override.
-  it("produces .parquet files when fileType is PARQUET without the tuning override", async () => {
+  // Parquet is a first-class fileType: fileType=PARQUET routes every table
+  // through the Parquet path, ignoring the compressed flag (no .gz suffix).
+  it("produces .parquet files when fileType is PARQUET", async () => {
     (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue({
       ...baseRow(undefined),
       fileType: "PARQUET",
@@ -199,25 +164,11 @@ describe("handleBlobStorageIntegrationProjectJob tuning wiring", () => {
 
     await handleBlobStorageIntegrationProjectJob(makeJob());
 
+    // exportSource TRACES_OBSERVATIONS → scores, traces, observations.
     expect(uploadCalls.length).toBe(3);
     for (const call of uploadCalls) {
       expect(call.fileName.endsWith(".parquet")).toBe(true);
       expect(call.fileName).not.toContain(".gz");
-      expect(call.fileType).toBe("application/vnd.apache.parquet");
-    }
-  });
-
-  it("parquet takes precedence over rawPassthrough", async () => {
-    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue({
-      ...baseRow({ parquet: true, rawPassthrough: true }),
-      fileType: "JSONL",
-    });
-
-    await handleBlobStorageIntegrationProjectJob(makeJob());
-
-    expect(uploadCalls.length).toBe(3);
-    for (const call of uploadCalls) {
-      expect(call.fileName.endsWith(".parquet")).toBe(true);
       expect(call.fileType).toBe("application/vnd.apache.parquet");
     }
   });

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -333,9 +333,6 @@ const processBlobStorageExport = async (config: {
   convertV4LatencyToSeconds: boolean;
   exportFieldGroups?: ObservationFieldGroupFull[];
   rawPassthrough: boolean;
-  // LFE-10463: when true, export via ClickHouse-native `FORMAT Parquet`,
-  // overriding `fileType` and `compressed`. Takes precedence over rawPassthrough.
-  parquet: boolean;
   // undefined concurrency/attempts => backend keeps its native default.
   partSizeBytes: number;
   maxConcurrentParts: number | undefined;
@@ -440,9 +437,7 @@ const processBlobStorageExport = async (config: {
       try {
         const blobStorageProps = getFileTypeProperties(config.fileType);
 
-        // Both paths converge: legacy exportTuning.parquet override and the new fileType=PARQUET.
         const parquetEligible =
-          config.parquet ||
           config.fileType === BlobStorageIntegrationFileType.PARQUET;
 
         // Raw passthrough (LFE-10402) is opt-in per project and only valid for
@@ -1198,7 +1193,6 @@ export const handleBlobStorageIntegrationProjectJob = async (
       exportFieldGroups:
         blobStorageIntegration.exportFieldGroups as ObservationFieldGroupFull[],
       rawPassthrough: exportTuning.rawPassthrough,
-      parquet: exportTuning.parquet,
       partSizeBytes: exportTuning.partSizeBytes,
       maxConcurrentParts: exportTuning.maxConcurrentParts,
       maxPartAttempts: exportTuning.maxPartAttempts,
@@ -1221,7 +1215,6 @@ export const handleBlobStorageIntegrationProjectJob = async (
     // dispatch and is intentionally not warned about (avoids ~hourly log noise).
     if (
       exportTuning.rawPassthrough &&
-      !exportTuning.parquet &&
       blobStorageIntegration.fileType !==
         BlobStorageIntegrationFileType.PARQUET &&
       (blobStorageIntegration.fileType !==


### PR DESCRIPTION
## What does this PR do?

Parquet is now the default `fileType` for all blob-storage exports (GA), so the interim per-project `exportTuning.parquet` override is redundant. This removes that special-casing end to end while leaving the `exportTuning` column and its other internal knobs (`rawPassthrough`, `gzipLevel`, upload tuning, `skipEnrichment`) untouched.

- **shared** (`blob-export-tuning.ts`): drop `parquet` from `BlobExportTuningSchema` and `ResolvedBlobExportTuning`, and remove the parquet-vs-`rawPassthrough` precedence branch in `resolveBlobExportTuning`.
- **worker** (`handleBlobStorageIntegrationProjectJob.ts`): `parquetEligible` now keys only off `fileType === PARQUET`; drop the `parquet` field from the export execution config and from the `rawPassthrough` ineligibility warning guard.
- **web**: remove `parquetEnabledFromTuning` and the `isParquetOverride` prop threaded through the form; the settings form now reflects Parquet behavior (locked gzip, Parquet field-group descriptions) purely from the selected `fileType`.
- **tests**: shared resolver, worker tuning-wiring, and web client tests updated; the worker E2E parquet test now drives the path via `fileType: PARQUET` instead of the removed override.

> [!IMPORTANT]
> Operational prerequisite: any project that relied **only** on the DB-set `exportTuning.parquet = true` override (with a persisted `fileType` of e.g. `CSV`/`JSONL`) must have `fileType` set to `PARQUET` before this ships — otherwise it silently reverts to its stored `fileType`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (refactor, cleanup, tooling — no user-facing behavior change beyond removing the interim override)

## Checklist

- [x] Lint + typecheck pass (web, worker, shared)
- [x] Targeted tests pass (shared resolver, worker tuning-wiring, web client)
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the `exportTuning.parquet` special-case override that was an internal mechanism to route exports through ClickHouse-native `FORMAT Parquet`, making `fileType=PARQUET` the sole first-class way to configure Parquet exports.

- Drops the `parquet` field from `BlobExportTuningSchema`, `ResolvedBlobExportTuning`, and the resolver — the DB key is now silently ignored on read.
- Removes the `isParquetOverride` prop chain through the form UI (`BlobStorageIntegrationForm` → `ExportScheduleFields`, `ExportFieldGroupsField`, `GzipCompressionField`), along with the `parquetEnabledFromTuning` helper.
- Updates the worker so `parquetEligible` is derived only from `fileType === PARQUET`, removing the dual-path logic.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge only after confirming no live DB row has exportTuning.parquet=true with a non-PARQUET fileType; such rows would silently revert to JSONL/CSV output on deploy.

The refactoring is clean and the test coverage is thorough. The one concern is backward compatibility: any project whose blobstorage integration was set up via the old exportTuning.parquet=true workaround (without updating fileType to PARQUET) would silently receive wrong-format files after this goes live. No migration or warning is added. If the team has audited that no such rows exist in production, this is a straightforward cleanup.

worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts — verify no production DB row combines exportTuning.parquet=true with a non-PARQUET fileType before deploying.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleBlobStorageIntegrationProjectJob] --> B[resolveBlobExportTuning\nexportTuning JSON from DB]
    B --> C{Before this PR}
    B --> D{After this PR}
    
    C --> E[parquet=true from tuning?]
    E -->|Yes| F[parquetEligible=true\nignore fileType]
    E -->|No| G[fileType===PARQUET?]
    G -->|Yes| F
    G -->|No| H[Standard / Passthrough path]
    
    D --> I[fileType===PARQUET?]
    I -->|Yes| J[parquetEligible=true]
    I -->|No| K[Standard / Passthrough path]
    
    J --> L[Export as .parquet\napplication/vnd.apache.parquet]
    F --> L
    H --> M[Export as JSONL/CSV]
    K --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[handleBlobStorageIntegrationProjectJob] --> B[resolveBlobExportTuning\nexportTuning JSON from DB]
    B --> C{Before this PR}
    B --> D{After this PR}
    
    C --> E[parquet=true from tuning?]
    E -->|Yes| F[parquetEligible=true\nignore fileType]
    E -->|No| G[fileType===PARQUET?]
    G -->|Yes| F
    G -->|No| H[Standard / Passthrough path]
    
    D --> I[fileType===PARQUET?]
    I -->|Yes| J[parquetEligible=true]
    I -->|No| K[Standard / Passthrough path]
    
    J --> L[Export as .parquet\napplication/vnd.apache.parquet]
    F --> L
    H --> M[Export as JSONL/CSV]
    K --> M
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:1193-1200
**Silent behavior change for existing `exportTuning.parquet=true` configs**

Any DB row that previously had `fileType=JSONL` (or CSV) plus `exportTuning: { parquet: true }` will silently revert to JSONL/CSV output after this deploy. The `resolveBlobExportTuning` function now ignores the `parquet` key entirely — no warning is emitted, and no migration converts those rows to `fileType=PARQUET`. If any live integration was set up via the old tuning override path (as the deleted test shows was a supported configuration), those projects will stop receiving Parquet files without any error.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(blobstorage): remove Parquet expor..."](https://github.com/langfuse/langfuse/commit/5483d4ce7e8bd69d1399004befa2f20038ec0c82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43764392)</sub>

<!-- /greptile_comment -->