### PR TITLE
fix(trace): budget aggregated graph layout so dense traces can't freeze the tab (LFE-10988)

### DIFF
--- a/web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx
+++ b/web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx
@@ -352,8 +352,22 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
           </Button>
         </div>
       )}
+      {layout?.tooLarge && (
+        // Budget exceeded: ELK was skipped rather than freeze the tab. No retry
+        // — it would just wedge again. Point the user at the tree/timeline.
+        <div className="text-muted-foreground absolute inset-0 flex flex-col items-center justify-center gap-1 px-4 text-center text-sm">
+          <span>
+            This graph is too large to lay out
+            {layout.nodeCount != null && layout.edgeCount != null
+              ? ` (${layout.nodeCount.toLocaleString()} nodes, ${layout.edgeCount.toLocaleString()} connections)`
+              : ""}
+            .
+          </span>
+          <span>Use the tree or timeline view to explore this trace.</span>
+        </div>
+      )}
 
-      {layout && (
+      {layout && !layout.tooLarge && (
         <div
           ref={worldRef}
           className="absolute top-0 left-0 origin-top-left"

--- a/web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx
+++ b/web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx
@@ -38,6 +38,12 @@ type ElkGraphRendererProps = {
   activeNodeNames?: ReadonlySet<string> | null;
   /** Layer direction: DOWN (default) or RIGHT (long expanded chains). */
   layoutDirection?: GraphLayoutDirection;
+  /**
+   * Recovery action for the "too large to lay out" notice: switch to the
+   * budget-exempt expanded view, which can render the same trace. Omitted when
+   * no view switch is available (or the view is already expanded).
+   */
+  onShowExpanded?: (() => void) | null;
 };
 
 type Transform = { x: number; y: number; k: number };
@@ -85,6 +91,7 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
   currentObservationIndices = {},
   activeNodeNames = null,
   layoutDirection = "DOWN",
+  onShowExpanded = null,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const worldRef = useRef<HTMLDivElement>(null);
@@ -363,7 +370,24 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
               : ""}
             .
           </span>
-          <span>Use the tree or timeline view to explore this trace.</span>
+          <span>
+            Try the{" "}
+            {onShowExpanded ? (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation(); // don't treat as a canvas deselect
+                  onShowExpanded();
+                }}
+                className="text-primary underline underline-offset-2 hover:opacity-80"
+              >
+                expanded graph
+              </button>
+            ) : (
+              "expanded graph"
+            )}
+            , tree, or timeline view to explore this trace.
+          </span>
         </div>
       )}
 

