### PR TITLE
ci(preview): reap stale PR preview environments after 3d inactivity

### DIFF
--- a/.github/workflows/preview-stale-cleanup.yml
+++ b/.github/workflows/preview-stale-cleanup.yml
@@ -1,0 +1,94 @@
+name: AWS preview stale cleanup
+
+# Reap stale PR preview environments by removing the `preview` label from open
+# PRs with no activity for STALE_DAYS. Label removal is the ONLY action: the
+# Argo CD ApplicationSet in the infrastructure repo polls labeled open PRs, so
+# dropping the label makes it stop generating the Application, and its
+# resources-finalizer cascade-deletes the namespace, PVCs, and DNS. Re-adding
+# the label redeploys.
+#
+# "Activity" = GitHub's PR updated_at (commits, comments, reviews, label edits).
+# The auto-labeler applies `preview` on open, which bumps updated_at, so a
+# freshly labeled PR is never immediately reaped.
+#
+# Safe triggers only: `schedule` + `workflow_dispatch`. No checkout, no PR-code
+# execution, no cloud credentials — only issues label/comment mutations — so it
+# stays off zizmor's dangerous-triggers list.
+on:
+  schedule:
+    - cron: "0 6 * * *" # daily 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List stale previews without removing the label"
+        type: boolean
+        default: false
+      stale_days:
+        description: "Inactivity threshold in days"
+        type: string
+        default: "2"
+
+permissions: {}
+
+concurrency:
+  group: preview-stale-cleanup
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Remove preview label from stale PRs
+    runs-on: ubuntu-latest
+    # AWS_PREVIEW_ECR_PUSH_ROLE_ARN is the preview-system feature flag (same gate
+    # as preview-build / preview-autolabel): unset => system off, nothing to reap.
+    if: vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != ''
+    permissions:
+      issues: write # label removal + teardown comment (issues API)
+      pull-requests: read # list open PRs
+    steps:
+      - name: Reap stale previews
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const label = "preview";
+            const staleDays = Number(context.payload.inputs?.stale_days ?? "2");
+            const dryRun = String(context.payload.inputs?.dry_run ?? "false") === "true";
+            const cutoff = Date.now() - staleDays * 86400000;
+            const { owner, repo } = context.repo;
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100,
+            });
+
+            const labeled = prs.filter(pr => pr.labels.some(l => l.name === label));
+            const stale = labeled.filter(pr => new Date(pr.updated_at).getTime() < cutoff);
+
+            for (const pr of stale) {
+              const ageDays = ((Date.now() - new Date(pr.updated_at).getTime()) / 86400000).toFixed(1);
+              core.info(`PR #${pr.number} stale ${ageDays}d (updated ${pr.updated_at}) — ${pr.html_url}`);
+              if (dryRun) continue;
+
+              // Remove the label first — this is what triggers teardown. Tolerate
+              // a race where the label is already gone.
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: pr.number,
+                name: label,
+              }).catch(e => { if (e.status !== 404) throw e; });
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body: `🧹 Preview environment torn down after **${staleDays} days** of inactivity `
+                  + `(last update ${pr.updated_at}). Re-add the \`${label}\` label to redeploy.`,
+              });
+            }
+
+            core.notice(
+              `${dryRun ? "[dry-run] " : ""}${stale.length} stale preview(s) `
+              + `(threshold ${staleDays}d) out of ${labeled.length} labeled.`
+            );

--- a/.github/workflows/preview-stale-cleanup.yml
+++ b/.github/workflows/preview-stale-cleanup.yml
@@ -52,6 +52,12 @@ jobs:
             const label = "preview";
             const staleDays = Number(context.payload.inputs?.stale_days ?? "2");
             const dryRun = String(context.payload.inputs?.dry_run ?? "false") === "true";
+            // Guard against stale_days <= 0: cutoff would be >= now and match
+            // every labeled PR, reaping all previews in one run.
+            if (!Number.isFinite(staleDays) || staleDays < 1) {
+              core.setFailed(`stale_days must be a positive integer, got: ${context.payload.inputs?.stale_days}`);
+              return;
+            }
             const cutoff = Date.now() - staleDays * 86400000;
             const { owner, repo } = context.repo;
 
@@ -71,21 +77,29 @@ jobs:
               if (dryRun) continue;
 
               // Remove the label first — this is what triggers teardown. Tolerate
