### PR TITLE
fix: make data retention cleaner more robust against large backlogs

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -434,6 +434,7 @@ export async function queryClickhouseExecRaw(
         ).exec({
           query: queryWithFormat,
           query_params: opts.params,
+          use_multipart_params_auto: opts.useMultipartParamsAuto,
           clickhouse_settings: {
             ...opts.clickhouseSettings,
             log_comment: JSON.stringify(normalizedTags),
@@ -550,6 +551,7 @@ function handleExceptionRow<T>(parsedRow: T): T {
 export type ClickhouseQueryOpts = {
   query: string;
   params?: Record<string, unknown>;
+  useMultipartParamsAuto?: boolean;
   clickhouseConfigs?: NodeClickHouseClientConfigOptions;
   tags?: ClickHouseQueryTags;
   preferredClickhouseService?: PreferredClickhouseService;
@@ -588,6 +590,7 @@ function setSpanQueryAttributes(span: Span, query: string): void {
 async function sendClickhouseQuery<F extends DataFormat>(opts: {
   query: string;
   params?: Record<string, unknown>;
+  useMultipartParamsAuto?: boolean;
   clickhouseConfigs?: NodeClickHouseClientConfigOptions;
   tags?: ClickHouseQueryTags;
   preferredClickhouseService?: PreferredClickhouseService;
@@ -603,6 +606,7 @@ async function sendClickhouseQuery<F extends DataFormat>(opts: {
     query: opts.query,
     format: opts.format,
     query_params: opts.params,
+    use_multipart_params_auto: opts.useMultipartParamsAuto,
     clickhouse_settings: {
       ...opts.clickhouseSettings,
       log_comment: JSON.stringify(normalizedTags),

--- a/worker/src/__tests__/batchDataRetentionCleaner.test.ts
+++ b/worker/src/__tests__/batchDataRetentionCleaner.test.ts
@@ -1,7 +1,13 @@
-import { expect, describe, it } from "vitest";
+import { afterEach, beforeEach, expect, describe, it, vi } from "vitest";
 import { randomUUID } from "crypto";
-import { BatchDataRetentionCleaner } from "../features/batch-data-retention-cleaner";
 import {
+  BatchDataRetentionCleaner,
+  type BatchDataRetentionTable,
+  TIMESTAMP_COLUMN_MAP,
+} from "../features/batch-data-retention-cleaner";
+import {
+  clickhouseClient,
+  commandClickhouse,
   createOrgProjectAndApiKey,
   createTracesCh,
   createTrace,
@@ -12,6 +18,61 @@ import {
   queryClickhouse,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
+import { env } from "../env";
+
+const integrationHooks = vi.hoisted(() => ({
+  failExactEnrichmentForProjectId: null as string | null,
+  failCandidateStreamAfterFirstRow: false,
+  activeCandidateStreams: 0,
+  gaugeCalls: [] as Array<[stat: string, value: number | undefined]>,
+  incrementCalls: [] as Array<[stat: string, value: number | undefined]>,
+}));
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+
+  return {
+    ...actual,
+    queryClickhouse: async <T>(
+      opts: Parameters<typeof actual.queryClickhouse>[0],
+    ) => {
+      if (
+        opts.query.includes("AS oldest_age_seconds") &&
+        integrationHooks.failExactEnrichmentForProjectId !== null &&
+        Object.values(opts.params ?? {}).includes(
+          integrationHooks.failExactEnrichmentForProjectId,
+        )
+      ) {
+        throw new Error("forced exact enrichment failure");
+      }
+      return actual.queryClickhouse<T>(opts);
+    },
+    queryClickhouseStream: async function* <T>(
+      opts: Parameters<typeof actual.queryClickhouseStream>[0],
+    ): AsyncGenerator<T> {
+      integrationHooks.activeCandidateStreams += 1;
+      try {
+        for await (const row of actual.queryClickhouseStream<T>(opts)) {
+          yield row;
+          if (integrationHooks.failCandidateStreamAfterFirstRow) {
+            throw new Error("forced candidate stream failure");
+          }
+        }
+      } finally {
+        integrationHooks.activeCandidateStreams -= 1;
+      }
+    },
+    recordGauge: (...args: Parameters<typeof actual.recordGauge>) => {
+      integrationHooks.gaugeCalls.push([args[0], args[1]]);
+      return actual.recordGauge(...args);
+    },
+    recordIncrement: (...args: Parameters<typeof actual.recordIncrement>) => {
+      integrationHooks.incrementCalls.push([args[0], args[1]]);
+      return actual.recordIncrement(...args);
+    },
+  };
+});
 
 async function getClickhouseCount(
   table: string,
@@ -19,6 +80,78 @@ async function getClickhouseCount(
 ): Promise<number> {
   const result = await queryClickhouse<{ count: number }>({
     query: `SELECT count() as count FROM ${table} FINAL WHERE project_id = {projectId: String}`,
+    params: { projectId },
+  });
+  return Number(result[0]?.count ?? 0);
+}
+
+function retentionTestTableName(): string {
+  return `batch_retention_${randomUUID().replaceAll("-", "")}`;
+}
+
+async function createRetentionTestTable(tableName: string): Promise<void> {
+  await commandClickhouse({
+    query: `
+      CREATE TABLE ${tableName} (
+        project_id String,
+        start_time DateTime64(3),
+        event_ts DateTime64(3)
+      )
+      ENGINE = MergeTree
+      PARTITION BY toYYYYMM(start_time)
+      ORDER BY (project_id, start_time)
+    `,
+  });
+}
+
+async function createProjectsWithRetention(count: number): Promise<string[]> {
+  const projectIds: string[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const { projectId } = await createOrgProjectAndApiKey();
+    await prisma.project.update({
+      where: { id: projectId },
+      data: { retentionDays: 7 },
+    });
+    projectIds.push(projectId);
+  }
+  return projectIds;
+}
+
+async function insertRetentionTestRows(
+  tableName: string,
+  rows: Array<{ projectId: string; startTime: number }>,
+): Promise<void> {
+  await clickhouseClient().insert({
+    table: tableName,
+    format: "JSONEachRow",
+    values: rows.map((row) => ({
+      project_id: row.projectId,
+      start_time: row.startTime,
+      event_ts: row.startTime,
+    })),
+  });
+}
+
+async function getRetentionTestRowCount(tableName: string): Promise<number> {
+  const result = await queryClickhouse<{ count: number }>({
+    query: `
+      SELECT count() AS count
+      FROM ${tableName}
+    `,
+  });
+  return Number(result[0]?.count ?? 0);
+}
+
+async function getRetentionTestProjectCount(
+  tableName: string,
+  projectId: string,
+): Promise<number> {
+  const result = await queryClickhouse<{ count: number }>({
+    query: `
+      SELECT count() AS count
+      FROM ${tableName}
+      WHERE project_id = {projectId: String}
+    `,
     params: { projectId },
   });
   return Number(result[0]?.count ?? 0);
@@ -305,6 +438,169 @@ describe("BatchDataRetentionCleaner", () => {
 
       // Verify score was deleted
       expect(await getClickhouseCount(TABLE, projectId)).toBe(0);
+    });
+  });
+
+  describe("candidate discovery and fallback queries", () => {
+    const timestampColumns = TIMESTAMP_COLUMN_MAP as Record<string, string>;
+    let tableName: string;
+    let table: BatchDataRetentionTable;
+    let originalChunkSize: number;
+    let originalProjectLimit: number;
+
+    beforeEach(async () => {
+      tableName = retentionTestTableName();
+      table = tableName as BatchDataRetentionTable;
+      originalChunkSize = env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CHUNK_SIZE;
+      originalProjectLimit =
+        env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT;
+      timestampColumns[tableName] = "start_time";
+      integrationHooks.failExactEnrichmentForProjectId = null;
+      integrationHooks.failCandidateStreamAfterFirstRow = false;
+      integrationHooks.activeCandidateStreams = 0;
+      integrationHooks.gaugeCalls = [];
+      integrationHooks.incrementCalls = [];
+      await createRetentionTestTable(tableName);
+    });
+
+    afterEach(async () => {
+      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CHUNK_SIZE = originalChunkSize;
+      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT =
+        originalProjectLimit;
+      delete timestampColumns[tableName];
+      await commandClickhouse({ query: `DROP TABLE IF EXISTS ${tableName}` });
+    });
+
+    it("discovers expired projects across every configured project chunk", async () => {
+      const projectIds = await createProjectsWithRetention(3);
+      await insertRetentionTestRows(
+        tableName,
+        projectIds.map((projectId) => ({
+          projectId,
+          startTime: Date.now() - 10 * 24 * 60 * 60 * 1000,
+        })),
+      );
+      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CHUNK_SIZE = 2;
+      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT = 3;
+
+      await new BatchDataRetentionCleaner(table).processBatch();
+
+      expect(await getRetentionTestRowCount(tableName)).toBe(0);
+      expect(integrationHooks.incrementCalls).toContainEqual([
+        "langfuse.batch_data_retention_cleaner.rows_matched_before_delete",
+        3,
+      ]);
+      expect(
+        integrationHooks.gaugeCalls.findLast(
+          ([stat]) =>
+            stat ===
+            "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
+        )?.[1],
+      ).toBeGreaterThan(0);
+    });
+
+    it("renews on progress and aborts when the final lease renewal fails", async () => {
+      const [projectId] = await createProjectsWithRetention(1);
+      await insertRetentionTestRows(tableName, [
+        {
+          projectId: projectId!,
+          startTime: Date.now() - 10 * 24 * 60 * 60 * 1000,
+        },
+      ]);
+
+      const cleaner = new BatchDataRetentionCleaner(table);
+      let extendedDuringCandidateStream = false;
+      const extend = vi.fn(async () => {
+        const isCandidateStreamActive =
+          integrationHooks.activeCandidateStreams > 0;
+        extendedDuringCandidateStream ||= isCandidateStreamActive;
+        return isCandidateStreamActive;
+      });
+      (
+        cleaner as unknown as {
+          lock: { extend: typeof extend };
+        }
+      ).lock.extend = extend;
+
+      await cleaner.processBatch();
+
+      expect(extendedDuringCandidateStream).toBe(true);
+      expect(await getRetentionTestRowCount(tableName)).toBe(1);
+      expect(integrationHooks.incrementCalls).toContainEqual([
+        "langfuse.batch_data_retention_cleaner.delete_failures",
+        1,
+      ]);
+    });
+
+    it("retains candidates yielded before the stream fails", async () => {
+      const [projectId] = await createProjectsWithRetention(1);
+      await insertRetentionTestRows(tableName, [
+        {
+          projectId: projectId!,
+          startTime: Date.now() - 10 * 24 * 60 * 60 * 1000,
+        },
+      ]);
+      integrationHooks.failCandidateStreamAfterFirstRow = true;
+
+      await new BatchDataRetentionCleaner(table).processBatch();
+
+      expect(await getRetentionTestRowCount(tableName)).toBe(0);
+      expect(integrationHooks.incrementCalls).toContainEqual([
+        "langfuse.batch_data_retention_cleaner.candidate_query_failures",
+        1,
+      ]);
+    });
+
+    it("prioritizes unenriched candidates and estimates lag from their oldest partition", async () => {
+      const [fallbackProjectId, exactProjectId] =
+        await createProjectsWithRetention(2);
+      const exactExpiredAt = Date.now() - 10 * 24 * 60 * 60 * 1000;
+      await insertRetentionTestRows(tableName, [
+        {
+          projectId: fallbackProjectId!,
+          startTime: new Date("2020-03-15T00:00:00.000Z").getTime(),
+        },
+        {
+          projectId: fallbackProjectId!,
+          startTime: new Date("2020-01-15T00:00:00.000Z").getTime(),
+        },
+        { projectId: exactProjectId!, startTime: exactExpiredAt },
+        { projectId: exactProjectId!, startTime: exactExpiredAt - 1 },
+        { projectId: exactProjectId!, startTime: exactExpiredAt - 2 },
+      ]);
+      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CHUNK_SIZE = 1;
+      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT = 1;
+      integrationHooks.failExactEnrichmentForProjectId = fallbackProjectId!;
+      const beforeRun = Date.now();
+
+      await new BatchDataRetentionCleaner(table).processBatch();
+
+      const afterRun = Date.now();
+      expect(
+        await getRetentionTestProjectCount(tableName, fallbackProjectId!),
+      ).toBe(0);
+      expect(
+        await getRetentionTestProjectCount(tableName, exactProjectId!),
+      ).toBe(3);
+
+      const lagGauge = integrationHooks.gaugeCalls.findLast(
+        ([stat]) =>
+          stat === "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
+      );
+      const partitionStart = new Date("2020-01-01T00:00:00.000Z").getTime();
+      const retentionMs = 7 * 24 * 60 * 60 * 1000;
+      const lagValue = lagGauge?.[1] ?? Number.NaN;
+
+      expect(lagValue).toBeGreaterThanOrEqual(
+        (beforeRun - retentionMs - partitionStart) / 1000,
+      );
+      expect(lagValue).toBeLessThanOrEqual(
+        (afterRun - retentionMs - partitionStart) / 1000,
+      );
+      expect(integrationHooks.incrementCalls).toContainEqual([
+        "langfuse.batch_data_retention_cleaner.row_count_unavailable",
+        1,
+      ]);
     });
   });
 });

--- a/worker/src/__tests__/batchDataRetentionCleaner.test.ts
+++ b/worker/src/__tests__/batchDataRetentionCleaner.test.ts
@@ -24,6 +24,7 @@ const integrationHooks = vi.hoisted(() => ({
   failExactEnrichmentForProjectId: null as string | null,
   failCandidateStreamAfterFirstRow: false,
   activeCandidateStreams: 0,
+  candidateHttpTimeouts: [] as Array<{ send: number; receive: number }>,
   gaugeCalls: [] as Array<[stat: string, value: number | undefined]>,
   incrementCalls: [] as Array<[stat: string, value: number | undefined]>,
 }));
@@ -51,6 +52,16 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
     queryClickhouseStream: async function* <T>(
       opts: Parameters<typeof actual.queryClickhouseStream>[0],
     ): AsyncGenerator<T> {
+      if (opts.query.includes("SELECT DISTINCT project_id")) {
+        integrationHooks.candidateHttpTimeouts.push({
+          send: Number(
+            opts.clickhouseConfigs?.clickhouse_settings?.http_send_timeout,
+          ),
+          receive: Number(
+            opts.clickhouseConfigs?.clickhouse_settings?.http_receive_timeout,
+          ),
+        });
+      }
       integrationHooks.activeCandidateStreams += 1;
       try {
         for await (const row of actual.queryClickhouseStream<T>(opts)) {
@@ -458,6 +469,7 @@ describe("BatchDataRetentionCleaner", () => {
       integrationHooks.failExactEnrichmentForProjectId = null;
       integrationHooks.failCandidateStreamAfterFirstRow = false;
       integrationHooks.activeCandidateStreams = 0;
+      integrationHooks.candidateHttpTimeouts = [];
       integrationHooks.gaugeCalls = [];
       integrationHooks.incrementCalls = [];
       await createRetentionTestTable(tableName);
@@ -490,6 +502,17 @@ describe("BatchDataRetentionCleaner", () => {
         "langfuse.batch_data_retention_cleaner.rows_matched_before_delete",
         3,
       ]);
+      expect(integrationHooks.candidateHttpTimeouts.length).toBeGreaterThan(0);
+      for (const timeouts of integrationHooks.candidateHttpTimeouts) {
+        const expectedTimeoutSeconds = Math.ceil(
+          env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CANDIDATE_QUERY_TIMEOUT_MS /
+            1000,
+        );
+        expect(timeouts).toEqual({
+          send: expectedTimeoutSeconds,
+          receive: expectedTimeoutSeconds,
+        });
+      }
       expect(
         integrationHooks.gaugeCalls.findLast(
           ([stat]) =>

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -427,6 +427,11 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(100), // Chunk size for counting projects in ClickHouse
+  LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CANDIDATE_QUERY_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(180_000), // 3 minutes for candidate discovery queries
   LANGFUSE_BATCH_DATA_RETENTION_CLEANER_DELETE_TIMEOUT_MS: z.coerce
     .number()
     .positive()

--- a/worker/src/features/batch-data-retention-cleaner/index.ts
+++ b/worker/src/features/batch-data-retention-cleaner/index.ts
@@ -199,7 +199,9 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       onUnavailable: "fail",
     });
     this.tableName = tableName;
-    this.candidateQueryHttpTimeoutSeconds = lockTtlSeconds;
+    this.candidateQueryHttpTimeoutSeconds = Math.ceil(
+      candidateQueryTimeoutMs / 1000,
+    );
     this.lockExtensionMinIntervalMs = Math.floor((lockTtlSeconds * 1000) / 3);
   }
 

--- a/worker/src/features/batch-data-retention-cleaner/index.ts
+++ b/worker/src/features/batch-data-retention-cleaner/index.ts
@@ -7,6 +7,7 @@ import {
   convertDateToClickhouseDateTime,
   logger,
   queryClickhouse,
+  queryClickhouseStream,
   recordGauge,
   recordIncrement,
 } from "@langfuse/shared/src/server";
@@ -28,6 +29,13 @@ export type BatchDataRetentionTable =
 
 const METRIC_PREFIX = "langfuse.batch_data_retention_cleaner";
 
+class BatchDataRetentionCleanerLeaseLostError extends Error {
+  constructor(tableName: BatchDataRetentionTable) {
+    super(`Batch data retention cleaner lost its lease for ${tableName}`);
+    this.name = "BatchDataRetentionCleanerLeaseLostError";
+  }
+}
+
 export const BATCH_DATA_RETENTION_CLEANER_LOCK_PREFIX =
   "langfuse:batch-data-retention-cleaner";
 
@@ -39,12 +47,61 @@ export const TIMESTAMP_COLUMN_MAP: Record<BatchDataRetentionTable, string> = {
   events_core: "start_time",
 };
 
-interface ProjectWorkload {
+interface ProjectRetention {
   projectId: string;
   retentionDays: number;
   cutoffDate: Date;
-  expiredRowCount: number;
+}
+
+interface ProjectWorkload extends ProjectRetention {
+  expiredRowCount: number | null;
   oldestAgeSeconds: number | null;
+}
+
+function parseMonthlyPartitionStart(partitionId: string): Date | null {
+  if (!/^\d{6}$/.test(partitionId)) {
+    return null;
+  }
+
+  const year = Number(partitionId.slice(0, 4));
+  const month = Number(partitionId.slice(4, 6));
+  if (year < 100 || month < 1 || month > 12) {
+    return null;
+  }
+
+  return new Date(Date.UTC(year, month - 1, 1));
+}
+
+async function getOldestProjectPartitionStarts(
+  tableName: BatchDataRetentionTable,
+  projectIds: string[],
+): Promise<Map<string, Date | null>> {
+  if (projectIds.length === 0) {
+    return new Map();
+  }
+
+  const result = await queryClickhouse<{
+    project_id: string;
+    oldest_expired_partition: string;
+  }>({
+    query: `
+      SELECT
+        project_id,
+        min(_partition_id) AS oldest_expired_partition
+      FROM ${tableName}
+      PREWHERE project_id IN ({candidateProjectIds: Array(String)})
+      GROUP BY project_id
+    `,
+    params: { candidateProjectIds: projectIds },
+    useMultipartParamsAuto: true,
+  });
+
+  return new Map(
+    result.map((row) => [
+      row.project_id,
+      parseMonthlyPartitionStart(row.oldest_expired_partition),
+    ]),
+  );
 }
 
 /**
@@ -61,7 +118,7 @@ function toParamKey(projectId: string): string {
  */
 function buildRetentionConditions(
   timestampColumn: string,
-  projects: ProjectWorkload[],
+  projects: ProjectRetention[],
 ): { conditions: string; params: Record<string, unknown> } {
   // Compute hashes once and check for collisions
   const projectToKey = new Map<string, string>();
@@ -106,30 +163,44 @@ function buildRetentionConditions(
  * Flow:
  * 1. Query PG for all projects with retentionDays > 0
  * 2. Calculate retention cutoff dates for each project
- * 3. Chunk projects and query CH for expired row counts (retention-aware)
- * 4. Sort by expired count DESC, select top N projects with expired data
- * 5. Execute single batch DELETE with OR conditions
+ * 3. Stream projects with expired rows from bounded project chunks
+ * 4. Best-effort enrich candidates with exact count and oldest timestamp
+ * 5. Sort by expired count DESC when enrichment is available
+ * 6. Execute a single batch DELETE with OR conditions
  */
 export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
   private readonly tableName: BatchDataRetentionTable;
+  private readonly candidateQueryHttpTimeoutSeconds: number;
+  private readonly lockExtensionMinIntervalMs: number;
+  private lastLockExtensionAt = 0;
+  private lockExtensionInFlight: Promise<void> | null = null;
 
   protected get defaultIntervalMs(): number {
     return env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_INTERVAL_MS;
   }
 
   constructor(tableName: BatchDataRetentionTable) {
-    // TTL = DELETE timeout + 5 minutes buffer
+    const candidateQueryTimeoutMs =
+      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CANDIDATE_QUERY_TIMEOUT_MS;
+
+    // TTL = longest bounded operation + 5 minutes buffer
     const lockTtlSeconds =
       Math.ceil(
-        env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_DELETE_TIMEOUT_MS / 1000,
+        Math.max(
+          env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_DELETE_TIMEOUT_MS,
+          candidateQueryTimeoutMs,
+        ) / 1000,
       ) + 300;
 
     super({
       name: `BatchDataRetentionCleaner(${tableName})`,
       lockKey: `${BATCH_DATA_RETENTION_CLEANER_LOCK_PREFIX}:${tableName}`,
       lockTtlSeconds,
+      onUnavailable: "fail",
     });
     this.tableName = tableName;
+    this.candidateQueryHttpTimeoutSeconds = lockTtlSeconds;
+    this.lockExtensionMinIntervalMs = Math.floor((lockTtlSeconds * 1000) / 3);
   }
 
   /**
@@ -139,10 +210,45 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
     logger.info(`Starting ${this.instanceName}`, {
       intervalMs: env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_INTERVAL_MS,
       projectLimit: env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT,
+      candidateQueryTimeoutMs:
+        env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CANDIDATE_QUERY_TIMEOUT_MS,
       deleteTimeoutMs:
         env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_DELETE_TIMEOUT_MS,
     });
     super.start();
+  }
+
+  /**
+   * Renew the lease when work advances, without issuing one Redis command per
+   * streamed row. A failed renewal means this worker no longer owns the batch.
+   */
+  private async extendLockOnProgress(force = false): Promise<void> {
+    if (
+      !force &&
+      Date.now() - this.lastLockExtensionAt < this.lockExtensionMinIntervalMs
+    ) {
+      return;
+    }
+
+    if (this.lockExtensionInFlight) {
+      return this.lockExtensionInFlight;
+    }
+
+    const extension = (async () => {
+      if (!(await this.lock.extend())) {
+        throw new BatchDataRetentionCleanerLeaseLostError(this.tableName);
+      }
+      this.lastLockExtensionAt = Date.now();
+    })();
+    this.lockExtensionInFlight = extension;
+
+    try {
+      await extension;
+    } finally {
+      if (this.lockExtensionInFlight === extension) {
+        this.lockExtensionInFlight = null;
+      }
+    }
   }
 
   /**
@@ -163,26 +269,32 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
 
     await this.withLock(
       async () => {
-        // Step 1: Get project workloads (chunked CH counts + PG retention config)
+        // Each acquisition starts a fresh lease, so progress in a prior run
+        // must not throttle the first renewal in this one.
+        this.lastLockExtensionAt = 0;
+
+        // Step 1: Get project workloads (streamed CH candidates + PG config)
         const workloads = await this.getProjectWorkloads();
 
         recordGauge(`${METRIC_PREFIX}.pending_projects`, workloads.length, {
           table: this.tableName,
         });
 
-        // Compute seconds past cutoff for each workload
         const SECONDS_PER_DAY = 86400;
         const secondsPastCutoffByProject = workloads
-          .filter((w) => w.oldestAgeSeconds !== null)
-          .map((w) => ({
-            projectId: w.projectId,
+          .filter((workload) => workload.oldestAgeSeconds !== null)
+          .map((workload) => ({
+            projectId: workload.projectId,
             secondsPastCutoff:
-              w.oldestAgeSeconds! - w.retentionDays * SECONDS_PER_DAY,
+              workload.oldestAgeSeconds! -
+              workload.retentionDays * SECONDS_PER_DAY,
           }));
 
         // Compute p90 for the gauge metric (0 when no pending work)
         const p90SecondsPastCutoff = percentile(
-          secondsPastCutoffByProject.map((p) => p.secondsPastCutoff),
+          secondsPastCutoffByProject.map((project) =>
+            Math.max(project.secondsPastCutoff, 0),
+          ),
           0.9,
         );
 
@@ -199,12 +311,34 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
           logger.info(
             `${this.instanceName}: Processing ${workloads.length} projects`,
             {
-              projectIds: workloads.map((w) => w.projectId),
+              projectIds: workloads.map((workload) => workload.projectId),
               secondsPastCutoffByProject,
             },
           );
 
           await this.executeBatchDelete(timestampColumn, workloads);
+
+          if (workloads.length > 0) {
+            const matchedRows = workloads.reduce<number | null>(
+              (sum, workload) =>
+                sum === null || workload.expiredRowCount === null
+                  ? null
+                  : sum + workload.expiredRowCount,
+              0,
+            );
+
+            if (matchedRows === null) {
+              recordIncrement(`${METRIC_PREFIX}.row_count_unavailable`, 1, {
+                table: this.tableName,
+              });
+            } else {
+              recordIncrement(
+                `${METRIC_PREFIX}.rows_matched_before_delete`,
+                matchedRows,
+                { table: this.tableName },
+              );
+            }
+          }
 
           logger.info(`${this.instanceName}: Batch deletion completed`, {
             table: this.tableName,
@@ -237,13 +371,12 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
   }
 
   /**
-   * Get project workloads using chunked queries:
+   * Get project workloads using bounded candidate discovery:
    * 1. PostgreSQL: Get all projects with retention enabled
    * 2. Calculate cutoffs for all projects
-   * 3. Chunk projects and query ClickHouse for expired row counts
-   * 4. Combine results, sort by count, select top N
-   *
-   * Chunking prevents running into CH query and param size limits.
+   * 3. Stream projects with expired data from each CHUNK_SIZE project chunk
+   * 4. Best-effort enrich each chunk's candidates with count/min
+   * 5. Sort by count when available and select top PROJECT_LIMIT
    */
   private async getProjectWorkloads(): Promise<ProjectWorkload[]> {
     const timestampColumn = TIMESTAMP_COLUMN_MAP[this.tableName];
@@ -263,51 +396,69 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
 
     // Step 2: Calculate cutoffs for all projects upfront
     const now = new Date();
-    const allProjectRetentions: ProjectWorkload[] = projectsWithRetention.map(
-      (p) => ({
-        projectId: p.id,
-        retentionDays: p.retentionDays!,
-        cutoffDate: getRetentionCutoffDate(p.retentionDays!, now),
-        expiredRowCount: 0,
-        oldestAgeSeconds: null,
+    const allProjectRetentions: ProjectRetention[] = projectsWithRetention.map(
+      (project) => ({
+        projectId: project.id,
+        retentionDays: project.retentionDays!,
+        cutoffDate: getRetentionCutoffDate(project.retentionDays!, now),
       }),
     );
 
-    // Step 3: Chunk projects and query ClickHouse for expired row counts
+    // Step 3: Bound both the project parameters and returned candidates for
+    // each ClickHouse query. A completed query can return every matching
+    // project in its input chunk because both use the same configured limit.
     const chunkSize = env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CHUNK_SIZE;
-    const chunks: (typeof allProjectRetentions)[] = [];
-    for (let i = 0; i < allProjectRetentions.length; i += chunkSize) {
-      chunks.push(allProjectRetentions.slice(i, i + chunkSize));
+    const projectChunks: ProjectRetention[][] = [];
+    for (
+      let offset = 0;
+      offset < allProjectRetentions.length;
+      offset += chunkSize
+    ) {
+      projectChunks.push(
+        allProjectRetentions.slice(offset, offset + chunkSize),
+      );
     }
 
-    // Query each chunk in parallel (counts only expired rows)
-    const chunkResults = await Promise.all(
-      chunks.map((chunk) =>
-        this.countExpiredRowsInChunk(timestampColumn, chunk),
-      ),
+    // Step 4: Exact count/min is useful for global ordering and metrics, but
+    // deletion must not depend on this more expensive grouped query succeeding.
+    // Keep enrichment per input chunk so its parameters remain bounded too.
+    const chunkWorkloads = await Promise.all(
+      projectChunks.map(async (projectChunk) => {
+        const candidates = await this.findExpiredProjectCandidates(
+          timestampColumn,
+          projectChunk,
+        );
+        return this.enrichProjectCandidates(timestampColumn, candidates);
+      }),
     );
+    const workloads = chunkWorkloads.flat();
 
-    // Step 4: Combine results, sort by count DESC, select top N
-    const allCounts = chunkResults.flat();
-    allCounts.sort((a, b) => b.expiredRowCount - a.expiredRowCount);
+    // A failed count can indicate a particularly large workload. Prioritize
+    // unknown counts ahead of exact counts instead of treating them as empty.
+    workloads.sort((left, right) => {
+      if (left.expiredRowCount === null) {
+        return right.expiredRowCount === null ? 0 : -1;
+      }
+      if (right.expiredRowCount === null) {
+        return 1;
+      }
+      return right.expiredRowCount - left.expiredRowCount;
+    });
 
-    // Filter out projects with no expired rows
-    const withExpiredRows = allCounts.filter((p) => p.expiredRowCount > 0);
-
-    return withExpiredRows.slice(
+    return workloads.slice(
       0,
       env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT,
     );
   }
 
   /**
-   * Count expired rows for a chunk of projects in ClickHouse.
-   * Uses the same retention conditions as delete to count only rows that will be deleted.
+   * Stream projects with expired rows from one bounded project chunk. Rows
+   * yielded before a query failure remain eligible for deletion.
    */
-  private async countExpiredRowsInChunk(
+  private async findExpiredProjectCandidates(
     timestampColumn: string,
-    projects: ProjectWorkload[],
-  ): Promise<ProjectWorkload[]> {
+    projects: ProjectRetention[],
+  ): Promise<ProjectRetention[]> {
     if (projects.length === 0) {
       return [];
     }
@@ -318,45 +469,191 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
     );
 
     const query = `
-      SELECT
-        project_id,
-        count() as count,
-        dateDiff('second', min(event_ts), now()) as oldest_age_seconds
+      SELECT DISTINCT project_id
       FROM ${this.tableName}
-      WHERE ${conditions}
-      GROUP BY project_id
-      HAVING count > 0
+      PREWHERE ${conditions}
+      LIMIT {candidateLimit: UInt32}
     `;
 
-    const result = await queryClickhouse<{
-      project_id: string;
-      count: number;
-      oldest_age_seconds: number;
-    }>({
-      query,
-      params,
-    });
-
-    // Build maps from the result
-    const resultMap = new Map(
-      result.map((r) => [
-        r.project_id,
-        {
-          count: Number(r.count),
-          oldestAgeSeconds: Number(r.oldest_age_seconds),
-        },
-      ]),
+    const candidatesById = new Map<string, ProjectRetention>();
+    const projectsById = new Map(
+      projects.map((project) => [project.projectId, project]),
     );
 
-    // Return workloads for all projects (with 0 count if not in result)
-    return projects.map((p) => {
-      const data = resultMap.get(p.projectId);
-      return {
-        ...p,
-        expiredRowCount: data?.count ?? 0,
-        oldestAgeSeconds: data?.oldestAgeSeconds ?? null,
-      };
-    });
+    try {
+      const stream = queryClickhouseStream<{ project_id: string }>({
+        query,
+        params: {
+          ...params,
+          candidateLimit: env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CHUNK_SIZE,
+        },
+        useMultipartParamsAuto: true,
+        clickhouseConfigs: {
+          // The shared client derives max_execution_time five seconds after
+          // this request timeout and sends progress headers.
+          request_timeout:
+            env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CANDIDATE_QUERY_TIMEOUT_MS,
+          clickhouse_settings: {
+            http_send_timeout: this.candidateQueryHttpTimeoutSeconds,
+            http_receive_timeout: this.candidateQueryHttpTimeoutSeconds,
+          },
+        },
+      });
+
+      for await (const row of stream) {
+        const project = projectsById.get(row.project_id);
+        if (project) {
+          candidatesById.set(row.project_id, project);
+        }
+        await this.extendLockOnProgress();
+      }
+    } catch (error) {
+      if (error instanceof BatchDataRetentionCleanerLeaseLostError) {
+        throw error;
+      }
+      recordIncrement(`${METRIC_PREFIX}.candidate_query_failures`, 1, {
+        table: this.tableName,
+      });
+      logger.warn(`${this.instanceName}: Candidate query did not complete`, {
+        error,
+        candidatesFound: candidatesById.size,
+      });
+    }
+
+    // A completed query is progress even when it did not yield a candidate.
+    await this.extendLockOnProgress();
+
+    return Array.from(candidatesById.values());
+  }
+
+  /**
+   * Best-effort exact count and oldest age for discovered candidates. If this
+   * query fails, estimate the oldest age from the monthly partition instead.
+   */
+  private async enrichProjectCandidates(
+    timestampColumn: string,
+    candidates: ProjectRetention[],
+  ): Promise<ProjectWorkload[]> {
+    if (candidates.length === 0) {
+      return [];
+    }
+
+    const { conditions, params } = buildRetentionConditions(
+      timestampColumn,
+      candidates,
+    );
+    const query = `
+      SELECT
+        project_id,
+        count() AS count,
+        dateDiff('second', min(event_ts), now()) AS oldest_age_seconds
+      FROM ${this.tableName}
+      PREWHERE ${conditions}
+      GROUP BY project_id
+    `;
+
+    try {
+      const result = await queryClickhouse<{
+        project_id: string;
+        count: number;
+        oldest_age_seconds: number;
+      }>({
+        query,
+        params,
+        useMultipartParamsAuto: true,
+      });
+
+      const resultByProjectId = new Map(
+        result.map((row) => {
+          const oldestAgeSeconds = Number(row.oldest_age_seconds);
+
+          return [
+            row.project_id,
+            {
+              count: Number(row.count),
+              oldestAgeSeconds: Number.isFinite(oldestAgeSeconds)
+                ? oldestAgeSeconds
+                : null,
+            },
+          ] as const;
+        }),
+      );
+
+      await this.extendLockOnProgress();
+
+      return candidates.map((candidate) => {
+        const resultForProject = resultByProjectId.get(candidate.projectId);
+        return {
+          ...candidate,
+          expiredRowCount: resultForProject?.count ?? null,
+          oldestAgeSeconds: resultForProject?.oldestAgeSeconds ?? null,
+        };
+      });
+    } catch (error) {
+      if (error instanceof BatchDataRetentionCleanerLeaseLostError) {
+        throw error;
+      }
+      recordIncrement(`${METRIC_PREFIX}.enrichment_query_failures`, 1, {
+        table: this.tableName,
+      });
+      logger.warn(`${this.instanceName}: Candidate enrichment failed`, {
+        error,
+        candidatesFound: candidates.length,
+      });
+
+      await this.extendLockOnProgress();
+      return this.enrichCandidatesFromOldestPartition(candidates);
+    }
+  }
+
+  /**
+   * Estimate each candidate's oldest age from its oldest monthly partition.
+   * The partition start is an upper bound on how far the oldest row is past
+   * cutoff. If this query also fails, retain the candidates without metrics.
+   */
+  private async enrichCandidatesFromOldestPartition(
+    candidates: ProjectRetention[],
+  ): Promise<ProjectWorkload[]> {
+    try {
+      const partitionStartByProjectId = await getOldestProjectPartitionStarts(
+        this.tableName,
+        candidates.map((candidate) => candidate.projectId),
+      );
+
+      await this.extendLockOnProgress();
+
+      const now = Date.now();
+      return candidates.map((candidate) => {
+        const partitionStart = partitionStartByProjectId.get(
+          candidate.projectId,
+        );
+        return {
+          ...candidate,
+          expiredRowCount: null,
+          oldestAgeSeconds: partitionStart
+            ? (now - partitionStart.getTime()) / 1000
+            : null,
+        };
+      });
+    } catch (error) {
+      if (error instanceof BatchDataRetentionCleanerLeaseLostError) {
+        throw error;
+      }
+      recordIncrement(`${METRIC_PREFIX}.partition_fallback_query_failures`, 1, {
+        table: this.tableName,
+      });
+      logger.warn(`${this.instanceName}: Partition fallback query failed`, {
+        error,
+        candidatesFound: candidates.length,
+      });
+
+      await this.extendLockOnProgress();
+      return candidates.map((candidate) => ({
+        ...candidate,
+        expiredRowCount: null,
+        oldestAgeSeconds: null,
+      }));
+    }
   }
 
   /**
@@ -377,6 +674,10 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
     );
 
     const query = `DELETE FROM ${this.tableName} WHERE ${conditions}`;
+
+    // Reset the full lease immediately before the only destructive query. Its
+    // TTL includes the configured DELETE timeout plus the existing buffer.
+    await this.extendLockOnProgress(true);
 
     await commandClickhouse({
       query,


### PR DESCRIPTION
## Summary
- Stream expired-project candidates in bounded ClickHouse chunks.
- Add lease renewal during long-running retention work and fail safely when the lease is lost.
- Add best-effort enrichment, partition-based lag estimates, metrics, and multipart query parameters.
- Expand Vitest coverage for chunking, lease renewal, query failures, and fallback prioritization.

## Testing
- Vitest coverage added for batch data retention scenarios.
- Not run (not requested).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the batch data retention cleaner to handle large backlogs more robustly by replacing chunked `COUNT` queries with bounded streaming candidate discovery, adding Redis lease renewal during long ClickHouse operations, and introducing a multi-level enrichment fallback chain (exact count → oldest partition estimate → no metrics).

- Candidate discovery now streams `DISTINCT project_id` rows chunk-by-chunk via `queryClickhouseStream`, accumulating results yielded before any partial failure so partial progress is preserved.
- `extendLockOnProgress` renews the Redis lease at most once per `lockTtl/3` seconds during streaming and enrichment, throwing `BatchDataRetentionCleanerLeaseLostError` if renewal fails so the batch aborts cleanly before the destructive DELETE.
- `useMultipartParamsAuto` is threaded through the shared ClickHouse client for both `queryClickhouseExecRaw` and `sendClickhouseQuery` to support large parameter arrays.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The streaming-and-lease-renewal machinery is sound, but a one-character condition mistake makes the empty-workload diagnostic branch permanently unreachable and silently emits a misleading log on idle runs.

The core change — streaming candidate discovery, lease renewal, and fallback enrichment — is well-structured and the new test suite covers key scenarios. However, the always-true `workloads.length >= 0` guard is a concrete logic defect in the changed path that removes observability for the no-work case. The candidate HTTP timeout issue is a secondary concern affecting resource efficiency under failure scenarios.

worker/src/features/batch-data-retention-cleaner/index.ts — specifically the `execute` method condition at line 310 and the `candidateQueryHttpTimeoutSeconds` assignment in the constructor.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[execute] --> B[Reset lastLockExtensionAt = 0]
    B --> C[getProjectWorkloads]
    C --> D[PG: fetch all projects with retentionDays > 0]
    D --> E[Calculate cutoff dates]
    E --> F[Split into CHUNK_SIZE project chunks]
    F --> G{Promise.all over chunks}
    G --> H[findExpiredProjectCandidates per chunk]
    H --> H1[Stream DISTINCT project_id via queryClickhouseStream]
    H1 --> H2{Row received?}
    H2 -- yes --> H3[extendLockOnProgress throttled]
    H3 --> H2
    H2 -- stream done or error --> H4{Error?}
    H4 -- LeaseLostError --> FAIL[Throw to withLock catches to delete_failures metric]
    H4 -- other error --> H5[record candidate_query_failures continue with partial results]
    H5 --> H6[extendLockOnProgress]
    H4 -- no error --> H6
    H6 --> I[enrichProjectCandidates]
    I --> I1{Exact count query OK?}
    I1 -- yes --> I2[Build expiredRowCount + oldestAgeSeconds]
    I1 -- no --> I3[enrichCandidatesFromOldestPartition]
    I3 --> I4{Partition query OK?}
    I4 -- yes --> I5[Estimate age from min partition_id]
    I4 -- no --> I6[expiredRowCount=null oldestAgeSeconds=null]
    I2 --> J
    I5 --> J
    I6 --> J
    G --> J[Flatten + sort: nulls first then by expiredRowCount DESC]
    J --> K[Slice top PROJECT_LIMIT workloads]
    K --> L{workloads.length >= 0 always true bug}
    L --> M[extendLockOnProgress force=true]
    M --> N[executeBatchDelete DELETE WHERE OR conditions]
    N --> O[record metrics delete_successes / projects_processed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[execute] --> B[Reset lastLockExtensionAt = 0]
    B --> C[getProjectWorkloads]
    C --> D[PG: fetch all projects with retentionDays > 0]
    D --> E[Calculate cutoff dates]
    E --> F[Split into CHUNK_SIZE project chunks]
    F --> G{Promise.all over chunks}
    G --> H[findExpiredProjectCandidates per chunk]
    H --> H1[Stream DISTINCT project_id via queryClickhouseStream]
    H1 --> H2{Row received?}
    H2 -- yes --> H3[extendLockOnProgress throttled]
    H3 --> H2
    H2 -- stream done or error --> H4{Error?}
    H4 -- LeaseLostError --> FAIL[Throw to withLock catches to delete_failures metric]
    H4 -- other error --> H5[record candidate_query_failures continue with partial results]
    H5 --> H6[extendLockOnProgress]
    H4 -- no error --> H6
    H6 --> I[enrichProjectCandidates]
    I --> I1{Exact count query OK?}
    I1 -- yes --> I2[Build expiredRowCount + oldestAgeSeconds]
    I1 -- no --> I3[enrichCandidatesFromOldestPartition]
    I3 --> I4{Partition query OK?}
    I4 -- yes --> I5[Estimate age from min partition_id]
    I4 -- no --> I6[expiredRowCount=null oldestAgeSeconds=null]
    I2 --> J
    I5 --> J
    I6 --> J
    G --> J[Flatten + sort: nulls first then by expiredRowCount DESC]
    J --> K[Slice top PROJECT_LIMIT workloads]
    K --> L{workloads.length >= 0 always true bug}
    L --> M[extendLockOnProgress force=true]
    M --> N[executeBatchDelete DELETE WHERE OR conditions]
    N --> O[record metrics delete_successes / projects_processed]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/batch-data-retention-cleaner/index.ts:310
**Always-true condition makes the else-branch unreachable**

`workloads.length` is a non-negative integer, so `>= 0` is always `true`. The `else` branch that logs `"No projects with retention and data to delete"` is dead code introduced by this PR. When there are no projects to process the code now logs `"Processing 0 projects"` and calls `executeBatchDelete` with an empty array (which returns early, so no DELETE fires), silently swallowing the diagnostic log that should fire in the empty-workload case. Change to `> 0`.

```suggestion
        if (workloads.length > 0) {
```

### Issue 2 of 2
worker/src/features/batch-data-retention-cleaner/index.ts:202-203
**`candidateQueryHttpTimeoutSeconds` is set to the full lock TTL, not the query timeout**

`this.candidateQueryHttpTimeoutSeconds = lockTtlSeconds` assigns the value that equals `max(deleteTimeoutMs, candidateQueryTimeoutMs) / 1000 + 300`. For typical defaults (`deleteTimeoutMs = 600s`, `candidateQueryTimeoutMs = 180s`), this is 900 seconds. When these seconds are forwarded as `http_send_timeout` / `http_receive_timeout` ClickHouse settings, ClickHouse may wait up to 900 s for client I/O, while the client-side `request_timeout` is already set to 180,000 ms (3 minutes). The server-side timeout should match the intended candidate query bound, otherwise an unresponsive ClickHouse server can hold streaming connections open for 15+ minutes beyond when the client has given up.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Improve batch retention candidate discov..."](https://github.com/langfuse/langfuse/commit/d83a70703c71b9cb58f3825b3ca8c08287c1ab37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45082141)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->