### PR TITLE
fix(mcp): Add user agent to mcp spans

### DIFF
--- a/web/src/features/mcp/core/run-mcp-tool.ts
+++ b/web/src/features/mcp/core/run-mcp-tool.ts
@@ -26,6 +26,7 @@ export const runMcpTool = async <TResult>({
         "langfuse.project.id": context.projectId,
         "langfuse.org.id": context.orgId,
         "mcp.api_key_id": context.apiKeyId,
+        ...(context.userAgent ? { user_agent: context.userAgent } : {}),
         ...Object.fromEntries(
           Object.entries(attributes ?? {}).filter(
             (entry): entry is [string, McpToolAttribute] =>

--- a/web/src/features/mcp/types.ts
+++ b/web/src/features/mcp/types.ts
@@ -51,6 +51,9 @@ export interface ServerContext {
   /** Public key used for authentication */
   publicKey: string;
 
+  /** User agent from the MCP client's HTTP request */
+  userAgent?: string;
+
   /** In-app-agent-specific MCP authorization state. */
   inAppAgent?: InAppAgentContext;
 }

--- a/web/src/pages/api/public/mcp/index.ts
+++ b/web/src/pages/api/public/mcp/index.ts
@@ -129,6 +129,7 @@ export default async function handler(
       apiKeyId: authCheck.scope.apiKeyId,
       accessLevel: "project",
       publicKey: authCheck.scope.publicKey,
+      userAgent: req.headers["user-agent"],
       inAppAgent: getInAppAgentContext(req, authCheck.scope.isInAppAgentKey),
     };
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the MCP client's `User-Agent` HTTP header to the OpenTelemetry spans generated by MCP tool invocations, enabling better client identification in traces.

- **`types.ts`**: Adds an optional `userAgent?: string` field to `ServerContext`.
- **`index.ts`**: Reads `req.headers["user-agent"]` and stores it on the constructed `ServerContext`.
- **`run-mcp-tool.ts`**: Conditionally spreads the `userAgent` value into span attributes when present.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is additive and read-only — it captures an existing request header and forwards it to tracing spans with no effect on business logic or authentication.

The change only reads a standard HTTP header that is already present in the request and writes it to an OTel span attribute. No existing behavior is modified, and the field is optional throughout, so there is no risk of breakage even when the header is absent.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as MCP Client
    participant Handler as /api/public/mcp
    participant Context as ServerContext
    participant Tool as runMcpTool
    participant Span as OTel Span

    Client->>Handler: HTTP request (User-Agent header)
    Handler->>Handler: authCheck
    Handler->>Context: "Build context (userAgent = req.headers["user-agent"])"
    Handler->>Tool: "runMcpTool({ context, ... })"
    Tool->>Span: "setAttributes({ "user_agent.original": context.userAgent, ... })"
    Tool->>Span: execute fn(span)
    Span-->>Client: Response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as MCP Client
    participant Handler as /api/public/mcp
    participant Context as ServerContext
    participant Tool as runMcpTool
    participant Span as OTel Span

    Client->>Handler: HTTP request (User-Agent header)
    Handler->>Handler: authCheck
    Handler->>Context: "Build context (userAgent = req.headers["user-agent"])"
    Handler->>Tool: "runMcpTool({ context, ... })"
    Tool->>Span: "setAttributes({ "user_agent.original": context.userAgent, ... })"
    Tool->>Span: execute fn(span)
    Span-->>Client: Response
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Use \`user\_agent\` instead of \`user\_agent...."](https://github.com/langfuse/langfuse/commit/35a366e8284f8f1d54bf2db359d594d0211bf8ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44139442)</sub>

<!-- /greptile_comment -->