### PR TITLE
chore(agents): add incident-alert-tickets skill and wire investigation skills to it

### DIFF
--- a/.agents/skills/datadog-query-recipes/SKILL.md
+++ b/.agents/skills/datadog-query-recipes/SKILL.md
@@ -60,6 +60,10 @@ data domain you need: traces, logs, metrics, and visualizations.
 - Use [`weekly-production-review`](../weekly-production-review/SKILL.md) when
   the user asks for a weekly engineering overview of production bugs, pages,
   and incidents.
+- Use [`incident-alert-tickets`](../incident-alert-tickets/SKILL.md) when the
+  research is anchored to a named production alert or monitor: look up
+  documented causes before measuring, and record new ones only after human
+  approval.
 - Use [`linear-bug-triage`](../linear-bug-triage/SKILL.md) only after a human
   approves sharing measured findings in Linear.
 

--- a/.agents/skills/debug-issue-with-datadog/SKILL.md
+++ b/.agents/skills/debug-issue-with-datadog/SKILL.md
@@ -42,6 +42,10 @@ supports them.
    the issue *and* its comments via the Linear MCP — the description is often
    updated inline as triage proceeds. For a GitHub issue, use `gh issue view`.
    For pasted text, treat it as the description.
+   If intake contains an alert identity (a Datadog monitor ID or title, an
+   incident.io alert/INC reference, or an on-call page), first apply
+   [`incident-alert-tickets`](../incident-alert-tickets/SKILL.md) — a
+   documented cause section may resolve the investigation before any sweep.
 
 2. **Scope the sweep.** From the intake, pick the affected subsystem and time
    window. Use [`references/repo-debug-map.md`](references/repo-debug-map.md)
@@ -71,6 +75,11 @@ supports them.
 
 7. **Deliver.** Default: print the analysis in chat. If the user asked for it,
    also save under the workflow they specified (file, Linear comment via, etc.).
+   If the investigation was anchored to an alert identity, also offer the
+   human-gated write-back from
+   [`incident-alert-tickets`](../incident-alert-tickets/SKILL.md): append the
+   established root cause as a dated cause section, or create the monitor's
+   ticket.
 
 ## Datadog MCP Usage Notes
 
@@ -110,6 +119,9 @@ do not invent root causes.
 
 ## Cross-References
 
+- Per-monitor knowledge base — look up documented causes before the sweep,
+  record new ones after (human-gated):
+  [`incident-alert-tickets`](../incident-alert-tickets/SKILL.md)
 - Production telemetry query recipes, tenant/public API usage, and queue
   consumer measurements:
   [`datadog-query-recipes`](../datadog-query-recipes/SKILL.md)

