### PR TITLE
feat(preview): previews for any write-access member (drop author allowlist)

### DIFF
--- a/.github/workflows/preview-autolabel.yml
+++ b/.github/workflows/preview-autolabel.yml
@@ -1,18 +1,17 @@
 name: AWS preview auto-label
 
-# Auto-apply the `preview` label to same-repo PRs opened by an allowlisted
-# author, so the Argo CD ApplicationSet (in the infrastructure repo) picks them
-# up and builds a preview. Anyone with write access can also apply the label
-# by hand; the build workflow re-checks the PR author before building with a
-# cloud credential, so a manual label from a non-allowlisted author is inert.
+# Auto-apply the `preview` label to same-repo PRs on open, so the Argo CD
+# ApplicationSet (in the infrastructure repo) picks them up and builds a
+# preview. Anyone with write access can also apply the label by hand.
 #
-# Uses the plain `pull_request` trigger (NOT pull_request_target): it holds no
-# cloud credentials, never checks out or executes PR code, and only calls
-# issues.addLabels. The label is not a security boundary — the build workflow
-# independently re-checks the PR author before using any credential — so
-# pull_request_target's tamper-resistance isn't needed here, and avoiding it
-# keeps this off the dangerous-triggers list. Same-repo PRs get a write token to
-# add the label; fork PRs are short-circuited below (and get a read-only token).
+# Trust boundary is WRITE access, not a per-author allowlist: opening a
+# same-repo PR requires push access, so labeling every same-repo PR is exactly
+# "auto-preview for write-access members." Fork PRs are short-circuited — they
+# can't mint an OIDC token to build anyway.
+#
+# Uses the plain `pull_request` trigger (NOT pull_request_target): no cloud
+# credentials, no checkout, no PR-code execution — only issues.addLabels — so it
+# stays off zizmor's dangerous-triggers list.
 on:
   pull_request:
     types: [opened, reopened]
@@ -21,38 +20,26 @@ permissions: {}
 
 jobs:
   autolabel:
-    name: Auto-label allowlisted PRs
+    name: Auto-label same-repo PRs
     runs-on: ubuntu-latest
-    if: vars.AWS_PREVIEW_ALLOWED_USERS != ''
+    # AWS_PREVIEW_ECR_PUSH_ROLE_ARN is the feature flag: unset => preview system
+    # off, so don't label.
+    if: vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != ''
     permissions:
       pull-requests: write
     steps:
-      - name: Label allowlisted, same-repo PRs
+      - name: Label same-repo PRs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          ALLOWED_USERS: ${{ vars.AWS_PREVIEW_ALLOWED_USERS }}
         with:
           script: |
             const pr = context.payload.pull_request;
             const { owner, repo } = context.repo;
 
-            // Same-repo only: fork PRs cannot mint an OIDC token, so the build
-            // workflow could never push their image — an auto-labeled fork PR
-            // would only create a broken environment.
+            // Same-repo only: opening a same-repo PR requires push (write)
+            // access, so this is "auto-preview for write-access members." Fork
+            // PRs can't mint an OIDC token to build, so skip them.
             if (pr.head.repo.full_name !== `${owner}/${repo}`) {
               core.info("Fork PR; auto-label is limited to same-repo branches.");
-              return;
-            }
-
-            // Exact-match allowlist (never substring — a login that is a
-            // substring of an allowlisted one must not pass).
-            const allowed = (process.env.ALLOWED_USERS || "")
-              .split(/[\s,]+/)
-              .filter(Boolean)
-              .map((u) => u.toLowerCase());
-            const author = pr.user.login.toLowerCase();
-            if (!allowed.includes(author)) {
-              core.info(`Author ${author} is not on the preview allowlist; skipping.`);
               return;
             }
 
@@ -62,4 +49,4 @@ jobs:
               issue_number: pr.number,
               labels: ["preview"],
             });
-            core.info(`Applied 'preview' label to PR #${pr.number} (author ${author}).`);
+            core.info(`Applied 'preview' label to PR #${pr.number}.`);

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -5,12 +5,12 @@ name: AWS preview build
 # tag exists for a labeled PR; this workflow only builds and pushes, then posts
 # the preview URL on the PR.
 #
