### PR TITLE
fix(otel): decode int64 attribute Long low word as unsigned

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.intValue.test.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.intValue.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { OtelIngestionProcessor } from "./OtelIngestionProcessor";
+
+// Regression coverage for protobuf int64 attribute decoding. Protobuf.js
+// decodes int64 into a Long `{ low, high }` where `low`/`high` are *signed*
+// 32-bit ints, so the low word must be read as unsigned (`low >>> 0`) when
+// reconstructing the value — otherwise every int64 whose low 32 bits have the
+// sign bit set (value ranges crossing 2^31) decodes to a negative/short number.
+
+const spanWithIntAttribute = (intValue: {
+  low: number;
+  high: number;
+  unsigned?: boolean;
+}) => ({
+  resource: { attributes: [] },
+  scopeSpans: [
+    {
+      scope: { name: "test" },
+      spans: [
+        {
+          traceId: {
+            type: "Buffer",
+            data: [
+              44, 206, 24, 247, 232, 205, 6, 90, 11, 78, 99, 78, 239, 114, 131,
+              145,
+            ],
+          },
+          spanId: { type: "Buffer", data: [87, 240, 37, 84, 23, 151, 65, 189] },
+          name: "my-span",
+          kind: 1,
+          startTimeUnixNano: {
+            low: 466848096,
+            high: 406528574,
+            unsigned: true,
+          },
+          endTimeUnixNano: { low: 467248096, high: 406528574, unsigned: true },
+          attributes: [{ key: "test.big_int", value: { intValue } }],
+        },
+      ],
+    },
+  ],
+});
+
+const decodeBigIntAttribute = async (intValue: {
+  low: number;
+  high: number;
+  unsigned?: boolean;
+}) => {
+  const processor = new OtelIngestionProcessor({
+    projectId: "p",
+    publicKey: "",
+    sdkName: "",
+    sdkVersion: "",
+  });
+  (processor as any).seenTraces = new Set();
+  (processor as any).isInitialized = true;
+  const events = await processor.processToIngestionEvents([
+    spanWithIntAttribute(intValue),
+  ] as any);
+  const withMetadata = events.find(
+    (e: any) => e.body?.metadata?.attributes?.["test.big_int"] !== undefined,
+  ) as any;
+  return withMetadata?.body?.metadata?.attributes?.["test.big_int"];
+};
+
+describe("OtelIngestionProcessor int64 attribute decoding", () => {
+  it("decodes a protobuf Long whose low word has the sign bit set (high=0)", async () => {
+    // 3_000_000_000 -> Long { low: -1294967296, high: 0 }
+    expect(await decodeBigIntAttribute({ low: -1294967296, high: 0 })).toBe(
+      "3000000000",
+    );
+  });
+
+  it("decodes a protobuf Long across the high word with a sign-bit-set low word", async () => {
+    // 1_721_000_000_000 -> Long { low: -1281885696, high: 400 }
+    expect(await decodeBigIntAttribute({ low: -1281885696, high: 400 })).toBe(
+      "1721000000000",
+    );
+  });
+
+  it("still decodes int64 -1 (the all-ones Long) as -1", async () => {
+    expect(await decodeBigIntAttribute({ low: -1, high: -1 })).toBe("-1");
+  });
+
+  it("still decodes a small positive Long unchanged", async () => {
+    expect(await decodeBigIntAttribute({ low: 42, high: 0 })).toBe("42");
+  });
+});

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1404,14 +1404,20 @@ export class OtelIngestionProcessor {
       return Number.isNaN(parsed) ? undefined : parsed;
     }
     if (intValue && typeof intValue === "object") {
+      // `low`/`high` are signed 32-bit words, so the low word must be read as
+      // unsigned (`>>> 0`) when reconstructing — otherwise any value whose low
+      // 32 bits have the sign bit set decodes short by 2^32. Mirrors
+      // `convertNanoTimestampToISO` below.
       if (intValue.high === 0) {
-        return intValue.low;
+        return intValue.low >>> 0;
       }
       if (intValue.high === -1 && intValue.low === -1) {
         return -1;
       }
       if (typeof intValue.high === "number") {
-        return intValue.high * Math.pow(2, 32) + intValue.low;
+        return Number(
+          (BigInt(intValue.high) << BigInt(32)) | BigInt(intValue.low >>> 0),
+        );
       }
     }
     return undefined;


