### PR TITLE
feat(blobstorage): auto-disable export on outbound-URL/SSRF validation rejections (LFE-10927)

### DIFF
--- a/packages/shared/src/server/services/blobStorageEndpointValidation.test.ts
+++ b/packages/shared/src/server/services/blobStorageEndpointValidation.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { OutboundUrlValidationError, parseOutboundUrl } from "../outbound-url";
+import { validateBlobStorageEndpoint } from "./blobStorageEndpointValidation";
+
+// Non-empty whitelist turns on validation in a non-cloud (DEV) deployment; the
+// entries are an *allow* list, so an endpoint outside them is still checked.
+const enablingWhitelist = { hosts: [], ips: [], ip_ranges: ["203.0.113.0/24"] };
+
+describe("outbound-url validation error typing", () => {
+  it("parseOutboundUrl throws a typed error with a specific code", () => {
+    try {
+      parseOutboundUrl("http://user:pass@example.com");
+      throw new Error("expected throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(OutboundUrlValidationError);
+      expect((error as OutboundUrlValidationError).code).toBe(
+        "url-credentials-not-allowed",
+      );
+    }
+  });
+});
+
+describe("validateBlobStorageEndpoint", () => {
+  it("rejects a disallowed protocol as a typed validation error", async () => {
+    await expect(
+      validateBlobStorageEndpoint("ftp://blob.example.com", enablingWhitelist),
+    ).rejects.toMatchObject({
+      name: "OutboundUrlValidationError",
+      code: "protocol-not-allowed",
+    });
+  });
+
+  it("rejects a blocked private IP and preserves the code through the guidance re-wrap", async () => {
+    let caught: unknown;
+    try {
+      await validateBlobStorageEndpoint("http://10.0.0.1", enablingWhitelist);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(OutboundUrlValidationError);
+    expect((caught as OutboundUrlValidationError).code).toBe("blocked-ip");
+    // The catch appends self-hosted guidance to the single authoritative
+    // message and does NOT chain `cause` (downstream formatters prefer a
+    // cause's message and would otherwise drop the guidance / duplicate text).
+    expect((caught as Error).message).toContain("Blocked IP address detected");
+    expect((caught as Error).message).toContain(
+      "LANGFUSE_BLOB_STORAGE_ENDPOINT_WHITELISTED_HOST",
+    );
+    expect((caught as Error).cause).toBeUndefined();
+  });
+
+  it("no-ops when validation is disabled (empty whitelist, non-cloud)", async () => {
+    await expect(
+      validateBlobStorageEndpoint("http://10.0.0.1", {
+        hosts: [],
+        ips: [],
+        ip_ranges: [],
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/shared/src/server/services/blobStorageEndpointValidation.ts
+++ b/packages/shared/src/server/services/blobStorageEndpointValidation.ts
@@ -2,6 +2,7 @@ import { env } from "../../env";
 import {
   type OutboundUrlConnectionValidationOptions,
   type OutboundUrlValidationWhitelist,
+  OutboundUrlValidationError,
   parseOutboundUrl,
   validateOutboundUrlHost,
 } from "../outbound-url";
@@ -47,11 +48,15 @@ export async function validateBlobStorageEndpoint(
   const url = parseOutboundUrl(endpoint);
 
   if (!["https:", "http:"].includes(url.protocol)) {
-    throw new Error("Only HTTP and HTTPS protocols are allowed");
+    throw new OutboundUrlValidationError(
+      "protocol-not-allowed",
+      "Only HTTP and HTTPS protocols are allowed",
+    );
   }
 
   if (isLangfuseCloudEndpointValidationEnabled() && url.protocol !== "https:") {
-    throw new Error(
+    throw new OutboundUrlValidationError(
+      "https-required",
       "Only HTTPS blob storage endpoints are allowed on Langfuse Cloud",
     );
   }
@@ -66,9 +71,21 @@ export async function validateBlobStorageEndpoint(
       shouldSkipDnsCheckForLiteralIps: true,
     });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Validation failed";
-    throw new Error(`${message}${getSelfHostedWhitelistGuidance()}`);
+    // Re-wrap to append self-hosted guidance while preserving the validation
+    // `code` so the worker's customer-fault classifier still recognises the
+    // rejection. Do not chain `cause`: the guidance-suffixed message is the
+    // authoritative one, and downstream formatters (worker
+    // extractStorageErrorMessage, tRPC getErrorMessage) prefer a cause's
+    // message and would otherwise drop the guidance / duplicate the text.
+    // Unexpected non-validation errors pass through untouched so they are not
+    // misclassified as customer faults.
+    if (error instanceof OutboundUrlValidationError) {
+      throw new OutboundUrlValidationError(
+        error.code,
+        `${error.message}${getSelfHostedWhitelistGuidance()}`,
+      );
+    }
+    throw error;
   }
 }
 

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -46,7 +46,10 @@ import {
 } from "./abortClassification";
 import { isSigtermReceived } from "../health";
 import { TimedGzip, ZLIB_DEFAULT_LEVEL, type GzipStats } from "./gzipStream";
-import { isCustomerFaultError } from "./isCustomerFaultError";
+import {
+  BLOB_INTEGRATION_DISABLED_METRIC,
+  classifyCustomerFault,
+} from "./isCustomerFaultError";
 import { ByteCounter, TimedByteCounter } from "./byteCounters";
 import { WORKER_HOST_ID } from "../../utils/hostId";
 import {
@@ -1430,8 +1433,11 @@ export const handleBlobStorageIntegrationProjectJob = async (
     // 0-based, so the final attempt is attempts - 1.
     const isFinalAttempt =
       (job.attemptsMade ?? 0) >= (job.opts?.attempts ?? 1) - 1;
+    // The reason bucket doubles as the disable decision (defined => disable) and
+    // as the tag on the disable log + metric below.
+    const customerFaultReason = classifyCustomerFault(error);
     const disableForCustomerFault =
-      isFinalAttempt && isCustomerFaultError(error);
+      isFinalAttempt && customerFaultReason !== undefined;
 
     // True only for the worker that actually flips enabled true→false, so the
     // "disabled" email (which bypasses the cooldown) is sent exactly once and
@@ -1460,8 +1466,14 @@ export const handleBlobStorageIntegrationProjectJob = async (
         disableClaimRan = true;
         persistedDisable = count === 1;
         if (persistedDisable) {
+          // Tag by reason so SSRF/abuse disables (ssrf_blocked_endpoint) can be
+          // separated from customer misconfig, and a mass-disable regression is
+          // visible as a spike in the non-SSRF buckets after rollout.
+          const reason = customerFaultReason ?? "unknown";
+          recordIncrement(BLOB_INTEGRATION_DISABLED_METRIC, 1, { reason });
           logger.warn(
-            `[BLOB INTEGRATION] Disabled blob storage integration for project ${projectId} after a customer-config/credential failure: ${errorMessage}`,
+            `[BLOB INTEGRATION] Disabled blob storage integration for project ${projectId} after a customer fault (reason=${reason}): ${errorMessage}`,
+            { blobStorageDisableReason: reason, projectId },
           );
         }
       }

--- a/worker/src/features/blobstorage/isCustomerFaultError.test.ts
+++ b/worker/src/features/blobstorage/isCustomerFaultError.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { OutboundUrlValidationError } from "@langfuse/shared/src/server";
-import { isCustomerFaultError } from "./isCustomerFaultError";
+import {
+  classifyCustomerFault,
+  isCustomerFaultError,
+} from "./isCustomerFaultError";
 
 // Builds the wrapper the handler actually sees: StorageService.handleStorageError
 // rethrows SDK errors as `new Error("Failed to ...", { cause: sdkError })`.
@@ -215,5 +218,75 @@ describe("isCustomerFaultError", () => {
       Object.assign(a, { cause: b });
       expect(isCustomerFaultError(a)).toBe(false);
     });
+  });
+});
+
+describe("classifyCustomerFault — disable reason buckets", () => {
+  it.each([
+    ["blocked-ip", "ssrf_blocked_endpoint"],
+    ["blocked-hostname", "ssrf_blocked_endpoint"],
+    ["invalid-syntax", "invalid_endpoint_url"],
+    ["invalid-encoding", "invalid_endpoint_url"],
+    ["https-required", "invalid_endpoint_url"],
+    ["protocol-not-allowed", "invalid_endpoint_url"],
+    ["url-credentials-not-allowed", "invalid_endpoint_url"],
+  ] as const)("maps outbound-url %s to %s", (code, reason) => {
+    const err = new OutboundUrlValidationError(code, "blocked");
+    expect(classifyCustomerFault(err)).toBe(reason);
+    expect(classifyCustomerFault(wrapped(err))).toBe(reason);
+  });
+
+  it.each(["InvalidAccessKeyId", "AccessDenied", "SignatureDoesNotMatch"])(
+    "maps S3 auth code %s to credentials",
+    (code) => {
+      expect(classifyCustomerFault(wrapped(s3Error(code, 403)))).toBe(
+        "credentials",
+      );
+    },
+  );
+
+  it.each(["AuthenticationFailed", "InsufficientAccountPermissions"])(
+    "maps Azure auth code %s to credentials",
+    (code) => {
+      expect(classifyCustomerFault(wrapped(azureError(code, 403)))).toBe(
+        "credentials",
+      );
+    },
+  );
+
+  it("maps a bare 401 and GCS forbidden to credentials", () => {
+    const unauthorized = new Error("Unauthorized");
+    Object.assign(unauthorized, { $metadata: { httpStatusCode: 401 } });
+    expect(classifyCustomerFault(wrapped(unauthorized))).toBe("credentials");
+    expect(classifyCustomerFault(wrapped(gcsError(403, "forbidden")))).toBe(
+      "credentials",
+    );
+  });
+
+  it.each([
+    ["NoSuchBucket", 404],
+    ["InvalidBucketName", 400],
+    ["ContainerNotFound", 404],
+    ["InvalidResourceName", 400],
+  ] as const)("maps %s to bucket_or_container", (code, status) => {
+    // extractErrorCodes reads .name/.Code/.code, so the code bucket is
+    // provider-agnostic here — the s3Error shape is enough to exercise it.
+    expect(classifyCustomerFault(wrapped(s3Error(code, status)))).toBe(
+      "bucket_or_container",
+    );
+  });
+
+  it("returns undefined for non-disabling errors (dns-lookup-failed, transient)", () => {
+    expect(
+      classifyCustomerFault(
+        new OutboundUrlValidationError(
+          "dns-lookup-failed",
+          "DNS lookup failed",
+        ),
+      ),
+    ).toBeUndefined();
+    const transient = new Error("network EAI_AGAIN");
+    Object.assign(transient, { code: "EAI_AGAIN" });
+    expect(classifyCustomerFault(wrapped(transient))).toBeUndefined();
   });
 });

--- a/worker/src/features/blobstorage/isCustomerFaultError.test.ts
+++ b/worker/src/features/blobstorage/isCustomerFaultError.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { OutboundUrlValidationError } from "@langfuse/shared/src/server";
 import { isCustomerFaultError } from "./isCustomerFaultError";
 
 // Builds the wrapper the handler actually sees: StorageService.handleStorageError
@@ -148,6 +149,55 @@ describe("isCustomerFaultError", () => {
       expect(isCustomerFaultError(undefined)).toBe(false);
       expect(isCustomerFaultError("AccessDenied")).toBe(false);
       expect(isCustomerFaultError(403)).toBe(false);
+    });
+  });
+
+  describe("customer_fault — outbound-URL / SSRF validation rejection", () => {
+    it.each([
+      "blocked-ip",
+      "blocked-hostname",
+      "invalid-syntax",
+      "invalid-encoding",
+      "https-required",
+      "protocol-not-allowed",
+      "url-credentials-not-allowed",
+    ] as const)(
+      "classifies a %s validation rejection as customer_fault",
+      (code) => {
+        const err = new OutboundUrlValidationError(code, "blocked");
+        expect(isCustomerFaultError(err)).toBe(true);
+        expect(isCustomerFaultError(wrapped(err))).toBe(true);
+      },
+    );
+
+    it("classifies dns-lookup-failed as other, not customer_fault", () => {
+      // Resolvability depends on runtime resolver state, not the endpoint
+      // config: a transient DNS outage across the retry window must not
+      // permanently disable a working integration. Keep it investigable,
+      // consistent with the network EAI_AGAIN case above.
+      const err = new OutboundUrlValidationError(
+        "dns-lookup-failed",
+        "DNS lookup failed for host.example",
+      );
+      expect(isCustomerFaultError(err)).toBe(false);
+      expect(isCustomerFaultError(wrapped(err))).toBe(false);
+    });
+
+    it("classifies a validation rejection re-wrapped with guidance (code preserved) as customer_fault", () => {
+      // Mirrors validateBlobStorageEndpoint's catch: a new typed error carrying
+      // the same deterministic code, with no `cause` chained.
+      const rewrapped = new OutboundUrlValidationError(
+        "blocked-ip",
+        "Blocked IP address detected For self-hosted deployments ...",
+      );
+      expect(isCustomerFaultError(wrapped(rewrapped))).toBe(true);
+    });
+
+    it("does NOT classify a code-less error that merely shares the message as customer_fault", () => {
+      // Classification is code-based, not message-based: a bare 'DNS lookup
+      // failed' Error (e.g. some future unrelated throw site) stays investigable.
+      const err = new Error("DNS lookup failed for host.example");
+      expect(isCustomerFaultError(wrapped(err))).toBe(false);
     });
   });
 

--- a/worker/src/features/blobstorage/isCustomerFaultError.ts
+++ b/worker/src/features/blobstorage/isCustomerFaultError.ts
@@ -32,6 +32,23 @@ const CUSTOMER_FAULT_ERROR_CODES = new Set<string>([
   "InvalidResourceName",
 ]);
 
+// Langfuse outbound-URL / SSRF validation rejections (OutboundUrlValidationError
+// from @langfuse/shared/.../outbound-url). Every code here is a deterministic
+// property of the endpoint config, so it is safe to auto-disable on. We
+// deliberately omit `dns-lookup-failed`: resolvability depends on runtime
+// resolver state, not the config, so a transient DNS outage across the retry
+// window must not permanently disable a working integration. secureLlmFetch
+// makes the same distinction (dns-lookup-failed -> "endpoint-unreachable").
+const CUSTOMER_FAULT_OUTBOUND_URL_CODES = new Set<string>([
+  "blocked-hostname",
+  "blocked-ip",
+  "invalid-syntax",
+  "invalid-encoding",
+  "https-required",
+  "protocol-not-allowed",
+  "url-credentials-not-allowed",
+]);
+
 // GCS JSON-API reasons (only reachable via a GCS-native client; S3-interop uses
 // the S3 codes above). Narrow on purpose: object-level notFound stays `other`.
 const CUSTOMER_FAULT_GCS_REASONS = new Set<string>(["forbidden"]);
@@ -87,7 +104,22 @@ function extractGcsReasons(err: object): string[] {
     .filter((r): r is string => typeof r === "string");
 }
 
+// Duck-type on `.name` (survives cross-package module duplication where
+// `instanceof` is unreliable) rather than importing the class, then gate on the
+// deterministic-code allowlist so transient reasons like `dns-lookup-failed`
+// stay non-disabling.
+function isOutboundUrlValidationCustomerFault(err: object): boolean {
+  if ((err as { name?: unknown }).name !== "OutboundUrlValidationError") {
+    return false;
+  }
+  const code = (err as { code?: unknown }).code;
+  return (
+    typeof code === "string" && CUSTOMER_FAULT_OUTBOUND_URL_CODES.has(code)
+  );
+}
+
 function isCustomerFaultLink(err: object): boolean {
+  if (isOutboundUrlValidationCustomerFault(err)) return true;
   if (extractErrorCodes(err).some((c) => CUSTOMER_FAULT_ERROR_CODES.has(c))) {
     return true;
   }

--- a/worker/src/features/blobstorage/isCustomerFaultError.ts
+++ b/worker/src/features/blobstorage/isCustomerFaultError.ts
@@ -7,9 +7,25 @@
 // retrying. Errors arrive wrapped via `new Error(..., { cause })`
 // (StorageService.handleStorageError), so we walk the cause chain.
 
+// Counter for integrations auto-disabled after a terminal customer fault, tagged
+// by `reason`. Lets a rollout regression (a classifier bug mass-disabling
+// working integrations) show up as a spike in the non-SSRF buckets against a
+// near-zero baseline, separately from expected SSRF/abuse disables.
+export const BLOB_INTEGRATION_DISABLED_METRIC =
+  "langfuse.blobstorage.integration_disabled.count";
+
+// Coarse cause bucket for a disable, for logs/metrics. `ssrf_blocked_endpoint`
+// is the SSRF-guard rejection (endpoint resolves to a blocked host/IP) — the
+// "likely abuse" bucket to watch — while the rest are customer misconfiguration.
+export type CustomerFaultReason =
+  | "ssrf_blocked_endpoint"
+  | "invalid_endpoint_url"
+  | "credentials"
+  | "bucket_or_container";
+
 // AWS SDK v3 sets `.name`/`.Code`; Azure RestError sets `.code`. S3-compatible
 // providers (incl. GCS S3-interop) surface the S3 codes.
-const CUSTOMER_FAULT_ERROR_CODES = new Set<string>([
+const CREDENTIAL_FAULT_CODES = new Set<string>([
   // S3 — auth & credentials
   "InvalidAccessKeyId",
   "SignatureDoesNotMatch",
@@ -17,9 +33,6 @@ const CUSTOMER_FAULT_ERROR_CODES = new Set<string>([
   "AllAccessDisabled",
   "AccountProblem",
   "AuthorizationHeaderMalformed",
-  // S3 — bucket & path
-  "NoSuchBucket",
-  "InvalidBucketName",
   // Azure — auth & credentials
   "AuthenticationFailed",
   "AuthorizationFailure",
@@ -27,21 +40,30 @@ const CUSTOMER_FAULT_ERROR_CODES = new Set<string>([
   "InvalidAuthenticationInfo",
   "AccountIsDisabled",
   "InsufficientAccountPermissions",
+]);
+
+const BUCKET_FAULT_CODES = new Set<string>([
+  // S3 — bucket & path
+  "NoSuchBucket",
+  "InvalidBucketName",
   // Azure — container & path
   "ContainerNotFound",
   "InvalidResourceName",
 ]);
 
 // Langfuse outbound-URL / SSRF validation rejections (OutboundUrlValidationError
-// from @langfuse/shared/.../outbound-url). Every code here is a deterministic
-// property of the endpoint config, so it is safe to auto-disable on. We
-// deliberately omit `dns-lookup-failed`: resolvability depends on runtime
+// from @langfuse/shared/.../outbound-url), split by cause. Every code here is a
+// deterministic property of the endpoint config, so it is safe to auto-disable
+// on. We deliberately omit `dns-lookup-failed`: resolvability depends on runtime
 // resolver state, not the config, so a transient DNS outage across the retry
 // window must not permanently disable a working integration. secureLlmFetch
 // makes the same distinction (dns-lookup-failed -> "endpoint-unreachable").
-const CUSTOMER_FAULT_OUTBOUND_URL_CODES = new Set<string>([
+const SSRF_BLOCKED_OUTBOUND_URL_CODES = new Set<string>([
   "blocked-hostname",
   "blocked-ip",
+]);
+
+const INVALID_URL_OUTBOUND_URL_CODES = new Set<string>([
   "invalid-syntax",
   "invalid-encoding",
   "https-required",
@@ -105,36 +127,56 @@ function extractGcsReasons(err: object): string[] {
 }
 
 // Duck-type on `.name` (survives cross-package module duplication where
-// `instanceof` is unreliable) rather than importing the class, then gate on the
-// deterministic-code allowlist so transient reasons like `dns-lookup-failed`
-// stay non-disabling.
-function isOutboundUrlValidationCustomerFault(err: object): boolean {
+// `instanceof` is unreliable) rather than importing the class, then map the
+// deterministic code to a reason; transient reasons like `dns-lookup-failed`
+// return undefined so they stay non-disabling.
+function classifyOutboundUrlFault(
+  err: object,
+): CustomerFaultReason | undefined {
   if ((err as { name?: unknown }).name !== "OutboundUrlValidationError") {
-    return false;
+    return undefined;
   }
   const code = (err as { code?: unknown }).code;
-  return (
-    typeof code === "string" && CUSTOMER_FAULT_OUTBOUND_URL_CODES.has(code)
-  );
+  if (typeof code !== "string") return undefined;
+  if (SSRF_BLOCKED_OUTBOUND_URL_CODES.has(code)) return "ssrf_blocked_endpoint";
+  if (INVALID_URL_OUTBOUND_URL_CODES.has(code)) return "invalid_endpoint_url";
+  return undefined;
 }
 
-function isCustomerFaultLink(err: object): boolean {
-  if (isOutboundUrlValidationCustomerFault(err)) return true;
-  if (extractErrorCodes(err).some((c) => CUSTOMER_FAULT_ERROR_CODES.has(c))) {
-    return true;
-  }
+function classifyCustomerFaultLink(
+  err: object,
+): CustomerFaultReason | undefined {
+  const outbound = classifyOutboundUrlFault(err);
+  if (outbound) return outbound;
+
+  const codes = extractErrorCodes(err);
+  if (codes.some((c) => CREDENTIAL_FAULT_CODES.has(c))) return "credentials";
+  if (codes.some((c) => BUCKET_FAULT_CODES.has(c)))
+    return "bucket_or_container";
+
   // 401 = credentials rejected: unambiguous, so it trips without a code. A bare
   // 403/404 does not (e.g. clock-skew RequestTimeTooSkewed is a 403).
-  if (extractHttpStatus(err) === 401) return true;
+  if (extractHttpStatus(err) === 401) return "credentials";
   if (extractGcsReasons(err).some((r) => CUSTOMER_FAULT_GCS_REASONS.has(r))) {
-    return true;
+    return "credentials";
   }
-  return false;
+  return undefined;
+}
+
+// Returns the deterministic customer-fault reason for the first matching link in
+// the cause chain, or undefined when nothing qualifies (retry-worthy / infra /
+// transient). The handler disables on any defined reason and tags the disable
+// log + metric with it.
+export function classifyCustomerFault(
+  error: unknown,
+): CustomerFaultReason | undefined {
+  for (const link of errorCauseChain(error)) {
+    const reason = classifyCustomerFaultLink(link);
+    if (reason) return reason;
+  }
+  return undefined;
 }
 
 export function isCustomerFaultError(error: unknown): boolean {
-  for (const link of errorCauseChain(error)) {
-    if (isCustomerFaultLink(link)) return true;
-  }
-  return false;
+  return classifyCustomerFault(error) !== undefined;
 }


### PR DESCRIPTION
## What does this PR do?

Extends the blob-export customer-fault breaker (#14628) so an export auto-disables on **deterministic outbound-URL / SSRF validation rejections**, not just stable S3/Azure/GCS credential/config error codes.

Motivated by a prod-EU episode (2026-07-14): two throwaway orgs configured OAST/Interactsh out-of-band domains as blob-storage endpoints (SSRF probing). Endpoints that passed IP validation kept failing at upload and re-running every cycle, spamming logs/metrics. Validation rejections are deterministic bad-endpoint config, so they now feed the existing breaker.

**How it works**
- New typed `OutboundUrlValidationError` (shared) carrying a stable `.code` (`LANGFUSE_OUTBOUND_URL_BLOCKED`) + a `reason` discriminant, thrown from every `outbound-url/validation.ts` rejection site (blocked host/IP, unresolvable DNS, invalid URL/encoding/credentials) and the blob-endpoint protocol checks. Messages are unchanged (LLM error-mapping still matches on them).
- `validateBlobStorageEndpoint` preserves the code/reason and chains the `cause` through its guidance-appending re-wrap.
- Worker `isCustomerFaultError` allowlists the code — the existing cause-chain walk classifies it, disabling **after BullMQ retry exhaustion** exactly as today.

**Deliberately out of scope:** TLS cert-altname mismatch and multipart "no UploadId" (55 of the 60 failures in the episode) pass SSRF validation and are ambiguous with legitimate customer misconfig / transient endpoint issues, so they stay investigable (retry + failure email), not auto-disabled.

Design decision: classification stays purely code-based (biased toward false — a false positive disables a working integration), so a stable `.code` is used rather than fragile message matching.

## Type of change

- [x] Bug fix / hardening (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Unit tests added/updated (`isCustomerFaultError`, `blobStorageEndpointValidation`)
- [x] `pnpm lint` + `pnpm typecheck` pass (web, worker, shared)
- [x] No customer-facing message changes; no change to disable timing

Closes LFE-10927

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the blob-export customer-fault circuit breaker so outbound-URL / SSRF validation rejections auto-disable an integration after BullMQ retry exhaustion, not just S3/Azure/GCS credential errors. Motivated by a production episode where OAST probe domains kept failing on every cycle, spamming logs.

- **New `OutboundUrlValidationError`** in `packages/shared/src/server/outbound-url/errors.ts` carries a stable `.code` (`LANGFUSE_OUTBOUND_URL_BLOCKED`) and a `reason` discriminant; all existing `throw new Error(...)` sites in `validation.ts` and `blobStorageEndpointValidation.ts` are replaced with typed throws.
- **`validateBlobStorageEndpoint`** catch block selectively re-wraps `OutboundUrlValidationError` to append self-hosted guidance while preserving `code`/`reason`/`cause`, letting non-validation errors pass through untouched to avoid misclassification.
- **`isCustomerFaultError`** adds `OUTBOUND_URL_VALIDATION_ERROR_CODE` to `CUSTOMER_FAULT_ERROR_CODES`; the existing cause-chain walk picks it up via `extractErrorCodes` without any structural changes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is well-scoped and thoroughly tested with one design tradeoff worth confirming before shipping.

The implementation is clean and the cause-chain classification works correctly. The one open question is whether `dns_lookup_failed` should trigger the auto-disable: unlike the other validation reasons (bad URL syntax, blocked IP, invalid protocol), DNS failures can be transient, so a brief resolver outage during the retry window would permanently disable an otherwise valid integration.

The `dns_lookup_failed` entry in `CUSTOMER_FAULT_ERROR_CODES` (`worker/src/features/blobstorage/isCustomerFaultError.ts`) warrants a second look given the transient-vs-deterministic distinction.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W as Worker (BullMQ)
    participant H as BlobStorageHandler
    participant V as validateBlobStorageEndpoint
    participant UV as validateOutboundUrlHost
    participant CF as isCustomerFaultError

    W->>H: process export job
    H->>V: validateBlobStorageEndpoint(endpoint)
    V->>V: parseOutboundUrl() throws OutboundUrlValidationError on syntax/creds
    V->>V: protocol check throws OutboundUrlValidationError on invalid protocol
    V->>UV: validateOutboundUrlHost()
    UV->>UV: isHostnameBlocked? throws OutboundUrlValidationError(blocked_hostname)
    UV->>UV: isIPAddress? validateOutboundResolvedIp throws OutboundUrlValidationError(blocked_ip)
    UV->>UV: resolveHost() throws OutboundUrlValidationError(dns_lookup_failed)
    UV-->>V: throws OutboundUrlValidationError
    V->>V: catch isOutboundUrlValidationError re-wrap preserving code+reason+cause
    V-->>H: "throws OutboundUrlValidationError code=LANGFUSE_OUTBOUND_URL_BLOCKED"
    H-->>W: throws after StorageService.handleStorageError wraps it
    W->>W: BullMQ retry exhaustion
    W->>CF: isCustomerFaultError(error)
    CF->>CF: walk cause chain extractErrorCodes
    CF->>CF: CUSTOMER_FAULT_ERROR_CODES.has LANGFUSE_OUTBOUND_URL_BLOCKED true
    CF-->>W: true
    W->>W: auto-disable blob export integration
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W as Worker (BullMQ)
    participant H as BlobStorageHandler
    participant V as validateBlobStorageEndpoint
    participant UV as validateOutboundUrlHost
    participant CF as isCustomerFaultError

    W->>H: process export job
    H->>V: validateBlobStorageEndpoint(endpoint)
    V->>V: parseOutboundUrl() throws OutboundUrlValidationError on syntax/creds
    V->>V: protocol check throws OutboundUrlValidationError on invalid protocol
    V->>UV: validateOutboundUrlHost()
    UV->>UV: isHostnameBlocked? throws OutboundUrlValidationError(blocked_hostname)
    UV->>UV: isIPAddress? validateOutboundResolvedIp throws OutboundUrlValidationError(blocked_ip)
    UV->>UV: resolveHost() throws OutboundUrlValidationError(dns_lookup_failed)
    UV-->>V: throws OutboundUrlValidationError
    V->>V: catch isOutboundUrlValidationError re-wrap preserving code+reason+cause
    V-->>H: "throws OutboundUrlValidationError code=LANGFUSE_OUTBOUND_URL_BLOCKED"
    H-->>W: throws after StorageService.handleStorageError wraps it
    W->>W: BullMQ retry exhaustion
    W->>CF: isCustomerFaultError(error)
    CF->>CF: walk cause chain extractErrorCodes
    CF->>CF: CUSTOMER_FAULT_ERROR_CODES.has LANGFUSE_OUTBOUND_URL_BLOCKED true
    CF-->>W: true
    W->>W: auto-disable blob export integration
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/features/blobstorage/isCustomerFaultError.ts:38
**`dns_lookup_failed` treated as permanent customer fault**

`dns_lookup_failed` is included alongside deterministic mis-config codes (`blocked_ip`, `invalid_url_syntax`, etc.), but DNS resolution failures can be transient — a momentary resolver outage or propagation delay could cause all BullMQ retries to exhaust during the window, permanently auto-disabling a working integration. The other `OutboundUrlValidationReason` values are genuinely deterministic (the URL is wrong), whereas a DNS failure depends on external resolver state at the time of the job run.

This is likely an acceptable tradeoff given the OAST/SSRF threat model, but it may be worth documenting in `CUSTOMER_FAULT_ERROR_CODES` (or restricting the auto-disable to the subset of reasons that are truly deterministic, e.g. `blocked_ip | blocked_hostname | invalid_url_syntax | invalid_url_encoding | invalid_protocol | url_credentials`) so that `dns_lookup_failed` continues through failure-email notification rather than silent disable.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(blobstorage): auto-disable export o..."](https://github.com/langfuse/langfuse/commit/6190e934fc39035b1d477fbd3fc325e131635bd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44185557)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->