### PR TITLE
feat(experiments): display average latency with Ø prefix

### DIFF
--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -597,7 +597,7 @@ export default function ExperimentsTable({
       cell: ({ row }) => {
         const value: number | undefined = row.getValue("latencyAvg");
         if (value === undefined || value === null) return undefined;
-        return <span>{numberFormatter(value / 1000, 4)}s</span>;
+        return <span>Ø {numberFormatter(value / 1000, 4)}s</span>;
       },
     },
     {


### PR DESCRIPTION
## Summary
- Prefix average latency values in the experiments table with Ø for clearer readability.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a Ø prefix to average latency values rendered in the experiments table, improving readability by visually distinguishing average metrics from raw values.

- The one-line change in `ExperimentsTable.tsx` wraps the formatted latency with `Ø ` before the number, consistent with how `scores-table-cell.tsx` uses the same symbol for average scores.
- The column header in `filter-config.ts` remains "Latency (s)" without the Ø prefix, creating a minor mismatch between the header label and the cell rendering.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

A one-line display change with no data or logic impact — safe to merge as-is.

The only change is prepending 'Ø ' to the latency cell text. The Ø symbol is already used elsewhere in the codebase for the same purpose, and no data transformation, filtering, or server-side logic is touched. The sole follow-up worth considering is whether the column header should also carry the Ø prefix for full consistency.

No files require special attention; the suggestion to update filter-config.ts is purely cosmetic.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ExperimentsTable row] --> B{latencyAvg defined?}
    B -- No --> C[return undefined]
    B -- Yes --> D["value / 1000 → seconds"]
    D --> E["numberFormatter(seconds, 4)"]
    E --> F["Render: Ø {formatted}s"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ExperimentsTable row] --> B{latencyAvg defined?}
    B -- No --> C[return undefined]
    B -- Yes --> D["value / 1000 → seconds"]
    D --> E["numberFormatter(seconds, 4)"]
    E --> F["Render: Ø {formatted}s"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/experiments/components/table/filter-config.ts:73-76
The column header is currently "Latency (s)" while the cell now renders "Ø X.XXXXs". Aligning the header with the Ø prefix would immediately signal to users that the column shows an average — consistent with how the symbol is used in `scores-table-cell.tsx`.

```suggestion
    name: "Ø Latency (s)",
    id: "latencyAvg",
    type: "number",
    internal: "latency_avg",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(experiments): display average laten..."](https://github.com/langfuse/langfuse/commit/df3eb75a2672a7b007d8474ad9b6d9d09fd6b964) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45011794)</sub>

<!-- /greptile_comment -->