### PR TITLE
chore(agent): add project url to metadata

### DIFF
--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -51,6 +51,7 @@ import {
 } from "@/src/features/public-api/server/RateLimitService";
 import { getLangfuseAITraceSinkParams } from "@/src/features/ai-features/server/bedrockCompletion";
 import { isProjectMemberOrAdmin } from "@/src/server/utils/checkProjectMembershipOrAdmin";
+import { getProductBaseUrl } from "@/src/utils/base-url";
 import { assertUnreachable } from "@/src/utils/types";
 import {
   BaseError,
@@ -477,6 +478,10 @@ export default async function handler(request: Request) {
                     langfuse_ai_feature: "in-app-agent",
                     langfuse_user_id: userId,
                     langfuse_project_id: projectId,
+                    langfuse_project_url: new URL(
+                      `project/${encodeURIComponent(projectId)}`,
+                      getProductBaseUrl(),
+                    ).toString(),
                     conversation_id: conversation.id,
                     thread_id: sanitizedInput.threadId,
                     run_id: sanitizedInput.runId,

--- a/web/src/ee/features/in-app-agent/server/persistence.ts
+++ b/web/src/ee/features/in-app-agent/server/persistence.ts
@@ -19,6 +19,7 @@ import {
   generateLangfuseAIText,
   getLangfuseAITraceSinkParams,
 } from "@/src/features/ai-features/server/bedrockCompletion";
+import { getProductBaseUrl } from "@/src/utils/base-url";
 import { truncate } from "@/src/utils/string";
 import { assertUnreachable } from "@/src/utils/types";
 import {
@@ -432,6 +433,10 @@ ${JSON.stringify(transcript, null, 2)}
             traceName: "in-app-agent-conversation-title",
             userId: params.userId,
             metadata: {
+              langfuse_project_url: new URL(
+                `project/${encodeURIComponent(params.projectId)}`,
+                getProductBaseUrl(),
+              ).toString(),
               conversation_id: params.conversationId,
             },
           })

--- a/web/src/features/search-bar/server/router.ts
+++ b/web/src/features/search-bar/server/router.ts
@@ -34,6 +34,7 @@ import {
   getLangfuseAITraceSinkParams,
   isLangfuseAITracingConfigured,
 } from "@/src/features/ai-features/server/bedrockCompletion";
+import { getProductBaseUrl } from "@/src/utils/base-url";
 
 // Caps shared with `observedScoreNamesFromOptions` (the client-side builder),
 // which sends a set as undefined instead of ever exceeding them.
@@ -160,6 +161,10 @@ export const searchBarRouter = createTRPCRouter({
                 userId: ctx.session.user.id,
                 metadata: {
                   langfuse_user_id: ctx.session.user.id,
+                  langfuse_project_url: new URL(
+                    `project/${encodeURIComponent(ctx.session.projectId)}`,
+                    getProductBaseUrl(),
+                  ).toString(),
                   ...(ctx.session.user.email
                     ? { langfuse_user_email: ctx.session.user.email }
                     : {}),


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enriches the telemetry metadata emitted when running the in-app agent by adding a `langfuse_project_url` field, letting observability traces carry a direct deep-link to the relevant project.

- Constructs the project URL by combining `getProductBaseUrl()` (which normalises `NEXTAUTH_URL`, strips auth suffixes, and ensures a trailing slash) with a relative `project/<projectId>` path via the `URL` constructor, correctly handling sub-path deployments.
- `encodeURIComponent` is applied to `projectId` before composing the relative path, and the new import is placed at the module's top level in keeping with the project's import-placement convention.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only appends a new read-only metadata field to an existing telemetry object and has no effect on request handling, auth, or data persistence.

The URL construction is correct: getProductBaseUrl() guarantees a trailing slash so the relative project/<id> segment resolves properly even in sub-path deployments. encodeURIComponent on the project ID is a reasonable defensive measure. The new import sits at the module's top level. No logic paths are altered, and the metadata is consumed only by the tracing sink.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Handler receives request] --> B{aiTelemetryEnabled?}
    B -- No --> C[langfuseTracing = undefined]
    B -- Yes --> D[getLangfuseAITraceSinkParams]
    D --> E[Build metadata object]
    E --> F["langfuse_project_url =\nnew URL('project/'+encodeURIComponent(projectId),\ngetProductBaseUrl())"]
    F --> G["getProductBaseUrl()\n→ strips /api/auth from NEXTAUTH_URL\n→ ensures trailing slash"]
    G --> H["e.g. https://cloud.langfuse.com/project/<id>"]
    E --> I[Other metadata fields\nuser_id, project_id, thread_id, run_id …]
    D --> J{traceSinkParams?}
    J -- Yes --> K[Return langfuseTracing config\nwith metadata]
    J -- No --> C
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Handler receives request] --> B{aiTelemetryEnabled?}
    B -- No --> C[langfuseTracing = undefined]
    B -- Yes --> D[getLangfuseAITraceSinkParams]
    D --> E[Build metadata object]
    E --> F["langfuse_project_url =\nnew URL('project/'+encodeURIComponent(projectId),\ngetProductBaseUrl())"]
    F --> G["getProductBaseUrl()\n→ strips /api/auth from NEXTAUTH_URL\n→ ensures trailing slash"]
    G --> H["e.g. https://cloud.langfuse.com/project/<id>"]
    E --> I[Other metadata fields\nuser_id, project_id, thread_id, run_id …]
    D --> J{traceSinkParams?}
    J -- Yes --> K[Return langfuseTracing config\nwith metadata]
    J -- No --> C
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(agent): add project url to metadat..."](https://github.com/langfuse/langfuse/commit/d97402afc10ae232d38df8b1b20f4f38490eacd6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44583872)</sub>

<!-- /greptile_comment -->