### PR TITLE
fix(filters): tolerate formatted column identifiers

### DIFF
--- a/web/src/features/filters/hooks/useFilterState.clienttest.ts
+++ b/web/src/features/filters/hooks/useFilterState.clienttest.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeFilterColumnIdentifier } from "./useFilterState";
+
+describe("normalizeFilterColumnIdentifier", () => {
+  it("normalizes casing and common separators in filter column identifiers", () => {
+    expect(normalizeFilterColumnIdentifier("Trace-Name")).toBe("tracename");
+    expect(normalizeFilterColumnIdentifier("session id")).toBe("sessionid");
+    expect(normalizeFilterColumnIdentifier("USER_ID")).toBe("userid");
+  });
+});

--- a/web/src/features/filters/hooks/useFilterState.ts
+++ b/web/src/features/filters/hooks/useFilterState.ts
@@ -210,11 +210,24 @@ const tableCols = {
   ],
 };
 
+export function normalizeFilterColumnIdentifier(identifier: string): string {
+  return identifier
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, "");
+}
+
 function getColumnId(table: TableName, name: string): string | undefined {
-  // TODO: make this more robust, will change with new filters
-  // to give more leeway to LLMs, we check against name or id
-  return tableCols[table]?.find((col) => col.name === name || col.id === name)
-    ?.id;
+  const normalizedName = normalizeFilterColumnIdentifier(name);
+
+  return tableCols[table]?.find((col) => {
+    const normalizedColumnName = normalizeFilterColumnIdentifier(col.name);
+    const normalizedColumnId = normalizeFilterColumnIdentifier(col.id);
+    return (
+      normalizedColumnName === normalizedName ||
+      normalizedColumnId === normalizedName
+    );
+  })?.id;
 }
 
 function getColumnName(table: TableName, id: string): string | undefined {


### PR DESCRIPTION
## Summary
- Normalize filter column identifiers before resolving URL filter state column names/ids.
- Accept common formatting differences such as casing, spaces, hyphens, and underscores while keeping exact normalized equality.
- Add focused client regression coverage for the identifier normalizer.

## Why
This makes filter state more tolerant when callers or generated query state use display-style names such as `Trace-Name`, `session id`, or `USER_ID` instead of the exact column identifier casing.

## Test Plan
- `git diff --check`
- `pnpm --filter web exec prettier --check src/features/filters/hooks/useFilterState.ts src/features/filters/hooks/useFilterState.clienttest.ts`
- `pnpm --filter web run lint` (ran via commit hook)
- Attempted: `pnpm --filter web run test-client useFilterState.clienttest.ts` — blocked in this sandbox before tests execute by an existing import-time Zod enum error also reproduced with an unrelated existing client test (`eventsTablePaths.clienttest.ts`). This environment is also running Node v26.0.0 while the repo requires Node 24.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the filter column identifier resolution more tolerant of formatting variations (casing, spaces, hyphens, underscores) by introducing a `normalizeFilterColumnIdentifier` helper that is applied in the `getColumnId` encode path. A focused client test covers the normalizer utility in isolation.

- **Encode path (`getColumnId`)**: Now normalizes both the input name and each column's `name`/`id` before comparing, so callers using display-style names like `\"Trace-Name\"` or `\"session id\"` are resolved correctly to the canonical `col.id`.
- **Decode path (`getColumnName`)**: Deliberately keeps exact matching since URL-encoded filter state already stores canonical column IDs produced by `getColumnId` \u2014 no behavioral change on the read side.
- **Test coverage**: Only the utility function itself is tested; integration coverage verifying `getColumnId` against real table column maps is absent.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the encode path change is backwards-compatible and the existing column definitions have no normalization collisions.

The change is narrow in scope and the normalization logic is straightforward. All current column IDs and names in every table are distinct after normalization, so there is no immediate breakage. Both findings are about future-proofing rather than present defects.

The getColumnName function in useFilterState.ts and the absence of cross-column collision tests warrant a closer look before the column definitions grow.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Filter state input\ne.g. column: 'Trace-Name'] --> B[encode path: getColumnId]
    B --> C[normalizeFilterColumnIdentifier\ntrim → lowercase → strip spaces/_/-]
    C --> D{Match col.name or col.id\nafter normalization?}
    D -- yes --> E[Return canonical col.id\ne.g. 'traceName']
    D -- no --> F[Return undefined\nfilter entry dropped]
    E --> G[URL query string\nfilter=traceName;...]
    G --> H[decode path: getColumnName]
    H --> I{Exact match col.id?}
    I -- yes --> J[Return col.name\nfor FilterState]
    I -- no --> K[Return undefined\nsingleFilter parse fails → null]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Filter state input\ne.g. column: 'Trace-Name'] --> B[encode path: getColumnId]
    B --> C[normalizeFilterColumnIdentifier\ntrim → lowercase → strip spaces/_/-]
    C --> D{Match col.name or col.id\nafter normalization?}
    D -- yes --> E[Return canonical col.id\ne.g. 'traceName']
    D -- no --> F[Return undefined\nfilter entry dropped]
    E --> G[URL query string\nfilter=traceName;...]
    G --> H[decode path: getColumnName]
    H --> I{Exact match col.id?}
    I -- yes --> J[Return col.name\nfor FilterState]
    I -- no --> K[Return undefined\nsingleFilter parse fails → null]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/filters/hooks/useFilterState.ts:233-235
**`getColumnName` intentionally skips normalization — worth a comment**

`getColumnName` is called in the decode path where `column` is always a canonical `col.id` stored by `getColumnId`, so exact matching is correct. However, without a comment, a future contributor may perceive this as an oversight and apply normalization here too. Normalized matching in the decode path could break URL-decoded filter state if two columns share a normalized ID — `getColumnName` would silently resolve to the first match rather than the exact one. A brief comment explaining that the decode path expects canonical IDs from the URL would protect this invariant.

### Issue 2 of 2
web/src/features/filters/hooks/useFilterState.ts:213-218
**Silent collision risk if future columns share a normalized form**

The normalizer strips all spaces, underscores, and hyphens and lowercases the result, so `"user_id"` and `"userId"` would both become `userid`. If two columns in the same table ever produce the same normalized name or ID — e.g., adding a `user_id` alias column alongside the existing `userId` — `getColumnId` silently returns the first `.find()` match with no warning. There are no collisions in the current column definitions, but nothing prevents a future addition from introducing one. Consider adding a dev-time assertion or a unit test that iterates over all `tableCols` entries and verifies no two columns within the same table share a normalized form.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(filters): tolerate formatted column ..."](https://github.com/langfuse/langfuse/commit/db6930ad207b8186402c83938b5bf928c04869b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43789888)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->