### PR TITLE
fix(codex): guard trap against unbound tmp_dir in ensure_migrate_binary

### DIFF
--- a/scripts/codex/cloud_services.sh
+++ b/scripts/codex/cloud_services.sh
@@ -156,7 +156,7 @@ ensure_migrate_binary() {
       ;;
   esac
   tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "$tmp_dir"' RETURN
+  trap 'rm -rf "${tmp_dir:-}"' RETURN
 
   download_and_verify_sha256 \
     "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_RELEASE_TAG}/migrate.linux-${migrate_arch}.tar.gz" \


### PR DESCRIPTION
## Summary
Under `set -u`, the `RETURN` trap in `ensure_migrate_binary` referenced `$tmp_dir` unguarded, so if the trap fired before `tmp_dir` was assigned the cleanup would abort with an unbound-variable error.

To achieve this we:
- Guarded the trap's cleanup with `${tmp_dir:-}` so it no-ops safely when the variable is unset.

## Verification

- [x] `bash -n scripts/codex/cloud_services.sh` (syntax check)
- [ ] Full lint/typecheck — not applicable to this standalone shell script

## Test plan

- [ ] Run the codex bootstrap flow and confirm `ensure_migrate_binary` still downloads and cleans up its temp dir
- [ ] Confirm no unbound-variable error when the trap fires early

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `${tmp_dir:-}` guard to the `RETURN` trap in `ensure_migrate_binary`, preventing an unbound-variable error under `set -u` if the variable is somehow unset when the trap fires.

- The one-character delta changes `"$tmp_dir"` to `"${tmp_dir:-}"` in the cleanup trap, so `rm -rf` becomes a harmless no-op when `tmp_dir` is unset rather than aborting with an unbound-variable error.
- In the current code the trap is registered **after** the `tmp_dir="$(mktemp -d)"` assignment, so the described failure path cannot arise at runtime today; the fix is best understood as defensive hardening against future reordering of those two lines.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line defensive bash variable guard with no functional impact on the happy path.

The fix is correct and well-scoped. In the current code the trap is registered only after tmp_dir is successfully assigned, so the unbound-variable abort cannot happen at runtime today; the change adds robustness against any future reordering of those two lines. No other logic is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ensure_migrate_binary called] --> B{migrate already installed?}
    B -- yes --> C[return 0]
    B -- no --> D[ensure_apt_package ca-certificates / curl]
    D --> E[detect_migrate_arch]
    E --> F{arch?}
    F -- amd64 --> G[migrate_sha256=AMD64 hash]
    F -- arm64 --> H[migrate_sha256=ARM64 hash]
    G & H --> I["tmp_dir=$(mktemp -d)"]
    I --> J["trap 'rm -rf ${tmp_dir:-}' RETURN"]
    J --> K[download_and_verify_sha256]
    K --> L[tar extract migrate]
    L --> M[install to /usr/local/bin/migrate]
    M --> N[RETURN trap fires → rm -rf tmp_dir]
    C --> N2[done]
    N --> N2
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ensure_migrate_binary called] --> B{migrate already installed?}
    B -- yes --> C[return 0]
    B -- no --> D[ensure_apt_package ca-certificates / curl]
    D --> E[detect_migrate_arch]
    E --> F{arch?}
    F -- amd64 --> G[migrate_sha256=AMD64 hash]
    F -- arm64 --> H[migrate_sha256=ARM64 hash]
    G & H --> I["tmp_dir=$(mktemp -d)"]
    I --> J["trap 'rm -rf ${tmp_dir:-}' RETURN"]
    J --> K[download_and_verify_sha256]
    K --> L[tar extract migrate]
    L --> M[install to /usr/local/bin/migrate]
    M --> N[RETURN trap fires → rm -rf tmp_dir]
    C --> N2[done]
    N --> N2
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(codex): guard trap against unbound t..."](https://github.com/langfuse/langfuse/commit/bbd339b5e5f7c79ecf9cde0723686ece1bb40445) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44443431)</sub>

<!-- /greptile_comment -->