### PR TITLE
feat(ci): record PR previews as native GitHub deployments

### DIFF
--- a/.agents/skills/langfuse-previews/SKILL.md
+++ b/.agents/skills/langfuse-previews/SKILL.md
@@ -36,9 +36,10 @@ Pushing updates it; closing the PR tears it down.
 ## Using a preview
 
 - **Spin up** — open a same-repo PR. It's auto-labeled and builds (~5 min); a
-  bot comment then posts the preview URL and login, and a one-line banner with
-  the same URL is pinned to the top of the PR description. No manual step, no
-  label to add.
+  bot comment then posts the preview URL and login, a one-line banner with the
+  same URL is pinned to the top of the PR description, and a GitHub deployment
+  (environment `pr-<n>`) gives the PR a **View deployment** button. No manual
+  step, no label to add.
 - **Log in** — use the credentials in the **bot's PR comment** (the source of
   truth). The demo project's shared seed identity is `demo@langfuse.com` /
   `password`, with API keys `pk-lf-1234567890` / `sk-lf-1234567890` — shared and

--- a/.agents/skills/langfuse-previews/SKILL.md
+++ b/.agents/skills/langfuse-previews/SKILL.md
@@ -36,8 +36,7 @@ Pushing updates it; closing the PR tears it down.
 ## Using a preview
 
 - **Spin up** — open a same-repo PR. It's auto-labeled and builds (~5 min); a
-  bot comment then posts the preview URL and login, a one-line banner with the
-  same URL is pinned to the top of the PR description, and a GitHub deployment
+  bot comment then posts the preview URL and login, and a GitHub deployment
   (environment `pr-<n>`) gives the PR a **View deployment** button. No manual
   step, no label to add.
 - **Log in** — use the credentials in the **bot's PR comment** (the source of

--- a/.agents/skills/langfuse-previews/SKILL.md
+++ b/.agents/skills/langfuse-previews/SKILL.md
@@ -36,8 +36,9 @@ Pushing updates it; closing the PR tears it down.
 ## Using a preview
 
 - **Spin up** — open a same-repo PR. It's auto-labeled and builds (~5 min); a
-  bot comment then posts the preview URL and login. No manual step, no label to
-  add.
+  bot comment then posts the preview URL and login, and a one-line banner with
+  the same URL is pinned to the top of the PR description. No manual step, no
+  label to add.
 - **Log in** — use the credentials in the **bot's PR comment** (the source of
   truth). The demo project's shared seed identity is `demo@langfuse.com` /
   `password`, with API keys `pk-lf-1234567890` / `sk-lf-1234567890` — shared and

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -2,6 +2,8 @@ name: AWS preview status comment
 description: >-
   Create or update the single marker-tagged AWS preview status comment on a
   pull request, so each PR carries exactly one authoritative preview comment.
+  Optionally also upserts a one-line banner at the very top of the PR
+  description, so the preview URL is visible without scrolling the timeline.
 
 inputs:
   pr-number:
@@ -10,6 +12,14 @@ inputs:
   body:
     description: Comment body (the hidden marker is prepended automatically)
     required: true
+  banner:
+    description: >-
+      Optional single-line markdown summary. When set, it is upserted as a
+      marker-delimited blockquote at the very top of the PR description, with
+      a link to the full status comment appended. When empty, the description
+      is left untouched.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -18,6 +28,7 @@ runs:
       env:
         PREVIEW_PR_NUMBER: ${{ inputs.pr-number }}
         PREVIEW_COMMENT_BODY: ${{ inputs.body }}
+        PREVIEW_BANNER: ${{ inputs.banner }}
       with:
         script: |
           const marker = "<!-- aws-preview -->";
@@ -37,6 +48,7 @@ runs:
               comment.body?.includes(marker),
           );
 
