### PR TITLE
fix(web): label average latency values in experiments table

### DIFF
--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -597,7 +597,7 @@ export default function ExperimentsTable({
       cell: ({ row }) => {
         const value: number | undefined = row.getValue("latencyAvg");
         if (value === undefined || value === null) return undefined;
-        return <span>{numberFormatter(value / 1000, 4)}s</span>;
+        return <span>Ø {numberFormatter(value / 1000, 4)}s</span>;
       },
     },
     {


### PR DESCRIPTION
## What does this PR do?

This PR clarifies the experiments table by labeling the displayed latency value as an average. The table now shows “Ø” before the latency value, making it clear that the column represents an average latency rather than a single measurement.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an "Ø" prefix to the latency value rendered in the experiments table cell, making it visually clear that the displayed figure is an average rather than a single measurement. The column header ("Latency (s)") and tooltip ("Average duration of the root span per experiment item") already conveyed this, but the in-cell label closes the gap for users who rely on cell values alone.

- Adds `Ø ` before the formatted latency string in the `latencyAvg` cell renderer in `ExperimentsTable.tsx` — a one-character UI-only change with no logic impact.
- No other latency-related rendering paths are affected; the column definition and data pipeline are unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-character label addition with no logic, data, or API impact.

The only modification is prepending 'Ø ' to the formatted latency string inside the cell renderer. It touches no data fetching, no state, no business logic, and no other components. The column header, tooltip, and backend are all unchanged.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["latencyAvg (ms from server)"] --> B["cell renderer"]
    B --> C{"value defined?"}
    C -- "No" --> D["return undefined (empty cell)"]
    C -- "Yes" --> E["value / 1000 → seconds"]
    E --> F["numberFormatter(value, 4)"]
    F --> G["<span>Ø {formatted}s</span>"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["latencyAvg (ms from server)"] --> B["cell renderer"]
    B --> C{"value defined?"}
    C -- "No" --> D["return undefined (empty cell)"]
    C -- "Yes" --> E["value / 1000 → seconds"]
    E --> F["numberFormatter(value, 4)"]
    F --> G["<span>Ø {formatted}s</span>"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add average latency prefix to experiment..."](https://github.com/langfuse/langfuse/commit/a71fefef2766e064623eb39ee93e1721479a2e3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45013671)</sub>

<!-- /greptile_comment -->