### PR TITLE
fix(web): preserve casing of prompt version labels in UI

### DIFF
--- a/web/src/components/TruncatedLabels.tsx
+++ b/web/src/components/TruncatedLabels.tsx
@@ -66,6 +66,7 @@ export function TruncatedLabels({
             key={label}
             className={cn("break-all sm:break-normal", badgeClassName)}
             isLive={label === PRODUCTION_LABEL}
+            preserveCase
           />
         ),
       )}
@@ -104,6 +105,7 @@ export function TruncatedLabels({
                         badgeClassName,
                       )}
                       isLive={label === PRODUCTION_LABEL}
+                      preserveCase
                     />
                   ),
                 )}

--- a/web/src/components/layouts/status-badge.tsx
+++ b/web/src/components/layouts/status-badge.tsx
@@ -20,12 +20,14 @@ export const StatusBadge = ({
   isLive = true,
   className,
   showText = true,
+  preserveCase = false,
   children,
 }: {
   type: Status | (string & {});
   isLive?: boolean;
   className?: string;
   showText?: boolean;
+  preserveCase?: boolean;
   children?: ReactNode;
 }) => {
   let badgeColor = "bg-muted-gray text-primary";
@@ -85,7 +87,11 @@ export const StatusBadge = ({
           ></span>
         </span>
       )}
-      {showText && type && <span>{type[0].toUpperCase() + type.slice(1)}</span>}
+      {showText && type && (
+        <span>
+          {preserveCase ? type : type[0].toUpperCase() + type.slice(1)}
+        </span>
+      )}
       {children}
     </div>
   );

--- a/web/src/features/prompts/components/ProtectedLabelsSettings.tsx
+++ b/web/src/features/prompts/components/ProtectedLabelsSettings.tsx
@@ -122,6 +122,7 @@ export default function ProtectedLabelsSettings({
               key={label}
               className="break-all sm:break-normal"
               isLive={label === PRODUCTION_LABEL}
+              preserveCase
             >
               {hasAccess && hasEntitlement && (
                 <Button


### PR DESCRIPTION
## Problem

Prompt version labels are displayed with their first letter capitalized in the web UI (e.g. a label stored as `production` or `var_h` renders as `Production` / `Var_h`), while the actual stored/API value is lowercase. This mismatch between the UI and the value used in code is confusing — reported as a customer feature request.

The capitalization came from the shared `StatusBadge` component, which uppercases the first character of its text (`type[0].toUpperCase() + type.slice(1)`). Prompt labels render through `StatusBadge` via `TruncatedLabels`.

## Fix

- Add an opt-in `preserveCase` prop to `StatusBadge` (default `false`, so every other status badge across the app — evals, batch jobs, datasets, integrations, etc. — is unchanged).
- Set `preserveCase` on the prompt-label render path in `TruncatedLabels`, which is used exclusively for prompt labels (prompt detail, history, experiments prompt picker, prompt metrics).

Prompt labels now render exactly as stored. Purely cosmetic; no data, API, or filtering behavior changes.

## Scope / blast radius

`StatusBadge` is shared across ~28 files. Keeping the transform as the default and opting out only on the prompt path means this PR does **not** re-case status text anywhere else.

## Verification

- `pnpm --filter web run lint` — passed (`Tasks: 7 successful, 7 total` via pre-commit turbo lint).
- Repo-wide `typecheck` currently fails on `main` for unrelated files (stale generated artifacts / unrelated in-flight type changes in sessions, blobstorage, mixpanel, experiments, etc.); the two files changed here have no type errors.
- Worth a visual check on the per-PR preview: prompt detail + version history label badges should show lowercase/original casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in `preserveCase` prop to `StatusBadge` and sets it on the prompt-label render path in `TruncatedLabels`, so prompt version labels (e.g. `production`, `var_h`) display exactly as stored instead of being capitalized. The change is backward-compatible — all other callers of `StatusBadge` keep the existing uppercasing behaviour.

- **`status-badge.tsx`**: Adds `preserveCase?: boolean` (default `false`); when true, `type` is rendered verbatim instead of `type[0].toUpperCase() + type.slice(1)`.
- **`TruncatedLabels.tsx`**: Passes `preserveCase` to both `StatusBadge` renders (visible labels and the hover-card overflow list), while the `showSimpleBadges` path that already renders labels verbatim is untouched.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely cosmetic, backward-compatible, and scoped to prompt labels only.

The change is two files, one new boolean prop with a safe default, and two call-sites that opt in. Every other consumer of StatusBadge across the ~28 files is unaffected, and the showSimpleBadges path in TruncatedLabels was already rendering labels verbatim. No data, API, or business logic is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TruncatedLabels] -->|showSimpleBadges=true| B[Plain div — label rendered verbatim]
    A -->|showSimpleBadges=false| C[StatusBadge with preserveCase=true]
    C --> D{preserveCase?}
    D -->|true — prompt labels| E[Render type as-is]
    D -->|false — all other callers| F[Render type with first char uppercased]
    G[All other StatusBadge callers] --> D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[TruncatedLabels] -->|showSimpleBadges=true| B[Plain div — label rendered verbatim]
    A -->|showSimpleBadges=false| C[StatusBadge with preserveCase=true]
    C --> D{preserveCase?}
    D -->|true — prompt labels| E[Render type as-is]
    D -->|false — all other callers| F[Render type with first char uppercased]
    G[All other StatusBadge callers] --> D
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): preserve casing of prompt vers..."](https://github.com/langfuse/langfuse/commit/195f096b98c0bd0dadec8e5657be79bc7916eb11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45033231)</sub>

<!-- /greptile_comment -->