### PR TITLE
feat(worker): export eval job configurations in core data S3 export

### DIFF
--- a/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
+++ b/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
@@ -50,13 +50,16 @@ describe("mapUserToCoreDataRow", () => {
 });
 
 describe("mapJobConfigurationToCoreDataRow", () => {
-  it("flattens the eval template relation to evalTemplateName", () => {
+  const decimal = (value: number) => ({ toNumber: () => value });
+
+  it("flattens the eval template and casts sampling to a number", () => {
     const row = mapJobConfigurationToCoreDataRow({
       id: "config-1",
       projectId: "project-1",
       scoreName: "toxicity",
       evalTemplateId: "template-1",
       evalTemplate: { name: "toxicity-v2" },
+      sampling: decimal(0.5),
     });
 
     expect(row).toStrictEqual({
@@ -65,16 +68,23 @@ describe("mapJobConfigurationToCoreDataRow", () => {
       scoreName: "toxicity",
       evalTemplateId: "template-1",
       evalTemplateName: "toxicity-v2",
+      sampling: 0.5,
     });
+    expect(JSON.stringify(row)).toContain('"sampling":0.5');
   });
 
   it("exports null for configurations without an eval template", () => {
     const row = mapJobConfigurationToCoreDataRow({
       id: "config-2",
       evalTemplate: null,
+      sampling: decimal(1),
     });
 
-    expect(row).toStrictEqual({ id: "config-2", evalTemplateName: null });
+    expect(row).toStrictEqual({
+      id: "config-2",
+      evalTemplateName: null,
+      sampling: 1,
+    });
   });
 });
 

--- a/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
+++ b/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { Readable } from "node:stream";
 import { type StorageService } from "@langfuse/shared/src/server";
 import {
+  mapJobConfigurationToCoreDataRow,
   mapUserToCoreDataRow,
   uploadTableCoreDataJsonl,
 } from "../coreDataS3ExportQueue";
@@ -45,6 +46,35 @@ describe("mapUserToCoreDataRow", () => {
     });
 
     expect(row).toStrictEqual({ id: "user-2", authMethods: [] });
+  });
+});
+
+describe("mapJobConfigurationToCoreDataRow", () => {
+  it("flattens the eval template relation to evalTemplateName", () => {
+    const row = mapJobConfigurationToCoreDataRow({
+      id: "config-1",
+      projectId: "project-1",
+      scoreName: "toxicity",
+      evalTemplateId: "template-1",
+      evalTemplate: { name: "toxicity-v2" },
+    });
+
+    expect(row).toStrictEqual({
+      id: "config-1",
+      projectId: "project-1",
+      scoreName: "toxicity",
+      evalTemplateId: "template-1",
+      evalTemplateName: "toxicity-v2",
+    });
+  });
+
+  it("exports null for configurations without an eval template", () => {
+    const row = mapJobConfigurationToCoreDataRow({
+      id: "config-2",
+      evalTemplate: null,
+    });
+
+    expect(row).toStrictEqual({ id: "config-2", evalTemplateName: null });
   });
 });
 

--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -58,15 +58,19 @@ export const mapUserToCoreDataRow = ({
 
 type JobConfigurationCoreDataInput = {
   evalTemplate: { name: string } | null;
+  sampling: { toNumber: () => number };
 } & Record<string, unknown>;
 
 // Flattens the joined eval template into a plain column so the export stays
-// one JSONL row per configured evaluator.
+// one JSONL row per configured evaluator. The sampling Decimal is cast to a
+// JS number so it lands as a JSON number instead of a quoted string.
 export const mapJobConfigurationToCoreDataRow = ({
   evalTemplate,
+  sampling,
   ...jobConfiguration
 }: JobConfigurationCoreDataInput) => ({
   ...jobConfiguration,
+  sampling: sampling.toNumber(),
   evalTemplateName: evalTemplate?.name ?? null,
 });
 

--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -56,6 +56,20 @@ export const mapUserToCoreDataRow = ({
   ],
 });
 
+type JobConfigurationCoreDataInput = {
+  evalTemplate: { name: string } | null;
+} & Record<string, unknown>;
+
+// Flattens the joined eval template into a plain column so the export stays
+// one JSONL row per configured evaluator.
+export const mapJobConfigurationToCoreDataRow = ({
+  evalTemplate,
+  ...jobConfiguration
+}: JobConfigurationCoreDataInput) => ({
+  ...jobConfiguration,
+  evalTemplateName: evalTemplate?.name ?? null,
+});
+
 type TablePageArgs<TCursor> = {
   lastRow: TCursor | null;
   take: number;
@@ -421,6 +435,43 @@ const coreDataTableExports: Array<
             updatedAt: true,
           },
         }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "jobConfigurations",
+      // blockMessage is excluded as free-text; the eval template relation is
+      // flattened to evalTemplateName below
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ id: string }>) =>
+        prisma.jobConfiguration.findMany({
+          take,
+          ...(lastRow ? { cursor: { id: lastRow.id }, skip: 1 } : {}),
+          orderBy: { id: "asc" },
+          select: {
+            id: true,
+            projectId: true,
+            jobType: true,
+            status: true,
+            blockedAt: true,
+            blockReason: true,
+            evalTemplateId: true,
+            scoreName: true,
+            filter: true,
+            targetObject: true,
+            variableMapping: true,
+            sampling: true,
+            delay: true,
+            timeScope: true,
+            createdAt: true,
+            updatedAt: true,
+            evalTemplate: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        }),
+      mapRow: mapJobConfigurationToCoreDataRow,
     }),
 ];
 


