### PR TITLE
feat(otel): tag x-langfuse-ingestion-version header on OTel API spans

### DIFF
--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -1,6 +1,7 @@
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import {
+  getCurrentSpan,
   logger,
   markProjectIngestFailure,
   OtelIngestionProcessor,
@@ -134,6 +135,12 @@ export default withMiddlewares({
         req.headers,
         "x-langfuse-ingestion-version",
       );
+      if (ingestionVersion) {
+        getCurrentSpan()?.setAttribute(
+          "langfuse.ingestion.version",
+          ingestionVersion,
+        );
+      }
 
       // Reject unsupported future ingestion versions (> 4)
       // Lower versions are valid but use dual write (path A)


### PR DESCRIPTION
## Summary

When an OTLP traces request carries the `x-langfuse-ingestion-version` header (the OTel v4 direct-write opt-in, see [langfuse.com/docs/v4](https://langfuse.com/docs/v4)), its value is now set as a `langfuse.ingestion.version` attribute on the active APM span.

This lets us filter Datadog spans for `POST /api/public/otel/v1/traces` by `@langfuse.ingestion.version` to see which direct-OTel ingestors have opted into the v4 direct write path — spans without the tag are ingestors still on the dual-write path (relevant for the ~10 min delay reports, #12541). Tagging happens before header validation, so malformed values on rejected (400) requests are visible too.

Follows the existing `langfuse.*` span attribute convention (`langfuse.ingestion.batch_size`, `langfuse.project.id` in `processEventBatch`).

## Impacted packages

- `web` (OTel public API route only)

## Verification

- `pnpm --filter web run lint` — exit 0 (also ran via pre-commit turbo lint: `Tasks: 7 successful, 7 total`)
- `pnpm --filter web exec tsc --noEmit` — exit 0
- OTel API servertests skipped: local DB stack not running; change is an additive span attribute on the request handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a single APM span attribute — `langfuse.ingestion.version` — to the OTel traces endpoint, sourced from the incoming `x-langfuse-ingestion-version` request header. The attribute is set before header validation so that even requests rejected with a 400 (malformed or unsupported version) are tagged in Datadog.

- `getCurrentSpan` is imported from `@langfuse/shared/src/server` and used with optional chaining, correctly handling environments where no active span exists.
- The attribute is only written when the header is present, and the raw string value is the same one that is subsequently parsed and validated, so there is no divergence between what is tagged and what is acted upon.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single additive span attribute write with no side effects on the request-handling logic.

The change adds exactly one conditional setAttribute call, guarded by optional chaining on getCurrentSpan(), which correctly handles spans being absent. It does not alter any control flow, validation, or response path. The import is at the module top level, consistent with the team's rule, and the attribute naming follows the existing langfuse.* convention.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant OTelRoute as POST /api/public/otel/v1/traces
    participant APMSpan as Current APM Span (Datadog)
    participant Validator as Header Validator
    participant Processor as OtelIngestionProcessor

    Client->>OTelRoute: Request with x-langfuse-ingestion-version header
    OTelRoute->>OTelRoute: "Parse body & content-type"
    OTelRoute->>OTelRoute: getLangfuseHeaderValue(req.headers, x-langfuse-ingestion-version)
    alt ingestionVersion present
        OTelRoute->>APMSpan: setAttribute(langfuse.ingestion.version, ingestionVersion)
    end
    OTelRoute->>Validator: "parseInt(ingestionVersion) > 4 or NaN?"
    alt Invalid / unsupported version
        Validator-->>Client: 400 error (span already tagged)
    else Valid version
        OTelRoute->>Processor: publishToOtelIngestionQueue(resourceSpans)
        Processor-->>Client: 200 OK
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant OTelRoute as POST /api/public/otel/v1/traces
    participant APMSpan as Current APM Span (Datadog)
    participant Validator as Header Validator
    participant Processor as OtelIngestionProcessor

    Client->>OTelRoute: Request with x-langfuse-ingestion-version header
    OTelRoute->>OTelRoute: "Parse body & content-type"
    OTelRoute->>OTelRoute: getLangfuseHeaderValue(req.headers, x-langfuse-ingestion-version)
    alt ingestionVersion present
        OTelRoute->>APMSpan: setAttribute(langfuse.ingestion.version, ingestionVersion)
    end
    OTelRoute->>Validator: "parseInt(ingestionVersion) > 4 or NaN?"
    alt Invalid / unsupported version
        Validator-->>Client: 400 error (span already tagged)
    else Valid version
        OTelRoute->>Processor: publishToOtelIngestionQueue(resourceSpans)
        Processor-->>Client: 200 OK
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(otel): tag x-langfuse-ingestion-ver..."](https://github.com/langfuse/langfuse/commit/aa28631d1ccbe28a44bef10b1d4e8a4ffa63da98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44135395)</sub>

<!-- /greptile_comment -->