### PR TITLE
feat(evals): emit code eval dispatch duration distribution metric

### DIFF
--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.test.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.test.ts
@@ -12,12 +12,14 @@ const mocks = vi.hoisted(() => {
   return {
     span,
     instrumentAsync: vi.fn(async (_ctx, callback) => callback(span)),
+    recordDistribution: vi.fn(),
     traceException: vi.fn(),
   };
 });
 
 vi.mock("../instrumentation", () => ({
   instrumentAsync: mocks.instrumentAsync,
+  recordDistribution: mocks.recordDistribution,
   traceException: mocks.traceException,
 }));
 
@@ -49,6 +51,18 @@ const baseInput: DispatchInput = {
 function expectSpanAttributes(attributes: Record<string, unknown>): void {
   expect(mocks.span.setAttributes).toHaveBeenCalledWith(
     expect.objectContaining(attributes),
+  );
+}
+
+function expectDispatchDurationRecorded(): void {
+  expect(mocks.recordDistribution).toHaveBeenCalledExactlyOnceWith(
+    "langfuse.code_eval.dispatch_duration",
+    expect.any(Number),
+    {
+      project_id: "project-1",
+      language: "TYPESCRIPT",
+      unit: "milliseconds",
+    },
   );
 }
 
@@ -107,6 +121,7 @@ describe("AwsLambdaCodeEvalDispatcher observability", () => {
       "aws.sdk.attempts": 2,
       "aws.sdk.total_retry_delay_ms": 15,
     });
+    expectDispatchDurationRecorded();
   });
 
   it("records the original AWS SDK error before throwing the derived dispatcher error", async () => {
@@ -146,6 +161,7 @@ describe("AwsLambdaCodeEvalDispatcher observability", () => {
       "aws.sdk.attempts": 3,
       "aws.sdk.total_retry_delay_ms": 25,
     });
+    expectDispatchDurationRecorded();
   });
 
   it("records dispatch context and error code for preflight limit failures", async () => {

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
@@ -5,7 +5,11 @@ import {
 } from "@aws-sdk/client-lambda";
 import { SpanKind, type AttributeValue, type Span } from "@opentelemetry/api";
 import { z } from "zod";
-import { instrumentAsync, traceException } from "../instrumentation";
+import {
+  instrumentAsync,
+  recordDistribution,
+  traceException,
+} from "../instrumentation";
 import { logger } from "../logger";
 import {
   assertDispatchInputWithinLimits,
@@ -171,7 +175,25 @@ export class AwsLambdaCodeEvalDispatcher implements CodeEvalDispatcher {
         traceScope: "code-eval-dispatcher",
         startNewTrace: true,
       },
-      async (span) => this.dispatchWithTracing(input, span),
+      async (span) => {
+        // Dispatch spans are ingestion-sampled, so fleet-slowness monitors
+        // (per-project p95 quorum) run on this unsampled distribution instead.
+        // Recorded on failures too: timeouts are the slow runs that matter most.
+        const startTime = Date.now();
+        try {
+          return await this.dispatchWithTracing(input, span);
+        } finally {
+          recordDistribution(
+            "langfuse.code_eval.dispatch_duration",
+            Date.now() - startTime,
+            {
+              project_id: input.scope.projectId,
+              language: input.runtime.language,
+              unit: "milliseconds",
+            },
+          );
+        }
+      },
     );
   }
 


### PR DESCRIPTION
## Summary

- Record `langfuse.code_eval.dispatch_duration` as a DogStatsD distribution (tagged `project_id`, `language`, `unit`) around every code eval Lambda dispatch in `AwsLambdaCodeEvalDispatcher`.
- Motivation: dispatch spans are ingestion-sampled, so they can't back a reliable per-project p95 alert. Last week a single tenant's slow evaluator dragged the function-wide `aws.lambda.duration.p95` monitor; this unsampled metric enables a fleet-level monitor (alert only when ≥N projects breach a p95 threshold) that is insensitive to one slow tenant.
- Durations are recorded on failures too, since timeouts are exactly the slow runs the monitor must see.
- Datadog side (percentile opt-in via metric tag configuration + quorum monitor) follows separately in the infrastructure repo once this is deployed and emitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a DogStatsD distribution metric `langfuse.code_eval.dispatch_duration` (tagged `project_id`, `language`, `unit`) recorded via a `finally` block around every AWS Lambda code eval dispatch. The motivation is that ingestion-sampled traces can't back a reliable p95 alert, so this unsampled metric enables a fleet-level quorum monitor.

- The metric is emitted on both success and failure paths (including timeouts) by wrapping `dispatchWithTracing` in a `try/finally` inside the `instrumentAsync` callback.
- Tests verify the metric is recorded on the success path and on the `TooManyRequestsException` failure path, but the "preflight limit" and "Lambda FunctionError" test cases are missing the corresponding `expectDispatchDurationRecorded()` assertion.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The production change is a narrow, additive try/finally wrapper that records a DogStatsD distribution metric on every dispatch; the core dispatch logic is untouched.

The implementation is straightforward and correct. Two test cases ("preflight limit failures" and "Lambda FunctionError") are missing expectDispatchDurationRecorded() assertions — the finally block does fire on those paths, but a future regression that suppresses the metric there would slip past the test suite unnoticed.

awsLambdaCodeEvalDispatcher.test.ts — two test cases need the dispatch duration assertion added.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant AwsLambdaCodeEvalDispatcher
    participant instrumentAsync
    participant DogStatsD
    participant LambdaClient

    Caller->>AwsLambdaCodeEvalDispatcher: dispatch(input)
    AwsLambdaCodeEvalDispatcher->>instrumentAsync: wrap in trace span
    Note over AwsLambdaCodeEvalDispatcher: startTime = Date.now()
    instrumentAsync->>AwsLambdaCodeEvalDispatcher: callback(span)
    AwsLambdaCodeEvalDispatcher->>LambdaClient: dispatchWithTracing(input, span)
    alt Success
        LambdaClient-->>AwsLambdaCodeEvalDispatcher: DispatchResult
    else Failure (timeout, error, FunctionError, preflight limit)
        LambdaClient-->>AwsLambdaCodeEvalDispatcher: throws CodeEvalDispatcherError
    end
    Note over AwsLambdaCodeEvalDispatcher: finally block always runs
    AwsLambdaCodeEvalDispatcher->>DogStatsD: recordDistribution(langfuse.code_eval.dispatch_duration, elapsed, tags)
    AwsLambdaCodeEvalDispatcher-->>Caller: DispatchResult or rethrows error
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant AwsLambdaCodeEvalDispatcher
    participant instrumentAsync
    participant DogStatsD
    participant LambdaClient

    Caller->>AwsLambdaCodeEvalDispatcher: dispatch(input)
    AwsLambdaCodeEvalDispatcher->>instrumentAsync: wrap in trace span
    Note over AwsLambdaCodeEvalDispatcher: startTime = Date.now()
    instrumentAsync->>AwsLambdaCodeEvalDispatcher: callback(span)
    AwsLambdaCodeEvalDispatcher->>LambdaClient: dispatchWithTracing(input, span)
    alt Success
        LambdaClient-->>AwsLambdaCodeEvalDispatcher: DispatchResult
    else Failure (timeout, error, FunctionError, preflight limit)
        LambdaClient-->>AwsLambdaCodeEvalDispatcher: throws CodeEvalDispatcherError
    end
    Note over AwsLambdaCodeEvalDispatcher: finally block always runs
    AwsLambdaCodeEvalDispatcher->>DogStatsD: recordDistribution(langfuse.code_eval.dispatch_duration, elapsed, tags)
    AwsLambdaCodeEvalDispatcher-->>Caller: DispatchResult or rethrows error
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.test.ts:167-194
**Missing metric assertion on two failure paths**

The "preflight limit failures" test (line 167) and the "Lambda FunctionError" test (line 196) both trigger the `finally` block — `assertDispatchInputWithinLimits` and `dispatchWithTracing`'s FunctionError path both throw inside the `try`, so `recordDistribution` is called in both cases. Neither test calls `expectDispatchDurationRecorded()`, so a regression that silently drops the metric on these paths would go undetected by the test suite.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): emit code eval dispatch dur..."](https://github.com/langfuse/langfuse/commit/14b6aa5ef2ae9b03bd43528177c7f15f2886a1f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44098855)</sub>

<!-- /greptile_comment -->