### PR TITLE
fix(evals): make code-eval execution traces readable in trace detail (LFE-10884)

### DIFF
--- a/packages/shared/src/server/llm/ai-sdk/telemetry.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetry.ts
@@ -11,7 +11,6 @@ import {
   trace,
   type Span,
 } from "@opentelemetry/api";
-import { JsonTraceSerializer } from "@opentelemetry/otlp-transformer";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import {
   BasicTracerProvider,
@@ -24,7 +23,7 @@ import { stringifyValue } from "../../../utils/stringChecks";
 import { traceException } from "../../instrumentation";
 import { logger } from "../../logger";
 import { LangfuseOtelSpanAttributes } from "../../otel/attributes";
-import { OtelIngestionProcessor } from "../../otel/OtelIngestionProcessor";
+import { publishInternalOtelSpans } from "../../otel/internalTraceOtelWriter";
 import type { InternalTraceExperimentContext } from "../internalTraceEvents";
 import type { TraceSinkParams } from "../types";
 
@@ -253,36 +252,11 @@ export function createAiSdkTelemetryCapture(params: {
       }
       if (matchingSpans.length === 0) return;
 
-      const serialized = JsonTraceSerializer.serializeRequest(matchingSpans);
-      if (!serialized) return;
-
-      const { resourceSpans } = JSON.parse(
-        new TextDecoder().decode(serialized),
-      );
-
-      if (!resourceSpans || resourceSpans.length === 0) return;
-
-      const processor = new OtelIngestionProcessor({
+      await publishInternalOtelSpans({
+        spans: matchingSpans,
         projectId: traceSinkParams.targetProjectId,
-        publicKey: "", // internal ingestion has no API key; mirrors internal event writes
         sdkName: INTERNAL_SDK_NAME,
-        sdkVersion: "unknown",
-        // Opt into the v4-native direct events write like a modern SDK batch:
-        // only that path runs processToEvent -> createEventRecord, which is
-        // the sole extractor of langfuse.experiment.* into experiment_*
-        // columns. Without it, dual-write mode routes internal batches
-        // (unknown SDK, no scope version) through legacy forwarding and
-        // experiment run items lose their linkage in events_full/v4 views.
-        // Legacy tables are still dual-written per v4WritesToLegacyTables.
-        ingestionVersion: "4",
-        // The consumer must parse these events with the internal ingestion
-        // schema; the public schema strips the "langfuse-" environment prefix,
-        // exposing internal traces as user environments and bypassing the
-        // trace-upsert eval-loop guard.
-        isLangfuseInternal: true,
       });
-
-      await processor.publishToOtelIngestionQueue(resourceSpans);
     } catch (e) {
       traceException(e);
       logger.error("Failed to publish AI SDK internal telemetry", {

--- a/packages/shared/src/server/otel/index.ts
+++ b/packages/shared/src/server/otel/index.ts
@@ -1,1 +1,2 @@
 export * from "./OtelIngestionProcessor";
+export * from "./internalTraceOtelWriter";

--- a/packages/shared/src/server/otel/internalTraceOtelWriter.test.ts
+++ b/packages/shared/src/server/otel/internalTraceOtelWriter.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  writeInternalTraceViaOtelIngestion,
+  type InternalOtelSpanInput,
+} from "./internalTraceOtelWriter";
+
+const publishToOtelIngestionQueue = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("./OtelIngestionProcessor", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./OtelIngestionProcessor")>();
+  return {
+    ...actual,
+    OtelIngestionProcessor: class {
+      publishToOtelIngestionQueue = publishToOtelIngestionQueue;
+    },
+  };
+});
+
+const TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+const START_ISO = "2026-07-09T14:10:41.143Z";
+const END_ISO = "2026-07-09T14:10:42.000Z";
+
+// Mirrors the shape buildCodeEvalTraceInput (codeEvalExecution.ts) produces:
+// a single finished root span whose spanId is the 32-hex trace ID.
+const codeEvalRootInput: InternalOtelSpanInput = {
+  projectId: "project-1",
+  traceId: TRACE_ID,
+  spanId: TRACE_ID,
+  startTimeISO: START_ISO,
+  endTimeISO: END_ISO,
+  name: "Execute evaluator: helpfulness",
+  traceName: "Execute evaluator: helpfulness",
+  environment: "langfuse-code-eval",
+  level: "ERROR",
+  statusMessage: "Code eval execution failed: boom",
+  input: '{"item":{}}',
+  output: '{"error":"boom"}',
+  metadata: { dispatcher_name: "test-dispatcher" },
+};
+
+// Convert the published OTLP payload through the REAL OTel ingestion
+// processor — the same code path the OTel ingestion queue runs — so a
+// regression in attribute naming or the internal-schema contract fails here
+// instead of only in production.
+const processPublishedSpans = async () => {
+  expect(publishToOtelIngestionQueue).toHaveBeenCalledTimes(1);
+  const resourceSpans = publishToOtelIngestionQueue.mock.calls[0][0];
+
+  const { OtelIngestionProcessor } = await vi.importActual<
+    typeof import("./OtelIngestionProcessor")
+  >("./OtelIngestionProcessor");
+  return new OtelIngestionProcessor({
+    projectId: "project-1",
+    publicKey: "",
+    sdkName: "langfuse-internal-otel-writer",
+    sdkVersion: "unknown",
+    isLangfuseInternal: true,
+  }).processToEvent(resourceSpans);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("writeInternalTraceViaOtelIngestion", () => {
+  it("publishes a trace that converts through the real OTel ingestion processor", async () => {
+    await writeInternalTraceViaOtelIngestion({
+      rootSpanId: TRACE_ID,
+      eventInputs: [codeEvalRootInput],
+    });
+
+    const events = await processPublishedSpans();
+    expect(events).toHaveLength(1);
+
+    const root = events[0];
+    expect(root.traceId).toBe(TRACE_ID);
+    expect(root.parentSpanId).toBeNull();
+    expect(root).toMatchObject({
+      name: "Execute evaluator: helpfulness",
+      traceName: "Execute evaluator: helpfulness",
+      // The langfuse- prefix must survive conversion; stripping it would
+      // bypass the trace-upsert eval-loop guard.
+      environment: "langfuse-code-eval",
+      level: "ERROR",
+      statusMessage: "Code eval execution failed: boom",
+      input: '{"item":{}}',
+      output: '{"error":"boom"}',
+      startTimeISO: START_ISO,
+      endTimeISO: END_ISO,
+    });
+    expect(root.metadata).toMatchObject({
+      dispatcher_name: "test-dispatcher",
+    });
+  });
+
+  it("remaps child parentSpanId onto the regenerated span ids", async () => {
+    await writeInternalTraceViaOtelIngestion({
+      rootSpanId: TRACE_ID,
+      eventInputs: [
+        codeEvalRootInput,
+        {
+          ...codeEvalRootInput,
+          spanId: "original-child-id",
+          // References the root's ORIGINAL spanId (the 32-hex trace id, not a
+          // valid OTel span id) — must resolve to the root's generated id.
+          parentSpanId: codeEvalRootInput.spanId,
+          name: "child step",
+        },
+      ],
+    });
+
+    const events = await processPublishedSpans();
+    expect(events).toHaveLength(2);
+
+    const root = events.find((e: any) => !e.parentSpanId);
+    const child = events.find((e: any) => e.parentSpanId);
+    expect(child.name).toBe("child step");
+    expect(child.traceId).toBe(TRACE_ID);
+    expect(child.parentSpanId).toBe(root.spanId);
+    // Trace-level fields stay on the root only.
+    expect(child.traceName).toBeNull();
+
+    // A parent that no preceding input declared cannot be linked once span
+    // ids are regenerated — refused instead of emitting broken linkage.
+    await expect(
+      writeInternalTraceViaOtelIngestion({
+        rootSpanId: TRACE_ID,
+        eventInputs: [
+          { ...codeEvalRootInput, parentSpanId: "unknown-span-id" },
+        ],
+      }),
+    ).rejects.toThrow(/parentSpanId/);
+  });
+
+  it("skips empty, non-langfuse-environment, and invalid-trace-id inputs", async () => {
+    await writeInternalTraceViaOtelIngestion({
+      rootSpanId: TRACE_ID,
+      eventInputs: [],
+    });
+    await writeInternalTraceViaOtelIngestion({
+      rootSpanId: TRACE_ID,
+      eventInputs: [{ ...codeEvalRootInput, environment: "production" }],
+    });
+    await writeInternalTraceViaOtelIngestion({
+      rootSpanId: "not-a-trace-id",
+      eventInputs: [{ ...codeEvalRootInput, traceId: "not-a-trace-id" }],
+    });
+
+    expect(publishToOtelIngestionQueue).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/server/otel/internalTraceOtelWriter.ts
+++ b/packages/shared/src/server/otel/internalTraceOtelWriter.ts
@@ -1,0 +1,225 @@
+import { randomBytes } from "node:crypto";
+
+import {
+  ROOT_CONTEXT,
+  TraceFlags,
+  trace as otelTraceApi,
+  type Attributes,
+} from "@opentelemetry/api";
+import { JsonTraceSerializer } from "@opentelemetry/otlp-transformer";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+
+import type { InternalTraceEventInput } from "../llm/internalTraceEvents";
+import { logger } from "../logger";
+import { LangfuseOtelSpanAttributes } from "./attributes";
+import { OtelIngestionProcessor } from "./OtelIngestionProcessor";
+
+const INTERNAL_TRACE_WRITER_SDK_NAME = "langfuse-internal-otel-writer";
+const INTERNAL_TRACE_WRITER_SCOPE = "langfuse-internal-trace-writer";
+const W3C_TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
+
+/**
+ * Publishes internally captured OTel spans through the regular OTel ingestion
+ * pipeline (same S3 + queue path as the public /api/public/otel/v1/traces
+ * endpoint), so internal traces get exactly the same write treatment as user
+ * traces: legacy traces/observations tables and events tables per the V4
+ * migration flags. Shared by the AI-SDK judge capture (`createAiSdkTelemetryCapture`)
+ * and `writeInternalTraceViaOtelIngestion`.
+ */
+export async function publishInternalOtelSpans(params: {
+  spans: ReadableSpan[];
+  projectId: string;
+  sdkName: string;
+}): Promise<void> {
+  const serialized = JsonTraceSerializer.serializeRequest(params.spans);
+  if (!serialized) return;
+
+  const { resourceSpans } = JSON.parse(new TextDecoder().decode(serialized));
+
+  if (!resourceSpans || resourceSpans.length === 0) return;
+
+  const processor = new OtelIngestionProcessor({
+    projectId: params.projectId,
+    publicKey: "", // internal ingestion has no API key; mirrors internal event writes
+    sdkName: params.sdkName,
+    sdkVersion: "unknown",
+    // Opt into the v4-native direct events write like a modern SDK batch:
+    // only that path runs processToEvent -> createEventRecord, which is
+    // the sole extractor of langfuse.experiment.* into experiment_*
+    // columns. Without it, dual-write mode routes internal batches
+    // (unknown SDK, no scope version) through legacy forwarding and
+    // experiment run items lose their linkage in events_full/v4 views.
+    // Legacy tables are still dual-written per v4WritesToLegacyTables.
+    ingestionVersion: "4",
+    // The consumer must parse these events with the internal ingestion
+    // schema; the public schema strips the "langfuse-" environment prefix,
+    // exposing internal traces as user environments and bypassing the
+    // trace-upsert eval-loop guard.
+    isLangfuseInternal: true,
+  });
+
+  await processor.publishToOtelIngestionQueue(resourceSpans);
+}
+
+/**
+ * Exactly the `InternalTraceEventInput` fields this writer maps onto OTel
+ * spans. Narrowed so a caller with richer inputs (usage, prompt, experiment
+ * linkage, ...) gets a compile-time surface mismatch instead of silent drops.
+ */
+export type InternalOtelSpanInput = Pick<
+  InternalTraceEventInput,
+  | "projectId"
+  | "traceId"
+  | "spanId"
+  | "parentSpanId"
+  | "startTimeISO"
+  | "endTimeISO"
+  | "name"
+  | "traceName"
+  | "environment"
+  | "level"
+  | "statusMessage"
+  | "input"
+  | "output"
+  | "metadata"
+>;
+
+/**
+ * Writes an already-finished internal trace (e.g. a code-eval execution trace)
+ * through the OTel ingestion pipeline via `publishInternalOtelSpans`. Unlike
+ * `createInternalEventsWriter` in the worker, which only writes the v4 events
+ * tables, this reaches every store the deployment's migration flags write to —
+ * without it, trace-level auth (which reads the legacy traces table in dual
+ * mode) 404s on these traces.
+ *
+ * Span IDs are newly generated (the code-eval producer sets `spanId` to the
+ * 32-hex trace ID, which is not a valid OTel span ID), so inputs must be
+ * ordered parents-first: a `parentSpanId` must reference a preceding input's
+ * `spanId` to be remapped onto the generated ID.
+ */
+export async function writeInternalTraceViaOtelIngestion(trace: {
+  rootSpanId: string;
+  eventInputs: InternalOtelSpanInput[];
+}): Promise<void> {
+  const { eventInputs } = trace;
+  if (eventInputs.length === 0) return;
+
+  // Mirrors the createAiSdkTelemetryCapture guards: non-langfuse environments
+  // would bypass the eval-loop safeguard, and a non-W3C trace ID would emit
+  // silently malformed OTLP IDs.
+  const invalidInput = eventInputs.find(
+    (eventInput) =>
+      !eventInput.environment?.startsWith("langfuse") ||
+      !W3C_TRACE_ID_PATTERN.test(eventInput.traceId.toLowerCase()) ||
+      eventInput.traceId.toLowerCase() === "0".repeat(32),
+  );
+  if (invalidInput) {
+    logger.warn(
+      "Skipping internal trace write: environment must be langfuse-prefixed and trace id a valid W3C trace id",
+      {
+        traceId: invalidInput.traceId,
+        environment: invalidInput.environment,
+      },
+    );
+    return;
+  }
+
+  const exporter = new InMemorySpanExporter();
+  let currentTraceId = eventInputs[0].traceId.toLowerCase();
+  const tracerProvider = new BasicTracerProvider({
+    resource: resourceFromAttributes({
+      [LangfuseOtelSpanAttributes.ENVIRONMENT]: eventInputs[0].environment,
+    }),
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+    // Root spans (no parent) receive the input's Langfuse trace ID via
+    // `currentTraceId`; span creation below is synchronous, so the closure is
+    // safe.
+    idGenerator: {
+      generateTraceId: () => currentTraceId,
+      generateSpanId: () => randomBytes(8).toString("hex"),
+    },
+  });
+
+  try {
+    const tracer = tracerProvider.getTracer(INTERNAL_TRACE_WRITER_SCOPE);
+    const generatedSpanIds = new Map<string, string>();
+
+    for (const eventInput of eventInputs) {
+      currentTraceId = eventInput.traceId.toLowerCase();
+      const isRoot = !eventInput.parentSpanId;
+      const metadataJson = JSON.stringify(eventInput.metadata);
+
+      const attributes: Attributes = {
+        ...(eventInput.environment !== undefined
+          ? { [LangfuseOtelSpanAttributes.ENVIRONMENT]: eventInput.environment }
+          : {}),
+        ...(eventInput.level !== undefined
+          ? { [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: eventInput.level }
+          : {}),
+        ...(eventInput.statusMessage !== undefined
+          ? {
+              [LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE]:
+                eventInput.statusMessage,
+            }
+          : {}),
+        ...(eventInput.input !== undefined
+          ? { [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: eventInput.input }
+          : {}),
+        ...(eventInput.output !== undefined
+          ? {
+              [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]:
+                eventInput.output,
+            }
+          : {}),
+        [LangfuseOtelSpanAttributes.OBSERVATION_METADATA]: metadataJson,
+        ...(isRoot && eventInput.traceName !== undefined
+          ? { [LangfuseOtelSpanAttributes.TRACE_NAME]: eventInput.traceName }
+          : {}),
+        ...(isRoot
+          ? { [LangfuseOtelSpanAttributes.TRACE_METADATA]: metadataJson }
+          : {}),
+      };
+
+      let context = ROOT_CONTEXT;
+      if (eventInput.parentSpanId) {
+        const generatedParentSpanId = generatedSpanIds.get(
+          eventInput.parentSpanId,
+        );
+        if (!generatedParentSpanId) {
+          throw new Error(
+            "Internal trace input's parentSpanId must reference a preceding input's spanId",
+          );
+        }
+        context = otelTraceApi.setSpanContext(ROOT_CONTEXT, {
+          traceId: currentTraceId,
+          spanId: generatedParentSpanId,
+          traceFlags: TraceFlags.SAMPLED,
+        });
+      }
+
+      const span = tracer.startSpan(
+        eventInput.name ?? "",
+        { startTime: new Date(eventInput.startTimeISO), attributes },
+        context,
+      );
+      generatedSpanIds.set(eventInput.spanId, span.spanContext().spanId);
+      span.end(new Date(eventInput.endTimeISO));
+    }
+
+    await tracerProvider.forceFlush();
+
+    await publishInternalOtelSpans({
+      spans: exporter.getFinishedSpans(),
+      projectId: eventInputs[0].projectId,
+      sdkName: INTERNAL_TRACE_WRITER_SDK_NAME,
+    });
+  } finally {
+    await tracerProvider.shutdown().catch(() => undefined);
+  }
+}

--- a/web/src/__tests__/server/traces-trpc.servertest.ts
+++ b/web/src/__tests__/server/traces-trpc.servertest.ts
@@ -549,6 +549,48 @@ describe("traces trpc", () => {
       expect(traceRes?.timestamp).toEqual(new Date(trace.timestamp));
     });
 
+    // In dual write mode, internally produced traces (e.g. code-eval execution
+    // traces) exist ONLY in the events tables. Trace access must fall back to
+    // the events table instead of 404ing on the legacy `traces` miss — the
+    // fast-preview list showed such traces while the detail view threw
+    // "Trace not found".
+    // Gate matches the code: events-table reads work in dual (fallback) and
+    // events_only (getTraceById routing); legacy deployments (azure /
+    // redis-cluster CI) have no events tables and skip.
+    const eventsTraceReadable =
+      env.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "legacy";
+    (eventsTraceReadable ? it : it.skip)(
+      "access trace that only exists in the events table",
+      async () => {
+        const traceId = randomUUID();
+
+        await createEventsCh([
+          createEvent({
+            id: traceId,
+            span_id: traceId,
+            trace_id: traceId,
+            project_id: projectId,
+            parent_span_id: null,
+          }),
+        ]);
+
+        // Precondition: legacy `traces` has no row.
+        expect(
+          await getTraceByIdFromTracesTable({ traceId, projectId }),
+        ).toBeUndefined();
+
+        // ClickHouse insert visibility can lag.
+        await waitForExpect(async () => {
+          const traceRes = await caller.traces.byId({
+            projectId,
+            traceId,
+          });
+          expect(traceRes?.id).toEqual(traceId);
+          expect(traceRes?.projectId).toEqual(projectId);
+        });
+      },
+    );
+
     it("access trace without any authentication", async () => {
       const unAuthedSession = createInnerTRPCContext({ session: null });
       const unAuthedCaller = appRouter.createCaller({

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -85,6 +85,7 @@ import { ZodError } from "zod";
 import { setUpSuperjson } from "@/src/utils/superjson";
 import {
   getTraceById,
+  getTraceByIdFromEventsTable,
   logger,
   addUserToSpan,
   contextWithLangfuseProps,
@@ -508,7 +509,7 @@ const enforceTraceAccess = t.middleware(async (opts) => {
   const fromTimestamp = result.data.fromTimestamp;
   const verbosity = result.data.verbosity;
 
-  const clickhouseTrace = traceId
+  let clickhouseTrace = traceId
     ? // eslint-disable-next-line @typescript-eslint/no-deprecated
       await getTraceById({
         traceId,
@@ -521,6 +522,29 @@ const enforceTraceAccess = t.middleware(async (opts) => {
         },
       })
     : null;
+
+  // In dual write mode the lookup above reads the legacy traces table, but
+  // internally produced traces (e.g. code-eval execution traces) were written
+  // to the events tables only — fall back so trace-level auth does not 404 on
+  // a trace the events-backed views can render (LFE-10884). Gated on "dual"
+  // because in "legacy" mode the events tables may not exist and in
+  // "events_only" mode getTraceById already read them.
+  if (
+    traceId &&
+    !clickhouseTrace &&
+    env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "dual"
+  ) {
+    clickhouseTrace = await getTraceByIdFromEventsTable({
+      traceId,
+      projectId,
+      timestamp: timestamp ?? undefined,
+      fromTimestamp: fromTimestamp ?? undefined,
+      renderingProps: {
+        truncated: verbosity === "truncated",
+        shouldJsonParse: false,
+      },
+    });
+  }
 
   if (traceId && !clickhouseTrace) {
     logger.error(`Trace with id ${traceId} not found for project ${projectId}`);

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -39,12 +39,9 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
     createW3CTraceId: mocks.createW3CTraceId,
     runCodeBasedEvaluationDispatch,
     resolveConfiguredCodeEvalDispatcher: vi.fn(() => mocks.dispatcher),
+    writeInternalTraceViaOtelIngestion: mocks.writeInternalTrace,
   };
 });
-
-vi.mock("../../internal-tracing/createInternalEventsWriter", () => ({
-  createInternalEventsWriter: () => ({ write: mocks.writeInternalTrace }),
-}));
 
 import { executeCodeBasedEvaluation } from "./executeCodeBasedEvaluation";
 

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -6,11 +6,11 @@ import {
   logger,
   resolveConfiguredCodeEvalDispatcher,
   runCodeBasedEvaluationDispatch,
+  writeInternalTraceViaOtelIngestion,
   type ExtractedVariable,
 } from "@langfuse/shared/src/server";
 import { UnrecoverableError } from "../../../errors/UnrecoverableError";
 import { createW3CTraceId } from "../../utils";
-import { createInternalEventsWriter } from "../../internal-tracing/createInternalEventsWriter";
 import { type EvalExecutionResult } from "../evalCompletion";
 import { type EvalExecutionDeps } from "../evalExecutionDeps";
 
@@ -68,7 +68,10 @@ export async function executeCodeBasedEvaluation(params: {
         hasExperimentContext: params.hasExperimentContext ?? false,
         traceName: `Execute evaluator: ${params.template.name}`,
         metadata: executionMetadata,
-        writeTrace: (trace) => createInternalEventsWriter().write(trace),
+        // Publish via the OTel ingestion pipeline (like LLM-as-a-judge) so the
+        // trace reaches the legacy tables too in dual write mode — a direct
+        // events-table write alone 404s in the trace detail view.
+        writeTrace: (trace) => writeInternalTraceViaOtelIngestion(trace),
       });
 
       if (!dispatchOutcome.success) {

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
@@ -44,10 +44,6 @@ vi.mock("../../evalService", () => ({
   runLLMAsJudgeEvaluation: vi.fn(),
 }));
 
-vi.mock("../../../internal-tracing/createInternalEventsWriter", () => ({
-  createInternalEventsWriter: () => ({ write: mocks.writeInternalTrace }),
-}));
-
 // Mock logger
 vi.mock("@langfuse/shared/src/server", async () => {
   const actual = await vi.importActual<
@@ -65,6 +61,7 @@ vi.mock("@langfuse/shared/src/server", async () => {
     resolveConfiguredCodeEvalDispatcher: vi.fn(
       () => new actual.LocalCodeEvalDispatcher(),
     ),
+    writeInternalTraceViaOtelIngestion: mocks.writeInternalTrace,
   };
 });
 


### PR DESCRIPTION
## Summary

- Scheduled code-eval executions write their "Execute evaluator" trace only to the v4 events tables, while trace-level auth (`enforceTraceAccess`) resolves traces from the **legacy traces table** in dual write mode. Since #14717 routed the v4 detail endpoints through that middleware, the events-backed list showed these traces but opening one threw `NOT_FOUND "Trace not found"`. LLM-as-a-judge was unaffected — it has always dual-written (via `processEventBatch`, now via #14791's OTel pipeline).
- Read side: `enforceTraceAccess` now falls back to `getTraceByIdFromEventsTable` on a legacy miss, gated to `dual` write mode (in `legacy` the events tables may not exist; in `events_only` the primary lookup already reads them). This unbreaks the existing events-only traces.
- Write side: code-eval execution traces now publish through the same OTel ingestion pipeline as LLM-as-a-judge — new `writeInternalTraceViaOtelIngestion` reusing the extracted `publishInternalOtelSpans` — so they reach every store the deployment's migration flags write to (also fixes `legacy`-mode deployments, where these traces were previously written nowhere).
- Capacity note: this adds one S3 PUT + one queue job per code-eval execution — the same shape of per-execution cost the score-persistence path already pays (`uploadScore` + `enqueueScoreIngestion`).

## Linear

- [LFE-10884](https://linear.app/langfuse/issue/LFE-10884/trace-details-for-code-evals-broken)

## Major Decisions

- **Read-route fallback instead of backfilling data.** Pre-fix events-only traces are repaired by a second lookup on legacy miss rather than a one-off backfill of the legacy tables — no migration to run, and the extra ClickHouse probe only fires on genuine misses (bloom-filter-carried). The fallback stays scoped to the auth middleware: the other `getTraceById` callers (annotate/bookmark/publish/public GET) were never switched by #14717 and behave as before; unifying them in the shared wrapper is a deliberate non-goal here (follow-up candidate).
- **Reuse the judge's OTel publisher rather than dual-writing in the internal events writer.** Keeps one ingestion contract for all internal traces and inherits the migration-flag routing for free; the writer's input is narrowed to exactly the fields it maps (`Pick<>`) so a future caller with richer inputs fails at compile time instead of silently dropping data.

## Review Focus

- `web/src/server/api/trpc.ts` — the fallback sits in the auth middleware: confirm the `dual`-gating reasoning holds for all three write modes and that returning an events-table trace through `ctx.trace` is acceptable for the `traces.byId` consumers.
- `packages/shared/src/server/otel/internalTraceOtelWriter.ts` — the OTLP construction (regenerated span IDs with parent remap, guard behavior mirroring the AI-SDK capture); the unit test round-trips through the real `processToEvent` to pin the ingestion-schema contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related issues that made code-eval execution traces unreadable in the trace detail view: (1) the read side now falls back to `getTraceByIdFromEventsTable` on a legacy miss when in `dual` write mode, and (2) the write side switches code-eval traces from `createInternalEventsWriter` (events-only) to the same OTel ingestion pipeline used by LLM-as-a-judge, so new traces reach every store the deployment's migration flags target.

- **Read fix**: `enforceTraceAccess` in `trpc.ts` adds a second ClickHouse probe against the events table when the legacy table returns no result, gated strictly to `dual` mode so `legacy` (no events tables) and `events_only` (already reads events) are unaffected.
- **Write fix**: `writeInternalTraceViaOtelIngestion` is introduced in `internalTraceOtelWriter.ts`, reconstructing valid 8-byte OTel span IDs from the 32-hex trace IDs the code-eval producer emits, and routing through `publishInternalOtelSpans` (shared with the AI-SDK judge capture). A unit test round-trips through the real `processToEvent` path to pin the ingestion-schema contract.
- **Refactor**: `publishInternalOtelSpans` is extracted from `telemetry.ts` and re-exported from `internalTraceOtelWriter.ts`, removing inline serialization logic from the AI-SDK capture path.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge. The read-side fallback is correctly gated to dual write mode and returns the same trace shape as the primary lookup, so downstream auth and access checks are unaffected. The write-side switch from the events-only writer to the OTel ingestion pipeline is well-tested and mirrors the path already used by LLM-as-a-judge.

The core fix is sound: the dual-mode gating in enforceTraceAccess prevents the fallback from running against non-existent events tables in legacy deployments, and the new OtelIngestionProcessor path writes to all stores the migration flags require. The only findings are a dead rootSpanId parameter and an asymmetric guard style in the new writer — neither affects runtime correctness.

No files require special attention for correctness. internalTraceOtelWriter.ts has the two style-level observations noted in the comments but the logic is correct.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Code-eval job executes] --> B[executeCodeBasedEvaluation]
    B --> C[runCodeBasedEvaluationDispatch]
    C --> D[writeTrace callback]

    D --> E[writeInternalTraceViaOtelIngestion]
    E --> F[Build OTel spans with valid 8-byte spanIds]
    F --> G[publishInternalOtelSpans]
    G --> H[OtelIngestionProcessor]
    H --> I{Migration flag}
    I -->|legacy| J[legacy traces table only]
    I -->|dual| K[legacy traces + events tables]
    I -->|events_only| L[events tables only]

    subgraph Read side - enforceTraceAccess
        M[traces.byId request] --> N[getTraceById deprecated wrapper]
        N --> O{Write mode?}
        O -->|events_only| P[getTraceByIdFromEventsTable]
        O -->|legacy / dual| Q[getTraceByIdFromTracesTable]
        Q -->|found| R[Return trace]
        Q -->|not found + dual mode| S[Fallback: getTraceByIdFromEventsTable]
        S -->|found| R
        S -->|not found| T[404 NOT_FOUND]
        P -->|found| R
        P -->|not found| T
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Code-eval job executes] --> B[executeCodeBasedEvaluation]
    B --> C[runCodeBasedEvaluationDispatch]
    C --> D[writeTrace callback]

    D --> E[writeInternalTraceViaOtelIngestion]
    E --> F[Build OTel spans with valid 8-byte spanIds]
    F --> G[publishInternalOtelSpans]
    G --> H[OtelIngestionProcessor]
    H --> I{Migration flag}
    I -->|legacy| J[legacy traces table only]
    I -->|dual| K[legacy traces + events tables]
    I -->|events_only| L[events tables only]

    subgraph Read side - enforceTraceAccess
        M[traces.byId request] --> N[getTraceById deprecated wrapper]
        N --> O{Write mode?}
        O -->|events_only| P[getTraceByIdFromEventsTable]
        O -->|legacy / dual| Q[getTraceByIdFromTracesTable]
        Q -->|found| R[Return trace]
        Q -->|not found + dual mode| S[Fallback: getTraceByIdFromEventsTable]
        S -->|found| R
        S -->|not found| T[404 NOT_FOUND]
        P -->|found| R
        P -->|not found| T
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/otel/internalTraceOtelWriter.ts:106-110
`rootSpanId` is accepted in the function signature (to satisfy the `InternalTraceWriteInput` interface) but is never read inside the function body. Only `eventInputs` is destructured. For the current code-eval single-span use case `rootSpanId === traceId === spanId`, so this has no impact on correctness, but the unused parameter could mislead future callers who expect it to influence span ordering or root identification.

```suggestion
export async function writeInternalTraceViaOtelIngestion(trace: {
  rootSpanId: string;
  eventInputs: InternalOtelSpanInput[];
}): Promise<void> {
  const { rootSpanId: _rootSpanId, eventInputs } = trace; // rootSpanId accepted for InternalTraceWriteInput compatibility; not used — ordering is inferred from parents-first input order
```

### Issue 2 of 2
packages/shared/src/server/otel/internalTraceOtelWriter.ts:116-131
**Asymmetric guard behaviour on bad inputs**

The `invalidInput` guard returns early (after a `logger.warn`) when any span has a non-`langfuse` environment or invalid trace ID, but an unknown `parentSpanId` later in the loop throws instead of returning. Both paths are ultimately swallowed by `writeCodeEvalTraceSafely`, and both result in a warning being logged, so there is no functional difference — but the inconsistency may surprise future callers who pattern-match on one guard and expect the other to behave the same way. Consider standardising both to `throw` (make the programmer error explicit) or both to a logged early-`return`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): make code-eval execution tra..."](https://github.com/langfuse/langfuse/commit/7ae55a08999c49b4f0074ed0d3c1423a5c9ea198) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43811349)</sub>

<!-- /greptile_comment -->