### PR TITLE
feat(api): agent-friendly deprecation responses for legacy endpoints (LFE-10895)

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -755,6 +755,7 @@ types:
     extends: DatasetRun
     properties:
       datasetRunItems: list<DatasetRunItem>
+      _deprecation: optional<Deprecation>
   # Source: web/src/features/public-api/types/models.ts - APIModelDefinition
   Model:
     docs: |

--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -1,4 +1,22 @@
 types:
+  # Migration signal attached as the top-level `_deprecation` key on responses
+  # from deprecated (legacy, pre-v4-data-model) endpoints. See LFE-10895.
+  Deprecation:
+    docs: Migration signal returned by deprecated endpoints. Optional fields are omitted when they have no value.
+    properties:
+      message:
+        type: string
+        docs: Human- and agent-readable summary of the deprecation and its replacement.
+      replacement:
+        type: optional<string>
+        docs: The replacement endpoint, e.g. "GET /api/public/v2/observations". Omitted when the endpoint is being removed without a direct replacement.
+      docsUrl:
+        type: optional<string>
+        docs: Link to the migration documentation (markdown), when available.
+      sunsetAt:
+        type: optional<string>
+        docs: ISO date after which the endpoint may stop working, when a removal date is committed.
+
   # Objects
   # Source: web/src/features/public-api/types/traces.ts - APITrace, APIExtendedTrace, GetTraceV1Response
   Trace:
@@ -78,6 +96,7 @@ types:
       scores:
         type: list<ScoreV1>
         docs: List of scores
+      _deprecation: optional<Deprecation>
   # Source: web/src/features/public-api/types/sessions.ts - APISession
   Session:
     properties:
@@ -91,6 +110,7 @@ types:
     extends: Session
     properties:
       traces: list<Trace>
+      _deprecation: optional<Deprecation>
   # Source: web/src/features/public-api/types/observations.ts - APIObservation
   Observation:
     properties:
@@ -194,6 +214,14 @@ types:
       timeToFirstToken:
         type: nullable<double>
         docs: The time to the first token in seconds
+
+  # Single-observation response (GET /observations/{observationId}); carries the
+  # deprecation signal without adding it to the shared ObservationsView (used as
+  # a list element and nested in TraceWithFullDetails).
+  ObservationsViewSingle:
+    extends: ObservationsView
+    properties:
+      _deprecation: optional<Deprecation>
 
   # Source: web/src/features/public-api/types/observations.ts - APIObservationV2
   ObservationV2:
@@ -556,6 +584,8 @@ types:
         docs: The text content of the score (1-500 characters)
   Score:
     discriminant: "dataType"
+    base-properties:
+      _deprecation: optional<Deprecation>
     union:
       NUMERIC:
         type: NumericScore

--- a/fern/apis/server/definition/dataset-run-items.yml
+++ b/fern/apis/server/definition/dataset-run-items.yml
@@ -7,12 +7,18 @@ service:
   base-path: /api/public
   endpoints:
     create:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, create experiment data via the SDK experiment runner or the OpenTelemetry endpoint at POST /api/public/otel/v1/traces."
       method: POST
       docs: Create a dataset run item
       path: /dataset-run-items
       request: CreateDatasetRunItemRequest
       response: commons.DatasetRunItem
     list:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, dataset run items are replaced by experiment items; use GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to> instead."
       method: GET
       docs: List dataset run items
       path: /dataset-run-items
@@ -58,3 +64,4 @@ types:
     properties:
       data: list<commons.DatasetRunItem>
       meta: pagination.MetaResponse
+      _deprecation: optional<commons.Deprecation>

--- a/fern/apis/server/definition/dataset-run-items.yml
+++ b/fern/apis/server/definition/dataset-run-items.yml
@@ -9,7 +9,7 @@ service:
     create:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, create experiment data via the SDK experiment runner or the OpenTelemetry endpoint at POST /api/public/otel/v1/traces."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, create experiment data via the SDK experiment runner or the OpenTelemetry endpoint at POST /api/public/otel/v1/traces."
       method: POST
       docs: Create a dataset run item
       path: /dataset-run-items
@@ -18,7 +18,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, dataset run items are replaced by experiment items; use GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, dataset run items are replaced by experiment items; use GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to> instead."
       method: GET
       docs: List dataset run items
       path: /dataset-run-items

--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -34,6 +34,9 @@ service:
       request: CreateDatasetRequest
       response: commons.Dataset
     getRun:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
       method: GET
       docs: Get a dataset run and its items
       path: /datasets/{datasetName}/runs/{runName}
@@ -42,6 +45,9 @@ service:
         runName: string
       response: commons.DatasetRunWithItems
     deleteRun:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, dataset runs are replaced by experiments."
       method: DELETE
       docs: Delete a dataset run and all its run items. This action is irreversible.
       path: /datasets/{datasetName}/runs/{runName}
@@ -50,6 +56,9 @@ service:
         runName: string
       response: DeleteDatasetRunResponse
     getRuns:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
       method: GET
       docs: Get dataset runs
       path: /datasets/{datasetName}/runs
@@ -86,6 +95,7 @@ types:
     properties:
       data: list<commons.DatasetRun>
       meta: pagination.MetaResponse
+      _deprecation: optional<commons.Deprecation>
   DeleteDatasetRunResponse:
     properties:
       message: string

--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -9,7 +9,7 @@ service:
     batch:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Send data via the OpenTelemetry endpoint at POST /api/public/otel/v1/traces instead. Learn more: https://langfuse.com/integrations/native/opentelemetry"
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Send data via the OpenTelemetry endpoint at POST /api/public/otel/v1/traces instead. Learn more: https://langfuse.com/integrations/native/opentelemetry"
       docs: |
         **Legacy endpoint for batch ingestion for Langfuse Observability.**
 

--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -9,7 +9,7 @@ service:
     batch:
       availability:
         status: deprecated
-        message: "Use the OpenTelemetry endpoint at /api/public/otel/v1/traces instead. Learn more: https://langfuse.com/integrations/native/opentelemetry"
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Send data via the OpenTelemetry endpoint at POST /api/public/otel/v1/traces instead. Learn more: https://langfuse.com/integrations/native/opentelemetry"
       docs: |
         **Legacy endpoint for batch ingestion for Langfuse Observability.**
 

--- a/fern/apis/server/definition/legacy/metrics-v1.yml
+++ b/fern/apis/server/definition/legacy/metrics-v1.yml
@@ -9,7 +9,7 @@ service:
     metrics:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v2/metrics?query=<urlencoded json query> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/metrics?query=<urlencoded json query> instead."
       docs: |
         Get metrics from the Langfuse project using a query object.
 

--- a/fern/apis/server/definition/legacy/metrics-v1.yml
+++ b/fern/apis/server/definition/legacy/metrics-v1.yml
@@ -9,7 +9,7 @@ service:
     metrics:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/metrics instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v2/metrics?query=<urlencoded json query> instead."
       docs: |
         Get metrics from the Langfuse project using a query object.
 

--- a/fern/apis/server/definition/legacy/metrics-v1.yml
+++ b/fern/apis/server/definition/legacy/metrics-v1.yml
@@ -7,6 +7,9 @@ service:
   base-path: /api/public
   endpoints:
     metrics:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/metrics instead."
       docs: |
         Get metrics from the Langfuse project using a query object.
 
@@ -72,3 +75,4 @@ types:
           The metrics data. Each item in the list contains the metric values and dimensions requested in the query.
           Format varies based on the query parameters.
           Histograms will return an array with [lower, upper, height] tuples.
+      _deprecation: optional<commons.Deprecation>

--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
       docs: Get a observation
       method: GET
       path: /observations/{observationId}
@@ -21,7 +21,7 @@ service:
     getMany:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
       docs: |
         Get a list of observations.
 

--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -7,6 +7,9 @@ service:
   base-path: /api/public
   endpoints:
     get:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/observations instead."
       docs: Get a observation
       method: GET
       path: /observations/{observationId}
@@ -14,8 +17,11 @@ service:
         observationId:
           type: string
           docs: The unique langfuse identifier of an observation, can be an event, span or generation
-      response: commons.ObservationsView
+      response: commons.ObservationsViewSingle
     getMany:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/observations instead."
       docs: |
         Get a list of observations.
 
@@ -160,3 +166,4 @@ types:
     properties:
       data: list<commons.ObservationsView>
       meta: pagination.MetaResponse
+      _deprecation: optional<commons.Deprecation>

--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/observations instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
       docs: Get a observation
       method: GET
       path: /observations/{observationId}
@@ -21,7 +21,7 @@ service:
     getMany:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/observations instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
       docs: |
         Get a list of observations.
 

--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -9,7 +9,7 @@ service:
     get-many:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v3/scores instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v3/scores instead."
       docs: |
         **Deprecated.** Use `GET /api/public/v3/scores` instead. This endpoint
         is no longer available on Langfuse v4 and later.
@@ -94,7 +94,7 @@ service:
     get-by-id:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v3/scores with the id filter instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v3/scores with the id filter instead."
       docs: |
         **Deprecated.** Use `GET /api/public/v3/scores` with the `id` filter
         instead. This endpoint is no longer available on Langfuse v4 and later.

--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -7,6 +7,9 @@ service:
   base-path: /api/public/v2
   endpoints:
     get-many:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v3/scores instead."
       docs: |
         **Deprecated.** Use `GET /api/public/v3/scores` instead. This endpoint
         is no longer available on Langfuse v4 and later.
@@ -89,6 +92,9 @@ service:
               Supported operators for stringObject: =, contains, does not contain, starts with, ends with.
       response: GetScoresResponse
     get-by-id:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v3/scores with the id filter instead."
       docs: |
         **Deprecated.** Use `GET /api/public/v3/scores` with the `id` filter
         instead. This endpoint is no longer available on Langfuse v4 and later.
