### PR TITLE
chore: preview write access

### DIFF
--- a/.github/workflows/preview-autolabel.yml
+++ b/.github/workflows/preview-autolabel.yml
@@ -1,18 +1,17 @@
 name: AWS preview auto-label
 
-# Auto-apply the `preview` label to same-repo PRs opened by an allowlisted
-# author, so the Argo CD ApplicationSet (in the infrastructure repo) picks them
-# up and builds a preview. Anyone with write access can also apply the label
-# by hand; the build workflow re-checks the PR author before building with a
-# cloud credential, so a manual label from a non-allowlisted author is inert.
+# Auto-apply the `preview` label to same-repo PRs on open, so the Argo CD
+# ApplicationSet (in the infrastructure repo) picks them up and builds a
+# preview. Anyone with write access can also apply the label by hand.
 #
-# Uses the plain `pull_request` trigger (NOT pull_request_target): it holds no
-# cloud credentials, never checks out or executes PR code, and only calls
-# issues.addLabels. The label is not a security boundary — the build workflow
-# independently re-checks the PR author before using any credential — so
-# pull_request_target's tamper-resistance isn't needed here, and avoiding it
-# keeps this off the dangerous-triggers list. Same-repo PRs get a write token to
-# add the label; fork PRs are short-circuited below (and get a read-only token).
+# Trust boundary is WRITE access, not a per-author allowlist: opening a
+# same-repo PR requires push access, so labeling every same-repo PR is exactly
+# "auto-preview for write-access members." Fork PRs are short-circuited — they
+# can't mint an OIDC token to build anyway.
+#
+# Uses the plain `pull_request` trigger (NOT pull_request_target): no cloud
+# credentials, no checkout, no PR-code execution — only issues.addLabels — so it
+# stays off zizmor's dangerous-triggers list.
 on:
   pull_request:
     types: [opened, reopened]
@@ -21,38 +20,26 @@ permissions: {}
 
 jobs:
   autolabel:
-    name: Auto-label allowlisted PRs
+    name: Auto-label same-repo PRs
     runs-on: ubuntu-latest
-    if: vars.AWS_PREVIEW_ALLOWED_USERS != ''
+    # AWS_PREVIEW_ECR_PUSH_ROLE_ARN is the feature flag: unset => preview system
+    # off, so don't label.
+    if: vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != ''
     permissions:
       pull-requests: write
     steps:
-      - name: Label allowlisted, same-repo PRs
+      - name: Label same-repo PRs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          ALLOWED_USERS: ${{ vars.AWS_PREVIEW_ALLOWED_USERS }}
         with:
           script: |
             const pr = context.payload.pull_request;
             const { owner, repo } = context.repo;
 
-            // Same-repo only: fork PRs cannot mint an OIDC token, so the build
-            // workflow could never push their image — an auto-labeled fork PR
-            // would only create a broken environment.
+            // Same-repo only: opening a same-repo PR requires push (write)
+            // access, so this is "auto-preview for write-access members." Fork
+            // PRs can't mint an OIDC token to build, so skip them.
             if (pr.head.repo.full_name !== `${owner}/${repo}`) {
               core.info("Fork PR; auto-label is limited to same-repo branches.");
-              return;
-            }
-
-            // Exact-match allowlist (never substring — a login that is a
-            // substring of an allowlisted one must not pass).
-            const allowed = (process.env.ALLOWED_USERS || "")
-              .split(/[\s,]+/)
-              .filter(Boolean)
-              .map((u) => u.toLowerCase());
-            const author = pr.user.login.toLowerCase();
-            if (!allowed.includes(author)) {
-              core.info(`Author ${author} is not on the preview allowlist; skipping.`);
               return;
             }
 
@@ -62,4 +49,4 @@ jobs:
               issue_number: pr.number,
               labels: ["preview"],
             });
