### PR TITLE
fix(trace): keep JSON-viewer meta-root row count in sync after collapse (LANGFUSE-456)

### DIFF
--- a/web/src/components/ui/AdvancedJsonViewer/utils/treeExpansion.ts
+++ b/web/src/components/ui/AdvancedJsonViewer/utils/treeExpansion.ts
@@ -320,44 +320,50 @@ export function applyExpansionState(
 
   // Apply expansion state to each node
   postOrder.forEach((node) => {
-    if (!node.isExpandable) return;
+    // Expansion decision only applies to expandable nodes.
+    if (node.isExpandable) {
+      let shouldExpand = true;
 
-    let shouldExpand = true;
+      if (collapsedPaths.has("*")) {
+        shouldExpand = false;
+      } else if (typeof expansionState === "boolean") {
+        shouldExpand = expansionState;
+      } else if (collapsedPaths.has(node.id)) {
+        // Exact match: explicitly collapsed
+        shouldExpand = false;
+      } else if (expandedPaths.has(node.id)) {
+        // Exact match: explicitly expanded
+        shouldExpand = true;
+      } else if (expandedAncestors.has(node.id)) {
+        // Prefix matching: This node is an ancestor of an expanded path
+        // e.g., if "messages.0.content.text" is expanded, expand "messages", "messages.0", etc.
+        shouldExpand = true;
+      }
+      // No match: keep default (shouldExpand = true)
+      // This ensures nodes not explicitly in stored state stay expanded
 
-    if (collapsedPaths.has("*")) {
-      shouldExpand = false;
-    } else if (typeof expansionState === "boolean") {
-      shouldExpand = expansionState;
-    } else if (collapsedPaths.has(node.id)) {
-      // Exact match: explicitly collapsed
-      shouldExpand = false;
-    } else if (expandedPaths.has(node.id)) {
-      // Exact match: explicitly expanded
-      shouldExpand = true;
-    } else if (expandedAncestors.has(node.id)) {
-      // Prefix matching: This node is an ancestor of an expanded path
-      // e.g., if "messages.0.content.text" is expanded, expand "messages", "messages.0", etc.
-      shouldExpand = true;
+      node.isExpanded = shouldExpand;
+      // Set userExpand for:
+      // - Exact matches from expansionState
+      // - Ancestor nodes expanded via prefix matching (so they're tracked for export)
+      if (typeof expansionState === "boolean") {
+        node.userExpand = undefined;
+      } else if (expansionState[node.id] !== undefined) {
+        node.userExpand = expansionState[node.id];
+      } else if (expandedAncestors.has(node.id)) {
+        // Ancestors expanded via prefix matching should be tracked
+        node.userExpand = true;
+      } else {
+        node.userExpand = undefined;
+      }
     }
-    // No match: keep default (shouldExpand = true)
-    // This ensures nodes not explicitly in stored state stay expanded
 
-    node.isExpanded = shouldExpand;
-    // Set userExpand for:
-    // - Exact matches from expansionState
-    // - Ancestor nodes expanded via prefix matching (so they're tracked for export)
-    if (typeof expansionState === "boolean") {
-      node.userExpand = undefined;
-    } else if (expansionState[node.id] !== undefined) {
-      node.userExpand = expansionState[node.id];
-    } else if (expandedAncestors.has(node.id)) {
-      // Ancestors expanded via prefix matching should be tracked
-      node.userExpand = true;
-    } else {
-      node.userExpand = undefined;
-    }
-
-    // Recompute offsets
+    // Recompute offsets for EVERY node, not just expandable ones. Post-order
+    // guarantees children are already updated, and recomputeNodeOffsets is a
+    // no-op for collapsed/childless nodes. Crucially this includes the synthetic
+    // meta-root (isExpandable: false) whose visibleDescendantCount drives the
+    // virtualizer's row count — skipping it left a stale/over-counted total after
+    // a section collapse, producing phantom row indexes (LANGFUSE-456).
     recomputeNodeOffsets(node);
   });
 
@@ -397,12 +403,16 @@ export function expandToDepth(tree: TreeState, depth: number): TreeState {
 
   // Apply expansion based on depth
   postOrder.forEach((node) => {
-    if (!node.isExpandable) return;
+    // Expansion decision only applies to expandable nodes.
+    if (node.isExpandable) {
+      const shouldExpand = node.depth < depth;
+      node.isExpanded = shouldExpand;
+      node.userExpand = shouldExpand;
+    }
 
-    const shouldExpand = node.depth < depth;
-    node.isExpanded = shouldExpand;
-    node.userExpand = shouldExpand;
-
+    // Recompute offsets for EVERY node (see applyExpansionState): post-order +
+    // no-op-on-collapsed makes this safe, and it keeps the non-expandable
+    // meta-root's visibleDescendantCount in sync with the virtualizer row count.
     recomputeNodeOffsets(node);
   });
 

--- a/web/src/components/ui/AdvancedJsonViewer/utils/treeNavigation.clienttest.ts
+++ b/web/src/components/ui/AdvancedJsonViewer/utils/treeNavigation.clienttest.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 
 import { buildTreeFromJSON } from "./treeStructure";
+import { buildMultiSectionTree } from "./multiSectionTree";
+import { applyExpansionState } from "./treeExpansion";
 import {
   getAllVisibleNodes,
   getNodeByIndex,
@@ -506,6 +508,60 @@ describe("getNodeByIndex after expansion changes", () => {
     }
 
     expect(failedIndexes).toEqual([]);
+  });
+
+  it("CRITICAL: multi-section — meta-root count stays in sync after collapsing a section", () => {
+    // Regression for LANGFUSE-456 ("[getNodeByIndex] Index out of bounds").
+    // The virtualizer's row count is driven by the synthetic meta-root's
+    // visibleDescendantCount. applyExpansionState used to skip non-expandable
+    // nodes, so the meta-root's cached count stayed over-counted after a section
+    // collapsed, and the virtualizer requested phantom row indexes.
+    const sections = [
+      {
+        key: "input",
+        data: {
+          messages: [
+            { role: "user", content: "hello" },
+            { role: "assistant", content: "hi there" },
+          ],
+        },
+      },
+      {
+        key: "output",
+        data: { result: { text: "answer", tokens: [1, 2, 3] } },
+      },
+    ];
+
+    const tree = buildMultiSectionTree(sections);
+
+    // Sanity: fully expanded on build, every index resolves.
+    const initialRowCount = 1 + tree.rootNode.visibleDescendantCount;
+    for (let i = 0; i < initialRowCount; i++) {
+      expect(getNodeByIndex(tree.rootNode, i)).not.toBeNull();
+    }
+
+    // Re-apply an expansion state that collapses the first section — this is what
+    // happens on load / when switching observations and the tree is rebuilt.
+    applyExpansionState(tree, { input__header: false });
+
+    const rowCount = 1 + tree.rootNode.visibleDescendantCount;
+
+    // The meta-root's cached descendant count MUST equal the real navigable count.
+    // Pre-fix this was over-counted (still included the collapsed section's rows).
+    const navigableCount = getAllVisibleNodes(tree.rootNode).length - 1;
+    expect(tree.rootNode.visibleDescendantCount).toBe(navigableCount);
+
+    // Every index in [0, rowCount) must resolve to a non-null node.
+    // Pre-fix: the trailing phantom indexes walked into the collapsed section
+    // header and returned null.
+    const failedIndexes: number[] = [];
+    for (let i = 0; i < rowCount; i++) {
+      const node = getNodeByIndex(tree.rootNode, i);
+      if (node === null) failedIndexes.push(i);
+    }
+
+    expect(failedIndexes).toEqual([]);
+    expect(failedIndexes.length).toBe(0);
   });
 });
 


### PR DESCRIPTION
## TL;DR

The "JSON Beta" I/O viewer logs `[getNodeByIndex] Index out of bounds` — **298 events / 59 users** — whenever a collapsed section's row count goes stale. Root cause: the virtualizer's row count comes from a synthetic **meta-root** node that is `isExpandable: false`, and the offset-recompute on state re-apply was gated behind `if (node.isExpandable)`, so the meta-root was skipped and kept an **over-counted** descendant count. One-line-shaped fix: recompute offsets for every node, not just expandable ones. New regression test fails on the old code, passes on the fix.

## Why

The viewer renders rows via `@tanstack/react-virtual` with `count = 1 + metaRoot.visibleDescendantCount`. When a persisted expansion state that **collapses a section** is re-applied — on load, and every time you switch to another observation (the tree rebuilds) — `applyExpansionState` / `expandToDepth` walk the tree post-order and call `recomputeNodeOffsets(node)`, but only inside `if (node.isExpandable)`. The meta-root aggregates all sections and is `isExpandable: false`, so it was never refreshed: its `childOffsets` / `visibleDescendantCount` stayed as if the collapsed section were still expanded. The virtualizer then asks for a phantom row past the real end, `getNodeByIndex` descends into a collapsed header, and logs out-of-bounds.

It's a caught `console.error` (returns `null`, all call sites handle null) — no crash, no error boundary — but it surfaces as phantom/blank rows + a too-tall scrollbar at a section boundary, and 298 events of Sentry noise.

## What

In `treeExpansion.ts`, both `applyExpansionState` and `expandToDepth`: keep the expand-decision logic gated behind `if (node.isExpandable)`, but move `recomputeNodeOffsets(node)` **out** so it runs unconditionally for every node in the post-order pass.

## Result

- Meta-root offsets stay in sync after collapse → no phantom rows → the log goes silent.
- **Other nodes are byte-identical:** `recomputeNodeOffsets` no-ops for collapsed/childless nodes, and expandable nodes run exactly as before (post-order unchanged). The only newly-recomputed node with children is the meta-root — the intended fix.
- The `getNodeByIndex` guard/log is **left in place** on purpose: once the root cause is fixed it should never fire, so any future occurrence is a real regression signal.
- 128 client tests pass; new regression test confirmed to fail pre-fix (`expected 17 to be 9`).

<details>
<summary>Mechanism, test, scope</summary>

**Files:** `web/src/components/ui/AdvancedJsonViewer/utils/treeExpansion.ts` (fix), `treeNavigation.clienttest.ts` (+56, new case).

**New test:** builds a 2-section tree, `applyExpansionState({ input__header: false })`, asserts (1) `metaRoot.visibleDescendantCount === visibleNodes − 1` and (2) every index in `[0, 1 + visibleDescendantCount)` resolves to a non-null node. Fails on old code (meta-root reports 17 vs real 9), passes after.

**Why only the re-apply path was affected:** interactive toggling (`toggleNodeExpansion`) already propagates offsets upward through the meta-root via `propagateOffsetsUpward`; build-time (`buildMultiSectionTree`) recomputes the meta-root correctly too. Only `applyExpansionState` / `expandToDepth` (the load / observation-switch re-apply) skipped it.

**Perf:** adds one O(children) recompute for the meta-root + O(1) no-ops for childless leaves — negligible vs the existing full post-order pass.
</details>

Surfaced by the nightly Sentry triage (Sentry as signal, not noise). Sentry: LANGFUSE-456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a stale `visibleDescendantCount` on the synthetic meta-root node that drove phantom row indexes in `@tanstack/react-virtual` whenever a persisted expansion state collapsed a section. The root cause was that `recomputeNodeOffsets` was only called inside an `if (node.isExpandable)` guard — which the meta-root (`isExpandable: false`) never entered.

- **`treeExpansion.ts`**: In both `applyExpansionState` and `expandToDepth`, the expansion-decision logic stays gated on `isExpandable`, but `recomputeNodeOffsets` is moved outside the guard so it runs unconditionally for every post-order node, including the meta-root. For collapsed or childless nodes the call is a no-op, so there is no behaviour change for any node other than the meta-root.
- **`treeNavigation.clienttest.ts`**: Adds a targeted regression test that builds a two-section tree, collapses the first section via `applyExpansionState`, and asserts both that `metaRoot.visibleDescendantCount` matches the real navigable count and that every virtualizer index resolves to a non-null node.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is a two-site restructuring that moves a function call outside a conditional guard; the expansion logic itself is untouched.

The fix is minimal and surgical. recomputeNodeOffsets is already a no-op for collapsed or childless nodes, so calling it unconditionally introduces no behavioural change for any node except the meta-root. A new regression test confirms the pre-fix failure and post-fix correctness.

No files require special attention. The test file has one redundant assertion that can be cleaned up but does not affect correctness.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["applyExpansionState / expandToDepth\ncollect postOrder nodes"] --> B["forEach node in postOrder"]
    B --> C{node.isExpandable?}
    C -- Yes --> D["Compute shouldExpand\nSet node.isExpanded\nSet node.userExpand"]
    C -- No --> E["Skip expansion logic\n(meta-root, spacers, footers)"]
    D --> F["recomputeNodeOffsets(node)\n— always runs —"]
    E --> F
    F --> G{node.isExpanded &&\nchildren.length > 0?}
    G -- No --> H["childOffsets = []\nvisibleDescendantCount = 0\n(no-op for collapsed/leaf)"]
    G -- Yes --> I["Accumulate children's\nvisibleDescendantCount\nUpdate childOffsets"]
    I --> J["✅ meta-root.visibleDescendantCount\nnow reflects collapsed sections\n→ virtualizer row count in sync"]
    H --> K["Next node in postOrder"]
    J --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["applyExpansionState / expandToDepth\ncollect postOrder nodes"] --> B["forEach node in postOrder"]
    B --> C{node.isExpandable?}
    C -- Yes --> D["Compute shouldExpand\nSet node.isExpanded\nSet node.userExpand"]
    C -- No --> E["Skip expansion logic\n(meta-root, spacers, footers)"]
    D --> F["recomputeNodeOffsets(node)\n— always runs —"]
    E --> F
    F --> G{node.isExpanded &&\nchildren.length > 0?}
    G -- No --> H["childOffsets = []\nvisibleDescendantCount = 0\n(no-op for collapsed/leaf)"]
    G -- Yes --> I["Accumulate children's\nvisibleDescendantCount\nUpdate childOffsets"]
    I --> J["✅ meta-root.visibleDescendantCount\nnow reflects collapsed sections\n→ virtualizer row count in sync"]
    H --> K["Next node in postOrder"]
    J --> K
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/ui/AdvancedJsonViewer/utils/treeNavigation.clienttest.ts:563-566
The second assertion is completely redundant — `toEqual([])` already verifies both that the array is empty and that its length is 0. Having two checks for the same thing can confuse readers into thinking they're guarding different conditions.

```suggestion
    expect(failedIndexes).toEqual([]);
  });
});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(json-viewer): recompute meta-root of..."](https://github.com/langfuse/langfuse/commit/1de0342d464915dead0b22f9b3998a514546387a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44955386)</sub>

<!-- /greptile_comment -->