### PR TITLE
chore(preview): link the debug guide from the preview PR comment

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -197,6 +197,10 @@ jobs:
             **API keys:** `${{ steps.meta.outputs.public_key }}` / `${{ steps.meta.outputs.secret_key }}`
             **Commit:** ${{ steps.meta.outputs.commit_sha }}
 
+            **URL not loading / 404?** Full debug guide — deploy allowlist,
+            sleeping preview, pod status, ClickHouse:
+            https://github.com/langfuse/langfuse/blob/main/.agents/skills/langfuse-previews/SKILL.md#debug-a-preview
+
             **Logs** (needs preview-cluster `kubectl` access):
             ```sh
             kubectl -n ${{ steps.meta.outputs.namespace }} logs -f deploy/${{ steps.meta.outputs.namespace }}-web      # web


### PR DESCRIPTION
## What
Adds a **"URL not loading / 404?"** line to the 🟢 "preview image pushed" comment in `preview-build.yml`, linking the `langfuse-previews` skill's debug section (deploy allowlist, sleeping preview, pod status, ClickHouse).

## Why
The PR comment is the zero-friction "doc" — it lands on the engineer's PR. It already advertises the demo-project login (`demo@langfuse.com` / `password`) and API keys (`pk-lf-1234567890` / `sk-lf-1234567890`) and inline log commands; this adds a pointer to the full troubleshooting so an engineer whose preview 404s can self-serve (the #1 cause — author not on the deploy allowlist — is covered there).

## Depends on
The link targets `.agents/skills/langfuse-previews/SKILL.md` on `main`, which lands via langfuse/langfuse#15128. Merge that first (or together) so the link resolves; until then it's a harmless dead link on new preview comments.

## Verification
- YAML parses; no trigger/permission changes (so no zizmor impact) — only markdown added inside the existing `body:` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a troubleshooting pointer to the automated preview-build PR comment. When Argo CD finishes rolling out a preview, the comment now includes a "URL not loading / 404?" line with a link to the debug guide in `.agents/skills/langfuse-previews/SKILL.md#debug-a-preview` on `main`.

- The only changed file is `.github/workflows/preview-build.yml`, and only the `body:` block of the "Mark preview image pushed" step is modified — no triggers, permissions, or logic are touched.
- The linked `SKILL.md` file does not yet exist in the repo (it lands in PR #15128); until that PR is merged, the link in new preview comments will resolve to a 404. The author acknowledges this and flags it as "a harmless dead link" in the PR description.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the only change is a helpfulness addition to a markdown comment body with no effect on workflow execution.

The diff touches a single YAML string block — three lines of plain markdown added to a PR comment template. No workflow steps, triggers, permissions, or secrets handling are affected. The one thing worth watching is that the linked SKILL.md does not exist on main yet (it arrives with PR #15128), so preview comments posted in the window between these two merges will contain a dead link. The author has explicitly flagged this ordering dependency, and the impact is cosmetic only.

No files require special attention. The only changed file is .github/workflows/preview-build.yml, and the modification is confined to a markdown comment string.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant ArgoCD as Argo CD
    participant Dev as Engineer

    GH->>GH: "Build & push preview image"
    GH->>Dev: "Post PR comment (🟢 image pushed)<br/>incl. URL, login, API keys, commit"
    Note over Dev: New: "URL not loading / 404?" link<br/>→ SKILL.md#debug-a-preview
    ArgoCD->>ArgoCD: Roll out preview (~few minutes)
    Dev->>ArgoCD: Visit preview URL
    alt URL works
        ArgoCD-->>Dev: Preview loads
    else 404 / not loading
        Dev->>Dev: Click debug guide link in PR comment
        Dev->>Dev: Self-serve: allowlist check, pod status, etc.
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant ArgoCD as Argo CD
    participant Dev as Engineer

    GH->>GH: "Build & push preview image"
    GH->>Dev: "Post PR comment (🟢 image pushed)<br/>incl. URL, login, API keys, commit"
    Note over Dev: New: "URL not loading / 404?" link<br/>→ SKILL.md#debug-a-preview
    ArgoCD->>ArgoCD: Roll out preview (~few minutes)
    Dev->>ArgoCD: Visit preview URL
    alt URL works
        ArgoCD-->>Dev: Preview loads
    else 404 / not loading
        Dev->>Dev: Click debug guide link in PR comment
        Dev->>Dev: Self-serve: allowlist check, pod status, etc.
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(preview): link the debug guide fro..."](https://github.com/langfuse/langfuse/commit/5dc2d24923f13842f460443d460a9b542b5b3e83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44554952)</sub>

<!-- /greptile_comment -->