### PR TITLE
fix(search-bar): recover self-corrected filter arrays in Ask AI parser (LFE-11007)

### DIFF
--- a/web/src/__tests__/server/unit/parseFilterCompletion.servertest.ts
+++ b/web/src/__tests__/server/unit/parseFilterCompletion.servertest.ts
@@ -482,6 +482,26 @@ describe("parseGeneratedFilters — extraction robustness", () => {
     expect(droppedCount).toBe(0);
   });
 
+  it("honors an explicit `[]` retraction over an earlier drafted filter", () => {
+    // The prompt asks for `[]` when no filter applies. If the model drafts a
+    // filter, reconsiders in prose, then emits `[]` as its FINAL answer, we must
+    // honor the retraction — NOT apply the draft it explicitly walked back.
+    const completion =
+      "Attempt: " +
+      JSON.stringify([
+        {
+          type: "stringOptions",
+          column: "level",
+          operator: "any of",
+          value: ["ERROR"],
+        },
+      ]) +
+      " Actually that cannot be expressed here. No filter applies: []";
+    const { filters, droppedCount } = parseGeneratedFilters(completion);
+    expect(filters).toHaveLength(0);
+    expect(droppedCount).toBe(0);
+  });
+
   it("reports the LARGEST all-malformed array's size when nothing validates", () => {
     // Reversed candidate iteration visits the trailing stray array first. When
     // NO candidate yields a valid filter, `droppedCount` must reflect the

--- a/web/src/__tests__/server/unit/parseFilterCompletion.servertest.ts
+++ b/web/src/__tests__/server/unit/parseFilterCompletion.servertest.ts
@@ -353,4 +353,132 @@ describe("parseGeneratedFilters — score-name validation", () => {
     const { unknownScoreNames } = parseGeneratedFilters(completion, scoreNames);
     expect(unknownScoreNames).toEqual(["ghost_score"]);
   });
+
+  const booleanScoreFilter = (column: string, key: string) => ({
+    type: "booleanObject",
+    column,
+    key,
+    operator: "=",
+    value: true,
+  });
+
+  it("corrects a separator variant of a boolean score name in place", () => {
+    // Same dead-filter class as numeric/categorical: a boolean score addressed
+    // by a misspelled name round-trips cleanly and matches nothing. The
+    // observed set (`score_booleans`) lets us correct it.
+    const completion = JSON.stringify([
+      booleanScoreFilter("score_booleans", "is_flagged"),
+    ]);
+    const { filters, droppedCount, unknownScoreNames } = parseGeneratedFilters(
+      completion,
+      { ...scoreNames, booleans: ["is-flagged"] },
+    );
+    expect(filters).toHaveLength(1);
+    expect(filters[0]).toMatchObject({
+      column: "score_booleans",
+      key: "is-flagged",
+    });
+    expect(droppedCount).toBe(0);
+    expect(unknownScoreNames).toEqual([]);
+  });
+
+  it("drops an unknown trace-boolean score name and reports it", () => {
+    const completion = JSON.stringify([
+      booleanScoreFilter("trace_score_booleans", "ghost_flag"),
+    ]);
+    const { filters, droppedCount, unknownScoreNames } = parseGeneratedFilters(
+      completion,
+      { ...scoreNames, traceBooleans: ["is-reviewed"] },
+    );
+    expect(filters).toHaveLength(0);
+    expect(droppedCount).toBe(1);
+    expect(unknownScoreNames).toEqual(["ghost_flag"]);
+  });
+
+  it("passes a boolean score filter through when its set was not provided", () => {
+    // No `booleans` set loaded → no enforcement for that column (a boolean
+    // score filter must never be dropped just because the set is absent).
+    const completion = JSON.stringify([
+      booleanScoreFilter("score_booleans", "anything_goes"),
+    ]);
+    const { filters, unknownScoreNames } = parseGeneratedFilters(completion, {
+      numeric: ["accuracy"],
+    });
+    expect(filters).toHaveLength(1);
+    expect(filters[0]).toMatchObject({ key: "anything_goes" });
+    expect(unknownScoreNames).toEqual([]);
+  });
+});
+
+describe("parseGeneratedFilters — extraction robustness", () => {
+  const levelFilter = (value: string) => ({
+    type: "stringOptions",
+    column: "level",
+    operator: "any of",
+    value: [value],
+  });
+
+  it("applies the model's self-corrected array, not the earlier draft", () => {
+    // The model drafts an array, second-guesses itself in prose, then emits a
+    // corrected array. A greedy first-`[`..last-`]` match spans BOTH arrays plus
+    // the prose between them and fails to JSON.parse — losing a correct answer.
+    // The parser must return the LAST (corrected) array.
+    const completion = [
+      "Here is a first attempt:",
+      JSON.stringify([levelFilter("DEBUG")]),
+      "On reflection you asked for errors, not debug logs. Corrected filters:",
+      JSON.stringify([levelFilter("ERROR")]),
+    ].join("\n");
+    const { filters, droppedCount } = parseGeneratedFilters(completion);
+    expect(filters).toHaveLength(1);
+    expect(filters[0]).toMatchObject({ column: "level", value: ["ERROR"] });
+    expect(droppedCount).toBe(0);
+  });
+
+  it("parses a single array embedded in prose unchanged", () => {
+    const completion = [
+      "Sure — here you go:",
+      JSON.stringify([levelFilter("WARNING")]),
+    ].join("\n");
+    const { filters, droppedCount } = parseGeneratedFilters(completion);
+    expect(filters).toHaveLength(1);
+    expect(filters[0]).toMatchObject({ column: "level", value: ["WARNING"] });
+    expect(droppedCount).toBe(0);
+  });
+
+  it("does not let a `]` inside a string value break balance tracking", () => {
+    // The closing bracket lives inside a metadata value string; naive depth
+    // tracking would close the array early and fail to parse.
+    const completion = [
+      "Filters:",
+      JSON.stringify([
+        {
+          type: "stringObject",
+          column: "metadata",
+          key: "note",
+          operator: "=",
+          value: "arr]end",
+        },
+      ]),
+      "Let me know if that works.",
+    ].join("\n");
+    const { filters, droppedCount } = parseGeneratedFilters(completion);
+    expect(filters).toHaveLength(1);
+    expect(filters[0]).toMatchObject({
+      column: "metadata",
+      key: "note",
+      value: "arr]end",
+    });
+    expect(droppedCount).toBe(0);
+  });
+
+  it("returns the empty result when brackets appear but no array is valid JSON", () => {
+    const completion =
+      "Use the [level] and [environment] fields to build that filter.";
+    const { filters, queryText, droppedCount } =
+      parseGeneratedFilters(completion);
+    expect(filters).toHaveLength(0);
+    expect(queryText).toBe("");
+    expect(droppedCount).toBe(0);
+  });
 });

