### PR TITLE
fix(auth): stop verification-token misses from spamming prisma:error logs

### DIFF
--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -656,69 +656,72 @@ const extendedPrismaAdapter: Adapter = {
     }
   },
 
-  // Make email-OTP login that is used for password reset safer
+  // Make email-OTP login that is used for password reset safer.
+  //
+  // Look the token up before consuming it. The upstream PrismaAdapter
+  // implements this as an unconditional `verificationToken.delete`, which
+  // rejects with Prisma P2025 whenever the token is missing — expired,
+  // already consumed (e.g. an email security scanner prefetching the magic
+  // link), or a bogus value from endpoint scanning. Every rejected query is
+  // surfaced by the global Prisma error handler (packages/shared/src/db.ts) as
+  // a `prisma:error` ERROR log, so a routine "invalid or expired token" spams
+  // error logs and error-rate dashboards. Reading first keeps the happy path
+  // identical while treating a missing token as the ordinary invalid-token
+  // outcome instead of a failed query.
   async useVerificationToken(params) {
-    if (!prismaAdapter.useVerificationToken)
-      throw new Error("useVerificationToken not implemented");
+    const identifier_token = {
+      identifier: params.identifier,
+      token: params.token,
+    };
 
-    try {
-      // First, attempt to use the token with the default behavior
-      const result = await prismaAdapter.useVerificationToken(params);
+    const verificationToken = await prisma.verificationToken.findUnique({
+      where: { identifier_token },
+    });
 
-      if (result) {
-        // Token was valid and successfully used
-        logger.info("OTP verification successful", {
-          identifier: params.identifier,
-          timestamp: new Date().toISOString(),
-        });
-        return result;
-      }
-
-      // If no result, the token was either invalid or expired
-      // Log security event for monitoring
+    if (!verificationToken) {
+      // Token invalid or expired-and-swept. Log the security event and clear
+      // any remaining tokens for this identifier to prevent enumeration.
       logger.info("Failed OTP verification attempt", {
         identifier: params.identifier,
-        token: params.token?.substring(0, 2) + "****", // Log partial token for debugging
+        token: params.token?.substring(0, 2) + "****", // partial token for debugging
         timestamp: new Date().toISOString(),
         reason: "invalid_or_expired",
       });
 
-      // Delete any existing token for this identifier to prevent enumeration
       await prisma.verificationToken.deleteMany({
-        where: {
-          identifier: params.identifier,
-        },
+        where: { identifier: params.identifier },
       });
 
       return null;
+    }
+
+    try {
+      // Consume the token. NextAuth validates `expires` on the returned row.
+      await prisma.verificationToken.delete({ where: { identifier_token } });
     } catch (error) {
-      // Log security event for any error during token verification
-      logger.error("OTP verification error", {
-        identifier: params.identifier,
-        token: params.token?.substring(0, 2) + "****",
-        timestamp: new Date().toISOString(),
-        error: error instanceof Error ? error.message : String(error),
-      });
-
-      // On any error (invalid token, etc.), delete all tokens for this identifier
-      // to prevent enumeration attacks
-      try {
-        await prisma.verificationToken.deleteMany({
-          where: {
-            identifier: params.identifier,
-          },
+      // A concurrent request may have consumed the token between the read and
+      // the delete. Treat that race as an already-used token, not a 500.
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        (error as { code?: unknown }).code === "P2025"
+      ) {
+        logger.info("OTP verification token already consumed", {
+          identifier: params.identifier,
+          timestamp: new Date().toISOString(),
         });
-      } catch (deleteError) {
-        // Log deletion error but don't throw to avoid masking original error
-        logger.error(
-          "Failed to delete verification tokens on error",
-          deleteError,
-        );
+        return null;
       }
-
-      // Re-throw the original error
       throw error;
     }
+
+    logger.info("OTP verification successful", {
+      identifier: params.identifier,
+      timestamp: new Date().toISOString(),
+    });
+
+    return verificationToken;
   },
 };
 


### PR DESCRIPTION
## What

Reworks the custom NextAuth `useVerificationToken` in `web/src/server/auth.ts` to look the token up with `findUnique` **before** deleting it, instead of delegating to the upstream `PrismaAdapter` (which does an unconditional `verificationToken.delete`).

## Why

The upstream adapter's `delete` rejects with Prisma **P2025** ("record not found") whenever the token is missing — expired, already consumed (e.g. an email security scanner pre-fetching the magic link), or a bogus value from endpoint scanning. That rejected query is caught by the adapter and the request is handled gracefully (returns `null` → NextAuth redirect, **not** a 500), **but** the failed query still fires the global Prisma error handler in `packages/shared/src/db.ts`, emitting a `prisma:error ... verificationToken.delete` **ERROR** log every time.

On prod-eu this is thousands of ERROR logs/hour during email-link prefetching and the current endpoint scan — inflating error dashboards and log-based alerting for what is a routine "invalid or expired token".

## Change

- Read the token first; a missing token is the ordinary invalid/expired path — log the existing `Failed OTP verification attempt` security event, run the anti-enumeration `deleteMany`, return `null`. No failing query, no `prisma:error`.
- On a hit, delete it and return the row (NextAuth still validates `expires`).
- A concurrent-consume race on the delete is caught as P2025 → `null` rather than surfacing as an error.

Behavior (happy path, invalid-token redirect, anti-enumeration cleanup) is unchanged; only the spurious ERROR logging is removed.

## Scope note

This targets the `prisma:error` log flood. It does **not** change the separate HTTP 500s seen on `/api/auth/*` (e.g. `ERR_INVALID_URL` from malformed `callbackUrl`, and 500s on `/providers`, `/csrf`, `/session`, `/signin/*`) — those need the NextAuth structured logging from #15096 to diagnose.

## Verification

- `pnpm --filter web run typecheck` — pass (exit 0)
- `eslint src/server/auth.ts` — clean
- prettier — clean
- Full `turbo lint` / server tests not run locally (heavy pre-commit hook exceeded the sandbox timeout); relying on CI + the PR preview environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reworks `useVerificationToken` in `web/src/server/auth.ts` to use a `findUnique` + `delete` pattern instead of delegating to the upstream `PrismaAdapter`, which issued an unconditional `delete` that triggered a Prisma P2025 error — and thus a global `prisma:error` log — on every missing/expired/already-consumed token. The logic is otherwise equivalent: the happy path, anti-enumeration `deleteMany`, and security event logging are all preserved.

- The read-before-delete replaces the noise source: a missing token now follows the ordinary `findUnique → null → deleteMany → return null` path with zero failed queries.
- An explicit P2025 catch on the `delete` handles the concurrent-consume TOCTOU race, returning `null` cleanly instead of surfacing as an error.
- Expired tokens that are still present in the DB continue to be found, deleted, and returned to NextAuth for expiry validation — unchanged behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is scoped to a single adapter method, all three execution paths (valid token, missing token, concurrent race) are explicitly handled, and the observable behavior for callers is identical to before.

The findUnique + delete pattern is sound: the TOCTOU race on the delete is caught and handled, anti-enumeration cleanup and all security-event logs are preserved, and the expired-but-present token path continues to delegate expiry validation to NextAuth exactly as before. No new code paths are left unhandled.

No files require special attention. web/src/server/auth.ts is the only changed file and the change is self-contained within one adapter method.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant NextAuth
    participant useVerificationToken
    participant Prisma DB

    NextAuth->>useVerificationToken: "useVerificationToken({identifier, token})"

    useVerificationToken->>Prisma DB: findUnique({identifier_token})
    alt Token not found (invalid / expired-and-swept)
        Prisma DB-->>useVerificationToken: null
        useVerificationToken->>useVerificationToken: log "Failed OTP verification attempt"
        useVerificationToken->>Prisma DB: deleteMany({identifier}) [anti-enumeration]
        Prisma DB-->>useVerificationToken: ok
        useVerificationToken-->>NextAuth: null (redirect, no 500)
    else Token found
        Prisma DB-->>useVerificationToken: verificationToken row
        useVerificationToken->>Prisma DB: delete({identifier_token})
        alt Delete succeeds (happy path)
            Prisma DB-->>useVerificationToken: ok
            useVerificationToken->>useVerificationToken: log "OTP verification successful"
            useVerificationToken-->>NextAuth: verificationToken (NextAuth checks expires)
        else P2025 — concurrent consume race
            Prisma DB-->>useVerificationToken: PrismaClientKnownRequestError P2025
            useVerificationToken->>useVerificationToken: log "OTP verification token already consumed"
            useVerificationToken-->>NextAuth: null
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant NextAuth
    participant useVerificationToken
    participant Prisma DB

    NextAuth->>useVerificationToken: "useVerificationToken({identifier, token})"

    useVerificationToken->>Prisma DB: findUnique({identifier_token})
    alt Token not found (invalid / expired-and-swept)
        Prisma DB-->>useVerificationToken: null
        useVerificationToken->>useVerificationToken: log "Failed OTP verification attempt"
        useVerificationToken->>Prisma DB: deleteMany({identifier}) [anti-enumeration]
        Prisma DB-->>useVerificationToken: ok
        useVerificationToken-->>NextAuth: null (redirect, no 500)
    else Token found
        Prisma DB-->>useVerificationToken: verificationToken row
        useVerificationToken->>Prisma DB: delete({identifier_token})
        alt Delete succeeds (happy path)
            Prisma DB-->>useVerificationToken: ok
            useVerificationToken->>useVerificationToken: log "OTP verification successful"
            useVerificationToken-->>NextAuth: verificationToken (NextAuth checks expires)
        else P2025 — concurrent consume race
            Prisma DB-->>useVerificationToken: PrismaClientKnownRequestError P2025
            useVerificationToken->>useVerificationToken: log "OTP verification token already consumed"
            useVerificationToken-->>NextAuth: null
        end
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): stop verification-token misse..."](https://github.com/langfuse/langfuse/commit/fa5c9b47e8ffa0c57e86517f6868e2bd8f83be2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44456235)</sub>

<!-- /greptile_comment -->