### PR TITLE
fix(sentry): scope httpClientIntegration to stop capturing expected poll/health 5xx (LFE-10975)

### DIFF
--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { isNoisyHttpClientPollEvent } from "@/src/utils/sentryFilters";
 
 const isEuOrUsRegionNonHipaa =
   process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined
@@ -26,6 +27,17 @@ Sentry.init({
     // Filter React DevTools internal errors - these are benign errors from DevTools
     // trying to access internal React properties
     if (errorValue.includes("__reactContextDevtoolDebugId")) {
+      return null;
+    }
+
+    // Drop expected/poll 5xx noise from httpClientIntegration. It flags every
+    // 5xx fetch/XHR as an unhandled "HTTP Client Error"; the NextAuth session
+    // poll (/api/auth/session, every 5 min + on window focus) dominates this and
+    // creates huge false-positive issues. Only the known poll/health endpoints
+    // are dropped — genuine 5xx on real API/tRPC endpoints are kept, and a real
+    // session outage is still observable server-side via request tracing/APM
+    // spans and application logs.
+    if (isNoisyHttpClientPollEvent(event)) {
       return null;
     }
 

--- a/web/src/utils/sentryFilters.clienttest.ts
+++ b/web/src/utils/sentryFilters.clienttest.ts
@@ -1,0 +1,179 @@
+import { type ErrorEvent } from "@sentry/nextjs";
+
+import { isNoisyHttpClientPollEvent } from "@/src/utils/sentryFilters";
+
+/**
+ * Build an event shaped exactly like the ones `httpClientIntegration` emits:
+ * message + a single exception value carrying the
+ * `auto.http.client.<fetch|xhr>` mechanism, plus `request.url`.
+ */
+function httpClientEvent(
+  url: string,
+  status = 500,
+  type: "fetch" | "xhr" = "fetch",
+): ErrorEvent {
+  const message = `HTTP Client Error with status code: ${status}`;
+  return {
+    message,
+    exception: {
+      values: [
+        {
+          type: "Error",
+          value: message,
+          mechanism: { type: `auto.http.client.${type}`, handled: false },
+        },
+      ],
+    },
+    request: { url, method: "GET" },
+    contexts: { response: { status_code: status } },
+  } as ErrorEvent;
+}
+
+describe("isNoisyHttpClientPollEvent", () => {
+  describe("drops expected poll/health 5xx from httpClientIntegration", () => {
+    it("drops the NextAuth session poll (fetch)", () => {
+      expect(
+        isNoisyHttpClientPollEvent(
+          httpClientEvent("https://cloud.langfuse.com/api/auth/session", 500),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops the NextAuth session poll (xhr)", () => {
+      expect(
+        isNoisyHttpClientPollEvent(
+          httpClientEvent(
+            "https://cloud.langfuse.com/api/auth/session",
+            502,
+            "xhr",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops the session poll behind a NEXT_PUBLIC_BASE_PATH prefix", () => {
+      expect(
+        isNoisyHttpClientPollEvent(
+          httpClientEvent(
+            "https://example.com/self-hosted/api/auth/session",
+            504,
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops the session poll even with a query string", () => {
+      expect(
+        isNoisyHttpClientPollEvent(
+          httpClientEvent(
+            "https://cloud.langfuse.com/api/auth/session?foo=bar",
+            500,
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops the health and readiness probes", () => {
+      expect(
+        isNoisyHttpClientPollEvent(
+          httpClientEvent("https://cloud.langfuse.com/api/public/health", 503),
+        ),
+      ).toBe(true);
+      expect(
+        isNoisyHttpClientPollEvent(
+          httpClientEvent("https://cloud.langfuse.com/api/public/ready", 500),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("KEEPS genuine 5xx on real endpoints (does not mask real errors)", () => {
+    it("keeps a tRPC 5xx", () => {
+      expect(
+        isNoisyHttpClientPollEvent(
+          httpClientEvent(
+            "https://cloud.langfuse.com/api/trpc/traces.all?batch=1",
+            500,
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps a public API 5xx (ingestion / traces)", () => {
+      expect(
+        isNoisyHttpClientPollEvent(
+          httpClientEvent(
+            "https://cloud.langfuse.com/api/public/ingestion",
+            500,
+          ),
+        ),
+      ).toBe(false);
+      expect(
+        isNoisyHttpClientPollEvent(
+          httpClientEvent("https://cloud.langfuse.com/api/public/traces", 502),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps other /api/auth endpoints (only /session is a poll)", () => {
+      expect(
+        isNoisyHttpClientPollEvent(
+          httpClientEvent("https://cloud.langfuse.com/api/auth/callback", 500),
+        ),
+      ).toBe(false);
+    });
+
+    it("does not match a path that merely contains a noise path as a substring", () => {
+      // endsWith on the pathname, so `/api/auth/sessionmanager` must NOT match.
+      expect(
+        isNoisyHttpClientPollEvent(
+          httpClientEvent(
+            "https://cloud.langfuse.com/api/auth/sessionmanager",
+            500,
+          ),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("never touches non-httpClient events", () => {
+    it("keeps a genuine thrown exception even if its URL looks like a poll endpoint", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "TypeError",
+              value: "Cannot read properties of undefined",
+              mechanism: { type: "onunhandledrejection", handled: false },
+            },
+          ],
+        },
+        request: { url: "https://cloud.langfuse.com/api/auth/session" },
+      } as ErrorEvent;
+      expect(isNoisyHttpClientPollEvent(event)).toBe(false);
+    });
+
+    it("keeps an event with no exception/mechanism (e.g. a message event)", () => {
+      const event = {
+        message: "some message",
+        request: { url: "https://cloud.langfuse.com/api/auth/session" },
+      } as ErrorEvent;
+      expect(isNoisyHttpClientPollEvent(event)).toBe(false);
+    });
+
+    it("keeps an httpClient event that has no request url", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "Error",
+              value: "HTTP Client Error with status code: 500",
+              mechanism: { type: "auto.http.client.fetch", handled: false },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isNoisyHttpClientPollEvent(event)).toBe(false);
+    });
+  });
+});

--- a/web/src/utils/sentryFilters.ts
+++ b/web/src/utils/sentryFilters.ts
@@ -1,0 +1,69 @@
+import { type ErrorEvent } from "@sentry/nextjs";
+
+/**
+ * High-frequency poll / health endpoints whose transient 5xx responses are
+ * expected background noise rather than actionable client-side errors.
+ *
+ * `Sentry.httpClientIntegration()` reports EVERY 5xx fetch/XHR the browser
+ * observes as an unhandled `HTTP Client Error with status code: N`. The worst
+ * offender by far is NextAuth's session poll: `SessionProvider` in `_app.tsx`
+ * refetches `/api/auth/session` every 5 minutes AND on every window focus, for
+ * every signed-in user. Its callback runs a heavy nested Prisma query, so any
+ * transient DB blip, slow response, or pod restart momentarily 5xxes here and is
+ * amplified across thousands of browsers into huge false-positive Sentry issues.
+ *
+ * Matched by URL path SUFFIX so an optional `NEXT_PUBLIC_BASE_PATH` prefix
+ * (e.g. `/self-hosted/api/auth/session`) still matches.
+ */
+export const HTTP_CLIENT_NOISE_PATHS = [
+  "/api/auth/session", // NextAuth session poll (5-min interval + on window focus)
+  // The two probes below are defensive/inert: they are only fetched by infra
+  // liveness/readiness checks, never by the browser, so they cannot actually
+  // match a client-side httpClient event. Only /api/auth/session suppresses
+  // real browser noise today; the probes are listed to be safe if a browser
+  // ever starts polling them.
+  "/api/public/health", // liveness probe (infra-only)
+  "/api/public/ready", // readiness probe (infra-only)
+] as const;
+
+/**
+ * True only for events created by `httpClientIntegration` (exception mechanism
+ * `auto.http.client.fetch` / `auto.http.client.xhr`) whose request URL targets
+ * one of the poll/health endpoints in {@link HTTP_CLIENT_NOISE_PATHS}.
+ *
+ * Deliberately narrow. It keys on the Sentry-set exception mechanism, so it can
+ * never drop:
+ *  - a genuine thrown exception or a captured console error (different / no
+ *    mechanism), or
+ *  - a 5xx on any real API/tRPC endpoint — e.g. `/api/trpc/...`,
+ *    `/api/public/traces`, `/api/public/ingestion` — those are not in the noise
+ *    list and keep flowing to Sentry.
+ *
+ * This does not hide real outages: a genuine `/api/auth/session` 5xx is still
+ * observable server-side via request tracing/APM spans and application logs, and
+ * via the health-check system — and the frontend already treats the session poll
+ * as non-fatal. This filter only removes the redundant client-side amplification
+ * of that same failure across thousands of browsers.
+ */
+export function isNoisyHttpClientPollEvent(event: ErrorEvent): boolean {
+  const mechanismType = event.exception?.values?.[0]?.mechanism?.type;
+  const isHttpClientEvent =
+    typeof mechanismType === "string" &&
+    mechanismType.startsWith("auto.http.client");
+  if (!isHttpClientEvent) return false;
+
+  const requestUrl = event.request?.url;
+  if (typeof requestUrl !== "string") return false;
+
+  // Reduce to a path so origin/query string don't affect matching. Fall back to
+  // the raw string if the URL cannot be parsed (httpClient URLs are absolute, so
+  // this is effectively unreachable, but we stay defensive).
+  let path = requestUrl;
+  try {
+    path = new URL(requestUrl, "http://localhost").pathname;
+  } catch {
+    // keep raw requestUrl
+  }
+
+  return HTTP_CLIENT_NOISE_PATHS.some((noisePath) => path.endsWith(noisePath));
+}


### PR DESCRIPTION
**TL;DR** — `Sentry.httpClientIntegration()` flags every 5xx browser fetch/XHR as an unhandled error. The NextAuth session poll dominates this and manufactures huge false-positive Sentry issues (~45k events / ~2,000 users across 5 issues). This adds a narrow `beforeSend` filter that drops only those poll/health events — genuine 5xx on real API/tRPC endpoints are still captured, and a real session outage is still observable server-side. Ref LFE-10975.

**Why** — `httpClientIntegration` (in `web/instrumentation-client.ts`) captures an unhandled `HTTP Client Error with status code: N` for every 5xx fetch/XHR the browser observes. `SessionProvider` refetches `/api/auth/session` every 5 minutes **and on every window focus, for every signed-in user**, and its callback runs a heavy nested query — so any transient blip, slow response, or pod restart momentarily 5xxes there and is amplified across thousands of browsers. Result: ~45k events / ~2,000 users bucketed into 5 large false-positive issues, drowning out real signal.

**What** — A precise, deny-list `beforeSend` filter. It drops an event only when both hold: (1) it came from `httpClientIntegration` (exception mechanism `auto.http.client.*`), and (2) its request path is a known poll/health endpoint (`/api/auth/session`, `/api/public/health`, `/api/public/ready`). Matched by path suffix so an optional base-path prefix still matches. Chosen over `failedRequestTargets` because that option is an inclusion allow-list — expressing "everything except the poll" there needs a fragile negative-lookahead regex that risks silently dropping real endpoints.

**Result** — The dominant noise (the session poll, 51–99% of events in each of the 5 issues) stops accruing. Everything else is untouched: genuine 5xx on `/api/trpc/*`, `/api/public/*`, other `/api/auth/*` routes, and all real exceptions/console errors still reach Sentry — and the underlying backend error for the poll endpoints is still observable server-side, so nothing real is masked.

<details>
<summary>Mechanism, matching, and verification detail</summary>

- **Event identity:** `httpClientIntegration` builds each event via `_createEvent()`, tagging `exception.values[0].mechanism.type = auto.http.client.fetch|xhr` (`handled: false`) and setting `request.url` to the failing request. The filter keys on both, so it can never drop a differently-sourced error even if its page URL resembles a poll endpoint.
- **Suffix match** on the parsed `URL(...).pathname` tolerates a base-path prefix and query strings, and avoids substring false matches (`/api/auth/sessionmanager` is not dropped).
- **Kept vs dropped** enumerated and locked in `web/src/utils/sentryFilters.clienttest.ts` (12 cases): poll/health dropped; tRPC/public-API/other-auth 5xx kept; non-httpClient events kept; url-less events kept.
- **No masking:** this integration is a client-side observer of HTTP status codes. A genuine `/api/auth/session` outage is still observable server-side via request tracing/APM spans and application logs, and via the health-check system; the frontend already treats the session poll as non-fatal. This PR removes only the redundant client-side amplification of that same failure across thousands of browsers.
- The `/api/public/health` + `/api/public/ready` entries are defensive/inert — those paths are only hit by infra liveness/readiness probes, never the browser, so they cannot match a client-side httpClient event today.
- Typecheck, lint (all packages), prettier, and the 12-case unit suite pass.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a narrow `beforeSend` filter to silence false-positive Sentry events generated by `httpClientIntegration` for the NextAuth session poll (`/api/auth/session`) and two infra health probes. The filter is keyed on both the Sentry-set exception mechanism (`auto.http.client.*`) and the request path, so only the named poll endpoints are suppressed; genuine 5xx on tRPC and public-API routes continue to reach Sentry.

- **`sentryFilters.ts`** introduces `isNoisyHttpClientPollEvent`, which extracts the URL pathname via `URL` parsing (with a safe raw-string fallback) and checks it against a small deny list using `endsWith`, correctly tolerating a `NEXT_PUBLIC_BASE_PATH` prefix.
- **`instrumentation-client.ts`** wires the filter into the existing `beforeSend` callback alongside the two existing error-value filters.
- **`sentryFilters.clienttest.ts`** covers 12 cases (drop/keep/non-httpClient) in the `client` vitest project (`jsdom` environment), consistent with the project's `*.clienttest.ts` naming convention confirmed in `vitest.config.mts`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to a single, narrowly-guarded `beforeSend` filter; no production logic or data paths are touched.

The filter only activates when both the Sentry exception mechanism and the request path match known poll/health endpoints, making accidental suppression of real errors essentially impossible. The URL-parsing fallback degrades conservatively (keeps the event) on malformed input. Test coverage is exhaustive for the stated goals, and the naming convention aligns with the project's vitest configuration.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sentry beforeSend receives event] --> B{errorValue contains\n'Invalid href'?}
    B -- yes --> Z1[return null\ndrop event]
    B -- no --> C{errorValue contains\n'__reactContextDevtoolDebugId'?}
    C -- yes --> Z2[return null\ndrop event]
    C -- no --> D[isNoisyHttpClientPollEvent]

    D --> E{mechanism type\nstarts with\nauto.http.client?}
    E -- no --> K[return false\nkeep event]
    E -- yes --> F{request.url\nis a string?}
    F -- no --> K
    F -- yes --> G[Parse URL pathname\nfallback to raw URL]
    G --> H{pathname endsWith\n/api/auth/session\n/api/public/health\n/api/public/ready?}
    H -- yes --> I[return true]
    H -- no --> K

    I --> Z3[return null\ndrop event]
    K --> L[return event\nforward to Sentry]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Sentry beforeSend receives event] --> B{errorValue contains\n'Invalid href'?}
    B -- yes --> Z1[return null\ndrop event]
    B -- no --> C{errorValue contains\n'__reactContextDevtoolDebugId'?}
    C -- yes --> Z2[return null\ndrop event]
    C -- no --> D[isNoisyHttpClientPollEvent]

    D --> E{mechanism type\nstarts with\nauto.http.client?}
    E -- no --> K[return false\nkeep event]
    E -- yes --> F{request.url\nis a string?}
    F -- no --> K
    F -- yes --> G[Parse URL pathname\nfallback to raw URL]
    G --> H{pathname endsWith\n/api/auth/session\n/api/public/health\n/api/public/ready?}
    H -- yes --> I[return true]
    H -- no --> K

    I --> Z3[return null\ndrop event]
    K --> L[return event\nforward to Sentry]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sentry): stop capturing expected pol..."](https://github.com/langfuse/langfuse/commit/eef7ce0677ccb1bf934f8ae7d45f8f61fd8af711) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44719895)</sub>

<!-- /greptile_comment -->