### PR TITLE
fix(api): handle legacy traces widgets on unstable dashboard-widgets API

### DIFF
--- a/fern/apis/server/definition/unstable/dashboard-widgets.yml
+++ b/fern/apis/server/definition/unstable/dashboard-widgets.yml
@@ -11,6 +11,9 @@ service:
       docs: |
         List dashboard widgets in the project, ordered by most recently
         updated first.
+
+        Responses may include legacy `traces` widgets created before this
+        API existed. New widgets cannot be created with `view: traces`.
       method: GET
       path: /dashboard-widgets
       request:
@@ -93,7 +96,10 @@ service:
                 type: HORIZONTAL_BAR
                 row_limit: 10
     get:
-      docs: Get a dashboard widget by id.
+      docs: |
+        Get a dashboard widget by id.
+
+        The response may use `view: traces` for legacy widgets.
       method: GET
       path: /dashboard-widgets/{widgetId}
       path-parameters:
@@ -115,6 +121,9 @@ service:
         Changing `chartType` without sending `chartConfig` resets the config
         to the new chart type's defaults. When `chartConfig.type` is given
         it must match the widget's (possibly updated) `chartType`.
+
+        `view` cannot be changed to the legacy `traces` value. Existing
+        `traces` widgets may be updated on other fields.
       method: PATCH
       path: /dashboard-widgets/{widgetId}
       path-parameters:
@@ -158,6 +167,18 @@ types:
         value: scores-numeric
       - name: ScoresCategorical
         value: scores-categorical
+
+  DashboardWidgetViewWithLegacy:
+    docs: |
+      Widget data view. Responses may include the legacy `traces` value for
+      widgets created before this API existed.
+    enum:
+      - observations
+      - name: ScoresNumeric
+        value: scores-numeric
+      - name: ScoresCategorical
+        value: scores-categorical
+      - traces
 
   DashboardWidgetChartType:
     enum:
@@ -341,7 +362,7 @@ types:
       description:
         type: string
       view:
-        type: DashboardWidgetView
+        type: DashboardWidgetViewWithLegacy
       dimensions:
         type: list<DashboardWidgetDimension>
       metrics:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -6538,6 +6538,9 @@ paths:
       description: |-
         List dashboard widgets in the project, ordered by most recently
         updated first.
+
+        Responses may include legacy `traces` widgets created before this
+        API existed. New widgets cannot be created with `view: traces`.
       operationId: unstable_dashboardWidgets_list
       tags:
         - UnstableDashboardWidgets
@@ -6689,7 +6692,10 @@ paths:
               $ref: '#/components/schemas/unstableCreateDashboardWidgetRequest'
   /api/public/unstable/dashboard-widgets/{widgetId}:
     get:
-      description: Get a dashboard widget by id.
+      description: |-
+        Get a dashboard widget by id.
+
+        The response may use `view: traces` for legacy widgets.
       operationId: unstable_dashboardWidgets_get
       tags:
         - UnstableDashboardWidgets
@@ -6752,6 +6758,9 @@ paths:
         Changing `chartType` without sending `chartConfig` resets the config
         to the new chart type's defaults. When `chartConfig.type` is given
         it must match the widget's (possibly updated) `chartType`.
+
+        `view` cannot be changed to the legacy `traces` value. Existing
+        `traces` widgets may be updated on other fields.
       operationId: unstable_dashboardWidgets_update
       tags:
         - UnstableDashboardWidgets
@@ -14811,6 +14820,17 @@ components:
         - observations
         - scores-numeric
         - scores-categorical
+    unstableDashboardWidgetViewWithLegacy:
+      title: unstableDashboardWidgetViewWithLegacy
+      type: string
+      enum:
+        - observations
+        - scores-numeric
+        - scores-categorical
+        - traces
+      description: |-
+        Widget data view. Responses may include the legacy `traces` value for
+        widgets created before this API existed.
     unstableDashboardWidgetChartType:
       title: unstableDashboardWidgetChartType
       type: string
@@ -15088,7 +15108,7 @@ components:
         description:
           type: string
         view:
-          $ref: '#/components/schemas/unstableDashboardWidgetView'
+          $ref: '#/components/schemas/unstableDashboardWidgetViewWithLegacy'
         dimensions:
           type: array
           items:

--- a/web/src/__tests__/server/unstable-dashboard-widgets-api.servertest.ts
+++ b/web/src/__tests__/server/unstable-dashboard-widgets-api.servertest.ts
@@ -165,6 +165,40 @@ describe("/api/public/unstable/dashboard-widgets API", () => {
     );
   });
 
