### PR TITLE
chore(unstable-llm-api): increase max eval rule count to 500

### DIFF
--- a/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
+++ b/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
@@ -42,7 +42,7 @@ import {
 import { createUnstablePublicApiError } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 import { assertUnreachable } from "@/src/utils/types";
 
-const MAX_ACTIVE_EVALUATION_RULES = 50;
+const MAX_ACTIVE_EVALUATION_RULES = 500;
 
 async function assertEvaluationRuleCanRunForPublicApi(params: {
   orgId: string;


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Increases the per-project active evaluation rule cap from 50 to 500 in the unstable public API service.

- The constant `MAX_ACTIVE_EVALUATION_RULES` is checked against a `prisma.jobConfiguration.count` query before creating or enabling any rule, so the new limit takes effect immediately with no migration needed.
- No other logic changes are included; error messages already interpolate the constant, so they will automatically reflect 500.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single constant bump from 50 to 500, guarded by a database count query that already handles the new value correctly.

The only change is raising the active evaluation rule cap. The count query, error message, and limit interpolation all reference the same constant, so everything remains consistent. No migration, schema, or logic changes are involved.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[API Request: Enable Evaluation Rule] --> B[assertActivePublicApiEvaluationRuleLimitNotExceeded]
    B --> C[countActiveEvaluationRules\nprisma.jobConfiguration.count\nstatus=ACTIVE, jobType=EVAL]
    C --> D{activeCount >= MAX?}
    D -- "MAX = 500 (was 50)" --> E[Throw 409 conflict error\nlimit exceeded]
    D -- activeCount < 500 --> F[assertEvaluationRuleCanRunForPublicApi]
    F --> G[createOrUpdateEvaluationRule\npersist to DB]
    G --> H[invalidateProjectEvalConfigCaches]
    H --> I[Return success]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[API Request: Enable Evaluation Rule] --> B[assertActivePublicApiEvaluationRuleLimitNotExceeded]
    B --> C[countActiveEvaluationRules\nprisma.jobConfiguration.count\nstatus=ACTIVE, jobType=EVAL]
    C --> D{activeCount >= MAX?}
    D -- "MAX = 500 (was 50)" --> E[Throw 409 conflict error\nlimit exceeded]
    D -- activeCount < 500 --> F[assertEvaluationRuleCanRunForPublicApi]
    F --> G[createOrUpdateEvaluationRule\npersist to DB]
    G --> H[invalidateProjectEvalConfigCaches]
    H --> I[Return success]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(unstable-llm-api): increase max ev..."](https://github.com/langfuse/langfuse/commit/87a232b436ff4127962c29098f9499598c743f8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44411499)</sub>

<!-- /greptile_comment -->