-            core.info(`Applied 'preview' label to PR #${pr.number} (author ${author}).`);
+            core.info(`Applied 'preview' label to PR #${pr.number}.`);

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -5,18 +5,21 @@ name: AWS preview build
 # tag exists for a labeled PR; this workflow only builds and pushes, then posts
 # the preview URL on the PR.
 #
-# Trust boundary is WRITE access: this builds a SAME-REPO PR's code with an AWS
-# (ECR push) credential, and opening a same-repo PR requires push access — so
-# only write-access members can trigger a build (applying the `preview` label is
-# itself a write action). No per-author allowlist. Fork PRs are excluded (the
-# head.repo check below) and can't mint an OIDC token anyway (public repo,
-# read-only token) — and the ECR-push role's trust is scoped to
+# Builds every SAME-REPO PR on open/update (write access is the gate — opening a
+# same-repo PR requires push access). It deliberately does NOT trigger on the
+# `preview` label: the auto-labeler applies that label with the default
+# GITHUB_TOKEN, and GitHub does not start workflow runs from GITHUB_TOKEN-applied
+# events (anti-recursion), so a `labeled` trigger would never fire for
+# auto-labeled PRs. The label is only the Argo *deploy* filter (infra repo), and
+# the deploy allowlist lives in the ApplicationSet — not here. Fork PRs are
+# excluded (the head.repo check below) and can't mint an OIDC token anyway
+# (public repo, read-only token); the ECR-push role's trust is scoped to
 # sub=repo:langfuse/langfuse:pull_request AND ref=refs/pull/* (GitHub OIDC has no
 # event_name claim), so pull_request_target / review — which carry the base
 # branch ref — cannot assume it either.
 on:
   pull_request:
-    types: [labeled, synchronize, reopened]
+    types: [opened, synchronize, reopened]
 
 permissions: {}
 
@@ -27,13 +30,13 @@ concurrency:
 jobs:
   build:
     name: Build and push preview images
-    # Any SAME-REPO PR (= write access) carrying the `preview` label builds.
-    # Fork PRs are excluded (head.repo check) and can't mint OIDC anyway; there
-    # is no per-author allowlist. AWS_PREVIEW_ECR_PUSH_ROLE_ARN doubles as the
-    # feature flag: unset => the workflow no-ops instead of failing per PR.
+    # Any SAME-REPO PR (= write access) builds on open/update. No label gate here:
+    # the auto-labeler's GITHUB_TOKEN-applied label can't trigger this workflow,
+    # and the label is the Argo deploy filter, not the build trigger. Fork PRs are
+    # excluded (head.repo check) and can't mint OIDC anyway.
+    # AWS_PREVIEW_ECR_PUSH_ROLE_ARN doubles as the feature flag: unset => no-op.
     if: >-
       vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != '' &&
-      contains(github.event.pull_request.labels.*.name, 'preview') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -5,12 +5,12 @@ name: AWS preview build
 # tag exists for a labeled PR; this workflow only builds and pushes, then posts
 # the preview URL on the PR.
 #
-# Authorization is intentionally stricter than "the PR is labeled": the
-# `preview` label can be applied by any org member, but this job builds the PR
-# AUTHOR's code with an AWS (ECR push) credential, so it also requires the PR
-# author to be on AWS_PREVIEW_ALLOWED_USERS. Fork PRs cannot mint an OIDC token
-# (public repo, read-only token), so they can never push regardless — and the
-# ECR-push role's trust policy is additionally scoped to
+# Trust boundary is WRITE access: this builds a SAME-REPO PR's code with an AWS
+# (ECR push) credential, and opening a same-repo PR requires push access — so
+# only write-access members can trigger a build (applying the `preview` label is
+# itself a write action). No per-author allowlist. Fork PRs are excluded (the
+# head.repo check below) and can't mint an OIDC token anyway (public repo,
+# read-only token) — and the ECR-push role's trust is scoped to
 # sub=repo:langfuse/langfuse:pull_request AND ref=refs/pull/* (GitHub OIDC has no
 # event_name claim), so pull_request_target / review — which carry the base
 # branch ref — cannot assume it either.
