### PR TITLE
feat(web): dark mode updates - layering model 

### DIFF
--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -126,7 +126,7 @@ const PageHeader = ({
         </div>
 
         {/* Bottom Row */}
-        <div className="bg-header">
+        <div>
           <div
             className={cn(
               "flex min-h-11 w-full flex-wrap items-center justify-between gap-1 px-3 py-1 md:flex-nowrap",

--- a/web/src/components/table/data-table-column-visibility-filter.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.tsx
@@ -403,7 +403,7 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
         <DrawerContent overlayClassName="bg-primary/10">
           <div className="mx-auto w-full overflow-y-auto md:max-h-full">
             <div className="sticky top-0 z-10">
-              <DrawerHeader className="bg-background flex flex-row items-center justify-between rounded-sm px-3 py-2">
+              <DrawerHeader className="bg-modal flex flex-row items-center justify-between rounded-sm px-3 py-2">
                 <DrawerTitle>Column Visibility</DrawerTitle>
                 <div className="flex flex-row gap-2">
                   <Button

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -335,7 +335,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
                 // No overflow-hidden here: the resize handle straddles the left
                 // edge (overhangs onto the table) so it's grabbable from either
                 // side. The body clips its own content instead.
-                "bg-background top-banner-offset h-screen-with-banner fixed right-0 bottom-0 flex max-h-full min-h-0 max-w-none flex-col gap-0 border-l",
+                "bg-modal top-banner-offset h-screen-with-banner fixed right-0 bottom-0 flex max-h-full min-h-0 max-w-none flex-col gap-0 border-l",
                 // Soft shadow cast leftward (toward the table) to lift the peek
                 // off the content behind it.
                 "shadow-[-12px_0_32px_-16px_rgb(0_0_0_/_0.30)]",

--- a/web/src/components/table/peek/PeekHeader.tsx
+++ b/web/src/components/table/peek/PeekHeader.tsx
@@ -206,7 +206,7 @@ export function PeekHeader({
     <TooltipProvider delayDuration={TOOLTIP_DELAY_MS}>
       <div
         ref={headerRef}
-        className="bg-header flex min-h-11 shrink-0 flex-row flex-nowrap items-center justify-between gap-2 overflow-hidden px-2 py-1"
+        className="bg-muted flex min-h-11 shrink-0 flex-row flex-nowrap items-center justify-between gap-2 overflow-hidden px-2 py-1"
       >
         <div className="flex min-w-0 flex-row items-center gap-2">
           {/* Badge never truncates: it shows the full label or just the icon. */}

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -469,7 +469,7 @@ export function TableViewPresetsDrawer({
         </DrawerTrigger>
         <DrawerContent overlayClassName="bg-primary/10">
           <div className="mx-auto w-full">
-            <DrawerHeader className="bg-background flex flex-row items-center justify-between rounded-sm px-3 py-1.5">
+            <DrawerHeader className="bg-modal flex flex-row items-center justify-between rounded-sm px-3 py-1.5">
               <DrawerTitle className="flex flex-row items-center gap-1">
                 Views{" "}
                 <a

--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -48,7 +48,7 @@ const AlertDialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         motionStyles.content,
-        "bg-background fixed top-[50%] left-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg sm:rounded-lg",
+        "bg-modal fixed top-[50%] left-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -60,7 +60,7 @@ const DialogOverlay = React.forwardRef<
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const dialogContentVariants = cva(
-  "fixed left-[50%] top-[50%] overflow-hidden flex w-full translate-x-[-50%] translate-y-[-50%] flex-col bg-background shadow-lg sm:rounded-lg",
+  "fixed left-[50%] top-[50%] overflow-hidden flex w-full translate-x-[-50%] translate-y-[-50%] flex-col bg-modal shadow-lg sm:rounded-lg",
   {
     variants: {
       size: {
@@ -166,7 +166,7 @@ const DialogContent = React.forwardRef<
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const dialogHeaderVariants = cva(
-  "bg-background sticky top-0 z-30 flex shrink-0 flex-col space-y-1.5 rounded-t-lg p-4",
+  "bg-modal sticky top-0 z-30 flex shrink-0 flex-col space-y-1.5 rounded-t-lg p-4",
   {
     variants: {
       variant: {
@@ -223,7 +223,7 @@ const DialogBody = React.forwardRef<
 DialogBody.displayName = "DialogBody";
 
 const dialogFooterVariants = cva(
-  "bg-background sticky bottom-0 z-10 flex shrink-0 flex-col-reverse rounded-b-lg p-6 px-6 sm:flex-row sm:justify-end sm:space-x-2",
+  "bg-modal sticky bottom-0 z-10 flex shrink-0 flex-col-reverse rounded-b-lg p-6 px-6 sm:flex-row sm:justify-end sm:space-x-2",
   {
     variants: {
       variant: {

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -36,7 +36,7 @@ type DrawerContentProps = React.ComponentPropsWithoutRef<
 // https://tailwindcss.com/docs/responsive-design
 const TAILWIND_MD_MEDIA_QUERY = 768;
 
-const drawerVariants = cva("fixed flex flex-col border bg-background", {
+const drawerVariants = cva("fixed flex flex-col border bg-modal", {
   variants: {
     direction: {
       bottom: "inset-x-0 bottom-0 rounded-t-lg",

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -43,7 +43,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-100 data-[state=open]:duration-100",
+  "fixed gap-4 bg-modal p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-100 data-[state=open]:duration-100",
   {
     variants: {
       side: {

--- a/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -217,7 +217,7 @@ const MessageCard = forwardRef<
           : "rounded-2xl px-3 py-1.5 text-sm",
         isUser
           ? "bg-primary text-primary-foreground"
-          : "bg-card dark:bg-header text-foreground border-border border",
+          : "bg-card text-foreground border-border border",
       )}
     >
       {content.type === "loading" ? (

--- a/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.tsx
@@ -29,7 +29,7 @@ export function InAppAgentToolCallCard({
   return (
     <div
       className={cn(
-        "bg-card dark:bg-header text-foreground border-border rounded-2xl border shadow-xs",
+        "bg-card text-foreground border-border rounded-2xl border shadow-xs",
         isCompact
           ? "rounded-xl px-2.5 py-2 text-[0.775rem]"
           : "px-3 py-2.5 text-sm",

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -789,9 +789,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
               {isExpanded && (
                 <>
                   {/* Gradient overlays for expanded state so that the edges fade out */}
-                  {/* Make sure this matches the color of the background */}
-                  <div className="from-header absolute top-0 right-0 h-full w-1/2 bg-linear-to-l to-transparent" />
-                  <div className="from-header absolute top-0 left-0 h-full w-1/2 bg-linear-to-r to-transparent" />
+                  {/* Match the assistant surface (bg-background) so edges fade cleanly */}
+                  <div className="from-background absolute top-0 right-0 h-full w-1/2 bg-linear-to-l to-transparent" />
+                  <div className="from-background absolute top-0 left-0 h-full w-1/2 bg-linear-to-r to-transparent" />
                 </>
               )}
             </div>

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -400,7 +400,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
           isHeaderDragHandleEnabled ? "true" : undefined
         }
         className={cn(
-          "bg-header flex min-h-11.25 shrink-0 items-center justify-between gap-2 border-b px-3 py-1",
+          "bg-card flex min-h-11.25 shrink-0 items-center justify-between gap-2 border-b px-3 py-1",
           isHeaderDragHandleEnabled && "cursor-move touch-none select-none",
         )}
       >
@@ -621,7 +621,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                       key={label}
                       type="button"
                       className={cn(
-                        "bg-card dark:bg-header text-foreground border-border hover:bg-muted/60 border text-[0.775rem] leading-none shadow-xs transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+                        "bg-card text-foreground border-border hover:bg-muted/60 border text-[0.775rem] leading-none shadow-xs transition-colors disabled:cursor-not-allowed disabled:opacity-60",
                         isExpanded
                           ? "rounded-2xl px-3 py-2"
                           : "rounded-xl px-2 py-1.5",
@@ -800,7 +800,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
         <div
           className={cn(
             "p-1.5",
-            isExpanded ? "pt-0" : "bg-header",
+            isExpanded ? "pt-0" : "bg-card",
             !isExpanded && hasUserMessage && "border-t",
           )}
         >

--- a/web/src/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
+++ b/web/src/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
@@ -258,7 +258,7 @@ export const CreateOrEditLLMSchemaDialog: React.FC<
               </div>
             </DialogBody>
 
-            <DialogFooter className="bg-background sticky bottom-0 mt-4 flex flex-col gap-2 border-t pt-4">
+            <DialogFooter className="bg-modal sticky bottom-0 mt-4 flex flex-col gap-2 border-t pt-4">
               <div className="flex w-full flex-col gap-2">
                 <p className="text-muted-foreground text-xs">
                   Note: Changes to schemas are reflected to all members of this

--- a/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
+++ b/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
@@ -262,7 +262,7 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
               </div>
             </DialogBody>
 
-            <DialogFooter className="bg-background sticky bottom-0 mt-4 flex flex-col gap-2 border-t pt-4">
+            <DialogFooter className="bg-modal sticky bottom-0 mt-4 flex flex-col gap-2 border-t pt-4">
               <div className="flex w-full flex-col gap-2">
                 <p className="text-muted-foreground text-xs">
                   Note: Changes to tools are reflected to all members of this

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -80,6 +80,8 @@
   --color-popover-foreground: hsl(var(--popover-foreground));
   --color-card: hsl(var(--card));
   --color-card-foreground: hsl(var(--card-foreground));
+  --color-modal: hsl(var(--modal));
+  --color-modal-foreground: hsl(var(--modal-foreground));
   --color-header: hsl(var(--header));
   --color-header-foreground: hsl(var(--header-foreground));
   --color-sidebar: hsl(var(--sidebar-background));
@@ -200,6 +202,12 @@
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
 
+    /* Blocking overlay surfaces (Dialog/AlertDialog/Sheet/Drawer/peek).
+       Light themes keep the alternating white model (Carbon: light layers
+       alternate, dark layers step lighter), so this matches --background. */
+    --modal: 0 0% 100%;
+    --modal-foreground: 222.2 84% 4.9%;
+
     --header: 210 40% 98%;
     --header-foreground: var(--foreground);
 
@@ -315,17 +323,26 @@
   }
 
   .dark {
-    /* Linear-style surface ladder: elevation is carried by lightness steps
-       (background < header/sidebar < card < popover) plus hairline borders —
-       not shadows. Values from linear.app's [data-theme=dark] tokens. */
-    /* Neutral (zero-saturation) surface ladder — lightness steps carry the
-       elevation (Linear's structure, de-tinted per Trang's call after a
-       cool/neutral/warm A-B). Text hierarchy comes from the WIDE GAP between
+    /* Surface ladder — "layers become one step lighter with each added
+       layer" (Carbon's dark-theme layering model; Hex and Cloudflare Kumo
+       follow the same structure). The GLOBAL FRAME (header/sidebar chrome)
+       is the darkest tier; the content canvas sits one step above it, and
+       every stacked layer steps up from there:
+         chrome 2% < canvas 6% < card 7.5% < modal 9% < popover 12%.
+       The bottom step is the widest (chrome→canvas) — equal pp steps read
+       smaller near black, and the frame/content split carries the layout.
+       Popovers outrank modals because menus/tooltips open on top of dialogs.
+       Never paint a surface darker than what it floats above (Carbon rule).
+       --surface-code stays BELOW its surroundings — it is the one recessed
+       tier ("code is a well"). Elevation is carried by these lightness steps
+       plus hairline borders, not shadows. */
+    /* Neutral (zero-saturation) ladder — de-tinted per Trang's call after a
+       cool/neutral/warm A-B. Text hierarchy comes from the WIDE GAP between
        tiers: emphasis 91% > body 88% > meta 54% > faint 40%, with sidebar nav
        dimmer than content until active. Bright tiers cap near 91% (the docs
        site caps at 90%) — never near-white. Don't compress the ramp — the
        gap is the hierarchy. */
-    --background: 0 0% 3.5%;
+    --background: 0 0% 6%;
     --foreground: 0 0% 88%;
 
     --muted: 0 0% 11.6%;
@@ -333,16 +350,20 @@
     --foreground-tertiary: 0 0% 40%;
     --surface-code: 0 0% 2.3%;
 
-    --popover: 0 0% 10.2%;
+    --popover: 0 0% 12%;
     --popover-foreground: 0 0% 88%;
 
-    --card: 0 0% 8.2%;
+    --card: 0 0% 7.5%;
     --card-foreground: 0 0% 88%;
 
-    --header: 0 0% 6.3%;
+    --modal: 0 0% 9%;
+    --modal-foreground: 0 0% 88%;
+
+    --header: 0 0% 2%;
     --header-foreground: var(--foreground);
 
-    --border: 0 0% 10.5%;
+    /* Hairline must read on EVERY surface tier, including popover (12%). */
+    --border: 0 0% 15%;
     --border-contrast: 0 0% 26%;
     --input: 0 0% 18%;
 
@@ -355,7 +376,7 @@
     --tertiary: 0 0% 16.5%;
     --tertiary-foreground: 0 0% 88%;
 
-    /* One clear step above --popover (10.2%) — focus:bg-accent is the only
+    /* One clear step above --popover (12%) — focus:bg-accent is the only
        focus cue in menus/selects/⌘K, and 14.3% was a near-invisible ~1.13:1. */
     --accent: 0 0% 18%;
     --accent-foreground: 0 0% 91%;
@@ -377,7 +398,7 @@
     --muted-blue: 215 95% 73.1%;
     --muted-green: 142 76.7% 73.1%;
     --muted-magenta: 330 76.7% 73.1%;
-    /* Keeps ~4pp above --card so chart grids (--chart-grid) and disabled
+    /* Stays clearly above --card so chart grids (--chart-grid) and disabled
        badge fills stay discernible on elevated surfaces, without the harshness
        of --border-contrast (26%). */
     --muted-gray: 0 0% 16%;
@@ -413,13 +434,13 @@
 
     --radius: 0.5rem;
 
-    --sidebar-background: 0 0% 6.3%;
+    --sidebar-background: 0 0% 2%;
     --sidebar-foreground: 0 0% 60%;
     --sidebar-primary: 0 0% 90%;
     --sidebar-primary-foreground: 0 0% 3.5%;
-    --sidebar-accent: 0 0% 11.6%;
+    --sidebar-accent: 0 0% 10%;
     --sidebar-accent-foreground: 0 0% 91%;
-    --sidebar-border: 0 0% 10.5%;
+    --sidebar-border: 0 0% 12%;
     --sidebar-ring: 246 55% 70%;
 
     --find-match-background: 60 100% 20%;


### PR DESCRIPTION
## Summary

First entry in the design-system series — the **dark-mode layering foundation**. Two changes:

1. **Remove the `bg-header` gray band** behind the page title row — the title sits on the plain page background, app-wide. Sticky behavior, bottom border, and shadow are unchanged (an earlier experiment removing those also stripped the tab underline, so they stay).
2. **Adopt the dark-theme layering model shared by Carbon, Hex, and Kumo**: the global frame (header/sidebar chrome) is the darkest tier, and every stacked layer steps one step lighter — nothing is ever painted darker than what it floats above. Blocking overlays (Dialog, AlertDialog, Sheet, Drawer, table peek) move off `bg-background` onto a new `bg-modal` token, and the hairline `--border` is raised so it reads on every tier. Light mode keeps its alternating white model (Carbon's light-theme rule), so `--modal` matches `--background` there — light mode is visually unchanged.

### The ladder (dark, HSL lightness)

| Tier | Before | After |
|---|---|---|
| chrome — `--header`, `--sidebar-background` | 6.3% (lighter than content) | **2%** (darkest tier) |
| canvas — `--background` | 3.5% | **6%** |
| card — `--card` | 8.2% | **7.5%** |
| modal — `--modal` *(new)* | = background | **9%** |
| popover — `--popover` | 10.2% | **12%** |
| hairline — `--border` | 10.5% (≈ popover → invisible there) | **15%** |

The widest step sits at chrome→canvas: equal steps read smaller near black, and the frame/content split carries the layout.

## Before / After

| | Before | After |
|---|---|---|
| **Tracing** (frame vs content) | <img width="400" alt="1-traces-before" src="https://github.com/user-attachments/assets/bb5f9de9-6dd8-41a9-9fcb-cd9b77d07212" /> | <img width="400" alt="2-traces-after" src="https://github.com/user-attachments/assets/9f17d76c-68e8-40a1-888e-dc9ccd517cc2" /> |
| **Column sheet** (panel lifts off canvas) | <img width="400" alt="3-sheet-before" src="https://github.com/user-attachments/assets/3c77bdf4-dd9c-4528-9320-6c98189fb381" /> | <img width="400" alt="4-sheet-after" src="https://github.com/user-attachments/assets/6c063c90-74c4-44ce-9aa0-25805d495896" /> |
| **Dialog** (modal tier above dimmed canvas) | <img width="400" alt="5-dialog-before" src="https://github.com/user-attachments/assets/d0a6a00d-3584-4531-8e83-490607336433" /> | <img width="400" alt="6-dialog-after" src="https://github.com/user-attachments/assets/f88397e4-a773-4404-a34e-d5305f4cc4aa" /> |
| **Assistant window** (review-fix follow-up; the modal-tier lift itself ships in `design-tuning`) | <img width="400" alt="1-assistant-before" src="https://github.com/user-attachments/assets/af2ebbe3-dfc5-402f-b03c-1af8486fad4f" /> | <img width="400" alt="2-assistant-after" src="https://github.com/user-attachments/assets/8e2777ba-f9a4-4afe-91b8-bf133494c46c" /> |

Click any image for full size — all pairs shot at the same viewport, "before" = main.

## Impacted packages

- `web` only: `globals.css` tokens + five overlay primitives (`dialog`, `alert-dialog`, `sheet`, `drawer`, table `peek`).

## Verification

- `pnpm exec eslint` on all changed components → exit 0 (`--max-warnings 0`)
- Browser-reviewed in dark and light mode across Tracing, Dashboards, Settings dialogs, and the column-visibility sheet; the pairs above are from that pass.

## Stacked PRs

This is the base of a three-branch stack; `typo-updates` (type system) and `design-tuning` (theme lab + visual tuning) follow, each reviewable against the one below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the `bg-header` gray band from the page-header bottom row (title/actions row) so it now renders directly on the page canvas, and introduces a new `--modal` surface token for elevated overlay components (Dialog, AlertDialog, Sheet, Drawer, peek). The dark-mode surface ladder is restructured so the chrome tier (header/sidebar at 2%) is the darkest tier, canvas sits above it (6%), and each overlay layer steps lighter: card 7.5% → modal 9% → popover 12%.

- **New `--modal` token**: replaces `bg-background` across all overlay components so dark-mode overlays are visually elevated above the canvas, following Carbon's layering model.
- **Surface ladder restructure**: `--background` moves 3.5% → 6%, `--header`/`--sidebar-background` move to 2% (chrome is now darker than canvas), and `--border` rises from 10.5% → 15% to remain visible on every surface tier including popovers at 12%.
- **Page header**: only the bottom row (title band) loses its `bg-header` override; the sticky shell, border, and shadow are unchanged.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is purely visual — no logic, data, or API paths are touched. It is safe to merge, though a dark-mode visual pass on card surfaces is recommended.

All modifications are Tailwind class substitutions and CSS variable definitions with no branching logic. The new `--modal` token is correctly registered in the `@theme inline` block and defined in both `:root` and `.dark`. The one thing worth verifying before shipping is the `--card` / `--background` proximity in dark mode (1.5 pp step): borderless card components may visually merge with the canvas, which would be a silent regression invisible in light mode.

A focused dark-mode visual QA pass on `globals.css` values is worthwhile, specifically checking any card components that render without an explicit border to ensure they remain distinguishable from the canvas at the new lightness levels.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Chrome: header / sidebar\n dark: 2% lightness\nbg-header / bg-sidebar"]
    B["Canvas: page background\n dark: 6% lightness\nbg-background"]
    C["Card surfaces\n dark: 7.5% lightness\nbg-card"]
    D["Modal overlays NEW\nDialog / Sheet / Drawer / Peek\n dark: 9% lightness\nbg-modal"]
    E["Popover / Tooltip / Menu\n dark: 12% lightness\nbg-popover"]
    F["Border hairline\n dark: 15% lightness\nborder-border"]

    A -->|"+4pp"| B
    B -->|"+1.5pp"| C
    C -->|"+1.5pp"| D
    D -->|"+3pp"| E
    F -. "reads on all tiers" .- E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Chrome: header / sidebar\n dark: 2% lightness\nbg-header / bg-sidebar"]
    B["Canvas: page background\n dark: 6% lightness\nbg-background"]
    C["Card surfaces\n dark: 7.5% lightness\nbg-card"]
    D["Modal overlays NEW\nDialog / Sheet / Drawer / Peek\n dark: 9% lightness\nbg-modal"]
    E["Popover / Tooltip / Menu\n dark: 12% lightness\nbg-popover"]
    F["Border hairline\n dark: 15% lightness\nborder-border"]

    A -->|"+4pp"| B
    B -->|"+1.5pp"| C
    C -->|"+1.5pp"| D
    D -->|"+3pp"| E
    F -. "reads on all tiers" .- E
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/styles/globals.css:356-357
**Card nearly indistinguishable from canvas in dark mode**

`--card` (7.5%) sits only 1.5 pp above `--background` (6%) — down from ~4.7 pp previously (8.2% − 3.5%). `rgb(19,19,19)` vs `rgb(15,15,15)` is a difference of 4 per channel, which is essentially imperceptible on large surfaces without a border. Any card component that relies on fill alone (no explicit `border border-border`) will look flat against the canvas in dark mode. Worth a visual pass on data-table cards, settings cards, and any borderless card variants during QA.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): dark-mode surface ladder — gl..."](https://github.com/langfuse/langfuse/commit/4f47155a7facfeba412d4f237809d613e90a908f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45036638)</sub>

<!-- /greptile_comment -->
