### PR TITLE
fix(events): force events_full for truncation-sensitive filters (LFE-10779)

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -10,6 +10,7 @@ import {
   FTS_OPERATOR_DESCRIPTORS,
   isFtsEventsTable,
   isFtsMetadataField,
+  isFtsTextField,
   isFtsTextTarget,
 } from "./fts";
 
@@ -716,3 +717,13 @@ export class FilterList {
     };
   }
 }
+
+// events_core stores input/output/metadata_values truncated to 200 chars
+// (events_core_mv); filters on these fields must run against events_full or
+// matches beyond the truncation point are silently dropped.
+export const filtersRequireEventsFull = (filters: FilterList): boolean =>
+  filters.some(
+    (f) =>
+      isFtsEventsTable(f.clickhouseTable) &&
+      (isFtsTextField(f.field) || isFtsMetadataField(f.field)),
+  );

--- a/packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts
@@ -2,7 +2,7 @@ import { eventsTableCols } from "../../../eventsTable";
 import type { TracingSearchType } from "../../../interfaces/search";
 import type { FilterCondition } from "../../../types";
 import { eventsTableUiColumnDefinitions } from "../../tableMappings/mapEventsTable";
-import { FilterList } from "./clickhouse-filter";
+import { FilterList, filtersRequireEventsFull } from "./clickhouse-filter";
 import { EventsQueryBuilder } from "./event-query-builder";
 import { createFilterFromFilterState } from "./factory";
 import { extractTimeFilter } from "./filter-utils";
@@ -217,7 +217,10 @@ const buildEventsObservationRowSelectionInternal = (
         "ON ts.trace_id = e.trace_id AND ts.project_id = e.project_id",
       ),
     )
-    .when(search.requiresEventsFull, (builder) => builder.forceFullTable());
+    .when(
+      search.requiresEventsFull || filtersRequireEventsFull(eventsFilter),
+      (builder) => builder.forceFullTable(),
+    );
 
   queryBuilder.applyFilters(eventsFilter).where(search);
 

--- a/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
@@ -93,6 +93,36 @@ describe("buildEventsStreamQuery", () => {
     expect(params).toEqual({ projectId, limit: 7 });
   });
 