+  it("preserves minVersion on patches that do not change the view", async () => {
+    const { auth, projectId } = await createOrgProjectAndApiKey();
+    const v1Widget = await DashboardService.createWidget(projectId, {
+      ...legacyTracesWidgetInput,
+      name: "Legacy v1 observations widget",
+      view: DashboardWidgetViews.OBSERVATIONS,
+    });
+
+    await makeZodVerifiedAPICall(
+      PatchUnstableDashboardWidgetResponse,
+      "PATCH",
+      `/api/public/unstable/dashboard-widgets/${v1Widget.id}`,
+      { name: "Renamed v1 observations widget" },
+      auth,
+    );
+    const afterRename = await prisma.dashboardWidget.findUniqueOrThrow({
+      where: { id: v1Widget.id, projectId },
+    });
+    expect(afterRename.minVersion).toBe(1);
+
+    const patchViewResponse = await makeZodVerifiedAPICall(
+      PatchUnstableDashboardWidgetResponse,
+      "PATCH",
+      `/api/public/unstable/dashboard-widgets/${v1Widget.id}`,
+      { view: "scores-numeric" },
+      auth,
+    );
+    expect(patchViewResponse.body.view).toBe("scores-numeric");
+    const afterViewChange = await prisma.dashboardWidget.findUniqueOrThrow({
+      where: { id: v1Widget.id, projectId },
+    });
+    expect(afterViewChange.minVersion).toBe(2);
+  });
+
   it("rejects patching a widget into the legacy traces view", async () => {
     const { auth } = await createOrgProjectAndApiKey();
 

--- a/web/src/__tests__/server/unstable-dashboard-widgets-api.servertest.ts
+++ b/web/src/__tests__/server/unstable-dashboard-widgets-api.servertest.ts
@@ -2,10 +2,19 @@ import {
   makeAPICall,
   makeZodVerifiedAPICall,
 } from "@/src/__tests__/test-utils";
-import { PostUnstableDashboardWidgetResponse } from "@/src/features/public-api/types/unstable-dashboard-widgets";
+import {
+  DeleteUnstableDashboardWidgetResponse,
+  GetUnstableDashboardWidgetsResponse,
+  PatchUnstableDashboardWidgetResponse,
+  PostUnstableDashboardWidgetResponse,
+} from "@/src/features/public-api/types/unstable-dashboard-widgets";
 import { UnstablePublicApiErrorResponse } from "@/src/features/public-api/types/unstable-public-evals-contract";
+import { DashboardWidgetViews } from "@langfuse/shared/src/db";
 import { prisma } from "@langfuse/shared/src/db";
-import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import {
+  createOrgProjectAndApiKey,
+  DashboardService,
+} from "@langfuse/shared/src/server";
 import type { z } from "zod";
 
 const baseWidgetBody = {
@@ -16,6 +25,18 @@ const baseWidgetBody = {
   metrics: [{ measure: "count", agg: "count" as const }],
   filters: [],
   chartType: "NUMBER" as const,
+};
+
+const legacyTracesWidgetInput = {
+  name: "Legacy traces widget",
+  description: "Seeded outside the unstable API",
+  view: DashboardWidgetViews.TRACES,
+  dimensions: [{ field: "name" }],
+  metrics: [{ measure: "count", agg: "count" as const }],
+  filters: [],
+  chartType: "NUMBER" as const,
+  chartConfig: { type: "NUMBER" as const },
+  minVersion: 1,
 };
 
 const expectUnstableError = (
@@ -90,6 +111,75 @@ describe("/api/public/unstable/dashboard-widgets API", () => {
         ...baseWidgetBody,
         view: "traces",
       },
+      auth,
+    );
+
+    expectUnstableError(response, {
+      status: 400,
+      code: "invalid_body",
+    });
+  });
+
+  it("lists, updates, and deletes legacy traces widgets", async () => {
+    const { auth, projectId } = await createOrgProjectAndApiKey();
+    const legacyWidget = await DashboardService.createWidget(
+      projectId,
+      legacyTracesWidgetInput,
+    );
+
+    const listResponse = await makeZodVerifiedAPICall(
+      GetUnstableDashboardWidgetsResponse,
+      "GET",
+      "/api/public/unstable/dashboard-widgets",
+      undefined,
+      auth,
+    );
+    expect(listResponse.body.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: legacyWidget.id,
+          view: "traces",
+        }),
+      ]),
+    );
+
+    const patchResponse = await makeZodVerifiedAPICall(
+      PatchUnstableDashboardWidgetResponse,
+      "PATCH",
+      `/api/public/unstable/dashboard-widgets/${legacyWidget.id}`,
+      { name: "Renamed legacy traces widget" },
+      auth,
+    );
+    expect(patchResponse.body).toMatchObject({
+      id: legacyWidget.id,
+      name: "Renamed legacy traces widget",
+      view: "traces",
+    });
+
+    await makeZodVerifiedAPICall(
+      DeleteUnstableDashboardWidgetResponse,
+      "DELETE",
+      `/api/public/unstable/dashboard-widgets/${legacyWidget.id}`,
+      undefined,
+      auth,
+    );
+  });
+
+  it("rejects patching a widget into the legacy traces view", async () => {
+    const { auth } = await createOrgProjectAndApiKey();
+
+    const createResponse = await makeZodVerifiedAPICall(
+      PostUnstableDashboardWidgetResponse,
+      "POST",
+      "/api/public/unstable/dashboard-widgets",
+      baseWidgetBody,
+      auth,
+    );
+
+    const response = await makeAPICall(
+      "PATCH",
+      `/api/public/unstable/dashboard-widgets/${createResponse.body.id}`,
+      { view: "traces" },
       auth,
     );
 

--- a/web/src/features/public-api/types/unstable-dashboard-widgets.ts
+++ b/web/src/features/public-api/types/unstable-dashboard-widgets.ts
@@ -14,6 +14,13 @@ export const PostUnstableDashboardWidgetView = z.enum([
   "scores-categorical",
 ]);
 
+export const DashboardWidgetViewOutput = z.enum([
+  "observations",
+  "scores-numeric",
+  "scores-categorical",
+  "traces",
+]);
+
 const DashboardWidgetMetricSchema = MetricSchema.extend({
   measure: z.string().min(1),
   agg: metricAggregations,
@@ -55,7 +62,7 @@ export const PublicDashboardWidget = z
     updatedAt: z.coerce.date(),
     name: z.string(),
     description: z.string(),
-    view: PostUnstableDashboardWidgetView,
+    view: DashboardWidgetViewOutput,
     dimensions: z.array(DashboardWidgetDimensionSchema),
     metrics: z.array(DashboardWidgetMetricSchema),
     filters: z.array(singleFilter),
@@ -93,4 +100,7 @@ export const DeleteUnstableDashboardWidgetResponse = z.object({
 
 export type PostUnstableDashboardWidgetBodyType = z.infer<
   typeof PostUnstableDashboardWidgetBody
+>;
+export type DashboardWidgetViewOutputType = z.infer<
+  typeof DashboardWidgetViewOutput
 >;

--- a/web/src/features/widgets/server/public-dashboard-widget-service.ts
+++ b/web/src/features/widgets/server/public-dashboard-widget-service.ts
@@ -341,8 +341,10 @@ export async function updatePublicDashboardWidget(params: {
   const chartTypeChanged =
     params.input.chartType !== undefined &&
     params.input.chartType !== currentPublic.chartType;
+  // Keep the stored minVersion (and thus v1/v2 query semantics) unless the
+  // caller explicitly changes the view; view changes land on v2 like create.
   const mergedView = params.input.view ?? currentPublic.view;
-  const minVersion = mergedView === "traces" ? current.minVersion : 2;
+  const minVersion = mergedView === currentPublic.view ? current.minVersion : 2;
   const input = normalizePublicDashboardWidgetInput(
     {
       ...currentPublic,

--- a/web/src/features/widgets/server/public-dashboard-widget-service.ts
+++ b/web/src/features/widgets/server/public-dashboard-widget-service.ts
@@ -18,6 +18,7 @@ import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { createUnstablePublicApiError } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 import {
   PostUnstableDashboardWidgetResponse,
+  type DashboardWidgetViewOutputType,
   type PostUnstableDashboardWidgetBodyType,
 } from "@/src/features/public-api/types/unstable-dashboard-widgets";
 import { ChartConfigSchema, LangfuseNotFoundError } from "@langfuse/shared";
@@ -37,14 +38,13 @@ type NormalizedWidgetInput = Omit<
   "id" | "createdAt" | "updatedAt"
 > & { minVersion: number };
 
-const viewMapping: Record<
-  PostUnstableDashboardWidgetBodyType["view"],
-  DashboardWidgetViews
-> = {
-  observations: DashboardWidgetViews.OBSERVATIONS,
-  "scores-numeric": DashboardWidgetViews.SCORES_NUMERIC,
-  "scores-categorical": DashboardWidgetViews.SCORES_CATEGORICAL,
-};
+const viewMapping: Record<DashboardWidgetViewOutputType, DashboardWidgetViews> =
+  {
+    observations: DashboardWidgetViews.OBSERVATIONS,
+    "scores-numeric": DashboardWidgetViews.SCORES_NUMERIC,
+    "scores-categorical": DashboardWidgetViews.SCORES_CATEGORICAL,
+    traces: DashboardWidgetViews.TRACES,
+  };
 
 const reverseViewMapping: Record<
   DashboardWidgetViews,
@@ -94,8 +94,13 @@ function getPublicDashboardWidgetViewDeclaration(
   }
 }
 
+type PublicDashboardWidgetInput = Omit<
+  PostUnstableDashboardWidgetBodyType,
+  "view"
+> & { view: DashboardWidgetViewOutputType };
+
 export function normalizePublicDashboardWidgetInput(
-  input: PostUnstableDashboardWidgetBodyType,
+  input: PublicDashboardWidgetInput,
   minVersion = 2,
 ): NormalizedWidgetInput {
   const { mappedFilters, unsupportedFilters } =
@@ -336,6 +341,8 @@ export async function updatePublicDashboardWidget(params: {
   const chartTypeChanged =
     params.input.chartType !== undefined &&
     params.input.chartType !== currentPublic.chartType;
+  const mergedView = params.input.view ?? currentPublic.view;
+  const minVersion = mergedView === "traces" ? current.minVersion : 2;
   const input = normalizePublicDashboardWidgetInput(
     {
       ...currentPublic,
@@ -349,7 +356,7 @@ export async function updatePublicDashboardWidget(params: {
           ? { type: params.input.chartType }
           : currentPublic.chartConfig),
     },
-    current.minVersion,
+    minVersion,
   );
   validatePublicDashboardWidgetInput(input);
   const updated = await DashboardService.updateWidget(


### PR DESCRIPTION
## Summary
- Fix unstable `dashboard-widgets` list/get returning 400 when a project has legacy `TRACES` widgets by widening the response view enum to include `traces`.
- Keep create and patch-into-`traces` rejected at the request schema; existing legacy widgets can be updated on other fields and deleted.
- Preserve v1 semantics for legacy widgets on update (`minVersion` stays on the current value when view remains `traces`).

## Test plan
- [x] Local smoke test: `GET /api/public/unstable/dashboard-widgets` returns seeded `cabc` with `view: traces` (200)
- [x] Local smoke test: `GET /api/public/unstable/dashboard-widgets/cabc` returns legacy widget (200)
- [x] Local smoke test: `PATCH` rename on legacy widget keeps `view: traces` (200)
- [x] Local smoke test: `POST` with `view: traces` still rejected (400 `invalid_body`)
- [x] `pnpm --filter web run test unstable-dashboard-widgets-api` (requires dev server + aligned test DB)
- [x] `pnpm run lint` (via pre-commit hook)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `GET /api/public/unstable/dashboard-widgets` (list and get-by-id) returned 400 for projects that contain legacy `TRACES` widgets, because the response Zod schema rejected `"traces"` as a valid `view` enum value. The fix widens the response-only enum (`DashboardWidgetViewOutput`) to include `"traces"` while keeping it absent from the request enums.

- **Response schema widened**: `PublicDashboardWidget.view` now uses `DashboardWidgetViewOutput` (includes `"traces"`) while all request bodies continue to use the narrower `PostUnstableDashboardWidgetView`.
- **`minVersion` preservation**: `updatePublicDashboardWidget` detects a `"traces"` merged view and keeps `current.minVersion` instead of bumping to 2, maintaining v1 query semantics for legacy widgets.
- **Tests added**: Two server tests cover the full legacy lifecycle (list → patch rename → delete) and the patch-into-traces rejection path.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core fix is narrow and well-tested, with the one area worth watching being whether production legacy traces widgets carry dimension/metric configurations that go beyond what the test seeds.

The schema split (response includes traces, request enums do not) is implemented consistently across Zod types, service layer, view mapping, and OpenAPI spec. The minVersion preservation avoids accidentally upgrading legacy widgets to v2 semantics on a rename. A speculative gap exists: validatePublicDashboardWidgetInput is called unconditionally during PATCH, so a legacy widget whose stored dimensions or metrics aren't recognised by the current v1 traces view declaration would still fail with 400 on any update — though the smoke tests show the common case works.

The updatePublicDashboardWidget function in public-dashboard-widget-service.ts is the right place to verify: if production legacy widget configurations are wider than what the test seeds, dimension/metric validation for unchanged fields on traces widgets may need a defensive skip.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant RouteHandler
    participant updatePublicDashboardWidget
    participant normalizeInput
    participant validateInput
    participant DashboardService

    Client->>RouteHandler: "PATCH /dashboard-widgets/:id {name: "foo"}"
    RouteHandler->>RouteHandler: Parse body via PatchUnstableDashboardWidgetBody
    Note over RouteHandler: view:"traces" rejected here with 400
    RouteHandler->>updatePublicDashboardWidget: "input = {name:"foo"}"
    updatePublicDashboardWidget->>DashboardService: getWidget(widgetId)
    DashboardService-->>updatePublicDashboardWidget: "current (view=TRACES, minVersion=1)"
    updatePublicDashboardWidget->>updatePublicDashboardWidget: "mergedView="traces", minVersion=current.minVersion"
    updatePublicDashboardWidget->>normalizeInput: "merged input, minVersion=1"
    normalizeInput-->>updatePublicDashboardWidget: NormalizedWidgetInput
    updatePublicDashboardWidget->>validateInput: widget (view:"traces", viewVersion:"v1")
    validateInput->>validateInput: getViewDeclaration("traces","v1")
    Note over validateInput: re-validates existing dimensions/metrics
    validateInput-->>updatePublicDashboardWidget: ok
    updatePublicDashboardWidget->>DashboardService: updateWidget
    DashboardService-->>updatePublicDashboardWidget: updated
    updatePublicDashboardWidget-->>RouteHandler: "{view:"traces"}"
    RouteHandler-->>Client: "200 {view:"traces"}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant RouteHandler
    participant updatePublicDashboardWidget
    participant normalizeInput
    participant validateInput
    participant DashboardService

    Client->>RouteHandler: "PATCH /dashboard-widgets/:id {name: "foo"}"
    RouteHandler->>RouteHandler: Parse body via PatchUnstableDashboardWidgetBody
    Note over RouteHandler: view:"traces" rejected here with 400
    RouteHandler->>updatePublicDashboardWidget: "input = {name:"foo"}"
    updatePublicDashboardWidget->>DashboardService: getWidget(widgetId)
    DashboardService-->>updatePublicDashboardWidget: "current (view=TRACES, minVersion=1)"
    updatePublicDashboardWidget->>updatePublicDashboardWidget: "mergedView="traces", minVersion=current.minVersion"
    updatePublicDashboardWidget->>normalizeInput: "merged input, minVersion=1"
    normalizeInput-->>updatePublicDashboardWidget: NormalizedWidgetInput
    updatePublicDashboardWidget->>validateInput: widget (view:"traces", viewVersion:"v1")
    validateInput->>validateInput: getViewDeclaration("traces","v1")
    Note over validateInput: re-validates existing dimensions/metrics
    validateInput-->>updatePublicDashboardWidget: ok
    updatePublicDashboardWidget->>DashboardService: updateWidget
    DashboardService-->>updatePublicDashboardWidget: updated
    updatePublicDashboardWidget-->>RouteHandler: "{view:"traces"}"
    RouteHandler-->>Client: "200 {view:"traces"}"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/__tests__/server/unstable-dashboard-widgets-api.servertest.ts:12-13
Duplicate import from the same module path — `DashboardWidgetViews` and `prisma` are both imported from `@langfuse/shared/src/db` in separate statements. These should be merged into one import to follow the codebase's import conventions.

```suggestion
import { DashboardWidgetViews, prisma } from "@langfuse/shared/src/db";
```

### Issue 2 of 2
web/src/features/widgets/server/public-dashboard-widget-service.ts:361
**Legacy traces patches always re-validate existing dimensions/metrics**

`validatePublicDashboardWidgetInput` is called unconditionally after merging the patch input, meaning a rename-only PATCH on a legacy `traces` widget re-validates its stored dimensions and metrics against the current v1 view declaration. If any production legacy widget stores a dimension or metric that `getViewDeclaration("traces", "v1")` does not recognise, the rename fails with a 400 even though the failing fields weren't touched by the request. The smoke test uses the minimal `{ field: "name" }` / `count/count` configuration, which may not cover the full range of real legacy data.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): handle legacy traces widgets o..."](https://github.com/langfuse/langfuse/commit/c6f2ae72f27276b58f72fdb1d0db877a6ad9fc87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44752656)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->