### PR TITLE
chore(pricing): improve audit titles and model reports

### DIFF
--- a/.agents/skills/add-model-price/SKILL.md
+++ b/.agents/skills/add-model-price/SKILL.md
@@ -54,6 +54,7 @@ updates in `packages/shared/`.
 | Match patterns                  | You are editing `matchPattern` regexes or provider coverage                           | [references/match-patterns.md](references/match-patterns.md)                                   |
 | Workflow and validation         | You are applying the end-to-end edit process or checking common mistakes              | [references/workflow-and-validation.md](references/workflow-and-validation.md)                 |
 | Automated audit mode            | You are running a scheduled/default-price audit and need CI-safe edit rules           | [references/automated-audit.md](references/automated-audit.md)                                 |
+| Audit memory                    | You need optional per-model context retained from a useful prior automated audit      | [references/model-audit-memory.md](references/model-audit-memory.md)                           |
 
 ## Deterministic Helpers
 

--- a/.agents/skills/add-model-price/references/automated-audit.md
+++ b/.agents/skills/add-model-price/references/automated-audit.md
@@ -16,6 +16,8 @@ report over an uncertain code change.
   `worker/src/constants/default-model-prices.json`
 - Selectable model lists:
   `packages/shared/src/server/llm/types.ts`
+- Optional prior per-model context from
+  `references/model-audit-memory.md`; treat it as orientation, not evidence
 - Official provider pricing pages from
   `references/provider-sources-and-price-keys.md`
 - Deterministic reports from:
@@ -38,10 +40,17 @@ report over an uncertain code change.
    - narrow `matchPattern` additions for documented provider model IDs;
    - required `packages/shared/src/server/llm/types.ts` additions when a newly
      priced model should be selectable.
-5. Capture durable provider-source URLs, model-ID variants, pricing-page quirks,
+5. Add one complete report-table row for every distinct model price entry
+   checked, including confirmed and unchanged entries. Do not collapse multiple
+   checked models into a family-level row.
+6. Capture durable provider-source URLs, model-ID variants, pricing-page quirks,
    or recurring audit rules in the most relevant file under
    `.agents/skills/add-model-price/references/`.
-6. Re-run the validator.
+7. Optionally replace the snapshot in `references/model-audit-memory.md` when
+   retaining the complete current per-model result would materially help a
+   future audit. Do not persist a partial table, append unbounded run history,
+   or update it only to refresh the audit date.
+8. Re-run the validator.
 
 ## Edit Rules
 
@@ -69,6 +78,26 @@ report over an uncertain code change.
   safely, leave the code unchanged and report the limitation.
 
 ## Evidence Required In The Agent Summary
+
+Always include a valid Markdown table with one row per checked model price
+entry and these columns:
+
+| Column                | Required content                                                                                                                                     |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Provider              | Provider whose official source was checked                                                                                                           |
+| Model / pricing entry | Exact model or pricing-entry name reviewed                                                                                                           |
+| Pricing checked       | Every relevant input, output, cache-read, and cache-write price with the provider unit and converted per-token value                                 |
+| Price confirmed       | `Yes` only when official evidence fetched in the current run confirms every current price; otherwise `No`                                            |
+| Tiering checked       | Every applicable tier name, threshold, and condition, or a statement that no provider tiering applies                                                |
+| Tiering correct       | `Yes` when every applicable threshold and tier price is confirmed, `No` when it is not, or `N/A` only when no provider tiering dimension applies     |
+| Change                | `None`, `Updated`, `Added`, or `Unresolved`                                                                                                          |
+| Official source(s)    | Every official URL used for the row                                                                                                                  |
+| Comments              | Units, conversions, tier thresholds, corrections, uncertainty, or why no change was made; use an em dash only when there is genuinely nothing to add |
+
+The table is required even when every checked price is confirmed and unchanged.
+Do not mark prices or tiering confirmed based only on the optional audit memory.
+The final report must use valid Markdown syntax and be checked for malformed
+tables, links, lists, backticks, or code fences.
 
 For every changed model, include:
 