+          let commentId;
           if (previous) {
             await github.rest.issues.updateComment({
               owner,
@@ -44,11 +56,49 @@ runs:
               comment_id: previous.id,
               body,
             });
+            commentId = previous.id;
           } else {
-            await github.rest.issues.createComment({
+            const { data: created } = await github.rest.issues.createComment({
               owner,
               repo,
               issue_number,
               body,
             });
+            commentId = created.id;
+          }
+
+          // Optionally pin a one-line banner at the very top of the PR
+          // description, so the preview URL is readable without scrolling past
+          // the review timeline. The banner lives between two HTML-comment
+          // markers and is replaced in place on every update, preserving the
+          // author's own description around it.
+          const banner = (process.env.PREVIEW_BANNER ?? "").trim();
+          if (banner) {
+            const bannerStart = "<!-- aws-preview-banner -->";
+            const bannerEnd = "<!-- /aws-preview-banner -->";
+            const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+            const commentUrl = `${serverUrl}/${owner}/${repo}/pull/${issue_number}#issuecomment-${commentId}`;
+            const block = `${bannerStart}\n> ${banner} ([details](${commentUrl}))\n${bannerEnd}`;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: issue_number,
+            });
+            const prBody = pr.body ?? "";
+            const blockRe = /<!-- aws-preview-banner -->[\s\S]*?<!-- \/aws-preview-banner -->/;
+            // Replacer function: a literal replacement string would mangle any
+            // `$` sequences in the banner text.
+            const nextBody = blockRe.test(prBody)
+              ? prBody.replace(blockRe, () => block)
+              : `${block}\n\n${prBody}`;
+
+            if (nextBody !== prBody) {
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: issue_number,
+                body: nextBody,
+              });
+            }
           }

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -2,8 +2,6 @@ name: AWS preview status comment
 description: >-
   Create or update the single marker-tagged AWS preview status comment on a
   pull request, so each PR carries exactly one authoritative preview comment.
-  Optionally also upserts a one-line banner at the very top of the PR
-  description, so the preview URL is visible without scrolling the timeline.
 
 inputs:
   pr-number:
@@ -12,14 +10,6 @@ inputs:
   body:
     description: Comment body (the hidden marker is prepended automatically)
     required: true
-  banner:
-    description: >-
-      Optional single-line markdown summary. When set, it is upserted as a
-      marker-delimited blockquote at the very top of the PR description, with
-      a link to the full status comment appended. When empty, the description
-      is left untouched.
-    required: false
-    default: ""
 
 runs:
   using: composite
@@ -28,7 +18,6 @@ runs:
       env:
         PREVIEW_PR_NUMBER: ${{ inputs.pr-number }}
         PREVIEW_COMMENT_BODY: ${{ inputs.body }}
-        PREVIEW_BANNER: ${{ inputs.banner }}
       with:
         script: |
           const marker = "<!-- aws-preview -->";
@@ -48,7 +37,6 @@ runs:
               comment.body?.includes(marker),
           );
 
-          let commentId;
           if (previous) {
             await github.rest.issues.updateComment({
               owner,
@@ -56,49 +44,11 @@ runs:
               comment_id: previous.id,
               body,
             });
-            commentId = previous.id;
           } else {
-            const { data: created } = await github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               owner,
               repo,
               issue_number,
               body,
             });
-            commentId = created.id;
-          }
-
-          // Optionally pin a one-line banner at the very top of the PR
-          // description, so the preview URL is readable without scrolling past
-          // the review timeline. The banner lives between two HTML-comment
-          // markers and is replaced in place on every update, preserving the
-          // author's own description around it.
-          const banner = (process.env.PREVIEW_BANNER ?? "").trim();
-          if (banner) {
-            const bannerStart = "<!-- aws-preview-banner -->";
-            const bannerEnd = "<!-- /aws-preview-banner -->";
-            const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
-            const commentUrl = `${serverUrl}/${owner}/${repo}/pull/${issue_number}#issuecomment-${commentId}`;
-            const block = `${bannerStart}\n> ${banner} ([details](${commentUrl}))\n${bannerEnd}`;
-
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: issue_number,
-            });
-            const prBody = pr.body ?? "";
-            const blockRe = /<!-- aws-preview-banner -->[\s\S]*?<!-- \/aws-preview-banner -->/;
-            // Replacer function: a literal replacement string would mangle any
-            // `$` sequences in the banner text.
-            const nextBody = blockRe.test(prBody)
-              ? prBody.replace(blockRe, () => block)
-              : `${block}\n\n${prBody}`;
-
-            if (nextBody !== prBody) {
-              await github.rest.pulls.update({
-                owner,
-                repo,
-                pull_number: issue_number,
-                body: nextBody,
-              });
-            }
           }

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -3,9 +3,9 @@ name: AWS preview build
 # Build the PR's web + worker images and push them to ECR as pr-<n>-<sha>.
 # The Argo CD ApplicationSet in the infrastructure repo deploys whichever image
 # tag exists for a labeled PR; this workflow only builds and pushes, then posts
