### PR TITLE
fix(automations): suppress spurious 404 toast on delete, instant not-found detection

### DIFF
--- a/web/src/features/automations/components/AutomationDetails.tsx
+++ b/web/src/features/automations/components/AutomationDetails.tsx
@@ -51,6 +51,9 @@ export const AutomationDetails: React.FC<AutomationDetailsProps> = ({
       },
       {
         enabled: !!projectId && !!automationId,
+        // Suppress 404 toast: after deletion the invalidation can refetch this
+        // query before the component unmounts, producing a spurious error toast.
+        meta: { silentHttpCodes: [404] },
       },
     );
 

--- a/web/src/features/automations/components/AutomationExecutionsTable.tsx
+++ b/web/src/features/automations/components/AutomationExecutionsTable.tsx
@@ -41,12 +41,17 @@ export const AutomationExecutionsTable: React.FC<
   );
 
   const { data, isLoading, isError, error } =
-    api.automations.getAutomationExecutions.useQuery({
-      projectId,
-      automationId,
-      page: paginationState.pageIndex,
-      limit: paginationState.pageSize,
-    });
+    api.automations.getAutomationExecutions.useQuery(
+      {
+        projectId,
+        automationId,
+        page: paginationState.pageIndex,
+        limit: paginationState.pageSize,
+      },
+      // Suppress 404 toast: invalidation after deletion can refetch this query
+      // before the component unmounts.
+      { meta: { silentHttpCodes: [404] } },
+    );
 
   const columns: LangfuseColumnDef<ActionExecutionRow>[] = [
     {

--- a/web/src/features/automations/components/AutomationSidebar.tsx
+++ b/web/src/features/automations/components/AutomationSidebar.tsx
@@ -16,9 +16,14 @@ export const AutomationSidebar: React.FC<AutomationSidebarProps> = ({
   onAutomationSelect,
 }) => {
   const { data: automations, isLoading } =
-    api.automations.getAutomations.useQuery({
-      projectId,
-    });
+    api.automations.getAutomations.useQuery(
+      {
+        projectId,
+      },
+      {
+        enabled: !!projectId,
+      },
+    );
 
   const sidebarWidth = "w-40 sm:w-64";
 

--- a/web/src/features/automations/components/automations.tsx
+++ b/web/src/features/automations/components/automations.tsx
@@ -82,6 +82,11 @@ export default function AutomationsPage() {
       },
       {
         enabled: view === "list" && !!selectedAutomation,
+        // Suppress 404 toast: invalidation after deletion can trigger a refetch
+        // before the URL update commits. The error *state* is preserved so the
+        // NOT_FOUND check below (renderAutomationNotFoundError) still works for
+        // stale/invalid automation URLs.
+        meta: { silentHttpCodes: [404] },
       },
     );
 

--- a/web/src/features/automations/components/automations.tsx
+++ b/web/src/features/automations/components/automations.tsx
@@ -57,9 +57,14 @@ export default function AutomationsPage() {
   );
 
   // Fetch automations to check if any exist
-  const { data: automations } = api.automations.getAutomations.useQuery({
-    projectId,
-  });
+  const { data: automations } = api.automations.getAutomations.useQuery(
+    {
+      projectId,
+    },
+    {
+      enabled: !!projectId,
+    },
+  );
 
   // Fetch editing automation when in edit mode
   const { data: editingAutomation, error: editingAutomationError } =
@@ -70,6 +75,10 @@ export default function AutomationsPage() {
       },
       {
         enabled: view === "edit" && !!automationId,
+        // Suppress 404 toast: invalidation after deletion can trigger a refetch
+        // before the URL update commits (reachable via the delete button
+        // rendered inside AutomationForm on the dedicated edit view).
+        meta: { silentHttpCodes: [404] },
       },
     );
 

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -353,17 +353,13 @@ export const api = createTRPCNext<AppRouter>({
           queries: {
             // react query defaults to `online`, but we want to disable it as it caused issues for some users
             networkMode: "always",
-            // Don't retry on 4xx errors — they're client errors and never transient.
-            // 429 is excluded from this: rate limiting is expected to be transient
-            // and self-heal on retry (see the dedicated 429 handling in trpcErrorToast.tsx).
+            // Don't retry on 404s: a deleted/missing resource never appears via
+            // retry, so failing fast avoids piling up pointless refetches (and
+            // ClickHouse load for resources backed by it). Every other 4xx keeps
+            // the default retry/backoff — some (e.g. a route param that hasn't
+            // hydrated yet, a proxy-level 429) are transient and self-heal.
             retry: (failureCount, error) => {
-              const httpStatus = getHttpStatus(error);
-              if (
-                httpStatus !== undefined &&
-                httpStatus >= 400 &&
-                httpStatus < 500 &&
-                httpStatus !== 429
-              ) {
+              if (getHttpStatus(error) === 404) {
                 return false;
               }
               return failureCount < 3;

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -67,6 +67,11 @@ const ERROR_DEBOUNCE_MS = 20000;
 const hasResponseMeta = (error: TRPCClientError<any>): boolean =>
   Boolean((error.meta as { response?: unknown } | undefined)?.response);
 
+const getHttpStatus = (error: unknown): number | undefined =>
+  error instanceof TRPCClientError && typeof error.data?.httpStatus === "number"
+    ? error.data.httpStatus
+    : undefined;
+
 const getCause = (error: unknown): unknown =>
   error instanceof Error ? error.cause : undefined;
 
@@ -280,10 +285,9 @@ const shouldSilenceError = (
   }
 
   if (Array.isArray(meta?.silentHttpCodes)) {
+    const httpStatus = getHttpStatus(error);
     return (
-      error instanceof TRPCClientError &&
-      typeof error.data?.httpStatus === "number" &&
-      meta.silentHttpCodes.includes(error.data?.httpStatus)
+      httpStatus !== undefined && meta.silentHttpCodes.includes(httpStatus)
     );
   }
 
@@ -349,6 +353,21 @@ export const api = createTRPCNext<AppRouter>({
           queries: {
             // react query defaults to `online`, but we want to disable it as it caused issues for some users
             networkMode: "always",
+            // Don't retry on 4xx errors — they're client errors and never transient.
+            // 429 is excluded from this: rate limiting is expected to be transient
+            // and self-heal on retry (see the dedicated 429 handling in trpcErrorToast.tsx).
+            retry: (failureCount, error) => {
+              const httpStatus = getHttpStatus(error);
+              if (
+                httpStatus !== undefined &&
+                httpStatus >= 400 &&
+                httpStatus < 500 &&
+                httpStatus !== 429
+              ) {
+                return false;
+              }
+              return failureCount < 3;
+            },
           },
           mutations: {
             onError: (error) => handleTrpcError(error),


### PR DESCRIPTION
## Summary

- **Spurious error toast after deletion**: deleting an automation fired `utils.automations.invalidate()` while child queries (`getAutomation`, `getAutomationExecutions`, and the detail-existence check in `automations.tsx`) were still mounted. React Query refetched them before the URL update committed, got a 404, and the global `QueryCache.onError` handler showed an error toast alongside the success toast. Fixed by adding `meta: { silentHttpCodes: [404] }` to each of those queries — this suppresses only the toast; the error state is preserved, so the "Webhook not found" error page for stale/invalid URLs continues to work correctly.

- **Slow not-found detection on stale URLs**: React Query's default `retry: 3` with exponential backoff caused the "Webhook not found" error page to take ~7 seconds to appear (retrying at ~1s, ~2s, ~4s). Added a global `retry` function to the React Query config in `api.ts` that skips retries for any 4xx response — these are definitive client errors, never transient — while keeping the standard 3-retry logic for 5xx and network errors. The error page now appears immediately.

## Linear

None

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two UX issues in the automations feature: a spurious error toast that appeared alongside the success toast when deleting an automation, and slow "not found" detection (~7s) for stale/invalid automation URLs.

- Adds `meta: { silentHttpCodes: [404] }` to three queries (`getAutomation` in the detail view, `getAutomation` in `automations.tsx`, and `getAutomationExecutions`) so that post-deletion refetch races suppress the toast while preserving the error state for the not-found page.
- Adds a global `retry` function in `api.ts` that skips retries for any 4xx response (except 429), making the not-found error page appear immediately instead of after ~7s of exponential backoff.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the core deletion and not-found flows work correctly, and the changes are narrowly scoped to toast suppression and retry configuration.

Both fixes are correctly implemented: `silentHttpCodes` suppresses the toast while leaving error state intact, and the global retry function stops 4xx errors from retrying. The only leftover issue is that `captureException` in `handleTrpcError` runs before the `shouldSilenceError` check, so intentionally silenced 404s still produce Sentry events — but this is noise rather than a functional defect.

All changed files look fine. `web/src/utils/api.ts` is the highest-leverage file: the global `retry` function affects every query in the app, but the logic correctly handles all the main status-code buckets.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant C as Component
    participant RQ as React Query
    participant API as tRPC API
    participant QC as QueryCache.onError

    Note over U,QC: After fix — delete automation

    U->>C: deleteAutomation()
    C->>RQ: utils.automations.invalidate()
    C->>C: navigateWithoutHistory(next automation)

    par Stale queries refetch (race window)
        RQ->>API: getAutomation(deleted id)
        API-->>RQ: 404 NOT_FOUND
        RQ->>QC: "onError(404, meta={silentHttpCodes:[404]})"
        QC->>QC: shouldSilenceError → true
        Note over QC: Toast suppressed ✓, Error state preserved ✓
    and
        RQ->>API: getAutomationExecutions(deleted id)
        API-->>RQ: 404 NOT_FOUND
        RQ->>QC: "onError(404, meta={silentHttpCodes:[404]})"
        QC->>QC: shouldSilenceError → true
        Note over QC: Toast suppressed ✓
    end

    C->>RQ: getAutomation(next id) [enabled after URL update]
    RQ->>API: getAutomation(next id)
    API-->>RQ: 200 OK
    RQ->>C: data ✓

    Note over U,QC: Stale URL — immediate not-found (after fix)
    U->>C: "navigate to ?automationId=invalid"
    RQ->>API: getAutomation(invalid)
    API-->>RQ: 404 NOT_FOUND
    RQ->>RQ: "retry(0, err) → httpStatus=404 → false (no retry)"
    RQ->>C: "error.data.code=NOT_FOUND (instant)"
    C->>U: ErrorPage shown immediately ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant C as Component
    participant RQ as React Query
    participant API as tRPC API
    participant QC as QueryCache.onError

    Note over U,QC: After fix — delete automation

    U->>C: deleteAutomation()
    C->>RQ: utils.automations.invalidate()
    C->>C: navigateWithoutHistory(next automation)

    par Stale queries refetch (race window)
        RQ->>API: getAutomation(deleted id)
        API-->>RQ: 404 NOT_FOUND
        RQ->>QC: "onError(404, meta={silentHttpCodes:[404]})"
        QC->>QC: shouldSilenceError → true
        Note over QC: Toast suppressed ✓, Error state preserved ✓
    and
        RQ->>API: getAutomationExecutions(deleted id)
        API-->>RQ: 404 NOT_FOUND
        RQ->>QC: "onError(404, meta={silentHttpCodes:[404]})"
        QC->>QC: shouldSilenceError → true
        Note over QC: Toast suppressed ✓
    end

    C->>RQ: getAutomation(next id) [enabled after URL update]
    RQ->>API: getAutomation(next id)
    API-->>RQ: 200 OK
    RQ->>C: data ✓

    Note over U,QC: Stale URL — immediate not-found (after fix)
    U->>C: "navigate to ?automationId=invalid"
    RQ->>API: getAutomation(invalid)
    API-->>RQ: 404 NOT_FOUND
    RQ->>RQ: "retry(0, err) → httpStatus=404 → false (no retry)"
    RQ->>C: "error.data.code=NOT_FOUND (instant)"
    C->>U: ErrorPage shown immediately ✓
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/utils/api.ts:183-185
**Silenced errors still reported to Sentry**

`captureException` is called unconditionally before the `shouldSilenceError` guard, so post-deletion 404s from the race window will still generate Sentry events even though the toast is now suppressed. The fix halves the noise (1 event instead of 4 thanks to the no-retry change), but intentionally silenced errors will still appear in Sentry dashboards. Passing `shouldSilenceError` into `captureException` or wrapping it with the same guard would eliminate this residual noise.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(automations): suppress 404 error toa..."](https://github.com/langfuse/langfuse/commit/468d0b71800fefd4bfa07338cc88b29cc42a2343) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44725839)</sub>

<!-- /greptile_comment -->