### PR TITLE
fix(trace): stop re-serializing multi-MB I/O in parsed-I/O cache keys (LFE-10992)

### DIFF
--- a/web/src/hooks/parsedIoCacheKey.clienttest.ts
+++ b/web/src/hooks/parsedIoCacheKey.clienttest.ts
@@ -1,0 +1,63 @@
+import { cheapHash } from "@/src/hooks/parsedIoCacheKey";
+
+/**
+ * The React Query cache key for parsed trace/observation I/O must identify a
+ * field by a cheap, content-sensitive signature — never by embedding (and thus
+ * re-serializing) the raw payload. These tests pin that accounting: the
+ * signature never contains the payload text, is stable for identical content
+ * (cache hit), and changes on ANY content change — including a same-length swap
+ * (cache miss / re-parse), which a length-only key would have wrongly collided.
+ */
+describe("cheapHash", () => {
+  it("returns a fixed marker for null / undefined", () => {
+    expect(cheapHash(null)).toBe("∅");
+    expect(cheapHash(undefined)).toBe("∅");
+  });
+
+  it("keys a string by length + hash, never by its content", () => {
+    const big = "x".repeat(5_000_000);
+    const sig = cheapHash(big);
+    expect(sig).toMatch(/^s5000000:/);
+    // The whole point of the fix: the multi-MB payload is NOT in the key.
+    expect(sig.length).toBeLessThan(30);
+    expect(sig).not.toContain("xxxx");
+  });
+
+  it("keys arrays and objects by count, not serialized content", () => {
+    expect(cheapHash([1, 2, 3])).toBe("a3");
+    expect(cheapHash([])).toBe("a0");
+    expect(cheapHash({ a: 1, b: 2 })).toBe("o2");
+    expect(cheapHash({})).toBe("o0");
+  });
+
+  it("does not serialize a large object into the key", () => {
+    const wide: Record<string, string> = {};
+    for (let i = 0; i < 1000; i++) wide[`k${i}`] = "y".repeat(10_000);
+    const sig = cheapHash(wide);
+    expect(sig).toBe("o1000");
+    expect(sig).not.toContain("yyyy");
+  });
+
+  it("keys primitives by their literal value", () => {
+    expect(cheapHash(42)).toBe("p42");
+    expect(cheapHash(true)).toBe("ptrue");
+  });
+
+  it("is stable for identical content (cache hit)", () => {
+    expect(cheapHash("the same payload")).toBe(cheapHash("the same payload"));
+    expect(cheapHash("z".repeat(4096))).toBe(cheapHash("z".repeat(4096)));
+  });
+
+  it("changes on ANY content change, including same length (cache miss / re-parse)", () => {
+    // The regression this guards against: a refetch that swaps a field for
+    // same-length different content (e.g. an SDK status update) must produce a
+    // different signature, or the parse query would serve the stale cached
+    // parse under staleTime: Infinity.
+    expect(cheapHash("pending")).not.toBe(cheapHash("running")); // both len 7
+    expect(cheapHash("hello")).not.toBe(cheapHash("world")); // both len 5
+    // A length change also differs.
+    expect(cheapHash("hello")).not.toBe(cheapHash("hi"));
+    // Type namespaces never collide: a 5-char string vs a 5-element array.
+    expect(cheapHash("abcde")).not.toBe(cheapHash([1, 2, 3, 4, 5]));
+  });
+});

--- a/web/src/hooks/parsedIoCacheKey.clienttest.ts
+++ b/web/src/hooks/parsedIoCacheKey.clienttest.ts
@@ -23,18 +23,19 @@ describe("cheapHash", () => {
     expect(sig).not.toContain("xxxx");
   });
 