--- a/.agents/skills/incident-alert-tickets/SKILL.md
+++ b/.agents/skills/incident-alert-tickets/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: incident-alert-tickets
+description: |
+  Look up, compare against, and (after human approval) update the Linear
+  incident-alert knowledge base: one ticket per production alert/monitor,
+  labeled `incident-alert`, with one dated cause section per distinct root
+  cause. Use whenever an investigation is anchored to a named alert identity —
+  a Datadog monitor ID or title, an incident.io alert/INC reference, or an
+  on-call page — both before debugging from scratch (a documented cause may
+  already answer it) and after establishing a new root cause (record it).
+---
+
+# Incident Alert Tickets
+
+Incident-alert tickets turn on-call debugging into searchable knowledge: one
+Linear ticket per production alert/monitor, one dated section per distinct
+root cause. This skill owns lookup, comparison, and the human-gated
+write-back; calling skills own the investigation itself. The team SOP is the
+Linear document titled "Incident Alert Tickets".
+
+## When to Apply
+
+Apply whenever the task is anchored to an **alert identity**:
+
+- a Datadog monitor ID or title,
+- an incident.io alert or INC reference,
+- an on-call page ("we got paged for X").
+
+Do not try to detect "incident mode" — the presence of a named alert is the
+condition, because the monitor is the ticket key. When an alert identity is
+present, the lookup is mandatory; recording is offered after the investigation
+and gated on human approval. A customer report or code question with no alert
+identity skips this skill.
+
+## Ticket Contract
+
+- One ticket per monitor (per env when monitors are per-env), titled
+  `[ENV] <Monitor title>`, in the Engineering (LFE) team, carrying the
+  `incident-alert` label. The label set is the knowledge base.
+- The description opens with an alert header: monitor ID, trigger condition,
+  and how it surfaces (incident.io urgency, auto-resolve behavior).
+- One dated section per distinct root cause, separated by `---`:
+
+  ```markdown
+  ## YYYY-MM-DD — <short cause name>
+
+  **Recognize it:** <signals that identify this cause: log patterns, span
+  filters, metric shapes, affected routes>
+
+  **How urgent?** <impact, auto-recovery behavior, escalation threshold>
+
+  **Fix:** <positive actions only — every "do not X" needs a working
+  alternative; verified levers, not speculation>
+  ```
+
+- Cause sections are append-only: never rewrite or delete an existing section;
+  new knowledge gets a new dated block.
+- Keep each cause section to roughly one screen.
+- A distinct problem discovered during the investigation that is *not* a cause
+  of this alert gets its own ticket (bug or incident-alert), cross-linked — do
+  not mix it into this ticket's cause sections.
+
+## Lookup
+
+1. List Linear issues carrying the `incident-alert` label.
+2. Match on monitor ID first (tickets carry it in the alert header), then on
+   monitor title and env.
+3. Read the matched ticket's cause sections and comments.
+
+## Compare and Classify
+
+Compare the current evidence against each cause section's "Recognize it"
+signals and classify:
+
+- **Known cause** — a section matches. Cite the ticket and section in the
+  analysis; its "Fix" is the starting recommendation. This may end the
+  investigation before any Datadog sweep.
+- **New cause on existing ticket** — the monitor has a ticket but no section
+  matches the evidence. Propose appending a dated section.
+- **No ticket** — no ticket matches the monitor. Propose creating one.
+
+## Write-Back (Human Approval Gate)
+
+Never create or update a ticket without explicit human approval. Present the
+proposal first:
+
+| ID | Alert / Monitor | Classification | Proposed Action | Draft Content | Human Decision |
+| --- | --- | --- | --- | --- | --- |
+
+- `Proposed Action`: `append cause section to LFE-XXXX`, `create ticket`, or
+  `none (known cause)`.
+- `Draft Content`: the dated section (or full ticket body) exactly as it would
+  be written.
+- `Human Decision`: leave blank for the human to choose.
+
+Wait for the human to select row IDs and actions before writing. On approval:
+
+- **Append**: add the new `---`-separated dated block after the existing
+  sections; leave everything else untouched.
+- **Create**: new Engineering (LFE) issue titled `[ENV] <Monitor title>` with
+  the `incident-alert` label; description = alert header plus the first dated
+  cause section.
+
+## Division of Labor
+
+- [`linear-bug-triage`](../linear-bug-triage/SKILL.md) owns bug deduplication
+  and creation from measured evidence. Incident-alert tickets are per-monitor
+  runbook knowledge, not defect reports.
+- An alert whose root cause is a code bug gets both: the cause section
+  documents recognition and mitigation, and links the bug ticket that tracks
+  the durable fix.

--- a/.agents/skills/incident-alert-tickets/SKILL.md
+++ b/.agents/skills/incident-alert-tickets/SKILL.md
@@ -32,6 +32,12 @@ present, the lookup is mandatory; recording is offered after the investigation
 and gated on human approval. A customer report or code question with no alert
 identity skips this skill.
 
+When multiple alerts fire together (a cascade), run lookup, compare, and
+classify for **each** alert identity — every monitor has its own ticket. If
+one root cause explains several alerts, write the full cause section on the
+monitor closest to the cause and propose a short dated section on the other
+monitors' tickets that links to it.
+
 ## Ticket Contract
 
 - One ticket per monitor (per env when monitors are per-env), titled
@@ -78,6 +84,11 @@ signals and classify:
 - **New cause on existing ticket** — the monitor has a ticket but no section
   matches the evidence. Propose appending a dated section.
 - **No ticket** — no ticket matches the monitor. Propose creating one.
+
+Treat a partial match — some "Recognize it" signals fit, others do not — as a
+**new cause**, never as a known one: do not recommend a documented "Fix"
+whose recognition signals only partially match. Name the near-miss section in
+the draft so the human can judge the overlap.
 
 ## Write-Back (Human Approval Gate)
 