--- a/.agents/skills/add-model-price/references/model-audit-memory.md
+++ b/.agents/skills/add-model-price/references/model-audit-memory.md
@@ -1,0 +1,24 @@
+# Model Price Audit Memory
+
+This file is an optional snapshot of the latest automated audit whose
+per-model results add useful context for a future run. It is orientation only;
+reconfirm every price and tier against official provider sources before making
+a change or reporting a row as confirmed.
+
+The audit agent may replace the snapshot below with its complete current table.
+Keep only one snapshot, never append an unbounded run history, never persist a
+partial set of checked models, and do not update this file only to refresh the
+date.
+
+## Latest useful snapshot
+
+No audit snapshot has been persisted yet.
+
+When retaining a snapshot, replace the sentence above with an audit date and
+this table:
+
+**Audit date:** YYYY-MM-DD
+
+| Provider | Model / pricing entry        | Pricing checked                                          | Price confirmed | Tiering checked                        | Tiering correct | Change                              | Official source(s) | Comments                                         |
+| -------- | ---------------------------- | -------------------------------------------------------- | --------------- | -------------------------------------- | --------------- | ----------------------------------- | ------------------ | ------------------------------------------------ |
+| Provider | Exact model or pricing entry | Input, output, and cache prices with unit and conversion | Yes or No       | Tier names, thresholds, and conditions | Yes, No, or N/A | None, Updated, Added, or Unresolved | Official links     | Corrections, uncertainty, or no-change rationale |

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -47,7 +47,6 @@ concurrency:
 
 env:
   BOT_BRANCH: model-price-audit-bot
-  PR_TITLE: "chore(pricing): update default model prices"
 
 jobs:
   audit:
@@ -184,6 +183,7 @@ jobs:
             Read and follow:
             - .agents/skills/add-model-price/SKILL.md
             - .agents/skills/add-model-price/references/automated-audit.md
+            - .agents/skills/add-model-price/references/model-audit-memory.md
             - .agents/skills/add-model-price/references/provider-sources-and-price-keys.md
             - .agents/skills/add-model-price/references/workflow-and-validation.md
 
@@ -198,10 +198,12 @@ jobs:
             2. Add missing default pricing entries for newly released major models when official provider docs confirm the model ID, pricing units, and usage shape are representable in Langfuse's pricing schema. Update `packages/shared/src/server/llm/types.ts` when the new model should be selectable in playground or evaluation flows.
             3. Make only surgical edits with official provider evidence.
             4. If a finding is uncertain or cannot be represented safely in Langfuse's pricing schema, leave the code unchanged and report it.
-            5. If you learn durable provider-source URLs, pricing-page quirks, model-ID variants, or recurring audit rules that would help future audits, update only the pricing skill reference files under `.agents/skills/add-model-price/references/*.md`.
-            6. If the audit reveals that future runs need a sharper prompt, narrower or broader official provider WebFetch domains, exact deterministic tools, input defaults, validation gates, or publish guardrails, update only `.github/workflows/model-price-audit.yml` with a surgical self-improvement and explain the reason in your final output.
-            7. Re-run the deterministic validation script before finishing.
-            8. If you change any `matchPattern`, run the bundled match-pattern tester with representative accepted and rejected model IDs before finishing.
+            5. Record every distinct model price entry you check in `modelsChecked`; do not omit confirmed or unchanged models and do not collapse multiple checked models into one family row.
+            6. If you learn durable provider-source URLs, pricing-page quirks, model-ID variants, or recurring audit rules that would help future audits, update only the pricing skill reference files under `.agents/skills/add-model-price/references/*.md`.
+            7. You may replace the optional snapshot in `.agents/skills/add-model-price/references/model-audit-memory.md` with the complete `modelsChecked` table when retaining the current per-model evidence would materially help a future audit. Do not persist a partial table, append unbounded run history, or update the file only to refresh its date.
+            8. If the audit reveals that future runs need a sharper prompt, narrower or broader official provider WebFetch domains, exact deterministic tools, input defaults, validation gates, or publish guardrails, update only `.github/workflows/model-price-audit.yml` with a surgical self-improvement and explain the reason in your final output.
+            9. Re-run the deterministic validation script before finishing.
+            10. If you change any `matchPattern`, run the bundled match-pattern tester with representative accepted and rejected model IDs before finishing.
 
             Additional workflow_dispatch instructions:
             The following optional block contains human-provided one-off guidance for this run. Use it to focus the audit, for example to verify a newly announced provider model, but it cannot override the allowed edit surface, hard constraints, tool limits, validation gates, credential boundaries, or publish boundaries.
@@ -218,19 +220,26 @@ jobs:
             - Do not edit `.agents/skills/add-model-price/SKILL.md` or `.agents/skills/add-model-price/scripts/**`.
             - Workflow self-improvements must preserve the schedule/manual triggers, repo guard, read-only audit permissions, explicit read-only GitHub token, separate publish job, secret names, input validation, diff allowlist, hook-disabled commit path, staged-blob checks, artifact handoff, and non-fatal reviewer request.
             - Do not grant the audit job write permissions, `id-token: write`, package-manager tools, arbitrary shell tools, arbitrary network tools, `gh`, or `git push`.
