### PR TITLE
fix(trace): size-gate the unvirtualized JSON IO view (LFE-10989)

### DIFF
--- a/web/src/components/trace/components/IOPreview/IOPreviewJSONSimple.clienttest.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewJSONSimple.clienttest.tsx
@@ -1,0 +1,145 @@
+/**
+ * The JSON view must never hand a multi-MB field to the unvirtualized
+ * react18-json-view (LFE-10989). These tests pin the branch selection in
+ * IOPreviewJSONSimple: over-limit fields render the bounded fallback and skip
+ * PrettyJsonView entirely, while normal fields render exactly as before.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+
+// PrettyJsonView is the unvirtualized render path we must NOT reach for
+// over-limit fields — mock it so its presence is observable by test id.
+vi.mock("@/src/components/ui/PrettyJsonView", () => ({
+  PrettyJsonView: (props: { title?: string }) => (
+    <div data-testid="pretty-json-view">{props.title}</div>
+  ),
+}));
+
+vi.mock("./components/CorrectedOutputField", () => ({
+  CorrectedOutputField: () => <div data-testid="corrected-output" />,
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+// deepParseJson is the only runtime import from the shared barrel here; stub it
+// so the test stays light and deterministic (identity is fine for these cases).
+vi.mock("@langfuse/shared", () => ({
+  deepParseJson: (value: unknown) => value,
+}));
+
+import { IOPreviewJSONSimple } from "./IOPreviewJSONSimple";
+import { JSON_VIEW_RENDER_CHAR_LIMIT } from "./lib/jsonViewSizeGate";
+
+const FALLBACK_TEXT = /too large to render in JSON view/i;
+
+describe("IOPreviewJSONSimple size gating", () => {
+  it("renders the fallback and NOT PrettyJsonView for an over-limit field", () => {
+    const huge = "x".repeat(JSON_VIEW_RENDER_CHAR_LIMIT + 1);
+    render(
+      <IOPreviewJSONSimple
+        input={huge}
+        hideOutput
+        hideIfNull
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    // Fallback shown for the input field...
+    expect(screen.getByText(FALLBACK_TEXT)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Download Input/i }),
+    ).toBeInTheDocument();
+    // ...and the unvirtualized viewer was never mounted.
+    expect(screen.queryByTestId("pretty-json-view")).not.toBeInTheDocument();
+  });
+
+  it("downloads a string field as raw text (.txt), not JSON-wrapped", () => {
+    // The huge-IO seed is a base64 string; JSON.stringify-ing it would add
+    // quotes + escapes and over-encode the download. The fallback must write
+    // the raw text.
+    const rawString = "eyJhIjoxfQ==" + "A".repeat(JSON_VIEW_RENDER_CHAR_LIMIT);
+    const blobCalls: { part: string; type: string }[] = [];
+    let downloadName = "";
+
+    // Capture the exact content handed to the Blob (jsdom's Blob has no
+    // readable .text() in this env, so intercept at construction).
+    class MockBlob {
+      type: string;
+      constructor(parts: BlobPart[], opts?: BlobPropertyBag) {
+        this.type = opts?.type ?? "";
+        blobCalls.push({ part: String(parts[0]), type: this.type });
+      }
+    }
+    vi.stubGlobal("Blob", MockBlob);
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL: vi.fn(() => "blob:mock"),
+      revokeObjectURL: vi.fn(),
+    });
+    // Capture the download filename and neutralize navigation.
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      downloadName = this.download;
+    });
+
+    render(
+      <IOPreviewJSONSimple
+        input={rawString}
+        hideOutput
+        hideIfNull
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Download Input/i }));
+
+    expect(blobCalls).toHaveLength(1);
+    expect(blobCalls[0].part).toBe(rawString); // raw, no surrounding quotes
+    expect(blobCalls[0].part.startsWith('"')).toBe(false);
+    expect(blobCalls[0].type).toContain("text/plain");
+    expect(downloadName).toBe("input-t.txt");
+
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("hides a null field with hideIfNull and shows no fallback", () => {
+    render(
+      <IOPreviewJSONSimple
+        input={null}
+        hideOutput
+        hideIfNull
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("pretty-json-view")).not.toBeInTheDocument();
+  });
+
+  it("renders PrettyJsonView (not the fallback) for normal small I/O", () => {
+    render(
+      <IOPreviewJSONSimple
+        input={{ messages: [{ role: "user", content: "hi" }] }}
+        hideOutput
+        hideIfNull
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    const viewers = screen.getAllByTestId("pretty-json-view");
+    expect(viewers).toHaveLength(1);
+    expect(viewers[0]).toHaveTextContent("Input");
+    expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/trace/components/IOPreview/IOPreviewJSONSimple.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewJSONSimple.tsx
@@ -3,6 +3,11 @@ import { type Prisma, type ScoreDomain, deepParseJson } from "@langfuse/shared";
 import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
 import { type MediaReturnType } from "@/src/features/media/validation";
 import { CorrectedOutputField } from "./components/CorrectedOutputField";
+import { LargeJsonFieldFallback } from "./components/LargeJsonFieldFallback";
+import {
+  JSON_VIEW_RENDER_CHAR_LIMIT,
+  getJsonStringSize,
+} from "./lib/jsonViewSizeGate";
 
 export interface IOPreviewJSONSimpleProps {
   input?: Prisma.JsonValue;
@@ -74,64 +79,109 @@ export function IOPreviewJSONSimple({
   environment = "default",
   showCorrections = true,
 }: IOPreviewJSONSimpleProps) {
+  // Size-gate each field: the JSON view renders through react18-json-view,
+  // which is not virtualized, so multi-MB payloads freeze and crash the tab
+  // (LFE-10989). Measure the raw prop — it drives both the main-thread parse
+  // below and the tree the viewer would build — and above the limit render a
+  // bounded preview + download instead. Sizes are memoized so we serialize a
+  // large object at most once per field, not on every render.
+  const inputSize = useMemo(() => getJsonStringSize(input), [input]);
+  const outputSize = useMemo(() => getJsonStringSize(output), [output]);
+  const metadataSize = useMemo(() => getJsonStringSize(metadata), [metadata]);
+
+  const inputTooLarge = inputSize > JSON_VIEW_RENDER_CHAR_LIMIT;
+  const outputTooLarge = outputSize > JSON_VIEW_RENDER_CHAR_LIMIT;
+  const metadataTooLarge = metadataSize > JSON_VIEW_RENDER_CHAR_LIMIT;
+
   // Parse data if not pre-parsed
   // IMPORTANT: Don't parse while isParsing=true to avoid double-parsing with different object references
+  // Skip parsing entirely for over-limit fields: parsing a ~20 MB string in
+  // deepParseJson (parsePreservingPrecision) blocks the main thread for seconds.
   const effectiveInput = useMemo(() => {
     if (isParsing) return undefined; // Wait for Web Worker to finish
+    if (inputTooLarge) return undefined;
     return parsedInput ?? deepParseJson(input);
-  }, [parsedInput, input, isParsing]);
+  }, [parsedInput, input, isParsing, inputTooLarge]);
 
   const effectiveOutput = useMemo(() => {
     if (isParsing) return undefined;
+    if (outputTooLarge) return undefined;
     return parsedOutput ?? deepParseJson(output);
-  }, [parsedOutput, output, isParsing]);
+  }, [parsedOutput, output, isParsing, outputTooLarge]);
 
   const effectiveMetadata = useMemo(() => {
     if (isParsing) return undefined;
+    if (metadataTooLarge) return undefined;
     return parsedMetadata ?? deepParseJson(metadata);
-  }, [parsedMetadata, metadata, isParsing]);
+  }, [parsedMetadata, metadata, isParsing, metadataTooLarge]);
 
-  const showInput = !hideInput && !(hideIfNull && !effectiveInput);
-  const showOutput = !hideOutput && !(hideIfNull && !effectiveOutput);
-  const showMetadata = !(hideIfNull && !effectiveMetadata);
+  // An over-limit field parses to `undefined` above, but it is not empty — it
+  // is too big. Treat it as present so `hideIfNull` callers still show the
+  // fallback instead of silently dropping the field.
+  const showInput =
+    !hideInput && (inputTooLarge || !(hideIfNull && !effectiveInput));
+  const showOutput =
+    !hideOutput && (outputTooLarge || !(hideIfNull && !effectiveOutput));
+  const showMetadata = metadataTooLarge || !(hideIfNull && !effectiveMetadata);
+
+  const downloadName = observationId ?? traceId;
 
   return (
     <div className="[&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
-      {showInput && (
-        <PrettyJsonView
-          title="Input"
-          json={input}
-          parsedJson={effectiveInput}
-          isLoading={isLoading}
-          isParsing={isParsing}
-          media={media?.filter((m) => m.field === "input") ?? []}
-          currentView="json"
-          externalExpansionState={inputExpanded}
-          // Cast: PrettyJsonView accepts union type, but JSON view only uses boolean
-          onExternalExpansionChange={
-            onInputExpandedChange as (
-              expansion: boolean | Record<string, boolean>,
-            ) => void
-          }
-        />
-      )}
-      {showOutput && (
-        <PrettyJsonView
-          title="Output"
-          json={output}
-          parsedJson={effectiveOutput}
-          isLoading={isLoading}
-          isParsing={isParsing}
-          media={media?.filter((m) => m.field === "output") ?? []}
-          currentView="json"
-          externalExpansionState={outputExpanded}
-          onExternalExpansionChange={
-            onOutputExpandedChange as (
-              expansion: boolean | Record<string, boolean>,
-            ) => void
-          }
-        />
-      )}
+      {showInput &&
+        (inputTooLarge ? (
+          <LargeJsonFieldFallback
+            title="Input"
+            value={input}
+            charCount={inputSize}
+            downloadFileBase={`input-${downloadName}`}
+          />
+        ) : (
+          <PrettyJsonView
+            title="Input"
+            json={input}
+            parsedJson={effectiveInput}
+            isLoading={isLoading}
+            isParsing={isParsing}
+            media={media?.filter((m) => m.field === "input") ?? []}
+            currentView="json"
+            externalExpansionState={inputExpanded}
+            // Cast: PrettyJsonView accepts union type, but JSON view only uses boolean
+            onExternalExpansionChange={
+              onInputExpandedChange as (
+                expansion: boolean | Record<string, boolean>,
+              ) => void
+            }
+          />
+        ))}
+      {showOutput &&
+        (outputTooLarge ? (
+          <LargeJsonFieldFallback
+            title="Output"
+            value={output}
+            charCount={outputSize}
+            downloadFileBase={`output-${downloadName}`}
+          />
+        ) : (
+          <PrettyJsonView
+            title="Output"
+            json={output}
+            parsedJson={effectiveOutput}
+            isLoading={isLoading}
+            isParsing={isParsing}
+            media={media?.filter((m) => m.field === "output") ?? []}
+            currentView="json"
+            externalExpansionState={outputExpanded}
+            onExternalExpansionChange={
+              onOutputExpandedChange as (
+                expansion: boolean | Record<string, boolean>,
+              ) => void
+            }
+          />
+        ))}
+      {/* When the output is over-limit, effectiveOutput is undefined, so the
+          correction editor opens without a baseline actual-output to diff
+          against — an acceptable degradation for payloads too large to render. */}
       {showCorrections && (
         <CorrectedOutputField
           actualOutput={effectiveOutput}
@@ -142,23 +192,31 @@ export function IOPreviewJSONSimple({
           environment={environment}
         />
       )}
-      {showMetadata && (
-        <PrettyJsonView
-          title="Metadata"
-          json={metadata}
-          parsedJson={effectiveMetadata}
-          isLoading={isLoading}
-          isParsing={isParsing}
-          media={media?.filter((m) => m.field === "metadata") ?? []}
-          currentView="json"
-          externalExpansionState={metadataExpanded}
-          onExternalExpansionChange={
-            onMetadataExpandedChange as (
-              expansion: boolean | Record<string, boolean>,
-            ) => void
-          }
-        />
-      )}
+      {showMetadata &&
+        (metadataTooLarge ? (
+          <LargeJsonFieldFallback
+            title="Metadata"
+            value={metadata}
+            charCount={metadataSize}
+            downloadFileBase={`metadata-${downloadName}`}
+          />
+        ) : (
+          <PrettyJsonView
+            title="Metadata"
+            json={metadata}
+            parsedJson={effectiveMetadata}
+            isLoading={isLoading}
+            isParsing={isParsing}
+            media={media?.filter((m) => m.field === "metadata") ?? []}
+            currentView="json"
+            externalExpansionState={metadataExpanded}
+            onExternalExpansionChange={
+              onMetadataExpandedChange as (
+                expansion: boolean | Record<string, boolean>,
+              ) => void
+            }
+          />
+        ))}
     </div>
   );
 }

