### PR TITLE
fix(llm): keep internal reasoning options off compatible requests

### DIFF
--- a/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
@@ -366,7 +366,7 @@ describe("AI SDK request shapes", () => {
     expect(request.headers.get("api-key")).toBe("azure-key");
   });
 
-  it("OpenAI chat completions: gpt-5.4 mini keeps non-reasoning request params", async () => {
+  it("OpenAI chat completions: gpt-5.4 mini uses portable non-reasoning settings", async () => {
     const { request } = await runCompletion({
       modelParams: {
         provider: "openai",
@@ -380,10 +380,50 @@ describe("AI SDK request shapes", () => {
       response: OPENAI_CHAT_RESPONSE,
     });
 
-    expect(request.body.max_tokens).toBe(64);
-    expect(request.body.max_completion_tokens).toBeUndefined();
+    expect(request.body.max_tokens).toBeUndefined();
+    expect(request.body.max_completion_tokens).toBe(64);
     expect(request.body.temperature).toBe(0.2);
     expect(request.body.top_p).toBe(0.9);
+    expect(request.body.reasoning_effort).toBe("none");
+    expect(request.body.forceReasoning).toBeUndefined();
+  });
+
+  it("OpenAI-compatible chat completions: gpt-5.4 mini does not leak internal reasoning controls", async () => {
+    const { request } = await runCompletion({
+      modelParams: {
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        model: "gpt-5.4-mini",
+        max_tokens: 64,
+        temperature: 0.2,
+        top_p: 0.9,
+      },
+      apiKey: "custom-key",
+      baseURL: "https://openai-compatible.example.com/v1",
+      response: OPENAI_CHAT_RESPONSE,
+    });
+
+    expect(request.body.max_tokens).toBe(64);
+    expect(request.body.temperature).toBe(0.2);
+    expect(request.body.top_p).toBe(0.9);
+    expect(request.body.forceReasoning).toBeUndefined();
+  });
+
+  it("OpenAI-compatible chat completions: explicit gpt-5.4 mini reasoning remains a wire setting", async () => {
+    const { request } = await runCompletion({
+      modelParams: {
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        model: "gpt-5.4-mini",
+        providerOptions: { reasoning_effort: "high" },
+      },
+      apiKey: "custom-key",
+      baseURL: "https://openai-compatible.example.com/v1",
+      response: OPENAI_CHAT_RESPONSE,
+    });
+
+    expect(request.body.reasoning_effort).toBe("high");
+    expect(request.body.forceReasoning).toBeUndefined();
   });
 
   it("Anthropic: /v1/messages on a custom origin with snake_case thinking body", async () => {

--- a/packages/shared/src/server/llm/llmText.test.ts
+++ b/packages/shared/src/server/llm/llmText.test.ts
@@ -408,22 +408,26 @@ describe("legacy compatibility boundary", () => {
     });
   });
 
-  it("preserves explicit non-reasoning OpenAI gpt-5.4 mini/nano handling", () => {
-    const mapped = mapLegacyLLMCompletionParams({
-      messages: legacyMessages,
-      modelParams: {
-        provider: "openai",
-        adapter: LLMAdapter.OpenAI,
-        model: "gpt-5.4-mini",
-        providerOptions: { service_tier: "flex" },
-      },
-      connection: encryptedConnection,
-    });
+  it.each(["gpt-5.4-mini", "gpt-5.4-nano"])(
+    "uses portable non-reasoning defaults for OpenAI %s",
+    (model) => {
+      const mapped = mapLegacyLLMCompletionParams({
+        messages: legacyMessages,
+        modelParams: {
+          provider: "openai",
+          adapter: LLMAdapter.OpenAI,
+          model,
+          providerOptions: { service_tier: "flex" },
+        },
+        connection: encryptedConnection,
+      });
 
-    expect(mapped.providerOptions).toEqual({
-      openai: { serviceTier: "flex", forceReasoning: false },
-    });
-  });
+      expect(mapped).toMatchObject({
+        reasoning: "none",
+        providerOptions: { openai: { serviceTier: "flex" } },
+      });
+    },
+  );
 
   it("passes unknown OpenAI provider options through for OpenAI-compatible endpoints", () => {
     const mapped = mapLegacyLLMCompletionParams({

--- a/packages/shared/src/server/llm/llmText.ts
+++ b/packages/shared/src/server/llm/llmText.ts
@@ -13,6 +13,7 @@ import {
   type GenerateTextResult,
   type Experimental_DownloadFunction,
   type JSONValue,
+  type LanguageModelCallOptions,
   type ModelMessage,
   type StreamTextOnErrorCallback,
   type StreamTextResult,
@@ -99,6 +100,7 @@ type BaseLLMTextOptions<TOOLS extends ToolSet, OUTPUT extends Output.Output> = {
   maxOutputTokens?: number;
   temperature?: number;
   topP?: number;
+  reasoning?: LanguageModelCallOptions["reasoning"];
   /** Canonical, provider-namespaced AI SDK options. */
   providerOptions?: ProviderOptions;
   maxRetries?: number;
@@ -143,6 +145,7 @@ type PreparedLLMTextCall<TOOLS extends ToolSet> = {
     maxOutputTokens?: number;
     temperature?: number;
     topP?: number;
+    reasoning?: LanguageModelCallOptions["reasoning"];
     providerOptions?: ProviderOptions;
     maxRetries?: number;
     timeout: TimeoutConfiguration<TOOLS>;
@@ -331,6 +334,7 @@ async function prepareLLMTextCall<
       maxOutputTokens: options.maxOutputTokens,
       temperature: options.temperature,
       topP: options.topP,
+      reasoning: options.reasoning,
       providerOptions: options.providerOptions,
       maxRetries: options.maxRetries,
       timeout,
@@ -438,6 +442,7 @@ export type LegacyLLMTextOptions = {
   maxOutputTokens?: number;
   temperature?: number;
   topP?: number;
+  reasoning?: LanguageModelCallOptions["reasoning"];
   providerOptions?: ProviderOptions;
   credentialSource: LLMCredentialSource;
 };
@@ -467,6 +472,11 @@ export function mapLegacyLLMCompletionParams(params: {
     maxOutputTokens: modelParams.max_tokens,
     temperature: modelParams.temperature,
     topP: modelParams.top_p,
+    reasoning:
+      modelParams.adapter === LLMAdapter.OpenAI &&
+      isOpenAIDefaultNonReasoningModel(modelParams.model)
+        ? "none"
+        : undefined,
     providerOptions,
     credentialSource: params.credentialSource ?? "user",
   };
@@ -490,16 +500,10 @@ function translateLegacyProviderOptions(params: {
         passthroughUnknown: useOpenAICompatibleChat,
         target: useOpenAICompatibleChat ? "openai-compatible" : "openai",
       });
-      if (
-        translated.ok &&
-        isOpenAINonReasoningChatModel(modelParams.model) &&
-        translated.value?.forceReasoning === undefined
-      ) {
-        translated.value = {
-          ...(translated.value ?? {}),
-          forceReasoning: false,
-        };
-      }
+      // Never add Langfuse-derived controls to these translated options.
+      // Custom OpenAI-compatible connections intentionally forward unknown
+      // keys to the wire. Portable controls such as reasoning belong on the
+      // top-level AI SDK call instead.
       break;
     }
     case LLMAdapter.Azure:
@@ -558,7 +562,7 @@ function translateLegacyProviderOptions(params: {
     : undefined;
 }
 
-function isOpenAINonReasoningChatModel(model: string): boolean {
+function isOpenAIDefaultNonReasoningModel(model: string): boolean {
   return /^gpt-5\.4-(mini|nano)(-\d{4}-\d{2}-\d{2})?$/i.test(
     model.replace(/^openai\//i, ""),
   );


### PR DESCRIPTION
## What changed

- replace the internal OpenAI `forceReasoning: false` provider override for GPT-5.4 mini/nano with the portable AI SDK `reasoning: "none"` call setting
- keep Langfuse-derived controls out of translated provider options because custom OpenAI-compatible endpoints intentionally forward unknown keys to the wire
- add real request-shape coverage for direct OpenAI and custom OpenAI-compatible endpoints, including explicit high reasoning

## Why

After the AI SDK-only migration, Langfuse injected `providerOptions.openai.forceReasoning = false` for GPT-5.4 mini/nano. `@ai-sdk/openai` consumes that internal option, but `@ai-sdk/openai-compatible` forwards it into the HTTP body. LiteLLM then rejects every completion with `Unknown parameter: 'forceReasoning'`.

This affects Eval creator preflight, experiments, playground calls, and evaluator execution through custom OpenAI-compatible connections. Report: https://github.com/orgs/langfuse/discussions/15095

The portable `reasoning` setting preserves the intended default while allowing the selected provider adapter to emit the correct wire shape. Explicit `reasoning_effort` still overrides the default.

## Impacted package

- `@langfuse/shared`

## Verification

- `pnpm --filter @langfuse/shared run test 'src/server/llm'` — 12 files, 122 tests passed
- `pnpm --filter web run test 'src/__tests__/server/unit/evaluator-preflight.servertest.ts'` — 6 tests passed
- `pnpm --filter worker run test 'src/features/evaluation/__tests__/evalExecutionDeps.test.ts'` — 2 tests passed
- `pnpm run lint` — 7 successful, 7 total
- `pnpm run typecheck` — 7 successful, 7 total
- `pnpm exec prettier --check 'packages/shared/src/server/llm/llmText.ts' 'packages/shared/src/server/llm/llmText.test.ts' 'packages/shared/src/server/llm/ai-sdk/requestShape.test.ts'`

## Security

No outbound URL or transport behavior changes. Existing secure LLM fetch, redirect validation, header stripping, and custom-endpoint handling remain unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `providerOptions.openai.forceReasoning = false` — an internal `@ai-sdk/openai` parameter — was being forwarded verbatim into the HTTP body by `@ai-sdk/openai-compatible`, causing LiteLLM to reject every completion with `Unknown parameter: 'forceReasoning'`. The fix replaces that injection with the portable AI SDK `reasoning: \"none\"` call setting, which each adapter translates to the correct wire format (or ignores, for compatible endpoints).

- **Core change** (`llmText.ts`): `reasoning: \"none\"` is now set at the top-level call options for `gpt-5.4-mini` / `gpt-5.4-nano` on the OpenAI adapter, threaded through all relevant types, and the `forceReasoning` injection is removed from `translateLegacyProviderOptions` with a clear comment explaining why Langfuse-derived controls must stay off that path.
- **Tests** (`requestShape.test.ts`, `llmText.test.ts`): Three new wire-shape tests cover the direct OpenAI path, the OpenAI-compatible no-reasoning path, and the OpenAI-compatible explicit-override path; `mapLegacyLLMCompletionParams` unit tests are updated to use `it.each` across both model variants.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the core behavioral fix is correct and well-covered; the open questions are about test completeness, not runtime behavior.

The implementation is straightforward and correct: the portable reasoning call setting reaches direct OpenAI with the right wire value (reasoning_effort: none), and custom endpoints no longer receive the internal forceReasoning field. The two gaps are in the test suite: the OpenAI-compatible test does not pin whether reasoning_effort appears on the wire, and there is no wire-level test for a direct OpenAI call where the user simultaneously supplies reasoning_effort: high via providerOptions alongside the auto-injected reasoning: none default.

requestShape.test.ts — the new OpenAI-compatible gpt-5.4-mini test should assert the presence or absence of reasoning_effort to fully document the intended wire contract.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[mapLegacyLLMCompletionParams] --> B{adapter === OpenAI &&\nisOpenAIDefaultNonReasoningModel?}
    B -- yes --> C["reasoning: 'none'\n(portable call setting)"]
    B -- no --> D["reasoning: undefined"]
    C --> E[translateLegacyProviderOptions]
    D --> E
    E --> F{baseURL set?\n= OpenAI-compatible}
    F -- no --> G["@ai-sdk/openai\nreasoningEffort: 'none' on wire"]
    F -- yes --> H["@ai-sdk/openai-compatible\nreasoning call option\n(may be ignored by adapter)"]
    G --> I[OpenAI API\nreasoning_effort: none ✓]
    H --> J[Custom endpoint\nno forceReasoning leaked ✓]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[mapLegacyLLMCompletionParams] --> B{adapter === OpenAI &&\nisOpenAIDefaultNonReasoningModel?}
    B -- yes --> C["reasoning: 'none'\n(portable call setting)"]
    B -- no --> D["reasoning: undefined"]
    C --> E[translateLegacyProviderOptions]
    D --> E
    E --> F{baseURL set?\n= OpenAI-compatible}
    F -- no --> G["@ai-sdk/openai\nreasoningEffort: 'none' on wire"]
    F -- yes --> H["@ai-sdk/openai-compatible\nreasoning call option\n(may be ignored by adapter)"]
    G --> I[OpenAI API\nreasoning_effort: none ✓]
    H --> J[Custom endpoint\nno forceReasoning leaked ✓]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/llm/ai-sdk/requestShape.test.ts:391-410
**Missing `reasoning_effort` wire assertion for OpenAI-compatible path**

The test confirms `forceReasoning` is absent but does not assert whether `reasoning_effort` appears in the body. Because `reasoning: "none"` is now unconditionally set for `gpt-5.4-mini` (regardless of endpoint type), if `@ai-sdk/openai-compatible` does translate that call option to `reasoning_effort: "none"` on the wire, the same class of "unknown parameter" rejection that affected `forceReasoning` could resurface on custom endpoints that do not support `reasoning_effort`. The mock returns a canned response regardless of body contents, so a stray field would not cause the test to fail. Adding `expect(request.body.reasoning_effort).toBeUndefined()` (or `.toBe("none")` if the adapter does emit it) would pin the actual wire shape and document the intended behavior explicitly.

### Issue 2 of 2
packages/shared/src/server/llm/ai-sdk/requestShape.test.ts:369-389
**No end-to-end test for direct OpenAI + explicit `reasoning_effort` override on gpt-5.4-mini**

The PR description states "Explicit `reasoning_effort` still overrides the default," but the only wire-level test covering explicit reasoning on `gpt-5.4-mini` uses an OpenAI-compatible endpoint (where `reasoning: "none"` is a no-op because `@ai-sdk/openai-compatible` does not translate the `reasoning` call option). For direct OpenAI (no `baseURL`), `reasoning: "none"` maps to `reasoning_effort: "none"` via `@ai-sdk/openai`, while a user-supplied `providerOptions: { reasoning_effort: "high" }` produces `providerOptions.openai.reasoningEffort: "high"`. The merge order between these two mechanisms is untested here; if a future AI SDK version changes precedence, reasoning would be silently disabled for users who explicitly opt in.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(llm): keep internal reasoning option..."](https://github.com/langfuse/langfuse/commit/bceb3956703983896062b7567fd6b7f79b80ee68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44598180)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->