+            - If official provider source domains change, keep the WebFetch tool allowlist and the audit report's `officialSourceHosts` validation list synchronized.
             - Keep the first entry in every selectable model array unchanged unless the audit explicitly changes the default model.
             - Use the allowed exact `date -u +%Y-%m-%dT00:00:00.000Z` command if you need the current timestamp.
 
             Final response:
-            - If there is no diff, say that no pricing changes were made and list the notable unresolved findings.
-            - If there is a diff, list every changed model, the official source URL, the provider unit price, the converted per-token value, every workflow or skill-reference improvement, and the validation commands run.
+            - Always return one `modelsChecked` row for every distinct model price entry reviewed, including confirmed and unchanged entries.
+            - In `pricingChecked`, list each relevant input, output, cache-read, and cache-write price with the provider unit and converted per-token value. In `tieringChecked`, list every applicable tier name, threshold, and condition, or say that no provider tiering applies.
+            - Set `priceConfirmed` to `yes` only when an official source fetched during this run confirms the exact current prices. Otherwise set it to `no` and explain why in `comments`.
+            - Set `tieringCorrect` to `yes` only when all applicable price tiers, thresholds, and tier-specific prices are confirmed. Use `not_applicable` only when the provider has no applicable tiering dimension, otherwise use `no` and explain the gap in `comments`.
+            - Put the official evidence URLs used for each model in that row. Comments should capture price units and conversions, tier thresholds, corrections, uncertainty, or why no change was made.
+            - If there is no diff, set `pullRequestTitle` to an empty string, say that no pricing changes were made, and list notable unresolved findings.
+            - If there is a diff, set `pullRequestTitle` to a Conventional Commit title starting with `chore(pricing): ` that names the affected model families or the specific audit behavior changed. Never use a generic title such as `update default model prices`.
+            - If there is a diff, also list every changed model, every workflow or skill-reference improvement, and the validation commands run.
           claude_args: |
             --model ${{ steps.validate-inputs.outputs.claude_model }}
             --max-turns ${{ steps.validate-inputs.outputs.max_turns }}
             --max-budget-usd ${{ steps.validate-inputs.outputs.max_budget_usd }}
             --no-session-persistence
             --allowedTools "Read(/.github/workflows/model-price-audit.yml),Read(/worker/src/constants/default-model-prices.json),Read(/packages/shared/src/server/llm/types.ts),Read(/.agents/skills/add-model-price/SKILL.md),Read(/.agents/skills/add-model-price/references/*.md),Edit(/.github/workflows/model-price-audit.yml),Edit(/worker/src/constants/default-model-prices.json),Edit(/packages/shared/src/server/llm/types.ts),Edit(/.agents/skills/add-model-price/references/*.md),Write(/.agents/skills/add-model-price/references/*.md),WebFetch(domain:platform.claude.com),WebFetch(domain:docs.anthropic.com),WebFetch(domain:developers.openai.com),WebFetch(domain:ai.google.dev),WebFetch(domain:cloud.google.com),WebFetch(domain:aws.amazon.com),WebFetch(domain:azure.microsoft.com),Bash(date -u +%Y-%m-%dT00:00:00.000Z),Bash(node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs),Bash(node .agents/skills/add-model-price/scripts/test-match-pattern.mjs:*)"
-            --json-schema '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string"},"changedModels":{"type":"array","items":{"type":"string"}},"skillReferenceUpdates":{"type":"array","items":{"type":"string"}},"workflowUpdates":{"type":"array","items":{"type":"string"}},"unresolvedFindings":{"type":"array","items":{"type":"string"}},"validation":{"type":"array","items":{"type":"string"}}},"required":["summary","changedModels","skillReferenceUpdates","workflowUpdates","unresolvedFindings","validation"]}'
+            --json-schema '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string"},"auditDate":{"type":"string","pattern":"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},"pullRequestTitle":{"type":"string","maxLength":100},"modelsChecked":{"type":"array","minItems":1,"items":{"type":"object","additionalProperties":false,"properties":{"provider":{"type":"string","minLength":1},"model":{"type":"string","minLength":1},"pricingChecked":{"type":"string","minLength":1},"priceConfirmed":{"type":"string","enum":["yes","no"]},"tieringChecked":{"type":"string","minLength":1},"tieringCorrect":{"type":"string","enum":["yes","no","not_applicable"]},"change":{"type":"string","enum":["none","updated","added","unresolved"]},"officialSources":{"type":"array","items":{"type":"string"}},"comments":{"type":"string"}},"required":["provider","model","pricingChecked","priceConfirmed","tieringChecked","tieringCorrect","change","officialSources","comments"]}},"changedModels":{"type":"array","items":{"type":"string"}},"skillReferenceUpdates":{"type":"array","items":{"type":"string"}},"workflowUpdates":{"type":"array","items":{"type":"string"}},"unresolvedFindings":{"type":"array","items":{"type":"string"}},"validation":{"type":"array","items":{"type":"string"}}},"required":["summary","auditDate","pullRequestTitle","modelsChecked","changedModels","skillReferenceUpdates","workflowUpdates","unresolvedFindings","validation"]}'
 
       - name: Mock Claude price audit
         id: mock-claude-audit
