### PR TITLE
feat(evals): remove propagation filter warning popup

### DIFF
--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -21,7 +21,6 @@ import {
   datasetFormFilterColsWithOptions,
   observationEvalFilterColsWithOptions,
   experimentEvalFilterColsWithOptions,
-  type ColumnDefinition,
   type availableDatasetEvalVariables,
   JobConfigState,
   validateEvaluatorFiltersForTarget,
@@ -30,10 +29,7 @@ import {
 import { z } from "zod";
 import { useEffect, useMemo, useState, memo } from "react";
 import { api } from "@/src/utils/api";
-import {
-  InlineFilterBuilder,
-  type ColumnDefinitionWithAlert,
-} from "@/src/features/filters/components/filter-builder";
+import { InlineFilterBuilder } from "@/src/features/filters/components/filter-builder";
 import {
   type EvalTemplate,
   EvalTemplateSourceCodeLanguage,
@@ -102,7 +98,6 @@ import {
   useEvaluatorTargetState,
 } from "@/src/features/evals/hooks/useEvaluatorTarget";
 import {
-  COLUMN_IDENTIFIERS_THAT_REQUIRE_PROPAGATION,
   DEFAULT_OBSERVATION_FILTER,
   DEFAULT_TRACE_FILTER,
 } from "@/src/features/evals/utils/evaluator-constants";
@@ -118,45 +113,6 @@ import {
 import { CodeEvalTestRunCard } from "@/src/features/evals/components/code-eval-test-run-card";
 import { getExperimentEvalPreviewFilters } from "@/src/features/evals/utils/experiment-eval-preview-utils";
 import { cn } from "@/src/utils/tailwind";
-
-/**
- * Adds propagation warnings to columns that require OTEL SDK with span propagation
- */
-const addPropagationWarnings = (
-  columns: ColumnDefinition[],
-  allowPropagationFilters: boolean,
-): ColumnDefinitionWithAlert[] => {
-  return columns.map((col) => {
-    if (
-      !allowPropagationFilters &&
-      COLUMN_IDENTIFIERS_THAT_REQUIRE_PROPAGATION.has(col.id)
-    ) {
-      return {
-        ...col,
-        alert: {
-          severity: "warning" as const,
-          content: (
-            <>
-              This filter requires JS SDK &ge; 4.0.0 or Python SDK &ge; 3.0.0
-              with attribute propagation enabled. Please{" "}
-              <a
-                href="https://langfuse.com/integrations/native/opentelemetry#propagating-attributes"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-dark-blue hover:opacity-80"
-              >
-                follow our docs
-              </a>{" "}
-              to configure your instrumentation to use this filter.
-            </>
-          ),
-        },
-      };
-    }
-
-    return col;
-  });
-};
 
 // Lazy load tables
 const TracesTable = lazy(
@@ -384,7 +340,7 @@ export const InnerEvaluatorForm = (props: {
     isCodeEvalEnabled && isCodeEvalTemplate(props.evalTemplate);
 
   // Destructure eval capabilities passed from parent
-  const { allowLegacy, allowPropagationFilters } = props.evalCapabilities;
+  const { allowLegacy } = props.evalCapabilities;
 
   // Custom hooks for managing evaluator state
   const {
@@ -1164,14 +1120,9 @@ export const InnerEvaluatorForm = (props: {
                     // Get appropriate columns based on target type
                     const getFilterColumns = () => {
                       if (isEventTarget(target)) {
-                        // Event evaluators - use observation columns with propagation warnings
-                        const baseColumns =
-                          observationEvalFilterColsWithOptions(
-                            observationEvalFilterOptions,
-                          );
-                        return addPropagationWarnings(
-                          baseColumns,
-                          allowPropagationFilters,
+                        // Event evaluators - use observation columns
+                        return observationEvalFilterColsWithOptions(
+                          observationEvalFilterOptions,
                         );
                       } else if (isTraceTarget(target)) {
                         return tracesTableColsWithOptions(

--- a/web/src/features/evals/hooks/useEvalCapabilities.ts
+++ b/web/src/features/evals/hooks/useEvalCapabilities.ts
@@ -8,7 +8,6 @@ export interface EvalCapabilities {
   isNewCompatible: boolean;
   compatibilityCheckWasPerformed: boolean;
   allowLegacy: boolean;
-  allowPropagationFilters: boolean;
   isLoading: boolean;
   hasLegacyEvals: boolean;
 }
@@ -41,8 +40,6 @@ export function useEvalCapabilities(
 
   // Determine OTEL status from SDK version info
   const isOtel = sdkVersionInfo.data?.isOtel ?? false;
-  // TODO: Implement propagation check
-  const isPropagating = false;
 
   // Get eval counts including legacy eval count
   const evalCounts = api.evals.counts.useQuery({ projectId });
@@ -76,8 +73,6 @@ export function useEvalCapabilities(
     // Allow legacy if: not a code eval AND (user has legacy evals to manage OR
     // the deployment mode/cohort offers the legacy experience).
     allowLegacy: !isCodeEvalConfig && (hasLegacyEvals || modeAllowsNewLegacy),
-    // Allow propagation filters only when using OTEL and spans are propagating
-    allowPropagationFilters: isOtel && isPropagating,
     isLoading:
       evalCounts.isLoading || isSessionLoading || sdkVersionInfo.isLoading,
     hasLegacyEvals,

--- a/web/src/features/evals/utils/evaluator-constants.ts
+++ b/web/src/features/evals/utils/evaluator-constants.ts
@@ -21,15 +21,6 @@ export const OBSERVATION_VARIABLES = [
   },
 ];
 
-export const COLUMN_IDENTIFIERS_THAT_REQUIRE_PROPAGATION = new Set([
-  "release",
-  "traceName",
-  "traceTags",
-  "userId",
-  "sessionId",
-  "tags",
-]);
-
 export const OUTPUT_MAPPING = [
   "generation",
   "output",


### PR DESCRIPTION
## Summary

Removes the warning popup shown on evaluator filter columns (Session ID, Tags, User ID, etc.):

> This filter requires JS SDK ≥ 4.0.0 or Python SDK ≥ 3.0.0 with attribute propagation enabled. Please follow our docs to configure your instrumentation to use this filter.

The gating boolean `isPropagating` was hardcoded to `false` with a `// TODO: Implement propagation check`, which meant `allowPropagationFilters` (`isOtel && isPropagating`) was always `false` and the warning always showed on those columns.

## Changes

- Delete the `addPropagationWarnings` helper and its call site in `inner-evaluator-form.tsx`; event evaluators now use the observation filter columns directly with no injected warning.
- Remove the unused `isPropagating` boolean and the `allowPropagationFilters` capability from `useEvalCapabilities` (interface + return).
- Remove the now-dead `COLUMN_IDENTIFIERS_THAT_REQUIRE_PROPAGATION` constant and clean up unused imports.

The separate observation-targeting compatibility notice in `remap-evaluator.tsx` is a different concern and left untouched.

## Verification

- Pre-commit hook: prettier clean, `turbo run lint` → `Tasks: 7 successful, 7 total`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes a propagation filter warning that was always showing for OTel evaluator users, because the underlying `isPropagating` flag was hardcoded to `false` (with a `// TODO: Implement propagation check` comment) — making `allowPropagationFilters` permanently `false` and the warning permanently visible regardless of the user's actual SDK setup.

- Deletes the `addPropagationWarnings` helper and its call in `inner-evaluator-form.tsx`; event evaluators now pass observation filter columns directly to `InlineFilterBuilder`.
- Removes `isPropagating`, `allowPropagationFilters`, and the `COLUMN_IDENTIFIERS_THAT_REQUIRE_PROPAGATION` constant, along with their now-unused imports and interface field.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — removes dead code that was causing a misleading warning to appear unconditionally for all OTel users.

The removed isPropagating flag was always false, so allowPropagationFilters was always false, meaning the propagation warning was shown to every user regardless of their actual SDK setup. Removing the always-wrong warning and its supporting dead code is straightforward and correct. The ColumnDefinition[] type passed to InlineFilterBuilder (which expects ColumnDefinitionWithAlert[]) is structurally compatible since alert is optional. The isOtel variable retained in useEvalCapabilities is still consumed by isNewCompatible, so no new dead code is introduced. All three changed files are cleanly edited with no leftover references.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[InnerEvaluatorForm] --> B{isEventTarget?}
    B -- Yes (before) --> C["observationEvalFilterColsWithOptions()"]
    C --> D["addPropagationWarnings(columns, allowPropagationFilters)"]
    D -- "allowPropagationFilters always false" --> E["Columns WITH warning injected"]
    E --> F[InlineFilterBuilder]

    B -- Yes (after) --> G["observationEvalFilterColsWithOptions()"]
    G --> F2[InlineFilterBuilder]

    B -- No, isTraceTarget --> H["tracesTableColsWithOptions()"]
    H --> F2

    style D fill:#f88,stroke:#c00
    style E fill:#f88,stroke:#c00
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[InnerEvaluatorForm] --> B{isEventTarget?}
    B -- Yes (before) --> C["observationEvalFilterColsWithOptions()"]
    C --> D["addPropagationWarnings(columns, allowPropagationFilters)"]
    D -- "allowPropagationFilters always false" --> E["Columns WITH warning injected"]
    E --> F[InlineFilterBuilder]

    B -- Yes (after) --> G["observationEvalFilterColsWithOptions()"]
    G --> F2[InlineFilterBuilder]

    B -- No, isTraceTarget --> H["tracesTableColsWithOptions()"]
    H --> F2

    style D fill:#f88,stroke:#c00
    style E fill:#f88,stroke:#c00
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): remove propagation filter w..."](https://github.com/langfuse/langfuse/commit/f5187d6880510157a518d95005f37f1fe2b2113b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44405118)</sub>

<!-- /greptile_comment -->