### PR TITLE
fix(trace): capture the real error on I/O parse-worker load failure (LANGFUSE-421/41Z)

### DIFF
--- a/web/src/hooks/parserWorkerError.clienttest.ts
+++ b/web/src/hooks/parserWorkerError.clienttest.ts
@@ -1,0 +1,98 @@
+import { reportParserWorkerError } from "@/src/hooks/parserWorkerError";
+import { captureException } from "@sentry/nextjs";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+const mockCaptureException = vi.mocked(captureException);
+
+/**
+ * Observability contract for the JSON-parser Web Worker `onerror` path
+ * (Sentry LANGFUSE-421 / LANGFUSE-41Z). The raw ErrorEvent used to be
+ * `console.error`'d and then stringified by captureConsoleIntegration to the
+ * opaque "[object ErrorEvent]", discarding message/filename/lineno.
+ * `reportParserWorkerError` must instead capture ONE legible Error with
+ * structured context, and log via `console.warn` (never `console.error`) so the
+ * same failure is not double-captured.
+ */
+describe("reportParserWorkerError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeErrorEvent(overrides: Partial<ErrorEvent> = {}): ErrorEvent {
+    return {
+      message: "ChunkLoadError: Loading chunk 123 failed",
+      filename: "https://app.example/_next/static/chunks/worker.js",
+      lineno: 1,
+      colno: 42,
+      error: undefined,
+      ...overrides,
+    } as ErrorEvent;
+  }
+
+  it("captures a synthesized, legible Error with structured context when event.error is absent", () => {
+    const event = makeErrorEvent();
+    reportParserWorkerError("useParsedTrace", event);
+
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    const [err, opts] = mockCaptureException.mock.calls[0];
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain(
+      "[useParsedTrace] worker failed to load",
+    );
+    expect((err as Error).message).toContain(event.message);
+    expect((err as Error).message).toContain(event.filename);
+    // The fields captureConsoleIntegration used to discard are preserved.
+    expect(opts).toMatchObject({
+      extra: {
+        workerHook: "useParsedTrace",
+        message: event.message,
+        filename: event.filename,
+        lineno: 1,
+        colno: 42,
+      },
+      tags: { area: "io-parse-worker" },
+    });
+  });
+
+  it("prefers the real Error when the worker threw during init", () => {
+    const real = new Error("worker init threw");
+    reportParserWorkerError(
+      "useParsedObservation",
+      makeErrorEvent({ error: real }),
+    );
+
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException.mock.calls[0][0]).toBe(real);
+  });
+
+  it("logs a readable string via console.warn, not console.error (no double-capture)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    reportParserWorkerError("useParsedTrace", makeErrorEvent());
+
+    // console.error would be re-captured by captureConsoleIntegration.
+    expect(error).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    const logged = String(warn.mock.calls[0][0]);
+    expect(logged).toContain("[useParsedTrace] Worker failed to load");
+    expect(logged).not.toContain("[object ErrorEvent]");
+
+    warn.mockRestore();
+    error.mockRestore();
+  });
+
+  it("degrades gracefully when ErrorEvent fields are empty", () => {
+    reportParserWorkerError(
+      "useParsedTrace",
+      makeErrorEvent({ message: "", filename: "" }),
+    );
+
+    const [err] = mockCaptureException.mock.calls[0];
+    expect((err as Error).message).toContain("unknown");
+    expect((err as Error).message).toContain("?");
+  });
+});

--- a/web/src/hooks/parserWorkerError.ts
+++ b/web/src/hooks/parserWorkerError.ts
@@ -1,0 +1,50 @@
+import { captureException } from "@sentry/nextjs";
+
+/**
+ * Turn a JSON-parser Web Worker `onerror` ErrorEvent into a legible,
+ * Sentry-reportable error.
+ *
+ * `Worker.onerror` fires when the worker *script* itself fails to load or throws
+ * during init — the dominant cause is a stale-deploy chunk 404. The previous
+ * handlers did `console.error("... Worker error:", event)` with the raw
+ * ErrorEvent; Sentry's captureConsoleIntegration stringifies that to
+ * "[object ErrorEvent]", discarding message/filename/lineno and making the
+ * resulting issues undiagnosable.
+ *
+ * This extracts the real fields, captures one proper Error with structured
+ * context, and logs a readable string via `console.warn` (NOT `console.error`,
+ * so captureConsoleIntegration — which captures the "error" level — does not
+ * double-capture a second, opaque event for the same failure).
+ *
+ * Note: in-worker parse failures are a separate, already-legible path — they
+ * post a "Parse error" string back over the message channel and are handled in
+ * the message callback, not here.
+ */
+export function reportParserWorkerError(
+  hookName: string,
+  event: ErrorEvent,
+): void {
+  const details = `${event.message || "unknown"} @ ${event.filename || "?"}:${event.lineno ?? "?"}:${event.colno ?? "?"}`;
+
+  // Prefer the real Error when the worker threw during init; otherwise
+  // synthesize one from the ErrorEvent's fields so the message is legible.
+  const realError =
+    event.error instanceof Error
+      ? event.error
+      : new Error(`[${hookName}] worker failed to load: ${details}`);
+
+  captureException(realError, {
+    extra: {
+      workerHook: hookName,
+      message: event.message,
+      filename: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+    },
+    tags: { area: "io-parse-worker" },
+  });
+
+  // console.warn (not console.error) keeps the console legible without
+  // triggering a duplicate capture via captureConsoleIntegration.
+  console.warn(`[${hookName}] Worker failed to load: ${details}`);
+}

