### PR TITLE
fix(pricing): price normalized Gemini reasoning tokens

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2810,7 +2810,7 @@
     "modelName": "gemini-2.5-flash",
     "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.5-flash)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
-    "updatedAt": "2026-03-19T00:00:00.000Z",
+    "updatedAt": "2026-07-14T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "cmcnjkfwn000107l43bf5e8ax_tier_default",
@@ -2833,6 +2833,7 @@
           "candidatesTokenCount": 0.0000025,
           "thoughtsTokenCount": 0.0000025,
           "thoughts_token_count": 0.0000025,
+          "output_reasoning_tokens": 0.0000025,
           "output_reasoning": 0.0000025,
           "input_audio_tokens": 0.000001
         }
@@ -2844,7 +2845,7 @@
     "modelName": "gemini-2.5-flash-lite",
     "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.5-flash-lite)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
-    "updatedAt": "2026-06-19T00:00:00.000Z",
+    "updatedAt": "2026-07-14T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "cmcnjkrfa000207l4fpnh5mnv_tier_default",
@@ -2867,6 +2868,7 @@
           "candidatesTokenCount": 4e-7,
           "thoughtsTokenCount": 4e-7,
           "thoughts_token_count": 4e-7,
+          "output_reasoning_tokens": 4e-7,
           "output_reasoning": 4e-7,
           "input_audio_tokens": 3e-7
         }
@@ -3512,7 +3514,7 @@
     "modelName": "gemini-2.5-pro",
     "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.5-pro)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
-    "updatedAt": "2026-03-19T00:00:00.000Z",
+    "updatedAt": "2026-07-14T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "cmig1hb7i000104l72qrzgc6h_tier_default",
@@ -3535,6 +3537,7 @@
           "candidatesTokenCount": 10e-6,
           "thoughtsTokenCount": 10e-6,
           "thoughts_token_count": 10e-6,
+          "output_reasoning_tokens": 10e-6,
           "output_reasoning": 10e-6
         }
       },
@@ -3566,6 +3569,7 @@
           "candidatesTokenCount": 15e-6,
           "thoughtsTokenCount": 15e-6,
           "thoughts_token_count": 15e-6,
+          "output_reasoning_tokens": 15e-6,
           "output_reasoning": 15e-6
         }
       }
@@ -3576,7 +3580,7 @@
     "modelName": "gemini-3-pro-preview",
     "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3-pro-preview)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
-    "updatedAt": "2026-06-10T00:00:00.000Z",
+    "updatedAt": "2026-07-14T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "cmig1wmep000404l7fh6q5uog_tier_default",
@@ -3599,6 +3603,7 @@
           "candidatesTokenCount": 12e-6,
           "thoughtsTokenCount": 12e-6,
           "thoughts_token_count": 12e-6,
+          "output_reasoning_tokens": 12e-6,
           "output_reasoning": 12e-6,
           "grounding_queries": 14e-3,
           "groundingQueries": 14e-3,
@@ -3634,6 +3639,7 @@
           "candidatesTokenCount": 18e-6,
           "thoughtsTokenCount": 18e-6,
           "thoughts_token_count": 18e-6,
+          "output_reasoning_tokens": 18e-6,
           "output_reasoning": 18e-6,
           "grounding_queries": 14e-3,
           "groundingQueries": 14e-3,
@@ -3648,7 +3654,7 @@
     "modelName": "gemini-3.1-pro-preview",
     "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.1-pro-preview(-customtools)?)$",
     "createdAt": "2026-02-19T00:00:00.000Z",
-    "updatedAt": "2026-06-10T00:00:00.000Z",
+    "updatedAt": "2026-07-14T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "55106bba-a5dd-441b-bc0d-5652582b349d_tier_default",
@@ -3671,6 +3677,7 @@
           "candidatesTokenCount": 12e-6,
           "thoughtsTokenCount": 12e-6,
           "thoughts_token_count": 12e-6,
+          "output_reasoning_tokens": 12e-6,
           "output_reasoning": 12e-6,
           "grounding_queries": 14e-3,
           "groundingQueries": 14e-3,
@@ -3706,6 +3713,7 @@
           "candidatesTokenCount": 18e-6,
           "thoughtsTokenCount": 18e-6,
           "thoughts_token_count": 18e-6,
+          "output_reasoning_tokens": 18e-6,
           "output_reasoning": 18e-6,
           "grounding_queries": 14e-3,
           "groundingQueries": 14e-3,
@@ -4278,7 +4286,7 @@
     "modelName": "gemini-3.5-flash",
     "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.5-flash)$",
     "createdAt": "2026-05-20T00:00:00.000Z",
-    "updatedAt": "2026-06-10T00:00:00.000Z",
+    "updatedAt": "2026-07-14T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "6ed696e7-5f3a-4113-a233-019155fb3ff0_tier_default",
@@ -4301,6 +4309,7 @@
           "candidatesTokenCount": 9e-6,
           "thoughtsTokenCount": 9e-6,
           "thoughts_token_count": 9e-6,
+          "output_reasoning_tokens": 9e-6,
           "output_reasoning": 9e-6,
           "grounding_queries": 14e-3,
           "groundingQueries": 14e-3,
@@ -4315,7 +4324,7 @@
     "modelName": "gemini-3-flash-preview",
     "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3-flash-preview)$",
     "createdAt": "2025-12-21T12:01:42.282Z",
-    "updatedAt": "2026-06-10T00:00:00.000Z",
+    "updatedAt": "2026-07-14T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "cmjfoeykl000004l8ffzra8c7_tier_default",
@@ -4338,6 +4347,7 @@
           "candidatesTokenCount": 3e-6,
           "thoughtsTokenCount": 3e-6,
           "thoughts_token_count": 3e-6,