--- a/.agents/skills/weekly-production-review/SKILL.md
+++ b/.agents/skills/weekly-production-review/SKILL.md
@@ -40,6 +40,9 @@ audit from the linked source rows.
   production Datadog query shapes and environment/site routing.
 - Use [`linear-bug-triage`](../linear-bug-triage/SKILL.md) only after a human
   explicitly approves a Linear write-back.
+- Use [`incident-alert-tickets`](../incident-alert-tickets/SKILL.md) to check
+  each Datadog alert cluster against the per-monitor knowledge base and, only
+  after explicit human approval, record newly root-caused clusters there.
 
 ## Workflow
 
@@ -69,7 +72,11 @@ audit from the linked source rows.
    Group repeated firings by monitor/page title or ID, environment, service/team,
    and trigger reason.
 6. For every Datadog alert/page cluster, perform the deep dive before writing the
-   final row. Do not stop at the monitor title or count. Inspect matching APM
+   final row. Do not stop at the monitor title or count. Check the monitor's
+   `incident-alert` ticket first (see
+   [`incident-alert-tickets`](../incident-alert-tickets/SKILL.md)); a
+   documented cause section may explain the cluster — cite the ticket in the
+   `incident.io / Linear Link` column. Inspect matching APM
    spans, representative traces, related logs, error records, exception details,
    failed job logs, dependency spans, queue backlog/delay context, and monitor
    time windows. Put the relevant trace/span evidence and relevant logs/errors
@@ -116,7 +123,8 @@ relationships instead of synthesizing a separate cross-source table.
 
 Use Linear as the source of truth for deduplication across weeks and workflows.
 Before reporting a bug, security finding, cost concern, or alert as new, search
-Linear for matching issue keys, titles, source URLs, and comments. If an
+Linear for matching issue keys, titles, source URLs, and comments — covering
+both the `bug` label set and the `incident-alert` label set. If an
 existing issue covers it, link to that issue and mark the row as already
 tracked instead of reporting it again as fresh work.
 


### PR DESCRIPTION
## What does this PR do?