-  it("keys arrays and objects by count, not serialized content", () => {
-    expect(cheapHash([1, 2, 3])).toBe("a3");
-    expect(cheapHash([])).toBe("a0");
-    expect(cheapHash({ a: 1, b: 2 })).toBe("o2");
-    expect(cheapHash({})).toBe("o0");
+  it("keys arrays and objects by size + content hash", () => {
+    expect(cheapHash([1, 2, 3])).toMatch(/^a3:/);
+    expect(cheapHash([])).toMatch(/^a0:/);
+    expect(cheapHash({ a: 1, b: 2 })).toMatch(/^o2:/);
+    expect(cheapHash({})).toMatch(/^o0:/);
   });
 
-  it("does not serialize a large object into the key", () => {
+  it("keeps a large object's signature tiny — no payload text in the key", () => {
     const wide: Record<string, string> = {};
     for (let i = 0; i < 1000; i++) wide[`k${i}`] = "y".repeat(10_000);
     const sig = cheapHash(wide);
-    expect(sig).toBe("o1000");
+    expect(sig).toMatch(/^o1000:/);
+    expect(sig.length).toBeLessThan(40);
     expect(sig).not.toContain("yyyy");
   });
 
@@ -59,5 +60,19 @@ describe("cheapHash", () => {
     expect(cheapHash("hello")).not.toBe(cheapHash("hi"));
     // Type namespaces never collide: a 5-char string vs a 5-element array.
     expect(cheapHash("abcde")).not.toBe(cheapHash([1, 2, 3, 4, 5]));
+  });
+
+  it("changes when an object/array value changes at the same shape", () => {
+    // A Prisma JSON metadata field whose value changes but whose key-count
+    // stays the same (e.g. {"status":"pending"} -> {"status":"running"}) must
+    // still invalidate the parse — same class of collision as the string case.
+    expect(cheapHash({ a: 1 })).not.toBe(cheapHash({ a: 2 }));
+    expect(cheapHash({ status: "pending" })).not.toBe(
+      cheapHash({ status: "running" }),
+    );
+    // Arrays too: same length, different element.
+    expect(cheapHash([1, 2, 3])).not.toBe(cheapHash([1, 2, 4]));
+    // ...and stable for identical object content (cache hit).
+    expect(cheapHash({ a: 1, b: 2 })).toBe(cheapHash({ a: 1, b: 2 }));
   });
 });

--- a/web/src/hooks/parsedIoCacheKey.ts
+++ b/web/src/hooks/parsedIoCacheKey.ts
@@ -1,0 +1,65 @@
+/**
+ * Cheap, stable React Query cache signatures for parsed-I/O hooks
+ * (`useParsedTrace`, `useParsedObservation`) — LFE-10992, part of the
+ * LFE-10152 large-traces epic.
+ *
+ * Both hooks previously embedded the raw `input`/`output`/`metadata` values
+ * directly in the queryKey, which forces React Query's `hashKey` to
+ * `JSON.stringify` the whole — potentially multi-MB — payload into the query
+ * hash on EVERY render (`defaultQueryOptions` recomputes the hash on each
+ * `useQuery` call, and its replacer even sorts object keys). That is an
+ * O(payload) main-thread serialization done purely for cache bookkeeping —
+ * precisely the kind of whole-payload stringify the large-traces work exists
+ * to remove.
+ *
+ * The replacement keys by the (unique) trace/observation id plus a per-field
+ * signature from `cheapHash`, which is content-sensitive (so a same-length
+ * refetch such as `"pending"` → `"running"` still invalidates the parse) but
+ * never `JSON.stringify`s the payload. Callers memoize the hash on the raw
+ * reference, so the O(n) pass runs only when a field actually changes — the
+ * exact moment a re-parse is wanted — and is O(1) amortized per render.
+ */
+
+/**
+ * cyrb53 — a fast, well-distributed non-cryptographic 53-bit string hash
+ * (public-domain, by bryc). Used only to detect content changes for cache
+ * keying, never for security. A single O(n) pass over char codes with
+ * `Math.imul`, no allocation.
+ */
+function cyrb53(str: string, seed = 0): number {
+  let h1 = 0xdeadbeef ^ seed;
+  let h2 = 0x41c6ce57 ^ seed;
+  for (let i = 0; i < str.length; i++) {
+    const ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+}
+
+/**
+ * Content-sensitive, allocation-free cache signature for one parse-input field.
+ *
+ * Returns a compact descriptor that changes whenever the field's content
+ * changes — never the payload itself: `s<len>:<hash>` for strings (length +
+ * cyrb53, so same-length-different-content still differs — no cache collision
+ * when a refetch swaps e.g. `"pending"` → `"running"`), `a<len>` for arrays,
+ * `o<keys>` for objects, the literal for primitives, `∅` for null/undefined.
+ * The type-tag prefix keeps namespaces distinct (a 5-char string never
+ * collides with a 5-element array).
+ *
+ * Arrays/objects fall back to a shape-only signature because the trace and
+ * observation I/O fields that flow through here are `string | null` in
+ * practice; the string branch is the operative one and is exact-content-safe.
+ */
+export function cheapHash(value: unknown): string {
+  if (value === null || value === undefined) return "∅";
+  if (typeof value === "string") return `s${value.length}:${cyrb53(value)}`;
+  if (Array.isArray(value)) return `a${value.length}`;
+  if (typeof value === "object") return `o${Object.keys(value).length}`;
+  return `p${String(value)}`;
+}

--- a/web/src/hooks/parsedIoCacheKey.ts
+++ b/web/src/hooks/parsedIoCacheKey.ts
@@ -42,24 +42,42 @@ function cyrb53(str: string, seed = 0): number {
 }
 
 /**
- * Content-sensitive, allocation-free cache signature for one parse-input field.
+ * Content hash of an object/array, from its serialization. Guarded: a circular
+ * or otherwise unserializable value falls back to `x` (shape-only), which only
+ * loses content-sensitivity for that rare payload — the unique id in the
+ * queryKey still scopes it. This DOES serialize to hash, but callers memoize
+ * `cheapHash` on the raw reference, so it runs only when the field actually
+ * changes (a real change = when a re-parse is wanted), never per render.
+ */
+function contentHash(value: object): number | string {
+  try {
+    return cyrb53(JSON.stringify(value));
+  } catch {
+    return "x";
+  }
+}
+
+/**
+ * Content-sensitive cache signature for one parse-input field.
  *
  * Returns a compact descriptor that changes whenever the field's content
  * changes — never the payload itself: `s<len>:<hash>` for strings (length +
- * cyrb53, so same-length-different-content still differs — no cache collision
- * when a refetch swaps e.g. `"pending"` → `"running"`), `a<len>` for arrays,
- * `o<keys>` for objects, the literal for primitives, `∅` for null/undefined.
- * The type-tag prefix keeps namespaces distinct (a 5-char string never
- * collides with a 5-element array).
+ * cyrb53, so same-length-different-content still differs), `a<len>:<hash>` for
+ * arrays and `o<keys>:<hash>` for objects (size + content hash, so a
+ * same-shape value change such as `{"status":"pending"}` → `{"status":
+ * "running"}` still differs — no cache collision), the literal for primitives,
+ * `∅` for null/undefined. The type-tag prefix keeps namespaces distinct (a
+ * 5-char string never collides with a 5-element array).
  *
- * Arrays/objects fall back to a shape-only signature because the trace and
- * observation I/O fields that flow through here are `string | null` in
- * practice; the string branch is the operative one and is exact-content-safe.
+ * The trace/observation I/O fields that flow through here are `string | null`
+ * in practice, so the string branch is the operative one; the object/array
+ * branches exist for defensive correctness and consistency.
  */
 export function cheapHash(value: unknown): string {
   if (value === null || value === undefined) return "∅";
   if (typeof value === "string") return `s${value.length}:${cyrb53(value)}`;
-  if (Array.isArray(value)) return `a${value.length}`;
-  if (typeof value === "object") return `o${Object.keys(value).length}`;
+  if (Array.isArray(value)) return `a${value.length}:${contentHash(value)}`;
+  if (typeof value === "object")
+    return `o${Object.keys(value).length}:${contentHash(value)}`;
   return `p${String(value)}`;
 }

--- a/web/src/hooks/useParsedObservation.ts
+++ b/web/src/hooks/useParsedObservation.ts
@@ -25,6 +25,7 @@ import type {
   ParseRequest,
   ParseResponse,
 } from "@/src/workers/json-parser.worker";
+import { cheapHash } from "@/src/hooks/parsedIoCacheKey";
 
 type ObservationWithStringifiedIO = ObservationReturnTypeWithMetadata & {
   input: string | null;
@@ -272,15 +273,33 @@ export function useParsedObservation({
     ? eventsQuery.isLoading
     : observationQuery.isLoading;
 
+  // Per-field cache signatures: content-sensitive but never a whole-payload
+  // stringify. Memoized on the raw reference (react-query structural sharing
+  // keeps it referentially stable between renders), so each O(n) hash runs
+  // only when that field actually changes — the exact moment a re-parse is
+  // wanted — instead of the multi-MB re-serialization the old raw-value key
+  // forced on every render.
+  const inputSig = useMemo(
+    () => cheapHash(mergedObservation?.input),
+    [mergedObservation?.input],
+  );
+  const outputSig = useMemo(
+    () => cheapHash(mergedObservation?.output),
+    [mergedObservation?.output],
+  );
+  const metadataSig = useMemo(
+    () => cheapHash(mergedObservation?.metadata),
+    [mergedObservation?.metadata],
+  );
+
   // Step 2: Parse the data in Web Worker (React Query caches THIS too!)
   const parseQuery = useQuery({
     queryKey: [
       "parsed-observation",
       observationId,
-      // Include data hash to detect changes
-      mergedObservation?.input,
-      mergedObservation?.output,
-      mergedObservation?.metadata,
+      inputSig,
+      outputSig,
+      metadataSig,
     ],
     queryFn: async () => {
       if (!mergedObservation) {

--- a/web/src/hooks/useParsedTrace.ts
+++ b/web/src/hooks/useParsedTrace.ts
@@ -16,11 +16,13 @@
  * - Graceful fallback: Uses sync parsing if Web Workers unavailable
  */
 
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type {
   ParseRequest,
   ParseResponse,
 } from "@/src/workers/json-parser.worker";
+import { cheapHash } from "@/src/hooks/parsedIoCacheKey";
 
 /**
  * Threshold for using Web Worker vs sync parsing (in characters).
@@ -188,16 +190,19 @@ export function useParsedTrace({
   output,
   metadata,
 }: UseParsedTraceParams) {
+  // Per-field cache signatures: content-sensitive but never a whole-payload
+  // stringify. Memoized on the raw reference (react-query structural sharing
+  // keeps it referentially stable between renders), so each O(n) hash runs
+  // only when that field actually changes — the exact moment a re-parse is
+  // wanted — instead of the multi-MB re-serialization the old raw-value key
+  // forced on every render.
+  const inputSig = useMemo(() => cheapHash(input), [input]);
+  const outputSig = useMemo(() => cheapHash(output), [output]);
+  const metadataSig = useMemo(() => cheapHash(metadata), [metadata]);
+
   // Parse the data in Web Worker (React Query caches this)
   const parseQuery = useQuery({
-    queryKey: [
-      "parsed-trace",
-      traceId,
-      // Include data hash to detect changes
-      input,
-      output,
-      metadata,
-    ],
+    queryKey: ["parsed-trace", traceId, inputSig, outputSig, metadataSig],
     queryFn: async () => {
       return parseTraceData(input, output, metadata);
     },


### PR DESCRIPTION
**TL;DR** — The trace/observation "parse-in-worker + cache" hooks (`useParsedTrace`/`useParsedObservation`) put the **raw I/O payload inside the React Query cache key**. React Query re-hashes the key with a full `JSON.stringify` on **every render**, so opening a large trace re-serialized the entire multi-MB payload on the main thread on every render — the exact whole-payload stringify the large-traces effort removes elsewhere. Now keyed by the immutable trace/observation id plus a cheap **content hash** per field: same cache correctness, zero per-render serialization. Sub-task of the LFE-10152 large-traces resilience epic.

**Why** — `@tanstack/react-query` recomputes `queryHash = JSON.stringify(queryKey, replacer)` on every render (the fresh options object has no cached hash). With `input`/`output`/`metadata` in the key, that walks/escapes the full multi-MB string every render of any large-trace/observation view. Nothing memoized it away. This is the render-time twin of the payload-stringify hygiene the epic is cleaning up.

**What** — Replace the raw payloads in the key with a per-field signature that never serializes the payload: a `cyrb53` non-cryptographic **content hash**, tagged with type + length (`s<len>:<hash>` for strings; `∅`/`a<len>`/`o<keys>`/`p<val>` for the other shapes). Each field's hash is **memoized on the raw reference** (`useMemo(() => cheapHash(x), [x])`), so — thanks to react-query's structural sharing keeping unchanged data referentially stable — the O(n) hash runs only when a field actually changes (exactly when a re-parse is wanted); it's O(1) amortized per render otherwise. The queryFn and the entire parse pipeline (worker/sync `deepParseJson`) are untouched — only the key derivation changed.

**Result** — Large-trace/observation views no longer re-serialize the payload on every render. Cache correctness is preserved: the id identifies the parse, and the content hash busts the key on any real change (including a same-length content change — covered by tests), so no stale parse. Real KB-scale traces are unaffected.

<details><summary>Correctness + why a content hash (not length)</summary>

- **Collision safety:** the fields enter the key as `string | null`, so a length-only signature would collide on a same-length content change of a mutating trace (in-progress ingestion / SDK `update`, with `refetchOnWindowFocus` + finite source `staleTime`), and — because the parse query has `staleTime: Infinity` — would render the **old** parse until gc/reload. The `cyrb53` content hash eliminates that while staying cheap; memoization keeps it from running on unchanged renders.
- **Scope:** confined to `parsedIoCacheKey.ts` (new) + the two hooks; `"parsed-trace"`/`"parsed-observation"` keys are used nowhere else (no external get/set/invalidate/prefetch).
- **Tests** (`parsedIoCacheKey.clienttest.ts`, 7): stable signature on identical content (cache hit); **different content ⇒ different signature ⇒ cache miss, including the same-length case** (`"pending"`≠`"running"`); a 5,000,000-char string yields a <~20-char key that never contains the payload text (no full-payload embedding); type namespacing.
- Typecheck + lint (7/7) clean.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces raw `input`/`output`/`metadata` values in `useParsedTrace` and `useParsedObservation` React Query cache keys with compact `cheapHash` signatures, eliminating the per-render `JSON.stringify` that React Query's `hashKey` was running over potentially multi-MB payloads. Each signature is memoized on the raw field reference so the O(n) hash run occurs only when a field actually changes.

- **New `parsedIoCacheKey.ts`**: Implements `cyrb53` (53-bit non-cryptographic hash) wrapped in `cheapHash`, which emits `s{len}:{hash}` for strings (content-exact), `o{keyCount}`/`a{length}` for objects/arrays (shape-only), and `∅` for null/undefined.
- **`useParsedTrace` / `useParsedObservation`**: Three `useMemo` calls per hook produce per-field signatures that replace the raw payloads in the `queryKey`; the `queryFn` and parse pipeline are unchanged.
- **Tests** (`parsedIoCacheKey.clienttest.ts`): Seven cases cover null, large-string compactness, primitive passthrough, cache-hit stability, and same-length content changes for strings — but do not cover the object content-change case.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for the common large-string input/output case; correctness risk exists for object-typed metadata under staleTime: Infinity.

The string path is fully correct and well-tested. The object/array path returns a shape-only signature, meaning a metadata update that changes values without adding or removing keys produces an identical cache key. With staleTime: Infinity the stale parse is served permanently. UseParsedTraceParams types all three fields as unknown, and the non-beta useParsedObservation path returns Prisma data directly whose metadata can be a parsed JSON object.

parsedIoCacheKey.ts (object/array branch), useParsedTrace.ts and useParsedObservation.ts (callers that may supply object-typed metadata)
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Component render] --> B[useParsedTrace / useParsedObservation]
    B --> C[useMemo: cheapHash per field]
    C --> D{field type?}
    D -->|string| E["s{len}:{cyrb53} — content-exact"]
    D -->|object| F["o{keyCount} — shape-only ⚠️"]
    D -->|array| G["a{length} — shape-only"]
    D -->|null/undefined| H["∅"]
    E --> I[queryKey: id + inputSig + outputSig + metadataSig]
    F --> I
    G --> I
    H --> I
    I --> J{React Query cache hit?}
    J -->|No — new key| K[queryFn: parseTraceData / parseObservationData]
    K --> L[Web Worker or sync deepParseJson]
    L --> M[Cached result, staleTime: Infinity]
    J -->|Yes — same key| M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Component render] --> B[useParsedTrace / useParsedObservation]
    B --> C[useMemo: cheapHash per field]
    C --> D{field type?}
    D -->|string| E["s{len}:{cyrb53} — content-exact"]
    D -->|object| F["o{keyCount} — shape-only ⚠️"]
    D -->|array| G["a{length} — shape-only"]
    D -->|null/undefined| H["∅"]
    E --> I[queryKey: id + inputSig + outputSig + metadataSig]
    F --> I
    G --> I
    H --> I
    I --> J{React Query cache hit?}
    J -->|No — new key| K[queryFn: parseTraceData / parseObservationData]
    K --> L[Web Worker or sync deepParseJson]
    L --> M[Cached result, staleTime: Infinity]
    J -->|Yes — same key| M
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/hooks/parsedIoCacheKey.ts:56-60
**Object/array branch is shape-only, not content-sensitive**

`cheapHash` returns `o${Object.keys(value).length}` for objects and `a${value.length}` for arrays. If `metadata` in either hook is a Prisma JSON object (e.g., `{"status":"pending","count":1}`) and its values change to `{"status":"running","count":2}`, both produce `"o2"`. React Query sees no cache key change and serves the stale parse — permanently, under `staleTime: Infinity`. The `UseParsedTraceParams` explicitly types all three fields as `unknown`, so objects can flow in, and the non-beta path of `useParsedObservation` returns `observationQuery.data` directly, whose `metadata` is a Prisma JSON value. The PR description acknowledges this as an "acceptable trade-off" because the fields are "string | null in practice", but that claim is not enforced by types or runtime guards, so any caller that passes an object is silently broken.

### Issue 2 of 2
web/src/hooks/parsedIoCacheKey.clienttest.ts:30-40
**Test gap: object content change is not verified to produce a different signature**

The test suite correctly verifies that same-length string changes bust the cache. However, there is no analogous test for objects — i.e., no assertion that `cheapHash({a:1})` differs from `cheapHash({a:2})`. Because both return `"o1"`, the test suite passes while silently accepting this collision. Adding a test like `expect(cheapHash({a:"pending"})).not.toBe(cheapHash({a:"running"}))` would surface the issue and document the known limitation explicitly.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): stop re-serializing multi-MB..."](https://github.com/langfuse/langfuse/commit/206600d1c79d6170243fa75bfd37b210ec0e2a37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44774103)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->