### PR DESCRIPTION
## Summary

Adds `job_configurations` to the core-data Postgres → S3 export (`coreDataS3ExportQueue`) so the internal DWH receives every configured evaluator per project.

- New `jobConfigurations` table export entry with keyset pagination on `id`, following the existing per-table pattern.
- Joined eval template is flattened to an `evalTemplateName` column via a new exported `mapJobConfigurationToCoreDataRow` mapper, so the warehouse can tell which evaluator each config uses without needing the templates table.
- Included columns: `id`, `projectId`, `jobType`, `status`, `blockedAt`, `blockReason`, `evalTemplateId`, `scoreName`, `filter`, `targetObject`, `variableMapping`, `sampling`, `delay`, `timeScope`, `createdAt`, `updatedAt`, `evalTemplateName`.
- Excluded: `blockMessage` (free text, low analytical value).
- Note for downstream staging: `sampling` (Prisma Decimal) serializes as a string in JSONL; `filter`/`variableMapping` land as nested JSON.

## Impacted packages

- `worker`

## Verification

- `pnpm --filter worker run test coreDataS3ExportQueue` → `Tests  9 passed (9)`
- `pnpm run lint` → `Tasks: 7 successful, 7 total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `jobConfigurations` as a new table export to the core-data S3 export pipeline, following the established keyset-pagination pattern. A new `mapJobConfigurationToCoreDataRow` mapper flattens the joined `evalTemplate` relation into a single `evalTemplateName` column, and `blockMessage` (free text) is deliberately excluded from the select.

- A new entry is appended to `coreDataTableExports` with pagination on `id` (primary key), matching the pattern of every other exported table.
- `mapJobConfigurationToCoreDataRow` is unit-tested for both the non-null and null `evalTemplate` cases.
- The `sampling` column is a Prisma `Decimal`; `JSON.stringify` will serialize it as a quoted string rather than a JSON number, which is noted in the PR description but will need type coercion in the warehouse ingestion layer.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change adds a new export table without touching existing exports or shared infrastructure.

The implementation is clean and closely follows every established pattern in the file. The one thing worth a second look before the warehouse ingestion layer is built is the `sampling` column: Prisma `Decimal` round-trips through `JSON.stringify` as a quoted string, so any loader that declares the column as a numeric type will need an explicit cast. This is already called out in the PR description, but the export itself does not perform the conversion.

worker/src/queues/coreDataS3ExportQueue.ts — specifically the `sampling` field serialization in the new `jobConfigurations` export entry.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Processor as coreDataS3ExportProcessor
    participant Limit as pLimit(3)
    participant Upload as uploadTableCoreDataJsonl
    participant Stream as createTableJsonlStream
    participant DB as Prisma (jobConfiguration)
    participant Mapper as mapJobConfigurationToCoreDataRow
    participant S3 as S3 / StorageService

    Processor->>Limit: Run all coreDataTableExports (including jobConfigurations)
    Limit->>Upload: "uploadTableCoreDataJsonl({ tableName: "jobConfigurations", ... })"
    Upload->>S3: uploadFileBuffered (streaming)
    loop Keyset pages (id ASC, page size 1000)
        Stream->>DB: "jobConfiguration.findMany({ cursor: lastRow.id, take: 1000 })"
        DB-->>Stream: page of rows (with evalTemplate.name)
        Stream->>Mapper: mapJobConfigurationToCoreDataRow(row)
        Mapper-->>Stream: "{ ...fields, evalTemplateName }"
        Stream-->>S3: JSON.stringify(mapped row) + newline
    end
    S3-->>Upload: upload complete
    Upload-->>Processor: resolved
    Processor->>Processor: Check for any rejected promises → throw on failure
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Processor as coreDataS3ExportProcessor
    participant Limit as pLimit(3)
    participant Upload as uploadTableCoreDataJsonl
    participant Stream as createTableJsonlStream
    participant DB as Prisma (jobConfiguration)
    participant Mapper as mapJobConfigurationToCoreDataRow
    participant S3 as S3 / StorageService

    Processor->>Limit: Run all coreDataTableExports (including jobConfigurations)
    Limit->>Upload: "uploadTableCoreDataJsonl({ tableName: "jobConfigurations", ... })"
    Upload->>S3: uploadFileBuffered (streaming)
    loop Keyset pages (id ASC, page size 1000)
        Stream->>DB: "jobConfiguration.findMany({ cursor: lastRow.id, take: 1000 })"
        DB-->>Stream: page of rows (with evalTemplate.name)
        Stream->>Mapper: mapJobConfigurationToCoreDataRow(row)
        Mapper-->>Stream: "{ ...fields, evalTemplateName }"
        Stream-->>S3: JSON.stringify(mapped row) + newline
    end
    S3-->>Upload: upload complete
    Upload-->>Processor: resolved
    Processor->>Processor: Check for any rejected promises → throw on failure
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/queues/coreDataS3ExportQueue.ts:462
The `sampling` field is a Prisma `Decimal`, and `JSON.stringify` will emit it as a quoted string (e.g., `"0.5"`) rather than a JSON number. Any downstream warehouse ingestion that declares the column as `FLOAT` or `NUMERIC` will either error or silently coerce the value. Converting to a JS `Number` at export time keeps the JSONL type-correct for standard warehouse loaders.

```suggestion
            sampling: true, // Decimal → serialized as string; cast to Number in mapRow if warehouse expects numeric
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): export eval job configurat..."](https://github.com/langfuse/langfuse/commit/df10b5ae3711414404ac55599cbf081608d1174a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44826207)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->