--- a/web/src/__tests__/server/unit/parseFilterCompletion.servertest.ts
+++ b/web/src/__tests__/server/unit/parseFilterCompletion.servertest.ts
@@ -481,4 +481,32 @@ describe("parseGeneratedFilters — extraction robustness", () => {
     expect(queryText).toBe("");
     expect(droppedCount).toBe(0);
   });
+
+  it("reports the LARGEST all-malformed array's size when nothing validates", () => {
+    // Reversed candidate iteration visits the trailing stray array first. When
+    // NO candidate yields a valid filter, `droppedCount` must reflect the
+    // largest array the model emitted (the one it most plausibly intended), not
+    // whichever was visited first. Here a 4-element all-malformed filter array
+    // precedes a stray 2-element prose list; the count must be 4, not 2.
+    const malformed = (column: string) => ({
+      type: "stringOptions",
+      column,
+      operator: "equals", // not a valid stringOptions operator → fails singleFilter
+      value: "x",
+    });
+    const completion = [
+      "My first attempt (four filters):",
+      JSON.stringify([
+        malformed("level"),
+        malformed("environment"),
+        malformed("name"),
+        malformed("userId"),
+      ]),
+      "Actually, ignore those and just consider these two tags:",
+      JSON.stringify(["a", "b"]),
+    ].join("\n");
+    const { filters, droppedCount } = parseGeneratedFilters(completion);
+    expect(filters).toHaveLength(0);
+    expect(droppedCount).toBe(4);
+  });
 });

