### PR TITLE
fix(prompts): namespace prompt cache selectors

### DIFF
--- a/packages/shared/src/server/services/PromptService/index.ts
+++ b/packages/shared/src/server/services/PromptService/index.ts
@@ -197,7 +197,13 @@ export class PromptService {
 
     const prefix = this.getCacheKeyPrefix(params, epoch);
 
-    return `${prefix}:${params.version ?? params.label}`;
+    // Numeric labels must not share a cache entry with the same prompt version.
+    const selector =
+      typeof params.version === "number"
+        ? `version:${params.version}`
+        : `label:${params.label}`;
+
+    return `${prefix}:${selector}`;
   }
 
   private getCacheKeyPrefix(

--- a/web/src/__e2e__/api.servertest.ts
+++ b/web/src/__e2e__/api.servertest.ts
@@ -311,7 +311,7 @@ describe("Prompts endpoint", () => {
 
     expect(validatedPrompt.name).toBe(promptName);
 
-    const pattern = `prompt:7a88fb47-b4e2-43b8-a06c-a5ce950dc53a:*:${promptName}:${validatedPrompt.labels[0]}`;
+    const pattern = `prompt:7a88fb47-b4e2-43b8-a06c-a5ce950dc53a:*:${promptName}:label:${validatedPrompt.labels[0]}`;
     const keys = await redis?.keys(pattern);
     expect(keys?.length).toBe(1);
 

--- a/web/src/__tests__/server/promptCache.servertest.ts
+++ b/web/src/__tests__/server/promptCache.servertest.ts
@@ -91,11 +91,56 @@ describe("PromptService", () => {
       );
 
       expect(mockRedis.set).toHaveBeenCalledWith(
-        "prompt:project1:epoch-1:testPrompt:1",
+        "prompt:project1:epoch-1:testPrompt:version:1",
         JSON.stringify(mockPrompt),
         "EX",
         expect.any(Number),
       );
+    });
+
+    it("does not share cached prompts between a version and numeric label", async () => {
+      const cache = new Map<string, string>([
+        ["prompt_cache_epoch:project1", "epoch-1"],
+      ]);
+      mockRedis.get.mockImplementation(async (key) => cache.get(key) ?? null);
+      mockRedis.set.mockImplementation(async (key, value) => {
+        cache.set(key, value.toString());
+        return "OK";
+      });
+
+      const versionPrompt = {
+        ...mockPrompt,
+        id: "version-3",
+        version: 3,
+        prompt: "Version 3 content",
+      };
+      const labelPrompt = {
+        ...mockPrompt,
+        id: "label-3",
+        version: 7,
+        labels: ["3"],
+        prompt: "Numeric label content",
+      };
+      mockPrisma.prompt.findFirst
+        .mockResolvedValueOnce(versionPrompt)
+        .mockResolvedValueOnce(labelPrompt);
+
+      const resultByVersion = await promptService.getPrompt({
+        projectId: "project1",
+        promptName: "testPrompt",
+        version: 3,
+        label: undefined,
+      });
+      const resultByLabel = await promptService.getPrompt({
+        projectId: "project1",
+        promptName: "testPrompt",
+        version: undefined,
+        label: "3",
+      });
+
+      expect(resultByVersion).toEqual(versionPrompt);
+      expect(resultByLabel).toEqual(labelPrompt);
+      expect(mockPrisma.prompt.findFirst).toHaveBeenCalledTimes(2);
     });
 
     it("should bypass cache entirely when resolve is false", async () => {


### PR DESCRIPTION
## What changed

- namespace prompt cache selectors as `version:<number>` and `label:<value>` so numeric labels cannot collide with prompt versions
- add a behavioral regression test that fetches version `3` and label `"3"` back-to-back and verifies they return different prompts
- update the E2E Redis-key assertion to the new `label:production` key shape

## Root cause

`PromptService.getCacheKey` serialized both selectors with `params.version ?? params.label`. As a result, version `3` and label `"3"` used the same Redis key and whichever request populated the cache first determined both responses.

The previous contributor PR (#14789) changed the production key format but left `web/src/__e2e__/api.servertest.ts` matching the old key shape. That caused the `e2e-server-tests` CI job to fail with `expected 0 to be 1` at the Redis-key assertion.

## Impact

Version and label lookups now use independent cache entries. Existing old-format entries are ignored and expire naturally via the configured TTL; no migration or cache flush is required.

Closes #14788.
Linear: LFE-10677.
Supersedes #14789.

## Verification

- `pnpm exec dotenv -e .env.test.example -e .env.dev.example -- pnpm --filter web run test promptCache.servertest.ts` — `Tests 10 passed (10)`
- `pnpm exec dotenv -e .env.dev.example -- pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm exec dotenv -e .env.dev.example -- pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- Prettier pre-commit check — `All matched files use Prettier code style!`

The container-backed E2E test could not be run locally because Docker is unavailable in this desktop runtime; the updated assertion is exercised by the PR's `e2e-server-tests` GitHub Actions job.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a cache key collision in `PromptService` where both `version: 3` and `label: "3"` resolved to the same Redis key, causing whichever request populated the cache first to serve both responses. The fix namespaces keys as `version:<n>` and `label:<value>` to guarantee independent cache entries.

- **Core fix** (`packages/shared/src/server/services/PromptService/index.ts`): `getCacheKey` now uses `typeof params.version === "number"` to distinguish the two lookup types, producing disjoint key suffixes. The `PromptParams` discriminated union ensures the else branch always has a string label, so no `label:undefined` key can be produced.
- **Regression test** (`web/src/__tests__/server/promptCache.servertest.ts`): New test wires an in-memory Map as a fake Redis store and asserts that fetching version `3` and label `"3"` in sequence each hits the database, directly guarding against the original bug.
- **E2E assertion** (`web/src/__e2e__/api.servertest.ts`): Redis key pattern updated from the bare label value to `label:<value>` to match the new format.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line logic fix in a private method, fully covered by a new targeted regression test and a corrected E2E assertion.

The fix is minimal and correct. The `PromptParams` discriminated union guarantees that the new else branch always receives a string label, so `label:undefined` cannot appear as a key suffix. Old-format cache entries expire naturally via TTL and require no migration. The new test directly simulates the version/label collision scenario that caused the original bug and verifies it is resolved.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(prompts): namespace prompt cache sel..."](https://github.com/langfuse/langfuse/commit/400f8a8898ec8a6f67b49cc850573717745fea9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43869012)</sub>

<!-- /greptile_comment -->