### PR TITLE
feat(monitors): deep-link alerts to the traces/observations table for the breaching window (LFE-11022)

### DIFF
--- a/packages/shared/src/features/monitors/processor/buildMonitorAlertSlackMessage.test.ts
+++ b/packages/shared/src/features/monitors/processor/buildMonitorAlertSlackMessage.test.ts
@@ -84,4 +84,54 @@ describe("buildMonitorAlertSlackMessage", () => {
     expect(inner.some((b: any) => b.type === "actions")).toBe(false);
     expect(inner.some((b: any) => b.type === "context")).toBe(true);
   });
+
+  it("adds a 'View observations' button to the windowed data table when dataPermalink is set (observations view)", () => {
+    const dataPermalink =
+      "https://cloud.langfuse.com/project/proj_01/observations?dateRange=1779450930000-1779451230000";
+    const { attachments } = buildMonitorAlertSlackMessage({
+      ...mockMonitorAlert,
+      dataPermalink,
+    });
+    const actions = attachments![0].blocks!.find(
+      (b: any) => b.type === "actions",
+    );
+    expect(actions.elements).toHaveLength(2);
+    // Config button kept.
+    expect(actions.elements[0]).toMatchObject({
+      text: { text: "View in Langfuse" },
+      url: mockMonitorAlert.permalink,
+    });
+    // Windowed data-table button added.
+    expect(actions.elements[1]).toMatchObject({
+      text: { text: "View observations" },
+      url: dataPermalink,
+    });
+  });
+
+  it("labels the data button 'View traces' for a scores view", () => {
+    const dataPermalink =
+      "https://cloud.langfuse.com/project/proj_01/traces?dateRange=1779450930000-1779451230000";
+    const { attachments } = buildMonitorAlertSlackMessage({
+      ...mockMonitorAlert,
+      view: "scores-numeric",
+      dataPermalink,
+    });
+    const actions = attachments![0].blocks!.find(
+      (b: any) => b.type === "actions",
+    );
+    expect(actions.elements).toHaveLength(2);
+    expect(actions.elements[1]).toMatchObject({
+      text: { text: "View traces" },
+      url: dataPermalink,
+    });
+  });
+
+  it("keeps only the config button when dataPermalink is absent", () => {
+    const { attachments } = buildMonitorAlertSlackMessage(mockMonitorAlert);
+    const actions = attachments![0].blocks!.find(
+      (b: any) => b.type === "actions",
+    );
+    expect(actions.elements).toHaveLength(1);
+    expect(actions.elements[0].text.text).toBe("View in Langfuse");
+  });
 });

--- a/packages/shared/src/features/monitors/processor/buildMonitorAlertSlackMessage.test.ts
+++ b/packages/shared/src/features/monitors/processor/buildMonitorAlertSlackMessage.test.ts
@@ -134,4 +134,23 @@ describe("buildMonitorAlertSlackMessage", () => {
     expect(actions.elements).toHaveLength(1);
     expect(actions.elements[0].text.text).toBe("View in Langfuse");
   });
+
+  // buildAlert only sets dataPermalink for breaching severities, so recovery
+  // (OK) and NO_DATA notifications arrive here with dataPermalink undefined and
+  // must render no "View traces" button — recovery messages stay unchanged.
+  it.each(["OK", "NO_DATA"] as const)(
+    "renders no secondary data button for a %s (non-breach) alert",
+    (severity) => {
+      const { attachments } = buildMonitorAlertSlackMessage({
+        ...mockMonitorAlert,
+        severity,
+        dataPermalink: undefined,
+      });
+      const actions = attachments![0].blocks!.find(
+        (b: any) => b.type === "actions",
+      );
+      expect(actions.elements).toHaveLength(1);
+      expect(actions.elements[0].text.text).toBe("View in Langfuse");
+    },
+  );
 });

