### PR TITLE
perf(preview): build web and worker images in parallel

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -5,6 +5,16 @@ name: AWS preview build
 # tag exists for a labeled PR; this workflow only builds and pushes, then posts
 # the preview URL on the PR.
 #
+# The two images are independent artifacts pushed to two independent ECR repos
+# under the same tag, with no ordering dependency between them. They therefore
+# build in PARALLEL: a `meta` job resolves the tags and posts the "building"
+# comment once, a matrix `build` job builds web and worker concurrently on
+# separate runners (so each gets a full runner's CPU/memory rather than sharing
+# one — their heavy stages, turbo prune/pnpm install/turbo build, are
+# scope-specific and share no layer cache anyway, so serializing them bought
+# nothing), and a `notify` job posts the single success/failure comment once
+# both builds finish. Wall-clock is now ~max(web, worker) instead of the sum.
+#
 # Builds every SAME-REPO PR on open/update (write access is the gate — opening a
 # same-repo PR requires push access). It deliberately does NOT trigger on the
 # `preview` label: the auto-labeler applies that label with the default
@@ -28,8 +38,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build and push preview images
+  # Resolve the image tags + preview metadata once, and post the single "building"
+  # comment. Downstream jobs consume these outputs so the tag is computed in one
+  # place. Lightweight: no build context, only the base-branch composite action.
+  meta:
+    name: Resolve tags and mark building
     # Any SAME-REPO PR (= write access) builds on open/update. No label gate here:
     # the auto-labeler's GITHUB_TOKEN-applied label can't trigger this workflow,
     # and the label is the Argo deploy filter, not the build trigger. Fork PRs are
@@ -38,19 +51,27 @@ jobs:
     if: >-
       vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != '' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
       pull-requests: write
+    outputs:
+      commit_sha: ${{ steps.meta.outputs.commit_sha }}
+      web_image: ${{ steps.meta.outputs.web_image }}
+      worker_image: ${{ steps.meta.outputs.worker_image }}
+      preview_host: ${{ steps.meta.outputs.preview_host }}
+      namespace: ${{ steps.meta.outputs.namespace }}
+      login_email: ${{ steps.meta.outputs.login_email }}
+      login_password: ${{ steps.meta.outputs.login_password }}
+      public_key: ${{ steps.meta.outputs.public_key }}
+      secret_key: ${{ steps.meta.outputs.secret_key }}
     steps:
       # Resolve the local composite action (./.github/actions/preview-comment)
       # from the BASE branch, which always has it. A local `uses: ./...`
       # resolves against the workspace, and a PR branched before the preview
-      # system landed on main has NO such action on its head — so checking out
-      # the PR head at the workspace root makes the action lookup fail with
-      # "Can't find action.yml". Sparse-checkout keeps this to just the actions
-      # dir, at the workspace root, and never enters the Docker build context.
+      # system landed on main has NO such action on its head. This job never
+      # touches the build context, so the base checkout at the workspace root is
+      # all it needs.
       - name: Checkout base local actions
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -58,22 +79,11 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: .github/actions
 
-      # The PR head is the Docker build context — the exact commit the image tag
-      # pins to. Kept in a subdir so it does not shadow the base's
-      # .github/actions checked out above.
-      - name: Checkout PR head (build context)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: pr-head
-
       - name: Resolve image tags and preview metadata
         id: meta
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          # The PR head SHA straight from the event — the workspace root is the
-          # base checkout now, so `git rev-parse HEAD` would give the wrong SHA.
+          # The PR head SHA straight from the event.
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           WEB_REPO: ${{ vars.AWS_PREVIEW_WEB_ECR_REPOSITORY_URL }}
           WORKER_REPO: ${{ vars.AWS_PREVIEW_WORKER_ECR_REPOSITORY_URL }}
