### PR TITLE
feat(llm): harmonize model params with AI SDK

### DIFF
--- a/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
@@ -5,6 +5,7 @@ import {
   type ChatMessage,
   ChatMessageRole,
   ChatMessageType,
+  type LegacyCompatibleModelParams,
   LLMAdapter,
   type ModelParams,
 } from "../types";
@@ -159,7 +160,7 @@ const FAKE_GCP_SERVICE_ACCOUNT_KEY = JSON.stringify({
 });
 
 async function runCompletion(params: {
-  modelParams: ModelParams;
+  modelParams: LegacyCompatibleModelParams;
   apiKey: string;
   baseURL?: string | null;
   extraHeaders?: Record<string, string>;
@@ -202,9 +203,9 @@ describe("AI SDK request shapes", () => {
         provider: "openai",
         adapter: LLMAdapter.OpenAI,
         model: "gpt-4o",
-        max_tokens: 128,
+        maxOutputTokens: 128,
         temperature: 0.2,
-        providerOptions: { reasoning_effort: "high" },
+        reasoning: "high",
       },
       apiKey: "sk-test",
       response: OPENAI_CHAT_RESPONSE,
@@ -246,7 +247,7 @@ describe("AI SDK request shapes", () => {
         provider: "openai",
         adapter: LLMAdapter.OpenAI,
         model: "custom-reasoning-model",
-        max_tokens: 64,
+        maxOutputTokens: 64,
         providerOptions: {
           reasoning_effort: "high",
           service_tier: "flex",
@@ -328,7 +329,8 @@ describe("AI SDK request shapes", () => {
         provider: "azure",
         adapter: LLMAdapter.Azure,
         model: "gpt4o-deployment",
-        max_tokens: 64,
+        maxOutputTokens: 64,
+        reasoning: "high",
         providerOptions: { logit_bias: { "42": 1 } },
       },
       apiKey: "azure-key",
@@ -343,6 +345,7 @@ describe("AI SDK request shapes", () => {
     expect(request.headers.get("api-key")).toBe("azure-key");
     expect(request.headers.get("x-custom")).toBe("1");
     expect(request.body.logit_bias).toEqual({ "42": 1 });
+    expect(request.body.reasoning_effort).toBe("high");
     expect(request.body.max_tokens).toBe(64);
   });
 
@@ -352,7 +355,7 @@ describe("AI SDK request shapes", () => {
         provider: "azure",
         adapter: LLMAdapter.Azure,
         model: "gpt4o-deployment",
-        max_tokens: 64,
+        maxOutputTokens: 64,
       },
       apiKey: "azure-key",
       baseURL:
@@ -372,9 +375,9 @@ describe("AI SDK request shapes", () => {
         provider: "openai",
         adapter: LLMAdapter.OpenAI,
         model: "gpt-5.4-mini",
-        max_tokens: 64,
+        maxOutputTokens: 64,
         temperature: 0.2,
-        top_p: 0.9,
+        topP: 0.9,
       },
       apiKey: "openai-key",
       response: OPENAI_CHAT_RESPONSE,
@@ -392,7 +395,7 @@ describe("AI SDK request shapes", () => {
         provider: "anthropic",
         adapter: LLMAdapter.Anthropic,
         model: "claude-sonnet-5",
-        max_tokens: 256,
+        maxOutputTokens: 256,
         providerOptions: { thinking: { type: "enabled", budget_tokens: 1024 } },
       },
       apiKey: "anthropic-key",
@@ -414,6 +417,24 @@ describe("AI SDK request shapes", () => {
     // The leading system message becomes the top-level system param.
     expect(JSON.stringify(request.body.system)).toContain("You are terse.");
     expect(request.body.messages).toHaveLength(1);
+  });
+
+  it("Anthropic: portable reasoning maps to adaptive thinking and effort", async () => {
+    const { request } = await runCompletion({
+      modelParams: {
+        provider: "anthropic",
+        adapter: LLMAdapter.Anthropic,
+        model: "claude-sonnet-5",
+        maxOutputTokens: 256,
+        reasoning: "high",
+      },
+      apiKey: "anthropic-key",
+      response: ANTHROPIC_RESPONSE,
+    });
+
+    expect(request.body.thinking).toEqual({ type: "adaptive" });
+    expect(request.body.output_config).toEqual({ effort: "high" });
+    expect(request.body.max_tokens).toBe(256);
   });
 
   it("Google AI Studio: /v1beta path on a custom origin with thinkingConfig", async () => {
@@ -443,7 +464,55 @@ describe("AI SDK request shapes", () => {
     });
   });
 
-  it("Vertex Gemini: regional host, SA-key project, OAuth bearer, maxReasoningTokens", async () => {
+  it("Google AI Studio: portable reasoning maps to a Gemini 3 thinking level", async () => {
+    const { request } = await runCompletion({
+      modelParams: {
+        provider: "google-ai-studio",
+        adapter: LLMAdapter.GoogleAIStudio,
+        model: "gemini-3-pro-preview",
+        reasoning: "high",
+      },
+      apiKey: "google-key",
+      response: GOOGLE_RESPONSE,
+    });
+
+    const generationConfig = request.body.generationConfig as Record<
+      string,
+      unknown
+    >;
+    expect(generationConfig.thinkingConfig).toEqual({
+      thinkingLevel: "high",
+    });
+  });
+
+  it("Vertex Gemini: portable reasoning maps through the regional Vertex request", async () => {
+    const { request } = await runCompletion({
+      modelParams: {
+        provider: "vertex",
+        adapter: LLMAdapter.VertexAI,
+        model: "gemini-3-pro-preview",
+        reasoning: "high",
+      },
+      apiKey: FAKE_GCP_SERVICE_ACCOUNT_KEY,
+      llmConnectionConfig: { location: "us-east5" },
+      response: GOOGLE_RESPONSE,
+    });
+
+    // The Google Vertex provider targets the v1beta1 generateContent API.
+    expect(request.url).toBe(
+      "https://us-east5-aiplatform.googleapis.com/v1beta1/projects/sa-project-123/locations/us-east5/publishers/google/models/gemini-3-pro-preview:generateContent",
+    );
+    expect(request.headers.get("authorization")).toBe("Bearer fake-gcp-token");
+    const generationConfig = request.body.generationConfig as Record<
+      string,
+      unknown
+    >;
+    expect(generationConfig.thinkingConfig).toEqual({
+      thinkingLevel: "high",
+    });
+  });
+
+  it("Vertex Gemini: legacy reasoning token budgets remain compatible", async () => {
     const { request } = await runCompletion({
       modelParams: {
         provider: "vertex",
@@ -456,11 +525,9 @@ describe("AI SDK request shapes", () => {
       response: GOOGLE_RESPONSE,
     });
 
-    // The Google Vertex provider targets the v1beta1 generateContent API.
     expect(request.url).toBe(
       "https://us-east5-aiplatform.googleapis.com/v1beta1/projects/sa-project-123/locations/us-east5/publishers/google/models/gemini-2.5-flash:generateContent",
     );
-    expect(request.headers.get("authorization")).toBe("Bearer fake-gcp-token");
     const generationConfig = request.body.generationConfig as Record<
       string,
       unknown
@@ -477,7 +544,7 @@ describe("AI SDK request shapes", () => {
         provider: "vertex",
         adapter: LLMAdapter.VertexAI,
         model: "claude-sonnet-4-5@20250929",
-        max_tokens: 128,
+        maxOutputTokens: 128,
       },
       apiKey: FAKE_GCP_SERVICE_ACCOUNT_KEY,
       llmConnectionConfig: { location: "us-east5" },
@@ -496,14 +563,15 @@ describe("AI SDK request shapes", () => {
 
   // The Bedrock builder deliberately uses no custom fetch (VPC endpoints),
   // so capture at the global fetch the AI SDK falls back to.
-  async function runBedrockCompletion() {
-    const modelParams: ModelParams = {
+  async function runBedrockCompletion(
+    modelParams: ModelParams = {
       provider: "bedrock",
       adapter: LLMAdapter.Bedrock,
       model: "anthropic.claude-3-5-sonnet-20241022-v2:0",
-      max_tokens: 64,
+      maxOutputTokens: 64,
       providerOptions: { top_k: 10 },
-    };
+    },
+  ) {
     const llmConnectionConfig = { region: "us-east-1" };
 
     const { calls, fetch } = createCaptureFetch(BEDROCK_RESPONSE);
@@ -557,5 +625,18 @@ describe("AI SDK request shapes", () => {
     expect(request.headers.get("authorization")).toContain("AKIA123");
     // No merged server session token (would surface as this SigV4 header).
     expect(request.headers.get("x-amz-security-token")).toBeNull();
+  });
+
+  it("Bedrock: portable reasoning maps to model-native reasoning config", async () => {
+    const request = await runBedrockCompletion({
+      provider: "bedrock",
+      adapter: LLMAdapter.Bedrock,
+      model: "amazon.nova-2-lite-v1:0",
+      reasoning: "high",
+    });
+
+    expect(request.body.additionalModelRequestFields).toEqual({
+      reasoningConfig: { maxReasoningEffort: "high" },
+    });
   });
 });

--- a/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
@@ -55,7 +55,7 @@ const modelParams: ModelParams = {
   provider: "openai",
   adapter: LLMAdapter.OpenAI,
   model: "gpt-4o",
-  max_tokens: 128,
+  maxOutputTokens: 128,
 };
 
 // System-first message lists are the norm for compiled experiment prompts and

--- a/packages/shared/src/server/llm/llmText.test.ts
+++ b/packages/shared/src/server/llm/llmText.test.ts
@@ -58,6 +58,50 @@ beforeEach(() => {
 });
 
 describe("generateLLMText", () => {
+  it("forwards the complete portable AI SDK settings contract", async () => {
+    const receivedOptions = vi.fn();
+    useModel(
+      new MockLanguageModelV4({
+        doGenerate: async (options) => {
+          receivedOptions(options);
+          return {
+            content: [{ type: "text", text: "ok" }],
+            finishReason,
+            usage,
+            warnings: [],
+          };
+        },
+      }),
+    );
+
+    await generateLLMText({
+      ...openAIOptions(),
+      maxOutputTokens: 512,
+      temperature: 0.2,
+      topP: 0.9,
+      topK: 40,
+      presencePenalty: 0.1,
+      frequencyPenalty: -0.2,
+      stopSequences: ["DONE"],
+      seed: 42,
+      reasoning: "high",
+    });
+
+    expect(receivedOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxOutputTokens: 512,
+        temperature: 0.2,
+        topP: 0.9,
+        topK: 40,
+        presencePenalty: 0.1,
+        frequencyPenalty: -0.2,
+        stopSequences: ["DONE"],
+        seed: 42,
+        reasoning: "high",
+      }),
+    );
+  });
+
   it("returns the native text and reasoning result", async () => {
     useModel(
       new MockLanguageModelV4({

--- a/packages/shared/src/server/llm/llmText.ts
+++ b/packages/shared/src/server/llm/llmText.ts
@@ -13,6 +13,7 @@ import {
   type GenerateTextResult,
   type Experimental_DownloadFunction,
   type JSONValue,
+  type LanguageModelCallOptions,
   type ModelMessage,
   type StreamTextOnErrorCallback,
   type StreamTextResult,
@@ -51,10 +52,11 @@ import type {
   ChatMessage,
   LLMJSONSchema,
   LLMToolDefinition,
+  LegacyCompatibleModelParams,
   ModelParams,
   TraceSinkParams,
 } from "./types";
-import { LLMAdapter } from "./types";
+import { LLMAdapter, ZodModelConfig } from "./types";
 import { decryptAndParseExtraHeaders } from "./utils";
 
 type RuntimeContext = Record<string, unknown>;
@@ -86,7 +88,23 @@ export type LLMOutput<
 export type StreamLLMTextOnAbortCallback<TOOLS extends ToolSet = ToolSet> =
   GenerateTextOnAbortCallback<TOOLS, RuntimeContext>;
 
-type BaseLLMTextOptions<TOOLS extends ToolSet, OUTPUT extends Output.Output> = {
+type PortableLLMCallSettings = Pick<
+  LanguageModelCallOptions,
+  | "maxOutputTokens"
+  | "temperature"
+  | "topP"
+  | "topK"
+  | "presencePenalty"
+  | "frequencyPenalty"
+  | "stopSequences"
+  | "seed"
+  | "reasoning"
+>;
+
+type BaseLLMTextOptions<
+  TOOLS extends ToolSet,
+  OUTPUT extends Output.Output,
+> = PortableLLMCallSettings & {
   model: LLMModelRef;
   connection: LLMConnection;
   messages: ModelMessage[];
@@ -96,9 +114,6 @@ type BaseLLMTextOptions<TOOLS extends ToolSet, OUTPUT extends Output.Output> = {
    */
   tools?: TOOLS;
   output?: OUTPUT;
-  maxOutputTokens?: number;
-  temperature?: number;
-  topP?: number;
   /** Canonical, provider-namespaced AI SDK options. */
   providerOptions?: ProviderOptions;
   maxRetries?: number;
@@ -136,13 +151,10 @@ type PreparedLLMTextCall<TOOLS extends ToolSet> = {
   languageModel: Awaited<ReturnType<typeof buildAiSdkModel>>;
   capture?: AiSdkTelemetryCapture;
   runInTraceContext: <T>(fn: () => T) => T;
-  callOptions: {
+  callOptions: PortableLLMCallSettings & {
     messages: ModelMessage[];
     allowSystemInMessages: true;
     tools?: TOOLS;
-    maxOutputTokens?: number;
-    temperature?: number;
-    topP?: number;
     providerOptions?: ProviderOptions;
     maxRetries?: number;
     timeout: TimeoutConfiguration<TOOLS>;
@@ -331,6 +343,12 @@ async function prepareLLMTextCall<
       maxOutputTokens: options.maxOutputTokens,
       temperature: options.temperature,
       topP: options.topP,
+      topK: options.topK,
+      presencePenalty: options.presencePenalty,
+      frequencyPenalty: options.frequencyPenalty,
+      stopSequences: options.stopSequences,
+      seed: options.seed,
+      reasoning: options.reasoning,
       providerOptions: options.providerOptions,
       maxRetries: options.maxRetries,
       timeout,
@@ -438,6 +456,12 @@ export type LegacyLLMTextOptions = {
   maxOutputTokens?: number;
   temperature?: number;
   topP?: number;
+  topK?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  stopSequences?: string[];
+  seed?: number;
+  reasoning?: LanguageModelCallOptions["reasoning"];
   providerOptions?: ProviderOptions;
   credentialSource: LLMCredentialSource;
 };
@@ -448,11 +472,17 @@ export type LegacyLLMTextOptions = {
  */
 export function mapLegacyLLMCompletionParams(params: {
   messages: ChatMessage[];
-  modelParams: ModelParams;
+  modelParams: LegacyCompatibleModelParams;
   connection: LLMConnection;
   credentialSource?: LLMCredentialSource;
 }): LegacyLLMTextOptions {
-  const { modelParams } = params;
+  const modelConfig = ZodModelConfig.parse(params.modelParams);
+  const modelParams: ModelParams = {
+    provider: params.modelParams.provider,
+    adapter: params.modelParams.adapter,
+    model: params.modelParams.model,
+    ...modelConfig,
+  };
   const providerOptions = translateLegacyProviderOptions({
     modelParams,
     connection: params.connection,
@@ -464,9 +494,15 @@ export function mapLegacyLLMCompletionParams(params: {
     messages: mapChatMessagesToModelMessages(params.messages, {
       adapter: modelParams.adapter,
     }),
-    maxOutputTokens: modelParams.max_tokens,
+    maxOutputTokens: modelParams.maxOutputTokens,
     temperature: modelParams.temperature,
-    topP: modelParams.top_p,
+    topP: modelParams.topP,
+    topK: modelParams.topK,
+    presencePenalty: modelParams.presencePenalty,
+    frequencyPenalty: modelParams.frequencyPenalty,
+    stopSequences: modelParams.stopSequences,
+    seed: modelParams.seed,
+    reasoning: modelParams.reasoning,
     providerOptions,
     credentialSource: params.credentialSource ?? "user",
   };
@@ -533,7 +569,7 @@ function translateLegacyProviderOptions(params: {
         : translateGoogleProviderOptions({
             providerOptions: modelParams.providerOptions,
             model: modelParams.model,
-            maxReasoningTokens: modelParams.maxReasoningTokens,
+            maxReasoningTokens: modelParams.legacyReasoningTokenBudget,
           });
       break;
     }

--- a/packages/shared/src/server/llm/types.test.ts
+++ b/packages/shared/src/server/llm/types.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { ZodModelConfig } from "./types";
+
+describe("ZodModelConfig", () => {
+  it("preserves AI SDK-native model settings", () => {
+    expect(
+      ZodModelConfig.parse({
+        maxOutputTokens: 512,
+        temperature: 0.2,
+        topP: 0.9,
+        topK: 40,
+        presencePenalty: 0.1,
+        frequencyPenalty: -0.2,
+        stopSequences: ["DONE"],
+        seed: 42,
+        reasoning: "high",
+        providerOptions: { openai: { reasoningSummary: "auto" } },
+      }),
+    ).toEqual({
+      maxOutputTokens: 512,
+      temperature: 0.2,
+      topP: 0.9,
+      topK: 40,
+      presencePenalty: 0.1,
+      frequencyPenalty: -0.2,
+      stopSequences: ["DONE"],
+      seed: 42,
+      reasoning: "high",
+      providerOptions: { openai: { reasoningSummary: "auto" } },
+    });
+  });
+
+  it("normalizes persisted legacy names to the AI SDK-native shape", () => {
+    expect(
+      ZodModelConfig.parse({
+        max_tokens: 256,
+        top_p: 0.8,
+        maxReasoningTokens: 2048,
+      }),
+    ).toEqual({
+      maxOutputTokens: 256,
+      topP: 0.8,
+      legacyReasoningTokenBudget: 2048,
+    });
+  });
+
+  it("prefers canonical settings when legacy and native names coexist", () => {
+    expect(
+      ZodModelConfig.parse({
+        maxOutputTokens: 512,
+        max_tokens: 256,
+        topP: 0.9,
+        top_p: 0.8,
+      }),
+    ).toEqual({
+      maxOutputTokens: 512,
+      topP: 0.9,
+    });
+  });
+});

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -267,24 +267,85 @@ export type ModelParams = {
   model: string;
 } & ModelConfig;
 
+export type LegacyCompatibleModelParams = {
+  provider: string;
+  adapter: LLMAdapter;
+  model: string;
+} & ModelConfigInput;
+
 type RecordWithEnabledFlag<T> = {
   [K in keyof T]: { value: T[K]; enabled: boolean };
 };
 export type UIModelParams = RecordWithEnabledFlag<
-  Required<ModelParams> & {
+  Required<Omit<ModelParams, "legacyReasoningTokenBudget">> & {
     maxTemperature: number;
   }
 >;
 
 // Generic config
-export type ModelConfig = z.infer<typeof ZodModelConfig>;
-export const ZodModelConfig = z.object({
-  max_tokens: z.coerce.number().optional(),
+export const MODEL_REASONING_LEVELS = [
+  "provider-default",
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
+export const ModelReasoningLevelSchema = z.enum(MODEL_REASONING_LEVELS);
+export type ModelReasoningLevel = z.infer<typeof ModelReasoningLevelSchema>;
+
+/**
+ * Accepts the current AI SDK-shaped contract and the persisted pre-AI-SDK
+ * field names. Consumers should use {@link ZodModelConfig}, whose output is
+ * canonical camelCase.
+ */
+export const ZodModelConfigInput = z.object({
+  maxOutputTokens: z.coerce.number().optional(),
   temperature: z.coerce.number().optional(),
+  topP: z.coerce.number().optional(),
+  topK: z.coerce.number().optional(),
+  presencePenalty: z.coerce.number().optional(),
+  frequencyPenalty: z.coerce.number().optional(),
+  stopSequences: z.array(z.string()).optional(),
+  seed: z.coerce.number().optional(),
+  reasoning: ModelReasoningLevelSchema.optional(),
+  providerOptions: JSONObjectSchema.optional(),
+
+  // Persisted legacy aliases. These are normalized and never emitted by new
+  // UI writes.
+  max_tokens: z.coerce.number().optional(),
   top_p: z.coerce.number().optional(),
   maxReasoningTokens: z.coerce.number().optional(),
-  providerOptions: JSONObjectSchema.optional(),
+  legacyReasoningTokenBudget: z.coerce.number().optional(),
 });
+export type ModelConfigInput = z.input<typeof ZodModelConfigInput>;
+
+export const ZodModelConfig = ZodModelConfigInput.transform(
+  ({
+    max_tokens,
+    top_p,
+    maxReasoningTokens,
+    legacyReasoningTokenBudget,
+    ...config
+  }) => ({
+    ...config,
+    ...(config.maxOutputTokens !== undefined || max_tokens === undefined
+      ? {}
+      : { maxOutputTokens: max_tokens }),
+    ...(config.topP !== undefined || top_p === undefined
+      ? {}
+      : { topP: top_p }),
+    ...(legacyReasoningTokenBudget !== undefined ||
+    maxReasoningTokens !== undefined
+      ? {
+          legacyReasoningTokenBudget:
+            legacyReasoningTokenBudget ?? maxReasoningTokens,
+        }
+      : {}),
+  }),
+);
+export type ModelConfig = z.output<typeof ZodModelConfig>;
 
 // Experiment config
 export const ExperimentMetadataSchema = z
@@ -419,7 +480,7 @@ export const vertexAIModels = [
   "gemini-1.0-pro",
 ] as const;
 
-// WARNING: The first entry in the array is chosen as the default model to add LLM API keys. Make sure it supports top_p, max_tokens and temperature.
+// WARNING: The first entry in the array is chosen as the default model to add LLM API keys. Make sure it supports topP, maxOutputTokens and temperature.
 export const googleAIStudioModels = [
   "gemini-2.5-flash",
   "gemini-2.5-pro",

--- a/web/src/__tests__/server/unit/chat-completion-handler.servertest.ts
+++ b/web/src/__tests__/server/unit/chat-completion-handler.servertest.ts
@@ -103,6 +103,32 @@ describe("chatCompletionHandler", () => {
     });
   });
 
+  it("returns AI SDK compatibility warnings in a response header", async () => {
+    mocks.generate.mockResolvedValue({
+      text: "Hello back",
+      finalStep: { reasoningText: undefined },
+      warnings: [
+        {
+          type: "unsupported",
+          feature: "temperature",
+          details: "temperature is not supported for this reasoning model",
+        },
+      ],
+    });
+
+    const response = await chatCompletionHandler(createRequest(baseBody));
+
+    expect(
+      JSON.parse(
+        decodeURIComponent(
+          response.headers.get("x-langfuse-llm-warnings") ?? "[]",
+        ),
+      ),
+    ).toEqual([
+      "Unsupported temperature: temperature is not supported for this reasoning model",
+    ]);
+  });
+
   it("returns only the generated structured output", async () => {
     const output = { kind: "object-output" };
     mocks.createOutput.mockReturnValue(output);
@@ -174,7 +200,29 @@ describe("chatCompletionHandler", () => {
         controller.close();
       },
     });
-    mocks.stream.mockResolvedValue({ textStream });
+    const fullStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: "start" });
+        controller.enqueue({
+          type: "start-step",
+          request: {},
+          warnings: [
+            {
+              type: "compatibility",
+              feature: "reasoning",
+              details: "reasoning was mapped to a token budget",
+            },
+          ],
+        });
+      },
+      // A teed stream may not settle this promise until the text branch ends.
+      // The handler must not await it before returning the streaming response.
+      cancel: () => new Promise(() => {}),
+    });
+    mocks.stream.mockResolvedValue({
+      textStream,
+      stream: fullStream,
+    });
 
     const response = await chatCompletionHandler(
       createRequest({ ...baseBody, streaming: true }),
@@ -184,6 +232,15 @@ describe("chatCompletionHandler", () => {
     expect(response.headers.get("content-type")).toBe(
       "text/plain; charset=utf-8",
     );
+    expect(
+      JSON.parse(
+        decodeURIComponent(
+          response.headers.get("x-langfuse-llm-warnings") ?? "[]",
+        ),
+      ),
+    ).toEqual([
+      "Compatibility mode for reasoning: reasoning was mapped to a token budget",
+    ]);
     expect(mocks.generate).not.toHaveBeenCalled();
   });
 

--- a/web/src/components/ModelParameters/index.tsx
+++ b/web/src/components/ModelParameters/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useRef, useCallback } from "react";
 import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
 import {
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from "@/src/components/ui/select";
 import { Slider } from "@/src/components/ui/slider";
+import { Textarea } from "@/src/components/ui/textarea";
 import { CreateLLMApiKeyDialog } from "@/src/features/public-api/components/CreateLLMApiKeyDialog";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
@@ -17,7 +18,9 @@ import { cn } from "@/src/utils/tailwind";
 import {
   type JSONObject,
   JSONObjectSchema,
-  LLMAdapter,
+  type LLMAdapter,
+  MODEL_REASONING_LEVELS,
+  type ModelReasoningLevel,
   type supportedModels,
   type UIModelParams,
 } from "@langfuse/shared";
@@ -70,7 +73,11 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
 }) => {
   const projectId = useProjectIdFromURL();
   const [modelSettingsOpen, setModelSettingsOpen] = useState(false);
-  const [modelSettingsUsed, setModelSettingsUsed] = useState(false);
+  const modelSettingsUsed = Object.entries(modelParams).some(
+    ([key, value]) =>
+      !["adapter", "provider", "model", "maxTemperature"].includes(key) &&
+      value.enabled,
+  );
 
   // Standalone dialog for the "no providers yet" empty state (renders its own
   // trigger button, not inside a dropdown).
@@ -79,20 +86,6 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
   // Coordinates the inline "Add LLM Connection" action inside the combined
   // provider/model Select (compact layout) — see useAddLlmConnectionSelect.
   const providerSelect = useAddLlmConnectionSelect();
-
-  useEffect(() => {
-    const hasEnabledModelSetting = Object.keys(modelParams).some(
-      (key) =>
-        !["adapter", "provider", "model"].includes(key) &&
-        modelParams[key as keyof typeof modelParams].enabled,
-    );
-
-    if (hasEnabledModelSetting) {
-      setModelSettingsUsed(true);
-    } else {
-      setModelSettingsUsed(false);
-    }
-  }, [setModelSettingsUsed, modelParams]);
 
   if (!projectId) return null;
 
@@ -120,6 +113,7 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
     <Popover open={modelSettingsOpen} onOpenChange={setModelSettingsOpen}>
       <PopoverTrigger asChild>
         <Button
+          aria-label="Configure model settings"
           variant="outline"
           size="icon"
           className="relative h-7 w-7"
@@ -132,7 +126,7 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="p-4"
+        className="max-h-[calc(var(--radix-popover-content-available-height)-1rem)] w-[min(24rem,calc(100vw-2rem))] overflow-y-auto p-4"
         align={layout === "compact" ? "start" : "end"}
         sideOffset={5}
       >
@@ -156,49 +150,94 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
             tooltip="The sampling temperature. Higher values will make the output more random, while lower values will make it more focused and deterministic."
             updateModelParam={updateModelParamValue}
           />
-          <ModelParamsSlider
+          <ModelParamsNumberInput
             title="Output token limit"
-            modelParamsKey="max_tokens"
+            modelParamsKey="maxOutputTokens"
             formDisabled={formDisabled}
-            enabled={modelParams.max_tokens.enabled}
+            enabled={modelParams.maxOutputTokens.enabled}
             setModelParamEnabled={setModelParamEnabled}
-            value={modelParams.max_tokens.value}
+            value={modelParams.maxOutputTokens.value}
             min={1}
-            max={16384}
-            step={1}
             tooltip="The maximum number of tokens that can be generated in the chat completion."
             updateModelParam={updateModelParamValue}
           />
           <ModelParamsSlider
             title="Top P"
-            modelParamsKey="top_p"
+            modelParamsKey="topP"
             formDisabled={formDisabled}
-            enabled={modelParams.top_p.enabled}
+            enabled={modelParams.topP.enabled}
             setModelParamEnabled={setModelParamEnabled}
-            value={modelParams.top_p.value}
+            value={modelParams.topP.value}
             min={0}
             max={1}
             step={0.01}
-            tooltip="An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both."
+            tooltip="An alternative to temperature called nucleus sampling. A value of 0.1 limits sampling to tokens comprising the top 10% probability mass. Most use cases should change either Top P or temperature, not both."
             updateModelParam={updateModelParamValue}
           />
-          {modelParams.adapter.value === LLMAdapter.VertexAI &&
-            modelParams.maxReasoningTokens && (
-              <ModelParamsSlider
-                title="Max. Reasoning Tokens"
-                modelParamsKey="maxReasoningTokens"
-                formDisabled={formDisabled}
-                enabled={modelParams.maxReasoningTokens.enabled}
-                setModelParamEnabled={setModelParamEnabled}
-                value={modelParams.maxReasoningTokens.value}
-                min={-1}
-                max={24576}
-                step={1}
-                tooltip="Maximum tokens for model thinking/reasoning. Set to -1 for default (auto) thinking, 0 to disable. Only supported on Gemini 2.5+ models."
-                updateModelParam={updateModelParamValue}
-              />
-            )}
+          <ModelParamsNumberInput
+            title="Top K"
+            modelParamsKey="topK"
+            formDisabled={formDisabled}
+            enabled={modelParams.topK.enabled}
+            setModelParamEnabled={setModelParamEnabled}
+            value={modelParams.topK.value}
+            min={1}
+            tooltip="Only sample from the K most likely next tokens. Most use cases should prefer temperature or Top P."
+            updateModelParam={updateModelParamValue}
+          />
+          <ModelParamsSlider
+            title="Presence penalty"
+            modelParamsKey="presencePenalty"
+            formDisabled={formDisabled}
+            enabled={modelParams.presencePenalty.enabled}
+            setModelParamEnabled={setModelParamEnabled}
+            value={modelParams.presencePenalty.value}
+            min={-1}
+            max={1}
+            step={0.01}
+            tooltip="Adjusts the likelihood of repeating information already present in the prompt or response."
+            updateModelParam={updateModelParamValue}
+          />
+          <ModelParamsSlider
+            title="Frequency penalty"
+            modelParamsKey="frequencyPenalty"
+            formDisabled={formDisabled}
+            enabled={modelParams.frequencyPenalty.enabled}
+            setModelParamEnabled={setModelParamEnabled}
+            value={modelParams.frequencyPenalty.value}
+            min={-1}
+            max={1}
+            step={0.01}
+            tooltip="Adjusts the likelihood of repeatedly using the same words or phrases."
+            updateModelParam={updateModelParamValue}
+          />
+          <ModelParamsReasoningSelect
+            value={modelParams.reasoning.value}
+            enabled={modelParams.reasoning.enabled}
+            formDisabled={formDisabled}
+            updateModelParam={updateModelParamValue}
+            setModelParamEnabled={setModelParamEnabled}
+          />
+          <ModelParamsNumberInput
+            title="Seed"
+            modelParamsKey="seed"
+            value={modelParams.seed.value}
+            enabled={modelParams.seed.enabled}
+            formDisabled={formDisabled}
+            tooltip="An integer seed for deterministic sampling when supported by the selected model."
+            updateModelParam={updateModelParamValue}
+            setModelParamEnabled={setModelParamEnabled}
+          />
+          <ModelParamsTextListInput
+            key={`stop-sequences-${modelParams.provider.value}:${modelParams.model.value}`}
+            value={modelParams.stopSequences.value}
+            enabled={modelParams.stopSequences.enabled}
+            formDisabled={formDisabled}
+            updateModelParam={updateModelParamValue}
+            setModelParamEnabled={setModelParamEnabled}
+          />
           <ProviderOptionsInput
+            key={`provider-options-${modelParams.provider.value}:${modelParams.model.value}`}
             value={modelParams.providerOptions.value}
             formDisabled={formDisabled}
             enabled={modelParams.providerOptions.enabled}
@@ -273,21 +312,6 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
           </div>
           <div className="shrink-0">{SettingsButton}</div>
         </div>
-
-        {modelParams.model.value?.startsWith("o1-") ? (
-          <p className="text-dark-yellow mt-1 text-xs">
-            For {modelParams.model.value}, the system message and the
-            temperature, max_tokens and top_p setting are not supported while it
-            is in beta.{" "}
-            <a
-              href="https://platform.openai.com/docs/guides/reasoning/beta-limitations"
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              More info ↗
-            </a>
-          </p>
-        ) : null}
       </div>
     );
   }
@@ -501,9 +525,11 @@ const ModelParamsSlider = ({
             step={step}
             value={value}
             onChange={(event) => {
+              const nextValue = Number.parseFloat(event.target.value);
+              if (Number.isNaN(nextValue)) return;
               updateModelParam(
                 modelParamsKey,
-                Math.max(Math.min(parseFloat(event.target.value), max), min),
+                Math.max(Math.min(nextValue, max), min),
               );
             }}
           />
@@ -529,6 +555,191 @@ const ModelParamsSlider = ({
             updateModelParam(modelParamsKey, value[0]);
         }}
         value={[value]}
+      />
+    </div>
+  );
+};
+
+type ModelParamsReasoningSelectProps = {
+  value: ModelReasoningLevel;
+  updateModelParam: ModelParamsContext["updateModelParamValue"];
+  setModelParamEnabled: ModelParamsContext["setModelParamEnabled"];
+  enabled: boolean;
+  formDisabled: boolean;
+};
+
+const ModelParamsReasoningSelect = ({
+  value,
+  updateModelParam,
+  setModelParamEnabled,
+  enabled,
+  formDisabled,
+}: ModelParamsReasoningSelectProps) => (
+  <div className="space-y-3">
+    <div className="flex items-center gap-3">
+      <div className="flex flex-1 items-center gap-1">
+        <span
+          className={cn(
+            "text-xs font-semibold",
+            (!enabled || formDisabled) && "text-muted-foreground",
+          )}
+        >
+          Reasoning effort
+        </span>
+        <Tooltip>
+          <TooltipTrigger aria-label="About reasoning effort">
+            <InfoIcon className="text-muted-foreground size-3" />
+          </TooltipTrigger>
+          <TooltipContent className="max-w-[240px] p-2">
+            Portable AI SDK reasoning intent. The provider adapter maps this to
+            reasoning effort, adaptive thinking, or a token budget. Exact
+            provider options override this setting.
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <Switch
+        title="Control sending the reasoning effort parameter"
+        disabled={formDisabled}
+        checked={enabled}
+        onCheckedChange={(checked) =>
+          setModelParamEnabled?.("reasoning", checked)
+        }
+      />
+    </div>
+    <Select
+      disabled={!enabled || formDisabled}
+      value={value}
+      onValueChange={(next) =>
+        updateModelParam("reasoning", next as ModelReasoningLevel)
+      }
+    >
+      <SelectTrigger className="h-8 capitalize">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {MODEL_REASONING_LEVELS.map((level) => (
+          <SelectItem className="capitalize" key={level} value={level}>
+            {level.replace("-", " ")}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  </div>
+);
+
+type ModelParamsNumberInputProps = {
+  title: string;
+  modelParamsKey: "maxOutputTokens" | "seed" | "topK";
+  value: number;
+  tooltip: string;
+  min?: number;
+  updateModelParam: ModelParamsContext["updateModelParamValue"];
+  setModelParamEnabled: ModelParamsContext["setModelParamEnabled"];
+  enabled: boolean;
+  formDisabled: boolean;
+};
+
+const ModelParamsNumberInput = ({
+  title,
+  modelParamsKey,
+  value,
+  tooltip,
+  min,
+  updateModelParam,
+  setModelParamEnabled,
+  enabled,
+  formDisabled,
+}: ModelParamsNumberInputProps) => (
+  <div className="flex items-center gap-3" title={tooltip}>
+    <p
+      className={cn(
+        "flex-1 text-xs font-semibold",
+        (!enabled || formDisabled) && "text-muted-foreground",
+      )}
+    >
+      {title}
+    </p>
+    <Input
+      className="h-7 w-28 appearance-none px-2 text-right"
+      type="number"
+      step={1}
+      min={min}
+      disabled={!enabled || formDisabled}
+      value={value}
+      onChange={(event) => {
+        const nextValue = Number.parseInt(event.target.value, 10);
+        if (Number.isNaN(nextValue)) return;
+        updateModelParam(
+          modelParamsKey,
+          min === undefined ? nextValue : Math.max(nextValue, min),
+        );
+      }}
+    />
+    <Switch
+      title={`Control sending the ${title} parameter`}
+      disabled={formDisabled}
+      checked={enabled}
+      onCheckedChange={(checked) =>
+        setModelParamEnabled?.(modelParamsKey, checked)
+      }
+    />
+  </div>
+);
+
+type ModelParamsTextListInputProps = {
+  value: string[];
+  updateModelParam: ModelParamsContext["updateModelParamValue"];
+  setModelParamEnabled: ModelParamsContext["setModelParamEnabled"];
+  enabled: boolean;
+  formDisabled: boolean;
+};
+
+const ModelParamsTextListInput = ({
+  value,
+  updateModelParam,
+  setModelParamEnabled,
+  enabled,
+  formDisabled,
+}: ModelParamsTextListInputProps) => {
+  const [inputValue, setInputValue] = useState(value.join("\n"));
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        <div className="flex-1">
+          <p
+            className={cn(
+              "text-xs font-semibold",
+              (!enabled || formDisabled) && "text-muted-foreground",
+            )}
+          >
+            Stop sequences
+          </p>
+          <p className="text-muted-foreground text-[11px]">
+            One sequence per line
+          </p>
+        </div>
+        <Switch
+          title="Control sending stop sequences"
+          disabled={formDisabled}
+          checked={enabled}
+          onCheckedChange={(checked) =>
+            setModelParamEnabled?.("stopSequences", checked)
+          }
+        />
+      </div>
+      <Textarea
+        className="min-h-16 text-xs"
+        disabled={!enabled || formDisabled}
+        value={inputValue}
+        onChange={(event) => {
+          const nextValue = event.target.value;
+          setInputValue(nextValue);
+          updateModelParam(
+            "stopSequences",
+            nextValue.split("\n").filter((line) => line.length > 0),
+          );
+        }}
       />
     </div>
   );
@@ -566,12 +777,13 @@ const ProviderOptionsInput = ({
             Additional options
           </span>
           <Tooltip>
-            <TooltipTrigger>
+            <TooltipTrigger aria-label="About additional model options">
               <InfoIcon className="text-muted-foreground size-3" />
             </TooltipTrigger>
             <TooltipContent className="max-w-[200px] p-2">
-              Additional options to pass to the invocation. Please check your
-              provider&apos;s API reference for supported values.
+              Namespaced AI SDK provider options for exact provider controls,
+              for example {`{ "openai": { ... } }`}. These override matching
+              portable settings.
             </TooltipContent>
           </Tooltip>
         </div>

--- a/web/src/features/ai-features/server/bedrockCompletion.ts
+++ b/web/src/features/ai-features/server/bedrockCompletion.ts
@@ -63,10 +63,10 @@ export async function generateLangfuseAIText(params: {
         provider: "bedrock",
         adapter: LLMAdapter.Bedrock,
         model,
-        // Intentionally omit temperature/top_p: newer Bedrock models reject these
+        // Intentionally omit temperature/topP: newer Bedrock models reject these
         // inference params, while AI-feature generation works at model defaults.
         ...(params.maxTokens !== undefined
-          ? { max_tokens: params.maxTokens }
+          ? { maxOutputTokens: params.maxTokens }
           : {}),
       },
       connection: {

--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { Form } from "@/src/components/ui/form";
 import {
@@ -183,6 +183,17 @@ export const MultiStepExperimentForm = ({
     form,
   });
 
+  const promptConfigModel = useMemo(
+    () =>
+      selectedPromptModelConfig
+        ? {
+            selectionKey: promptIdFromHook,
+            ...selectedPromptModelConfig,
+          }
+        : null,
+    [promptIdFromHook, selectedPromptModelConfig],
+  );
+
   const {
     modelParams,
     updateModelParamValue,
@@ -191,15 +202,7 @@ export const MultiStepExperimentForm = ({
     providerModelCombinations,
     availableProviders,
   } = useModelParams(undefined, {
-    promptConfigModel: selectedPromptModelConfig
-      ? {
-          selectionKey: promptIdFromHook,
-          ...(selectedPromptModelConfig.provider
-            ? { provider: selectedPromptModelConfig.provider }
-            : {}),
-          model: selectedPromptModelConfig.model,
-        }
-      : null,
+    promptConfigModel,
   });
 
   useExperimentNameValidation({

--- a/web/src/features/experiments/components/steps/ReviewStep.tsx
+++ b/web/src/features/experiments/components/steps/ReviewStep.tsx
@@ -86,10 +86,10 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
                 <span>{modelParams.temperature.value}</span>
               </div>
             )}
-            {modelParams.max_tokens.enabled && (
+            {modelParams.maxOutputTokens.enabled && (
               <div className="flex gap-2">
                 <span className="text-muted-foreground">Max Tokens:</span>
-                <span>{modelParams.max_tokens.value}</span>
+                <span>{modelParams.maxOutputTokens.value}</span>
               </div>
             )}
             {structuredOutputEnabled && selectedSchemaName && (

--- a/web/src/features/experiments/hooks/useExperimentPromptData.ts
+++ b/web/src/features/experiments/hooks/useExperimentPromptData.ts
@@ -6,7 +6,9 @@ import {
   PromptType,
   extractPlaceholderNames,
   type PromptMessage,
+  type ModelConfig,
   ZodModelConfig,
+  ZodModelConfigInput,
 } from "@langfuse/shared";
 import { z } from "zod/v4";
 
@@ -18,7 +20,7 @@ type ExperimentPromptDataProps = {
 export type ExperimentPromptModelConfig = {
   provider?: string;
   model: string;
-};
+} & ModelConfig;
 
 export function useExperimentPromptData({
   projectId,
@@ -82,10 +84,14 @@ export function useExperimentPromptData({
   };
 }
 
-const PromptConfigSchema = ZodModelConfig.extend({
+const PromptConfigSchema = ZodModelConfigInput.extend({
   provider: z.string().min(1).optional(),
   model: z.string().min(1),
-});
+}).transform(({ provider, model, ...config }) => ({
+  provider,
+  model,
+  ...ZodModelConfig.parse(config),
+}));
 
 const getPromptModelConfig = (
   config: unknown,
@@ -94,9 +100,10 @@ const getPromptModelConfig = (
 
   if (!parsedConfig.success) return null;
 
-  const { provider, model } = parsedConfig.data;
+  const { provider, model, ...modelConfig } = parsedConfig.data;
   return {
     ...(provider ? { provider } : {}),
     model,
+    ...modelConfig,
   };
 };

--- a/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -1,5 +1,5 @@
 import { Terminal, ChevronDown } from "lucide-react";
-import { useEffect, useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { useRouter } from "next/router";
 import { v4 as uuidv4 } from "uuid";
 
@@ -23,6 +23,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import {
   ChatMessageRole,
+  LLMAdapter,
   type Observation,
   type Prompt,
   supportedModels as playgroundSupportedModels,
@@ -41,6 +42,7 @@ import { extractTools } from "@/src/utils/chatml/extractTools";
 import { convertChatMlToPlayground } from "@/src/utils/chatml/playgroundConverter";
 import { api } from "@/src/utils/api";
 import { cn } from "@/src/utils/tailwind";
+import { getEnabledModelParamState } from "@/src/utils/getFinalModelParams";
 import usePlaygroundCache from "@/src/features/playground/page/hooks/usePlaygroundCache";
 import {
   type MetadataDomainClient,
@@ -77,8 +79,6 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
   const capture = usePostHogClientCapture();
   const projectId = useProjectIdFromURL();
   const { addWindowWithId, clearAllCache } = usePersistedWindowIds();
-  const [capturedState, setCapturedState] = useState<PlaygroundCache>(null);
-  const [isAvailable, setIsAvailable] = useState<boolean>(false);
   const [includeOutput, setIncludeOutput] = useState<boolean>(false);
 
   // Generate a stable window ID based on the source data
@@ -123,23 +123,16 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
   const generationData =
     props.source === "generation" ? props.generation : null;
 
-  useEffect(() => {
-    if (promptData) {
-      setCapturedState(parsePrompt(promptData));
-    } else if (generationData) {
-      setCapturedState(
-        parseGeneration(generationData, modelToProviderMap, includeOutput),
-      );
-    }
-  }, [promptData, generationData, modelToProviderMap, includeOutput]);
-
-  useEffect(() => {
-    if (capturedState) {
-      setIsAvailable(true);
-    } else {
-      setIsAvailable(false);
-    }
-  }, [capturedState, setIsAvailable]);
+  const capturedState = useMemo(
+    () =>
+      promptData
+        ? parsePrompt(promptData, modelToProviderMap)
+        : generationData
+          ? parseGeneration(generationData, modelToProviderMap, includeOutput)
+          : null,
+    [generationData, includeOutput, modelToProviderMap, promptData],
+  );
+  const isAvailable = Boolean(capturedState);
 
   const handlePlaygroundAction = (useFreshPlayground: boolean) => {
     capture(props.analyticsEventName, {
@@ -239,7 +232,10 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
 
 const parsePrompt = (
   prompt: Prompt & { resolvedPrompt?: Prisma.JsonValue },
+  modelToProviderMap: Record<string, string>,
 ): PlaygroundCache => {
+  const modelParams = parsePromptModelParams(prompt, modelToProviderMap);
+
   if (prompt.type === PromptType.Chat) {
     try {
       const inResult = normalizeInput(prompt.resolvedPrompt);
@@ -254,7 +250,7 @@ const parsePrompt = (
 
       if (messages.length === 0) return null;
 
-      return { messages };
+      return { messages, modelParams };
     } catch {
       return null;
     }
@@ -270,9 +266,45 @@ const parsePrompt = (
           content: typeof promptString === "string" ? promptString : "",
         }),
       ],
+      modelParams,
     };
   }
 };
+
+function parsePromptModelParams(
+  prompt: Prompt,
+  modelToProviderMap: Record<string, string>,
+):
+  | (Partial<UIModelParams> & Pick<UIModelParams, "provider" | "model">)
+  | undefined {
+  const config = prompt.config?.valueOf();
+  if (!config || typeof config !== "object" || Array.isArray(config)) return;
+
+  const model = "model" in config ? config.model : undefined;
+  if (typeof model !== "string") return;
+
+  const configuredProvider = "provider" in config ? config.provider : undefined;
+  const provider =
+    typeof configuredProvider === "string"
+      ? configuredProvider
+      : modelToProviderMap[model];
+  if (!provider) return;
+
+  const parsedConfig = ZodModelConfig.safeParse(config);
+  const configuredAdapter = "adapter" in config ? config.adapter : undefined;
+  const adapter = Object.values(LLMAdapter).find(
+    (candidate) => candidate === configuredAdapter,
+  );
+
+  return {
+    provider: { value: provider, enabled: true },
+    model: { value: model, enabled: true },
+    ...(adapter ? { adapter: { value: adapter, enabled: true } } : {}),
+    ...(parsedConfig.success
+      ? getEnabledModelParamState(parsedConfig.data)
+      : {}),
+  };
+}
 
 const parseGeneration = (
   generation: Omit<WithStringifiedMetadata<Observation>, "input" | "output"> & {
@@ -468,14 +500,10 @@ function parseModelParams(
       const parsedParams = ZodModelConfig.safeParse(generationModelParams);
 
       if (parsedParams.success) {
-        Object.entries(parsedParams.data).forEach(([key, value]) => {
-          if (!modelParams) return;
-
-          modelParams[key as keyof typeof parsedParams.data] = {
-            value: value as any,
-            enabled: true,
-          };
-        });
+        modelParams = {
+          ...modelParams,
+          ...getEnabledModelParamState(parsedParams.data),
+        };
       }
     }
   }
@@ -570,7 +598,7 @@ function parseStructuredOutputSchema(
 
 /**
  * LiteLLM supports custom providers such as with its CustomLLM interface. Clients may
- * send provider‑specific options in addition to standard parameters (e.g., temperature, top_p, max_tokens).
+ * send provider-specific options in addition to standard parameters (for example, temperature, topP, maxOutputTokens).
  * LiteLLM records those extras on the generation as metadata.requester_metadata. When a user clicks
  * “Open in Playground,” we lift requester_metadata into providerOptions so those custom options carry
  * over for re‑run/compare/edit. This lets the Playground faithfully replay LiteLLM CustomLLM‑based

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -48,8 +48,13 @@ import {
   useWindowCoordination,
 } from "@/src/features/playground/page/hooks/useWindowCoordination";
 import { useSyncMessageSearchMessages } from "@/src/components/ChatMessages/MessageSearch";
-import { getFinalModelParams } from "@/src/utils/getFinalModelParams";
+import {
+  getFinalModelParams,
+  normalizeLegacyUIModelParams,
+} from "@/src/utils/getFinalModelParams";
 import { STREAMING_PREF_KEY } from "@/src/features/playground/page/storage/keys";
+import { readLlmWarnings } from "@/src/features/playground/utils/llmWarnings";
+import { toast } from "sonner";
 
 type PlaygroundContextType = {
   windowId: string;
@@ -212,7 +217,10 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
     }
 
     if (cachedModelParams) {
-      setModelParams((prev) => ({ ...prev, ...cachedModelParams }));
+      setModelParams((prev) => ({
+        ...prev,
+        ...normalizeLegacyUIModelParams(cachedModelParams),
+      }));
     }
 
     if (cachedPromptVariables) {
@@ -787,6 +795,7 @@ async function getChatCompletionWithTools(
   if (!result.ok) {
     throw new Error(`Completion failed: ${responseData.message}`);
   }
+  showLlmWarnings(result);
 
   const parsed = ToolCallResponseSchema.safeParse(responseData);
   if (!parsed.success)
@@ -831,6 +840,7 @@ async function getChatCompletionWithStructuredOutput(
     const responseData = await result.json();
     throw new Error(`Completion failed: ${responseData.message}`);
   }
+  showLlmWarnings(result);
 
   const responseData = await result.text();
 
@@ -880,6 +890,7 @@ async function* getChatCompletionStream(
 
     throw new Error(`Completion failed: ${errorData.message}`);
   }
+  showLlmWarnings(result);
 
   const reader = result.body?.getReader();
   if (!reader) {
@@ -939,12 +950,22 @@ async function getChatCompletionNonStreaming(
     const errorData = await result.json();
     throw new Error(`Completion failed: ${errorData.message}`);
   }
+  showLlmWarnings(result);
 
   const responseData = await result.json();
   return {
     content: responseData.content || "",
     reasoning: responseData.reasoning,
   };
+}
+
+function showLlmWarnings(response: Response) {
+  const warnings = readLlmWarnings(response);
+  if (warnings.length === 0) return;
+
+  toast.warning("Some model settings were adjusted", {
+    description: warnings.join("\n"),
+  });
 }
 
 function getFinalMessages(

--- a/web/src/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/features/playground/page/hooks/useModelParams.ts
@@ -5,17 +5,19 @@ import { api } from "@/src/utils/api";
 import useLocalStorage from "@/src/components/useLocalStorage";
 import {
   LLMAdapter,
+  type ModelConfig,
   supportedModels,
   type UIModelParams,
 } from "@langfuse/shared";
 import { type ModelParamsContext } from "@/src/components/ModelParameters";
+import { getEnabledModelParamState } from "@/src/utils/getFinalModelParams";
 import { getModelNameKey, getModelProviderKey } from "../storage/keys";
 
 type PromptConfigModel = {
   selectionKey?: string;
   provider?: string;
   model: string;
-};
+} & ModelConfig;
 
 type UseModelParamsOptions = {
   promptConfigModel?: PromptConfigModel | null;
@@ -72,6 +74,7 @@ export const useModelParams = (
   const promptConfigSelectionKey = options?.promptConfigModel?.selectionKey;
   const promptConfigProvider = options?.promptConfigModel?.provider;
   const promptConfigModel = options?.promptConfigModel?.model;
+  const promptConfig = options?.promptConfigModel;
   const resolvedPromptConfigProvider = useMemo(() => {
     if (!promptConfigModel) return undefined;
 
@@ -88,6 +91,9 @@ export const useModelParams = (
 
     return matchingApiKey?.provider;
   }, [availableLLMApiKeys.data?.data, promptConfigModel, promptConfigProvider]);
+  const resolvedPromptConfigAdapter = availableLLMApiKeys.data?.data.find(
+    ({ provider }) => provider === resolvedPromptConfigProvider,
+  )?.adapter;
 
   const providerModelCombinations =
     availableLLMApiKeys.data?.data.reduce((acc, v) => {
@@ -136,10 +142,33 @@ export const useModelParams = (
     ModelParamsContext["updateModelParamValue"]
   >(
     (key, value) => {
-      setModelParams((prev) => ({
-        ...prev,
-        [key]: { ...prev[key], value },
-      }));
+      setModelParams((prev) => {
+        const updated = {
+          ...prev,
+          [key]: { ...prev[key], value },
+        };
+
+        if (key !== "provider" || typeof value !== "string") return updated;
+
+        const adapter = availableLLMApiKeys.data?.data.find(
+          (connection) => connection.provider === value,
+        )?.adapter;
+        if (!adapter) return updated;
+
+        const defaults = getDefaultAdapterParams(adapter);
+        return {
+          ...updated,
+          adapter: defaults.adapter,
+          maxTemperature: defaults.maxTemperature,
+          temperature: {
+            ...prev.temperature,
+            value: Math.min(
+              prev.temperature.value,
+              defaults.maxTemperature.value,
+            ),
+          },
+        };
+      });
 
       if (value && key === "model") {
         setPersistedModelName(String(value));
@@ -148,7 +177,12 @@ export const useModelParams = (
         setPersistedModelProvider(String(value));
       }
     },
-    [setPersistedModelName, setPersistedModelProvider, setModelParams],
+    [
+      availableLLMApiKeys.data?.data,
+      setPersistedModelName,
+      setPersistedModelProvider,
+      setModelParams,
+    ],
   );
 
   const setModelParamEnabled: ModelParamsContext["setModelParamEnabled"] = (
@@ -161,12 +195,12 @@ export const useModelParams = (
         [key]: { ...prev[key], enabled },
       };
 
-      // For Anthropic models, temperature and top_p are mutually exclusive
+      // For Anthropic models, temperature and topP are mutually exclusive
       // When enabling one, disable the other
       if (updated.adapter.value === LLMAdapter.Anthropic && enabled) {
-        if (key === "temperature" && prev.top_p.enabled) {
-          updated.top_p = { ...prev.top_p, enabled: false };
-        } else if (key === "top_p" && prev.temperature.enabled) {
+        if (key === "temperature" && prev.topP.enabled) {
+          updated.topP = { ...prev.topP, enabled: false };
+        } else if (key === "topP" && prev.temperature.enabled) {
           updated.temperature = { ...prev.temperature, enabled: false };
         }
       }
@@ -219,6 +253,7 @@ export const useModelParams = (
 
   useEffect(() => {
     if (
+      !promptConfig ||
       !promptConfigSelectionKey ||
       !resolvedPromptConfigProvider ||
       !promptConfigModel
@@ -226,56 +261,34 @@ export const useModelParams = (
       return;
     }
 
+    const {
+      selectionKey: _,
+      provider: __,
+      model: ___,
+      ...config
+    } = promptConfig;
+    const adapterDefaults = resolvedPromptConfigAdapter
+      ? getDefaultAdapterParams(resolvedPromptConfigAdapter)
+      : undefined;
     setModelParams((prev) => ({
       ...prev,
+      ...getEnabledModelParamState(config),
       provider: { value: resolvedPromptConfigProvider, enabled: true },
       model: { value: promptConfigModel, enabled: true },
+      ...(adapterDefaults
+        ? {
+            adapter: adapterDefaults.adapter,
+            maxTemperature: adapterDefaults.maxTemperature,
+          }
+        : {}),
     }));
   }, [
     promptConfigSelectionKey,
     promptConfigModel,
+    promptConfig,
+    resolvedPromptConfigAdapter,
     resolvedPromptConfigProvider,
   ]);
-
-  // Update adapter, max temperature, temperature, max_tokens, top_p when provider changes
-  useEffect(() => {
-    if (selectedProviderApiKey?.adapter) {
-      setModelParams((prev) => ({
-        ...prev,
-        adapter: {
-          value: selectedProviderApiKey.adapter,
-          enabled: true,
-        },
-        maxTemperature: {
-          value: getDefaultAdapterParams(selectedProviderApiKey.adapter)
-            .maxTemperature.value,
-          enabled: getDefaultAdapterParams(selectedProviderApiKey.adapter)
-            .maxTemperature.enabled,
-        },
-        temperature: {
-          value: Math.min(
-            prev.temperature.value,
-            getDefaultAdapterParams(selectedProviderApiKey.adapter)
-              .maxTemperature.value,
-          ),
-          enabled: getDefaultAdapterParams(selectedProviderApiKey.adapter)
-            .temperature.enabled,
-        },
-        max_tokens: {
-          value: getDefaultAdapterParams(selectedProviderApiKey.adapter)
-            .max_tokens.value,
-          enabled: getDefaultAdapterParams(selectedProviderApiKey.adapter)
-            .max_tokens.enabled,
-        },
-        top_p: {
-          value: getDefaultAdapterParams(selectedProviderApiKey.adapter).top_p
-            .value,
-          enabled: getDefaultAdapterParams(selectedProviderApiKey.adapter).top_p
-            .enabled,
-        },
-      }));
-    }
-  }, [selectedProviderApiKey?.adapter]);
 
   return {
     modelParams,
@@ -291,91 +304,43 @@ export const useModelParams = (
 function getDefaultAdapterParams(
   adapter: LLMAdapter,
 ): Omit<UIModelParams, "provider" | "model"> {
+  let temperature: number;
+  let maxTemperature: number;
+
   switch (adapter) {
     // Docs: https://platform.openai.com/docs/api-reference/chat/create
     case LLMAdapter.OpenAI:
-      return {
-        adapter: {
-          value: adapter,
-          enabled: true,
-        },
-        temperature: { value: 0, enabled: false },
-        maxTemperature: { value: 2, enabled: false },
-        max_tokens: { value: 4096, enabled: false },
-        top_p: { value: 1, enabled: false },
-        maxReasoningTokens: { value: 0, enabled: false },
-        providerOptions: { value: {}, enabled: false },
-      };
-
     case LLMAdapter.Azure:
-      return {
-        adapter: {
-          value: adapter,
-          enabled: true,
-        },
-        temperature: { value: 0, enabled: false },
-        maxTemperature: { value: 2, enabled: false },
-        max_tokens: { value: 4096, enabled: false },
-        top_p: { value: 1, enabled: false },
-        maxReasoningTokens: { value: 0, enabled: false },
-        providerOptions: { value: {}, enabled: false },
-      };
+      temperature = 0;
+      maxTemperature = 2;
+      break;
 
     // Docs: https://docs.anthropic.com/claude/reference/messages_post
     case LLMAdapter.Anthropic:
-      return {
-        adapter: {
-          value: adapter,
-          enabled: true,
-        },
-        temperature: { value: 0, enabled: false },
-        maxTemperature: { value: 1, enabled: false },
-        max_tokens: { value: 4096, enabled: false },
-        top_p: { value: 1, enabled: false },
-        maxReasoningTokens: { value: 0, enabled: false },
-        providerOptions: { value: {}, enabled: false },
-      };
-
     case LLMAdapter.Bedrock:
-      return {
-        adapter: {
-          value: adapter,
-          enabled: true,
-        },
-        temperature: { value: 0, enabled: false },
-        maxTemperature: { value: 1, enabled: false },
-        max_tokens: { value: 4096, enabled: false },
-        top_p: { value: 1, enabled: false },
-        maxReasoningTokens: { value: 0, enabled: false },
-        providerOptions: { value: {}, enabled: false },
-      };
+      temperature = 0;
+      maxTemperature = 1;
+      break;
 
     case LLMAdapter.VertexAI:
-      return {
-        adapter: {
-          value: adapter,
-          enabled: true,
-        },
-        temperature: { value: 1, enabled: false },
-        maxTemperature: { value: 2, enabled: false },
-        max_tokens: { value: 4096, enabled: false },
-        top_p: { value: 1, enabled: false },
-        maxReasoningTokens: { value: 0, enabled: false },
-        providerOptions: { value: {}, enabled: false },
-      };
-
     case LLMAdapter.GoogleAIStudio:
-      return {
-        adapter: {
-          value: adapter,
-          enabled: true,
-        },
-        temperature: { value: 1, enabled: false },
-        maxTemperature: { value: 2, enabled: false },
-        max_tokens: { value: 4096, enabled: false },
-        top_p: { value: 1, enabled: false },
-        maxReasoningTokens: { value: 0, enabled: false },
-        providerOptions: { value: {}, enabled: false },
-      };
+      temperature = 1;
+      maxTemperature = 2;
+      break;
   }
+
+  return {
+    adapter: { value: adapter, enabled: true },
+    temperature: { value: temperature, enabled: false },
+    maxTemperature: { value: maxTemperature, enabled: false },
+    maxOutputTokens: { value: 4096, enabled: false },
+    topP: { value: 1, enabled: false },
+    topK: { value: 40, enabled: false },
+    presencePenalty: { value: 0, enabled: false },
+    frequencyPenalty: { value: 0, enabled: false },
+    stopSequences: { value: [], enabled: false },
+    seed: { value: 0, enabled: false },
+    reasoning: { value: "provider-default", enabled: false },
+    providerOptions: { value: {}, enabled: false },
+  };
 }

--- a/web/src/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/features/playground/server/chatCompletionHandler.ts
@@ -24,6 +24,46 @@ import {
   streamLLMText,
 } from "@langfuse/shared/src/server";
 import * as opentelemetry from "@opentelemetry/api";
+import { createLlmWarningsHeader } from "../utils/llmWarnings";
+
+type AiSdkWarning =
+  | { type: "unsupported" | "compatibility"; feature: string; details?: string }
+  | { type: "deprecated"; setting: string; message: string }
+  | { type: "other"; message: string };
+
+function formatLlmWarnings(warnings: readonly AiSdkWarning[] | undefined) {
+  return (warnings ?? []).map((warning) => {
+    switch (warning.type) {
+      case "unsupported":
+        return `Unsupported ${warning.feature}${warning.details ? `: ${warning.details}` : ""}`;
+      case "compatibility":
+        return `Compatibility mode for ${warning.feature}${warning.details ? `: ${warning.details}` : ""}`;
+      case "deprecated":
+        return `Deprecated ${warning.setting}: ${warning.message}`;
+      case "other":
+        return warning.message;
+    }
+  });
+}
+
+async function getInitialStreamWarnings(
+  completion: Awaited<ReturnType<typeof streamLLMText>>,
+) {
+  const reader = completion.stream.getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return [];
+      if (value.type === "error") throw value.error;
+      if (value.type === "start-step") return value.warnings;
+    }
+  } finally {
+    // Do not await cancellation: for a teed stream, that promise may settle
+    // only after the text branch finishes consuming the source.
+    reader.cancel().catch(() => undefined);
+  }
+}
 
 export default async function chatCompletionHandler(req: NextRequest) {
   try {
@@ -116,7 +156,9 @@ export default async function chatCompletionHandler(req: NextRequest) {
           ...completionParams,
           output: createLLMOutput(structuredOutputSchema),
         });
-        return NextResponse.json(result.output);
+        return NextResponse.json(result.output, {
+          headers: createLlmWarningsHeader(formatLlmWarnings(result.warnings)),
+        });
       }
 
       if ((tools && tools.length > 0) || hasToolResults) {
@@ -124,43 +166,62 @@ export default async function chatCompletionHandler(req: NextRequest) {
           ...completionParams,
           tools: createLLMToolSet(tools ?? []),
         });
-        return NextResponse.json({
-          content: result.text,
-          tool_calls: result.toolCalls.map((toolCall) => ({
-            name: toolCall.toolName,
-            id: toolCall.toolCallId,
-            args:
-              typeof toolCall.input === "object" &&
-              toolCall.input !== null &&
-              !Array.isArray(toolCall.input)
-                ? toolCall.input
-                : {},
-          })),
-          ...(result.finalStep.reasoningText
-            ? { reasoning: result.finalStep.reasoningText }
-            : {}),
-        });
+        return NextResponse.json(
+          {
+            content: result.text,
+            tool_calls: result.toolCalls.map((toolCall) => ({
+              name: toolCall.toolName,
+              id: toolCall.toolCallId,
+              args:
+                typeof toolCall.input === "object" &&
+                toolCall.input !== null &&
+                !Array.isArray(toolCall.input)
+                  ? toolCall.input
+                  : {},
+            })),
+            ...(result.finalStep.reasoningText
+              ? { reasoning: result.finalStep.reasoningText }
+              : {}),
+          },
+          {
+            headers: createLlmWarningsHeader(
+              formatLlmWarnings(result.warnings),
+            ),
+          },
+        );
       }
 
       if (streaming) {
         const completion = await streamLLMText(completionParams);
+        // Probe the first step from a teed full stream. AI SDK exposes provider
+        // warnings there before the first text delta, so response headers can
+        // include them without waiting for the generation to finish.
+        const warnings = await getInitialStreamWarnings(completion);
         return new Response(
           completion.textStream.pipeThrough(new TextEncoderStream()),
           {
             status: 200,
             headers: {
               "Content-Type": "text/plain; charset=utf-8",
+              ...createLlmWarningsHeader(formatLlmWarnings(warnings)),
             },
           },
         );
       }
       const completion = await generateLLMText(completionParams);
-      return NextResponse.json({
-        content: completion.text,
-        ...(completion.finalStep.reasoningText
-          ? { reasoning: completion.finalStep.reasoningText }
-          : {}),
-      });
+      return NextResponse.json(
+        {
+          content: completion.text,
+          ...(completion.finalStep.reasoningText
+            ? { reasoning: completion.finalStep.reasoningText }
+            : {}),
+        },
+        {
+          headers: createLlmWarningsHeader(
+            formatLlmWarnings(completion.warnings),
+          ),
+        },
+      );
     });
   } catch (err) {
     logger.error("Failed to handle chat completion", err);

--- a/web/src/features/playground/server/validateChatCompletionBody.ts
+++ b/web/src/features/playground/server/validateChatCompletionBody.ts
@@ -4,19 +4,20 @@ import {
   LLMJSONSchema,
   LLMToolDefinitionSchema,
   ChatMessageSchema,
-  JSONObjectSchema,
+  ZodModelConfig,
+  ZodModelConfigInput,
 } from "@langfuse/shared";
 
-const ModelParamsSchema = z.object({
+const ModelParamsSchema = ZodModelConfigInput.extend({
   provider: z.string(),
   adapter: z.enum(LLMAdapter),
   model: z.string(),
-  temperature: z.number().optional(),
-  max_tokens: z.number().optional(),
-  top_p: z.number().optional(),
-  maxReasoningTokens: z.number().optional(),
-  providerOptions: JSONObjectSchema.optional(),
-});
+}).transform(({ provider, adapter, model, ...config }) => ({
+  provider,
+  adapter,
+  model,
+  ...ZodModelConfig.parse(config),
+}));
 
 export const ChatCompletionBodySchema = z.object({
   projectId: z.string(),

--- a/web/src/features/playground/utils/llmWarnings.clienttest.ts
+++ b/web/src/features/playground/utils/llmWarnings.clienttest.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { createLlmWarningsHeader, readLlmWarnings } from "./llmWarnings";
+
+describe("LLM warning response headers", () => {
+  it("round-trips warnings for the Playground client", () => {
+    const response = new Response(null, {
+      headers: createLlmWarningsHeader([
+        "Unsupported temperature: ignored for this model",
+      ]),
+    });
+
+    expect(readLlmWarnings(response)).toEqual([
+      "Unsupported temperature: ignored for this model",
+    ]);
+  });
+
+  it("ignores malformed warning headers", () => {
+    const response = new Response(null, {
+      headers: { "x-langfuse-llm-warnings": "%broken" },
+    });
+
+    expect(readLlmWarnings(response)).toEqual([]);
+  });
+});

--- a/web/src/features/playground/utils/llmWarnings.ts
+++ b/web/src/features/playground/utils/llmWarnings.ts
@@ -1,0 +1,36 @@
+export const LLM_WARNINGS_HEADER = "x-langfuse-llm-warnings";
+
+const MAX_WARNING_COUNT = 5;
+const MAX_WARNING_LENGTH = 500;
+
+export function createLlmWarningsHeader(
+  warnings: readonly string[],
+): Record<string, string> {
+  if (warnings.length === 0) return {};
+
+  return {
+    [LLM_WARNINGS_HEADER]: encodeURIComponent(
+      JSON.stringify(
+        warnings
+          .slice(0, MAX_WARNING_COUNT)
+          .map((warning) => warning.slice(0, MAX_WARNING_LENGTH)),
+      ),
+    ),
+  };
+}
+
+export function readLlmWarnings(response: Response): string[] {
+  const header = response.headers.get(LLM_WARNINGS_HEADER);
+  if (!header) return [];
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(header));
+    return Array.isArray(parsed)
+      ? parsed.filter(
+          (warning): warning is string => typeof warning === "string",
+        )
+      : [];
+  } catch {
+    return [];
+  }
+}

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -47,6 +47,7 @@ import { CodeMirrorEditor } from "@/src/components/editor/CodeMirrorEditor";
 import { PromptLinkingEditor } from "@/src/components/editor/PromptLinkingEditor";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import usePlaygroundCache from "@/src/features/playground/page/hooks/usePlaygroundCache";
+import { getFinalModelConfig } from "@/src/utils/getFinalModelParams";
 import { useQueryParam } from "use-query-params";
 import { usePromptNameValidation } from "@/src/features/prompts/hooks/usePromptNameValidation";
 import { useFormPersistence } from "@/src/hooks/useFormPersistence";
@@ -187,6 +188,24 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
 
     if (shouldLoadPlaygroundCache && playgroundCache) {
       form.setValue("type", PromptType.Chat);
+      const cachedModelParams = playgroundCache.modelParams;
+      if (cachedModelParams?.provider && cachedModelParams.model) {
+        form.setValue(
+          "config",
+          JSON.stringify(
+            {
+              provider: cachedModelParams.provider.value,
+              model: cachedModelParams.model.value,
+              ...(cachedModelParams.adapter
+                ? { adapter: cachedModelParams.adapter.value }
+                : {}),
+              ...getFinalModelConfig(cachedModelParams),
+            },
+            null,
+            2,
+          ),
+        );
+      }
       setInitialMessages(playgroundCache.messages);
     } else if (initialPrompt?.type === PromptType.Chat) {
       setInitialMessages(initialPrompt.prompt);

--- a/web/src/utils/getFinalModelParams.clienttest.ts
+++ b/web/src/utils/getFinalModelParams.clienttest.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LLMAdapter,
+  type UIModelParams,
+  ZodModelConfig,
+} from "@langfuse/shared";
+import {
+  getEnabledModelParamState,
+  getFinalModelParams,
+  normalizeLegacyUIModelParams,
+} from "./getFinalModelParams";
+
+const modelParams: UIModelParams = {
+  provider: { value: "openai", enabled: true },
+  adapter: { value: LLMAdapter.OpenAI, enabled: true },
+  model: { value: "gpt-5.5", enabled: true },
+  maxTemperature: { value: 2, enabled: false },
+  maxOutputTokens: { value: 512, enabled: true },
+  temperature: { value: 0.2, enabled: false },
+  topP: { value: 0.9, enabled: true },
+  topK: { value: 40, enabled: true },
+  presencePenalty: { value: 0, enabled: false },
+  frequencyPenalty: { value: 0, enabled: false },
+  stopSequences: { value: ["DONE"], enabled: true },
+  seed: { value: 42, enabled: true },
+  reasoning: { value: "high", enabled: true },
+  providerOptions: {
+    value: { openai: { reasoningSummary: "auto" } },
+    enabled: true,
+  },
+};
+
+describe("model parameter serialization", () => {
+  it("emits only enabled AI SDK-native settings", () => {
+    expect(getFinalModelParams(modelParams)).toEqual({
+      provider: "openai",
+      adapter: LLMAdapter.OpenAI,
+      model: "gpt-5.5",
+      maxOutputTokens: 512,
+      topP: 0.9,
+      topK: 40,
+      stopSequences: ["DONE"],
+      seed: 42,
+      reasoning: "high",
+      providerOptions: { openai: { reasoningSummary: "auto" } },
+    });
+  });
+
+  it("moves the legacy Vertex reasoning budget into namespaced provider options", () => {
+    const parsed = ZodModelConfig.parse({ maxReasoningTokens: 2048 });
+
+    expect(getEnabledModelParamState(parsed)).toEqual({
+      providerOptions: {
+        value: { google: { thinkingBudget: 2048 } },
+        enabled: true,
+      },
+    });
+  });
+
+  it("normalizes legacy Playground cache fields", () => {
+    expect(
+      normalizeLegacyUIModelParams({
+        max_tokens: { value: 256, enabled: true },
+        top_p: { value: 0.8, enabled: true },
+        maxReasoningTokens: { value: 1024, enabled: true },
+      }),
+    ).toEqual({
+      maxOutputTokens: { value: 256, enabled: true },
+      topP: { value: 0.8, enabled: true },
+      providerOptions: {
+        value: { google: { thinkingBudget: 1024 } },
+        enabled: true,
+      },
+    });
+  });
+});

--- a/web/src/utils/getFinalModelParams.tsx
+++ b/web/src/utils/getFinalModelParams.tsx
@@ -2,21 +2,57 @@ import {
   type ModelConfig,
   type ModelParams,
   type UIModelParams,
+  ZodModelConfig,
 } from "@langfuse/shared";
 
 export function getFinalModelParams(modelParams: UIModelParams): ModelParams {
-  return Object.entries(modelParams)
-    .filter(([key, value]) => value.enabled && key !== "maxTemperature")
-    .reduce(
+  return {
+    provider: modelParams.provider.value,
+    adapter: modelParams.adapter.value,
+    model: modelParams.model.value,
+    ...getFinalModelConfig(modelParams),
+  };
+}
+
+export function getFinalModelConfig(
+  modelParams: Partial<UIModelParams>,
+): ModelConfig {
+  const enabledParams = Object.entries(modelParams)
+    .filter(
+      ([key, value]) =>
+        value.enabled &&
+        !["adapter", "provider", "model", "maxTemperature"].includes(key),
+    )
+    .reduce<Record<string, unknown>>(
       (params, [key, value]) => ({ ...params, [key]: value.value }),
-      {} as ModelParams,
+      {},
     );
+
+  return ZodModelConfig.parse(enabledParams);
 }
 
 export function getEnabledModelParamState(
   modelParams: ModelConfig,
 ): Partial<UIModelParams> {
-  return Object.entries(modelParams).reduce<Partial<UIModelParams>>(
+  const { legacyReasoningTokenBudget, providerOptions, ...canonicalParams } =
+    modelParams;
+  const normalizedProviderOptions =
+    legacyReasoningTokenBudget === undefined
+      ? providerOptions
+      : {
+          ...(providerOptions ?? {}),
+          google: {
+            ...((providerOptions?.google as Record<string, unknown>) ?? {}),
+            thinkingBudget: legacyReasoningTokenBudget,
+          },
+        };
+
+  return Object.entries({
+    ...canonicalParams,
+    ...(normalizedProviderOptions === undefined
+      ? {}
+      : { providerOptions: normalizedProviderOptions }),
+  }).reduce<Partial<UIModelParams>>(
     (state, [key, value]) =>
       value === undefined
         ? state
@@ -26,4 +62,47 @@ export function getEnabledModelParamState(
           },
     {},
   );
+}
+
+type LegacyUIModelParams = Partial<UIModelParams> & {
+  max_tokens?: { value: number; enabled: boolean };
+  top_p?: { value: number; enabled: boolean };
+  maxReasoningTokens?: { value: number; enabled: boolean };
+};
+
+/** Normalizes pre-AI-SDK Playground cache entries before they enter UI state. */
+export function normalizeLegacyUIModelParams(
+  modelParams: LegacyUIModelParams,
+): Partial<UIModelParams> {
+  const { max_tokens, top_p, maxReasoningTokens, ...canonicalParams } =
+    modelParams;
+  const reasoningBudget = maxReasoningTokens?.enabled
+    ? maxReasoningTokens.value
+    : undefined;
+  const providerOptions = canonicalParams.providerOptions;
+
+  return {
+    ...canonicalParams,
+    ...(canonicalParams.maxOutputTokens || !max_tokens
+      ? {}
+      : { maxOutputTokens: max_tokens }),
+    ...(canonicalParams.topP || !top_p ? {} : { topP: top_p }),
+    ...(reasoningBudget === undefined
+      ? {}
+      : {
+          providerOptions: {
+            value: {
+              ...(providerOptions?.value ?? {}),
+              google: {
+                ...((providerOptions?.value?.google as Record<
+                  string,
+                  unknown
+                >) ?? {}),
+                thinkingBudget: reasoningBudget,
+              },
+            },
+            enabled: true,
+          },
+        }),
+  };
 }


### PR DESCRIPTION
## Summary

- define one canonical AI SDK-native model-settings contract for Playground, evaluators, experiments, and prompt configuration
- expose the complete portable AI SDK settings surface: output-token limit, temperature, top P/K, presence/frequency penalties, stop sequences, seed, reasoning effort, and namespaced provider options
- normalize legacy `max_tokens`, `top_p`, and Vertex reasoning budgets at persistence boundaries while emitting canonical settings for all new writes
- preserve settings when switching providers and across prompt, generation, Playground, and experiment round trips
- surface AI SDK compatibility/unsupported/deprecation warnings in the Playground without delaying streaming responses

## UI and compatibility

- advanced settings are responsive and scroll within the actual available popover height
- provider-specific controls remain available through namespaced `providerOptions`, with exact options taking precedence over portable settings
- old saved evaluator configs and Playground cache entries continue to load through explicit legacy normalization
- no new PostHog event was added; the existing Playground execution event remains the meaningful intent signal, and per-field events would risk high-cardinality/raw configuration capture

## Verification

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- `pnpm run format:check` — `All matched files use Prettier code style!`
- shared LLM tests — `Test Files 13 passed (13)`, `Tests 128 passed (128)`
- Playground client tests — `Test Files 2 passed (2)`, `Tests 5 passed (5)`
- chat-completion handler tests — `Test Files 1 passed (1)`, `Tests 6 passed (6)`
- worker evaluator test — `Test Files 1 passed (1)`, `Tests 2 passed (2)`
- real-browser review at 1280px and 390px: verified all controls, multi-line stop sequences, provider-options JSON, responsive scrolling, and zero browser-console errors

The live worker connection suite was not run because it requires OpenAI, Anthropic, Azure, AWS, and GCP credentials that are not present locally; provider request-shape coverage runs against all adapters with captured transports instead.

Linear: [LFE-10954](https://linear.app/langfuse/issue/LFE-10954/harmonize-model-parameters-with-ai-sdk-native-settings)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a canonical AI SDK-native model settings contract (`maxOutputTokens`, `topP`, `topK`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, `seed`, `reasoning`) across Playground, evaluators, experiments, and prompt configuration, while preserving backward compatibility with persisted legacy field names (`max_tokens`, `top_p`, `maxReasoningTokens`) through `ZodModelConfig`'s normalization transform.

- `ZodModelConfigInput`/`ZodModelConfig` (shared package) normalize legacy snake_case fields to canonical camelCase at parse time; `mapLegacyLLMCompletionParams` and `validateChatCompletionBody` both use this boundary.
- The Playground streaming handler probes the AI SDK's teed full stream for `start-step` warnings and surfaces them to the client via a new `x-langfuse-llm-warnings` response header decoded as a toast notification.
- `useModelParams` collapses six per-adapter `useEffect`s into a single `updateModelParamValue` path and a unified prompt-config effect; `getDefaultAdapterParams` now emits the full new parameter set for each adapter.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core normalization logic and server-side completion paths are solid, but the stop-sequences textarea in ModelParameters can display stale data when the same model/provider pair is reused across different prompt configurations.

The largest risk is in ModelParamsTextListInput: its local inputValue state is initialised from the prop on mount, and the key prop only forces a remount when the provider or model changes. Switching between two prompts that share the same provider+model but carry different stop sequences leaves the textarea showing the previous values while modelParams.stopSequences.value has already been updated — so what the user sees diverges from what is sent in the completion request. All other changed paths are well-covered by the new tests.

web/src/components/ModelParameters/index.tsx — the ModelParamsTextListInput component needs its state-sync strategy reconsidered
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as ModelParameters UI
    participant Hook as useModelParams
    participant Handler as chatCompletionHandler
    participant SDK as AI SDK
    participant Client as Playground Context

    UI->>Hook: updateModelParamValue(key, value)
    Hook->>Hook: getDefaultAdapterParams(adapter) on provider change
    Hook-->>UI: re-render with new UIModelParams

    UI->>Handler: POST /chat-completion (canonical ModelParams)
    Handler->>Handler: ZodModelConfig.parse normalize legacy fields
    Handler->>SDK: streamLLMText / generateLLMText

    alt streaming
        SDK-->>Handler: completion.stream + textStream (teed)
        Handler->>Handler: getInitialStreamWarnings reads start-step
        Handler-->>Client: Response(textStream) + x-langfuse-llm-warnings
    else non-streaming
        SDK-->>Handler: result.text + result.warnings
        Handler-->>Client: NextResponse.json + x-langfuse-llm-warnings
    end

    Client->>Client: readLlmWarnings(response)
    Client-->>UI: toast warning
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as ModelParameters UI
    participant Hook as useModelParams
    participant Handler as chatCompletionHandler
    participant SDK as AI SDK
    participant Client as Playground Context

    UI->>Hook: updateModelParamValue(key, value)
    Hook->>Hook: getDefaultAdapterParams(adapter) on provider change
    Hook-->>UI: re-render with new UIModelParams

    UI->>Handler: POST /chat-completion (canonical ModelParams)
    Handler->>Handler: ZodModelConfig.parse normalize legacy fields
    Handler->>SDK: streamLLMText / generateLLMText

    alt streaming
        SDK-->>Handler: completion.stream + textStream (teed)
        Handler->>Handler: getInitialStreamWarnings reads start-step
        Handler-->>Client: Response(textStream) + x-langfuse-llm-warnings
    else non-streaming
        SDK-->>Handler: result.text + result.warnings
        Handler-->>Client: NextResponse.json + x-langfuse-llm-warnings
    end

    Client->>Client: readLlmWarnings(response)
    Client-->>UI: toast warning
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/components/ModelParameters/index.tsx:721-751
**Stop sequences textarea shows stale data after prompt swap**

`ModelParamsTextListInput` initializes `inputValue` from `value.join("\n")` once on mount and never re-syncs. The `key` prop (`stop-sequences-${provider}:${model}`) forces a remount when provider or model changes, but if two prompts share the same provider and model with different stop sequences, switching between them calls `setModelParams` with the new stop sequences while the component stays mounted — so the textarea keeps showing the old sequences even though `modelParams.stopSequences.value` has changed. The user sees one set of stop sequences, but the completion request uses another.

The fix is to either add `selectionKey` to the `key` (e.g., `stop-sequences-${provider}:${model}:${selectionKey}`) or convert to a controlled component (derive display value from `value` prop and a `useEffect` that syncs when `value` changes).

### Issue 2 of 3
web/src/features/playground/server/chatCompletionHandler.ts:49-67
**`getInitialStreamWarnings` could block indefinitely on a mal-formed stream**

The `while (true)` loop exits on `done`, `error`, or a `start-step` event — but there is no timeout. If an AI SDK version emits chunks in a different order (or never emits `start-step` before text data), the handler will suspend until the entire generation completes before returning the streaming `Response`. This turns a progressive stream into a full-buffered response for the caller, defeating the purpose of streaming. A lightweight guard — e.g., bailing out after a small fixed number of chunks (say, 10) — would keep latency bounded.

### Issue 3 of 3
web/src/components/ModelParameters/index.tsx:620-624
`String.prototype.replace` only replaces the first hyphen occurrence. While only `"provider-default"` currently contains a hyphen, using `replaceAll` is more defensive should the `MODEL_REASONING_LEVELS` array ever gain a multi-hyphen entry like `"very-high"` in the future.

```suggestion
        {MODEL_REASONING_LEVELS.map((level) => (
          <SelectItem className="capitalize" key={level} value={level}>
            {level.replaceAll("-", " ")}
          </SelectItem>
        ))}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(llm): harmonize model params with A..."](https://github.com/langfuse/langfuse/commit/9ac66b500d5fddd26be0ed2110e9866f27d6e1a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44464274)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->