@@ -25,45 +25,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  authorize:
-    name: Authorize
-    runs-on: ubuntu-latest
-    # AWS_PREVIEW_ECR_PUSH_ROLE_ARN doubles as the feature flag: unset => the
-    # whole workflow no-ops instead of failing on every labeled PR.
+  build:
+    name: Build and push preview images
+    # Any SAME-REPO PR (= write access) carrying the `preview` label builds.
+    # Fork PRs are excluded (head.repo check) and can't mint OIDC anyway; there
+    # is no per-author allowlist. AWS_PREVIEW_ECR_PUSH_ROLE_ARN doubles as the
+    # feature flag: unset => the workflow no-ops instead of failing per PR.
     if: >-
       vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != '' &&
       contains(github.event.pull_request.labels.*.name, 'preview') &&
       github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      pull-requests: read
-    outputs:
-      authorized: ${{ steps.gate.outputs.authorized }}
-    steps:
-      - name: Require an allowlisted PR author
-        id: gate
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          ALLOWED_USERS: ${{ vars.AWS_PREVIEW_ALLOWED_USERS }}
-        with:
-          script: |
-            const author = context.payload.pull_request.user.login.toLowerCase();
-            const allowed = (process.env.ALLOWED_USERS || "")
-              .split(/[\s,]+/)
-              .filter(Boolean)
-              .map((u) => u.toLowerCase());
-            const ok = allowed.includes(author);
-            if (!ok) {
-              core.warning(
-                `PR author ${author} is not on the preview allowlist; not building. ` +
-                  "Ask an admin to add the author to AWS_PREVIEW_ALLOWED_USERS.",
-              );
-            }
-            core.setOutput("authorized", ok ? "true" : "false");
-
-  build:
-    name: Build and push preview images
-    needs: authorize
-    if: needs.authorize.outputs.authorized == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -158,8 +158,7 @@ jobs:
             **API keys:** `${{ steps.meta.outputs.public_key }}` / `${{ steps.meta.outputs.secret_key }}`
             **Commit:** ${{ steps.meta.outputs.commit_sha }}
 
-            Synthetic preview data only — never enter a real credential. Remove
-            the `preview` label or close the PR to destroy the environment.
+            Synthetic preview data only. Never add production data to public accounts.
 
       - name: Report failure
         if: failure()

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -114,36 +114,44 @@ jobs:
           # tag fails. Tags embed the commit SHA, so an existing tag is byte-for-
           # byte the same image — skip build+push if it is already there (this
           # makes workflow re-runs on an unchanged commit idempotent).