-# Authorization is intentionally stricter than "the PR is labeled": the
-# `preview` label can be applied by any org member, but this job builds the PR
-# AUTHOR's code with an AWS (ECR push) credential, so it also requires the PR
-# author to be on AWS_PREVIEW_ALLOWED_USERS. Fork PRs cannot mint an OIDC token
-# (public repo, read-only token), so they can never push regardless — and the
-# ECR-push role's trust policy is additionally scoped to
+# Trust boundary is WRITE access: this builds a SAME-REPO PR's code with an AWS
+# (ECR push) credential, and opening a same-repo PR requires push access — so
+# only write-access members can trigger a build (applying the `preview` label is
+# itself a write action). No per-author allowlist. Fork PRs are excluded (the
+# head.repo check below) and can't mint an OIDC token anyway (public repo,
+# read-only token) — and the ECR-push role's trust is scoped to
 # sub=repo:langfuse/langfuse:pull_request AND ref=refs/pull/* (GitHub OIDC has no
 # event_name claim), so pull_request_target / review — which carry the base
 # branch ref — cannot assume it either.
@@ -25,45 +25,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  authorize:
-    name: Authorize
-    runs-on: ubuntu-latest
-    # AWS_PREVIEW_ECR_PUSH_ROLE_ARN doubles as the feature flag: unset => the
-    # whole workflow no-ops instead of failing on every labeled PR.
+  build:
+    name: Build and push preview images
+    # Any SAME-REPO PR (= write access) carrying the `preview` label builds.
+    # Fork PRs are excluded (head.repo check) and can't mint OIDC anyway; there
+    # is no per-author allowlist. AWS_PREVIEW_ECR_PUSH_ROLE_ARN doubles as the
+    # feature flag: unset => the workflow no-ops instead of failing per PR.
     if: >-
       vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != '' &&
       contains(github.event.pull_request.labels.*.name, 'preview') &&
       github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      pull-requests: read
-    outputs:
-      authorized: ${{ steps.gate.outputs.authorized }}
-    steps:
-      - name: Require an allowlisted PR author
-        id: gate
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          ALLOWED_USERS: ${{ vars.AWS_PREVIEW_ALLOWED_USERS }}
-        with:
-          script: |
-            const author = context.payload.pull_request.user.login.toLowerCase();
-            const allowed = (process.env.ALLOWED_USERS || "")
-              .split(/[\s,]+/)
-              .filter(Boolean)
-              .map((u) => u.toLowerCase());
-            const ok = allowed.includes(author);
-            if (!ok) {
-              core.warning(
-                `PR author ${author} is not on the preview allowlist; not building. ` +
-                  "Ask an admin to add the author to AWS_PREVIEW_ALLOWED_USERS.",
-              );
-            }
-            core.setOutput("authorized", ok ? "true" : "false");
-
-  build:
-    name: Build and push preview images
-    needs: authorize
-    if: needs.authorize.outputs.authorized == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -158,8 +158,7 @@ jobs:
             **API keys:** `${{ steps.meta.outputs.public_key }}` / `${{ steps.meta.outputs.secret_key }}`
             **Commit:** ${{ steps.meta.outputs.commit_sha }}
 
-            Synthetic preview data only — never enter a real credential. Remove
-            the `preview` label or close the PR to destroy the environment.
+            Synthetic preview data only. Never add production data to public accounts.
 
       - name: Report failure
         if: failure()


### PR DESCRIPTION
## What
Replace the per-author allowlist (`AWS_PREVIEW_ALLOWED_USERS`) with a **write-access** trust boundary for previews.

- `preview-autolabel.yml`: auto-labels **any same-repo PR** on open (opening one requires push access); drops the allowlist check; feature-flagged on `AWS_PREVIEW_ECR_PUSH_ROLE_ARN`.
- `preview-build.yml`: removes the `authorize` job — the build gates on same-repo + `preview` label + feature-flag, no per-author allowlist.
- Rewords the preview-data warning in the status comment.

