### PR TITLE
fix(observability): stop sending opaque non-Error captures to Sentry (LANGFUSE-5EX cluster)

### DIFF
--- a/web/src/components/table/data-table-ai-filters.tsx
+++ b/web/src/components/table/data-table-ai-filters.tsx
@@ -48,7 +48,10 @@ export function DataTableAIFilters({
           onFiltersGenerated(result.filters as FilterState);
           setAiPrompt("");
         } else {
-          console.error(result);
+          console.error(
+            "dataTable.aiFilters: invalid response format",
+            JSON.stringify(result),
+          );
           setAiError("Invalid response format from API");
         }
       } catch (error) {

--- a/web/src/components/ui/resizable-image.tsx
+++ b/web/src/components/ui/resizable-image.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/src/components/ui/button";
 import { ImageOff, Maximize2, Minimize2 } from "lucide-react";
 import { api } from "@/src/utils/api";
 import { Skeleton } from "@/src/components/ui/skeleton";
-import { captureException } from "@sentry/nextjs";
 import { useSession } from "next-auth/react";
 import { buildResizableImageSrc } from "./resizable-image.utils";
 import { getSafeImageUrl } from "@/src/components/ui/safe-url";
@@ -143,9 +142,13 @@ export const ResizableImage = ({
                   "rounded border",
                   fitContent ? "h-auto w-full" : "h-full w-full object-contain",
                 )}
-                onError={(error) => {
+                onError={() => {
+                  // An image failing to load is an <img> error Event (a
+                  // SyntheticEvent), not an Error, and is expected: rendered
+                  // markdown routinely points at dead user-content URLs. Show
+                  // the fallback UI; do not report it to Sentry (a non-Error
+                  // capture is opaque and not actionable for us).
                   setHasFetchError(true);
-                  captureException(error);
                 }}
               />
               <Button

--- a/web/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -326,10 +326,12 @@ export const NewDatasetItemForm = (props: {
           return;
         }
 
+        // The user already sees the validation errors via setFormError above;
+        // a bare console.error(object) would only add an opaque, non-actionable
+        // Sentry capture (captureConsoleIntegration), so we omit it here.
         setFormError(
           `Item does not match dataset schema. Errors: ${JSON.stringify(result.validationErrors, null, 2)}`,
         );
-        console.error(result.validationErrors);
       })
       .catch((error) => {
         console.error(error);

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -548,7 +548,10 @@ function FilterBuilderForm({
           setAiPrompt("");
           setShowAiFilter(false);
         } else {
-          console.error(result);
+          console.error(
+            "filterBuilder.aiGenerate: invalid response format",
+            JSON.stringify(result),
+          );
           setAiError("Invalid response format from API");
         }
       } catch (error) {

--- a/web/src/features/playground/page/components/Messages.tsx
+++ b/web/src/features/playground/page/components/Messages.tsx
@@ -11,6 +11,7 @@ import { Settings } from "lucide-react";
 import useLocalStorage from "@/src/components/useLocalStorage";
 import { env } from "@/src/env.mjs";
 import { STREAMING_PREF_KEY } from "@/src/features/playground/page/storage/keys";
+import { captureUnknownError } from "@/src/utils/captureUnknownError";
 
 import { GenerationOutput } from "./GenerationOutput";
 import { ChatMessages } from "@/src/components/ChatMessages";
@@ -56,7 +57,9 @@ const SubmitButton = () => {
       <Button
         className="flex-1"
         onClick={() => {
-          handleSubmit(streamingEnabled).catch((err) => console.error(err));
+          handleSubmit(streamingEnabled).catch((err) =>
+            captureUnknownError("playground.run", err),
+          );
         }}
         loading={isStreaming}
       >

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -50,6 +50,7 @@ import {
 import { useSyncMessageSearchMessages } from "@/src/components/ChatMessages/MessageSearch";
 import { getFinalModelParams } from "@/src/utils/getFinalModelParams";
 import { STREAMING_PREF_KEY } from "@/src/features/playground/page/storage/keys";
+import { captureUnknownError } from "@/src/utils/captureUnknownError";
 
 type PlaygroundContextType = {
   windowId: string;
@@ -633,7 +634,9 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
             // malformed localStorage value — fall back to default
           }
 
-          handleSubmit(streaming).catch((err) => console.error(err));
+          handleSubmit(streaming).catch((err) =>
+            captureUnknownError("playground.run", err),
+          );
         }
         // If no content, skip silently
       }

--- a/web/src/features/playground/page/hooks/useCommandEnter.ts
+++ b/web/src/features/playground/page/hooks/useCommandEnter.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { captureUnknownError } from "@/src/utils/captureUnknownError";
 
 export default function useCommandEnter(
   isEnabled: boolean,
@@ -13,7 +14,7 @@ export default function useCommandEnter(
       if (isEnabled && hasRunAllModifier && event.key === "Enter") {
         event.preventDefault();
         event.stopPropagation();
-        callback().catch((err) => console.error(err));
+        callback().catch((err) => captureUnknownError("playground.run", err));
       }
     }
 

--- a/web/src/pages/auth/enterprise-sso-required.tsx
+++ b/web/src/pages/auth/enterprise-sso-required.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { env } from "@/src/env.mjs";
-import { captureException } from "@sentry/nextjs";
+import { captureUnknownError } from "@/src/utils/captureUnknownError";
 
 const enterpriseSsoFormSchema = z.object({
   email: z.email(),
@@ -123,7 +123,7 @@ export default function EnterpriseSsoRequiredPage() {
           "Unable to start the Enterprise SSO sign-in flow. Please try again.",
       );
     } catch (err) {
-      captureException(err);
+      captureUnknownError("auth.enterpriseSso", err);
       setError(
         "Something went wrong while checking your Enterprise SSO configuration. Please try again.",
       );

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -39,6 +39,7 @@ import { isEmailVerificationRequired } from "@/src/features/auth-credentials/lib
 import { Code, Key } from "lucide-react";
 import { useRouter } from "next/router";
 import { captureException } from "@sentry/nextjs";
+import { captureUnknownError } from "@/src/utils/captureUnknownError";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import useLocalStorage from "@/src/components/useLocalStorage";
 import { AuthProviderButton } from "@/src/features/auth/components/AuthProviderButton";
@@ -220,7 +221,7 @@ export function SSOButtons({
         // do not reset loadingProvider here, as the page will reload
       })
       .catch((error) => {
-        console.error(error);
+        captureUnknownError("auth.signIn.provider", error, { provider });
         setProviderSigningIn(null);
       });
   };
@@ -640,8 +641,7 @@ export default function SignIn({
         );
       }
     } catch (error) {
-      captureException(error);
-      console.error(error);
+      captureUnknownError("auth.signIn.credentials", error);
       setCredentialsFormError("An unexpected error occurred.");
     }
   }
@@ -710,7 +710,7 @@ export default function SignIn({
         }
       }, 100);
     } catch (error) {
-      console.error(error);
+      captureUnknownError("auth.signIn.checkSso", error);
       setCredentialsFormError(
         "Unable to check SSO configuration. Please try again.",
       );

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -29,6 +29,7 @@ import { PasswordInput } from "@/src/components/ui/password-input";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useRouter } from "next/router";
 import { getSafeRedirectPath } from "@/src/utils/redirect";
+import { captureUnknownError } from "@/src/utils/captureUnknownError";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import useLocalStorage from "@/src/components/useLocalStorage";
 import { noUrlCheck, StringNoHTMLNonEmpty } from "@langfuse/shared";
@@ -182,7 +183,7 @@ function StandardSignupFlow({
         }
       }, 100);
     } catch (error) {
-      console.error(error);
+      captureUnknownError("auth.signUp.checkSso", error);
       setFormError("Unable to check SSO configuration. Please try again.");
     } finally {
       setContinueLoading(false);

--- a/web/src/utils/captureUnknownError.clienttest.ts
+++ b/web/src/utils/captureUnknownError.clienttest.ts
@@ -1,0 +1,102 @@
+import { captureUnknownError } from "@/src/utils/captureUnknownError";
+
+const { captureExceptionMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: captureExceptionMock,
+}));
+
+describe("captureUnknownError", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    captureExceptionMock.mockClear();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("passes a real Error through untouched (preserves the instance/stack)", () => {
+    const original = new Error("boom");
+    captureUnknownError("test.ctx", original);
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    const call = captureExceptionMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [err, options] = call!;
+    expect(err).toBe(original); // same instance → original stack preserved
+    expect(options.extra.context).toBe("test.ctx");
+    expect(options.tags.area).toBe("test.ctx");
+  });
+
+  it("wraps a string as `[context] string`", () => {
+    captureUnknownError("test.ctx", "something failed");
+
+    const [err] = captureExceptionMock.mock.calls[0]!;
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("[test.ctx] something failed");
+  });
+
+  it("renders a plain object legibly (not [object Object])", () => {
+    captureUnknownError("test.ctx", { code: 42, reason: "bad" });
+
+    const [err] = captureExceptionMock.mock.calls[0]!;
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).not.toContain("[object Object]");
+    expect(err.message).toContain("code");
+    expect(err.message).toContain("42");
+  });
+
+  it("renders a key-less object (Event/SyntheticEvent) via its constructor name, not [object …]", () => {
+    // An <img> onError / a DOM Event exposes its fields as prototype getters,
+    // so it has no own enumerable keys → JSON.stringify yields "{}". This class
+    // instance reproduces that shape deterministically (jsdom, unlike real
+    // browsers, adds an own `isTrusted` key to DOM Events).
+    class SyntheticErrorEvent {
+      get type() {
+        return "error";
+      }
+    }
+    captureUnknownError("test.ctx", new SyntheticErrorEvent());
+
+    const [err] = captureExceptionMock.mock.calls[0]!;
+    expect(err.message).not.toContain("[object");
+    expect(err.message).toContain("SyntheticErrorEvent");
+  });
+
+  it("renders a real DOM Event legibly (never [object Event])", () => {
+    captureUnknownError("test.ctx", new Event("error"));
+
+    const [err] = captureExceptionMock.mock.calls[0]!;
+    expect(err.message).not.toContain("[object");
+  });
+
+  it("handles circular references without throwing", () => {
+    const circular: Record<string, unknown> = { a: 1 };
+    circular.self = circular;
+
+    expect(() => captureUnknownError("test.ctx", circular)).not.toThrow();
+    const [err] = captureExceptionMock.mock.calls[0]!;
+    expect(err.message).not.toContain("[object Object]");
+    expect(err.message).toContain("a"); // constructor-name fallback lists keys
+  });
+
+  it("logs via console.warn, never console.error (avoids captureConsole double-capture)", () => {
+    captureUnknownError("test.ctx", "x");
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("captures exactly once per call", () => {
+    captureUnknownError("test.ctx", new Error("once"));
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/utils/captureUnknownError.clienttest.ts
+++ b/web/src/utils/captureUnknownError.clienttest.ts
@@ -95,6 +95,25 @@ describe("captureUnknownError", () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
+  it("prints the context tag exactly once for a non-Error value (no double-tag)", () => {
+    captureUnknownError("auth.signIn.credentials", { reason: "bad" });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]![0]);
+    const occurrences = message.split("[auth.signIn.credentials]").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("prints the context once plus the original message for a real Error", () => {
+    captureUnknownError("auth.signIn.credentials", new Error("kaboom"));
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]![0]);
+    const occurrences = message.split("[auth.signIn.credentials]").length - 1;
+    expect(occurrences).toBe(1);
+    expect(message).toContain("kaboom");
+  });
+
   it("captures exactly once per call", () => {
     captureUnknownError("test.ctx", new Error("once"));
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);

--- a/web/src/utils/captureUnknownError.ts
+++ b/web/src/utils/captureUnknownError.ts
@@ -62,6 +62,11 @@ export function captureUnknownError(
     tags: { area: context },
   });
   // warn, not error → captureConsoleIntegration only captures console.error,
-  // so this line does not create a second, opaque Sentry event.
-  console.warn(`[${context}]`, err.message);
+  // so this line does not create a second, opaque Sentry event. The
+  // synthesized (non-Error) message already carries the `[context]` prefix; a
+  // pass-through Error does not, so add it here only in that branch to keep the
+  // context present exactly once in both cases.
+  console.warn(
+    value instanceof Error ? `[${context}] ${err.message}` : err.message,
+  );
 }

--- a/web/src/utils/captureUnknownError.ts
+++ b/web/src/utils/captureUnknownError.ts
@@ -1,0 +1,67 @@
+import { captureException } from "@sentry/nextjs";
+
+/**
+ * Turn an unknown thrown/logged value into a legible string.
+ *
+ * `String(value)` and template interpolation collapse most objects to the
+ * useless `[object Object]` / `[object ErrorEvent]`. We try `JSON.stringify`
+ * first, and when that yields nothing useful — `"{}"` for objects whose fields
+ * live on the prototype (DOM `Event`s, `DOMException`), or a throw on circular
+ * references — we fall back to a descriptor built from the value's constructor
+ * name and own enumerable keys.
+ */
+function safeStringify(value: unknown): string {
+  try {
+    const json = JSON.stringify(value);
+    if (json !== undefined && json !== "{}") {
+      return json;
+    }
+  } catch {
+    // circular reference or a throwing getter — fall through to describe()
+  }
+  return describeUnknown(value);
+}
+
+function describeUnknown(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value !== "object") return String(value);
+  const ctorName =
+    (value as { constructor?: { name?: string } }).constructor?.name ??
+    "Object";
+  const keys = Object.keys(value as Record<string, unknown>);
+  return keys.length > 0 ? `${ctorName} { ${keys.join(", ")} }` : ctorName;
+}
+
+/**
+ * Report an unknown (possibly non-Error) value to Sentry as a legible Error.
+ *
+ * `instrumentation-client.ts` enables
+ * `captureConsoleIntegration({ levels: ["error"] })`, so every
+ * `console.error(nonError)` also becomes an opaque Sentry event
+ * (`[object Object]` / "Object captured as exception with keys …"). Route
+ * caught-unknown values through here instead: real `Error`s pass through
+ * untouched (stack preserved); anything else is synthesized into an `Error`
+ * with a readable message. We log with `console.warn` (not `console.error`) so
+ * the integration does not double-capture the same failure.
+ */
+export function captureUnknownError(
+  context: string,
+  value: unknown,
+  extra?: Record<string, unknown>,
+): void {
+  const err =
+    value instanceof Error
+      ? value
+      : new Error(
+          `[${context}] ${
+            typeof value === "string" ? value : safeStringify(value)
+          }`,
+        );
+  captureException(err, {
+    extra: { context, ...extra },
+    tags: { area: context },
+  });
+  // warn, not error → captureConsoleIntegration only captures console.error,
+  // so this line does not create a second, opaque Sentry event.
+  console.warn(`[${context}]`, err.message);
+}


### PR DESCRIPTION
## TL;DR

Several frontend error paths send Sentry **opaque non-Error** captures — `Object captured as exception with keys: _reactName…`, `[object TypeError]`, `[object Object]` — which are undiagnosable. The biggest, `resizable-image.tsx`, captures a React **SyntheticEvent** every time a rendered markdown image fails to load: **~227 events / ~60 users across LANGFUSE-5EX + 9 sibling fingerprints**, all noise. This drops that capture and routes the remaining caught-unknown sites through one shared helper that always produces a **legible Error**. Error-reporting only — no behavior change.

## Why

`instrumentation-client.ts` runs `captureConsoleIntegration({ levels: ["error"] })`, so `console.error(nonError)` becomes an opaque Sentry event, and an explicit `captureException(nonError)` does the same. A sweep found the live offenders. The dominant one isn't even a bug — a dead image URL in user content isn't actionable for us, but it was generating hundreds of opaque events. This is the "if we log `[object ErrorEvent]`, fix it everywhere" cleanup.

## What

- **P0 — drop the image-load capture** (`resizable-image.tsx`): `<Image onError>` gave a `SyntheticEvent`, not an Error. Removed the `captureException`; kept the `setHasFetchError(true)` UI fallback. Collapses the entire 5EX cluster (~227 ev / ~60 u).
- **Shared helper** `captureUnknownError(context, value, extra?)`: passes real `Error`s through unchanged (stack preserved); otherwise synthesizes `new Error("[context] " + string|safeStringify(value))` — where `safeStringify` degrades a DOM Event / circular / key-less object to a legible `ConstructorName { keys }` instead of `[object Object]`. Captures once, logs via `console.warn` (so `captureConsoleIntegration` doesn't double-capture).
- **P1 — 8 caught-unknown sites** (auth sign-in/sign-up/enterprise-sso, playground run/command-enter/messages) now use the helper. The sign-in credentials path had a **double-capture** (`captureException` + `console.error` of the same value) — collapsed to one legible capture (halves that issue's volume). LANGFUSE-5R0 (`[object TypeError]`, sign-up) is fixed here.
- **P2 — 3 plain-object logs** (AI-filter builder ×2, dataset-item form) made string-first / removed the redundant one.

## Result

- The 5EX cluster stops (dead-image noise gone); the auth/playground catches now report legible errors; `[object Object]`/`[object TypeError]` from these paths disappear.
- **No behavior change**: every touched site changed only its reporting call — control flow, user-facing errors (`setError`/`setFormError`), and state updates are untouched. Out-of-scope sites (the ~40 post-`mutateAsync` tRPC catches, `_error.tsx`, server logger) deliberately left alone.
- Helper has 8 unit tests (Error pass-through, string, plain object, key-less class, real DOM Event, circular ref, warn-not-error, capture-once). typecheck + eslint + prettier clean across all 12 files.

<details>
<summary>Files, helper semantics, scope</summary>

**New:** `web/src/utils/captureUnknownError.ts` + `.clienttest.ts`.
**P0:** `web/src/components/ui/resizable-image.tsx`.
**P1:** `pages/auth/sign-in.tsx` (3 sites + double-capture collapse), `sign-up.tsx`, `enterprise-sso-required.tsx`, `features/playground/page/{context/index.tsx, hooks/useCommandEnter.ts, components/Messages.tsx}`.
**P2:** `features/filters/components/filter-builder.tsx`, `components/table/data-table-ai-filters.tsx`, `features/datasets/components/NewDatasetItemForm.tsx`.

**`tags.area`** = the small fixed context set (`auth.*`, `playground.run`, …) so Sentry tag cardinality stays bounded. **jsdom vs browser** for Events (own-key vs prototype-getter) both resolve to a legible message — covered by two explicit tests.

**Follow-up (not here):** ~40 component `console.error(error)` after tRPC `mutateAsync` double-capture with the tRPC link's own `captureException` — a separate hygiene cleanup (LFE-10980 territory).
</details>

Surfaced by the nightly Sentry triage (Sentry as signal, not noise). Sentry: LANGFUSE-5EX (+ siblings), LANGFUSE-5R0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR eliminates a class of opaque, undiagnosable Sentry events by removing a noise-generating `captureException` on image-load `SyntheticEvent`s and routing 8 caught-unknown error sites through a new `captureUnknownError` helper. The helper normalises non-Error values into legible `Error` objects (real Errors pass through untouched), uses `console.warn` instead of `console.error` to prevent the `captureConsoleIntegration` from double-firing, and is covered by 8 focused unit tests. No control flow, UI state, or user-facing behaviour changes.

- **New `captureUnknownError` utility** (`web/src/utils/captureUnknownError.ts`): wraps unknown values via `safeStringify` (JSON → constructor-name fallback for prototype-getter objects and circular refs), tags each Sentry event with a bounded `area` context string, and avoids double-capture by logging with `console.warn`.
- **Eight call-sites migrated** across auth sign-in/sign-up/enterprise-SSO and playground run/command-enter/messages; the sign-in credentials path also collapses a pre-existing `captureException` + `console.error` double-fire into a single capture.
- **Three `console.error` log lines** in AI-filter builder and dataset-item form are made string-first or removed to prevent `captureConsoleIntegration` from forwarding plain objects as opaque events.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all changes are isolated to error-reporting paths with no control flow or user-facing behaviour modifications.

The helper's core logic and the eight migrated call-sites are well-tested and the change is tightly scoped. One cosmetic defect in the console.warn call causes the context tag to appear twice in the console output for non-Error values (the test suite checks call count but not call arguments for this case), which is harmless at runtime but slightly misleading in dev/staging logs.

web/src/utils/captureUnknownError.ts — the console.warn line on L66 double-prints the context prefix for wrapped non-Error values.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Error thrown or caught in auth or playground or image] --> B{instanceof Error}
    B -- Yes --> C[Pass Error through stack preserved]
    B -- No --> D{typeof string}
    D -- Yes --> E[new Error with context prefix plus value]
    D -- No --> F{JSON.stringify succeeds and result is not empty object}
    F -- Yes --> G[new Error with context prefix plus json]
    F -- No --> H[describeUnknown CtorName with key list]
    H --> I[new Error with context prefix plus description]
    C --> J[captureException to Sentry tags.area equals context]
    E --> J
    G --> J
    I --> J
    J --> K[console.warn not console.error avoids double-capture]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Error thrown or caught in auth or playground or image] --> B{instanceof Error}
    B -- Yes --> C[Pass Error through stack preserved]
    B -- No --> D{typeof string}
    D -- Yes --> E[new Error with context prefix plus value]
    D -- No --> F{JSON.stringify succeeds and result is not empty object}
    F -- Yes --> G[new Error with context prefix plus json]
    F -- No --> H[describeUnknown CtorName with key list]
    H --> I[new Error with context prefix plus description]
    C --> J[captureException to Sentry tags.area equals context]
    E --> J
    G --> J
    I --> J
    J --> K[console.warn not console.error avoids double-capture]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/utils/captureUnknownError.ts:66
When `value` is a non-Error (the wrapping branch), `err.message` is already prefixed with `[${context}]` (e.g. `"[auth.signIn.credentials] {\"code\":403}"`). Passing `[${context}]` as a separate first argument to `console.warn` then prints the context tag twice — `[auth.signIn.credentials] [auth.signIn.credentials] {"code":403}` — in the console for every non-Error capture. This case isn't covered by the warn-content assertions in the test suite (the test only checks `.toHaveBeenCalledTimes(1)`), so it silently escapes. For the real-Error pass-through path the duplication doesn't occur since the original message has no prefix.

```suggestion
  // For wrapped non-Errors, err.message already starts with `[context]`;
  // log the raw value directly so the prefix doesn't appear twice.
  console.warn(value instanceof Error ? `[${context}] ${err.message}` : err.message);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): stop opaque non-Error Sentry c..."](https://github.com/langfuse/langfuse/commit/8ac3ed760917eead73d43a1808af5b402c4017fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44965574)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->