### PR TITLE
fix(agent): Add gradient animation to loading state

### DIFF
--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.module.css
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.module.css
@@ -1,0 +1,29 @@
+@property --in-app-agent-loading-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+.loadingGradient {
+  background: conic-gradient(
+    from var(--in-app-agent-loading-angle),
+    transparent 90deg,
+    var(--color-2) 145deg,
+    var(--color-3) 215deg,
+    transparent 270deg
+  );
+  filter: drop-shadow(0 0 2rem var(--color-3));
+  animation: rotate-loading-gradient 2s linear infinite alternate;
+}
+
+@keyframes rotate-loading-gradient {
+  to {
+    --in-app-agent-loading-angle: 360deg;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loadingGradient {
+    animation: none;
+  }
+}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -741,6 +741,8 @@ export const Conversation = meta.story({
 
 export const Streaming = meta.story({
   args: {
+    isAssistantTurnInProgress: true,
+    isInputDisabled: true,
     selectedConversationId: "conversation-1",
     messages: streamingSeedMessages,
   },
@@ -749,6 +751,8 @@ export const Streaming = meta.story({
 
 export const LoadingResponse = meta.story({
   args: {
+    isAssistantTurnInProgress: true,
+    isInputDisabled: true,
     messages: [
       {
         id: "user-1",
@@ -771,6 +775,7 @@ export const LoadingResponse = meta.story({
 
 export const LoadingAfterToolCall = meta.story({
   args: {
+    isAssistantTurnInProgress: true,
     isInputDisabled: true,
     messages: [
       {
@@ -936,6 +941,7 @@ export const FeedbackControlsShowAfterTurnEnd = meta.story({
 
 export const Connecting = meta.story({
   args: {
+    isAssistantTurnInProgress: true,
     isInputDisabled: true,
     messages: [
       {

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -38,6 +38,7 @@ import {
   type InAppAgentError,
   isInAppAgentRateLimited,
 } from "@/src/ee/features/in-app-agent/components/utils/utils";
+import styles from "./InAppAgentWindow.module.css";
 
 const AUTO_SCROLL_THRESHOLD_PX = 50;
 const SCROLL_DIRECTION_TOLERANCE_PX = 1;
@@ -649,6 +650,32 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
             <InAppAgentRateLimitError error={error} isExpanded={isExpanded} />
           </div>
         )}
+        {isAssistantTurnInProgress && pendingToolCalls.length === 0 ? (
+          <div
+            className={cn(
+              "pointer-events-none relative h-px w-full shrink-0 select-none",
+              isExpanded && "mx-auto max-w-3xl",
+            )}
+          >
+            <div className="absolute top-0 h-4 w-full -translate-y-full overflow-hidden">
+              <div className="absolute top-0 h-12 w-full bg-radial from-(--color-3) to-transparent to-60% bg-center opacity-25" />
+            </div>
+            <div className="absolute bottom-0 left-0 h-px w-full overflow-hidden">
+              <div
+                aria-hidden="true"
+                className={cn("h-[4rem]", styles.loadingGradient)}
+              />
+              {isExpanded && (
+                <>
+                  {/* Gradient overlays for expanded state so that the edges fade out */}
+                  {/* Make sure this matches the color of the background */}
+                  <div className="from-header absolute top-0 right-0 h-full w-1/2 bg-linear-to-l to-transparent" />
+                  <div className="from-header absolute top-0 left-0 h-full w-1/2 bg-linear-to-r to-transparent" />
+                </>
+              )}
+            </div>
+          </div>
+        ) : null}
         <div
           className={cn(
             "p-1.5",
@@ -706,6 +733,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 size="icon"
                 className="h-8 w-8 rounded-md border"
                 aria-label="Send message"
+                variant="outline"
                 disabled={isInputDisabled || !input.trim()}
               >
                 <SendHorizontal className="h-4 w-4" />


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a gradient animation to the loading state of the in-app agent window. When the assistant is processing (no pending tool calls), a conic-gradient sweep animates along the bottom edge of the conversation area. A new CSS module handles the animation via an `@property`-registered custom property, and Storybook stories are updated to properly reflect the `isAssistantTurnInProgress` state.

- A new `.module.css` file introduces a conic-gradient loading animation, with a `prefers-reduced-motion` accessibility override.
- The `LoadingResponse`, `Streaming`, `LoadingAfterToolCall`, and `Connecting` Storybook stories are updated to include `isAssistantTurnInProgress: true` so the new indicator renders correctly in those states.
- A minor `variant="outline"` is added to the Send button for the collapsed view.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are purely presentational (a CSS animation and story updates) with no effect on data flow or business logic.

The change introduces a new CSS module with a conic-gradient loading animation and updates Storybook stories. The only debatable point is the `alternate` keyword on the animation, which makes the gradient oscillate rather than spin continuously — a minor visual inconsistency. Everything else (accessibility via `prefers-reduced-motion`, `aria-hidden` on the decorative element, story correctness) looks solid.

InAppAgentWindow.module.css — worth confirming whether the `alternate` oscillation is the intended visual effect or if a continuous one-direction spin was wanted.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[InAppAgentWindow renders] --> B{isAssistantTurnInProgress?}
    B -- No --> C[No loading indicator]
    B -- Yes --> D{pendingToolCalls.length === 0?}
    D -- No --> C
    D -- Yes --> E[Render loading gradient bar]
    E --> F{isExpanded?}
    F -- Yes --> G[Add fade-out edge overlays + max-w-3xl constraint]
    F -- No --> H[Full-width gradient bar]
    G --> I[Conic gradient animates via --in-app-agent-loading-angle]
    H --> I
    I --> J{prefers-reduced-motion: reduce?}
    J -- Yes --> K[animation: none]
    J -- No --> L[rotate-loading-gradient 2s linear infinite alternate]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[InAppAgentWindow renders] --> B{isAssistantTurnInProgress?}
    B -- No --> C[No loading indicator]
    B -- Yes --> D{pendingToolCalls.length === 0?}
    D -- No --> C
    D -- Yes --> E[Render loading gradient bar]
    E --> F{isExpanded?}
    F -- Yes --> G[Add fade-out edge overlays + max-w-3xl constraint]
    F -- No --> H[Full-width gradient bar]
    G --> I[Conic gradient animates via --in-app-agent-loading-angle]
    H --> I
    I --> J{prefers-reduced-motion: reduce?}
    J -- Yes --> K[animation: none]
    J -- No --> L[rotate-loading-gradient 2s linear infinite alternate]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/ee/features/in-app-agent/components/InAppAgentWindow.module.css:16
The `alternate` direction causes the gradient to spin clockwise for 2 s then counter-clockwise for 2 s, producing a back-and-forth oscillation rather than continuous rotation. This is inconsistent with the keyframe name `rotate-loading-gradient` and is unusual for a loading indicator. If a one-directional continuous spin is the intent, `alternate` should be dropped.

```suggestion
  animation: rotate-loading-gradient 2s linear infinite;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Add gradient animation to lo..."](https://github.com/langfuse/langfuse/commit/fc1f169511a5a968b3c6a13dd3f22e8b01c39aa2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44088497)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->