### PR TITLE
fix(mcp): don't falsely advertise sse and close connections

### DIFF
--- a/web/src/__tests__/server/mcp-auth.servertest.ts
+++ b/web/src/__tests__/server/mcp-auth.servertest.ts
@@ -95,5 +95,20 @@ describe("MCP Authentication", () => {
       expect(response.status).toBe(200);
     });
 
+    it("should close authenticated GET requests with 405", async () => {
+      const { auth } = await createMcpTestSetup();
+
+      const response = await fetch(`http://localhost:3000${MCP_ENDPOINT}`, {
+        method: "GET",
+        headers: {
+          Accept: "text/event-stream",
+          Authorization: auth,
+        },
+      });
+
+      expect(response.status).toBe(405);
+      expect(response.headers.get("Allow")).toBe("POST, OPTIONS");
+      expect(await response.text()).toBe("");
+    });
   });
 });

--- a/web/src/__tests__/server/mcp-auth.servertest.ts
+++ b/web/src/__tests__/server/mcp-auth.servertest.ts
@@ -94,5 +94,21 @@ describe("MCP Authentication", () => {
       // MCP initialize should succeed with valid auth
       expect(response.status).toBe(200);
     });
+
+    it("should close authenticated GET requests with 405", async () => {
+      const { auth } = await createMcpTestSetup();
+
+      const response = await fetch(`http://localhost:3000${MCP_ENDPOINT}`, {
+        method: "GET",
+        headers: {
+          Accept: "text/event-stream",
+          Authorization: auth,
+        },
+      });
+
+      expect(response.status).toBe(405);
+      expect(response.headers.get("Allow")).toBe("POST, OPTIONS");
+      expect(await response.text()).toBe("");
+    });
   });
 });

--- a/web/src/__tests__/server/mcp-auth.servertest.ts
+++ b/web/src/__tests__/server/mcp-auth.servertest.ts
@@ -95,20 +95,5 @@ describe("MCP Authentication", () => {
       expect(response.status).toBe(200);
     });
 
-    it("should close authenticated GET requests with 405", async () => {
-      const { auth } = await createMcpTestSetup();
-
-      const response = await fetch(`http://localhost:3000${MCP_ENDPOINT}`, {
-        method: "GET",
-        headers: {
-          Accept: "text/event-stream",
-          Authorization: auth,
-        },
-      });
-
-      expect(response.status).toBe(405);
-      expect(response.headers.get("Allow")).toBe("POST, OPTIONS");
-      expect(await response.text()).toBe("");
-    });
   });
 });

--- a/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
@@ -3,57 +3,9 @@ import {
   createInAppAgentMcpRunOverride,
   InAppAgentMcpRunOverrideSchema,
 } from "@/src/ee/features/in-app-agent/server/human-in-the-loop";