-# the preview URL on the PR — both as the marker-tagged status comment and as a
-# one-line banner pinned to the top of the PR description, so the URL is
-# visible without scrolling the timeline.
+# the preview URL on the PR — as the marker-tagged status comment and as a
+# native GitHub deployment (the "View deployment" button), so the URL is
+# findable without scrolling the timeline.
 #
 # The two images are independent artifacts pushed to two independent ECR repos
 # under the same tag, with no ordering dependency between them. They therefore
@@ -124,9 +124,6 @@ jobs:
         uses: ./.github/actions/preview-comment
         with:
           pr-number: ${{ github.event.pull_request.number }}
-          banner: >-
-            🟡 **AWS preview building** — deploys to
-            https://${{ steps.meta.outputs.preview_host }} in ~5 min
           body: |
             ### 🟡 AWS preview building
 
@@ -260,10 +257,6 @@ jobs:
         uses: ./.github/actions/preview-comment
         with:
           pr-number: ${{ github.event.pull_request.number }}
-          banner: >-
-            🟢 **AWS preview:** https://${{ needs.meta.outputs.preview_host }}
-            — login `${{ needs.meta.outputs.login_email }}` /
-            `${{ needs.meta.outputs.login_password }}`
           body: |
             ### 🟢 AWS preview image pushed
 
@@ -359,9 +352,6 @@ jobs:
         uses: ./.github/actions/preview-comment
         with:
           pr-number: ${{ github.event.pull_request.number }}
