### PR TITLE
fix(prompts): read v4 usage from events

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -32,6 +32,59 @@ export const eventsTraceMetadata = (projectId: string): EventsQueryBuilder =>
     .whereRaw("e.is_deleted = 0")
     .limitBy("e.trace_id");
 
+export const promptEventsForMetrics = (params: {
+  projectId: string;
+  promptIds: string[];
+  fromTimestamp?: string;
+  toTimestamp?: string;
+}): CTEWithSchema => {
+  const builder = new EventsQueryBuilder({ projectId: params.projectId })
+    .selectRaw(
+      "e.project_id AS project_id",
+      "e.prompt_id AS prompt_id",
+      "e.prompt_version AS prompt_version",
+      "e.trace_id AS trace_id",
+      "e.span_id AS span_id",
+      "e.start_time AS start_time",
+      "e.end_time AS end_time",
+      "e.usage_details AS usage_details",
+      "e.cost_details AS cost_details",
+      "e.is_deleted AS is_deleted",
+    )
+    .whereRaw("e.type = 'GENERATION'")
+    .whereRaw("e.prompt_id IN ({promptIds: Array(String)})", {
+      promptIds: params.promptIds,
+    })
+    .when(Boolean(params.fromTimestamp), (b) =>
+      b.whereRaw("e.start_time >= {fromTimestamp: DateTime64(6)}", {
+        fromTimestamp: params.fromTimestamp,
+      }),
+    )
+    .when(Boolean(params.toTimestamp), (b) =>
+      b.whereRaw("e.start_time <= {toTimestamp: DateTime64(6)}", {
+        toTimestamp: params.toTimestamp,
+      }),
+    )
+    .orderByColumns([{ column: "e.event_ts", direction: "DESC" }])
+    .limitBy("e.span_id", "e.project_id");
+
+  return {
+    ...builder.buildWithParams(),
+    schema: [
+      "project_id",
+      "prompt_id",
+      "prompt_version",
+      "trace_id",
+      "span_id",
+      "start_time",
+      "end_time",
+      "usage_details",
+      "cost_details",
+      "is_deleted",
+    ],
+  };
+};
+
 interface EventsTracesAggregationParams {
   projectId: string;
   traceIds?: string[];

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -87,6 +87,7 @@ export {
   eventsTraceMetadata,
   eventsTracesAggregation,
   eventsTracesScoresAggregation,
+  promptEventsForMetrics,
   scoreBooleansAggregation,
 } from "./clickhouse-sql/query-fragments";
 export {

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -561,6 +561,80 @@ export async function getObservationsWithModelDataFromEventsTable(
   });
 }
 
