### PR TITLE
feat(charts): add `hideXAxisLabels` option to improve readability

### DIFF
--- a/web/src/features/experiments/components/ExperimentChartSlot.tsx
+++ b/web/src/features/experiments/components/ExperimentChartSlot.tsx
@@ -216,6 +216,10 @@ export function ExperimentChartSlot({
             isExternalLoading={isExternalLoading}
             layoutHint="compact"
             entityDimensionLabelMap={entityDimensionLabelMap}
+            // Experiment names are long and add clutter on the x-axis; show them
+            // on hover instead. The axis is always an entity (experiment/run)
+            // dimension here.
+            hideXAxisLabels={Boolean(widgetConfig.entityDimension)}
           />
         ) : (
           <div className="flex h-full items-center justify-center rounded-lg border-2 border-dashed">

--- a/web/src/features/widgets/chart-library/AreaChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/AreaChartTimeSeries.tsx
@@ -49,6 +49,7 @@ export const AreaChartTimeSeries: React.FC<ChartProps> = ({
   subtleFill = false,
   missingValue = "gap",
   connectNulls = false,
+  hideXAxisLabels = false,
 }) => {
   const [selfHovered, setSelfHovered] = useState(false);
   const allDimensions = useMemo(() => getUniqueDimensions(data), [data]);
@@ -83,8 +84,9 @@ export const AreaChartTimeSeries: React.FC<ChartProps> = ({
       prepareTimeAxis(
         groupedData.map((d) => d.time_dimension),
         maxTicks,
+        { hideCategoryTickLabels: hideXAxisLabels },
       ),
-    [groupedData, maxTicks],
+    [groupedData, maxTicks, hideXAxisLabels],
   );
 
   const { legendItems, onLegendClick, isRendered, isDimmed } = useSeriesLegend({

--- a/web/src/features/widgets/chart-library/Chart.tsx
+++ b/web/src/features/widgets/chart-library/Chart.tsx
@@ -49,6 +49,7 @@ const ChartComponent = ({
   metricFormatter: metricFormatterOverride,
   thresholds,
   missingValue,
+  hideXAxisLabels,
 }: {
   chartType: DashboardWidgetChartType;
   data: DataPoint[];
@@ -80,6 +81,13 @@ const ChartComponent = ({
   thresholds?: ChartThreshold[];
   /** See {@link MissingBucketValue}; consumed by line/area time series. */
   missingValue?: MissingBucketValue;
+  /**
+   * Hide x-axis tick labels on a categorical (entity-name) axis; the full name
+   * stays in the hover tooltip. Off by default. Consumed by the time-series
+   * charts and forwarded to `prepareTimeAxis`. Used by the experiments /
+   * dataset-compare charts.
+   */
+  hideXAxisLabels?: boolean;
 }) => {
   const [forceRender, setForceRender] = useState(overrideWarning);
   const shouldWarn = data.length > 2000 && !forceRender;
@@ -134,6 +142,7 @@ const ChartComponent = ({
             showDataPointDots={chartConfig?.show_data_point_dots ?? false}
             thresholds={thresholds}
             missingValue={missingValue}
+            hideXAxisLabels={hideXAxisLabels}
           />
         );
       case "AREA_TIME_SERIES":
@@ -149,6 +158,7 @@ const ChartComponent = ({
             syncId={syncId}
             subtleFill={chartConfig?.subtle_fill}
             missingValue={missingValue}
+            hideXAxisLabels={hideXAxisLabels}
           />
         );
       case "BAR_TIME_SERIES":
@@ -163,6 +173,7 @@ const ChartComponent = ({
             maxVisibleSeries={maxVisibleSeries}
             syncId={syncId}
             subtleFill={chartConfig?.subtle_fill}
+            hideXAxisLabels={hideXAxisLabels}
           />
         );
       case "HORIZONTAL_BAR":

--- a/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
@@ -204,6 +204,7 @@ export const LineChartTimeSeries: React.FC<ChartProps> = ({
   thresholds,
   missingValue = "gap",
   connectNulls = false,
+  hideXAxisLabels = false,
 }) => {
   const metricExtent = useMemo(() => computeMetricExtent(data), [data]);
 
@@ -239,8 +240,9 @@ export const LineChartTimeSeries: React.FC<ChartProps> = ({
       prepareTimeAxis(
         groupedData.map((d) => d.time_dimension),
         maxTicks,
+        { hideCategoryTickLabels: hideXAxisLabels },
       ),
-    [groupedData, maxTicks],
+    [groupedData, maxTicks, hideXAxisLabels],
   );
 
   const {

--- a/web/src/features/widgets/chart-library/VerticalBarChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/VerticalBarChartTimeSeries.tsx
@@ -48,6 +48,7 @@ export const VerticalBarChartTimeSeries: React.FC<ChartProps> = ({
   maxVisibleSeries,
   syncId,
   subtleFill = false,
+  hideXAxisLabels = false,
 }) => {
   const [selfHovered, setSelfHovered] = useState(false);
   const groupedData = useMemo(() => groupDataByTimeDimension(data), [data]);
@@ -66,8 +67,9 @@ export const VerticalBarChartTimeSeries: React.FC<ChartProps> = ({
       prepareTimeAxis(
         groupedData.map((d) => d.time_dimension),
         maxTicks,
+        { hideCategoryTickLabels: hideXAxisLabels },
       ),
-    [groupedData, maxTicks],
+    [groupedData, maxTicks, hideXAxisLabels],
   );
 
   const { legendItems, onLegendClick, isRendered, isDimmed } = useSeriesLegend({

--- a/web/src/features/widgets/chart-library/chart-props.ts
+++ b/web/src/features/widgets/chart-library/chart-props.ts
@@ -142,4 +142,12 @@ export interface ChartProps {
    * gap. (LFE-10694, manifesto V2)
    */
   connectNulls?: boolean;
+  /**
+   * Hide the x-axis tick labels on a categorical (entity-name) axis, keeping the
+   * full name in the hover tooltip. Off by default. Opt in for the experiments /
+   * dataset-compare charts, whose long entity names clutter the axis with little
+   * value. Forwarded to `prepareTimeAxis` as `hideCategoryTickLabels`, so it only
+   * affects a categorical axis — a temporal axis keeps its timestamp labels.
+   */
+  hideXAxisLabels?: boolean;
 }

--- a/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
+++ b/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
@@ -198,6 +198,36 @@ describe("prepareTimeAxis", () => {
     expect(typeof timeAxis.interval).toBe("number");
   });
 
+  it("hideCategoryTickLabels blanks the entity axis but keeps the full name in the tooltip", () => {
+    // Opt-in for the experiments / dataset-compare charts: long entity names are
+    // hidden from the axis and surfaced only on hover.
+    const runs = [
+      "demo-dataset-run-0-demo-english-transcription-dataset",
+      "demo-dataset-run-1-demo-english-transcription-dataset",
+    ];
+    const axis = prepareTimeAxis(runs, 6, { hideCategoryTickLabels: true });
+    expect(axis.mode).toBe("category");
+    // Every tick drawn (interval 0), but the label is blank…
+    expect(axis.interval).toBe(0);
+    expect(axis.formatTick(runs[0])).toBe("");
+    // …no angle needed, just a slim axis…
+    expect(axis.tickProps.angle).toBeUndefined();
+    expect(axis.tickProps.height).toBeGreaterThan(0);
+    // …and the full name is still available for the tooltip.
+    expect(axis.formatTooltip(runs[0])).toBe(runs[0]);
+  });
+
+  it("hideCategoryTickLabels leaves a temporal axis untouched (timestamp labels stay)", () => {
+    const start = Date.UTC(2026, 5, 28, 0);
+    const timeVals = Array.from({ length: 24 }, (_, h) =>
+      iso(start + h * HOUR),
+    );
+    const axis = prepareTimeAxis(timeVals, 6, { hideCategoryTickLabels: true });
+    expect(axis.mode).toBe("time");
+    // The flag only affects the categorical branch — time ticks still render.
+    expect(axis.formatTick(timeVals[0]).length).toBeGreaterThan(0);
+  });
+
   it("does not coerce bare numeric strings into epoch dates", () => {
     expect(parseChartTimestamp("1")).toBeNull();
     expect(parseChartTimestamp("20241230")).toBeNull();

--- a/web/src/features/widgets/chart-library/prepareTimeAxis.ts
+++ b/web/src/features/widgets/chart-library/prepareTimeAxis.ts
@@ -167,11 +167,28 @@ export type TimeAxis = {
   };
 };
 
+/** Options that let a caller override the default axis presentation. */
+export type PrepareTimeAxisOptions = {
+  /**
+   * Hide the tick labels on a categorical (entity-name) axis entirely, keeping
+   * the full name in the tooltip. Off by default: the category branch shows its
+   * (truncated, angled) labels. Opt in for the experiments / dataset-compare
+   * charts, whose long entity names add clutter with little value on the axis
+   * itself, so we surface them only on hover. No effect on a temporal axis,
+   * whose timestamp labels are always useful.
+   */
+  hideCategoryTickLabels?: boolean;
+};
+
 /**
  * Decide the time-axis format + tick spacing for a set of raw bucket values.
  * `maxTicks` is how many labels fit the chart's measured width.
  */
-export function prepareTimeAxis(rawValues: unknown[], maxTicks = 6): TimeAxis {
+export function prepareTimeAxis(
+  rawValues: unknown[],
+  maxTicks = 6,
+  options: PrepareTimeAxisOptions = {},
+): TimeAxis {
   const timestamps: number[] = [];
   for (const value of rawValues) {
     const date = parseChartTimestamp(value);
@@ -189,6 +206,20 @@ export function prepareTimeAxis(rawValues: unknown[], maxTicks = 6): TimeAxis {
   if (!temporal) {
     const full = (raw: unknown): string =>
       raw == null ? "" : typeof raw === "string" ? raw : String(raw);
+    // Opt-in (experiments / dataset-compare): hide the entity names on the axis
+    // entirely and surface the full name on hover instead — the names cluttered
+    // the axis with little value. Nothing to fit, so draw every tick (`0`)
+    // label-less with a slim x-axis height; the tooltip keeps the full name.
+    if (options.hideCategoryTickLabels) {
+      return {
+        interval: 0,
+        formatTick: () => "",
+        formatTooltip: full,
+        mode: "category",
+        showVerticalGrid: false,
+        tickProps: { height: 8 },
+      };
+    }
     return {
       // The fix for the categorical smear (LFE-10583). A numeric interval makes
       // recharts show every Nth tick BY INDEX and skip its label-collision test,

--- a/web/src/features/widgets/components/InlineWidget.tsx
+++ b/web/src/features/widgets/components/InlineWidget.tsx
@@ -75,6 +75,12 @@ export interface WidgetContentProps {
    * Optional presentation-only labels for entity_dimension values.
    */
   entityDimensionLabelMap?: Record<string, string>;
+  /**
+   * Hide x-axis tick labels on a categorical (entity-name) axis; the full name
+   * stays in the hover tooltip. Off by default. Opt in on entity-dimension
+   * charts (experiments) whose long names clutter the axis.
+   */
+  hideXAxisLabels?: boolean;
 }
 
 export interface WidgetHeaderProps {
@@ -180,6 +186,7 @@ export function WidgetContent({
   onSortChange,
   className,
   entityDimensionLabelMap,
+  hideXAxisLabels,
 }: WidgetContentProps) {
   const { isBetaEnabled } = useV4Beta();
   const [retryCount, setRetryCount] = useState(0);
@@ -441,6 +448,7 @@ export function WidgetContent({
         isLoading={queryResult.isPending || isExternalLoading}
         metricFormatter={chartPresentation?.metricFormatter}
         missingValue={getWidgetMissingBucketValue(metrics[0]?.agg ?? "count")}
+        hideXAxisLabels={hideXAxisLabels}
       />
       <ChartLoadingState
         isLoading={chartLoadingState.isLoading}

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare/charts.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare/charts.tsx
@@ -244,6 +244,9 @@ export default function DatasetCompare() {
                             type: chartType,
                             unit: getCompareViewChartUnit(key),
                           }}
+                          // The x-axis is dataset-run names — long and cluttered;
+                          // show them on hover instead of on the axis.
+                          hideXAxisLabels
                         />
                       </div>
                     </div>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `hideXAxisLabels` option to the chart library that suppresses tick labels on categorical (entity-name) x-axes while preserving full names in hover tooltips. It is wired into the experiments slot and dataset-compare view, where long run names cluttered the axis with little value.

- **`prepareTimeAxis`** gains a `PrepareTimeAxisOptions` parameter; when `hideCategoryTickLabels` is true on a non-temporal axis it returns `interval: 0`, a blank `formatTick`, the full name in `formatTooltip`, and a slim 8 px axis height — temporal axes are unaffected.
- **Prop chain**: `hideXAxisLabels` flows from `ChartProps` → `Chart.tsx` → each time-series chart component → `prepareTimeAxis`, with two new tests covering both the categorical and temporal branches.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, opt-in, and isolated to its own axis-preparation path with no impact on existing temporal charts.

The implementation correctly short-circuits the existing categorical-axis path, leaves temporal axes completely unchanged, and is guarded by two new targeted tests. The prop flows cleanly from both call sites through the full chain. No pre-existing behavior is altered.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ExperimentChartSlot\nhideXAxisLabels={Boolean(entityDimension)}"] -->|prop| B["WidgetContent\nInlineWidget.tsx"]
    C["DatasetCompare/charts.tsx\nhideXAxisLabels={true}"] -->|prop| B
    B -->|hideXAxisLabels| D["Chart.tsx\nChartComponent"]
    D -->|LINE_TIME_SERIES| E["LineChartTimeSeries"]
    D -->|AREA_TIME_SERIES| F["AreaChartTimeSeries"]
    D -->|BAR_TIME_SERIES| G["VerticalBarChartTimeSeries"]
    E -->|hideCategoryTickLabels: hideXAxisLabels| H["prepareTimeAxis()"]
    F -->|hideCategoryTickLabels: hideXAxisLabels| H
    G -->|hideCategoryTickLabels: hideXAxisLabels| H
    H --> I{temporal axis?}
    I -->|Yes| J["Normal timestamp labels\ninterval: N, formatTick: date string"]
    I -->|No + hideCategoryTickLabels| K["Hidden labels\ninterval: 0, formatTick: empty, height: 8\nformatTooltip: full name"]
    I -->|No, labels shown| L["Truncated + angled labels\ninterval: equidistantPreserveStart\nheight: 60"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["ExperimentChartSlot\nhideXAxisLabels={Boolean(entityDimension)}"] -->|prop| B["WidgetContent\nInlineWidget.tsx"]
    C["DatasetCompare/charts.tsx\nhideXAxisLabels={true}"] -->|prop| B
    B -->|hideXAxisLabels| D["Chart.tsx\nChartComponent"]
    D -->|LINE_TIME_SERIES| E["LineChartTimeSeries"]
    D -->|AREA_TIME_SERIES| F["AreaChartTimeSeries"]
    D -->|BAR_TIME_SERIES| G["VerticalBarChartTimeSeries"]
    E -->|hideCategoryTickLabels: hideXAxisLabels| H["prepareTimeAxis()"]
    F -->|hideCategoryTickLabels: hideXAxisLabels| H
    G -->|hideCategoryTickLabels: hideXAxisLabels| H
    H --> I{temporal axis?}
    I -->|Yes| J["Normal timestamp labels\ninterval: N, formatTick: date string"]
    I -->|No + hideCategoryTickLabels| K["Hidden labels\ninterval: 0, formatTick: empty, height: 8\nformatTooltip: full name"]
    I -->|No, labels shown| L["Truncated + angled labels\ninterval: equidistantPreserveStart\nheight: 60"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(charts): add \`hideXAxisLabels\` opti..."](https://github.com/langfuse/langfuse/commit/4d3fa297359229cb96476e04e4cc76e0130ae514) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43768220)</sub>

<!-- /greptile_comment -->