### PR TITLE
fix(sessions): guard session-view trace-card I/O against non-array shape (regression from #15124)

### DIFF
--- a/web/src/__tests__/server/sessions-observations-io-cap.servertest.ts
+++ b/web/src/__tests__/server/sessions-observations-io-cap.servertest.ts
@@ -6,6 +6,12 @@
  * whole (cards render exactly as before); larger fields come back as a
  * preview head plus their true length and a truncated flag, with the trace
  * peek / `sessions.observationFullIOFromEvents` as the full-reading surfaces.
+ *
+ * The procedure returns a BARE ARRAY of observations (backward-compatible with
+ * clients that call `.find` on the response directly, LFE-10958 regression).
+ * "More observations exist" is signalled in-band: up to
+ * SESSION_OBSERVATIONS_PER_TRACE_LIMIT + 1 real observations come back, and
+ * the extra (+1) row is the client's "has more" sentinel.
  */
 import type { Session } from "next-auth";
 import { prisma } from "@langfuse/shared/src/db";
@@ -33,6 +39,12 @@ describe("sessions observations io cap liveness", () => {
 const INLINE_LIMIT = 300_000;
 const PREVIEW_LIMIT = 4_000;
 const PER_TRACE_LIMIT = 50;
+
+// The client derives "more exist" from the +1 sentinel: the response is a bare
+// array of up to PER_TRACE_LIMIT + 1 real observations, so more than
+// PER_TRACE_LIMIT real rows means the trace has more than the card shows.
+const hasMore = (observations: { id: string }[], traceId: string) =>
+  observations.filter((o) => o.id !== `t-${traceId}`).length > PER_TRACE_LIMIT;
 
 maybe("sessions observations bounded I/O (events)", () => {
   const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
@@ -128,8 +140,8 @@ maybe("sessions observations bounded I/O (events)", () => {
         traceId,
         filter: [],
       });
-      expect(result.observations.length).toBeGreaterThanOrEqual(
-        Math.min(events.length, PER_TRACE_LIMIT),
+      expect(result.length).toBeGreaterThanOrEqual(
+        Math.min(events.length, PER_TRACE_LIMIT + 1),
       );
     });
 
@@ -143,15 +155,14 @@ maybe("sessions observations bounded I/O (events)", () => {
       { input: bigInput, output: "small" },
     ]);
 
-    const { observations, hasMoreObservations } =
-      await caller.sessions.observationsForTraceFromEvents({
-        projectId,
-        sessionId,
-        traceId,
-        filter: [],
-      });
+    const observations = await caller.sessions.observationsForTraceFromEvents({
+      projectId,
+      sessionId,
+      traceId,
+      filter: [],
+    });
 
-    expect(hasMoreObservations).toBe(false);
+    expect(hasMore(observations, traceId)).toBe(false);
 
     const small = observations.find((o) => o.id === `${traceId}-o0`);
     expect(small?.input).toBe("hello");
@@ -174,13 +185,12 @@ maybe("sessions observations bounded I/O (events)", () => {
       { metadataValues: [bigValue, "tiny"], metadataNames: ["big", "small"] },
     ]);
 
-    const { observations } =
-      await caller.sessions.observationsForTraceFromEvents({
-        projectId,
-        sessionId,
-        traceId,
-        filter: [],
-      });
+    const observations = await caller.sessions.observationsForTraceFromEvents({
+      projectId,
+      sessionId,
+      traceId,
+      filter: [],
+    });
 
     const observation = observations[0];
     expect(observation.metadataTruncated).toBe(true);
@@ -189,21 +199,22 @@ maybe("sessions observations bounded I/O (events)", () => {
     expect(metadata.small).toBe("tiny");
   });
 
-  it("caps observations per card and reports more exist", async () => {
+  it("caps observations per card and signals more exist via the +1 sentinel", async () => {
     const { sessionId, traceId } = await seedObservations(
       Array.from({ length: PER_TRACE_LIMIT + 2 }, () => ({})),
     );
 
-    const { observations, hasMoreObservations } =
-      await caller.sessions.observationsForTraceFromEvents({
-        projectId,
-        sessionId,
-        traceId,
-        filter: [],
-      });
+    const observations = await caller.sessions.observationsForTraceFromEvents({
+      projectId,
+      sessionId,
+      traceId,
+      filter: [],
+    });
 
-    expect(observations.length).toBe(PER_TRACE_LIMIT);
-    expect(hasMoreObservations).toBe(true);
+    // The response is bounded to the display limit plus one sentinel row; the
+    // sentinel is what tells the client "more observations exist".
+    expect(observations.length).toBe(PER_TRACE_LIMIT + 1);
+    expect(hasMore(observations, traceId)).toBe(true);
   });
 
   it("trims to preview heads once the cumulative I/O budget is exhausted (valid-JSON payloads)", async () => {
@@ -218,13 +229,12 @@ maybe("sessions observations bounded I/O (events)", () => {
       Array.from({ length: 8 }, () => ({ input: nearCap, output: "ok" })),
     );
 
-    const { observations } =
-      await caller.sessions.observationsForTraceFromEvents({
-        projectId,
-        sessionId,
-        traceId,
-        filter: [],
-      });
+    const observations = await caller.sessions.observationsForTraceFromEvents({
+      projectId,
+      sessionId,
+      traceId,
+      filter: [],
+    });
 
     const first = observations[0];
     expect(first.inputTruncated).toBe(false);
@@ -242,9 +252,8 @@ maybe("sessions observations bounded I/O (events)", () => {
   it("does not let the synthetic trace row consume a card slot or trip hasMore", async () => {
     // 50 real observations + the synthetic trace-level row (id `t-<traceId>`,
     // the shape handleEventPropagationJob writes): all 50 real observations
-    // must come back alongside the synthetic row, and hasMoreObservations
-    // must stay false — the synthetic row is trace metadata, not observation
-    // number 51.
+    // must come back alongside the synthetic row, and the +1 sentinel must not
+    // appear — the synthetic row is trace metadata, not observation number 51.
     const { sessionId, traceId, baseTime } = await seedObservations(
       Array.from({ length: PER_TRACE_LIMIT }, () => ({})),
     );
@@ -271,22 +280,21 @@ maybe("sessions observations bounded I/O (events)", () => {
         traceId,
         filter: [],
       });
-      expect(result.observations.length).toBe(PER_TRACE_LIMIT + 1);
+      expect(result.length).toBe(PER_TRACE_LIMIT + 1);
     });
 
-    const { observations, hasMoreObservations } =
-      await caller.sessions.observationsForTraceFromEvents({
-        projectId,
-        sessionId,
-        traceId,
-        filter: [],
-      });
+    const observations = await caller.sessions.observationsForTraceFromEvents({
+      projectId,
+      sessionId,
+      traceId,
+      filter: [],
+    });
 
     expect(observations.some((o) => o.id === `t-${traceId}`)).toBe(true);
     expect(observations.filter((o) => o.id !== `t-${traceId}`).length).toBe(
       PER_TRACE_LIMIT,
     );
-    expect(hasMoreObservations).toBe(false);
+    expect(hasMore(observations, traceId)).toBe(false);
   });
 
   it("collapses un-merged span versions to one observation (newest wins)", async () => {
@@ -332,19 +340,18 @@ maybe("sessions observations bounded I/O (events)", () => {
         traceId,
         filter: [],
       });
-      expect(result.observations.length).toBeGreaterThanOrEqual(1);
+      expect(result.length).toBeGreaterThanOrEqual(1);
     });
 
-    const { observations, hasMoreObservations } =
-      await caller.sessions.observationsForTraceFromEvents({
-        projectId,
-        sessionId,
-        traceId,
-        filter: [],
-      });
+    const observations = await caller.sessions.observationsForTraceFromEvents({
+      projectId,
+      sessionId,
+      traceId,
+      filter: [],
+    });
 
     expect(observations.length).toBe(1);
-    expect(hasMoreObservations).toBe(false);
+    expect(hasMore(observations, traceId)).toBe(false);
     expect(observations[0].output).toBe("completed answer");
   });
 
@@ -360,13 +367,12 @@ maybe("sessions observations bounded I/O (events)", () => {
       },
     ]);
 
-    const { observations } =
-      await caller.sessions.observationsForTraceFromEvents({
-        projectId,
-        sessionId,
-        traceId,
-        filter: [],
-      });
+    const observations = await caller.sessions.observationsForTraceFromEvents({
+      projectId,
+      sessionId,
+      traceId,
+      filter: [],
+    });
 
     const observation = observations[0];
     expect((observation.metadata as Record<string, unknown>).k).toBe(
@@ -389,13 +395,12 @@ maybe("sessions observations bounded I/O (events)", () => {
       })),
     );
 
-    const { observations } =
-      await caller.sessions.observationsForTraceFromEvents({
-        projectId,
-        sessionId,
-        traceId,
-        filter: [],
-      });
+    const observations = await caller.sessions.observationsForTraceFromEvents({
+      projectId,
+      sessionId,
+      traceId,
+      filter: [],
+    });
 
     const first = observations[0];
     expect(first.metadataTruncated).toBe(false);

--- a/web/src/components/session/SessionObservationIO.tsx
+++ b/web/src/components/session/SessionObservationIO.tsx
@@ -9,7 +9,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { compactNumberFormatter } from "@/src/utils/numbers";
 
 export type SessionTraceObservation =
-  RouterOutputs["sessions"]["observationsForTraceFromEvents"]["observations"][number];
+  RouterOutputs["sessions"]["observationsForTraceFromEvents"][number];
 
 /** Display cap of a preview section — matches the server's preview head. */
 const PREVIEW_DISPLAY_CHARS = 4_000;

--- a/web/src/components/session/TraceEventsRow.tsx
+++ b/web/src/components/session/TraceEventsRow.tsx
@@ -157,10 +157,22 @@ export const TraceEventsRow = React.memo(
     // trace-level I/O that no observation shows (a v3-migrated trace can set
     // trace I/O apart from any observation; dropping it would lose content and
     // blind the annotation queue, which hides the trace panel).
-    const observations = observationsQuery.data?.observations;
-    const hasMoreObservations = Boolean(
-      observationsQuery.data?.hasMoreObservations,
-    );
+    // `observationsForTraceFromEvents` returns a BARE ARRAY of observations.
+    // #15124 briefly wrapped it as `{ observations, hasMoreObservations }`,
+    // which crashed in-flight old clients that call `.find` on the response
+    // directly during a rollout (LFE-10958 regression). Read it defensively so
+    // BOTH shapes are safe: this new client can also briefly hit a not-yet-
+    // updated server that still returns the envelope, so an Array method must
+    // never run on a non-array value.
+    type ObservationsResponse =
+      RouterOutputs["sessions"]["observationsForTraceFromEvents"];
+    const observationsData = observationsQuery.data as
+      | ObservationsResponse
+      | { observations?: ObservationsResponse }
+      | undefined;
+    const observations = Array.isArray(observationsData)
+      ? observationsData
+      : (observationsData?.observations ?? undefined);
 
     // Opens the trace peek AT the observation (the session page's peek config
     // mirrors row.observationId into the ?observation= param; the annotation
@@ -171,13 +183,38 @@ export const TraceEventsRow = React.memo(
       },
       [openPeek, trace],
     );
-    const visibleObservations = React.useMemo(() => {
-      if (!observations) return undefined;
+    const { visibleObservations, hasMoreObservations } = React.useMemo(() => {
+      const all = observations;
+      if (!all)
+        return {
+          visibleObservations: undefined,
+          hasMoreObservations: false,
+        };
       const syntheticTraceRowId = `t-${trace.id}`;
-      const syntheticRow = observations.find(
+      // The server returns up to SESSION_CARD_OBSERVATIONS_NOTICE_COUNT + 1
+      // real observations; the extra (+1) row is the "more exist" sentinel.
+      // Show only the first NOTICE_COUNT real observations, keeping the
+      // synthetic trace-level row wherever it sits (it never consumes a slot).
+      let realCount = 0;
+      let realShown = 0;
+      const page: typeof all = [];
+      for (const observation of all) {
+        if (observation.id === syntheticTraceRowId) {
+          page.push(observation);
+          continue;
+        }
+        realCount++;
+        if (realShown >= SESSION_CARD_OBSERVATIONS_NOTICE_COUNT) continue;
+        page.push(observation);
+        realShown++;
+      }
+      const hasMoreObservations =
+        realCount > SESSION_CARD_OBSERVATIONS_NOTICE_COUNT;
+
+      const syntheticRow = page.find(
         (observation) => observation.id === syntheticTraceRowId,
       );
-      const realObservations = observations.filter(
+      const realObservations = page.filter(
         (observation) => observation.id !== syntheticTraceRowId,
       );
       // I/O can be server-truncated to a preview head (LFE-10958), so equal
@@ -195,8 +232,12 @@ export const TraceEventsRow = React.memo(
               isEqual(observation.output, syntheticRow.output) &&
               observation.outputLength === syntheticRow.outputLength),
         );
-      if (!syntheticRowIsRedundant) return observations;
-      return realObservations.length > 0 ? realObservations : observations;
+      const visibleObservations = !syntheticRowIsRedundant
+        ? page
+        : realObservations.length > 0
+          ? realObservations
+          : page;
+      return { visibleObservations, hasMoreObservations };
     }, [observations, trace.id]);
 
     return (

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -835,9 +835,10 @@ export const sessionRouter = createTRPCRouter({
       ];
 
       let orderBy: OrderByState = { column: "startTime", order: "ASC" };
-      // One extra row detects "more observations than the card shows", and
-      // one more because the synthetic trace-level row (id `t-<traceId>`)
-      // may sit in the fetched window without consuming a card slot.
+      // One extra row is returned as the "more observations exist" sentinel
+      // (the client shows the first LIMIT and surfaces a notice when it sees
+      // the +1), and one more because the synthetic trace-level row (id
+      // `t-<traceId>`) may sit in the fetched window without consuming a slot.
       let limit: number = SESSION_OBSERVATIONS_PER_TRACE_LIMIT + 2;
       let offset: number | undefined;
 
@@ -880,15 +881,21 @@ export const sessionRouter = createTRPCRouter({
 
       // The synthetic trace-level row is metadata about the trace, not one of
       // its observations: it must neither consume one of the card's slots
-      // (displacing a real observation) nor count toward hasMore. The client
-      // decides whether to show or drop it (redundancy dedupe).
+      // (displacing a real observation) nor count toward the "more exist"
+      // signal. The client decides whether to show or drop it (redundancy
+      // dedupe).
+      //
+      // BACKWARD-COMPATIBLE RESPONSE SHAPE (LFE-10958 regression): this
+      // procedure returns a BARE ARRAY of observations. The client consumes
+      // the response as an array and calls `.find`/`.filter` on it directly,
+      // so wrapping it in an `{ observations, ... }` envelope crashes in-flight
+      // old clients during a rollout ("x.find is not a function"). "More
+      // observations exist" is therefore signalled IN-BAND: we return up to
+      // SESSION_OBSERVATIONS_PER_TRACE_LIMIT + 1 real observations, and the
+      // client treats that extra (+1) row as the "has more" sentinel, showing
+      // only the first LIMIT. (With a positionFilter the fetch limit is 1, so
+      // at most one row is returned and the sentinel can never appear.)
       const syntheticTraceRowId = `t-${input.traceId}`;
-      const realFetchedCount = fetched.filter(
-        (observation) => observation.id !== syntheticTraceRowId,
-      ).length;
-      const hasMoreObservations =
-        !positionFilter &&
-        realFetchedCount > SESSION_OBSERVATIONS_PER_TRACE_LIMIT;
       let realTaken = 0;
       const page: typeof fetched = [];
       for (const observation of fetched) {
@@ -896,7 +903,8 @@ export const sessionRouter = createTRPCRouter({
           page.push(observation);
           continue;
         }
-        if (realTaken >= SESSION_OBSERVATIONS_PER_TRACE_LIMIT) continue;
+        // Keep one past the display limit as the "more exist" sentinel.
+        if (realTaken >= SESSION_OBSERVATIONS_PER_TRACE_LIMIT + 1) continue;
         page.push(observation);
         realTaken++;
       }
@@ -958,7 +966,7 @@ export const sessionRouter = createTRPCRouter({
         };
       });
 
-      return { observations, hasMoreObservations };
+      return observations;
     }),
   /**
    * Full raw I/O for one observation, for the session card's download


### PR DESCRIPTION
## TL;DR

A production regression on the session detail view: **every session detail page throws `TypeError: h.find is not a function`** for any browser still running a pre-#15124 bundle. #15124 changed the `sessions.observationsForTraceFromEvents` response from a bare array to an `{ observations, hasMoreObservations }` object; the trace-card `useMemo` calls `.find` on the response directly, so in-flight old clients crash during the rollout. This restores the **backward-compatible bare-array shape** (old clients stop crashing) while keeping #15124's I/O bounding fully intact, and hardens the consumer so it is safe against either shape.

## Why

#15124 (LFE-10958) bounded the trace-card I/O in the session detail view — a good and necessary memory fix. But it also changed the top-level **shape** of the `observationsForTraceFromEvents` tRPC procedure:

- before: `return observations` — a bare `Observation[]`
- after: `return { observations, hasMoreObservations }` — an object

The session-card component reads the response and, inside a `useMemo`, does `observationsQuery.data.find(...)` / `.filter(...)` directly on it. Bundles built before #15124 are still live in users' browsers (and CDN caches) during a deploy; they hit the new backend, get an object, and `.find` on it throws `TypeError: …find is not a function` (minified `h.find is not a function`) — a hard crash of the whole session detail page.

## What

Keep the memory fix, restore compatibility, and make the client defensive:

1. **Backend returns a bare array again** — old clients can `.find`/`.filter`/`.map` on it. All of #15124's server-side I/O bounding is unchanged (per-field 300K inline size cap + 4K preview head, 50-observation page, 2M cumulative budget trim, span-version dedupe).
2. **"More observations exist" is signalled in-band via a +1 sentinel** — the server returns up to `LIMIT + 1` real observations; the client displays the first `LIMIT` and shows the "open the trace" notice when the sentinel is present. No object envelope needed.
3. **Consumer hardened** — the response is normalized with `Array.isArray(...)` before any array method, so it is safe against BOTH the array and the legacy object shape (a freshly-deployed client can itself briefly hit a not-yet-updated server mid-rollout).

Related: #15124, LFE-10958.

<details>
<summary>Mechanism, decisions, and verification</summary>

**Why not just re-add the field to an array?** The tRPC transformer is superjson, which serializes an array as a JSON array literal — extra own-properties on an array do not survive the wire. So a single response value cannot be both `.find`-able (array) for old clients and carry an `.observations` key for the #15124 client. The bare array + in-band sentinel is the shape that is backward-compatible and still conveys "has more".

**Files changed**
- `web/src/server/api/routers/sessions.ts` — return the array; keep up to `LIMIT + 1` real observations as the sentinel (drops the now-unused `hasMoreObservations`/`realFetchedCount`); budget/dedupe/cap logic untouched.
- `web/src/components/session/TraceEventsRow.tsx` — normalize response to an array (`Array.isArray`); derive `hasMoreObservations` and cap the display to `LIMIT` real observations inside the `useMemo`, keeping the synthetic trace-row dedupe.
- `web/src/components/session/SessionObservationIO.tsx` — `RouterOutputs` type updated to the bare-array shape.
- `web/src/__tests__/server/sessions-observations-io-cap.servertest.ts` — assertions updated to the bare-array + sentinel contract.

**Verification**
- Reproduced the exact crash and confirmed the fix in **Chromium and Firefox**: the session "with I/O" view (`__langfuse_with_io__` preset) on a 52-observation trace renders with **zero console/page errors**, the "open the trace" notice shows, and the tRPC response over the wire is a **bare array** (length 51 = 50 shown + 1 sentinel). Both engines confirm the pre-fix object shape throws `TypeError: …find is not a function` while the fixed array shape does not.
- Bounded-I/O **servertests (10)** pass against ClickHouse; **client tests (6)** pass; typecheck clean; lint/prettier clean.
- The normal session view (small-I/O, under-50-observation traces) is unaffected.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a production crash (`TypeError: h.find is not a function`) on the session detail page caused by #15124 changing the `observationsForTraceFromEvents` response from a bare array to an object envelope. Old clients cached in browsers called `.find` on the envelope and crashed.

- **Backend**: returns a bare array again; \"more observations exist\" is signalled in-band by returning up to `LIMIT + 1` real rows — old clients can safely call `.find`/`.filter` on it, and all of #15124's per-field cap, preview-head trim, cumulative budget, and span-dedup logic is preserved unchanged.
- **Client**: normalizes the response with `Array.isArray` so it is safe against both the new array shape and the old object envelope (for mid-rollout server lag), then derives `hasMoreObservations` by comparing real row count against the display limit.
- **Tests**: updated to the bare-array + sentinel contract; all 10 server integration tests and 6 client tests are adjusted.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The regression fix is sound: the wire contract is restored to the original array shape, all memory-bounding logic from #15124 is intact, and the client guard handles both shapes correctly during rollout.

The sentinel-based 'has more' signal works correctly across the server paging loop and the client counting loop, and the defensive Array.isArray check covers the mid-rollout case. The one minor rough edge is a TypeScript type alias declared inside the component function body; it does not affect runtime behavior, but a module-level alias or the type inlined directly into the cast would be cleaner.

TraceEventsRow.tsx — the type ObservationsResponse declaration inside the component body should be hoisted to module scope or inlined directly into the as cast.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant OldClient as Old Client
    participant NewClient as New Client
    participant Server as tRPC Server

    Note over OldClient,Server: Regression from #15124
    OldClient->>Server: observationsForTraceFromEvents
    Server-->>OldClient: "{observations, hasMoreObservations}"
    OldClient->>OldClient: data.find() TypeError crash

    Note over NewClient,Server: This PR - bare array plus sentinel
    NewClient->>Server: observationsForTraceFromEvents
    Server-->>NewClient: "Observation[] up to LIMIT+1 real rows"
    NewClient->>NewClient: Array.isArray guard normalizes data
    NewClient->>NewClient: realCount over LIMIT means hasMore

    Note over OldClient,Server: Old client hits new server
    OldClient->>Server: observationsForTraceFromEvents
    Server-->>OldClient: "Observation[] bare array"
    OldClient->>OldClient: data.find() works correctly
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant OldClient as Old Client
    participant NewClient as New Client
    participant Server as tRPC Server

    Note over OldClient,Server: Regression from #15124
    OldClient->>Server: observationsForTraceFromEvents
    Server-->>OldClient: "{observations, hasMoreObservations}"
    OldClient->>OldClient: data.find() TypeError crash

    Note over NewClient,Server: This PR - bare array plus sentinel
    NewClient->>Server: observationsForTraceFromEvents
    Server-->>NewClient: "Observation[] up to LIMIT+1 real rows"
    NewClient->>NewClient: Array.isArray guard normalizes data
    NewClient->>NewClient: realCount over LIMIT means hasMore

    Note over OldClient,Server: Old client hits new server
    OldClient->>Server: observationsForTraceFromEvents
    Server-->>OldClient: "Observation[] bare array"
    OldClient->>OldClient: data.find() works correctly
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/session/TraceEventsRow.tsx:160-169
The `type ObservationsResponse` alias is declared inside the component function body. TypeScript type aliases declared inside functions are erased at compile time, but it's a readability oddity — types are easier to find and reuse when placed at module scope alongside other type-level declarations.

```suggestion
    // `observationsForTraceFromEvents` returns a BARE ARRAY of observations.
    // #15124 briefly wrapped it as `{ observations, hasMoreObservations }`,
    // which crashed in-flight old clients that call `.find` on the response
    // directly during a rollout (LFE-10958 regression). Read it defensively so
    // BOTH shapes are safe: this new client can also briefly hit a not-yet-
    // updated server that still returns the envelope, so an Array method must
    // never run on a non-array value.
    const observationsData = observationsQuery.data as
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sessions): restore bare-array trace-..."](https://github.com/langfuse/langfuse/commit/aec2248fd0f33a6e7eff5053cf4de98282748d90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44554741)</sub>

<!-- /greptile_comment -->