+export const getObservationMetricsForPromptsFromEvents = async (
+  projectId: string,
+  promptIds: string[],
+  {
+    fromTimestamp,
+    toTimestamp,
+  }: { fromTimestamp?: Date; toTimestamp?: Date } = {},
+) => {
+  const queryBuilder = new EventsAggQueryBuilder({
+    projectId,
+    groupByColumn: "e.prompt_id, e.prompt_version",
+    selectExpression: `
+      count(*) AS count,
+      e.prompt_id AS prompt_id,
+      e.prompt_version AS prompt_version,
+      min(e.start_time) AS first_observation,
+      max(e.start_time) AS last_observation,
+      medianExact(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, e.usage_details)))) AS median_input_usage,
+      medianExact(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, e.usage_details)))) AS median_output_usage,
+      medianExact(e.cost_details['total']) AS median_total_cost,
+      medianExact(dateDiff('millisecond', e.start_time, e.end_time)) AS median_latency_ms
+    `,
+  })
+    .whereRaw("e.type = 'GENERATION'")
+    .whereRaw("e.prompt_id IN ({promptIds: Array(String)})", { promptIds })
+    .when(Boolean(fromTimestamp), (builder) =>
+      builder.whereRaw(
+        "e.start_time >= {fromTimestamp: DateTime64(6)}",
+        fromTimestamp
+          ? { fromTimestamp: convertDateToClickhouseDateTime(fromTimestamp) }
+          : undefined,
+      ),
+    )
+    .when(Boolean(toTimestamp), (builder) =>
+      builder.whereRaw(
+        "e.start_time <= {toTimestamp: DateTime64(6)}",
+        toTimestamp
+          ? { toTimestamp: convertDateToClickhouseDateTime(toTimestamp) }
+          : undefined,
+      ),
+    )
+    .orderBy("ORDER BY e.prompt_version DESC");
+
+  const { query, params } = queryBuilder.buildWithParams();
+  const rows = await queryClickhouse<{
+    count: string;
+    prompt_id: string;
+    prompt_version: number;
+    first_observation: string;
+    last_observation: string;
+    median_input_usage: string;
+    median_output_usage: string;
+    median_total_cost: string;
+    median_latency_ms: string;
+  }>({
+    query,
+    params,
+    tags: { projectId },
+    preferredClickhouseService: "EventsReadOnly",
+  });
+
+  return rows.map((row) => ({
+    count: Number(row.count),
+    promptId: row.prompt_id,
+    promptVersion: row.prompt_version,
+    firstObservation: parseClickhouseUTCDateTimeFormat(row.first_observation),
+    lastObservation: parseClickhouseUTCDateTimeFormat(row.last_observation),
+    medianInputUsage: Number(row.median_input_usage),
+    medianOutputUsage: Number(row.median_output_usage),
+    medianTotalCost: Number(row.median_total_cost),
+    medianLatencyMs: Number(row.median_latency_ms),
+  }));
+};
+
 export const getTraceDeleteCursorPageFromEvents = async (props: {
   projectId: string;
   filter: FilterState;

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -57,6 +57,7 @@ import {
   eventsTraceMetadata,
   eventsTracesAggregation,
   eventsTracesScoresAggregation,
+  promptEventsForMetrics,
 } from "../queries/clickhouse-sql/query-fragments";
 import {
   eventsTableNativeUiColumnDefinitions,
@@ -569,39 +570,34 @@ export const getObservationMetricsForPromptsFromEvents = async (
     toTimestamp,
   }: { fromTimestamp?: Date; toTimestamp?: Date } = {},
 ) => {
-  const queryBuilder = new EventsAggQueryBuilder({
-    projectId,
-    groupByColumn: "e.prompt_id, e.prompt_version",
-    selectExpression: `
-      count(*) AS count,
-      e.prompt_id AS prompt_id,
-      e.prompt_version AS prompt_version,
-      min(e.start_time) AS first_observation,
-      max(e.start_time) AS last_observation,
-      medianExact(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, e.usage_details)))) AS median_input_usage,
-      medianExact(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, e.usage_details)))) AS median_output_usage,
-      medianExact(e.cost_details['total']) AS median_total_cost,
-      medianExact(dateDiff('millisecond', e.start_time, e.end_time)) AS median_latency_ms
-    `,
-  })
-    .whereRaw("e.type = 'GENERATION'")
-    .whereRaw("e.prompt_id IN ({promptIds: Array(String)})", { promptIds })
-    .when(Boolean(fromTimestamp), (builder) =>
-      builder.whereRaw(
-        "e.start_time >= {fromTimestamp: DateTime64(6)}",
-        fromTimestamp
+  const queryBuilder = new CTEQueryBuilder()
+    .withCTE(
+      "prompt_events",
+      promptEventsForMetrics({
+        projectId,
+        promptIds,
+        ...(fromTimestamp
           ? { fromTimestamp: convertDateToClickhouseDateTime(fromTimestamp) }
-          : undefined,
-      ),
-    )
-    .when(Boolean(toTimestamp), (builder) =>
-      builder.whereRaw(
-        "e.start_time <= {toTimestamp: DateTime64(6)}",
-        toTimestamp
+          : {}),
+        ...(toTimestamp
           ? { toTimestamp: convertDateToClickhouseDateTime(toTimestamp) }
-          : undefined,
-      ),
+          : {}),
+      }),
     )
+    .from("prompt_events", "e")
+    .select(
+      "count(*) AS count",
+      "e.prompt_id AS prompt_id",
+      "e.prompt_version AS prompt_version",
+      "min(e.start_time) AS first_observation",
+      "max(e.start_time) AS last_observation",
+      "medianExact(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, e.usage_details)))) AS median_input_usage",
+      "medianExact(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, e.usage_details)))) AS median_output_usage",
+      "medianExact(e.cost_details['total']) AS median_total_cost",
+      "medianExact(dateDiff('millisecond', e.start_time, e.end_time)) AS median_latency_ms",
+    )
+    .whereRaw("e.is_deleted = 0")
+    .groupBy("e.prompt_id", "e.prompt_version")
     .orderBy("ORDER BY e.prompt_version DESC");
 
   const { query, params } = queryBuilder.buildWithParams();

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -29,7 +29,7 @@ import {
   orderByToClickhouseSql,
   StringOptionsFilter,
   DateTimeFilter,
-  EventsAggQueryBuilder,
+  CTEQueryBuilder,
   NumberFilter,
 } from "../queries";
 import { FilterCondition, FilterState, TimeFilter } from "../../types";
@@ -68,6 +68,7 @@ import {
   eventsTraceMetadata,
   eventsExperimentTraceIds,
   eventsExperiments,
+  promptEventsForMetrics,
 } from "../queries/clickhouse-sql/query-fragments";
 import { scoresTableCols } from "../../tableDefinitions/scoresTable";
 import {
@@ -2035,7 +2036,7 @@ export const getAggregatedScoresForPrompts = async (
   }));
 };
 
-export const getAggregatedScoresForPromptsFromEvents = async (
+export const buildAggregatedScoresForPromptsFromEventsQuery = (
   projectId: string,
   promptIds: string[],
   fetchScoreRelation: "observation" | "trace",
@@ -2044,87 +2045,109 @@ export const getAggregatedScoresForPromptsFromEvents = async (
     toTimestamp,
   }: { fromTimestamp?: Date; toTimestamp?: Date } = {},
 ) => {
+  const promptEvents = promptEventsForMetrics({
+    projectId,
+    promptIds,
+    ...(fromTimestamp
+      ? { fromTimestamp: convertDateToClickhouseDateTime(fromTimestamp) }
+      : {}),
+    ...(toTimestamp
+      ? { toTimestamp: convertDateToClickhouseDateTime(toTimestamp) }
+      : {}),
+  });
+
   const scoreRows = {
     query: `
       SELECT
-        project_id,
-        trace_id,
-        observation_id,
-        id,
-        name,
-        string_value,
-        value,
-        source,
-        data_type,
-        comment,
-        timestamp,
-        metadata
-      FROM scores FINAL
-      WHERE project_id = {scoreProjectId: String}
-      AND name IS NOT NULL
-      AND data_type IN ({dataTypes: Array(String)})
-      ${fetchScoreRelation === "trace" ? "AND observation_id IS NULL" : "AND observation_id IS NOT NULL"}
+        e.prompt_id AS prompt_id,
+        s.id AS id,
+        s.name AS name,
+        s.string_value AS string_value,
+        s.value AS value,
+        s.source AS source,
+        s.data_type AS data_type,
+        s.comment AS comment,
+        s.timestamp AS timestamp,
+        s.metadata AS metadata
+      FROM scores s FINAL
+      INNER JOIN prompt_events e
+        ON s.project_id = e.project_id
+        AND s.trace_id = e.trace_id
+        ${fetchScoreRelation === "observation" ? "AND s.observation_id = e.span_id" : ""}
+      WHERE s.project_id = {scoreProjectId: String}
+      AND e.is_deleted = 0
+      AND s.name IS NOT NULL
+      AND s.data_type IN ({dataTypes: Array(String)})
+      ${
+        fetchScoreRelation === "trace"
+          ? `AND s.observation_id IS NULL
+      AND s.trace_id IN (SELECT trace_id FROM prompt_events WHERE is_deleted = 0)`
+          : `AND s.observation_id IS NOT NULL
+      AND (s.trace_id, s.observation_id) IN (SELECT trace_id, span_id FROM prompt_events WHERE is_deleted = 0)`
+      }
     `,
     params: {
       scoreProjectId: projectId,
       dataTypes: LISTABLE_SCORE_TYPES,
     },
+    schema: [
+      "prompt_id",
+      "id",
+      "name",
+      "string_value",
+      "value",
+      "source",
+      "data_type",
+      "comment",
+      "timestamp",
+      "metadata",
+    ],
   };
 
-  const queryBuilder = new EventsAggQueryBuilder({
-    projectId,
-    groupByColumn: `
-      e.prompt_id,
-      s.id,
-      s.name,
-      s.string_value,
-      s.value,
-      s.source,
-      s.data_type,
-      s.comment,
-      s.timestamp,
-      s.metadata
-    `,
-    selectExpression: `
-      e.prompt_id AS prompt_id,
-      s.id AS id,
-      s.name AS name,
-      s.string_value AS string_value,
-      s.value AS value,
-      s.source AS source,
-      s.data_type AS data_type,
-      s.comment AS comment,
-      s.timestamp AS timestamp,
-      length(mapKeys(s.metadata)) > 0 AS has_metadata
-    `,
-  })
+  return new CTEQueryBuilder()
+    .withCTE("prompt_events", promptEvents)
     .withCTE("score_rows", scoreRows)
-    .innerJoin(
-      "score_rows s",
-      fetchScoreRelation === "observation"
-        ? "ON s.project_id = e.project_id AND s.trace_id = e.trace_id AND s.observation_id = e.span_id"
-        : "ON s.project_id = e.project_id AND s.trace_id = e.trace_id",
+    .from("score_rows", "s")
+    .select(
+      "s.prompt_id AS prompt_id",
+      "s.id AS id",
+      "s.name AS name",
+      "s.string_value AS string_value",
+      "s.value AS value",
+      "s.source AS source",
+      "s.data_type AS data_type",
+      "s.comment AS comment",
+      "s.timestamp AS timestamp",
+      "length(mapKeys(s.metadata)) > 0 AS has_metadata",
     )
-    .whereRaw("e.type = 'GENERATION'")
-    .whereRaw("e.prompt_id IN ({promptIds: Array(String)})", { promptIds })
-    .when(Boolean(fromTimestamp), (builder) =>
-      builder.whereRaw(
-        "e.start_time >= {fromTimestamp: DateTime64(6)}",
-        fromTimestamp
-          ? { fromTimestamp: convertDateToClickhouseDateTime(fromTimestamp) }
-          : undefined,
-      ),
+    .groupBy(
+      "s.prompt_id",
+      "s.id",
+      "s.name",
+      "s.string_value",
+      "s.value",
+      "s.source",
+      "s.data_type",
+      "s.comment",
+      "s.timestamp",
+      "s.metadata",
     )
-    .when(Boolean(toTimestamp), (builder) =>
-      builder.whereRaw(
-        "e.start_time <= {toTimestamp: DateTime64(6)}",
-        toTimestamp
-          ? { toTimestamp: convertDateToClickhouseDateTime(toTimestamp) }
-          : undefined,
-      ),
-    );
+    .buildWithParams();
+};
 
-  const { query, params } = queryBuilder.buildWithParams();
+export const getAggregatedScoresForPromptsFromEvents = async (
+  projectId: string,
+  promptIds: string[],
+  fetchScoreRelation: "observation" | "trace",
+  timeWindow: { fromTimestamp?: Date; toTimestamp?: Date } = {},
+) => {
+  const { query, params } = buildAggregatedScoresForPromptsFromEventsQuery(
+    projectId,
+    promptIds,
+    fetchScoreRelation,
+    timeWindow,
+  );
+
   const rows = await queryClickhouse<
     ScoreAggregation & {
       prompt_id: string;

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -29,6 +29,7 @@ import {
   orderByToClickhouseSql,
   StringOptionsFilter,
   DateTimeFilter,
+  EventsAggQueryBuilder,
   NumberFilter,
 } from "../queries";
 import { FilterCondition, FilterState, TimeFilter } from "../../types";
@@ -2025,6 +2026,115 @@ export const getAggregatedScoresForPrompts = async (
         : {}),
     },
     tags: { projectId },
+  });
+
+  return rows.map((row) => ({
+    ...convertScoreAggregation<ListableScoreDataType>(row),
+    promptId: row.prompt_id,
+    hasMetadata: !!row.has_metadata,
+  }));
+};
+
+export const getAggregatedScoresForPromptsFromEvents = async (
+  projectId: string,
+  promptIds: string[],
+  fetchScoreRelation: "observation" | "trace",
+  {
+    fromTimestamp,
+    toTimestamp,
+  }: { fromTimestamp?: Date; toTimestamp?: Date } = {},
+) => {
+  const scoreRows = {
+    query: `
+      SELECT
+        project_id,
+        trace_id,
+        observation_id,
+        id,
+        name,
+        string_value,
+        value,
+        source,
+        data_type,
+        comment,
+        timestamp,
+        metadata
+      FROM scores FINAL
+      WHERE project_id = {scoreProjectId: String}
+      AND name IS NOT NULL
+      AND data_type IN ({dataTypes: Array(String)})
+      ${fetchScoreRelation === "trace" ? "AND observation_id IS NULL" : "AND observation_id IS NOT NULL"}
+    `,
+    params: {
+      scoreProjectId: projectId,
+      dataTypes: LISTABLE_SCORE_TYPES,
+    },
+  };
+
+  const queryBuilder = new EventsAggQueryBuilder({
+    projectId,
+    groupByColumn: `
+      e.prompt_id,
+      s.id,
+      s.name,
+      s.string_value,
+      s.value,
+      s.source,
+      s.data_type,
+      s.comment,
+      s.timestamp,
+      s.metadata
+    `,
+    selectExpression: `
+      e.prompt_id AS prompt_id,
+      s.id AS id,
+      s.name AS name,
+      s.string_value AS string_value,
+      s.value AS value,
+      s.source AS source,
+      s.data_type AS data_type,
+      s.comment AS comment,
+      s.timestamp AS timestamp,
+      length(mapKeys(s.metadata)) > 0 AS has_metadata
+    `,
+  })
+    .withCTE("score_rows", scoreRows)
+    .innerJoin(
+      "score_rows s",
+      fetchScoreRelation === "observation"
+        ? "ON s.project_id = e.project_id AND s.trace_id = e.trace_id AND s.observation_id = e.span_id"
+        : "ON s.project_id = e.project_id AND s.trace_id = e.trace_id",
+    )
+    .whereRaw("e.type = 'GENERATION'")
+    .whereRaw("e.prompt_id IN ({promptIds: Array(String)})", { promptIds })
+    .when(Boolean(fromTimestamp), (builder) =>
+      builder.whereRaw(
+        "e.start_time >= {fromTimestamp: DateTime64(6)}",
+        fromTimestamp
+          ? { fromTimestamp: convertDateToClickhouseDateTime(fromTimestamp) }
+          : undefined,
+      ),
+    )
+    .when(Boolean(toTimestamp), (builder) =>
+      builder.whereRaw(
+        "e.start_time <= {toTimestamp: DateTime64(6)}",
+        toTimestamp
+          ? { toTimestamp: convertDateToClickhouseDateTime(toTimestamp) }
+          : undefined,
+      ),
+    );
+
+  const { query, params } = queryBuilder.buildWithParams();
+  const rows = await queryClickhouse<
+    ScoreAggregation & {
+      prompt_id: string;
+      has_metadata: 0 | 1;
+    }
+  >({
+    query,
+    params,
+    tags: { projectId },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   return rows.map((row) => ({

--- a/web/src/__tests__/server/api/tables/prompts-ui.servertest.ts
+++ b/web/src/__tests__/server/api/tables/prompts-ui.servertest.ts
@@ -13,7 +13,11 @@ import {
   getObservationMetricsForPromptsFromEvents,
   getObservationsWithPromptName,
 } from "@langfuse/shared/src/server";
+import { env } from "@/src/env.mjs";
 import { v4 } from "uuid";
+
+const itIfEventsTable =
+  env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true" ? it : it.skip;
 
 describe("UI Prompts Table", () => {
   it("should count the observations which belong to a prompt", async () => {
@@ -322,94 +326,102 @@ describe("UI Prompts Table", () => {
     );
   });
 
-  it("should correctly calculate prompt metrics from events", async () => {
-    const projectId = v4();
-    const promptId = v4();
-    const startTime = Date.parse("2026-07-16T13:42:33.028Z") * 1000;
+  itIfEventsTable(
+    "should correctly calculate prompt metrics from events",
+    async () => {
+      const projectId = v4();
+      const promptId = v4();
+      const startTime = Date.parse("2026-07-16T13:42:33.028Z") * 1000;
 
-    await createEventsCh([
-      createEvent({
+      await createEventsCh([
+        createEvent({
+          project_id: projectId,
+          trace_id: v4(),
+          span_id: v4(),
+          type: "GENERATION",
+          prompt_id: promptId,
+          prompt_name: "folder/test-prompt",
+          prompt_version: 7,
+          start_time: startTime,
+          end_time: startTime + 2_000_000,
+          usage_details: { input: 100, output: 200, total: 300 },
+          cost_details: { input: 1, output: 2, total: 3 },
+        }),
+      ]);
+
+      const result = await getObservationMetricsForPromptsFromEvents(
+        projectId,
+        [promptId],
+      );
+
+      expect(result).toEqual([
+        {
+          count: 1,
+          firstObservation: new Date("2026-07-16T13:42:33.028Z"),
+          lastObservation: new Date("2026-07-16T13:42:33.028Z"),
+          medianInputUsage: 100,
+          medianLatencyMs: 2000,
+          medianOutputUsage: 200,
+          medianTotalCost: 3,
+          promptId,
+          promptVersion: 7,
+        },
+      ]);
+    },
+  );
+
+  itIfEventsTable(
+    "should aggregate only the latest event version for prompt metrics",
+    async () => {
+      const projectId = v4();
+      const promptId = v4();
+      const traceId = v4();
+      const spanId = v4();
+      const startTime = Date.parse("2026-07-16T13:42:33.028Z") * 1000;
+      const event = createEvent({
         project_id: projectId,
-        trace_id: v4(),
-        span_id: v4(),
+        trace_id: traceId,
+        span_id: spanId,
         type: "GENERATION",
         prompt_id: promptId,
         prompt_name: "folder/test-prompt",
         prompt_version: 7,
         start_time: startTime,
-        end_time: startTime + 2_000_000,
+        end_time: startTime + 1_000_000,
+        event_ts: startTime,
         usage_details: { input: 100, output: 200, total: 300 },
         cost_details: { input: 1, output: 2, total: 3 },
-      }),
-    ]);
+      });
 
-    const result = await getObservationMetricsForPromptsFromEvents(projectId, [
-      promptId,
-    ]);
+      await createEventsCh([event]);
+      await createEventsCh([
+        {
+          ...event,
+          end_time: startTime + 4_000_000,
+          event_ts: startTime + 1_000_000,
+          usage_details: { input: 400, output: 500, total: 900 },
+          cost_details: { input: 4, output: 5, total: 9 },
+        },
+      ]);
 
-    expect(result).toEqual([
-      {
-        count: 1,
-        firstObservation: new Date("2026-07-16T13:42:33.028Z"),
-        lastObservation: new Date("2026-07-16T13:42:33.028Z"),
-        medianInputUsage: 100,
-        medianLatencyMs: 2000,
-        medianOutputUsage: 200,
-        medianTotalCost: 3,
-        promptId,
-        promptVersion: 7,
-      },
-    ]);
-  });
+      const result = await getObservationMetricsForPromptsFromEvents(
+        projectId,
+        [promptId],
+      );
 
-  it("should aggregate only the latest event version for prompt metrics", async () => {
-    const projectId = v4();
-    const promptId = v4();
-    const traceId = v4();
-    const spanId = v4();
-    const startTime = Date.parse("2026-07-16T13:42:33.028Z") * 1000;
-    const event = createEvent({
-      project_id: projectId,
-      trace_id: traceId,
-      span_id: spanId,
-      type: "GENERATION",
-      prompt_id: promptId,
-      prompt_name: "folder/test-prompt",
-      prompt_version: 7,
-      start_time: startTime,
-      end_time: startTime + 1_000_000,
-      event_ts: startTime,
-      usage_details: { input: 100, output: 200, total: 300 },
-      cost_details: { input: 1, output: 2, total: 3 },
-    });
+      expect(result).toEqual([
+        expect.objectContaining({
+          count: 1,
+          medianInputUsage: 400,
+          medianLatencyMs: 4000,
+          medianOutputUsage: 500,
+          medianTotalCost: 9,
+        }),
+      ]);
+    },
+  );
 
-    await createEventsCh([event]);
-    await createEventsCh([
-      {
-        ...event,
-        end_time: startTime + 4_000_000,
-        event_ts: startTime + 1_000_000,
-        usage_details: { input: 400, output: 500, total: 900 },
-        cost_details: { input: 4, output: 5, total: 9 },
-      },
-    ]);
-
-    const result = await getObservationMetricsForPromptsFromEvents(projectId, [
-      promptId,
-    ]);
-
-    expect(result).toEqual([
-      expect.objectContaining({
-        count: 1,
-        medianInputUsage: 400,
-        medianLatencyMs: 4000,
-        medianOutputUsage: 500,
-        medianTotalCost: 9,
-      }),
-    ]);
-  });
-
-  it("should fetch prompt scores from events", async () => {
+  itIfEventsTable("should fetch prompt scores from events", async () => {
     const projectId = v4();
     const promptId = v4();
     const traceId = v4();

--- a/web/src/__tests__/server/api/tables/prompts-ui.servertest.ts
+++ b/web/src/__tests__/server/api/tables/prompts-ui.servertest.ts
@@ -1,9 +1,15 @@
 import {
+  createEvent,
+  createEventsCh,
   createObservation,
   createObservationsCh,
+  createScoresCh,
+  createTraceScore,
 } from "@langfuse/shared/src/server";
 import {
+  getAggregatedScoresForPromptsFromEvents,
   getObservationMetricsForPrompts,
+  getObservationMetricsForPromptsFromEvents,
   getObservationsWithPromptName,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
@@ -313,6 +319,109 @@ describe("UI Prompts Table", () => {
         },
       ]),
     );
+  });
+
+  it("should correctly calculate prompt metrics from events", async () => {
+    const projectId = v4();
+    const promptId = v4();
+    const startTime = Date.parse("2026-07-16T13:42:33.028Z") * 1000;
+
+    await createEventsCh([
+      createEvent({
+        project_id: projectId,
+        trace_id: v4(),
+        span_id: v4(),
+        type: "GENERATION",
+        prompt_id: promptId,
+        prompt_name: "folder/test-prompt",
+        prompt_version: 7,
+        start_time: startTime,
+        end_time: startTime + 2_000_000,
+        usage_details: { input: 100, output: 200, total: 300 },
+        cost_details: { input: 1, output: 2, total: 3 },
+      }),
+    ]);
+
+    const result = await getObservationMetricsForPromptsFromEvents(projectId, [
+      promptId,
+    ]);
+
+    expect(result).toEqual([
+      {
+        count: 1,
+        firstObservation: new Date("2026-07-16T13:42:33.028Z"),
+        lastObservation: new Date("2026-07-16T13:42:33.028Z"),
+        medianInputUsage: 100,
+        medianLatencyMs: 2000,
+        medianOutputUsage: 200,
+        medianTotalCost: 3,
+        promptId,
+        promptVersion: 7,
+      },
+    ]);
+  });
+
+  it("should fetch prompt scores from events", async () => {
+    const projectId = v4();
+    const promptId = v4();
+    const traceId = v4();
+    const spanId = v4();
+
+    await Promise.all([
+      createEventsCh([
+        createEvent({
+          project_id: projectId,
+          trace_id: traceId,
+          span_id: spanId,
+          type: "GENERATION",
+          prompt_id: promptId,
+          prompt_name: "folder/test-prompt",
+          prompt_version: 7,
+        }),
+      ]),
+      createScoresCh([
+        createTraceScore({
+          id: v4(),
+          project_id: projectId,
+          trace_id: traceId,
+          observation_id: spanId,
+          name: "observation-score",
+          value: 1,
+        }),
+        createTraceScore({
+          id: v4(),
+          project_id: projectId,
+          trace_id: traceId,
+          observation_id: null,
+          name: "trace-score",
+          value: 2,
+        }),
+      ]),
+    ]);
+
+    const [observationScores, traceScores] = await Promise.all([
+      getAggregatedScoresForPromptsFromEvents(
+        projectId,
+        [promptId],
+        "observation",
+      ),
+      getAggregatedScoresForPromptsFromEvents(projectId, [promptId], "trace"),
+    ]);
+
+    expect(observationScores).toEqual([
+      expect.objectContaining({
+        promptId,
+        name: "observation-score",
+        value: 1,
+      }),
+    ]);
+    expect(traceScores).toEqual([
+      expect.objectContaining({
+        promptId,
+        name: "trace-score",
+        value: 2,
+      }),
+    ]);
   });
 
   it("should filter prompt metrics by date range", async () => {

--- a/web/src/__tests__/server/api/tables/prompts-ui.servertest.ts
+++ b/web/src/__tests__/server/api/tables/prompts-ui.servertest.ts
@@ -8,6 +8,7 @@ import {
 } from "@langfuse/shared/src/server";
 import {
   getAggregatedScoresForPromptsFromEvents,
+  buildAggregatedScoresForPromptsFromEventsQuery,
   getObservationMetricsForPrompts,
   getObservationMetricsForPromptsFromEvents,
   getObservationsWithPromptName,
@@ -361,6 +362,53 @@ describe("UI Prompts Table", () => {
     ]);
   });
 
+  it("should aggregate only the latest event version for prompt metrics", async () => {
+    const projectId = v4();
+    const promptId = v4();
+    const traceId = v4();
+    const spanId = v4();
+    const startTime = Date.parse("2026-07-16T13:42:33.028Z") * 1000;
+    const event = createEvent({
+      project_id: projectId,
+      trace_id: traceId,
+      span_id: spanId,
+      type: "GENERATION",
+      prompt_id: promptId,
+      prompt_name: "folder/test-prompt",
+      prompt_version: 7,
+      start_time: startTime,
+      end_time: startTime + 1_000_000,
+      event_ts: startTime,
+      usage_details: { input: 100, output: 200, total: 300 },
+      cost_details: { input: 1, output: 2, total: 3 },
+    });
+
+    await createEventsCh([event]);
+    await createEventsCh([
+      {
+        ...event,
+        end_time: startTime + 4_000_000,
+        event_ts: startTime + 1_000_000,
+        usage_details: { input: 400, output: 500, total: 900 },
+        cost_details: { input: 4, output: 5, total: 9 },
+      },
+    ]);
+
+    const result = await getObservationMetricsForPromptsFromEvents(projectId, [
+      promptId,
+    ]);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        count: 1,
+        medianInputUsage: 400,
+        medianLatencyMs: 4000,
+        medianOutputUsage: 500,
+        medianTotalCost: 9,
+      }),
+    ]);
+  });
+
   it("should fetch prompt scores from events", async () => {
     const projectId = v4();
     const promptId = v4();
@@ -422,6 +470,19 @@ describe("UI Prompts Table", () => {
         value: 2,
       }),
     ]);
+  });
+
+  it("should prefilter scores by prompt event identifiers before joining", () => {
+    const { query } = buildAggregatedScoresForPromptsFromEventsQuery(
+      v4(),
+      [v4()],
+      "observation",
+    );
+
+    expect(query).toContain("INNER JOIN prompt_events");
+    expect(query).toContain(
+      "(s.trace_id, s.observation_id) IN (SELECT trace_id, span_id FROM prompt_events",
+    );
   });
 
   it("should filter prompt metrics by date range", async () => {

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -203,6 +203,8 @@ export type EventsTableRow = {
 export type EventsTableProps = {
   projectId: string;
   userId?: string;
+  promptName?: string;
+  promptVersion?: number;
   omittedFilter?: ObservationEventsOmittableFilterColumn[];
   hideControls?: boolean;
   // External control props for embedded preview tables
@@ -249,6 +251,8 @@ const toStartTimeFilterState = (range?: TableDateRange): FilterState =>
 export default function ObservationsEventsTable({
   projectId,
   userId,
+  promptName,
+  promptVersion,
   omittedFilter = [],
   hideControls = false,
   externalFilterState,
@@ -633,12 +637,36 @@ export default function ObservationsEventsTable({
       ]
     : [];
 
+  const promptNameFilter: FilterState = promptName
+    ? [
+        {
+          column: "promptName",
+          type: "string",
+          operator: "=",
+          value: promptName,
+        },
+      ]
+    : [];
+
+  const promptVersionFilter: FilterState = promptVersion
+    ? [
+        {
+          column: "promptVersion",
+          type: "number",
+          operator: "=",
+          value: promptVersion,
+        },
+      ]
+    : [];
+
   // The sidebar's effective filter state is the single source of truth in both
   // modes — the search bar syncs into it rather than replacing it.
   const combinedFilterState = queryFilter.effectiveFilterState
     .concat(dateRangeFilter)
     .concat(userIdFilter)
-    .concat(sessionIdFilter);
+    .concat(sessionIdFilter)
+    .concat(promptNameFilter)
+    .concat(promptVersionFilter);
 
   // Use external filter state if provided, otherwise use combined filter
   // state. Even with an external filter, still apply the date-range bound so

--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -75,7 +75,10 @@ export const migrateLegacyRootObservationFilters = (
   });
 };
 
-export type ObservationEventsOmittableFilterColumn = "sessionId" | "userId";
+export type ObservationEventsOmittableFilterColumn =
+  | "sessionId"
+  | "userId"
+  | "promptName";
 
 export const observationEventsFilterConfig: FilterConfig = {
   tableName: "observations-events",

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -33,7 +33,9 @@ import {
 import { PromptHistoryNode } from "./prompt-history";
 import { JumpToPlaygroundButton } from "@/src/features/playground/page/components/JumpToPlaygroundButton";
 import { ChatMlArraySchema } from "@/src/components/schemas/ChatMlSchema";
-import Generations from "@/src/components/table/use-cases/observations";
+import LegacyGenerations from "@/src/components/table/use-cases/observations";
+import EventsTable from "@/src/features/events/components/EventsTable";
+import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { FlaskConical, MoreVertical, Plus } from "lucide-react";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { Button } from "@/src/components/ui/button";
@@ -112,6 +114,7 @@ export const PromptDetail = ({
   const projectId = useProjectIdFromURL();
   const capture = usePostHogClientCapture();
   const router = useRouter();
+  const { isBetaEnabled } = useV4Beta();
 
   const promptName =
     promptNameProp ||
@@ -490,12 +493,21 @@ export const PromptDetail = ({
               className="mt-0 mb-2 flex max-h-full min-h-0 flex-1 flex-col overflow-hidden"
             >
               <div className="flex h-full flex-1 flex-col overflow-hidden">
-                <Generations
-                  projectId={prompt.projectId}
-                  promptName={prompt.name}
-                  promptVersion={prompt.version}
-                  omittedFilter={["promptName"]}
-                />
+                {isBetaEnabled ? (
+                  <EventsTable
+                    projectId={prompt.projectId}
+                    promptName={prompt.name}
+                    promptVersion={prompt.version}
+                    omittedFilter={["promptName"]}
+                  />
+                ) : (
+                  <LegacyGenerations
+                    projectId={prompt.projectId}
+                    promptName={prompt.name}
+                    promptVersion={prompt.version}
+                    omittedFilter={["promptName"]}
+                  />
+                )}
               </div>
             </TabsBarContent>
             <TabsBarContent

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -35,7 +35,9 @@ import {
   tableColumnsToSqlFilterAndPrefix,
   getObservationsWithPromptName,
   getObservationMetricsForPrompts,
+  getObservationMetricsForPromptsFromEvents,
   getAggregatedScoresForPrompts,
+  getAggregatedScoresForPromptsFromEvents,
   postgresSearchCondition,
 } from "@langfuse/shared/src/server";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
@@ -1287,6 +1289,7 @@ export const promptRouter = createTRPCRouter({
     )
     .query(async ({ input, ctx }) => {
       const { projectId, promptIds, ...timeWindow } = input;
+      const useEventsTable = ctx.session.user.v4BetaEnabled === true;
 
       throwIfNoProjectAccess({
         session: ctx.session,
@@ -1294,10 +1297,29 @@ export const promptRouter = createTRPCRouter({
         scope: "prompts:read",
       });
 
+      const getPromptMetrics = useEventsTable
+        ? getObservationMetricsForPromptsFromEvents
+        : getObservationMetricsForPrompts;
+      const getPromptScores = useEventsTable
+        ? getAggregatedScoresForPromptsFromEvents
+        : getAggregatedScoresForPrompts;
+
       const [observations, observationScores, traceScores] = await Promise.all([
-        getObservationMetricsForPrompts(projectId, promptIds, timeWindow),
-        getScoresForPromptIds(projectId, promptIds, "observation", timeWindow),
-        getScoresForPromptIds(projectId, promptIds, "trace", timeWindow),
+        getPromptMetrics(projectId, promptIds, timeWindow),
+        getScoresForPromptIds(
+          projectId,
+          promptIds,
+          "observation",
+          timeWindow,
+          getPromptScores,
+        ),
+        getScoresForPromptIds(
+          projectId,
+          promptIds,
+          "trace",
+          timeWindow,
+          getPromptScores,
+        ),
       ]);
 
       return observations.map((r) => {
@@ -1499,8 +1521,9 @@ const getScoresForPromptIds = async (
     fromTimestamp?: Date;
     toTimestamp?: Date;
   } = {},
+  getScores: typeof getAggregatedScoresForPrompts = getAggregatedScoresForPrompts,
 ) => {
-  const scores = await getAggregatedScoresForPrompts(
+  const scores = await getScores(
     projectId,
     promptIds,
     fetchScoreRelation,


### PR DESCRIPTION
## What
- read prompt version metrics and linked scores from events_core when Fast Preview/V4 is enabled
- render the V4 events table for linked generations while preserving the legacy observations path
- add regression coverage for event-backed prompt usage, cost, latency, and score lookup

## Root cause
Prompt detail already resolved prompt metadata from V4 events, but the Linked Generations tab and Metrics route still queried the legacy observations table. Events-only generations therefore linked to the prompt from their detail page while the prompt page showed no usage.

## Verification
- pnpm --filter web run test src/__tests__/server/api/tables/prompts-ui.servertest.ts — Tests 7 passed (7)
- pnpm run lint — Tasks: 7 successful, 7 total
- pnpm --filter web run typecheck — passed
- pnpm --filter worker run typecheck — passed
- seeded local browser review in V4: linked event visible; metrics showed count 1, input 17, output 1, and expected cost

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a gap where the Linked Generations tab and Metrics route still queried the legacy `observations` table even when the V4/Fast Preview beta was enabled, causing events-only generations to appear in the prompt detail page but not in the usage metrics or linked generations list.

- Adds `getObservationMetricsForPromptsFromEvents` and `getAggregatedScoresForPromptsFromEvents` to query `events_core` and `scores` tables via `EventsAggQueryBuilder`, gated behind `v4BetaEnabled` in the prompt router.
- Conditionally renders `EventsTable` or `LegacyGenerations` in the linked generations tab based on the beta flag, adding `promptName`/`promptVersion` prop filters to `EventsTable`.
- Adds server-side regression tests covering event-backed metrics, observation scores, and trace scores.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for V4 beta users; legacy path is untouched and the two findings are non-blocking.

The correctness of the events queries is solid and the tests verify all key cases. The only active concern is that `promptVersion` is not hidden from the sidebar filter panel when viewing a specific prompt version's linked generations — a user who manually adds a version filter from the sidebar will inadvertently see zero results. The `scoreRows` CTE also materializes all project scores before the join, which could show slower query times on large projects.

`web/src/features/prompts/components/prompt-detail.tsx` and `web/src/features/events/config/filter-config.ts` for the missing `promptVersion` omitted filter; `packages/shared/src/server/repositories/scores.ts` for the `scoreRows` CTE scan on high-volume projects.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as prompt-detail.tsx
    participant Router as promptRouter.ts
    participant EventRepo as events.ts (repo)
    participant ScoresRepo as scores.ts (repo)
    participant CH as ClickHouse (events_core / scores)

    UI->>Router: metrics query (promptIds, timeWindow)
    Router->>Router: check ctx.session.user.v4BetaEnabled
    alt V4 Beta enabled
        Router->>EventRepo: getObservationMetricsForPromptsFromEvents()
        EventRepo->>CH: SELECT count/median metrics FROM events_core WHERE prompt_id IN (...)
        CH-->>EventRepo: metric rows
        EventRepo-->>Router: mapped metrics[]
        Router->>ScoresRepo: getAggregatedScoresForPromptsFromEvents(observation)
        ScoresRepo->>CH: "WITH score_rows AS (SELECT FROM scores WHERE project_id=...) SELECT FROM events_core INNER JOIN score_rows ON trace_id+span_id"
        CH-->>ScoresRepo: score rows
        Router->>ScoresRepo: getAggregatedScoresForPromptsFromEvents(trace)
        ScoresRepo->>CH: "WITH score_rows AS (SELECT FROM scores WHERE project_id=...) SELECT FROM events_core INNER JOIN score_rows ON trace_id"
        CH-->>ScoresRepo: score rows
    else Legacy path
        Router->>EventRepo: getObservationMetricsForPrompts()
        EventRepo->>CH: SELECT FROM observations WHERE prompt_id IN (...)
        CH-->>EventRepo: metric rows
        Router->>ScoresRepo: getAggregatedScoresForPrompts()
        ScoresRepo->>CH: SELECT FROM observations o LEFT JOIN scores s ON ...
        CH-->>ScoresRepo: score rows
    end
    Router-->>UI: observations[] with merged scores
    UI->>UI: isBetaEnabled?
    alt V4 Beta
        UI->>UI: render EventsTable(promptName, promptVersion)
    else Legacy
        UI->>UI: render LegacyGenerations(promptName, promptVersion)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as prompt-detail.tsx
    participant Router as promptRouter.ts
    participant EventRepo as events.ts (repo)
    participant ScoresRepo as scores.ts (repo)
    participant CH as ClickHouse (events_core / scores)

    UI->>Router: metrics query (promptIds, timeWindow)
    Router->>Router: check ctx.session.user.v4BetaEnabled
    alt V4 Beta enabled
        Router->>EventRepo: getObservationMetricsForPromptsFromEvents()
        EventRepo->>CH: SELECT count/median metrics FROM events_core WHERE prompt_id IN (...)
        CH-->>EventRepo: metric rows
        EventRepo-->>Router: mapped metrics[]
        Router->>ScoresRepo: getAggregatedScoresForPromptsFromEvents(observation)
        ScoresRepo->>CH: "WITH score_rows AS (SELECT FROM scores WHERE project_id=...) SELECT FROM events_core INNER JOIN score_rows ON trace_id+span_id"
        CH-->>ScoresRepo: score rows
        Router->>ScoresRepo: getAggregatedScoresForPromptsFromEvents(trace)
        ScoresRepo->>CH: "WITH score_rows AS (SELECT FROM scores WHERE project_id=...) SELECT FROM events_core INNER JOIN score_rows ON trace_id"
        CH-->>ScoresRepo: score rows
    else Legacy path
        Router->>EventRepo: getObservationMetricsForPrompts()
        EventRepo->>CH: SELECT FROM observations WHERE prompt_id IN (...)
        CH-->>EventRepo: metric rows
        Router->>ScoresRepo: getAggregatedScoresForPrompts()
        ScoresRepo->>CH: SELECT FROM observations o LEFT JOIN scores s ON ...
        CH-->>ScoresRepo: score rows
    end
    Router-->>UI: observations[] with merged scores
    UI->>UI: isBetaEnabled?
    alt V4 Beta
        UI->>UI: render EventsTable(promptName, promptVersion)
    else Legacy
        UI->>UI: render LegacyGenerations(promptName, promptVersion)
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/prompts/components/prompt-detail.tsx:503-510
**`promptVersion` omittable filter not applied in prompt detail**

`promptName` is in `omittedFilter` so the sidebar hides it and can't generate a conflicting user filter, but `promptVersion` is not. A user on the linked-generations tab could add a "Prompt Version" filter from the sidebar set to a different version; the prop-injected filter and the user-added filter would both land in `combinedFilterState` and combine with AND logic (`e.prompt_version = 5 AND e.prompt_version = 3`), always yielding zero rows. Adding `"promptVersion"` to `ObservationEventsOmittableFilterColumn` and passing it in `omittedFilter` here would prevent the conflict, matching how `promptName` is handled.

### Issue 2 of 2
packages/shared/src/server/repositories/scores.ts:2047-2072
**`scoreRows` CTE pre-materializes all project scores**

The `scoreRows` CTE fetches every score in the project (`WHERE project_id = {scoreProjectId}`) before the join with the events table narrows results to the relevant `promptIds`. ClickHouse will build a hash table from the full CTE before applying join filters. For projects with millions of scores this could be significantly slower than the legacy query, which filters directly on `o.prompt_id IN (...)` before joining scores. Consider adding a pre-filter using a sub-query or semi-join on `trace_id` to reduce the CTE scan size.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into hassiebbot/inve..."](https://github.com/langfuse/langfuse/commit/743e979b63906272cb6d156ea5423003c7035a41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45036883)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->