### PR TITLE
fix(client): fall back to v4 UUID generation when crypto.randomUUID is unavailable (#15008)

### DIFF
--- a/packages/shared/src/__tests__/uuid.test.ts
+++ b/packages/shared/src/__tests__/uuid.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { generateUUID } from "../utils/uuid";
+
+describe("generateUUID", () => {
+  it("returns a valid v4 UUID string", () => {
+    const uuid = generateUUID();
+    expect(typeof uuid).toBe("string");
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+  });
+
+  it("falls back gracefully when crypto.randomUUID is undefined", () => {
+    const originalCrypto = globalThis.crypto;
+    // Simulate non-secure HTTP browser origin where crypto.randomUUID is unavailable
+    Object.defineProperty(globalThis, "crypto", {
+      value: { randomUUID: undefined },
+      writable: true,
+      configurable: true,
+    });
+
+    const uuid = generateUUID();
+    expect(typeof uuid).toBe("string");
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+
+    Object.defineProperty(globalThis, "crypto", {
+      value: originalCrypto,
+      writable: true,
+      configurable: true,
+    });
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,6 +19,7 @@ export * from "./utils/prompts";
 export * from "./utils/jsonSchemaValidation";
 export * from "./utils/chatml";
 export * from "./utils/math";
+export * from "./utils/uuid";
 export * from "./features/entitlements/plans";
 export * from "./interfaces/rate-limits";
 export * from "./tableDefinitions/typeHelpers";

--- a/packages/shared/src/utils/uuid.ts
+++ b/packages/shared/src/utils/uuid.ts
@@ -1,0 +1,17 @@
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Generates an RFC4122 v4 UUID safely across browser and server environments.
+ * Uses crypto.randomUUID() when available (Node.js & HTTPS Secure Contexts),
+ * falling back to uuidv4() for non-secure HTTP origins (such as self-hosted LAN IP access).
+ */
+export function generateUUID(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      // Fallback for non-secure browser contexts
+    }
+  }
+  return uuidv4();
+}

--- a/web/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/src/components/ui/button";
 import * as z from "zod";
-import { v4 as uuidv4 } from "uuid";
+import { generateUUID } from "@langfuse/shared";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { type Control, useForm, useWatch } from "react-hook-form";
 import {
@@ -158,9 +158,8 @@ export const NewDatasetItemForm = (props: {
   const getDatasetItemId = useCallback((datasetId: string) => {
     const existing = itemIdByDataset.current.get(datasetId);
     if (existing) return existing;
-    // uuid's v4() falls back to crypto.getRandomValues, so it works on
-    // non-secure (HTTP) origins where crypto.randomUUID is unavailable.
-    const id = uuidv4();
+    // generateUUID() handles fallback for non-secure (HTTP) origins where crypto.randomUUID is unavailable.
+    const id = generateUUID();
     itemIdByDataset.current.set(datasetId, id);
     return id;
   }, []);

--- a/web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts
+++ b/web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts
@@ -1,11 +1,6 @@
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { useCallback, useState } from "react";
-import { v4 as uuidv4 } from "uuid";
-
-import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import { MediaContentType } from "@/src/features/media/validation";
-import { api } from "@/src/utils/api";
-import { type DatasetItemMediaField } from "@langfuse/shared";
+import { generateUUID, type DatasetItemMediaField } from "@langfuse/shared";
 
 const SUPPORTED_CONTENT_TYPES = new Set<string>(
   Object.values(MediaContentType),
@@ -86,9 +81,8 @@ export function useDatasetItemMediaUpload({
         return null;
       }
 
-      // uuid's v4() falls back to crypto.getRandomValues, so it works on
-      // non-secure (HTTP) origins where crypto.randomUUID is unavailable.
-      const pendingId = uuidv4();
+      // generateUUID() handles fallback for non-secure (HTTP) origins where crypto.randomUUID is unavailable.
+      const pendingId = generateUUID();
       setPendingUploads((prev) => [
         ...prev,
         { id: pendingId, fileName: file.name },


### PR DESCRIPTION
## Description

Fixes #15008 where accessing self-hosted Langfuse instances over non-HTTPS / LAN IP origins (\http://192.168.x.x:3000\) throws a client-side exception:
\TypeError: crypto.randomUUID is not a function\

Modern browsers restrict \crypto.randomUUID\ strictly to Secure Contexts (\https://\ or \localhost\). On non-secure HTTP origins (such as self-hosted LAN IP setups), \crypto.randomUUID\ is \undefined\.

## Changes

1. **\packages/shared/src/utils/uuid.ts\**: Introduced \generateUUID()\ utility which safely uses \crypto.randomUUID()\ when available (Node.js & HTTPS Secure Contexts) and falls back to \uuid\ package's \4()\ for non-secure HTTP origins.
2. **\packages/shared/src/index.ts\**: Re-exported \generateUUID\ from \@langfuse/shared\.
3. **\packages/shared/src/__tests__/uuid.test.ts\**: Added unit tests covering both standard execution and fallback when \crypto.randomUUID\ is \undefined\.
4. **\web/src/features/datasets/\**: Updated dataset form and dataset media upload hook to use \generateUUID\ from \@langfuse/shared\.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes UUID generation into a shared `generateUUID()` utility that prefers `crypto.randomUUID()` and falls back to the `uuid` package's `v4()` for non-secure HTTP origins (e.g. self-hosted LAN setups). The two dataset files that call-site-swapped `uuidv4()` for the new helper are correct, but the hook file has a critical import problem.

- **`packages/shared/src/utils/uuid.ts`**: New `generateUUID()` with proper fallback and tests.
- **`web/src/features/datasets/components/NewDatasetItemForm.tsx`**: Import swap is clean and complete.
- **`web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts`**: While consolidating the `@langfuse/shared` import, three other imports (`showErrorToast`, `MediaContentType`, `api`) were accidentally deleted — all three are still used throughout the file, causing a build failure.
</details>

<details><summary><h3>Confidence Score: 1/5</h3></summary>

Not safe to merge — the hook file will not compile due to deleted imports.

The change to useDatasetItemMediaUpload.ts accidentally drops the imports for showErrorToast, MediaContentType, and api while consolidating the @langfuse/shared import. All three identifiers are still referenced in the file body (SUPPORTED_CONTENT_TYPES initialization, api.datasets calls, and every showErrorToast call site). The build will fail on merge.

web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts — the three missing imports must be restored before this is mergeable.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["generateUUID() called"] --> B{"typeof crypto !== 'undefined'\nAND crypto.randomUUID === 'function'?"}
    B -- Yes --> C["try crypto.randomUUID()"]
    C -- Success --> D["Return UUID"]
    C -- throws --> E["Fall through to fallback"]
    B -- No --> E
    E --> F["uuidv4() from 'uuid' package"]
    F --> G["Return UUID"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["generateUUID() called"] --> B{"typeof crypto !== 'undefined'\nAND crypto.randomUUID === 'function'?"}
    B -- Yes --> C["try crypto.randomUUID()"]
    C -- Success --> D["Return UUID"]
    C -- throws --> E["Fall through to fallback"]
    B -- No --> E
    E --> F["uuidv4() from 'uuid' package"]
    F --> G["Return UUID"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/datasets/hooks/useDatasetItemMediaUpload.ts:1-6
**Missing imports break compilation**

The PR removes three imports that are still actively used throughout the file: `showErrorToast` (lines 69, 77, 136), `MediaContentType` (lines 6, 101), and `api` (lines 59, 61). None of these are re-exported from `@langfuse/shared`, so the file will fail to compile as-is. The missing `MediaContentType` also causes an immediate reference error on line 6 where `SUPPORTED_CONTENT_TYPES` is initialized.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(client): fall back to v4 UUID genera..."](https://github.com/langfuse/langfuse/commit/197ed72165b6f2df4570575c2cca2f6624adaf92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44391504)</sub>

<!-- /greptile_comment -->