### PR TITLE
fix(prompts): isolate linked generation filters

### DIFF
--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -35,6 +35,7 @@ import {
   BatchActionType,
   ActionId,
   RESOURCE_LIMIT_ERROR_MESSAGE,
+  type TracingSearchType,
 } from "@langfuse/shared";
 import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
 import { cn } from "@/src/utils/tailwind";
@@ -124,6 +125,7 @@ import {
 import { CategoryPresetChips } from "@/src/features/events/components/CategoryPresetChips";
 import { TableViewPresetsDrawer } from "@/src/components/table/table-view-presets/components/data-table-view-presets-drawer";
 import { withMetadataPathOptions } from "@/src/features/search-bar/lib/metadata-paths";
+import { getEventsTableStatePolicy } from "@/src/features/events/lib/eventsTableStatePolicy";
 import {
   useObservedMetadataPaths,
   useObservedMetadataRecorder,
@@ -221,6 +223,11 @@ export type EventsTableProps = {
   showControlsInPageHeader?: boolean;
   /** Explicit signal from the Fast Preview/v4 page routes. */
   enableAppRootDefault?: boolean;
+  /**
+   * Keep an embedded table's filters, search, and saved views independent from
+   * the project-wide observations page. The project date range remains shared.
+   */
+  isolateTableState?: boolean;
 };
 
 // Build the start-time `FilterState` for an absolute date range (lower bound
@@ -261,6 +268,7 @@ export default function ObservationsEventsTable({
   sessionId,
   showControlsInPageHeader = false,
   enableAppRootDefault = false,
+  isolateTableState = false,
 }: EventsTableProps) {
   const peekContext = usePeekTableState();
   const router = useRouter();
@@ -272,8 +280,31 @@ export default function ObservationsEventsTable({
 
   const { setDetailPageList } = useDetailPageLists();
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
-  const { searchQuery, searchType, setSearchQuery, setSearchType } =
-    useFullTextSearch();
+  const urlSearch = useFullTextSearch();
+  const [isolatedSearchQuery, setIsolatedSearchQuery] = useState<string | null>(
+    null,
+  );
+  const [isolatedSearchType, setIsolatedSearchType] = useState<
+    TracingSearchType[]
+  >(["id"]);
+  const tableStatePolicy = getEventsTableStatePolicy({
+    hideControls,
+    isolateTableState,
+  });
+  const searchQuery = tableStatePolicy.useIsolatedSearch
+    ? isolatedSearchQuery
+    : urlSearch.searchQuery;
+  const searchType = tableStatePolicy.useIsolatedSearch
+    ? isolatedSearchType
+    : urlSearch.searchType;
+  const setSearchQuery: (query: string | null) => void =
+    tableStatePolicy.useIsolatedSearch
+      ? setIsolatedSearchQuery
+      : urlSearch.setSearchQuery;
+  const setSearchType: (type: TracingSearchType[]) => void =
+    tableStatePolicy.useIsolatedSearch
+      ? setIsolatedSearchType
+      : urlSearch.setSearchType;
 
   const { selectAll, setSelectAll } = useSelectAll(projectId, "observations");
   const [showRunEvaluationDialog, setShowRunEvaluationDialog] = useState(false);
@@ -432,7 +463,7 @@ export default function ObservationsEventsTable({
   // Facet options are scoped only by the time window (the facet hook reads just
   // the start-time filters); use the tick-decoupled range so the auto refresh
   // leaves them alone.
-  const oldFilterState = inputFilterState.concat(
+  const oldFilterState = (isolateTableState ? [] : inputFilterState).concat(
     toStartTimeFilterState(filterOptionsDateRange),
   );
 
@@ -475,7 +506,7 @@ export default function ObservationsEventsTable({
       };
     }
 
-    if (hideControls) {
+    if (tableStatePolicy.filterStateLocation === "memory") {
       return {
         ...baseOptions,
         stateLocation: "memory",
@@ -488,7 +519,7 @@ export default function ObservationsEventsTable({
       sessionFilterContextId: projectId,
     };
   }, [
-    hideControls,
+    tableStatePolicy.filterStateLocation,
     isFilterOptionsPending,
     loadingColumns,
     peekContext,
@@ -524,6 +555,7 @@ export default function ObservationsEventsTable({
     !hideControls &&
     !externalFilterState &&
     !peekContext &&
+    tableStatePolicy.allowGrammarSearch &&
     // Embedded user/session-detail tables are page-scoped (a userId/sessionId
     // filter is AND-combined into the query); the bar reads the full FIELDS
     // registry and would let e.g. `userId:other` fight that scope. Keep it to
@@ -1633,7 +1665,7 @@ export default function ObservationsEventsTable({
       appRootDefault.isAutoManaged,
     ),
     currentExpandedFilters: queryFilter.expanded,
-    disabled: hideControls,
+    disabled: tableStatePolicy.disableSavedViews,
     allowBackendSystemPresets: true,
   });
 
@@ -1897,32 +1929,34 @@ export default function ObservationsEventsTable({
               // left-aligned, so they sit on the same line as the right-aligned
               // Columns/Export controls.
               leadingControls={
-                <div className="flex flex-wrap items-center gap-2">
-                  <CategoryPresetChips
-                    projectId={projectId}
-                    activeViewId={
-                      viewControllers.appliedViewId ??
-                      viewControllers.selectedViewId
-                    }
-                    onApplyView={viewControllers.handleSetViewId}
-                    applyViewState={viewControllers.applyViewState}
-                    onPreviewView={previewViewInSearchBar}
-                  />
-                  <TableViewPresetsDrawer
-                    viewConfig={{
-                      tableName: TableViewPresetTableName.ObservationsEvents,
-                      projectId,
-                      controllers: viewControllers,
-                    }}
-                    currentState={{
-                      orderBy: orderByState ?? null,
-                      filters: queryFilter.explicitFilterState ?? [],
-                      columnOrder,
-                      columnVisibility,
-                      searchQuery: searchQuery ?? "",
-                    }}
-                  />
-                </div>
+                tableStatePolicy.disableSavedViews ? undefined : (
+                  <div className="flex flex-wrap items-center gap-2">
+                    <CategoryPresetChips
+                      projectId={projectId}
+                      activeViewId={
+                        viewControllers.appliedViewId ??
+                        viewControllers.selectedViewId
+                      }
+                      onApplyView={viewControllers.handleSetViewId}
+                      applyViewState={viewControllers.applyViewState}
+                      onPreviewView={previewViewInSearchBar}
+                    />
+                    <TableViewPresetsDrawer
+                      viewConfig={{
+                        tableName: TableViewPresetTableName.ObservationsEvents,
+                        projectId,
+                        controllers: viewControllers,
+                      }}
+                      currentState={{
+                        orderBy: orderByState ?? null,
+                        filters: queryFilter.explicitFilterState ?? [],
+                        columnOrder,
+                        columnVisibility,
+                        searchQuery: searchQuery ?? "",
+                      }}
+                    />
+                  </div>
+                )
               }
             />
           </div>

--- a/web/src/features/events/lib/eventsTableStatePolicy.clienttest.ts
+++ b/web/src/features/events/lib/eventsTableStatePolicy.clienttest.ts
@@ -1,0 +1,45 @@
+import { getEventsTableStatePolicy } from "@/src/features/events/lib/eventsTableStatePolicy";
+
+describe("getEventsTableStatePolicy", () => {
+  it("isolates embedded table filters, search, and saved views", () => {
+    expect(
+      getEventsTableStatePolicy({
+        hideControls: false,
+        isolateTableState: true,
+      }),
+    ).toEqual({
+      filterStateLocation: "memory",
+      useIsolatedSearch: true,
+      allowGrammarSearch: false,
+      disableSavedViews: true,
+    });
+  });
+
+  it("keeps the standard events table URL-backed", () => {
+    expect(
+      getEventsTableStatePolicy({
+        hideControls: false,
+        isolateTableState: false,
+      }),
+    ).toEqual({
+      filterStateLocation: "urlAndSessionStorage",
+      useIsolatedSearch: false,
+      allowGrammarSearch: true,
+      disableSavedViews: false,
+    });
+  });
+
+  it("keeps hidden-control tables in memory without changing their search policy", () => {
+    expect(
+      getEventsTableStatePolicy({
+        hideControls: true,
+        isolateTableState: false,
+      }),
+    ).toEqual({
+      filterStateLocation: "memory",
+      useIsolatedSearch: false,
+      allowGrammarSearch: true,
+      disableSavedViews: true,
+    });
+  });
+});

--- a/web/src/features/events/lib/eventsTableStatePolicy.ts
+++ b/web/src/features/events/lib/eventsTableStatePolicy.ts
@@ -1,0 +1,20 @@
+export type EventsTableStatePolicy = {
+  filterStateLocation: "memory" | "urlAndSessionStorage";
+  useIsolatedSearch: boolean;
+  allowGrammarSearch: boolean;
+  disableSavedViews: boolean;
+};
+
+export const getEventsTableStatePolicy = ({
+  hideControls,
+  isolateTableState,
+}: {
+  hideControls: boolean;
+  isolateTableState: boolean;
+}): EventsTableStatePolicy => ({
+  filterStateLocation:
+    hideControls || isolateTableState ? "memory" : "urlAndSessionStorage",
+  useIsolatedSearch: isolateTableState,
+  allowGrammarSearch: !isolateTableState,
+  disableSavedViews: hideControls || isolateTableState,
+});

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -499,6 +499,7 @@ export const PromptDetail = ({
                     promptName={prompt.name}
                     promptVersion={prompt.version}
                     omittedFilter={["promptName"]}
+                    isolateTableState
                   />
                 ) : (
                   <LegacyGenerations


### PR DESCRIPTION
## What changed

- isolate Prompt > Linked Generations sidebar filters from the main Observations URL/session state
- keep full-text search local to the embedded table and disable the grammar search bar
- disable saved views/category presets in this isolated state so they cannot reapply project-wide filters
- continue inheriting the project date range

Follow-up to #15184.

## Why

The v4 events table embedded on a prompt detail page reused the main Observations table's `filter`, `search`, and `viewId` state. Those restored conditions were ANDed with the prompt name/version constraints and could make Linked Generations appear empty.

## Verification

- `Tests  3 passed (3)`
- web typecheck passed
- `Tasks: 7 successful, 7 total` (lint)
- browser-tested a prompt URL containing stale `filter`, `search`, and `viewId`: the embedded v4 table ignored them, showed an empty local search field, omitted grammar/saved-view controls, and retained the shared date-range control

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the Prompt → Linked Generations sidebar table was inheriting `filter`, `search`, and `viewId` URL state from the main Observations page, which could cause the embedded table to show no results when stale constraints were ANDed with the prompt name/version filters.

- Adds a new `eventsTableStatePolicy.ts` module that derives four policy flags (`filterStateLocation`, `useIsolatedSearch`, `allowGrammarSearch`, `disableSavedViews`) from the `hideControls` and `isolateTableState` props, then uses those flags throughout `EventsTable` instead of the raw `hideControls` boolean.
- Adds `isolateTableState` prop to `EventsTable` (defaulting to `false`, so existing callers are unaffected) and passes `isolateTableState` from `prompt-detail.tsx`; when set, filter state moves to in-memory, full-text search uses local React state, grammar search bar and saved-view controls are hidden, and stale URL filters are excluded from facet computation — while the project date range continues to be shared.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is isolated to the embedded prompt-detail table, all existing callers of EventsTable are unaffected by the new prop defaulting to false, and the fix is browser-verified.

The fix is surgical: a new policy module with clear unit tests handles the four isolation flags, and the component changes follow the policy consistently. URL-backed search state is correctly shadowed by local React state in isolated mode, the grammar search bar and saved-view controls are properly gated, and stale URL filters are excluded from both the data query (via memory-mode sidebar state) and facet computation (via the oldFilterState guard). The date range remains shared as intended. No existing call sites are affected.

No files require special attention. The eventsTableStatePolicy.ts and its tests are self-contained, and the EventsTable changes are well-scoped.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EventsTable mount] --> B{isolateTableState?}
    B -- false --> C[Standard mode]
    B -- true --> D[Isolated mode]

    C --> C1[filterStateLocation: urlAndSessionStorage]
    C --> C2[searchQuery from URL params]
    C --> C3[Grammar search bar enabled]
    C --> C4[Saved views enabled]
    C --> C5[inputFilterState included in facets]

    D --> D1[filterStateLocation: memory]
    D --> D2[searchQuery from local useState]
    D --> D3[Grammar search bar disabled]
    D --> D4[Saved views disabled]
    D --> D5[inputFilterState excluded from facets]

    D1 --> Q[useSidebarFilterState - memory]
    C1 --> QU[useSidebarFilterState - URL + session]

    Q --> F[combinedFilterState]
    QU --> F

    F --> G[promptNameFilter + promptVersionFilter + dateRangeFilter]
    G --> H[useEventsTableData API call]

    subgraph Always Shared
        TR[useTableDateRange - project-wide date range]
    end
    TR --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[EventsTable mount] --> B{isolateTableState?}
    B -- false --> C[Standard mode]
    B -- true --> D[Isolated mode]

    C --> C1[filterStateLocation: urlAndSessionStorage]
    C --> C2[searchQuery from URL params]
    C --> C3[Grammar search bar enabled]
    C --> C4[Saved views enabled]
    C --> C5[inputFilterState included in facets]

    D --> D1[filterStateLocation: memory]
    D --> D2[searchQuery from local useState]
    D --> D3[Grammar search bar disabled]
    D --> D4[Saved views disabled]
    D --> D5[inputFilterState excluded from facets]

    D1 --> Q[useSidebarFilterState - memory]
    C1 --> QU[useSidebarFilterState - URL + session]

    Q --> F[combinedFilterState]
    QU --> F

    F --> G[promptNameFilter + promptVersionFilter + dateRangeFilter]
    G --> H[useEventsTableData API call]

    subgraph Always Shared
        TR[useTableDateRange - project-wide date range]
    end
    TR --> G
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(prompts): isolate linked generation ..."](https://github.com/langfuse/langfuse/commit/df0288fd7f96700afa8b66d16d7f5e6a2ab76072) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45056293)</sub>

<!-- /greptile_comment -->