Adds a shared agent skill `incident-alert-tickets` that owns the incident-alert knowledge-base contract: one Linear ticket per production alert/monitor (label `incident-alert`), one dated cause section per distinct root cause. The skill covers lookup by alert identity (Datadog monitor ID/title, incident.io reference, on-call page), comparison of current evidence against documented "Recognize it" sections, and a human-approval-gated write-back (append a dated cause section or create the monitor's ticket).

Wires the three production-investigation skills to it with thin hooks instead of duplicating the logic:

- `debug-issue-with-datadog`: consult the knowledge base at intake (a documented cause may resolve the investigation before any Datadog sweep); offer the gated write-back at deliver.
- `weekly-production-review`: check each Datadog alert cluster against its monitor's ticket during the deep dive; dedupe against the `incident-alert` label set alongside `bug`.
- `datadog-query-recipes`: cross-reference pointer for alert-anchored research.

All Linear references are by label name, ticket ID, or document title only — no Linear URLs, so the skills survive a workspace migration.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Chore (refactoring, adding tests, agent setup, etc.)

## How did you test it?

- `pnpm run agents:sync` and `pnpm run agents:check` pass.
- Pre-commit: Prettier clean, `turbo run lint` 7/7 successful.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Was this feature tested in staging or with a preview deployment?

Not applicable — agent-setup markdown only, no runtime code changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new `incident-alert-tickets` agent skill that creates a per-monitor runbook knowledge base in Linear, and wires lookup and write-back calls into three existing investigation skills (`debug-issue-with-datadog`, `weekly-production-review`, `datadog-query-recipes`).

- **New skill (`incident-alert-tickets`)**: defines ticket structure (one ticket per monitor, dated cause sections, `incident-alert` label), a lookup-compare-classify flow, and a human-gated write-back table. Division of labor with `linear-bug-triage` is clearly articulated.
- **`debug-issue-with-datadog` integration**: adds an early-exit knowledge-base lookup at step 1 when an alert identity is present, and an offer to write back at step 7 after the investigation concludes.
- **`weekly-production-review` integration**: extends step 6 to consult the incident-alert ticket before a Datadog sweep, and widens deduplication to cover both `bug` and `incident-alert` label sets.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all changes are agent skill documentation with no runtime code affected.

The new skill is well-structured and the three integration points are consistent with each other. The only gaps are in edge-case guidance within the skill prose: the classify step has no defined behaviour for partial signal matches, the human-approval table has no enumerated acceptance values, and cascading multi-alert investigations are not addressed. None of these prevent the skill from working correctly in the common case.

incident-alert-tickets/SKILL.md — the classify and write-back sections would benefit from the clarifications noted in the inline comments before this skill sees heavy use.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Investigation starts with alert identity] --> B[Look up Linear tickets\nwith 'incident-alert' label]
    B --> C{Match found?}
    C -- No ticket --> D[Classify: No Ticket\nPropose creating new ticket]
    C -- Ticket exists, no section match --> E[Classify: New Cause\nPropose appending dated section]
    C -- Section matches evidence --> F[Classify: Known Cause\nCite ticket + Fix recommendation]
    F --> G{Investigation resolved?}
    G -- Yes --> H[Deliver — offer write-back\nnone needed for known cause]
    G -- No, new details --> E
    D --> I[Present write-back table\nto human]
    E --> I
    I --> J{Human approves?}
    J -- Yes: create --> K[Create LFE ticket\nwith alert header + dated section]
    J -- Yes: append --> L[Append new dated section\nto existing ticket]
    J -- No / not yet --> M[Deliver analysis only]
    H --> M
    K --> M
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Investigation starts with alert identity] --> B[Look up Linear tickets\nwith 'incident-alert' label]
    B --> C{Match found?}
    C -- No ticket --> D[Classify: No Ticket\nPropose creating new ticket]
    C -- Ticket exists, no section match --> E[Classify: New Cause\nPropose appending dated section]
    C -- Section matches evidence --> F[Classify: Known Cause\nCite ticket + Fix recommendation]
    F --> G{Investigation resolved?}
    G -- Yes --> H[Deliver — offer write-back\nnone needed for known cause]
    G -- No, new details --> E
    D --> I[Present write-back table\nto human]
    E --> I
    I --> J{Human approves?}
    J -- Yes: create --> K[Create LFE ticket\nwith alert header + dated section]
    J -- Yes: append --> L[Append new dated section\nto existing ticket]
    J -- No / not yet --> M[Deliver analysis only]
    H --> M
    K --> M
    L --> M
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.agents/skills/incident-alert-tickets/SKILL.md:63-69
**"Compare and Classify" lacks a partial-match category**

The three-way classification (Known / New on existing / No ticket) has no guidance for signals that partially overlap with an existing cause section — some indicators match but others don't. Without explicit guidance, an agent encountering a partial overlap will either over-confidently call it "Known" (risking a wrong "Fix" recommendation) or call it "New cause" and propose a redundant append. A fourth category like "Partial match — review required" or an explicit instruction to default to "New cause" when signals only partially align would resolve the ambiguity.

### Issue 2 of 3
.agents/skills/incident-alert-tickets/SKILL.md:76-86
**"Human Decision" column has no defined value set**

The approval table leaves `Human Decision` blank with no enumeration of valid responses. A human reviewer doesn't know whether to write "approved", "yes", a row ID, or something else. When the agent later checks whether it has received approval before writing, it would need to parse freeform input — which risks either false approvals or blocked writes. Specifying accepted values (e.g., `approve` / `reject` or a row-number check) in the prose just before the table would eliminate this ambiguity.

### Issue 3 of 3
.agents/skills/incident-alert-tickets/SKILL.md:1-111
**No guidance for multi-alert cascade investigations**

The skill is framed entirely around a single alert identity. `debug-issue-with-datadog` investigations can involve cascades where multiple monitors fire together. When the intake contains two or more alert identities (e.g., a worker-queue saturation alert + a latency alert), the skill gives no direction: should the agent run the lookup-compare-classify flow for each alert independently, or pick the primary one? Without this, agents handling cascades may silently skip the secondary alerts or duplicate effort inconsistently.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(agents): add incident-alert-ticket..."](https://github.com/langfuse/langfuse/commit/4fec417332eec15f8f5ff079627a594910d83433) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44744739)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->