+          "output_reasoning_tokens": 3e-6,
           "output_reasoning": 3e-6,
           "grounding_queries": 14e-3,
           "groundingQueries": 14e-3,
@@ -4352,7 +4362,7 @@
     "modelName": "gemini-3.1-flash-lite",
     "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.1-flash-lite)$",
     "createdAt": "2026-05-20T00:00:00.000Z",
-    "updatedAt": "2026-06-10T00:00:00.000Z",
+    "updatedAt": "2026-07-14T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "79f4d62c-22fb-4ec3-82e1-6e56cdd5e23c_tier_default",
@@ -4375,6 +4385,7 @@
           "candidatesTokenCount": 1.5e-6,
           "thoughtsTokenCount": 1.5e-6,
           "thoughts_token_count": 1.5e-6,
+          "output_reasoning_tokens": 1.5e-6,
           "output_reasoning": 1.5e-6,
           "input_audio_tokens": 0.5e-6,
           "grounding_queries": 14e-3,
@@ -4390,7 +4401,7 @@
     "modelName": "gemini-3.1-flash-lite-preview",
     "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.1-flash-lite-preview)$",
     "createdAt": "2026-03-03T00:00:00.000Z",
-    "updatedAt": "2026-06-10T00:00:00.000Z",
+    "updatedAt": "2026-07-14T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "0707bef8-10c8-46e2-a871-0436f05f0b92_tier_default",
@@ -4413,6 +4424,7 @@
           "candidatesTokenCount": 1.5e-6,
           "thoughtsTokenCount": 1.5e-6,
           "thoughts_token_count": 1.5e-6,
+          "output_reasoning_tokens": 1.5e-6,
           "output_reasoning": 1.5e-6,
           "input_audio_tokens": 0.5e-6,
           "grounding_queries": 14e-3,


### PR DESCRIPTION
## What changed

- Add `output_reasoning_tokens` pricing aliases to Gemini models that already price `output_reasoning`.
- Keep each alias at the existing reasoning/output token rate across Standard and Large Context tiers.
- Refresh the affected model entries' `updatedAt` timestamps.

## Why

OTel usage normalization emits reasoning usage as `output_reasoning_tokens`. Cost calculation only prices exact usage-detail keys, while several Gemini pricing tiers only exposed `output_reasoning`. Those normalized reasoning tokens were therefore omitted from calculated cost for affected integrations.

This is intentionally limited to alias coverage: it does not change Gemini price values, model matching, service-tier handling, or ingestion behavior.

Related to LFE-10228 and #14144.

## Impact

Reasoning tokens emitted under the canonical normalized key are now priced at the same rate as the existing Gemini reasoning/output aliases.

## Verification

- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
  - `Validated 162 pricing entries in worker/src/constants/default-model-prices.json.`
- `pnpm --filter worker run test pricing-tier-matcher.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  52 passed (52)`
- `pnpm run lint`
  - `Tasks: 7 successful, 7 total`
- Pre-commit formatting
  - `All matched files use Prettier code style!`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `output_reasoning_tokens` as a pricing alias alongside the existing `output_reasoning` key for eight Gemini models (gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3.1-pro-preview, gemini-3.5-flash, gemini-3-flash-preview, gemini-3.1-flash-lite, and gemini-3.1-flash-lite-preview). This fixes a silent cost-calculation gap where OTel-normalized reasoning tokens emitted under `output_reasoning_tokens` were not priced because the Gemini pricing tiers only exposed the `output_reasoning` key.

- All affected pricing tiers (both Standard and Large Context where applicable) receive the new alias at the same rate as the existing `output_reasoning` entry — no price values changed.
- `updatedAt` timestamps are refreshed to the PR date across all eight model entries.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Additive-only pricing configuration change; no existing prices or tier structures were modified.

The change is mechanical and easily verifiable: every `output_reasoning` key across all affected Gemini tiers now has a matching `output_reasoning_tokens` alias at the same rate. The validation script confirmed 162 entries pass, the pricing-tier matcher tests all pass, and no existing pricing values were modified. No Gemini model with reasoning capabilities appears to have been overlooked.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OTel normalized usage event] --> B{Token type?}
    B -->|output_reasoning_tokens| C[Look up pricing key in tier]
    B -->|output_reasoning| C
    B -->|thoughtsTokenCount| C
    B -->|thoughts_token_count| C
    C --> D{Key found in prices map?}
    D -->|Yes - after this PR| E[Apply price × token count]
    D -->|No - before this PR for output_reasoning_tokens| F[Token cost = 0, silently omitted]
    E --> G[Add to trace cost]
    F --> H[Underreported cost in Langfuse]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[OTel normalized usage event] --> B{Token type?}
    B -->|output_reasoning_tokens| C[Look up pricing key in tier]
    B -->|output_reasoning| C
    B -->|thoughtsTokenCount| C
    B -->|thoughts_token_count| C
    C --> D{Key found in prices map?}
    D -->|Yes - after this PR| E[Apply price × token count]
    D -->|No - before this PR for output_reasoning_tokens| F[Token cost = 0, silently omitted]
    E --> G[Add to trace cost]
    F --> H[Underreported cost in Langfuse]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing): price normalized Gemini re..."](https://github.com/langfuse/langfuse/commit/bee209b49bbaf43cd2d1ae47f9d7c541dafa9adc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44150424)</sub>

<!-- /greptile_comment -->