### PR TITLE
fix(prompts): type redis keys correctly

### DIFF
--- a/web/src/__tests__/server/promptCache.servertest.ts
+++ b/web/src/__tests__/server/promptCache.servertest.ts
@@ -106,9 +106,11 @@ describe("PromptService", () => {
       const cache = new Map<string, string>([
         ["prompt_cache_epoch:project1", "epoch-1"],
       ]);
-      mockRedis.get.mockImplementation(async (key) => cache.get(key) ?? null);
+      mockRedis.get.mockImplementation(
+        async (key) => cache.get(key.toString()) ?? null,
+      );
       mockRedis.set.mockImplementation(async (key, value) => {
-        cache.set(key, value.toString());
+        cache.set(key.toString(), value.toString());
         return "OK";
       });
 
@@ -125,7 +127,7 @@ describe("PromptService", () => {
         labels: ["3"],
         prompt: "Numeric label content",
       };
-      mockPrisma.prompt.findFirst
+      promptFindFirstMock
         .mockResolvedValueOnce(versionPrompt)
         .mockResolvedValueOnce(labelPrompt);
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes three test-only corrections to `promptCache.servertest.ts` to match the actual ioredis key type (`string | Buffer`) and fix Prisma mock chaining.

- The Redis `get` and `set` mock implementations now call `.toString()` on the `key` argument, guarding against the ioredis `KeyType = string | Buffer` union so Map lookups always use a plain string.
- The chained `.mockResolvedValueOnce()` calls are moved from `mockPrisma.prompt.findFirst` to `promptFindFirstMock` (a plain `vi.fn()`) because Prisma's overloaded `findFirst` signature prevents vitest's `Mocked<T>` from typing the mock chain correctly, which could silently break multi-call setup.
- No production code is modified.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only change with no production code touched; all three fixes are correct and tighten the existing mocks.

The changes are confined to a single test file. Replacing the raw Prisma handle with the plain `vi.fn()` instance for mock chaining is correct, `.toString()` on the Redis key parameter is a safe defensive addition, and no observable behavior in production is affected.

No files require special attention; the one minor inconsistency (line 149 assertion still referencing `mockPrisma.prompt.findFirst`) does not affect test correctness.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant PromptService
    participant Redis
    participant DB as Prisma DB

    Client->>PromptService: getPrompt(params)
    alt cacheEnabled
        PromptService->>Redis: get(epochKey)
        Redis-->>PromptService: epoch token
        PromptService->>Redis: get(cacheKey)
        alt cache hit
            Redis-->>PromptService: JSON prompt
            PromptService-->>Client: cached PromptResult
        else cache miss
            Redis-->>PromptService: null
            PromptService->>DB: findFirst(...)
            DB-->>PromptService: Prompt
            PromptService->>Redis: set(cacheKey, JSON, EX, ttl)
            PromptService-->>Client: DB PromptResult
        end
    else cache disabled / null Redis
        PromptService->>DB: findFirst(...)
        DB-->>PromptService: Prompt
        PromptService-->>Client: PromptResult
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant PromptService
    participant Redis
    participant DB as Prisma DB

    Client->>PromptService: getPrompt(params)
    alt cacheEnabled
        PromptService->>Redis: get(epochKey)
        Redis-->>PromptService: epoch token
        PromptService->>Redis: get(cacheKey)
        alt cache hit
            Redis-->>PromptService: JSON prompt
            PromptService-->>Client: cached PromptResult
        else cache miss
            Redis-->>PromptService: null
            PromptService->>DB: findFirst(...)
            DB-->>PromptService: Prompt
            PromptService->>Redis: set(cacheKey, JSON, EX, ttl)
            PromptService-->>Client: DB PromptResult
        end
    else cache disabled / null Redis
        PromptService->>DB: findFirst(...)
        DB-->>PromptService: Prompt
        PromptService-->>Client: PromptResult
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/promptCache.servertest.ts:149
For consistency with the rest of this test's refactoring, the `toHaveBeenCalledTimes` assertion could also reference `promptFindFirstMock` directly. It works today because both point to the same `vi.fn()` instance, but mixing the two references in the same test block makes it less clear which handle is preferred for assertions.

```suggestion
      expect(promptFindFirstMock).toHaveBeenCalledTimes(2);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(prompts): type redis keys correctly"](https://github.com/langfuse/langfuse/commit/7fcc92c11269b7c2b7832c00b1e3ff7132358349) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43900906)</sub>

<!-- /greptile_comment -->