@@ -87,7 +97,6 @@ jobs:
           image_tag="pr-${PR_NUMBER}-${commit_sha}"
           {
             echo "commit_sha=${commit_sha}"
-            echo "image_tag=${image_tag}"
             echo "web_image=${WEB_REPO}:${image_tag}"
             echo "worker_image=${WORKER_REPO}:${image_tag}"
             echo "preview_host=pr-${PR_NUMBER}.${DOMAIN_NAME}"
@@ -117,8 +126,44 @@ jobs:
             ### 🟡 AWS preview building
 
             Building images for `${{ steps.meta.outputs.commit_sha }}` (~5 min).
-            Argo CD deploys the preview once the push completes; it may briefly
-            show `ImagePullBackOff` until this image propagates.
+            Argo CD deploys the preview once both images finish pushing; it may
+            briefly show `ImagePullBackOff` until they propagate.
+
+  # web and worker build concurrently, each on its own runner. fail-fast: false
+  # so one failing build does not cancel the other — the notify job below reports
+  # the aggregate result.
+  build:
+    name: Build and push ${{ matrix.target }}
+    needs: meta
+    if: >-
+      vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != '' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: web
+            image: ${{ needs.meta.outputs.web_image }}
+            dockerfile: web/Dockerfile
+            # web disables sign-up on previews; worker has no such arg.
+            extra_build_args: --build-arg NEXT_PUBLIC_SIGN_UP_DISABLED=true
+          - target: worker
+            image: ${{ needs.meta.outputs.worker_image }}
+            dockerfile: worker/Dockerfile
+            extra_build_args: ""
+    steps:
+      # The PR head is the Docker build context — the exact commit the image tag
+      # pins to. This job posts no comments, so it needs no base checkout and can
+      # take the build context at the workspace root.
+      - name: Checkout PR head (build context)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
@@ -129,11 +174,13 @@ jobs:
       - name: Login to AWS ECR
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
-      - name: Build and push preview images
+      - name: Build and push ${{ matrix.target }} image
         env:
-          COMMIT_SHA: ${{ steps.meta.outputs.commit_sha }}
-          WEB_IMAGE: ${{ steps.meta.outputs.web_image }}
-          WORKER_IMAGE: ${{ steps.meta.outputs.worker_image }}
+          COMMIT_SHA: ${{ needs.meta.outputs.commit_sha }}
+          IMAGE: ${{ matrix.image }}
+          DOCKERFILE: ${{ matrix.dockerfile }}
+          # Static, workflow-defined literal (per-target flags) — no user input.
+          EXTRA_BUILD_ARGS: ${{ matrix.extra_build_args }}
         run: |
           set -euo pipefail
 
@@ -148,41 +195,57 @@ jobs:
           # inconclusive, so fail loudly here rather than falling through to a
           # push that would hard-fail on the immutable tag with a confusing
           # ImageAlreadyExistsException.
-          ensure_image() {
-            local image="$1"; shift   # remaining args: docker build flags
-            local repo tag describe_out
-            repo="${image%:*}"; repo="${repo#*/}"   # strip only the registry host; keep any namespace
-            tag="${image##*:}"
+          repo="${IMAGE%:*}"; repo="${repo#*/}"   # strip only the registry host; keep any namespace
+          tag="${IMAGE##*:}"
 
-            if describe_out="$(aws ecr describe-images --repository-name "${repo}" \
-                  --image-ids imageTag="${tag}" 2>&1)"; then
-              echo "${image} already present — skipping."
-              return 0
-            fi
-            if ! grep -q 'ImageNotFoundException' <<<"${describe_out}"; then
-              echo "::error::Cannot confirm ${image} in ECR — describe-images failed" \
-                   "for a reason other than ImageNotFound; refusing to build+push" \
-                   "against the tag-immutable repo. ${describe_out}"
-              return 1
-            fi
+          if describe_out="$(aws ecr describe-images --repository-name "${repo}" \
+                --image-ids imageTag="${tag}" 2>&1)"; then
+            echo "${IMAGE} already present — skipping."
+            exit 0
+          fi
+          if ! grep -q 'ImageNotFoundException' <<<"${describe_out}"; then
+            echo "::error::Cannot confirm ${IMAGE} in ECR — describe-images failed" \
+                 "for a reason other than ImageNotFound; refusing to build+push" \
+                 "against the tag-immutable repo. ${describe_out}"
+            exit 1
+          fi
 
-            echo "${image} not found — building and pushing."
-            # Build context is the PR-head checkout (pr-head/); the base checkout
-            # at the workspace root only carries .github/actions.
-            docker build "$@" -t "${image}" pr-head
-            docker push "${image}"
-          }
-
-          ensure_image "${WEB_IMAGE}" \
+          echo "${IMAGE} not found — building and pushing."
+          # EXTRA_BUILD_ARGS is a trusted workflow literal and must word-split
+          # into separate flags, so it is intentionally left unquoted.
+          # shellcheck disable=SC2086
+          docker build \
             --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
-            --build-arg NEXT_PUBLIC_SIGN_UP_DISABLED=true \
-            -f pr-head/web/Dockerfile
+            ${EXTRA_BUILD_ARGS} \
+            -f "${DOCKERFILE}" \
+            -t "${IMAGE}" \
+            .
+          docker push "${IMAGE}"
 
-          ensure_image "${WORKER_IMAGE}" \
-            --build-arg NEXT_PUBLIC_BUILD_ID="${COMMIT_SHA}" \
-            -f pr-head/worker/Dockerfile
+  # Single authoritative status comment once both builds settle. Runs even when a
+  # build fails (if: always()) so the PR always gets a definitive success or
+  # failure comment, updating the same marker-tagged comment the meta job posted.
+  notify:
+    name: Report preview result
+    needs: [meta, build]
+    if: >-
+      always() &&
+      vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != '' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout base local actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: .github/actions
 
       - name: Mark preview image pushed
+        if: needs.build.result == 'success'
         uses: ./.github/actions/preview-comment
         with:
           pr-number: ${{ github.event.pull_request.number }}
@@ -192,23 +255,23 @@ jobs:
             Argo CD is rolling it out — the environment is usually ready within a
             few minutes of this comment.
 
-            **URL:** https://${{ steps.meta.outputs.preview_host }}
-            **Login:** `${{ steps.meta.outputs.login_email }}` / `${{ steps.meta.outputs.login_password }}`
-            **API keys:** `${{ steps.meta.outputs.public_key }}` / `${{ steps.meta.outputs.secret_key }}`
-            **Commit:** ${{ steps.meta.outputs.commit_sha }}
+            **URL:** https://${{ needs.meta.outputs.preview_host }}
+            **Login:** `${{ needs.meta.outputs.login_email }}` / `${{ needs.meta.outputs.login_password }}`
+            **API keys:** `${{ needs.meta.outputs.public_key }}` / `${{ needs.meta.outputs.secret_key }}`
+            **Commit:** ${{ needs.meta.outputs.commit_sha }}
 
             **Logs** (needs preview-cluster `kubectl` access):
             ```sh
-            kubectl -n ${{ steps.meta.outputs.namespace }} logs -f deploy/${{ steps.meta.outputs.namespace }}-web      # web
-            kubectl -n ${{ steps.meta.outputs.namespace }} logs -f deploy/${{ steps.meta.outputs.namespace }}-worker   # worker
+            kubectl -n ${{ needs.meta.outputs.namespace }} logs -f deploy/${{ needs.meta.outputs.namespace }}-web      # web
+            kubectl -n ${{ needs.meta.outputs.namespace }} logs -f deploy/${{ needs.meta.outputs.namespace }}-worker   # worker
             ```
             Add `--previous` for a crashed container, `--tail=200` to limit, or
-            `kubectl -n ${{ steps.meta.outputs.namespace }} get pods` to inspect status.
+            `kubectl -n ${{ needs.meta.outputs.namespace }} get pods` to inspect status.
 
             Synthetic preview data only. Never add production data to public accounts.
 
       - name: Report failure
-        if: failure()
+        if: needs.build.result != 'success'
         uses: ./.github/actions/preview-comment
         with:
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -222,9 +222,12 @@ jobs:
             .
           docker push "${IMAGE}"
 
-  # Single authoritative status comment once both builds settle. Runs even when a
-  # build fails (if: always()) so the PR always gets a definitive success or
-  # failure comment, updating the same marker-tagged comment the meta job posted.
+  # Single authoritative status comment once both builds settle, updating the
+  # same marker-tagged comment the meta job posted. Runs on always() so it still
+  # reports after a failure, but each step keys on a definite success/failure
+  # result (see the per-step guards) so a cancelled run — e.g. superseded by a
+  # newer push — posts nothing and leaves the incoming run's "building" comment
+  # to take over.
   notify:
     name: Report preview result
     needs: [meta, build]
@@ -270,8 +273,26 @@ jobs:
 
             Synthetic preview data only. Never add production data to public accounts.
 
-      - name: Report failure
-        if: needs.build.result != 'success'
+      # Two distinct failure paths, each keyed on `== 'failure'` (NOT
+      # `!= 'success'`): that keeps them from firing on `cancelled` (a
+      # superseding push cancels the run via cancel-in-progress, and always()
+      # still runs this job — a `!= 'success'` guard would post a spurious
+      # "failed" comment on every new commit) or on `skipped`. meta-failure and
+      # build-failure are mutually exclusive: if meta fails, build is skipped
+      # (not failure), so at most one comment posts, pointing at the job that
+      # actually broke.
+      - name: Report setup failure
+        if: needs.meta.result == 'failure'
+        uses: ./.github/actions/preview-comment
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          body: |
+            ### ⚠️ AWS preview build failed
+
+            Preview setup failed during tag resolution — no image was built: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Report build failure
+        if: needs.build.result == 'failure'
         uses: ./.github/actions/preview-comment
         with:
           pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## What

The AWS preview-build workflow built the `web` and `worker` images **sequentially** in a single bash step on one runner, so wall-clock was `web + worker`. The two images are independent artifacts (separate ECR repos, same tag, no ordering dependency) whose heavy stages — `turbo prune` / `pnpm install` / `turbo build` — are scope-specific and share no Docker layer cache, so serializing them bought nothing.

This splits the workflow into three jobs so the two builds run **concurrently**, each on its own runner (full CPU/memory rather than sharing one):

| Job | Runner | Role |
|-----|--------|------|
| `meta` | `ubuntu-latest` | Resolve image tags once, post the single 🟡 "building" comment |
| `build` (matrix `[web, worker]`) | `blacksmith-4vcpu` ×2 | Build both images in parallel, `fail-fast: false` |
| `notify` | `ubuntu-latest` | `if: always()` — post the single 🟢 "pushed" / ⚠️ "failed" comment once both settle |

Wall-clock drops from `web + worker` to `~max(web, worker)`.

## Behavior preserved

- **Idempotent skip**: the tag-immutable ECR `describe-images` check (skip if present, fail loudly if inconclusive) is intact, now per matrix target.
- **Single PR comment**: the `preview-comment` composite action upserts one marker-tagged comment, so `meta` → `notify` updating it reads clean.
- **Same guards** on every job: `AWS_PREVIEW_ECR_PUSH_ROLE_ARN` feature flag + same-repo (fork-exclusion) gate.
- **Build context / build-args unchanged**: web keeps `NEXT_PUBLIC_SIGN_UP_DISABLED=true`; both keep `NEXT_PUBLIC_BUILD_ID`.

## Trade-off

Setup steps (checkout, AWS creds, ECR login) now run per build job instead of once. That overhead is paid in parallel so it doesn't add to wall-clock; it costs slightly more runner-minutes — the right trade for a time-critical path.

## Verification

- YAML parses; **zizmor: no findings**; actionlint clean except the pre-existing custom `blacksmith-*` runner label (false positive).
- This PR itself exercises the new workflow (PR-triggered workflows use the PR's own workflow file), so the parallel build + preview deploy validate it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR splits the original single sequential build job into three jobs — `meta`, `build` (matrix), and `notify` — so the `web` and `worker` Docker images are built concurrently on separate runners, reducing wall-clock time from `web + worker` to `~max(web, worker)`.

- **`meta` job**: resolves image tags once and posts the single "🟡 building" PR comment; uses `ubuntu-latest` (no OIDC needed) and exposes all preview metadata as job outputs for downstream consumption.
- **`build` job (matrix)**: two parallel `blacksmith-4vcpu` runners each run the full checkout → AWS auth → ECR login → describe-or-skip → docker build/push sequence; `fail-fast: false` lets one target fail without cancelling the other.
- **`notify` job**: runs with `if: always()` after both builds settle and upserts the PR comment to "🟢 pushed" or "⚠️ failed", consuming metadata from `needs.meta.outputs.*`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the parallelisation is structurally correct and all original guards (idempotent ECR skip, single upserted PR comment, fork exclusion, feature-flag gate) are preserved.

The restructuring is clean and the job DAG is correct. The one thing worth watching is that `notify`'s failure step fires on `needs.build.result != 'success'`, which includes `skipped` — a state that arises only when `meta` itself fails. In that scenario the PR comment says "image build/push failed" even though no build ran, which can misdirect debugging. It's a diagnostic annoyance rather than a functional regression.

.github/workflows/preview-build.yml — specifically the `notify` job's step conditions and failure message wording.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    trigger([PR opened/synchronize/reopened]) --> meta

    meta["**meta** job\nubuntu-latest\nResolve image tags\nPost 🟡 'building' comment"]
    meta -->|outputs: commit_sha, web_image,\nworker_image, preview metadata| build

    build["**build** job — matrix\nblacksmith-4vcpu × 2\nfail-fast: false"]
    build --> web["matrix: web\nCheckout PR head\nAWS credentials + ECR login\nDescribe → skip if present\nDocker build + push"]
    build --> worker["matrix: worker\nCheckout PR head\nAWS credentials + ECR login\nDescribe → skip if present\nDocker build + push"]

    web --> notify
    worker --> notify

    notify["**notify** job\nubuntu-latest\nif: always()"]
    notify -->|build.result == 'success'| success["Post 🟢 'image pushed' comment\n(upserts the 'building' comment)"]
    notify -->|build.result != 'success'| failure["Post ⚠️ 'build failed' comment\n(upserts the 'building' comment)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    trigger([PR opened/synchronize/reopened]) --> meta

    meta["**meta** job\nubuntu-latest\nResolve image tags\nPost 🟡 'building' comment"]
    meta -->|outputs: commit_sha, web_image,\nworker_image, preview metadata| build

    build["**build** job — matrix\nblacksmith-4vcpu × 2\nfail-fast: false"]
    build --> web["matrix: web\nCheckout PR head\nAWS credentials + ECR login\nDescribe → skip if present\nDocker build + push"]
    build --> worker["matrix: worker\nCheckout PR head\nAWS credentials + ECR login\nDescribe → skip if present\nDocker build + push"]

    web --> notify
    worker --> notify

    notify["**notify** job\nubuntu-latest\nif: always()"]
    notify -->|build.result == 'success'| success["Post 🟢 'image pushed' comment\n(upserts the 'building' comment)"]
    notify -->|build.result != 'success'| failure["Post ⚠️ 'build failed' comment\n(upserts the 'building' comment)"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/preview-build.yml:273-274
**Misleading failure message when `meta` fails**

When `meta` fails at runtime (e.g., a bad ECR URL, expired AWS creds before the build step, or a flaky network during tag resolution), `build` ends up in `skipped` state. Because `notify` runs with `always()` and `needs.build.result != 'success'` is true for `skipped`, it posts "The image build/push failed" — even though no build or push was ever attempted. A developer seeing this comment would likely search the `build` job logs and find nothing, before realising the fault was in `meta`. Adding a check on `needs.meta.result`, or splitting the step into a `meta`-failure path and a `build`-failure path, would make the run link's target immediately obvious.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(preview): build web and worker imag..."](https://github.com/langfuse/langfuse/commit/d364ed44346eb5f72132bb605f5cbad8a2410973) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44619779)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->