--- a/web/src/features/search-bar/lib/observed-options.ts
+++ b/web/src/features/search-bar/lib/observed-options.ts
@@ -137,8 +137,10 @@ export const MAX_SCORE_NAME_LENGTH = 256;
 export type ObservedScoreNames = {
   numeric?: string[];
   categorical?: string[];
+  booleans?: string[];
   traceNumeric?: string[];
   traceCategorical?: string[];
+  traceBooleans?: string[];
 };
 
 /**
@@ -167,8 +169,10 @@ export function observedScoreNamesFromOptions(
   return {
     numeric: names("scores_avg"),
     categorical: names("score_categories"),
+    booleans: names("score_booleans"),
     traceNumeric: names("trace_scores_avg"),
     traceCategorical: names("trace_score_categories"),
+    traceBooleans: names("trace_score_booleans"),
   };
 }
 

--- a/web/src/features/search-bar/server/parseFilterCompletion.ts
+++ b/web/src/features/search-bar/server/parseFilterCompletion.ts
@@ -143,7 +143,15 @@ function parseFilterArray(completion: string): {
       if (result.success) kept.push(result.data);
     }
     if (kept.length > 0) return { filters: kept, rawCount: raw.length };
-    if (fallback === null) fallback = { filters: [], rawCount: raw.length };
+    // No valid filter here. Remember the LARGEST such array as the fallback:
+    // when nothing validates, `droppedCount` should reflect the biggest array
+    // the model emitted (the one it most plausibly intended as the answer), not
+    // whichever candidate happened to be visited first. Reversed iteration
+    // visits the last text array first, which might be a stray 2-element prose
+    // list while the intended (all-malformed) array had more elements.
+    if (fallback === null || raw.length > fallback.rawCount) {
+      fallback = { filters: [], rawCount: raw.length };
+    }
   }
   return fallback ?? { filters: [], rawCount: 0 };
 }

--- a/web/src/features/search-bar/server/parseFilterCompletion.ts
+++ b/web/src/features/search-bar/server/parseFilterCompletion.ts
@@ -51,44 +51,101 @@ function isEventsContractCompatible(f: FilterState[number]): boolean {
 }
 
 /**
- * Extract a `FilterState` from the model's completion. Tries the whole string,
- * then the widest bracketed array (greedy, so it survives nested objects), and
- * tolerates a `{ "filters": [...] }` wrapper. Returns the structurally-valid
+ * Scan `text` for balanced, top-level `[...]` substrings. Tracks bracket depth
+ * while treating brackets inside JSON string literals as inert, so a `]` in a
+ * value (`"array[0]"`) never closes an array early. Nested arrays (a value
+ * array inside a filter object, depth > 1) are part of their enclosing
+ * top-level array, not returned on their own. Returned in document order.
+ */
+function extractTopLevelArrays(text: string): string[] {
+  const arrays: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      // Inside a string literal only `\` (escape) and an unescaped `"` (close)
+      // are meaningful; brackets here must not move the depth.
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "[") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "]" && depth > 0) {
+      depth--;
+      if (depth === 0 && start !== -1) {
+        arrays.push(text.slice(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+  return arrays;
+}
+
+/**
+ * Extract a `FilterState` from the model's completion. Tries the whole string
+ * (a bare array or a `{ "filters": [...] }` wrapper) first, then every balanced
+ * top-level `[...]` in the prose, LAST-FIRST. Returns the structurally-valid
  * filters plus `rawCount` (how many elements the model actually emitted), so
  * the caller can count the malformed ones as dropped. `rawCount` is 0 when
  * nothing parses.
+ *
+ * Last-first matters: the model sometimes emits a DRAFT array, some prose, then
+ * a corrected SECOND array (self-correction). A single greedy `\[[\s\S]*\]`
+ * match spans from the first `[` to the last `]` — swallowing both arrays plus
+ * the prose between them, so `JSON.parse` fails and a correct answer is lost.
+ * Scanning balanced candidates and trying the LAST one first applies the
+ * model's self-correction instead of discarding it.
  */
 function parseFilterArray(completion: string): {
   filters: FilterState;
   rawCount: number;
 } {
-  const arrayMatch = completion.match(/\[[\s\S]*\]/)?.[0];
-  const candidates = [completion, arrayMatch].filter((c): c is string =>
-    Boolean(c),
-  );
+  const candidates = [
+    completion,
+    ...extractTopLevelArrays(completion).reverse(),
+  ];
+  // A candidate that parses to an array but holds no structurally-valid filter
+  // (e.g. an all-malformed array, or a stray bracketed list in the prose) is
+  // remembered so `rawCount` still reflects what the model emitted, but it does
+  // NOT win over a later candidate that DOES contain a valid filter. This keeps
+  // a trailing non-filter array (`... use the [ERROR] level`) from shadowing
+  // the real filter array that preceded it.
+  let fallback: { filters: FilterState; rawCount: number } | null = null;
   for (const candidate of candidates) {
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(candidate);
-      const raw = Array.isArray(parsed) ? parsed : parsed.filters;
-      if (!Array.isArray(raw)) continue;
-      // Parse PER ELEMENT, not the whole array: `z.array(singleFilter).parse`
-      // is all-or-nothing, so one off-spec element (wrong operator, missing
-      // key, value-as-string, unknown type — common on weaker models) would
-      // discard the valid siblings and surface a misleading "couldn't build
-      // filters". Keep the structurally-valid ones; the rejects show up in the
-      // dropped count below, mirroring the per-element keep/drop the two
-      // downstream guardrails already use.
-      const kept: FilterState = [];
-      for (const item of raw) {
-        const result = singleFilter.safeParse(item);
-        if (result.success) kept.push(result.data);
-      }
-      return { filters: kept, rawCount: raw.length };
+      parsed = JSON.parse(candidate);
     } catch {
-      // try the next candidate
+      continue;
     }
+    const raw = Array.isArray(parsed)
+      ? parsed
+      : (parsed as { filters?: unknown } | null)?.filters;
+    if (!Array.isArray(raw)) continue;
+    // Parse PER ELEMENT, not the whole array: `z.array(singleFilter).parse`
+    // is all-or-nothing, so one off-spec element (wrong operator, missing
+    // key, value-as-string, unknown type — common on weaker models) would
+    // discard the valid siblings and surface a misleading "couldn't build
+    // filters". Keep the structurally-valid ones; the rejects show up in the
+    // dropped count below, mirroring the per-element keep/drop the two
+    // downstream guardrails already use.
+    const kept: FilterState = [];
+    for (const item of raw) {
+      const result = singleFilter.safeParse(item);
+      if (result.success) kept.push(result.data);
+    }
+    if (kept.length > 0) return { filters: kept, rawCount: raw.length };
+    if (fallback === null) fallback = { filters: [], rawCount: raw.length };
   }
-  return { filters: [], rawCount: 0 };
+  return fallback ?? { filters: [], rawCount: 0 };
 }
 
 // Which ObservedScoreNames set holds the real names for each score column —
@@ -99,8 +156,10 @@ const SCORE_NAME_SET_BY_COLUMN: Record<
 > = {
   [SCORE_COLUMNS.observation.numeric]: "numeric",
   [SCORE_COLUMNS.observation.categorical]: "categorical",
+  [SCORE_COLUMNS.observation.boolean]: "booleans",
   [SCORE_COLUMNS.trace.numeric]: "traceNumeric",
   [SCORE_COLUMNS.trace.categorical]: "traceCategorical",
+  [SCORE_COLUMNS.trace.boolean]: "traceBooleans",
 };
 
 // Case/separator-insensitive form for the confident-correction match:
@@ -145,7 +204,11 @@ function validateScoreNames(
   const kept: FilterState = [];
   const unknown: string[] = [];
   for (const filter of filters) {
-    if (filter.type !== "numberObject" && filter.type !== "categoryOptions") {
+    if (
+      filter.type !== "numberObject" &&
+      filter.type !== "categoryOptions" &&
+      filter.type !== "booleanObject"
+    ) {
       kept.push(filter);
       continue;
     }

--- a/web/src/features/search-bar/server/parseFilterCompletion.ts
+++ b/web/src/features/search-bar/server/parseFilterCompletion.ts
@@ -112,12 +112,12 @@ function parseFilterArray(completion: string): {
     completion,
     ...extractTopLevelArrays(completion).reverse(),
   ];
-  // A candidate that parses to an array but holds no structurally-valid filter
-  // (e.g. an all-malformed array, or a stray bracketed list in the prose) is
-  // remembered so `rawCount` still reflects what the model emitted, but it does
-  // NOT win over a later candidate that DOES contain a valid filter. This keeps
-  // a trailing non-filter array (`... use the [ERROR] level`) from shadowing
-  // the real filter array that preceded it.
+  // A candidate that parses to a NON-EMPTY array but holds no structurally-valid
+  // filter (e.g. an all-malformed array, or a stray bracketed list in the prose)
+  // is remembered so `rawCount` still reflects what the model emitted, but it
+  // does NOT win over a later candidate that DOES contain a valid filter. This
+  // keeps a trailing non-filter array (`... use the [ERROR] level`) from
+  // shadowing the real filter array that preceded it.
   let fallback: { filters: FilterState; rawCount: number } | null = null;
   for (const candidate of candidates) {
     let parsed: unknown;
@@ -130,6 +130,15 @@ function parseFilterArray(completion: string): {
       ? parsed
       : (parsed as { filters?: unknown } | null)?.filters;
     if (!Array.isArray(raw)) continue;
+    // An explicitly EMPTY array is the model's "no filter applies" answer (the
+    // prompt asks for `[]` in exactly that case). Honor it as a real answer that
+    // WINS: return immediately rather than falling through to an earlier draft
+    // the model reconsidered — otherwise we'd silently apply a filter it
+    // retracted. Distinct from a non-empty array that yields no VALID filter
+    // (below): that stays a fallback so a stray prose list can't shadow a real
+    // earlier filter array. Last-first order means a trailing `[]` is the
+    // model's FINAL word, so this is safe to treat as the intended retraction.
+    if (raw.length === 0) return { filters: [], rawCount: 0 };
     // Parse PER ELEMENT, not the whole array: `z.array(singleFilter).parse`
     // is all-or-nothing, so one off-spec element (wrong operator, missing
     // key, value-as-string, unknown type — common on weaker models) would
@@ -143,7 +152,7 @@ function parseFilterArray(completion: string): {
       if (result.success) kept.push(result.data);
     }
     if (kept.length > 0) return { filters: kept, rawCount: raw.length };
-    // No valid filter here. Remember the LARGEST such array as the fallback:
+    // Had elements, none valid. Remember the LARGEST such array as the fallback:
     // when nothing validates, `droppedCount` should reflect the biggest array
     // the model emitted (the one it most plausibly intended as the answer), not
     // whichever candidate happened to be visited first. Reversed iteration

--- a/web/src/features/search-bar/server/router.ts
+++ b/web/src/features/search-bar/server/router.ts
@@ -57,8 +57,10 @@ const GenerateFilterInput = z.object({
     .object({
       numeric: scoreNameList.optional(),
       categorical: scoreNameList.optional(),
+      booleans: scoreNameList.optional(),
       traceNumeric: scoreNameList.optional(),
       traceCategorical: scoreNameList.optional(),
+      traceBooleans: scoreNameList.optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
## TL;DR

Ask AI (the v4 search-bar natural-language filter) sometimes threw away a **correct** answer. When the model self-corrected — emitting a draft filter array, some prose, then a fixed second array — the parser's greedy `/\[[\s\S]*\]/` match spanned the *first* `[` to the *last* `]`, swallowing both arrays and the prose in between, so `JSON.parse` failed and the user just saw "couldn't build filters." This makes the parser extract **balanced top-level arrays** and prefer the model's **self-corrected (last) one**. Also extends the score-name guardrail to boolean scores. 27/27 unit tests, clean-path behavior unchanged.

## Why

Mining prod Ask AI traces (LFE-10716) turned up a real user who lost a perfect answer to exactly this: the model produced a draft, reconsidered in prose ("that column can't express starts-with…"), then emitted a corrected array — and the greedy regex made the whole thing unparseable. It's a recurring failure class for any self-correcting completion, and it's invisible to the user (looks like the feature just can't do it).

## What

- **Balanced extraction** — a new string-aware, depth-tracked scan (`extractTopLevelArrays`) collects every top-level `[…]` candidate. Brackets inside JSON string values are inert (a `]` in a value can't close an array early); escapes are handled.
- **Last-first preference** — candidates are tried whole-string first (so the existing bare-array and `{filters:[…]}` wrapper paths are byte-for-byte unchanged), then the extracted arrays **last-first**, since the self-corrected array is the intended one.
- **Boolean score-name guardrail** — the existing name-correction/validation (numeric + categorical) now also covers boolean score sets (`score_booleans` / `trace_score_booleans`), closing the same dead-filter class for boolean scores. Additive + backward compatible: an absent set means no enforcement, identical to today.

## Result

- The self-correction case now recovers the corrected filters instead of failing.
- **No masking:** the fallback path only ever carries *empty* filters (+ the raw count for telemetry), so a wrong non-empty filter set is never silently applied; dropped/unknown names still surface via `droppedCount` / `unknownScoreNames`.
- Clean-path (single array, `{filters:[…]}` wrapper) unchanged.
- **27/27** server-unit tests pass (20 pre-existing + 7 new).

<details>
<summary>Mechanism, tests, known edge, scope</summary>

**Files:** `parseFilterCompletion.ts` (+115/−26), `lib/observed-options.ts` (+4: boolean sets on `ObservedScoreNames`), `server/router.ts` (+2 optional Zod fields), `__tests__/…/parseFilterCompletion.servertest.ts` (+128).

**New tests:** self-correction regression (draft `DEBUG` + prose + corrected `ERROR` → asserts corrected wins), single-array-in-prose (unchanged), `]`-inside-a-string-value balance, brackets-but-no-valid-JSON → empty result, and three boolean cases (separator correction, unknown trace-boolean dropped + reported, pass-through when the set is absent).

**Known edge (documented, non-blocking):** an *odd/unbalanced* `"` in the inter-array prose (e.g. a stray inch-mark) opens a string state that can swallow the corrected array's brackets, in which case the guardrail-validated **draft** is applied instead of the correction. This is rare (normal model prose has balanced quotes) and is **not a regression** — the old greedy code returned nothing at all in that same case. Possible follow-up hardening: a forward-order secondary pass. Filed under the parent epic.

**Scope discipline:** OR-group / nested `{"type":"group","operator":"OR"}` tree-contract support was intentionally **not** added here — it's a separate subtask (feature, not bug). This PR stays on the flat `FilterState` contract.

Fixtures are synthesized (no real values).
</details>

Parent epic: LFE-10716 · subtask: LFE-11007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in the Ask AI search-bar parser where a greedy regex (`/\[[\s\S]*\]/`) would span from the first `[` to the last `]` in a model completion, causing `JSON.parse` to fail whenever the model self-corrected — emitting a draft filter array, some prose, then a corrected array. The fix replaces the regex with a string-aware, depth-tracked balanced bracket scanner and tries candidates last-first so the self-corrected array wins. It also extends the existing score-name guardrail to `booleanObject` filters.

- **`extractTopLevelArrays`**: a character-by-character scanner that tracks `"..."` string state (including escape sequences), so a `]` inside a JSON string value never closes an array prematurely, and nested arrays inside filter objects are captured as part of their enclosing top-level array.
- **Last-first candidate preference**: the whole completion is still tried first (preserving the clean-path and `{filters:[…]}` wrapper paths byte-for-byte), then extracted arrays are tried last-first; the `fallback` mechanism ensures a stray zero-valid-filter array in the prose never shadows a real filter array that preceded it.
- **Boolean score guardrail**: `booleans` / `traceBooleans` added to `ObservedScoreNames`, `router.ts` Zod schema, and `SCORE_NAME_SET_BY_COLUMN`, closing the same dead-filter class for boolean scores that was already fixed for numeric and categorical.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The core filter extraction path is unchanged for the common cases (bare array, `{filters:[…]}` wrapper), and the new balanced-bracket scanner is thoroughly tested.

The `extractTopLevelArrays` scanner and the last-first candidate ordering are logically correct and well-covered by 27 tests. The only issue found is a telemetry inaccuracy in the `droppedCount` for a degenerate edge case where every candidate parses as JSON but no candidate yields valid filter items — the fallback `rawCount` can reflect a stray prose array's element count rather than the intended filter array's. This has no effect on the filters actually applied to queries.

`parseFilterCompletion.ts` is the only file with non-trivial logic changes and warrants the most attention, specifically the `fallback` accumulation in `parseFilterArray` and the new `extractTopLevelArrays` scanner.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[completion string] --> B[parseFilterArray]
    B --> C[candidates = completion + extractTopLevelArrays reversed]
    C --> D{Try each candidate}
    D --> E[JSON.parse]
    E -->|throws| D
    E -->|ok| F{raw is array?}
    F -->|no| D
    F -->|yes| G[safeParse each element]
    G --> H{kept.length > 0?}
    H -->|yes| I[return filters + rawCount]
    H -->|no| J{fallback set?}
    J -->|no| K[store as fallback rawCount=raw.length]
    K --> D
    J -->|yes| D
    D -->|exhausted| L{fallback?}
    L -->|yes| M[return fallback: filters=empty]
    L -->|no| N[return filters=empty rawCount=0]

    subgraph extractTopLevelArrays
    O[scan text char by char] --> P{in string?}
    P -->|yes| Q[handle escape + close-quote only]
    P -->|no| R{char type?}
    R -->|quote| S[set inString=true]
    R -->|open bracket at depth 0| T[record start, depth++]
    R -->|open bracket at depth > 0| U[depth++]
    R -->|close bracket| V[depth--]
    V --> W{depth==0?}
    W -->|yes| X[emit top-level array]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[completion string] --> B[parseFilterArray]
    B --> C[candidates = completion + extractTopLevelArrays reversed]
    C --> D{Try each candidate}
    D --> E[JSON.parse]
    E -->|throws| D
    E -->|ok| F{raw is array?}
    F -->|no| D
    F -->|yes| G[safeParse each element]
    G --> H{kept.length > 0?}
    H -->|yes| I[return filters + rawCount]
    H -->|no| J{fallback set?}
    J -->|no| K[store as fallback rawCount=raw.length]
    K --> D
    J -->|yes| D
    D -->|exhausted| L{fallback?}
    L -->|yes| M[return fallback: filters=empty]
    L -->|no| N[return filters=empty rawCount=0]

    subgraph extractTopLevelArrays
    O[scan text char by char] --> P{in string?}
    P -->|yes| Q[handle escape + close-quote only]
    P -->|no| R{char type?}
    R -->|quote| S[set inString=true]
    R -->|open bracket at depth 0| T[record start, depth++]
    R -->|open bracket at depth > 0| U[depth++]
    R -->|close bracket| V[depth--]
    V --> W{depth==0?}
    W -->|yes| X[emit top-level array]
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/search-bar/server/parseFilterCompletion.ts:121-148
**`fallback` rawCount may reflect the wrong array in the all-fail case**

When every candidate parses as a JSON array but none yields valid filter items, the `fallback` is set from whichever candidate first hits the `kept.length === 0` branch — in iteration order that is the last text array (tried first after reversing). If that first no-valid-filter candidate happens to be a stray JSON array in the prose (e.g. `["a", "b"]`, 2 elements) while the model's intended filter array is a different candidate (e.g. 4 elements, all malformed), the returned `rawCount` is 2, so `droppedCount` is 2 rather than 4 in the caller. This is telemetry-only (filters are empty either way), but the count misrepresents how many model items were actually dropped.

In the common cases — at least one candidate has valid filters, or no candidate parses as a JSON array at all — the `fallback` is either never consulted or never set, so those paths are unaffected.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search-bar): recover self-corrected ..."](https://github.com/langfuse/langfuse/commit/bbb58b459a83f30c27ace83e33af97eb2ba0ff04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44809623)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->