### PR TITLE
fix(dashboard): tune default home widgets to avoid scroll + brighten chart bars (LFE-11035)

### DIFF
--- a/web/src/features/dashboard/components/LatencyTables.tsx
+++ b/web/src/features/dashboard/components/LatencyTables.tsx
@@ -9,6 +9,7 @@ import {
 
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { truncate } from "@/src/utils/string";
+import { cn } from "@/src/utils/tailwind";
 import { Popup } from "@/src/components/layouts/doc-popup";
 import { type QueryType, type ViewVersion } from "@langfuse/shared/query";
 import { mapLegacyUiTableFilterToView } from "@/src/features/dashboard/lib/dashboardUiTableToViewMapping";
@@ -198,7 +199,11 @@ export const LatencyTable = ({
 
   return (
     <DashboardCard
-      className={className}
+      // h-full pins the card to the tile so the table fits its rows to the
+      // AVAILABLE height instead of overflowing; min-h-0 lets the flex column
+      // shrink so the row area scrolls internally. (LFE-11035)
+      className={cn(className, "h-full")}
+      cardContentClassName="min-h-0"
       title={title}
       isLoading={isLoading || latencies.isPending}
     >

--- a/web/src/features/dashboard/components/ModelCostTable.tsx
+++ b/web/src/features/dashboard/components/ModelCostTable.tsx
@@ -11,6 +11,7 @@ import { truncate } from "@/src/utils/string";
 import { type QueryType, type ViewVersion } from "@langfuse/shared/query";
 import { mapLegacyUiTableFilterToView } from "@/src/features/dashboard/lib/dashboardUiTableToViewMapping";
 import { useScheduledDashboardExecuteQuery } from "@/src/hooks/useDashboardQueryScheduler";
+import { cn } from "@/src/utils/tailwind";
 
 export const ModelCostTable = ({
   className,
@@ -102,7 +103,11 @@ export const ModelCostTable = ({
 
   return (
     <DashboardCard
-      className={className}
+      // h-full pins the card to the tile so the table fits its rows to the
+      // AVAILABLE height instead of overflowing; min-h-0 lets the flex column
+      // shrink so the row area scrolls internally. (LFE-11035)
+      className={cn(className, "h-full")}
+      cardContentClassName="min-h-0"
       title="Model costs"
       isLoading={isLoading || metrics.isLoading}
     >

--- a/web/src/features/dashboard/components/ScoresTable.tsx
+++ b/web/src/features/dashboard/components/ScoresTable.tsx
@@ -10,6 +10,7 @@ import { api } from "@/src/utils/api";
 import { compactNumberFormatter } from "@/src/utils/numbers";
 import { RightAlignedCell } from "./RightAlignedCell";
 import { LeftAlignedCell } from "@/src/features/dashboard/components/LeftAlignedCell";
+import { cn } from "@/src/utils/tailwind";
 import { TotalMetric } from "./TotalMetric";
 import { createTracesTimeFilter } from "@/src/features/dashboard/lib/dashboard-utils";
 import { getScoreDataTypeIcon } from "@/src/features/scores/lib/scoreColumns";
@@ -193,7 +194,11 @@ export const ScoresTable = ({
 
   return (
     <DashboardCard
-      className={className}
+      // h-full pins the card to the tile so the table fits its rows to the
+      // AVAILABLE height instead of overflowing; min-h-0 lets the flex column
+      // shrink so the row area scrolls internally. (LFE-11035)
+      className={cn(className, "h-full")}
+      cardContentClassName="min-h-0"
       title="Scores"
       isLoading={
         isLoading ||

--- a/web/src/features/dashboard/components/TabsComponent.tsx
+++ b/web/src/features/dashboard/components/TabsComponent.tsx
@@ -14,8 +14,9 @@ export const TabComponent = ({ tabs }: TabComponentProps) => {
   const capture = usePostHogClientCapture();
   return (
     // Grows inside the card's flex column so tab content (charts) can absorb
-    // extra tile height on dashboards. (LFE-10813)
-    <div className="flex grow flex-col">
+    // extra tile height on dashboards; min-h-0 lets it also shrink so a
+    // height-aware child can measure the available space. (LFE-10813, LFE-11035)
+    <div className="flex min-h-0 grow flex-col">
       <div className="sm:hidden">
         <label htmlFor="tabs" className="sr-only">
           Select a tab
@@ -61,7 +62,7 @@ export const TabComponent = ({ tabs }: TabComponentProps) => {
           </nav>
         </div>
       </div>
-      <div className="mt-4 flex grow flex-col">
+      <div className="mt-4 flex min-h-0 grow flex-col">
         {tabs[selectedIndex]?.content}
       </div>
     </div>

--- a/web/src/features/dashboard/components/TracesBarListChart.tsx
+++ b/web/src/features/dashboard/components/TracesBarListChart.tsx
@@ -155,11 +155,13 @@ export const TracesBarListChart = ({
           description="Total traces tracked"
         />
         {transformedTraces.length > 0 ? (
-          // The chart fills the leftover tile height (flex-1). Collapsed, it
-          // shows exactly the bars that fit (h-full → the bars spread to use the
-          // whole area, so a sparse list has no dead gap and a full one has no
-          // scrollbar). Expanded, it grows to the bars' natural height and this
-          // viewport scrolls within the tile. (LFE-11035, revises LFE-10813)
+          // The chart fills the leftover tile height (flex-1) and never forces
+          // the card past its tile. Collapsed, it renders only the bars that fit
+          // the measured area and sizes the chart to that same measured height,
+          // so the bars spread to use it: a sparse list has no dead gap and a
+          // full one has no scrollbar. Expanded, it grows to the bars' natural
+          // height and this viewport scrolls within the tile. (LFE-11035,
+          // revises LFE-10813)
           <div
             ref={containerRef}
             className="mt-4 min-h-0 w-full flex-1 overflow-y-auto"

--- a/web/src/features/dashboard/components/TracesBarListChart.tsx
+++ b/web/src/features/dashboard/components/TracesBarListChart.tsx
@@ -11,6 +11,15 @@ import { formatMetric } from "@/src/features/widgets/chart-library/utils";
 import { barListToDataPoints } from "@/src/features/dashboard/lib/chart-data-adapters";
 import { traceViewQuery } from "@/src/features/dashboard/lib/dashboard-utils";
 import { useScheduledDashboardExecuteQuery } from "@/src/hooks/useDashboardQueryScheduler";
+import { useFitRowCount } from "@/src/features/dashboard/hooks/useFitRowCount";
+import { cn } from "@/src/utils/tailwind";
+
+// Target height of one bar row (bar + spacing) and the x-axis strip below the
+// bars. Used both to decide how many bars fit and to size the expanded chart.
+const BAR_ROW_HEIGHT = 40;
+const CHART_AXIS_PADDING = 30;
+// Cap on bars shown when expanded ("Show all"); the rest stay hidden.
+const MAX_EXPANDED_BARS = 20;
 
 export const TracesBarListChart = ({
   className,
@@ -107,19 +116,31 @@ export const TracesBarListChart = ({
       };
     }) ?? [];
 
-  const maxNumberOfEntries = { collapsed: 5, expanded: 20 };
+  // Fit the number of bars to the tile height instead of a fixed count: the
+  // collapsed view renders exactly as many bars as fill the measured chart area
+  // (no scrollbar, no dead gap), and "Show all" reveals the rest. (LFE-11035)
+  const { containerRef, rowCount, height } = useFitRowCount({
+    rowHeightPx: BAR_ROW_HEIGHT,
+    reservedPx: CHART_AXIS_PADDING,
+    min: 1,
+    fallback: 5,
+  });
 
-  const adjustedData = isExpanded
-    ? transformedTraces.slice(0, maxNumberOfEntries.expanded)
-    : transformedTraces.slice(0, maxNumberOfEntries.collapsed);
-
-  // Height scales with bar count so each bar keeps the same height when expanding, otherwise recharts chart would resize to fit into the container.
-  const BAR_ROW_HEIGHT = 32;
-  const CHART_AXIS_PADDING = 32;
+  const expandedCount = Math.min(MAX_EXPANDED_BARS, transformedTraces.length);
+  const collapsedCount = Math.min(rowCount, transformedTraces.length);
+  const adjustedData = transformedTraces.slice(
+    0,
+    isExpanded ? expandedCount : collapsedCount,
+  );
 
   return (
     <DashboardCard
-      className={className}
+      // h-full (not just min-h-full) pins the card to the tile so the chart
+      // area measures the AVAILABLE height, not its own content; min-h-0 on the
+      // content lets the flex column shrink so the chart viewport does too and
+      // scrolls internally instead of overflowing the tile. (LFE-11035)
+      className={cn(className, "h-full")}
+      cardContentClassName="min-h-0"
       title="Traces"
       description={null}
       isLoading={isLoading || traces.isPending || totalTraces.isPending}
@@ -133,40 +154,48 @@ export const TracesBarListChart = ({
           )}
           description="Total traces tracked"
         />
-        {adjustedData.length > 0 ? (
-          // Size the chart to exactly the bars it draws and DON'T grow: bars
-          // stay grouped at the top at a fixed row height instead of stretching
-          // to fill a tall tile (which spread thin, maxBarSize-capped bars into
-          // large gaps). Extra tile height stays as clean space below rather
-          // than as inter-bar gaps. (LFE-11035, revises LFE-10813)
+        {transformedTraces.length > 0 ? (
+          // The chart fills the leftover tile height (flex-1). Collapsed, it
+          // shows exactly the bars that fit (h-full → the bars spread to use the
+          // whole area, so a sparse list has no dead gap and a full one has no
+          // scrollbar). Expanded, it grows to the bars' natural height and this
+          // viewport scrolls within the tile. (LFE-11035, revises LFE-10813)
           <div
-            className="mt-4 w-full shrink-0"
-            style={{
-              height: Math.max(
-                96,
-                adjustedData.length * BAR_ROW_HEIGHT + CHART_AXIS_PADDING,
-              ),
-            }}
+            ref={containerRef}
+            className="mt-4 min-h-0 w-full flex-1 overflow-y-auto"
           >
-            <Chart
-              chartType="HORIZONTAL_BAR"
-              data={barListToDataPoints(adjustedData)}
-              metricFormatter={(value) =>
-                formatMetric(value, { style: "full" })
-              }
-              config={{
-                metric: {
-                  label: "Traces",
-                },
+            <div
+              className="w-full"
+              style={{
+                // Collapsed: fill the measured area exactly (definite px so
+                // recharts renders and the bars spread to use the height).
+                // Expanded: grow to the bars' natural height so the viewport
+                // above scrolls.
+                height: isExpanded
+                  ? adjustedData.length * BAR_ROW_HEIGHT + CHART_AXIS_PADDING
+                  : (height ?? 200),
               }}
-              rowLimit={maxNumberOfEntries.expanded}
-              chartConfig={{
-                type: "HORIZONTAL_BAR",
-                row_limit: maxNumberOfEntries.expanded,
-                unit: "traces",
-                show_value_labels: true,
-              }}
-            />
+            >
+              <Chart
+                chartType="HORIZONTAL_BAR"
+                data={barListToDataPoints(adjustedData)}
+                metricFormatter={(value) =>
+                  formatMetric(value, { style: "full" })
+                }
+                config={{
+                  metric: {
+                    label: "Traces",
+                  },
+                }}
+                rowLimit={MAX_EXPANDED_BARS}
+                chartConfig={{
+                  type: "HORIZONTAL_BAR",
+                  row_limit: MAX_EXPANDED_BARS,
+                  unit: "traces",
+                  show_value_labels: true,
+                }}
+              />
+            </div>
           </div>
         ) : (
           <NoDataOrLoading
@@ -180,10 +209,10 @@ export const TracesBarListChart = ({
           isExpanded={isExpanded}
           setExpanded={setIsExpanded}
           totalLength={transformedTraces.length}
-          maxLength={maxNumberOfEntries.collapsed}
+          maxLength={collapsedCount}
           expandText={
-            transformedTraces.length > maxNumberOfEntries.expanded
-              ? `Show top ${maxNumberOfEntries.expanded}`
+            transformedTraces.length > MAX_EXPANDED_BARS
+              ? `Show top ${MAX_EXPANDED_BARS}`
               : "Show all"
           }
         />

--- a/web/src/features/dashboard/components/TracesBarListChart.tsx
+++ b/web/src/features/dashboard/components/TracesBarListChart.tsx
@@ -114,7 +114,7 @@ export const TracesBarListChart = ({
     : transformedTraces.slice(0, maxNumberOfEntries.collapsed);
 
   // Height scales with bar count so each bar keeps the same height when expanding, otherwise recharts chart would resize to fit into the container.
-  const BAR_ROW_HEIGHT = 36;
+  const BAR_ROW_HEIGHT = 32;
   const CHART_AXIS_PADDING = 32;
 
   return (
@@ -134,15 +134,16 @@ export const TracesBarListChart = ({
           description="Total traces tracked"
         />
         {adjustedData.length > 0 ? (
-          // The computed height is the flex basis (floor); grow lets the chart
-          // absorb extra tile height on dashboards — bar thickness stays
-          // capped, only the spacing stretches. (LFE-10813)
+          // Size the chart to exactly the bars it draws and DON'T grow: bars
+          // stay grouped at the top at a fixed row height instead of stretching
+          // to fill a tall tile (which spread thin, maxBarSize-capped bars into
+          // large gaps). Extra tile height stays as clean space below rather
+          // than as inter-bar gaps. (LFE-11035, revises LFE-10813)
           <div
-            className="mt-4 w-full shrink-0 grow"
+            className="mt-4 w-full shrink-0"
             style={{
-              minHeight: 200,
               height: Math.max(
-                200,
+                96,
                 adjustedData.length * BAR_ROW_HEIGHT + CHART_AXIS_PADDING,
               ),
             }}
@@ -163,7 +164,6 @@ export const TracesBarListChart = ({
                 type: "HORIZONTAL_BAR",
                 row_limit: maxNumberOfEntries.expanded,
                 unit: "traces",
-                subtle_fill: true,
                 show_value_labels: true,
               }}
             />

--- a/web/src/features/dashboard/components/UserChart.tsx
+++ b/web/src/features/dashboard/components/UserChart.tsx
@@ -226,11 +226,12 @@ export const UserChart = ({
                       description={item.metricDescription}
                     />
                     {/* The chart fills the leftover tile height. Collapsed it
-                        shows exactly the bars that fit (h-full → they spread to
-                        use the whole area: no dead gap for a sparse list, no
-                        scrollbar for a full one). Expanded it grows to the bars'
-                        natural height and this viewport scrolls within the tile.
-                        Mirrors TracesBarListChart. (LFE-11035, revises LFE-10813) */}
+                        renders only the bars that fit the measured area and
+                        sizes the chart to that same height, so they spread to
+                        use it: no dead gap for a sparse list, no scrollbar for a
+                        full one. Expanded it grows to the bars' natural height
+                        and this viewport scrolls within the tile. Mirrors
+                        TracesBarListChart. (LFE-11035, revises LFE-10813) */}
                     <div
                       ref={containerRef}
                       className="mt-4 min-h-0 w-full flex-1 overflow-y-auto"

--- a/web/src/features/dashboard/components/UserChart.tsx
+++ b/web/src/features/dashboard/components/UserChart.tsx
@@ -13,6 +13,13 @@ import { Chart } from "@/src/features/widgets/chart-library/Chart";
 import { barListToDataPoints } from "@/src/features/dashboard/lib/chart-data-adapters";
 import { traceViewQuery } from "@/src/features/dashboard/lib/dashboard-utils";
 import { useScheduledDashboardExecuteQuery } from "@/src/hooks/useDashboardQueryScheduler";
+import { useFitRowCount } from "@/src/features/dashboard/hooks/useFitRowCount";
+import { cn } from "@/src/utils/tailwind";
+
+// Target height of one bar row (bar + spacing) and the x-axis strip; matches
+// TracesBarListChart so bars are the same thickness across the two cards.
+const BAR_ROW_HEIGHT = 40;
+const CHART_AXIS_PADDING = 30;
 
 type BarChartDataPoint = {
   name: string;
@@ -159,18 +166,20 @@ export const UserChart = ({
     0,
   );
 
-  // Slightly tighter rows than TracesBarListChart: this card also stacks tabs
-  // and an expand button, and grow stretches the spacing back out whenever the
-  // tile offers more height. (LFE-10813)
-  const BAR_ROW_HEIGHT = 32;
-  const CHART_AXIS_PADDING = 32;
+  // Fit the number of bars to the tile height (see TracesBarListChart): render
+  // exactly the bars that fill the measured chart area, no scrollbar, and defer
+  // the rest to "Show all". (LFE-11035)
+  const { containerRef, rowCount, height } = useFitRowCount({
+    rowHeightPx: BAR_ROW_HEIGHT,
+    reservedPx: CHART_AXIS_PADDING,
+    min: 1,
+    fallback: maxNumberOfEntries.collapsed,
+  });
 
   const data = [
     {
       tabTitle: "Token cost",
-      data: isExpanded
-        ? transformedCost.slice(0, maxNumberOfEntries.expanded)
-        : transformedCost.slice(0, maxNumberOfEntries.collapsed),
+      data: transformedCost,
       totalMetric: costFormatter(totalCost),
       metricDescription: "Total cost",
       chartMetricLabel: "USD",
@@ -178,9 +187,7 @@ export const UserChart = ({
     },
     {
       tabTitle: "Count of Traces",
-      data: isExpanded
-        ? transformedNumberOfTraces.slice(0, maxNumberOfEntries.expanded)
-        : transformedNumberOfTraces.slice(0, maxNumberOfEntries.collapsed),
+      data: transformedNumberOfTraces,
       totalMetric: totalTraces
         ? compactNumberFormatter(totalTraces)
         : compactNumberFormatter(0),
@@ -192,54 +199,70 @@ export const UserChart = ({
 
   return (
     <DashboardCard
-      className={className}
+      // h-full pins the card to the tile so the chart area measures the
+      // AVAILABLE height, not its own content; min-h-0 lets the flex column
+      // shrink so the chart viewport scrolls internally. (LFE-11035)
+      className={cn(className, "h-full")}
+      cardContentClassName="min-h-0"
       title="User consumption"
       isLoading={isLoading || user.isPending}
     >
       <TabComponent
         tabs={data.map((item) => {
+          const shown = item.data.slice(
+            0,
+            isExpanded
+              ? Math.min(maxNumberOfEntries.expanded, item.data.length)
+              : Math.min(rowCount, item.data.length),
+          );
           return {
             tabTitle: item.tabTitle,
             content: (
               <>
                 {item.data.length > 0 ? (
-                  <div className="flex grow flex-col">
+                  <div className="flex min-h-0 grow flex-col">
                     <TotalMetric
                       metric={item.totalMetric}
                       description={item.metricDescription}
                     />
-                    {/* The computed height is the flex basis (floor); grow
-                        lets the chart absorb extra tile height on dashboards —
-                        bar thickness stays capped, only the spacing
-                        stretches. (LFE-10813) */}
+                    {/* The chart fills the leftover tile height. Collapsed it
+                        shows exactly the bars that fit (h-full → they spread to
+                        use the whole area: no dead gap for a sparse list, no
+                        scrollbar for a full one). Expanded it grows to the bars'
+                        natural height and this viewport scrolls within the tile.
+                        Mirrors TracesBarListChart. (LFE-11035, revises LFE-10813) */}
                     <div
-                      className="mt-4 w-full shrink-0 grow"
-                      style={{
-                        minHeight: 200,
-                        height: Math.max(
-                          200,
-                          item.data.length * BAR_ROW_HEIGHT +
-                            CHART_AXIS_PADDING,
-                        ),
-                      }}
+                      ref={containerRef}
+                      className="mt-4 min-h-0 w-full flex-1 overflow-y-auto"
                     >
-                      <Chart
-                        chartType="HORIZONTAL_BAR"
-                        data={barListToDataPoints(item.data)}
-                        config={{
-                          metric: {
-                            label: item.chartMetricLabel,
-                          },
+                      <div
+                        className="w-full"
+                        style={{
+                          // Collapsed: fill the measured area (definite px).
+                          // Expanded: grow to the bars' natural height so the
+                          // viewport scrolls.
+                          height: isExpanded
+                            ? shown.length * BAR_ROW_HEIGHT + CHART_AXIS_PADDING
+                            : (height ?? 200),
                         }}
-                        rowLimit={maxNumberOfEntries.expanded}
-                        chartConfig={{
-                          type: "HORIZONTAL_BAR",
-                          row_limit: maxNumberOfEntries.expanded,
-                          unit: item.chartUnit,
-                          show_value_labels: true,
-                          subtle_fill: true,
-                        }}
-                      />
+                      >
+                        <Chart
+                          chartType="HORIZONTAL_BAR"
+                          data={barListToDataPoints(shown)}
+                          config={{
+                            metric: {
+                              label: item.chartMetricLabel,
+                            },
+                          }}
+                          rowLimit={maxNumberOfEntries.expanded}
+                          chartConfig={{
+                            type: "HORIZONTAL_BAR",
+                            row_limit: maxNumberOfEntries.expanded,
+                            unit: item.chartUnit,
+                            show_value_labels: true,
+                          }}
+                        />
+                      </div>
                     </div>
                   </div>
                 ) : (
@@ -259,7 +282,7 @@ export const UserChart = ({
         isExpanded={isExpanded}
         setExpanded={setIsExpanded}
         totalLength={transformedCost.length}
-        maxLength={maxNumberOfEntries.collapsed}
+        maxLength={Math.min(rowCount, transformedCost.length)}
         expandText={
           transformedCost.length > maxNumberOfEntries.expanded
             ? `Show top ${maxNumberOfEntries.expanded}`

--- a/web/src/features/dashboard/components/cards/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/cards/DashboardTable.tsx
@@ -1,6 +1,12 @@
 import { ExpandListButton } from "@/src/features/dashboard/components/cards/ChevronButton";
-import { useState, type ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
+import { useFitRowCount } from "@/src/features/dashboard/hooks/useFitRowCount";
+
+// Approximate rendered height of one <tr> (py-2 + text-xs) and of the sticky
+// header row, used to decide how many rows fit in the tile. (LFE-11035)
+const TABLE_ROW_HEIGHT = 33;
+const TABLE_HEADER_HEIGHT = 45;
 
 type TableHeaders = ReactNode[];
 type TableRows = ReactNode[][];
@@ -28,12 +34,36 @@ export const DashboardTable = ({
   isLoading,
 }: DashboardTableProps) => {
   const [isExpanded, setExpanded] = useState(false);
+
+  // Fit the number of rows to the tile height: by default render exactly the
+  // rows that fill the measured area (no scrollbar), and let "Show all" reveal
+  // the rest (scrolling within the tile). Falls back to the old fixed count
+  // before the first measurement. (LFE-11035)
+  const { containerRef, rowCount } = useFitRowCount({
+    rowHeightPx: TABLE_ROW_HEIGHT,
+    reservedPx: TABLE_HEADER_HEIGHT,
+    min: 1,
+    fallback: collapse?.collapsed ?? rows.length,
+  });
+
+  const collapsedCount = collapse ? Math.min(rowCount, rows.length) : undefined;
+  const visibleRows = rows.slice(
+    0,
+    collapse ? (isExpanded ? collapse.expanded : collapsedCount) : undefined,
+  );
+
   return (
     <>
       {children}
       {rows.length > 0 ? (
-        <div className="mt-4">
-          <div className="overflow-x-auto">
+        // Fill the leftover card height so the table can size itself to the
+        // tile; the row area scrolls only once expanded past what fits, while
+        // the "Show all" button stays pinned below. (LFE-11035)
+        <div className="mt-4 flex min-h-0 flex-1 flex-col">
+          <div
+            ref={containerRef}
+            className="min-h-0 flex-1 overflow-x-auto overflow-y-auto"
+          >
             <div className="inline-block min-w-full align-middle">
               <table className="divide-border animate-in animate-out min-w-full divide-y">
                 <thead>
@@ -51,27 +81,18 @@ export const DashboardTable = ({
                 </thead>
 
                 <tbody className="divide-accent divide-y">
-                  {rows
-                    .slice(
-                      0,
-                      collapse
-                        ? isExpanded
-                          ? collapse.expanded
-                          : collapse.collapsed
-                        : undefined,
-                    )
-                    .map((row, i) => (
-                      <tr key={i}>
-                        {row.map((cell, j) => (
-                          <td
-                            key={j}
-                            className="text-muted-foreground py-2 pr-2 pl-3 text-xs whitespace-nowrap sm:pl-0"
-                          >
-                            {cell}
-                          </td>
-                        ))}
-                      </tr>
-                    ))}
+                  {visibleRows.map((row, i) => (
+                    <tr key={i}>
+                      {row.map((cell, j) => (
+                        <td
+                          key={j}
+                          className="text-muted-foreground py-2 pr-2 pl-3 text-xs whitespace-nowrap sm:pl-0"
+                        >
+                          {cell}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
                 </tbody>
               </table>
             </div>
@@ -81,7 +102,7 @@ export const DashboardTable = ({
               isExpanded={isExpanded}
               setExpanded={setExpanded}
               totalLength={rows.length}
-              maxLength={collapse.collapsed}
+              maxLength={collapsedCount ?? collapse.collapsed}
               expandText={
                 rows.length > collapse.expanded
                   ? `Show top ${collapse.expanded}`

--- a/web/src/features/dashboard/hooks/useFitRowCount.ts
+++ b/web/src/features/dashboard/hooks/useFitRowCount.ts
@@ -1,0 +1,61 @@
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Measures a container and reports how many fixed-height rows fit inside it, so
+ * a list/table/bar-chart can render exactly that many by default — filling the
+ * tile with NO scrollbar and no dead gap — and defer the rest to a "Show all"
+ * affordance. Re-measures whenever the container resizes (tile drag/resize,
+ * viewport change). (LFE-11035)
+ *
+ * Uses a callback ref (not useRef + useEffect) so the ResizeObserver attaches
+ * the moment the measured node mounts — critical here because the node lives
+ * behind a loading gate and only appears once data has loaded.
+ *
+ * The observed element must have a height that does NOT depend on how many rows
+ * are rendered (e.g. a `flex-1 min-h-0` region that fills leftover card height),
+ * otherwise measuring and rendering would feed back into each other.
+ */
+export function useFitRowCount({
+  rowHeightPx,
+  reservedPx = 0,
+  min = 1,
+  fallback,
+}: {
+  /** Approximate height of one row, including its spacing. */
+  rowHeightPx: number;
+  /** Height consumed by non-row chrome inside the measured box (axis, etc.). */
+  reservedPx?: number;
+  /** Never report fewer than this many rows. */
+  min?: number;
+  /** Row count to use before the first measurement (SSR / initial paint). */
+  fallback: number;
+}) {
+  const [rowCount, setRowCount] = useState<number>(fallback);
+  // Measured px height of the container. `null` until first measured; consumers
+  // that need a definite height (e.g. recharts) fall back until then.
+  const [height, setHeight] = useState<number | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const containerRef = useCallback(
+    (node: HTMLElement | null) => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      if (!node || typeof ResizeObserver === "undefined") return;
+
+      const measure = () => {
+        const measuredHeight = node.clientHeight;
+        const fit = Math.floor((measuredHeight - reservedPx) / rowHeightPx);
+        setHeight(measuredHeight);
+        setRowCount(Math.max(min, Number.isFinite(fit) ? fit : min));
+      };
+
+      measure();
+      const observer = new ResizeObserver(measure);
+      observer.observe(node);
+      observerRef.current = observer;
+    },
+    [rowHeightPx, reservedPx, min],
+  );
+
+  return { containerRef, rowCount, height };
+}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -299,7 +299,10 @@
     --find-match-selected-background: 60 100% 50%;
     --find-match-selected-foreground: 0 0% 0%;
 
-    --chart-1: 239 84% 58%;
+    /* Primary series blue. A cleaner, more saturated blue (tailwind blue-500)
+       reads more legibly than the old muddy indigo on white; the dark theme
+       lifts it further (see .dark). (LFE-11035) */
+    --chart-1: 217 91% 60%;
     --chart-2: 188 94% 43%;
     --chart-3: 240 4% 46%;
     --chart-4: 271 91% 65%;
@@ -447,7 +450,9 @@
     --find-match-selected-background: 60 100% 50%;
     --find-match-selected-foreground: 0 0% 0%;
 
-    --chart-1: 239 84% 58%;
+    /* Lighter, brighter blue (tailwind blue-400) so the primary series pops
+       against the near-black canvas instead of reading as a dark indigo. (LFE-11035) */
+    --chart-1: 213 94% 68%;
     --chart-2: 188 94% 43%;
     --chart-3: 240 4% 46%;
     --chart-4: 271 91% 65%;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -299,10 +299,7 @@
     --find-match-selected-background: 60 100% 50%;
     --find-match-selected-foreground: 0 0% 0%;
 
-    /* Primary series blue. A cleaner, more saturated blue (tailwind blue-500)
-       reads more legibly than the old muddy indigo on white; the dark theme
-       lifts it further (see .dark). (LFE-11035) */
-    --chart-1: 217 91% 60%;
+    --chart-1: 239 84% 58%;
     --chart-2: 188 94% 43%;
     --chart-3: 240 4% 46%;
     --chart-4: 271 91% 65%;
@@ -450,9 +447,7 @@
     --find-match-selected-background: 60 100% 50%;
     --find-match-selected-foreground: 0 0% 0%;
 
-    /* Lighter, brighter blue (tailwind blue-400) so the primary series pops
-       against the near-black canvas instead of reading as a dark indigo. (LFE-11035) */
-    --chart-1: 213 94% 68%;
+    --chart-1: 239 84% 58%;
     --chart-2: 188 94% 43%;
     --chart-3: 240 4% 46%;
     --chart-4: 271 91% 65%;


### PR DESCRIPTION
## TL;DR

The default home dashboard's bar/list widgets (Traces, Model costs, User consumption, latency tables) scrolled for no reason and left dead space at their default tile size, and the bars were dimmed (30%-opacity navy). This makes the widgets **size to their tile** — render exactly the rows that fit, no scrollbar, "Show all" reveals the rest — and **un-dims the bars** so they render at the standard chart blue. No color token was changed. Verified live (light + dark, seeded data).

## Why

Reported visual friction on the default home dashboard: needless scrollbars + empty space on the Traces / Model-costs / User-consumption tiles, and bars that were low-contrast (dimmed navy). Root cause: the cards were `min-h-full` while the chart used a **fixed pixel height**, so content overflowed the tile (e.g. Traces content 380px inside a 354px tile → the wrapper scrolled 26px even collapsed), and `CardContent`'s `min-height: auto` meant the region never shrank below its content, so no "fit" logic could converge.

## What

- **Fit-to-height (the core fix):** new `useFitRowCount` hook measures the available tile area (callback-ref + `ResizeObserver`) and returns how many rows fit. Widgets render exactly that many → **no scrollbar at default size**; "Show all" reveals the rest, scrolling *inside* the chart area with the headline pinned. Applied through `DashboardTable` (fixes Model costs, Scores, and all latency tables at once) plus `TracesBarListChart` and `UserChart`. Cards are pinned `h-full` + `min-h-0` so the fit math has a bounded box.
- **Un-dim the bars:** dropped `subtle_fill` on the home bars so they render solid at the standard `--chart-1` instead of a 30%-opacity navy.

## Result

Traces / Model-costs / User-consumption / latency widgets render scroll-free with their height well-used; the single-bar User-consumption case sizes to the area and sits centered (no dead gap). Bars are no longer dim, but **no chart changed hue** — bar fill, line stroke and the pie's first slice are all the same standard `rgb(58,61,238)`. typecheck / eslint / prettier clean. Verified live on the curated Langfuse Home dashboard (dark + light, seeded data).

<details>
<summary>Approach note + blast radius</summary>

**Color left untouched on purpose.** An earlier pass brightened the shared `--chart-1` token globally, which regressed charts that were fine (the "cost by env" pie/line). That was fully reverted — **`globals.css` has zero net diff vs `main`**. The only visual change to the bars is removing `subtle_fill` (the dimming), not the color.

**Layout blast radius:** `h-full` + `min-h-0` are added to the 6 refactored cards, and `min-h-0` to the shared `TabsComponent` / `DashboardTable` grow columns (so tabbed charts can shrink/measure). Other tabbed/tabular dashboards (Model Usage, generation latency, custom dashboards) read fine in the full-page check but weren't each clicked through exhaustively.

Files: `web/src/features/dashboard/hooks/useFitRowCount.ts` (new), `TracesBarListChart.tsx`, `UserChart.tsx`, `cards/DashboardTable.tsx`, `ModelCostTable.tsx`, `ScoresTable.tsx`, `LatencyTables.tsx`, `TabsComponent.tsx`. Subjective constants for review: `BAR_ROW_HEIGHT=40`, `CHART_AXIS_PADDING=30`, table `TABLE_ROW_HEIGHT=33` / `HEADER=45` (tuned for ~1300–1500px grid width).
</details>

LFE-11035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