-import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
-import {
-  RateLimitHelper,
-  RateLimitService,
-} from "@/src/features/public-api/server/RateLimitService";
-import handler, { getInAppAgentContext } from "@/src/pages/api/public/mcp";
+import { getInAppAgentContext } from "@/src/pages/api/public/mcp";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
-
-describe("MCP route HTTP methods", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("returns 405 for authenticated GET requests after rate limiting", async () => {
-    const verifyAuth = vi
-      .spyOn(ApiAuthService.prototype, "verifyAuthHeaderAndReturnScope")
-      .mockResolvedValue({
-        validKey: true,
-        scope: {
-          projectId: "project-1",
-          orgId: "org-1",
-          plan: "cloud:hobby",
-          accessLevel: "project",
-          rateLimitOverrides: [],
-          apiKeyId: "api-key-1",
-          publicKey: "pk-test",
-          isIngestionSuspended: false,
-          isInAppAgentKey: false,
-        },
-      });
-    const rateLimit = vi
-      .spyOn(RateLimitService.getInstance(), "rateLimitRequest")
-      .mockResolvedValue(new RateLimitHelper(undefined));
-    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
-      method: "GET",
-      headers: {
-        host: "localhost:3000",
-        authorization: "Basic test",
-      },
-    });
-
-    await handler(req, res);
-
-    expect(verifyAuth).toHaveBeenCalledOnce();
-    expect(rateLimit).toHaveBeenCalledOnce();
-    expect(res.statusCode).toBe(405);
-    expect(res.getHeader("Allow")).toBe("POST, OPTIONS");
-    expect(res._isEndCalled()).toBe(true);
-  });
-});
 
 describe("MCP route in-app-agent context", () => {
   const createRequest = (overrideHeader?: string) => {

--- a/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
@@ -3,9 +3,57 @@ import {
   createInAppAgentMcpRunOverride,
   InAppAgentMcpRunOverrideSchema,
 } from "@/src/ee/features/in-app-agent/server/human-in-the-loop";
-import { getInAppAgentContext } from "@/src/pages/api/public/mcp";
+import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
+import {
+  RateLimitHelper,
+  RateLimitService,
+} from "@/src/features/public-api/server/RateLimitService";
+import handler, { getInAppAgentContext } from "@/src/pages/api/public/mcp";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
+
+describe("MCP route HTTP methods", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 405 for authenticated GET requests after rate limiting", async () => {
+    const verifyAuth = vi
+      .spyOn(ApiAuthService.prototype, "verifyAuthHeaderAndReturnScope")
+      .mockResolvedValue({
+        validKey: true,
+        scope: {
+          projectId: "project-1",
+          orgId: "org-1",
+          plan: "cloud:hobby",
+          accessLevel: "project",
+          rateLimitOverrides: [],
+          apiKeyId: "api-key-1",
+          publicKey: "pk-test",
+          isIngestionSuspended: false,
+          isInAppAgentKey: false,
+        },
+      });
+    const rateLimit = vi
+      .spyOn(RateLimitService.getInstance(), "rateLimitRequest")
+      .mockResolvedValue(new RateLimitHelper(undefined));
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      headers: {
+        host: "localhost:3000",
+        authorization: "Basic test",
+      },
+    });
+
+    await handler(req, res);
+
+    expect(verifyAuth).toHaveBeenCalledOnce();
+    expect(rateLimit).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(405);
+    expect(res.getHeader("Allow")).toBe("POST, OPTIONS");
+    expect(res._isEndCalled()).toBe(true);
+  });
+});
 
 describe("MCP route in-app-agent context", () => {
   const createRequest = (overrideHeader?: string) => {

--- a/web/src/pages/api/public/mcp/index.ts
+++ b/web/src/pages/api/public/mcp/index.ts
@@ -11,7 +11,9 @@
  * - Context captured in closures (no session storage)
  *
  * Transport: Streamable HTTP (NOT the deprecated HTTP+SSE transport)
- * - Single endpoint handles POST (JSON-RPC), GET (SSE streams), DELETE (sessions)
+ * - POST carries JSON-RPC; GET returns 405 because there is no shared event stream
+ * - DELETE is handled by the transport (returns 405 in stateless mode)
+ * - OPTIONS handles CORS preflight
  * - JSON-RPC messages sent via POST body
  * - No separate /message endpoint needed
  *
@@ -50,7 +52,7 @@ import "@/src/features/mcp/server/bootstrap";
 /**
  * MCP API Route Handler
  *
- * Handles MCP protocol requests using Streamable HTTP (SSE) transport.
+ * Handles MCP protocol requests using Streamable HTTP transport.
  *
  * Request flow:
  * 1. Validate Host/Origin headers and handle CORS
@@ -58,7 +60,7 @@ import "@/src/features/mcp/server/bootstrap";
  * 3. Check rate limits
  * 4. Extract ServerContext from authenticated API key
  * 5. Create fresh MCP server instance with context in closures
- * 6. Connect to SSE transport
+ * 6. Connect to Streamable HTTP transport
  * 7. Handle MCP protocol communication
  * 8. Discard server instance after request
  *
@@ -119,6 +121,14 @@ export default async function handler(
       return rateLimitCheck.sendRestResponseIfLimited(res);
     }
 
+    // Each request gets an isolated transport, so a standalone GET stream
+    // cannot receive events from subsequent requests.
+    if (req.method === "GET") {
+      res.setHeader("Allow", "POST, OPTIONS");
+      res.status(405).end();
+      return;
+    }
+
     // Build ServerContext from authenticated scope. In-app-agent keys need a
     // run override for mutating tools; read-only tools remain available
     // without it via their MCP readOnlyHint annotation.
@@ -147,7 +157,6 @@ export default async function handler(
     const server = createMcpServer(context);
 
     // Handle the MCP request using Streamable HTTP transport
-    // Transport handles routing based on HTTP method (POST, GET, DELETE, OPTIONS)
     await handleMcpRequest(server, req, res);
   } catch (error) {
     logger.error("MCP API route error", {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a correctness issue where the MCP endpoint was accepting `GET` requests and passing them to the Streamable HTTP transport, which would advertise an SSE stream that could never actually deliver events from subsequent requests (because each request gets its own isolated transport instance). The fix explicitly returns `405 Method Not Allowed` with an `Allow: POST, OPTIONS` header for all `GET` requests after authentication passes.

- The GET 405 guard is inserted **after** auth and rate-limit checks (line 126), meaning unauthenticated `GET` requests still return 401 instead of 405, and rate-limit budget is consumed before the method is rejected.
- A focused integration test is added that validates the 405 status, the `Allow` header value, and an empty response body for authenticated GET requests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change closes a real connection-handling bug and is accompanied by a covering test. The only non-ideal aspect is that GET requests reach rate-limiting before being rejected.

The core fix is correct: GET requests can no longer open a useless SSE stream that would never deliver events. The 405 guard position (after auth and rate-limit) means misrouted GET requests consume rate-limit budget unnecessarily, which could affect clients in aggressive retry loops but does not break correctness.

web/src/pages/api/public/mcp/index.ts — specifically the ordering of the GET method guard relative to the rate-limit check.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as MCP Client
    participant Handler as /api/public/mcp
    participant Auth as ApiAuthService
    participant RL as RateLimitService
    participant Transport as handleMcpRequest

    Client->>Handler: GET /api/public/mcp (SSE attempt)
    Handler->>Handler: validateMcpRequestSecurity()
    Handler->>Auth: verifyAuthHeaderAndReturnScope()
    Auth-->>Handler: authCheck (valid)
    Handler->>RL: rateLimitRequest()
    RL-->>Handler: not limited
    Handler-->>Client: 405 Method Not Allowed\nAllow: POST, OPTIONS (empty body)

    Note over Client,Transport: Before this PR, GET was passed to transport<br/>which opened an SSE stream that could never<br/>receive events from subsequent requests

    Client->>Handler: POST /api/public/mcp (JSON-RPC)
    Handler->>Handler: validateMcpRequestSecurity()
    Handler->>Auth: verifyAuthHeaderAndReturnScope()
    Auth-->>Handler: authCheck (valid)
    Handler->>RL: rateLimitRequest()
    RL-->>Handler: not limited
    Handler->>Transport: handleMcpRequest(server, req, res)
    Transport-->>Client: 200 JSON-RPC response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as MCP Client
    participant Handler as /api/public/mcp
    participant Auth as ApiAuthService
    participant RL as RateLimitService
    participant Transport as handleMcpRequest

    Client->>Handler: GET /api/public/mcp (SSE attempt)
    Handler->>Handler: validateMcpRequestSecurity()
    Handler->>Auth: verifyAuthHeaderAndReturnScope()
    Auth-->>Handler: authCheck (valid)
    Handler->>RL: rateLimitRequest()
    RL-->>Handler: not limited
    Handler-->>Client: 405 Method Not Allowed\nAllow: POST, OPTIONS (empty body)

    Note over Client,Transport: Before this PR, GET was passed to transport<br/>which opened an SSE stream that could never<br/>receive events from subsequent requests

    Client->>Handler: POST /api/public/mcp (JSON-RPC)
    Handler->>Handler: validateMcpRequestSecurity()
    Handler->>Auth: verifyAuthHeaderAndReturnScope()
    Auth-->>Handler: authCheck (valid)
    Handler->>RL: rateLimitRequest()
    RL-->>Handler: not limited
    Handler->>Transport: handleMcpRequest(server, req, res)
    Transport-->>Client: 200 JSON-RPC response
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/api/public/mcp/index.ts:114-130
**GET check fires after rate-limit deduction**

The 405 guard is placed after `rateLimitRequest()` (line 114–122), so every `GET` from an SSE-expecting client — including any client in a reconnect loop — consumes a rate-limit token even though the method is categorically not allowed. If a misconfigured or legacy client retries aggressively, it can exhaust rate-limit budget for the legitimate POST traffic coming from the same API key.

Moving the method check directly after the `OPTIONS` early-return (before auth and rate-limiting) would also avoid a redundant round-trip to `ApiAuthService` for an always-rejected path, and aligns with RFC 9110 §15.5.6 which treats 405 as a property of the resource, not the caller's identity.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["simp"](https://github.com/langfuse/langfuse/commit/664884d59405e4d5e5b67ecae97c0cb06d7dcac7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44444054)</sub>

<!-- /greptile_comment -->