### PR TITLE
feat(agent): add contextual assistant entry points

### DIFF
--- a/packages/shared/src/server/services/DashboardService/DashboardService.ts
+++ b/packages/shared/src/server/services/DashboardService/DashboardService.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../../db";
 import {
   LangfuseConflictError,
@@ -18,6 +20,104 @@ import { z } from "zod";
 import { singleFilter } from "../../../";
 
 export class DashboardService {
+  /**
+   * Places a reusable widget below the existing content of a project-owned
+   * dashboard. The scoped reads and definition update are one serializable
+   * operation so concurrent placements cannot overwrite each other.
+   */
+  public static async addWidgetToDashboard(props: {
+    dashboardId: string;
+    widgetId: string;
+    projectId: string;
+    userId?: string;
+  }): Promise<{
+    beforeDashboard: DashboardDomain;
+    updatedDashboard: DashboardDomain;
+    widget: WidgetDomain;
+  }> {
+    const { dashboardId, widgetId, projectId, userId } = props;
+
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        return await prisma.$transaction(
+          async (tx) => {
+            const [dashboard, widget] = await Promise.all([
+              tx.dashboard.findFirst({
+                where: { id: dashboardId, projectId },
+              }),
+              tx.dashboardWidget.findFirst({
+                where: {
+                  id: widgetId,
+                  OR: [{ projectId }, { projectId: null }],
+                },
+              }),
+            ]);
+
+            if (!dashboard) {
+              throw new LangfuseNotFoundError("Dashboard not found");
+            }
+            if (!widget) {
+              throw new LangfuseNotFoundError("Dashboard widget not found");
+            }
+
+            const beforeDashboard = DashboardDomainSchema.parse({
+              ...dashboard,
+              owner: "PROJECT",
+            });
+            const domainWidget = WidgetDomainSchema.parse({
+              ...widget,
+              owner: widget.projectId ? "PROJECT" : "LANGFUSE",
+            });
+            const maxY = beforeDashboard.definition.widgets.reduce(
+              (currentMax, placement) =>
+                Math.max(currentMax, placement.y + placement.y_size),
+              0,
+            );
+
+            const updated = await tx.dashboard.update({
+              where: { id: dashboardId, projectId },
+              data: {
+                updatedBy: userId,
+                definition: {
+                  widgets: [
+                    ...beforeDashboard.definition.widgets,
+                    {
+                      type: "widget",
+                      id: randomUUID(),
+                      widgetId: domainWidget.id,
+                      x: 0,
+                      y: maxY,
+                      x_size: 6,
+                      y_size: 6,
+                    },
+                  ],
+                },
+              },
+            });
+
+            return {
+              beforeDashboard,
+              updatedDashboard: DashboardDomainSchema.parse({
+                ...updated,
+                owner: "PROJECT",
+              }),
+              widget: domainWidget,
+            };
+          },
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        );
+      } catch (error) {
+        const shouldRetry =
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === "P2034" &&
+          attempt < 2;
+        if (!shouldRetry) {
+          throw error;
+        }
+      }
+    }
+  }
+
   /**
    * Retrieves a list of dashboards for a given project.
    */

--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -242,7 +242,9 @@ describe("MCP public API tools", () => {
       .sort();
     expect(destructiveToolNames).toEqual(
       [
+        "addWidgetToDashboard",
         "createChatPrompt",
+        "createDashboard",
         "createDashboardWidget",
         "createEvaluationRule",
         "upsertEvaluator",

--- a/web/src/__tests__/server/mcp-tools-write.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-write.servertest.ts
@@ -626,6 +626,77 @@ describe("MCP Write Tools", () => {
         ),
       ).rejects.toThrow("Dashboard widget not found");
     });
+
+    it("should reject a dashboard from another project", async () => {
+      const setup = await createMcpTestSetup();
+      const foreignSetup = await createMcpTestSetup();
+      const foreignDashboard = await prisma.dashboard.create({
+        data: {
+          projectId: foreignSetup.projectId,
+          name: `mcp-dashboard-${nanoid()}`,
+          description: "Dashboard",
+          definition: { widgets: [] },
+        },
+      });
+      const widget = await prisma.dashboardWidget.create({
+        data: {
+          projectId: setup.projectId,
+          name: `mcp-widget-${nanoid()}`,
+          description: "Widget",
+          view: "OBSERVATIONS",
+          dimensions: [],
+          metrics: [{ measure: "count", agg: "count" }],
+          filters: [],
+          chartType: "NUMBER",
+          chartConfig: { type: "NUMBER" },
+          minVersion: 2,
+        },
+      });
+
+      await expect(
+        handleAddWidgetToDashboard(
+          { dashboardId: foreignDashboard.id, widgetId: widget.id },
+          setup.context,
+        ),
+      ).rejects.toThrow("Dashboard not found");
+    });
+
+    it("should reject a Langfuse-managed dashboard", async () => {
+      const setup = await createMcpTestSetup();
+      const managedDashboard = await prisma.dashboard.create({
+        data: {
+          projectId: null,
+          name: `managed-dashboard-${nanoid()}`,
+          description: "Managed dashboard",
+          definition: { widgets: [] },
+        },
+      });
+      const widget = await prisma.dashboardWidget.create({
+        data: {
+          projectId: setup.projectId,
+          name: `mcp-widget-${nanoid()}`,
+          description: "Widget",
+          view: "OBSERVATIONS",
+          dimensions: [],
+          metrics: [{ measure: "count", agg: "count" }],
+          filters: [],
+          chartType: "NUMBER",
+          chartConfig: { type: "NUMBER" },
+          minVersion: 2,
+        },
+      });
+
+      try {
+        await expect(
+          handleAddWidgetToDashboard(
+            { dashboardId: managedDashboard.id, widgetId: widget.id },
+            setup.context,
+          ),
+        ).rejects.toThrow("Dashboard not found");
+      } finally {
+        await prisma.dashboard.delete({ where: { id: managedDashboard.id } });
+      }
+    });
   });
 
   describe("createTextPrompt tool", () => {

--- a/web/src/__tests__/server/mcp-tools-write.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-write.servertest.ts
@@ -85,6 +85,14 @@ import {
   createDashboardWidgetTool,
   handleCreateDashboardWidget,
 } from "@/src/features/mcp/features/dashboardWidgets/tools/createDashboardWidget";
+import {
+  createDashboardTool,
+  handleCreateDashboard,
+} from "@/src/features/mcp/features/dashboardWidgets/tools/createDashboard";
+import {
+  addWidgetToDashboardTool,
+  handleAddWidgetToDashboard,
+} from "@/src/features/mcp/features/dashboardWidgets/tools/addWidgetToDashboard";
 
 const createScoreConfig = async (projectId: string) =>
   prisma.scoreConfig.create({
@@ -471,6 +479,152 @@ describe("MCP Write Tools", () => {
           action: "create",
         }),
       ).resolves.toMatchObject({ resourceId: result.id, action: "create" });
+    });
+  });
+
+  describe("dashboard composition tools", () => {
+    it("should create a dashboard and audit the write", async () => {
+      const setup = await createMcpTestSetup();
+      const name = `mcp-dashboard-${nanoid()}`;
+
+      verifyToolAnnotations(createDashboardTool, { destructiveHint: true });
+
+      const result = (await handleCreateDashboard(
+        { name, description: "Created by MCP" },
+        setup.context,
+      )) as { id: string; name: string; url: string };
+
+      expect(result).toMatchObject({
+        id: expect.any(String),
+        name,
+        url: expect.stringContaining(`/project/${setup.projectId}/dashboards/`),
+      });
+      await expect(
+        prisma.dashboard.findFirst({
+          where: { id: result.id, projectId: setup.projectId },
+        }),
+      ).resolves.toMatchObject({ name, definition: { widgets: [] } });
+      await expect(
+        verifyAuditLog({
+          projectId: setup.projectId,
+          apiKeyId: setup.apiKeyId,
+          resourceType: "dashboard",
+          resourceId: result.id,
+          action: "create",
+        }),
+      ).resolves.toMatchObject({ resourceId: result.id, action: "create" });
+    });
+
+    it("should place a project widget at the bottom of a dashboard", async () => {
+      const setup = await createMcpTestSetup();
+      const dashboard = await prisma.dashboard.create({
+        data: {
+          projectId: setup.projectId,
+          name: `mcp-dashboard-${nanoid()}`,
+          description: "Dashboard",
+          definition: {
+            widgets: [
+              {
+                type: "preset",
+                id: "existing",
+                presetId: "home-traces",
+                x: 0,
+                y: 0,
+                x_size: 6,
+                y_size: 4,
+              },
+            ],
+          },
+        },
+      });
+      const widget = await prisma.dashboardWidget.create({
+        data: {
+          projectId: setup.projectId,
+          name: `mcp-widget-${nanoid()}`,
+          description: "Widget",
+          view: "OBSERVATIONS",
+          dimensions: [],
+          metrics: [{ measure: "count", agg: "count" }],
+          filters: [],
+          chartType: "NUMBER",
+          chartConfig: { type: "NUMBER" },
+          minVersion: 2,
+        },
+      });
+
+      verifyToolAnnotations(addWidgetToDashboardTool, {
+        destructiveHint: true,
+      });
+
+      await handleAddWidgetToDashboard(
+        { dashboardId: dashboard.id, widgetId: widget.id },
+        setup.context,
+      );
+
+      await expect(
+        prisma.dashboard.findFirstOrThrow({
+          where: { id: dashboard.id, projectId: setup.projectId },
+        }),
+      ).resolves.toMatchObject({
+        definition: {
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              type: "widget",
+              widgetId: widget.id,
+              x: 0,
+              y: 4,
+              x_size: 6,
+              y_size: 6,
+            }),
+          ]),
+        },
+      });
+      await expect(
+        verifyAuditLog({
+          projectId: setup.projectId,
+          apiKeyId: setup.apiKeyId,
+          resourceType: "dashboard",
+          resourceId: dashboard.id,
+          action: "update",
+        }),
+      ).resolves.toMatchObject({
+        resourceId: dashboard.id,
+        action: "update",
+      });
+    });
+
+    it("should reject a widget from another project", async () => {
+      const setup = await createMcpTestSetup();
+      const foreignSetup = await createMcpTestSetup();
+      const dashboard = await prisma.dashboard.create({
+        data: {
+          projectId: setup.projectId,
+          name: `mcp-dashboard-${nanoid()}`,
+          description: "Dashboard",
+          definition: { widgets: [] },
+        },
+      });
+      const foreignWidget = await prisma.dashboardWidget.create({
+        data: {
+          projectId: foreignSetup.projectId,
+          name: `mcp-widget-${nanoid()}`,
+          description: "Widget",
+          view: "OBSERVATIONS",
+          dimensions: [],
+          metrics: [{ measure: "count", agg: "count" }],
+          filters: [],
+          chartType: "NUMBER",
+          chartConfig: { type: "NUMBER" },
+          minVersion: 2,
+        },
+      });
+
+      await expect(
+        handleAddWidgetToDashboard(
+          { dashboardId: dashboard.id, widgetId: foreignWidget.id },
+          setup.context,
+        ),
+      ).rejects.toThrow("Dashboard widget not found");
     });
   });
 

