### PR TITLE
fix(experiments): pass prompt tools to dataset runs

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,6 +30,7 @@ export * from "./domain/home-dashboard";
 
 // llm api
 export * from "./server/llm/types";
+export * from "./server/llm/promptToolConfig";
 
 // evals
 export * from "./features/evals/types";

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -47,6 +47,7 @@ export * from "./llm/llmText";
 export * from "./llm/errors";
 export * from "./llm/utils";
 export * from "./llm/types";
+export * from "./llm/promptToolConfig";
 export * from "./llm/internalTraceEvents";
 export * from "./llm/compileChatMessages";
 export * from "./llm/testModelCall";

--- a/packages/shared/src/server/llm/promptToolConfig.test.ts
+++ b/packages/shared/src/server/llm/promptToolConfig.test.ts
@@ -59,20 +59,43 @@ describe("parsePromptToolConfig", () => {
         }),
       ).toEqual({ status: "valid", tools: [weatherTool, timeTool] });
     });
+
+    it("normalizes omitted optional fields in the flat shape", () => {
+      expect(parsePromptToolConfig({ tools: [{ name: "get_time" }] })).toEqual({
+        status: "valid",
+        tools: [
+          {
+            name: "get_time",
+            description: "",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      });
+    });
+
+    it("normalizes omitted optional fields in the OpenAI wrapper", () => {
+      expect(
+        parsePromptToolConfig({
+          tools: [{ type: "function", function: { name: "get_time" } }],
+        }),
+      ).toEqual({
+        status: "valid",
+        tools: [
+          {
+            name: "get_time",
+            description: "",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      });
+    });
   });
 
   describe("invalid tool configs", () => {
     it.each([
       ["tools is not an array", { tools: "get_weather" }],
       ["tools is an object", { tools: { get_weather: weatherTool } }],
-      ["entry missing parameters", { tools: [{ name: "broken" }] }],
       ["entry missing name", { tools: [{ parameters: { type: "object" } }] }],
-      [
-        "entry missing description",
-        {
-          tools: [{ name: "get_weather", parameters: { type: "object" } }],
-        },
-      ],
       ["entry is a string", { tools: ["get_weather"] }],
       ["entry has an empty name", { tools: [{ ...weatherTool, name: "" }] }],
       [
@@ -81,7 +104,7 @@ describe("parsePromptToolConfig", () => {
       ],
       [
         "one invalid entry invalidates all tools",
-        { tools: [weatherTool, { name: "broken" }] },
+        { tools: [weatherTool, { name: "broken", parameters: "invalid" }] },
       ],
       [
         "duplicate tool names",

--- a/packages/shared/src/server/llm/promptToolConfig.test.ts
+++ b/packages/shared/src/server/llm/promptToolConfig.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasPromptToolStructuredOutputConflict,
+  parsePromptToolConfig,
+} from "./promptToolConfig";
+
+const weatherTool = {
+  name: "get_weather",
+  description: "Get the weather for a location",
+  parameters: {
+    type: "object",
+    properties: { location: { type: "string" } },
+    required: ["location"],
+  },
+};
+
+describe("parsePromptToolConfig", () => {
+  describe("configs without tools", () => {
+    it.each([
+      ["null config", null],
+      ["undefined config", undefined],
+      ["string config", "some config"],
+      ["array config", [weatherTool]],
+      ["empty object", {}],
+      ["object without tools key", { model: "gpt-4.1" }],
+      ["empty tools array", { tools: [] }],
+    ])("returns none for %s", (_label, config) => {
+      expect(parsePromptToolConfig(config)).toEqual({ status: "none" });
+    });
+  });
+
+  describe("valid tool configs", () => {
+    it("parses the flat Langfuse shape", () => {
+      expect(parsePromptToolConfig({ tools: [weatherTool] })).toEqual({
+        status: "valid",
+        tools: [weatherTool],
+      });
+    });
+
+    it("unwraps the OpenAI function shape", () => {
+      expect(
+        parsePromptToolConfig({
+          tools: [{ type: "function", function: weatherTool }],
+        }),
+      ).toEqual({ status: "valid", tools: [weatherTool] });
+    });
+
+    it("parses mixed flat and OpenAI-wrapped tools", () => {
+      const timeTool = {
+        name: "get_time",
+        description: "Get the current time",
+        parameters: { type: "object", properties: {} },
+      };
+
+      expect(
+        parsePromptToolConfig({
+          tools: [weatherTool, { type: "function", function: timeTool }],
+        }),
+      ).toEqual({ status: "valid", tools: [weatherTool, timeTool] });
+    });
+  });
+
+  describe("invalid tool configs", () => {
+    it.each([
+      ["tools is not an array", { tools: "get_weather" }],
+      ["tools is an object", { tools: { get_weather: weatherTool } }],
+      ["entry missing parameters", { tools: [{ name: "broken" }] }],
+      ["entry missing name", { tools: [{ parameters: { type: "object" } }] }],
+      [
+        "entry missing description",
+        {
+          tools: [{ name: "get_weather", parameters: { type: "object" } }],
+        },
+      ],
+      ["entry is a string", { tools: ["get_weather"] }],
+      ["entry has an empty name", { tools: [{ ...weatherTool, name: "" }] }],
+      [
+        "entry has a provider-incompatible name",
+        { tools: [{ ...weatherTool, name: "get weather" }] },
+      ],
+      [
+        "one invalid entry invalidates all tools",
+        { tools: [weatherTool, { name: "broken" }] },
+      ],
+      [
+        "duplicate tool names",
+        { tools: [weatherTool, { ...weatherTool, description: "duplicate" }] },
+      ],
+    ])("returns invalid for %s", (_label, config) => {
+      expect(parsePromptToolConfig(config)).toEqual({ status: "invalid" });
+    });
+  });
+});
+
+describe("hasPromptToolStructuredOutputConflict", () => {
+  const validConfig = parsePromptToolConfig({ tools: [weatherTool] });
+
+  it("detects valid tools combined with structured output", () => {
+    expect(hasPromptToolStructuredOutputConflict(validConfig, true)).toBe(true);
+  });
+
+  it("allows tools or structured output independently", () => {
+    expect(hasPromptToolStructuredOutputConflict(validConfig, false)).toBe(
+      false,
+    );
+    expect(
+      hasPromptToolStructuredOutputConflict({ status: "invalid" }, true),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/server/llm/promptToolConfig.test.ts
+++ b/packages/shared/src/server/llm/promptToolConfig.test.ts
@@ -24,6 +24,7 @@ describe("parsePromptToolConfig", () => {
       ["array config", [weatherTool]],
       ["empty object", {}],
       ["object without tools key", { model: "gpt-4.1" }],
+      ["null tools", { tools: null }],
       ["empty tools array", { tools: [] }],
     ])("returns none for %s", (_label, config) => {
       expect(parsePromptToolConfig(config)).toEqual({ status: "none" });

--- a/packages/shared/src/server/llm/promptToolConfig.test.ts
+++ b/packages/shared/src/server/llm/promptToolConfig.test.ts
@@ -89,6 +89,38 @@ describe("parsePromptToolConfig", () => {
         ],
       });
     });
+
+    it("normalizes explicit null fields in flat and OpenAI-wrapped tools", () => {
+      expect(
+        parsePromptToolConfig({
+          tools: [
+            { name: "get_time", description: null, parameters: null },
+            {
+              type: "function",
+              function: {
+                name: "get_date",
+                description: null,
+                parameters: null,
+              },
+            },
+          ],
+        }),
+      ).toEqual({
+        status: "valid",
+        tools: [
+          {
+            name: "get_time",
+            description: "",
+            parameters: { type: "object", properties: {} },
+          },
+          {
+            name: "get_date",
+            description: "",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      });
+    });
   });
 
   describe("invalid tool configs", () => {

--- a/packages/shared/src/server/llm/promptToolConfig.ts
+++ b/packages/shared/src/server/llm/promptToolConfig.ts
@@ -12,10 +12,15 @@ const EMPTY_TOOL_PARAMETERS = { type: "object", properties: {} };
 
 const PromptToolDefinitionSchema = LLMToolDefinitionSchema.extend({
   name: LLMToolNameSchema,
-  // OpenAI-compatible prompt configs may omit these fields. Keep the runtime
-  // representation complete for createLLMToolSet.
-  description: z.string().default(""),
-  parameters: LLMJSONSchema.default(EMPTY_TOOL_PARAMETERS),
+  // OpenAI-compatible prompt configs may omit or explicitly null these fields.
+  // Keep the runtime representation complete for createLLMToolSet.
+  description: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? ""),
+  parameters: LLMJSONSchema.nullish().transform(
+    (value) => value ?? EMPTY_TOOL_PARAMETERS,
+  ),
 });
 
 const PromptConfigToolSchema = z.union([

--- a/packages/shared/src/server/llm/promptToolConfig.ts
+++ b/packages/shared/src/server/llm/promptToolConfig.ts
@@ -65,6 +65,9 @@ export function parsePromptToolConfig(config: unknown): PromptToolConfig {
   }
 
   const rawTools = (config as Record<string, unknown>).tools;
+  if (rawTools === null || rawTools === undefined) {
+    return { status: "none" };
+  }
   if (!Array.isArray(rawTools)) {
     return { status: "invalid" };
   }

--- a/packages/shared/src/server/llm/promptToolConfig.ts
+++ b/packages/shared/src/server/llm/promptToolConfig.ts
@@ -1,0 +1,67 @@
+import z from "zod";
+
+import {
+  LLMToolDefinitionSchema,
+  OpenAIToolSchema,
+  type LLMToolDefinition,
+} from "./types";
+
+const PromptConfigToolSchema = z.union([
+  LLMToolDefinitionSchema,
+  OpenAIToolSchema.transform((tool) => tool.function),
+]);
+
+export type PromptToolConfig =
+  | { status: "none" }
+  | { status: "valid"; tools: LLMToolDefinition[] }
+  | { status: "invalid" };
+
+export const PROMPT_TOOL_STRUCTURED_OUTPUT_CONFLICT_MESSAGE =
+  "Your prompt contains tool definitions - tool calls are not compatible with structured output";
+
+export const hasPromptToolStructuredOutputConflict = (
+  toolConfig: PromptToolConfig,
+  structuredOutputEnabled: boolean,
+) => toolConfig.status === "valid" && structuredOutputEnabled;
+
+/**
+ * Extracts LLM tool definitions from a prompt's free-form `config` JSON.
+ *
+ * Accepts both the flat Langfuse shape (`{name, description, parameters}`)
+ * and the OpenAI wrapper (`{type: "function", function: {...}}`).
+ *
+ * - `none`: config carries no tools — nothing to pass, nothing to warn about.
+ * - `valid`: every entry parsed; pass `tools` to the LLM call.
+ * - `invalid`: a `tools` key exists but cannot be used as a whole (not an
+ *   array, an entry is malformed, or duplicate tool names). Callers must
+ *   ignore ALL tools and surface a warning — running with a silently
+ *   altered tool set would be worse than running without tools.
+ */
+export function parsePromptToolConfig(config: unknown): PromptToolConfig {
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return { status: "none" };
+  }
+  if (!("tools" in config)) {
+    return { status: "none" };
+  }
+
+  const rawTools = (config as Record<string, unknown>).tools;
+  if (!Array.isArray(rawTools)) {
+    return { status: "invalid" };
+  }
+  if (rawTools.length === 0) {
+    return { status: "none" };
+  }
+
+  const parsed = z.array(PromptConfigToolSchema).safeParse(rawTools);
+  if (!parsed.success) {
+    return { status: "invalid" };
+  }
+
+  const uniqueNames = new Set(parsed.data.map((tool) => tool.name));
+  if (uniqueNames.size !== parsed.data.length) {
+    return { status: "invalid" };
+  }
+
+  return { status: "valid", tools: parsed.data };
+}

--- a/packages/shared/src/server/llm/promptToolConfig.ts
+++ b/packages/shared/src/server/llm/promptToolConfig.ts
@@ -1,14 +1,28 @@
 import z from "zod";
 
 import {
+  LLMJSONSchema,
   LLMToolDefinitionSchema,
+  LLMToolNameSchema,
   OpenAIToolSchema,
   type LLMToolDefinition,
 } from "./types";
 
+const EMPTY_TOOL_PARAMETERS = { type: "object", properties: {} };
+
+const PromptToolDefinitionSchema = LLMToolDefinitionSchema.extend({
+  name: LLMToolNameSchema,
+  // OpenAI-compatible prompt configs may omit these fields. Keep the runtime
+  // representation complete for createLLMToolSet.
+  description: z.string().default(""),
+  parameters: LLMJSONSchema.default(EMPTY_TOOL_PARAMETERS),
+});
+
 const PromptConfigToolSchema = z.union([
-  LLMToolDefinitionSchema,
-  OpenAIToolSchema.transform((tool) => tool.function),
+  PromptToolDefinitionSchema,
+  OpenAIToolSchema.extend({
+    function: PromptToolDefinitionSchema,
+  }).transform((tool) => tool.function),
 ]);
 
 export type PromptToolConfig =

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -51,7 +51,7 @@ export const LLMToolNameSchema = z
   .min(1, "Name is required");
 
 export const LLMToolDefinitionSchema = z.object({
-  name: LLMToolNameSchema,
+  name: z.string(),
   description: z.string(),
   parameters: LLMJSONSchema,
 });

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -42,8 +42,16 @@ export const JSONSchemaFormSchema = z
       .transform((data) => JSON.stringify(data, null, 2)),
   );
 
+export const LLMToolNameSchema = z
+  .string()
+  .regex(
+    /^[a-zA-Z0-9._-]+$/,
+    "Name must contain only alphanumeric letters, hyphens, periods and underscores",
+  )
+  .min(1, "Name is required");
+
 export const LLMToolDefinitionSchema = z.object({
-  name: z.string(),
+  name: LLMToolNameSchema,
   description: z.string(),
   parameters: LLMJSONSchema,
 });

--- a/web/src/__tests__/server/unit/chat-completion-handler.servertest.ts
+++ b/web/src/__tests__/server/unit/chat-completion-handler.servertest.ts
@@ -167,6 +167,34 @@ describe("chatCompletionHandler", () => {
     );
   });
 
+  it("preserves extracted tool names for provider validation", async () => {
+    const toolSet = { "ns:get_time": { description: "Get the time" } };
+    mocks.createToolSet.mockReturnValue(toolSet);
+    mocks.generate.mockResolvedValue({
+      text: "",
+      finalStep: {},
+      toolCalls: [],
+    });
+
+    const toolDefinition = {
+      name: "ns:get_time",
+      description: "Get the time",
+      parameters: { type: "object", properties: {} },
+    };
+    const response = await chatCompletionHandler(
+      createRequest({
+        ...baseBody,
+        tools: [toolDefinition],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.createToolSet).toHaveBeenCalledWith([toolDefinition]);
+    expect(mocks.generate).toHaveBeenCalledWith(
+      expect.objectContaining({ tools: toolSet }),
+    );
+  });
+
   it("preserves the text/plain streaming response", async () => {
     const textStream = new ReadableStream<string>({
       start(controller) {

--- a/web/src/components/ModelParameters/index.tsx
+++ b/web/src/components/ModelParameters/index.tsx
@@ -302,6 +302,11 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
           {customHeader ? customHeader : <p className="font-semibold">Model</p>}
           {SettingsButton}
         </div>
+      ) : customHeader ? (
+        <div className="mb-2 flex items-center justify-between">
+          {customHeader}
+          {SettingsButton}
+        </div>
       ) : (
         <div className="mb-2 flex justify-end">{SettingsButton}</div>
       )}

--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -50,7 +50,11 @@ import { ExperimentDetailsStep } from "./steps/ExperimentDetailsStep";
 import { ReviewStep } from "./steps/ReviewStep";
 
 // Import step prop types
-import { PromptType } from "@langfuse/shared";
+import {
+  hasPromptToolStructuredOutputConflict,
+  PROMPT_TOOL_STRUCTURED_OUTPUT_CONFLICT_MESSAGE,
+  PromptType,
+} from "@langfuse/shared";
 
 export const MultiStepExperimentForm = ({
   projectId,
@@ -178,6 +182,7 @@ export const MultiStepExperimentForm = ({
     promptsByName,
     expectedColumns,
     selectedPromptModelConfig,
+    selectedPromptToolConfig,
   } = useExperimentPromptData({
     projectId,
     form,
@@ -269,6 +274,19 @@ export const MultiStepExperimentForm = ({
   };
 
   const onSubmit = async (data: CreateExperiment) => {
+    if (
+      hasPromptToolStructuredOutputConflict(
+        selectedPromptToolConfig,
+        Boolean(data.structuredOutputSchema),
+      )
+    ) {
+      showErrorToast(
+        PROMPT_TOOL_STRUCTURED_OUTPUT_CONFLICT_MESSAGE,
+        "Disable structured output or choose a prompt without tools.",
+      );
+      return;
+    }
+
     capture("dataset_run:new_form_submit");
     const experiment = {
       ...data,
@@ -329,6 +347,10 @@ export const MultiStepExperimentForm = ({
 
   // Get dataset info for review step
   const selectedDataset = datasets.data?.find((d) => d.id === datasetId);
+  const hasToolStructuredOutputConflict = hasPromptToolStructuredOutputConflict(
+    selectedPromptToolConfig,
+    structuredOutputEnabled,
+  );
 
   // Step validation function
   const isStepValid = (stepId: string): boolean => {
@@ -338,6 +360,7 @@ export const MultiStepExperimentForm = ({
           form.getValues("promptId") &&
           modelParams.provider.value &&
           modelParams.model.value &&
+          !hasToolStructuredOutputConflict &&
           !form.formState.errors.promptId &&
           !form.formState.errors.modelConfig
         );
@@ -379,6 +402,7 @@ export const MultiStepExperimentForm = ({
     selectedPromptVersion,
     setSelectedPromptVersion,
     promptsByName,
+    selectedPromptToolConfig,
   };
   const modelState = {
     modelParams,
@@ -566,6 +590,7 @@ export const MultiStepExperimentForm = ({
                     disabled={
                       (Boolean(promptIdFromHook && datasetId) &&
                         !validationResult.data?.isValid) ||
+                      hasToolStructuredOutputConflict ||
                       !!form.formState.errors.name
                     }
                     loading={form.formState.isSubmitting}

--- a/web/src/features/experiments/components/steps/PromptModelStep.tsx
+++ b/web/src/features/experiments/components/steps/PromptModelStep.tsx
@@ -20,9 +20,19 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/src/components/ui/popover";
-import { ChevronDown, CheckIcon, PlusIcon, EyeIcon } from "lucide-react";
+import {
+  ChevronDown,
+  CheckIcon,
+  PlusIcon,
+  EyeIcon,
+  TriangleAlert,
+} from "lucide-react";
 import { CreateOrEditLLMSchemaDialog } from "@/src/features/playground/page/components/CreateOrEditLLMSchemaDialog";
-import { type LlmSchema } from "@langfuse/shared";
+import {
+  hasPromptToolStructuredOutputConflict,
+  PROMPT_TOOL_STRUCTURED_OUTPUT_CONFLICT_MESSAGE,
+  type LlmSchema,
+} from "@langfuse/shared";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { api } from "@/src/utils/api";
 import { CardDescription } from "@/src/components/ui/card";
@@ -45,6 +55,7 @@ export const PromptModelStep: React.FC<PromptModelStepProps> = ({
     setSelectedPromptName,
     selectedPromptVersion,
     setSelectedPromptVersion,
+    selectedPromptToolConfig,
   } = promptModelState;
   const {
     modelParams,
@@ -62,6 +73,10 @@ export const PromptModelStep: React.FC<PromptModelStepProps> = ({
   const [open, setOpen] = useState(false);
   const [selectedSchema, setSelectedSchema] = useState<LlmSchema | null>(null);
   const [schemaPopoverOpen, setSchemaPopoverOpen] = useState(false);
+  const hasToolStructuredOutputConflict = hasPromptToolStructuredOutputConflict(
+    selectedPromptToolConfig,
+    structuredOutputEnabled,
+  );
 
   const savedSchemas = api.llmSchemas.getAll.useQuery(
     { projectId },
@@ -239,6 +254,13 @@ export const PromptModelStep: React.FC<PromptModelStepProps> = ({
                 </PopoverContent>
               </Popover>
             </div>
+            {selectedPromptToolConfig.status === "invalid" && (
+              <p className="text-dark-yellow flex items-center gap-1.5 text-sm">
+                <TriangleAlert className="h-4 w-4 shrink-0" />
+                Invalid tool config detected on this prompt version. Its tools
+                will be ignored when running the experiment.
+              </p>
+            )}
             <FormMessage />
           </FormItem>
         )}
@@ -249,8 +271,8 @@ export const PromptModelStep: React.FC<PromptModelStepProps> = ({
         name="modelConfig"
         render={() => (
           <FormItem>
-            <FormLabel>Model</FormLabel>
             <ModelParameters
+              customHeader={<FormLabel>Model</FormLabel>}
               {...{
                 modelParams,
                 availableModels,
@@ -397,10 +419,16 @@ export const PromptModelStep: React.FC<PromptModelStepProps> = ({
               </>
             )}
 
-            <CardDescription>
-              {structuredOutputEnabled
-                ? "Configure the schema for structured LLM outputs"
-                : "Enable to enforce a specific output format"}
+            <CardDescription
+              className={cn(
+                hasToolStructuredOutputConflict && "text-destructive",
+              )}
+            >
+              {hasToolStructuredOutputConflict
+                ? PROMPT_TOOL_STRUCTURED_OUTPUT_CONFLICT_MESSAGE
+                : structuredOutputEnabled
+                  ? "Configure the schema for structured LLM outputs"
+                  : "Enable to enforce a specific output format"}
             </CardDescription>
             <FormMessage />
           </FormItem>

--- a/web/src/features/experiments/hooks/useExperimentPromptData.ts
+++ b/web/src/features/experiments/hooks/useExperimentPromptData.ts
@@ -3,9 +3,11 @@ import { api } from "@/src/utils/api";
 import { type UseFormReturn } from "react-hook-form";
 import {
   extractVariables,
+  parsePromptToolConfig,
   PromptType,
   extractPlaceholderNames,
   type PromptMessage,
+  type PromptToolConfig,
   ZodModelConfig,
 } from "@langfuse/shared";
 import { z } from "zod/v4";
@@ -74,11 +76,17 @@ export function useExperimentPromptData({
     return getPromptModelConfig(prompt?.config);
   }, [promptId, promptMeta.data]);
 
+  const selectedPromptToolConfig: PromptToolConfig = useMemo(() => {
+    const prompt = promptMeta.data?.find((p) => p.id === promptId);
+    return parsePromptToolConfig(prompt?.config);
+  }, [promptId, promptMeta.data]);
+
   return {
     expectedColumns,
     promptsByName,
     promptId,
     selectedPromptModelConfig,
+    selectedPromptToolConfig,
   };
 }
 

--- a/web/src/features/experiments/server/router.ts
+++ b/web/src/features/experiments/server/router.ts
@@ -48,6 +48,10 @@ import {
   timeFilter,
   AGGREGATABLE_SCORE_TYPES,
   filterAndValidateDbScoreList,
+  hasPromptToolStructuredOutputConflict,
+  InvalidRequestError,
+  parsePromptToolConfig,
+  PROMPT_TOOL_STRUCTURED_OUTPUT_CONFLICT_MESSAGE,
 } from "@langfuse/shared";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
@@ -230,6 +234,19 @@ export const experimentsRouter = createTRPCRouter({
         projectId: input.projectId,
         scope: "promptExperiments:CUD",
       });
+
+      if (input.structuredOutputSchema) {
+        const prompt = await ctx.prisma.prompt.findUnique({
+          where: { id: input.promptId, projectId: input.projectId },
+          select: { config: true },
+        });
+        const toolConfig = parsePromptToolConfig(prompt?.config);
+        if (hasPromptToolStructuredOutputConflict(toolConfig, true)) {
+          throw new InvalidRequestError(
+            PROMPT_TOOL_STRUCTURED_OUTPUT_CONFLICT_MESSAGE,
+          );
+        }
+      }
 
       if (!redis) {
         throw new UnauthorizedError("Experiment creation failed");

--- a/web/src/features/experiments/types/stepProps.ts
+++ b/web/src/features/experiments/types/stepProps.ts
@@ -2,7 +2,11 @@ import { type UseFormReturn } from "react-hook-form";
 import { type CreateExperiment } from "@/src/features/experiments/types";
 import { type UIModelParams } from "@langfuse/shared/src/server";
 import { type ModelParamsContext } from "@/src/components/ModelParameters";
-import { type EvalTemplate, type PromptType } from "@langfuse/shared";
+import {
+  type EvalTemplate,
+  type PromptToolConfig,
+  type PromptType,
+} from "@langfuse/shared";
 import { type PartialConfig } from "@/src/features/evals/types";
 
 type ValidationResult =
@@ -45,6 +49,7 @@ export type PromptModelState = {
   promptsByName:
     | Record<string, Array<{ id: string; version: number; labels: string[] }>>
     | undefined;
+  selectedPromptToolConfig: PromptToolConfig;
 };
 
 export type ModelState = {

--- a/web/src/features/llm-tools/validation.ts
+++ b/web/src/features/llm-tools/validation.ts
@@ -1,13 +1,7 @@
 import { z } from "zod";
-import { LLMJSONSchema } from "@langfuse/shared";
+import { LLMJSONSchema, LLMToolNameSchema } from "@langfuse/shared";
 
-export const LLMToolNameSchema = z
-  .string()
-  .regex(
-    /^[a-zA-Z0-9\._-]+$/,
-    "Name must contain only alphanumeric letters, hyphens, periods and underscores",
-  )
-  .min(1, "Name is required");
+export { LLMToolNameSchema } from "@langfuse/shared";
 
 export const LLMToolInput = z.object({
   name: LLMToolNameSchema,

--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -7,6 +7,7 @@ import { createExperimentJobClickhouse } from "../features/experiments/experimen
 import {
   createDatasetItem,
   createOrgProjectAndApiKey,
+  generateLLMText,
   logger,
 } from "@langfuse/shared/src/server";
 
@@ -573,5 +574,163 @@ describe("experiment processing integration", () => {
     //     }),
     //   }),
     // );
+  });
+});
+
+describe("experiment prompt tool config", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(generateLLMText).mockResolvedValue({
+      text: "test output",
+    } as any);
+  });
+
+  const setupExperimentWithPromptConfig = async (
+    promptConfig: unknown,
+    runMetadata: Record<string, unknown> = {},
+  ) => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const datasetId = randomUUID();
+    const runId = randomUUID();
+    const promptId = randomUUID();
+
+    await prisma.prompt.create({
+      data: {
+        id: promptId,
+        projectId,
+        name: "Test Prompt",
+        prompt: "Hello {{name}}",
+        config: promptConfig as any,
+        type: "text",
+        version: 1,
+        createdBy: "test-user",
+      },
+    });
+    await prisma.dataset.create({
+      data: { id: datasetId, projectId, name: "Test Dataset" },
+    });
+    await prisma.datasetRuns.create({
+      data: {
+        id: runId,
+        name: "Test Run",
+        projectId,
+        datasetId,
+        metadata: {
+          prompt_id: promptId,
+          provider: "openai",
+          model: "gpt-3.5-turbo",
+          model_params: { temperature: 0 },
+          ...runMetadata,
+        },
+      },
+    });
+    await createDatasetItem({
+      projectId,
+      datasetId,
+      input: { name: "World" },
+    });
+    await prisma.llmApiKeys.create({
+      data: {
+        id: randomUUID(),
+        projectId,
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        displaySecretKey: "test-key",
+        secretKey: encrypt("test-key"),
+      },
+    });
+
+    return { projectId, datasetId, runId };
+  };
+
+  test("passes valid prompt config tools to the LLM call", async () => {
+    const { projectId, datasetId, runId } =
+      await setupExperimentWithPromptConfig({
+        tools: [
+          {
+            name: "get_weather",
+            description: "Get the weather for a location",
+            parameters: {
+              type: "object",
+              properties: { location: { type: "string" } },
+              required: ["location"],
+            },
+          },
+          // OpenAI-wrapped shape must be accepted as well
+          {
+            type: "function",
+            function: {
+              name: "get_time",
+              description: "Get the current time",
+              parameters: { type: "object", properties: {} },
+            },
+          },
+        ],
+      });
+
+    const result = await createExperimentJobClickhouse({
+      event: { projectId, datasetId, runId },
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(vi.mocked(generateLLMText)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: expect.objectContaining({
+          get_weather: expect.anything(),
+          get_time: expect.anything(),
+        }),
+      }),
+    );
+  });
+
+  test("ignores invalid prompt config tools and runs without tools", async () => {
+    const { projectId, datasetId, runId } =
+      await setupExperimentWithPromptConfig({
+        tools: [{ name: "broken_tool" }], // missing parameters
+      });
+
+    const result = await createExperimentJobClickhouse({
+      event: { projectId, datasetId, runId },
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(vi.mocked(generateLLMText)).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(generateLLMText).mock.calls[0][0];
+    expect(callArgs.tools).toBeUndefined();
+  });
+
+  test("rejects combining prompt config tools with structured output", async () => {
+    const { projectId, datasetId, runId } =
+      await setupExperimentWithPromptConfig(
+        {
+          tools: [
+            {
+              name: "get_weather",
+              description: "Get the weather for a location",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+        {
+          structured_output_schema: {
+            type: "object",
+            properties: { answer: { type: "string" } },
+          },
+        },
+      );
+
+    const result = await createExperimentJobClickhouse({
+      event: { projectId, datasetId, runId },
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(vi.mocked(generateLLMText)).not.toHaveBeenCalled();
+    expect(vi.mocked(logger).error).toHaveBeenCalledWith(
+      "Failed to validate and setup experiment",
+      expect.objectContaining({
+        message:
+          "Your prompt contains tool definitions - tool calls are not compatible with structured output",
+      }),
+    );
   });
 });

--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -649,7 +649,6 @@ describe("experiment prompt tool config", () => {
         tools: [
           {
             name: "get_weather",
-            description: "Get the weather for a location",
             parameters: {
               type: "object",
               properties: { location: { type: "string" } },
@@ -662,7 +661,6 @@ describe("experiment prompt tool config", () => {
             function: {
               name: "get_time",
               description: "Get the current time",
-              parameters: { type: "object", properties: {} },
             },
           },
         ],
@@ -686,7 +684,7 @@ describe("experiment prompt tool config", () => {
   test("ignores invalid prompt config tools and runs without tools", async () => {
     const { projectId, datasetId, runId } =
       await setupExperimentWithPromptConfig({
-        tools: [{ name: "broken_tool" }], // missing parameters
+        tools: [{ name: "broken_tool", parameters: "invalid" }],
       });
 
     const result = await createExperimentJobClickhouse({

--- a/worker/src/features/experiments/experimentServiceClickhouse.ts
+++ b/worker/src/features/experiments/experimentServiceClickhouse.ts
@@ -8,6 +8,7 @@ import {
   ChatMessage,
   convertDateToClickhouseDateTime,
   createLLMOutput,
+  createLLMToolSet,
   createUnknownSdkIngestionAttribution,
   createDatasetItemFilterState,
   DatasetRunItemUpsertQueue,
@@ -222,9 +223,12 @@ async function processLLMCall(
   await generateLLMText({
     ...llmParams,
     maxRetries: 1,
+    // Setup rejects the unsupported tools + structured-output combination.
     ...(config.structuredOutputSchema
       ? { output: createLLMOutput(config.structuredOutputSchema) }
-      : {}),
+      : config.tools.length > 0
+        ? { tools: createLLMToolSet(config.tools) }
+        : {}),
     trace: traceSinkParams,
   }).catch(() => undefined); // catch errors and do not retry
 

--- a/worker/src/features/experiments/utils.ts
+++ b/worker/src/features/experiments/utils.ts
@@ -5,7 +5,9 @@ import {
   compileChatMessages,
   extractPlaceholderNames,
   extractVariables,
+  hasPromptToolStructuredOutputConflict,
   MessagePlaceholderValues,
+  PROMPT_TOOL_STRUCTURED_OUTPUT_CONFLICT_MESSAGE,
   Prisma,
   PromptContent,
   PromptType,
@@ -14,6 +16,7 @@ import {
 import { compileTemplateString } from "../utils/utilities";
 import {
   logger,
+  parsePromptToolConfig,
   PromptService,
   type PromptMessage,
   redis,
@@ -196,6 +199,27 @@ export async function validateAndSetupExperiment(
     throw new UnrecoverableError(`Prompt ${prompt_id} has invalid format`);
   }
 
+  // Tools are lenient by design: the experiment form warns about invalid tool
+  // configs at creation time, so at execution time we run without tools
+  // instead of failing the whole run.
+  const toolConfig = parsePromptToolConfig(prompt.config);
+  if (toolConfig.status === "invalid") {
+    logger.info(
+      `Prompt ${prompt_id} has an invalid tool config, ignoring tools for experiment run ${runId}`,
+    );
+  }
+
+  if (
+    hasPromptToolStructuredOutputConflict(
+      toolConfig,
+      Boolean(validatedRunMetadata.data.structured_output_schema),
+    )
+  ) {
+    throw new UnrecoverableError(
+      PROMPT_TOOL_STRUCTURED_OUTPUT_CONFLICT_MESSAGE,
+    );
+  }
+
   // Fetch and validate API key
   const apiKey = await prisma.llmApiKeys.findFirst({
     where: { projectId, provider },
@@ -231,6 +255,7 @@ export async function validateAndSetupExperiment(
     provider,
     model,
     model_params,
+    tools: toolConfig.status === "valid" ? toolConfig.tools : [],
     structuredOutputSchema: validatedRunMetadata.data.structured_output_schema,
     experimentName: validatedRunMetadata.data.experiment_name,
     experimentRunName: validatedRunMetadata.data.experiment_run_name,


### PR DESCRIPTION
## Summary

- Parse tool definitions from selected prompt configurations and pass valid tools to dataset experiment LLM calls.
- Support both native Langfuse and OpenAI-wrapped tool definitions while warning about invalid configurations.
- Surface prompt tool conflicts clearly in the experiment form and prevent unsupported runs from being created.

## Linear

- [LFE-10767](https://linear.app/langfuse/issue/LFE-10767/bug-tool-config-does-not-get-passed-in-dataset-experiments-via-ui)

## Major Decisions

- Reject prompts containing tool definitions when structured output is enabled instead of silently prioritizing structured output and dropping the tools. Dataset experiments record native tool calls but do not execute them, so a single invocation cannot also guarantee a provider-enforced structured final response.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires prompt-level tool definitions through the experiment pipeline so dataset runs actually receive the tools declared in a prompt's `config`. It introduces `parsePromptToolConfig` to normalise both the flat Langfuse shape and the OpenAI `{type:"function", function:{…}}` wrapper, rejects any combination of valid tools and structured output at the UI, tRPC router, and worker levels, and surfaces a warning when a prompt's tool config is structurally invalid.

- **New `parsePromptToolConfig` + `hasPromptToolStructuredOutputConflict`** (shared package) centralise all tool-config parsing with a typed discriminated-union result; the logic is well-tested across valid, invalid, and \"none\" cases.
- **Three-layer conflict guard** (form submit, tRPC mutation, worker setup) prevents tools + structured output from being combined; the worker falls back to creating error run items when the constraint is violated at execution time.
- **`LLMToolNameSchema` consolidated** from `web/src/features/llm-tools/validation.ts` into the shared package, eliminating a duplicated regex definition.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for most users, but prompts with OpenAI-format tool definitions that omit `description` will have their tools silently ignored, which is a quiet behavior regression for anyone relying on that format.

The core logic — parsing, conflict detection, and wiring tools into the LLM call — is well-structured and covered by integration tests. The outstanding concern is that `LLMToolDefinitionSchema` requires `description` while OpenAI's own spec marks it optional. A user who stored prompt tools via the API without a description field (valid per OpenAI, but not valid per Langfuse's existing schema) will now find those tools silently dropped at experiment runtime with only a generic 'Invalid tool config' UI warning that doesn't identify the missing field as the cause.

`packages/shared/src/server/llm/promptToolConfig.ts` — the `description`-required constraint in `LLMToolDefinitionSchema` (inherited by `PromptConfigToolSchema`) is the source of the silent-failure path worth reviewing before merge.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as MultiStepExperimentForm
    participant Hook as useExperimentPromptData
    participant Router as experimentsRouter (tRPC)
    participant Worker as createExperimentJobClickhouse
    participant Utils as validateAndSetupExperiment
    participant LLM as generateLLMText

    UI->>Hook: select prompt version
    Hook->>Hook: parsePromptToolConfig(prompt.config)
    Hook-->>UI: "selectedPromptToolConfig {status}"

    UI->>UI: hasPromptToolStructuredOutputConflict?
    alt conflict detected
        UI-->>UI: disable submit / show warning
    end

    UI->>Router: createExperiment(input)
    Router->>Router: if input.structuredOutputSchema
    Router->>Router: parsePromptToolConfig(prompt.config)
    Router->>Router: hasPromptToolStructuredOutputConflict?
    alt conflict at server
        Router-->>UI: InvalidRequestError
    end
    Router-->>UI: "success -> enqueue job"

    Worker->>Utils: validateAndSetupExperiment(event)
    Utils->>Utils: fetchPrompt(prompt_id)
    Utils->>Utils: parsePromptToolConfig(prompt.config)
    alt "status == invalid"
        Utils->>Utils: logger.info (ignore tools)
    end
    alt tools + structuredOutput conflict
        Utils-->>Worker: throw UnrecoverableError
        Worker->>Worker: createAllDatasetRunItemsWithConfigError
    else "status == valid"
        Utils-->>Worker: "config { tools: [...] }"
        Worker->>LLM: generateLLMText with createLLMToolSet
    else no tools
        Worker->>LLM: generateLLMText with structuredSchema
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as MultiStepExperimentForm
    participant Hook as useExperimentPromptData
    participant Router as experimentsRouter (tRPC)
    participant Worker as createExperimentJobClickhouse
    participant Utils as validateAndSetupExperiment
    participant LLM as generateLLMText

    UI->>Hook: select prompt version
    Hook->>Hook: parsePromptToolConfig(prompt.config)
    Hook-->>UI: "selectedPromptToolConfig {status}"

    UI->>UI: hasPromptToolStructuredOutputConflict?
    alt conflict detected
        UI-->>UI: disable submit / show warning
    end

    UI->>Router: createExperiment(input)
    Router->>Router: if input.structuredOutputSchema
    Router->>Router: parsePromptToolConfig(prompt.config)
    Router->>Router: hasPromptToolStructuredOutputConflict?
    alt conflict at server
        Router-->>UI: InvalidRequestError
    end
    Router-->>UI: "success -> enqueue job"

    Worker->>Utils: validateAndSetupExperiment(event)
    Utils->>Utils: fetchPrompt(prompt_id)
    Utils->>Utils: parsePromptToolConfig(prompt.config)
    alt "status == invalid"
        Utils->>Utils: logger.info (ignore tools)
    end
    alt tools + structuredOutput conflict
        Utils-->>Worker: throw UnrecoverableError
        Worker->>Worker: createAllDatasetRunItemsWithConfigError
    else "status == valid"
        Utils-->>Worker: "config { tools: [...] }"
        Worker->>LLM: generateLLMText with createLLMToolSet
    else no tools
        Worker->>LLM: generateLLMText with structuredSchema
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/llm/promptToolConfig.ts:9-11
**`description` required, but OpenAI spec has it optional**

`LLMToolDefinitionSchema` (and its OpenAI wrapper) require `description: z.string()` — a missing key fails Zod. OpenAI's function-definition spec marks `description` as optional. Any prompt whose `config` stores tools in OpenAI format without a `description` field will parse to `{ status: "invalid" }` and have every tool silently dropped. The only user-visible feedback is the generic "Invalid tool config detected" warning in `PromptModelStep`, which gives no hint that a missing description is the cause. Users who created prompts programmatically (API) using the OpenAI tool format will hit this without a clear path to fix it.

### Issue 2 of 2
worker/src/features/experiments/utils.ts:212-221
**`UnrecoverableError` thrown but swallowed upstream**

`validateAndSetupExperiment` throws `UnrecoverableError` for the tools + structured-output conflict, signalling "don't retry this job". However, `createExperimentJobClickhouse` catches ALL errors from this call indiscriminately and returns `{ success: true }` after creating error run items. `UnrecoverableError` is therefore never seen by BullMQ; the retry-prevention semantic is meaningless here. The end result (creating error run items) is correct per the tests, but if this error is intentionally treated differently from a regular `Error` elsewhere in the job-runner stack, the handler may need to be adjusted.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): pass prompt tools to d..."](https://github.com/langfuse/langfuse/commit/a72f62c348d8b776ba53543f10d17797a96efb3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44762445)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->