-              // a race where the label is already gone.
+              // a race where the label is already gone (removed by another path).
+              let labelRemoved = true;
               await github.rest.issues.removeLabel({
                 owner,
                 repo,
                 issue_number: pr.number,
                 name: label,
-              }).catch(e => { if (e.status !== 404) throw e; });
-
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: pr.number,
-                body: `🧹 Preview environment torn down after **${staleDays} days** of inactivity `
-                  + `(last update ${pr.updated_at}). Re-add the \`${label}\` label to redeploy.`,
+              }).catch(e => {
+                if (e.status === 404) { labelRemoved = false; }
+                else throw e;
               });
+
+              // Only comment when we actually removed the label; a 404 means
+              // another path already tore it down, so our message would mislead.
+              if (labelRemoved) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  body: `🧹 Preview environment torn down after **${staleDays} days** of inactivity `
+                    + `(last update ${pr.updated_at}). Re-add the \`${label}\` label to redeploy.`,
+                });
+              }
             }
 
             core.notice(

--- a/.github/workflows/preview-stale-cleanup.yml
+++ b/.github/workflows/preview-stale-cleanup.yml
@@ -12,7 +12,7 @@ name: AWS preview stale cleanup
 # freshly labeled PR is never immediately reaped.
 #
 # Safe triggers only: `schedule` + `workflow_dispatch`. No checkout, no PR-code
-# execution, no cloud credentials — only issues label/comment mutations — so it
+# execution, no cloud credentials — only PR label/comment mutations — so it
 # stays off zizmor's dangerous-triggers list.
 on:
   schedule:
@@ -42,8 +42,10 @@ jobs:
     # as preview-build / preview-autolabel): unset => system off, nothing to reap.
     if: vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != ''
     permissions:
-      issues: write # label removal + teardown comment (issues API)
-      pull-requests: read # list open PRs
+      # Label + comment mutations on PRs are gated by the pull-requests scope
+      # (NOT issues), even though they go through the issues REST endpoints —
+      # same pattern as preview-autolabel / preview-build. Also covers pulls.list.
+      pull-requests: write
     steps:
       - name: Reap stale previews
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -71,38 +73,53 @@ jobs:
             const labeled = prs.filter(pr => pr.labels.some(l => l.name === label));
             const stale = labeled.filter(pr => new Date(pr.updated_at).getTime() < cutoff);
 
+            // Isolate failures per PR: an unhandled rejection fails the whole
+            // github-script step, so without this a single transient error
+            // (5xx, secondary rate limit, PR locked/closed since pulls.list)
+            // would skip every remaining stale PR and the summary.
+            let failures = 0;
             for (const pr of stale) {
               const ageDays = ((Date.now() - new Date(pr.updated_at).getTime()) / 86400000).toFixed(1);
               core.info(`PR #${pr.number} stale ${ageDays}d (updated ${pr.updated_at}) — ${pr.html_url}`);
               if (dryRun) continue;
 
-              // Remove the label first — this is what triggers teardown. Tolerate
-              // a race where the label is already gone (removed by another path).
-              let labelRemoved = true;
-              await github.rest.issues.removeLabel({
-                owner,
-                repo,
-                issue_number: pr.number,
-                name: label,
-              }).catch(e => {
-                if (e.status === 404) { labelRemoved = false; }
-                else throw e;
-              });
-
-              // Only comment when we actually removed the label; a 404 means
-              // another path already tore it down, so our message would mislead.
-              if (labelRemoved) {
-                await github.rest.issues.createComment({
+              try {
+                // Remove the label first — this is what triggers teardown. Tolerate
+                // a race where the label is already gone (removed by another path).
+                let labelRemoved = true;
+                await github.rest.issues.removeLabel({
                   owner,
                   repo,
                   issue_number: pr.number,
-                  body: `🧹 Preview environment torn down after **${staleDays} days** of inactivity `
-                    + `(last update ${pr.updated_at}). Re-add the \`${label}\` label to redeploy.`,
+                  name: label,
+                }).catch(e => {
+                  if (e.status === 404) { labelRemoved = false; }
+                  else throw e;
                 });
+
+                // Only comment when we actually removed the label; a 404 means
+                // another path already tore it down, so our message would mislead.
+                if (labelRemoved) {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: pr.number,
+                    body: `🧹 Preview environment torn down after **${staleDays} days** of inactivity `
+                      + `(last update ${pr.updated_at}). Re-add the \`${label}\` label to redeploy.`,
+                  });
+                }
+              } catch (e) {
+                failures++;
+                core.warning(`PR #${pr.number}: ${e.message} — continuing with remaining PRs`);
               }
             }
 
             core.notice(
               `${dryRun ? "[dry-run] " : ""}${stale.length} stale preview(s) `
-              + `(threshold ${staleDays}d) out of ${labeled.length} labeled.`
+              + `(threshold ${staleDays}d) out of ${labeled.length} labeled`
+              + `${failures ? `; ${failures} failed (see warnings)` : ""}.`
             );
+            // Surface partial failure as a failed run so it isn't silently green.
+            if (failures) {
+              core.setFailed(`${failures} of ${stale.length} stale preview(s) could not be reaped.`);
+            }

--- a/.github/workflows/preview-stale-cleanup.yml
+++ b/.github/workflows/preview-stale-cleanup.yml
@@ -26,7 +26,7 @@ on:
       stale_days:
         description: "Inactivity threshold in days"
         type: string
-        default: "2"
+        default: "3"
 
 permissions: {}
 
@@ -52,7 +52,7 @@ jobs:
         with:
           script: |
             const label = "preview";
-            const staleDays = Number(context.payload.inputs?.stale_days ?? "2");
+            const staleDays = Number(context.payload.inputs?.stale_days ?? "3");
             const dryRun = String(context.payload.inputs?.dry_run ?? "false") === "true";
             // Guard against stale_days <= 0: cutoff would be >= now and match
             // every labeled PR, reaping all previews in one run.


### PR DESCRIPTION
## What

Adds a daily **`preview-stale-cleanup`** workflow that reaps stale PR preview environments.

Today the AWS preview lifecycle is purely event-driven: an environment is torn down only when the PR is **closed** or the `preview` label is **removed**. A PR left open but untouched keeps its namespace, PVCs, and DNS indefinitely (`kube-downscaler` only scales workloads to zero off-hours; it never deletes).

## How

The workflow runs daily and, for open PRs labeled `preview` whose GitHub `updated_at` is older than **3 days**, it **removes the `preview` label**. That's the only action — it drives the *existing* teardown path: the Argo CD ApplicationSet (infra repo) stops generating the Application, and its `resources-finalizer` cascade-deletes the namespace, PVCs, and DNS. A comment is posted explaining the reap; **re-adding the label redeploys**.

- **`schedule` + `workflow_dispatch` only** — no checkout, no PR-code execution, no cloud credentials (only `issues:write` + `pull-requests:read`), so it stays off zizmor's dangerous-triggers list.
- **Gated on `vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN`** — the same feature flag as `preview-build` / `preview-autolabel`; when the preview system is off, this is a no-op.
- **`workflow_dispatch` inputs**: `dry_run` (list what would be reaped without acting) and `stale_days` (override the threshold).

## Notes

- `updated_at` counts any activity (commits, comments, reviews, label edits); the auto-labeler applies `preview` on open, which bumps `updated_at`, so freshly-labeled PRs are never immediately reaped. A paused-but-alive PR *will* reap at 3 days — re-labeling restores it in full.
- **Recommend running once via `workflow_dispatch` with `dry_run: true`** after merge to confirm the target list before it acts for real.
- Companion docs in the infra repo: langfuse/infrastructure#1145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `preview-stale-cleanup` GitHub Actions workflow that runs daily to remove the `preview` label from open PRs with no activity for 2 days, which drives the existing Argo CD teardown path (namespace/PVC/DNS deletion) without any new cloud credentials or PR-code execution.

- **Teardown-only via label removal**: the workflow pages all open PRs, filters for those labeled `preview` with `updated_at` older than the threshold, removes the label, then posts an explanatory comment.
- **Feature-flagged**: guarded on `vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN`, matching the other preview workflows; `workflow_dispatch` with `dry_run: true` lets operators preview the target list safely.
- **Permission-minimal**: `issues: write` + `pull-requests: read` only; no checkout, no cloud credentials, no PR-code execution.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the stale_days validation addressed; the mass-reap footgun is the only meaningful operational risk.

The workflow is well-structured and follows established patterns in the repo. The main concern is that stale_days: 0 via workflow_dispatch would set the cutoff to the current timestamp and immediately reap every labeled PR, since there is no lower-bound guard on the input. The secondary issue of posting a torn-down comment when the label was already absent is cosmetic. The dry-run mode is a good mitigation but does not prevent accidental mass teardown.

.github/workflows/preview-stale-cleanup.yml — specifically the stale_days input parsing around line 53.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant S as Scheduler (daily 06:00 UTC)
    participant W as preview-stale-cleanup workflow
    participant GH as GitHub API
    participant A as Argo CD ApplicationSet

    S->>W: trigger (or workflow_dispatch)
    W->>GH: paginate pulls.list (open, per_page: 100)
    GH-->>W: all open PRs
    W->>W: "filter: labels includes preview AND updated_at < cutoff"

    loop for each stale PR
        W->>GH: issues.removeLabel(preview)
        alt label already gone (404)
            GH-->>W: 404 silently ignored
        else success
            GH-->>W: OK
        end
        W->>GH: issues.createComment(Preview torn down)
        GH-->>W: OK
    end

    W->>GH: core.notice(summary)
    A->>A: polls labeled open PRs, preview gone, stops generating Application
    A->>A: resources-finalizer cascade-deletes namespace, PVCs, DNS
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant S as Scheduler (daily 06:00 UTC)
    participant W as preview-stale-cleanup workflow
    participant GH as GitHub API
    participant A as Argo CD ApplicationSet

    S->>W: trigger (or workflow_dispatch)
    W->>GH: paginate pulls.list (open, per_page: 100)
    GH-->>W: all open PRs
    W->>W: "filter: labels includes preview AND updated_at < cutoff"

    loop for each stale PR
        W->>GH: issues.removeLabel(preview)
        alt label already gone (404)
            GH-->>W: 404 silently ignored
        else success
            GH-->>W: OK
        end
        W->>GH: issues.createComment(Preview torn down)
        GH-->>W: OK
    end

    W->>GH: core.notice(summary)
    A->>A: polls labeled open PRs, preview gone, stops generating Application
    A->>A: resources-finalizer cascade-deletes namespace, PVCs, DNS
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/preview-stale-cleanup.yml:52-55
`stale_days: 0` (or any value ≤ 0) sets `cutoff = Date.now()`, which matches every labeled PR — causing a mass teardown of all preview environments in a single run. Since this is exposed as a free-form `workflow_dispatch` input (default `"2"`), it's easy to accidentally pass `0` while testing. A guard that rejects sub-1 values prevents this class of mistake with no operational downside.

```suggestion
            const label = "preview";
            const staleDays = Number(context.payload.inputs?.stale_days ?? "2");
            const dryRun = String(context.payload.inputs?.dry_run ?? "false") === "true";
            if (!Number.isFinite(staleDays) || staleDays < 1) {
              core.setFailed(`stale_days must be a positive integer, got: ${context.payload.inputs?.stale_days}`);
              return;
            }
            const cutoff = Date.now() - staleDays * 86400000;
```

### Issue 2 of 2
.github/workflows/preview-stale-cleanup.yml:73-88
The teardown comment is posted unconditionally even when `removeLabel` returned a 404 (the label was already gone, meaning the environment was torn down by another path). In that case the comment still says "Preview environment torn down after N days of inactivity," which is misleading — the workflow didn't actually initiate the teardown. Tracking whether the removal was a no-op and skipping the comment avoids confusing authors in this edge case.

```suggestion
              // Remove the label first — this is what triggers teardown. Tolerate
              // a race where the label is already gone.
              let labelRemoved = true;
              await github.rest.issues.removeLabel({
                owner,
                repo,
                issue_number: pr.number,
                name: label,
              }).catch(e => {
                if (e.status === 404) { labelRemoved = false; }
                else throw e;
              });

              if (labelRemoved) {
                await github.rest.issues.createComment({
                  owner,
                  repo,
                  issue_number: pr.number,
                  body: `🧹 Preview environment torn down after **${staleDays} days** of inactivity `
                    + `(last update ${pr.updated_at}). Re-add the \`${label}\` label to redeploy.`,
                });
              }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(preview): reap stale PR preview envir..."](https://github.com/langfuse/langfuse/commit/01a1314957151cc0a4cdac70ac4c9c46c020c120) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44619661)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->
