### PR TITLE
fix(auth): Clean up next-auth type definitions

### DIFF
--- a/web/src/components/layouts/app-layout/hooks/useFilteredNavigation.ts
+++ b/web/src/components/layouts/app-layout/hooks/useFilteredNavigation.ts
@@ -5,7 +5,7 @@
 
 import { useRouter } from "next/router";
 import { useMemo } from "react";
-import type { Session, User } from "next-auth";
+import type { Session } from "next-auth";
 import { useEntitlements } from "@/src/features/entitlements/hooks";
 import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
@@ -21,7 +21,10 @@ import type { NavigationFilterContext } from "../utils/navigationFilters.types";
 import { isPathActive } from "../utils/pathClassification";
 
 /** Organization type from user session (can be null when not in project/org context) */
-type Organization = User["organizations"][number] | null | undefined;
+type Organization =
+  | NonNullable<Session["user"]>["organizations"][number]
+  | null
+  | undefined;
 
 /** Grouped navigation structure */
 type GroupedNavigation = {

--- a/web/src/components/layouts/app-layout/utils/navigationFilters.ts
+++ b/web/src/components/layouts/app-layout/utils/navigationFilters.ts
@@ -7,10 +7,13 @@ import type { Route } from "@/src/components/layouts/routes";
 import type { NavigationFilterContext } from "./navigationFilters.types";
 import { hasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { hasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
-import type { User } from "next-auth";
+import type { Session } from "next-auth";
 
 /** Organization type from user session (can be null when not in project/org context) */
-type Organization = User["organizations"][number] | null | undefined;
+type Organization =
+  | NonNullable<Session["user"]>["organizations"][number]
+  | null
+  | undefined;
 
 /**
  * Individual filter functions - each handles one concern

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 import { type ReactNode } from "react";
 import { type Entitlement } from "@/src/features/entitlements/constants/entitlements";
-import { type User } from "next-auth";
+import { type Session } from "next-auth";
 import { type OrganizationScope } from "@/src/features/rbac/constants/organizationAccessRights";
 import { SupportButton } from "@/src/components/nav/support-button";
 import { InAppAiAgentButton } from "@/src/components/nav/in-app-ai-agent-button";
@@ -62,7 +62,9 @@ export type Route = {
   entitlements?: Entitlement[]; // entitlements required, array treated as OR
   productModule?: ProductModule; // Product module this route belongs to. Used to show/hide modules via ui customization.
   show?: (p: {
-    organization: User["organizations"][number] | undefined;
+    organization:
+      | NonNullable<Session["user"]>["organizations"][number]
+      | undefined;
     projectId: string | undefined;
     isLangfuseCloud: boolean;
     v4WriteMode: undefined | "legacy" | "dual" | "events_only"; // undefined until the session has loaded

--- a/web/src/features/entitlements/server/hasEntitlement.ts
+++ b/web/src/features/entitlements/server/hasEntitlement.ts
@@ -3,12 +3,12 @@ import {
   type Entitlement,
 } from "@/src/features/entitlements/constants/entitlements";
 import { TRPCError } from "@trpc/server";
-import { type User } from "next-auth";
+import { type Session } from "next-auth";
 import { type Plan } from "@langfuse/shared";
 
 type HasEntitlementParams = {
   entitlement: Entitlement;
-  sessionUser: User;
+  sessionUser: NonNullable<Session["user"]>;
 } & ({ projectId: string } | { orgId: string });
 
 /**

--- a/web/src/features/entitlements/server/hasEntitlementLimit.ts
+++ b/web/src/features/entitlements/server/hasEntitlementLimit.ts
@@ -4,11 +4,11 @@ import {
 } from "@/src/features/entitlements/constants/entitlements";
 import { type Plan } from "@langfuse/shared";
 import { TRPCError } from "@trpc/server";
-import { type User } from "next-auth";
+import { type Session } from "next-auth";
 
 type HasEntitlementLimitParams = {
   entitlementLimit: EntitlementLimit;
-  sessionUser: User;
+  sessionUser: NonNullable<Session["user"]>;
 } & ({ projectId: string } | { orgId: string });
 
 /**

--- a/web/src/features/organizations/components/ProjectOverview.tsx
+++ b/web/src/features/organizations/components/ProjectOverview.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/src/features/setup/setupRoutes";
 import { isCloudPlan, planLabels } from "@langfuse/shared";
 import ContainerPage from "@/src/components/layouts/container-page";
-import { type User } from "next-auth";
+import { type Session } from "next-auth";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { AgentToolsBanner } from "@/src/features/developer-tools/components/AgentToolsBanner";
 
@@ -39,7 +39,7 @@ const OrganizationProjectTiles = ({
   org,
   search,
 }: {
-  org: User["organizations"][number];
+  org: NonNullable<Session["user"]>["organizations"][number];
   search?: string;
 }) => {
   return (

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -1,7 +1,6 @@
 import { type GetServerSidePropsContext } from "next";
 import {
   getServerSession,
-  type User,
   type NextAuthOptions,
   type Session,
 } from "next-auth";
@@ -123,7 +122,7 @@ const staticProviders: Provider[] = [
       );
       if (!isValidPassword) throw new Error("Invalid credentials");
 
-      const userObj: User = {
+      const userObj = {
         id: dbUser.id,
         name: dbUser.name,
         email: dbUser.email,

--- a/web/src/server/utils/checkProjectMembershipOrAdmin.ts
+++ b/web/src/server/utils/checkProjectMembershipOrAdmin.ts
@@ -1,7 +1,7 @@
-import { type User } from "next-auth";
+import { type Session } from "next-auth";
 
 export const isProjectMemberOrAdmin = (
-  user: User | null | undefined,
+  user: Session["user"] | undefined,
   projectId: string,
 ): boolean => {
   if (!user) return false;

--- a/web/types/next-auth.d.ts
+++ b/web/types/next-auth.d.ts
@@ -1,4 +1,4 @@
-import { type DefaultSession, type DefaultUser } from "next-auth";
+import { type DefaultSession } from "next-auth";
 import {
   type User as PrismaUser,
   type Project as PrismaProject,
@@ -17,7 +17,43 @@ import { type Plan } from "@langfuse/shared";
  */
 declare module "next-auth" {
   interface Session extends DefaultSession {
-    user: User | null; // null if user does not exist anymore in the database but has active jwt
+    user:
+      | ({
+          id: PrismaUser["id"];
+          name?: PrismaUser["name"];
+          email?: PrismaUser["email"];
+          emailSupportHash?: string | null;
+          image?: PrismaUser["image"];
+          admin?: PrismaUser["admin"];
+          v4BetaEnabled?: boolean;
+          canToggleV4?: boolean;
+          emailVerified?: string | null; // iso datetime string, need to stringify as JWT & useSession do not support Date objects
+          canCreateOrganizations: boolean; // default true, allowlist can be set via LANGFUSE_ALLOWED_ORGANIZATION_CREATORS
+          organizations: {
+            id: PrismaOrganization["id"];
+            name: PrismaOrganization["name"];
+            role: Role;
+            cloudConfig: CloudConfigSchema | undefined;
+            plan: Plan;
+            metadata: Record<string, unknown>;
+            aiFeaturesEnabled: boolean;
+            aiTelemetryEnabled: boolean;
+            projects: {
+              id: PrismaProject["id"];
+              name: PrismaProject["name"];
+              deletedAt: PrismaProject["deletedAt"];
+              retentionDays: PrismaProject["retentionDays"];
+              hasTraces: PrismaProject["hasTraces"];
+              metadata: Record<string, unknown>;
+              role: Role; // include only projects where user has a role
+              createdAt: string; // iso datetime string — JWT does not support Date objects
+            }[];
+          }[];
+          featureFlags: Flags;
+          hasPassword?: boolean;
+        } & DefaultSession["user"])
+      | null; // null if user does not exist anymore in the database but has active jwt
+
     environment: {
       // Run-time environment variables that need to be available client-side
       enableExperimentalFeatures: boolean;
@@ -32,40 +68,9 @@ declare module "next-auth" {
     };
   }
 
-  interface User extends DefaultUser {
-    id: PrismaUser["id"];
-    name?: PrismaUser["name"];
-    email?: PrismaUser["email"];
-    emailSupportHash?: string | null;
-    image?: PrismaUser["image"];
-    admin?: PrismaUser["admin"];
-    v4BetaEnabled?: boolean;
-    canToggleV4?: boolean;
-    emailVerified?: string | null; // iso datetime string, need to stringify as JWT & useSession do not support Date objects
-    canCreateOrganizations: boolean; // default true, allowlist can be set via LANGFUSE_ALLOWED_ORGANIZATION_CREATORS
-    organizations: {
-      id: PrismaOrganization["id"];
-      name: PrismaOrganization["name"];
-      role: Role;
-      cloudConfig: CloudConfigSchema | undefined;
-      plan: Plan;
-      metadata: Record<string, unknown>;
-      aiFeaturesEnabled: boolean;
-      aiTelemetryEnabled: boolean;
-      projects: {
-        id: PrismaProject["id"];
-        name: PrismaProject["name"];
-        deletedAt: PrismaProject["deletedAt"];
-        retentionDays: PrismaProject["retentionDays"];
-        hasTraces: PrismaProject["hasTraces"];
-        metadata: Record<string, unknown>;
-        role: Role; // include only projects where user has a role
-        createdAt: string; // iso datetime string — JWT does not support Date objects
-      }[];
-    }[];
-    featureFlags: Flags;
-    hasPassword?: boolean;
-  }
+  // Do not add `interface User extends DefaultUser` here.
+  // OAuth provider `profile` callbacks return `User` before the session callback enriches it.
+  // App-specific fields therefore belong on `Session.user`.
 }
 
 declare module "next-auth/jwt" {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the custom `interface User extends DefaultUser` augmentation from `next-auth` and relocates all app-specific user fields directly onto `Session.user`. The motivation is sound: OAuth `profile` callbacks return a `User` before the session callback enriches it, so declaring rich app fields on `User` was semantically incorrect — those fields only exist after the session callback runs. All consumer sites are updated to reference `NonNullable<Session["user"]>` instead of `User`.

- **`web/types/next-auth.d.ts`**: Removes `interface User extends DefaultUser` entirely; the custom user shape (with `id`, `organizations`, `featureFlags`, etc.) is now inlined directly into `Session[\"user\"]`.
- **Eight consumer files** (`auth.ts`, `checkProjectMembershipOrAdmin.ts`, navigation hooks/filters, routes, entitlement helpers, `ProjectOverview.tsx`) are updated to import `Session` instead of `User` and use `NonNullable<Session[\"user\"]>` or `Session[\"user\"]` for parameter and local types.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are type-level only with no runtime behavior differences.

Every changed line is a TypeScript type annotation or import. The underlying runtime behavior is unchanged: the session callback still re-fetches from the database and builds the user shape from scratch on every request. Consumer sites are consistently updated across all eight files.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant NextAuth
    participant OAuth as "OAuth Provider"
    participant CB as "Session Callback"
    participant DB as "Prisma DB"

    Browser->>NextAuth: "Sign in"
    alt OAuth provider
        NextAuth->>OAuth: "Exchange code"
        OAuth-->>NextAuth: "profile (DefaultUser, no app fields)"
    else Credentials
        NextAuth->>NextAuth: "authorize() returns userObj for JWT"
    end
    NextAuth->>NextAuth: "Store JWT (id, name, email, image)"
    Browser->>NextAuth: "getServerSession"
    NextAuth->>CB: "session callback"
    CB->>DB: "findUnique user + orgs"
    DB-->>CB: "dbUser with organizationMemberships"
    CB->>CB: "Build full Session user shape"
    CB-->>Browser: "Session user (nullable) with all app fields"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant NextAuth
    participant OAuth as "OAuth Provider"
    participant CB as "Session Callback"
    participant DB as "Prisma DB"

    Browser->>NextAuth: "Sign in"
    alt OAuth provider
        NextAuth->>OAuth: "Exchange code"
        OAuth-->>NextAuth: "profile (DefaultUser, no app fields)"
    else Credentials
        NextAuth->>NextAuth: "authorize() returns userObj for JWT"
    end
    NextAuth->>NextAuth: "Store JWT (id, name, email, image)"
    Browser->>NextAuth: "getServerSession"
    NextAuth->>CB: "session callback"
    CB->>DB: "findUnique user + orgs"
    DB-->>CB: "dbUser with organizationMemberships"
    CB->>CB: "Build full Session user shape"
    CB-->>Browser: "Session user (nullable) with all app fields"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): Clean up next-auth type defin..."](https://github.com/langfuse/langfuse/commit/ecdb31796cf1cfd49e739b5921723f6c0ad6c8de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43785473)</sub>

<!-- /greptile_comment -->