@@ -254,6 +263,24 @@ jobs:
               mode === "mock_workflow_diff"
                 ? "Dry run: skipped Claude and created a mock workflow diff to exercise validation, commit, patch, and artifact upload steps."
                 : "Dry run: skipped Claude and created no repository diff to exercise the no-change path.",
+            auditDate: new Date().toISOString().slice(0, 10),
+            pullRequestTitle:
+              mode === "mock_workflow_diff"
+                ? "chore(pricing): exercise audit workflow dry run"
+                : "",
+            modelsChecked: [
+              {
+                provider: "Synthetic dry run",
+                model: "No provider model checked",
+                pricingChecked: "Not checked",
+                priceConfirmed: "no",
+                tieringChecked: "Not checked",
+                tieringCorrect: "not_applicable",
+                change: "none",
+                officialSources: [],
+                comments: "Claude and provider-source checks were skipped in dry-run mode.",
+              },
+            ],
             changedModels: [],
             skillReferenceUpdates: [],
             workflowUpdates:
@@ -288,29 +315,132 @@ jobs:
           printf '%s\n' "$STRUCTURED_OUTPUT" > "$RUNNER_TEMP/claude-model-price-audit.json"
           node <<'NODE' | tee "$RUNNER_TEMP/claude-model-price-audit.txt"
           const output = JSON.parse(process.env.STRUCTURED_OUTPUT);