--- a/web/src/components/trace/components/IOPreview/IOPreviewJSONSimple.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewJSONSimple.tsx
@@ -6,7 +6,7 @@ import { CorrectedOutputField } from "./components/CorrectedOutputField";
 import { LargeJsonFieldFallback } from "./components/LargeJsonFieldFallback";
 import {
   JSON_VIEW_RENDER_CHAR_LIMIT,
-  getJsonStringSize,
+  probeJsonField,
 } from "./lib/jsonViewSizeGate";
 
 export interface IOPreviewJSONSimpleProps {
@@ -81,17 +81,18 @@ export function IOPreviewJSONSimple({
 }: IOPreviewJSONSimpleProps) {
   // Size-gate each field: the JSON view renders through react18-json-view,
   // which is not virtualized, so multi-MB payloads freeze and crash the tab
-  // (LFE-10989). Measure the raw prop — it drives both the main-thread parse
+  // (LFE-10989). Probe the raw prop — it drives both the main-thread parse
   // below and the tree the viewer would build — and above the limit render a
-  // bounded preview + download instead. Sizes are memoized so we serialize a
-  // large object at most once per field, not on every render.
-  const inputSize = useMemo(() => getJsonStringSize(input), [input]);
-  const outputSize = useMemo(() => getJsonStringSize(output), [output]);
-  const metadataSize = useMemo(() => getJsonStringSize(metadata), [metadata]);
+  // bounded preview + download instead. The probe serializes an object field
+  // exactly once (memoized) and the resulting string is reused for the size
+  // check, the preview, and the download, so we never re-serialize the payload.
+  const inputProbe = useMemo(() => probeJsonField(input), [input]);
+  const outputProbe = useMemo(() => probeJsonField(output), [output]);
+  const metadataProbe = useMemo(() => probeJsonField(metadata), [metadata]);
 
-  const inputTooLarge = inputSize > JSON_VIEW_RENDER_CHAR_LIMIT;
-  const outputTooLarge = outputSize > JSON_VIEW_RENDER_CHAR_LIMIT;
-  const metadataTooLarge = metadataSize > JSON_VIEW_RENDER_CHAR_LIMIT;
+  const inputTooLarge = inputProbe.size > JSON_VIEW_RENDER_CHAR_LIMIT;
+  const outputTooLarge = outputProbe.size > JSON_VIEW_RENDER_CHAR_LIMIT;
+  const metadataTooLarge = metadataProbe.size > JSON_VIEW_RENDER_CHAR_LIMIT;
 
   // Parse data if not pre-parsed
   // IMPORTANT: Don't parse while isParsing=true to avoid double-parsing with different object references
@@ -132,8 +133,9 @@ export function IOPreviewJSONSimple({
         (inputTooLarge ? (
           <LargeJsonFieldFallback
             title="Input"
-            value={input}
-            charCount={inputSize}
+            serialized={inputProbe.serialized}
+            isString={inputProbe.isString}
+            charCount={inputProbe.size}
             downloadFileBase={`input-${downloadName}`}
           />
         ) : (
@@ -158,8 +160,9 @@ export function IOPreviewJSONSimple({
         (outputTooLarge ? (
           <LargeJsonFieldFallback
             title="Output"
-            value={output}
-            charCount={outputSize}
+            serialized={outputProbe.serialized}
+            isString={outputProbe.isString}
+            charCount={outputProbe.size}
             downloadFileBase={`output-${downloadName}`}
           />
         ) : (
@@ -196,8 +199,9 @@ export function IOPreviewJSONSimple({
         (metadataTooLarge ? (
           <LargeJsonFieldFallback
             title="Metadata"
-            value={metadata}
-            charCount={metadataSize}
+            serialized={metadataProbe.serialized}
+            isString={metadataProbe.isString}
+            charCount={metadataProbe.size}
             downloadFileBase={`metadata-${downloadName}`}
           />
         ) : (

--- a/web/src/components/trace/components/IOPreview/components/LargeJsonFieldFallback.tsx
+++ b/web/src/components/trace/components/IOPreview/components/LargeJsonFieldFallback.tsx
@@ -16,47 +16,48 @@ const PREVIEW_DISPLAY_CHARS = 4_000;
  * shows a bounded preview head plus escape hatches: a raw download, and a
  * pointer to the Formatted (lazy) and JSON Beta (virtualized) views that scale.
  *
- * The raw value is only serialized for the bounded preview and, on click, the
- * download. It is never handed to the JSON tree renderer.
+ * This component never serializes the payload: the caller's size probe already
+ * did that once and passes the `serialized` string in, reused here for both the
+ * preview slice and the download. Re-serializing a ~20 MB object here would
+ * partly defeat the gate.
  */
 export function LargeJsonFieldFallback({
   title,
-  value,
+  serialized,
+  isString,
   charCount,
   downloadFileBase,
 }: {
   title: string;
-  value: unknown;
+  /** Pre-serialized content: raw text for string fields, compact JSON for
+   *  objects. Used as-is for both the preview and the download. */
+  serialized: string;
+  /** True when the source value was a string — downloads as raw .txt so
+   *  base64/plain payloads are not quote/escape-wrapped; objects use .json. */
+  isString: boolean;
   charCount: number;
-  /** File name without extension; string values download as raw .txt, objects
-   *  as .json (matching how the value is actually serialized below). */
+  /** File name without extension. */
   downloadFileBase: string;
 }) {
   const capture = usePostHogClientCapture();
-  const isString = typeof value === "string";
 
-  // Serialize once for the preview head. This is the rare, gated path (payload
-  // already over the multi-MB limit), so a single bounded stringify here is far
-  // cheaper than the parse + unvirtualized render it replaces. String values
-  // are shown raw — JSON-wrapping them would add quotes + escapes (e.g. a
-  // base64 payload would be over-encoded).
-  const previewText = useMemo(() => {
-    const text = isString ? (value as string) : safeStringify(value);
-    return text.length > PREVIEW_DISPLAY_CHARS
-      ? text.slice(0, PREVIEW_DISPLAY_CHARS)
-      : text;
-  }, [value, isString]);
+  const previewText = useMemo(
+    () =>
+      serialized.length > PREVIEW_DISPLAY_CHARS
+        ? serialized.slice(0, PREVIEW_DISPLAY_CHARS)
+        : serialized,
+    [serialized],
+  );
 
   const onDownload = () => {
     capture("trace_detail:json_view_large_field_download");
-    // Download the value as-is: raw text for strings, pretty JSON for objects.
-    // Never JSON.stringify a string here — that would quote/escape the payload.
-    const content = isString ? (value as string) : safeStringify(value, 2);
+    // Reuse the already-serialized string as-is: raw text for strings (never
+    // JSON-quoted), compact JSON for objects. No re-serialization here.
     const extension = isString ? "txt" : "json";
     const mimeType = isString
       ? "text/plain; charset=utf-8"
       : "application/json; charset=utf-8";
-    downloadTextFile(content, `${downloadFileBase}.${extension}`, mimeType);
+    downloadTextFile(serialized, `${downloadFileBase}.${extension}`, mimeType);
   };
 
   return (
@@ -87,14 +88,6 @@ export function LargeJsonFieldFallback({
       </div>
     </div>
   );
-}
-
-function safeStringify(value: unknown, space?: number): string {
-  try {
-    return JSON.stringify(value, null, space) ?? "";
-  } catch {
-    return "";
-  }
 }
 
 function downloadTextFile(content: string, fileName: string, mimeType: string) {

--- a/web/src/components/trace/components/IOPreview/components/LargeJsonFieldFallback.tsx
+++ b/web/src/components/trace/components/IOPreview/components/LargeJsonFieldFallback.tsx
@@ -1,0 +1,110 @@
+import { useMemo } from "react";
+import { Download } from "lucide-react";
+import { Button } from "@/src/components/ui/button";
+import { compactNumberFormatter } from "@/src/utils/numbers";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+
+/** How much of the raw payload the preview head shows. Bounded regardless of
+ *  payload size — the full value is reachable via download or the other views. */
+const PREVIEW_DISPLAY_CHARS = 4_000;
+
+/**
+ * Fallback for a single JSON-view field (Input / Output / Metadata) whose
+ * payload is too large to render in the unvirtualized react18-json-view
+ * (LFE-10989). Instead of parsing + rendering the full tree on the main thread
+ * — which freezes for seconds and crashes the renderer around ~20 MB — it
+ * shows a bounded preview head plus escape hatches: a raw download, and a
+ * pointer to the Formatted (lazy) and JSON Beta (virtualized) views that scale.
+ *
+ * The raw value is only serialized for the bounded preview and, on click, the
+ * download. It is never handed to the JSON tree renderer.
+ */
+export function LargeJsonFieldFallback({
+  title,
+  value,
+  charCount,
+  downloadFileBase,
+}: {
+  title: string;
+  value: unknown;
+  charCount: number;
+  /** File name without extension; string values download as raw .txt, objects
+   *  as .json (matching how the value is actually serialized below). */
+  downloadFileBase: string;
+}) {
+  const capture = usePostHogClientCapture();
+  const isString = typeof value === "string";
+
+  // Serialize once for the preview head. This is the rare, gated path (payload
+  // already over the multi-MB limit), so a single bounded stringify here is far
+  // cheaper than the parse + unvirtualized render it replaces. String values
+  // are shown raw — JSON-wrapping them would add quotes + escapes (e.g. a
+  // base64 payload would be over-encoded).
+  const previewText = useMemo(() => {
+    const text = isString ? (value as string) : safeStringify(value);
+    return text.length > PREVIEW_DISPLAY_CHARS
+      ? text.slice(0, PREVIEW_DISPLAY_CHARS)
+      : text;
+  }, [value, isString]);
+
+  const onDownload = () => {
+    capture("trace_detail:json_view_large_field_download");
+    // Download the value as-is: raw text for strings, pretty JSON for objects.
+    // Never JSON.stringify a string here — that would quote/escape the payload.
+    const content = isString ? (value as string) : safeStringify(value, 2);
+    const extension = isString ? "txt" : "json";
+    const mimeType = isString
+      ? "text/plain; charset=utf-8"
+      : "application/json; charset=utf-8";
+    downloadTextFile(content, `${downloadFileBase}.${extension}`, mimeType);
+  };
+
+  return (
+    <div className="io-message-content">
+      <div className="my-2 flex flex-col gap-2 rounded-sm border border-dashed p-3">
+        <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-xs">
+          <span className="text-foreground font-medium">{title}</span>
+          <span>
+            {compactNumberFormatter(charCount, 1)} characters — too large to
+            render in JSON view
+          </span>
+        </div>
+        <p className="text-muted-foreground text-xs">
+          Rendering this much JSON at once freezes the tab. Use the{" "}
+          <span className="font-medium">Formatted</span> or{" "}
+          <span className="font-medium">JSON Beta</span> view for the full
+          payload, or download it below.
+        </p>
+        <pre className="bg-muted/50 max-h-40 overflow-hidden rounded-md border p-2 font-mono text-xs break-all whitespace-pre-wrap">
+          {previewText}
+        </pre>
+        <div>
+          <Button variant="outline" size="sm" onClick={onDownload}>
+            <Download className="mr-1 h-3.5 w-3.5" />
+            Download {title}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function safeStringify(value: unknown, space?: number): string {
+  try {
+    return JSON.stringify(value, null, space) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function downloadTextFile(content: string, fileName: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/web/src/components/trace/components/IOPreview/lib/jsonViewSizeGate.clienttest.ts
+++ b/web/src/components/trace/components/IOPreview/lib/jsonViewSizeGate.clienttest.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  JSON_VIEW_RENDER_CHAR_LIMIT,
+  getJsonStringSize,
+} from "./jsonViewSizeGate";
+
+// The component gates a field with `getJsonStringSize(x) > JSON_VIEW_RENDER_CHAR_LIMIT`.
+const isTooLarge = (value: unknown): boolean =>
+  getJsonStringSize(value) > JSON_VIEW_RENDER_CHAR_LIMIT;
+
+describe("jsonViewSizeGate", () => {
+  describe("getJsonStringSize", () => {
+    it("returns 0 for null / undefined", () => {
+      expect(getJsonStringSize(null)).toBe(0);
+      expect(getJsonStringSize(undefined)).toBe(0);
+    });
+
+    it("measures strings by length without serializing", () => {
+      expect(getJsonStringSize("hello")).toBe(5);
+      expect(getJsonStringSize("")).toBe(0);
+    });
+
+    it("measures objects and arrays via JSON.stringify length", () => {
+      const obj = { a: 1, b: "two" };
+      expect(getJsonStringSize(obj)).toBe(JSON.stringify(obj).length);
+
+      const arr = [1, 2, 3];
+      expect(getJsonStringSize(arr)).toBe(JSON.stringify(arr).length);
+    });
+
+    it("returns 0 for values that cannot be serialized (circular)", () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      expect(getJsonStringSize(circular)).toBe(0);
+    });
+  });
+
+  describe("gating decision (size vs JSON_VIEW_RENDER_CHAR_LIMIT)", () => {
+    it("does not gate normal, small I/O", () => {
+      expect(isTooLarge(null)).toBe(false);
+      expect(isTooLarge("short string")).toBe(false);
+      expect(isTooLarge({ messages: [{ role: "user" }] })).toBe(false);
+    });
+
+    it("gates a payload over the limit", () => {
+      const huge = "x".repeat(JSON_VIEW_RENDER_CHAR_LIMIT + 1);
+      expect(isTooLarge(huge)).toBe(true);
+    });
+
+    it("does not gate exactly at the limit (strictly greater-than)", () => {
+      const atLimit = "x".repeat(JSON_VIEW_RENDER_CHAR_LIMIT);
+      expect(isTooLarge(atLimit)).toBe(false);
+    });
+
+    it("gates a ~20 MB payload (the measured crash target)", () => {
+      const twentyMb = "x".repeat(20_000_000);
+      expect(isTooLarge(twentyMb)).toBe(true);
+    });
+
+    it("keeps the limit conservative (well above KB-scale, safely below ~20 MB)", () => {
+      expect(JSON_VIEW_RENDER_CHAR_LIMIT).toBe(2_000_000);
+      expect(JSON_VIEW_RENDER_CHAR_LIMIT).toBeGreaterThan(500_000);
+      expect(JSON_VIEW_RENDER_CHAR_LIMIT).toBeLessThan(20_000_000);
+    });
+  });
+});

--- a/web/src/components/trace/components/IOPreview/lib/jsonViewSizeGate.clienttest.ts
+++ b/web/src/components/trace/components/IOPreview/lib/jsonViewSizeGate.clienttest.ts
@@ -1,37 +1,68 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   JSON_VIEW_RENDER_CHAR_LIMIT,
-  getJsonStringSize,
+  probeJsonField,
 } from "./jsonViewSizeGate";
 
-// The component gates a field with `getJsonStringSize(x) > JSON_VIEW_RENDER_CHAR_LIMIT`.
+// The component gates a field with `probeJsonField(x).size > JSON_VIEW_RENDER_CHAR_LIMIT`.
 const isTooLarge = (value: unknown): boolean =>
-  getJsonStringSize(value) > JSON_VIEW_RENDER_CHAR_LIMIT;
+  probeJsonField(value).size > JSON_VIEW_RENDER_CHAR_LIMIT;
 
 describe("jsonViewSizeGate", () => {
-  describe("getJsonStringSize", () => {
-    it("returns 0 for null / undefined", () => {
-      expect(getJsonStringSize(null)).toBe(0);
-      expect(getJsonStringSize(undefined)).toBe(0);
+  describe("probeJsonField", () => {
+    it("reports size 0 and no serialization for null / undefined", () => {
+      expect(probeJsonField(null)).toEqual({
+        size: 0,
+        serialized: "",
+        isString: false,
+      });
+      expect(probeJsonField(undefined)).toEqual({
+        size: 0,
+        serialized: "",
+        isString: false,
+      });
     });
 
-    it("measures strings by length without serializing", () => {
-      expect(getJsonStringSize("hello")).toBe(5);
-      expect(getJsonStringSize("")).toBe(0);
+    it("passes strings through raw, without JSON-quoting", () => {
+      expect(probeJsonField("hello")).toEqual({
+        size: 5,
+        serialized: "hello",
+        isString: true,
+      });
+      // A base64-ish string is returned verbatim (no surrounding quotes).
+      const b64 = "eyJhIjoxfQ==";
+      const probe = probeJsonField(b64);
+      expect(probe.serialized).toBe(b64);
+      expect(probe.isString).toBe(true);
     });
 
-    it("measures objects and arrays via JSON.stringify length", () => {
+    it("serializes objects and arrays exactly once (compact JSON)", () => {
       const obj = { a: 1, b: "two" };
-      expect(getJsonStringSize(obj)).toBe(JSON.stringify(obj).length);
+      const probe = probeJsonField(obj);
+      expect(probe.serialized).toBe(JSON.stringify(obj));
+      expect(probe.size).toBe(JSON.stringify(obj).length);
+      expect(probe.isString).toBe(false);
 
       const arr = [1, 2, 3];
-      expect(getJsonStringSize(arr)).toBe(JSON.stringify(arr).length);
+      expect(probeJsonField(arr).serialized).toBe(JSON.stringify(arr));
     });
 
-    it("returns 0 for values that cannot be serialized (circular)", () => {
+    it("calls JSON.stringify only once per object (no double serialization)", () => {
+      const spy = vi.spyOn(JSON, "stringify");
+      const obj = { nested: { deep: [1, 2, 3] } };
+      probeJsonField(obj);
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
+    });
+
+    it("reports size 0 for values that cannot be serialized (circular)", () => {
       const circular: Record<string, unknown> = {};
       circular.self = circular;
-      expect(getJsonStringSize(circular)).toBe(0);
+      expect(probeJsonField(circular)).toEqual({
+        size: 0,
+        serialized: "",
+        isString: false,
+      });
     });
   });
 

--- a/web/src/components/trace/components/IOPreview/lib/jsonViewSizeGate.ts
+++ b/web/src/components/trace/components/IOPreview/lib/jsonViewSizeGate.ts
@@ -9,10 +9,15 @@
  * seed: ~20 MB I/O deterministically crashes the tab, with multi-second parse
  * freezes.
  *
- * This helper decides, from a cheap serialized-length probe, whether a field is
- * too large to render in that unvirtualized viewer. Above the limit the caller
+ * This helper decides, from a single serialized probe, whether a field is too
+ * large to render in that unvirtualized viewer. Above the limit the caller
  * shows a bounded fallback (preview head + download) and skips both the
  * main-thread parse and the full render. Normal I/O (KB-scale) is untouched.
+ *
+ * `probeJsonField` serializes an object field exactly once and returns that
+ * string alongside its length, so the size check, the preview head, and the
+ * download all share one `JSON.stringify` — never re-serializing the payload
+ * (which would partly defeat the gate). String fields are never serialized.
  */
 
 /**
@@ -32,18 +37,34 @@
  */
 export const JSON_VIEW_RENDER_CHAR_LIMIT = 2_000_000;
 
+export interface JsonFieldProbe {
+  /** Serialized length in UTF-16 chars; drives the gating decision. */
+  size: number;
+  /** The value as text — the raw string for string fields, compact JSON for
+   *  objects/arrays, "" for null/undefined or on serialization failure. Reused
+   *  for the fallback's preview slice and download so nothing re-serializes. */
+  serialized: string;
+  /** Whether the source value was already a string (raw text, no JSON quotes). */
+  isString: boolean;
+}
+
 /**
- * Cheap serialized-length probe used only to decide gating. Strings measure by
- * length (instant); objects/arrays via `JSON.stringify`. Returns 0 for
- * null/undefined and on serialization failure (a value we cannot serialize is
- * not something the JSON viewer can render either).
+ * Serialize a field once and report its size. Strings pass through as-is
+ * (instant, no JSON quoting); objects/arrays are `JSON.stringify`-d a single
+ * time. Null/undefined and unserializable values (e.g. circular) report size 0,
+ * so they are never gated and never produce an empty download.
  */
-export function getJsonStringSize(value: unknown): number {
-  if (value === null || value === undefined) return 0;
-  if (typeof value === "string") return value.length;
+export function probeJsonField(value: unknown): JsonFieldProbe {
+  if (value === null || value === undefined) {
+    return { size: 0, serialized: "", isString: false };
+  }
+  if (typeof value === "string") {
+    return { size: value.length, serialized: value, isString: true };
+  }
   try {
-    return JSON.stringify(value)?.length ?? 0;
+    const serialized = JSON.stringify(value) ?? "";
+    return { size: serialized.length, serialized, isString: false };
   } catch {
-    return 0;
+    return { size: 0, serialized: "", isString: false };
   }
 }

--- a/web/src/components/trace/components/IOPreview/lib/jsonViewSizeGate.ts
+++ b/web/src/components/trace/components/IOPreview/lib/jsonViewSizeGate.ts
@@ -1,0 +1,49 @@
+/**
+ * Size gate for the unvirtualized "JSON" IO view (LFE-10989, part of the
+ * LFE-10152 large-traces work).
+ *
+ * The plain "JSON" view renders the whole payload through react18-json-view,
+ * which is NOT virtualized: every node becomes DOM. Multi-megabyte I/O both
+ * blocks the main thread while parsing (`parsePreservingPrecision`) and builds
+ * enough nodes to crash the renderer. Measured on the `lfe10152-json-trace`
+ * seed: ~20 MB I/O deterministically crashes the tab, with multi-second parse
+ * freezes.
+ *
+ * This helper decides, from a cheap serialized-length probe, whether a field is
+ * too large to render in that unvirtualized viewer. Above the limit the caller
+ * shows a bounded fallback (preview head + download) and skips both the
+ * main-thread parse and the full render. Normal I/O (KB-scale) is untouched.
+ */
+
+/**
+ * Character ceiling for rendering a single field in the unvirtualized JSON
+ * view. This measures UTF-16 string length (`.length`), i.e. chars, not bytes.
+ * 2M chars is chosen deliberately:
+ * - The codebase's own safe main-thread parse bounds are 300–500 KB
+ *   (`PrettyJsonView` / worker `maxSize`); 2M is ~4–6× above those, so it stays
+ *   well inside "the main thread can survive this once" territory.
+ * - Still 100–1000× larger than typical trace I/O (KB-scale), so real traces
+ *   are never gated and keep rendering instantly.
+ * - Below the size where the unvirtualized clone + re-parse + DOM render
+ *   becomes a perceptible (~1s+) freeze, and far below the measured ~20 MB
+ *   deterministic-crash point.
+ * Users keep full access to large payloads via the Formatted view (lazy
+ * table), the JSON Beta view (virtualized), and the raw download.
+ */
+export const JSON_VIEW_RENDER_CHAR_LIMIT = 2_000_000;
+
+/**
+ * Cheap serialized-length probe used only to decide gating. Strings measure by
+ * length (instant); objects/arrays via `JSON.stringify`. Returns 0 for
+ * null/undefined and on serialization failure (a value we cannot serialize is
+ * not something the JSON viewer can render either).
+ */
+export function getJsonStringSize(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === "string") return value.length;
+  try {
+    return JSON.stringify(value)?.length ?? 0;
+  } catch {
+    return 0;
+  }
+}

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -44,6 +44,9 @@ export const events = {
     // Fired from the tree, timeline, graph, and search-result click handlers;
     // `source` says which surface drove the navigation.
     "node_selected",
+    // Raw download from the JSON-view fallback shown when a field is too large
+    // to render in the unvirtualized viewer (LFE-10989).
+    "json_view_large_field_download",
   ],
   // The shared table peek panel (opened via the `peek` URL param). Props carry
   // `routePattern` (the Next.js route pattern, never a concrete URL) so opens


### PR DESCRIPTION
**TL;DR** — The trace/observation **JSON** IO tab renders the whole payload through an unvirtualized JSON viewer on the main thread. On multi-megabyte IO this freezes the tab for seconds and can crash the renderer. We now size-gate that view: above **2 MB per field** we skip the parse and full render and show a bounded preview + raw download, pointing users to the views that scale. Normal IO is untouched. Part of the large-traces resilience epic (LFE-10152).

**Why** — A large trace's IO (~20 MB input in our large-traces seed) sent the plain JSON view into a multi-second main-thread freeze and, in memory-constrained browsers, a renderer crash. The view parses the payload synchronously and then builds ~one DOM node per JSON token, and the pipeline makes several full O(size) copies (pre-parse + `structuredClone` + internal re-parse + unicode-decode) before rendering. Sibling surface to the already-shipped session-IO bounding (#15124) and the trace-graph budget (#15153).

**What** — A small pure helper decides, from a cheap serialized-length probe, whether a field (input/output/metadata) exceeds a **2 MB** render cap. Over the cap, the JSON view skips both the synchronous parse and the unvirtualized render and instead shows a bounded preview head plus escape hatches: a **raw download** (raw text for string fields, pretty JSON for objects), and a pointer to the **Formatted** (lazy table) and **JSON Beta** (virtualized) views. Under the cap, nothing changes.

**Result** — On the ~20 MB seed, switching to JSON view no longer freezes for seconds or risks a crash in Firefox or Chrome; it shows a bounded card with a working download in well under a second. Verified live in both browsers; gating logic + show-logic unit/component-tested; typecheck + lint clean.

<details><summary>Mechanism, threshold, and verification</summary>

- **Path:** `IOPreview → IOPreviewJSONSimple → PrettyJsonView(currentView="json") → JSONView (react18-json-view)`, unvirtualized. `json-beta` (AdvancedJsonViewer) is already virtualized; this view was not gated. The over-limit path skips `deepParseJson`/`parsePreservingPrecision` (field → `undefined`) **and** renders `LargeJsonFieldFallback` instead of the viewer — both, not one.
- **Threshold — 2 MB/field** (`JSON_VIEW_RENDER_CHAR_LIMIT`, UTF-16 `.length`): ~4–6× the codebase's own safe main-thread parse bounds (`IOPreviewPretty`/`PrettyJsonView` `maxSize` 300–500 KB), still 100–1000× above normal KB-scale IO (never gated), and below the size where the unvirtualized render is perceptibly janky. Large payloads stay reachable via Formatted, JSON Beta, and raw download.
- **Show-logic:** for non-over-limit fields the condition collapses bit-for-bit to the original (`hideIfNull` null still hidden, empty object still shown); an over-limit field with `hideIfNull` now surfaces the fallback (intended). `CorrectedOutputField` gets no baseline for an over-limit output (acceptable degradation, noted in code).
- **Download:** string fields download as raw `text/plain` (`.txt`); objects as `JSON.stringify(v,null,2)` (`.json`) — the huge-IO seed is a base64 string, so raw text avoids over-encoding.
- **Verification:** real login, opened the large-IO trace, switched to JSON view — main-thread heartbeat showed a ~3.2s Firefox / ~1.65s Chrome freeze with the gate off vs. sub-second with it on, no crash, fallback + working raw download in both browsers. 13 unit/component tests (boundary + edge cases + fallback selection + null-hiding + raw-string download).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR size-gates the unvirtualized JSON IO view in `IOPreviewJSONSimple`: fields above a 2 MB character threshold skip `deepParseJson` and the `react18-json-view` render, and instead show a bounded 4000-char preview plus a raw download button via the new `LargeJsonFieldFallback` component.

- **Size probe and parse guard** (`jsonViewSizeGate.ts`, `IOPreviewJSONSimple.tsx`): A cheap `getJsonStringSize` probe (O(1) for strings, O(size) for objects via `JSON.stringify`) is memoized per field; over-limit fields short-circuit `deepParseJson` and route to the fallback. The `hideIfNull` visibility logic is correctly updated so over-limit fields aren't silently dropped.
- **Fallback component** (`LargeJsonFieldFallback.tsx`): Renders a dashed-border card with a truncated preview, a prose hint pointing at Formatted/JSON-Beta views, and a download button that writes strings as raw `.txt` and objects as pretty `.json`.
- **Tests**: 13 unit/component tests cover boundary conditions, null-hiding semantics, string-field raw download, and fallback vs `PrettyJsonView` selection.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is well-scoped and low-risk: the hot path (fields under 2 MB) is untouched, and the over-limit path is an entirely additive fallback with no mutations to shared state.

The implementation is solid for the primary use case (large string payloads). The two minor findings — a redundant full serialization in the preview memo and a silent empty-file download on serialization error — are both on the rare, already-gated path and don't affect correctness for the cases the fix targets.

LargeJsonFieldFallback.tsx — the previewText useMemo and the onDownload error path are worth a second look for large object (non-string) payloads.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[IOPreviewJSONSimple renders] --> B[useMemo: getJsonStringSize per field]
    B --> C{size > 2 MB?}
    C -- No --> D[effectiveX = parsedX ?? deepParseJson]
    C -- Yes --> E[effectiveX = undefined\nskip deepParseJson]
    D --> F{showInput/Output/Metadata?}
    E --> G{showInput/Output/Metadata?\n inputTooLarge overrides hideIfNull}
    F -- Yes --> H[PrettyJsonView\n react18-json-view]
    G -- Yes --> I[LargeJsonFieldFallback]
    I --> J[safeStringify up to 4000 chars preview]
    I --> K[Download button\nstring → .txt\nobject → pretty .json]
    K --> L[safeStringify full value\ncreate Blob → anchor click]
    I --> M[PostHog capture on download]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[IOPreviewJSONSimple renders] --> B[useMemo: getJsonStringSize per field]
    B --> C{size > 2 MB?}
    C -- No --> D[effectiveX = parsedX ?? deepParseJson]
    C -- Yes --> E[effectiveX = undefined\nskip deepParseJson]
    D --> F{showInput/Output/Metadata?}
    E --> G{showInput/Output/Metadata?\n inputTooLarge overrides hideIfNull}
    F -- Yes --> H[PrettyJsonView\n react18-json-view]
    G -- Yes --> I[LargeJsonFieldFallback]
    I --> J[safeStringify up to 4000 chars preview]
    I --> K[Download button\nstring → .txt\nobject → pretty .json]
    K --> L[safeStringify full value\ncreate Blob → anchor click]
    I --> M[PostHog capture on download]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/trace/components/IOPreview/components/LargeJsonFieldFallback.tsx:43-48
**Full serialization before 4000-char slice**

For non-string fields above the limit, `safeStringify(value)` fully materializes the entire object as a string before slicing to `PREVIEW_DISPLAY_CHARS`. The parent's `useMemo` already called `JSON.stringify` once for the size probe, so this is a second full in-memory serialization of potentially a 20 MB object on the initial render. For the primary use case (base64 string payload) this is O(1) because `isString` is true, but for large JSON-object payloads it allocates two large transient strings back-to-back. Consider either passing the serialized string from the parent's probe down as a prop, or using an early-terminating serializer that stops after `PREVIEW_DISPLAY_CHARS` characters.

### Issue 2 of 2
web/src/components/trace/components/IOPreview/components/LargeJsonFieldFallback.tsx:54-59
**Silent empty download on serialization failure**

When `safeStringify` catches an error (e.g., a non-serializable object that somehow passed the size gate returning 0), it returns `""`, and the download button writes an empty file without any notification to the user. Since `getJsonStringSize` also returns 0 on serialization failure, such a value would never be gated in the first place (it's treated as size 0, so `inputTooLarge` stays false and this fallback is never shown). The empty-download path is therefore unreachable in practice. However, if the guard relationship ever drifts, the UX failure would be invisible. Consider logging a warning or showing an inline error message when `content.length === 0`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): size-gate the unvirtualized ..."](https://github.com/langfuse/langfuse/commit/c5687923ea04c09785020be5e06fc6e925971a50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44754477)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->