@@ -156,3 +162,4 @@ types:
     properties:
       data: list<GetScoresResponseData>
       meta: pagination.MetaResponse
+      _deprecation: optional<commons.Deprecation>

--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -9,7 +9,7 @@ service:
     get-many:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v3/scores instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v3/scores instead."
       docs: |
         **Deprecated.** Use `GET /api/public/v3/scores` instead. This endpoint
         is no longer available on Langfuse v4 and later.
@@ -94,7 +94,7 @@ service:
     get-by-id:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v3/scores with the id filter instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v3/scores with the id filter instead."
       docs: |
         **Deprecated.** Use `GET /api/public/v3/scores` with the `id` filter
         instead. This endpoint is no longer available on Langfuse v4 and later.

--- a/fern/apis/server/definition/sessions.yml
+++ b/fern/apis/server/definition/sessions.yml
@@ -9,7 +9,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
       docs: |
         Get sessions.
 
@@ -42,7 +42,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
       docs: |
         Get a session.
 

--- a/fern/apis/server/definition/sessions.yml
+++ b/fern/apis/server/definition/sessions.yml
@@ -9,7 +9,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via GET /api/public/v2/observations filtered by sessionId."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
       docs: |
         Get sessions.
 
@@ -42,7 +42,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via GET /api/public/v2/observations filtered by sessionId."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
       docs: |
         Get a session.
 

--- a/fern/apis/server/definition/sessions.yml
+++ b/fern/apis/server/definition/sessions.yml
@@ -7,6 +7,9 @@ service:
   base-path: /api/public
   endpoints:
     list:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. It has no replacement."
       docs: |
         Get sessions.
 
@@ -37,6 +40,9 @@ service:
             docs: Optional filter for sessions where the environment is one of the provided values.
       response: PaginatedSessions
     get:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. It has no replacement."
       docs: |
         Get a session.
 
@@ -56,3 +62,4 @@ types:
     properties:
       data: list<commons.Session>
       meta: pagination.MetaResponse
+      _deprecation: optional<commons.Deprecation>

--- a/fern/apis/server/definition/sessions.yml
+++ b/fern/apis/server/definition/sessions.yml
@@ -9,7 +9,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. It has no replacement."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via GET /api/public/v2/observations filtered by sessionId."
       docs: |
         Get sessions.
 
@@ -42,7 +42,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. It has no replacement."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via GET /api/public/v2/observations filtered by sessionId."
       docs: |
         Get a session.
 

--- a/fern/apis/server/definition/trace.yml
+++ b/fern/apis/server/definition/trace.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via GET /api/public/v2/observations."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
       docs: Get a specific trace
       method: GET
       path: /traces/{traceId}
@@ -36,7 +36,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via GET /api/public/v2/observations."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
       docs: Get list of traces
       method: GET
       path: /traces

--- a/fern/apis/server/definition/trace.yml
+++ b/fern/apis/server/definition/trace.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
       docs: Get a specific trace
       method: GET
       path: /traces/{traceId}
@@ -36,7 +36,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
       docs: Get list of traces
       method: GET
       path: /traces

--- a/fern/apis/server/definition/trace.yml
+++ b/fern/apis/server/definition/trace.yml
@@ -7,6 +7,9 @@ service:
   base-path: /api/public
   endpoints:
     get:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via GET /api/public/v2/observations."
       docs: Get a specific trace
       method: GET
       path: /traces/{traceId}
@@ -31,6 +34,9 @@ service:
           docs: The unique langfuse identifier of the trace to delete
       response: DeleteTraceResponse
     list:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via GET /api/public/v2/observations."
       docs: Get list of traces
       method: GET
       path: /traces
@@ -201,6 +207,7 @@ types:
     properties:
       data: list<commons.TraceWithDetails>
       meta: pagination.MetaResponse
+      _deprecation: optional<commons.Deprecation>
   DeleteTraceResponse:
     properties:
       message: string

--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -158,6 +158,19 @@ export const paginationMetaResponseZod = z.object({
   totalPages: z.number().int().nonnegative(),
 });
 
+/**
+ * Top-level `_deprecation` metadata returned by legacy public API endpoints.
+ * Optional fields are omitted when empty (never null). See LFE-10895.
+ */
+export const deprecationResponseZod = z.object({
+  message: z.string(),
+  replacement: z.string().optional(),
+  docsUrl: z.string().optional(),
+  sunsetAt: z.string().optional(),
+});
+
+export type ApiDeprecationInfo = z.infer<typeof deprecationResponseZod>;
+
 export const urlRegex = /https?:\/\/[^\s/$.?#].[^\s]*/i;
 export const noUrlCheck = (value: string) => !urlRegex.test(value);
 

--- a/web/src/__tests__/server/deprecation-signal.servertest.ts
+++ b/web/src/__tests__/server/deprecation-signal.servertest.ts
@@ -18,7 +18,6 @@ import {
   SCORES_DEPRECATION,
   SESSIONS_DEPRECATION,
   TRACES_DEPRECATION,
-  V3_SUNSET_DATE,
 } from "@/src/features/public-api/server/deprecations";
 import { OBSERVATIONS_API_V2_DOCS_URL } from "@/src/features/public-api/server/rateLimitUpgradePaths";
 import { randomUUID } from "crypto";
@@ -51,7 +50,7 @@ describe("public API deprecation signal", () => {
     );
   });
 
