### PR TITLE
fix(agent): Make user aware of screen context

### DIFF
--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useMemo } from "react";
+import { useRouter } from "next/router";
 import { InAppAgentWindow } from "./InAppAgentWindow";
 import type { InAppAgentWindowConversation } from "./InAppAgentWindow";
 import { useInAppAiAgent } from "./InAppAiAgentProvider";
 import { getDrawerMessages } from "./utils/utils";
+import { getInAppAgentScreenContextDescription } from "@/src/ee/features/in-app-agent/context";
 
 type ControlledInAppAgentWindowBaseProps = {
   isHeaderDragHandleEnabled?: boolean;
@@ -28,6 +30,7 @@ type ControlledInAppAgentWindowProps = ControlledInAppAgentWindowBaseProps &
 export function ControlledInAppAgentWindow(
   props: ControlledInAppAgentWindowProps,
 ) {
+  const router = useRouter();
   const {
     conversations,
     error,
@@ -52,6 +55,9 @@ export function ControlledInAppAgentWindow(
     isSubmitting ||
     isSelectedConversationHydrating ||
     pendingToolApprovals.length > 0;
+  const screenContextDescription = getInAppAgentScreenContextDescription(
+    router.asPath,
+  );
 
   const drawerMessages = useMemo(
     () =>
@@ -77,6 +83,7 @@ export function ControlledInAppAgentWindow(
       isExpanded={props.isExpanded}
       isInputDisabled={isInputDisabled}
       messages={drawerMessages}
+      screenContextDescription={screenContextDescription}
       conversations={conversations}
       hasMoreConversations={hasMoreConversations}
       isLoadingMoreConversations={isLoadingMoreConversations}

--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -55,8 +55,9 @@ export function ControlledInAppAgentWindow(
     isSubmitting ||
     isSelectedConversationHydrating ||
     pendingToolApprovals.length > 0;
-  const screenContextDescription = getInAppAgentScreenContextDescription(
-    router.asPath,
+  const screenContextDescription = useMemo(
+    () => getInAppAgentScreenContextDescription(router.asPath),
+    [router.asPath],
   );
 
   const drawerMessages = useMemo(

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -521,6 +521,7 @@ const meta = preview.meta({
     onExpandedChange: fn(),
     onSubmit: fn(),
     onSubmitFeedback: fn(),
+    screenContextDescription: { type: "page" as const },
     showCloseButton: true,
   },
   render: (args) => <StatefulInAppAgentWindow {...args} />,
@@ -528,6 +529,7 @@ const meta = preview.meta({
 
 export const ToolApprovalRequired = meta.story({
   args: {
+    isAssistantTurnInProgress: true,
     isInputDisabled: true,
     selectedConversationId: "conversation-1",
     messages: [
@@ -573,6 +575,7 @@ export const Empty = meta.story({
 export const Conversation = meta.story({
   args: {
     selectedConversationId: "conversation-1",
+    screenContextDescription: { type: "experimentRun" as const },
     messages: [
       {
         id: "user-1",
@@ -742,7 +745,6 @@ export const Conversation = meta.story({
 export const Streaming = meta.story({
   args: {
     isAssistantTurnInProgress: true,
-    isInputDisabled: true,
     selectedConversationId: "conversation-1",
     messages: streamingSeedMessages,
   },
@@ -752,7 +754,6 @@ export const Streaming = meta.story({
 export const LoadingResponse = meta.story({
   args: {
     isAssistantTurnInProgress: true,
-    isInputDisabled: true,
     messages: [
       {
         id: "user-1",

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -988,7 +988,28 @@ export const RateLimited = meta.story({
   name: "(Test) Rate Limited",
   args: {
     error: null,
-    messages: [],
+    isAssistantTurnInProgress: true,
+    isInputDisabled: true,
+    messages: [
+      {
+        id: "approval-1",
+        role: "assistant",
+        content: {
+          type: "toolGroup",
+          tools: [
+            {
+              type: "tool",
+              name: "langfuse_upsertDataset",
+              args: JSON.stringify({ name: "regression-examples" }),
+              approval: {
+                id: "approval-1",
+                status: "pending",
+              },
+            },
+          ],
+        },
+      },
+    ],
   },
   render: function Render(args) {
     const [retryAt] = useState(() => Date.now() + 12_000);
@@ -1016,14 +1037,15 @@ export const RateLimited = meta.story({
       canvas.getByRole("textbox", { name: "Ask the assistant a question" }),
     ).toBeDisabled();
     await expect(
-      canvas.getByRole("button", { name: "Get started with Langfuse" }),
+      canvas.getByRole("button", { name: "Confirm" }),
     ).toBeDisabled();
+    await expect(canvas.getByRole("button", { name: "Reject" })).toBeDisabled();
     await expect(
       canvas.getByRole("button", { name: "Start new conversation" }),
-    ).toBeEnabled();
+    ).toBeDisabled();
     await expect(
       canvas.getByRole("button", { name: "Conversation history" }),
-    ).toBeEnabled();
+    ).toBeDisabled();
   },
 });
 

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -10,6 +10,7 @@ import {
 import {
   BotMessageSquare,
   History,
+  Info,
   Maximize2,
   Minimize2,
   Minus,
@@ -39,12 +40,14 @@ import {
   type InAppAgentMessageRole,
 } from "./InAppAgentMessage";
 import type { InAppAgentMessageFeedbackValue } from "@/src/ee/features/in-app-agent/schema";
+import type { InAppAgentScreenContextDescription } from "@/src/ee/features/in-app-agent/context";
 import { InAppAgentToolCallCard } from "@/src/ee/features/in-app-agent/components/InAppAgentToolCallCard";
 import {
   type InAppAgentError,
   isInAppAgentRateLimited,
 } from "@/src/ee/features/in-app-agent/components/utils/utils";
 import styles from "./InAppAgentWindow.module.css";
+import { assertUnreachable } from "@/src/utils/types";
 
 const AUTO_SCROLL_THRESHOLD_PX = 50;
 const SCROLL_DIRECTION_TOLERANCE_PX = 1;
@@ -73,6 +76,64 @@ function scrollViewportToBottom(viewport: HTMLDivElement | null) {
     top: viewport.scrollHeight,
     behavior: "auto",
   });
+}
+
+function formatScreenContextNotice(
+  description: InAppAgentScreenContextDescription,
+) {
+  if (description.type === "page") {
+    return "The assistant is aware of your current page.";
+  }
+
+  if (description.type === "observation") {
+    return "The assistant is aware that you're viewing this observation.";
+  }
+
+  if (description.type === "trace") {
+    return "The assistant is aware that you're viewing this trace.";
+  }
+
+  if (description.type === "prompt") {
+    return "The assistant is aware that you're viewing this prompt.";
+  }
+
+  if (description.type === "session") {
+    return "The assistant is aware that you're viewing this session.";
+  }
+
+  if (description.type === "dataset") {
+    return "The assistant is aware that you're viewing this dataset.";
+  }
+
+  if (description.type === "datasetItem") {
+    return "The assistant is aware that you're viewing this dataset item.";
+  }
+
+  if (description.type === "experimentRun") {
+    return "The assistant is aware that you're viewing this experiment run.";
+  }
+
+  if (
+    description.type === "trace-list" ||
+    description.type === "observations-list" ||
+    description.type === "sessions-list" ||
+    description.type === "prompts-list" ||
+    description.type === "datasets-list"
+  ) {
+    const listLabel = {
+      "trace-list": "trace",
+      "observations-list": "observation",
+      "sessions-list": "session",
+      "prompts-list": "prompt",
+      "datasets-list": "dataset",
+    }[description.type];
+
+    return description.hasAppliedFilters
+      ? `The assistant is aware of this ${listLabel} view and its filters.`
+      : `The assistant is aware of this ${listLabel} view.`;
+  }
+
+  return assertUnreachable(description);
 }
 
 export type InAppAgentWindowMessage = {
@@ -123,6 +184,7 @@ export type InAppAgentWindowProps = {
     value: InAppAgentMessageFeedbackValue | null;
     comment?: string | null;
   }) => Promise<void>;
+  screenContextDescription: InAppAgentScreenContextDescription;
   selectedConversationId: string | undefined;
 } & InAppAgentWindowCloseButtonProps;
 
@@ -156,7 +218,7 @@ function InAppAgentRateLimitError({
     <div
       role="alert"
       className={cn(
-        "border-border bg-muted/60 text-foreground rounded-lg border px-2 py-1",
+        "border-border bg-muted/60 text-foreground w-full rounded-lg border px-2 py-1",
         isExpanded ? "text-sm" : "text-xs",
       )}
     >
@@ -211,8 +273,12 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     onSelectConversation,
     onSubmit,
     onSubmitFeedback,
+    screenContextDescription,
     selectedConversationId,
   } = props;
+  const screenContextNotice = formatScreenContextNotice(
+    screenContextDescription,
+  );
   const isRateLimited = isInAppAgentRateLimited(error);
   const isInputDisabled = baseIsInputDisabled || isRateLimited;
   const viewportRef = useRef<HTMLDivElement>(null);
@@ -659,11 +725,42 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
             </div>
           </div>
         ) : null}
-        {error?.type === "rate_limit" && (
+        <div
+          aria-hidden={isAssistantTurnInProgress}
+          className={cn(
+            "flex shrink-0 flex-col overflow-hidden transition-[max-height,opacity] duration-200 ease-out motion-reduce:transition-none",
+            isAssistantTurnInProgress
+              ? "max-h-0 opacity-0"
+              : "max-h-40 opacity-100",
+          )}
+        >
           <div className="p-2">
-            <InAppAgentRateLimitError error={error} isExpanded={isExpanded} />
+            <div
+              className={cn(
+                "flex w-full flex-col gap-1.5",
+                isExpanded && "mx-auto max-w-3xl",
+              )}
+            >
+              <p
+                className={cn(
+                  "border-border bg-muted/60 text-foreground flex w-full items-center gap-1 rounded-lg border px-2 py-1",
+                  isExpanded ? "text-sm" : "text-xs",
+                )}
+              >
+                <Info aria-hidden="true" className="size-3 shrink-0" />
+                <span className="min-w-0 truncate" title={screenContextNotice}>
+                  {screenContextNotice}
+                </span>
+              </p>
+              {error?.type === "rate_limit" && (
+                <InAppAgentRateLimitError
+                  error={error}
+                  isExpanded={isExpanded}
+                />
+              )}
+            </div>
           </div>
-        )}
+        </div>
         {isAssistantTurnInProgress && pendingToolCalls.length === 0 ? (
           <div
             className={cn(

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -752,15 +752,21 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                   {screenContextNotice}
                 </span>
               </p>
-              {error?.type === "rate_limit" && (
-                <InAppAgentRateLimitError
-                  error={error}
-                  isExpanded={isExpanded}
-                />
-              )}
             </div>
           </div>
         </div>
+        {error?.type === "rate_limit" && (
+          <div
+            className={cn(
+              "shrink-0 px-2 pb-2",
+              isAssistantTurnInProgress && "pt-2",
+            )}
+          >
+            <div className={cn(isExpanded && "mx-auto max-w-3xl")}>
+              <InAppAgentRateLimitError error={error} isExpanded={isExpanded} />
+            </div>
+          </div>
+        )}
         {isAssistantTurnInProgress && pendingToolCalls.length === 0 ? (
           <div
             className={cn(

--- a/web/src/ee/features/in-app-agent/context.clienttest.ts
+++ b/web/src/ee/features/in-app-agent/context.clienttest.ts
@@ -1,0 +1,126 @@
+import { getInAppAgentScreenContextDescription } from "./context";
+
+describe("getInAppAgentScreenContextDescription", () => {
+  it.each([
+    {
+      name: "trace detail",
+      url: "/project/project-1/traces/trace-1",
+      expected: { type: "trace" },
+    },
+    {
+      name: "selected observation in a trace",
+      url: "/project/project-1/traces/trace-1?observation=observation-1",
+      expected: { type: "observation" },
+    },
+    {
+      name: "empty observation selection",
+      url: "/project/project-1/traces/trace-1?observation=",
+      expected: { type: "trace" },
+    },
+    {
+      name: "observation peek",
+      url: "/project/project-1/observations?peek=observation-1&traceId=trace-1",
+      expected: { type: "observation" },
+    },
+    {
+      name: "trace peek",
+      url: "/project/project-1/traces?peek=trace-1",
+      expected: { type: "trace" },
+    },
+    {
+      name: "trace list without filters",
+      url: "/project/project-1/traces",
+      expected: { type: "trace-list", hasAppliedFilters: false },
+    },
+    {
+      name: "trace list with structured filters",
+      url: "/project/project-1/traces?filter=level%3BstringOptions%3B%3Bany+of%3BERROR",
+      expected: { type: "trace-list", hasAppliedFilters: true },
+    },
+    {
+      name: "observations list with full-text search",
+      url: "/project/project-1/observations?search=checkout&searchType=id",
+      expected: { type: "observations-list", hasAppliedFilters: true },
+    },
+    {
+      name: "trace setup page",
+      url: "/project/project-1/traces/setup",
+      expected: { type: "page" },
+    },
+    {
+      name: "prompt version",
+      url: "/project/project-1/prompts/folder%2Fcheckout?version=12",
+      expected: {
+        type: "prompt",
+        name: "folder/checkout",
+        selector: { type: "version", value: "12" },
+      },
+    },
+    {
+      name: "prompt label",
+      url: "/project/project-1/prompts/checkout?label=production",
+      expected: {
+        type: "prompt",
+        name: "checkout",
+        selector: { type: "label", value: "production" },
+      },
+    },
+    {
+      name: "prompt metrics",
+      url: "/project/project-1/prompts/folder/checkout/metrics",
+      expected: { type: "prompt", name: "folder/checkout" },
+    },
+    {
+      name: "legacy prompt detail",
+      url: "/project/project-1/prompts/prompt-detail?promptName=checkout",
+      expected: { type: "prompt", name: "checkout" },
+    },
+    {
+      name: "session detail",
+      url: "/project/project-1/sessions/support%2F123",
+      expected: { type: "session", id: "support/123" },
+    },
+    {
+      name: "sessions list",
+      url: "/project/project-1/sessions",
+      expected: { type: "sessions-list", hasAppliedFilters: false },
+    },
+    {
+      name: "prompts list",
+      url: "/project/project-1/prompts?filter=type%3BstringOptions%3B%3D%3Bchat",
+      expected: { type: "prompts-list", hasAppliedFilters: true },
+    },
+    {
+      name: "dataset detail",
+      url: "/project/project-1/datasets/dataset-1/items",
+      expected: { type: "dataset" },
+    },
+    {
+      name: "dataset item detail",
+      url: "/project/project-1/datasets/dataset-1/items/item-1",
+      expected: { type: "datasetItem" },
+    },
+    {
+      name: "experiment run detail",
+      url: "/project/project-1/datasets/dataset-1/runs/run-1",
+      expected: { type: "experimentRun" },
+    },
+    {
+      name: "datasets list",
+      url: "/project/project-1/datasets",
+      expected: { type: "datasets-list", hasAppliedFilters: false },
+    },
+    {
+      name: "unknown project page",
+      url: "/project/project-1/scores",
+      expected: { type: "page" },
+    },
+    {
+      name: "malformed encoded path",
+      url: "/project/project-1/prompts/%E0%A4%A",
+      expected: { type: "page" },
+    },
+  ])("describes $name", ({ url, expected }) => {
+    expect(getInAppAgentScreenContextDescription(url)).toEqual(expected);
+  });
+});

--- a/web/src/ee/features/in-app-agent/context.clienttest.ts
+++ b/web/src/ee/features/in-app-agent/context.clienttest.ts
@@ -23,6 +23,11 @@ describe("getInAppAgentScreenContextDescription", () => {
       expected: { type: "observation" },
     },
     {
+      name: "observation peek in V4 events table",
+      url: "/project/project-1/traces?peek=trace-1&observation=observation-1",
+      expected: { type: "observation" },
+    },
+    {
       name: "trace peek",
       url: "/project/project-1/traces?peek=trace-1",
       expected: { type: "trace" },

--- a/web/src/ee/features/in-app-agent/context.ts
+++ b/web/src/ee/features/in-app-agent/context.ts
@@ -76,7 +76,7 @@ export function getInAppAgentScreenContextDescription(
   );
 
   if (
-    (section === "traces" && detailId && observationId) ||
+    (section === "traces" && observationId && (detailId || peekId)) ||
     (section === "observations" && peekId)
   ) {
     return { type: "observation" };

--- a/web/src/ee/features/in-app-agent/context.ts
+++ b/web/src/ee/features/in-app-agent/context.ts
@@ -2,6 +2,27 @@ import type { AgUiRunAgentInput } from "@/src/ee/features/in-app-agent/schema";
 
 type InAppAgentContext = AgUiRunAgentInput["context"];
 
+export type InAppAgentScreenContextDescription =
+  | { type: "page" }
+  | { type: "observation" }
+  | { type: "trace" }
+  | {
+      type: "prompt";
+      name: string;
+      selector?:
+        | { type: "version"; value: string }
+        | { type: "label"; value: string };
+    }
+  | { type: "session"; id: string }
+  | { type: "dataset" }
+  | { type: "datasetItem" }
+  | { type: "experimentRun" }
+  | { type: "trace-list"; hasAppliedFilters: boolean }
+  | { type: "observations-list"; hasAppliedFilters: boolean }
+  | { type: "sessions-list"; hasAppliedFilters: boolean }
+  | { type: "prompts-list"; hasAppliedFilters: boolean }
+  | { type: "datasets-list"; hasAppliedFilters: boolean };
+
 const CURRENT_URL_CONTEXT_DESCRIPTION = "current_url";
 const MAX_SCREEN_CONTEXT_SEARCH_PARAMS = 30;
 const MAX_CONTEXT_KEY_LENGTH = 80;
@@ -14,6 +35,130 @@ const USER_CONTEXT_DESCRIPTIONS = new Set([
   "current_timezone",
   "browser_languages",
 ]);
+
+export function getInAppAgentScreenContextDescription(
+  currentUrl: string,
+): InAppAgentScreenContextDescription {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(currentUrl, "https://langfuse.local");
+  } catch {
+    return { type: "page" };
+  }
+
+  const rawPathSegments = parsedUrl.pathname.split("/").filter(Boolean);
+  const projectSegmentIndex = rawPathSegments.indexOf("project");
+
+  if (
+    projectSegmentIndex === -1 ||
+    rawPathSegments.length <= projectSegmentIndex + 2
+  ) {
+    return { type: "page" };
+  }
+
+  let routeSegments: string[];
+
+  try {
+    routeSegments = rawPathSegments
+      .slice(projectSegmentIndex + 2)
+      .map((segment) => decodeURIComponent(segment));
+  } catch {
+    return { type: "page" };
+  }
+
+  const section = routeSegments[0];
+  const detailId = routeSegments[1];
+  const peekId = parsedUrl.searchParams.get("peek");
+  const observationId = parsedUrl.searchParams.get("observation");
+  const hasAppliedFilters = ["filter", "search"].some((parameter) =>
+    Boolean(parsedUrl.searchParams.get(parameter)?.trim()),
+  );
+
+  if (
+    (section === "traces" && detailId && observationId) ||
+    (section === "observations" && peekId)
+  ) {
+    return { type: "observation" };
+  }
+
+  if (section === "traces" && ((detailId && detailId !== "setup") || peekId)) {
+    return { type: "trace" };
+  }
+
+  if (section === "traces" && !detailId) {
+    return { type: "trace-list", hasAppliedFilters };
+  }
+
+  if (section === "observations" && !detailId) {
+    return { type: "observations-list", hasAppliedFilters };
+  }
+
+  if (section === "prompts") {
+    const promptPathSegments = routeSegments.slice(1);
+    const isMetricsPage =
+      promptPathSegments[promptPathSegments.length - 1] === "metrics";
+    const promptName = (
+      isMetricsPage ? promptPathSegments.slice(0, -1) : promptPathSegments
+    ).join("/");
+    const legacyPromptName = parsedUrl.searchParams.get("promptName");
+    const resolvedPromptName =
+      promptName === "prompt-detail" ? legacyPromptName : promptName;
+
+    if (resolvedPromptName && resolvedPromptName !== "new") {
+      const version = parsedUrl.searchParams.get("version");
+      const label = parsedUrl.searchParams.get("label");
+
+      if (version && /^\d+$/.test(version)) {
+        return {
+          type: "prompt",
+          name: resolvedPromptName,
+          selector: { type: "version", value: version },
+        };
+      }
+
+      if (label) {
+        return {
+          type: "prompt",
+          name: resolvedPromptName,
+          selector: { type: "label", value: label },
+        };
+      }
+
+      return { type: "prompt", name: resolvedPromptName };
+    }
+
+    if (promptPathSegments.length === 0) {
+      return { type: "prompts-list", hasAppliedFilters };
+    }
+  }
+
+  if (section === "sessions" && detailId) {
+    return { type: "session", id: detailId };
+  }
+
+  if (section === "sessions" && !detailId) {
+    return { type: "sessions-list", hasAppliedFilters };
+  }
+
+  if (section === "datasets" && detailId) {
+    if (routeSegments[2] === "runs" && routeSegments[3]) {
+      return { type: "experimentRun" };
+    }
+
+    if (routeSegments[2] === "items" && routeSegments[3]) {
+      return { type: "datasetItem" };
+    }
+
+    return { type: "dataset" };
+  }
+
+  if (section === "datasets" && !detailId) {
+    return { type: "datasets-list", hasAppliedFilters };
+  }
+
+  return { type: "page" };
+}
 
 export function createInAppAgentScreenContext(params: {
   currentUrl: string;


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a contextual awareness notice to the in-app agent window, informing users which resource (trace, prompt, dataset, etc.) the assistant can see based on the current route. The URL is parsed in `context.ts` into a typed `InAppAgentScreenContextDescription` union, which drives both the UI banner and the TypeScript exhaustiveness check via `assertUnreachable`.

- **New `getInAppAgentScreenContextDescription`**: Parses `router.asPath` into a typed context descriptor, covering traces, observations, prompts (including encoded-slash names and legacy routes), sessions, datasets, experiment runs, and filtered list views. Edge cases like `%E0%A4%A` (malformed encoding), the `setup` pseudo-route, and empty `observation=` params are all guarded and tested.
- **UI notice in `InAppAgentWindow`**: A small info banner is shown below the message list using CSS `max-height`/`opacity` transitions; it is hidden (`aria-hidden`) during active assistant turns to avoid visual noise. The `InAppAgentRateLimitError` receives a `w-full` fix bundled in the same hunk.
- **Story updates**: The `RateLimited` story is corrected to use a pending tool-approval context (matching its disabled-button assertions), and `isInputDisabled: true` is removed from the `Streaming`/`LoadingResponse` stories where it was redundant.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are purely additive UI and URL-parsing logic with no mutations to existing data flows.

The URL parser is well-isolated, defensively guarded with try/catch, and backed by a thorough test matrix including malformed inputs and edge-case routes. The UI change is cosmetic (an info banner that hides during streaming) with no impact on agent logic or data persistence.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["router.asPath"] --> B["getInAppAgentScreenContextDescription(asPath)"]
    B --> C{Parse URL}
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["router.asPath"] --> B["getInAppAgentScreenContextDescription(asPath)"]
    B --> C{Parse URL}
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address PR feedback"](https://github.com/langfuse/langfuse/commit/0a57c91c8c0feeb5fade368b7a202ccb4ea989f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44143138)</sub>

<!-- /greptile_comment -->