### PR TITLE
feat(sessions): allow metadata filtering on v4

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.test.ts
@@ -3,7 +3,26 @@ import { describe, expect, it } from "vitest";
 import {
   buildEventsFullTableSplitQuery,
   EventsQueryBuilder,
+  EventsSessionAggregationQueryBuilder,
 } from "./event-query-builder";
+
+describe("EventsSessionAggregationQueryBuilder", () => {
+  it("selects metadata arrays from the same deterministic latest observation", () => {
+    const { query } = new EventsSessionAggregationQueryBuilder({
+      projectId: "test-project",
+    })
+      .selectFieldSet("all")
+      .buildWithParams();
+
+    expect(query).toContain(
+      "argMax(metadata_names, tuple(start_time, event_ts, span_id)) AS metadata_names",
+    );
+    expect(query).toContain(
+      "argMax(metadata_values, tuple(start_time, event_ts, span_id)) AS metadata_values",
+    );
+    expect(query).toContain("e.project_id = {projectId: String}");
+  });
+});
 
 describe("EventsQueryBuilder.selectIOWithSizeCap", () => {
   const build = () =>

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.test.ts
@@ -11,7 +11,7 @@ describe("EventsSessionAggregationQueryBuilder", () => {
     const { query } = new EventsSessionAggregationQueryBuilder({
       projectId: "test-project",
     })
-      .selectFieldSet("all")
+      .selectFieldSet("metadata")
       .buildWithParams();
 
     expect(query).toContain(
@@ -21,6 +21,17 @@ describe("EventsSessionAggregationQueryBuilder", () => {
       "argMax(metadata_values, tuple(start_time, event_ts, span_id)) AS metadata_values",
     );
     expect(query).toContain("e.project_id = {projectId: String}");
+  });
+
+  it("omits metadata aggregation from the base field set", () => {
+    const { query } = new EventsSessionAggregationQueryBuilder({
+      projectId: "test-project",
+    })
+      .selectFieldSet("base")
+      .buildWithParams();
+
+    expect(query).not.toContain("metadata_names");
+    expect(query).not.toContain("metadata_values");
   });
 });
 

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -1434,6 +1434,10 @@ const EVENTS_SESSION_AGGREGATION_FIELDS = {
   trace_tags: "groupUniqArrayArrayIf(tags, notEmpty(tags)) AS trace_tags",
   environment:
     "argMaxIf(environment, event_ts, environment <> '') AS environment",
+  metadata_names:
+    "argMax(metadata_names, tuple(start_time, event_ts, span_id)) AS metadata_names",
+  metadata_values:
+    "argMax(metadata_values, tuple(start_time, event_ts, span_id)) AS metadata_values",
   total_observations:
     "uniqIf(span_id, parent_span_id != '') AS total_observations",
   duration:

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -1463,6 +1463,10 @@ const SESSION_AGGREGATION_FIELD_SETS = {
   all: Object.keys(EVENTS_SESSION_AGGREGATION_FIELDS) as Array<
     keyof typeof EVENTS_SESSION_AGGREGATION_FIELDS
   >,
+  base: Object.keys(EVENTS_SESSION_AGGREGATION_FIELDS).filter(
+    (field) => field !== "metadata_names" && field !== "metadata_values",
+  ) as Array<keyof typeof EVENTS_SESSION_AGGREGATION_FIELDS>,
+  metadata: ["metadata_names", "metadata_values"],
 } as const;
 
 /**

--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -259,11 +259,15 @@ export const eventsSessionsAggregation = (params: {
   projectId: string;
   sessionIds?: string[];
   startTimeFrom?: string | null;
+  includeMetadata?: boolean;
 }): EventsSessionAggregationQueryBuilder => {
   return new EventsSessionAggregationQueryBuilder({
     projectId: params.projectId,
   })
-    .selectFieldSet("all")
+    .selectFieldSet("base")
+    .when(Boolean(params.includeMetadata), (builder) =>
+      builder.selectFieldSet("metadata"),
+    )
     .withSessionIds(params.sessionIds)
     .withStartTimeFrom(params.startTimeFrom)
     .whereRaw("session_id != ''");

--- a/packages/shared/src/server/services/sessions-ui-table-events-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-events-service.ts
@@ -18,7 +18,10 @@ import {
   eventsTracesAggregation,
 } from "../queries/clickhouse-sql/query-fragments";
 import { queryClickhouse } from "../repositories";
-import { sessionEventsCols } from "../tableMappings/mapSessionTable";
+import {
+  sessionEventsCols,
+  sessionEventsOrderByCols,
+} from "../tableMappings/mapSessionTable";
 import { sessionsEventsViewCols } from "../../tableDefinitions/sessionsView";
 import { findUiColumnMapping } from "../../tableDefinitions";
 import { parseClickhouseUTCDateTimeFormat } from "../repositories/clickhouse";
@@ -224,8 +227,12 @@ const getSessionsTableFromEventsGeneric = async <T>(
 
   const requiresScoresJoin =
     sessionFilters.some((f) => f.clickhouseTable === "scores") ||
-    findUiColumnMapping(sessionEventsCols, orderBy?.column)
+    findUiColumnMapping(sessionEventsOrderByCols, orderBy?.column)
       ?.clickhouseTableName === "scores";
+  const requiresMetadata = sessionFilters.some(
+    (filter) =>
+      filter.clickhouseTable === "events_proto" && filter.field === "metadata",
+  );
 
   // Build session_data CTE
   const sessionsBuilder = eventsSessionsAggregation({
@@ -234,6 +241,7 @@ const getSessionsTableFromEventsGeneric = async <T>(
     startTimeFrom: traceTimestampFilter
       ? convertDateToClickhouseDateTime(traceTimestampFilter.value)
       : null,
+    includeMetadata: requiresMetadata,
   });
 
   // Compose query using CTEQueryBuilder
@@ -304,7 +312,10 @@ const getSessionsTableFromEventsGeneric = async <T>(
     queryBuilder.whereRaw(sessionsFilterRes.query, sessionsFilterRes.params);
   }
 
-  const orderBySql = orderByToClickhouseSql(orderBy ?? null, sessionEventsCols);
+  const orderBySql = orderByToClickhouseSql(
+    orderBy ?? null,
+    sessionEventsOrderByCols,
+  );
   if (orderBySql) {
     queryBuilder.orderBy(orderBySql);
   }

--- a/packages/shared/src/server/services/sessions-ui-table-events-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-events-service.ts
@@ -18,8 +18,8 @@ import {
   eventsTracesAggregation,
 } from "../queries/clickhouse-sql/query-fragments";
 import { queryClickhouse } from "../repositories";
-import { sessionCols } from "../tableMappings/mapSessionTable";
-import { sessionsViewCols } from "../../tableDefinitions/sessionsView";
+import { sessionEventsCols } from "../tableMappings/mapSessionTable";
+import { sessionsEventsViewCols } from "../../tableDefinitions/sessionsView";
 import { findUiColumnMapping } from "../../tableDefinitions";
 import { parseClickhouseUTCDateTimeFormat } from "../repositories/clickhouse";
 
@@ -198,7 +198,11 @@ const getSessionsTableFromEventsGeneric = async <T>(
     props;
 
   const sessionFilters = new FilterList(
-    createFilterFromFilterState(filter, sessionCols, sessionsViewCols),
+    createFilterFromFilterState(
+      filter,
+      sessionEventsCols,
+      sessionsEventsViewCols,
+    ),
   );
   const sessionsFilterRes = sessionFilters.apply();
 
@@ -220,8 +224,8 @@ const getSessionsTableFromEventsGeneric = async <T>(
 
   const requiresScoresJoin =
     sessionFilters.some((f) => f.clickhouseTable === "scores") ||
-    findUiColumnMapping(sessionCols, orderBy?.column)?.clickhouseTableName ===
-      "scores";
+    findUiColumnMapping(sessionEventsCols, orderBy?.column)
+      ?.clickhouseTableName === "scores";
 
   // Build session_data CTE
   const sessionsBuilder = eventsSessionsAggregation({
@@ -300,7 +304,7 @@ const getSessionsTableFromEventsGeneric = async <T>(
     queryBuilder.whereRaw(sessionsFilterRes.query, sessionsFilterRes.params);
   }
 
-  const orderBySql = orderByToClickhouseSql(orderBy ?? null, sessionCols);
+  const orderBySql = orderByToClickhouseSql(orderBy ?? null, sessionEventsCols);
   if (orderBySql) {
     queryBuilder.orderBy(orderBySql);
   }

--- a/packages/shared/src/server/services/sessions-ui-table-events-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-events-service.ts
@@ -1,4 +1,5 @@
 import { ClickHouseClientConfigOptions } from "@clickhouse/client";
+import { InvalidRequestError } from "../../errors";
 import { OrderByState } from "../../interfaces/orderBy";
 import { FilterState } from "../../types";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
@@ -199,6 +200,18 @@ const getSessionsTableFromEventsGeneric = async <T>(
 ) => {
   const { select, projectId, filter, orderBy, limit, page, clickhouseConfigs } =
     props;
+
+  const nullMetadataFilter = filter.find(
+    (candidate) =>
+      candidate.type === "null" &&
+      findUiColumnMapping(sessionEventsCols, candidate.column)?.uiTableId ===
+        "metadata",
+  );
+  if (nullMetadataFilter) {
+    throw new InvalidRequestError(
+      `Invalid filter type 'null' for column '${nullMetadataFilter.column}'. Expected filter type 'stringObject'.`,
+    );
+  }
 
   const sessionFilters = new FilterList(
     createFilterFromFilterState(

--- a/packages/shared/src/server/tableMappings/mapSessionTable.ts
+++ b/packages/shared/src/server/tableMappings/mapSessionTable.ts
@@ -158,13 +158,13 @@ export const sessionCols: UiColumnMappings = [
   },
 ];
 
-export const sessionEventsCols: UiColumnMappings = [
-  ...sessionCols,
-  {
-    uiTableName: "Metadata",
-    uiTableId: "metadata",
-    clickhouseTableName: "events_proto",
-    clickhouseSelect: "metadata",
-    queryPrefix: "s",
-  },
-];
+export const sessionEventsCols: UiColumnMappings = sessionCols.concat({
+  uiTableName: "Metadata",
+  uiTableId: "metadata",
+  clickhouseTableName: "events_proto",
+  clickhouseSelect: "metadata",
+  queryPrefix: "s",
+});
+
+export const sessionEventsOrderByCols: UiColumnMappings =
+  sessionEventsCols.filter((column) => column.uiTableId !== "metadata");

--- a/packages/shared/src/server/tableMappings/mapSessionTable.ts
+++ b/packages/shared/src/server/tableMappings/mapSessionTable.ts
@@ -157,3 +157,14 @@ export const sessionCols: UiColumnMappings = [
     clickhouseSelect: "score_booleans",
   },
 ];
+
+export const sessionEventsCols: UiColumnMappings = [
+  ...sessionCols,
+  {
+    uiTableName: "Metadata",
+    uiTableId: "metadata",
+    clickhouseTableName: "events_proto",
+    clickhouseSelect: "metadata",
+    queryPrefix: "s",
+  },
+];

--- a/packages/shared/src/tableDefinitions/sessionsView.ts
+++ b/packages/shared/src/tableDefinitions/sessionsView.ts
@@ -131,6 +131,16 @@ export const sessionsViewCols: ColumnDefinition[] = [
   },
 ];
 
+export const sessionsEventsViewCols: ColumnDefinition[] = [
+  ...sessionsViewCols,
+  {
+    name: "Metadata",
+    id: "metadata",
+    type: "stringObject",
+    internal: 's."metadata"',
+  },
+];
+
 export type SessionOptions = {
   userIds: Array<SingleValueOption>;
   environment: Array<SingleValueOption>;

--- a/packages/shared/src/tableDefinitions/sessionsView.ts
+++ b/packages/shared/src/tableDefinitions/sessionsView.ts
@@ -131,15 +131,13 @@ export const sessionsViewCols: ColumnDefinition[] = [
   },
 ];
 
-export const sessionsEventsViewCols: ColumnDefinition[] = [
-  ...sessionsViewCols,
-  {
+export const sessionsEventsViewCols: ColumnDefinition[] =
+  sessionsViewCols.concat({
     name: "Metadata",
     id: "metadata",
     type: "stringObject",
     internal: 's."metadata"',
-  },
-];
+  });
 
 export type SessionOptions = {
   userIds: Array<SingleValueOption>;

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -106,8 +106,8 @@ export default function SessionsTable({
   showControlsInPageHeader = false,
 }: SessionTableProps) {
   const sessionsFilterConfig = useMemo(
-    () => getSessionFilterConfig(omittedFilter),
-    [omittedFilter],
+    () => getSessionFilterConfig(omittedFilter, isBetaEnabled),
+    [isBetaEnabled, omittedFilter],
   );
   const { setDetailPageList } = useDetailPageLists();
   const { timeRange, setTimeRange } = useTableDateRange(projectId);
@@ -271,8 +271,9 @@ export default function SessionsTable({
       sessionFilterContextId: projectId,
       // Sidebar-only implicit environment defaults
       implicitDefaultConfig: DEFAULT_SIDEBAR_IMPLICIT_ENVIRONMENT_CONFIG,
+      isV4: isBetaEnabled,
     }),
-    [isSidebarFilterLoading, projectId],
+    [isBetaEnabled, isSidebarFilterLoading, projectId],
   );
 
   const queryFilter = useSidebarFilterState(

--- a/web/src/features/filters/config/sessions-config.ts
+++ b/web/src/features/filters/config/sessions-config.ts
@@ -1,6 +1,9 @@
 import { omitFilterFacets } from "@/src/features/filters/lib/filter-config";
-import { sessionsViewCols } from "@langfuse/shared";
-import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
+import { sessionsEventsViewCols, sessionsViewCols } from "@langfuse/shared";
+import type {
+  Facet,
+  FilterConfig,
+} from "@/src/features/filters/lib/filter-config";
 import type { ColumnToBackendKeyMap } from "@/src/features/filters/lib/filter-transform";
 
 export type SessionOmittableFilterColumn = "userIds";
@@ -138,8 +141,26 @@ export const sessionFilterConfig: FilterConfig = {
   ],
 };
 
+const sessionMetadataFacet: Facet = {
+  type: "stringKeyValue",
+  column: "metadata",
+  label: "Metadata",
+};
+
+export const sessionEventsFilterConfig: FilterConfig = {
+  ...sessionFilterConfig,
+  columnDefinitions: sessionsEventsViewCols,
+  facets: sessionFilterConfig.facets.flatMap((facet) =>
+    facet.column === "tags" ? [facet, sessionMetadataFacet] : [facet],
+  ),
+};
+
 export function getSessionFilterConfig(
   omittedFilter: SessionOmittableFilterColumn[] = [],
+  fromEvents = false,
 ): FilterConfig {
-  return omitFilterFacets(sessionFilterConfig, omittedFilter);
+  return omitFilterFacets(
+    fromEvents ? sessionEventsFilterConfig : sessionFilterConfig,
+    omittedFilter,
+  );
 }

--- a/web/src/features/filters/filter-integration.clienttest.ts
+++ b/web/src/features/filters/filter-integration.clienttest.ts
@@ -19,7 +19,10 @@ import { validateFilters } from "@/src/components/table/table-view-presets/valid
 import { traceFilterConfig } from "./config/traces-config";
 import { observationFilterConfig } from "./config/observations-config";
 import { transformFiltersForBackend } from "./lib/filter-transform";
-import { sessionFilterConfig } from "./config/sessions-config";
+import {
+  sessionEventsFilterConfig,
+  sessionFilterConfig,
+} from "./config/sessions-config";
 import { observationEventsFilterConfig } from "@/src/features/events/config/filter-config";
 import {
   decodeAndNormalizeFilters,
@@ -564,6 +567,28 @@ describe("Config Validation of old saved views", () => {
     );
 
     expect(invalidFacets).toEqual([]);
+  });
+
+  it("exposes metadata only on the v4 sessions filter config", () => {
+    expect(
+      sessionEventsFilterConfig.columnDefinitions.find(
+        (column) => column.id === "metadata",
+      ),
+    ).toMatchObject({ type: "stringObject" });
+    expect(
+      sessionEventsFilterConfig.facets.find(
+        (facet) => facet.column === "metadata",
+      ),
+    ).toMatchObject({ type: "stringKeyValue", label: "Metadata" });
+
+    expect(
+      sessionFilterConfig.columnDefinitions.some(
+        (column) => column.id === "metadata",
+      ),
+    ).toBe(false);
+    expect(
+      sessionFilterConfig.facets.some((facet) => facet.column === "metadata"),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the v4 (events-table-based) sessions UI to support metadata key-value filtering, mirroring the metadata filter already available for traces and observations.

- Adds `metadata_names` and `metadata_values` aggregation fields to `EventsSessionAggregationQueryBuilder` (via `argMax`) so the session CTE exposes these columns.
- Introduces `sessionEventsCols` / `sessionsEventsViewCols` variants of the column mappings and view definitions with the metadata column, and wires them into `getSessionsTableFromEventsGeneric` and the frontend filter config (`sessionEventsFilterConfig`) gated behind `isBetaEnabled`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is well-scoped and gated entirely behind the existing `isBetaEnabled` flag, so v3 users are unaffected. The metadata filter is correctly routed through the array-column path using `events_proto` as the table name, and the CTE now exports the needed columns.

The wiring is correct end-to-end: aggregation fields, column mappings, view definitions, filter config, and call sites are all updated consistently. The main concern is that `argMax` picks metadata from one representative event per session rather than any event in the session, which may not match user expectations when metadata is set on early traces. The `internal` field in `sessionsEventsViewCols` references a non-existent Map column but is unused in the current query path. Neither of these affects correctness today.

`sessionsView.ts` (misleading `internal` field) and `sessions-config.ts` (fragile `tags`-anchor for metadata facet insertion).
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["SessionsTable (sessions.tsx)"] -->|isBetaEnabled| B{"V4 mode?"}
    B -->|yes| C["getSessionFilterConfig(omittedFilter, true)\n→ sessionEventsFilterConfig\n(includes metadata facet)"]
    B -->|no| D["getSessionFilterConfig(omittedFilter, false)\n→ sessionFilterConfig\n(no metadata)"]

    C --> E["useSidebarFilterState\n(isV4: true)"]
    D --> F["useSidebarFilterState\n(isV4: false)"]

    E --> G["api.sessions.allFromEvents\n(backendFilterState)"]
    F --> H["api.sessions.all\n(backendFilterState)"]

    G --> I["getSessionsTableFromEventsGeneric\n(createFilterFromFilterState\nusing sessionEventsCols +\nsessionsEventsViewCols)"]

    I --> J["StringObjectFilter\n(clickhouseTable: events_proto)\n→ array-column path:\nhas(s.metadata_names, key) AND\ns.metadata_values[indexOf(...)] = value"]

    J --> K["CTEQueryBuilder:\nWITH session_data AS (\n  SELECT argMax(metadata_names, tuple(...)) AS metadata_names,\n  argMax(metadata_values, tuple(...)) AS metadata_values, ...\n  GROUP BY session_id\n)\nSELECT ... FROM session_data s\nWHERE [metadata filter]"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["SessionsTable (sessions.tsx)"] -->|isBetaEnabled| B{"V4 mode?"}
    B -->|yes| C["getSessionFilterConfig(omittedFilter, true)\n→ sessionEventsFilterConfig\n(includes metadata facet)"]
    B -->|no| D["getSessionFilterConfig(omittedFilter, false)\n→ sessionFilterConfig\n(no metadata)"]

    C --> E["useSidebarFilterState\n(isV4: true)"]
    D --> F["useSidebarFilterState\n(isV4: false)"]

    E --> G["api.sessions.allFromEvents\n(backendFilterState)"]
    F --> H["api.sessions.all\n(backendFilterState)"]

    G --> I["getSessionsTableFromEventsGeneric\n(createFilterFromFilterState\nusing sessionEventsCols +\nsessionsEventsViewCols)"]

    I --> J["StringObjectFilter\n(clickhouseTable: events_proto)\n→ array-column path:\nhas(s.metadata_names, key) AND\ns.metadata_values[indexOf(...)] = value"]

    J --> K["CTEQueryBuilder:\nWITH session_data AS (\n  SELECT argMax(metadata_names, tuple(...)) AS metadata_names,\n  argMax(metadata_values, tuple(...)) AS metadata_values, ...\n  GROUP BY session_id\n)\nSELECT ... FROM session_data s\nWHERE [metadata filter]"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts:1437-1440
**Single-event metadata semantics may surprise users**

`argMax(metadata_names, tuple(start_time, event_ts, span_id))` picks the metadata arrays from the one event with the highest `(start_time, event_ts, span_id)` tuple within the session. A metadata filter such as `foo = bar` will only match sessions where that specific latest event carries the key, not sessions where an earlier event carries it. If users set session-level metadata on the first trace only (a common pattern), those sessions would be invisible to the filter.

### Issue 2 of 3
packages/shared/src/tableDefinitions/sessionsView.ts:134-142
**`internal` field references a non-existent Map column**

The `internal: 's."metadata"'` value points to a Map-style column, but the events-table CTE exposes only `metadata_names` / `metadata_values` array columns — there is no `metadata` Map column. The `internal` field is not consumed by the ClickHouse filter path today, so this is harmless in the current flow, but it could mislead a future developer adding a cross-path query or a Postgres fallback for v4 sessions.

### Issue 3 of 3
web/src/features/filters/config/sessions-config.ts:150-156
**Metadata facet silently disappears if `tags` facet is removed**

The `flatMap` that inserts `sessionMetadataFacet` only fires when it encounters `facet.column === "tags"`. If the `tags` facet is ever removed or renamed in `sessionFilterConfig`, the metadata facet will silently vanish from `sessionEventsFilterConfig` without a type error or runtime warning.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(sessions): allow metadata filtering..."](https://github.com/langfuse/langfuse/commit/456b97f7f2e6d4cf48daa91fcc6f3ac61077b503) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44592049)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->