## Why
Opening a same-repo PR already requires write access, so the allowlist was a redundant second layer plus a maintenance burden. Fork/external PRs are still fully excluded (they can't mint the OIDC token to build). Write access = trusted for previews (they can already merge code and run CI with secrets).

## Follow-up
Delete the now-unreferenced `AWS_PREVIEW_ALLOWED_USERS` repo variable after this merges. Companion infra PR removes the ApplicationSet author `selector`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the per-author allowlist (`AWS_PREVIEW_ALLOWED_USERS`) with a write-access trust boundary for the preview build system, removing the separate `authorize` job and updating the autolabel feature flag to `AWS_PREVIEW_ECR_PUSH_ROLE_ARN`.

- **`preview-autolabel.yml`**: Drops the allowlist check and now labels every same-repo PR on open/reopen; feature flag is unified with the build workflow (`AWS_PREVIEW_ECR_PUSH_ROLE_ARN`).
- **`preview-build.yml`**: Eliminates the `authorize` job; the `build` job's `if` condition now encodes all three gates (feature flag, `preview` label, same-repo check) inline. Fork PRs remain excluded via both the repo check and the inability to mint an OIDC token under the role's trust policy.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the write-access trust boundary is correctly enforced by both the same-repo head check and the OIDC role's trust policy, and the simplified workflow is less complex than what it replaces.

The logic is straightforward: the three-condition `if` guard on the build job is equivalent in security outcome to the old two-job arrangement, and the OIDC token mint restriction provides hard enforcement that no workflow-level `if` can bypass. The only substantive change worth noting is the dropped teardown hint in the status comment.

.github/workflows/preview-build.yml — specifically the status comment text at line 161, which no longer tells users how to destroy the preview environment.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Write-Access Dev
    participant GH as GitHub (pull_request)
    participant AL as preview-autolabel.yml
    participant BL as preview-build.yml
    participant AWS as AWS ECR (OIDC)
    participant Argo as Argo CD

    Dev->>GH: Opens same-repo PR
    GH->>AL: trigger (opened)
    AL->>AL: AWS_PREVIEW_ECR_PUSH_ROLE_ARN set?
    AL->>AL: "head.repo == base.repo?"
    AL->>GH: addLabels("preview")

    GH->>BL: trigger (labeled)
    BL->>BL: AWS_PREVIEW_ECR_PUSH_ROLE_ARN set? ✓
    BL->>BL: has 'preview' label? ✓
    BL->>BL: "head.repo == github.repository? ✓"
    BL->>GH: Post "🟡 building" comment
    BL->>AWS: Assume ECR-push role via OIDC
    AWS-->>BL: Credentials (scoped to pull_request ref)
    BL->>AWS: docker push pr-N-SHA
    BL->>GH: Post "🟢 image pushed" comment
    AWS-->>Argo: Image tag available
    Argo->>Argo: Deploy preview environment

    Note over Dev,Argo: Fork PRs: cannot mint OIDC token → excluded by head.repo check + role trust policy
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Write-Access Dev
    participant GH as GitHub (pull_request)
    participant AL as preview-autolabel.yml
    participant BL as preview-build.yml
    participant AWS as AWS ECR (OIDC)
    participant Argo as Argo CD

    Dev->>GH: Opens same-repo PR
    GH->>AL: trigger (opened)
    AL->>AL: AWS_PREVIEW_ECR_PUSH_ROLE_ARN set?
    AL->>AL: "head.repo == base.repo?"
    AL->>GH: addLabels("preview")

    GH->>BL: trigger (labeled)
    BL->>BL: AWS_PREVIEW_ECR_PUSH_ROLE_ARN set? ✓
    BL->>BL: has 'preview' label? ✓
    BL->>BL: "head.repo == github.repository? ✓"
    BL->>GH: Post "🟡 building" comment
    BL->>AWS: Assume ECR-push role via OIDC
    AWS-->>BL: Credentials (scoped to pull_request ref)
    BL->>AWS: docker push pr-N-SHA
    BL->>GH: Post "🟢 image pushed" comment
    AWS-->>Argo: Image tag available
    Argo->>Argo: Deploy preview environment

    Note over Dev,Argo: Fork PRs: cannot mint OIDC token → excluded by head.repo check + role trust policy
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/preview-build.yml:161
The revised status comment drops the actionable teardown instruction that was previously present. Without it, users who want to reclaim the preview environment (and stop incurring build cycles on future pushes) may not know they need to remove the `preview` label or close the PR. The old text was the only in-context hint about how to destroy the environment.

```suggestion
            Synthetic preview data only. Never add production data to public accounts. Remove the `preview` label or close the PR to destroy the environment.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(preview): reword the preview-data w..."](https://github.com/langfuse/langfuse/commit/a219b53cbc5b501e76b487d22b1c13ed3a6bb210) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44048760)</sub>

<!-- /greptile_comment -->