### PR TITLE
fix(web): resolve test-file type errors failing the production next build typecheck

### DIFF
--- a/web/src/__tests__/server/audit-log-in-app-agent.servertest.ts
+++ b/web/src/__tests__/server/audit-log-in-app-agent.servertest.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "crypto";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { prisma, AuditLogRecordType } from "../../../../packages/shared/src/db";
-import { createAndAddApiKeysToDb } from "../../../../packages/shared/src/server/auth/apiKeys";
-import { createOrgProjectAndApiKey } from "../../../../packages/shared/src/server/test-utils/org-factory";
+import { prisma, AuditLogRecordType } from "@langfuse/shared/src/db";
+import { createAndAddApiKeysToDb } from "@langfuse/shared/src/server/auth/apiKeys";
+import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 
 describe("in-app agent audit logging", () => {
   it("stores the creator on in-app-agent MCP keys", async () => {

--- a/web/src/features/evals/utils/code-eval-template-completions.clienttest.ts
+++ b/web/src/features/evals/utils/code-eval-template-completions.clienttest.ts
@@ -56,7 +56,11 @@ function runCompletionSource(
     extensions: [languageExtensionFor(sourceCodeLanguage)],
   });
   const source = getCodeEvalCompletionSource(sourceCodeLanguage);
-  return source(new CompletionContext(state, position, false));
+  const result = source(new CompletionContext(state, position, false));
+  if (result instanceof Promise) {
+    throw new Error("code eval completion source must resolve synchronously");
+  }
+  return result;
 }
 
 function mountEditor(


### PR DESCRIPTION
## Summary

Main and production ECS deploys are red: the Docker image build fails in `next build`'s TypeScript step ([failed run](https://github.com/langfuse/langfuse/actions/runs/29238944713)). Two independent type errors landed this morning, both in test files:

- #14920's new servertest imported shared code via relative `../../../../packages/shared/src` paths. This bypasses `@langfuse/shared`'s exports map (which points at built `dist/`) and pulls shared **source** into web's TS program: `src/db.ts` → `src/server/index.ts` → `customSsoProvider.ts`. There the `web/types/next-auth.d.ts` `User` augmentation applies (it requires `canCreateOrganizations`, `organizations`, `featureFlags`), so `customSsoProvider`'s `profile()` — untouched for 1.5 years — suddenly fails TS2322. Fixed by switching to the package subpaths every other servertest uses; via `dist` the augmentation never reaches shared internals.
- #14992's clienttest read `.from`/`.options` directly off a codemirror `CompletionSource` result, which is typed `CompletionResult | Promise<CompletionResult | null> | null`. Fixed by narrowing `runCompletionSource` with an `instanceof Promise` guard (the source is synchronous in practice).

Why no PR check caught either: CI test builds set `NEXT_IGNORE_BUILD_ERRORS=true`, and the CI typecheck job uses `tsconfig.build.json`, which excludes `*.servertest.*`/`*.clienttest.*`. The production Docker build is the only place `next build`'s full check — `web/tsconfig.json`, including all test files — actually runs, so type errors in test files merge green and only surface as failed ECS deploys. Closing that gap is a follow-up worth its own discussion.

Verified: both errors reproduce at `07b6661df` with a fresh full typecheck and disappear after this change; a real `pnpm --filter web run build` (the exact Docker step, `NEXT_IGNORE_BUILD_ERRORS` unset) passes; the touched tests still pass (`21 passed`, `2 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This hotfix resolves two TypeScript type errors in test files that were causing the production `next build` step to fail, even though CI test builds and the typecheck job didn't catch them (due to `NEXT_IGNORE_BUILD_ERRORS=true` and `tsconfig.build.json` exclusions respectively).

- **Audit-log servertest**: Replaces three deep relative imports (`../../../../packages/shared/src/…`) with proper package subpath imports (`@langfuse/shared/src/…`), preventing shared source from being pulled into web's TS program and triggering a `User` augmentation conflict.
- **Completions clienttest**: Narrows the return type of `runCompletionSource` with an `instanceof Promise` guard, resolving a TS2322 that arose because `CompletionSource` returns `CompletionResult | Promise<CompletionResult | null> | null` but the tests accessed `.from`/`.options` without narrowing out the `Promise` branch.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Both changes are narrow, targeted test-file fixes that restore a broken production build without touching any runtime production code paths.

The audit-log servertest now uses the same @langfuse/shared/src/* import pattern as every other servertest in the codebase, and the completions clienttest's Promise guard correctly narrows the type while doubling as an explicit synchrony assertion. Neither change alters production logic or shared module APIs.

No files require special attention; the diff is confined to two test files making minimal, well-scoped corrections.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["next build TypeScript check"] --> B{Type errors?}
    B -- "Before fix" --> C["❌ Fail: TS2322 in test files"]
    B -- "After fix" --> D["✅ Pass"]

    C --> E["Error 1: audit-log servertest\nRelative path imports pulled\nshared src into web's TS program\n→ User augmentation conflict"]
    C --> F["Error 2: completions clienttest\nCompletionSource return typed as\nResult | Promise | null\nbut .from/.options accessed directly"]

    E --> G["Fix: Use @langfuse/shared/src/db\n@langfuse/shared/src/server/auth/apiKeys\n@langfuse/shared/src/server"]
    F --> H["Fix: instanceof Promise guard\n→ throws on async\n→ narrows type to Result | null"]

    G --> D
    H --> D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["next build TypeScript check"] --> B{Type errors?}
    B -- "Before fix" --> C["❌ Fail: TS2322 in test files"]
    B -- "After fix" --> D["✅ Pass"]

    C --> E["Error 1: audit-log servertest\nRelative path imports pulled\nshared src into web's TS program\n→ User augmentation conflict"]
    C --> F["Error 2: completions clienttest\nCompletionSource return typed as\nResult | Promise | null\nbut .from/.options accessed directly"]

    E --> G["Fix: Use @langfuse/shared/src/db\n@langfuse/shared/src/server/auth/apiKeys\n@langfuse/shared/src/server"]
    F --> H["Fix: instanceof Promise guard\n→ throws on async\n→ narrows type to Result | null"]

    G --> D
    H --> D
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): resolve test-file type errors ..."](https://github.com/langfuse/langfuse/commit/aaca2f901e48206f00d805b5da2d49cdd2b3b828) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43779352)</sub>

<!-- /greptile_comment -->