### PR TITLE
fix(agent): Add code generation instructions to system prompt

### DIFF
--- a/web/src/ee/features/in-app-agent/prompts/in-app-agent-system-prompt.txt
+++ b/web/src/ee/features/in-app-agent/prompts/in-app-agent-system-prompt.txt
@@ -29,6 +29,12 @@ For questions about best practices or specific workflows (e.g. setting up evals)
 If the skill ever tells you to reference the docs, always use the langfuse-docs-mcp server to access those docs.
 </tools>
 
+<code_generation>
+Avoid generating code assets intended to run in the user's environment, this could be one-off scripts or SDK changes. Instead, recommend using a coding agent with access to their environment, such as Claude or Codex, and provide a self-contained prompt they can give that agent in a code block.
+The user should be made aware of the Langfuse skill: https://github.com/langfuse/skills
+You may still provide short code snippets when they help explain an API or concept. If, after receiving the coding-agent prompt, the user explicitly asks you to write the complete code instead, you may do so. Clearly state any unverified assumptions and mention that the code should be checked before use.
+</code_generation>
+
 <data_scope>
 Langfuse uses internal environments for Langfuse-managed product workflows, such as evaluations, prompt experiments or code evals. These environments can create traces, observations, or scores that are useful for debugging Langfuse-managed features, but they are usually not part of the user's application traffic.
 
@@ -42,7 +48,7 @@ Some tools can change the user's project. The product will ask the user for expl
 Do not claim that a tool action succeeded until the tool result confirms it. If the user rejects an action or the tool fails, say that the action was not completed and provide the next best option.
 If the user asks you to perform an action you cannot, see if the action is available in the UI or via the CLI, and suggest that to the user.
 - Explain to the user how they can perform the action themselves in the UI (use the docs for this if needed).
-- If the action is available via the CLI, suggest that the user can ask their own agent (Claude, Codex or similar) to perform the action for them using the CLI, for that they should use the Langfuse skill: https://github.com/langfuse/skills. When suggesting this, provide a prompt the user can use as a code block.
+- If the action is available via the CLI, suggest that the user can ask their own agent (Claude, Codex or similar) to perform the action for them using the CLI. When suggesting this, provide a prompt the user can use as a code block.
 </permissions>
 
 <user_navigation>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `<code_generation>` section to the in-app agent system prompt, instructing the assistant to defer full runnable-code generation to an external coding agent (Claude, Codex, etc.) and instead supply the user with a self-contained prompt. It also removes the now-redundant Langfuse skill URL from the `<permissions>` CLI-action bullet, since the new section covers it.

- The new `<code_generation>` block correctly allows short explanatory snippets and lets the user override the behavior explicitly.
- The Langfuse skill URL was removed from the `<permissions>` CLI bullet, which may leave it unmentioned when the assistant only suggests a CLI action without generating code.
- A duplicate-word typo ("the the Langfuse skill") exists on line 34.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — this is a prompt-only change with no runtime code affected. The two findings are minor and unlikely to break any user flow.

The change is confined to a single text file (the system prompt). A duplicate-word typo appears verbatim in the LLM context but has no functional impact. Removing the Langfuse skill URL from the CLI-action bullet is a small logical gap — users asking for CLI help without triggering the code-generation path may not see the skill URL — but this is a soft behavior concern, not a hard failure. Both findings are easy to fix.

Only web/src/ee/features/in-app-agent/prompts/in-app-agent-system-prompt.txt changed; the duplicate-word typo and the removed skill URL from the CLI bullet are worth a quick second look before merging.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/ee/features/in-app-agent/prompts/in-app-agent-system-prompt.txt:34
There is a duplicate "the" — "the the Langfuse skill" — which will appear verbatim in the LLM's context and may slightly degrade instruction clarity.

```suggestion
The user should be made aware of the Langfuse skill: https://github.com/langfuse/skills
```

### Issue 2 of 2
web/src/ee/features/in-app-agent/prompts/in-app-agent-system-prompt.txt:51
**Skill URL dropped from CLI-action path** — The `<permissions>` section no longer mentions the Langfuse skill URL after this change. The new `<code_generation>` section only fires when the assistant is generating code; a pure CLI-action suggestion (e.g. "use the CLI to do X") may never trigger that section, so the user won't learn about the skill in that scenario. The old wording explicitly included the URL at the CLI-suggestion call-site.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Add code generation instruct..."](https://github.com/langfuse/langfuse/commit/336746c10082cb5cd767504311dfaf8bf6cc3bb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43860126)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->