### PR DESCRIPTION
## What does this PR do?

`OtelIngestionProcessor.convertOtelIntValue` reconstructs a protobuf.js `Long`
(`{ low, high }`) without treating the low word as unsigned. `low`/`high` are
**signed** 32-bit ints, so any int64 whose low 32 bits have the sign bit set
decodes short by 2^32:

- `if (intValue.high === 0) return intValue.low;` returns a raw negative low
  word — e.g. `3_000_000_000` arrives as `{ low: -1294967296, high: 0 }` and
  decodes to `-1294967296`.
- `intValue.high * 2^32 + intValue.low` is likewise short by 2^32 whenever
  `low` is negative (sign-bit set), and uses float math for the high word.

The sibling `convertNanoTimestampToISO` in this same file already does this
correctly: `const lowBits = BigInt(timestamp.low >>> 0);`. This PR mirrors that
so the two int64 decoders agree, and switches the multi-word branch to BigInt
to avoid float rounding.

### Honest note on reachability

The OTLP `/v1/traces` endpoint stages int64 fields as decimal **strings**
(`toObject(..., { longs: String })`, added in #13342), and OTLP/JSON already
sends int64 as strings per spec — so on the main ingestion path
`convertOtelIntValue` receives a string and takes the (correct) string branch,
not this Long branch. This change therefore isn't fixing a hot production path;
it hardens the `Long`-object branch that still exists in the function for any
direct-`Long` caller, and removes the inconsistency with the timestamp decoder
right next to it. Happy to close if you'd rather keep the Long branch as-is.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] Code is formatted (`pnpm run format`) and lints clean (targeted `eslint` on the changed files) and `tsc --noEmit` passes for `@langfuse/shared`.
- [x] Added colocated tests (`OtelIngestionProcessor.intValue.test.ts`) that fail before the fix and pass after; the existing `packages/shared` otel suite stays green.

---

*Disclosure: authored with AI assistance (Claude Code) and reviewed by me before submitting. The bug, fix, and tests were verified locally against the real code as described above.*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the protobuf.js `Long` (`{ low, high }`) decoding branch in `convertOtelIntValue`: `low` and `high` are signed 32-bit ints, so any int64 whose low 32 bits have the sign bit set was decoded short by 2^32 before this change. The fix mirrors the adjacent `convertNanoTimestampToISO` decoder by applying `low >>> 0` and switching the multi-word path to BigInt arithmetic.

- **`high === 0` branch**: changed `return intValue.low` → `return intValue.low >>> 0`, making the result always non-negative and correct for the full 0–4,294,967,295 range.
- **Multi-word BigInt branch**: replaced `high * Math.pow(2, 32) + low` with `Number((BigInt(high) << 32n) | BigInt(low >>> 0))`, which also incidentally corrects negative int64s where `high === -1` and `low` has the sign bit set (e.g., int64 `-5` was previously decoded as `-4,294,967,301`).
- **Regression tests** exercise both fixed branches for positive large values and the existing `-1` / small-positive cases.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The two changed lines are mathematically sound and mirror the pattern already used in convertNanoTimestampToISO. The bug fix is in a code path that is not hot on the main ingestion route (strings take the string branch), so the risk of regression is low.

The fix is correct and well-reasoned. The only gap is that the new test suite does not exercise the BigInt path with a negative high word and a sign-bit-set low (e.g., int64 -5 = { low: -5, high: -1 }), which the old code also mishandled. Adding a test for that shape would fully guard the change.

The test file would benefit from one additional case: a Long with high === -1 and a sign-bit-set low that is not -1 (e.g., { low: -5, high: -1 }).
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[convertOtelIntValue] --> B{typeof intValue}
    B -- number --> C[return intValue]
    B -- string --> D["parse = Number(intValue)"]
    D --> E{isNaN?}
    E -- yes --> F[return undefined]
    E -- no --> G[return parsed]
    B -- object --> H{high === 0?}
    H -- yes OLD --> OLD["return intValue.low ❌\n(negative if sign-bit set)"]
    H -- yes NEW --> NEW["return intValue.low >>> 0 ✅\n(always unsigned 0..2^32-1)"]
    H -- no --> I{"high === -1 AND low === -1?"}
    I -- yes --> J[return -1]
    I -- no --> K{typeof high === number?}
    K -- yes OLD --> OLDBIG["return high × 2^32 + low ❌\n(short by 2^32 when low < 0)"]
    K -- yes NEW --> NEWBIG["return Number(BigInt(high)<<32n | BigInt(low>>>0)) ✅"]
    K -- no --> L[return undefined]

    style OLD fill:#ffcccc,stroke:#cc0000
    style OLDBIG fill:#ffcccc,stroke:#cc0000
    style NEW fill:#ccffcc,stroke:#006600
    style NEWBIG fill:#ccffcc,stroke:#006600
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[convertOtelIntValue] --> B{typeof intValue}
    B -- number --> C[return intValue]
    B -- string --> D["parse = Number(intValue)"]
    D --> E{isNaN?}
    E -- yes --> F[return undefined]
    E -- no --> G[return parsed]
    B -- object --> H{high === 0?}
    H -- yes OLD --> OLD["return intValue.low ❌\n(negative if sign-bit set)"]
    H -- yes NEW --> NEW["return intValue.low >>> 0 ✅\n(always unsigned 0..2^32-1)"]
    H -- no --> I{"high === -1 AND low === -1?"}
    I -- yes --> J[return -1]
    I -- no --> K{typeof high === number?}
    K -- yes OLD --> OLDBIG["return high × 2^32 + low ❌\n(short by 2^32 when low < 0)"]
    K -- yes NEW --> NEWBIG["return Number(BigInt(high)<<32n | BigInt(low>>>0)) ✅"]
    K -- no --> L[return undefined]

    style OLD fill:#ffcccc,stroke:#cc0000
    style OLDBIG fill:#ffcccc,stroke:#cc0000
    style NEW fill:#ccffcc,stroke:#006600
    style NEWBIG fill:#ccffcc,stroke:#006600
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fshared%2Fsrc%2Fserver%2Fotel%2FOtelIngestionProcessor.intValue.test.ts%3A67-89%0A**Missing%20test%20for%20BigInt%20path%20with%20negative%20%60high%60%20and%20sign-bit-set%20%60low%60**%0A%0AThe%20test%20suite%20verifies%20the%20%60high%20%3D%3D%3D%200%60%20early-return%20branch%20and%20the%20all-ones%20%28%60%7B%20low%3A%20-1%2C%20high%3A%20-1%20%7D%60%29%20case%2C%20but%20never%20exercises%20the%20BigInt%20path%20with%20a%20negative%20%60high%60%20word%20and%20a%20sign-bit-set%20%60low%60.%20For%20example%2C%20int64%20%60-5%60%20is%20%60%7B%20low%3A%20-5%2C%20high%3A%20-1%20%7D%60%3A%20the%20old%20code%20computed%20%60%28-1%29%20*%202%5E32%20%2B%20%28-5%29%20%3D%20-4294967301%60%20%28wrong%29%2C%20while%20the%20new%20BigInt%20path%20gives%20%60Number%28-5n%29%20%3D%20-5%60%20%28correct%29.%20Without%20a%20test%20for%20this%20shape%2C%20the%20regression%20is%20not%20guarded.%0A%0A&pr=15144&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/otel/OtelIngestionProcessor.intValue.test.ts:67-89
**Missing test for BigInt path with negative `high` and sign-bit-set `low`**

The test suite verifies the `high === 0` early-return branch and the all-ones (`{ low: -1, high: -1 }`) case, but never exercises the BigInt path with a negative `high` word and a sign-bit-set `low`. For example, int64 `-5` is `{ low: -5, high: -1 }`: the old code computed `(-1) * 2^32 + (-5) = -4294967301` (wrong), while the new BigInt path gives `Number(-5n) = -5` (correct). Without a test for this shape, the regression is not guarded.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): decode int64 attribute Long l..."](https://github.com/langfuse/langfuse/commit/6aa0cde977a333b707418a8e92b5001076b97309) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44686877)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->