### PR TITLE
fix: validate auth callbacks before passing them to nextauth

### DIFF
--- a/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
+++ b/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
@@ -136,6 +136,18 @@ describe("NextAuth error route malformed input handling", () => {
     );
   });
 
+  it("does not throw when the auth error path segment contains invalid Location header characters", async () => {
+    const { req, res } = createRequest({
+      nextauth: ["error", "configuration\r\nscanner-payload"],
+    });
+
+    await expect(auth(req, res)).resolves.toBeUndefined();
+    expect(res.statusCode).toBe(302);
+    expect(res.getHeader("Location")).toBe(
+      "/auth/error?error=configuration%0D%0Ascanner-payload",
+    );
+  });
+
   it("uses a generic error for an ambiguous array-valued error", async () => {
     const { req, res } = createRequest({
       nextauth: ["error"],

--- a/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
+++ b/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
@@ -13,8 +13,29 @@ vi.mock("@/src/server/auth", () => ({
   getAuthOptions: mockGetAuthOptions,
 }));
 
+vi.mock("@langfuse/shared/src/server", () => ({
+  redis: null,
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  ClickHouseClientManager: {
+    getInstance: () => ({
+      closeAllConnections: vi.fn(async () => undefined),
+    }),
+  },
+}));
+
 vi.mock("@/src/env.mjs", () => ({
-  env: { NEXT_PUBLIC_BASE_PATH: "" },
+  env: {
+    NEXTAUTH_URL: "http://localhost:3000",
+    NEXT_PUBLIC_BASE_PATH: "",
+    NEXTAUTH_COOKIE_DOMAIN: undefined,
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined,
+    NEXTAUTH_COOKIE_NAME_SUFFIX: undefined,
+  },
 }));
 
 import auth from "@/src/pages/api/auth/[...nextauth]";
@@ -82,7 +103,7 @@ function createRequest({
   return { req, res };
 }
 
-describe("NextAuth route malformed input handling", () => {
+describe("NextAuth error route malformed input handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAuthOptions.mockResolvedValue(authOptions);
@@ -113,56 +134,6 @@ describe("NextAuth route malformed input handling", () => {
     expect(res.getHeader("Location")).toBe(
       "/auth/error?error=configuration%0D%0Ascanner-payload",
     );
-  });
-
-  it("does not return 500 for a malformed callbackUrl query parameter", async () => {
-    const { req, res } = createRequest({
-      nextauth: ["callback", "credentials"],
-      query: { callbackUrl: ".....///.....///etc/passwd" },
-    });
-
-    await auth(req, res);
-
-    expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
-  });
-
-  it("rejects a callbackUrl containing decoded control characters", async () => {
-    const { req, res } = createRequest({
-      nextauth: ["callback", "credentials"],
-      query: { callbackUrl: "/project/test\r\nscanner-payload" },
-    });
-
-    await auth(req, res);
-
-    expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
-  });
-
-  it("rejects an ambiguous array-valued callbackUrl", async () => {
-    const { req, res } = createRequest({
-      nextauth: ["callback", "credentials"],
-      query: { callbackUrl: ["/project/first", "/project/second"] },
-    });
-
-    await auth(req, res);
-
-    expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
-  });
-
-  it("does not return 500 for a malformed callbackUrl cookie", async () => {
-    const { req, res } = createRequest({
-      nextauth: ["callback", "credentials"],
-      cookies: {
-        "next-auth.callback-url": ".....///.....///etc/passwd",
-      },
-    });
-
-    await auth(req, res);
-
-    expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
   });
 
   it("uses a generic error for an ambiguous array-valued error", async () => {

--- a/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
+++ b/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
@@ -5,8 +5,9 @@ import type { NextAuthOptions } from "next-auth";
 import { createMocks } from "node-mocks-http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetAuthOptions } = vi.hoisted(() => ({
+const { mockGetAuthOptions, mockLoggerWarn } = vi.hoisted(() => ({
   mockGetAuthOptions: vi.fn(),
+  mockLoggerWarn: vi.fn(),
 }));
 
 vi.mock("@/src/server/auth", () => ({
@@ -18,7 +19,7 @@ vi.mock("@langfuse/shared/src/server", () => ({
   logger: {
     debug: vi.fn(),
     info: vi.fn(),
-    warn: vi.fn(),
+    warn: mockLoggerWarn,
     error: vi.fn(),
   },
   ClickHouseClientManager: {
@@ -121,6 +122,7 @@ describe("NextAuth error route malformed input handling", () => {
     expect(res.getHeader("Location")).toBe(
       "http://localhost:3000/api/auth/signin?error=OAuthCallback",
     );
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
   });
 
   it("does not throw when an auth error contains invalid Location header characters", async () => {
@@ -158,5 +160,54 @@ describe("NextAuth error route malformed input handling", () => {
 
     expect(res.statusCode).toBe(302);
     expect(res.getHeader("Location")).toBe("/auth/error?error=Configuration");
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "[NEXT_AUTH] Replaced malformed auth error with Configuration",
+      {
+        reason: "invalid_type",
+        source: "query",
+        errorType: "array",
+      },
+    );
+  });
+
+  it("logs when an oversized error uses the generic fallback", async () => {
+    const error = "a".repeat(1_001);
+    const { req, res } = createRequest({
+      nextauth: ["error"],
+      query: { error },
+    });
+
+    await auth(req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.getHeader("Location")).toBe("/auth/error?error=Configuration");
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "[NEXT_AUTH] Replaced malformed auth error with Configuration",
+      {
+        reason: "too_long",
+        source: "query",
+        errorLength: error.length,
+      },
+    );
+  });
+
+  it("logs the path source when an unencodable error uses the generic fallback", async () => {
+    const error = "\uD800";
+    const { req, res } = createRequest({
+      nextauth: ["error", error],
+    });
+
+    await auth(req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.getHeader("Location")).toBe("/auth/error?error=Configuration");
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "[NEXT_AUTH] Replaced malformed auth error with Configuration",
+      {
+        reason: "encoding_failed",
+        source: "path",
+        errorLength: error.length,
+      },
+    );
   });
 });

--- a/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
+++ b/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
@@ -102,36 +102,30 @@ describe("NextAuth route malformed input handling", () => {
     );
   });
 
-  it(
-    "does not throw when an auth error contains invalid Location header characters",
-    async () => {
-      const { req, res } = createRequest({
-        nextauth: ["error"],
-        query: { error: "configuration\r\nscanner-payload" },
-      });
+  it("does not throw when an auth error contains invalid Location header characters", async () => {
+    const { req, res } = createRequest({
+      nextauth: ["error"],
+      query: { error: "configuration\r\nscanner-payload" },
+    });
 
-      await expect(auth(req, res)).resolves.toBeUndefined();
-      expect(res.statusCode).toBe(302);
-      expect(res.getHeader("Location")).toBe(
-        "/auth/error?error=configuration%0D%0Ascanner-payload",
-      );
-    },
-  );
+    await expect(auth(req, res)).resolves.toBeUndefined();
+    expect(res.statusCode).toBe(302);
+    expect(res.getHeader("Location")).toBe(
+      "/auth/error?error=configuration%0D%0Ascanner-payload",
+    );
+  });
 
-  it(
-    "does not return 500 for a malformed callbackUrl query parameter",
-    async () => {
-      const { req, res } = createRequest({
-        nextauth: ["callback", "credentials"],
-        query: { callbackUrl: ".....///.....///etc/passwd" },
-      });
+  it("does not return 500 for a malformed callbackUrl query parameter", async () => {
+    const { req, res } = createRequest({
+      nextauth: ["callback", "credentials"],
+      query: { callbackUrl: ".....///.....///etc/passwd" },
+    });
 
-      await auth(req, res);
+    await auth(req, res);
 
-      expect(res.statusCode).toBe(400);
-      expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
-    },
-  );
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
+  });
 
   it("does not return 500 for a malformed callbackUrl cookie", async () => {
     const { req, res } = createRequest({

--- a/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
+++ b/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
@@ -1,0 +1,149 @@
+import { validateHeaderValue } from "node:http";
+
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { NextAuthOptions } from "next-auth";
+import { createMocks } from "node-mocks-http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetAuthOptions } = vi.hoisted(() => ({
+  mockGetAuthOptions: vi.fn(),
+}));
+
+vi.mock("@/src/server/auth", () => ({
+  getAuthOptions: mockGetAuthOptions,
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: { NEXT_PUBLIC_BASE_PATH: "" },
+}));
+
+import auth from "@/src/pages/api/auth/[...nextauth]";
+
+const authOptions: NextAuthOptions = {
+  secret: "test-secret",
+  providers: [],
+  cookies: {
+    callbackUrl: {
+      name: "next-auth.callback-url",
+      options: {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: false,
+      },
+    },
+  },
+  pages: {
+    error: "/auth/error",
+    signIn: "/auth/sign-in",
+  },
+  callbacks: {
+    redirect({ url, baseUrl }) {
+      try {
+        if (url.startsWith("/")) return `${baseUrl}${url}`;
+        if (new URL(url).origin === baseUrl) return url;
+      } catch {
+        // Match the application callback that safely handles malformed POST
+        // body callbackUrl values. Query and cookie validation happens before
+        // NextAuth invokes this callback.
+      }
+      return baseUrl;
+    },
+  },
+};
+
+function createRequest({
+  nextauth,
+  query = {},
+  cookies = {},
+}: {
+  nextauth: string[];
+  query?: Record<string, string>;
+  cookies?: Record<string, string>;
+}) {
+  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method: "GET",
+    headers: { host: "localhost:3000" },
+    query: { nextauth, ...query },
+  });
+  req.cookies = cookies;
+
+  // node-mocks-http accepts control characters in headers while a real
+  // ServerResponse rejects them. Keep the lightweight Next.js response mock,
+  // but apply Node's production header validation to every setHeader call.
+  const setHeader = res.setHeader.bind(res);
+  vi.spyOn(res, "setHeader").mockImplementation((name, value) => {
+    for (const item of Array.isArray(value) ? value : [value]) {
+      validateHeaderValue(name, String(item));
+    }
+    return setHeader(name, value);
+  });
+
+  return { req, res };
+}
+
+describe("NextAuth route malformed input handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthOptions.mockResolvedValue(authOptions);
+  });
+
+  it("redirects a supported auth error without returning a 5xx", async () => {
+    const { req, res } = createRequest({
+      nextauth: ["error"],
+      query: { error: "OAuthCallback" },
+    });
+
+    await auth(req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.getHeader("Location")).toBe(
+      "http://localhost:3000/api/auth/signin?error=OAuthCallback",
+    );
+  });
+
+  it(
+    "does not throw when an auth error contains invalid Location header characters",
+    async () => {
+      const { req, res } = createRequest({
+        nextauth: ["error"],
+        query: { error: "configuration\r\nscanner-payload" },
+      });
+
+      await expect(auth(req, res)).resolves.toBeUndefined();
+      expect(res.statusCode).toBe(302);
+      expect(res.getHeader("Location")).toBe(
+        "/auth/error?error=configuration%0D%0Ascanner-payload",
+      );
+    },
+  );
+
+  it(
+    "does not return 500 for a malformed callbackUrl query parameter",
+    async () => {
+      const { req, res } = createRequest({
+        nextauth: ["callback", "credentials"],
+        query: { callbackUrl: ".....///.....///etc/passwd" },
+      });
+
+      await auth(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
+    },
+  );
+
+  it("does not return 500 for a malformed callbackUrl cookie", async () => {
+    const { req, res } = createRequest({
+      nextauth: ["callback", "credentials"],
+      cookies: {
+        "next-auth.callback-url": ".....///.....///etc/passwd",
+      },
+    });
+
+    await auth(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
+  });
+});

--- a/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
+++ b/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
@@ -58,7 +58,7 @@ function createRequest({
   cookies = {},
 }: {
   nextauth: string[];
-  query?: Record<string, string>;
+  query?: Record<string, string | string[]>;
   cookies?: Record<string, string>;
 }) {
   const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
@@ -127,6 +127,30 @@ describe("NextAuth route malformed input handling", () => {
     expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
   });
 
+  it("rejects a callbackUrl containing decoded control characters", async () => {
+    const { req, res } = createRequest({
+      nextauth: ["callback", "credentials"],
+      query: { callbackUrl: "/project/test\r\nscanner-payload" },
+    });
+
+    await auth(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
+  });
+
+  it("rejects an ambiguous array-valued callbackUrl", async () => {
+    const { req, res } = createRequest({
+      nextauth: ["callback", "credentials"],
+      query: { callbackUrl: ["/project/first", "/project/second"] },
+    });
+
+    await auth(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
+  });
+
   it("does not return 500 for a malformed callbackUrl cookie", async () => {
     const { req, res } = createRequest({
       nextauth: ["callback", "credentials"],
@@ -139,5 +163,17 @@ describe("NextAuth route malformed input handling", () => {
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual({ error: "Invalid callback URL" });
+  });
+
+  it("uses a generic error for an ambiguous array-valued error", async () => {
+    const { req, res } = createRequest({
+      nextauth: ["error"],
+      query: { error: ["OAuthCallback", "scanner-payload"] },
+    });
+
+    await auth(req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.getHeader("Location")).toBe("/auth/error?error=Configuration");
   });
 });

--- a/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
+++ b/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
@@ -91,6 +91,18 @@ describe("[...nextauth] invalid callbackUrl handling", () => {
     expect(mockNextAuth).not.toHaveBeenCalled();
   });
 
+  it("rejects a callbackUrl containing decoded control characters", async () => {
+    const { res } = await callHandler({
+      query: {
+        nextauth: ["callback", "email"],
+        callbackUrl: "/project/test\r\nscanner-payload",
+      },
+    });
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+
   it("rejects an invalid callback-url cookie with 400", async () => {
     const { res } = await callHandler({
       cookies: { "next-auth.callback-url": "z`z'z\"${{%{{\\" },

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -5,7 +5,7 @@ import { getCookieName } from "@/src/server/utils/cookies";
 import { env } from "@/src/env.mjs";
 import { logger } from "@langfuse/shared/src/server";
 import type { NextApiRequest, NextApiResponse } from "next";
-import NextAuth, { type NextAuthOptions } from "next-auth";
+import NextAuth from "next-auth";
 
 const maxAuthErrorLength = 1_000;
 
@@ -26,38 +26,6 @@ const encodeAuthError = (error: unknown) => {
   }
 };
 
-const isValidHttpCallbackUrl = (value: unknown) => {
-  if (typeof value !== "string") return false;
-
-  try {
-    validateHeaderValue("Location", value);
-    const url = new URL(
-      value,
-      value.startsWith("/") ? "http://localhost" : undefined,
-    );
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-};
-
-const hasInvalidCallbackUrl = (
-  req: NextApiRequest,
-  authOptions: NextAuthOptions,
-) => {
-  const callbackUrl = req.query.callbackUrl;
-  if (callbackUrl && !isValidHttpCallbackUrl(callbackUrl)) return true;
-
-  const callbackUrlCookieName =
-    authOptions.cookies?.callbackUrl?.name ??
-    `${authOptions.useSecureCookies ? "__Secure-" : ""}next-auth.callback-url`;
-  const callbackUrlCookie = req.cookies[callbackUrlCookieName];
-
-  return Boolean(
-    callbackUrlCookie && !isValidHttpCallbackUrl(callbackUrlCookie),
-  );
-};
-
 // Mirrors next-auth's assertConfig check (core/lib/assert.ts). Must never be
 // stricter than next-auth: relative URLs always pass (next-auth resolves them
 // against the deployment origin), absolute URLs must parse with an http(s)
@@ -65,6 +33,7 @@ const hasInvalidCallbackUrl = (
 const isValidCallbackUrl = (url: unknown): boolean => {
   if (typeof url !== "string") return false;
   try {
+    validateHeaderValue("Location", url);
     return /^https?:/.test(
       new URL(url, url.startsWith("/") ? "http://localhost" : undefined)
         .protocol,
@@ -150,13 +119,6 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   );
   res.setHeader("Pragma", "no-cache");
   res.setHeader("Expires", "0");
-
-  // NextAuth treats invalid callback URLs as configuration errors and returns
-  // a 500 before invoking the application's redirect callback. Classify
-  // malformed query and cookie input as a bad request at the HTTP boundary.
-  if (hasInvalidCallbackUrl(req, authOptions)) {
-    return res.status(400).json({ error: "Invalid callback URL" });
-  }
 
   // NextAuth interpolates unknown error values directly into a Location
   // header. Encode user-controlled text before it reaches that code path so

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -8,21 +8,47 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import NextAuth from "next-auth";
 
 const maxAuthErrorLength = 1_000;
+const authErrorFallback = "Configuration";
+
+type AuthErrorSource = "query" | "path";
 
 const getAuthAction = (req: NextApiRequest) => {
   const nextauth = req.query.nextauth;
   return Array.isArray(nextauth) ? nextauth[0] : nextauth;
 };
 
-const encodeAuthError = (error: unknown) => {
-  if (typeof error !== "string" || error.length > maxAuthErrorLength) {
-    return "Configuration";
+const logAuthErrorFallback = (
+  reason: "invalid_type" | "too_long" | "encoding_failed",
+  source: AuthErrorSource,
+  metadata: Record<string, unknown>,
+) => {
+  logger.warn("[NEXT_AUTH] Replaced malformed auth error with Configuration", {
+    reason,
+    source,
+    ...metadata,
+  });
+  return authErrorFallback;
+};
+
+const encodeAuthError = (error: unknown, source: AuthErrorSource) => {
+  if (typeof error !== "string") {
+    return logAuthErrorFallback("invalid_type", source, {
+      errorType: Array.isArray(error) ? "array" : typeof error,
+    });
+  }
+
+  if (error.length > maxAuthErrorLength) {
+    return logAuthErrorFallback("too_long", source, {
+      errorLength: error.length,
+    });
   }
 
   try {
     return encodeURIComponent(error);
   } catch {
-    return "Configuration";
+    return logAuthErrorFallback("encoding_failed", source, {
+      errorLength: error.length,
+    });
   }
 };
 
@@ -128,7 +154,8 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
     const error =
       req.query.error ?? (Array.isArray(nextauth) ? nextauth[1] : undefined);
     if (error !== undefined) {
-      req.query.error = encodeAuthError(error);
+      const source = req.query.error !== undefined ? "query" : "path";
+      req.query.error = encodeAuthError(error, source);
     }
   }
 

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -1,3 +1,5 @@
+import { validateHeaderValue } from "node:http";
+
 import { getAuthOptions } from "@/src/server/auth";
 import { env } from "@/src/env.mjs";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -26,6 +28,7 @@ const isValidHttpCallbackUrl = (value: unknown) => {
   if (typeof value !== "string") return false;
 
   try {
+    validateHeaderValue("Location", value);
     const url = new URL(
       value,
       value.startsWith("/") ? "http://localhost" : undefined,

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -123,8 +123,13 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // NextAuth interpolates unknown error values directly into a Location
   // header. Encode user-controlled text before it reaches that code path so
   // control characters cannot make Node throw ERR_INVALID_CHAR.
-  if (getAuthAction(req) === "error" && req.query.error !== undefined) {
-    req.query.error = encodeAuthError(req.query.error);
+  if (getAuthAction(req) === "error") {
+    const nextauth = req.query.nextauth;
+    const error =
+      req.query.error ?? (Array.isArray(nextauth) ? nextauth[1] : undefined);
+    if (error !== undefined) {
+      req.query.error = encodeAuthError(error);
+    }
   }
 
   return await NextAuth(req, res, authOptions);

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -1,7 +1,57 @@
 import { getAuthOptions } from "@/src/server/auth";
 import { env } from "@/src/env.mjs";
 import type { NextApiRequest, NextApiResponse } from "next";
-import NextAuth from "next-auth";
+import NextAuth, { type NextAuthOptions } from "next-auth";
+
+const maxAuthErrorLength = 1_000;
+
+const getAuthAction = (req: NextApiRequest) => {
+  const nextauth = req.query.nextauth;
+  return Array.isArray(nextauth) ? nextauth[0] : nextauth;
+};
+
+const encodeAuthError = (error: unknown) => {
+  if (typeof error !== "string" || error.length > maxAuthErrorLength) {
+    return "Configuration";
+  }
+
+  try {
+    return encodeURIComponent(error);
+  } catch {
+    return "Configuration";
+  }
+};
+
+const isValidHttpCallbackUrl = (value: unknown) => {
+  if (typeof value !== "string") return false;
+
+  try {
+    const url = new URL(
+      value,
+      value.startsWith("/") ? "http://localhost" : undefined,
+    );
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+const hasInvalidCallbackUrl = (
+  req: NextApiRequest,
+  authOptions: NextAuthOptions,
+) => {
+  const callbackUrl = req.query.callbackUrl;
+  if (callbackUrl && !isValidHttpCallbackUrl(callbackUrl)) return true;
+
+  const callbackUrlCookieName =
+    authOptions.cookies?.callbackUrl?.name ??
+    `${authOptions.useSecureCookies ? "__Secure-" : ""}next-auth.callback-url`;
+  const callbackUrlCookie = req.cookies[callbackUrlCookieName];
+
+  return Boolean(
+    callbackUrlCookie && !isValidHttpCallbackUrl(callbackUrlCookie),
+  );
+};
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // Workaround for corporate email link checkers (e.g., Outlook SafeLink)
@@ -48,6 +98,20 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   );
   res.setHeader("Pragma", "no-cache");
   res.setHeader("Expires", "0");
+
+  // NextAuth treats invalid callback URLs as configuration errors and returns
+  // a 500 before invoking the application's redirect callback. Classify
+  // malformed query and cookie input as a bad request at the HTTP boundary.
+  if (hasInvalidCallbackUrl(req, authOptions)) {
+    return res.status(400).json({ error: "Invalid callback URL" });
+  }
+
+  // NextAuth interpolates unknown error values directly into a Location
+  // header. Encode user-controlled text before it reaches that code path so
+  // control characters cannot make Node throw ERR_INVALID_CHAR.
+  if (getAuthAction(req) === "error" && req.query.error !== undefined) {
+    req.query.error = encodeAuthError(req.query.error);
+  }
 
   return await NextAuth(req, res, authOptions);
 }


### PR DESCRIPTION
## Summary
- Reject malformed callback URLs with a 400 response
- Encode auth error values before NextAuth redirects
- Add unit tests for malformed query, cookie, and header input

## Testing
- Added and ran Vitest unit tests for the NextAuth route

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the NextAuth route handler against two classes of malformed user input: invalid callback URLs that previously caused NextAuth to return 500, and error query params containing control characters that could trigger `ERR_INVALID_CHAR` when set as `Location` header values.

- Adds `hasInvalidCallbackUrl` to pre-validate `callbackUrl` from both the query string and the callback-URL cookie, returning 400 before NextAuth is invoked.
- Adds `encodeAuthError` to percent-encode the `error` query param for `action=error` requests, preventing CRLF injection into the `Location` header that NextAuth constructs.
- Introduces four Vitest unit tests that verify the new behaviour, including a realistic header-validation spy that mirrors Node's production `validateHeaderValue` check.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge. Both new guards are additive and fail-closed; no existing auth path is removed or weakened.

The callbackUrl guard in hasInvalidCallbackUrl does not account for req.query.callbackUrl being a string[] — any duplicated query key causes a blanket 400 regardless of whether the values are valid. This is a real defect introduced by the PR, even though the practical impact is low (duplicate callbackUrl params are rare in OAuth flows). The same array-handling gap exists in the error encoding path, though there the fallback to 'Configuration' is at least safe. The rest of the change — the URL protocol check, CRLF encoding, and the test suite — is well-reasoned.

web/src/pages/api/auth/[...nextauth].ts — specifically the array-value handling in hasInvalidCallbackUrl (line 43) and the error encoding block (line 112).
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant NextAuthRoute as /api/auth/[...nextauth]
    participant NextAuth

    Client->>NextAuthRoute: GET/POST request

    alt HEAD request
        NextAuthRoute-->>Client: 200 OK (SafeLink workaround)
    end

    alt OAuth callback with error + error_description
        NextAuthRoute-->>Client: "302 → /auth/sign-in?error=…&error_description=…"
    end

    NextAuthRoute->>NextAuthRoute: await getAuthOptions()
    NextAuthRoute->>NextAuthRoute: Set no-cache headers

    NextAuthRoute->>NextAuthRoute: hasInvalidCallbackUrl(req, authOptions)
    Note over NextAuthRoute: Checks req.query.callbackUrl<br/>and the callback URL cookie

    alt callbackUrl is malformed
        NextAuthRoute-->>Client: "400 {error: Invalid callback URL}"
    end

    alt "action === error and req.query.error present"
        NextAuthRoute->>NextAuthRoute: encodeAuthError(req.query.error)
        Note over NextAuthRoute: Prevents CRLF injection<br/>in Location header
    end

    NextAuthRoute->>NextAuth: NextAuth(req, res, authOptions)
    NextAuth-->>Client: 302 redirect / 200 / 401 / etc.
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant NextAuthRoute as /api/auth/[...nextauth]
    participant NextAuth

    Client->>NextAuthRoute: GET/POST request

    alt HEAD request
        NextAuthRoute-->>Client: 200 OK (SafeLink workaround)
    end

    alt OAuth callback with error + error_description
        NextAuthRoute-->>Client: "302 → /auth/sign-in?error=…&error_description=…"
    end

    NextAuthRoute->>NextAuthRoute: await getAuthOptions()
    NextAuthRoute->>NextAuthRoute: Set no-cache headers

    NextAuthRoute->>NextAuthRoute: hasInvalidCallbackUrl(req, authOptions)
    Note over NextAuthRoute: Checks req.query.callbackUrl<br/>and the callback URL cookie

    alt callbackUrl is malformed
        NextAuthRoute-->>Client: "400 {error: Invalid callback URL}"
    end

    alt "action === error and req.query.error present"
        NextAuthRoute->>NextAuthRoute: encodeAuthError(req.query.error)
        Note over NextAuthRoute: Prevents CRLF injection<br/>in Location header
    end

    NextAuthRoute->>NextAuth: NextAuth(req, res, authOptions)
    NextAuth-->>Client: 302 redirect / 200 / 401 / etc.
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/api/auth/[...nextauth].ts:43-44
**Array-valued `callbackUrl` query param causes a false 400**

`req.query.callbackUrl` is typed `string | string[] | undefined`. When a request arrives with a repeated key (`?callbackUrl=https://app.example.com&callbackUrl=…`), the value is a `string[]`. `isValidHttpCallbackUrl` returns `false` for any non-string, so `!isValidHttpCallbackUrl(string[])` is `true` and the handler rejects the request with 400 — even if every value in the array is a valid URL. Extracting just the first element (the value NextAuth itself would consume) is sufficient: `Array.isArray(callbackUrl) ? callbackUrl[0] : callbackUrl`.

### Issue 2 of 2
web/src/pages/api/auth/[...nextauth].ts:112-114
**Array-valued `error` query param is silently coerced to `"Configuration"`**

`req.query.error` is `string | string[] | undefined`. When a client sends `?error=OAuthCallback&error=OtherValue`, the value is `string[]`. `encodeAuthError` returns `"Configuration"` for any non-string, so a genuine multi-value error param (or a repeated key from a browser form) would replace the real error code with `"Configuration"`, sending the user to the wrong error page. Consider normalising to the first element before encoding: `const errorVal = Array.isArray(req.query.error) ? req.query.error[0] : req.query.error`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Prevent malformed auth inputs from causi..."](https://github.com/langfuse/langfuse/commit/95487b00a32e827506d6c9b0c78891656c64e892) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45055399)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->