### PR TITLE
fix(seeder): make the demo seeder import-safe outside a monorepo checkout

### DIFF
--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -49,10 +49,17 @@ const IN_APP_AGENT_SYSTEM_PROMPT_PATH = resolve(
   "web/src/ee/features/in-app-agent/prompts/in-app-agent-system-prompt.txt",
 );
 
-const inAppAgentSystemPrompt = readFileSync(
-  IN_APP_AGENT_SYSTEM_PROMPT_PATH,
-  "utf-8",
-);
+// The path above resolves to `web/src` relative to this file, which only exists
+// in a monorepo checkout. In built/published packages (e.g. the worker image
+// that runs the seeder in deployed environments) the web source isn't present,
+// so fall back to an empty prompt instead of throwing at import time — the
+// in-app-agent demo prompt is optional seed content.
+let inAppAgentSystemPrompt = "";
+try {
+  inAppAgentSystemPrompt = readFileSync(IN_APP_AGENT_SYSTEM_PROMPT_PATH, "utf-8");
+} catch {
+  inAppAgentSystemPrompt = "";
+}
 
 async function main() {
   const environment = parseArgs({

--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -56,7 +56,10 @@ const IN_APP_AGENT_SYSTEM_PROMPT_PATH = resolve(
 // in-app-agent demo prompt is optional seed content.
 let inAppAgentSystemPrompt = "";
 try {
-  inAppAgentSystemPrompt = readFileSync(IN_APP_AGENT_SYSTEM_PROMPT_PATH, "utf-8");
+  inAppAgentSystemPrompt = readFileSync(
+    IN_APP_AGENT_SYSTEM_PROMPT_PATH,
+    "utf-8",
+  );
 } catch {
   inAppAgentSystemPrompt = "";
 }


### PR DESCRIPTION
## Problem
`packages/shared/scripts/seeder/seed-postgres.ts` reads the in-app-agent system prompt at **module top level**:

```ts
const IN_APP_AGENT_SYSTEM_PROMPT_PATH = resolve(
  __dirname, "../../../..",
  "web/src/ee/features/in-app-agent/prompts/in-app-agent-system-prompt.txt",
);
const inAppAgentSystemPrompt = readFileSync(IN_APP_AGENT_SYSTEM_PROMPT_PATH, "utf-8");
```

That `__dirname`-relative path only resolves in a **monorepo checkout**. In a built/published package — e.g. the compiled `@langfuse/shared` shipped in the **worker image**, which is how `db:seed` runs in deployed environments — there is no sibling `web/src` (and `@langfuse/web` is not a dependency of `@langfuse/shared`), so the seeder throws on import before any seeding:

```
Error: ENOENT: no such file or directory, open
  '.../@langfuse/web/src/ee/features/in-app-agent/prompts/in-app-agent-system-prompt.txt'
```

Repro: running the built worker image's `seed-postgres.js` in a Kubernetes preview crashes at import with the above.

## Fix
Wrap the read in `try/catch` with an empty fallback so the seeder imports and runs in any context. The in-app-agent demo prompt is optional seed content; when the web source isn't present the demo prompt is simply empty and the rest of the seed (users/org/project/API keys, and the `examples` data) runs normally.

A more thorough follow-up could co-locate the `.txt` into `@langfuse/shared` so the real prompt is preserved in published packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a crash in the demo seeder when run outside a monorepo checkout (e.g. in the worker Docker image) by wrapping the top-level `readFileSync` for the in-app-agent system prompt in a `try/catch` with an empty-string fallback, so the seeder imports and runs normally even when the `web/src` path is absent.

- **Crash fix**: the bare `readFileSync` at module top-level was throwing `ENOENT` before `main()` could run in any deployed/built environment, blocking all seed operations including users, orgs, and API keys.
- **Scope**: only the in-app-agent demo prompt is affected; all other seed data is unaffected. The PR notes that a proper fix would be to co-locate the `.txt` file inside `@langfuse/shared`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a one-function guard around a single readFileSync call with a well-understood fallback value, and does not touch any database writes or business logic.

The fix is correct and targeted. The only open items are a redundant reassignment in the catch block and the absence of a warning log when the prompt file is missing, both of which are cosmetic and do not affect correctness.

No files require special attention; the single changed file is low-risk seed infrastructure.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[seed-postgres.ts module load] --> B{Try readFileSync prompt file}
    B -->|File exists monorepo checkout| C[inAppAgentSystemPrompt = file contents]
    B -->|ENOENT worker image| D[catch: inAppAgentSystemPrompt = empty string]
    C --> E[main runs]
    D --> E
    E --> F[Seed users / org / project / API keys]
    E --> G[Seed in-app-agent demo conversation with prompt may be empty]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[seed-postgres.ts module load] --> B{Try readFileSync prompt file}
    B -->|File exists monorepo checkout| C[inAppAgentSystemPrompt = file contents]
    B -->|ENOENT worker image| D[catch: inAppAgentSystemPrompt = empty string]
    C --> E[main runs]
    D --> E
    E --> F[Seed users / org / project / API keys]
    E --> G[Seed in-app-agent demo conversation with prompt may be empty]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/scripts/seeder/seed-postgres.ts:58-62
**Silent failure gives no operational signal**

When the `readFileSync` fails, the seeder continues with an empty prompt and no diagnostic output. If the failure happens for an unexpected reason (e.g. a permissions error on a file that does exist, or a typo in the path during development), nothing surfaces it. Adding a `logger.warn` in the catch would distinguish "expected absence in non-monorepo builds" from a surprising I/O error, without breaking any existing behaviour.

### Issue 2 of 2
packages/shared/scripts/seeder/seed-postgres.ts:57-62
The `inAppAgentSystemPrompt = ""` assignment inside `catch` is redundant — the variable is already initialised to `""` on the line above. The catch body can be left empty (or replaced with a warning log).

```suggestion
let inAppAgentSystemPrompt = "";
try {
  inAppAgentSystemPrompt = readFileSync(IN_APP_AGENT_SYSTEM_PROMPT_PATH, "utf-8");
} catch (e) {
  logger.warn(
    `[Seeder] In-app-agent system prompt not found at ${IN_APP_AGENT_SYSTEM_PROMPT_PATH}; seeding with empty prompt.`,
    e,
  );
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(seeder): make the demo seeder import..."](https://github.com/langfuse/langfuse/commit/fa5971fb9cf39d7987dc6734399ba2e68f9087b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44096827)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->