-  it("carries the docs URL and the committed sunset date", async () => {
+  it("carries the docs URL", async () => {
     const response = await makeZodVerifiedAPICall(
       GetObservationsV1Response,
       "GET",
@@ -64,8 +63,6 @@ describe("public API deprecation signal", () => {
     expect(response.body._deprecation?.docsUrl).toBe(
       OBSERVATIONS_API_V2_DOCS_URL,
     );
-    // sunsetAt is committed → present.
-    expect(response.body._deprecation?.sunsetAt).toBe(V3_SUNSET_DATE);
   });
 
   // Single-item response: `_deprecation` is added via `.extend()` at the

--- a/web/src/__tests__/server/deprecation-signal.servertest.ts
+++ b/web/src/__tests__/server/deprecation-signal.servertest.ts
@@ -3,6 +3,7 @@ import {
   createObservationsCh,
   createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
+import { prisma } from "@langfuse/shared/src/db";
 import {
   makeAPICall,
   makeZodVerifiedAPICall,
@@ -12,6 +13,7 @@ import {
   GetObservationV1Response,
 } from "@/src/features/public-api/types/observations";
 import {
+  DATASET_RUN_ITEMS_DEPRECATION,
   OBSERVATIONS_V1_DEPRECATION,
   SCORES_DEPRECATION,
   SESSIONS_DEPRECATION,
@@ -138,6 +140,29 @@ describe("public API deprecation signal", () => {
     expect(deprecation).toEqual(SESSIONS_DEPRECATION);
     expect((deprecation as Record<string, unknown>)?.replacement).toBe(
       "GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>",
+    );
+  });
+
+  // Dataset run items (Group C) → experiment items. Needs a real dataset + run
+  // (the endpoint 404s otherwise); an empty run returns an empty list + signal.
+  it("attaches `_deprecation` to the legacy GET /dataset-run-items list response", async () => {
+    const dataset = await prisma.dataset.create({
+      data: { name: `deprecation-test-${randomUUID()}`, projectId },
+    });
+    const run = await prisma.datasetRuns.create({
+      data: { name: `run-${randomUUID()}`, datasetId: dataset.id, projectId },
+    });
+
+    const response = await makeAPICall(
+      "GET",
+      `/api/public/dataset-run-items?datasetId=${dataset.id}&runName=${run.name}`,
+      undefined,
+      auth,
+    );
+
+    expect(response.status).toBe(200);
+    expect((response.body as Record<string, unknown>)._deprecation).toEqual(
+      DATASET_RUN_ITEMS_DEPRECATION,
     );
   });
 });

--- a/web/src/__tests__/server/deprecation-signal.servertest.ts
+++ b/web/src/__tests__/server/deprecation-signal.servertest.ts
@@ -120,10 +120,8 @@ describe("public API deprecation signal", () => {
 
     expect(response.status).toBe(200);
     const deprecation = (response.body as Record<string, unknown>)._deprecation;
+    // toEqual against the constant covers `replacement` (incl. query params).
     expect(deprecation).toEqual(TRACES_DEPRECATION);
-    expect((deprecation as Record<string, unknown>).replacement).toBe(
-      "GET /api/public/v2/observations",
-    );
   });
 
   // Sessions is deprecated and not replaced, so `_deprecation` is message-only.

--- a/web/src/__tests__/server/deprecation-signal.servertest.ts
+++ b/web/src/__tests__/server/deprecation-signal.servertest.ts
@@ -1,0 +1,140 @@
+import {
+  createObservation,
+  createObservationsCh,
+  createOrgProjectAndApiKey,
+} from "@langfuse/shared/src/server";
+import {
+  makeAPICall,
+  makeZodVerifiedAPICall,
+} from "@/src/__tests__/test-utils";
+import {
+  GetObservationsV1Response,
+  GetObservationV1Response,
+} from "@/src/features/public-api/types/observations";
+import {
+  OBSERVATIONS_V1_DEPRECATION,
+  SCORES_DEPRECATION,
+  SESSIONS_DEPRECATION,
+  TRACES_DEPRECATION,
+  V3_SUNSET_DATE,
+} from "@/src/features/public-api/server/deprecations";
+import { randomUUID } from "crypto";
+
+// LFE-10895: legacy (v3-data-model) endpoints attach a top-level `_deprecation`
+// object so coding agents get a self-correcting migration signal.
+describe("public API deprecation signal", () => {
+  let auth: string;
+  let projectId: string;
+
+  beforeAll(async () => {
+    const fixture = await createOrgProjectAndApiKey();
+    auth = fixture.auth;
+    projectId = fixture.projectId;
+  });
+
+  it("attaches `_deprecation` to the legacy GET /observations list response", async () => {
+    const response = await makeZodVerifiedAPICall(
+      GetObservationsV1Response,
+      "GET",
+      "/api/public/observations",
+      undefined,
+      auth,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body._deprecation).toEqual(OBSERVATIONS_V1_DEPRECATION);
+    expect(response.body._deprecation?.replacement).toBe(
+      "GET /api/public/v2/observations",
+    );
+  });
+
+  it("omits empty `_deprecation` fields but carries the committed sunset date", async () => {
+    const response = await makeZodVerifiedAPICall(
+      GetObservationsV1Response,
+      "GET",
+      "/api/public/observations",
+      undefined,
+      auth,
+    );
+
+    // docsUrl has no value yet → omitted (never emitted as null).
+    expect(response.body._deprecation).not.toHaveProperty("docsUrl");
+    // sunsetAt is committed → present.
+    expect(response.body._deprecation?.sunsetAt).toBe(V3_SUNSET_DATE);
+  });
+
+  // Single-item response: `_deprecation` is added via `.extend()` at the
+  // response level (not on the shared item schema). makeZodVerifiedAPICall
+  // validates the strict single-item schema accepts the injected field.
+  it("attaches `_deprecation` to the legacy single GET /observations/{id}", async () => {
+    const observationId = randomUUID();
+    await createObservationsCh([
+      createObservation({
+        id: observationId,
+        project_id: projectId,
+        trace_id: randomUUID(),
+        type: "GENERATION",
+      }),
+    ]);
+
+    const response = await makeZodVerifiedAPICall(
+      GetObservationV1Response,
+      "GET",
+      `/api/public/observations/${observationId}`,
+      undefined,
+      auth,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body._deprecation).toEqual(OBSERVATIONS_V1_DEPRECATION);
+  });
+
+  // Scores v2 uses a non-strict response schema, so this also proves the
+  // injection works without a schema edit on the response type.
+  it("attaches `_deprecation` to the legacy GET /v2/scores list response", async () => {
+    const response = await makeAPICall(
+      "GET",
+      "/api/public/v2/scores",
+      undefined,
+      auth,
+    );
+
+    expect(response.status).toBe(200);
+    expect((response.body as Record<string, unknown>)._deprecation).toEqual(
+      SCORES_DEPRECATION,
+    );
+  });
+
+  // Traces is being removed; it points at observations v2 as a soft
+  // replacement for reading span/trace data in v4.
+  it("attaches `_deprecation` with the observations-v2 soft replacement to legacy GET /traces", async () => {
+    const response = await makeAPICall(
+      "GET",
+      "/api/public/traces",
+      undefined,
+      auth,
+    );
+
+    expect(response.status).toBe(200);
+    const deprecation = (response.body as Record<string, unknown>)._deprecation;
+    expect(deprecation).toEqual(TRACES_DEPRECATION);
+    expect((deprecation as Record<string, unknown>).replacement).toBe(
+      "GET /api/public/v2/observations",
+    );
+  });
+
+  // Sessions is deprecated and not replaced, so `_deprecation` is message-only.
+  it("attaches a replacement-less `_deprecation` to legacy GET /sessions", async () => {
+    const response = await makeAPICall(
+      "GET",
+      "/api/public/sessions",
+      undefined,
+      auth,
+    );
+
+    expect(response.status).toBe(200);
+    const deprecation = (response.body as Record<string, unknown>)._deprecation;
+    expect(deprecation).toEqual(SESSIONS_DEPRECATION);
+    expect(deprecation).not.toHaveProperty("replacement");
+  });
+});

--- a/web/src/__tests__/server/deprecation-signal.servertest.ts
+++ b/web/src/__tests__/server/deprecation-signal.servertest.ts
@@ -20,11 +20,21 @@ import {
   TRACES_DEPRECATION,
 } from "@/src/features/public-api/server/deprecations";
 import { OBSERVATIONS_API_V2_DOCS_URL } from "@/src/features/public-api/server/rateLimitUpgradePaths";
+import { env } from "@/src/env.mjs";
 import { randomUUID } from "crypto";
+
+// `_deprecation` injection is gated on LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN,
+// which also enables the events read path (requires ClickHouse >= 25.12). The
+// -azure / -redis-cluster CI modes intentionally run older ClickHouse with the
+// flag off, so skip there — same pattern as the other events-read-path suites.
+const maybeDescribe =
+  env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+    ? describe
+    : describe.skip;
 
 // LFE-10895: legacy (v3-data-model) endpoints attach a top-level `_deprecation`
 // object so coding agents get a self-correcting migration signal.
-describe("public API deprecation signal", () => {
+maybeDescribe("public API deprecation signal", () => {
   let auth: string;
   let projectId: string;
 

--- a/web/src/__tests__/server/deprecation-signal.servertest.ts
+++ b/web/src/__tests__/server/deprecation-signal.servertest.ts
@@ -18,6 +18,7 @@ import {
   TRACES_DEPRECATION,
   V3_SUNSET_DATE,
 } from "@/src/features/public-api/server/deprecations";
+import { OBSERVATIONS_API_V2_DOCS_URL } from "@/src/features/public-api/server/rateLimitUpgradePaths";
 import { randomUUID } from "crypto";
 
 // LFE-10895: legacy (v3-data-model) endpoints attach a top-level `_deprecation`
@@ -48,7 +49,7 @@ describe("public API deprecation signal", () => {
     );
   });
 
-  it("omits empty `_deprecation` fields but carries the committed sunset date", async () => {
+  it("carries the docs URL and the committed sunset date", async () => {
     const response = await makeZodVerifiedAPICall(
       GetObservationsV1Response,
       "GET",
@@ -57,8 +58,10 @@ describe("public API deprecation signal", () => {
       auth,
     );
 
-    // docsUrl has no value yet → omitted (never emitted as null).
-    expect(response.body._deprecation).not.toHaveProperty("docsUrl");
+    // docsUrl points at the migration guidance for the endpoint family.
+    expect(response.body._deprecation?.docsUrl).toBe(
+      OBSERVATIONS_API_V2_DOCS_URL,
+    );
     // sunsetAt is committed → present.
     expect(response.body._deprecation?.sunsetAt).toBe(V3_SUNSET_DATE);
   });
@@ -135,6 +138,8 @@ describe("public API deprecation signal", () => {
     expect(response.status).toBe(200);
     const deprecation = (response.body as Record<string, unknown>)._deprecation;
     expect(deprecation).toEqual(SESSIONS_DEPRECATION);
-    expect(deprecation).not.toHaveProperty("replacement");
+    expect((deprecation as Record<string, unknown>)?.replacement).toBe(
+      "GET /api/public/v2/observations",
+    );
   });
 });

--- a/web/src/__tests__/server/deprecation-signal.servertest.ts
+++ b/web/src/__tests__/server/deprecation-signal.servertest.ts
@@ -45,7 +45,7 @@ describe("public API deprecation signal", () => {
     expect(response.status).toBe(200);
     expect(response.body._deprecation).toEqual(OBSERVATIONS_V1_DEPRECATION);
     expect(response.body._deprecation?.replacement).toBe(
-      "GET /api/public/v2/observations",
+      "GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>",
     );
   });
 
@@ -139,7 +139,7 @@ describe("public API deprecation signal", () => {
     const deprecation = (response.body as Record<string, unknown>)._deprecation;
     expect(deprecation).toEqual(SESSIONS_DEPRECATION);
     expect((deprecation as Record<string, unknown>)?.replacement).toBe(
-      "GET /api/public/v2/observations",
+      "GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>",
     );
   });
 });

--- a/web/src/__tests__/server/deprecation-signal.servertest.ts
+++ b/web/src/__tests__/server/deprecation-signal.servertest.ts
@@ -14,6 +14,7 @@ import {
 } from "@/src/features/public-api/types/observations";
 import {
   DATASET_RUN_ITEMS_DEPRECATION,
+  DATASET_RUNS_DEPRECATION,
   OBSERVATIONS_V1_DEPRECATION,
   SCORES_DEPRECATION,
   SESSIONS_DEPRECATION,
@@ -170,6 +171,48 @@ maybeDescribe("public API deprecation signal", () => {
     expect(response.status).toBe(200);
     expect((response.body as Record<string, unknown>)._deprecation).toEqual(
       DATASET_RUN_ITEMS_DEPRECATION,
+    );
+  });
+
+  it("attaches `_deprecation` to the legacy GET /datasets/{name}/runs list response", async () => {
+    const dataset = await prisma.dataset.create({
+      data: { name: `deprecation-test-${randomUUID()}`, projectId },
+    });
+    await prisma.datasetRuns.create({
+      data: { name: `run-${randomUUID()}`, datasetId: dataset.id, projectId },
+    });
+
+    const response = await makeAPICall(
+      "GET",
+      `/api/public/datasets/${encodeURIComponent(dataset.name)}/runs`,
+      undefined,
+      auth,
+    );
+
+    expect(response.status).toBe(200);
+    expect((response.body as Record<string, unknown>)._deprecation).toEqual(
+      DATASET_RUNS_DEPRECATION,
+    );
+  });
+
+  it("attaches `_deprecation` to the legacy single GET /datasets/{name}/runs/{runName}", async () => {
+    const dataset = await prisma.dataset.create({
+      data: { name: `deprecation-test-${randomUUID()}`, projectId },
+    });
+    const run = await prisma.datasetRuns.create({
+      data: { name: `run-${randomUUID()}`, datasetId: dataset.id, projectId },
+    });
+
+    const response = await makeAPICall(
+      "GET",
+      `/api/public/datasets/${encodeURIComponent(dataset.name)}/runs/${encodeURIComponent(run.name)}`,
+      undefined,
+      auth,
+    );
+
+    expect(response.status).toBe(200);
+    expect((response.body as Record<string, unknown>)._deprecation).toEqual(
+      DATASET_RUNS_DEPRECATION,
     );
   });
 });

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -10,7 +10,11 @@ import {
   traceException,
   logger,
 } from "@langfuse/shared/src/server";
-import { PayloadTooLargeError, type RateLimitResource } from "@langfuse/shared";
+import {
+  PayloadTooLargeError,
+  type RateLimitResource,
+  type ApiDeprecationInfo,
+} from "@langfuse/shared";
 import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 import { type RateLimitUpgradePath } from "@/src/features/public-api/server/rateLimitUpgradePaths";
 import { contextWithLangfuseProps } from "@langfuse/shared/src/server";
@@ -26,6 +30,7 @@ import {
   type PublicApiErrorContract,
 } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 import { clickHouseRouteForRequest } from "@/src/features/public-api/server/clickHouseRequestTags";
+import { attachDeprecation } from "@/src/features/public-api/server/deprecations";
 
 /** Access levels that can be accepted by project-scoped API routes. */
 type RouteAccessLevel = Exclude<ApiAccessLevel, "organization">;
@@ -81,6 +86,8 @@ export type AuthedProjectAPIRouteConfig<
    * events_only mode and would silently return stale or empty data.
    */
   rejectInEventsOnlyMode?: boolean;
+  /** Stamps a top-level `_deprecation` object onto responses (LFE-10895). */
+  deprecation?: ApiDeprecationInfo;
   fn: (params: {
     query: z.infer<TQuery>;
     body: z.infer<TBody>;
@@ -313,10 +320,15 @@ export const createAuthedProjectAPIRoute = <
       routeConfig.rejectInEventsOnlyMode &&
       env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only"
     ) {
-      res.status(404).json({
-        message:
-          "This endpoint is not available on deployments running in Langfuse v4 events_only mode. Learn more about Langfuse v4 at: https://langfuse.com/docs/v4",
-      });
+      res.status(404).json(
+        attachDeprecation(
+          {
+            message:
+              "This endpoint is not available on deployments running in Langfuse v4 events_only mode. Learn more about Langfuse v4 at: https://langfuse.com/docs/v4",
+          },
+          routeConfig.deprecation,
+        ),
+      );
       return;
     }
 
@@ -466,7 +478,12 @@ export const createAuthedProjectAPIRoute = <
       );
 
       try {
-        res.json(response || { message: "OK" });
+        res.json(
+          attachDeprecation(
+            response || { message: "OK" },
+            routeConfig.deprecation,
+          ),
+        );
       } catch (error) {
         if (isJsonStringTooLargeError(error)) {
           throw new PayloadTooLargeError();

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -312,6 +312,14 @@ export const createAuthedProjectAPIRoute = <
   routeConfig: AuthedProjectAPIRouteConfig<TQuery, TBody, TResponse>,
 ): ((req: NextApiRequest, res: NextApiResponse) => Promise<void>) => {
   return async (req: NextApiRequest, res: NextApiResponse) => {
+    // Only surface deprecation notices on deployments on (or opting into) v4.
+    // Self-hosted deployments still on v3 (opt-in unset/false) should not see
+    // them yet, so gate the injected `_deprecation` on the preview flag.
+    const deprecation =
+      env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+        ? routeConfig.deprecation
+        : undefined;
+
     // Short-circuit routes that read from legacy traces/observations tables
     // when the deployment is in events_only mode — those tables are no longer
     // populated, so the response would be stale or empty. Returning 404 keeps
@@ -326,7 +334,7 @@ export const createAuthedProjectAPIRoute = <
             message:
               "This endpoint is not available on deployments running in Langfuse v4 events_only mode. Learn more about Langfuse v4 at: https://langfuse.com/docs/v4",
           },
-          routeConfig.deprecation,
+          deprecation,
         ),
       );
       return;
@@ -478,12 +486,7 @@ export const createAuthedProjectAPIRoute = <
       );
 
       try {
-        res.json(
-          attachDeprecation(
-            response || { message: "OK" },
-            routeConfig.deprecation,
-          ),
-        );
+        res.json(attachDeprecation(response || { message: "OK" }, deprecation));
       } catch (error) {
         if (isJsonStringTooLargeError(error)) {
           throw new PayloadTooLargeError();

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -1,4 +1,5 @@
 import { type ApiDeprecationInfo } from "@langfuse/shared";
+import { OBSERVATIONS_API_V2_DOCS_URL } from "./rateLimitUpgradePaths";
 
 // LFE-10895. Family-level deprecation signals for legacy (v3) public API
 // endpoints. Attach one via the `deprecation` route-config field; the response
@@ -21,9 +22,19 @@ const REPLACEMENT = {
   otelTraces: "POST /api/public/otel/v1/traces",
 } as const;
 
+// Migration guidance pages; each family points at the page that documents its
+// replacement (all pages also serve markdown to agents via the `.md` routes).
+const DOCS = {
+  observationsV2: OBSERVATIONS_API_V2_DOCS_URL,
+  metricsV2: "https://langfuse.com/docs/metrics/features/metrics-api",
+  compatibility: "https://langfuse.com/docs/compatibility",
+  otel: "https://langfuse.com/integrations/native/opentelemetry",
+} as const;
+
 export const OBSERVATIONS_V1_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Use ${REPLACEMENT.observationsV2} instead.`,
   replacement: REPLACEMENT.observationsV2,
+  docsUrl: DOCS.observationsV2,
   sunsetAt: V3_SUNSET_DATE,
 };
 
@@ -31,24 +42,29 @@ export const OBSERVATIONS_V1_DEPRECATION: ApiDeprecationInfo = {
 export const TRACES_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} In Langfuse v4, read span and trace data via ${REPLACEMENT.observationsV2}.`,
   replacement: REPLACEMENT.observationsV2,
+  docsUrl: DOCS.observationsV2,
   sunsetAt: V3_SUNSET_DATE,
 };
 
-// Sessions have no replacement.
+// Sessions have no drop-in successor; filter observations v2 by session instead.
 export const SESSIONS_DEPRECATION: ApiDeprecationInfo = {
-  message: `${V3_NOTICE} It has no replacement.`,
+  message: `${V3_NOTICE} In Langfuse v4, read session data via ${REPLACEMENT.observationsV2} filtered by sessionId.`,
+  replacement: REPLACEMENT.observationsV2,
+  docsUrl: DOCS.observationsV2,
   sunsetAt: V3_SUNSET_DATE,
 };
 
 export const SCORES_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Use ${REPLACEMENT.scoresV3} instead.`,
   replacement: REPLACEMENT.scoresV3,
+  docsUrl: DOCS.compatibility,
   sunsetAt: V3_SUNSET_DATE,
 };
 
 export const METRICS_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Use ${REPLACEMENT.metricsV2} instead.`,
   replacement: REPLACEMENT.metricsV2,
+  docsUrl: DOCS.metricsV2,
   sunsetAt: V3_SUNSET_DATE,
 };
 
@@ -56,6 +72,7 @@ export const METRICS_DEPRECATION: ApiDeprecationInfo = {
 export const LEGACY_INGESTION_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Send data via the OpenTelemetry endpoint at ${REPLACEMENT.otelTraces} instead.`,
   replacement: REPLACEMENT.otelTraces,
+  docsUrl: DOCS.otel,
   sunsetAt: V3_SUNSET_DATE,
 };
 

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -6,13 +6,13 @@ import { OBSERVATIONS_API_V2_DOCS_URL } from "./rateLimitUpgradePaths";
 // gets a top-level `_deprecation` key.
 
 // Sunset date for the legacy v3 public API — single source of truth. Set to the
-// end of October 2026; update here if the date moves.
+// end of October 2026; update both constants together if the date moves.
 export const V3_SUNSET_DATE = "2026-10-31";
+const V3_SUNSET_HUMAN = "October 31, 2026";
 
 // Shared deprecation reason — references the deprecated Langfuse v3 system
 // version (not an API version). Customer-facing wording lives here — edit once.
-const V3_NOTICE =
-  "Langfuse v3 is deprecated; this endpoint will be removed in a future release.";
+const V3_NOTICE = `Langfuse v3 is deprecated; this endpoint will be removed on ${V3_SUNSET_HUMAN}.`;
 
 // v4 replacement endpoints, referenced by both the message and `replacement`.
 // Placeholder style matches rateLimitUpgradePaths (<from>, <to>, filters).

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -30,6 +30,8 @@ const REPLACEMENT = {
 // replacement (all pages also serve markdown to agents via the `.md` routes).
 const DOCS = {
   observationsV2: OBSERVATIONS_API_V2_DOCS_URL,
+  scoresV3:
+    "https://langfuse.com/docs/api-and-data-platform/features/scores-api",
   metricsV2: "https://langfuse.com/docs/metrics/features/metrics-api",
   compatibility: "https://langfuse.com/docs/compatibility",
   otel: "https://langfuse.com/integrations/native/opentelemetry",
@@ -61,7 +63,7 @@ export const SESSIONS_DEPRECATION: ApiDeprecationInfo = {
 export const SCORES_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Use ${REPLACEMENT.scoresV3} instead.`,
   replacement: REPLACEMENT.scoresV3,
-  docsUrl: DOCS.compatibility,
+  docsUrl: DOCS.scoresV3,
   sunsetAt: V3_SUNSET_DATE,
 };
 

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -24,6 +24,8 @@ const REPLACEMENT = {
   scoresV3: "GET /api/public/v3/scores",
   metricsV2: "GET /api/public/v2/metrics?query=<urlencoded json query>",
   otelTraces: "POST /api/public/otel/v1/traces",
+  experimentItems:
+    "GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>",
 } as const;
 
 // Migration guidance pages; each family points at the page that documents its
@@ -79,6 +81,15 @@ export const LEGACY_INGESTION_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Send data via the OpenTelemetry endpoint at ${REPLACEMENT.otelTraces} instead.`,
   replacement: REPLACEMENT.otelTraces,
   docsUrl: DOCS.otel,
+  sunsetAt: V3_SUNSET_DATE,
+};
+
+// Legacy dataset-run-items reads → experiment items (dataset runs are replaced
+// by experiments in v4).
+export const DATASET_RUN_ITEMS_DEPRECATION: ApiDeprecationInfo = {
+  message: `${V3_NOTICE} In Langfuse v4, dataset run items are replaced by experiment items; use ${REPLACEMENT.experimentItems} instead.`,
+  replacement: REPLACEMENT.experimentItems,
+  docsUrl: DOCS.compatibility,
   sunsetAt: V3_SUNSET_DATE,
 };
 

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -1,0 +1,78 @@
+import { type ApiDeprecationInfo } from "@langfuse/shared";
+
+// LFE-10895. Family-level deprecation signals for legacy (v3) public API
+// endpoints. Attach one via the `deprecation` route-config field; the response
+// gets a top-level `_deprecation` key.
+
+// Sunset date for the legacy v3 public API — single source of truth. Set to the
+// end of October 2026; update here if the date moves.
+export const V3_SUNSET_DATE = "2026-10-31";
+
+// Shared deprecation reason — references the deprecated Langfuse v3 system
+// version (not an API version). Customer-facing wording lives here — edit once.
+const V3_NOTICE =
+  "Langfuse v3 is deprecated; this endpoint will be removed in a future release.";
+
+// v4 replacement endpoints, referenced by both the message and `replacement`.
+const REPLACEMENT = {
+  observationsV2: "GET /api/public/v2/observations",
+  scoresV3: "GET /api/public/v3/scores",
+  metricsV2: "GET /api/public/v2/metrics",
+  otelTraces: "POST /api/public/otel/v1/traces",
+} as const;
+
+export const OBSERVATIONS_V1_DEPRECATION: ApiDeprecationInfo = {
+  message: `${V3_NOTICE} Use ${REPLACEMENT.observationsV2} instead.`,
+  replacement: REPLACEMENT.observationsV2,
+  sunsetAt: V3_SUNSET_DATE,
+};
+
+// Traces have no drop-in successor; observations v2 is the closest v4 read surface.
+export const TRACES_DEPRECATION: ApiDeprecationInfo = {
+  message: `${V3_NOTICE} In Langfuse v4, read span and trace data via ${REPLACEMENT.observationsV2}.`,
+  replacement: REPLACEMENT.observationsV2,
+  sunsetAt: V3_SUNSET_DATE,
+};
+
+// Sessions have no replacement.
+export const SESSIONS_DEPRECATION: ApiDeprecationInfo = {
+  message: `${V3_NOTICE} It has no replacement.`,
+  sunsetAt: V3_SUNSET_DATE,
+};
+
+export const SCORES_DEPRECATION: ApiDeprecationInfo = {
+  message: `${V3_NOTICE} Use ${REPLACEMENT.scoresV3} instead.`,
+  replacement: REPLACEMENT.scoresV3,
+  sunsetAt: V3_SUNSET_DATE,
+};
+
+export const METRICS_DEPRECATION: ApiDeprecationInfo = {
+  message: `${V3_NOTICE} Use ${REPLACEMENT.metricsV2} instead.`,
+  replacement: REPLACEMENT.metricsV2,
+  sunsetAt: V3_SUNSET_DATE,
+};
+
+// Legacy create/update endpoints (trace, generation, span, event) → OpenTelemetry.
+export const LEGACY_INGESTION_DEPRECATION: ApiDeprecationInfo = {
+  message: `${V3_NOTICE} Send data via the OpenTelemetry endpoint at ${REPLACEMENT.otelTraces} instead.`,
+  replacement: REPLACEMENT.otelTraces,
+  sunsetAt: V3_SUNSET_DATE,
+};
+
+// Stamp a deprecation signal onto a JSON response body as the top-level
+// `_deprecation` key. Non-object bodies (arrays, null, primitives) pass through
+// unchanged so array/primitive responses are never corrupted.
+export function attachDeprecation(
+  body: unknown,
+  deprecation: ApiDeprecationInfo | undefined,
+): unknown {
+  if (
+    !deprecation ||
+    typeof body !== "object" ||
+    body === null ||
+    Array.isArray(body)
+  ) {
+    return body;
+  }
+  return { ...body, _deprecation: deprecation };
+}

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -15,10 +15,14 @@ const V3_NOTICE =
   "Langfuse v3 is deprecated; this endpoint will be removed in a future release.";
 
 // v4 replacement endpoints, referenced by both the message and `replacement`.
+// Placeholder style matches rateLimitUpgradePaths (<from>, <to>, filters).
 const REPLACEMENT = {
-  observationsV2: "GET /api/public/v2/observations",
+  observationsV2:
+    "GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>",
+  observationsV2BySession:
+    "GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>",
   scoresV3: "GET /api/public/v3/scores",
-  metricsV2: "GET /api/public/v2/metrics",
+  metricsV2: "GET /api/public/v2/metrics?query=<urlencoded json query>",
   otelTraces: "POST /api/public/otel/v1/traces",
 } as const;
 
@@ -48,8 +52,8 @@ export const TRACES_DEPRECATION: ApiDeprecationInfo = {
 
 // Sessions have no drop-in successor; filter observations v2 by session instead.
 export const SESSIONS_DEPRECATION: ApiDeprecationInfo = {
-  message: `${V3_NOTICE} In Langfuse v4, read session data via ${REPLACEMENT.observationsV2} filtered by sessionId.`,
-  replacement: REPLACEMENT.observationsV2,
+  message: `${V3_NOTICE} In Langfuse v4, read session data via ${REPLACEMENT.observationsV2BySession}.`,
+  replacement: REPLACEMENT.observationsV2BySession,
   docsUrl: DOCS.observationsV2,
   sunsetAt: V3_SUNSET_DATE,
 };

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -5,14 +5,9 @@ import { OBSERVATIONS_API_V2_DOCS_URL } from "./rateLimitUpgradePaths";
 // endpoints. Attach one via the `deprecation` route-config field; the response
 // gets a top-level `_deprecation` key.
 
-// Sunset date for the legacy v3 public API — single source of truth. Set to the
-// end of October 2026; update both constants together if the date moves.
-export const V3_SUNSET_DATE = "2026-10-31";
-const V3_SUNSET_HUMAN = "October 31, 2026";
-
 // Shared deprecation reason — references the deprecated Langfuse v3 system
 // version (not an API version). Customer-facing wording lives here — edit once.
-const V3_NOTICE = `Langfuse v3 is deprecated; this endpoint will be removed on ${V3_SUNSET_HUMAN}.`;
+const V3_NOTICE = `Langfuse v3 is deprecated; this endpoint will be removed in a future release.`;
 
 // v4 replacement endpoints, referenced by both the message and `replacement`.
 // Placeholder style matches rateLimitUpgradePaths (<from>, <to>, filters).
@@ -43,7 +38,6 @@ export const OBSERVATIONS_V1_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Use ${REPLACEMENT.observationsV2} instead.`,
   replacement: REPLACEMENT.observationsV2,
   docsUrl: DOCS.observationsV2,
-  sunsetAt: V3_SUNSET_DATE,
 };
 
 // Traces have no drop-in successor; observations v2 is the closest v4 read surface.
@@ -51,7 +45,6 @@ export const TRACES_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} In Langfuse v4, read span and trace data via ${REPLACEMENT.observationsV2}.`,
   replacement: REPLACEMENT.observationsV2,
   docsUrl: DOCS.observationsV2,
-  sunsetAt: V3_SUNSET_DATE,
 };
 
 // Sessions have no drop-in successor; filter observations v2 by session instead.
@@ -59,21 +52,18 @@ export const SESSIONS_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} In Langfuse v4, read session data via ${REPLACEMENT.observationsV2BySession}.`,
   replacement: REPLACEMENT.observationsV2BySession,
   docsUrl: DOCS.observationsV2,
-  sunsetAt: V3_SUNSET_DATE,
 };
 
 export const SCORES_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Use ${REPLACEMENT.scoresV3} instead.`,
   replacement: REPLACEMENT.scoresV3,
   docsUrl: DOCS.scoresV3,
-  sunsetAt: V3_SUNSET_DATE,
 };
 
 export const METRICS_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Use ${REPLACEMENT.metricsV2} instead.`,
   replacement: REPLACEMENT.metricsV2,
   docsUrl: DOCS.metricsV2,
-  sunsetAt: V3_SUNSET_DATE,
 };
 
 // Legacy create/update endpoints (trace, generation, span, event) → OpenTelemetry.
@@ -81,7 +71,6 @@ export const LEGACY_INGESTION_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Send data via the OpenTelemetry endpoint at ${REPLACEMENT.otelTraces} instead.`,
   replacement: REPLACEMENT.otelTraces,
   docsUrl: DOCS.otel,
-  sunsetAt: V3_SUNSET_DATE,
 };
 
 // Legacy dataset-run-items reads → experiment items (dataset runs are replaced
@@ -90,7 +79,6 @@ export const DATASET_RUN_ITEMS_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} In Langfuse v4, dataset run items are replaced by experiment items; use ${REPLACEMENT.experimentItems} instead.`,
   replacement: REPLACEMENT.experimentItems,
   docsUrl: DOCS.compatibility,
-  sunsetAt: V3_SUNSET_DATE,
 };
 
 // Stamp a deprecation signal onto a JSON response body as the top-level

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -66,13 +66,6 @@ export const METRICS_DEPRECATION: ApiDeprecationInfo = {
   docsUrl: DOCS.metricsV2,
 };
 
-// Legacy create/update endpoints (trace, generation, span, event) → OpenTelemetry.
-export const LEGACY_INGESTION_DEPRECATION: ApiDeprecationInfo = {
-  message: `${V3_NOTICE} Send data via the OpenTelemetry endpoint at ${REPLACEMENT.otelTraces} instead.`,
-  replacement: REPLACEMENT.otelTraces,
-  docsUrl: DOCS.otel,
-};
-
 // Legacy dataset-run-items reads → experiment items (dataset runs are replaced
 // by experiments in v4).
 export const DATASET_RUN_ITEMS_DEPRECATION: ApiDeprecationInfo = {

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -21,6 +21,7 @@ const REPLACEMENT = {
   otelTraces: "POST /api/public/otel/v1/traces",
   experimentItems:
     "GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>",
+  experiments: "GET /api/public/experiments",
 } as const;
 
 // Migration guidance pages; each family points at the page that documents its
@@ -71,6 +72,14 @@ export const METRICS_DEPRECATION: ApiDeprecationInfo = {
 export const DATASET_RUN_ITEMS_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} In Langfuse v4, dataset run items are replaced by experiment items; use ${REPLACEMENT.experimentItems} instead.`,
   replacement: REPLACEMENT.experimentItems,
+  docsUrl: DOCS.compatibility,
+};
+
+// Legacy dataset-run reads → experiments (dataset runs are replaced by
+// experiments in v4).
+export const DATASET_RUNS_DEPRECATION: ApiDeprecationInfo = {
+  message: `${V3_NOTICE} In Langfuse v4, dataset runs are replaced by experiments; use ${REPLACEMENT.experiments} instead.`,
+  replacement: REPLACEMENT.experiments,
   docsUrl: DOCS.compatibility,
 };
 

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -1,4 +1,5 @@
 import {
+  deprecationResponseZod,
   jsonSchema,
   publicApiPaginationZod,
   paginationZod,
@@ -282,6 +283,7 @@ export const GetDatasetRunItemsV1Response = z
   .object({
     data: z.array(APIDatasetRunItem),
     meta: paginationMetaResponseZod,
+    _deprecation: deprecationResponseZod.optional(),
   })
   .strict();
 

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -179,6 +179,7 @@ export const GetDatasetRunsV1Response = z
   .object({
     data: z.array(APIDatasetRun),
     meta: paginationMetaResponseZod,
+    _deprecation: deprecationResponseZod.optional(),
   })
   .strict();
 
@@ -189,6 +190,7 @@ export const GetDatasetRunV1Query = z.object({
 });
 export const GetDatasetRunV1Response = APIDatasetRun.extend({
   datasetRunItems: z.array(APIDatasetRunItem),
+  _deprecation: deprecationResponseZod.optional(),
 }).strict();
 
 export const publicApiIdSchema = z

--- a/web/src/features/public-api/types/metrics.ts
+++ b/web/src/features/public-api/types/metrics.ts
@@ -1,4 +1,5 @@
 import {
+  deprecationResponseZod,
   InvalidRequestError,
   paginationMetaResponseZod,
   publicApiPaginationZod,
@@ -194,5 +195,6 @@ export const GetMetricsDailyV1Response = z
         .strict(),
     ),
     meta: paginationMetaResponseZod,
+    _deprecation: deprecationResponseZod.optional(),
   })
   .strict();

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -1,6 +1,7 @@
 import {
   type Observation,
   commaSeparatedEnumArray,
+  deprecationResponseZod,
   type EventsObservation,
   OBSERVATION_FIELD_GROUPS_PUBLIC_API,
   ObservationLevel,
@@ -234,6 +235,7 @@ export const GetObservationsV1Response = z
   .object({
     data: z.array(APIObservation),
     meta: paginationMetaResponseZod,
+    _deprecation: deprecationResponseZod.optional(),
   })
   .strict();
 
@@ -242,8 +244,11 @@ export const GetObservationV1Query = z.object({
   observationId: z.string(),
   useEventsTable: useEventsTableSchema,
 });
-/** @alias */
-export const GetObservationV1Response = APIObservation;
+// `_deprecation` at the response level, not on the shared `APIObservation`
+// (which is also the list element type).
+export const GetObservationV1Response = APIObservation.extend({
+  _deprecation: deprecationResponseZod.optional(),
+});
 
 /**
  * Cursor schema for v2 observations pagination

--- a/web/src/features/public-api/types/sessions.ts
+++ b/web/src/features/public-api/types/sessions.ts
@@ -1,5 +1,6 @@
 import { APITrace } from "@/src/features/public-api/types/traces";
 import {
+  deprecationResponseZod,
   paginationMetaResponseZod,
   publicApiPaginationZod,
 } from "@langfuse/shared";
@@ -35,6 +36,7 @@ export const GetSessionsV1Response = z
   .object({
     data: z.array(APISession),
     meta: paginationMetaResponseZod,
+    _deprecation: deprecationResponseZod.optional(),
   })
   .strict();
 
@@ -44,4 +46,5 @@ export const GetSessionV1Query = z.object({
 });
 export const GetSessionV1Response = APISession.extend({
   traces: z.array(APITrace),
+  _deprecation: deprecationResponseZod.optional(),
 }).strict();

--- a/web/src/features/public-api/types/traces.ts
+++ b/web/src/features/public-api/types/traces.ts
@@ -2,6 +2,7 @@ import { APIObservation } from "@/src/features/public-api/types/observations";
 import {
   APIScoreSchemaV1,
   commaSeparatedEnumArray,
+  deprecationResponseZod,
   paginationMetaResponseZod,
   orderBy,
   optionalJsonParam,
@@ -90,6 +91,7 @@ export const GetTracesV1Response = z
   .object({
     data: z.array(APIExtendedTrace),
     meta: paginationMetaResponseZod,
+    _deprecation: deprecationResponseZod.optional(),
   })
   .strict();
 
@@ -107,6 +109,7 @@ export const GetTraceV1Query = z.object({
 export const GetTraceV1Response = APIExtendedTrace.extend({
   scores: z.array(APIScoreSchemaV1),
   observations: z.array(APIObservation),
+  _deprecation: deprecationResponseZod.optional(),
 }).strict();
 
 // DELETE /api/public/traces/{traceId}

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -13,10 +13,6 @@ import {
 import { DATASET_RUN_ITEMS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
-  // POST is a write: legacy writes carry only the Fern `availability: deprecated`
-  // marker (+ generated-SDK @deprecated), no runtime `_deprecation` body field
-  // (design decision — write responses are too thin to carry it). The GET below
-  // does get the runtime signal. rejectInEventsOnlyMode gates both at cutover.
   POST: createAuthedProjectAPIRoute({
     name: "Create Dataset Run Item",
     bodySchema: PostDatasetRunItemsV1Body,

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -13,12 +13,10 @@ import {
 import { DATASET_RUN_ITEMS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
-  // POST is a write: its deprecation signal is the Fern `availability: deprecated`
-  // marker (+ generated-SDK @deprecated), not a runtime `_deprecation` body field.
-  // Unlike the ingestion write siblings (which attach LEGACY_INGESTION_DEPRECATION),
-  // there is no create-appropriate replacement constant to wire here —
-  // DATASET_RUN_ITEMS_DEPRECATION is read-oriented (→ GET /experiment-items) and
-  // would be wrong guidance on a create endpoint.
+  // POST is a write: legacy writes carry only the Fern `availability: deprecated`
+  // marker (+ generated-SDK @deprecated), no runtime `_deprecation` body field
+  // (design decision — write responses are too thin to carry it). The GET below
+  // does get the runtime signal. rejectInEventsOnlyMode gates both at cutover.
   POST: createAuthedProjectAPIRoute({
     name: "Create Dataset Run Item",
     bodySchema: PostDatasetRunItemsV1Body,

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -10,8 +10,11 @@ import {
   createDatasetRunItemForApi,
   listDatasetRunItemsForApi,
 } from "@/src/features/datasets/server/publicDatasetService";
+import { DATASET_RUN_ITEMS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
+  // POST is a write → Fern availability: deprecated only (no _deprecation body
+  // field), consistent with the other legacy write endpoints.
   POST: createAuthedProjectAPIRoute({
     name: "Create Dataset Run Item",
     bodySchema: PostDatasetRunItemsV1Body,
@@ -29,6 +32,7 @@ export default withMiddlewares({
     name: "Get Dataset Run Items",
     querySchema: GetDatasetRunItemsV1Query,
     responseSchema: GetDatasetRunItemsV1Response,
+    deprecation: DATASET_RUN_ITEMS_DEPRECATION,
     rateLimitResource: "datasets",
     // Reads from the legacy dataset_run_items ClickHouse table, which is no
     // longer populated in events_only mode; GET /api/public/experiment-items

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -13,8 +13,12 @@ import {
 import { DATASET_RUN_ITEMS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
-  // POST is a write → Fern availability: deprecated only (no _deprecation body
-  // field), consistent with the other legacy write endpoints.
+  // POST is a write: its deprecation signal is the Fern `availability: deprecated`
+  // marker (+ generated-SDK @deprecated), not a runtime `_deprecation` body field.
+  // Unlike the ingestion write siblings (which attach LEGACY_INGESTION_DEPRECATION),
+  // there is no create-appropriate replacement constant to wire here —
+  // DATASET_RUN_ITEMS_DEPRECATION is read-oriented (→ GET /experiment-items) and
+  // would be wrong guidance on a create endpoint.
   POST: createAuthedProjectAPIRoute({
     name: "Create Dataset Run Item",
     bodySchema: PostDatasetRunItemsV1Body,

--- a/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
+++ b/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
@@ -10,12 +10,14 @@ import {
   deleteDatasetRunForApi,
   getDatasetRunForApi,
 } from "@/src/features/datasets/server/publicDatasetService";
+import { DATASET_RUNS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "get-dataset-run",
     querySchema: GetDatasetRunV1Query,
     responseSchema: GetDatasetRunV1Response,
+    deprecation: DATASET_RUNS_DEPRECATION,
     rateLimitResource: "datasets",
     // Embeds run items read from the legacy dataset_run_items ClickHouse
     // table, which is no longer populated in events_only mode;

--- a/web/src/pages/api/public/datasets/[name]/runs/index.ts
+++ b/web/src/pages/api/public/datasets/[name]/runs/index.ts
@@ -5,12 +5,14 @@ import {
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { listDatasetRunsForApi } from "@/src/features/datasets/server/publicDatasetService";
+import { DATASET_RUNS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "get-dataset-runs",
     querySchema: GetDatasetRunsV1Query,
     responseSchema: GetDatasetRunsV1Response,
+    deprecation: DATASET_RUNS_DEPRECATION,
     rateLimitResource: "datasets",
     // Lists legacy dataset runs whose items live in the dataset_run_items
     // ClickHouse table, which is no longer populated in events_only mode;

--- a/web/src/pages/api/public/events.ts
+++ b/web/src/pages/api/public/events.ts
@@ -11,14 +11,12 @@ import {
   processEventBatch,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
-import { LEGACY_INGESTION_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
     name: "Create Event",
     bodySchema: PostEventsV1Body,
     responseSchema: PostEventsV1Response,
-    deprecation: LEGACY_INGESTION_DEPRECATION,
     // Writes an observation-create event that lands in the legacy observations
     // ClickHouse table; events_only deployments expect OTel ingestion.
     rejectInEventsOnlyMode: true,

--- a/web/src/pages/api/public/events.ts
+++ b/web/src/pages/api/public/events.ts
@@ -11,12 +11,14 @@ import {
   processEventBatch,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
+import { LEGACY_INGESTION_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
     name: "Create Event",
     bodySchema: PostEventsV1Body,
     responseSchema: PostEventsV1Response,
+    deprecation: LEGACY_INGESTION_DEPRECATION,
     // Writes an observation-create event that lands in the legacy observations
     // ClickHouse table; events_only deployments expect OTel ingestion.
     rejectInEventsOnlyMode: true,

--- a/web/src/pages/api/public/generations.ts
+++ b/web/src/pages/api/public/generations.ts
@@ -13,14 +13,12 @@ import {
   processEventBatch,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
-import { LEGACY_INGESTION_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
     name: "Create Generation (Legacy)",
     bodySchema: PostGenerationsV1Body,
     responseSchema: PostGenerationsV1Response,
-    deprecation: LEGACY_INGESTION_DEPRECATION,
     rateLimitResource: "legacy-ingestion",
     // Writes an observation-create event that lands in the legacy observations
     // ClickHouse table; events_only deployments expect OTel ingestion.
@@ -65,7 +63,6 @@ export default withMiddlewares({
     name: "Patch Generation (Legacy)",
     bodySchema: PatchGenerationsV1Body,
     responseSchema: PatchGenerationsV1Response,
-    deprecation: LEGACY_INGESTION_DEPRECATION,
     rateLimitResource: "legacy-ingestion",
     rejectInEventsOnlyMode: true,
     fn: async ({ body, auth, req, res }) => {

--- a/web/src/pages/api/public/generations.ts
+++ b/web/src/pages/api/public/generations.ts
@@ -13,12 +13,14 @@ import {
   processEventBatch,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
+import { LEGACY_INGESTION_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
     name: "Create Generation (Legacy)",
     bodySchema: PostGenerationsV1Body,
     responseSchema: PostGenerationsV1Response,
+    deprecation: LEGACY_INGESTION_DEPRECATION,
     rateLimitResource: "legacy-ingestion",
     // Writes an observation-create event that lands in the legacy observations
     // ClickHouse table; events_only deployments expect OTel ingestion.
@@ -63,6 +65,7 @@ export default withMiddlewares({
     name: "Patch Generation (Legacy)",
     bodySchema: PatchGenerationsV1Body,
     responseSchema: PatchGenerationsV1Response,
+    deprecation: LEGACY_INGESTION_DEPRECATION,
     rateLimitResource: "legacy-ingestion",
     rejectInEventsOnlyMode: true,
     fn: async ({ body, auth, req, res }) => {

--- a/web/src/pages/api/public/metrics/daily.ts
+++ b/web/src/pages/api/public/metrics/daily.ts
@@ -8,12 +8,14 @@ import {
   generateDailyMetrics,
   getDailyMetricsCount,
 } from "@/src/features/public-api/server/dailyMetrics";
+import { METRICS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Daily Metrics",
     querySchema: GetMetricsDailyV1Query,
     responseSchema: GetMetricsDailyV1Response,
+    deprecation: METRICS_DEPRECATION,
     rateLimitResource: "public-api-daily-metrics-legacy",
     // Aggregates over the legacy traces and observations tables without an
     // events_full fallback.

--- a/web/src/pages/api/public/metrics/index.ts
+++ b/web/src/pages/api/public/metrics/index.ts
@@ -9,6 +9,7 @@ import {
   GetMetricsV1Response,
 } from "@/src/features/public-api/types/metrics";
 import { executeQuery } from "@langfuse/shared/query/server";
+import { METRICS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 export default withMiddlewares(
   {
     GET: createAuthedProjectAPIRoute({
@@ -16,6 +17,7 @@ export default withMiddlewares(
       rateLimitResource: "public-api-metrics",
       querySchema: GetMetricsV1Query,
       responseSchema: GetMetricsV1Response,
+      deprecation: METRICS_DEPRECATION,
       // v1 metrics executes QueryBuilder against the legacy traces/observations
       // tables; the v2 endpoint at /api/public/v2/metrics targets events_full.
       rejectInEventsOnlyMode: true,

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -16,6 +16,7 @@ import {
   getObservationByIdFromEventsTable,
 } from "@langfuse/shared/src/server";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
+import { OBSERVATIONS_V1_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares(
   {
@@ -27,6 +28,7 @@ export default withMiddlewares(
       responseSchema: GetObservationV1Response,
       rateLimitUpgradePath: legacyPublicApiRateLimitUpgradePaths.observationGet,
       rejectInEventsOnlyMode: true,
+      deprecation: OBSERVATIONS_V1_DEPRECATION,
       fn: async ({ query, auth }) => {
         const clickhouseObservation = query.useEventsTable
           ? await getObservationByIdFromEventsTable({

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -20,6 +20,7 @@ import {
   getObservationsCountForPublicApi,
 } from "@/src/features/public-api/server/observations";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
+import { OBSERVATIONS_V1_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares(
   {
@@ -32,6 +33,7 @@ export default withMiddlewares(
       rateLimitUpgradePath:
         legacyPublicApiRateLimitUpgradePaths.observationsList,
       rejectInEventsOnlyMode: true,
+      deprecation: OBSERVATIONS_V1_DEPRECATION,
       fn: async ({ query, auth }) => {
         const filterProps = {
           projectId: auth.scope.projectId,

--- a/web/src/pages/api/public/scores/[scoreId].ts
+++ b/web/src/pages/api/public/scores/[scoreId].ts
@@ -10,12 +10,14 @@ import {
 } from "@langfuse/shared";
 import { logger, traceException } from "@langfuse/shared/src/server";
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
+import { SCORES_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Score",
     querySchema: GetScoreQueryV1,
     responseSchema: GetScoreResponseV1,
+    deprecation: SCORES_DEPRECATION,
     rejectInEventsOnlyMode: true,
     fn: async ({ query, auth }) => {
       const scoresApiService = new ScoresApiService("v1");

--- a/web/src/pages/api/public/scores/index.ts
+++ b/web/src/pages/api/public/scores/index.ts
@@ -13,6 +13,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { ForbiddenError } from "@langfuse/shared";
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
+import { SCORES_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 import { randomUUID } from "crypto";
 
 export default withMiddlewares({
@@ -63,6 +64,7 @@ export default withMiddlewares({
     name: "/api/public/scores",
     querySchema: GetScoresQueryV1,
     responseSchema: GetScoresResponseV1,
+    deprecation: SCORES_DEPRECATION,
     rejectInEventsOnlyMode: true,
     fn: async ({ query, auth }) => {
       const scoresApiService = new ScoresApiService("v1");

--- a/web/src/pages/api/public/sessions/[sessionId].ts
+++ b/web/src/pages/api/public/sessions/[sessionId].ts
@@ -8,10 +8,12 @@ import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/cr
 import { LangfuseNotFoundError } from "@langfuse/shared";
 import { getTracesBySessionId } from "@langfuse/shared/src/server";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
+import { SESSIONS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Session",
+    deprecation: SESSIONS_DEPRECATION,
     rateLimitResource: "public-api-legacy",
     querySchema: GetSessionV1Query,
     responseSchema: GetSessionV1Response,

--- a/web/src/pages/api/public/sessions/index.ts
+++ b/web/src/pages/api/public/sessions/index.ts
@@ -6,10 +6,12 @@ import {
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
+import { SESSIONS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Sessions",
+    deprecation: SESSIONS_DEPRECATION,
     rateLimitResource: "public-api-legacy",
     querySchema: GetSessionsV1Query,
     responseSchema: GetSessionsV1Response,

--- a/web/src/pages/api/public/spans.ts
+++ b/web/src/pages/api/public/spans.ts
@@ -13,12 +13,14 @@ import {
   processEventBatch,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
+import { LEGACY_INGESTION_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
     name: "Create Span (Legacy)",
     bodySchema: PostSpansV1Body,
     responseSchema: PostSpansV1Response,
+    deprecation: LEGACY_INGESTION_DEPRECATION,
     // Writes an observation-create event that lands in the legacy observations
     // ClickHouse table; events_only deployments expect OTel ingestion.
     rejectInEventsOnlyMode: true,
@@ -59,6 +61,7 @@ export default withMiddlewares({
     name: "Update Span (Legacy)",
     bodySchema: PatchSpansV1Body,
     responseSchema: PatchSpansV1Response,
+    deprecation: LEGACY_INGESTION_DEPRECATION,
     rejectInEventsOnlyMode: true,
     fn: async ({ body, auth, req, res }) => {
       const event = {

--- a/web/src/pages/api/public/spans.ts
+++ b/web/src/pages/api/public/spans.ts
@@ -13,14 +13,12 @@ import {
   processEventBatch,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
-import { LEGACY_INGESTION_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
     name: "Create Span (Legacy)",
     bodySchema: PostSpansV1Body,
     responseSchema: PostSpansV1Response,
-    deprecation: LEGACY_INGESTION_DEPRECATION,
     // Writes an observation-create event that lands in the legacy observations
     // ClickHouse table; events_only deployments expect OTel ingestion.
     rejectInEventsOnlyMode: true,
@@ -61,7 +59,6 @@ export default withMiddlewares({
     name: "Update Span (Legacy)",
     bodySchema: PatchSpansV1Body,
     responseSchema: PatchSpansV1Response,
-    deprecation: LEGACY_INGESTION_DEPRECATION,
     rejectInEventsOnlyMode: true,
     fn: async ({ body, auth, req, res }) => {
       const event = {

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -28,11 +28,13 @@ import {
 import Decimal from "decimal.js";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
+import { TRACES_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares(
   {
     GET: createAuthedProjectAPIRoute({
       name: "Get Single Trace",
+      deprecation: TRACES_DEPRECATION,
       rateLimitResource: "public-api-legacy",
       querySchema: GetTraceV1Query,
       responseSchema: GetTraceV1Response,

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -32,10 +32,7 @@ import {
 } from "@/src/features/public-api/server/traces";
 import { env } from "@/src/env.mjs";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
-import {
-  LEGACY_INGESTION_DEPRECATION,
-  TRACES_DEPRECATION,
-} from "@/src/features/public-api/server/deprecations";
+import { TRACES_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares(
   {
@@ -43,7 +40,6 @@ export default withMiddlewares(
       name: "Create Trace (Legacy)",
       bodySchema: PostTracesV1Body,
       responseSchema: PostTracesV1Response, // Adjust this if you have a specific response schema
-      deprecation: LEGACY_INGESTION_DEPRECATION,
       rateLimitResource: "legacy-ingestion",
       // Legacy POST writes a trace-create event that lands in the legacy traces
       // ClickHouse table; events_only deployments expect OTel ingestion.

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -32,6 +32,10 @@ import {
 } from "@/src/features/public-api/server/traces";
 import { env } from "@/src/env.mjs";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
+import {
+  LEGACY_INGESTION_DEPRECATION,
+  TRACES_DEPRECATION,
+} from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares(
   {
@@ -39,6 +43,7 @@ export default withMiddlewares(
       name: "Create Trace (Legacy)",
       bodySchema: PostTracesV1Body,
       responseSchema: PostTracesV1Response, // Adjust this if you have a specific response schema
+      deprecation: LEGACY_INGESTION_DEPRECATION,
       rateLimitResource: "legacy-ingestion",
       // Legacy POST writes a trace-create event that lands in the legacy traces
       // ClickHouse table; events_only deployments expect OTel ingestion.
@@ -80,6 +85,7 @@ export default withMiddlewares(
       rateLimitResource: "public-api-legacy",
       querySchema: GetTracesV1Query,
       responseSchema: GetTracesV1Response,
+      deprecation: TRACES_DEPRECATION,
       rateLimitUpgradePath: legacyPublicApiRateLimitUpgradePaths.tracesList,
       rejectInEventsOnlyMode: true,
       fn: async ({ query, auth }) => {

--- a/web/src/pages/api/public/v2/scores/[scoreId].ts
+++ b/web/src/pages/api/public/v2/scores/[scoreId].ts
@@ -8,12 +8,14 @@ import {
   LangfuseNotFoundError,
 } from "@langfuse/shared";
 import { logger, traceException } from "@langfuse/shared/src/server";
+import { SCORES_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Score",
     querySchema: GetScoreQueryV2,
     responseSchema: GetScoreResponseV2,
+    deprecation: SCORES_DEPRECATION,
     rejectInEventsOnlyMode: true,
     fn: async ({ query, auth }) => {
       const scoresApiService = new ScoresApiService("v2");

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -7,12 +7,14 @@ import {
   InvalidRequestError,
 } from "@langfuse/shared";
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
+import { SCORES_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "/api/public/scores",
     querySchema: GetScoresQueryV2,
     responseSchema: GetScoresResponseV2,
+    deprecation: SCORES_DEPRECATION,
     rejectInEventsOnlyMode: true,
     fn: async ({ query, auth }) => {
       // Validate that trace filters are not used when trace field is excluded


### PR DESCRIPTION
## What does this PR do?

Legacy (pre-v4) public API endpoints now return a machine-readable migration signal so API consumers — especially coding agents — can self-correct toward the v4 surface without reading release notes.

Two channels:

1. **`_deprecation` response object** on legacy responses: `{ message, replacement?, docsUrl?, sunsetAt? }`.
   - `replacement` is a family-level pointer (omitted for endpoints removed without a successor); optional fields are omitted when empty (never `null`).
   - Injected once at the shared public-API route choke point via `attachDeprecation` — on both the success body and the `events_only` 404 — so each legacy route opts in with a single `deprecation` config line.
   - Message wording, replacement endpoints, and the v3 sunset date (`V3_SUNSET_DATE`, currently `2026-10-31`) live as single-source constants in `deprecations.ts`. The message references the deprecated **Langfuse v3 system version** (not an API version).
2. **Fern `availability: deprecated`** markers on legacy endpoints (drives generated-SDK `@deprecated` annotations + API-reference notices), plus a shared `commons.Deprecation` type on the response schemas so `_deprecation` is a **typed field in the generated SDKs** — including the v2-scores list, the v2-scores by-id union (via Fern `base-properties`), and single-observation (via a dedicated `ObservationsViewSingle` wrapper so the shared `ObservationsView` stays clean).

Wired onto: **observations v1** (→ v2), **scores v1/v2** (→ v3), **metrics v1 & daily** (→ v2), **traces** (being removed; observations v2 offered as the closest v4 read surface), **sessions** (being removed; no replacement), and **legacy ingestion writes** (→ OpenTelemetry).

Adding an optional response field is backwards-compatible: production does not validate responses against the schema, and the generated TypeScript/Python SDKs tolerate extra fields.

Delivered as two commits: (1) Fern definition updates; (2) the `_deprecation` field mechanism + per-route wiring + server test.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] `turbo run lint typecheck --filter=web` passes
- [x] Server tests pass (`deprecation-signal.servertest.ts` — 6/6, covering list, single-item, non-strict-schema, replacement-less, sunset-date, and omit-when-empty cases)
- [x] Fern definition validated (`fern check`) and SDK codegen verified (`_deprecation` typed on the scores union, list, and single-observation responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds machine-readable deprecation signals to legacy (pre-v4) public API endpoints so that API consumers — particularly coding agents — can self-correct toward v4 equivalents without reading release notes. Two delivery channels are used: a `_deprecation` response object injected at the shared route layer via `attachDeprecation`, and Fern `availability: deprecated` markers that drive `@deprecated` annotations in generated SDKs.

- A new `deprecations.ts` module defines per-family deprecation constants (observations v1, traces, sessions, scores v1/v2, metrics v1/daily, legacy ingestion writes, dataset-run-items) and the `attachDeprecation` helper; the injection is gated on `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN` so self-hosted v3 deployments do not receive premature notices.
- Fern definitions are updated with `availability: deprecated` on all covered endpoints, and a shared `commons.Deprecation` type is added so `_deprecation` is typed in generated SDK clients.
- Six server tests cover list, single-item, non-strict-schema, soft-replacement, and omit-when-empty cases.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — adds an optional field to legacy responses behind an opt-in flag, with no changes to existing data paths, auth logic, or write operations.

The core injection mechanism is a pure function that passes non-object bodies through unchanged, preventing response corruption. The preview flag gate ensures self-hosted v3 deployments are unaffected. The only gaps are non-blocking: sunsetAt is never populated despite schema support, and the metrics v1 Zod type lacks _deprecation because it is aliased to the non-deprecated v2 schema.

web/src/features/public-api/server/deprecations.ts — the sunsetAt field across all constants is left empty even though the schema and PR description indicate it should be set to 2026-10-31.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as API Client / Agent
    participant MW as createAuthedProjectAPIRoute
    participant FN as Route fn()
    participant AD as attachDeprecation()

    Client->>MW: GET /api/public/observations (legacy)
    MW->>MW: Check LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN
    alt events_only mode and rejectInEventsOnlyMode
        MW->>AD: "attachDeprecation({message}, deprecation)"
        AD-->>MW: "{message, _deprecation}"
        MW-->>Client: 404 + _deprecation
    else normal path
        MW->>MW: Auth + rate-limit
        MW->>FN: "invoke fn({query, body, auth})"
        FN-->>MW: "{data, meta}"
        MW->>AD: attachDeprecation(response, deprecation)
        AD-->>MW: "{data, meta, _deprecation: {message, replacement, docsUrl}}"
        MW-->>Client: 200 + _deprecation
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as API Client / Agent
    participant MW as createAuthedProjectAPIRoute
    participant FN as Route fn()
    participant AD as attachDeprecation()

    Client->>MW: GET /api/public/observations (legacy)
    MW->>MW: Check LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN
    alt events_only mode and rejectInEventsOnlyMode
        MW->>AD: "attachDeprecation({message}, deprecation)"
        AD-->>MW: "{message, _deprecation}"
        MW-->>Client: 404 + _deprecation
    else normal path
        MW->>MW: Auth + rate-limit
        MW->>FN: "invoke fn({query, body, auth})"
        FN-->>MW: "{data, meta}"
        MW->>AD: attachDeprecation(response, deprecation)
        AD-->>MW: "{data, meta, _deprecation: {message, replacement, docsUrl}}"
        MW-->>Client: 200 + _deprecation
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(api): defer the concrete v3 sunset ..."](https://github.com/langfuse/langfuse/commit/6d50acce6ba2708669897cc1f46a1dbb6224e09e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44834965)</sub>

<!-- /greptile_comment -->