-          image_present() {
-            local image="$1" repo tag
+          #
+          # Only a definitive ImageNotFoundException counts as "absent -> build".
+          # A present image -> skip. ANY OTHER describe failure (throttling, a
+          # transient network blip, a missing ecr:DescribeImages grant) is
+          # inconclusive, so fail loudly here rather than falling through to a
+          # push that would hard-fail on the immutable tag with a confusing
+          # ImageAlreadyExistsException.
+          ensure_image() {
+            local image="$1"; shift   # remaining args: docker build flags
+            local repo tag describe_out
             repo="${image%:*}"; repo="${repo#*/}"   # strip only the registry host; keep any namespace
             tag="${image##*:}"
-            aws ecr describe-images --repository-name "${repo}" \
-              --image-ids imageTag="${tag}" >/dev/null 2>&1
+
+            if describe_out="$(aws ecr describe-images --repository-name "${repo}" \
+                  --image-ids imageTag="${tag}" 2>&1)"; then
+              echo "${image} already present — skipping."
+              return 0
+            fi
+            if ! grep -q 'ImageNotFoundException' <<<"${describe_out}"; then
+              echo "::error::Cannot confirm ${image} in ECR — describe-images failed" \
+                   "for a reason other than ImageNotFound; refusing to build+push" \
+                   "against the tag-immutable repo. ${describe_out}"
+              return 1
+            fi
+
+            echo "${image} not found — building and pushing."
+            docker build "$@" -t "${image}" .
+            docker push "${image}"
           }
 
-          if image_present "${WEB_IMAGE}"; then
-            echo "${WEB_IMAGE} already present — skipping."
-          else
-            docker build \
-              --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
-              --build-arg NEXT_PUBLIC_SIGN_UP_DISABLED=true \
-              -f ./web/Dockerfile \
-              -t "${WEB_IMAGE}" \
-              .
-            docker push "${WEB_IMAGE}"
-          fi
+          ensure_image "${WEB_IMAGE}" \
+            --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
+            --build-arg NEXT_PUBLIC_SIGN_UP_DISABLED=true \
+            -f ./web/Dockerfile
 
-          if image_present "${WORKER_IMAGE}"; then
-            echo "${WORKER_IMAGE} already present — skipping."
-          else
-            docker build \
-              --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
-              -f ./worker/Dockerfile \
-              -t "${WORKER_IMAGE}" \
-              .
-            docker push "${WORKER_IMAGE}"
-          fi
+          ensure_image "${WORKER_IMAGE}" \
+            --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
+            -f ./worker/Dockerfile
 
       - name: Mark preview image pushed
         uses: ./.github/actions/preview-comment

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -60,10 +60,9 @@ jobs:
         run: |
           set -euo pipefail
           commit_sha="$(git rev-parse HEAD)"
-          short_sha="${commit_sha:0:12}"
           # The ApplicationSet deploys pr-<n>-{{.head_sha}} — Argo's FULL 40-char
           # SHA — so the pushed tag MUST use the full SHA or the deployed image
-          # never resolves (permanent ImagePullBackOff). short_sha is display-only.
+          # never resolves (permanent ImagePullBackOff).
           image_tag="pr-${PR_NUMBER}-${commit_sha}"
           {
             echo "commit_sha=${commit_sha}"
@@ -117,7 +116,7 @@ jobs:
           # makes workflow re-runs on an unchanged commit idempotent).
           image_present() {
             local image="$1" repo tag
-            repo="${image%:*}"; repo="${repo##*/}"
+            repo="${image%:*}"; repo="${repo#*/}"   # strip only the registry host; keep any namespace
             tag="${image##*:}"
             aws ecr describe-images --repository-name "${repo}" \
               --image-ids imageTag="${tag}" >/dev/null 2>&1


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a GitHub Actions-based PR preview system for AWS: a composite action that upserts a single marker-tagged comment per PR, an autolabel workflow that applies the `preview` label to same-repo PRs on open/reopen, and a build workflow that constructs and pushes web and worker Docker images to ECR when a PR carries the `preview` label.

- **`preview-autolabel.yml`** — safely uses the `pull_request` trigger (not `pull_request_target`), feature-flagged via `AWS_PREVIEW_ECR_PUSH_ROLE_ARN`, and short-circuits fork PRs so only write-access members get auto-labeled.
- **`preview-build.yml`** — OIDC auth, pinned action SHAs, `persist-credentials: false`, and a same-repo head check all look correct; the idempotency helper (`image_present`) has a shell glob bug that silently fails for namespaced ECR repos, which would break re-runs against tag-immutable repositories.
- **`preview-comment/action.yml`** — body injection via environment variable (not script interpolation) avoids injection risk; `github.paginate` correctly handles PRs with many comments.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for repos using flat (non-namespaced) ECR repository names; the idempotency check in the build script silently breaks for namespaced repos, causing push failures on workflow re-runs against immutable tags.

The autolabel and comment action files are clean. The build workflow is well-structured with sound security practices. The one concrete defect is the ${repo##*/} glob in image_present: it strips all namespace path components from the ECR URL, so describe-images gets the wrong repository name, silently returns an error, and docker push then hits the immutable-tag guard on every re-run.

preview-build.yml — specifically the image_present bash function and the absence of any PR-close or label-removal teardown step.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Events
    participant AL as preview-autolabel.yml
    participant PB as preview-build.yml
    participant PC as preview-comment action
    participant AWS as AWS ECR
    participant ArgoCD as Argo CD

    Dev->>GH: Open same-repo PR
    GH->>AL: pull_request [opened]
    AL->>AL: Check same-repo (not fork)
    AL->>GH: issues.addLabels("preview")

    GH->>PB: pull_request [labeled]
    PB->>PB: Check same-repo + preview label + role ARN set
    PB->>GH: Checkout PR head SHA
    PB->>PB: Resolve image tags and metadata
    PB->>PC: Post building comment
    PB->>AWS: configure-aws-credentials (OIDC)
    PB->>AWS: ecr-login
    PB->>PB: image_present(web)? skip : docker build+push web
    PB->>PB: image_present(worker)? skip : docker build+push worker
    PB->>PC: Update comment with preview URL
    PC->>GH: createComment or updateComment (marker-tagged)

    AWS-->>ArgoCD: New image tag available
    ArgoCD-->>Dev: Preview environment deployed
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Events
    participant AL as preview-autolabel.yml
    participant PB as preview-build.yml
    participant PC as preview-comment action
    participant AWS as AWS ECR
    participant ArgoCD as Argo CD

    Dev->>GH: Open same-repo PR
    GH->>AL: pull_request [opened]
    AL->>AL: Check same-repo (not fork)
    AL->>GH: issues.addLabels("preview")

    GH->>PB: pull_request [labeled]
    PB->>PB: Check same-repo + preview label + role ARN set
    PB->>GH: Checkout PR head SHA
    PB->>PB: Resolve image tags and metadata
    PB->>PC: Post building comment
    PB->>AWS: configure-aws-credentials (OIDC)
    PB->>AWS: ecr-login
    PB->>PB: image_present(web)? skip : docker build+push web
    PB->>PB: image_present(worker)? skip : docker build+push worker
    PB->>PC: Update comment with preview URL
    PC->>GH: createComment or updateComment (marker-tagged)

    AWS-->>ArgoCD: New image tag available
    ArgoCD-->>Dev: Preview environment deployed
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/preview-build.yml:117
The `image_present` helper uses `${repo##*/}` (greedy strip) to extract the ECR repository name from the image URL. This strips everything up to and including the **last** `/`, leaving only the final path component. For namespaced ECR repositories (e.g., `123456789.dkr.ecr.us-east-1.amazonaws.com/langfuse/preview-web`), this produces `preview-web` instead of the full name `langfuse/preview-web`. Since `aws ecr describe-images` requires the full repository name, the call silently returns non-zero (error swallowed by `>/dev/null 2>&1`), `image_present` always returns false, and on any re-run the subsequent `docker push` will fail against the tag-immutable repo. Using `${repo#*/}` (non-greedy) removes only the hostname prefix, preserving any namespace path.

```suggestion
            repo="${image%:*}"; repo="${repo#*/}"
```

### Issue 2 of 2
.github/workflows/preview-build.yml:17-19
**Missing teardown on PR close / label removal**

This workflow only builds and posts status — there's no complementary workflow listening to `pull_request: [closed]` or `pull_request: [unlabeled]` to signal the Argo CD ApplicationSet to tear down the preview environment. If the ApplicationSet generator is driven solely by the image tag in ECR rather than live PR labels, preview namespaces will persist indefinitely after PRs merge or are closed. Could you confirm teardown is handled (e.g., by another workflow in the infra repo, or an ApplicationSet `preservedResources` policy)?

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(preview): reword the preview-data w..."](https://github.com/langfuse/langfuse/commit/78b0d1a48703e93173fcd0fd5bee224d18aa8b86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44049248)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->