### PR TITLE
fix(trace): tighten data-URI detection so ordinary strings aren't mistaken for media (LFE-10990)

### DIFF
--- a/web/src/components/ui/media/mediaUtils.clienttest.ts
+++ b/web/src/components/ui/media/mediaUtils.clienttest.ts
@@ -26,8 +26,75 @@ describe("classifyMediaValue", () => {
     });
   });
 
+  it("classifies a multi-megabyte base64 data URI (the huge-IO case)", () => {
+    // One unbroken 8 MB base64 token — the payload shape from LFE-10152 seeding.
+    const src = "data:image/png;base64," + "A".repeat(8 * 1024 * 1024);
+    const descriptor = classifyMediaValue(src);
+    expect(descriptor).toMatchObject({
+      kind: "dataUri",
+      contentType: "image/png",
+    });
+    // Whole payload is preserved as the src; only the head is scanned.
+    expect(descriptor?.kind === "dataUri" && descriptor.src).toBe(src);
+  });
+
+  it("classifies genuine data URIs with header variants", () => {
+    // Percent-encoded (non-base64) SVG image.
+    expect(
+      classifyMediaValue("data:image/svg+xml,%3Csvg%3E%3C/svg%3E")?.contentType,
+    ).toBe("image/svg+xml");
+    // A parameter (charset) before the mandatory comma.
+    expect(
+      classifyMediaValue("data:image/svg+xml;charset=utf-8,<svg></svg>")
+        ?.contentType,
+    ).toBe("image/svg+xml");
+    // Audio + video top-level types are previewable too.
+    expect(classifyMediaValue("data:audio/mpeg;base64,AAAA")?.contentType).toBe(
+      "audio/mpeg",
+    );
+    expect(classifyMediaValue("data:video/mp4;base64,AAAA")?.contentType).toBe(
+      "video/mp4",
+    );
+    // Empty payload is still a well-formed (comma-terminated) data URI.
+    expect(classifyMediaValue("data:image/png;base64,")?.contentType).toBe(
+      "image/png",
+    );
+  });
+
   it("ignores non-previewable data URIs", () => {
     expect(classifyMediaValue("data:text/plain,hello")).toBeNull();
+    expect(classifyMediaValue("data:application/json,{}")).toBeNull();
+  });
+
+  it("does not mistake prose or malformed 'data:' strings for media", () => {
+    // No comma at all -> not a data URI, just a string that starts like one.
+    expect(classifyMediaValue("data:image/png")).toBeNull();
+    // Prose after the MIME head: the header is not comma-terminated.
+    expect(
+      classifyMediaValue("data:image/png is the best format for screenshots"),
+    ).toBeNull();
+    // A comma appears, but only later inside prose — the header itself is not
+    // well-formed up to a comma.
+    expect(
+      classifyMediaValue("data:audio/mpeg not supported, sadly"),
+    ).toBeNull();
+    // "base64" without the terminating comma is still malformed.
+    expect(classifyMediaValue("data:image/png;base64")).toBeNull();
+    // A huge non-data-URI string that merely starts with the prefix must fall
+    // through (so the caller truncates it) instead of being handed off whole.
+    expect(
+      classifyMediaValue("data:image/png " + "x".repeat(5_000_000)),
+    ).toBeNull();
+  });
+
+  it("does not treat a bare base64-ish token or embedded substring as media", () => {
+    // Short base64-looking tokens are not data URIs.
+    expect(classifyMediaValue("aGVsbG8gd29ybGQ=")).toBeNull();
+    expect(classifyMediaValue("iVBORw0KGgoAAAANSUhEUgAA")).toBeNull();
+    // A JSON string that merely contains a "data:" substring, not at the start.
+    expect(
+      classifyMediaValue('{"note":"see data:image/png;base64,AAAA"}'),
+    ).toBeNull();
   });
 
   it("classifies image/audio/video URLs by extension", () => {

--- a/web/src/components/ui/media/mediaUtils.clienttest.ts
+++ b/web/src/components/ui/media/mediaUtils.clienttest.ts
@@ -61,6 +61,30 @@ describe("classifyMediaValue", () => {
     );
   });
 
+  it("accepts the base64 token case-insensitively (WHATWG data-URL spec)", () => {
+    // Browsers accept `;BASE64,` / `;Base64,`; the regex's `i` flag matches
+    // them. The lowercase mediatype still gates previewability.
+    expect(classifyMediaValue("data:image/png;BASE64,AAAA")?.contentType).toBe(
+      "image/png",
+    );
+    expect(classifyMediaValue("data:audio/mpeg;Base64,AAAA")?.contentType).toBe(
+      "audio/mpeg",
+    );
+  });
+
+  it("does not classify a data URI whose header exceeds the scan window", () => {
+    // Documents the intentional bound: only the first 256 chars of the head are
+    // scanned, so a (valid but) pathologically long header pushes its mandatory
+    // comma out of range and the value falls through to plain-string handling.
+    // Real image/audio/video headers are well under 40 chars, so this never
+    // affects genuine media.
+    const longHeader = "data:image/png;charset=" + "a".repeat(300) + ",AAAA";
+    expect(classifyMediaValue(longHeader)).toBeNull();
+    // Same header, comfortably within the window, is classified normally.
+    const shortHeader = "data:image/png;charset=" + "a".repeat(10) + ",AAAA";
+    expect(classifyMediaValue(shortHeader)?.contentType).toBe("image/png");
+  });
+
   it("ignores non-previewable data URIs", () => {
     expect(classifyMediaValue("data:text/plain,hello")).toBeNull();
     expect(classifyMediaValue("data:application/json,{}")).toBeNull();

--- a/web/src/components/ui/media/mediaUtils.ts
+++ b/web/src/components/ui/media/mediaUtils.ts
@@ -49,8 +49,14 @@ const MAX_DATA_URI_HEADER_SCAN = 256;
 // is MANDATORY — requiring it (and a well-formed parameter list up to it) is
 // what stops ordinary strings that merely start with "data:image/…" from being
 // mistaken for previewable media. The first capture group is the MIME type.
+//
+// The `i` flag matches the `;base64` token ASCII-case-insensitively, per the
+// WHATWG data-URL spec (browsers accept `;BASE64,` / `;Base64,`). It does NOT
+// widen which media is previewable: the top-level type is still gated by the
+// lowercase `PREVIEWABLE_TOP_LEVEL` check below, so `data:IMAGE/PNG,…` remains
+// non-previewable regardless of the flag.
 const DATA_URI_HEADER_PATTERN =
-  /^data:([\w.+-]+\/[\w.+-]+)(?:;[\w.+-]+=[^;,]*)*(?:;base64)?,/;
+  /^data:([\w.+-]+\/[\w.+-]+)(?:;[\w.+-]+=[^;,]*)*(?:;base64)?,/i;
 
 /**
  * Classifies a string value as previewable media, or returns null. Pure and

--- a/web/src/components/ui/media/mediaUtils.ts
+++ b/web/src/components/ui/media/mediaUtils.ts
@@ -38,6 +38,20 @@ const PREVIEWABLE_TOP_LEVEL = new Set(["image", "audio", "video"]);
 // Guards the per-value hot path: bail before parsing a URL out of long strings.
 const MAX_URL_LENGTH = 2048;
 
+// A data: payload can be many megabytes, so we only ever validate the head.
+// This is comfortably longer than any real image/audio/video data-URI header
+// (`data:<mediatype>(;param=value)*(;base64)?,` — typically well under 40
+// chars) while keeping the regex cost bounded regardless of payload size.
+const MAX_DATA_URI_HEADER_SCAN = 256;
+
+// RFC 2397 data-URI header shape: `data:<type>/<subtype>(;<param>=<value>)*
+// (;base64)?,`. The trailing comma that separates the header from the payload
+// is MANDATORY — requiring it (and a well-formed parameter list up to it) is
+// what stops ordinary strings that merely start with "data:image/…" from being
+// mistaken for previewable media. The first capture group is the MIME type.
+const DATA_URI_HEADER_PATTERN =
+  /^data:([\w.+-]+\/[\w.+-]+)(?:;[\w.+-]+=[^;,]*)*(?:;base64)?,/;
+
 /**
  * Classifies a string value as previewable media, or returns null. Pure and
  * cheap: a prefix check gates every branch so non-media strings (the common
@@ -59,8 +73,14 @@ export function classifyMediaValue(value: unknown) {
   }
 
   if (value.startsWith(DATA_URI_PREFIX)) {
-    // Read only the head — a base64 payload can be megabytes long.
-    const match = /^data:([\w.+-]+\/[\w.+-]+)/.exec(value.slice(0, 100));
+    // Validate the head against the RFC 2397 shape — reading only the head,
+    // since a base64 payload can be megabytes long. Requiring a well-formed
+    // header terminated by its mandatory comma rejects prose / JSON strings
+    // that happen to start with "data:image/…" (false positives that would
+    // otherwise render a broken media chip and skip the normal truncation).
+    const match = DATA_URI_HEADER_PATTERN.exec(
+      value.slice(0, MAX_DATA_URI_HEADER_SCAN),
+    );
     const contentType = match?.[1];
     if (!contentType) return null;
     if (!PREVIEWABLE_TOP_LEVEL.has(contentType.split("/")[0]!)) return null;


### PR DESCRIPTION
**TL;DR** — The JSON viewers' media classifier treated any string starting `data:image/…` (or audio/video) as previewable media, without checking it's actually a data URI. Ordinary text/JSON values got a broken preview chip and skipped normal truncation. We now validate the RFC 2397 header shape (comma-terminated), fixing the false-positive while still detecting genuine data URIs. Part of the large-traces resilience epic (LFE-10152).

**Why** — A giant single-line base64 data-URI in a trace's I/O is a known browser-killer, so viewers special-handle data URIs (preview chip instead of raw dump). But the detection matched a bare `data:<type>/<subtype>` prefix with **no comma** — the mandatory separator between a data URI's header and payload (RFC 2397). So prose like `"data:image/png is the best format"`, or a payload-less `"data:image/png"`, was misclassified: a broken chip, and — because the media path opts out of truncation (`needsTruncation: false`) — a route by which an oversized value is handed off whole instead of being clipped by the normal cell truncation.

**What** — Match the head against the RFC 2397 shape `data:<type>/<subtype>(;<param>=<value>)*(;base64)?,` before classifying (the trailing comma is required; `;base64` matched case-insensitively per the WHATWG data-URL spec). Only the first 256 chars are scanned, so multi-MB payloads stay cheap. Single shared classifier (`classifyMediaValue`), so every JSON viewer benefits.

**Result** — Genuine data URIs (base64, `;BASE64` casing, percent-encoded SVG, `;charset` params, empty payload, audio/video) still preview; ordinary strings that merely start with `data:` fall through to normal string rendering + truncation. Verified in-browser on a seeded multi-MB base64 trace: still detected as a chip, no raw dump, tab stays responsive.

<details><summary>Detail — grammar, scope, tests</summary>

- Predicate: `web/src/components/ui/media/mediaUtils.ts` → `classifyMediaValue` `data:` branch. Regex `/^data:([\w.+-]+\/[\w.+-]+)(?:;[\w.+-]+=[^;,]*)*(?:;base64)?,/i` over `value.slice(0, 256)`. Anchored + comma-terminated + hard `;`/`=` delimiters ⇒ bounded backtracking (measured <0.1ms steady-state on adversarial 256-char input); the `startsWith("data:")` gate keeps the non-media hot path a single check.
- The `i` flag covers the case-insensitive `;base64` token only; it does **not** widen previewable mediatypes — uppercase `data:IMAGE/PNG,…` stays gated by the lowercase `PREVIEWABLE_TOP_LEVEL` set (pre-existing, out of scope).
- Known intentional bound: a data URI whose header exceeds the 256-char scan falls through to plain-string handling (no real previewable data URI has a 256-char header; payload is after the comma). Graceful — no crash. Documented by a test.
- Unit tests (`mediaUtils.clienttest.ts`, 13): true positives (8 MB base64, `;BASE64`/`;Base64` casing, SVG percent-encoded, `;charset` param, empty payload, audio/video); true negatives (no-comma, prose, prose-with-later-comma, `;base64` without comma, 5 MB non-data-URI prefix, bare base64 tokens, embedded `data:` substring, >256-char header).
- No change to media rendering, the huge-JSON size-gate (#15155), or the graph budget (#15153) — scoped to detection only.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens the data-URI detection in `classifyMediaValue` so that ordinary strings starting with `data:image/…` are no longer misclassified as previewable media. The old regex matched any `data:<type>/<subtype>` prefix without requiring the RFC 2397 mandatory comma that separates the header from the payload, causing false-positive media chips and bypassing normal cell truncation for oversized values.

- Replaces the loose prefix-only regex with `DATA_URI_HEADER_PATTERN`, which requires a well-formed RFC 2397 header terminated by its mandatory comma before classifying a value as a data URI; only the first 256 characters are scanned so multi-MB payloads remain cheap.
- Adds 13 new test cases covering true positives (8 MB base64, case variants, charset params, audio/video, empty payload) and true negatives (no-comma, prose, comma-in-prose, long header beyond the scan window, embedded `data:` substring, bare base64 tokens).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is scoped to the detection predicate only, with no modifications to rendering, truncation, or the graph budget path.

The fix correctly plugs the false-positive path by requiring the RFC 2397 mandatory comma before classifying a value as a data URI. The scan window is bounded to 256 chars, the regex structure avoids catastrophic backtracking, and the PREVIEWABLE_TOP_LEVEL gate is unchanged. All prior behavior for genuine data URIs is preserved and verified by the new test suite. No regressions are apparent in the classification logic or the downstream rendering path.

No files require special attention. Both changed files — the implementation and its test — are straightforward and internally consistent.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[classifyMediaValue] --> B{string and non-empty?}
    B -- No --> Z[return null]
    B -- Yes --> C{startsWith langfuseMedia prefix?}
    C -- Yes --> D{length ok and schema valid?}
    D -- No --> Z
    D -- Yes --> E[return langfuseRef descriptor]
    C -- No --> F{startsWith data colon?}
    F -- Yes --> G[slice to first 256 chars]
    G --> H{RFC 2397 regex matches comma-terminated header?}
    H -- No --> Z
    H -- Yes --> I{top-level type in PREVIEWABLE_TOP_LEVEL?}
    I -- No --> Z
    I -- Yes --> J[return dataUri descriptor with full src]
    F -- No --> K{startsWith http or https?}
    K -- No --> Z
    K -- Yes --> L{length under 2048?}
    L -- No --> Z
    L -- Yes --> M{extension maps to known MIME?}
    M -- No --> Z
    M -- Yes --> N[return url descriptor]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[classifyMediaValue] --> B{string and non-empty?}
    B -- No --> Z[return null]
    B -- Yes --> C{startsWith langfuseMedia prefix?}
    C -- Yes --> D{length ok and schema valid?}
    D -- No --> Z
    D -- Yes --> E[return langfuseRef descriptor]
    C -- No --> F{startsWith data colon?}
    F -- Yes --> G[slice to first 256 chars]
    G --> H{RFC 2397 regex matches comma-terminated header?}
    H -- No --> Z
    H -- Yes --> I{top-level type in PREVIEWABLE_TOP_LEVEL?}
    I -- No --> Z
    I -- Yes --> J[return dataUri descriptor with full src]
    F -- No --> K{startsWith http or https?}
    K -- No --> Z
    K -- Yes --> L{length under 2048?}
    L -- No --> Z
    L -- Yes --> M{extension maps to known MIME?}
    M -- No --> Z
    M -- Yes --> N[return url descriptor]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): match the data-URI base64 to..."](https://github.com/langfuse/langfuse/commit/1c0c57b817193f5e333e1d55e2d39918e5d300ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44759587)</sub>

<!-- /greptile_comment -->