### PR TITLE
fix(cloud-usage-metering): raise interval count query timeout to 5 minutes

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1621,7 +1621,7 @@ export const getObservationCountsByProjectInCreationInterval = async ({
       end: convertDateToClickhouseDateTime(end),
     },
     clickhouseConfigs: {
-      request_timeout: 120000, // 2 minutes timeout
+      request_timeout: 300000, // 5 minutes timeout
     },
   });
 

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2060,7 +2060,7 @@ export const getScoreCountsByProjectInCreationInterval = async ({
       dataTypes: LISTABLE_SCORE_TYPES,
     },
     clickhouseConfigs: {
-      request_timeout: 120000, // 2 minutes timeout
+      request_timeout: 300000, // 5 minutes timeout
     },
   });
 

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -435,7 +435,7 @@ export const getTraceCountsByProjectInCreationInterval = async ({
           query,
           params: input.params,
           clickhouseConfigs: {
-            request_timeout: 120000, // 2 minutes timeout
+            request_timeout: 300000, // 5 minutes timeout
           },
         },
       );


### PR DESCRIPTION
The hourly metering job counts observations/traces/scores per project by created_at, which is not part of these tables' sort keys, so each count is effectively a full scan. In prod-eu the observations scan's p95 grew from ~89s (Jul 9) to ~125s (Jul 13) - exactly the server-side kill derived from request_timeout 120s + 5s grace (max_execution_time=125) - so first attempts now time out regularly and fire the metering failure and burn-rate monitors.

Raise request_timeout to 300s for the three metering count queries to restore headroom until the scan itself is fixed (follow-up: minmax skip index on created_at). Worst-case job runtime rises to ~27min (three 5-min scans plus the ~12-min Stripe loop), still finishing well before the next hourly repeat, so the 20-minute stale-retry override cannot start a concurrent run.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR raises the ClickHouse `request_timeout` from 120 s (120 000 ms) to 300 s (300 000 ms) for the three hourly metering count queries — `getObservationCountsByProjectInCreationInterval`, `getScoreCountsByProjectInCreationInterval`, and `getTraceCountsByProjectInCreationInterval` — to prevent them from being killed by the server-side execution limit derived from that client timeout.

- The three changed functions each scan the `observations`, `scores`, and `traces` tables filtered only on `created_at`, which is not part of any sort key, making each effectively a full-table scan; the increased timeout gives headroom until a minmax skip index on `created_at` is added as a follow-up.
- The change is applied consistently across all three repositories; the updated comments correctly reflect the new 5-minute value.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, identical one-line timeout increase in three isolated metering query helpers with no side effects on other callers.

All three metering count functions receive the same 120 000 → 300 000 ms adjustment; comments are updated to match, and the rationale (server-side kill at 125 s derived from the previous client timeout) is clearly documented. Worst-case job duration (~27 min) stays within the hourly window and below any stale-retry threshold that could cause a concurrent run. No logic, data handling, or API surface changes.

No files require special attention. All three changes are structurally identical and low-risk.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Job as Hourly Metering Job
    participant CH as ClickHouse
    participant Stripe as Stripe API

    Job->>CH: getTraceCountsByProjectInCreationInterval (request_timeout: 300s)
    Note over CH: Full scan on traces.created_at (no sort-key match)
    CH-->>Job: trace counts per project

    Job->>CH: getObservationCountsByProjectInCreationInterval (request_timeout: 300s)
    Note over CH: Full scan on observations.created_at (no sort-key match)
    CH-->>Job: observation counts per project

    Job->>CH: getScoreCountsByProjectInCreationInterval (request_timeout: 300s)
    Note over CH: Full scan on scores.created_at (no sort-key match)
    CH-->>Job: score counts per project

    Job->>Stripe: Report usage (~12 min loop)
    Stripe-->>Job: Confirmed
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Job as Hourly Metering Job
    participant CH as ClickHouse
    participant Stripe as Stripe API

    Job->>CH: getTraceCountsByProjectInCreationInterval (request_timeout: 300s)
    Note over CH: Full scan on traces.created_at (no sort-key match)
    CH-->>Job: trace counts per project

    Job->>CH: getObservationCountsByProjectInCreationInterval (request_timeout: 300s)
    Note over CH: Full scan on observations.created_at (no sort-key match)
    CH-->>Job: observation counts per project

    Job->>CH: getScoreCountsByProjectInCreationInterval (request_timeout: 300s)
    Note over CH: Full scan on scores.created_at (no sort-key match)
    CH-->>Job: score counts per project

    Job->>Stripe: Report usage (~12 min loop)
    Stripe-->>Job: Confirmed
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cloud-usage-metering): raise interva..."](https://github.com/langfuse/langfuse/commit/b2cd0c5cc35f8865c206b857cf9e1a86e748c40d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43808779)</sub>

<!-- /greptile_comment -->