### PR TITLE
fix(otel): add validation for experiment-item-version

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2978,7 +2978,7 @@ export class OtelIngestionProcessor {
       return stringValue;
     }
     logger.warn(
-      "OTEL invalid experiment item version, dropping. Expected format: YYYY-MM-DD HH:MM:SS.SSSSSS",
+      "OTEL invalid experiment item version, dropping. Expected timestamp.",
     );
     return undefined;
   }

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -28,6 +28,7 @@ import { ObservationTypeMapperRegistry } from "./ObservationTypeMapper";
 import { env } from "../../env";
 import { OtelIngestionQueue } from "../redis/otelIngestionQueue";
 import { isValidDateString, flattenJsonToPathArrays } from "./utils";
+import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 
 // Type definitions for internal processor state
 interface TraceState {
@@ -2975,7 +2976,7 @@ export class OtelIngestionProcessor {
     if (value == null || value === "") return undefined;
     const stringValue = String(value);
     if (isValidDateString(stringValue)) {
-      return stringValue;
+      return convertDateToClickhouseDateTime(new Date(stringValue));
     }
     logger.warn(
       "OTEL invalid experiment item version, dropping. Expected timestamp.",

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -21,6 +21,7 @@ import {
   UsageDetails,
   normalizeToolsForObservation,
   normalizeToolMetadataForObservation,
+  convertDateToClickhouseDateTime,
 } from "../";
 
 import { LangfuseOtelSpanAttributes } from "./attributes";
@@ -2939,9 +2940,9 @@ export class OtelIngestionProcessor {
         ? String(experimentDatasetId)
         : undefined,
       experimentItemId: experimentItemId ? String(experimentItemId) : undefined,
-      experimentItemVersion: experimentItemVersion
-        ? String(experimentItemVersion)
-        : undefined,
+      experimentItemVersion: this.parseExperimentItemVersion(
+        experimentItemVersion,
+      ),
       experimentItemRootSpanId: experimentItemRootSpanId
         ? String(experimentItemRootSpanId)
         : undefined,
@@ -2965,6 +2966,22 @@ export class OtelIngestionProcessor {
           ? experimentItemMetadataFlattened.values
           : undefined,
     };
+  }
+
+  /**
+   * The item version is a pointer to a dataset item version (`valid_from` timestamp),
+   * not a free-form label; "v1" or "latest" cannot resolve to one, so we drop them.
+   */
+  private parseExperimentItemVersion(value: unknown): string | undefined {
+    if (value == null || value === "") return undefined;
+    const stringValue = String(value);
+    if (isValidDateString(stringValue)) {
+      return convertDateToClickhouseDateTime(new Date(stringValue));
+    }
+    logger.warn(
+      "OTEL invalid experiment item version, dropping. Expected format: YYYY-MM-DD HH:MM:SS.SSSSSS",
+    );
+    return undefined;
   }
 
   private parseLangfusePromptFromAISDK(

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -21,7 +21,6 @@ import {
   UsageDetails,
   normalizeToolsForObservation,
   normalizeToolMetadataForObservation,
-  convertDateToClickhouseDateTime,
 } from "../";
 
 import { LangfuseOtelSpanAttributes } from "./attributes";
@@ -2976,7 +2975,7 @@ export class OtelIngestionProcessor {
     if (value == null || value === "") return undefined;
     const stringValue = String(value);
     if (isValidDateString(stringValue)) {
-      return convertDateToClickhouseDateTime(new Date(stringValue));
+      return stringValue;
     }
     logger.warn(
       "OTEL invalid experiment item version, dropping. Expected format: YYYY-MM-DD HH:MM:SS.SSSSSS",

--- a/worker/src/queues/__tests__/otelMetadataProcessing.test.ts
+++ b/worker/src/queues/__tests__/otelMetadataProcessing.test.ts
@@ -342,10 +342,10 @@ describe("OTel metadata processing", () => {
   describe("experiment item version", () => {
     it.each([
       ["2026-04-24 15:22:36.622", "2026-04-24 15:22:36.622"],
-      ["2026-04-24T15:22:36.622Z", "2026-04-24T15:22:36.622Z"],
+      ["2026-04-24T15:22:36.622Z", "2026-04-24 15:22:36.622"],
       ["None", undefined],
       ["v1", undefined],
-    ])("passes through '%s' as %s", async (input, expected) => {
+    ])("normalizes '%s' to %s", async (input, expected) => {
       const otelSpan = buildOtelSpan({
         scopeVersion: "4.5.0",
         resourceAttrKey: "service.name",

--- a/worker/src/queues/__tests__/otelMetadataProcessing.test.ts
+++ b/worker/src/queues/__tests__/otelMetadataProcessing.test.ts
@@ -338,4 +338,29 @@ describe("OTel metadata processing", () => {
       });
     });
   });
+
+  describe("experiment item version", () => {
+    it.each([
+      ["2026-04-24 15:22:36.622", "2026-04-24 15:22:36.622"],
+      ["2026-04-24T15:22:36.622Z", "2026-04-24T15:22:36.622Z"],
+      ["None", undefined],
+      ["v1", undefined],
+    ])("passes through '%s' as %s", async (input, expected) => {
+      const otelSpan = buildOtelSpan({
+        scopeVersion: "4.5.0",
+        resourceAttrKey: "service.name",
+        resourceAttrValue: "svc",
+        scopeAttrKey: "public_key",
+        scopeAttrValue: "pk-test",
+        metadataAttrs: [],
+      });
+      otelSpan.scopeSpans[0].spans[0].attributes.push({
+        key: "langfuse.experiment.item.version",
+        value: { stringValue: input },
+      });
+
+      const { eventRecord } = await processAndCreateEvent(otelSpan);
+      expect(eventRecord.experiment_item_version).toBe(expected);
+    });
+  });
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `parseExperimentItemVersion` to validate that `langfuse.experiment.item.version` OTEL span attributes are genuine timestamps (rejecting free-form strings like `"v1"` or `"latest"`) and normalises them into ClickHouse DateTime format.

- **Validation logic**: any string that passes JavaScript's `new Date()` date parser is accepted; strings that do not are silently dropped with a `logger.warn`.
- **Import**: `convertDateToClickhouseDateTime` is added to the top-level import from `"../"` to support the conversion step.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a narrow validation guard; the main risk is that valid ClickHouse-format timestamps could be silently dropped if Node.js's Date parser doesn't accept the space-separated format.

The core logic is sound for ISO 8601 inputs, but there's a mismatch between what the error message tells callers to send and what `new Date()` reliably parses. There's also a potential timezone-shift for inputs lacking an explicit UTC offset. Neither is likely to affect the happy path under normal SDK usage, but both could cause silent data loss in edge cases.

packages/shared/src/server/otel/OtelIngestionProcessor.ts — specifically the `parseExperimentItemVersion` method and the `isValidDateString` utility it depends on.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SDK as OTEL SDK/Client
    participant OIP as OtelIngestionProcessor
    participant VAL as parseExperimentItemVersion
    participant UTIL as isValidDateString
    participant CH as ClickHouse

    SDK->>OIP: OTEL span with langfuse.experiment.item.version attribute
    OIP->>VAL: parseExperimentItemVersion(value)
    VAL->>VAL: String(value)
    alt value is null/empty
        VAL-->>OIP: undefined (dropped)
    else value is non-empty
        VAL->>UTIL: isValidDateString(stringValue)
        UTIL->>UTIL: new Date(stringValue).getTime()
        alt valid date
            UTIL-->>VAL: true
            VAL->>VAL: convertDateToClickhouseDateTime(new Date(stringValue))
            VAL-->>OIP: YYYY-MM-DD HH:MM:SS.SSS (ClickHouse format)
            OIP->>CH: store experimentItemVersion
        else invalid date (e.g. v1, latest)
            UTIL-->>VAL: false
            VAL->>VAL: logger.warn(drop message)
            VAL-->>OIP: undefined (dropped)
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SDK as OTEL SDK/Client
    participant OIP as OtelIngestionProcessor
    participant VAL as parseExperimentItemVersion
    participant UTIL as isValidDateString
    participant CH as ClickHouse

    SDK->>OIP: OTEL span with langfuse.experiment.item.version attribute
    OIP->>VAL: parseExperimentItemVersion(value)
    VAL->>VAL: String(value)
    alt value is null/empty
        VAL-->>OIP: undefined (dropped)
    else value is non-empty
        VAL->>UTIL: isValidDateString(stringValue)
        UTIL->>UTIL: new Date(stringValue).getTime()
        alt valid date
            UTIL-->>VAL: true
            VAL->>VAL: convertDateToClickhouseDateTime(new Date(stringValue))
            VAL-->>OIP: YYYY-MM-DD HH:MM:SS.SSS (ClickHouse format)
            OIP->>CH: store experimentItemVersion
        else invalid date (e.g. v1, latest)
            UTIL-->>VAL: false
            VAL->>VAL: logger.warn(drop message)
            VAL-->>OIP: undefined (dropped)
        end
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/shared/src/server/otel/OtelIngestionProcessor.ts:2981-2983
The `logger.warn` call drops the invalid value without logging it, so a warning in production logs gives no indication of what string was actually received. Adding the value makes the log actionable for debugging.

```suggestion
    logger.warn(
      `OTEL invalid experiment item version "${stringValue}", dropping. Expected format: YYYY-MM-DD HH:MM:SS.SSSSSS`,
    );
```

### Issue 2 of 3
packages/shared/src/server/otel/OtelIngestionProcessor.ts:2976-2984
**Error message describes a format the validator may not accept**

The warning says "Expected format: YYYY-MM-DD HH:MM:SS.SSSSSS", which is ClickHouse DateTime format with a space separator. However `isValidDateString` simply calls `new Date(string)`, and JavaScript's `Date` constructor does not reliably parse space-separated datetimes — the behaviour is implementation-defined per the ECMAScript spec. A valid ClickHouse timestamp like `"2024-01-15 10:30:00.123456"` may therefore fail validation and be silently dropped, while the warning message tells the caller to use exactly that format. Accepted formats should align with what `new Date()` reliably parses (ISO 8601 with `T` and a timezone offset), and the message should reflect that.

### Issue 3 of 3
packages/shared/src/server/otel/OtelIngestionProcessor.ts:2976-2984
**Timezone ambiguity with timezone-naïve date strings**

`isValidDateString` delegates to `new Date(string)`, which treats ISO 8601 datetime strings *without* an explicit offset (e.g. `"2024-01-15T10:30:00.123456"`) as **local time**. `convertDateToClickhouseDateTime` then calls `.toISOString()` which always outputs UTC. If the OTEL ingestor runs on a host whose system timezone is not UTC, any version string lacking a `Z`/offset will silently have its timestamp shifted by the host's UTC offset before being stored in ClickHouse, making the version lookup fail for that item.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): add validation for experiment..."](https://github.com/langfuse/langfuse/commit/6935d81d48dbbd27bcf168fe79719aaaaef72a40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44083480)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->