### PR TITLE
fix(shared): compare patch version in Python SDK <=3.3.0 OTel override

### DIFF
--- a/packages/shared/src/server/otel/ObservationTypeMapper.test.ts
+++ b/packages/shared/src/server/otel/ObservationTypeMapper.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { ObservationTypeMapperRegistry } from "./ObservationTypeMapper";
+import { LangfuseOtelSpanAttributes } from "./attributes";
+
+/**
+ * The "PythonSDKv330Override" mapper (priority 0) exists to work around a bug
+ * in Python SDK versions <= 3.3.0 (see
+ * https://github.com/langfuse/langfuse/issues/8682): if a span reports type
+ * "span" but carries generation-like attributes, treat it as a generation
+ * anyway. The mapper's own comments say this only applies to SDK versions
+ * <= 3.3.0, but the version guard compares only major.minor and ignores the
+ * patch component, so any 3.3.x patch release above 3.3.0 is incorrectly
+ * still treated as affected.
+ */
+describe("ObservationTypeMapperRegistry — PythonSDKv330Override version gate", () => {
+  const registry = new ObservationTypeMapperRegistry();
+
+  const spanAttributesWithModel = {
+    [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: "span",
+    [LangfuseOtelSpanAttributes.OBSERVATION_MODEL]: "gpt-4",
+  };
+  const pythonResourceAttributes = { "telemetry.sdk.language": "python" };
+
+  it("applies the generation override for the exact affected version 3.3.0", () => {
+    const result = registry.mapToObservationType(
+      spanAttributesWithModel,
+      pythonResourceAttributes,
+      { name: "langfuse-sdk", version: "3.3.0" },
+    );
+
+    expect(result).toBe("GENERATION");
+  });
+
+  it("does NOT apply the override for a 3.3.x patch release above 3.3.0", () => {
+    const result = registry.mapToObservationType(
+      spanAttributesWithModel,
+      pythonResourceAttributes,
+      { name: "langfuse-sdk", version: "3.3.1" },
+    );
+
+    // The SDK bug was fixed after 3.3.0, so a span explicitly typed "span"
+    // must stay "SPAN" instead of being forced to "GENERATION".
+    expect(result).toBe("SPAN");
+  });
+
+  it("does not apply the override for a newer minor/major version", () => {
+    expect(
+      registry.mapToObservationType(
+        spanAttributesWithModel,
+        pythonResourceAttributes,
+        { name: "langfuse-sdk", version: "3.4.0" },
+      ),
+    ).toBe("SPAN");
+
+    expect(
+      registry.mapToObservationType(
+        spanAttributesWithModel,
+        pythonResourceAttributes,
+        { name: "langfuse-sdk", version: "4.0.0" },
+      ),
+    ).toBe("SPAN");
+  });
+});

--- a/packages/shared/src/server/otel/ObservationTypeMapper.ts
+++ b/packages/shared/src/server/otel/ObservationTypeMapper.ts
@@ -184,8 +184,12 @@ export class ObservationTypeMapperRegistry {
         // Check version <= 3.3.0
         const scopeVersion = scopeData?.version as string;
         if (scopeVersion) {
-          const [major, minor] = scopeVersion.split(".").map(Number);
-          if (major > 3 || (major === 3 && minor > 3)) {
+          const [major, minor, patch] = scopeVersion.split(".").map(Number);
+          if (
+            major > 3 ||
+            (major === 3 && minor > 3) ||
+            (major === 3 && minor === 3 && patch > 0)
+          ) {
             return null;
           }
         }


### PR DESCRIPTION
## What does this PR do?

`ObservationTypeMapperRegistry`'s `PythonSDKv330Override` mapper exists to work around a bug in the Python SDK (see #8682): SDK versions `<= 3.3.0` can emit a span with `langfuse.observation.type = "span"` even though the span carries generation-like attributes (model name, usage details, etc). The mapper's own comments say the override is scoped to `Python SDK <= 3.3.0`, but the version guard only compared `major` and `minor`, ignoring `patch`:

```ts
const [major, minor] = scopeVersion.split(".").map(Number);
if (major > 3 || (major === 3 && minor > 3)) {
  return null;
}
```

Any `3.3.x` patch release above `3.3.0` (e.g. `3.3.1`) is numerically newer than `3.3.0`, but this guard treats it identically to `3.3.0` — it never returns `null`, so the override keeps firing. A span reported by a fixed `3.3.1`+ SDK that is explicitly typed `"span"` gets silently force-mapped to `"GENERATION"` instead of falling through to the direct `"span" -> "SPAN"` mapping one priority level down.

## Fix

Add the missing patch component to the comparison so the override only applies for versions `<= 3.3.0`, matching its own doc comment and the linked issue:

```ts
const [major, minor, patch] = scopeVersion.split(".").map(Number);
if (
  major > 3 ||
  (major === 3 && minor > 3) ||
  (major === 3 && minor === 3 && patch > 0)
) {
  return null;
}
```

## Verification

- Added `packages/shared/src/server/otel/ObservationTypeMapper.test.ts` (no test file previously existed for this source file). It reproduces the bug against unfixed code: `version: "3.3.1"` incorrectly returned `"GENERATION"` for a span that was explicitly typed `"span"`.
- Confirmed the new test fails (RED) against the unfixed code, then passes (GREEN) after the fix. Also covers the exact-boundary version `3.3.0` (override should still apply) and newer minor/major versions (override should not apply).
- Ran the full `packages/shared` test suite after the fix: `Test Files  53 passed (53)` / `Tests  557 passed (557)` — no regressions.
- `eslint` and `tsc --noEmit` on the touched files: clean.

## AI-assisted contribution disclosure

This bug was found, diagnosed, and fixed with Claude Code assistance (human-in-the-loop): the candidate was investigated, the failing test was confirmed red against the unfixed code, the fix was confirmed green, and the full `packages/shared` suite was re-run before submission by a human reviewer. Not an unsupervised/autonomous agent submission.

Fixes # (no existing issue — happy to open one if you'd prefer that order)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

<!-- Everything below applies; the "I haven't ..." bullets from the template that would be untrue for this PR are removed per its instructions. -->

- [x] Read the contributing guide.
- [x] Style: `pnpm run format` clean.
- [x] Lint: no new warnings.
- [x] Tests: added `ObservationTypeMapper.test.ts` (the file had no coverage at all) — red before the fix, green after; full `packages/shared` suite 53 files / 557 tests green.
- [x] Docs: no user-facing surface changed.

---

_AI-assisted (Claude). I reproduced the mis-mapping against the unfixed code before writing anything, and ran every test above myself._
