### PR TITLE
fix(worker): stream core data S3 exports with keyset pagination

### DIFF
--- a/packages/shared/src/server/redis/dataRetentionQueue.ts
+++ b/packages/shared/src/server/redis/dataRetentionQueue.ts
@@ -35,25 +35,12 @@ export class DataRetentionQueue {
 
     if (DataRetentionQueue.instance) {
       logger.debug("Scheduling jobs for DataRetentionQueue");
-      // Remove the old 3:15am cron pattern - BullMQ keys repeatable jobs by
-      // name + pattern, so changing the pattern creates a second schedule
-      // while the old one keeps firing.
-      DataRetentionQueue.instance
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- Existing repeatable-job cleanup; job scheduler migration should be handled separately.
-        .removeRepeatable(QueueJobs.DataRetentionJob, {
-          pattern: "15 3 * * *",
-        })
-        .catch((err) => {
-          logger.error("Error removing legacy DataRetentionJob schedule", err);
-        });
       DataRetentionQueue.instance
         .add(
           QueueJobs.DataRetentionJob,
           {},
           {
-            // every day at 2:45am, 30min before the core data S3 export to
-            // avoid contending for the same worker postgres connection pools
-            repeat: { pattern: "45 2 * * *" },
+            repeat: { pattern: "15 3 * * *" }, // every day at 3:15am
           },
         )
         .catch((err) => {

--- a/packages/shared/src/server/redis/dataRetentionQueue.ts
+++ b/packages/shared/src/server/redis/dataRetentionQueue.ts
@@ -35,12 +35,25 @@ export class DataRetentionQueue {
 
     if (DataRetentionQueue.instance) {
       logger.debug("Scheduling jobs for DataRetentionQueue");
+      // Remove the old 3:15am cron pattern - BullMQ keys repeatable jobs by
+      // name + pattern, so changing the pattern creates a second schedule
+      // while the old one keeps firing.
+      DataRetentionQueue.instance
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- Existing repeatable-job cleanup; job scheduler migration should be handled separately.
+        .removeRepeatable(QueueJobs.DataRetentionJob, {
+          pattern: "15 3 * * *",
+        })
+        .catch((err) => {
+          logger.error("Error removing legacy DataRetentionJob schedule", err);
+        });
       DataRetentionQueue.instance
         .add(
           QueueJobs.DataRetentionJob,
           {},
           {
-            repeat: { pattern: "15 3 * * *" }, // every day at 3:15am
+            // every day at 2:45am, 30min before the core data S3 export to
+            // avoid contending for the same worker postgres connection pools
+            repeat: { pattern: "45 2 * * *" },
           },
         )
         .catch((err) => {

--- a/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
+++ b/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
@@ -3,7 +3,7 @@ import { Readable } from "node:stream";
 import { type StorageService } from "@langfuse/shared/src/server";
 import {
   mapUserToCoreDataRow,
-  uploadPromptsCoreDataJsonl,
+  uploadTableCoreDataJsonl,
 } from "../coreDataS3ExportQueue";
 
 const readStream = async (stream: Readable): Promise<string> => {
@@ -48,73 +48,150 @@ describe("mapUserToCoreDataRow", () => {
   });
 });
 
-describe("coreDataS3ExportQueue", () => {
-  it("streams prompt core data in pages", async () => {
+describe("uploadTableCoreDataJsonl", () => {
+  const createS3Client = (
+    uploadFileBuffered: ReturnType<typeof vi.fn>,
+  ): StorageService => ({ uploadFileBuffered }) as unknown as StorageService;
+
+  it("streams table rows in keyset pages", async () => {
     const createdAt = new Date("2026-05-14T00:00:00.000Z");
-    const updatedAt = new Date("2026-05-14T01:00:00.000Z");
-    const pages = [
-      [
-        {
-          id: "prompt-1",
-          name: "first",
-          projectId: "project-1",
-          createdAt,
-          updatedAt,
-        },
-        {
-          id: "prompt-2",
-          name: "second",
-          projectId: "project-1",
-          createdAt,
-          updatedAt,
-        },
-      ],
-      [
-        {
-          id: "prompt-3",
-          name: "third",
-          projectId: "project-2",
-          createdAt,
-          updatedAt,
-        },
-      ],
+    const rows = [
+      { id: "row-1", name: "first", createdAt },
+      { id: "row-2", name: "second", createdAt },
+      { id: "row-3", name: "third", createdAt },
     ];
 
-    const fetchPromptPage = vi.fn(async ({ skip }: { skip: number }) => {
-      return pages[Math.floor(skip / 2)] ?? [];
-    });
+    const fetchPage = vi.fn(
+      async ({ lastRow }: { lastRow: { id: string } | null; take: number }) => {
+        if (lastRow === null) return rows.slice(0, 2);
+        if (lastRow.id === "row-2") return rows.slice(2);
+        return [];
+      },
+    );
 
     const uploadFileBuffered = vi.fn(async ({ data }: { data: Readable }) => {
       expect(await readStream(data)).toBe(
-        [
-          JSON.stringify(pages[0][0]),
-          JSON.stringify(pages[0][1]),
-          JSON.stringify(pages[1][0]),
-        ].join("\n"),
+        rows.map((row) => JSON.stringify(row)).join("\n"),
       );
     });
 
-    const s3Client = {
-      uploadFileBuffered,
-    } as unknown as StorageService;
-
-    await uploadPromptsCoreDataJsonl({
-      s3Client,
+    await uploadTableCoreDataJsonl({
+      s3Client: createS3Client(uploadFileBuffered),
       uploadPrefix: "core/",
+      tableName: "rows",
       pageSize: 2,
-      fetchPromptPage,
+      fetchPage,
     });
 
-    expect(fetchPromptPage).toHaveBeenCalledTimes(2);
-    expect(fetchPromptPage).toHaveBeenNthCalledWith(1, { skip: 0, take: 2 });
-    expect(fetchPromptPage).toHaveBeenNthCalledWith(2, { skip: 2, take: 2 });
+    // The second page is short, so pagination stops without a third fetch.
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(fetchPage).toHaveBeenNthCalledWith(1, { lastRow: null, take: 2 });
+    expect(fetchPage).toHaveBeenNthCalledWith(2, { lastRow: rows[1], take: 2 });
     expect(uploadFileBuffered).toHaveBeenCalledTimes(1);
     expect(uploadFileBuffered).toHaveBeenCalledWith(
       expect.objectContaining({
-        fileName: "core/prompts.jsonl",
+        fileName: "core/rows.jsonl",
         fileType: "application/x-ndjson",
         partSizeBytes: 100 * 1024 * 1024,
       }),
     );
+  });
+
+  it("stops after a full page that is followed by an empty page", async () => {
+    const rows = [{ id: "row-1" }, { id: "row-2" }];
+
+    const fetchPage = vi.fn(
+      async ({ lastRow }: { lastRow: { id: string } | null; take: number }) =>
+        lastRow === null ? rows : [],
+    );
+
+    const uploadFileBuffered = vi.fn(async ({ data }: { data: Readable }) => {
+      expect(await readStream(data)).toBe(
+        rows.map((row) => JSON.stringify(row)).join("\n"),
+      );
+    });
+
+    await uploadTableCoreDataJsonl({
+      s3Client: createS3Client(uploadFileBuffered),
+      uploadPrefix: "core/",
+      tableName: "rows",
+      pageSize: 2,
+      fetchPage,
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(fetchPage).toHaveBeenNthCalledWith(2, { lastRow: rows[1], take: 2 });
+  });
+
+  it("applies mapRow to every row", async () => {
+    const fetchPage = vi.fn(
+      async ({ lastRow }: { lastRow: { id: string } | null; take: number }) =>
+        lastRow === null
+          ? [
+              { id: "user-1", password: "secret", accounts: [] },
+              {
+                id: "user-2",
+                password: null,
+                accounts: [{ provider: "google" }],
+              },
+            ]
+          : [],
+    );
+
+    const uploadFileBuffered = vi.fn(async ({ data }: { data: Readable }) => {
+      expect(await readStream(data)).toBe(
+        [
+          JSON.stringify({ id: "user-1", authMethods: ["credentials"] }),
+          JSON.stringify({ id: "user-2", authMethods: ["google"] }),
+        ].join("\n"),
+      );
+    });
+
+    await uploadTableCoreDataJsonl({
+      s3Client: createS3Client(uploadFileBuffered),
+      uploadPrefix: "core/",
+      tableName: "users",
+      pageSize: 2,
+      fetchPage,
+      mapRow: mapUserToCoreDataRow,
+    });
+  });
+
+  it("uploads an empty file for tables without rows", async () => {
+    const fetchPage = vi.fn(async () => []);
+
+    const uploadFileBuffered = vi.fn(async ({ data }: { data: Readable }) => {
+      expect(await readStream(data)).toBe("");
+    });
+
+    await uploadTableCoreDataJsonl({
+      s3Client: createS3Client(uploadFileBuffered),
+      uploadPrefix: "core/",
+      tableName: "empty",
+      fetchPage,
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(uploadFileBuffered).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows upload failures after logging the table context", async () => {
+    const fetchPage = vi.fn(
+      async ({ lastRow }: { lastRow: { id: string } | null; take: number }) =>
+        lastRow === null ? [{ id: "row-1" }] : [],
+    );
+
+    const uploadFileBuffered = vi.fn(async () => {
+      throw new Error("upload failed");
+    });
+
+    await expect(
+      uploadTableCoreDataJsonl({
+        s3Client: createS3Client(uploadFileBuffered),
+        uploadPrefix: "core/",
+        tableName: "rows",
+        fetchPage,
+      }),
+    ).rejects.toThrow("upload failed");
   });
 });

--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -1,5 +1,6 @@
 import { Processor } from "bullmq";
 import { Readable } from "node:stream";
+import pLimit from "p-limit";
 import {
   logger,
   StorageServiceFactory,
@@ -8,8 +9,13 @@ import {
 import { prisma } from "@langfuse/shared/src/db";
 import { env } from "../env";
 
-const PROMPT_EXPORT_PAGE_SIZE = 1_000;
-const PROMPT_EXPORT_PART_SIZE_BYTES = 100 * 1024 * 1024;
+const CORE_DATA_EXPORT_PAGE_SIZE = 1_000;
+const CORE_DATA_EXPORT_PART_SIZE_BYTES = 100 * 1024 * 1024;
+// Each table export holds at most one postgres connection at a time (short
+// keyset page queries). Keep this below the worker's Prisma pool size
+// (default: 5 connections) so other queue jobs on the same worker never
+// starve on connection acquisition.
+const CORE_DATA_EXPORT_TABLE_CONCURRENCY = 3;
 
 let s3StorageServiceClient: StorageService;
 
@@ -50,251 +56,405 @@ export const mapUserToCoreDataRow = ({
   ],
 });
 
-type PromptCoreData = {
-  id: string;
-  name: string;
-  projectId: string;
-  createdAt: Date;
-  updatedAt: Date;
+type TablePageArgs<TCursor> = {
+  lastRow: TCursor | null;
+  take: number;
 };
 
-type FetchPromptPage = (args: {
-  skip: number;
+type FetchTablePage<TRow> = (args: {
+  lastRow: TRow | null;
   take: number;
-}) => Promise<PromptCoreData[]>;
+}) => Promise<TRow[]>;
 
-async function* createPromptJsonlStream({
-  fetchPromptPage,
+async function* createTableJsonlStream<TRow>({
+  fetchPage,
+  mapRow,
   pageSize,
+  onPage,
 }: {
-  fetchPromptPage: FetchPromptPage;
+  fetchPage: FetchTablePage<TRow>;
+  mapRow?: (row: TRow) => unknown;
   pageSize: number;
+  onPage?: (pageRowCount: number) => void;
 }): AsyncGenerator<string> {
-  let skip = 0;
+  let lastRow: TRow | null = null;
   let isFirstRow = true;
 
   while (true) {
-    const prompts = await fetchPromptPage({ skip, take: pageSize });
+    const rows = await fetchPage({ lastRow, take: pageSize });
 
-    if (prompts.length === 0) {
+    if (rows.length === 0) {
       break;
     }
 
-    for (const prompt of prompts) {
-      yield `${isFirstRow ? "" : "\n"}${JSON.stringify(prompt)}`;
+    for (const row of rows) {
+      yield `${isFirstRow ? "" : "\n"}${JSON.stringify(mapRow ? mapRow(row) : row)}`;
       isFirstRow = false;
     }
 
-    if (prompts.length < pageSize) {
+    onPage?.(rows.length);
+
+    if (rows.length < pageSize) {
       break;
     }
 
-    skip += prompts.length;
+    lastRow = rows[rows.length - 1];
   }
 }
 
-export const uploadPromptsCoreDataJsonl = async ({
+// Streams a table to S3 as JSONL via keyset pagination so memory usage stays
+// O(page size) regardless of table size and no postgres connection is held
+// across pages. `fetchPage` must return rows in a stable unique order,
+// resuming strictly after `lastRow`.
+export const uploadTableCoreDataJsonl = async <TRow>({
   s3Client,
   uploadPrefix,
-  pageSize = PROMPT_EXPORT_PAGE_SIZE,
-  fetchPromptPage = (args) =>
-    prisma.prompt.findMany({
-      ...args,
-      orderBy: { id: "asc" },
-      select: {
-        id: true,
-        name: true,
-        projectId: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    }),
+  tableName,
+  fetchPage,
+  mapRow,
+  pageSize = CORE_DATA_EXPORT_PAGE_SIZE,
 }: {
   s3Client: StorageService;
   uploadPrefix: string;
+  tableName: string;
+  fetchPage: FetchTablePage<TRow>;
+  mapRow?: (row: TRow) => unknown;
   pageSize?: number;
-  fetchPromptPage?: FetchPromptPage;
 }): Promise<void> => {
-  await s3Client.uploadFileBuffered({
-    fileName: `${uploadPrefix}prompts.jsonl`,
-    fileType: "application/x-ndjson",
-    data: Readable.from(createPromptJsonlStream({ fetchPromptPage, pageSize })),
-    partSizeBytes: PROMPT_EXPORT_PART_SIZE_BYTES,
-  });
+  logger.info(`[CORE DATA] Exporting table ${tableName}`);
+
+  let rowCount = 0;
+
+  try {
+    await s3Client.uploadFileBuffered({
+      fileName: `${uploadPrefix}${tableName}.jsonl`,
+      fileType: "application/x-ndjson",
+      data: Readable.from(
+        createTableJsonlStream({
+          fetchPage,
+          mapRow,
+          pageSize,
+          onPage: (pageRowCount) => {
+            rowCount += pageRowCount;
+          },
+        }),
+      ),
+      partSizeBytes: CORE_DATA_EXPORT_PART_SIZE_BYTES,
+    });
+  } catch (error) {
+    logger.error(
+      `[CORE DATA] Export of table ${tableName} failed after ${rowCount} rows`,
+      error,
+    );
+    throw error;
+  }
+
+  logger.info(`[CORE DATA] Finished table ${tableName} (${rowCount} rows)`);
 };
+
+// One entry per exported table. The tableName doubles as the S3 object base
+// name — keep names stable, downstream DWH consumers depend on them.
+const coreDataTableExports: Array<
+  (args: { s3Client: StorageService; uploadPrefix: string }) => Promise<void>
+> = [
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "projects",
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ id: string }>) =>
+        prisma.project.findMany({
+          take,
+          ...(lastRow ? { cursor: { id: lastRow.id }, skip: 1 } : {}),
+          orderBy: { id: "asc" },
+          select: {
+            id: true,
+            name: true,
+            orgId: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "users",
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ id: string }>) =>
+        prisma.user.findMany({
+          take,
+          ...(lastRow ? { cursor: { id: lastRow.id }, skip: 1 } : {}),
+          orderBy: { id: "asc" },
+          select: {
+            id: true,
+            name: true,
+            admin: true,
+            email: true,
+            featureFlags: true,
+            v4BetaEnabled: true,
+            createdAt: true,
+            updatedAt: true,
+            // password and accounts are mapped to authMethods below and must
+            // not be exported as-is
+            password: true,
+            accounts: {
+              select: {
+                provider: true,
+              },
+            },
+          },
+        }),
+      mapRow: mapUserToCoreDataRow,
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "organizations",
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ id: string }>) =>
+        prisma.organization.findMany({
+          take,
+          ...(lastRow ? { cursor: { id: lastRow.id }, skip: 1 } : {}),
+          orderBy: { id: "asc" },
+          select: {
+            id: true,
+            name: true,
+            cloudConfig: true,
+            sfdcOrgId: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "orgMemberships",
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ id: string }>) =>
+        prisma.organizationMembership.findMany({
+          take,
+          ...(lastRow ? { cursor: { id: lastRow.id }, skip: 1 } : {}),
+          orderBy: { id: "asc" },
+          select: {
+            id: true,
+            role: true,
+            orgId: true,
+            userId: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "projectMemberships",
+      fetchPage: ({
+        lastRow,
+        take,
+      }: TablePageArgs<{ projectId: string; userId: string }>) =>
+        prisma.projectMembership.findMany({
+          take,
+          ...(lastRow
+            ? {
+                cursor: {
+                  projectId_userId: {
+                    projectId: lastRow.projectId,
+                    userId: lastRow.userId,
+                  },
+                },
+                skip: 1,
+              }
+            : {}),
+          orderBy: [{ projectId: "asc" }, { userId: "asc" }],
+          select: {
+            role: true,
+            projectId: true,
+            userId: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "billingMeterBackup",
+      fetchPage: ({
+        lastRow,
+        take,
+      }: TablePageArgs<{
+        stripeCustomerId: string;
+        meterId: string;
+        startTime: Date;
+        endTime: Date;
+      }>) =>
+        prisma.billingMeterBackup.findMany({
+          take,
+          ...(lastRow
+            ? {
+                cursor: {
+                  stripeCustomerId_meterId_startTime_endTime: {
+                    stripeCustomerId: lastRow.stripeCustomerId,
+                    meterId: lastRow.meterId,
+                    startTime: lastRow.startTime,
+                    endTime: lastRow.endTime,
+                  },
+                },
+                skip: 1,
+              }
+            : {}),
+          orderBy: [
+            { stripeCustomerId: "asc" },
+            { meterId: "asc" },
+            { startTime: "asc" },
+            { endTime: "asc" },
+          ],
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "surveys",
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ id: string }>) =>
+        prisma.survey.findMany({
+          take,
+          ...(lastRow ? { cursor: { id: lastRow.id }, skip: 1 } : {}),
+          orderBy: { id: "asc" },
+          select: {
+            id: true,
+            surveyName: true,
+            response: true,
+            userId: true,
+            userEmail: true,
+            orgId: true,
+            createdAt: true,
+          },
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "blobStorageIntegrations",
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ projectId: string }>) =>
+        prisma.blobStorageIntegration.findMany({
+          take,
+          ...(lastRow
+            ? { cursor: { projectId: lastRow.projectId }, skip: 1 }
+            : {}),
+          orderBy: { projectId: "asc" },
+          select: {
+            projectId: true,
+            type: true,
+            bucketName: true,
+            prefix: true,
+            region: true,
+            endpoint: true,
+            forcePathStyle: true,
+            nextSyncAt: true,
+            lastSyncAt: true,
+            enabled: true,
+            exportFrequency: true,
+            fileType: true,
+            exportMode: true,
+            exportStartDate: true,
+            exportSource: true,
+            exportFieldGroups: true,
+            compressed: true,
+            lastError: true,
+            lastErrorAt: true,
+            lastFailureNotificationSentAt: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "ssoConfigs",
+      // authConfig is excluded as it may contain client secrets
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ domain: string }>) =>
+        prisma.ssoConfig.findMany({
+          take,
+          ...(lastRow ? { cursor: { domain: lastRow.domain }, skip: 1 } : {}),
+          orderBy: { domain: "asc" },
+          select: {
+            domain: true,
+            authProvider: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "verifiedDomains",
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ id: string }>) =>
+        prisma.verifiedDomain.findMany({
+          take,
+          ...(lastRow ? { cursor: { id: lastRow.id }, skip: 1 } : {}),
+          orderBy: { id: "asc" },
+          select: {
+            id: true,
+            organizationId: true,
+            domain: true,
+            verifiedAt: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "prompts",
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ id: string }>) =>
+        prisma.prompt.findMany({
+          take,
+          ...(lastRow ? { cursor: { id: lastRow.id }, skip: 1 } : {}),
+          orderBy: { id: "asc" },
+          select: {
+            id: true,
+            name: true,
+            projectId: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        }),
+    }),
+];
 
 export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
   if (!env.LANGFUSE_S3_CORE_DATA_UPLOAD_BUCKET) {
-    logger.error("No bucket name provided for core data S3 export");
+    logger.error("[CORE DATA] No bucket name provided for core data S3 export");
     throw new Error(
       "Must provide LANGFUSE_S3_CORE_DATA_UPLOAD_BUCKET to use core data S3 exports",
     );
   }
 
-  logger.info("Starting core data S3 export");
+  logger.info("[CORE DATA] Starting core data S3 export");
 
   const s3Client = getS3StorageServiceClient(
     env.LANGFUSE_S3_CORE_DATA_UPLOAD_BUCKET,
   );
+  const uploadPrefix = env.LANGFUSE_S3_CORE_DATA_UPLOAD_PREFIX;
 
-  // Fetch table data
-  const [
-    projects,
-    usersWithAuthData,
-    organizations,
-    orgMemberships,
-    projectMemberships,
-    billingMeterBackup,
-    surveys,
-    blobStorageIntegrations,
-    ssoConfigs,
-    verifiedDomains,
-  ] = await Promise.all([
-    prisma.project.findMany({
-      select: {
-        id: true,
-        name: true,
-        orgId: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    }),
-    prisma.user.findMany({
-      select: {
-        id: true,
-        name: true,
-        admin: true,
-        email: true,
-        featureFlags: true,
-        v4BetaEnabled: true,
-        createdAt: true,
-        updatedAt: true,
-        // password and accounts are mapped to authMethods below and must not
-        // be exported as-is
-        password: true,
-        accounts: {
-          select: {
-            provider: true,
-          },
-        },
-      },
-    }),
-    prisma.organization.findMany({
-      select: {
-        id: true,
-        name: true,
-        cloudConfig: true,
-        sfdcOrgId: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    }),
-    prisma.organizationMembership.findMany({
-      select: {
-        id: true,
-        role: true,
-        orgId: true,
-        userId: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    }),
-    prisma.projectMembership.findMany({
-      select: {
-        role: true,
-        projectId: true,
-        userId: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    }),
-    prisma.billingMeterBackup.findMany(),
-    prisma.survey.findMany({
-      select: {
-        id: true,
-        surveyName: true,
-        response: true,
-        userId: true,
-        userEmail: true,
-        orgId: true,
-        createdAt: true,
-      },
-    }),
-    prisma.blobStorageIntegration.findMany({
-      select: {
-        projectId: true,
-        type: true,
-        bucketName: true,
-        prefix: true,
-        region: true,
-        endpoint: true,
-        forcePathStyle: true,
-        nextSyncAt: true,
-        lastSyncAt: true,
-        enabled: true,
-        exportFrequency: true,
-        fileType: true,
-        exportMode: true,
-        exportStartDate: true,
-        exportSource: true,
-        exportFieldGroups: true,
-        compressed: true,
-        lastError: true,
-        lastErrorAt: true,
-        lastFailureNotificationSentAt: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    }),
-    // authConfig is excluded as it may contain client secrets
-    prisma.ssoConfig.findMany({
-      select: {
-        domain: true,
-        authProvider: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    }),
-    prisma.verifiedDomain.findMany({
-      select: {
-        id: true,
-        organizationId: true,
-        domain: true,
-        verifiedAt: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    }),
-  ]);
-
-  const users = usersWithAuthData.map(mapUserToCoreDataRow);
-
-  // Iterate through the tables and upload them to S3 as JSONLs
-  await Promise.all(
-    Object.entries({
-      projects,
-      users,
-      organizations,
-      orgMemberships,
-      projectMemberships,
-      billingMeterBackup,
-      surveys,
-      blobStorageIntegrations,
-      ssoConfigs,
-      verifiedDomains,
-    }).map(async ([key, value]) =>
-      s3Client.uploadFile({
-        fileName: `${env.LANGFUSE_S3_CORE_DATA_UPLOAD_PREFIX}${key}.jsonl`,
-        fileType: "application/x-ndjson",
-        data: value.map((item) => JSON.stringify(item)).join("\n"),
-      }),
+  const limit = pLimit(CORE_DATA_EXPORT_TABLE_CONCURRENCY);
+  const results = await Promise.allSettled(
+    coreDataTableExports.map((exportTable) =>
+      limit(() => exportTable({ s3Client, uploadPrefix })),
     ),
   );
 
-  await uploadPromptsCoreDataJsonl({
-    s3Client,
-    uploadPrefix: env.LANGFUSE_S3_CORE_DATA_UPLOAD_PREFIX,
-  });
+  const failures = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failures.length > 0) {
+    logger.error(
+      `[CORE DATA] Core data S3 export failed for ${failures.length} of ${results.length} tables`,
+    );
+    throw failures[0].reason;
+  }
 
-  logger.info("Finished core data S3 export");
+  logger.info("[CORE DATA] Finished core data S3 export");
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the all-at-once in-memory fetch (`Promise.all` + `findMany` for every table) with a keyset-paginated streaming export: each table is streamed in 1,000-row pages via an `AsyncGenerator`, uploaded to S3 with `uploadFileBuffered`, and run with `pLimit(3)` concurrency so the Prisma pool stays available to other worker jobs. The `DataRetentionJob` cron is shifted from 3:15 am to 2:45 am to avoid competing for the same connections.

- **Keyset pagination (`createTableJsonlStream`)**: uses `cursor + skip: 1` on a stable `orderBy: { id: \"asc\" }` (or composite key) per table; memory footprint is now O(page size) instead of O(table size).
- **Concurrency and error handling**: `Promise.allSettled` lets all 11 tables attempt export even if one fails; failures are counted and logged, though only the first error is re-thrown.
- **Schedule migration**: `removeRepeatable(\"15 3 * * *\")` fires async on first queue instantiation to clean up the old BullMQ key before installing the new `\"45 2 * * *\"` pattern.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core pagination logic is correct and well-tested, with two minor quality gaps worth addressing in a follow-up.

The keyset streaming implementation is correct and the tests cover all meaningful edge cases (empty tables, full pages, partial last pages, error propagation). Two gaps remain: when multiple table exports fail simultaneously only the first error is rethrown, and `billingMeterBackup` is the only table without an explicit `select`, leaving it exposed to future schema additions that could silently widen the export surface.

The failure-aggregation block in `coreDataS3ExportProcessor` (around the `failures[0].reason` throw) and the `billingMeterBackup` `fetchPage` definition both deserve a second look before the next schema change or alerting integration lands.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/queues/coreDataS3ExportQueue.ts:449-457
**Only first failure re-thrown; others silently dropped**

When multiple table exports fail, `failures[0].reason` is thrown but the remaining errors are not surfaced beyond the count in the aggregate log. BullMQ will retry the job with only that one error visible in the retry payload, and the root causes of the other failures are lost (per-table `logger.error` lines still fire, but the thrown error aggregates nothing). Consider throwing an `AggregateError(failures.map((f) => f.reason), ...)` so all failure reasons are preserved in the retry / alerting context.

### Issue 2 of 2
worker/src/queues/coreDataS3ExportQueue.ts:277-312
**`billingMeterBackup` fetches all columns — no `select` guard**

Every other table export uses an explicit `select` to control which columns are exported and to deliberately exclude sensitive fields (e.g., `password`, `authConfig`). The `billingMeterBackup` entry omits `select` entirely, so any column added to that model in the future will appear in the S3 export without a conscious decision to include it. Aligning this with the other tables by adding an explicit `select` would make the exported surface area intentional and safe across schema changes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: revert retention queue settings"](https://github.com/langfuse/langfuse/commit/faa5893ade395c9c605f4842665dc94c938e4f01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44154992)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->