### PR TITLE
fix(auth): return 400 instead of 500 for invalid callbackUrl

### DIFF
--- a/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
+++ b/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
@@ -139,4 +139,44 @@ describe("[...nextauth] invalid callbackUrl handling", () => {
     expect(res._getStatusCode()).toBe(200);
     expect(mockNextAuth).toHaveBeenCalledTimes(1);
   });
+
+  it("passes through an empty callbackUrl query param (next-auth treats it as absent)", async () => {
+    const { res } = await callHandler({
+      query: { nextauth: ["callback", "email"], callbackUrl: "" },
+    });
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockNextAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes through an empty callback-url cookie (next-auth treats it as absent)", async () => {
+    const { res } = await callHandler({
+      cookies: { "next-auth.callback-url": "" },
+    });
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockNextAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes an invalid callbackUrl through on GET signin (next-auth redirects to its error page instead of 500ing)", async () => {
+    const { res } = await callHandler({
+      query: { nextauth: ["signin"], callbackUrl: "www.example.com/foo" },
+    });
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockNextAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an invalid callbackUrl on POST signin with 400 (no HTML error-page carve-out for POST)", async () => {
+    const { res } = await callHandler({
+      method: "POST",
+      query: {
+        nextauth: ["signin", "email"],
+        callbackUrl: "www.example.com/foo",
+      },
+    });
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
+++ b/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
@@ -1,0 +1,142 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+
+const { mockNextAuth, mockGetAuthOptions } = vi.hoisted(() => ({
+  mockNextAuth: vi.fn(async (_req: unknown, res: any) => res.status(200).end()),
+  mockGetAuthOptions: vi.fn(async () => ({})),
+}));
+
+vi.mock("next-auth", () => ({ default: mockNextAuth }));
+
+vi.mock("@/src/server/auth", () => ({
+  getAuthOptions: mockGetAuthOptions,
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  redis: null,
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  ClickHouseClientManager: {
+    getInstance: () => ({
+      closeAllConnections: vi.fn(async () => undefined),
+    }),
+  },
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: {
+    NEXTAUTH_URL: "http://localhost:3000",
+    NEXT_PUBLIC_BASE_PATH: undefined,
+    NEXTAUTH_COOKIE_DOMAIN: undefined,
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined,
+    NEXTAUTH_COOKIE_NAME_SUFFIX: undefined,
+  },
+}));
+
+import handler from "@/src/pages/api/auth/[...nextauth]";
+
+const callHandler = async (options: Parameters<typeof createMocks>[0] = {}) => {
+  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method: "GET",
+    query: { nextauth: ["callback", "email"] },
+    ...options,
+  });
+  await handler(req, res);
+  return { req, res };
+};
+
+describe("[...nextauth] invalid callbackUrl handling", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a SQL-injection callbackUrl query param with 400", async () => {
+    const { res } = await callHandler({
+      query: {
+        nextauth: ["callback", "email"],
+        callbackUrl:
+          "'+convert(int, cast(0x5f21403264696c656d6d61 as varchar(8000)))+'",
+      },
+    });
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-http(s) scheme callbackUrl with 400", async () => {
+    const { res } = await callHandler({
+      query: {
+        nextauth: ["callback", "email"],
+        callbackUrl: "javascript:alert(1)",
+      },
+    });
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+
+  it("rejects a repeated (array) callbackUrl query param with 400", async () => {
+    const { res } = await callHandler({
+      query: {
+        nextauth: ["callback", "email"],
+        callbackUrl: ["https://a.example.com", "https://b.example.com"],
+      },
+    });
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid callback-url cookie with 400", async () => {
+    const { res } = await callHandler({
+      cookies: { "next-auth.callback-url": "z`z'z\"${{%{{\\" },
+    });
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+
+  it("passes through a valid absolute callbackUrl", async () => {
+    const { res } = await callHandler({
+      query: {
+        nextauth: ["callback", "email"],
+        callbackUrl: "https://cloud.langfuse.com/project/abc",
+      },
+    });
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockNextAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes through a relative callbackUrl", async () => {
+    const { res } = await callHandler({
+      query: {
+        nextauth: ["callback", "email"],
+        callbackUrl: "/project/abc",
+      },
+    });
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockNextAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes through a valid callback-url cookie", async () => {
+    const { res } = await callHandler({
+      cookies: { "next-auth.callback-url": "https://cloud.langfuse.com" },
+    });
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockNextAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes through when no callbackUrl is present", async () => {
+    const { res } = await callHandler();
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockNextAuth).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -31,13 +31,25 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // next-auth rejects malformed callbackUrl values (query param or cookie)
   // with a hardcoded 500, so vulnerability scanners probing auth routes page
   // our server-error monitors. Malformed client input is a 4xx; reject it
-  // before next-auth sees it.
+  // before next-auth sees it. Two carve-outs keep parity with next-auth:
+  // falsy values are treated as absent (assertConfig checks truthiness), and
+  // GET requests to next-auth's HTML page actions are exempt — those never
+  // 500; next-auth redirects them to the configured error page.
+  const nextAuthAction = Array.isArray(req.query.nextauth)
+    ? req.query.nextauth[0]
+    : req.query.nextauth;
+  const rendersHtmlErrorPage =
+    req.method === "GET" &&
+    ["signin", "signout", "error", "verify-request"].includes(
+      nextAuthAction ?? "",
+    );
   const callbackUrlParam = req.query.callbackUrl;
   const callbackUrlCookie =
     req.cookies[getCookieName("next-auth.callback-url")];
   const invalidCallbackUrl =
-    (callbackUrlParam !== undefined && !isValidCallbackUrl(callbackUrlParam)) ||
-    (callbackUrlCookie !== undefined && !isValidCallbackUrl(callbackUrlCookie));
+    !rendersHtmlErrorPage &&
+    ((Boolean(callbackUrlParam) && !isValidCallbackUrl(callbackUrlParam)) ||
+      (Boolean(callbackUrlCookie) && !isValidCallbackUrl(callbackUrlCookie)));
   if (invalidCallbackUrl) {
     logger.warn("[NEXT_AUTH] Rejected invalid callback URL", {
       callbackUrlParam: String(callbackUrlParam).slice(0, 200),

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -1,13 +1,50 @@
 import { getAuthOptions } from "@/src/server/auth";
+import { getCookieName } from "@/src/server/utils/cookies";
 import { env } from "@/src/env.mjs";
+import { logger } from "@langfuse/shared/src/server";
 import type { NextApiRequest, NextApiResponse } from "next";
 import NextAuth from "next-auth";
+
+// Mirrors next-auth's assertConfig check (core/lib/assert.ts). Must never be
+// stricter than next-auth: relative URLs always pass (next-auth resolves them
+// against the deployment origin), absolute URLs must parse with an http(s)
+// scheme.
+const isValidCallbackUrl = (url: unknown): boolean => {
+  if (typeof url !== "string") return false;
+  try {
+    return /^https?:/.test(
+      new URL(url, url.startsWith("/") ? "http://localhost" : undefined)
+        .protocol,
+    );
+  } catch {
+    return false;
+  }
+};
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // Workaround for corporate email link checkers (e.g., Outlook SafeLink)
   // https://next-auth.js.org/tutorials/avoid-corporate-link-checking-email-provider
   if (req.method === "HEAD") {
     return res.status(200).end();
+  }
+
+  // next-auth rejects malformed callbackUrl values (query param or cookie)
+  // with a hardcoded 500, so vulnerability scanners probing auth routes page
+  // our server-error monitors. Malformed client input is a 4xx; reject it
+  // before next-auth sees it.
+  const callbackUrlParam = req.query.callbackUrl;
+  const callbackUrlCookie =
+    req.cookies[getCookieName("next-auth.callback-url")];
+  const invalidCallbackUrl =
+    (callbackUrlParam !== undefined && !isValidCallbackUrl(callbackUrlParam)) ||
+    (callbackUrlCookie !== undefined && !isValidCallbackUrl(callbackUrlCookie));
+  if (invalidCallbackUrl) {
+    logger.warn("[NEXT_AUTH] Rejected invalid callback URL", {
+      callbackUrlParam: String(callbackUrlParam).slice(0, 200),
+      callbackUrlCookie: String(callbackUrlCookie).slice(0, 200),
+      path: req.url?.slice(0, 200),
+    });
+    return res.status(400).json({ message: "Invalid callback URL" });
   }
 
   // Intercept OAuth callback errors to preserve error_description from IdP


### PR DESCRIPTION
## What does this PR do?

Vulnerability scanners probing `/api/auth/*` with injection payloads in the `callbackUrl` query parameter (or callback-url cookie) currently produce HTTP 500 responses: next-auth's `assertConfig` rejects the malformed URL but returns a hardcoded 500. These register as server errors in error-rate monitoring even though the input is client garbage and is handled safely.

This PR validates `callbackUrl` (query param and cookie) in the `[...nextauth]` API route before invoking NextAuth, mirroring next-auth's own `isValidHttpUrl` check, and rejects invalid values with a 400. The check is deliberately never stricter than next-auth's: relative URLs always pass, absolute URLs must parse with an http(s) scheme. Rejected requests are logged at warn level (truncated payload) to retain visibility.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have added tests that prove my fix is effective (`web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts`)
- New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a pre-flight validation step in the NextAuth API handler that rejects malformed `callbackUrl` values (both query params and cookies) with a `400` before they reach next-auth, which previously responded to these inputs with a hardcoded `500`. A suite of 8 unit tests covers the main accept/reject paths.

- A new `isValidCallbackUrl` helper validates that the URL is a string with an `http(s)` scheme (or a valid relative path), rejecting arrays, non-http schemes (e.g. `javascript:`), and syntactically broken strings.
- Both the `callbackUrl` query parameter and the `next-auth.callback-url` cookie are validated using the environment-aware `getCookieName` helper to ensure the correct prefixed cookie name is looked up.
- Warnings with truncated URL values are logged on rejection to aid incident investigation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change narrows the attack surface and the happy paths are well-tested.

The core logic is correct and the test suite is thorough. The validator handling of non-slash-prefixed relative URLs is marginally stricter than next-auth's own behavior, but this edge case is extremely unlikely in practice.

web/src/pages/api/auth/[...nextauth].ts — specifically the base-URL logic in isValidCallbackUrl for non-slash-prefixed relative paths.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Handler as [...nextauth].ts
    participant Validator as isValidCallbackUrl
    participant Logger as logger
    participant NextAuth

    Client->>Handler: "GET /api/auth/callback/email?callbackUrl=..."
    Handler->>Handler: "Check req.method === HEAD"
    Handler->>Handler: Read callbackUrlParam and callbackUrlCookie
    Handler->>Validator: isValidCallbackUrl(callbackUrlParam)
    Validator-->>Handler: valid / invalid
    Handler->>Validator: isValidCallbackUrl(callbackUrlCookie)
    Validator-->>Handler: valid / invalid

    alt Invalid callbackUrl param or cookie
        Handler->>Logger: warn NEXT_AUTH Rejected invalid callback URL
        Handler-->>Client: 400 Invalid callback URL
    else Valid callbackUrl
        Handler->>NextAuth: NextAuth(req, res, authOptions)
        NextAuth-->>Client: 200 / redirect / etc.
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Handler as [...nextauth].ts
    participant Validator as isValidCallbackUrl
    participant Logger as logger
    participant NextAuth

    Client->>Handler: "GET /api/auth/callback/email?callbackUrl=..."
    Handler->>Handler: "Check req.method === HEAD"
    Handler->>Handler: Read callbackUrlParam and callbackUrlCookie
    Handler->>Validator: isValidCallbackUrl(callbackUrlParam)
    Validator-->>Handler: valid / invalid
    Handler->>Validator: isValidCallbackUrl(callbackUrlCookie)
    Validator-->>Handler: valid / invalid

    alt Invalid callbackUrl param or cookie
        Handler->>Logger: warn NEXT_AUTH Rejected invalid callback URL
        Handler-->>Client: 400 Invalid callback URL
    else Valid callbackUrl
        Handler->>NextAuth: NextAuth(req, res, authOptions)
        NextAuth-->>Client: 200 / redirect / etc.
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/api/auth/[...nextauth].ts:14-21
The validator rejects relative URLs that don't start with `"/"` (e.g. `"path/resource"`), because `new URL("path/resource", undefined)` throws, causing `isValidCallbackUrl` to return `false`. The comment explicitly states the function "Must never be stricter than next-auth," but next-auth does accept rootless relative paths by resolving them against the deployment origin. In practice these paths are rare as `callbackUrl` inputs, but passing `undefined` as the base for non-slash-prefixed strings means they are silently treated the same as malformed URLs and blocked with a 400.

```suggestion
  try {
    // Relative URLs (with or without a leading slash) are resolved against a
    // dummy base so next-auth's own relative-URL logic is mirrored exactly.
    const base = /^https?:\/\//i.test(url) ? undefined : "http://localhost";
    return /^https?:/.test(new URL(url, base).protocol);
  } catch {
    return false;
  }
```

### Issue 2 of 2
web/src/pages/api/auth/[...nextauth].ts:42-46
**Log always stringifies both values, even when only one triggered rejection**

When only `callbackUrlParam` is invalid, `callbackUrlCookie` may be `undefined`, and `String(undefined)` logs the string `"undefined"`. This can make incident triage confusing — a reader seeing `callbackUrlCookie: "undefined"` might wonder whether the cookie was the source of the issue. Consider logging only the values that actually exist, or adding a field indicating which one triggered the rejection.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): return 400 instead of 500 for..."](https://github.com/langfuse/langfuse/commit/4733e762cbe8bb79ca845c6bccbc9edba9ca5d27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44845157)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->