--- a/packages/shared/src/features/monitors/processor/buildMonitorAlertSlackMessage.ts
+++ b/packages/shared/src/features/monitors/processor/buildMonitorAlertSlackMessage.ts
@@ -22,5 +22,8 @@ export function buildMonitorAlertSlackMessage(
     body: alert.message.body,
     timestamp: alert.timestamp,
     url: alert.permalink,
+    secondaryUrl: alert.dataPermalink,
+    secondaryLabel:
+      alert.view === "observations" ? "View observations" : "View traces",
   });
 }

--- a/packages/shared/src/features/monitors/processor/buildPermalink.test.ts
+++ b/packages/shared/src/features/monitors/processor/buildPermalink.test.ts
@@ -5,7 +5,7 @@ const envMock = vi.hoisted(() => ({
 }));
 vi.mock("../../../env", () => envMock);
 
-import { buildPermalink } from "./processor";
+import { buildDataWindowPermalink, buildPermalink } from "./processor";
 
 describe("buildPermalink", () => {
   beforeEach(() => {
@@ -20,6 +20,45 @@ describe("buildPermalink", () => {
     envMock.env.NEXTAUTH_URL = "https://cloud.langfuse.com";
     expect(buildPermalink("proj_01", "mon_01")).toBe(
       "https://cloud.langfuse.com/project/proj_01/monitors/mon_01",
+    );
+  });
+});
+
+describe("buildDataWindowPermalink", () => {
+  const from = new Date("2026-05-18T11:55:30.000Z"); // 1779450930000
+  const to = new Date("2026-05-18T12:00:30.000Z"); // 1779451230000
+
+  beforeEach(() => {
+    envMock.env.NEXTAUTH_URL = undefined;
+  });
+
+  it("returns undefined when NEXTAUTH_URL is unset (self-hosted)", () => {
+    expect(
+      buildDataWindowPermalink("proj_01", "observations", from, to),
+    ).toBeUndefined();
+  });
+
+  it("links an observations monitor to the observations table windowed by dateRange", () => {
+    envMock.env.NEXTAUTH_URL = "https://cloud.langfuse.com";
+    expect(buildDataWindowPermalink("proj_01", "observations", from, to)).toBe(
+      `https://cloud.langfuse.com/project/proj_01/observations?dateRange=${from.getTime()}-${to.getTime()}`,
+    );
+  });
+
+  it.each(["scores-numeric", "scores-categorical"] as const)(
+    "links a %s monitor to the traces table windowed by dateRange",
+    (view) => {
+      envMock.env.NEXTAUTH_URL = "https://cloud.langfuse.com";
+      expect(buildDataWindowPermalink("proj_01", view, from, to)).toBe(
+        `https://cloud.langfuse.com/project/proj_01/traces?dateRange=${from.getTime()}-${to.getTime()}`,
+      );
+    },
+  );
+
+  it("strips a trailing slash on NEXTAUTH_URL", () => {
+    envMock.env.NEXTAUTH_URL = "https://cloud.langfuse.com/";
+    expect(buildDataWindowPermalink("proj_01", "observations", from, to)).toBe(
+      `https://cloud.langfuse.com/project/proj_01/observations?dateRange=${from.getTime()}-${to.getTime()}`,
     );
   });
 });

--- a/packages/shared/src/features/monitors/processor/buildPermalink.test.ts
+++ b/packages/shared/src/features/monitors/processor/buildPermalink.test.ts
@@ -5,7 +5,11 @@ const envMock = vi.hoisted(() => ({
 }));
 vi.mock("../../../env", () => envMock);
 
-import { buildDataWindowPermalink, buildPermalink } from "./processor";
+import {
+  buildDataWindowPermalink,
+  buildPermalink,
+  isBreaching,
+} from "./processor";
 
 describe("buildPermalink", () => {
   beforeEach(() => {
@@ -61,4 +65,20 @@ describe("buildDataWindowPermalink", () => {
       `https://cloud.langfuse.com/project/proj_01/observations?dateRange=${from.getTime()}-${to.getTime()}`,
     );
   });
+});
+
+describe("isBreaching", () => {
+  it.each(["ALERT", "WARNING"] as const)(
+    "treats %s as a breach (gets a data-window link)",
+    (severity) => {
+      expect(isBreaching(severity)).toBe(true);
+    },
+  );
+
+  it.each(["OK", "NO_DATA", "UNKNOWN", "PAUSED"] as const)(
+    "treats %s as a non-breach (no data-window link)",
+    (severity) => {
+      expect(isBreaching(severity)).toBe(false);
+    },
+  );
 });

--- a/packages/shared/src/features/monitors/processor/processor.ts
+++ b/packages/shared/src/features/monitors/processor/processor.ts
@@ -29,6 +29,7 @@ import {
   MonitorStatusSchema,
   type MonitorAlert,
   type MonitorWindow,
+  type MonitorView,
   type Monitor,
 } from "../types";
 import { applyStateMachine, type MonitorCompletion } from "./applyStateMachine";
@@ -382,6 +383,12 @@ function buildAlert(args: {
     fromTimestamp,
     toTimestamp,
     permalink: buildPermalink(prev.projectId, prev.id),
+    dataPermalink: buildDataWindowPermalink(
+      prev.projectId,
+      prev.view,
+      fromTimestamp,
+      toTimestamp,
+    ),
     message: renderAlertMessage({ monitor: prev, completion: next }),
     view: prev.view,
     filters: prev.filters,
@@ -397,6 +404,29 @@ export function buildPermalink(
   if (!env.NEXTAUTH_URL) return undefined;
   const base = env.NEXTAUTH_URL.replace(/\/$/, "");
   return `${base}/project/${projectId}/monitors/${monitorId}`;
+}
+
+/**
+ * buildDataWindowPermalink composes the absolute Langfuse data-table URL scoped
+ * to the breaching evaluation window, or undefined when NEXTAUTH_URL is unset.
+ *
+ * The window is encoded as the table's custom `?dateRange=<fromMs>-<toMs>`
+ * param (absolute epoch-ms range; the client date-range parser accepts custom
+ * ranges directly, bypassing the preset gating). An `observations` monitor
+ * links to the observations table; every other view (scores-*) links to the
+ * traces table, which is the row-level data users expect to inspect.
+ */
+export function buildDataWindowPermalink(
+  projectId: string,
+  view: MonitorView,
+  fromTimestamp: Date,
+  toTimestamp: Date,
+): string | undefined {
+  if (!env.NEXTAUTH_URL) return undefined;
+  const base = env.NEXTAUTH_URL.replace(/\/$/, "");
+  const table = view === "observations" ? "observations" : "traces";
+  const dateRange = `${fromTimestamp.getTime()}-${toTimestamp.getTime()}`;
+  return `${base}/project/${projectId}/${table}?dateRange=${dateRange}`;
 }
 
 /** toMonitorWebhookInputs fans an alert out to one webhook input per matched automation. */

--- a/packages/shared/src/features/monitors/processor/processor.ts
+++ b/packages/shared/src/features/monitors/processor/processor.ts
@@ -28,6 +28,7 @@ import {
   MonitorSeveritySchema,
   MonitorStatusSchema,
   type MonitorAlert,
+  type MonitorSeverity,
   type MonitorWindow,
   type MonitorView,
   type Monitor,
@@ -383,12 +384,17 @@ function buildAlert(args: {
     fromTimestamp,
     toTimestamp,
     permalink: buildPermalink(prev.projectId, prev.id),
-    dataPermalink: buildDataWindowPermalink(
-      prev.projectId,
-      prev.view,
-      fromTimestamp,
-      toTimestamp,
-    ),
+    // Only a threshold-cross (ALERT/WARNING) links to the breaching data window;
+    // recovery (OK) and lifecycle states (NO_DATA/UNKNOWN/PAUSED) would point at
+    // a recovered/empty window, so they carry no data link.
+    dataPermalink: isBreaching(next.severity)
+      ? buildDataWindowPermalink(
+          prev.projectId,
+          prev.view,
+          fromTimestamp,
+          toTimestamp,
+        )
+      : undefined,
     message: renderAlertMessage({ monitor: prev, completion: next }),
     view: prev.view,
     filters: prev.filters,
@@ -404,6 +410,14 @@ export function buildPermalink(
   if (!env.NEXTAUTH_URL) return undefined;
   const base = env.NEXTAUTH_URL.replace(/\/$/, "");
   return `${base}/project/${projectId}/monitors/${monitorId}`;
+}
+
+/** isBreaching returns true for the threshold-cross severities (ALERT/WARNING) whose alert should deep-link to the breaching data window; OK (recovery) and the lifecycle states (NO_DATA/UNKNOWN/PAUSED) return false. */
+export function isBreaching(severity: MonitorSeverity): boolean {
+  return (
+    severity === MonitorSeveritySchema.enum.ALERT ||
+    severity === MonitorSeveritySchema.enum.WARNING
+  );
 }
 
 /**

--- a/packages/shared/src/features/monitors/types.test.ts
+++ b/packages/shared/src/features/monitors/types.test.ts
@@ -212,6 +212,33 @@ describe("MonitorAlertSchema", () => {
     expect(MonitorAlertSchema.safeParse(withoutPermalink).success).toBe(true);
   });
 
+  it("round-trips an optional dataPermalink", () => {
+    const withDataPermalink = {
+      ...validAlert,
+      dataPermalink:
+        "https://cloud.langfuse.com/project/proj_01/traces?dateRange=1779450930000-1779451230000",
+    };
+    const result = MonitorAlertSchema.safeParse(withDataPermalink);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.dataPermalink).toBe(withDataPermalink.dataPermalink);
+    }
+  });
+
+  it("accepts an alert without dataPermalink (backward-compatible in-flight message)", () => {
+    // validAlert already omits dataPermalink.
+    expect(MonitorAlertSchema.safeParse(validAlert).success).toBe(true);
+  });
+
+  it("rejects a relative (path-only) dataPermalink", () => {
+    expect(
+      MonitorAlertSchema.safeParse({
+        ...validAlert,
+        dataPermalink: "/project/proj_01/traces?dateRange=1-2",
+      }).success,
+    ).toBe(false);
+  });
+
   it("rejects a relative (path-only) permalink", () => {
     expect(
       MonitorAlertSchema.safeParse({

--- a/packages/shared/src/features/monitors/types.ts
+++ b/packages/shared/src/features/monitors/types.ts
@@ -299,6 +299,8 @@ export const MonitorAlertSchema = z.object({
   monitorId: z.string(),
   projectId: z.string(),
   permalink: z.url().optional(),
+  /** dataPermalink deep-links to the data table scoped to the breaching window. Optional so in-flight webhook messages without it still parse. */
+  dataPermalink: z.url().optional(),
   message: z.object({ title: z.string(), body: z.string() }),
   severity: MonitorSeveritySchema,
   timestamp: z.coerce.date(),

--- a/packages/shared/src/server/services/buildColoredAttachmentSlackMessage.test.ts
+++ b/packages/shared/src/server/services/buildColoredAttachmentSlackMessage.test.ts
@@ -39,4 +39,40 @@ describe("buildColoredAttachmentSlackMessage", () => {
     expect(serialized).not.toContain("View in Langfuse");
     expect(serialized).toContain("*Something failed*");
   });
+
+  it("renders a labeled secondary button after the primary when secondaryUrl is set", () => {
+    const blocks = buildColoredAttachmentSlackMessage({
+      ...base,
+      secondaryUrl: "https://cloud.langfuse.com/y?dateRange=1-2",
+      secondaryLabel: "View traces",
+    }).attachments![0].blocks!;
+    const actions = blocks.find((b: any) => b.type === "actions");
+    expect(actions.elements).toHaveLength(2);
+    expect(actions.elements[0]).toMatchObject({
+      type: "button",
+      text: { text: "View in Langfuse" },
+      url: base.url,
+    });
+    expect(actions.elements[1]).toMatchObject({
+      type: "button",
+      text: { text: "View traces" },
+      url: "https://cloud.langfuse.com/y?dateRange=1-2",
+    });
+  });
+
+  it("defaults the secondary button label to 'View data'", () => {
+    const blocks = buildColoredAttachmentSlackMessage({
+      ...base,
+      secondaryUrl: "https://cloud.langfuse.com/y?dateRange=1-2",
+    }).attachments![0].blocks!;
+    const actions = blocks.find((b: any) => b.type === "actions");
+    expect(actions.elements[1].text.text).toBe("View data");
+  });
+
+  it("omits the secondary button when secondaryUrl is absent", () => {
+    const blocks =
+      buildColoredAttachmentSlackMessage(base).attachments![0].blocks!;
+    const actions = blocks.find((b: any) => b.type === "actions");
+    expect(actions.elements).toHaveLength(1);
+  });
 });

--- a/packages/shared/src/server/services/buildColoredAttachmentSlackMessage.ts
+++ b/packages/shared/src/server/services/buildColoredAttachmentSlackMessage.ts
@@ -16,6 +16,14 @@ export function buildColoredAttachmentSlackMessage(args: {
   url?: string;
   /** contextText is an optional extra context element rendered next to the timestamp. */
   contextText?: string;
+  /**
+   * secondaryUrl, when set alongside `url`, renders a second action button
+   * after "View in Langfuse" (e.g. a monitor alert's link to the breaching
+   * data). Absent by default so project notifications stay single-button.
+   */
+  secondaryUrl?: string;
+  /** secondaryLabel is the second button's label; defaults to "View data". */
+  secondaryLabel?: string;
 }): SlackMessage {
   const { color } = args;
   const title = escapeSlackMrkdwn(args.title);
@@ -60,6 +68,19 @@ export function buildColoredAttachmentSlackMessage(args: {
                 },
                 url: args.url,
               },
+              ...(args.secondaryUrl
+                ? [
+                    {
+                      type: "button",
+                      text: {
+                        type: "plain_text",
+                        text: args.secondaryLabel ?? "View data",
+                        emoji: true,
+                      },
+                      url: args.secondaryUrl,
+                    },
+                  ]
+                : []),
             ],
           },
         ]


### PR DESCRIPTION
## TL;DR

When a monitor alert fires and posts to Slack, its only link opens the **monitor config page** — not the data that breached the threshold. A customer (relying on monitors for real-time model-performance visibility ahead of launch) flagged this as major friction: "clicking an alert should show the problematic outputs, not send us to edit the monitor." This adds a second **"View traces" / "View observations"** button that deep-links to the data table for the **breaching time window**. Keeps the existing config button; only fires on breaching alerts.

## Why

The alert Slack message's link is the monitor's `permalink` = `…/project/<id>/monitors/<id>` (the config page). The point of a monitor is to surface the outputs that crossed the threshold, so the alert should take you *there*.

## What

- Adds `buildDataWindowPermalink(projectId, view, from, to)` → `…/project/<id>/<table>?dateRange=<fromMs>-<toMs>` for the breaching evaluation window. **View-aware:** observations-view monitors → observations table; score-view monitors → traces table (the pragmatic row-level default — monitors never operate on a "traces" view).
- Surfaces it as a **second Slack button** (opt-in via a new optional `secondaryUrl`/`secondaryLabel` on the shared attachment builder). The existing "View in Langfuse" config button stays.
- **Gated to breaching alerts** (`ALERT`/`WARNING`): recovery (`OK`), `NO_DATA`, etc. get no data button — so the (already-noisy) recovery notifications are unchanged.
- `dataPermalink` is an optional schema field → backward-compatible with in-flight webhook messages, and it also lands in customer webhook payloads (additive).

## Result

- Alert → one click to the traces/observations for the exact window that breached. Big jump from "opens the config page."
- 64 unit tests (button label/url/count, view→table mapping, `isBreaching` gate across all severities, schema round-trip + backward-compat, `NEXTAUTH_URL`-unset→omitted). typecheck/eslint/prettier clean.

<details>
<summary>Scope, correctness, deliberate deferrals</summary>

**Deliberately deferred (not in this PR):**
- **Filter-scoping** — the link lands on *all* rows in the breaching window, not filtered to the monitor's query. Lossless filter→table-column translation is exactly what **LFE-11021** (widget→traces navigation) is building; layer it on once that lands. Still a large improvement over the config page.
- **Specific failing trace** — monitors run a scalar aggregate, so no individual trace ids exist at alert time; a windowed table view is the realistic deliverable.
- **Recovery-notification suppression** (the customer's item 2) — that's the *recovery* message, and an opt-out needs a new per-monitor "notify on recovery" flag (Prisma column + migration + form toggle) → tracked as a separate ticket.

**Correctness confirmed (code-level):** monitor windows can be 5m, below the smallest table date *preset* (30m). `rangeFromString` parses a `"<num>-<num>"` custom range and returns it as-is (gated only by `from <= to`); preset/`allowedRanges` gating does **not** apply to custom ranges, and the URL value is authoritative on first load (no mount effect clobbers it). So a 5m window renders correctly on both tables.

Files: `packages/shared/src/features/monitors/processor/{processor.ts, buildMonitorAlertSlackMessage.ts}`, `.../monitors/types.ts`, `.../server/services/buildColoredAttachmentSlackMessage.ts` (+ 4 test files).
</details>

LFE-11022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "View traces" / "View observations" deep-link button to Slack monitor alert messages that takes users directly to the data table for the breaching evaluation window, rather than only to the monitor config page.

- `buildDataWindowPermalink` constructs a `?dateRange=<fromMs>-<toMs>` URL pointing to the observations or traces table based on the monitor's view, exposed via a new optional `secondaryUrl`/`secondaryLabel` on the shared Slack attachment builder.
- The data button is gated to breaching severities (`ALERT`/`WARNING`) only; recovery and lifecycle-state notifications remain unchanged.
- `dataPermalink` is added as an optional field on `MonitorAlertSchema`, making it backward-compatible in webhook payloads.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is additive and all new code paths are well-guarded and tested.

The new helpers are straightforward and the 64-test suite covers the gating logic thoroughly. Both findings are minor quality observations with no incorrect runtime behaviour on current callers.

buildColoredAttachmentSlackMessage.ts — the secondary button’s silent dependency on the primary url being present is worth a documentation note for future callers.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/features/monitors/processor/buildMonitorAlertSlackMessage.ts:25-27
`secondaryLabel` is always evaluated and forwarded even when `alert.dataPermalink` is `undefined` (non-breaching alerts like OK/NO_DATA). The label is harmlessly ignored by `buildColoredAttachmentSlackMessage` because the secondary button is guarded by `secondaryUrl`, but the unconditional expression can be confusing — it suggests a button will appear even for recovery notifications. Conditioning it on `dataPermalink` makes the intent self-evident and keeps the two values coupled at the call site.

```suggestion
    secondaryUrl: alert.dataPermalink,
    secondaryLabel: alert.dataPermalink
      ? alert.view === "observations"
        ? "View observations"
        : "View traces"
      : undefined,
```

### Issue 2 of 2
packages/shared/src/server/services/buildColoredAttachmentSlackMessage.ts:57-87
**Secondary button silently dropped without `url`**

The secondary button is nested inside the `args.url` guard, so any future caller that supplies `secondaryUrl` but omits `url` (e.g., a notification that doesn't have a config permalink yet) will get no secondary button and no error. The current callers all couple both values via `NEXTAUTH_URL` so this isn't a live bug, but the silent-drop behaviour is easy to miss. Consider either documenting the coupling explicitly in the JSDoc, or surfacing a warning/guard when `secondaryUrl` is provided without `url`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(monitors): gate alert data-window li..."](https://github.com/langfuse/langfuse/commit/b403fb201fb63d8307d68e5d24ca3a723da54778) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45056229)</sub>

<!-- /greptile_comment -->