--- a/web/src/features/trace-graph-view/components/TraceGraphView.tsx
+++ b/web/src/features/trace-graph-view/components/TraceGraphView.tsx
@@ -337,6 +337,14 @@ export const TraceGraphView: React.FC<TraceGraphViewProps> = ({
           // Expanded runs are long chains — left→right reads like a
           // timeline and fits the wide graph panel far better than top-down.
           layoutDirection={isExpanded ? "RIGHT" : "DOWN"}
+          // Only the aggregated (DOWN) layout hits the size budget; when it
+          // does, offer the budget-exempt expanded view as the in-place
+          // recovery (it renders the same trace as an acyclic DAG).
+          onShowExpanded={
+            onViewModeChange && !isExpanded
+              ? () => onViewModeChange("expanded")
+              : null
+          }
         />
       )}
       {onViewModeChange && (

--- a/web/src/features/trace-graph-view/layout/elkLayout.clienttest.ts
+++ b/web/src/features/trace-graph-view/layout/elkLayout.clienttest.ts
@@ -105,26 +105,39 @@ describe("dedupeEdges", () => {
 
 describe("computeGraphLayout layout budget", () => {
   // A dense cyclic aggregated graph freezes ELK (measured: 100 nodes/800 edges
-  // ≈ 177s on the main thread, a real trace fed 1,422 edges froze >110s). ELK
+  // ≈ 177s on the main thread, a real trace fed ~1,400 edges froze >110s). ELK
   // is synchronous, so the only safe fix is to refuse the layout up front.
-  const distinctEdges = (n: number): GraphCanvasData["edges"] => {
+
+  // `edgeCount` distinct directed edges among the first `nodeCount` node ids
+  // (no self-loops) — a dense graph, but edge endpoints stay within the nodes.
+  const denseEdges = (
+    nodeCount: number,
+    edgeCount: number,
+  ): GraphCanvasData["edges"] => {
     const edges: GraphCanvasData["edges"] = [];
-    let i = 0;
-    outer: for (let a = 0; a < n; a++) {
-      for (let b = 0; b < n; b++) {
-        if (a === b) continue;
-        edges.push({ from: `n${a}`, to: `n${b}` });
-        if (++i > n) break outer;
+    for (let a = 0; a < nodeCount && edges.length < edgeCount; a++) {
+      for (let b = 0; b < nodeCount && edges.length < edgeCount; b++) {
+        if (a !== b) edges.push({ from: `n${a}`, to: `n${b}` });
       }
     }
     return edges;
   };
 
-  it("refuses to lay out an over-budget aggregated (DOWN) graph without running ELK", async () => {
+  // A sparse acyclic chain of `edgeCount` edges over edgeCount+1 nodes — lays
+  // out in milliseconds even past the edge budget, so boundary/exempt cases
+  // stay fast.
+  const chain = (edgeCount: number): GraphCanvasData => ({
+    nodes: Array.from({ length: edgeCount + 1 }, (_, i) => node(`n${i}`)),
+    edges: Array.from({ length: edgeCount }, (_, i) => ({
+      from: `n${i}`,
+      to: `n${i + 1}`,
+    })),
+  });
+
+  it("refuses an over-budget aggregated (DOWN) graph without running ELK", async () => {
     const count = MAX_GRAPH_LAYOUT_EDGES + 10;
     const nodes = Array.from({ length: 60 }, (_, i) => node(`n${i}`));
-    const edges = distinctEdges(count).slice(0, count);
-    const graph: GraphCanvasData = { nodes, edges };
+    const graph: GraphCanvasData = { nodes, edges: denseEdges(60, count) };
 
     // If ELK actually ran on this dense graph the test would hang for minutes;
     // the budget must make it return near-instantly.
@@ -152,18 +165,52 @@ describe("computeGraphLayout layout budget", () => {
     expect(layout.nodeCount).toBe(MAX_GRAPH_LAYOUT_NODES + 1);
   });
 
-  it("still lays out an over-budget expanded (RIGHT) chain — exempt from the budget", async () => {
-    // Expanded graphs are acyclic and bounded upstream; a long thin chain of
-    // more than MAX_GRAPH_LAYOUT_EDGES edges lays out in milliseconds.
-    const n = MAX_GRAPH_LAYOUT_EDGES + 5;
-    const nodes = Array.from({ length: n + 1 }, (_, i) => node(`n${i}`));
-    const edges = Array.from({ length: n }, (_, i) => ({
+  it("lays out a DOWN graph exactly AT the edge budget (the > boundary)", async () => {
+    // The gate is strictly greater-than, so exactly MAX edges is allowed.
+    const layout = await computeGraphLayout(
+      chain(MAX_GRAPH_LAYOUT_EDGES),
+      {},
+      "DOWN",
+    );
+    expect(layout.tooLarge).toBeFalsy();
+    expect(layout.nodes.length).toBeGreaterThan(0);
+  });
+
+  it("lays out a DOWN graph exactly AT the node budget (the > boundary)", async () => {
+    const nodes = Array.from({ length: MAX_GRAPH_LAYOUT_NODES }, (_, i) =>
+      node(`n${i}`),
+    );
+    // Sparse (well under the edge budget) so ELK stays fast.
+    const edges = Array.from({ length: 20 }, (_, i) => ({
       from: `n${i}`,
       to: `n${i + 1}`,
     }));
-    const graph: GraphCanvasData = { nodes, edges };
+    const layout = await computeGraphLayout({ nodes, edges }, {}, "DOWN");
+    expect(layout.tooLarge).toBeFalsy();
+    expect(layout.nodes).toHaveLength(MAX_GRAPH_LAYOUT_NODES);
+  });
 
-    const layout = await computeGraphLayout(graph, {}, "RIGHT");
+  it("does not flag a small DOWN graph as too large", async () => {
+    const graph: GraphCanvasData = {
+      nodes: [node("a"), node("b"), node("c")],
+      edges: [
+        { from: "a", to: "b" },
+        { from: "b", to: "c" },
+      ],
+    };
+    const layout = await computeGraphLayout(graph, {}, "DOWN");
+    expect(layout.tooLarge).toBeFalsy();
+    expect(layout.nodes).toHaveLength(3);
+  });
+
+  it("still lays out an over-budget expanded (RIGHT) chain — exempt from the budget", async () => {
+    // Expanded graphs are acyclic and bounded upstream; a long thin chain of
+    // more than MAX_GRAPH_LAYOUT_EDGES edges lays out in milliseconds.
+    const layout = await computeGraphLayout(
+      chain(MAX_GRAPH_LAYOUT_EDGES + 5),
+      {},
+      "RIGHT",
+    );
     expect(layout.tooLarge).toBeFalsy();
     expect(layout.nodes.length).toBeGreaterThan(0);
   });

--- a/web/src/features/trace-graph-view/layout/elkLayout.clienttest.ts
+++ b/web/src/features/trace-graph-view/layout/elkLayout.clienttest.ts
@@ -1,5 +1,10 @@
 import { type GraphCanvasData, type GraphNodeData } from "../types";
-import { computeGraphLayout } from "./elkLayout";
+import {
+  computeGraphLayout,
+  dedupeEdges,
+  MAX_GRAPH_LAYOUT_EDGES,
+  MAX_GRAPH_LAYOUT_NODES,
+} from "./elkLayout";
 
 const node = (id: string): GraphNodeData => ({ id, label: id, type: "AGENT" });
 
@@ -72,5 +77,94 @@ describe("computeGraphLayout", () => {
       (n) => n.id === "important-node",
     )!.width;
     expect(multiWidth).toBeGreaterThan(singleWidth);
+  });
+});
+
+describe("dedupeEdges", () => {
+  it("collapses duplicate (from,to) pairs and drops self-loops", () => {
+    const result = dedupeEdges([
+      { from: "a", to: "b" },
+      { from: "a", to: "b" },
+      { from: "b", to: "a" }, // reverse is distinct
+      { from: "c", to: "c" }, // self-loop
+    ]);
+    expect(result).toEqual([
+      { from: "a", to: "b" },
+      { from: "b", to: "a" },
+    ]);
+  });
+
+  it("does not collide edges whose ids would merge when space-joined", () => {
+    const result = dedupeEdges([
+      { from: "a b", to: "c" },
+      { from: "a", to: "b c" },
+    ]);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe("computeGraphLayout layout budget", () => {
+  // A dense cyclic aggregated graph freezes ELK (measured: 100 nodes/800 edges
+  // ≈ 177s on the main thread, a real trace fed 1,422 edges froze >110s). ELK
+  // is synchronous, so the only safe fix is to refuse the layout up front.
+  const distinctEdges = (n: number): GraphCanvasData["edges"] => {
+    const edges: GraphCanvasData["edges"] = [];
+    let i = 0;
+    outer: for (let a = 0; a < n; a++) {
+      for (let b = 0; b < n; b++) {
+        if (a === b) continue;
+        edges.push({ from: `n${a}`, to: `n${b}` });
+        if (++i > n) break outer;
+      }
+    }
+    return edges;
+  };
+
+  it("refuses to lay out an over-budget aggregated (DOWN) graph without running ELK", async () => {
+    const count = MAX_GRAPH_LAYOUT_EDGES + 10;
+    const nodes = Array.from({ length: 60 }, (_, i) => node(`n${i}`));
+    const edges = distinctEdges(count).slice(0, count);
+    const graph: GraphCanvasData = { nodes, edges };
+
+    // If ELK actually ran on this dense graph the test would hang for minutes;
+    // the budget must make it return near-instantly.
+    const start = Date.now();
+    const layout = await computeGraphLayout(graph, {}, "DOWN");
+    expect(Date.now() - start).toBeLessThan(1000);
+
+    expect(layout.tooLarge).toBe(true);
+    expect(layout.nodes).toHaveLength(0);
+    expect(layout.edges).toHaveLength(0);
+    expect(layout.edgeCount).toBe(count);
+  });
+
+  it("refuses an aggregated graph with too many nodes", async () => {
+    const nodes = Array.from({ length: MAX_GRAPH_LAYOUT_NODES + 1 }, (_, i) =>
+      node(`n${i}`),
+    );
+    const graph: GraphCanvasData = {
+      nodes,
+      edges: [{ from: "n0", to: "n1" }],
+    };
+
+    const layout = await computeGraphLayout(graph, {}, "DOWN");
+    expect(layout.tooLarge).toBe(true);
+    expect(layout.nodeCount).toBe(MAX_GRAPH_LAYOUT_NODES + 1);
+  });
+
+  it("still lays out an over-budget expanded (RIGHT) chain — exempt from the budget", async () => {
+    // Expanded graphs are acyclic and bounded upstream; a long thin chain of
+    // more than MAX_GRAPH_LAYOUT_EDGES edges lays out in milliseconds.
+    const n = MAX_GRAPH_LAYOUT_EDGES + 5;
+    const nodes = Array.from({ length: n + 1 }, (_, i) => node(`n${i}`));
+    const edges = Array.from({ length: n }, (_, i) => ({
+      from: `n${i}`,
+      to: `n${i + 1}`,
+    }));
+    const graph: GraphCanvasData = { nodes, edges };
+
+    const layout = await computeGraphLayout(graph, {}, "RIGHT");
+    expect(layout.tooLarge).toBeFalsy();
+    expect(layout.nodes.length).toBeGreaterThan(0);
   });
 });

--- a/web/src/features/trace-graph-view/layout/elkLayout.ts
+++ b/web/src/features/trace-graph-view/layout/elkLayout.ts
@@ -31,6 +31,15 @@ export interface GraphLayout {
   /** Bounding size of the laid-out graph. */
   width: number;
   height: number;
+  /**
+   * Set when the graph exceeded the layout budget: ELK was NOT run (it would
+   * freeze the tab), `nodes`/`edges` are empty, and the renderer shows a
+   * "too large to lay out" notice instead. See MAX_GRAPH_LAYOUT_* below.
+   */
+  tooLarge?: boolean;
+  /** Distinct node / deduped-edge counts — surfaced in the "too large" notice. */
+  nodeCount?: number;
+  edgeCount?: number;
 }
 
 export type GraphLayoutDirection = "DOWN" | "RIGHT";
@@ -63,9 +72,62 @@ const LAYOUT_OPTIONS: Record<string, string> = {
  */
 const MAX_WRAP_NODES = 300;
 
-/** Map our {nodes, edges} into an ELK graph, deduping edges and dropping self-loops. */
+/**
+ * Layout budget for the aggregated (DOWN) graph. Aggregation collapses repeated
+ * step names into one node, which turns a large trace into a small-but-DENSE,
+ * often CYCLIC multigraph — the pathological input for ELK's layered algorithm
+ * (cycle breaking + crossing minimization + orthogonal routing all blow up
+ * super-linearly with edge density). Measured with the app's exact layout
+ * options on dense cyclic graphs: ~40 nodes/200 edges ≈ 1.4s, 50/250 ≈ 5.8s,
+ * 60/300 ≈ 10s, 80/600 ≈ 70s, 100/800 ≈ 177s — and a real reported trace fed
+ * ELK 1,422 distinct edges and froze the tab for >110s (indefinite wedge /
+ * "too much recursion" on small-stack browsers). elkjs runs synchronously on
+ * the main thread, so once started it can't be interrupted or caught — the ONLY
+ * safe fix is to not start it. Above the budget we skip layout and the renderer
+ * shows a "too large" notice.
+ *
+ * Sized to sit well below the danger zone (worst-case dense layout at the cap
+ * stays a few seconds, never minutes) while leaving large headroom over real
+ * aggregated graphs, which have far fewer distinct name-pairs. SPARSE/acyclic
+ * graphs of any size are cheap (3,840 acyclic edges lay out in ~0.6s), but the
+ * aggregated view rarely reaches this many distinct nodes/edges without also
+ * being dense — exactly the case we must protect against.
+ *
+ * The expanded (RIGHT) path is exempt: it unrolls loops into an ACYCLIC DAG and
+ * is already bounded upstream (MAX_EXPANDED_EDGES + the MAX_WRAP_NODES wrapping
+ * cap), so it lays out in ~2.5s even at its own limits.
+ */
+export const MAX_GRAPH_LAYOUT_EDGES = 250;
+export const MAX_GRAPH_LAYOUT_NODES = 500;
+
+/**
+ * Distinct, self-loop-free edges keyed by (from, to). The aggregated graph
+ * hands ELK the same name-pair edge many times over (measured: ~23k raw → ~1.4k
+ * distinct, 16×), so deduping before the layout call is the cheapest single win
+ * — and gives us the true edge count the budget is measured against.
+ *
+ * JSON key, not a space-joined one: node ids are SDK-supplied names that
+ * commonly contain spaces, so two distinct edges must not collide.
+ */
+export function dedupeEdges(
+  edges: GraphCanvasData["edges"],
+): GraphCanvasData["edges"] {
+  const seen = new Set<string>();
+  const out: GraphCanvasData["edges"] = [];
+  for (const edge of edges) {
+    if (edge.from === edge.to) continue; // self-loop
+    const key = JSON.stringify([edge.from, edge.to]);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(edge);
+  }
+  return out;
+}
+
+/** Map our {nodes, edges} into an ELK graph. Edges are pre-deduped by the caller. */
 function buildElkGraph(
   graph: GraphCanvasData,
+  dedupedEdges: GraphCanvasData["edges"],
   counterReserve: Map<string, number>,
   direction: GraphLayoutDirection,
 ): ElkNode {
@@ -100,22 +162,11 @@ function buildElkGraph(
     };
   });
 
-  const seen = new Set<string>();
-  const edges = graph.edges
-    .filter((edge) => {
-      if (edge.from === edge.to) return false; // self-loop
-      // JSON key, not a space-joined one: node ids are SDK-supplied names that
-      // commonly contain spaces, so two distinct edges must not collide.
-      const key = JSON.stringify([edge.from, edge.to]);
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    })
-    .map((edge, index) => ({
-      id: `edge-${index}`,
-      sources: [edge.from],
-      targets: [edge.to],
-    }));
+  const edges = dedupedEdges.map((edge, index) => ({
+    id: `edge-${index}`,
+    sources: [edge.from],
+    targets: [edge.to],
+  }));
 
   return {
     id: "root",
@@ -189,11 +240,42 @@ export async function computeGraphLayout(
     return { nodes: [], edges: [], width: 0, height: 0 };
   }
 
+  const dedupedEdges = dedupeEdges(graph.edges);
+
+  // Budget gate (aggregated DOWN layout only — see MAX_GRAPH_LAYOUT_* and the
+  // RIGHT-path exemption). elkjs is synchronous and uninterruptible, so a graph
+  // past the budget is refused BEFORE the layout call — the only way to avoid a
+  // multi-minute main-thread freeze / stack overflow.
+  if (
+    direction === "DOWN" &&
+    (graph.nodes.length > MAX_GRAPH_LAYOUT_NODES ||
+      dedupedEdges.length > MAX_GRAPH_LAYOUT_EDGES)
+  ) {
+    return {
+      nodes: [],
+      edges: [],
+      width: 0,
+      height: 0,
+      tooLarge: true,
+      nodeCount: graph.nodes.length,
+      edgeCount: dedupedEdges.length,
+    };
+  }
+
   const elk = await getElk();
   const counterReserve = buildCounterReserve(nodeToObservationsMap);
-  const result = await elk.layout(
-    buildElkGraph(graph, counterReserve, direction),
-  );
+  // Defensive guard around the synchronous elkjs call: a graph that slips past
+  // the budget could still throw (e.g. RangeError "too much recursion"). Rethrow
+  // so the renderer surfaces a recoverable error state instead of an unhandled
+  // rejection.
+  let result: ElkNode;
+  try {
+    result = await elk.layout(
+      buildElkGraph(graph, dedupedEdges, counterReserve, direction),
+    );
+  } catch (error) {
+    throw error instanceof Error ? error : new Error(String(error));
+  }
 
   const nodes: PositionedNode[] = (result.children ?? []).map((child) => ({
     id: child.id,


### PR DESCRIPTION
**TL;DR** — Opening a trace whose aggregated agent-graph is large and dense could freeze the browser tab for minutes (>110s measured), and hang or crash outright on Firefox. The graph now refuses to lay out above a size budget and shows a short "graph too large to lay out" notice — with a one-click link to the Expanded view — instead of wedging the tab. Small and normal graphs are unchanged.

**Why** — The aggregated graph collapses repeated step names into a single node, so a big trace becomes a small-but-very-dense, often cyclic graph (one reported trace produced ~47 nodes with ~1,400 distinct edges). That's the worst possible input for the layered graph-layout engine — cycle-breaking, crossing-minimization and orthogonal routing all scale super-linearly with edge density. The engine runs synchronously on the main thread, so once it starts on such a graph it blocks everything for minutes and can't be interrupted; on small-stack browsers it recurses until it throws. This is the graph half of the large-trace resilience epic (LFE-10152).

**What** — Refuse the layout above a node/edge budget and show a "graph too large to lay out (N nodes, M connections)" notice instead. Because the engine can't be interrupted, the only safe fix is not to start it. The notice offers the Expanded view as the in-place recovery — it renders the same trace as an acyclic DAG and is exempt from the budget. The budget is measured against the true (deduped) edge count, and the layout call is guarded so anything that slips past degrades to a recoverable error state rather than a frozen tab.

**Result** — The reported freezing trace now renders instantly with the notice in both Chrome and Firefox (verified end-to-end with a headless browser on the repro seed) and the page stays fully responsive; the "expanded graph" link switches the view in one click. A normal agentic graph renders exactly as before.

<details>
<summary>Mechanism, thresholds, and verification</summary>

**Thresholds** (`elkLayout.ts`): `MAX_GRAPH_LAYOUT_EDGES = 250`, `MAX_GRAPH_LAYOUT_NODES = 500`, applied to the aggregated (top-down) layout only. Calibrated from measured layout cost on dense cyclic graphs with the app's exact layout options:

| nodes | edges | layout time |
|---|---|---|
| 40 | 200 | 1.4s |
| 50 | 250 | 5.8s |
| 60 | 300 | 10s |
| 80 | 600 | 70s |
| 100 | 800 | 177s |

A sparse/acyclic graph of 3,840 edges lays out in ~0.6s, so density (not raw count) is the driver; the cap sits well below the danger zone while leaving large headroom over real aggregated graphs, which have far fewer distinct name-pairs.

**Expanded ("as it ran") graphs are exempt.** They unroll loops into an acyclic DAG and are already bounded upstream (edge limit + a wrapping cap), so they lay out quickly even at their own limits — which is exactly why the notice steers the user there.

**Edge dedupe** is extracted into a tested helper (self-loop drop + `(from,to)` key) so the budget is measured against exactly what the layout engine would receive. **Guard**: the layout call is wrapped so a graph that somehow slips past the budget throws into the renderer's existing error+retry state instead of an unhandled rejection.

**Verification** (headless browser, dev server, repro seed — ~47 nodes / ~1,370 dense cyclic edges):
- Chrome & Firefox: the graph shows the notice and the page stays responsive (main-thread probe returns immediately). Previously: >110s freeze / indefinite Firefox wedge.
- The "expanded graph" link switches the view (aggregated → expanded) and the notice clears.
- A normal agentic trace (30 obs) still renders its aggregated graph with edges in both browsers.

**Tests** (`elkLayout.clienttest.ts`, 12 total): dedupe helper (collapse + self-loop + space-in-id collision); over-budget aggregated graph returns the "too large" state in <1s without running the layout; node-count cap; exactly-at-budget node/edge counts still lay out (the strict greater-than boundary); a small graph is never flagged; an over-budget expanded chain still lays out (exemption). Typecheck + lint clean.

Part of the large-trace resilience epic (LFE-10152); builds on the custom graph renderer (#14659) and the aggregated/expanded mode switch (#14934).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents the browser tab from freezing when a user opens a dense, cyclic aggregated trace graph by refusing to call the synchronous ELK layout engine above configurable node/edge budgets and displaying a "too large to lay out" notice with a one-click link to the expanded view instead.

- **Budget gate in `elkLayout.ts`**: `dedupeEdges` is extracted into a tested, exported helper and called before the budget check. If `direction === \"DOWN\"` and the deduped edge count exceeds 250 or node count exceeds 500, `computeGraphLayout` returns immediately with `tooLarge: true` — the ELK call is never made, keeping the main thread unblocked.
- **`tooLarge` render branch in `ElkGraphRenderer`**: A new `onShowExpanded` prop surfaces the expanded-view switch as a clickable link inside the notice; the full graph canvas and its fit/zoom logic are suppressed when `tooLarge` is set.
- **Tests in `elkLayout.clienttest.ts`**: 9 new cases cover the deduplication helper (collision, self-loop, space-in-id), the budget refusal (timing guard, node cap, exact-boundary still lays out, small graph unaffected), and the RIGHT-direction exemption.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the budget gate is well-tested, the deduplication refactor is a clean extraction with identical behaviour, and normal-sized graphs follow the same code path as before.

The core logic is correct and backed by timing-anchored tests. The only finding is a cosmetic one: the zoom/fit toolbar remains visible alongside the too-large notice where it has no effect, which could mildly confuse users but does not affect correctness or data.

No files require special attention; ElkGraphRenderer.tsx has the minor cosmetic issue with the toolbar, and elkLayout.ts and the test file are in good shape.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[computeGraphLayout called] --> B{nodes empty?}
    B -- yes --> C[Return empty layout]
    B -- no --> D[dedupeEdges: drop self-loops and duplicate pairs]
    D --> E{direction is DOWN?}
    E -- no RIGHT --> H[getElk then buildElkGraph then elk.layout]
    E -- yes --> F{nodes above NODE_MAX or deduped edges above EDGE_MAX?}
    F -- no --> H
    F -- yes --> G[Return tooLarge layout with nodeCount and edgeCount]
    H --> I{elk.layout throws?}
    I -- yes --> J[Normalise and rethrow as Error]
    I -- no --> K[Map result into PositionedNode and PositionedEdge lists]
    K --> L[Return GraphLayout]
    G --> M[Renderer shows too-large notice]
    L --> N[Renderer draws graph canvas]
    J --> O[Renderer catch sets layoutError and shows Retry UI]
    M --> P{onShowExpanded provided?}
    P -- yes --> Q[Clickable expanded graph button]
    P -- no --> R[Plain expanded graph text]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[computeGraphLayout called] --> B{nodes empty?}
    B -- yes --> C[Return empty layout]
    B -- no --> D[dedupeEdges: drop self-loops and duplicate pairs]
    D --> E{direction is DOWN?}
    E -- no RIGHT --> H[getElk then buildElkGraph then elk.layout]
    E -- yes --> F{nodes above NODE_MAX or deduped edges above EDGE_MAX?}
    F -- no --> H
    F -- yes --> G[Return tooLarge layout with nodeCount and edgeCount]
    H --> I{elk.layout throws?}
    I -- yes --> J[Normalise and rethrow as Error]
    I -- no --> K[Map result into PositionedNode and PositionedEdge lists]
    K --> L[Return GraphLayout]
    G --> M[Renderer shows too-large notice]
    L --> N[Renderer draws graph canvas]
    J --> O[Renderer catch sets layoutError and shows Retry UI]
    M --> P{onShowExpanded provided?}
    P -- yes --> Q[Clickable expanded graph button]
    P -- no --> R[Plain expanded graph text]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx:494-525
**Zoom controls visible on the too-large notice**

The zoom/fit toolbar is rendered unconditionally, so it appears on top of the "too large to lay out" message even though there is no graph canvas to zoom or pan. A user who sees the notice may try the zoom controls expecting them to help, but they have no visible effect. Hiding them when `layout?.tooLarge` avoids the confusion without any behaviour change.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): point the &quot;too large&quot; notice..."](https://github.com/langfuse/langfuse/commit/cfa1f6872843179e571155afe868704b2dcfadd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44746198)</sub>

<!-- /greptile_comment -->