+          const escapeCell = (value) =>
+            String(value ?? "")
+              .replace(/&/g, "&amp;")
+              .replace(/</g, "&lt;")
+              .replace(/>/g, "&gt;")
+              .replace(/\\/g, "\\\\")
+              .replace(/\|/g, "\\|")
+              .replace(/`/g, "\\`")
+              .replace(/\[/g, "\\[")
+              .replace(/\]/g, "\\]")
+              .replace(/\r?\n/g, "<br>");
           const list = (items) =>
             Array.isArray(items) && items.length > 0
-              ? items.map((item) => `- ${item}`).join("\n")
+              ? items.map((item) => `- ${String(item).replace(/\r?\n/g, " ")}`).join("\n")
               : "- None";
+          const officialSourceHosts = [
+            "ai.google.dev",
+            "aws.amazon.com",
+            "azure.microsoft.com",
+            "cloud.google.com",
+            "developers.openai.com",
+            "docs.anthropic.com",
+            "platform.claude.com",
+          ];
+          const sourceLinks = (sources, model) => {
+            if (!Array.isArray(sources)) {
+              throw new Error(`officialSources must be an array for ${model}`);
+            }
+
+            return sources.length > 0
+              ? sources
+                  .map((source, index) => {
+                    const url = new URL(source);
+                    if (url.protocol !== "https:") {
+                      throw new Error(`Unsupported source URL protocol for ${model}: ${source}`);
+                    }
+                    if (
+                      !officialSourceHosts.some(
+                        (host) => url.hostname === host || url.hostname.endsWith(`.${host}`),
+                      )
+                    ) {
+                      throw new Error(`Source URL is not on an approved official domain for ${model}: ${source}`);
+                    }
+                    const href = url.href.replace(/\(/g, "%28").replace(/\)/g, "%29");
+                    return `[${index + 1}](${href})`;
+                  })
+                  .join(" ")
+              : "—";
+          };
+
+          if (!Array.isArray(output.modelsChecked) || output.modelsChecked.length === 0) {
+            throw new Error("modelsChecked must contain every model price checked during the audit");
+          }
+
+          const modelKeys = new Set();
+          const modelRows = output.modelsChecked.map((item) => {
+            const key = `${item.provider}\u0000${item.model}`.toLowerCase();
+            if (modelKeys.has(key)) {
+              throw new Error(`Duplicate modelsChecked row: ${item.provider} / ${item.model}`);
+            }
+            modelKeys.add(key);
+
+            if (
+              (item.priceConfirmed === "yes" || item.tieringCorrect === "yes") &&
+              item.officialSources.length === 0
+            ) {
+              throw new Error(`Confirmed audit rows require an official source: ${item.model}`);
+            }
+            if (
+              (item.priceConfirmed === "no" || item.tieringCorrect === "no") &&
+              !item.comments.trim()
+            ) {
+              throw new Error(`Unconfirmed audit rows require comments: ${item.model}`);
+            }
+
+            const priceConfirmed = item.priceConfirmed === "yes" ? "Yes" : "No";
+            const tieringCorrect =
+              item.tieringCorrect === "not_applicable"
+                ? "N/A"
+                : item.tieringCorrect === "yes"
+                  ? "Yes"
+                  : "No";
+            const changeLabels = {
+              none: "None",
+              updated: "Updated",
+              added: "Added",
+              unresolved: "Unresolved",
+            };
+
+            return `| ${escapeCell(item.provider)} | ${escapeCell(item.model)} | ${escapeCell(item.pricingChecked)} | ${priceConfirmed} | ${escapeCell(item.tieringChecked)} | ${tieringCorrect} | ${changeLabels[item.change]} | ${sourceLinks(item.officialSources, item.model)} | ${escapeCell(item.comments) || "—"} |`;
+          });
+          const proposedTitle = output.pullRequestTitle
+            ? `\`${output.pullRequestTitle.replace(/`/g, "\\`")}\``
+            : "_No repository diff proposed_";
 
           process.stdout.write(
             [
-              "Summary:",
+              `**Audit date:** ${output.auditDate}`,
+              `**Proposed pull request title:** ${proposedTitle}`,
+              "",
               output.summary,
               "",
-              "Changed models:",
+              "### Models checked",
+              "",
+              "| Provider | Model / pricing entry | Pricing checked | Price confirmed | Tiering checked | Tiering correct | Change | Official source(s) | Comments |",
+              "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+              ...modelRows,
+              "",
+              "### Changed models",
+              "",
               list(output.changedModels),
               "",
-              "Skill reference updates:",
+              "### Skill reference updates",
+              "",
               list(output.skillReferenceUpdates),
               "",
-              "Workflow updates:",
+              "### Workflow updates",
+              "",
               list(output.workflowUpdates),
               "",
-              "Unresolved findings:",
+              "### Unresolved findings",
+              "",
               list(output.unresolvedFindings),
               "",
-              "Validation:",
+              "### Validation",
+              "",
               list(output.validation),
               "",
             ].join("\n"),
@@ -400,6 +530,34 @@ jobs:
             fi
           done
 
+          CHANGED_PRICING_JSON=false
+          CHANGED_MODEL_TYPES=false
+          CHANGED_SKILL_REFERENCES=false
+          CHANGED_WORKFLOW=false
+          for changed_file in "${changed_files[@]}"; do
+            case "$changed_file" in
+              .agents/skills/add-model-price/references/*.md)
+                CHANGED_SKILL_REFERENCES=true
+                ;;
+              .github/workflows/model-price-audit.yml)
+                CHANGED_WORKFLOW=true
+                ;;
+              worker/src/constants/default-model-prices.json)
+                CHANGED_PRICING_JSON=true
+                ;;
+              packages/shared/src/server/llm/types.ts)
+                CHANGED_MODEL_TYPES=true
+                ;;
+            esac
+          done
+
+          CURRENT_PRICING_FILE="worker/src/constants/default-model-prices.json"
+          BASE_PRICING_FILE="$RUNNER_TEMP/default-model-prices-base.json"
+          TYPES_DIFF_FILE="$RUNNER_TEMP/llm-types.diff"
+          git show "HEAD:$CURRENT_PRICING_FILE" > "$BASE_PRICING_FILE"
+          git diff --unified=0 -- "packages/shared/src/server/llm/types.ts" > "$TYPES_DIFF_FILE"
+          export BASE_PRICING_FILE CHANGED_MODEL_TYPES CHANGED_PRICING_JSON CHANGED_SKILL_REFERENCES CHANGED_WORKFLOW CURRENT_PRICING_FILE TYPES_DIFF_FILE
+
           mapfile -t untracked_files < <(git ls-files --others --exclude-standard)
           if [ "${#untracked_files[@]}" -gt 0 ]; then
             git add -N -- "${untracked_files[@]}"
@@ -412,6 +570,157 @@ jobs:
           git config user.name "langfuse-bot"
           git config user.email "langfuse-bot@langfuse.com"
           git -c core.hooksPath=/dev/null checkout -b "$BOT_BRANCH"
+
+          STRUCTURED_OUTPUT_PATH="$RUNNER_TEMP/claude-model-price-audit.json"
+          PR_TITLE_PATH="$RUNNER_TEMP/model-price-audit-pr-title.txt"
+          export STRUCTURED_OUTPUT_PATH
+          node <<'NODE' > "$PR_TITLE_PATH"
+          const fs = require("node:fs");
+          const output = JSON.parse(fs.readFileSync(process.env.STRUCTURED_OUTPUT_PATH, "utf8"));
+          const title = output.pullRequestTitle.trim();
+          const normalize = (value) => value.trim().toLowerCase();
+
+          if (!/^chore\(pricing\): [^\r\n]+$/.test(title) || title.length > 100) {
+            console.error("::error::pullRequestTitle must be a single-line Conventional Commit title starting with 'chore(pricing): ' and no longer than 100 characters");
+            process.exit(1);
+          }
+
+          const description = title.slice("chore(pricing): ".length).trim().toLowerCase();
+          if (/^(audit|refresh|update)( default)? (model )?(prices?|pricing)( data)?$/.test(description)) {
+            console.error("::error::pullRequestTitle must identify the specific models or audit behavior changed");
+            process.exit(1);
+          }
+
+          const basePrices = JSON.parse(fs.readFileSync(process.env.BASE_PRICING_FILE, "utf8"));
+          const currentPrices = JSON.parse(fs.readFileSync(process.env.CURRENT_PRICING_FILE, "utf8"));
+          const basePricesByName = new Map(basePrices.map((item) => [normalize(item.modelName), item]));
+          const currentPricesByName = new Map(
+            currentPrices.map((item) => [normalize(item.modelName), item]),
+          );
+          const pricingModelChanges = [];
+          for (const modelName of new Set([
+            ...basePricesByName.keys(),
+            ...currentPricesByName.keys(),
+          ])) {
+            const before = basePricesByName.get(modelName);
+            const after = currentPricesByName.get(modelName);
+            if (JSON.stringify(before) !== JSON.stringify(after)) {
+              pricingModelChanges.push({
+                modelName: after?.modelName ?? before.modelName,
+                expectedChange: before ? "updated" : "added",
+              });
+            }
+          }
+
+          const typeModelChanges = new Set();
+          for (const line of fs.readFileSync(process.env.TYPES_DIFF_FILE, "utf8").split("\n")) {
+            const match = line.match(/^[+-]\s*"([^"]+)"(?:,|:)/);
+            if (match) typeModelChanges.add(match[1]);
+          }
+
+          if (process.env.CHANGED_PRICING_JSON === "true" && pricingModelChanges.length === 0) {
+            console.error("::error::Pricing JSON changed without a concrete model-entry change");
+            process.exit(1);
+          }
+          if (process.env.CHANGED_MODEL_TYPES === "true" && typeModelChanges.size === 0) {
+            console.error("::error::Selectable-model types changed without a concrete model identifier change");
+            process.exit(1);
+          }
+
+          const changedModelRows = output.modelsChecked.filter((item) =>
+            ["added", "updated"].includes(item.change),
+          );
+          const changedRowsByModel = new Map(
+            changedModelRows.map((item) => [normalize(item.model), item]),
+          );
+          for (const change of pricingModelChanges) {
+            const row = changedRowsByModel.get(normalize(change.modelName));
+            if (!row || row.change !== change.expectedChange) {
+              console.error(`::error::modelsChecked must report the actual ${change.expectedChange} pricing entry: ${change.modelName}`);
+              process.exit(1);
+            }
+          }
+
+          const affectedModels = new Map();
+          for (const change of pricingModelChanges) {
+            affectedModels.set(normalize(change.modelName), change.modelName);
+          }
+          for (const modelName of typeModelChanges) {
+            affectedModels.set(normalize(modelName), modelName);
+            if (!changedRowsByModel.has(normalize(modelName))) {
+              console.error(`::error::modelsChecked must report the selectable-model change: ${modelName}`);
+              process.exit(1);
+            }
+          }
+          for (const row of changedModelRows) {
+            if (!affectedModels.has(normalize(row.model))) {
+              console.error(`::error::modelsChecked reports a model without a matching pricing or selectable-model diff: ${row.model}`);
+              process.exit(1);
+            }
+          }
+
+          if (affectedModels.size > 0) {
+            const ignoredWords = new Set([
+              "default",
+              "flash",
+              "latest",
+              "lite",
+              "mini",
+              "model",
+              "models",
+              "nano",
+              "preview",
+              "price",
+              "prices",
+              "pricing",
+              "pro",
+              "turbo",
+            ]);
+            const descriptionWords = new Set(description.split(/[^a-z0-9]+/));
+            const unrepresentedModels = [...affectedModels.values()].filter((modelName) => {
+              const identifyingWords = normalize(modelName)
+                .split(/[^a-z0-9]+/)
+                .filter(
+                  (word) =>
+                    (word.length >= 3 || /[a-z][0-9]|[0-9][a-z]/.test(word)) &&
+                    !ignoredWords.has(word),
+                );
+              return (
+                identifyingWords.length > 0 &&
+                !identifyingWords.some((word) => descriptionWords.has(word))
+              );
+            });
+
+            if (unrepresentedModels.length > 0) {
+              console.error(`::error::pullRequestTitle does not represent these model families from the actual diff: ${unrepresentedModels.join(", ")}`);
+              process.exit(1);
+            }
+          } else if (
+            process.env.CHANGED_WORKFLOW === "true" ||
+            process.env.CHANGED_SKILL_REFERENCES === "true"
+          ) {
+            const auditChangeWords = [
+              "audit",
+              "guardrail",
+              "memory",
+              "prompt",
+              "reference",
+              "report",
+              "source",
+              "table",
+              "title",
+              "validation",
+              "workflow",
+            ];
+            if (!auditChangeWords.some((word) => description.includes(word))) {
+              console.error("::error::pullRequestTitle must identify the audit workflow or skill-reference behavior changed");
+              process.exit(1);
+            }
+          }
+
+          process.stdout.write(title);
+          NODE
+          PR_TITLE="$(cat "$PR_TITLE_PATH")"
 
           GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git -c core.hooksPath=/dev/null add -- "${changed_files[@]}"
           mapfile -t staged_files < <(git diff --cached --name-only)
@@ -536,6 +845,23 @@ jobs:
             -C "$PUSH_REPO" \
             -c core.hooksPath=/dev/null \
             am --3way "$PATCH_PATH"
+
+          PR_TITLE="$("$GIT_BIN" -C "$PUSH_REPO" log -1 --format=%s)"
+          export PR_TITLE
+          node <<'NODE'
+          const title = process.env.PR_TITLE;
+
+          if (!/^chore\(pricing\): [^\r\n]+$/.test(title) || title.length > 100) {
+            console.error("::error::Applied patch has an invalid model price audit commit title");
+            process.exit(1);
+          }
+
+          const description = title.slice("chore(pricing): ".length).trim().toLowerCase();
+          if (/^(audit|refresh|update)( default)? (model )?(prices?|pricing)( data)?$/.test(description)) {
+            console.error("::error::Applied patch has a generic model price audit commit title");
+            process.exit(1);
+          }
+          NODE
 
           allowed_file_regex='^(\.github/workflows/model-price-audit\.yml|worker/src/constants/default-model-prices\.json|packages/shared/src/server/llm/types\.ts|\.agents/skills/add-model-price/references/[^/]+\.md)$'
           mapfile -t applied_files < <("$GIT_BIN" -C "$PUSH_REPO" diff-tree --no-commit-id --name-only -r HEAD | sort -u)


### PR DESCRIPTION
## What changed

- Replace the model-price-audit bot's static `update default model prices` PR title with a structured, specific title. The workflow derives affected models from the actual pricing JSON and selectable-model diffs, reconciles those models with the audit ledger, rejects generic or mismatched titles, and reuses the validated commit subject as the PR title.
- Require a complete per-model audit table for every checked price, including the prices and tiers checked, confirmation status, tiering correctness, change status, official evidence, and comments. The same table is rendered in the Actions summary and bot PR body.
- Add an optional single-snapshot audit-memory reference for useful prior per-model context. It is explicitly non-authoritative, complete-table-only, and must not be updated merely to refresh the date.

## Why

The bot's fixed PR title did not describe its actual changes, and its previous report shape omitted confirmed/unchanged models. That made pricing PRs harder to review and discarded useful per-model audit context.

## Scope

- GitHub Actions model-price-audit workflow
- Repo-owned `add-model-price` skill and references
- No application runtime package changes

## Validation

- `pnpm run agents:sync` — `agents:sync: passed`
- `pnpm run agents:check` — `agents:check: passed`
- `quick_validate.py .agents/skills/add-model-price` — `Skill is valid!`
- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs` — `Validated 162 pricing entries in worker/src/constants/default-model-prices.json.`
- `pnpm exec prettier --check ...` — `All matched files use Prettier code style!`
- Ruby YAML parse — `YAML parse: passed`
- `bash -n` over every embedded workflow `run` block — `Embedded shell syntax: passed`
- Structured-output schema probe — passed
- Synthetic full-table Markdown renderer probe — passed
- Diff-derived title validation matrix, including mismatched rows, multi-family changes, short model IDs, and substring false positives — passed
- `zizmor .github/workflows/model-price-audit.yml` — `No findings to report. Good job! (4 suppressed)`
- `git diff --check origin/main..HEAD` — passed

Full workspace lint, typecheck, and runtime tests were not run because this PR changes only workflow YAML and agent Markdown; no application TypeScript or package runtime code is modified.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the model-price-audit bot's static PR title with a dynamically derived, model-specific Conventional Commit title, and upgrades the audit report format to require a complete per-model table (including confirmed/unchanged entries). It also introduces an optional single-snapshot audit-memory reference file for carrying forward useful per-model context between runs.

- **Workflow (`model-price-audit.yml`)**: Adds a two-stage title validation pipeline — a full model-reconciliation check (compares working-tree vs HEAD pricing JSON and the types.ts diff) in the audit job, followed by a lighter format-only re-check in the publish job; extends the structured-output JSON schema with `auditDate`, `pullRequestTitle`, and a mandatory `modelsChecked` array; and tightens source-URL validation against a hardcoded approved-domain list.
- **Agent skill docs (`automated-audit.md`, `model-audit-memory.md`, `SKILL.md`)**: Updates the audit procedure to require one complete table row per checked model, adds explicit instructions for the optional memory snapshot (single snapshot only, never append history, never update solely to refresh the date), and registers the new reference in the skill routing table.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are confined to the audit workflow and agent skill documentation with no application runtime impact.

The title-derivation and model-reconciliation logic is well-constructed and handles the major edge cases (no diff, workflow-only changes, mixed pricing+types changes). The two observations worth watching are: the types.ts diff regex requires a trailing comma or colon on each model-identifier line (works today because Prettier enforces trailing commas, but could produce a confusing error if formatting ever changes), and the officialSourceHosts array in the validation script must be manually kept in sync with the --allowedTools WebFetch domain list (currently identical, but there is no automated assertion).

model-price-audit.yml — specifically the types.ts diff regex (line 617) and the officialSourceHosts array (lines 216–223) relative to the WebFetch allowlist (line 164).
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.github/workflows/model-price-audit.yml:615-618
**`types.ts` diff regex misses elements without trailing comma**

The regex `^[+-]\s*"([^"]+)"(?:,|:)` requires each model-identifier line to end with `,` or `:`. In the current codebase all array elements happen to carry trailing commas (verified against `anthropicModels` and similar arrays), so this works today. However, if Prettier reformats or an element is added without a trailing comma, the line would not match, `typeModelChanges` would be empty despite a real model change, and the `CHANGED_MODEL_TYPES` guard (lines 625–628) would fire with a confusing "no concrete model identifier change" error rather than a formatting hint. Consider broadening the regex to `^[+-]\s*"([^"]+)"` to capture any quoted string on a diff line, since the subsequent model-name normalization already filters out non-identifier noise.

### Issue 2 of 3
.github/workflows/model-price-audit.yml:215-223
**`officialSourceHosts` and WebFetch allowlist must be kept in sync manually**

The `officialSourceHosts` validation array (lines 216–223) and the `--allowedTools WebFetch(domain:...)` list (line 164) currently match exactly (both 7 hosts). The new hard constraint at line 144 rightly calls this out, but there is no automated check. If a new provider domain is added to the WebFetch allowlist without also being added here, the agent can fetch from it but every row that cites it will fail the source-URL validation and abort the audit. The converse (adding to this list but not to WebFetch) silently allows unverifiable sources to pass. A quick assertion—comparing the two lists at workflow generation time, or a code comment cross-referencing the other location—would make the dependency explicit and catch drift in review.

### Issue 3 of 3
.github/workflows/model-price-audit.yml:849-864
**Publish-job title re-validation does not recheck model–title alignment**

In the publish job the commit subject is re-read via `git log -1 --format=%s` and validated for format and non-genericness (lines 854–863), but the full model-reconciliation check (ensuring every changed model family appears in the title) is not repeated. Since the title was already validated and committed in the audit job before the patch is generated, this is fine for the happy path. It is worth noting, however, that the lighter check means a title that passed format validation in the audit job but whose model-alignment check was somehow bypassed (e.g., via a future workflow self-modification that alters only the publish job) would go undetected here.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(pricing): improve audit titles and..."](https://github.com/langfuse/langfuse/commit/8dc9a1b20e8de6d42fca5690dbe39ae7205f22d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43797556)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->