### PR TITLE
docs(contributing): tighten wording in making-a-change section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ The maintainers are available on [Discord](https://langfuse.com/discord) in case
 
 _Before making any significant changes, please [open an issue](https://github.com/langfuse/langfuse/issues)._ Discussing your proposed changes ahead of time will make the contribution process smooth for everyone. Changes that were not discussed in an issue may be rejected.
 
-Once we've discussed your changes and you've got your code ready, make sure that tests are passing and open your pull request.
+Once we've discussed your changes and your code is ready, make sure that tests are passing before opening your pull request.
 
 A good first step is to search for open [issues](https://github.com/langfuse/langfuse/issues). Issues are labeled, and some good issues to start with are labeled: [good first issue](https://github.com/langfuse/langfuse/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 


### PR DESCRIPTION
## Summary

Dummy PR with a small documentation wording change (for testing purposes).

- Reword one sentence in the "Making a change" section of `CONTRIBUTING.md` for clarity: "make sure that tests are passing **before opening** your pull request".

## Impacted packages

- None (root-level docs only).

## Verification

- Pre-commit hooks passed: prettier check and `turbo run lint` (`Tasks: 7 successful, 7 total`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes a minor wording clarification in `CONTRIBUTING.md`, rephrasing one sentence in the "Making a change" section to explicitly state that tests must pass *before* opening a pull request (rather than implying simultaneity with "and open your pull request").

- The only changed file is `CONTRIBUTING.md` at the root level; no code, configuration, or package is affected.
- The new phrasing — "make sure that tests are passing before opening your pull request" — is clearer and more actionable for contributors.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no impact on code, configuration, or runtime behavior.

A single sentence in `CONTRIBUTING.md` is reworded for clarity. The change is accurate and improves contributor guidance with no risk of introducing regressions.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Contributor has an idea]) --> B[Open an issue to discuss changes]
    B --> C{Maintainers approve?}
    C -- No --> D([Changes not accepted])
    C -- Yes --> E[Write code & implement changes]
    E --> F[Run tests]
    F --> G{Tests passing?}
    G -- No --> E
    G -- Yes --> H[Open Pull Request]
    H --> I[Maintainer review]
    I --> J([Merged 🎉])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([Contributor has an idea]) --> B[Open an issue to discuss changes]
    B --> C{Maintainers approve?}
    C -- No --> D([Changes not accepted])
    C -- Yes --> E[Write code & implement changes]
    E --> F[Run tests]
    F --> G{Tests passing?}
    G -- No --> E
    G -- Yes --> H[Open Pull Request]
    H --> I[Maintainer review]
    I --> J([Merged 🎉])
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(contributing): tighten wording in m..."](https://github.com/langfuse/langfuse/commit/7f312d752abe5816a435feb39ed70501554eac08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44050743)</sub>

<!-- /greptile_comment -->