--- a/web/src/hooks/useParsedObservation.ts
+++ b/web/src/hooks/useParsedObservation.ts
@@ -26,6 +26,7 @@ import type {
   ParseResponse,
 } from "@/src/workers/json-parser.worker";
 import { cheapHash } from "@/src/hooks/parsedIoCacheKey";
+import { reportParserWorkerError } from "@/src/hooks/parserWorkerError";
 
 type ObservationWithStringifiedIO = ObservationReturnTypeWithMetadata & {
   input: string | null;
@@ -86,8 +87,8 @@ function getOrCreateWorker(): Worker | null {
         }
       };
 
-      workerInstance.onerror = (error) => {
-        console.error("[useParsedObservation] Worker error:", error);
+      workerInstance.onerror = (event) => {
+        reportParserWorkerError("useParsedObservation", event);
       };
     } catch (error) {
       console.error("[useParsedObservation] Failed to create worker:", error);

--- a/web/src/hooks/useParsedTrace.ts
+++ b/web/src/hooks/useParsedTrace.ts
@@ -23,6 +23,7 @@ import type {
   ParseResponse,
 } from "@/src/workers/json-parser.worker";
 import { cheapHash } from "@/src/hooks/parsedIoCacheKey";
+import { reportParserWorkerError } from "@/src/hooks/parserWorkerError";
 
 /**
  * Threshold for using Web Worker vs sync parsing (in characters).
@@ -73,8 +74,8 @@ function getOrCreateWorker(): Worker | null {
         }
       };
 
-      workerInstance.onerror = (error) => {
-        console.error("[useParsedTrace] Worker error:", error);
+      workerInstance.onerror = (event) => {
+        reportParserWorkerError("useParsedTrace", event);
       };
     } catch (error) {
       console.error("[useParsedTrace] Failed to create worker:", error);


### PR DESCRIPTION
## TL;DR

The large-I/O parse web worker reports load failures as literally `[object ErrorEvent]` in Sentry — **~930 users across two issues (LANGFUSE-421 + LANGFUSE-41Z), for 7 months, completely undiagnosable.** This extracts the real error fields (message / filename / lineno) and captures one proper, legible exception instead. **Zero behavior change** — it only fixes what we log.

## Why

`useParsedObservation` / `useParsedTrace` offload >100 KB I/O parsing to a web worker. When the worker *script* fails to load, `Worker.onerror` fires with an `ErrorEvent`, and the old handler did `console.error("… Worker error:", event)` — passing the raw event. Sentry's `captureConsoleIntegration` stringifies that to `[object ErrorEvent]`, throwing away every useful field. So the single largest "real" error signal in our Sentry stream was invisible.

Investigation (mining the events) pinned the cause: it's the worker **chunk failing to load** — a stale-deploy 404 (an older tab requests a hashed worker chunk the server no longer serves), spread across 6+ releases, all Chromium, 100% on `/traces`, a trickle of one-off users. (In-worker *parse* throws are a separate, already-legible path that posts a `"Parse error"` string back over the message channel — which has zero Sentry issues, confirming every one of these events is the opaque load-failure path.)

## What

- New shared helper `reportParserWorkerError(hookName, event)` (the two hooks were byte-identical): prefers a real `event.error` (init-throw) or synthesizes `new Error("… worker failed to load: <message> @ <filename>:<lineno>:<colno>")`, then `captureException(realError, { extra: {message, filename, lineno, colno}, tags: { area: "io-parse-worker" } })`.
- Logs a readable string via **`console.warn`** (not `console.error`) so `captureConsoleIntegration` (which captures the `error` level) doesn't double-capture a second opaque event.
- Both `onerror` handlers now call the helper.

## Result

- 930 undiagnosable users → actionable events (the captured `filename` will reveal the failing chunk URL, confirming stale-deploy vs anything else).
- **No behavior change**: only the `onerror` reporting body changed — parse logic, the 100 KB threshold, the sync fallback, the singleton lifecycle, and all render paths are untouched.
- 4 unit tests; typecheck + eslint + prettier clean.

<details>
<summary>Mechanism, no-double-capture, and the follow-up</summary>

**No double-capture (verified):** `web/instrumentation-client.ts` runs `captureConsoleIntegration({ levels: ["error"] })`. The helper captures the exception explicitly once and logs via `console.warn`, so each worker-load failure yields exactly one legible Sentry event.

**Files:** `web/src/hooks/parserWorkerError.ts` (new helper), `parserWorkerError.clienttest.ts` (new, 4 cases: synthesized-error path, real-`event.error` preference, warn-not-error, sparse-field degradation), `useParsedObservation.ts` + `useParsedTrace.ts` (one import + a 2-line handler swap each).

**`ErrorEvent` typing:** the global DOM `ErrorEvent` (`Worker.onerror`), not the `@sentry/nextjs` one — typecheck confirms. Cross-origin load failures can leave fields sparse; the `|| "unknown"` / `?? "?"` fallbacks handle that.

**Deliberately scoped out (follow-up):** there's a second, higher-effort bug — on worker-load failure the handler doesn't reject the pending parse promises or reset the singleton worker, so one stale chunk silently hangs all large-I/O parsing in that tab until reload. The fix (reject + reset + fall back to main-thread parse) must respect the recent I/O size gates so it never sync-parses a multi-MB payload on the main thread. Tracked separately; this PR is the safe, zero-risk observability win that also unblocks precise root-causing.
</details>

Surfaced by the nightly Sentry triage (making Sentry alert on real signal, not noise). Sentry: LANGFUSE-421, LANGFUSE-41Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a 7-month observability blind spot where `Worker.onerror` events were being stringified to `[object ErrorEvent]` by Sentry's `captureConsoleIntegration`, discarding all useful diagnostic fields. The fix introduces a shared helper `reportParserWorkerError` that extracts `message`, `filename`, `lineno`, and `colno` from the `ErrorEvent`, synthesizes a legible `Error` (or reuses `event.error` when it's already an `Error`), and calls `captureException` directly via `@sentry/nextjs` — logging via `console.warn` instead of `console.error` to avoid a second opaque Sentry capture.

- **`web/src/hooks/parserWorkerError.ts`**: New shared helper; handles both the stale-chunk-404 path (synthesized Error from `ErrorEvent` fields) and the worker-init-throw path (`event.error` preference). Four unit tests cover the synthesized-error path, real-error preference, `console.warn`-not-`error` contract, and sparse-field degradation.
- **`useParsedObservation.ts` / `useParsedTrace.ts`**: Each replaces its two-line `console.error(event)` handler with a single call to the new helper. The parse logic, 100 KB threshold, sync fallback, singleton lifecycle, and all render paths are untouched.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only the onerror reporting body changed; all parsing logic, thresholds, fallbacks, and render paths are untouched.

The change is narrowly scoped to error observability: one new helper, one import per hook, a 2-line handler swap. The console.warn-not-console.error choice correctly prevents double-capture by captureConsoleIntegration. The event.error instanceof Error guard correctly handles both the stale-chunk path and the init-throw path. The four unit tests cover synthesized-error construction, real-error preference, the warn-not-error contract, and sparse-field degradation. No runtime behavior changes.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Worker as json-parser.worker chunk
    participant Hook as useParsedTrace or useParsedObservation
    participant Helper as reportParserWorkerError
    participant Sentry as captureException

    Browser->>Worker: load chunk
    Worker-->>Hook: onerror fires with ErrorEvent
    Hook->>Helper: reportParserWorkerError(hookName, event)
    alt event.error instanceof Error
        Helper->>Sentry: "captureException(event.error, {extra, tags})"
    else no real Error
        Helper->>Helper: synthesize new Error from message+filename+lineno
        Helper->>Sentry: "captureException(synthesizedError, {extra, tags})"
    end
    Helper->>Browser: console.warn readable string
    Note over Browser: NOT console.error, so captureConsoleIntegration does not double-capture
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Worker as json-parser.worker chunk
    participant Hook as useParsedTrace or useParsedObservation
    participant Helper as reportParserWorkerError
    participant Sentry as captureException

    Browser->>Worker: load chunk
    Worker-->>Hook: onerror fires with ErrorEvent
    Hook->>Helper: reportParserWorkerError(hookName, event)
    alt event.error instanceof Error
        Helper->>Sentry: "captureException(event.error, {extra, tags})"
    else no real Error
        Helper->>Helper: synthesize new Error from message+filename+lineno
        Helper->>Sentry: "captureException(synthesizedError, {extra, tags})"
    end
    Helper->>Browser: console.warn readable string
    Note over Browser: NOT console.error, so captureConsoleIntegration does not double-capture
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): make JSON-parser worker load f..."](https://github.com/langfuse/langfuse/commit/d8cfe02f0a78fd4ee17c8ab1db18c4924be0e892) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44952959)</sub>

<!-- /greptile_comment -->