### PR TITLE
fix(experiments): sum item cost across full observation subtree

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -337,7 +337,14 @@ export const eventsExperimentsAggregation = (params: {
     .whereRaw("e.experiment_id != ''");
 };
 
-export const eventsExperimentsRootSpans = (params: {
+/**
+ * Scopes events to a project/experiment/item-id set, without narrowing to
+ * root-span rows. Use this (instead of eventsExperimentsRootSpans) when a
+ * query needs to see every observation for an item - e.g. to aggregate cost
+ * across an item's full subtree - and will pick the root row itself via
+ * ORDER BY / LIMIT BY rather than WHERE, so aggregates see sibling rows too.
+ */
+export const eventsExperimentsForItems = (params: {
   projectId: string;
   experimentIds?: string[];
   experimentItemIds?: string[];
@@ -345,18 +352,25 @@ export const eventsExperimentsRootSpans = (params: {
   eventsExperiments({
     projectId: params.projectId,
     experimentIds: params.experimentIds,
-  })
-    .whereRaw("e.experiment_item_root_span_id = e.span_id")
-    .when(
-      Boolean(params.experimentItemIds && params.experimentItemIds.length > 0),
-      (b) =>
-        b.whereRaw(
-          "e.experiment_item_id IN ({experimentItemIds: Array(String)})",
-          {
-            experimentItemIds: params.experimentItemIds,
-          },
-        ),
-    );
+  }).when(
+    Boolean(params.experimentItemIds && params.experimentItemIds.length > 0),
+    (b) =>
+      b.whereRaw(
+        "e.experiment_item_id IN ({experimentItemIds: Array(String)})",
+        {
+          experimentItemIds: params.experimentItemIds,
+        },
+      ),
+  );
+
+export const eventsExperimentsRootSpans = (params: {
+  projectId: string;
+  experimentIds?: string[];
+  experimentItemIds?: string[];
+}): EventsQueryBuilder =>
+  eventsExperimentsForItems(params).whereRaw(
+    "e.experiment_item_root_span_id = e.span_id",
+  );
 
 /**
  * Session-level scores aggregation CTE.

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -1074,15 +1074,10 @@ export const getExperimentItemsFromEvents = async (
   ];
 
   // ========== QUERY 2: Fetch data for ALL experiments ==========
-  // total_cost is summed across the item's full observation subtree via a
-  // window function - the root span itself usually carries no cost of its
-  // own, so reading e.total_cost directly would just return 0. WHERE only
-  // scopes to project/experiment/item; root-row selection happens in
-  // ORDER BY/LIMIT BY below, so the window function still sees sibling rows.
-  // The partition includes trace_id so items with multiple repetitions
-  // (until we model them properly, LFE-8965) sum only the selected
-  // iteration's own subtree, not every repetition's cost combined.
-  const queryBuilderData = eventsExperimentsForItems({
+  // Collapses un-merged ReplacingMergeTree span versions to the newest one
+  // (by event_ts) before summing cost, so a duplicate version isn't counted
+  // twice.
+  const dedupBuilder = eventsExperimentsForItems({
     projectId,
     experimentItemIds: itemIds,
     experimentIds: allExperimentIds,
@@ -1092,24 +1087,56 @@ export const getExperimentItemsFromEvents = async (
       "e.experiment_id as experiment_id",
       "e.level as level",
       "e.start_time as start_time",
-      "sum(e.total_cost) OVER (PARTITION BY e.experiment_item_id, e.experiment_id, e.trace_id) as total_cost",
-      "if(isNull(e.end_time), NULL, date_diff('millisecond', e.start_time, e.end_time)) as latency_ms",
+      "e.end_time as end_time",
+      "e.total_cost as total_cost",
       "e.span_id as observation_id",
       "e.trace_id as trace_id",
+      "e.experiment_item_root_span_id as experiment_item_root_span_id",
     )
-    // We must deterministically return the latest row for each experiment_item_id, experiment_id pair until we model repetitions (LFE-8965).
-    // Uses raw orderBy() rather than orderByColumns(), which auto-prepends a
-    // toStartOfMinute(start_time) primary-key-read-order prefix whenever a
-    // start_time entry is present - that prefix would outrank the root-flag
-    // tiebreak below whenever a child observation starts in a later minute
-    // bucket than its root, causing LIMIT BY to keep the child row instead.
+    .orderBy("ORDER BY e.event_ts DESC")
+    .limitBy("e.span_id");
+
+  // total_cost sums the item's full observation subtree (root spans usually
+  // carry no cost of their own); partitioned by trace_id too so items with
+  // multiple repetitions (LFE-8965) sum only the selected iteration.
+  // ORDER BY uses a raw clause, not orderByColumns(), to avoid its
+  // auto-prepended toStartOfMinute(start_time) prefix outranking the
+  // root-flag tiebreak.
+  const queryBuilder = new CTEQueryBuilder()
+    .withCTE("deduped_events", {
+      ...dedupBuilder.buildWithParams(),
+      schema: [
+        "item_id",
+        "experiment_id",
+        "level",
+        "start_time",
+        "end_time",
+        "total_cost",
+        "observation_id",
+        "trace_id",
+        "experiment_item_root_span_id",
+      ],
+    })
+    .from("deduped_events", "d")
+    .selectColumns(
+      "d.item_id",
+      "d.experiment_id",
+      "d.level",
+      "d.start_time",
+      "d.observation_id",
+      "d.trace_id",
+    )
+    .select(
+      "sum(d.total_cost) OVER (PARTITION BY d.item_id, d.experiment_id, d.trace_id) as total_cost",
+      "if(isNull(d.end_time), NULL, date_diff('millisecond', d.start_time, d.end_time)) as latency_ms",
+    )
     .orderBy(
-      "ORDER BY (e.span_id = e.experiment_item_root_span_id) DESC, e.start_time DESC",
+      "ORDER BY (d.observation_id = d.experiment_item_root_span_id) DESC, d.start_time DESC",
     )
-    .limitBy("e.experiment_item_id, e.experiment_id");
+    .limitBy("d.item_id, d.experiment_id");
 
   const { query: dataQuery, params: dataParams } =
-    queryBuilderData.buildWithParams();
+    queryBuilder.buildWithParams();
 
   const rows = await queryClickhouse<ExperimentItemEventsDataReturnType>({
     query: dataQuery,

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -1097,14 +1097,15 @@ export const getExperimentItemsFromEvents = async (
       "e.span_id as observation_id",
       "e.trace_id as trace_id",
     )
-    // We must deterministically return the latest row for each experiment_item_id, experiment_id pair until we model repetitions (LFE-8965)
-    .orderByColumns([
-      {
-        column: "(e.span_id = e.experiment_item_root_span_id)",
-        direction: "DESC",
-      },
-      { column: "e.start_time", direction: "DESC" },
-    ])
+    // We must deterministically return the latest row for each experiment_item_id, experiment_id pair until we model repetitions (LFE-8965).
+    // Uses raw orderBy() rather than orderByColumns(), which auto-prepends a
+    // toStartOfMinute(start_time) primary-key-read-order prefix whenever a
+    // start_time entry is present - that prefix would outrank the root-flag
+    // tiebreak below whenever a child observation starts in a later minute
+    // bucket than its root, causing LIMIT BY to keep the child row instead.
+    .orderBy(
+      "ORDER BY (e.span_id = e.experiment_item_root_span_id) DESC, e.start_time DESC",
+    )
     .limitBy("e.experiment_item_id, e.experiment_id");
 
   const { query: dataQuery, params: dataParams } =

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -2,6 +2,7 @@ import { env } from "../../env";
 import { type ScoreSourceType } from "../../domain";
 import { type OrderByState } from "../../interfaces/orderBy";
 import { type FilterState } from "../../types";
+import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import { measureAndReturn } from "../clickhouse/measureAndReturn";
 import {
   FilterList,
@@ -976,7 +977,10 @@ const getExperimentItemsFromEventsGeneric = (params: {
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
     groupByColumn: "e.experiment_item_id",
-    selectExpression: "e.experiment_item_id as item_id",
+    // min(start_time) is the item's root start_time (WHERE below restricts
+    // to root rows), used as a coarse partition-prune lower bound for Query 2.
+    selectExpression:
+      "e.experiment_item_id as item_id, min(e.start_time) as start_time",
   })
     .whereRaw("e.span_id = e.experiment_item_root_span_id")
     .when(hasScoreFilters, (b) =>
@@ -1055,7 +1059,10 @@ export const getExperimentItemsFromEvents = async (
       offset,
     });
 
-  const itemIdsResult = await queryClickhouse<{ item_id: string }>({
+  const itemIdsResult = await queryClickhouse<{
+    item_id: string;
+    start_time: string;
+  }>({
     query: itemIdsQuery,
     params: itemIdsParams,
     tags: { projectId },
@@ -1073,6 +1080,17 @@ export const getExperimentItemsFromEvents = async (
     ...compExperimentIds,
   ];
 
+  // Earliest root start_time among the qualified items - a coarse partition
+  // prune for Query 2. Children always start at or after their own root, so
+  // this bound can't exclude a legitimate descendant.
+  const minStartTime = new Date(
+    Math.min(
+      ...itemIdsResult.map((r) =>
+        parseClickhouseUTCDateTimeFormat(r.start_time).getTime(),
+      ),
+    ),
+  );
+
   // ========== QUERY 2: Fetch data for ALL experiments ==========
   // total_cost is summed across the item's full observation subtree via a
   // window function - the root span itself usually carries no cost of its
@@ -1087,6 +1105,9 @@ export const getExperimentItemsFromEvents = async (
     experimentItemIds: itemIds,
     experimentIds: allExperimentIds,
   })
+    .whereRaw("e.start_time >= {itemsMinStartTime: DateTime64(3)}", {
+      itemsMinStartTime: convertDateToClickhouseDateTime(minStartTime),
+    })
     .selectRaw(
       "e.experiment_item_id as item_id",
       "e.experiment_id as experiment_id",

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -18,6 +18,7 @@ import {
   buildScoreRowsCTE,
   buildScoresCTE,
   eventsExperimentsRootSpans,
+  eventsExperimentsForItems,
   eventsExperiments,
   eventsExperimentsAggregation,
   eventsScoresAggregation,
@@ -1073,7 +1074,12 @@ export const getExperimentItemsFromEvents = async (
   ];
 
   // ========== QUERY 2: Fetch data for ALL experiments ==========
-  const queryBuilderData = eventsExperimentsRootSpans({
+  // total_cost is summed across the item's full observation subtree via a
+  // window function - the root span itself usually carries no cost of its
+  // own, so reading e.total_cost directly would just return 0. WHERE only
+  // scopes to project/experiment/item; root-row selection happens in
+  // ORDER BY/LIMIT BY below, so the window function still sees sibling rows.
+  const queryBuilderData = eventsExperimentsForItems({
     projectId,
     experimentItemIds: itemIds,
     experimentIds: allExperimentIds,
@@ -1083,13 +1089,19 @@ export const getExperimentItemsFromEvents = async (
       "e.experiment_id as experiment_id",
       "e.level as level",
       "e.start_time as start_time",
-      "e.total_cost as total_cost",
+      "sum(e.total_cost) OVER (PARTITION BY e.experiment_item_id, e.experiment_id) as total_cost",
       "if(isNull(e.end_time), NULL, date_diff('millisecond', e.start_time, e.end_time)) as latency_ms",
       "e.span_id as observation_id",
       "e.trace_id as trace_id",
     )
     // We must deterministically return the latest row for each experiment_item_id, experiment_id pair until we model repetitions (LFE-8965)
-    .orderByColumns([{ column: "e.start_time", direction: "DESC" }])
+    .orderByColumns([
+      {
+        column: "(e.span_id = e.experiment_item_root_span_id)",
+        direction: "DESC",
+      },
+      { column: "e.start_time", direction: "DESC" },
+    ])
     .limitBy("e.experiment_item_id, e.experiment_id");
 
   const { query: dataQuery, params: dataParams } =

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -1079,6 +1079,9 @@ export const getExperimentItemsFromEvents = async (
   // own, so reading e.total_cost directly would just return 0. WHERE only
   // scopes to project/experiment/item; root-row selection happens in
   // ORDER BY/LIMIT BY below, so the window function still sees sibling rows.
+  // The partition includes trace_id so items with multiple repetitions
+  // (until we model them properly, LFE-8965) sum only the selected
+  // iteration's own subtree, not every repetition's cost combined.
   const queryBuilderData = eventsExperimentsForItems({
     projectId,
     experimentItemIds: itemIds,
@@ -1089,7 +1092,7 @@ export const getExperimentItemsFromEvents = async (
       "e.experiment_id as experiment_id",
       "e.level as level",
       "e.start_time as start_time",
-      "sum(e.total_cost) OVER (PARTITION BY e.experiment_item_id, e.experiment_id) as total_cost",
+      "sum(e.total_cost) OVER (PARTITION BY e.experiment_item_id, e.experiment_id, e.trace_id) as total_cost",
       "if(isNull(e.end_time), NULL, date_diff('millisecond', e.start_time, e.end_time)) as latency_ms",
       "e.span_id as observation_id",
       "e.trace_id as trace_id",

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -1074,10 +1074,15 @@ export const getExperimentItemsFromEvents = async (
   ];
 
   // ========== QUERY 2: Fetch data for ALL experiments ==========
-  // Collapses un-merged ReplacingMergeTree span versions to the newest one
-  // (by event_ts) before summing cost, so a duplicate version isn't counted
-  // twice.
-  const dedupBuilder = eventsExperimentsForItems({
+  // total_cost is summed across the item's full observation subtree via a
+  // window function - the root span itself usually carries no cost of its
+  // own, so reading e.total_cost directly would just return 0. WHERE only
+  // scopes to project/experiment/item; root-row selection happens in
+  // ORDER BY/LIMIT BY below, so the window function still sees sibling rows.
+  // The partition includes trace_id so items with multiple repetitions
+  // (until we model them properly, LFE-8965) sum only the selected
+  // iteration's own subtree, not every repetition's cost combined.
+  const queryBuilderData = eventsExperimentsForItems({
     projectId,
     experimentItemIds: itemIds,
     experimentIds: allExperimentIds,
@@ -1087,56 +1092,24 @@ export const getExperimentItemsFromEvents = async (
       "e.experiment_id as experiment_id",
       "e.level as level",
       "e.start_time as start_time",
-      "e.end_time as end_time",
-      "e.total_cost as total_cost",
+      "sum(e.total_cost) OVER (PARTITION BY e.experiment_item_id, e.experiment_id, e.trace_id) as total_cost",
+      "if(isNull(e.end_time), NULL, date_diff('millisecond', e.start_time, e.end_time)) as latency_ms",
       "e.span_id as observation_id",
       "e.trace_id as trace_id",
-      "e.experiment_item_root_span_id as experiment_item_root_span_id",
     )
-    .orderBy("ORDER BY e.event_ts DESC")
-    .limitBy("e.span_id");
-
-  // total_cost sums the item's full observation subtree (root spans usually
-  // carry no cost of their own); partitioned by trace_id too so items with
-  // multiple repetitions (LFE-8965) sum only the selected iteration.
-  // ORDER BY uses a raw clause, not orderByColumns(), to avoid its
-  // auto-prepended toStartOfMinute(start_time) prefix outranking the
-  // root-flag tiebreak.
-  const queryBuilder = new CTEQueryBuilder()
-    .withCTE("deduped_events", {
-      ...dedupBuilder.buildWithParams(),
-      schema: [
-        "item_id",
-        "experiment_id",
-        "level",
-        "start_time",
-        "end_time",
-        "total_cost",
-        "observation_id",
-        "trace_id",
-        "experiment_item_root_span_id",
-      ],
-    })
-    .from("deduped_events", "d")
-    .selectColumns(
-      "d.item_id",
-      "d.experiment_id",
-      "d.level",
-      "d.start_time",
-      "d.observation_id",
-      "d.trace_id",
-    )
-    .select(
-      "sum(d.total_cost) OVER (PARTITION BY d.item_id, d.experiment_id, d.trace_id) as total_cost",
-      "if(isNull(d.end_time), NULL, date_diff('millisecond', d.start_time, d.end_time)) as latency_ms",
-    )
+    // We must deterministically return the latest row for each experiment_item_id, experiment_id pair until we model repetitions (LFE-8965).
+    // Uses raw orderBy() rather than orderByColumns(), which auto-prepends a
+    // toStartOfMinute(start_time) primary-key-read-order prefix whenever a
+    // start_time entry is present - that prefix would outrank the root-flag
+    // tiebreak below whenever a child observation starts in a later minute
+    // bucket than its root, causing LIMIT BY to keep the child row instead.
     .orderBy(
-      "ORDER BY (d.observation_id = d.experiment_item_root_span_id) DESC, d.start_time DESC",
+      "ORDER BY (e.span_id = e.experiment_item_root_span_id) DESC, e.start_time DESC",
     )
-    .limitBy("d.item_id, d.experiment_id");
+    .limitBy("e.experiment_item_id, e.experiment_id");
 
   const { query: dataQuery, params: dataParams } =
-    queryBuilder.buildWithParams();
+    queryBuilderData.buildWithParams();
 
   const rows = await queryClickhouse<ExperimentItemEventsDataReturnType>({
     query: dataQuery,

--- a/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
@@ -1268,6 +1268,87 @@ describe("Clickhouse Experiment Items Repository Test", () => {
       expect(experimentMetrics.totalCost).toBe(525);
       expect(summedItemCost).toBeCloseTo(experimentMetrics.totalCost!, 6);
     });
+
+    it("should scope cost to the selected (latest) iteration, not sum across an item's repetitions", async () => {
+      // GIVEN: one item run 3 times (repetitions/iterations aren't modeled
+      // yet - LFE-8965 - so each iteration is its own trace sharing the same
+      // experiment_item_id/experiment_id). Each iteration costs a different
+      // amount so a wrong (unscoped) sum is easy to distinguish from the
+      // correct, iteration-scoped one.
+      const baselineExpId = randomUUID();
+      const datasetId = randomUUID();
+      const itemId = randomUUID();
+      const now = Date.now() * 1000;
+
+      const makeIteration = (cost: number, startOffsetMs: number) => {
+        const traceId = randomUUID();
+        const rootId = randomUUID();
+        const childId = randomUUID();
+
+        return {
+          traceId,
+          rootId,
+          events: [
+            createExperimentEvent({
+              project_id: projectId,
+              trace_id: traceId,
+              span_id: rootId,
+              parent_span_id: null,
+              experimentId: baselineExpId,
+              experimentName: "baseline-exp",
+              datasetId,
+              itemId,
+              experimentItemRootSpanId: rootId,
+              start_time: now + startOffsetMs * 1000,
+              cost_details: { input: 0, output: 0, total: 0 },
+              provided_cost_details: { input: 0, output: 0, total: 0 },
+            }),
+            createExperimentEvent({
+              project_id: projectId,
+              trace_id: traceId,
+              span_id: childId,
+              parent_span_id: rootId,
+              experimentId: baselineExpId,
+              experimentName: "baseline-exp",
+              datasetId,
+              itemId,
+              experimentItemRootSpanId: rootId,
+              start_time: now + startOffsetMs * 1000 + 500,
+              cost_details: { input: 0, output: 0, total: cost },
+              provided_cost_details: { input: 0, output: 0, total: cost },
+            }),
+          ],
+        };
+      };
+
+      const iteration1 = makeIteration(10, 0); // oldest
+      const iteration2 = makeIteration(20, 1000);
+      const iteration3 = makeIteration(30, 2000); // latest
+
+      await createEventsCh([
+        ...iteration1.events,
+        ...iteration2.events,
+        ...iteration3.events,
+      ]);
+
+      // WHEN
+      const result = await getExperimentItemsFromEvents({
+        projectId,
+        baseExperimentId: baselineExpId,
+        compExperimentIds: [],
+        filterByExperiment: [],
+        limit: 10,
+        offset: 0,
+      });
+
+      // THEN: still a single row (latest iteration), and its cost is that
+      // iteration's own (30), not the sum across all iterations (60).
+      expect(result).toHaveLength(1);
+      expect(result[0].experiments).toHaveLength(1);
+      expect(result[0].experiments[0].traceId).toBe(iteration3.traceId);
+      expect(result[0].experiments[0].observationId).toBe(iteration3.rootId);
+      expect(result[0].experiments[0].totalCost).toBe(30);
+    });
   });
 
   maybe("getExperimentItemsFromEvents - Item Visibility", () => {

--- a/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
@@ -1167,10 +1167,16 @@ describe("Clickhouse Experiment Items Repository Test", () => {
       // GIVEN: 3 items with different cost distributions across their trees -
       // cost only on a child (the common v4-events bug shape: wrapper/root
       // spans are cost-free, cost lives on nested generations), cost split
-      // root/child, and cost only on the root (no children).
+      // root/child, and cost only on the root (no children). Root/child start
+      // times straddle a clock-minute boundary so this also covers the
+      // orderByColumns() primary-key-prefix pitfall (a child starting in a
+      // later minute bucket than its root must not outrank the root).
       const expId = randomUUID();
       const datasetId = randomUUID();
-      const now = Date.now() * 1000;
+      const minuteBoundaryMs =
+        Math.ceil(Date.now() / 60_000) * 60_000 + 5 * 60_000; // a future, clean minute boundary
+      const now = (minuteBoundaryMs - 500) * 1000; // root: just before the boundary (microseconds)
+      const childOffsetMicros = 2_500_000; // child: 2.5s later, in the next minute bucket
 
       const makeItemEvents = (rootCost: number, childCost: number | null) => {
         const itemId = randomUUID();
@@ -1206,7 +1212,7 @@ describe("Clickhouse Experiment Items Repository Test", () => {
               datasetId,
               itemId,
               experimentItemRootSpanId: rootId,
-              start_time: now + 1000,
+              start_time: now + childOffsetMicros,
               cost_details: { input: 0, output: 0, total: childCost },
               provided_cost_details: { input: 0, output: 0, total: childCost },
             }),
@@ -1246,8 +1252,10 @@ describe("Clickhouse Experiment Items Repository Test", () => {
       });
 
       // THEN: the bug-shape item's cost is the sum of root (0) + child (300),
-      // still returned as the root span's own identity; and the sum of all
-      // per-item costs equals the independently-computed experiment total.
+      // still returned as the root span's own identity (observationId,
+      // traceId) despite the child starting in a later minute bucket; and the
+      // sum of all per-item costs equals the independently-computed
+      // experiment total.
       expect(items).toHaveLength(3);
 
       const bugShapeResult = items.find(

--- a/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
@@ -5,6 +5,7 @@ import {
   getExperimentItemsFromEvents,
   getExperimentItemsCountFromEvents,
   getExperimentItemsBatchIO,
+  getExperimentMetricsFromEvents,
   createTraceScore,
   type EventRecordInsertType,
 } from "@langfuse/shared/src/server";
@@ -1158,6 +1159,114 @@ describe("Clickhouse Experiment Items Repository Test", () => {
       // THEN: count = 4, results.length = 4
       expect(count).toBe(4);
       expect(result).toHaveLength(4);
+    });
+  });
+
+  maybe("getExperimentItemsFromEvents - Cost Aggregation", () => {
+    it("should sum cost across each item's full observation subtree, matching the independently-computed experiment-level aggregate", async () => {
+      // GIVEN: 3 items with different cost distributions across their trees -
+      // cost only on a child (the common v4-events bug shape: wrapper/root
+      // spans are cost-free, cost lives on nested generations), cost split
+      // root/child, and cost only on the root (no children).
+      const expId = randomUUID();
+      const datasetId = randomUUID();
+      const now = Date.now() * 1000;
+
+      const makeItemEvents = (rootCost: number, childCost: number | null) => {
+        const itemId = randomUUID();
+        const traceId = randomUUID();
+        const rootId = randomUUID();
+
+        const events = [
+          createExperimentEvent({
+            project_id: projectId,
+            trace_id: traceId,
+            span_id: rootId,
+            parent_span_id: null,
+            experimentId: expId,
+            experimentName: "cost-consistency-exp",
+            datasetId,
+            itemId,
+            experimentItemRootSpanId: rootId,
+            start_time: now,
+            cost_details: { input: 0, output: 0, total: rootCost },
+            provided_cost_details: { input: 0, output: 0, total: rootCost },
+          }),
+        ];
+
+        if (childCost !== null) {
+          events.push(
+            createExperimentEvent({
+              project_id: projectId,
+              trace_id: traceId,
+              span_id: randomUUID(),
+              parent_span_id: rootId,
+              experimentId: expId,
+              experimentName: "cost-consistency-exp",
+              datasetId,
+              itemId,
+              experimentItemRootSpanId: rootId,
+              start_time: now + 1000,
+              cost_details: { input: 0, output: 0, total: childCost },
+              provided_cost_details: { input: 0, output: 0, total: childCost },
+            }),
+          );
+        }
+
+        return { itemId, traceId, rootId, events };
+      };
+
+      const bugShapeItem = makeItemEvents(0, 300); // cost only on child
+      const splitItem = makeItemEvents(50, 100); // cost split across root and child
+      const rootOnlyItem = makeItemEvents(75, null); // no children, cost on root only
+
+      await createEventsCh([
+        ...bugShapeItem.events,
+        ...splitItem.events,
+        ...rootOnlyItem.events,
+      ]);
+
+      // WHEN
+      const items = await getExperimentItemsFromEvents({
+        projectId,
+        baseExperimentId: expId,
+        compExperimentIds: [],
+        filterByExperiment: [],
+        limit: 10,
+        offset: 0,
+      });
+
+      // getExperimentMetricsFromEvents computes the experiment total via a
+      // plain SUM(e.total_cost) over every row (event-query-builder.ts:1922)
+      // - unrelated to the per-item root-span selection logic under test, so
+      // it's a good independent cross-check.
+      const [experimentMetrics] = await getExperimentMetricsFromEvents({
+        projectId,
+        experimentIds: [expId],
+      });
+
+      // THEN: the bug-shape item's cost is the sum of root (0) + child (300),
+      // still returned as the root span's own identity; and the sum of all
+      // per-item costs equals the independently-computed experiment total.
+      expect(items).toHaveLength(3);
+
+      const bugShapeResult = items.find(
+        (item) => item.itemId === bugShapeItem.itemId,
+      );
+      expect(bugShapeResult?.experiments).toHaveLength(1);
+      expect(bugShapeResult?.experiments[0].totalCost).toBe(300);
+      expect(bugShapeResult?.experiments[0].observationId).toBe(
+        bugShapeItem.rootId,
+      );
+      expect(bugShapeResult?.experiments[0].traceId).toBe(bugShapeItem.traceId);
+
+      const summedItemCost = items.reduce(
+        (sum, item) => sum + (item.experiments[0]?.totalCost ?? 0),
+        0,
+      );
+
+      expect(experimentMetrics.totalCost).toBe(525);
+      expect(summedItemCost).toBeCloseTo(experimentMetrics.totalCost!, 6);
     });
   });
 


### PR DESCRIPTION
## Summary

- The experiments grid's per-item cost query read a single root-span's own `total_cost` instead of aggregating cost across the item's full observation subtree. Root spans in the v4 events pipeline are typically cost-free wrapper nodes (real cost lives on nested generations), so the per-row cost showed $0 even when the experiment's aggregate cost was correct.
- Fixed the query to sum cost via a window function (`SUM(e.total_cost) OVER (PARTITION BY experiment_item_id, experiment_id)`) scoped to the same bounded item/experiment set the query already filters on, and moved root-row selection from `WHERE` into `ORDER BY`/`LIMIT BY` so the window function still sees sibling (child) rows before the root row is picked.
- Added a regression test seeding items with different cost distributions (cost-only-on-child, split root/child, root-only), asserting both the per-item fix and that summed per-item costs match the independently-computed experiment-level aggregate (`getExperimentMetricsFromEvents`).

## Linear

- [LFE-11025](https://linear.app/langfuse/issue/LFE-11025/ramp-experiments-table-shows-non-aggregated-costs)

## Major Decisions

- None.

## Review Focus

- **Query shape**: the fix moves the `experiment_item_root_span_id = span_id` narrowing out of `WHERE` and into `ORDER BY (span_id = experiment_item_root_span_id) DESC, start_time DESC` + `LIMIT 1 BY (experiment_item_id, experiment_id)`, so the window function sees every observation in scope before the root row is picked. The query already preselects a bounded page of item IDs upstream, so this stays bounded by nature.
- ClickHouse query profiling before/after shows no meaningful cost regression: same row count read (4,456,536 rows), elapsed 0.121s → 0.104s, bytes read 737.74 MB → 759.32 MB (~3% more, negligible).
  - Before: 
    <img width="469" height="62" alt="CleanShot 2026-07-17 at 11 48 20" src="https://github.com/user-attachments/assets/4064f2f1-d7ff-4561-80f4-743958690b0b" />
  - After: 
    <img width="433" height="44" alt="CleanShot 2026-07-17 at 11 49 14" src="https://github.com/user-attachments/assets/79f69f35-041c-4e13-9189-40093cf98735" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the experiments grid showed `$0` per-item cost because the query read only the root span's own `total_cost` — but root spans in the v4 events pipeline are cost-free wrapper nodes with real cost living on child generations. The fix introduces a window function (`SUM(e.total_cost) OVER (PARTITION BY experiment_item_id, experiment_id)`) and moves root-span selection from `WHERE` to `ORDER BY (span_id = experiment_item_root_span_id) DESC` + `LIMIT 1 BY`, so the window aggregates across the full subtree before the root row is selected.

- **`query-fragments.ts`**: Extracts a new `eventsExperimentsForItems` helper that omits the `experiment_item_root_span_id = span_id` filter, then rebuilds `eventsExperimentsRootSpans` as a thin wrapper around it, preserving existing callers.
- **`experiments.ts`**: Switches `getExperimentItemsFromEvents` to use `eventsExperimentsForItems` + the window-function cost column, and adds a two-column ORDER BY so `LIMIT 1 BY` still lands on the root span.
- **Test**: Seeds three items with distinct cost distributions (child-only, split, root-only) and cross-checks per-item sums against the independently-computed experiment-level aggregate from `getExperimentMetricsFromEvents`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the query rework is logically sound and verified by profiling data showing no performance regression.

The window-function approach is correct: ClickHouse evaluates window expressions before LIMIT BY, so the aggregate sees all child observations before the root row is selected. The ORDER BY prioritising `(span_id = experiment_item_root_span_id) DESC` reliably lifts the root span to position 1 in each partition. The one minor shift worth awareness is that `SUM()` over an all-NULL partition returns 0 rather than NULL, which changes the downstream `totalCost` value from `null` to `0` for items with no recorded cost anywhere in their subtree.

The `experiments.ts` change is the core query modification; the NULL-to-zero coercion is the only subtle difference from the previous behaviour.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Experiments Grid
    participant Repo as getExperimentItemsFromEvents
    participant CH as ClickHouse

    UI->>Repo: fetch items (projectId, baseExperimentId, ...)
    Repo->>CH: QUERY 1 — get paged item IDs\n(eventsExperimentsRootSpans)
    CH-->>Repo: [item_id, ...]
    Repo->>CH: "QUERY 2 — fetch data for all experiments\n(eventsExperimentsForItems)\nSELECT SUM(total_cost) OVER (PARTITION BY item_id, exp_id)\nORDER BY (span_id = root_span_id) DESC, start_time DESC\nLIMIT 1 BY item_id, exp_id"
    Note over CH: Window fn sees ALL child observations\nbefore LIMIT BY selects root span row
    CH-->>Repo: one row per (item_id, exp_id) with aggregated total_cost
    Repo-->>UI: ExperimentItemData[] (correct cost)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Experiments Grid
    participant Repo as getExperimentItemsFromEvents
    participant CH as ClickHouse

    UI->>Repo: fetch items (projectId, baseExperimentId, ...)
    Repo->>CH: QUERY 1 — get paged item IDs\n(eventsExperimentsRootSpans)
    CH-->>Repo: [item_id, ...]
    Repo->>CH: "QUERY 2 — fetch data for all experiments\n(eventsExperimentsForItems)\nSELECT SUM(total_cost) OVER (PARTITION BY item_id, exp_id)\nORDER BY (span_id = root_span_id) DESC, start_time DESC\nLIMIT 1 BY item_id, exp_id"
    Note over CH: Window fn sees ALL child observations\nbefore LIMIT BY selects root span row
    CH-->>Repo: one row per (item_id, exp_id) with aggregated total_cost
    Repo-->>UI: ExperimentItemData[] (correct cost)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/repositories/experiments.ts:1092
**NULL total_cost becomes 0 after aggregation**

`SUM(total_cost)` in ClickHouse returns `0` (not `NULL`) when every row in the partition has a `NULL` `total_cost`. Before this change, the root span's own `total_cost` was returned directly — preserving `NULL` when absent. After the change, items whose entire observation subtree has no recorded cost will now surface `totalCost: 0` instead of `totalCost: null` downstream. In practice this is unlikely to matter (a $0 cost is treated the same as a missing cost in the UI), but worth noting if any caller uses a strict null-check to mean "no cost data available".

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): sum item cost across f..."](https://github.com/langfuse/langfuse/commit/dc6c0a45767fe72e216092df4a658f76505b0e6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45050850)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->