### PR TITLE
feat(web): add trigger action to admin bullmq API for one-off scheduled jobs

### DIFF
--- a/web/src/__tests__/server/unit/admin-bullmq-trigger.servertest.ts
+++ b/web/src/__tests__/server/unit/admin-bullmq-trigger.servertest.ts
@@ -1,0 +1,118 @@
+import { type NextApiRequest, type NextApiResponse } from "next";
+import type * as SharedServer from "@langfuse/shared/src/server";
+
+const { getQueueMock } = vi.hoisted(() => ({
+  getQueueMock: vi.fn(),
+}));
+
+vi.mock("@/src/env.mjs", async (importOriginal) => {
+  const actual = (await importOriginal()) as { env: Record<string, unknown> };
+  return {
+    env: {
+      ...actual.env,
+      ADMIN_API_KEY: "test-admin-key",
+      NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined,
+    },
+  };
+});
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof SharedServer>();
+  return {
+    ...actual,
+    getQueue: getQueueMock,
+  };
+});
+
+import handler from "@/src/pages/api/admin/bullmq";
+import { QueueJobs, QueueName } from "@langfuse/shared/src/server";
+
+const makeReqRes = (opts: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) => {
+  const json = vi.fn();
+  const status = vi.fn().mockReturnValue({ json });
+  const req = {
+    method: opts.method ?? "POST",
+    headers: opts.headers ?? { authorization: "Bearer test-admin-key" },
+    body: opts.body,
+  } as unknown as NextApiRequest;
+  const res = { status } as unknown as NextApiResponse;
+  return { req, res, status, json };
+};
+
+describe("POST /api/admin/bullmq action=trigger", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("enqueues a one-off core data export job", async () => {
+    const add = vi.fn().mockResolvedValue({ id: "job-1" });
+    getQueueMock.mockReturnValue({ add });
+
+    const { req, res, status, json } = makeReqRes({
+      body: {
+        action: "trigger",
+        queueName: QueueName.CoreDataS3ExportQueue,
+      },
+    });
+
+    await handler(req, res);
+
+    expect(getQueueMock).toHaveBeenCalledWith(QueueName.CoreDataS3ExportQueue);
+    expect(add).toHaveBeenCalledWith(QueueJobs.CoreDataS3ExportJob, {});
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "job-1" }),
+    );
+  });
+
+  it("returns 400 when the queue is not instantiated on this container", async () => {
+    getQueueMock.mockReturnValue(null);
+
+    const { req, res, status, json } = makeReqRes({
+      body: {
+        action: "trigger",
+        queueName: QueueName.CoreDataS3ExportQueue,
+      },
+    });
+
+    await handler(req, res);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining("not available"),
+      }),
+    );
+  });
+
+  it("rejects queues outside the trigger allowlist", async () => {
+    const { req, res, status } = makeReqRes({
+      body: {
+        action: "trigger",
+        queueName: QueueName.IngestionQueue,
+      },
+    });
+
+    await handler(req, res);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(getQueueMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects requests without a valid admin token", async () => {
+    const { req, res, status } = makeReqRes({
+      headers: { authorization: "Bearer wrong-key" },
+      body: {
+        action: "trigger",
+        queueName: QueueName.CoreDataS3ExportQueue,
+      },
+    });
+
+    await handler(req, res);
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(getQueueMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/server/unit/admin-bullmq-trigger.servertest.ts
+++ b/web/src/__tests__/server/unit/admin-bullmq-trigger.servertest.ts
@@ -48,7 +48,8 @@ describe("POST /api/admin/bullmq action=trigger", () => {
 
   it("enqueues a one-off core data export job", async () => {
     const add = vi.fn().mockResolvedValue({ id: "job-1" });
-    getQueueMock.mockReturnValue({ add });
+    const getJobCounts = vi.fn().mockResolvedValue({ active: 0, waiting: 0 });
+    getQueueMock.mockReturnValue({ add, getJobCounts });
 
     const { req, res, status, json } = makeReqRes({
       body: {
@@ -65,6 +66,30 @@ describe("POST /api/admin/bullmq action=trigger", () => {
     expect(json).toHaveBeenCalledWith(
       expect.objectContaining({ jobId: "job-1" }),
     );
+  });
+
+  it("returns 409 when a job is already active or waiting", async () => {
+    const add = vi.fn();
+    const getJobCounts = vi.fn().mockResolvedValue({ active: 1, waiting: 0 });
+    getQueueMock.mockReturnValue({ add, getJobCounts });
+
+    const { req, res, status, json } = makeReqRes({
+      body: {
+        action: "trigger",
+        queueName: QueueName.CoreDataS3ExportQueue,
+      },
+    });
+
+    await handler(req, res);
+
+    expect(getJobCounts).toHaveBeenCalledWith("active", "waiting");
+    expect(status).toHaveBeenCalledWith(409);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining("active or waiting"),
+      }),
+    );
+    expect(add).not.toHaveBeenCalled();
   });
 
   it("returns 400 when the queue is not instantiated on this container", async () => {

--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -343,6 +343,17 @@ export default async function handler(
         });
       }
 
+      // Guard against overlapping runs. Deliberately not counting "delayed":
+      // the nightly repeatable job always sits there and would permanently
+      // block manual triggers.
+      const counts = await queue.getJobCounts("active", "waiting");
+      const inFlight = (counts.active ?? 0) + (counts.waiting ?? 0);
+      if (inFlight > 0) {
+        return res.status(409).json({
+          error: `Queue ${queueName} already has ${inFlight} active or waiting job(s); not enqueueing a duplicate.`,
+        });
+      }
+
       const jobName = TRIGGERABLE_SCHEDULED_JOBS[queueName];
       const job = await queue.add(jobName, {});
       logger.info(

--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -8,6 +8,7 @@ import {
   SecondaryIngestionQueue,
   logger,
   QueueName,
+  QueueJobs,
   getQueue,
   IngestionQueue,
   TraceUpsertQueue,
@@ -31,6 +32,14 @@ const BullStatus = z.enum([
   "wait",
 ]);
 
+// Scheduled jobs that can be started one-off via the "trigger" action. Their
+// processors read no job payload, so an ad-hoc empty job behaves exactly like
+// a scheduled run. Extend deliberately — most queues require typed payloads
+// and must not be triggerable with an empty job.
+const TRIGGERABLE_SCHEDULED_JOBS = {
+  [QueueName.CoreDataS3ExportQueue]: QueueJobs.CoreDataS3ExportJob,
+} as const;
+
 const ManageBullBody = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("retry"),
@@ -45,6 +54,10 @@ const ManageBullBody = z.discriminatedUnion("action", [
     action: z.literal("add"),
     queueName: z.literal(QueueName.IngestionSecondaryQueue),
     events: z.array(IngestionEvent),
+  }),
+  z.object({
+    action: z.literal("trigger"),
+    queueName: z.literal(QueueName.CoreDataS3ExportQueue),
   }),
 ]);
 
@@ -318,6 +331,27 @@ export default async function handler(
       }
 
       return res.status(200).json({ message: "Retried all jobs" });
+    }
+
+    if (req.method === "POST" && body.data.action === "trigger") {
+      const { queueName } = body.data;
+      const queue = getQueue(queueName);
+
+      if (!queue) {
+        return res.status(400).json({
+          error: `Queue ${queueName} is not available. It is only instantiated when its enabling env var is set on this container (LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED for the core data export).`,
+        });
+      }
+
+      const jobName = TRIGGERABLE_SCHEDULED_JOBS[queueName];
+      const job = await queue.add(jobName, {});
+      logger.info(
+        `Triggered one-off ${jobName} job ${job.id} on queue ${queueName}`,
+      );
+      return res.status(200).json({
+        message: `Triggered ${jobName} on queue ${queueName}`,
+        jobId: job.id,
+      });
     }
 
     // if (req.method === "POST" && body.data.action === "add") {


### PR DESCRIPTION
## Summary

Follow-up to #15167 (eval configs in the core-data S3 export): allows triggering a one-off core data S3 export run externally, instead of waiting for the nightly 03:15 UTC schedule.

- Adds a `trigger` action to `POST /api/admin/bullmq` (admin-API-key auth, cloud-allowed):
  ```bash
  curl -X POST https://<host>/api/admin/bullmq \
    -H "Authorization: Bearer $ADMIN_API_KEY" \
    -H "Content-Type: application/json" \
    -d '{"action": "trigger", "queueName": "core-data-s3-export-queue"}'
  ```
- Triggerable queues are an explicit allowlist (`TRIGGERABLE_SCHEDULED_JOBS`) of payload-less scheduled jobs — currently only the core data export. Other queues are rejected by schema validation.
- Returns the BullMQ `jobId` on success; 400 with a clear message when the queue isn't instantiated on the web container (requires `LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED="true"`).

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test src/__tests__/server/unit/admin-bullmq-trigger.servertest.ts` → `Tests  4 passed (4)`
- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `trigger` action to `POST /api/admin/bullmq`, letting operators immediately start a one-off core-data S3 export instead of waiting for the nightly 03:15 UTC cron job. The allowlist approach (`TRIGGERABLE_SCHEDULED_JOBS` + `z.literal` in the discriminated union schema) is a clean, deliberate gate that prevents arbitrary queue manipulation via empty payloads.

- **New endpoint action**: `{"action":"trigger","queueName":"core-data-s3-export-queue"}` — authenticated by admin API key, allowed on Langfuse Cloud; returns `{jobId}` on success or 400 if the queue is not instantiated.
- **Test coverage**: Four unit tests cover the happy path, queue-not-available, non-allowlisted queue, and invalid auth — all passing.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This is a small, admin-only API extension with correct auth, schema validation, and test coverage — safe to merge for the current use case.

The change is narrowly scoped and correctly guarded: only the CoreDataS3ExportQueue is reachable through the new code path, auth is required, and the schema rejects all other queue names. The error message wording will become stale if the allowlist grows, and the endpoint silently stacks jobs if called while an export is already running — neither blocks the current use case but both are worth addressing before the allowlist expands.

No files require special attention for this merge. If TRIGGERABLE_SCHEDULED_JOBS is extended in the future, index.ts will need both an updated error message and potentially a concurrency check.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller (Admin)
    participant H as POST /api/admin/bullmq
    participant A as AdminApiAuthService
    participant Z as Zod (ManageBullBody)
    participant GQ as getQueue()
    participant Q as CoreDataS3ExportQueue

    C->>H: "POST {action:"trigger", queueName:"core-data-s3-export-queue"}"
    H->>A: "handleAdminAuth(req, res, {isAllowedOnLangfuseCloud:true})"
    alt auth fails
        A-->>H: false
        H-->>C: 401 Unauthorized
    end
    A-->>H: true
    H->>Z: safeParse(req.body)
    alt queueName not in allowlist
        Z-->>H: "{success:false, error}"
        H-->>C: 400 Bad Request
    end
    Z-->>H: "{success:true, data:{action:"trigger", queueName}}"
    H->>GQ: getQueue(QueueName.CoreDataS3ExportQueue)
    alt "LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED != "true""
        GQ-->>H: null
        H-->>C: 400 Queue not available
    end
    GQ->>Q: CoreDataS3ExportQueue.getInstance()
    Q-->>GQ: Queue instance
    GQ-->>H: Queue
    H->>Q: "queue.add(QueueJobs.CoreDataS3ExportJob, {})"
    Q-->>H: "Job {id: "job-id"}"
    H-->>C: "200 {message, jobId: "job-id"}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller (Admin)
    participant H as POST /api/admin/bullmq
    participant A as AdminApiAuthService
    participant Z as Zod (ManageBullBody)
    participant GQ as getQueue()
    participant Q as CoreDataS3ExportQueue

    C->>H: "POST {action:"trigger", queueName:"core-data-s3-export-queue"}"
    H->>A: "handleAdminAuth(req, res, {isAllowedOnLangfuseCloud:true})"
    alt auth fails
        A-->>H: false
        H-->>C: 401 Unauthorized
    end
    A-->>H: true
    H->>Z: safeParse(req.body)
    alt queueName not in allowlist
        Z-->>H: "{success:false, error}"
        H-->>C: 400 Bad Request
    end
    Z-->>H: "{success:true, data:{action:"trigger", queueName}}"
    H->>GQ: getQueue(QueueName.CoreDataS3ExportQueue)
    alt "LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED != "true""
        GQ-->>H: null
        H-->>C: 400 Queue not available
    end
    GQ->>Q: CoreDataS3ExportQueue.getInstance()
    Q-->>GQ: Queue instance
    GQ-->>H: Queue
    H->>Q: "queue.add(QueueJobs.CoreDataS3ExportJob, {})"
    Q-->>H: "Job {id: "job-id"}"
    H-->>C: "200 {message, jobId: "job-id"}"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/api/admin/bullmq/index.ts:340-344
**Hardcoded error message won't generalize**

The error text mentions `LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED` by name. Since `TRIGGERABLE_SCHEDULED_JOBS` is designed to be extended, a second entry would silently produce a misleading message pointing to the wrong env var. Consider either generating the message from a per-queue metadata map alongside `TRIGGERABLE_SCHEDULED_JOBS`, or keeping the message generic (e.g., "Queue `${queueName}` is not available on this container — check that its enabling env var is set.").

### Issue 2 of 2
web/src/pages/api/admin/bullmq/index.ts:347-354
**No deduplication guard against concurrent export runs**

Calling this endpoint while a previous triggered or scheduled job is already active (or waiting) enqueues a second job with no warning. For a nightly S3 export, two overlapping runs could write duplicate or conflicting data. If the underlying worker does not enforce concurrency-1, consider checking `queue.getJobCounts("active", "waiting", "delayed")` before adding and returning an early `409` when a job is already in flight.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): add trigger action to admin b..."](https://github.com/langfuse/langfuse/commit/9118f2704a95d5931fa24a870662099ce4883453) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44839698)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->