### PR TITLE
feat(auth): add NEXTAUTH_COOKIE_NAME_SUFFIX to namespace auth cookies across instances

### DIFF
--- a/web/src/__tests__/server/unit/cookieName.servertest.ts
+++ b/web/src/__tests__/server/unit/cookieName.servertest.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// getCookieName / shouldSecureCookies read these off `env` at call time, so the
+// tests mutate mockEnv.env between cases.
+const mockEnv = vi.hoisted(() => ({
+  env: {
+    NEXTAUTH_URL: "https://example.com",
+    NEXTAUTH_COOKIE_DOMAIN: undefined as string | undefined,
+    NEXT_PUBLIC_BASE_PATH: "",
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined as string | undefined,
+    NEXTAUTH_COOKIE_NAME_SUFFIX: undefined as string | undefined,
+    VERCEL: undefined as string | undefined,
+  },
+}));
+
+vi.mock("@/src/env.mjs", () => mockEnv);
+
+import { getCookieName } from "@/src/server/utils/cookies";
+
+const BASE = "next-auth.session-token";
+// Every region accepted by env.mjs's NEXT_PUBLIC_LANGFUSE_CLOUD_REGION enum.
+const CLOUD_REGIONS = ["US", "EU", "STAGING", "DEV", "HIPAA", "JP"] as const;
+
+describe("getCookieName", () => {
+  beforeEach(() => {
+    mockEnv.env.NEXTAUTH_URL = "https://example.com";
+    mockEnv.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    mockEnv.env.NEXTAUTH_COOKIE_NAME_SUFFIX = undefined;
+  });
+
+  it("no region and no suffix -> bare secure name (unchanged self-hosted default)", () => {
+    expect(getCookieName(BASE)).toBe(`__Secure-${BASE}`);
+  });
+
+  it.each(CLOUD_REGIONS)(
+    "region %s -> region suffix (unchanged cloud behavior)",
+    (region) => {
+      mockEnv.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = region;
+      expect(getCookieName(BASE)).toBe(`__Secure-${BASE}.${region}`);
+    },
+  );
+
+  it("suffix with no region -> suffix applied (new self-hosted capability)", () => {
+    mockEnv.env.NEXTAUTH_COOKIE_NAME_SUFFIX = "pr-1234";
+    expect(getCookieName(BASE)).toBe(`__Secure-${BASE}.pr-1234`);
+  });
+
+  // The production safety guarantee: a configured region ALWAYS wins, so setting
+  // NEXTAUTH_COOKIE_NAME_SUFFIX on a cloud deployment (e.g. by config mistake)
+  // can never change its cookie names -> existing sessions are never invalidated.
+  it.each(CLOUD_REGIONS)(
+    "region %s takes precedence over an also-set suffix (never alters cloud cookies)",
+    (region) => {
+      mockEnv.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = region;
+      mockEnv.env.NEXTAUTH_COOKIE_NAME_SUFFIX = "pr-1234";
+      expect(getCookieName(BASE)).toBe(`__Secure-${BASE}.${region}`);
+    },
+  );
+
+  it("non-https NEXTAUTH_URL drops the __Secure- prefix but keeps the suffix", () => {
+    mockEnv.env.NEXTAUTH_URL = "http://localhost:3000";
+    mockEnv.env.NEXTAUTH_COOKIE_NAME_SUFFIX = "pr-1234";
+    expect(getCookieName(BASE)).toBe(`${BASE}.pr-1234`);
+  });
+
+  it("applies to every auth cookie name it is given", () => {
+    mockEnv.env.NEXTAUTH_COOKIE_NAME_SUFFIX = "pr-1234";
+    for (const n of [
+      "next-auth.session-token",
+      "next-auth.csrf-token",
+      "next-auth.callback-url",
+    ]) {
+      expect(getCookieName(n)).toBe(`__Secure-${n}.pr-1234`);
+    }
+  });
+});

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -77,9 +77,12 @@ export const env = createEnv({
     // "__Secure-next-auth.session-token.pr-1234"). Lets multiple Langfuse
     // instances that share a parent cookie domain (preview/review environments)
     // avoid reading each other's session cookie, which — encrypted with a
-    // different NEXTAUTH_SECRET — fails to decrypt and wedges login. This is the
+    // different NEXTAUTH_SECRET — fails to decrypt and wedges login. It is the
     // self-hosted-friendly equivalent of the per-region suffix Langfuse Cloud
     // derives from NEXT_PUBLIC_LANGFUSE_CLOUD_REGION, without enabling cloud mode.
+    // SAFETY: the cloud region ALWAYS takes precedence over this (see
+    // getCookieName), so it can never alter cookie names on a region deployment
+    // even if set by mistake; it only takes effect when no region is configured.
     NEXTAUTH_COOKIE_NAME_SUFFIX: z
       .string()
       .regex(

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -73,6 +73,20 @@ export const env = createEnv({
           : [],
       ),
     NEXTAUTH_COOKIE_DOMAIN: z.string().optional(),
+    // Optional suffix appended to the auth cookie NAMES (e.g. ".pr-1234" ->
+    // "__Secure-next-auth.session-token.pr-1234"). Lets multiple Langfuse
+    // instances that share a parent cookie domain (preview/review environments)
+    // avoid reading each other's session cookie, which — encrypted with a
+    // different NEXTAUTH_SECRET — fails to decrypt and wedges login. This is the
+    // self-hosted-friendly equivalent of the per-region suffix Langfuse Cloud
+    // derives from NEXT_PUBLIC_LANGFUSE_CLOUD_REGION, without enabling cloud mode.
+    NEXTAUTH_COOKIE_NAME_SUFFIX: z
+      .string()
+      .regex(
+        /^[a-zA-Z0-9_-]+$/,
+        "NEXTAUTH_COOKIE_NAME_SUFFIX may only contain letters, numbers, hyphens, and underscores",
+      )
+      .optional(),
     LANGFUSE_TEAM_SLACK_WEBHOOK: z.url().optional(),
     LANGFUSE_NEW_USER_SIGNUP_WEBHOOK: z.url().optional(),
     LANGFUSE_ADMIN_ACCESS_WEBHOOK: z.url().optional(),
@@ -528,6 +542,7 @@ export const env = createEnv({
     NEXT_PUBLIC_BUILD_ID: process.env.NEXT_PUBLIC_BUILD_ID,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_COOKIE_DOMAIN: process.env.NEXTAUTH_COOKIE_DOMAIN,
+    NEXTAUTH_COOKIE_NAME_SUFFIX: process.env.NEXTAUTH_COOKIE_NAME_SUFFIX,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     LANGFUSE_MCP_ALLOWED_HOSTS: process.env.LANGFUSE_MCP_ALLOWED_HOSTS,
     NEXT_PUBLIC_LANGFUSE_CLOUD_REGION:

--- a/web/src/server/utils/cookies.ts
+++ b/web/src/server/utils/cookies.ts
@@ -20,22 +20,24 @@ export const getCookieOptions = () => ({
   secure: shouldSecureCookies(),
 });
 
-// Suffix that namespaces the cookie NAME so instances sharing a parent cookie
-// domain never read each other's session cookie (a foreign one, encrypted with a
-// different NEXTAUTH_SECRET, fails to decrypt -> JWT_SESSION_ERROR -> login loop).
-// An explicit NEXTAUTH_COOKIE_NAME_SUFFIX (self-hosted, e.g. per-PR preview
-// environments) takes precedence; otherwise fall back to the cloud region.
-const getCookieNameSuffix = () =>
-  env.NEXTAUTH_COOKIE_NAME_SUFFIX
-    ? `.${env.NEXTAUTH_COOKIE_NAME_SUFFIX}`
-    : env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
-      ? `.${env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION}`
-      : "";
-
 export const getCookieName = (name: string) =>
-  [shouldSecureCookies() ? "__Secure-" : "", name, getCookieNameSuffix()].join(
-    "",
-  );
+  [
+    shouldSecureCookies() ? "__Secure-" : "",
+    name,
+    // Namespaces the cookie NAME so instances that share a parent cookie domain
+    // never read each other's session cookie (a foreign one, encrypted with a
+    // different NEXTAUTH_SECRET, fails to decrypt -> JWT_SESSION_ERROR -> login
+    // loop). The Langfuse Cloud region ALWAYS takes precedence, so any deployment
+    // that sets NEXT_PUBLIC_LANGFUSE_CLOUD_REGION (US/EU/STAGING/HIPAA/JP) keeps
+    // byte-identical cookie names — NEXTAUTH_COOKIE_NAME_SUFFIX can never change
+    // them, even if it is also set by mistake. The suffix applies only to
+    // self-hosted deployments with no region (e.g. per-PR preview environments).
+    env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
+      ? `.${env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION}`
+      : env.NEXTAUTH_COOKIE_NAME_SUFFIX
+        ? `.${env.NEXTAUTH_COOKIE_NAME_SUFFIX}`
+        : "",
+  ].join("");
 
 /** ProjectCookie carries the server-stamped origin and project id of a user's most recent project. */
 export type ProjectCookie = {

--- a/web/src/server/utils/cookies.ts
+++ b/web/src/server/utils/cookies.ts
@@ -20,14 +20,22 @@ export const getCookieOptions = () => ({
   secure: shouldSecureCookies(),
 });
 
-export const getCookieName = (name: string) =>
-  [
-    shouldSecureCookies() ? "__Secure-" : "",
-    name,
-    env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
+// Suffix that namespaces the cookie NAME so instances sharing a parent cookie
+// domain never read each other's session cookie (a foreign one, encrypted with a
+// different NEXTAUTH_SECRET, fails to decrypt -> JWT_SESSION_ERROR -> login loop).
+// An explicit NEXTAUTH_COOKIE_NAME_SUFFIX (self-hosted, e.g. per-PR preview
+// environments) takes precedence; otherwise fall back to the cloud region.
+const getCookieNameSuffix = () =>
+  env.NEXTAUTH_COOKIE_NAME_SUFFIX
+    ? `.${env.NEXTAUTH_COOKIE_NAME_SUFFIX}`
+    : env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
       ? `.${env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION}`
-      : "",
-  ].join("");
+      : "";
+
+export const getCookieName = (name: string) =>
+  [shouldSecureCookies() ? "__Secure-" : "", name, getCookieNameSuffix()].join(
+    "",
+  );
 
 /** ProjectCookie carries the server-stamped origin and project id of a user's most recent project. */
 export type ProjectCookie = {


### PR DESCRIPTION
## In plain English (why preview deployments need this)

**What's a preview deployment?** Every PR can spin up its own throwaway Langfuse at `pr-<number>.preview.langfuse.com` so we can click through the change before merging. Many run at once, all under the shared `langfuse.com` family of domains (alongside `cloud.langfuse.com`, `staging.langfuse.com`, etc.).

**The one idea this hinges on:** a website only ever reads the cookie whose *exact name* it's looking for. Every other cookie in your browser is invisible to it.

**Why previews break today.** Every preview looks for a login cookie named exactly `next-auth.session-token`. But previews are disposable — when one is rebuilt (its namespace recreated), it generates a fresh `NEXTAUTH_SECRET`. Your browser still holds the **old** `next-auth.session-token` from the previous build, locked with the old key. So the rebuilt preview asks the browser for `next-auth.session-token`, gets handed the stale one, and its current key can't open it → `JWT_SESSION_ERROR: Invalid Compact JWE` → "you're not logged in." Logging in writes a fresh cookie, but it has the **same name** as the stale one, and same-named cookies can get tangled, so the bad one keeps winning — you're stuck at the login screen. Incognito works only because it starts with an empty jar: no stale cookie to trip over. (The same thing can happen with a cookie from a *sibling* instance on the shared domain — same root cause: everyone uses the same cookie name.)

**How this PR fixes it.** It gives each deployment a **unique cookie name** — e.g. `next-auth.session-token.pr-1234`. Now the preview asks for `next-auth.session-token.pr-1234`, a name **nothing else in your browser has ever written**: not the old build (it used plain `next-auth.session-token`), not another preview, not a cloud region. So the only cookie that can answer is the one the preview **just created for you**. The stale cookie is still sitting in the jar — but the preview never asks for it, so it can never trip over it. **You can't trip over a cookie you never look at.** Every browser then behaves like the clean incognito tab: log in, done, no cookie-clearing.

**Why this is safe for US / EU / HIPAA / JP / staging.** They already do exactly this — each stamps its region onto the cookie name (`.US`, `.EU`, `.HIPAA`, …), which is precisely why they coexist on the shared domain and never collide with each other. This PR gives previews the same treatment. And the region label **always takes precedence**, so a region's cookie names never change — the new setting only affects deployments that have *no* region (the previews). Details in **Safety** below.

**Coat-check analogy.** Today every preview's claim ticket just says "coat," so an old "coat" ticket left in your wallet gets you handed the wrong, locked coat. This PR prints a unique number on each ticket — "coat #1234" — so a ticket can only ever retrieve the exact coat it was issued for. No mix-up possible.

---

## Problem

NextAuth cookie names come from `getCookieName` (`web/src/server/utils/cookies.ts`):

```
__Secure- + <name> + (NEXT_PUBLIC_LANGFUSE_CLOUD_REGION ? `.${REGION}` : "")
```

A deployment with **no region** (self-hosted, previews) uses the bare `__Secure-next-auth.session-token`. Because a server reads a cookie only by its exact name, that instance will read **any** `__Secure-next-auth.session-token` the browser sends it — including one it did not issue. Two ways that happens:

1. **Its own stale cookie after a rebuild (the common preview case).** Disposable previews regenerate their `NEXTAUTH_SECRET` when their namespace is recreated. The browser still holds the previous build's host-only `__Secure-next-auth.session-token`; the rebuilt instance reads it and can't decrypt it (new secret).
2. **A sibling on a shared parent domain.** Any `*.langfuse.com` cookie scoped to `Domain=.langfuse.com` is delivered to every sibling host; if it shares the bare name, a region-less instance will read it.

Either way the result is:

```
[next-auth][error][JWT_SESSION_ERROR] Invalid Compact JWE
```

and a **login loop** — the instance keeps reading a cookie it can neither decrypt nor reliably replace (a fresh login writes the same-named cookie, which can get tangled with the stale one). Only clearing cookies / incognito works today. Cloud regions never hit this: their secret is permanent (never stale) and their cookie name is region-unique (never reads a sibling's).

## Fix

New optional server env `NEXTAUTH_COOKIE_NAME_SUFFIX`. `getCookieName` appends `.<suffix>` so a per-instance-unique value (e.g. `pr-1234`) namespaces all NextAuth cookies (`session-token`, `csrf-token`, `callback-url`). The instance then reads **only** its own uniquely-named cookie and is blind to every other one in the jar — stale or foreign. It's the self-hosted equivalent of the per-region suffix Cloud already derives from `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION`, without enabling cloud mode.

## Safety — why this cannot affect US / EU / STAGING / HIPAA / JP

This function runs for every cookie on every deployment, so the change is designed to be **provably inert in production**:

- **The cloud region always takes precedence.** `getCookieName` checks `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` first; `NEXTAUTH_COOKIE_NAME_SUFFIX` is only consulted in the `else` branch (no region). Every Cloud/staging deployment sets a region, so its cookie names are **byte-identical to today** — the new env is inert there **even if it is set by mistake**. The diff only touches the no-region branch.
- **Opt-in, unset by default** → existing self-hosted deployments are unchanged.
- **Validated** to `^[a-zA-Z0-9_-]+$`, so it can never produce a malformed cookie name; `.optional()` means unset never fails env validation (no boot risk).
- **Fail-safe:** if a region and the suffix are both set, the region silently wins — no throw on boot.

## Tests

`web/src/__tests__/server/unit/cookieName.servertest.ts` (server-unit, **16 cases, all green** locally):

- no region + no suffix → bare name (unchanged self-hosted default)
- each of `US/EU/STAGING/DEV/HIPAA/JP` → `.<region>` (unchanged cloud behavior)
- suffix + no region → `.<suffix>` (new capability)
- **region + suffix → region wins** (the guarantee: never alters cloud cookies)
- non-https → drops `__Secure-`, keeps the suffix
- applies across session-token / csrf-token / callback-url

## Rollout

- **Cloud/staging: no action, no impact** — they set a region, so no configuration alters their cookie names. (Verifiable by confirming those environments set `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION`, which they do.)
- **Self-hosted / preview:** set `NEXTAUTH_COOKIE_NAME_SUFFIX=<unique-id>` (e.g. `pr-1234`) to namespace that instance's cookies.

### Note on preview rebuilds
The suffix makes a preview ignore every *differently-named* leftover cookie (all of today's are the bare name). If the **same** PR's namespace is later fully recreated (which also rotates its secret), the new `.pr-1234` cookie can't read the old `.pr-1234` one — that self-heals on a single login and only happens on teardown/rebuild, not normal redeploys. Pairing this with a stable per-PR secret would remove even that one-time re-login, but is out of scope here.
