### PR TITLE
chore(filters): document and pin getColumnId tolerance contract

### DIFF
--- a/web/src/features/filters/hooks/useFilterState.clienttest.ts
+++ b/web/src/features/filters/hooks/useFilterState.clienttest.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getColumnId,
+  getColumnName,
+} from "@/src/features/filters/lib/columnLookup";
+
+const widgetsTable = {
+  widgets: [
+    { id: "environment", name: "Environment" },
+    { id: "traceName", name: "Trace Name" },
+    { id: "tags", name: "Tags" },
+    { id: "release", name: "Release" },
+    { id: "user", name: "User" },
+    { id: "session", name: "Session" },
+    { id: "version", name: "Version" },
+  ],
+} as const;
+
+// Simulates the inline tableCols map in `useFilterState.ts`: shares the
+// `traceName` id between widgets and dashboard but exposes different
+// column sets. `toolNames` is a name that exists only in `widgets` so we
+// can assert the lookup never crosses the table boundary.
+const disjointTable = {
+  widgets: [
+    { id: "traceName", name: "Trace Name" },
+    { id: "toolNames", name: "Tool Names" },
+  ],
+  dashboard: [
+    { id: "traceName", name: "Trace Name" },
+    { id: "sessionId", name: "Session ID" },
+  ],
+} as const;
+
+describe("getColumnId", () => {
+  describe("LLM-tolerant lookup", () => {
+    it("resolves a column by its display name", () => {
+      expect(getColumnId(widgetsTable, "widgets", "Trace Name")).toBe(
+        "traceName",
+      );
+    });
+
+    it("resolves a column by its stable id", () => {
+      expect(getColumnId(widgetsTable, "widgets", "traceName")).toBe(
+        "traceName",
+      );
+    });
+
+    it("returns the same id regardless of whether the caller passes the display name or the id", () => {
+      expect(getColumnId(widgetsTable, "widgets", "Trace Name")).toBe(
+        getColumnId(widgetsTable, "widgets", "traceName"),
+      );
+    });
+  });
+
+  describe("table scoping", () => {
+    it("does not leak columns defined only on one table into the other", () => {
+      // `toolNames` exists only in the `widgets` registry; `sessionId`
+      // exists only in the `dashboard` registry. The lookup must be
+      // strictly scoped to the requested table.
+      expect(getColumnId(disjointTable, "dashboard", "toolNames")).toBeUndefined();
+      expect(getColumnId(disjointTable, "dashboard", "Tool Names")).toBeUndefined();
+
+      expect(getColumnId(disjointTable, "widgets", "sessionId")).toBeUndefined();
+      expect(getColumnId(disjointTable, "widgets", "Session ID")).toBeUndefined();
+    });
+  });
+
+  describe("non-normalized input", () => {
+    it("returns undefined for an unknown display name", () => {
+      expect(
+        getColumnId(widgetsTable, "widgets", "Unknown Column"),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for whitespace-padded names (no implicit trimming)", () => {
+      expect(
+        getColumnId(widgetsTable, "widgets", "  Trace Name  "),
+      ).toBeUndefined();
+      expect(
+        getColumnId(widgetsTable, "widgets", "\tTrace Name\n"),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for case-mismatched names (no implicit lower-casing)", () => {
+      expect(
+        getColumnId(widgetsTable, "widgets", "trace name"),
+      ).toBeUndefined();
+      expect(getColumnId(widgetsTable, "widgets", "TRACENAME")).toBeUndefined();
+    });
+
+    it("returns undefined for empty input", () => {
+      expect(getColumnId(widgetsTable, "widgets", "")).toBeUndefined();
+    });
+  });
+});
+
+describe("getColumnName", () => {
+  it("resolves the display name for a column by its stable id", () => {
+    expect(getColumnName(widgetsTable, "widgets", "traceName")).toBe(
+      "Trace Name",
+    );
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(
+      getColumnName(widgetsTable, "widgets", "notARealColumn"),
+    ).toBeUndefined();
+  });
+
+  it("does not perform the LLM-tolerance name-match fallback", () => {
+    // `getColumnName` is the inverse of `getColumnId` and only accepts
+    // stable ids. Passing a display name must not match.
+    expect(getColumnName(widgetsTable, "widgets", "Trace Name")).toBeUndefined();
+  });
+});

--- a/web/src/features/filters/hooks/useFilterState.ts
+++ b/web/src/features/filters/hooks/useFilterState.ts
@@ -28,6 +28,10 @@ import {
   splitOnUnescapedPipe,
   unescapePipeInValue,
 } from "../lib/filter-query-encoding";
+import {
+  getColumnId as getColumnIdImpl,
+  getColumnName as getColumnNameImpl,
+} from "../lib/columnLookup";
 import { normalizeLegacySessionPositionInTraceKey } from "@/src/components/session/session-position-in-trace";
 import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTableStateContext";
 
@@ -210,13 +214,20 @@ const tableCols = {
   ],
 };
 
-function getColumnId(table: TableName, name: string): string | undefined {
-  // TODO: make this more robust, will change with new filters
-  // to give more leeway to LLMs, we check against name or id
-  return tableCols[table]?.find((col) => col.name === name || col.id === name)
-    ?.id;
+/**
+ * Resolves a column entry on `table` by either its stable id or its
+ * human-readable display name. See `lib/columnLookup.ts` for the full
+ * tolerance contract.
+ */
+export function getColumnId(table: TableName, name: string): string | undefined {
+  return getColumnIdImpl(tableCols, table, name);
 }
 
-function getColumnName(table: TableName, id: string): string | undefined {
-  return tableCols[table]?.find((col) => col.id === id)?.name;
+/**
+ * Inverse of {@link getColumnId}: resolves a column's display name on
+ * `table` from its stable id. See `lib/columnLookup.ts` for the full
+ * tolerance contract.
+ */
+export function getColumnName(table: TableName, id: string): string | undefined {
+  return getColumnNameImpl(tableCols, table, id);
 }

--- a/web/src/features/filters/lib/columnLookup.ts
+++ b/web/src/features/filters/lib/columnLookup.ts
@@ -1,0 +1,44 @@
+import { type TableName } from "@langfuse/shared";
+
+type ColumnDef = { id: string; name: string };
+
+type ColumnRegistry = {
+  [K in TableName]?: readonly ColumnDef[];
+};
+
+/**
+ * Resolves a column entry on `table` by either its stable id or its
+ * human-readable display name.
+ *
+ * Tolerance contract:
+ * - Matches are exact and case-sensitive. Neither id nor display name is
+ *   normalized (no trimming, no lower-casing). Callers that need to
+ *   tolerate user/LLM-provided input must normalize upstream.
+ * - The lookup is strictly scoped to `table`. A column defined only in
+ *   another table's registry (for example an observations-only column)
+ *   returns `undefined` here even if its id is well known.
+ * - Matching by id and by display name are equivalent: both return the
+ *   column's stable id. This is the LLM-tolerance layer for filter-state
+ *   URL encoding.
+ */
+export function getColumnId(
+  tableCols: ColumnRegistry,
+  table: TableName,
+  name: string,
+): string | undefined {
+  return tableCols[table]?.find((col) => col.name === name || col.id === name)
+    ?.id;
+}
+
+/**
+ * Inverse of {@link getColumnId}: resolves a column's display name on
+ * `table` from its stable id. Does not perform the LLM-tolerance fallback
+ * (name-match) — callers must pass the canonical id.
+ */
+export function getColumnName(
+  tableCols: ColumnRegistry,
+  table: TableName,
+  id: string,
+): string | undefined {
+  return tableCols[table]?.find((col) => col.id === id)?.name;
+}


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

Replaces the `// TODO: make this more robust, will change with new filters`  <br>marker on `getColumnId` / `getColumnName` in  <br>`web/src/features/filters/hooks/useFilterState.ts` with an explicit,  <br>regression-pinned tolerance contract.

The LLM-tolerance layer that sits between filter-state URL encoding  <br>(`encodeDelimitedArray`) and the strict `tableCols[table]` registry is  <br>the only place in the filters code path that silently accepts a display  <br>name as a substitute for the canonical column id. Until now this was  <br>both undocumented and untested:

* The TODO gave no guidance on whether lookups were case-sensitive,  <br>whitespace-tolerant, or table-scoped.
* Any future refactor of the filters system could silently regress the  <br>LLM-tolerance contract with no test catching it.

### Changes

1. `web/src/features/filters/lib/columnLookup.ts` (new): pure module  <br>containing `getColumnId` and `getColumnName`. The tolerance contract is  <br>documented here and the registry is injected so the helpers are  <br>trivial to unit-test in isolation (no `env.mjs` / `@langfuse/shared`  <br>import cost).
2. `web/src/features/filters/hooks/useFilterState.ts`: re-exports  <br>the two helpers as thin wrappers around `columnLookup` so the public  <br>surface is unchanged. Removes the TODO and adds a short doc-comment  <br>that points to `columnLookup.ts` for the full contract.
3. `web/src/features/filters/hooks/useFilterState.clienttest.ts` (new):  <br>pins the contract with 11 regression cases covering  <br>display-name / stable-id lookups, table scoping (no cross-table  <br>leakage), whitespace-padded input, case-mismatched input, empty input,  <br>and the inverse `getColumnName` no-fallback guarantee.

### Risk

Zero runtime behavior change. Pure doc + extract + test.

### Out of scope

* Case-insensitive matching.
* Whitespace trimming.
* A refactor of the broader `useFilterState` hook.

These would be behaviour changes and deserve their own PR.

Fixes langfuse/langfuse#15016

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [X] I have read the [contributing guide](<https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md>)
- [X] My code follows the style guidelines of this project (`pnpm run format`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked if new and existing unit tests pass locally with my changes

<details><summary>Greptile Summary</summary>

This PR refactors the `getColumnId` / `getColumnName` helpers from `useFilterState.ts` into a new pure module `lib/columnLookup.ts`, documents their LLM-tolerance contract, and pins it with 11 regression tests.

* **New** `lib/columnLookup.ts`: Extracts the two lookup helpers into a registry-injected pure module with a fully documented tolerance contract (exact/case-sensitive, table-scoped, display-name-or-id equivalent).
* `useFilterState.ts`: Delegates to `columnLookup` via aliased imports and adds JSDoc pointing to the new module; also changes both functions from module-private to `export`ed — a surface expansion not called out in the PR description.
* `useFilterState.clienttest.ts`: Adds 11 cases covering id/name resolution, table scoping, whitespace padding, case mismatch, and empty input — but the test file lives in `hooks/` while the code under test lives in `lib/`, and both new files are missing a trailing newline.

</details>

<details><summary>Confidence Score: 4/5</summary>

Safe to merge — no runtime behaviour changes; the refactor is a pure extract-and-document of two existing helper functions.

The logic extraction is faithful (identical one-liner implementations), the tests correctly pin the documented contract, and there are no new dependencies or side effects introduced. The only issues are cosmetic: two files are missing a trailing newline, the test is in a slightly unexpected location, and the functions gain an export keyword that the PR description says was not added.

The new export keywords on getColumnId and getColumnName in useFilterState.ts are worth a second look to confirm whether exposing them publicly is intentional.

</details>

<details><summary>Sequence Diagram</summary>

[%%{init: {'theme': 'neutral'}}%% sequenceDiagram participant Caller as LLM / URL State participant useFilterState as useFilterState.ts participant columnLookup as lib/columnLookup.ts participant registry as tableCols Registry Caller->>useFilterState: "getColumnId(table, displayName | stableId)" useFilterState->>columnLookup: getColumnIdImpl(tableCols, table, name) columnLookup->>registry: find col by name or id registry-->>columnLookup: "matched ColumnDef | undefined" columnLookup-->>useFilterState: "col.id | undefined" useFilterState-->>Caller: "canonical id | undefined" Caller->>useFilterState: getColumnName(table, stableId) useFilterState->>columnLookup: getColumnNameImpl(tableCols, table, id) columnLookup->>registry: find col by id only registry-->>columnLookup: "matched ColumnDef | undefined" columnLookup-->>useFilterState: "col.name | undefined" useFilterState-->>Caller: "display name | undefined"](<#gh-light-mode-only>) [%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%% sequenceDiagram participant Caller as LLM / URL State participant useFilterState as useFilterState.ts participant columnLookup as lib/columnLookup.ts participant registry as tableCols Registry Caller->>useFilterState: "getColumnId(table, displayName | stableId)" useFilterState->>columnLookup: getColumnIdImpl(tableCols, table, name) columnLookup->>registry: find col by name or id registry-->>columnLookup: "matched ColumnDef | undefined" columnLookup-->>useFilterState: "col.id | undefined" useFilterState-->>Caller: "canonical id | undefined" Caller->>useFilterState: getColumnName(table, stableId) useFilterState->>columnLookup: getColumnNameImpl(tableCols, table, id) columnLookup->>registry: find col by id only registry-->>columnLookup: "matched ColumnDef | undefined" columnLookup-->>useFilterState: "col.name | undefined" useFilterState-->>Caller: "display name | undefined"](<#gh-dark-mode-only>)

</details>

<details><summary>Prompt To Fix All With AI</summary>

```markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
web/src/features/filters/hooks/useFilterState.ts:222-233
**Functions newly exported, contradicting PR description**

The PR description states "the public surface is unchanged," but both `getColumnId` and `getColumnName` were previously module-private (`function`, not `export function`) and are now part of the module's public API. No existing callers outside this file import them, so there is no immediate breakage, but the claim in the PR description is inaccurate and may mislead future readers who rely on that changelog. If the intent is to allow callers to look up columns outside the hook, the PR description should say so explicitly; if the functions should remain internal, the `export` keyword should be removed.

### Issue 2 of 4
web/src/features/filters/hooks/useFilterState.clienttest.ts:1-7
**Test file placement doesn't match the code under test**

The test is named `useFilterState.clienttest.ts` and lives in `hooks/`, but it imports exclusively from `lib/columnLookup.ts` and exercises no hook behaviour. Collocating it with the tested module as `lib/columnLookup.clienttest.ts` would make it easier to find, keep consistent with the project's file-naming convention for pure-lib tests, and avoid the misleading implication that it exercises the hook.

### Issue 3 of 4
web/src/features/filters/lib/columnLookup.ts:43-44
Both `columnLookup.ts` and `useFilterState.clienttest.ts` are missing a trailing newline. Most editors and the project's formatter (`pnpm run format`) expect files to end with a newline; without it, `git diff` shows `\ No newline at end of file` and some linters will warn.

```suggestion
  return tableCols[table]?.find((col) => col.id === id)?.name;
}
```

### Issue 4 of 4

web/src/features/filters/hooks/useFilterState.clienttest.ts:114-116 Missing trailing newline at end of file.

```suggestion
    expect(getColumnName(widgetsTable, "widgets", "Trace Name")).toBeUndefined();
  });
});
```

```

</details>

Reviews (1): Last reviewed commit: ["chore(filters): document and pin getColu..."](<https://github.com/langfuse/langfuse/commit/93031941d3af4362791e92f8dd0985f3de7f347a>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=44113308>)
```

</details>