### PR TITLE
fix(preview): resolve preview-comment action from base, build from PR head

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -44,22 +44,43 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - name: Checkout PR head (build context only)
+      # Resolve the local composite action (./.github/actions/preview-comment)
+      # from the BASE branch, which always has it. A local `uses: ./...`
+      # resolves against the workspace, and a PR branched before the preview
+      # system landed on main has NO such action on its head — so checking out
+      # the PR head at the workspace root makes the action lookup fail with
+      # "Can't find action.yml". Sparse-checkout keeps this to just the actions
+      # dir, at the workspace root, and never enters the Docker build context.
+      - name: Checkout base local actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: .github/actions
+
+      # The PR head is the Docker build context — the exact commit the image tag
+      # pins to. Kept in a subdir so it does not shadow the base's
+      # .github/actions checked out above.
+      - name: Checkout PR head (build context)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
 
       - name: Resolve image tags and preview metadata
         id: meta
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # The PR head SHA straight from the event — the workspace root is the
+          # base checkout now, so `git rev-parse HEAD` would give the wrong SHA.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           WEB_REPO: ${{ vars.AWS_PREVIEW_WEB_ECR_REPOSITORY_URL }}
           WORKER_REPO: ${{ vars.AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL }}
           DOMAIN_NAME: ${{ vars.AWS_PREVIEW_DOMAIN_NAME }}
         run: |
           set -euo pipefail
-          commit_sha="$(git rev-parse HEAD)"
+          commit_sha="${HEAD_SHA}"
           # The ApplicationSet deploys pr-<n>-{{.head_sha}} — Argo's FULL 40-char
           # SHA — so the pushed tag MUST use the full SHA or the deployed image
           # never resolves (permanent ImagePullBackOff).
@@ -140,18 +161,20 @@ jobs:
             fi
 
             echo "${image} not found — building and pushing."
-            docker build "$@" -t "${image}" .
+            # Build context is the PR-head checkout (pr-head/); the base checkout
+            # at the workspace root only carries .github/actions.
+            docker build "$@" -t "${image}" pr-head
             docker push "${image}"
           }
 
           ensure_image "${WEB_IMAGE}" \
             --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
             --build-arg NEXT_PUBLIC_SIGN_UP_DISABLED=true \
-            -f ./web/Dockerfile
+            -f pr-head/web/Dockerfile
 
           ensure_image "${WORKER_IMAGE}" \
             --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
-            -f ./worker/Dockerfile
+            -f pr-head/worker/Dockerfile
 
       - name: Mark preview image pushed
         uses: ./.github/actions/preview-comment


### PR DESCRIPTION
### What / why
The `AWS preview build` workflow fails for any PR whose branch was cut **before** the preview system landed on `main` (#15020) — e.g. https://github.com/langfuse/langfuse/pull/15069:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/_work/langfuse/langfuse/.github/actions/preview-comment'.
Did you forget to run actions/checkout before running your local action?
```

**Root cause:** the workflow checks out the **PR head** into the workspace root, then calls `uses: ./.github/actions/preview-comment` (a *local* composite action). A local `./` action resolves against the checked-out workspace = the PR head. A PR branched before #15020 has no such action on its head, so the lookup fails. The workflow itself runs because `pull_request` triggers/runs it from the base branch (`main`), which is why `main` having the file isn't enough.

This hits **every** open PR older than #15020, not just #15069.

### Fix
- Check out the **base** branch (`base.sha`) **sparsely** (`.github/actions` only) at the workspace root, so `./.github/actions/preview-comment` always resolves from trusted base code.
- Check out the **PR head** into `pr-head/` and use it as the Docker build context — unchanged build semantics (still the exact PR-head commit, same image tag).
- Derive the image tag from `github.event.pull_request.head.sha` (the root is the base checkout now, so `git rev-parse HEAD` would be wrong).

Kept the action reference **local** (rather than a pinned remote `@ref`) to stay clean under `zizmor`'s `unpinned-uses`.

### Verification
- `yaml.safe_load` parses; step order intact (9 steps).
- `bash -n` clean on the build script.
- `ensure_image` three-state logic unchanged (present→skip / not-found→build / other→fail loudly), still tested.
- Real end-to-end validation happens when this merges and the next old-branch PR (e.g. #15069) re-runs the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a workflow failure for PRs branched before the preview system (merged in #15020) by restructuring the checkout strategy so the local composite action always resolves from a known-good source.

- **Two-checkout approach**: A sparse checkout of the base branch (`base.sha`) at the workspace root provides `.github/actions/preview-comment` for local action resolution; a full checkout of the PR head at `pr-head/` provides the Docker build context, keeping build semantics identical to before.
- **SHA sourcing fix**: `commit_sha` is now derived from `github.event.pull_request.head.sha` instead of `git rev-parse HEAD`, which is necessary because the workspace root is now the base-branch checkout rather than the PR head.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix cleanly separates action resolution from the Docker build context using two well-scoped checkouts, with no changes to build semantics or security posture.

The two-checkout strategy is correct: the sparse base checkout provides stable composite-action resolution, the full PR-head checkout at pr-head/ is a self-contained Docker build context, and the SHA is sourced directly from the event payload rather than git rev-parse HEAD. The persist-credentials: false flag is present on both checkouts, the three-state ECR idempotency guard is unchanged, and all Dockerfile and build-context paths are updated consistently.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Base as Base Branch (base.sha)
    participant Head as PR Head (head.sha)
    participant ECR as AWS ECR
    participant PR as Pull Request

    GH->>Base: Sparse checkout → workspace root (.github/actions only)
    GH->>Head: Full checkout → pr-head/
    Note over GH: SHA from github.event.pull_request.head.sha
    GH->>PR: Post building comment via ./.github/actions/preview-comment
    GH->>ECR: aws ecr describe-images
    alt Image already present
        ECR-->>GH: Found → skip build
    else ImageNotFoundException
        GH->>GH: docker build pr-head -f pr-head/web/Dockerfile
        GH->>GH: docker build pr-head -f pr-head/worker/Dockerfile
        GH->>ECR: docker push images
    else Other ECR error
        GH-->>GH: fail loudly
    end
    GH->>PR: Post image pushed comment
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Base as Base Branch (base.sha)
    participant Head as PR Head (head.sha)
    participant ECR as AWS ECR
    participant PR as Pull Request

    GH->>Base: Sparse checkout → workspace root (.github/actions only)
    GH->>Head: Full checkout → pr-head/
    Note over GH: SHA from github.event.pull_request.head.sha
    GH->>PR: Post building comment via ./.github/actions/preview-comment
    GH->>ECR: aws ecr describe-images
    alt Image already present
        ECR-->>GH: Found → skip build
    else ImageNotFoundException
        GH->>GH: docker build pr-head -f pr-head/web/Dockerfile
        GH->>GH: docker build pr-head -f pr-head/worker/Dockerfile
        GH->>ECR: docker push images
    else Other ECR error
        GH-->>GH: fail loudly
    end
    GH->>PR: Post image pushed comment
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(preview): resolve preview-comment ac..."](https://github.com/langfuse/langfuse/commit/99363b6c5d4f3bef45badbc7338157e1572ec2cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44125761)</sub>

<!-- /greptile_comment -->