### PR TITLE
fix(mcp): Instrument more auth level fields

### DIFF
--- a/web/src/features/mcp/core/run-mcp-tool.ts
+++ b/web/src/features/mcp/core/run-mcp-tool.ts
@@ -1,5 +1,5 @@
 import { BaseError } from "@langfuse/shared";
-import { instrumentAsync } from "@langfuse/shared/src/server";
+import { addUserToSpan, instrumentAsync } from "@langfuse/shared/src/server";
 import { SpanKind, type Span } from "@opentelemetry/api";
 
 import { UnstablePublicApiError } from "@/src/features/public-api/server/unstable-public-api-error-contract";
@@ -22,10 +22,16 @@ export const runMcpTool = async <TResult>({
   instrumentAsync(
     { name: spanName, spanKind: SpanKind.INTERNAL },
     async (span) => {
+      addUserToSpan(
+        {
+          projectId: context.projectId,
+          orgId: context.orgId,
+          apiKeyId: context.apiKeyId,
+        },
+        span,
+      );
+
       span.setAttributes({
-        "langfuse.project.id": context.projectId,
-        "langfuse.org.id": context.orgId,
-        "mcp.api_key_id": context.apiKeyId,
         ...(context.userAgent ? { user_agent: context.userAgent } : {}),
         ...Object.fromEntries(
           Object.entries(attributes ?? {}).filter(

--- a/web/src/pages/api/public/mcp/index.ts
+++ b/web/src/pages/api/public/mcp/index.ts
@@ -33,7 +33,7 @@ import {
 } from "@/src/features/mcp/server/security";
 import { formatErrorForUser } from "@/src/features/mcp/core/error-formatting";
 import { type ServerContext } from "@/src/features/mcp/types";
-import { logger, redis } from "@langfuse/shared/src/server";
+import { addUserToSpan, logger, redis } from "@langfuse/shared/src/server";
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 import { prisma } from "@langfuse/shared/src/db";
@@ -100,6 +100,14 @@ export default async function handler(
         "Access denied: MCP requires project-scoped API keys with BasicAuth",
       );
     }
+
+    addUserToSpan({
+      apiKeyId: authCheck.scope.apiKeyId,
+      publicKey: authCheck.scope.publicKey,
+      projectId: authCheck.scope.projectId,
+      orgId: authCheck.scope.orgId,
+      plan: authCheck.scope.plan,
+    });
 
     // Check if ingestion is suspended due to usage limits
     if (authCheck.scope.isIngestionSuspended) {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands OpenTelemetry instrumentation for the MCP endpoint by replacing manual `span.setAttributes` calls with the centralized `addUserToSpan` helper and adding `plan`/`publicKey` fields to the handler-level span annotation.

- **`run-mcp-tool.ts`**: Swaps three manual `span.setAttribute` calls for `addUserToSpan`, also setting baggage for downstream propagation. The attribute key for the API key ID changes from `mcp.api_key_id` to `langfuse.api_key.id` to match the canonical naming used by `addUserToSpan`.
- **`index.ts`**: Adds an `addUserToSpan` call immediately after authentication succeeds, decorating the root request span (if any) with `apiKeyId`, `publicKey`, `projectId`, `orgId`, and `plan` before the MCP server is invoked.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The changes are additive instrumentation only — no business logic is altered, and addUserToSpan is a no-op when no active span exists, so there is no runtime risk.

Both files receive straightforward observability improvements: manual span.setAttribute calls are replaced with the centralized helper, and the handler gains richer auth-level context on its root span. No data flow, auth logic, or error handling is touched.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Handler as index.ts handler
    participant Auth as ApiAuthService
    participant Span as Root OTel Span
    participant Tool as runMcpTool
    participant ToolSpan as Tool Child Span

    Client->>Handler: POST /api/public/mcp
    Handler->>Auth: verifyAuthHeaderAndReturnScope()
    Auth-->>Handler: authCheck.scope
    Handler->>Span: "addUserToSpan({ apiKeyId, publicKey, projectId, orgId, plan })"
    Note over Span: Sets attrs + baggage on root span
    Handler->>Tool: "runMcpTool({ context, ... })"
    Tool->>ToolSpan: instrumentAsync(spanName)
    Tool->>ToolSpan: "addUserToSpan({ projectId, orgId, apiKeyId }, span)"
    Note over ToolSpan: Sets attrs + baggage on child span
    Tool->>ToolSpan: "span.setAttributes({ user_agent, ...custom })"
    Tool-->>Handler: result
    Handler-->>Client: response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Handler as index.ts handler
    participant Auth as ApiAuthService
    participant Span as Root OTel Span
    participant Tool as runMcpTool
    participant ToolSpan as Tool Child Span

    Client->>Handler: POST /api/public/mcp
    Handler->>Auth: verifyAuthHeaderAndReturnScope()
    Auth-->>Handler: authCheck.scope
    Handler->>Span: "addUserToSpan({ apiKeyId, publicKey, projectId, orgId, plan })"
    Note over Span: Sets attrs + baggage on root span
    Handler->>Tool: "runMcpTool({ context, ... })"
    Tool->>ToolSpan: instrumentAsync(spanName)
    Tool->>ToolSpan: "addUserToSpan({ projectId, orgId, apiKeyId }, span)"
    Note over ToolSpan: Sets attrs + baggage on child span
    Tool->>ToolSpan: "span.setAttributes({ user_agent, ...custom })"
    Tool-->>Handler: result
    Handler-->>Client: response
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Instrument more auth level fie..."](https://github.com/langfuse/langfuse/commit/7b4660132ec5bcc5f2571bc0f00ec3f1863d831e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44440408)</sub>

<!-- /greptile_comment -->