### PR TITLE
chore(agent): run model price audit daily

### DIFF
--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -2,10 +2,9 @@ name: Default Model Price Audit
 
 on:
   schedule:
-    # Tuesday and Friday evening in San Francisco.
+    # Every evening in San Francisco.
     # 02:17 UTC is 19:17 PDT and 18:17 PST.
-    - cron: "17 2 * * 3"
-    - cron: "17 2 * * 6"
+    - cron: "17 2 * * *"
   workflow_dispatch:
     inputs:
       claude_model:


### PR DESCRIPTION
## Summary

- run the default model price audit every day at 02:17 UTC
- keep the scheduled run in the same San Francisco evening window
- leave the audit's permissions, tools, timeout, budget, validation, and publish boundaries unchanged

## Why

The workflow currently runs twice weekly. A daily cadence reduces the maximum time before detecting provider model or pricing changes from several days to roughly 24 hours.

This increases scheduled runs from 2 to 7 per week. The existing 45-minute timeout and $15 per-run budget cap remain unchanged.

## Impact

GitHub Actions workflow only; no web, worker, or shared package runtime behavior changes.

## Validation

- Ruby YAML parse: `YAML parse: passed`
- schedule assertion: `Schedule check: 1 daily cron at 02:17 UTC`
- `pnpm exec prettier --check .github/workflows/model-price-audit.yml`: `All matched files use Prettier code style!`
- `git diff --check`: passed
- pre-commit formatting hook: `All matched files use Prettier code style!`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes the `Default Model Price Audit` workflow from a twice-weekly schedule (Wednesday and Saturday at 02:17 UTC, corresponding to Tuesday and Friday SF evenings) to a single daily cron entry at the same time. No other aspect of the workflow is modified.

- The two cron entries (`17 2 * * 3` and `17 2 * * 6`) are replaced with `17 2 * * *`, correctly reducing the maximum detection window from several days to ~24 hours.
- The `concurrency: cancel-in-progress: true` guard already prevents overlapping runs if the 45-minute job ever spills past midnight UTC.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line cron replacement with no effect on runtime code paths.

The only modification is collapsing two weekly cron expressions into a single daily one at the same UTC time. The cron syntax is correct, the comment is updated to match, and the existing cancel-in-progress: true concurrency guard already handles any potential run overlap. No permissions, secrets, tool limits, budget caps, or validation logic are touched.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(agent): run model price audit dail..."](https://github.com/langfuse/langfuse/commit/51e945b7347ffc41cd48ae749aef69176ebdc34e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44094194)</sub>

<!-- /greptile_comment -->