### PR TITLE
fix(mcp): keep-alive pings and drain-aware close for GET SSE streams

### DIFF
--- a/web/src/__tests__/server/unit/mcpSseKeepAlive.servertest.ts
+++ b/web/src/__tests__/server/unit/mcpSseKeepAlive.servertest.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { startSseKeepAlive } from "@/src/features/mcp/server/sseKeepAlive";
+
+const PING_INTERVAL_MS = 30_000;
+const MAX_AGE_MS = 900_000;
+
+const makeRes = () => {
+  const res = {
+    headersSent: true,
+    writableEnded: false,
+    destroyed: false,
+    writes: [] as string[],
+    write(chunk: string) {
+      res.writes.push(chunk);
+      return true;
+    },
+    end() {
+      res.writableEnded = true;
+    },
+  };
+  return res;
+};
+
+const start = (
+  res: ReturnType<typeof makeRes>,
+  isDraining: () => boolean = () => false,
+) =>
+  startSseKeepAlive({
+    res,
+    pingIntervalMs: PING_INTERVAL_MS,
+    maxConnectionAgeMs: MAX_AGE_MS,
+    isDraining,
+  });
+
+describe("startSseKeepAlive", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("writes an SSE comment ping every interval", () => {
+    const res = makeRes();
+    const keepAlive = start(res);
+
+    vi.advanceTimersByTime(PING_INTERVAL_MS * 3);
+
+    expect(res.writes).toEqual([
+      ": keep-alive\n\n",
+      ": keep-alive\n\n",
+      ": keep-alive\n\n",
+    ]);
+    expect(res.writableEnded).toBe(false);
+    keepAlive.stop();
+  });
+
+  it("does not write before response headers are sent", () => {
+    const res = makeRes();
+    res.headersSent = false;
+    const keepAlive = start(res);
+
+    vi.advanceTimersByTime(PING_INTERVAL_MS * 2);
+    expect(res.writes).toEqual([]);
+
+    res.headersSent = true;
+    vi.advanceTimersByTime(PING_INTERVAL_MS);
+    expect(res.writes).toEqual([": keep-alive\n\n"]);
+    keepAlive.stop();
+  });
+
+  it("ends the stream when the process starts draining", () => {
+    const res = makeRes();
+    let draining = false;
+    start(res, () => draining);
+
+    vi.advanceTimersByTime(PING_INTERVAL_MS);
+    expect(res.writableEnded).toBe(false);
+
+    draining = true;
+    vi.advanceTimersByTime(PING_INTERVAL_MS);
+    expect(res.writableEnded).toBe(true);
+
+    // Interval self-stopped: no further writes after end
+    const writesAfterEnd = res.writes.length;
+    vi.advanceTimersByTime(PING_INTERVAL_MS * 3);
+    expect(res.writes.length).toBe(writesAfterEnd);
+  });
+
+  it("ends the stream after the max connection age", () => {
+    const res = makeRes();
+    start(res);
+
+    vi.advanceTimersByTime(MAX_AGE_MS - PING_INTERVAL_MS);
+    expect(res.writableEnded).toBe(false);
+
+    vi.advanceTimersByTime(PING_INTERVAL_MS);
+    expect(res.writableEnded).toBe(true);
+  });
+
+  it("stops itself when the response ended elsewhere (client disconnect)", () => {
+    const res = makeRes();
+    start(res);
+
+    vi.advanceTimersByTime(PING_INTERVAL_MS);
+    expect(res.writes.length).toBe(1);
+
+    res.writableEnded = true; // transport ended the response
+    vi.advanceTimersByTime(PING_INTERVAL_MS * 3);
+    expect(res.writes.length).toBe(1);
+  });
+
+  it("stop() prevents any further activity", () => {
+    const res = makeRes();
+    const keepAlive = start(res);
+
+    keepAlive.stop();
+    vi.advanceTimersByTime(PING_INTERVAL_MS * 5);
+
+    expect(res.writes).toEqual([]);
+    expect(res.writableEnded).toBe(false);
+  });
+});

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -333,6 +333,18 @@ export const env = createEnv({
     LANGFUSE_CACHE_API_KEY_ENABLED: z.enum(["true", "false"]).default("true"),
     LANGFUSE_CACHE_API_KEY_TTL_SECONDS: z.coerce.number().default(300),
 
+    // MCP GET SSE stream keep-alive (see web/src/features/mcp/server/sseKeepAlive.ts)
+    LANGFUSE_MCP_SSE_PING_INTERVAL_MS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(30_000),
+    LANGFUSE_MCP_SSE_MAX_CONNECTION_AGE_MS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(900_000),
+
     // Multimodal media upload to S3
     LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH: z.coerce
       .number()
@@ -819,6 +831,10 @@ export const env = createEnv({
     LANGFUSE_CACHE_API_KEY_ENABLED: process.env.LANGFUSE_CACHE_API_KEY_ENABLED,
     LANGFUSE_CACHE_API_KEY_TTL_SECONDS:
       process.env.LANGFUSE_CACHE_API_KEY_TTL_SECONDS,
+    LANGFUSE_MCP_SSE_PING_INTERVAL_MS:
+      process.env.LANGFUSE_MCP_SSE_PING_INTERVAL_MS,
+    LANGFUSE_MCP_SSE_MAX_CONNECTION_AGE_MS:
+      process.env.LANGFUSE_MCP_SSE_MAX_CONNECTION_AGE_MS,
     LANGFUSE_ALLOWED_ORGANIZATION_CREATORS:
       process.env.LANGFUSE_ALLOWED_ORGANIZATION_CREATORS,
     STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,

--- a/web/src/features/mcp/server/sseKeepAlive.ts
+++ b/web/src/features/mcp/server/sseKeepAlive.ts
@@ -1,0 +1,74 @@
+/**
+ * Keep-alive management for MCP GET SSE streams.
+ *
+ * In stateless mode the Streamable HTTP transport opens an SSE stream on GET
+ * that it never writes to, never pings, and never closes server-side — its
+ * lifetime is bounded only by client disconnect or LB idle timeout. That has
+ * two operational problems:
+ *
+ * 1. Idle streams die silently at the load balancer idle timeout instead of
+ *    being kept alive intentionally.
+ * 2. Open streams ride through graceful shutdown: nothing closes them on
+ *    SIGTERM, so draining tasks hold MCP client connections until the
+ *    orchestrator SIGKILLs the container and clients see a hard reset.
+ *
+ * This helper periodically writes an SSE comment (`: keep-alive`) as a ping
+ * and proactively ends the stream when the process is draining or the stream
+ * exceeds its max age. Per the MCP Streamable HTTP spec, clients tolerate
+ * server-closed SSE streams and reconnect — during a drain they reconnect to
+ * a healthy task.
+ *
+ * Writing to the response from outside the transport is safe ONLY because the
+ * stateless transport never emits bytes on the GET stream (no session, no
+ * eventStore), so there is no event to interleave with. Revisit this if
+ * sessions or server-initiated messages are ever enabled.
+ */
+
+interface SseResponseLike {
+  headersSent: boolean;
+  writableEnded: boolean;
+  destroyed: boolean;
+  write: (chunk: string) => boolean;
+  end: () => void;
+}
+
+export function startSseKeepAlive(params: {
+  res: SseResponseLike;
+  pingIntervalMs: number;
+  maxConnectionAgeMs: number;
+  /** Checked every tick; when true the stream is ended so clients reconnect elsewhere. */
+  isDraining: () => boolean;
+}): { stop: () => void } {
+  const { res, pingIntervalMs, maxConnectionAgeMs, isDraining } = params;
+  const startedAt = Date.now();
+
+  const interval = setInterval(() => {
+    if (res.writableEnded || res.destroyed) {
+      stop();
+      return;
+    }
+    // The SSE response is established asynchronously by the transport; skip
+    // ticks until headers are out so we never write ahead of them.
+    if (!res.headersSent) {
+      return;
+    }
+    if (isDraining() || Date.now() - startedAt >= maxConnectionAgeMs) {
+      // Ending the response triggers the transport's close/cancel path: the
+      // piped ReadableStream is cancelled, handleRequest resolves, and the
+      // caller's cleanup (server.close()) runs.
+      res.end();
+      stop();
+      return;
+    }
+    res.write(": keep-alive\n\n");
+  }, pingIntervalMs);
+
+  // The ping timer must never be the thing keeping the event loop alive.
+  interval.unref?.();
+
+  function stop(): void {
+    clearInterval(interval);
+  }
+
+  return { stop };
+}

--- a/web/src/features/mcp/server/transport.ts
+++ b/web/src/features/mcp/server/transport.ts
@@ -12,6 +12,9 @@ import { type Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { formatErrorForUser } from "../core/error-formatting";
 import { logger } from "@langfuse/shared/src/server";
+import { env } from "@/src/env.mjs";
+import { isSigtermReceived } from "@/src/utils/shutdown";
+import { startSseKeepAlive } from "./sseKeepAlive";
 
 /**
  * Handle MCP request using Streamable HTTP transport.
@@ -68,6 +71,20 @@ export async function handleMcpRequest(
       enableJsonResponse: true, // Use JSON response (simpler for stateless mode)
     });
 
+    // GET opens a long-lived SSE stream that the stateless transport never
+    // pings or closes on its own. Keep it alive through LB idle timeouts and
+    // proactively end it during graceful shutdown / after max age so drains
+    // don't hold MCP connections until the SIGKILL (see sseKeepAlive.ts).
+    const keepAlive =
+      req.method === "GET"
+        ? startSseKeepAlive({
+            res,
+            pingIntervalMs: env.LANGFUSE_MCP_SSE_PING_INTERVAL_MS,
+            maxConnectionAgeMs: env.LANGFUSE_MCP_SSE_MAX_CONNECTION_AGE_MS,
+            isDraining: () => Boolean(isSigtermReceived()),
+          })
+        : undefined;
+
     try {
       // Connect server to transport
       await server.connect(transport);
@@ -85,6 +102,7 @@ export async function handleMcpRequest(
       // Note: Do NOT end the response here. The transport has already
       // sent the response (JSON or SSE) and ended it appropriately.
     } finally {
+      keepAlive?.stop();
       // Clean up server and transport to prevent memory leaks
       // server.close() internally calls transport.close()
       await server.close().catch((err) => {


### PR DESCRIPTION
The stateless Streamable HTTP transport opens an SSE stream on GET that it never pings, never times out, and never closes server-side. Idle streams die silently at the LB idle timeout, and open streams ride through graceful shutdown until the orchestrator SIGKILLs the container, so MCP clients see hard resets on every deploy or task stop.

Add a per-connection keep-alive that writes an SSE comment ping every 30s (configurable via LANGFUSE_MCP_SSE_PING_INTERVAL_MS) and proactively ends the stream when SIGTERM has been received or the stream exceeds its max age (LANGFUSE_MCP_SSE_MAX_CONNECTION_AGE_MS, default 15min). Per the MCP spec clients tolerate server-closed SSE streams and reconnect, which during a drain routes them to a healthy task.

Writing to the response from outside the transport is safe because the stateless transport never emits bytes on the GET stream (no session, no eventStore); documented in sseKeepAlive.ts.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds keep-alive support for the MCP GET SSE streams that the stateless Streamable HTTP transport holds open indefinitely. Two new configurable env vars (`LANGFUSE_MCP_SSE_PING_INTERVAL_MS`, `LANGFUSE_MCP_SSE_MAX_CONNECTION_AGE_MS`) control a periodic SSE comment ping and a proactive stream termination on drain or max-age.

- **`sseKeepAlive.ts`** \u2014 new module running a `setInterval` that writes `\": keep-alive\
\
\"` pings and calls `res.end()` when `isDraining()` returns `true` or the connection exceeds its configured max age; guards on `writableEnded`, `destroyed`, and `headersSent` prevent race conditions with the transport's own lifecycle.
- **`transport.ts`** \u2014 wires up `startSseKeepAlive` for GET requests only and stops it in the `finally` block; the drain check delegates to `isSigtermReceived()`, which requires `NEXT_MANUAL_SIG_HANDLE` to be set in the environment for the graceful-drain path to be active.
- **`env.mjs`** \u2014 adds the two new env vars with `z.coerce.number().int().positive()` validation and sensible defaults (30 s / 15 min).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is self-contained and well-guarded, with a focused test suite covering the critical paths.

The keep-alive logic is clean and the guards (headersSent, writableEnded, destroyed) are correct. Two non-blocking observations: drain-aware close is silently inert unless NEXT_MANUAL_SIG_HANDLE is configured, and the max-age termination can overshoot by up to one full ping interval. Neither affects correctness of the keep-alive pings themselves, which are the primary fix.

transport.ts — the implicit dependency on NEXT_MANUAL_SIG_HANDLE for the drain path is the one area operators should verify before relying on graceful-drain behaviour.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as MCP Client
    participant LB as Load Balancer
    participant Handler as handleMcpRequest
    participant KA as sseKeepAlive (interval)
    participant Shutdown as SIGTERM handler

    Client->>LB: GET /mcp (SSE)
    LB->>Handler: forward GET
    Handler->>Handler: new StreamableHTTPServerTransport
    Handler->>KA: startSseKeepAlive(res, 30s, 15min)
    Handler->>Handler: transport.handleRequest() awaits (SSE open)

    loop every 30 s
        KA->>KA: check writableEnded / destroyed
        KA->>KA: check headersSent
        KA->>KA: "check isDraining() or age >= maxAge"
        alt healthy, within age
            KA->>Client: write keep-alive comment
        else SIGTERM or age exceeded
            KA->>Client: res.end()
            KA->>KA: clearInterval (stop)
            Client-->>LB: reconnect to healthy task
        end
    end

    Shutdown->>Shutdown: SIGTERM setSigtermReceived()
    Note over KA,Shutdown: Next tick isDraining() = true (requires NEXT_MANUAL_SIG_HANDLE)
    KA->>Client: res.end()
    Client-->>Handler: response closed handleRequest resolves
    Handler->>KA: keepAlive.stop() (finally)
    Handler->>Handler: server.close()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as MCP Client
    participant LB as Load Balancer
    participant Handler as handleMcpRequest
    participant KA as sseKeepAlive (interval)
    participant Shutdown as SIGTERM handler

    Client->>LB: GET /mcp (SSE)
    LB->>Handler: forward GET
    Handler->>Handler: new StreamableHTTPServerTransport
    Handler->>KA: startSseKeepAlive(res, 30s, 15min)
    Handler->>Handler: transport.handleRequest() awaits (SSE open)

    loop every 30 s
        KA->>KA: check writableEnded / destroyed
        KA->>KA: check headersSent
        KA->>KA: "check isDraining() or age >= maxAge"
        alt healthy, within age
            KA->>Client: write keep-alive comment
        else SIGTERM or age exceeded
            KA->>Client: res.end()
            KA->>KA: clearInterval (stop)
            Client-->>LB: reconnect to healthy task
        end
    end

    Shutdown->>Shutdown: SIGTERM setSigtermReceived()
    Note over KA,Shutdown: Next tick isDraining() = true (requires NEXT_MANUAL_SIG_HANDLE)
    KA->>Client: res.end()
    Client-->>Handler: response closed handleRequest resolves
    Handler->>KA: keepAlive.stop() (finally)
    Handler->>Handler: server.close()
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/mcp/server/transport.ts:80-85
**Drain detection silently disabled without `NEXT_MANUAL_SIG_HANDLE`**

`isSigtermReceived()` in `shutdown.ts` is guarded by `Boolean(process.env.NEXT_MANUAL_SIG_HANDLE)` — if that env var is not set the function always returns `false`, so `isDraining` never becomes `true` and the advertised graceful-drain behaviour never fires. Deployments that rely on drain-aware close for MCP clients must have `NEXT_MANUAL_SIG_HANDLE` configured, but there is nothing in this path that warns operators when the guard is absent. The keep-alive pings themselves still work regardless, so LB idle timeouts are addressed; only the SIGTERM-triggered stream termination is silently inert.

### Issue 2 of 2
web/src/features/mcp/server/sseKeepAlive.ts:55-62
**Max-age termination can overshoot by one full interval**

The age check fires inside the `setInterval` callback, so a connection is actually terminated between `maxConnectionAgeMs` and `maxConnectionAgeMs + pingIntervalMs`. With the defaults (15 min age, 30 s interval) the overshoot is at most 30 s — harmless in practice. However, if operators lower the interval close to the max age, connections can live up to 2× the configured age before being closed. The behaviour is inherent to the polling approach but is worth documenting alongside the env-var descriptions so operators set the two values with the relationship in mind.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): keep-alive pings and drain-awa..."](https://github.com/langfuse/langfuse/commit/924c54f126762b8709c9e186a39efbcb38643a14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44393706)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->