--- a/web/src/__tests__/server/unit/in-app-agent-selection.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-selection.servertest.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { IN_APP_AGENT_TRACE_SELECTION_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
+import { InAppAgentRuntimeStateSchema } from "@/src/ee/features/in-app-agent/schema";
+import {
+  createSelectedTraceIdentifiersTool,
+  withInAppAgentToolApproval,
+} from "@/src/ee/features/in-app-agent/server/tools";
+
+describe("createSelectedTraceIdentifiersTool", () => {
+  it("returns a deduplicated large selection in bounded pages", async () => {
+    const tool = createSelectedTraceIdentifiersTool({
+      kind: "traces",
+      ids: [
+        ...Array.from({ length: 55 }, (_, index) => `trace-${index}`),
+        "trace-0",
+      ],
+    });
+    const tools = withInAppAgentToolApproval({
+      [IN_APP_AGENT_TRACE_SELECTION_TOOL_NAME]: tool,
+    });
+
+    expect(
+      InAppAgentRuntimeStateSchema.safeParse({
+        type: "newConversation",
+        projectId: "project-1",
+        traceSelection: {
+          kind: "traces",
+          ids: Array.from({ length: 55 }, (_, index) => `trace-${index}`),
+        },
+      }).success,
+    ).toBe(true);
+    expect(
+      tools[IN_APP_AGENT_TRACE_SELECTION_TOOL_NAME]?.requireApproval,
+    ).not.toBe(true);
+
+    await expect(tool.execute?.({} as never, {} as never)).resolves.toEqual({
+      kind: "traces",
+      ids: Array.from({ length: 50 }, (_, index) => `trace-${index}`),
+      totalCount: 55,
+      nextCursor: 50,
+    });
+    await expect(
+      tool.execute?.({ cursor: 50 } as never, {} as never),
+    ).resolves.toEqual({
+      kind: "traces",
+      ids: Array.from({ length: 5 }, (_, index) => `trace-${index + 50}`),
+      totalCount: 55,
+      nextCursor: null,
+    });
+  });
+});

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -121,8 +121,8 @@ const PageHeader = ({
                 hoisted from a list table via PageHeaderControlsPortal.
                 Empty on pages that don't use it. */}
             <div className="flex flex-wrap items-center gap-2">
-              <PageHeaderControlsSlotTarget />
               <InAppAgentHeaderButton />
+              <PageHeaderControlsSlotTarget />
             </div>
           </div>
         </div>

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -2,6 +2,7 @@ import { EnvLabel } from "@/src/components/EnvLabel";
 import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
 import BreadcrumbComponent from "@/src/components/layouts/breadcrumb";
 import { PageHeaderControlsSlotTarget } from "@/src/components/layouts/page-header-controls-slot";
+import { InAppAgentHeaderButton } from "@/src/ee/features/in-app-agent/components/InAppAgentHeaderButton";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { SidebarTrigger } from "@/src/components/ui/sidebar";
 import {
@@ -121,6 +122,7 @@ const PageHeader = ({
                 Empty on pages that don't use it. */}
             <div className="flex flex-wrap items-center gap-2">
               <PageHeaderControlsSlotTarget />
+              <InAppAgentHeaderButton />
             </div>
           </div>
         </div>

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -1,225 +1,30 @@
-import { useLayoutEffect, useRef, useState } from "react";
 import { BotMessageSquare } from "lucide-react";
 
-import { Button } from "@/src/components/ui/button";
-import { ConfirmDialog } from "@/src/components/ui/confirm-dialog";
-import {
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/src/components/ui/dialog";
-import { DialogController } from "@/src/components/ui/dialog-controller";
-import { Layer } from "@/src/components/ui/layer";
 import { SidebarMenuButton } from "@/src/components/ui/sidebar";
-import { ControlledInAppAgentWindow } from "@/src/ee/features/in-app-agent/components";
-import {
-  InAppAgentWindowShell,
-  useInAppAgentWindowShellPanelControl,
-} from "@/src/ee/features/in-app-agent/components/InAppAgentWindowShell";
 import { useInAppAiAgent } from "@/src/ee/features/in-app-agent/components/InAppAiAgentProvider";
-import type { InAppAgentWindowConversation } from "@/src/ee/features/in-app-agent/components/InAppAgentWindow";
-import { useHasEntitlement } from "@/src/features/entitlements/hooks";
-import { AIFeaturesDisabledNotice } from "@/src/features/organizations/components/AIFeaturesDisabledNotice";
-import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback";
-
-function DeleteConversationDialog({
-  close,
-  conversation,
-  onDeleteConversation,
-}: {
-  close: () => void;
-  conversation: InAppAgentWindowConversation | null;
-  onDeleteConversation: (conversationId: string) => Promise<void>;
-}) {
-  const [deleteConversation, isDeletingConversation] =
-    useWatchedPromiseCallback(async () => {
-      if (!conversation) {
-        return;
-      }
-
-      try {
-        await onDeleteConversation(conversation.id);
-        close();
-      } catch {
-        // Error is already surfaced by the provider; keep the dialog open for retry.
-      }
-    }, [close, conversation, onDeleteConversation]);
-
-  return (
-    <ConfirmDialog
-      open={conversation !== null}
-      onOpenChange={(open) => {
-        if (!open) {
-          close();
-        }
-      }}
-      title="Delete conversation"
-      description="This removes the conversation from your recent conversations. This action cannot be undone."
-      confirmLabel="Delete conversation"
-      loading={isDeletingConversation}
-      onConfirm={deleteConversation}
-    />
-  );
-}
 
 export const InAppAiAgentButton = () => {
-  const { organization } = useQueryProjectOrOrganization();
-  const {
-    deleteConversation,
-    isAvailable,
-    open,
-    setOpen,
-    isExpanded,
-    setIsExpanded,
-  } = useInAppAiAgent();
-  const hasInAppAgentEntitlement = useHasEntitlement("in-app-agent");
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
-  const previousPanelRectRef = useRef<DOMRect | null>(null);
-  const [enableDialogOpen, setEnableDialogOpen] = useState(false);
+  const { isAvailable, open, openAssistant, setOpen } = useInAppAiAgent();
 
-  const floatingPanelHandle = useInAppAgentWindowShellPanelControl({
-    anchorRef: buttonRef,
-  });
-
-  useLayoutEffect(() => {
-    const previousRect = previousPanelRectRef.current;
-    const panel = panelRef.current;
-
-    previousPanelRectRef.current = null;
-
-    if (!previousRect || !panel) {
-      return;
-    }
-
-    const nextRect = panel.getBoundingClientRect();
-
-    panel.animate(
-      [
-        {
-          transform: `translate(${previousRect.left - nextRect.left}px, ${previousRect.top - nextRect.top}px) scale(${nextRect.width > 0 ? previousRect.width / nextRect.width : 1}, ${nextRect.height > 0 ? previousRect.height / nextRect.height : 1})`,
-        },
-        { transform: "translate(0, 0) scale(1, 1)" },
-      ],
-      {
-        duration: 180,
-        easing: "cubic-bezier(0.2, 0, 0, 1)",
-      },
-    );
-  }, [isExpanded]);
-
-  useLayoutEffect(() => {
-    if (!open || isExpanded || floatingPanelHandle.geometry) {
-      return;
-    }
-
-    floatingPanelHandle.initializeGeometry();
-  }, [floatingPanelHandle, isExpanded, open]);
-
-  if (!isAvailable || !hasInAppAgentEntitlement) {
+  if (!isAvailable) {
     return null;
   }
 
-  const handleClick = () => {
-    if (organization && !organization.aiFeaturesEnabled) {
-      setEnableDialogOpen(true);
-      return;
-    }
-
-    const willOpen = !open;
-
-    if (willOpen) {
-      floatingPanelHandle.resetGeometry();
-    }
-
-    setOpen((currentOpen) => !currentOpen);
-  };
-
   return (
-    <>
-      <SidebarMenuButton
-        ref={buttonRef}
-        data-ignore-outside-interaction
-        isActive={open}
-        onClick={handleClick}
-      >
-        <BotMessageSquare className="h-4 w-4" />
-        Assistant
-      </SidebarMenuButton>
-      {open ? (
-        <DialogController<InAppAgentWindowConversation>
-          dialog={(close, conversation) => (
-            <DeleteConversationDialog
-              close={close}
-              conversation={conversation}
-              onDeleteConversation={deleteConversation}
-            />
-          )}
-        >
-          {(deleteConversationDialog) => (
-            // The assistant window lives in the `agent` overlay layer — a
-            // <body>-level layer container that floats above page content and
-            // panel surfaces, but below true modals and transient overlays by DOM
-            // order alone. No z-index: layer ORDER stacks it (see
-            // components/ui/layer.tsx). This replaces the old body portal + z-51,
-            // which fought the nav-user dropdown's z-60 at <body> level.
-            <Layer name="agent">
-              <InAppAgentWindowShell
-                floatingPanelHandle={floatingPanelHandle}
-                isExpanded={isExpanded}
-                panelRef={panelRef}
-              >
-                {({ isHeaderDragHandleEnabled }) => (
-                  <ControlledInAppAgentWindow
-                    isHeaderDragHandleEnabled={isHeaderDragHandleEnabled}
-                    isExpanded={isExpanded}
-                    onDeleteConversation={(conversation) =>
-                      deleteConversationDialog.open(conversation)
-                    }
-                    onExpandedChange={(nextIsExpanded) => {
-                      previousPanelRectRef.current =
-                        panelRef.current?.getBoundingClientRect() ?? null;
-                      setIsExpanded(nextIsExpanded);
-                    }}
-                    onClose={() => {
-                      floatingPanelHandle.clearGeometry();
-                      setOpen(false);
-                    }}
-                  />
-                )}
-              </InAppAgentWindowShell>
-            </Layer>
-          )}
-        </DialogController>
-      ) : null}
-      <Dialog open={enableDialogOpen} onOpenChange={setEnableDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>AI features are disabled</DialogTitle>
-          </DialogHeader>
-          <DialogBody>
-            <AIFeaturesDisabledNotice organizationId={organization?.id}>
-              The assistant requires AI features to be enabled for this
-              organization.
-            </AIFeaturesDisabledNotice>
-          </DialogBody>
-          <DialogFooter>
-            <div className="flex justify-end">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setEnableDialogOpen(false)}
-              >
-                Close
-              </Button>
-            </div>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+    <SidebarMenuButton
+      data-ignore-outside-interaction
+      isActive={open}
+      onClick={() => {
+        if (open) {
+          setOpen(false);
+          return;
+        }
+
+        openAssistant("sidebar");
+      }}
+    >
+      <BotMessageSquare className="h-4 w-4" />
+      Assistant
+    </SidebarMenuButton>
   );
 };

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -62,6 +62,7 @@ import { InfoIcon, MoreVertical } from "lucide-react";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import React from "react";
 import { TableActionMenu } from "@/src/features/table/components/TableActionMenu";
+import { InAppAgentAnalyzeSelectionButton } from "@/src/ee/features/in-app-agent/components/InAppAgentTraceButtons";
 import { useSelectAll } from "@/src/features/table/hooks/useSelectAll";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { TableSelectionManager } from "@/src/features/table/components/TableSelectionManager";
@@ -1485,7 +1486,13 @@ export default function TracesTable({
                     setSelectedRows({});
                     setSelectAll(false);
                   }}
-                />
+                >
+                  <InAppAgentAnalyzeSelectionButton
+                    traceIds={selectedTraceIds}
+                    observationIds={[]}
+                    selectAll={selectAll}
+                  />
+                </TableActionMenu>
               ) : null,
               <BatchExportTableButton
                 {...{

--- a/web/src/components/trace/components/ObservationDetailView/ObservationDetailViewHeader.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationDetailViewHeader.tsx
@@ -60,6 +60,7 @@ import {
 } from "@/src/components/ui/drawer";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { DualAnnotationContent } from "@/src/features/scores/components/DualAnnotationContent";
+import { InAppAgentExplainErrorButton } from "@/src/ee/features/in-app-agent/components/InAppAgentTraceButtons";
 
 export interface ObservationDetailViewHeaderProps {
   observation: ObservationReturnTypeWithMetadata;
@@ -149,6 +150,12 @@ export const ObservationDetailViewHeader = memo(
           </div>
           {/* Action buttons */}
           <div className="flex h-full flex-wrap content-start items-start justify-start gap-0.5 @2xl:mr-1 @2xl:justify-end">
+            {observation.level === "ERROR" && (
+              <InAppAgentExplainErrorButton
+                traceId={traceId}
+                observationId={observation.id}
+              />
+            )}
             {observationWithIO && (
               <NewDatasetItemFromExistingObject
                 traceId={traceId}

--- a/web/src/components/trace/components/TraceDetailView/TraceDetailViewHeader.tsx
+++ b/web/src/components/trace/components/TraceDetailView/TraceDetailViewHeader.tsx
@@ -42,6 +42,7 @@ import {
 import { aggregateTraceMetrics } from "@/src/components/trace/lib/trace-aggregation";
 import { resolveEvalExecutionMetadata } from "@/src/components/trace/lib/resolve-metadata";
 import { useViewPreferences } from "@/src/components/trace/contexts/ViewPreferencesContext";
+import { InAppAgentExplainErrorButton } from "@/src/ee/features/in-app-agent/components/InAppAgentTraceButtons";
 
 export interface TraceDetailViewHeaderProps {
   trace: Omit<WithStringifiedMetadata<TraceDomain>, "input" | "output"> & {
@@ -78,6 +79,9 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
     () => aggregateTraceMetrics(observations),
     [observations],
   );
+  const hasErrors = observations.some(
+    (observation) => observation.level === "ERROR",
+  );
 
   const targetTraceId =
     trace.environment === LangfuseInternalTraceEnvironment.LLMJudge
@@ -104,6 +108,12 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
         </div>
         {/* Action buttons */}
         <div className="flex h-full flex-wrap content-start items-start justify-start gap-0.5 @2xl:mr-1 @2xl:justify-end">
+          {hasErrors && (
+            <InAppAgentExplainErrorButton
+              traceId={trace.id}
+              label="Investigate errors"
+            />
+          )}
           <NewDatasetItemFromExistingObject
             traceId={trace.id}
             projectId={projectId}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentDashboardButtons.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentDashboardButtons.clienttest.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import {
+  InAppAgentDashboardComposer,
+  InAppAgentWidgetComposer,
+} from "./InAppAgentDashboardButtons";
+
+const startAssistantRun = vi.fn().mockResolvedValue(true);
+
+vi.mock("./InAppAiAgentProvider", () => ({
+  useInAppAiAgent: () => ({
+    isAvailable: true,
+    isRunning: false,
+    isSubmitting: false,
+    startAssistantRun,
+  }),
+}));
+
+describe("in-app agent dashboard entry points", () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+  });
+
+  beforeEach(() => {
+    startAssistantRun.mockClear();
+  });
+
+  it("creates the requested widget from the add-widget dialog", async () => {
+    const onSubmitted = vi.fn();
+    render(
+      <InAppAgentWidgetComposer
+        dashboardId="dashboard-1"
+        onSubmitted={onSubmitted}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Describe the widget you want"), {
+      target: { value: "Show p95 latency by model" },
+    });
+    const form = screen
+      .getByRole("button", { name: "Create with Assistant" })
+      .closest("form");
+    if (!form) {
+      throw new Error("Expected widget composer form");
+    }
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(startAssistantRun).toHaveBeenCalledWith({
+        source: "dashboard_widget",
+        dashboardId: "dashboard-1",
+        request: "Show p95 latency by model",
+      });
+    });
+    expect(onSubmitted).toHaveBeenCalledOnce();
+  });
+
+  it("uses the dashboard purpose and selected widget preference", async () => {
+    render(
+      <InAppAgentDashboardComposer
+        name="Reliability"
+        description="Track latency and errors for production"
+      />,
+    );
+
+    const includeWidgets = screen.getByRole("checkbox", {
+      name: "Design and add widgets for this dashboard",
+    });
+    expect(includeWidgets).toBeChecked();
+    fireEvent.click(includeWidgets);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue with Assistant" }),
+    );
+
+    await waitFor(() => {
+      expect(startAssistantRun).toHaveBeenCalledWith({
+        source: "dashboard_create",
+        name: "Reliability",
+        description: "Track latency and errors for production",
+        includeWidgets: false,
+      });
+    });
+  });
+});

--- a/web/src/ee/features/in-app-agent/components/InAppAgentDashboardButtons.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentDashboardButtons.clienttest.tsx
@@ -6,11 +6,12 @@ import {
 } from "./InAppAgentDashboardButtons";
 
 const startAssistantRun = vi.fn().mockResolvedValue(true);
+let isRunning = false;
 
 vi.mock("./InAppAiAgentProvider", () => ({
   useInAppAiAgent: () => ({
     isAvailable: true,
-    isRunning: false,
+    isRunning,
     isSubmitting: false,
     startAssistantRun,
   }),
@@ -29,10 +30,11 @@ describe("in-app agent dashboard entry points", () => {
   });
 
   beforeEach(() => {
+    isRunning = false;
     startAssistantRun.mockClear();
   });
 
-  it("creates the requested widget from the add-widget dialog", async () => {
+  it("creates the requested widget once when Enter is pressed", async () => {
     const onSubmitted = vi.fn();
     render(
       <InAppAgentWidgetComposer
@@ -44,13 +46,10 @@ describe("in-app agent dashboard entry points", () => {
     fireEvent.change(screen.getByLabelText("Describe the widget you want"), {
       target: { value: "Show p95 latency by model" },
     });
-    const form = screen
-      .getByRole("button", { name: "Create with Assistant" })
-      .closest("form");
-    if (!form) {
-      throw new Error("Expected widget composer form");
-    }
-    fireEvent.submit(form);
+    fireEvent.keyDown(screen.getByLabelText("Describe the widget you want"), {
+      key: "Enter",
+      code: "Enter",
+    });
 
     await waitFor(() => {
       expect(startAssistantRun).toHaveBeenCalledWith({
@@ -59,6 +58,7 @@ describe("in-app agent dashboard entry points", () => {
         request: "Show p95 latency by model",
       });
     });
+    expect(startAssistantRun).toHaveBeenCalledOnce();
     expect(onSubmitted).toHaveBeenCalledOnce();
   });
 
@@ -88,5 +88,25 @@ describe("in-app agent dashboard entry points", () => {
         includeWidgets: false,
       });
     });
+  });
+
+  it("locks the dashboard creation preferences while the assistant runs", () => {
+    isRunning = true;
+
+    render(
+      <InAppAgentDashboardComposer
+        name="Reliability"
+        description="Track production reliability"
+      />,
+    );
+
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Design and add widgets for this dashboard",
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Continue with Assistant" }),
+    ).toBeDisabled();
   });
 });

--- a/web/src/ee/features/in-app-agent/components/InAppAgentDashboardButtons.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentDashboardButtons.tsx
@@ -64,6 +64,16 @@ export function InAppAgentWidgetComposer({
           onChange={(event) => {
             setRequest(event.target.value);
           }}
+          onKeyDown={(event) => {
+            if (
+              event.key === "Enter" &&
+              !event.shiftKey &&
+              !event.nativeEvent.isComposing
+            ) {
+              event.preventDefault();
+              event.currentTarget.form?.requestSubmit();
+            }
+          }}
         />
         <Button
           type="submit"
@@ -128,6 +138,7 @@ export function InAppAgentDashboardComposer({
         <Checkbox
           id="assistant-dashboard-widgets"
           checked={includeWidgets}
+          disabled={isRunning || isSubmitting}
           onCheckedChange={(checked) => {
             setIncludeWidgets(checked === true);
           }}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentDashboardButtons.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentDashboardButtons.tsx
@@ -1,0 +1,154 @@
+import { type SyntheticEvent, useState } from "react";
+import { BotMessageSquare, Sparkles } from "lucide-react";
+
+import { Button } from "@/src/components/ui/button";
+import { Checkbox } from "@/src/components/ui/checkbox";
+import { Input } from "@/src/components/ui/input";
+import { Label } from "@/src/components/ui/label";
+import { useInAppAiAgent } from "./InAppAiAgentProvider";
+
+export function InAppAgentWidgetComposer({
+  dashboardId,
+  onSubmitted,
+}: {
+  dashboardId: string;
+  onSubmitted: () => void;
+}) {
+  const { isAvailable, isRunning, isSubmitting, startAssistantRun } =
+    useInAppAiAgent();
+  const [request, setRequest] = useState("");
+
+  if (!isAvailable) {
+    return null;
+  }
+
+  const handleSubmit = async (event: SyntheticEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedRequest = request.trim();
+    if (!trimmedRequest || isRunning || isSubmitting) {
+      return;
+    }
+
+    const started = await startAssistantRun({
+      source: "dashboard_widget",
+      dashboardId,
+      request: trimmedRequest,
+    });
+
+    if (started) {
+      setRequest("");
+      onSubmitted();
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-muted/30 flex flex-col gap-2 rounded-lg border p-3"
+    >
+      <div className="flex items-center gap-2 font-medium">
+        <Sparkles className="h-4 w-4" />
+        Create with Assistant
+      </div>
+      <p className="text-muted-foreground text-xs">
+        Describe the chart you need. The assistant will create it and add it to
+        this dashboard.
+      </p>
+      <div className="flex gap-2">
+        <Input
+          aria-label="Describe the widget you want"
+          autoComplete="off"
+          maxLength={2000}
+          placeholder="e.g. Show p95 latency by model over the last 7 days"
+          value={request}
+          onChange={(event) => {
+            setRequest(event.target.value);
+          }}
+        />
+        <Button
+          type="submit"
+          size="sm"
+          aria-label="Create with Assistant"
+          disabled={!request.trim() || isRunning || isSubmitting}
+        >
+          <BotMessageSquare className="h-4 w-4" />
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export function InAppAgentDashboardComposer({
+  name,
+  description,
+}: {
+  name: string;
+  description: string;
+}) {
+  const { isAvailable, isRunning, isSubmitting, startAssistantRun } =
+    useInAppAiAgent();
+  const [includeWidgets, setIncludeWidgets] = useState(true);
+
+  if (!isAvailable) {
+    return null;
+  }
+
+  const handleSubmit = async (event: SyntheticEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedName = name.trim();
+    const trimmedDescription = description.trim();
+    if (!trimmedName || !trimmedDescription || isRunning || isSubmitting) {
+      return;
+    }
+
+    await startAssistantRun({
+      source: "dashboard_create",
+      name: trimmedName,
+      description: trimmedDescription,
+      includeWidgets,
+    });
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-muted/30 flex flex-col gap-3 rounded-lg border p-4"
+    >
+      <div>
+        <div className="flex items-center gap-2 font-medium">
+          <Sparkles className="h-4 w-4" />
+          Build with Assistant
+        </div>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Use the name and purpose above to create this dashboard in a fresh
+          assistant conversation.
+        </p>
+      </div>
+      <div className="flex items-start gap-2">
+        <Checkbox
+          id="assistant-dashboard-widgets"
+          checked={includeWidgets}
+          onCheckedChange={(checked) => {
+            setIncludeWidgets(checked === true);
+          }}
+        />
+        <Label
+          htmlFor="assistant-dashboard-widgets"
+          className="cursor-pointer leading-4"
+        >
+          Design and add widgets for this dashboard
+        </Label>
+      </div>
+      <Button
+        type="submit"
+        variant="outline"
+        disabled={
+          !name.trim() || !description.trim() || isRunning || isSubmitting
+        }
+      >
+        <BotMessageSquare className="mr-1 h-4 w-4" />
+        Continue with Assistant
+      </Button>
+    </form>
+  );
+}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentDisabledDialog.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentDisabledDialog.tsx
@@ -1,0 +1,49 @@
+import { Button } from "@/src/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import { AIFeaturesDisabledNotice } from "@/src/features/organizations/components/AIFeaturesDisabledNotice";
+
+export function InAppAgentDisabledDialog({
+  open,
+  onOpenChange,
+  organizationId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId?: string;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>AI features are disabled</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <AIFeaturesDisabledNotice organizationId={organizationId}>
+            The assistant requires AI features to be enabled for this
+            organization.
+          </AIFeaturesDisabledNotice>
+        </DialogBody>
+        <DialogFooter>
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                onOpenChange(false);
+              }}
+            >
+              Close
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentHeaderButton.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentHeaderButton.clienttest.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { TooltipProvider } from "@/src/components/ui/tooltip";
+import { InAppAgentHeaderButton } from "./InAppAgentHeaderButton";
+
+const openAssistant = vi.fn();
+
+vi.mock("./InAppAiAgentProvider", () => ({
+  useInAppAiAgent: () => ({
+    isAvailable: true,
+    open: false,
+    openAssistant,
+  }),
+}));
+
+describe("InAppAgentHeaderButton", () => {
+  it("opens the assistant from the page header", () => {
+    render(
+      <TooltipProvider>
+        <InAppAgentHeaderButton />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open assistant" }));
+
+    expect(openAssistant).toHaveBeenCalledOnce();
+    expect(openAssistant).toHaveBeenCalledWith("page_header");
+  });
+});

--- a/web/src/ee/features/in-app-agent/components/InAppAgentHeaderButton.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentHeaderButton.tsx
@@ -1,0 +1,45 @@
+import { BotMessageSquare } from "lucide-react";
+
+import { Button } from "@/src/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
+import { useInAppAiAgent } from "./InAppAiAgentProvider";
+
+export function InAppAgentHeaderButton() {
+  const { isAvailable, open, openAssistant, setOpen } = useInAppAiAgent();
+
+  if (!isAvailable) {
+    return null;
+  }
+
+  const label = open ? "Close assistant" : "Open assistant";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          aria-label={label}
+          aria-pressed={open}
+          data-ignore-outside-interaction
+          onClick={() => {
+            if (open) {
+              setOpen(false);
+              return;
+            }
+
+            openAssistant("page_header");
+          }}
+          size="sm"
+          variant="ghost"
+        >
+          <BotMessageSquare className="h-4 w-4" />
+          <span className="hidden sm:inline">Assistant</span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentHeaderButton.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentHeaderButton.tsx
@@ -1,6 +1,6 @@
 import { BotMessageSquare } from "lucide-react";
 
-import { Button } from "@/src/components/ui/button";
+import { RainbowButton } from "@/src/components/magicui/rainbow-button";
 import {
   Tooltip,
   TooltipContent,
@@ -20,7 +20,7 @@ export function InAppAgentHeaderButton() {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Button
+        <RainbowButton
           aria-label={label}
           aria-pressed={open}
           data-ignore-outside-interaction
@@ -33,11 +33,10 @@ export function InAppAgentHeaderButton() {
             openAssistant("page_header");
           }}
           size="sm"
-          variant="ghost"
         >
           <BotMessageSquare className="h-4 w-4" />
           <span className="hidden sm:inline">Assistant</span>
-        </Button>
+        </RainbowButton>
       </TooltipTrigger>
       <TooltipContent>{label}</TooltipContent>
     </Tooltip>

--- a/web/src/ee/features/in-app-agent/components/InAppAgentHeaderButton.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentHeaderButton.tsx
@@ -32,6 +32,7 @@ export function InAppAgentHeaderButton() {
 
             openAssistant("page_header");
           }}
+          className="rounded-md"
           size="sm"
         >
           <BotMessageSquare className="h-4 w-4" />

--- a/web/src/ee/features/in-app-agent/components/InAppAgentHost.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentHost.tsx
@@ -1,0 +1,146 @@
+import { useLayoutEffect, useRef } from "react";
+
+import { ConfirmDialog } from "@/src/components/ui/confirm-dialog";
+import { DialogController } from "@/src/components/ui/dialog-controller";
+import { Layer } from "@/src/components/ui/layer";
+import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback";
+import { ControlledInAppAgentWindow } from "./ControlledInAppAgentWindow";
+import {
+  InAppAgentWindowShell,
+  useInAppAgentWindowShellPanelControl,
+} from "./InAppAgentWindowShell";
+import { useInAppAiAgent } from "./InAppAiAgentProvider";
+import type { InAppAgentWindowConversation } from "./InAppAgentWindow";
+
+function DeleteConversationDialog({
+  close,
+  conversation,
+  onDeleteConversation,
+}: {
+  close: () => void;
+  conversation: InAppAgentWindowConversation | null;
+  onDeleteConversation: (conversationId: string) => Promise<void>;
+}) {
+  const [deleteConversation, isDeletingConversation] =
+    useWatchedPromiseCallback(async () => {
+      if (!conversation) {
+        return;
+      }
+
+      try {
+        await onDeleteConversation(conversation.id);
+        close();
+      } catch {
+        // Error is already surfaced by the provider; keep the dialog open for retry.
+      }
+    }, [close, conversation, onDeleteConversation]);
+
+  return (
+    <ConfirmDialog
+      open={conversation !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          close();
+        }
+      }}
+      title="Delete conversation"
+      description="This removes the conversation from your recent conversations. This action cannot be undone."
+      confirmLabel="Delete conversation"
+      loading={isDeletingConversation}
+      onConfirm={deleteConversation}
+    />
+  );
+}
+
+export function InAppAgentHost() {
+  const {
+    deleteConversation,
+    isAvailable,
+    open,
+    setOpen,
+    isExpanded,
+    setIsExpanded,
+  } = useInAppAiAgent();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previousPanelRectRef = useRef<DOMRect | null>(null);
+  const floatingPanelHandle = useInAppAgentWindowShellPanelControl();
+
+  useLayoutEffect(() => {
+    const previousRect = previousPanelRectRef.current;
+    const panel = panelRef.current;
+
+    previousPanelRectRef.current = null;
+
+    if (!previousRect || !panel) {
+      return;
+    }
+
+    const nextRect = panel.getBoundingClientRect();
+
+    panel.animate(
+      [
+        {
+          transform: `translate(${previousRect.left - nextRect.left}px, ${previousRect.top - nextRect.top}px) scale(${nextRect.width > 0 ? previousRect.width / nextRect.width : 1}, ${nextRect.height > 0 ? previousRect.height / nextRect.height : 1})`,
+        },
+        { transform: "translate(0, 0) scale(1, 1)" },
+      ],
+      {
+        duration: 180,
+        easing: "cubic-bezier(0.2, 0, 0, 1)",
+      },
+    );
+  }, [isExpanded]);
+
+  useLayoutEffect(() => {
+    if (!open || isExpanded || floatingPanelHandle.geometry) {
+      return;
+    }
+
+    floatingPanelHandle.initializeGeometry();
+  }, [floatingPanelHandle, isExpanded, open]);
+
+  if (!isAvailable || !open) {
+    return null;
+  }
+
+  return (
+    <DialogController<InAppAgentWindowConversation>
+      dialog={(close, conversation) => (
+        <DeleteConversationDialog
+          close={close}
+          conversation={conversation}
+          onDeleteConversation={deleteConversation}
+        />
+      )}
+    >
+      {(deleteConversationDialog) => (
+        <Layer name="agent">
+          <InAppAgentWindowShell
+            floatingPanelHandle={floatingPanelHandle}
+            isExpanded={isExpanded}
+            panelRef={panelRef}
+          >
+            {({ isHeaderDragHandleEnabled }) => (
+              <ControlledInAppAgentWindow
+                isHeaderDragHandleEnabled={isHeaderDragHandleEnabled}
+                isExpanded={isExpanded}
+                onDeleteConversation={(conversation) => {
+                  deleteConversationDialog.open(conversation);
+                }}
+                onExpandedChange={(nextIsExpanded) => {
+                  previousPanelRectRef.current =
+                    panelRef.current?.getBoundingClientRect() ?? null;
+                  setIsExpanded(nextIsExpanded);
+                }}
+                onClose={() => {
+                  floatingPanelHandle.clearGeometry();
+                  setOpen(false);
+                }}
+              />
+            )}
+          </InAppAgentWindowShell>
+        </Layer>
+      )}
+    </DialogController>
+  );
+}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentTraceButtons.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentTraceButtons.clienttest.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/src/components/ui/tooltip";
+
+import {
+  InAppAgentAnalyzeSelectionButton,
+  InAppAgentExplainErrorButton,
+} from "./InAppAgentTraceButtons";
+
+const startAssistantRun = vi.fn();
+
+vi.mock("./InAppAiAgentProvider", () => ({
+  useInAppAiAgent: () => ({
+    isAvailable: true,
+    startAssistantRun,
+  }),
+}));
+
+describe("InAppAgentExplainErrorButton", () => {
+  beforeEach(() => {
+    startAssistantRun.mockClear();
+  });
+
+  it("starts a fresh assistant run for the selected error", () => {
+    render(
+      <InAppAgentExplainErrorButton
+        traceId="trace-1"
+        observationId="observation-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Explain error" }));
+
+    expect(startAssistantRun).toHaveBeenCalledOnce();
+    expect(startAssistantRun).toHaveBeenCalledWith({
+      source: "trace_error",
+      traceId: "trace-1",
+      observationId: "observation-1",
+    });
+  });
+
+  it("passes the explicit trace selection to the assistant", () => {
+    render(
+      <InAppAgentAnalyzeSelectionButton
+        traceIds={["trace-1", "trace-2"]}
+        observationIds={[]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Analyze with Assistant" }),
+    );
+
+    expect(startAssistantRun).toHaveBeenCalledOnce();
+    expect(startAssistantRun).toHaveBeenCalledWith({
+      source: "trace_selection",
+      traceIds: ["trace-1", "trace-2"],
+      observationIds: [],
+    });
+  });
+
+  it("disables analysis when more than 20 rows are selected", () => {
+    render(
+      <TooltipProvider>
+        <InAppAgentAnalyzeSelectionButton
+          traceIds={Array.from({ length: 21 }, (_, index) => `trace-${index}`)}
+          observationIds={[]}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Analyze with Assistant" }),
+    ).toBeDisabled();
+  });
+});

--- a/web/src/ee/features/in-app-agent/components/InAppAgentTraceButtons.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentTraceButtons.clienttest.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { TooltipProvider } from "@/src/components/ui/tooltip";
 
 import {
   InAppAgentAnalyzeSelectionButton,
@@ -58,18 +57,24 @@ describe("InAppAgentExplainErrorButton", () => {
     });
   });
 
-  it("disables analysis when more than 20 rows are selected", () => {
+  it("passes selections larger than 20 rows to the assistant", () => {
+    const traceIds = Array.from({ length: 21 }, (_, index) => `trace-${index}`);
+
     render(
-      <TooltipProvider>
-        <InAppAgentAnalyzeSelectionButton
-          traceIds={Array.from({ length: 21 }, (_, index) => `trace-${index}`)}
-          observationIds={[]}
-        />
-      </TooltipProvider>,
+      <InAppAgentAnalyzeSelectionButton
+        traceIds={traceIds}
+        observationIds={[]}
+      />,
     );
 
-    expect(
+    fireEvent.click(
       screen.getByRole("button", { name: "Analyze with Assistant" }),
-    ).toBeDisabled();
+    );
+
+    expect(startAssistantRun).toHaveBeenCalledWith({
+      source: "trace_selection",
+      traceIds,
+      observationIds: [],
+    });
   });
 });

--- a/web/src/ee/features/in-app-agent/components/InAppAgentTraceButtons.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentTraceButtons.tsx
@@ -54,7 +54,7 @@ export function InAppAgentAnalyzeSelectionButton({
   const selectedCount = new Set(
     observationIds.length > 0 ? observationIds : traceIds,
   ).size;
-  const isDisabled = selectAll || selectedCount === 0 || selectedCount > 20;
+  const isDisabled = selectAll || selectedCount === 0;
 
   if (!isAvailable) {
     return null;
@@ -84,10 +84,8 @@ export function InAppAgentAnalyzeSelectionButton({
   }
 
   const explanation = selectAll
-    ? "Select up to 20 individual traces or observations to analyze."
-    : selectedCount > 20
-      ? "The assistant can analyze up to 20 selected traces or observations."
-      : "Select at least one trace or observation to analyze.";
+    ? "Select individual traces or observations to analyze."
+    : "Select at least one trace or observation to analyze.";
 
   return (
     <Tooltip>

--- a/web/src/ee/features/in-app-agent/components/InAppAgentTraceButtons.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentTraceButtons.tsx
@@ -1,0 +1,100 @@
+import { BotMessageSquare } from "lucide-react";
+
+import { Button } from "@/src/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
+import { useInAppAiAgent } from "./InAppAiAgentProvider";
+
+export function InAppAgentExplainErrorButton({
+  traceId,
+  observationId,
+  label = "Explain error",
+}: {
+  traceId: string;
+  observationId?: string;
+  label?: string;
+}) {
+  const { isAvailable, startAssistantRun } = useInAppAiAgent();
+
+  if (!isAvailable) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={async () => {
+        await startAssistantRun({
+          source: "trace_error",
+          traceId,
+          observationId,
+        });
+      }}
+    >
+      <BotMessageSquare className="mr-1 h-4 w-4" />
+      {label}
+    </Button>
+  );
+}
+
+export function InAppAgentAnalyzeSelectionButton({
+  traceIds,
+  observationIds,
+  selectAll = false,
+}: {
+  traceIds: string[];
+  observationIds: string[];
+  selectAll?: boolean;
+}) {
+  const { isAvailable, startAssistantRun } = useInAppAiAgent();
+  const selectedCount = new Set(
+    observationIds.length > 0 ? observationIds : traceIds,
+  ).size;
+  const isDisabled = selectAll || selectedCount === 0 || selectedCount > 20;
+
+  if (!isAvailable) {
+    return null;
+  }
+
+  const button = (
+    <Button
+      variant="outline"
+      size="sm"
+      className="h-8"
+      disabled={isDisabled}
+      onClick={async () => {
+        await startAssistantRun({
+          source: "trace_selection",
+          traceIds,
+          observationIds,
+        });
+      }}
+    >
+      <BotMessageSquare className="mr-1 h-4 w-4" />
+      <span className="hidden sm:inline">Analyze with Assistant</span>
+    </Button>
+  );
+
+  if (!isDisabled) {
+    return button;
+  }
+
+  const explanation = selectAll
+    ? "Select up to 20 individual traces or observations to analyze."
+    : selectedCount > 20
+      ? "The assistant can analyze up to 20 selected traces or observations."
+      : "Select at least one trace or observation to analyze.";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span>{button}</span>
+      </TooltipTrigger>
+      <TooltipContent>{explanation}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -43,11 +43,68 @@ import {
   getInAppAgentError,
   isInAppAgentRateLimited,
 } from "@/src/ee/features/in-app-agent/components/utils/utils";
+import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
+import { InAppAgentDisabledDialog } from "./InAppAgentDisabledDialog";
 
 const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";
 const OPEN_STORAGE_KEY_PREFIX = "langfuse:in-app-ai-agent-open";
 const FEEDBACK_STORAGE_KEY_PREFIX = "langfuse:in-app-ai-agent-feedback";
+
+export type InAppAgentEntryPoint =
+  | "page_header"
+  | "sidebar"
+  | "trace_error"
+  | "trace_selection"
+  | "dashboard_create"
+  | "dashboard_widget";
+
+export type InAppAgentInvocation =
+  | {
+      source: "trace_error";
+      traceId: string;
+      observationId?: string;
+    }
+  | {
+      source: "trace_selection";
+      traceIds: string[];
+      observationIds: string[];
+    }
+  | {
+      source: "dashboard_create";
+      name: string;
+      description: string;
+      includeWidgets: boolean;
+    }
+  | {
+      source: "dashboard_widget";
+      dashboardId: string;
+      request: string;
+    };
+
+const getInvocationPrompt = (invocation: InAppAgentInvocation): string => {
+  if (invocation.source === "trace_error") {
+    const observationContext = invocation.observationId
+      ? ` Focus on observation ${invocation.observationId}.`
+      : "";
+
+    return `Investigate the errors in trace ${invocation.traceId}.${observationContext} Explain the likely cause, cite the relevant evidence from the trace, and suggest concrete debugging steps.`;
+  }
+
+  if (invocation.source === "trace_selection") {
+    return `Analyze the selected traces (${invocation.traceIds.join(", ")}) and observations (${invocation.observationIds.join(", ")}). Compare them, identify common failures and meaningful outliers, cite the relevant evidence, and suggest concrete next steps.`;
+  }
+
+  if (invocation.source === "dashboard_create") {
+    const widgetInstruction = invocation.includeWidgets
+      ? "Design useful widgets for this purpose, create them, and place them on the dashboard."
+      : "Create the dashboard without adding widgets.";
+
+    return `Create a dashboard named "${invocation.name}". Its purpose is: ${invocation.description}\n\n${widgetInstruction} Briefly explain the plan, then use the available dashboard tools. Each write will still require my approval.`;
+  }
+
+  return `Create and add a widget to dashboard ${invocation.dashboardId}. The widget should satisfy this request:\n\n${invocation.request}\n\nChoose an appropriate data view, metrics, dimensions, filters, and chart type. Briefly explain the plan, then create the widget and place it on this dashboard. Each write will still require my approval.`;
+};
 
 const MastraSuspendEventSchema = z.object({
   type: z.literal("mastra_suspend"),
@@ -70,6 +127,8 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
   isAvailable: false,
   open: false,
   setOpen: () => undefined,
+  openAssistant: () => false,
+  startAssistantRun: async () => false,
   isExpanded: false,
   setIsExpanded: () => undefined,
   isRunning: false,
@@ -115,6 +174,8 @@ type InAppAiAgentContextType = {
   isAvailable: boolean;
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
+  openAssistant: (source: InAppAgentEntryPoint) => boolean;
+  startAssistantRun: (invocation: InAppAgentInvocation) => Promise<boolean>;
   isExpanded: boolean;
   setIsExpanded: Dispatch<SetStateAction<boolean>>;
   isRunning: boolean;
@@ -211,6 +272,8 @@ function InAppAiAgentProviderInner({
   const utils = api.useUtils();
   const capture = usePostHogClientCapture();
   const session = useSession();
+  const { organization } = useQueryProjectOrOrganization();
+  const [enableDialogOpen, setEnableDialogOpen] = useState(false);
   const [selectedConversationId, setSelectedConversationId] = useSessionStorage<
     string | null
   >(`${SELECTED_CONVERSATION_STORAGE_KEY_PREFIX}:${projectId}`, null);
@@ -696,7 +759,7 @@ function InAppAiAgentProviderInner({
   );
 
   const submit = useCallback(
-    async (content: string) => {
+    async (content: string, options?: { newConversation?: boolean }) => {
       if (
         !content ||
         isRunning ||
@@ -713,9 +776,15 @@ function InAppAiAgentProviderInner({
 
       let startedRun = false;
       try {
-        const isNewConversation = !selectedConversationId;
-        const conversationId =
-          selectedConversationId ?? createInAppAgentConversationId();
+        const isNewConversation =
+          options?.newConversation === true || !selectedConversationId;
+        const conversationId = isNewConversation
+          ? createInAppAgentConversationId()
+          : selectedConversationId;
+
+        if (!conversationId) {
+          return false;
+        }
 
         if (isNewConversation) {
           setSelectedConversationId(conversationId);
@@ -956,11 +1025,51 @@ function InAppAiAgentProviderInner({
     [resumeToolApproval],
   );
 
+  const openAssistant = useCallback(
+    (source: InAppAgentEntryPoint) => {
+      capture("in_app_agent:entry_point_click", { source });
+
+      if (organization && !organization.aiFeaturesEnabled) {
+        setEnableDialogOpen(true);
+        return false;
+      }
+
+      setOpen(true);
+      return true;
+    },
+    [capture, organization, setOpen],
+  );
+
+  const startAssistantRun = useCallback(
+    async (invocation: InAppAgentInvocation) => {
+      if (invocation.source === "trace_selection") {
+        const selectedIds = new Set(
+          invocation.observationIds.length > 0
+            ? invocation.observationIds
+            : invocation.traceIds,
+        );
+
+        if (selectedIds.size === 0 || selectedIds.size > 20) {
+          return false;
+        }
+      }
+
+      if (!openAssistant(invocation.source)) {
+        return false;
+      }
+
+      return submit(getInvocationPrompt(invocation), { newConversation: true });
+    },
+    [openAssistant, submit],
+  );
+
   const value = useMemo<InAppAiAgentContextType>(
     () => ({
       isAvailable: true,
       open,
       setOpen,
+      openAssistant,
+      startAssistantRun,
       isExpanded,
       setIsExpanded,
       isRunning,
@@ -996,6 +1105,8 @@ function InAppAiAgentProviderInner({
       loadMoreConversations,
       messagesWithFeedback,
       open,
+      openAssistant,
+      startAssistantRun,
       pendingToolApprovals,
       rejectToolCall,
       invalidateConversations,
@@ -1010,6 +1121,11 @@ function InAppAiAgentProviderInner({
   return (
     <InAppAiAgentContext.Provider value={value}>
       {children}
+      <InAppAgentDisabledDialog
+        open={enableDialogOpen}
+        onOpenChange={setEnableDialogOpen}
+        organizationId={organization?.id}
+      />
     </InAppAiAgentContext.Provider>
   );
 }

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/src/ee/features/in-app-agent/components/utils/utils";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { InAppAgentDisabledDialog } from "./InAppAgentDisabledDialog";
+import { parseDashboardToolResultContent } from "./dashboard-tool-result";
 
 const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";
@@ -81,6 +82,23 @@ export type InAppAgentInvocation =
       dashboardId: string;
       request: string;
     };
+
+export type InAppAgentDashboardOwnership =
+  | { type: "create" }
+  | { type: "dashboard"; dashboardId: string };
+
+export type InAppAgentDashboardUpdate = {
+  dashboardId: string;
+  sequence: number;
+};
+
+const CreatedDashboardToolResultSchema = z.object({
+  id: z.string().min(1),
+});
+
+const UpdatedDashboardToolResultSchema = z.object({
+  dashboardId: z.string().min(1),
+});
 
 const getInvocationPrompt = (invocation: InAppAgentInvocation): string => {
   if (invocation.source === "trace_error") {
@@ -133,6 +151,8 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
   setIsExpanded: () => undefined,
   isRunning: false,
   isSubmitting: false,
+  dashboardOwnership: null,
+  dashboardUpdate: null,
   pendingToolApprovals: [],
   isSelectedConversationHydrating: false,
   error: null,
@@ -180,6 +200,8 @@ type InAppAiAgentContextType = {
   setIsExpanded: Dispatch<SetStateAction<boolean>>;
   isRunning: boolean;
   isSubmitting: boolean;
+  dashboardOwnership: InAppAgentDashboardOwnership | null;
+  dashboardUpdate: InAppAgentDashboardUpdate | null;
   pendingToolApprovals: InAppAgentPendingToolApproval[];
   isSelectedConversationHydrating: boolean;
   error: InAppAgentError | null;
@@ -269,6 +291,7 @@ function InAppAiAgentProviderInner({
   open,
   setOpen,
 }: InAppAiAgentProviderInnerProps) {
+  const router = useRouter();
   const utils = api.useUtils();
   const capture = usePostHogClientCapture();
   const session = useSession();
@@ -290,6 +313,11 @@ function InAppAiAgentProviderInner({
   const [isRunning, setIsRunning] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [dashboardOwnership, setDashboardOwnership] =
+    useState<InAppAgentDashboardOwnership | null>(null);
+  const [dashboardUpdate, setDashboardUpdate] =
+    useState<InAppAgentDashboardUpdate | null>(null);
+  const dashboardUpdateSequenceRef = useRef(0);
   const [error, setError] = useState<InAppAgentError | null>(null);
   const agentRef = useRef<HttpAgent | null>(null);
   const activeRunIdRef = useRef<string | null>(null);
@@ -551,12 +579,72 @@ function InAppAiAgentProviderInner({
           });
         },
         onToolCallResultEvent: ({ event }) => {
+          const completedApproval = pendingToolApprovalsRef.current.find(
+            (approval) =>
+              approval.approvalRequest.toolCallId === event.toolCallId,
+          );
+
           updatePendingToolApprovals((currentApprovals) =>
             currentApprovals.filter(
               (approval) =>
                 approval.approvalRequest.toolCallId !== event.toolCallId,
             ),
           );
+
+          if (
+            !completedApproval ||
+            ("error" in event && typeof event.error === "string")
+          ) {
+            return;
+          }
+
+          const result = parseDashboardToolResultContent(event.content);
+          const toolName = completedApproval.approvalRequest.toolName;
+
+          if (toolName === "langfuse_createDashboard") {
+            const dashboard =
+              CreatedDashboardToolResultSchema.safeParse(result);
+            if (!dashboard.success) {
+              return;
+            }
+
+            setDashboardOwnership({
+              type: "dashboard",
+              dashboardId: dashboard.data.id,
+            });
+            Promise.all([
+              utils.dashboard.invalidate(),
+              router.push(
+                `/project/${projectId}/dashboards/${dashboard.data.id}`,
+              ),
+            ]).catch((error) => {
+              console.error("Failed to refresh the created dashboard", error);
+            });
+            return;
+          }
+
+          if (toolName === "langfuse_createDashboardWidget") {
+            utils.dashboardWidgets.invalidate().catch((error) => {
+              console.error("Failed to refresh dashboard widgets", error);
+            });
+            return;
+          }
+
+          if (toolName === "langfuse_addWidgetToDashboard") {
+            const update = UpdatedDashboardToolResultSchema.safeParse(result);
+            if (!update.success) {
+              return;
+            }
+
+            dashboardUpdateSequenceRef.current += 1;
+            setDashboardUpdate({
+              dashboardId: update.data.dashboardId,
+              sequence: dashboardUpdateSequenceRef.current,
+            });
+            utils.dashboard.invalidate().catch((error) => {
+              console.error("Failed to refresh the updated dashboard", error);
+            });
+          }
         },
         onRunErrorEvent: ({ event }) => {
           if (intentionalAbortRef.current) {
@@ -584,7 +672,7 @@ function InAppAiAgentProviderInner({
         },
       });
     },
-    [updatePendingToolApprovals],
+    [projectId, router, updatePendingToolApprovals, utils],
   );
 
   const getOrCreateAgent = useCallback(
@@ -662,6 +750,7 @@ function InAppAiAgentProviderInner({
         .finally(() => {
           const runId = activeRunIdRef.current;
           setIsRunning(false);
+          setDashboardOwnership(null);
           setMessages(
             attachActiveRunIdToAssistantMessages(
               agent.messages.filter(isAgentConversationMessage),
@@ -1058,7 +1147,22 @@ function InAppAiAgentProviderInner({
         return false;
       }
 
-      return submit(getInvocationPrompt(invocation), { newConversation: true });
+      if (invocation.source === "dashboard_create") {
+        setDashboardOwnership({ type: "create" });
+      } else if (invocation.source === "dashboard_widget") {
+        setDashboardOwnership({
+          type: "dashboard",
+          dashboardId: invocation.dashboardId,
+        });
+      }
+
+      const started = await submit(getInvocationPrompt(invocation), {
+        newConversation: true,
+      });
+      if (!started) {
+        setDashboardOwnership(null);
+      }
+      return started;
     },
     [openAssistant, submit],
   );
@@ -1074,6 +1178,8 @@ function InAppAiAgentProviderInner({
       setIsExpanded,
       isRunning,
       isSubmitting,
+      dashboardOwnership,
+      dashboardUpdate,
       pendingToolApprovals,
       isSelectedConversationHydrating,
       error,
@@ -1101,6 +1207,8 @@ function InAppAiAgentProviderInner({
       isRunning,
       isSelectedConversationHydrating,
       isSubmitting,
+      dashboardOwnership,
+      dashboardUpdate,
       deleteConversation,
       loadMoreConversations,
       messagesWithFeedback,

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -28,6 +28,7 @@ import {
   type InAppAgentMessageFeedback,
   type InAppAgentMessageFeedbackValue,
   type InAppAgentRuntimeState,
+  type InAppAgentTraceSelection,
   type InAppAgentToolApprovalRequest,
 } from "@/src/ee/features/in-app-agent/schema";
 import type { InAppAgentError } from "@/src/ee/features/in-app-agent/components/utils/utils";
@@ -110,7 +111,7 @@ const getInvocationPrompt = (invocation: InAppAgentInvocation): string => {
   }
 
   if (invocation.source === "trace_selection") {
-    return `Analyze the selected traces (${invocation.traceIds.join(", ")}) and observations (${invocation.observationIds.join(", ")}). Compare them, identify common failures and meaningful outliers, cite the relevant evidence, and suggest concrete next steps.`;
+    return "Analyze the currently selected traces or observations. Use the selected-trace identifier tool to read the selection in bounded pages, then compare the selected items, identify common failures and meaningful outliers, cite the relevant evidence, and suggest concrete next steps.";
   }
 
   if (invocation.source === "dashboard_create") {
@@ -136,9 +137,10 @@ const getConversationAgentState = (
   projectId: string,
   conversationId: string,
   isNewConversation: boolean,
+  traceSelection?: InAppAgentTraceSelection,
 ): InAppAgentRuntimeState =>
   isNewConversation
-    ? { type: "newConversation", projectId }
+    ? { type: "newConversation", projectId, traceSelection }
     : { type: "existingConversation", projectId, conversationId };
 
 const NOOP_CONTEXT: InAppAiAgentContextType = {
@@ -680,6 +682,7 @@ function InAppAiAgentProviderInner({
       conversationId: string,
       initialMessages: InAppAiAgentMessage[],
       isNewConversation: boolean,
+      traceSelection?: InAppAgentTraceSelection,
     ) => {
       if (agentRef.current?.threadId === conversationId) {
         return agentRef.current;
@@ -695,6 +698,7 @@ function InAppAiAgentProviderInner({
           projectId,
           conversationId,
           isNewConversation,
+          traceSelection,
         ),
       });
 
@@ -848,7 +852,13 @@ function InAppAiAgentProviderInner({
   );
 
   const submit = useCallback(
-    async (content: string, options?: { newConversation?: boolean }) => {
+    async (
+      content: string,
+      options?: {
+        newConversation?: boolean;
+        traceSelection?: InAppAgentTraceSelection;
+      },
+    ) => {
       if (
         !content ||
         isRunning ||
@@ -892,6 +902,7 @@ function InAppAiAgentProviderInner({
           conversationId,
           initialMessages,
           isNewConversation,
+          options?.traceSelection,
         );
 
         if (agent.isRunning) {
@@ -1138,7 +1149,7 @@ function InAppAiAgentProviderInner({
             : invocation.traceIds,
         );
 
-        if (selectedIds.size === 0 || selectedIds.size > 20) {
+        if (selectedIds.size === 0) {
           return false;
         }
       }
@@ -1158,6 +1169,20 @@ function InAppAiAgentProviderInner({
 
       const started = await submit(getInvocationPrompt(invocation), {
         newConversation: true,
+        ...(invocation.source === "trace_selection"
+          ? {
+              traceSelection: {
+                kind:
+                  invocation.observationIds.length > 0
+                    ? ("observations" as const)
+                    : ("traces" as const),
+                ids:
+                  invocation.observationIds.length > 0
+                    ? invocation.observationIds
+                    : invocation.traceIds,
+              },
+            }
+          : {}),
       });
       if (!started) {
         setDashboardOwnership(null);

--- a/web/src/ee/features/in-app-agent/components/dashboard-tool-result.clienttest.ts
+++ b/web/src/ee/features/in-app-agent/components/dashboard-tool-result.clienttest.ts
@@ -1,0 +1,28 @@
+import { parseDashboardToolResultContent } from "./dashboard-tool-result";
+
+describe("parseDashboardToolResultContent", () => {
+  it("unwraps the MCP text result emitted by an approved dashboard tool", () => {
+    const content = JSON.stringify({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ id: "dashboard-1", name: "Reliability" }),
+        },
+      ],
+    });
+
+    expect(parseDashboardToolResultContent(content)).toEqual({
+      id: "dashboard-1",
+      name: "Reliability",
+    });
+  });
+
+  it("does not treat an MCP error envelope as a successful write", () => {
+    const content = JSON.stringify({
+      isError: true,
+      content: [{ type: "text", text: JSON.stringify({ id: "dashboard-1" }) }],
+    });
+
+    expect(parseDashboardToolResultContent(content)).toBeNull();
+  });
+});

--- a/web/src/ee/features/in-app-agent/components/dashboard-tool-result.ts
+++ b/web/src/ee/features/in-app-agent/components/dashboard-tool-result.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+const McpToolResultEnvelopeSchema = z.object({
+  content: z.array(
+    z.object({
+      type: z.literal("text"),
+      text: z.string(),
+    }),
+  ),
+  isError: z.boolean().optional(),
+});
+
+export function parseDashboardToolResultContent(content: string): unknown {
+  const parsed = parseJson(content);
+  const envelope = McpToolResultEnvelopeSchema.safeParse(parsed);
+
+  if (!envelope.success || envelope.data.isError) {
+    return envelope.success ? null : parsed;
+  }
+
+  for (const item of envelope.data.content) {
+    const result = parseJson(item.text);
+    if (result !== null) {
+      return result;
+    }
+  }
+
+  return null;
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/ee/features/in-app-agent/constants.ts
+++ b/web/src/ee/features/in-app-agent/constants.ts
@@ -1,6 +1,11 @@
 // Avoid renaming this as the FE is aware of this when rendering, renaming it would cause history issues
 export const IN_APP_AGENT_REDIRECT_TOOL_NAME = "langfuse_proposeRedirect";
 
+// Selection identifiers are supplied as trusted run context and exposed to the
+// model in bounded pages instead of being interpolated into the user prompt.
+export const IN_APP_AGENT_TRACE_SELECTION_TOOL_NAME =
+  "langfuse_getSelectedTraceIdentifiers";
+
 // Header used only by Langfuse's server-side in-app agent when it calls the
 // Langfuse MCP endpoint with a temporary in-app-agent API key and run override.
 export const IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER =

--- a/web/src/ee/features/in-app-agent/schema.ts
+++ b/web/src/ee/features/in-app-agent/schema.ts
@@ -248,10 +248,20 @@ export const ResumeForwardedPropsSchema = z.object({
 
 export type ResumeForwardedProps = z.infer<typeof ResumeForwardedPropsSchema>;
 
+export const InAppAgentTraceSelectionSchema = z.object({
+  kind: z.enum(["traces", "observations"]),
+  ids: z.array(z.string().min(1).max(200)).min(1),
+});
+
+export type InAppAgentTraceSelection = z.infer<
+  typeof InAppAgentTraceSelectionSchema
+>;
+
 export const InAppAgentRuntimeStateSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("newConversation"),
     projectId: z.string(),
+    traceSelection: InAppAgentTraceSelectionSchema.optional(),
   }),
   z.object({
     type: z.literal("existingConversation"),

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -12,6 +12,7 @@ import type { Langfuse } from "langfuse";
 import {
   type AgUiEvent,
   type AgUiRunAgentInput,
+  type InAppAgentTraceSelection,
   type InAppAgentToolApprovalRequest,
   type ResumeForwardedProps,
 } from "@/src/ee/features/in-app-agent/schema";
@@ -23,6 +24,7 @@ import type {
 import { createInAppAgentInstrumentation } from "@/src/ee/features/in-app-agent/server/instrumentation";
 import {
   createRedirectActionTool,
+  createSelectedTraceIdentifiersTool,
   filterInAppAgentAvailableLangfuseMcpTools,
   type InAppAgentUserAccess,
   withInAppAgentToolApproval,
@@ -31,6 +33,7 @@ import { LANGFUSE_IN_APP_AGENT_SKILLS } from "@/src/ee/features/in-app-agent/ser
 import { DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS } from "@/src/features/filters/constants/internal-environments";
 import { logger } from "@langfuse/shared/src/server";
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
+import { IN_APP_AGENT_TRACE_SELECTION_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
 import { IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER } from "@/src/ee/features/in-app-agent/constants";
 import { assertUnreachable } from "@/src/utils/types";
 
@@ -160,6 +163,7 @@ type CreateAgUiStreamOptions = {
     projectId: string;
     isV4Enabled: boolean;
   };
+  traceSelection?: InAppAgentTraceSelection;
   langfuseClient: Langfuse;
   useLocalPrompt: boolean;
   langfuseTracing?: InAppAgentTracingConfig;
@@ -743,6 +747,12 @@ async function createMastraAdapter(params: {
         projectId: params.options.redirectAction.projectId,
         isV4Enabled: params.options.redirectAction.isV4Enabled,
       }),
+      ...(params.options.traceSelection
+        ? {
+            [IN_APP_AGENT_TRACE_SELECTION_TOOL_NAME]:
+              createSelectedTraceIdentifiersTool(params.options.traceSelection),
+          }
+        : {}),
     });
     params.onToolsAvailable?.(tools);
 

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -457,6 +457,10 @@ export default async function handler(request: Request) {
                 projectId,
                 isV4Enabled: user?.v4BetaEnabled ?? false,
               },
+              traceSelection:
+                parsedState.data.type === "newConversation"
+                  ? parsedState.data.traceSelection
+                  : undefined,
               langfuseClient,
               useLocalPrompt,
               langfuseTracing: (() => {

--- a/web/src/ee/features/in-app-agent/server/tools.ts
+++ b/web/src/ee/features/in-app-agent/server/tools.ts
@@ -305,6 +305,14 @@ export const IN_APP_AGENT_LANGFUSE_MCP_TOOL_POLICIES: Record<
     approval: "approval",
     availability: { scope: "dashboards:CUD" },
   },
+  createDashboard: {
+    approval: "approval",
+    availability: { scope: "dashboards:CUD" },
+  },
+  addWidgetToDashboard: {
+    approval: "approval",
+    availability: { scope: "dashboards:CUD" },
+  },
 };
 
 export const IN_APP_AGENT_LANGFUSE_MCP_TOOL_NAMES = new Set<McpToolName>(

--- a/web/src/ee/features/in-app-agent/server/tools.ts
+++ b/web/src/ee/features/in-app-agent/server/tools.ts
@@ -24,7 +24,11 @@ import z from "zod";
 import { TABLE_AGGREGATION_OPTIONS } from "@/src/utils/date-range-utils";
 import { ObservationLevelDomain, TracingSearchType } from "@langfuse/shared";
 import { Role } from "@langfuse/shared/src/db";
-import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
+import {
+  IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  IN_APP_AGENT_TRACE_SELECTION_TOOL_NAME,
+} from "@/src/ee/features/in-app-agent/constants";
+import type { InAppAgentTraceSelection } from "@/src/ee/features/in-app-agent/schema";
 import type { McpToolName } from "@/src/features/mcp/server/bootstrap";
 
 type InAppAgentMcpToolApproval = "auto" | "approval";
@@ -321,6 +325,7 @@ export const IN_APP_AGENT_LANGFUSE_MCP_TOOL_NAMES = new Set<McpToolName>(
 
 export const IN_APP_AGENT_AUTO_APPROVED_EXTERNAL_TOOL_NAMES = new Set([
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  IN_APP_AGENT_TRACE_SELECTION_TOOL_NAME,
 ]);
 
 // Tools in this set can run without a human-in-the-loop approval prompt. Every
@@ -383,6 +388,38 @@ export function filterInAppAgentAvailableLangfuseMcpTools<TTool>(params: {
 }
 
 type InAppAgentTool = object;
+
+const SELECTED_TRACE_IDENTIFIER_PAGE_SIZE = 50;
+
+export function createSelectedTraceIdentifiersTool(
+  selection: InAppAgentTraceSelection,
+) {
+  const ids = [...new Set(selection.ids)];
+
+  return createTool({
+    id: IN_APP_AGENT_TRACE_SELECTION_TOOL_NAME,
+    description:
+      "Read the trace or observation identifiers explicitly selected by the user. Call this before analyzing a selected set. Results are paginated; continue with nextCursor until it is null, and inspect each page with the corresponding Langfuse trace or observation read tools.",
+    inputSchema: z.object({
+      cursor: z.number().int().nonnegative().optional(),
+    }),
+    execute: async ({ cursor = 0 }) => {
+      const pageIds = ids.slice(
+        cursor,
+        cursor + SELECTED_TRACE_IDENTIFIER_PAGE_SIZE,
+      );
+      const nextCursor =
+        cursor + pageIds.length < ids.length ? cursor + pageIds.length : null;
+
+      return {
+        kind: selection.kind,
+        ids: pageIds,
+        totalCount: ids.length,
+        nextCursor,
+      };
+    },
+  });
+}
 
 export function withInAppAgentToolApproval<TTool extends InAppAgentTool>(
   tools: Record<string, TTool>,

--- a/web/src/features/audit-logs/auditLog.ts
+++ b/web/src/features/audit-logs/auditLog.ts
@@ -43,6 +43,7 @@ export type AuditableResource =
   | "automation"
   | "action"
   | "dashboardWidget"
+  | "dashboard"
   | "slackIntegration"
   | "cloudSpendAlert"
   | "verifiedDomain"

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -77,6 +77,7 @@ import { useFullTextSearch } from "@/src/components/table/use-cases/useFullTextS
 import { TableSelectionManager } from "@/src/features/table/components/TableSelectionManager";
 import { useSelectAll } from "@/src/features/table/hooks/useSelectAll";
 import { TableActionMenu } from "@/src/features/table/components/TableActionMenu";
+import { InAppAgentAnalyzeSelectionButton } from "@/src/ee/features/in-app-agent/components/InAppAgentTraceButtons";
 import { type TableAction } from "@/src/features/table/types";
 import { type DataTablePeekViewProps } from "@/src/components/table/peek";
 import { useScoreColumns } from "@/src/features/scores/hooks/useScoreColumns";
@@ -1806,7 +1807,13 @@ export default function ObservationsEventsTable({
                         setShowAddToDatasetDialog(true);
                       }
                     }}
-                  />
+                  >
+                    <InAppAgentAnalyzeSelectionButton
+                      traceIds={selectedTraceIds}
+                      observationIds={selectedObservationIds}
+                      selectAll={selectAll}
+                    />
+                  </TableActionMenu>
                 ) : null,
               ]}
               multiSelect={{

--- a/web/src/features/mcp/features/dashboardWidgets/index.ts
+++ b/web/src/features/mcp/features/dashboardWidgets/index.ts
@@ -3,14 +3,31 @@ import {
   createDashboardWidgetTool,
   handleCreateDashboardWidget,
 } from "./tools/createDashboardWidget";
+import {
+  createDashboardTool,
+  handleCreateDashboard,
+} from "./tools/createDashboard";
+import {
+  addWidgetToDashboardTool,
+  handleAddWidgetToDashboard,
+} from "./tools/addWidgetToDashboard";
 
 export const dashboardWidgetsFeature = {
   name: "dashboardWidgets",
-  description: "Manage dashboard widgets in the current Langfuse project",
+  description:
+    "Manage dashboards and dashboard widgets in the current Langfuse project",
   tools: [
+    {
+      definition: createDashboardTool,
+      handler: handleCreateDashboard,
+    },
     {
       definition: createDashboardWidgetTool,
       handler: handleCreateDashboardWidget,
+    },
+    {
+      definition: addWidgetToDashboardTool,
+      handler: handleAddWidgetToDashboard,
     },
   ],
 } as const satisfies McpFeatureModule;

--- a/web/src/features/mcp/features/dashboardWidgets/tools/addWidgetToDashboard.ts
+++ b/web/src/features/mcp/features/dashboardWidgets/tools/addWidgetToDashboard.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from "node:crypto";
-import { LangfuseNotFoundError } from "@langfuse/shared";
 import { DashboardService } from "@langfuse/shared/src/server";
 import { z } from "zod";
 
@@ -32,63 +30,31 @@ export const [addWidgetToDashboardTool, handleAddWidgetToDashboard] =
           "mcp.dashboard_widget_id": input.widgetId,
         },
         fn: async () => {
-          const [dashboard, widget] = await Promise.all([
-            DashboardService.getDashboard(input.dashboardId, context.projectId),
-            DashboardService.getWidget(input.widgetId, context.projectId),
-          ]);
-
-          if (!dashboard || dashboard.projectId !== context.projectId) {
-            throw new LangfuseNotFoundError("Dashboard not found");
-          }
-          if (!widget) {
-            throw new LangfuseNotFoundError("Dashboard widget not found");
-          }
-
-          const maxY = dashboard.definition.widgets.reduce(
-            (currentMax, placement) =>
-              Math.max(currentMax, placement.y + placement.y_size),
-            0,
-          );
-          const definition = {
-            widgets: [
-              ...dashboard.definition.widgets,
-              {
-                type: "widget" as const,
-                id: randomUUID(),
-                widgetId: widget.id,
-                x: 0,
-                y: maxY,
-                x_size: 6,
-                y_size: 6,
-              },
-            ],
-          };
-
-          const updatedDashboard =
-            await DashboardService.updateDashboardDefinition(
-              dashboard.id,
-              context.projectId,
-              definition,
-              context.userId,
-            );
+          const { beforeDashboard, updatedDashboard, widget } =
+            await DashboardService.addWidgetToDashboard({
+              dashboardId: input.dashboardId,
+              widgetId: input.widgetId,
+              projectId: context.projectId,
+              userId: context.userId,
+            });
 
           await auditLog({
             action: "update",
             resourceType: "dashboard",
-            resourceId: dashboard.id,
+            resourceId: beforeDashboard.id,
             projectId: context.projectId,
             orgId: context.orgId,
             apiKeyId: context.apiKeyId,
-            before: dashboard,
+            before: beforeDashboard,
             after: updatedDashboard,
           });
 
           return {
-            dashboardId: dashboard.id,
+            dashboardId: updatedDashboard.id,
             widgetId: widget.id,
             url: buildDashboardUrl({
               projectId: context.projectId,
-              dashboardId: dashboard.id,
+              dashboardId: updatedDashboard.id,
             }),
           };
         },

--- a/web/src/features/mcp/features/dashboardWidgets/tools/addWidgetToDashboard.ts
+++ b/web/src/features/mcp/features/dashboardWidgets/tools/addWidgetToDashboard.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from "node:crypto";
+import { LangfuseNotFoundError } from "@langfuse/shared";
+import { DashboardService } from "@langfuse/shared/src/server";
+import { z } from "zod";
+
+import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { defineTool } from "@/src/features/mcp/core/define-tool";
+import { runMcpTool } from "@/src/features/mcp/core/run-mcp-tool";
+import { buildDashboardUrl } from "@/src/utils/product-url";
+
+const AddWidgetToDashboardSchema = z
+  .object({
+    dashboardId: z.string().min(1),
+    widgetId: z.string().min(1),
+  })
+  .strict();
+
+export const [addWidgetToDashboardTool, handleAddWidgetToDashboard] =
+  defineTool({
+    name: "addWidgetToDashboard",
+    description:
+      "Place an existing reusable widget on a custom dashboard. The widget is added as a 6 by 6 tile below the existing dashboard content.",
+    baseSchema: AddWidgetToDashboardSchema,
+    inputSchema: AddWidgetToDashboardSchema,
+    destructiveHint: true,
+    handler: async (input, context) =>
+      runMcpTool({
+        spanName: "mcp.dashboards.add_widget",
+        context,
+        attributes: {
+          "mcp.dashboard_id": input.dashboardId,
+          "mcp.dashboard_widget_id": input.widgetId,
+        },
+        fn: async () => {
+          const [dashboard, widget] = await Promise.all([
+            DashboardService.getDashboard(input.dashboardId, context.projectId),
+            DashboardService.getWidget(input.widgetId, context.projectId),
+          ]);
+
+          if (!dashboard || dashboard.projectId !== context.projectId) {
+            throw new LangfuseNotFoundError("Dashboard not found");
+          }
+          if (!widget) {
+            throw new LangfuseNotFoundError("Dashboard widget not found");
+          }
+
+          const maxY = dashboard.definition.widgets.reduce(
+            (currentMax, placement) =>
+              Math.max(currentMax, placement.y + placement.y_size),
+            0,
+          );
+          const definition = {
+            widgets: [
+              ...dashboard.definition.widgets,
+              {
+                type: "widget" as const,
+                id: randomUUID(),
+                widgetId: widget.id,
+                x: 0,
+                y: maxY,
+                x_size: 6,
+                y_size: 6,
+              },
+            ],
+          };
+
+          const updatedDashboard =
+            await DashboardService.updateDashboardDefinition(
+              dashboard.id,
+              context.projectId,
+              definition,
+              context.userId,
+            );
+
+          await auditLog({
+            action: "update",
+            resourceType: "dashboard",
+            resourceId: dashboard.id,
+            projectId: context.projectId,
+            orgId: context.orgId,
+            apiKeyId: context.apiKeyId,
+            before: dashboard,
+            after: updatedDashboard,
+          });
+
+          return {
+            dashboardId: dashboard.id,
+            widgetId: widget.id,
+            url: buildDashboardUrl({
+              projectId: context.projectId,
+              dashboardId: dashboard.id,
+            }),
+          };
+        },
+      }),
+  });

--- a/web/src/features/mcp/features/dashboardWidgets/tools/createDashboard.ts
+++ b/web/src/features/mcp/features/dashboardWidgets/tools/createDashboard.ts
@@ -1,0 +1,58 @@
+import { StringNoHTML } from "@langfuse/shared";
+import { DashboardService } from "@langfuse/shared/src/server";
+import { z } from "zod";
+
+import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { defineTool } from "@/src/features/mcp/core/define-tool";
+import { runMcpTool } from "@/src/features/mcp/core/run-mcp-tool";
+import { buildDashboardUrl } from "@/src/utils/product-url";
+
+const CreateDashboardSchema = z
+  .object({
+    name: StringNoHTML.trim().min(1).max(200),
+    description: StringNoHTML.max(2000).default(""),
+  })
+  .strict();
+
+export const [createDashboardTool, handleCreateDashboard] = defineTool({
+  name: "createDashboard",
+  description:
+    "Create an empty custom dashboard in the current Langfuse project. Use createDashboardWidget and addWidgetToDashboard to populate it.",
+  baseSchema: CreateDashboardSchema,
+  inputSchema: CreateDashboardSchema,
+  destructiveHint: true,
+  handler: async (input, context) =>
+    runMcpTool({
+      spanName: "mcp.dashboards.create",
+      context,
+      attributes: { "mcp.dashboard_name": input.name },
+      fn: async (span) => {
+        const dashboard = await DashboardService.createDashboard(
+          context.projectId,
+          input.name,
+          input.description,
+          context.userId,
+        );
+
+        span.setAttribute("mcp.dashboard_id", dashboard.id);
+
+        await auditLog({
+          action: "create",
+          resourceType: "dashboard",
+          resourceId: dashboard.id,
+          projectId: context.projectId,
+          orgId: context.orgId,
+          apiKeyId: context.apiKeyId,
+          after: dashboard,
+        });
+
+        return {
+          ...dashboard,
+          url: buildDashboardUrl({
+            projectId: context.projectId,
+            dashboardId: dashboard.id,
+          }),
+        };
+      },
+    }),
+});

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -263,7 +263,7 @@ export const events = {
     "message_sent",
     "community_hours_click",
   ], // also used on landing page for consistency
-  in_app_agent: ["new_chat_started", "new_chat_turn"],
+  in_app_agent: ["entry_point_click", "new_chat_started", "new_chat_turn"],
   cmd_k_menu: ["opened", "search_entered", "navigated"],
   spend_alert: ["created", "updated", "deleted"],
   sidebar: ["book_a_call_clicked", "v4_beta_toggled"],

--- a/web/src/features/table/components/TableActionMenu.clienttest.tsx
+++ b/web/src/features/table/components/TableActionMenu.clienttest.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import {
+  ActionId,
+  BatchActionType,
+  BatchExportTableName,
+} from "@langfuse/shared";
+
+import { TableActionMenu } from "./TableActionMenu";
+
+describe("TableActionMenu", () => {
+  it("renders custom actions after the standard table actions", () => {
+    render(
+      <TableActionMenu
+        projectId="project-1"
+        tableName={BatchExportTableName.Traces}
+        selectedCount={2}
+        onClearSelection={() => undefined}
+        actions={[
+          {
+            id: ActionId.TraceDelete,
+            type: BatchActionType.Delete,
+            label: "Delete Traces",
+            description: "Delete selected traces",
+            accessCheck: { scope: "trace:delete" },
+            execute: async () => undefined,
+          },
+        ]}
+      >
+        <button>Analyze with Assistant</button>
+      </TableActionMenu>,
+    );
+
+    const actions = screen.getAllByRole("button");
+    expect(
+      actions.indexOf(screen.getByRole("button", { name: "Delete Traces" })),
+    ).toBeLessThan(
+      actions.indexOf(
+        screen.getByRole("button", { name: "Analyze with Assistant" }),
+      ),
+    );
+  });
+});

--- a/web/src/features/table/components/TableActionMenu.tsx
+++ b/web/src/features/table/components/TableActionMenu.tsx
@@ -108,7 +108,6 @@ export function TableActionMenu({
           </Button>
           <div className="bg-border h-5 w-px" />
           <div className="flex items-center gap-2">
-            {children}
             {actions.map((action) => {
               const menuItem = (
                 <Button
@@ -140,6 +139,7 @@ export function TableActionMenu({
 
               return menuItem;
             })}
+            {children}
           </div>
         </div>
       </div>

--- a/web/src/features/table/components/TableActionMenu.tsx
+++ b/web/src/features/table/components/TableActionMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { X, Trash } from "lucide-react";
 import { Plus } from "lucide-react";
@@ -27,6 +27,7 @@ type TableActionMenuProps = {
   approximateCount?: boolean;
   onClearSelection: () => void;
   onCustomAction?: (actionType: CustomDialogTableAction["id"]) => void;
+  children?: ReactNode;
 };
 
 const getDefaultIcon = (type: TableAction["type"]) => {
@@ -44,6 +45,7 @@ export function TableActionMenu({
   approximateCount = false,
   onClearSelection,
   onCustomAction,
+  children,
 }: TableActionMenuProps) {
   const [selectedActionId, setSelectedActionId] = useState<
     TableAction["id"] | null
@@ -106,6 +108,7 @@ export function TableActionMenu({
           </Button>
           <div className="bg-border h-5 w-px" />
           <div className="flex items-center gap-2">
+            {children}
             {actions.map((action) => {
               const menuItem = (
                 <Button

--- a/web/src/features/widgets/components/SelectWidgetDialog.tsx
+++ b/web/src/features/widgets/components/SelectWidgetDialog.tsx
@@ -26,6 +26,7 @@ import {
 } from "@langfuse/shared";
 import { HOME_PRESET_METADATA } from "@/src/features/dashboard/components/home-preset-registry";
 import { type DashboardWidgetChartType } from "@langfuse/shared/src/db";
+import { InAppAgentWidgetComposer } from "@/src/ee/features/in-app-agent/components/InAppAgentDashboardButtons";
 
 export type WidgetItem = {
   id: string;
@@ -159,6 +160,12 @@ export function SelectWidgetDialog({
             </div>
           ) : (
             <div className="flex flex-col gap-3 p-1">
+              <InAppAgentWidgetComposer
+                dashboardId={dashboardId}
+                onSubmitted={() => {
+                  onOpenChange(false);
+                }}
+              />
               <button
                 type="button"
                 onClick={() => {

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -76,6 +76,7 @@ import { ThemeProvider } from "@/src/features/theming/ThemeProvider";
 import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
 import { SupportDrawerProvider } from "@/src/features/support-chat/SupportDrawerProvider";
 import { InAppAiAgentProvider } from "@/src/ee/features/in-app-agent/components/InAppAiAgentProvider";
+import { InAppAgentHost } from "@/src/ee/features/in-app-agent/components/InAppAgentHost";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { ScoreCacheProvider } from "@/src/features/scores/contexts/ScoreCacheContext";
 import { CorrectionCacheProvider } from "@/src/features/corrections/contexts/CorrectionCacheContext";
@@ -157,6 +158,7 @@ const MyApp: AppType<{ session: Session | null }> = ({
                               <Component {...pageProps} />
                               <UserTracking />
                             </AppLayout>
+                            <InAppAgentHost />
                           </InAppAiAgentProvider>
                         </SupportDrawerProvider>
                       </CorrectionCacheProvider>

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -80,6 +80,7 @@ import { useClipboardWidgetProbe } from "@/src/features/widgets/hooks/useClipboa
 import { extractTransferFiles } from "@/src/components/editor/fileDropPaste";
 import { Layer } from "@/src/components/ui/layer";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { useInAppAiAgent } from "@/src/ee/features/in-app-agent/components/InAppAiAgentProvider";
 
 // Position for a tile inserted "next to" an anchor tile: same size,
 // immediately to the right when that fits the 12-column grid, otherwise
@@ -98,6 +99,7 @@ export default function DashboardDetail() {
   const router = useRouter();
   const utils = api.useUtils();
   const capture = usePostHogClientCapture();
+  const { dashboardOwnership, dashboardUpdate } = useInAppAiAgent();
 
   const { projectId, dashboardId, addWidgetId } = router.query as {
     projectId: string;
@@ -113,13 +115,18 @@ export default function DashboardDetail() {
     projectId,
     dashboardId,
   });
+  const refetchDashboard = dashboard.refetch;
 
   const hasRbacCUDAccess = useHasProjectAccess({
     projectId,
     scope: "dashboards:CUD",
   });
   const isLockedDashboard = dashboard.data?.owner === "LANGFUSE";
-  const hasCUDAccess = hasRbacCUDAccess && !isLockedDashboard;
+  const isAssistantOwned =
+    dashboardOwnership?.type === "dashboard" &&
+    dashboardOwnership.dashboardId === dashboardId;
+  const hasCUDAccess =
+    hasRbacCUDAccess && !isLockedDashboard && !isAssistantOwned;
 
   // Langfuse-managed dashboards keep full edit affordances; edit attempts
   // route through the clone-first flow instead of mutating.
@@ -984,6 +991,22 @@ export default function DashboardDetail() {
     }
   }, [dashboard.data, localDashboardDefinition]);
 
+  useEffect(() => {
+    if (dashboardUpdate?.dashboardId !== dashboardId) {
+      return;
+    }
+
+    refetchDashboard()
+      .then((result) => {
+        if (result.data) {
+          setLocalDashboardDefinition(result.data.definition);
+        }
+      })
+      .catch((error) => {
+        showErrorToast("Error refreshing dashboard", error.message);
+      });
+  }, [dashboardId, dashboardUpdate, refetchDashboard]);
+
   // Initialize filters from dashboard data
   useEffect(() => {
     if (dashboard.data?.filters) {
@@ -1202,7 +1225,7 @@ export default function DashboardDetail() {
                     : "Save Filters"}
                 </Button>
               )}
-              {hasRbacCUDAccess && (
+              {hasRbacCUDAccess && !isAssistantOwned && (
                 <Button onClick={handleAddWidget}>
                   <PlusIcon size={16} className="mr-1 h-4 w-4" />
                   Add Widget
@@ -1218,7 +1241,7 @@ export default function DashboardDetail() {
                   Clone
                 </Button>
               )}
-              {hasRbacCUDAccess && (
+              {hasRbacCUDAccess && !isAssistantOwned && (
                 <DropdownMenu onOpenChange={setIsDashboardMenuOpen}>
                   <DropdownMenuTrigger asChild>
                     <Button
@@ -1275,6 +1298,12 @@ export default function DashboardDetail() {
           ),
         }}
       >
+        {isAssistantOwned && (
+          <div className="border-border bg-muted/30 mb-4 rounded-md border p-3 text-sm">
+            The assistant owns this dashboard while it is running. Editing will
+            be available again when the run finishes.
+          </div>
+        )}
         <PageHeaderControlsPortal>
           <TimeRangePicker
             timeRange={timeRange}
@@ -1367,7 +1396,7 @@ export default function DashboardDetail() {
                   widgets: updatedWidgets,
                 });
               }}
-              canEdit={hasRbacCUDAccess}
+              canEdit={hasRbacCUDAccess && !isAssistantOwned}
               dashboardId={dashboardId}
               projectId={projectId}
               dateRange={absoluteTimeRange}

--- a/web/src/pages/project/[projectId]/dashboards/new.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/new.tsx
@@ -10,10 +10,13 @@ import { showSuccessToast } from "@/src/features/notifications/showSuccessToast"
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { InAppAgentDashboardComposer } from "@/src/ee/features/in-app-agent/components/InAppAgentDashboardButtons";
+import { useInAppAiAgent } from "@/src/ee/features/in-app-agent/components/InAppAiAgentProvider";
 
 export default function NewDashboard() {
   const router = useRouter();
   const { projectId } = router.query as { projectId: string };
+  const { dashboardOwnership } = useInAppAiAgent();
+  const isAssistantOwned = dashboardOwnership !== null;
 
   // State for new dashboard
   const [dashboardName, setDashboardName] = useState("New Dashboard");
@@ -74,6 +77,7 @@ export default function NewDashboard() {
               disabled={
                 !dashboardName.trim() ||
                 createDashboard.isPending ||
+                isAssistantOwned ||
                 !hasCUDAccess
               }
               loading={createDashboard.isPending}
@@ -95,6 +99,7 @@ export default function NewDashboard() {
             }}
             placeholder="Enter dashboard name"
             required
+            disabled={isAssistantOwned}
           />
         </div>
 
@@ -108,6 +113,7 @@ export default function NewDashboard() {
             }}
             placeholder="Describe what this dashboard should help you monitor or understand."
             rows={4}
+            disabled={isAssistantOwned}
           />
         </div>
 
@@ -116,6 +122,13 @@ export default function NewDashboard() {
             name={dashboardName}
             description={dashboardDescription}
           />
+        )}
+
+        {isAssistantOwned && (
+          <p className="border-border bg-muted/30 rounded-md border p-3 text-sm">
+            The assistant owns this dashboard draft while it is running. Manual
+            changes will be available again when the run finishes.
+          </p>
         )}
 
         <p className="text-muted-foreground text-sm">

--- a/web/src/pages/project/[projectId]/dashboards/new.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/new.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/src/components/ui/label";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { InAppAgentDashboardComposer } from "@/src/ee/features/in-app-agent/components/InAppAgentDashboardButtons";
 
 export default function NewDashboard() {
   const router = useRouter();
@@ -98,24 +99,29 @@ export default function NewDashboard() {
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="dashboard-description">Description</Label>
+          <Label htmlFor="dashboard-description">Purpose</Label>
           <Textarea
             id="dashboard-description"
             value={dashboardDescription}
             onChange={(e) => {
               setDashboardDescription(e.target.value);
             }}
-            placeholder="Describe the purpose of this dashboard. Optional, but very helpful."
+            placeholder="Describe what this dashboard should help you monitor or understand."
             rows={4}
           />
         </div>
 
-        <div className="text-muted-foreground text-sm">
-          <p>
-            After creating the dashboard, you can add widgets to visualize your
-            data.
-          </p>
-        </div>
+        {hasCUDAccess && (
+          <InAppAgentDashboardComposer
+            name={dashboardName}
+            description={dashboardDescription}
+          />
+        )}
+
+        <p className="text-muted-foreground text-sm">
+          You can also create the empty dashboard now and add widgets manually
+          later.
+        </p>
       </div>
     </Page>
   );

--- a/web/src/utils/product-url.ts
+++ b/web/src/utils/product-url.ts
@@ -97,6 +97,12 @@ export const buildProjectPath = (params: { projectId: string }) =>
 export const buildDashboardsPath = (params: { projectId: string }) =>
   `${buildProjectPath(params)}/dashboards`;
 
+export const buildDashboardPath = (params: {
+  projectId: string;
+  dashboardId: string;
+}) =>
+  `${buildDashboardsPath(params)}/${encodeURIComponent(params.dashboardId)}`;
+
 export const buildDashboardWidgetsPath = (params: { projectId: string }) =>
   `${buildProjectPath(params)}/widgets`;
 
@@ -479,6 +485,11 @@ export const buildDashboardWidgetUrl = (params: {
   projectId: string;
   widgetId: string;
 }) => buildProductUrl(buildDashboardWidgetPath(params));
+
+export const buildDashboardUrl = (params: {
+  projectId: string;
+  dashboardId: string;
+}) => buildProductUrl(buildDashboardPath(params));
 
 export const buildEvaluatorUrl = (params: {
   projectId: string;


### PR DESCRIPTION
## Summary

Moves the in-app assistant from a hard-to-discover sidebar-only entry into contextual product workflows.

- adds a persistent page-header launcher
- adds error investigation and multi-trace analysis entry points
- embeds natural-language widget creation in the existing Add Widget dialog
- embeds assistant-driven dashboard creation in the existing Create Dashboard flow
- adds approved MCP tools for creating dashboards and placing widgets
- navigates to assistant-created dashboards and reconciles widget placements without a reload
- gives the assistant temporary, resource-scoped ownership of the affected dashboard draft while a run is active
- tracks entry-point source without capturing prompt content

## Why

The sidebar entry can fall below the viewport on smaller screens and gives users little indication of what the assistant can do. Contextual entry points make the assistant visible at the moment it can help.

## Impact

Impacted packages: `web`, `@langfuse/shared`.

All mutating assistant tools remain gated by project RBAC and explicit human approval. Dashboard writes are project-scoped, audited, and the widget placement read-modify-write now runs through a serializable service transaction.

## Validation

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- focused dashboard assistant client tests — `Tests 5 passed (5)`
- MCP write server tests — `Tests 56 passed (56)`
- browser-reviewed Enter submission, dashboard draft locking, create navigation, and no-reload widget reconciliation

Local PostHog delivery is disabled, so the live browser emitted no analytics request; code review confirms the existing event remains `in_app_agent:entry_point_click` with only the metadata-only `source` property.