-          banner: >-
-            ⚠️ **AWS preview build failed** —
-            [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           body: |
             ### ⚠️ AWS preview build failed
 
@@ -372,9 +362,6 @@ jobs:
         uses: ./.github/actions/preview-comment
         with:
           pr-number: ${{ github.event.pull_request.number }}
-          banner: >-
-            ⚠️ **AWS preview build failed** —
-            [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           body: |
             ### ⚠️ AWS preview build failed
 

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -244,6 +244,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # createDeployment/createDeploymentStatus for the native "View deployment"
+      # button on the PR (see "Record GitHub deployment" below).
+      deployments: write
     steps:
       - name: Checkout base local actions
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -285,6 +288,63 @@ jobs:
             `kubectl -n ${{ needs.meta.outputs.namespace }} get pods` to inspect status.
 
             Synthetic preview data only. Never add production data to public accounts.
+
+      # Record a native GitHub deployment for the preview, so the PR shows
+      # "deployed to pr-<n>" with a "View deployment" button in the timeline /
+      # merge box, and the environment appears on the repo's Deployments page.
+      # Inline step (not the base-checkout composite action): it needs no shared
+      # logic, and inline steps run from the PR's own workflow file.
+      #
+      # `state: success` mirrors the 🟢 comment's semantics — images pushed,
+      # Argo CD rolling out; the URL is usually live minutes later. Like the
+      # comment, it cannot see the infra-repo deploy allowlist, so for a
+      # non-allowlisted author the deployment records but the URL 404s (same
+      # caveat as the comment's debug-guide link). `auto_inactive` retires the
+      # previous SHA's deployment on every new push; the preview-deactivate
+      # workflow retires the last one when the PR closes.
+      - name: Record GitHub deployment
+        if: needs.build.result == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PREVIEW_SHA: ${{ needs.meta.outputs.commit_sha }}
+          PREVIEW_HOST: ${{ needs.meta.outputs.preview_host }}
+          PREVIEW_ENVIRONMENT: pr-${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const environment = process.env.PREVIEW_ENVIRONMENT;
+
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner,
+              repo,
+              ref: process.env.PREVIEW_SHA,
+              environment,
+              // The images are the deployable; don't gate on commit statuses
+              // (this very workflow is one of them) and never let GitHub
+              // auto-merge base into the ref.
+              required_contexts: [],
+              auto_merge: false,
+              transient_environment: true,
+              description: `Langfuse PR preview at https://${process.env.PREVIEW_HOST}`,
+            });
+            // required_contexts: [] makes a non-201 unrepresentable in practice,
+            // but createDeployment's 202 "merged deployment" response has no id
+            // — fail loudly rather than posting a status against undefined.
+            if (!deployment?.id) {
+              core.setFailed(`createDeployment did not return a deployment id: ${JSON.stringify(deployment)}`);
+              return;
+            }
+
+            await github.rest.repos.createDeploymentStatus({
+              owner,
+              repo,
+              deployment_id: deployment.id,
+              state: "success",
+              environment_url: `https://${process.env.PREVIEW_HOST}`,
+              log_url: `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+              auto_inactive: true,
+            });
+            core.info(`Recorded deployment ${deployment.id} for ${environment}.`);
 
       # Two distinct failure paths, each keyed on `== 'failure'` (NOT
       # `!= 'success'`): that keeps them from firing on `cancelled` (a

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -3,7 +3,9 @@ name: AWS preview build
 # Build the PR's web + worker images and push them to ECR as pr-<n>-<sha>.
 # The Argo CD ApplicationSet in the infrastructure repo deploys whichever image
 # tag exists for a labeled PR; this workflow only builds and pushes, then posts
-# the preview URL on the PR.
+# the preview URL on the PR — both as the marker-tagged status comment and as a
+# one-line banner pinned to the top of the PR description, so the URL is
+# visible without scrolling the timeline.
 #
 # The two images are independent artifacts pushed to two independent ECR repos
 # under the same tag, with no ordering dependency between them. They therefore
@@ -122,6 +124,9 @@ jobs:
         uses: ./.github/actions/preview-comment
         with:
           pr-number: ${{ github.event.pull_request.number }}
+          banner: >-
+            🟡 **AWS preview building** — deploys to
+            https://${{ steps.meta.outputs.preview_host }} in ~5 min
           body: |
             ### 🟡 AWS preview building
 
@@ -252,6 +257,10 @@ jobs:
         uses: ./.github/actions/preview-comment
         with:
           pr-number: ${{ github.event.pull_request.number }}
+          banner: >-
+            🟢 **AWS preview:** https://${{ needs.meta.outputs.preview_host }}
+            — login `${{ needs.meta.outputs.login_email }}` /
+            `${{ needs.meta.outputs.login_password }}`
           body: |
             ### 🟢 AWS preview image pushed
 
@@ -290,6 +299,9 @@ jobs:
         uses: ./.github/actions/preview-comment
         with:
           pr-number: ${{ github.event.pull_request.number }}
+          banner: >-
+            ⚠️ **AWS preview build failed** —
+            [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           body: |
             ### ⚠️ AWS preview build failed
 
@@ -300,6 +312,9 @@ jobs:
         uses: ./.github/actions/preview-comment
         with:
           pr-number: ${{ github.event.pull_request.number }}
+          banner: >-
+            ⚠️ **AWS preview build failed** —
+            [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           body: |
             ### ⚠️ AWS preview build failed
 

--- a/.github/workflows/preview-deactivate.yml
+++ b/.github/workflows/preview-deactivate.yml
@@ -1,0 +1,74 @@
+name: AWS preview deactivate
+
+# Mark the PR's GitHub deployments (environment pr-<n>, recorded by
+# preview-build's "Record GitHub deployment" step) inactive when the PR closes.
+# Closing/merging is what tears the preview down — the Argo CD ApplicationSet
+# only generates Applications for OPEN labeled PRs — so without this the PR and
+# the repo's Deployments page keep advertising an "Active" environment whose
+# URL is gone.
+#
+# Deactivation only: GITHUB_TOKEN cannot delete environments (that needs repo
+# administration permission), and inactive deployments are the standard way
+# GitHub renders retired preview environments.
+#
+# Safe trigger: plain `pull_request: closed` with no checkout, no PR-code
+# execution, no cloud credentials — only deployment-status mutations — so it
+# stays off zizmor's dangerous-triggers list.
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  deactivate:
+    name: Mark preview deployments inactive
+    runs-on: ubuntu-latest
+    # AWS_PREVIEW_ECR_PUSH_ROLE_ARN is the preview-system feature flag (same
+    # gate as preview-build / preview-autolabel): unset => system off, no
+    # deployments were ever recorded.
+    if: vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != ''
+    permissions:
+      deployments: write
+    steps:
+      - name: Deactivate pr-<n> deployments
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PREVIEW_ENVIRONMENT: pr-${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const environment = process.env.PREVIEW_ENVIRONMENT;
+
+            const deployments = await github.paginate(github.rest.repos.listDeployments, {
+              owner,
+              repo,
+              environment,
+              per_page: 100,
+            });
+            if (deployments.length === 0) {
+              core.info(`No deployments recorded for ${environment}; nothing to deactivate.`);
+              return;
+            }
+
+            // Isolate failures per deployment (same pattern as the stale-cleanup
+            // sweep): one transient 5xx must not skip the rest, and partial
+            // failure should surface as a failed run rather than silent green.
+            let failures = 0;
+            for (const deployment of deployments) {
+              try {
+                await github.rest.repos.createDeploymentStatus({
+                  owner,
+                  repo,
+                  deployment_id: deployment.id,
+                  state: "inactive",
+                });
+              } catch (e) {
+                failures++;
+                core.warning(`Deployment ${deployment.id}: ${e.message} — continuing`);
+              }
+            }
+            core.info(`Marked ${deployments.length - failures} of ${deployments.length} deployment(s) for ${environment} inactive.`);
+            if (failures) {
+              core.setFailed(`${failures} of ${deployments.length} deployment(s) could not be deactivated.`);
+            }

--- a/.github/workflows/preview-stale-cleanup.yml
+++ b/.github/workflows/preview-stale-cleanup.yml
@@ -46,6 +46,10 @@ jobs:
       # (NOT issues), even though they go through the issues REST endpoints —
       # same pattern as preview-autolabel / preview-build. Also covers pulls.list.
       pull-requests: write
+      # Mark the reaped preview's GitHub deployments (environment pr-<n>,
+      # recorded by preview-build) inactive alongside the label removal, so the
+      # PR stops advertising an "Active" environment whose URL is gone.
+      deployments: write
     steps:
       - name: Reap stale previews
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -107,6 +111,25 @@ jobs:
                     body: `🧹 Preview environment torn down after **${staleDays} days** of inactivity `
                       + `(last update ${pr.updated_at}). Re-add the \`${label}\` label to redeploy.`,
                   });
+
+                  // Retire the PR's GitHub deployments along with the preview
+                  // itself, so the PR stops showing an "Active" environment.
+                  // Re-adding the label redeploys, and the next build records a
+                  // fresh deployment.
+                  const deployments = await github.paginate(github.rest.repos.listDeployments, {
+                    owner,
+                    repo,
+                    environment: `pr-${pr.number}`,
+                    per_page: 100,
+                  });
+                  for (const deployment of deployments) {
+                    await github.rest.repos.createDeploymentStatus({
+                      owner,
+                      repo,
+                      deployment_id: deployment.id,
+                      state: "inactive",
+                    });
+                  }
                 }
               } catch (e) {
                 failures++;


### PR DESCRIPTION
## Motivation

The AWS preview status comment (URL, login, debug commands) gets buried in the review timeline on busy PRs, so engineers scroll to find where a PR is deployed. This PR records each preview as a **native GitHub deployment**, so the PR gets GitHub's built-in "deployed to pr-N" entry with a **View deployment** button, and the environment shows on the repo's Deployments page — no scrolling.

(An earlier iteration also pinned a banner into the PR description; that was dropped in favor of the native deployment UI — see the revert commit.)

## Changes

- `.github/workflows/preview-build.yml`: on build success, the notify job creates a GitHub deployment for environment `pr-<n>` with `environment_url` set to the preview host. `auto_inactive` retires the previous SHA's deployment on each push. Job gains `deployments: write`.
- `.github/workflows/preview-deactivate.yml` (new): on PR close/merge — which is what tears the preview down — marks all `pr-<n>` deployments inactive, so the PR and the repo's Deployments page stop advertising a dead URL. Safe trigger: no checkout, no PR-code execution, deployment-status mutations only.
- `.github/workflows/preview-stale-cleanup.yml`: the daily sweep also retires deployments when it reaps an idle preview (re-adding the label redeploys and records a fresh one).
- `.agents/skills/langfuse-previews/SKILL.md`: document the deployment surface.

No recursion risk: deployments created with GITHUB_TOKEN don't start workflow runs, and no preview workflow listens to `deployment`/`deployment_status` anyway.

Known caveat (same as the existing 🟢 comment): the workflow can't see the infra-repo deploy allowlist, so for a non-allowlisted author the deployment records `success` but the URL 404s.

## Impacted packages

None (CI workflows + agent skill docs only).

## Verification

- `yaml.safe_load` on all changed/new YAML files — OK
- `node --check` on every embedded github-script block — OK
- `uvx zizmor` on all four touched files — `No findings to report. Good job! (6 suppressed)` (suppressions pre-existing)
- `pnpm run agents:sync` && `pnpm run agents:check` — passed
- Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`
- **End-to-end on this PR**: the deployment step is inline in the workflow, so this PR's own builds exercise it — deployment for environment `pr-15158` with `state: success` and `environment_url: https://pr-15158.preview.langfuse.com` verified via the API; the "View deployment" button is visible on this PR. The close-path (`preview-deactivate`) runs when this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