+  it("reads events_full when a metadata filter is present", () => {
+    const { queryBuilder } = buildEventsStreamQuery({
+      projectId,
+      filter: [
+        {
+          column: "metadata",
+          key: "payload",
+          operator: "contains",
+          value: "needle",
+          type: "stringObject",
+        },
+      ],
+      rowLimit: 7,
+    });
+    const { query } = queryBuilder.selectFieldSet("eval").buildWithParams();
+
+    expect(normalizeSql(query)).toContain("FROM events_full e");
+  });
+
+  it("reads events_core when neither search nor filters need full I/O", () => {
+    const { queryBuilder } = buildEventsStreamQuery({
+      projectId,
+      filter: [nativeFilter],
+      rowLimit: 7,
+    });
+    const { query } = queryBuilder.selectFieldSet("eval").buildWithParams();
+
+    expect(normalizeSql(query)).toContain("FROM events_core e");
+  });
+
   it("keeps the blob-export score projection and source together", () => {
     const { queryBuilder } = buildEventsBlobExportStreamQuery({
       projectId,

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -19,6 +19,7 @@ export {
   StringObjectFilter,
   NullFilter,
   encodeBooleanScoreEntry,
+  filtersRequireEventsFull,
   type ClickhouseOperator,
 } from "./clickhouse-sql/clickhouse-filter";
 export {

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -42,9 +42,9 @@ import {
   createPublicApiObservationsColumnMapping,
   createPublicApiTracesColumnMapping,
   deriveFilters,
+  filtersRequireEventsFull,
   isFtsAcceleratedIoOperator,
   isFtsEventsTable,
-  isFtsMetadataField,
   isFtsTextField,
   type ApiColumnMapping,
   ObservationPriceFields,
@@ -728,7 +728,10 @@ async function getObservationsFromEventsTableInternal<T>(
         "e.span_id",
         `ROW_NUMBER() OVER (PARTITION BY e.trace_id ORDER BY e.start_time ${direction}, e.event_ts ${direction}, e.span_id ${direction}) as _rn`,
       )
-      .when(search.requiresEventsFull, (b) => b.forceFullTable())
+      .when(
+        search.requiresEventsFull || filtersRequireEventsFull(nativeFilter),
+        (b) => b.forceFullTable(),
+      )
       .where(appliedNativeFilter)
       .where(search);
 
@@ -1269,11 +1272,7 @@ function buildObservationsQueryComponents(
   const hasTraceFilter = observationsFilter.some(
     (f) => f.clickhouseTable === "traces",
   );
-  const filtersNeedFullTable = observationsFilter.some(
-    (f) =>
-      f.clickhouseTable.startsWith("events") &&
-      (isFtsTextField(f.field) || isFtsMetadataField(f.field)),
-  );
+  const filtersNeedFullTable = filtersRequireEventsFull(observationsFilter);
 
   // Extract time filter and apply filters
   const startTimeFrom = extractTimeFilter(observationsFilter);

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -27,7 +27,10 @@ import {
 import { prisma } from "@langfuse/shared/src/db";
 import { randomUUID } from "crypto";
 import { env } from "@/src/env.mjs";
-import { type FilterCondition } from "@langfuse/shared";
+import {
+  type EventsTableFilterState,
+  type FilterCondition,
+} from "@langfuse/shared";
 import waitForExpect from "wait-for-expect";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
@@ -2186,6 +2189,129 @@ describe("Clickhouse Events Repository Test", () => {
         });
 
         expect(result.length).toBe(0);
+      });
+    });
+
+    describe("Truncation-sensitive filters (must read events_full)", () => {
+      // events_core stores input/output/metadata_values truncated to 200 chars
+      // (events_core_mv). Filters on these fields must run against events_full,
+      // otherwise matches beyond the truncation point are silently dropped.
+
+      it("metadata 'contains' matches a value beyond the 200-char truncation point", async () => {
+        const traceId = randomUUID();
+        const observationId = randomUUID();
+        const now = Date.now();
+        const filterTime = new Date(now - 5000);
+        const needle = `needle-${randomUUID()}`;
+        const longValue = "x".repeat(220) + needle;
+
+        await createEventsCh([
+          createEvent({
+            id: observationId,
+            span_id: observationId,
+            project_id: projectId,
+            trace_id: traceId,
+            type: "SPAN",
+            name: "long-metadata-value",
+            metadata_names: ["payload"],
+            metadata_values: [longValue],
+            start_time: now * 1000,
+          }),
+        ]);
+
+        const filter: FilterCondition[] = [
+          {
+            type: "stringObject",
+            column: "metadata",
+            operator: "contains",
+            key: "payload",
+            value: needle,
+          },
+          {
+            type: "datetime",
+            column: "startTime",
+            operator: ">=",
+            value: filterTime,
+          },
+          {
+            type: "string",
+            column: "traceId",
+            operator: "=",
+            value: traceId,
+          },
+        ];
+
+        const result = await getObservationsWithModelDataFromEventsTable({
+          projectId,
+          filter,
+          limit: 1000,
+          offset: 0,
+        });
+
+        expect(result.length).toBe(1);
+        expect(result[0].name).toBe("long-metadata-value");
+
+        const count = await getObservationsCountFromEventsTable({
+          projectId,
+          filter,
+        });
+        expect(count).toBe(1);
+      });
+
+      it("input 'matches' finds a token beyond the 200-char truncation point", async () => {
+        const traceId = randomUUID();
+        const observationId = randomUUID();
+        const now = Date.now();
+        const filterTime = new Date(now - 5000);
+        const token = `needletoken${randomUUID().replaceAll("-", "")}`;
+        const longInput = "x".repeat(220) + " " + token;
+
+        await createEventsCh([
+          createEvent({
+            id: observationId,
+            span_id: observationId,
+            project_id: projectId,
+            trace_id: traceId,
+            type: "SPAN",
+            name: "long-input-value",
+            input: longInput,
+            start_time: now * 1000,
+          }),
+        ]);
+
+        // "matches" belongs to the events-table filter grammar
+        // (EventsTableFilterState); the events service passes it through the
+        // FilterState-typed repository signature untyped, so mirror that here.
+        const matchesFilter = {
+          type: "string",
+          column: "input",
+          operator: "matches",
+          value: token,
+        } satisfies EventsTableFilterState[number] as unknown as FilterCondition;
+
+        const result = await getObservationsWithModelDataFromEventsTable({
+          projectId,
+          filter: [
+            matchesFilter,
+            {
+              type: "datetime",
+              column: "startTime",
+              operator: ">=",
+              value: filterTime,
+            },
+            {
+              type: "string",
+              column: "traceId",
+              operator: "=",
+              value: traceId,
+            },
+          ],
+          limit: 1000,
+          offset: 0,
+        });
+
+        expect(result.length).toBe(1);
+        expect(result[0].name).toBe("long-input-value");
       });
     });
   });


### PR DESCRIPTION
## What does this PR do?

Filters on `input`, `output`, or `metadata` in the v4 events view silently dropped matches beyond the 200-char truncation point: `events_core` stores these columns truncated (via `events_core_mv`), and the UI list/count path and the events stream query only switched to `events_full` for full-text search, never for filters.

This PR extracts the filter predicate the public-API path already used into a shared `filtersRequireEventsFull(FilterList)` helper and applies it to all three query paths:

- `getObservationsFromEventsTableInternal` (v4 events UI list + counts), including the `positionInTrace` qualifying-observations CTE
- `buildEventsStreamQuery` (batch exports/actions)
- `buildObservationsQueryComponents` (public API — behavior unchanged, now uses the shared helper)

Table selection is derived server-side from the `FilterState` the request already carries; the `searchType` contract and `Boolean(query)` search semantics are untouched, so existing URLs and saved views keep their behavior and cost profile.

Tests: two red-first servertests (metadata `contains` and input `matches` with the match target beyond char 200 — both returned 0 rows before the fix) plus unit tests pinning `FROM events_full`/`FROM events_core` selection in the stream query.

Fixes [LFE-10779](https://linear.app/langfuse/issue/LFE-10779)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a correctness bug where `events_core`, which stores `input`, `output`, and `metadata_values` truncated to 200 characters, was being queried even when filters targeted those truncated fields — silently dropping results whose values extended beyond the truncation point. The fix centralizes the "does this filter list require `events_full`?" check into a new exported helper `filtersRequireEventsFull` and applies it consistently.

- **`filtersRequireEventsFull` added in `clickhouse-filter.ts`**: checks whether any filter in a `FilterList` targets a truncation-sensitive field (`input`, `output`, or `metadata_values`) on an events table, and returns `true` if so.
- **`buildEventsStreamQuery` fixed**: the streaming query path now calls `forceFullTable()` when either the full-text search requires it *or* a filter targets a truncated field; previously only the FTS search path was covered.
- **`getObservationsFromEventsTableInternal` fixed**: both the qualifying-row CTE and the main query now independently check `filtersRequireEventsFull`; the refactoring of `buildObservationsQueryComponents` replaces the equivalent inline `startsWith("events")` check with the new helper.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are well-scoped to three query-building sites and the new helper is a pure predicate with no side effects.

The new filtersRequireEventsFull helper is a straightforward set-membership check; the refactoring from the old startsWith('events') inline guard to this helper is behaviorally equivalent for all current table names. The bug fix is applied consistently across both the streaming-query path and the internal observations query path. Unit and integration tests cover the two missing cases (metadata filter and input truncation). No external dependencies changed.

No files require special attention. events.ts contains two independent call sites for filtersRequireEventsFull (the CTE and the main query) — both are correct.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(events): force events\_full for trunc..."](https://github.com/langfuse/langfuse/commit/6fa04d8bd34e3fc62f848119a59f58b0a55b0373) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44094726)</sub>

<!-- /greptile_comment -->