### PR TITLE
fix(otel): drop only malformed spans instead of failing the whole OTLP batch (LFE-10870)

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.spanIsolation.test.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.spanIsolation.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Per-span failure isolation: one malformed span in an OTLP batch must not
+ * discard its well-formed siblings on either conversion path
+ * (processToEvent and processToIngestionEvents), and both paths must skip
+ * the identical span set.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { OtelIngestionProcessor } from "./OtelIngestionProcessor";
+import { logger } from "../logger";
+
+const { recordIncrementMock } = vi.hoisted(() => ({
+  recordIncrementMock: vi.fn(),
+}));
+vi.mock("../index", async (importOriginal) => {
+  const original = (await importOriginal()) as object;
+  return {
+    ...original,
+    recordIncrement: recordIncrementMock,
+    // Truthy redis stub so getSeenTracesSet reaches its trace-id collection
+    redis: { set: vi.fn().mockResolvedValue("OK") },
+  };
+});
+
+const CONVERSION_FAILURE_METRIC = "langfuse.ingestion.otel.conversion_failure";
+const PROJECT_ID = "test-project";
+const TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+const createProcessor = () => {
+  const processor = new OtelIngestionProcessor({
+    projectId: PROJECT_ID,
+    publicKey: "pk-lf-test",
+    sdkName: "test-sdk",
+    sdkVersion: "1.0.0",
+  });
+  // Bypass Redis-backed seen-traces initialization
+  (processor as any).seenTraces = new Set();
+  (processor as any).isInitialized = true;
+  return processor;
+};
+
+const makeSpan = (spanId: string, overrides: Record<string, unknown> = {}) => ({
+  traceId: TRACE_ID,
+  spanId,
+  name: `span-${spanId}`,
+  startTimeUnixNano: "1700000000000000000",
+  endTimeUnixNano: "1700000001000000000",
+  attributes: [{ key: "some.attribute", value: { stringValue: "ok" } }],
+  ...overrides,
+});
+
+const makeResourceSpan = (spans: unknown[]) => ({
+  resource: {
+    attributes: [
+      { key: "service.name", value: { stringValue: "test-service" } },
+      { key: "telemetry.sdk.language", value: { stringValue: "nodejs" } },
+    ],
+  },
+  scopeSpans: [{ scope: { name: "test-scope", version: "0.1.0" }, spans }],
+});
+
+// Well-formed siblings
+const goodSpanA = makeSpan("aaaaaaaaaaaaaaaa");
+const goodSpanB = makeSpan("bbbbbbbbbbbbbbbb");
+// Prod failure 1: attribute with a key but no value (legal in OTLP protobuf)
+const spanWithValuelessAttribute = makeSpan("cccccccccccccccc", {
+  attributes: [{ key: "orphan.key" }],
+});
+// Prod failure 2: span without traceId
+const spanWithoutTraceId = makeSpan("dddddddddddddddd", {
+  traceId: undefined,
+});
+const spanWithoutSpanId = makeSpan("eeeeeeeeeeeeeeee", {
+  spanId: undefined,
+});
+// Unknown malformation: throws inside attribute conversion
+const spanWithThrowingAttribute = makeSpan("ffffffffffffffff", {
+  attributes: [
+    { key: "bad.array", value: { arrayValue: { values: "not-an-array" } } },
+  ],
+});
+
+const eventSpanIds = (events: any[]) =>
+  events.map((e) => e.spanId as string).sort();
+const observationIds = (events: any[]) =>
+  events
+    .filter((e) => e.type !== "trace-create")
+    .map((e) => e.body.id as string)
+    .sort();
+const skipMetricCalls = () =>
+  recordIncrementMock.mock.calls.filter(
+    ([metric, , tags]) =>
+      metric === CONVERSION_FAILURE_METRIC &&
+      tags?.failure_type === "span_skipped",
+  );
+
+describe("OtelIngestionProcessor per-span failure isolation", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    recordIncrementMock.mockClear();
+  });
+
+  describe("attribute with key but no value (null guard)", () => {
+    const batch = [
+      makeResourceSpan([goodSpanA, spanWithValuelessAttribute, goodSpanB]),
+    ];
+
+    it("processToEvent ingests all spans without throwing", () => {
+      const events = createProcessor().processToEvent(batch as any);
+      expect(eventSpanIds(events)).toEqual([
+        "aaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbb",
+        "cccccccccccccccc",
+      ]);
+    });
+
+    it("processToIngestionEvents ingests all spans", async () => {
+      const events = await createProcessor().processToIngestionEvents(
+        batch as any,
+      );
+      expect(observationIds(events)).toEqual([
+        "aaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbb",
+        "cccccccccccccccc",
+      ]);
+    });
+
+    it("drops the valueless attribute instead of crashing", () => {
+      const events = createProcessor().processToEvent(batch as any);
+      const affected = events.find((e: any) => e.spanId === "cccccccccccccccc");
+      expect(affected.metadata.attributes).toEqual({});
+    });
+  });
+
+  describe.each([
+    ["missing traceId", spanWithoutTraceId, "missing_trace_id"],
+    ["missing spanId", spanWithoutSpanId, "missing_span_id"],
+    [
+      "throwing attribute conversion",
+      spanWithThrowingAttribute,
+      "conversion_error",
+    ],
+  ])("span with %s", (_label, malformedSpan, expectedReason) => {
+    const batch = [makeResourceSpan([goodSpanA, malformedSpan, goodSpanB])];
+
+    it("processToEvent skips only the malformed span and does not throw", () => {
+      const events = createProcessor().processToEvent(batch as any);
+      expect(eventSpanIds(events)).toEqual([
+        "aaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbb",
+      ]);
+    });
+
+    it("processToIngestionEvents skips only the malformed span", async () => {
+      const events = await createProcessor().processToIngestionEvents(
+        batch as any,
+      );
+      expect(observationIds(events)).toEqual([
+        "aaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbb",
+      ]);
+    });
+
+    it("increments the conversion_failure metric with reason and project", () => {
+      createProcessor().processToEvent(batch as any);
+      const calls = skipMetricCalls();
+      expect(calls).toHaveLength(1);
+      expect(calls[0][2]).toMatchObject({
+        failure_type: "span_skipped",
+        reason: expectedReason,
+        project_id: PROJECT_ID,
+      });
+    });
+  });
+
+  it("both paths skip the identical span set on a mixed batch", async () => {
+    const batch = [
+      makeResourceSpan([
+        goodSpanA,
+        spanWithoutTraceId,
+        spanWithThrowingAttribute,
+        spanWithValuelessAttribute,
+        goodSpanB,
+        spanWithoutSpanId,
+      ]),
+    ];
+    const eventRecords = createProcessor().processToEvent(batch as any);
+    const ingestionEvents = await createProcessor().processToIngestionEvents(
+      batch as any,
+    );
+    const survivors = [
+      "aaaaaaaaaaaaaaaa",
+      "bbbbbbbbbbbbbbbb",
+      "cccccccccccccccc",
+    ];
+    expect(eventSpanIds(eventRecords)).toEqual(survivors);
+    expect(observationIds(ingestionEvents)).toEqual(survivors);
+  });
+
+  it("logs one aggregated warning per batch, not one per span", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+    const batch = [
+      makeResourceSpan([
+        goodSpanA,
+        spanWithoutTraceId,
+        spanWithThrowingAttribute,
+      ]),
+    ];
+    createProcessor().processToEvent(batch as any);
+    const skipWarnings = warnSpy.mock.calls.filter(([message]) =>
+      String(message).includes("malformed OTEL span"),
+    );
+    expect(skipWarnings).toHaveLength(1);
+  });
+
+  describe("batch-level catch remains the backstop for non-span-scoped errors", () => {
+    it("processToEvent still throws (preserving retry behavior)", () => {
+      const processor = createProcessor();
+      vi.spyOn(
+        processor as any,
+        "extractResourceAttributes",
+      ).mockImplementation(() => {
+        throw new Error("redis exploded");
+      });
+      expect(() =>
+        processor.processToEvent([makeResourceSpan([goodSpanA])] as any),
+      ).toThrow("redis exploded");
+    });
+
+    it("processToIngestionEvents still swallows and returns []", async () => {
+      const processor = createProcessor();
+      vi.spyOn(
+        processor as any,
+        "filterRedundantShallowTraces",
+      ).mockImplementation(() => {
+        throw new Error("non-span-scoped failure");
+      });
+      await expect(
+        processor.processToIngestionEvents([
+          makeResourceSpan([goodSpanA]),
+        ] as any),
+      ).resolves.toEqual([]);
+    });
+  });
+
+  describe("state consistency under per-span failures", () => {
+    // Throws inside createObservationEvent (span.events is not an array),
+    // i.e. AFTER trace bookkeeping would have run in processSpan.
+    const spanThrowingLate = makeSpan("abadcafeabadcafe", {
+      parentSpanId: "aaaaaaaaaaaaaaaa",
+      events: "not-an-array",
+    });
+    const nonRootSibling = makeSpan("bbbbbbbbbbbbbbb1", {
+      parentSpanId: "aaaaaaaaaaaaaaaa",
+    });
+
+    it("still emits a trace-create when an earlier span of the trace fails mid-conversion", async () => {
+      const events = await createProcessor().processToIngestionEvents([
+        makeResourceSpan([spanThrowingLate, nonRootSibling]),
+      ] as any);
+      expect(observationIds(events)).toEqual(["bbbbbbbbbbbbbbb1"]);
+      const traceEvents = events.filter((e: any) => e.type === "trace-create");
+      expect(traceEvents.map((e: any) => e.body.id)).toEqual([TRACE_ID]);
+    });
+
+    it("tags skips with the conversion path when both paths run on one instance", async () => {
+      const processor = createProcessor();
+      const batch = [makeResourceSpan([spanWithoutSpanId])];
+      processor.processToEvent(batch as any);
+      await processor.processToIngestionEvents(batch as any);
+      const paths = skipMetricCalls()
+        .map(([, , tags]) => tags.path)
+        .sort();
+      expect(paths).toEqual(["event", "ingestion"]);
+    });
+
+    it("accepts plain {data: [...]} ids identically on both paths", async () => {
+      const bufferLikeSpan = {
+        ...makeSpan("unused"),
+        traceId: { data: Array.from(Buffer.from(TRACE_ID, "hex")) },
+        spanId: { data: Array.from(Buffer.from("0102030405060708", "hex")) },
+      };
+      const batch = [makeResourceSpan([bufferLikeSpan])];
+      expect(
+        eventSpanIds(createProcessor().processToEvent(batch as any)),
+      ).toEqual(["0102030405060708"]);
+      expect(
+        observationIds(
+          await createProcessor().processToIngestionEvents(batch as any),
+        ),
+      ).toEqual(["0102030405060708"]);
+    });
+
+    it("does not leak skipped spans from a failed batch into the next flush", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+      const processor = createProcessor();
+      vi.spyOn(
+        processor as any,
+        "filterRedundantShallowTraces",
+      ).mockImplementation(() => {
+        throw new Error("non-span-scoped failure");
+      });
+      await processor.processToIngestionEvents([
+        makeResourceSpan([spanWithoutTraceId, goodSpanA]),
+      ] as any);
+      const warnsAfterFirstCall = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("malformed OTEL span"),
+      ).length;
+      processor.processToEvent([makeResourceSpan([goodSpanA])] as any);
+      const warnsAfterSecondCall = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("malformed OTEL span"),
+      ).length;
+      // The failed batch flushes its own skips; the clean batch adds none.
+      expect(warnsAfterFirstCall).toBe(1);
+      expect(warnsAfterSecondCall).toBe(1);
+    });
+  });
+
+  it("getSeenTracesSet tolerates spans without traceId", async () => {
+    const processor = new OtelIngestionProcessor({
+      projectId: PROJECT_ID,
+      publicKey: "pk-lf-test",
+      sdkName: "test-sdk",
+      sdkVersion: "1.0.0",
+    });
+    // Must not throw while collecting trace ids from malformed spans
+    await expect(
+      (processor as any).getSeenTracesSet([
+        makeResourceSpan([goodSpanA, spanWithoutTraceId]),
+      ]),
+    ).resolves.toBeInstanceOf(Set);
+  });
+});

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -153,6 +153,13 @@ export class OtelIngestionProcessor {
 
   private seenTraces: Set<string> = new Set();
   private isInitialized = false;
+  private skippedSpans: Array<{
+    spanId: string | null;
+    scopeName?: string;
+    path: "event" | "ingestion";
+    reason: string;
+    error?: string;
+  }> = [];
   private traceEventCounts = {
     shallow: 0,
     rootSpanClosed: 0,
@@ -256,295 +263,301 @@ export class OtelIngestionProcessor {
           return [];
         }
 
-        return resourceSpans
+        const events = resourceSpans
           .filter((r) => Boolean(r))
           .flatMap((resourceSpan) => {
             const resourceAttributes =
               this.extractResourceAttributes(resourceSpan);
-            const events: any[] = [];
+            const resourceSpanEvents: any[] = [];
 
             for (const scopeSpan of resourceSpan?.scopeSpans ?? []) {
               const scopeAttributes = this.extractScopeAttributes(scopeSpan);
-              for (const span of scopeSpan?.spans ?? []) {
-                const spanAttributes = this.extractSpanAttributes(span);
-                const traceId = this.parseId(span.traceId);
-                const spanId = this.parseId(span.spanId);
-                const parentSpanId = span?.parentSpanId
-                  ? this.parseId(span.parentSpanId)
-                  : null;
-                const name = this.extractName(span.name, spanAttributes);
-                const { startTimeISO, endTimeISO } =
-                  OtelIngestionProcessor.resolveSpanTimestamps({
-                    startTimeUnixNano: span.startTimeUnixNano,
-                    endTimeUnixNano: span.endTimeUnixNano,
-                  });
-
-                const isLangfuseSDKSpans =
-                  scopeSpan.scope?.name?.startsWith("langfuse-sdk") ?? false;
-
-                // Extract metadata from different sources
-                const spanMetadata = this.extractMetadata(
-                  spanAttributes,
-                  "observation",
-                );
-                const traceMetadata = this.extractMetadata(
-                  spanAttributes,
-                  "trace",
-                );
-
-                const { input, output, filteredAttributes } =
-                  this.extractInputAndOutput({
-                    events: span?.events ?? [],
-                    attributes: spanAttributes,
-                    instrumentationScopeName: scopeSpan?.scope?.name ?? "",
-                  });
-
-                // Construct metadata object with the specified structure
-                // Match v3 path: store full scope object (name, version, attributes)
-                const metadata = {
-                  ...(isLangfuseSDKSpans
-                    ? {}
-                    : { attributes: filteredAttributes }),
-                  resourceAttributes: resourceAttributes,
-                  scope: {
-                    ...(scopeSpan.scope || {}),
-                    attributes: scopeAttributes,
-                  },
-                  // Note: top-level user metadata can overwrite `scope` here.
-                  // This preserves the v3 behavior/shape, even though it means
-                  // the instrumentation scope object is not guaranteed to win.
-                  ...spanMetadata,
-                  ...traceMetadata,
-                };
-                const normalizedTools = normalizeToolsForObservation(
-                  input,
-                  output,
-                  metadata,
-                );
-
-                // Extract instrumentation metadata
-                const serviceName = resourceAttributes?.["service.name"] as
-                  | string
-                  | undefined;
-                const serviceVersion = resourceAttributes?.[
-                  "service.version"
-                ] as string | undefined;
-                const telemetrySdkLanguage = resourceAttributes?.[
-                  "telemetry.sdk.language"
-                ] as string | undefined;
-                const telemetrySdkName = resourceAttributes?.[
-                  "telemetry.sdk.name"
-                ] as string | undefined;
-                const telemetrySdkVersion = resourceAttributes?.[
-                  "telemetry.sdk.version"
-                ] as string | undefined;
-                const scopeName = scopeSpan?.scope?.name;
-                const scopeVersion = scopeSpan?.scope?.version;
-
-                const stringifiedSpan = JSON.stringify(span);
-                const eventBytes = Buffer.byteLength(stringifiedSpan, "utf8");
-
-                recordDistribution(
-                  "langfuse.ingestion.otel.event.byte_length",
-                  eventBytes,
-                  {
-                    source: "otel",
-                    sdk_language: telemetrySdkLanguage || "",
-                  },
-                );
-
-                this.logOversizedSpan(span, spanAttributes, {
-                  spanId,
-                  traceId,
-                  eventBytes,
-                });
-
-                const experimentFields =
-                  this.extractExperimentFields(spanAttributes);
-
-                const spanContext = {
-                  spanId,
-                  traceId,
-                  source: "event" as const,
-                };
-
-                // AI SDK agent spans carry aggregate usage duplicating their
-                // child model-call spans — skip model/usage/cost for them.
-                const isAiSdkAgentSpan =
-                  this.isAiSdkAgentOperation(spanAttributes);
-
-                const usageDetails = UsageDetails.safeParse(
-                  isAiSdkAgentSpan
-                    ? {}
-                    : this.extractUsageDetails(
-                        spanAttributes,
-                        scopeSpan?.scope?.name ?? "",
-                        spanContext,
-                      ),
-                );
-                if (!usageDetails.success) {
-                  logger.warn(
-                    `Invalid usage details extracted from OTEL span for traceId ${traceId}: ${JSON.stringify(usageDetails.error)}`,
-                  );
-                }
-
-                const toolDefinitions =
-                  Object.keys(normalizedTools.toolDefinitions).length > 0
-                    ? normalizedTools.toolDefinitions
-                    : undefined;
-                const toolCalls =
-                  normalizedTools.toolCalls.length > 0
-                    ? normalizedTools.toolCalls
-                    : undefined;
-                const toolCallNames =
-                  normalizedTools.toolCallNames.length > 0
-                    ? normalizedTools.toolCallNames
-                    : undefined;
-
-                const observationType =
-                  observationTypeMapper.mapToObservationType(
-                    spanAttributes,
-                    resourceAttributes,
-                    scopeSpan?.scope,
-                    span.name,
-                  );
-                // Prompts can only be linked to GENERATION observations
-                const canLinkPrompt =
-                  observationType === ObservationType.GENERATION;
-
-                events.push({
-                  projectId: this.projectId,
-                  traceId,
-                  spanId,
-                  parentSpanId,
-
-                  name,
-                  type: observationType,
-                  environment: this.extractEnvironment(
-                    spanAttributes,
-                    resourceAttributes,
+              for (const otelSpan of scopeSpan?.spans ?? []) {
+                resourceSpanEvents.push(
+                  ...this.isolateSpanConversion(
+                    otelSpan,
+                    scopeSpan,
+                    "event",
+                    () => [
+                      this.convertSpanToEventRecord({
+                        span: otelSpan,
+                        scopeSpan,
+                        resourceAttributes,
+                        scopeAttributes,
+                      }),
+                    ],
                   ),
-                  version:
-                    spanAttributes?.[LangfuseOtelSpanAttributes.VERSION] ??
-                    resourceAttributes?.["service.version"] ??
-                    null,
-
-                  startTimeISO,
-                  endTimeISO,
-
-                  level:
-                    spanAttributes[
-                      LangfuseOtelSpanAttributes.OBSERVATION_LEVEL
-                    ] ??
-                    (span.status?.code === 2
-                      ? ObservationLevel.ERROR
-                      : scopeSpan?.scope?.name === "livekit-agents" &&
-                          LIVEKIT_DEBUG_SPAN_NAMES.has(span.name)
-                        ? ObservationLevel.DEBUG
-                        : ObservationLevel.DEFAULT),
-                  statusMessage:
-                    spanAttributes[
-                      LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE
-                    ] ??
-                    span.status?.message ??
-                    null,
-
-                  promptName: canLinkPrompt
-                    ? (spanAttributes?.[
-                        LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME
-                      ] ??
-                      spanAttributes["langfuse.prompt.name"] ??
-                      this.parseLangfusePromptFromAISDK(spanAttributes)?.name ??
-                      null)
-                    : null,
-                  promptVersion: canLinkPrompt
-                    ? (spanAttributes?.[
-                        LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
-                      ] ??
-                      spanAttributes["langfuse.prompt.version"] ??
-                      this.parseLangfusePromptFromAISDK(spanAttributes)
-                        ?.version ??
-                      null)
-                    : null,
-
-                  modelParameters: this.extractModelParameters(
-                    spanAttributes,
-                    scopeSpan?.scope?.name ?? "",
-                  ),
-                  modelName: isAiSdkAgentSpan
-                    ? undefined
-                    : this.extractModelName(spanAttributes),
-                  completionStartTime: this.extractCompletionStartTime(
-                    spanAttributes,
-                    startTimeISO,
-                  ),
-
-                  // Usage and cost details
-                  providedUsageDetails: usageDetails.success
-                    ? usageDetails.data
-                    : undefined,
-                  providedCostDetails: isAiSdkAgentSpan
-                    ? {}
-                    : this.extractCostDetails(spanAttributes, spanContext),
-
-                  // Properties
-                  tags: this.extractTags(spanAttributes),
-                  public: this.extractPublic(spanAttributes),
-                  isAppRoot: this.extractIsAppRoot(spanAttributes),
-                  traceName:
-                    spanAttributes?.[LangfuseOtelSpanAttributes.TRACE_NAME] ??
-                    null,
-                  userId: this.extractUserId(spanAttributes),
-                  sessionId: this.extractSessionId(spanAttributes),
-                  release:
-                    (spanAttributes?.[
-                      LangfuseOtelSpanAttributes.RELEASE
-                    ] as string) ??
-                    resourceAttributes?.[LangfuseOtelSpanAttributes.RELEASE] ??
-                    null,
-
-                  input: normalizedTools.input,
-                  output: normalizedTools.output,
-
-                  // Metadata
-                  metadata: normalizedTools.metadata,
-
-                  // Instrumentation metadata
-                  source: "otel",
-                  ingestionApiKey: this.publicKey,
-                  ingestionSdkName: this.sdkName,
-                  ingestionSdkVersion: this.sdkVersion,
-                  serviceName,
-                  serviceVersion,
-                  scopeName,
-                  scopeVersion,
-                  telemetrySdkLanguage,
-                  telemetrySdkName,
-                  telemetrySdkVersion,
-
-                  // Source data
-                  // eventRaw: stringifiedSpan,
-                  eventBytes,
-
-                  // Experiment fields
-                  ...experimentFields,
-
-                  // Tool calling
-                  toolDefinitions,
-                  toolCalls,
-                  toolCallNames,
-                });
+                );
               }
             }
 
-            return events;
+            return resourceSpanEvents;
           });
+
+        this.flushSkippedSpanWarning();
+        return events;
       } catch (error) {
+        this.flushSkippedSpanWarning();
         logger.error("Error processing OTEL spans to events:", error);
         traceException(error, span);
         throw error;
       }
     });
+  }
+
+  private convertSpanToEventRecord(params: {
+    span: any;
+    scopeSpan: any;
+    resourceAttributes: Record<string, unknown>;
+    scopeAttributes: Record<string, unknown>;
+  }): any {
+    const { span, scopeSpan, resourceAttributes, scopeAttributes } = params;
+    const spanAttributes = this.extractSpanAttributes(span);
+    // Unwrap {data: [...]} like the v3 path (processSpan) so both paths
+    // accept and skip the identical span set
+    const traceId = this.parseId(span.traceId?.data ?? span.traceId);
+    const spanId = this.parseId(span.spanId?.data ?? span.spanId);
+    const parentSpanId = span?.parentSpanId
+      ? this.parseId(span.parentSpanId?.data ?? span.parentSpanId)
+      : null;
+    const name = this.extractName(span.name, spanAttributes);
+    const { startTimeISO, endTimeISO } =
+      OtelIngestionProcessor.resolveSpanTimestamps({
+        startTimeUnixNano: span.startTimeUnixNano,
+        endTimeUnixNano: span.endTimeUnixNano,
+      });
+
+    const isLangfuseSDKSpans =
+      scopeSpan.scope?.name?.startsWith("langfuse-sdk") ?? false;
+
+    // Extract metadata from different sources
+    const spanMetadata = this.extractMetadata(spanAttributes, "observation");
+    const traceMetadata = this.extractMetadata(spanAttributes, "trace");
+
+    const { input, output, filteredAttributes } = this.extractInputAndOutput({
+      events: span?.events ?? [],
+      attributes: spanAttributes,
+      instrumentationScopeName: scopeSpan?.scope?.name ?? "",
+    });
+
+    // Construct metadata object with the specified structure
+    // Match v3 path: store full scope object (name, version, attributes)
+    const metadata = {
+      ...(isLangfuseSDKSpans ? {} : { attributes: filteredAttributes }),
+      resourceAttributes: resourceAttributes,
+      scope: {
+        ...(scopeSpan.scope || {}),
+        attributes: scopeAttributes,
+      },
+      // Note: top-level user metadata can overwrite `scope` here.
+      // This preserves the v3 behavior/shape, even though it means
+      // the instrumentation scope object is not guaranteed to win.
+      ...spanMetadata,
+      ...traceMetadata,
+    };
+    const normalizedTools = normalizeToolsForObservation(
+      input,
+      output,
+      metadata,
+    );
+
+    // Extract instrumentation metadata
+    const serviceName = resourceAttributes?.["service.name"] as
+      | string
+      | undefined;
+    const serviceVersion = resourceAttributes?.["service.version"] as
+      | string
+      | undefined;
+    const telemetrySdkLanguage = resourceAttributes?.[
+      "telemetry.sdk.language"
+    ] as string | undefined;
+    const telemetrySdkName = resourceAttributes?.["telemetry.sdk.name"] as
+      | string
+      | undefined;
+    const telemetrySdkVersion = resourceAttributes?.[
+      "telemetry.sdk.version"
+    ] as string | undefined;
+    const scopeName = scopeSpan?.scope?.name;
+    const scopeVersion = scopeSpan?.scope?.version;
+
+    const stringifiedSpan = JSON.stringify(span);
+    const eventBytes = Buffer.byteLength(stringifiedSpan, "utf8");
+
+    recordDistribution(
+      "langfuse.ingestion.otel.event.byte_length",
+      eventBytes,
+      {
+        source: "otel",
+        sdk_language: telemetrySdkLanguage || "",
+      },
+    );
+
+    this.logOversizedSpan(span, spanAttributes, {
+      spanId,
+      traceId,
+      eventBytes,
+    });
+
+    const experimentFields = this.extractExperimentFields(spanAttributes);
+
+    const spanContext = {
+      spanId,
+      traceId,
+      source: "event" as const,
+    };
+
+    // AI SDK agent spans carry aggregate usage duplicating their
+    // child model-call spans — skip model/usage/cost for them.
+    const isAiSdkAgentSpan = this.isAiSdkAgentOperation(spanAttributes);
+
+    const usageDetails = UsageDetails.safeParse(
+      isAiSdkAgentSpan
+        ? {}
+        : this.extractUsageDetails(
+            spanAttributes,
+            scopeSpan?.scope?.name ?? "",
+            spanContext,
+          ),
+    );
+    if (!usageDetails.success) {
+      logger.warn(
+        `Invalid usage details extracted from OTEL span for traceId ${traceId}: ${JSON.stringify(usageDetails.error)}`,
+      );
+    }
+
+    const toolDefinitions =
+      Object.keys(normalizedTools.toolDefinitions).length > 0
+        ? normalizedTools.toolDefinitions
+        : undefined;
+    const toolCalls =
+      normalizedTools.toolCalls.length > 0
+        ? normalizedTools.toolCalls
+        : undefined;
+    const toolCallNames =
+      normalizedTools.toolCallNames.length > 0
+        ? normalizedTools.toolCallNames
+        : undefined;
+
+    const observationType = observationTypeMapper.mapToObservationType(
+      spanAttributes,
+      resourceAttributes,
+      scopeSpan?.scope,
+      span.name,
+    );
+    // Prompts can only be linked to GENERATION observations
+    const canLinkPrompt = observationType === ObservationType.GENERATION;
+
+    return {
+      projectId: this.projectId,
+      traceId,
+      spanId,
+      parentSpanId,
+
+      name,
+      type: observationType,
+      environment: this.extractEnvironment(spanAttributes, resourceAttributes),
+      version:
+        spanAttributes?.[LangfuseOtelSpanAttributes.VERSION] ??
+        resourceAttributes?.["service.version"] ??
+        null,
+
+      startTimeISO,
+      endTimeISO,
+
+      level:
+        spanAttributes[LangfuseOtelSpanAttributes.OBSERVATION_LEVEL] ??
+        (span.status?.code === 2
+          ? ObservationLevel.ERROR
+          : scopeSpan?.scope?.name === "livekit-agents" &&
+              LIVEKIT_DEBUG_SPAN_NAMES.has(span.name)
+            ? ObservationLevel.DEBUG
+            : ObservationLevel.DEFAULT),
+      statusMessage:
+        spanAttributes[LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE] ??
+        span.status?.message ??
+        null,
+
+      promptName: canLinkPrompt
+        ? (spanAttributes?.[
+            LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME
+          ] ??
+          spanAttributes["langfuse.prompt.name"] ??
+          this.parseLangfusePromptFromAISDK(spanAttributes)?.name ??
+          null)
+        : null,
+      promptVersion: canLinkPrompt
+        ? (spanAttributes?.[
+            LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+          ] ??
+          spanAttributes["langfuse.prompt.version"] ??
+          this.parseLangfusePromptFromAISDK(spanAttributes)?.version ??
+          null)
+        : null,
+
+      modelParameters: this.extractModelParameters(
+        spanAttributes,
+        scopeSpan?.scope?.name ?? "",
+      ),
+      modelName: isAiSdkAgentSpan
+        ? undefined
+        : this.extractModelName(spanAttributes),
+      completionStartTime: this.extractCompletionStartTime(
+        spanAttributes,
+        startTimeISO,
+      ),
+
+      // Usage and cost details
+      providedUsageDetails: usageDetails.success
+        ? usageDetails.data
+        : undefined,
+      providedCostDetails: isAiSdkAgentSpan
+        ? {}
+        : this.extractCostDetails(spanAttributes, spanContext),
+
+      // Properties
+      tags: this.extractTags(spanAttributes),
+      public: this.extractPublic(spanAttributes),
+      isAppRoot: this.extractIsAppRoot(spanAttributes),
+      traceName:
+        spanAttributes?.[LangfuseOtelSpanAttributes.TRACE_NAME] ?? null,
+      userId: this.extractUserId(spanAttributes),
+      sessionId: this.extractSessionId(spanAttributes),
+      release:
+        (spanAttributes?.[LangfuseOtelSpanAttributes.RELEASE] as string) ??
+        resourceAttributes?.[LangfuseOtelSpanAttributes.RELEASE] ??
+        null,
+
+      input: normalizedTools.input,
+      output: normalizedTools.output,
+
+      // Metadata
+      metadata: normalizedTools.metadata,
+
+      // Instrumentation metadata
+      source: "otel",
+      ingestionApiKey: this.publicKey,
+      ingestionSdkName: this.sdkName,
+      ingestionSdkVersion: this.sdkVersion,
+      serviceName,
+      serviceVersion,
+      scopeName,
+      scopeVersion,
+      telemetrySdkLanguage,
+      telemetrySdkName,
+      telemetrySdkVersion,
+
+      // Source data
+      // eventRaw: stringifiedSpan,
+      eventBytes,
+
+      // Experiment fields
+      ...experimentFields,
+
+      // Tool calling
+      toolDefinitions,
+      toolCalls,
+      toolCallNames,
+    };
   }
 
   /**
@@ -591,6 +604,8 @@ export class OtelIngestionProcessor {
           // Filter out redundant shallow trace events
           const finalEvents = this.filterRedundantShallowTraces(allEvents);
 
+          this.flushSkippedSpanWarning();
+
           span.setAttribute("events_generated", finalEvents.length);
 
           this.traceEventCounts.shallow = Math.max(
@@ -611,6 +626,7 @@ export class OtelIngestionProcessor {
 
           return finalEvents;
         } catch (error) {
+          this.flushSkippedSpanWarning();
           if (error instanceof ForbiddenError) {
             traceException(error, span);
             throw error;
@@ -758,12 +774,18 @@ export class OtelIngestionProcessor {
       }
 
       for (const span of scopeSpan?.spans ?? []) {
-        const spanEvents = this.processSpan(
+        const spanEvents = this.isolateSpanConversion(
           span,
           scopeSpan,
-          resourceAttributes,
-          scopeAttributes,
-          isLangfuseSDKSpans,
+          "ingestion",
+          () =>
+            this.processSpan(
+              span,
+              scopeSpan,
+              resourceAttributes,
+              scopeAttributes,
+              isLangfuseSDKSpans,
+            ),
         );
         events.push(...spanEvents);
       }
@@ -808,7 +830,29 @@ export class OtelIngestionProcessor {
     const hasTraceUpdates = this.hasTraceUpdates(attributes);
 
     // Handle trace creation logic with internal seen traces management
-    if (isRootSpan || hasTraceUpdates || !this.seenTraces.has(traceId)) {
+    const shouldCreateTraceEvent =
+      isRootSpan || hasTraceUpdates || !this.seenTraces.has(traceId);
+
+    // Build the observation event BEFORE creating the trace event and
+    // mutating seenTraces: conversion throws are caught per-span by
+    // isolateSpanConversion, and a throw after the seenTraces mutation would
+    // suppress the trace-create event for all later spans of this trace.
+    const observationEvent = this.createObservationEvent({
+      span,
+      traceId,
+      parentObservationId,
+      attributes,
+      resourceAttributes,
+      resourceAttributeMetadata,
+      spanAttributeMetadata,
+      scopeSpan,
+      scopeAttributes,
+      isLangfuseSDKSpans,
+      startTimeISO,
+      endTimeISO,
+    });
+
+    if (shouldCreateTraceEvent) {
       const traceEvent = this.createTraceEvent({
         traceId,
         startTimeISO,
@@ -829,21 +873,6 @@ export class OtelIngestionProcessor {
       this.seenTraces.add(traceId);
     }
 
-    // Create observation event
-    const observationEvent = this.createObservationEvent({
-      span,
-      traceId,
-      parentObservationId,
-      attributes,
-      resourceAttributes,
-      resourceAttributeMetadata,
-      spanAttributeMetadata,
-      scopeSpan,
-      scopeAttributes,
-      isLangfuseSDKSpans,
-      startTimeISO,
-      endTimeISO,
-    });
     events.push(observationEvent);
 
     return events;
@@ -1170,7 +1199,9 @@ export class OtelIngestionProcessor {
   ): Record<string, unknown> {
     return (
       resourceSpan?.resource?.attributes?.reduce((acc: any, attr: any) => {
-        acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+        if (attr?.value != null) {
+          acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+        }
         return acc;
       }, {}) ?? {}
     );
@@ -1179,7 +1210,9 @@ export class OtelIngestionProcessor {
   private extractScopeAttributes(scopeSpan: any): Record<string, unknown> {
     return (
       scopeSpan?.scope?.attributes?.reduce((acc: any, attr: any) => {
-        acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+        if (attr?.value != null) {
+          acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+        }
         return acc;
       }, {}) ?? {}
     );
@@ -1188,7 +1221,9 @@ export class OtelIngestionProcessor {
   private extractSpanAttributes(span: any): Record<string, unknown> {
     return (
       span?.attributes?.reduce((acc: any, attr: any) => {
-        acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+        if (attr?.value != null) {
+          acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+        }
         return acc;
       }, {}) ?? {}
     );
@@ -1333,6 +1368,10 @@ export class OtelIngestionProcessor {
   }
 
   private convertValueToPlainJavascript(value: Record<string, any>): any {
+    // OTLP AnyValue may legally arrive with no value field set
+    if (value == null) {
+      return null;
+    }
     if (value.stringValue !== undefined) {
       return value.stringValue;
     }
@@ -1703,7 +1742,9 @@ export class OtelIngestionProcessor {
       const eventAttributes: Record<string, unknown> =
         event.attributes?.reduce(
           (acc: Record<string, unknown>, attr: any) => {
-            acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+            if (attr?.value != null) {
+              acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+            }
             return acc;
           },
           {} as Record<string, unknown>,
@@ -1734,9 +1775,11 @@ export class OtelIngestionProcessor {
           ? inputEvents.map((event: any) => {
               const eventAttributes =
                 event.attributes?.reduce((acc: any, attr: any) => {
-                  acc[attr.key] = this.convertValueToPlainJavascript(
-                    attr.value,
-                  );
+                  if (attr?.value != null) {
+                    acc[attr.key] = this.convertValueToPlainJavascript(
+                      attr.value,
+                    );
+                  }
                   return acc;
                 }, {}) ?? {};
 
@@ -1752,9 +1795,11 @@ export class OtelIngestionProcessor {
           ? outputEvents.map((event: any) => {
               const eventAttributes =
                 event.attributes?.reduce((acc: any, attr: any) => {
-                  acc[attr.key] = this.convertValueToPlainJavascript(
-                    attr.value,
-                  );
+                  if (attr?.value != null) {
+                    acc[attr.key] = this.convertValueToPlainJavascript(
+                      attr.value,
+                    );
+                  }
                   return acc;
                 }, {}) ?? {};
 
@@ -1786,12 +1831,16 @@ export class OtelIngestionProcessor {
     if (input || output) {
       input =
         input?.reduce((acc: any, attr: any) => {
-          acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+          if (attr?.value != null) {
+            acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+          }
           return acc;
         }, {}) ?? {};
       output =
         output?.reduce((acc: any, attr: any) => {
-          acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+          if (attr?.value != null) {
+            acc[attr.key] = this.convertValueToPlainJavascript(attr.value);
+          }
           return acc;
         }, {}) ?? {};
 
@@ -3000,7 +3049,10 @@ export class OtelIngestionProcessor {
       resourceSpans.forEach((resourceSpan) => {
         for (const scopeSpan of resourceSpan?.scopeSpans ?? []) {
           for (const span of scopeSpan?.spans ?? []) {
-            traceIds.add(this.parseId(span.traceId?.data ?? span.traceId));
+            const rawTraceId = span?.traceId?.data ?? span?.traceId;
+            if (OtelIngestionProcessor.isParseableId(rawTraceId)) {
+              traceIds.add(this.parseId(rawTraceId));
+            }
           }
         }
       });
@@ -3040,7 +3092,121 @@ export class OtelIngestionProcessor {
   private parseId(data: any): string {
     // JS SDK sends IDs already in hex strings
     // Python SDK sends Int array
-    return typeof data === "string" ? data : Buffer.from(data).toString("hex");
+    if (typeof data === "string") {
+      return data;
+    }
+    if (data == null) {
+      // Callers must skip id-less spans via isolateSpanConversion; this
+      // throw is only reached on unexpected call paths.
+      throw new Error("Cannot parse missing OTEL span/trace id");
+    }
+    return Buffer.from(data).toString("hex");
+  }
+
+  /**
+   * Runs a single span's conversion in isolation so one malformed span cannot
+   * discard its siblings (one OTLP POST = one batch = up to ~512 spans).
+   * Spans without parseable ids are skipped up front — they cannot be stored.
+   * Any conversion throw skips only that span; the batch-level catches in
+   * processToEvent/processToIngestionEvents remain as backstop for
+   * non-span-scoped errors. A skipped span may be the parent of others; its
+   * children still ingest (as orphans) rather than cascading the skip.
+   */
+  private isolateSpanConversion<T>(
+    span: any,
+    scopeSpan: any,
+    path: "event" | "ingestion",
+    convert: () => T[],
+  ): T[] {
+    const skipReason = OtelIngestionProcessor.getSpanSkipReason(span);
+    if (skipReason) {
+      this.recordSkippedSpan(span, scopeSpan, path, skipReason);
+      return [];
+    }
+    try {
+      return convert();
+    } catch (error) {
+      this.recordSkippedSpan(span, scopeSpan, path, "conversion_error", error);
+      return [];
+    }
+  }
+
+  private static getSpanSkipReason(span: any): string | null {
+    if (span == null || typeof span !== "object") {
+      return "span_not_object";
+    }
+    if (
+      !OtelIngestionProcessor.isParseableId(span.traceId?.data ?? span.traceId)
+    ) {
+      return "missing_trace_id";
+    }
+    if (
+      !OtelIngestionProcessor.isParseableId(span.spanId?.data ?? span.spanId)
+    ) {
+      return "missing_span_id";
+    }
+    return null;
+  }
+
+  // Accepts every id shape parseId handled before per-span isolation existed
+  // (including empty strings/arrays) so only previously-crashing spans skip.
+  private static isParseableId(data: unknown): boolean {
+    return (
+      typeof data === "string" ||
+      Array.isArray(data) ||
+      data instanceof Uint8Array
+    );
+  }
+
+  private recordSkippedSpan(
+    span: any,
+    scopeSpan: any,
+    path: "event" | "ingestion",
+    reason: string,
+    error?: unknown,
+  ): void {
+    // The worker runs both conversion paths over the same batch, so each
+    // malformed span is recorded once per path — the path tag keeps the
+    // counts distinguishable and surfaces path divergence.
+    recordIncrement(OtelIngestionProcessor.OTEL_CONVERSION_FAILURE_METRIC, 1, {
+      failure_type: "span_skipped",
+      reason,
+      path,
+      project_id: this.projectId,
+    });
+    const rawSpanId = span?.spanId?.data ?? span?.spanId;
+    this.skippedSpans.push({
+      spanId: OtelIngestionProcessor.isParseableId(rawSpanId)
+        ? this.parseId(rawSpanId)
+        : null,
+      scopeName: scopeSpan?.scope?.name,
+      path,
+      reason,
+      ...(error instanceof Error ? { error: error.message } : {}),
+    });
+  }
+
+  /**
+   * Logs one aggregated warning per batch for all skipped spans so a
+   * systematically malformed SDK stays visible without log spam.
+   */
+  private flushSkippedSpanWarning(): void {
+    if (this.skippedSpans.length === 0) return;
+    const reasonCounts: Record<string, number> = {};
+    for (const skipped of this.skippedSpans) {
+      reasonCounts[skipped.reason] = (reasonCounts[skipped.reason] ?? 0) + 1;
+    }
+    logger.warn(
+      `Skipped ${this.skippedSpans.length} malformed OTEL span(s) during conversion`,
+      {
+        projectId: this.projectId,
+        reasonCounts,
+        spans: this.skippedSpans.slice(0, 20),
+        sdkName: this.sdkName,
+        sdkVersion: this.sdkVersion,
+      },
+    );
+    this.skippedSpans = [];
   }
 
   /**


### PR DESCRIPTION
## What does this PR do?

One malformed span currently discards its **entire OTLP batch** (one POST = one S3 file = one worker job; typically 1–512 spans with OTel `BatchSpanProcessor` defaults) on both conversion paths of `OtelIngestionProcessor`:

- `processToIngestionEvents`: the batch-level catch swallows the error and returns `[]` → every span in the batch is silently dropped from traces/observations.
- `processToEvent`: the batch-level catch rethrows → the BullMQ job retries a deterministic error (observed: 6 attempts), then abandons the batch.

Observed in production with two malformation shapes: a span attribute with a `key` but no `value` field (legal in OTLP protobuf), and spans without `traceId`/`spanId`.

### Changes

1. **Null guards at the known crash sites** — attribute reduces skip valueless attributes; `convertValueToPlainJavascript` tolerates nullish values; `getSeenTracesSet` skips unparseable trace ids; `parseId` throws a descriptive error instead of crashing inside `Buffer.from`.
2. **Per-span failure isolation** — both paths route every span through a shared `isolateSpanConversion` guard: spans with unparseable ids are skipped up front, and any conversion throw skips only that span. The shared guard plus identical `{data: [...]}` unwrapping on both paths guarantees **both paths skip the identical span set**, keeping the traces/observations store and the events table consistent.
3. **Observability** — every skipped span increments `langfuse.ingestion.otel.conversion_failure` with `failure_type=span_skipped`, `reason` (`missing_trace_id` | `missing_span_id` | `conversion_error` | `span_not_object`), the conversion `path` (`event` | `ingestion`), and `project_id`. One aggregated warning is logged per batch/path with span ids (where parseable), scope name, and SDK attribution.
4. **State-consistency hardening** — `processSpan` now builds the observation event *before* creating the trace event and mutating `seenTraces`, so a mid-conversion throw cannot suppress the trace-create event for later sibling spans of the same trace.

### Accepted trade-offs

- **Silently incomplete traces**: a skipped span may be the parent/root of others — children still ingest (as orphans) and root-derived trace fields (userId, sessionId, tags) may be lost. Partial ingestion beats losing the whole batch; children are deliberately not cascade-skipped.
- **Backstop preserved**: batch-level catches still handle non-span-scoped errors (e.g. Redis failures), preserving current retry behavior on both paths (covered by tests).
- **Keep it loud**: deterministic parse errors no longer page via job failures; the `conversion_failure` metric with `reason`/`path` tags is the alerting hook. Adding a monitor threshold is a follow-up so a systematically buggy SDK release cannot degrade into silent 100% span-skipping.
- **Replay semantics**: previously a failed batch was atomically absent, so replaying its S3 file after a fix ingested it exactly once. With partial ingestion, replay re-ingests already-succeeded spans — benign under `IngestionService.mergeAndWrite` upsert semantics.
- The metric fires once per path per skipped span (the worker runs both paths over the same batch); the `path` tag keeps counts distinguishable and doubles as a path-divergence detector.

Fixes LFE-10870.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective (failing-first: batch isolation, identical skip sets on both paths, metric/warning assertions, batch-level backstop regression)
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds per-span failure isolation to the OTLP ingestion pipeline: instead of one malformed span aborting the entire batch, each span is now wrapped in `isolateSpanConversion`, which silently drops only that span and accumulates a single aggregated warning per batch via the new `skippedSpans` instance buffer.

- **`isolateSpanConversion`** validates parseable `traceId`/`spanId` up front (via `getSpanSkipReason` / `isParseableId`), then wraps the conversion callback in a try/catch, recording each skip with a reason tag (`missing_trace_id`, `missing_span_id`, `conversion_error`) and incrementing a metric; `flushSkippedSpanWarning` is called on both the success and error paths in `processToEvent` and `processToIngestionEvents`.
- **`processSpan` reordering**: `createObservationEvent` is now called *before* `seenTraces.add(traceId)`, so a throw inside observation creation no longer silently marks the trace as seen, which previously would have suppressed a `trace-create` event for all later spans of the same trace.
- **Null guards** added to all attribute-reduction loops (`extractResourceAttributes`, `extractScopeAttributes`, `extractSpanAttributes`, event attribute loops) to silently drop attributes that arrive with a key but no value, matching legal OTLP protobuf semantics.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the isolation wrapper is correctly guarded by both an upfront ID check and a per-span try/catch, and the skippedSpans buffer is flushed on every success and error code path in both public methods.

The reordering of createObservationEvent before seenTraces.add is the most behaviorally sensitive change, but the logic is sound and the test 'still emits a trace-create when an earlier span of the trace fails mid-conversion' directly validates it. The isParseableId design choice of passing empty strings/arrays through is documented but could produce odd data for pathological inputs. The byte-length metric is emitted before the span is known to succeed, creating a minor count inflation for dropped spans.

No files require special attention. The two observations in OtelIngestionProcessor.ts are minor and well-contained.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as OTLP Client
    participant PE as processToEvent / processToIngestionEvents
    participant ISC as isolateSpanConversion
    participant GSR as getSpanSkipReason
    participant Conv as convertSpanToEventRecord / processSpan
    participant SS as skippedSpans[]
    participant FL as flushSkippedSpanWarning

    Client->>PE: POST /otlp (batch of spans)
    loop for each span in batch
        PE->>ISC: isolateSpanConversion(span, scopeSpan, path, convert)
        ISC->>GSR: getSpanSkipReason(span)
        alt traceId / spanId missing or unparseable
            GSR-->>ISC: missing_trace_id or missing_span_id
            ISC->>SS: recordSkippedSpan(reason, path)
            ISC-->>PE: [] (span dropped)
        else span passes id checks
            GSR-->>ISC: null
            ISC->>Conv: convert()
            alt conversion succeeds
                Conv-->>ISC: [event(s)]
                ISC-->>PE: [event(s)]
            else conversion throws
                Conv-->>ISC: throws
                ISC->>SS: recordSkippedSpan(conversion_error, path)
                ISC-->>PE: [] (span dropped)
            end
        end
    end
    PE->>FL: flushSkippedSpanWarning()
    FL->>SS: aggregate reasons, log once, clear []
    PE-->>Client: all surviving events
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as OTLP Client
    participant PE as processToEvent / processToIngestionEvents
    participant ISC as isolateSpanConversion
    participant GSR as getSpanSkipReason
    participant Conv as convertSpanToEventRecord / processSpan
    participant SS as skippedSpans[]
    participant FL as flushSkippedSpanWarning

    Client->>PE: POST /otlp (batch of spans)
    loop for each span in batch
        PE->>ISC: isolateSpanConversion(span, scopeSpan, path, convert)
        ISC->>GSR: getSpanSkipReason(span)
        alt traceId / spanId missing or unparseable
            GSR-->>ISC: missing_trace_id or missing_span_id
            ISC->>SS: recordSkippedSpan(reason, path)
            ISC-->>PE: [] (span dropped)
        else span passes id checks
            GSR-->>ISC: null
            ISC->>Conv: convert()
            alt conversion succeeds
                Conv-->>ISC: [event(s)]
                ISC-->>PE: [event(s)]
            else conversion throws
                Conv-->>ISC: throws
                ISC->>SS: recordSkippedSpan(conversion_error, path)
                ISC-->>PE: [] (span dropped)
            end
        end
    end
    PE->>FL: flushSkippedSpanWarning()
    FL->>SS: aggregate reasons, log once, clear []
    PE-->>Client: all surviving events
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/otel/OtelIngestionProcessor.ts:3153-3158
**`isParseableId` passes empty strings and empty arrays through to storage**

`typeof data === "string"` accepts `""`, and `Array.isArray(data)` accepts `[]`. Both pass through `parseId` and become the empty string `""` (`Buffer.from([]).toString("hex")` is `""`). Any span arriving with `traceId: ""` or `traceId: []` is not skipped — it is ingested with `traceId: ""`, which will create an observation and possibly a trace-create event keyed to the empty string. The comment acknowledges this is intentional to preserve backward behaviour; if empty IDs cause downstream data integrity issues (duplicate `""` key collisions across projects), a cheap extra guard like `&& data.length > 0` on the string/array branches would be straightforward to add.

### Issue 2 of 2
packages/shared/src/server/otel/OtelIngestionProcessor.ts:749-765
**`recordDistribution` byte-length metric emitted for spans that are subsequently dropped**

`recordDistribution("langfuse.ingestion.otel.event.byte_length", eventBytes, ...)` runs near the top of `convertSpanToEventRecord`. If the method throws later (e.g. during `normalizeToolsForObservation` or `extractUsageDetails`), `isolateSpanConversion` catches the error and drops the span — but the byte-length metric is already incremented. Over time, this inflates the `event.byte_length` distribution with data from spans that never reached ingestion. Moving the `recordDistribution` call to after the return value is assembled (or after `isolateSpanConversion` confirms success) would keep the metric accurate.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): drop only malformed spans ins..."](https://github.com/langfuse/langfuse/commit/6f635b19bb5aebf379596d7c3e4973b3df21c372) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43765803)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->