### PR TITLE
chore(preview): add web/worker log commands to the preview PR comment

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -70,6 +70,10 @@ jobs:
             echo "web_image=${WEB_REPO}:${image_tag}"
             echo "worker_image=${WORKER_REPO}:${image_tag}"
             echo "preview_host=pr-${PR_NUMBER}.${DOMAIN_NAME}"
+            # k8s namespace/release for this PR (web+worker deploys are
+            # <namespace>-web / <namespace>-worker) — used for the log commands
+            # in the "ready" comment below.
+            echo "namespace=langfuse-pr-${PR_NUMBER}"
             # Shared, intentionally-public seed login + API keys (synthetic data
             # only) — must match the LANGFUSE_INIT_* values in the preview chart
             # (k8s/preview/chart/values.yaml). Each preview is its own isolated
@@ -167,6 +171,14 @@ jobs:
             **Login:** `${{ steps.meta.outputs.login_email }}` / `${{ steps.meta.outputs.login_password }}`
             **API keys:** `${{ steps.meta.outputs.public_key }}` / `${{ steps.meta.outputs.secret_key }}`
             **Commit:** ${{ steps.meta.outputs.commit_sha }}
+
+            **Logs** (needs preview-cluster `kubectl` access):
+            ```sh
+            kubectl -n ${{ steps.meta.outputs.namespace }} logs -f deploy/${{ steps.meta.outputs.namespace }}-web      # web
+            kubectl -n ${{ steps.meta.outputs.namespace }} logs -f deploy/${{ steps.meta.outputs.namespace }}-worker   # worker
+            ```
+            Add `--previous` for a crashed container, `--tail=200` to limit, or
+            `kubectl -n ${{ steps.meta.outputs.namespace }} get pods` to inspect status.
 
             Synthetic preview data only. Never add production data to public accounts.
 


### PR DESCRIPTION
Adds ready-to-copy **kubectl log commands** for the web and worker deploys to the "🟢 AWS preview image pushed" comment, so reviewers can debug a preview without looking up the namespace/deploy names.

## What changed
`.github/workflows/preview-build.yml`:
- New `namespace` output on the meta step (`langfuse-pr-<n>`).
- A **Logs** section in the success comment:

  ````
  **Logs** (needs preview-cluster `kubectl` access):
  ```sh
  kubectl -n langfuse-pr-<n> logs -f deploy/langfuse-pr-<n>-web      # web
  kubectl -n langfuse-pr-<n> logs -f deploy/langfuse-pr-<n>-worker   # worker
  ```
  Add `--previous` for a crashed container, `--tail=200` to limit, or
  `kubectl -n langfuse-pr-<n> get pods` to inspect status.
  ````

## Privacy note
This repo is public, so the comment intentionally includes **only** the PR-derived namespace and deploy names — which are already implied by the preview URL (`pr-<n>.…`) — and **no** cluster name, account, region, or profile. How to obtain preview-cluster `kubectl` access stays in the internal runbook.

Prettier-clean; YAML validated.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds ready-to-copy `kubectl` log commands to the "🟢 AWS preview image pushed" PR comment, derived from a new `namespace` output (`langfuse-pr-<n>`) on the meta step.

- Adds `namespace=langfuse-pr-${PR_NUMBER}` to the `GITHUB_OUTPUT` block, keeping it consistent with the naming convention implied by the existing preview URL.
- Injects a fenced `sh` code block into the success comment body with `logs -f` commands for both the web and worker deployments, along with brief usage tips — no cluster name, region, or account details are exposed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only adds informational text to an existing PR comment and a single derived string output to the meta step.

The new `namespace` output is a straightforward string derivation from `PR_NUMBER`, consistent with the pattern already used for `preview_host`. The kubectl commands in the comment body are static, human-readable text with no secrets — only the PR-number-derived namespace, which is already implied by the public preview URL. The YAML literal block scalar handles the triple-backtick fenced code block correctly, and all `${{ steps.meta.outputs.namespace }}` expressions reference a properly-set output.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant meta as meta step
    participant ECR as AWS ECR
    participant comment as preview-comment action
    participant PR as Pull Request

    GH->>meta: "Resolve image tags & preview metadata"
    meta-->>GH: "outputs: commit_sha, image_tag, preview_host,<br/>namespace (new), login_email, public_key, …"

    GH->>PR: 🟡 Building comment

    GH->>ECR: "Build & push web + worker images"

    GH->>comment: Mark preview image pushed
    comment->>PR: "🟢 Ready comment<br/>(URL, login, API keys, commit)<br/>+ Logs section with kubectl commands<br/>using steps.meta.outputs.namespace"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant meta as meta step
    participant ECR as AWS ECR
    participant comment as preview-comment action
    participant PR as Pull Request

    GH->>meta: "Resolve image tags & preview metadata"
    meta-->>GH: "outputs: commit_sha, image_tag, preview_host,<br/>namespace (new), login_email, public_key, …"

    GH->>PR: 🟡 Building comment

    GH->>ECR: "Build & push web + worker images"

    GH->>comment: Mark preview image pushed
    comment->>PR: "🟢 Ready comment<br/>(URL, login, API keys, commit)<br/>+ Logs section with kubectl commands<br/>using steps.meta.outputs.namespace"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(preview): add web/worker log comma..."](https://github.com/langfuse/langfuse/commit/25f54638dd8fde0e9004dcbd2c4f49f101a1768d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44508733)</sub>

<!-- /greptile_comment -->