### PR TITLE
fix(dashboards): return 404 instead of 500 when deleting a missing dashboard

### DIFF
--- a/packages/shared/src/server/services/DashboardService/DashboardService.ts
+++ b/packages/shared/src/server/services/DashboardService/DashboardService.ts
@@ -1,4 +1,4 @@
-import { prisma } from "../../../db";
+import { prisma, Prisma } from "../../../db";
 import {
   LangfuseConflictError,
   LangfuseNotFoundError,
@@ -217,12 +217,26 @@ export class DashboardService {
     dashboardId: string,
     projectId: string,
   ): Promise<void> {
-    await prisma.dashboard.delete({
-      where: {
-        id: dashboardId,
-        projectId,
-      },
-    });
+    try {
+      await prisma.dashboard.delete({
+        where: {
+          id: dashboardId,
+          projectId,
+        },
+      });
+    } catch (e) {
+      // P2025 = row not found; also thrown for cross-project ids, so the 404
+      // does not leak whether the dashboard exists in another project.
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === "P2025"
+      ) {
+        throw new LangfuseNotFoundError(
+          `Dashboard ${dashboardId} not found in project ${projectId}`,
+        );
+      }
+      throw e;
+    }
   }
 
   /**

--- a/web/src/__tests__/server/dashboard-service-delete.servertest.ts
+++ b/web/src/__tests__/server/dashboard-service-delete.servertest.ts
@@ -1,0 +1,45 @@
+import { v4 as uuidv4 } from "uuid";
+import {
+  createOrgProjectAndApiKey,
+  DashboardService,
+} from "@langfuse/shared/src/server";
+import { LangfuseNotFoundError } from "@langfuse/shared";
+
+describe("DashboardService.deleteDashboard", () => {
+  it("deletes an existing dashboard and throws LangfuseNotFoundError on repeat delete", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const dashboard = await DashboardService.createDashboard(
+      projectId,
+      "delete-me",
+      "",
+    );
+
+    await DashboardService.deleteDashboard(dashboard.id, projectId);
+
+    await expect(
+      DashboardService.deleteDashboard(dashboard.id, projectId),
+    ).rejects.toThrow(LangfuseNotFoundError);
+  });
+
+  it("throws LangfuseNotFoundError for an unknown dashboard id", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    await expect(
+      DashboardService.deleteDashboard(uuidv4(), projectId),
+    ).rejects.toThrow(LangfuseNotFoundError);
+  });
+
+  it("throws LangfuseNotFoundError when the dashboard belongs to another project", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const { projectId: otherProjectId } = await createOrgProjectAndApiKey();
+    const dashboard = await DashboardService.createDashboard(
+      otherProjectId,
+      "other-project",
+      "",
+    );
+
+    await expect(
+      DashboardService.deleteDashboard(dashboard.id, projectId),
+    ).rejects.toThrow(LangfuseNotFoundError);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`DashboardService.deleteDashboard` calls `prisma.dashboard.delete()` without handling Prisma's `P2025` (record not found). Deleting a dashboard that no longer exists — e.g. a repeated delete of the same dashboard, or an id from another project — bubbled the raw Prisma error up to the tRPC middleware and surfaced as HTTP 500 `INTERNAL_SERVER_ERROR`.

This maps `P2025` to `LangfuseNotFoundError`, which the tRPC middleware translates to a 404 `NOT_FOUND`. Repeated/invalid deletes are a client error, not a server fault, so they no longer pollute server error rates. Cross-project ids also fail with `P2025` (the `where` clause scopes by `projectId`), so the 404 does not leak whether a dashboard exists in another project.

Test-first: added `web/src/__tests__/server/dashboard-service-delete.servertest.ts` covering repeat delete, unknown id, and cross-project id — all three failed with `PrismaClientKnownRequestError` before the fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `deleteDashboard` method in `DashboardService` to return a 404 (`LangfuseNotFoundError`) instead of an unhandled 500 when attempting to delete a dashboard that doesn't exist. The change wraps the Prisma `delete` call in a try-catch and maps Prisma's `P2025` (record not found) error to the appropriate application-level not-found error.

- **Error mapping**: Catches `Prisma.PrismaClientKnownRequestError` with code `P2025` on `delete` and re-throws as `LangfuseNotFoundError`, while all other errors are re-thrown unchanged.
- **Security note**: The catch also covers the cross-project case (dashboard ID exists but belongs to another project), so a 404 is returned without leaking whether the record exists in a different project.
- **Tests**: A new server test file covers three scenarios — repeat delete, unknown ID, and cross-project delete — each asserting `LangfuseNotFoundError` is thrown.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is a minimal, well-tested error mapping that prevents unhandled Prisma exceptions from bubbling up as 500 responses on delete-not-found.

The fix is small and correctly scoped: only P2025 errors from `delete` are mapped to a not-found response, and all other errors continue to propagate unchanged. The cross-project case is handled transparently without leaking existence information. Three server tests cover the main failure paths and were clearly authored alongside the fix.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as dashboard-router
    participant DS as DashboardService.deleteDashboard
    participant Prisma

    Client->>Router: DELETE /dashboard (dashboardId, projectId)
    Router->>DS: deleteDashboard(dashboardId, projectId)
    DS->>Prisma: "prisma.dashboard.delete({ where: { id, projectId } })"
    
    alt "Dashboard found & deleted"
        Prisma-->>DS: success
        DS-->>Router: void
        Router-->>Client: "{ success: true }"
    else Dashboard not found (P2025)
        Prisma-->>DS: PrismaClientKnownRequestError (P2025)
        DS-->>Router: throw LangfuseNotFoundError
        Router-->>Client: 404 Not Found
    else Other error
        Prisma-->>DS: other error
        DS-->>Router: re-throw error
        Router-->>Client: 500 Internal Server Error
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as dashboard-router
    participant DS as DashboardService.deleteDashboard
    participant Prisma

    Client->>Router: DELETE /dashboard (dashboardId, projectId)
    Router->>DS: deleteDashboard(dashboardId, projectId)
    DS->>Prisma: "prisma.dashboard.delete({ where: { id, projectId } })"
    
    alt "Dashboard found & deleted"
        Prisma-->>DS: success
        DS-->>Router: void
        Router-->>Client: "{ success: true }"
    else Dashboard not found (P2025)
        Prisma-->>DS: PrismaClientKnownRequestError (P2025)
        DS-->>Router: throw LangfuseNotFoundError
        Router-->>Client: 404 Not Found
    else Other error
        Prisma-->>DS: other error
        DS-->>Router: re-throw error
        Router-->>Client: 500 Internal Server Error
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboards): return 404 instead of 5..."](https://github.com/langfuse/langfuse/commit/a43d69fea34fb8b0b77f8779326110a027e07516) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44841237)</sub>

<!-- /greptile_comment -->