### PR TITLE
chore(agents): codify regional-twin tickets and cause-trailer in incident-alert-tickets skill

### DIFF
--- a/.agents/skills/incident-alert-tickets/SKILL.md
+++ b/.agents/skills/incident-alert-tickets/SKILL.md
@@ -43,6 +43,9 @@ monitors' tickets that links to it.
 - One ticket per monitor (per env when monitors are per-env), titled
   `[ENV] <Monitor title>`, in the Engineering (LFE) team, carrying the
   `incident-alert` label. The label set is the knowledge base.
+- Regional twins of one monitor (same metric and threshold per env) may share
+  a single ticket titled `[ENV1/ENV2] <Monitor title>` when the causes are
+  region-independent; list each env's monitor ID in the alert header.
 - The description opens with an alert header: monitor ID, trigger condition,
   and how it surfaces (incident.io urgency, auto-resolve behavior).
 - One dated section per distinct root cause, separated by `---`:
@@ -61,6 +64,9 @@ monitors' tickets that links to it.
 
 - Cause sections are append-only: never rewrite or delete an existing section;
   new knowledge gets a new dated block.
+- The description ends with a `## Your cause is not listed?` trailer: it
+  records firings that were never root-caused and tells the next engineer to
+  insert new dated sections above it, in the same format.
 - Keep each cause section to roughly one screen.
 - A distinct problem discovered during the investigation that is *not* a cause
   of this alert gets its own ticket (bug or incident-alert), cross-linked — do
@@ -106,11 +112,12 @@ proposal first:
 
 Wait for the human to select row IDs and actions before writing. On approval:
 
-- **Append**: add the new `---`-separated dated block after the existing
-  sections; leave everything else untouched.
+- **Append**: insert the new `---`-separated dated block after the existing
+  cause sections, above the `Your cause is not listed?` trailer; leave
+  everything else untouched.
 - **Create**: new Engineering (LFE) issue titled `[ENV] <Monitor title>` with
-  the `incident-alert` label; description = alert header plus the first dated
-  cause section.
+  the `incident-alert` label; description = alert header, the first dated
+  cause section, and the `Your cause is not listed?` trailer.
 
 ## Division of Labor
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #15150. Records two conventions in the `incident-alert-tickets` skill contract that already exist on the live incident-alert tickets, so agent-created tickets reproduce them:

- **Regional twins**: two per-env monitors for the same metric/threshold may share one ticket (`[ENV1/ENV2] <Monitor title>`) when causes are region-independent, with each env's monitor ID in the alert header.
- **`## Your cause is not listed?` trailer**: every ticket ends with a trailer that records never-root-caused firings and tells the next engineer to insert new dated cause sections above it. Append/create instructions updated accordingly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Chore (refactoring, adding tests, agent setup, etc.)

## How did you test it?

- `pnpm run agents:check` passes; pre-commit Prettier + lint passed on commit.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Was this feature tested in staging or with a preview deployment?

Not applicable — agent-setup markdown only.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the `incident-alert-tickets` agent skill with two new conventions: regional twin monitors (same metric and threshold across regions) may now share a single ticket when their causes are region-independent, and every ticket description must close with a `## Your cause is not listed?` trailer that captures unresolved firings. The append and create write-back instructions are updated accordingly.

- Adds the regional-twin rule allowing a shared `[ENV1/ENV2] <Monitor title>` ticket with both monitor IDs listed in the alert header.
- Adds the cause-trailer convention, requiring the trailer at the end of every description and updating the **Append** path to insert new blocks above it rather than at the end.
- Updates the **Create** write-back template to include the new trailer in freshly created tickets.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are documentation only, scoped to an agent skill definition with no runtime code paths.

The two new conventions (regional twins, cause trailer) are internally consistent and the write-back instructions are correctly updated to match. The trailer's literal body text is never defined, so agents executing the Create path must improvise its content, which could lead to divergent ticket formats across the knowledge base. The multi-region title format beyond two regions is also unspecified. Neither gap is blocking, but both are worth resolving before the skill is widely used.

.agents/skills/incident-alert-tickets/SKILL.md — the trailer body template and 3+ region title format both need a short clarifying addition.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Alert identity detected] --> B[Lookup Linear tickets with incident-alert label]
    B --> C{Match found?}
    C -- No --> D[Propose Create new ticket]
    C -- Yes --> E{Regional twins?}
    E -- Yes, causes region-independent --> F[Share single ticket\nENV1/ENV2 title\nList both monitor IDs in header]
    E -- No --> G[Separate ticket per env]
    F --> H{Evidence matches cause section?}
    G --> H
    H -- Known cause --> I[Cite ticket & section\nRecommend Fix]
    H -- New cause --> J[Propose Append dated block]
    H -- No ticket --> D
    D --> K[Human approval gate]
    J --> K
    K -- Approved Append --> L[Insert dated block above\nYour cause is not listed? trailer]
    K -- Approved Create --> M[New ticket: alert header\n+ first dated cause section\n+ Your cause is not listed? trailer]
    K -- Rejected --> N[No write-back]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Alert identity detected] --> B[Lookup Linear tickets with incident-alert label]
    B --> C{Match found?}
    C -- No --> D[Propose Create new ticket]
    C -- Yes --> E{Regional twins?}
    E -- Yes, causes region-independent --> F[Share single ticket\nENV1/ENV2 title\nList both monitor IDs in header]
    E -- No --> G[Separate ticket per env]
    F --> H{Evidence matches cause section?}
    G --> H
    H -- Known cause --> I[Cite ticket & section\nRecommend Fix]
    H -- New cause --> J[Propose Append dated block]
    H -- No ticket --> D
    D --> K[Human approval gate]
    J --> K
    K -- Approved Append --> L[Insert dated block above\nYour cause is not listed? trailer]
    K -- Approved Create --> M[New ticket: alert header\n+ first dated cause section\n+ Your cause is not listed? trailer]
    K -- Rejected --> N[No write-back]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.agents/skills/incident-alert-tickets/SKILL.md:65-67
**Trailer content left undefined**

The new `## Your cause is not listed?` trailer is referenced in both the contract and the write-back instructions, but its actual body text is never specified. When an agent executes the **Create** path it is told to include "the `Your cause is not listed?` trailer" yet has no template to follow — it will either fabricate content or omit the trailer entirely, defeating the purpose of codifying it. Adding the literal section text (even a minimal placeholder) would make this unambiguous.

### Issue 2 of 2
.agents/skills/incident-alert-tickets/SKILL.md:45-47
**Regional-twin format undefined for 3+ regions**

The new rule uses `[ENV1/ENV2]` as the shared-ticket title format but only illustrates the two-region case. When three or more regional twins are consolidated (e.g., US/EU/AP), the format is ambiguous. A short note clarifying whether additional regions are appended with the same separator, or whether a cap applies (e.g., after N regions keep separate tickets), would prevent inconsistent ticket titles across the knowledge base.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(agents): codify regional-twin tick..."](https://github.com/langfuse/langfuse/commit/3b0b453431939c3d7b4eed6519f5004c26b0ed2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44790888)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->