### PR TITLE
fix(tests): align eval rule limit tests with 500 cap

### DIFF
--- a/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
+++ b/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
@@ -972,8 +972,8 @@ describe("unstable public eval services", () => {
     expect(mockedPrisma.jobConfiguration.create).not.toHaveBeenCalled();
   });
 
-  it("rejects creating more than 50 active evaluation rules", async () => {
-    mockCountActiveEvaluationRules.mockResolvedValueOnce(50);
+  it("rejects creating more than 500 active evaluation rules", async () => {
+    mockCountActiveEvaluationRules.mockResolvedValueOnce(500);
 
     await expect(
       createPublicEvaluationRule({
@@ -994,7 +994,7 @@ describe("unstable public eval services", () => {
         },
       }),
     ).rejects.toThrow(
-      "This project already has the maximum number of active evaluation rules (50).",
+      "This project already has the maximum number of active evaluation rules (500).",
     );
 
     expect(mockLoadEvaluatorForEvaluationRule).not.toHaveBeenCalled();
@@ -1382,7 +1382,7 @@ describe("unstable public eval services", () => {
         status: JobConfigState.INACTIVE,
       }),
     );
-    mockCountActiveEvaluationRules.mockResolvedValueOnce(50);
+    mockCountActiveEvaluationRules.mockResolvedValueOnce(500);
 
     await expect(
       updatePublicEvaluationRule({
@@ -1394,7 +1394,7 @@ describe("unstable public eval services", () => {
         },
       }),
     ).rejects.toThrow(
-      "This project already has the maximum number of active evaluation rules (50).",
+      "This project already has the maximum number of active evaluation rules (500).",
     );
 
     expect(mockLoadEvaluatorForEvaluationRule).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Updates two tests in `unstable-evals-service.servertest.ts` that still mocked/asserted the old 50 active evaluation rule limit
- Aligns mocks to return `500` and expected error messages to `(500)` after #15103 raised `MAX_ACTIVE_EVALUATION_RULES` from 50 to 500
- Unblocks main CI (and PRs merged against current main) that were failing with "Cannot destructure property 'template' of undefined"

## Test plan
- [x] `pnpm --filter web run test unstable-evals-service.servertest.ts` — Tests 28 passed (28)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates two test cases in `unstable-evals-service.servertest.ts` to reflect the raised evaluation rule cap (50 → 500) introduced in #15103. No production logic is changed.

- The mock count returned by `mockCountActiveEvaluationRules` is updated from `50` to `500` in both the `createPublicEvaluationRule` and `updatePublicEvaluationRule` limit tests.
- The expected error message strings are updated from `(50)` to `(500)` to match the error produced by the service (`MAX_ACTIVE_EVALUATION_RULES = 500`).
- The service uses `activeCount >= MAX_ACTIVE_EVALUATION_RULES`, so mocking exactly `500` correctly triggers the boundary condition and the tests accurately validate it.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only change that correctly aligns mock values and expected error strings with the already-merged service constant change; no production code is touched.

Both updated test cases mock the count at exactly 500 and assert the error message containing "(500)", which correctly exercises the activeCount >= 500 boundary in the service. No production code is modified, and no other references to the old limit of 50 remain in the test file.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test
    participant Service as evaluation-rule-service
    participant Prisma as countActiveEvaluationRules (mock)

    Test->>Service: createPublicEvaluationRule(...)
    Service->>Prisma: countActiveEvaluationRules()
    Prisma-->>Service: 500
    Service->>Service: "500 >= MAX_ACTIVE_EVALUATION_RULES (500) → true"
    Service-->>Test: throws "maximum number of active evaluation rules (500)"
    Test->>Test: ✓ rejects.toThrow("...(500)")
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test
    participant Service as evaluation-rule-service
    participant Prisma as countActiveEvaluationRules (mock)

    Test->>Service: createPublicEvaluationRule(...)
    Service->>Prisma: countActiveEvaluationRules()
    Prisma-->>Service: 500
    Service->>Service: "500 >= MAX_ACTIVE_EVALUATION_RULES (500) → true"
    Service-->>Test: throws "maximum number of active evaluation rules (500)"
    Test->>Test: ✓ rejects.toThrow("...(500)")
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): align eval rule limit tests ..."](https://github.com/langfuse/langfuse/commit/91070e54a28dbac014d7633b18a29cb527763c29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44431199)</sub>

<!-- /greptile_comment -->