### PR TITLE
fix(ui): resolve peek trace id across v3/v4 URL dialects (LFE-11041)

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -328,8 +328,11 @@ export const SessionPage: React.FC<{
     () => ({
       expandConfig: {
         basePath: `/project/${projectId}/traces`,
+        pathParam: "traceId",
       },
-      queryParams: ["observation", "display", "timestamp"],
+      // traceId: not written here, but cleared so a v4-dialect shared URL
+      // cannot pin the trace peek (LFE-11041).
+      queryParams: ["observation", "display", "timestamp", "traceId"],
       extractParamsValuesFromRow: (row: any) => ({
         timestamp: row.timestamp.toISOString(),
       }),
@@ -754,8 +757,11 @@ const LoadedSessionEventsPage: React.FC<{
     () => ({
       expandConfig: {
         basePath: `/project/${projectId}/traces`,
+        pathParam: "traceId",
       },
-      queryParams: ["observation", "display", "timestamp"],
+      // traceId: not written here, but cleared so a v4-dialect shared URL
+      // cannot pin the trace peek (LFE-11041).
+      queryParams: ["observation", "display", "timestamp", "traceId"],
       // observationId: set by a card's "Open in trace view" on a truncated
       // observation so the peek opens AT that observation (LFE-10958).
       extractParamsValuesFromRow: (row: any) => ({

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -329,6 +329,7 @@ export const SessionPage: React.FC<{
       expandConfig: {
         basePath: `/project/${projectId}/traces`,
         pathParam: "traceId",
+        reader: "trace" as const,
       },
       // traceId: not written here, but cleared so a v4-dialect shared URL
       // cannot pin the trace peek (LFE-11041).
@@ -758,6 +759,7 @@ const LoadedSessionEventsPage: React.FC<{
       expandConfig: {
         basePath: `/project/${projectId}/traces`,
         pathParam: "traceId",
+        reader: "trace" as const,
       },
       // traceId: not written here, but cleared so a v4-dialect shared URL
       // cannot pin the trace peek (LFE-11041).

--- a/web/src/components/table/peek/hooks/usePeekNavigation.clienttest.tsx
+++ b/web/src/components/table/peek/hooks/usePeekNavigation.clienttest.tsx
@@ -27,6 +27,7 @@ describe("usePeekNavigation expandPeek", () => {
     expandConfig: {
       basePath: "/project/p1/traces",
       pathParam: "traceId",
+      reader: "trace" as const,
     },
   };
 
@@ -49,7 +50,26 @@ describe("usePeekNavigation expandPeek", () => {
     expect(target.startsWith("/project/p1/traces/trace-1?")).toBe(true);
   });
 
-  it("v3-dialect URL (no traceId param): falls back to peek for the path segment", () => {
+  it("v4-dialect URL: does not forward the observation startTime as the trace timestamp", () => {
+    // The timestamp on a v4-dialect URL is the observation's startTime; the
+    // standalone page would use it as the trace-timestamp lookup filter
+    // (day-equality) and observation-window anchor — 404s / truncated trees
+    // on long traces (LFE-10947 class).
+    window.history.replaceState(
+      {},
+      "",
+      "/project/p1/traces?peek=obs-uuid&observation=obs-uuid&traceId=trace-1&timestamp=2026-07-14T19%3A47%3A57.703Z",
+    );
+
+    const { result } = renderHook(() => usePeekNavigation(config));
+    result.current.expandPeek(false);
+
+    const target = mockPush.mock.calls[0][0] as string;
+    expect(target).not.toContain("timestamp=");
+    expect(target).toContain("observation=obs-uuid");
+  });
+
+  it("v3-dialect URL (no traceId param): falls back to peek for the path segment and keeps the trace timestamp", () => {
     window.history.replaceState(
       {},
       "",
@@ -62,5 +82,29 @@ describe("usePeekNavigation expandPeek", () => {
     expect(mockPush).toHaveBeenCalledTimes(1);
     const target = mockPush.mock.calls[0][0] as string;
     expect(target.startsWith("/project/p1/traces/trace-1?")).toBe(true);
+    expect(target).toContain("timestamp=2026-07-14T19:47:57.703Z");
+  });
+
+  it("without a reader, expand forwards params verbatim (non-trace peeks unchanged)", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/project/p1/traces?peek=obs-uuid&traceId=trace-1&timestamp=2026-07-14T19%3A47%3A57.703Z",
+    );
+
+    const { result } = renderHook(() =>
+      usePeekNavigation({
+        ...config,
+        expandConfig: {
+          basePath: "/project/p1/traces",
+          pathParam: "traceId",
+        },
+      }),
+    );
+    result.current.expandPeek(false);
+
+    const target = mockPush.mock.calls[0][0] as string;
+    expect(target.startsWith("/project/p1/traces/trace-1?")).toBe(true);
+    expect(target).toContain("timestamp=");
   });
 });

--- a/web/src/components/table/peek/hooks/usePeekNavigation.clienttest.tsx
+++ b/web/src/components/table/peek/hooks/usePeekNavigation.clienttest.tsx
@@ -1,0 +1,66 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavigation";
+
+const { mockPush, mockPathname } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockPathname: { value: "/project/[projectId]/traces" },
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: mockPush, pathname: mockPathname.value }),
+}));
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+vi.mock("@/src/features/events/hooks/useV4Beta", () => ({
+  useV4Beta: () => ({ isBetaEnabled: false }),
+}));
+
+// expandPeek builds the standalone-page path from `expandConfig.pathParam`.
+// The trace reader's expand must survive both peek URL dialects (LFE-11041):
+// v4 URLs put the trace id in `traceId`, v3 URLs put it in `peek`.
+describe("usePeekNavigation expandPeek", () => {
+  const config = {
+    queryParams: ["observation", "display", "timestamp", "traceId"],
+    expandConfig: {
+      basePath: "/project/p1/traces",
+      pathParam: "traceId",
+    },
+  };
+
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
+  it("v4-dialect URL: expands to the traceId param, not the observation id in peek", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/project/p1/traces?peek=obs-uuid&observation=obs-uuid&traceId=trace-1&timestamp=2026-07-14T19%3A47%3A57.703Z",
+    );
+
+    const { result } = renderHook(() => usePeekNavigation(config));
+    result.current.expandPeek(false);
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const target = mockPush.mock.calls[0][0] as string;
+    expect(target.startsWith("/project/p1/traces/trace-1?")).toBe(true);
+  });
+
+  it("v3-dialect URL (no traceId param): falls back to peek for the path segment", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/project/p1/traces?peek=trace-1&timestamp=2026-07-14T19%3A47%3A57.703Z",
+    );
+
+    const { result } = renderHook(() => usePeekNavigation(config));
+    result.current.expandPeek(false);
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const target = mockPush.mock.calls[0][0] as string;
+    expect(target.startsWith("/project/p1/traces/trace-1?")).toBe(true);
+  });
+});

--- a/web/src/components/table/peek/hooks/usePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/usePeekNavigation.ts
@@ -3,6 +3,7 @@ import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { useRouter } from "next/router";
 import { useCallback } from "react";
 import { urlSearchParamsToQuery } from "@/src/utils/navigation";
+import { resolvePeekTraceParams } from "@/src/components/table/peek/resolvePeekTraceParams";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
@@ -39,6 +40,12 @@ interface PeekConfigWithExpand extends BasePeekConfig {
     basePath: string;
     /** URL parameter to use for path param (defaults to "peek") */
     pathParam?: string;
+    /**
+     * Set for trace-detail peeks: routes the expand target's trace id and
+     * timestamp through resolvePeekTraceParams so the standalone page gets
+     * the same dialect handling as the peek pane (LFE-11041).
+     */
+    reader?: "trace" | "observation";
   };
 }
 
@@ -198,15 +205,36 @@ export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
       const url = new URL(window.location.href);
       const params = new URLSearchParams(url.search);
       const pathParam = config?.expandConfig?.pathParam ?? PEEK_PARAM;
+      const reader = config?.expandConfig?.reader;
+
+      // Trace-detail expands resolve the id and timestamp through the shared
+      // dialect helper so the standalone page gets the same params as the
+      // pane (LFE-11041): a v4-dialect timestamp is an observation startTime
+      // and must not become the trace-timestamp lookup filter.
+      const resolved = reader
+        ? resolvePeekTraceParams({
+            reader,
+            peek: params.get(PEEK_PARAM) ?? undefined,
+            traceId: params.get("traceId") ?? undefined,
+            timestamp: params.get("timestamp") ?? undefined,
+          })
+        : undefined;
 
       // Fall back to `peek` when the configured pathParam is absent: the trace
       // reader's URLs carry the trace id in `traceId` (v4 dialect) or in
       // `peek` (v3 dialect) — see resolvePeekTraceParams (LFE-11041).
-      const pathId = params.get(pathParam) ?? params.get(PEEK_PARAM);
+      const pathId = resolved
+        ? resolved.traceId
+        : (params.get(pathParam) ?? params.get(PEEK_PARAM));
       const pathname = `${config?.expandConfig?.basePath}/${pathId}`;
       const queryParams = config?.queryParams
         ?.map((param) => {
-          const value = params.get(param);
+          // The resolved trace id is the path segment; don't repeat it.
+          if (resolved && param === "traceId") return null;
+          const value =
+            resolved && param === "timestamp"
+              ? (resolved.timestamp?.toISOString() ?? null)
+              : params.get(param);
           return value ? `${param}=${value}` : null;
         })
         .filter(Boolean)

--- a/web/src/components/table/peek/hooks/usePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/usePeekNavigation.ts
@@ -199,7 +199,11 @@ export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
       const params = new URLSearchParams(url.search);
       const pathParam = config?.expandConfig?.pathParam ?? PEEK_PARAM;
 
-      const pathname = `${config?.expandConfig?.basePath}/${params.get(pathParam)}`;
+      // Fall back to `peek` when the configured pathParam is absent: the trace
+      // reader's URLs carry the trace id in `traceId` (v4 dialect) or in
+      // `peek` (v3 dialect) — see resolvePeekTraceParams (LFE-11041).
+      const pathId = params.get(pathParam) ?? params.get(PEEK_PARAM);
+      const pathname = `${config?.expandConfig?.basePath}/${pathId}`;
       const queryParams = config?.queryParams
         ?.map((param) => {
           const value = params.get(param);

--- a/web/src/components/table/peek/peek-observation-detail.tsx
+++ b/web/src/components/table/peek/peek-observation-detail.tsx
@@ -8,7 +8,7 @@ import {
   traceDetailTitle,
 } from "@/src/components/trace/TraceDetailBody";
 import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
-import { parseTraceTimestampFromQuery } from "@/src/utils/parseTraceTimestampFromQuery";
+import { resolvePeekTraceParams } from "@/src/components/table/peek/resolvePeekTraceParams";
 import { useRouter } from "next/router";
 import { useRef } from "react";
 
@@ -23,9 +23,13 @@ export const TablePeekViewObservationDetail = (
   const router = useRouter();
 
   const { projectId } = props;
-  const peekId = router.query.peek as string | undefined;
-  const timestamp = parseTraceTimestampFromQuery(router.query.timestamp);
-  const traceId = router.query.traceId as string | undefined;
+  const peekObservationId = router.query.peek as string | undefined;
+  const { traceId, timestamp } = resolvePeekTraceParams({
+    reader: "observation",
+    peek: peekObservationId,
+    traceId: router.query.traceId as string | undefined,
+    timestamp: router.query.timestamp,
+  });
 
   // Live handle on the peeked observation's trace id: an in-flight delete that
   // resolves after K/J-navigation reads the CURRENT trace here, so it only
@@ -68,7 +72,11 @@ export const TablePeekViewObservationDetail = (
         ) : undefined
       }
     >
-      <TraceDetailBody trace={trace.data} context="peek" keySuffix={peekId} />
+      <TraceDetailBody
+        trace={trace.data}
+        context="peek"
+        keySuffix={peekObservationId}
+      />
     </TablePeekView>
   );
 };

--- a/web/src/components/table/peek/peek-trace-detail.tsx
+++ b/web/src/components/table/peek/peek-trace-detail.tsx
@@ -10,7 +10,7 @@ import {
   shouldClosePeekAfterDelete,
 } from "@/src/components/table/peek";
 import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
-import { parseTraceTimestampFromQuery } from "@/src/utils/parseTraceTimestampFromQuery";
+import { resolvePeekTraceParams } from "@/src/components/table/peek/resolvePeekTraceParams";
 
 export const TablePeekViewTraceDetail = (
   props: Omit<
@@ -23,18 +23,22 @@ export const TablePeekViewTraceDetail = (
   const { projectId } = props;
 
   const router = useRouter();
-  const peekId = router.query.peek as string | undefined;
-  const timestamp = parseTraceTimestampFromQuery(router.query.timestamp);
+  const { traceId, timestamp } = resolvePeekTraceParams({
+    reader: "trace",
+    peek: router.query.peek as string | undefined,
+    traceId: router.query.traceId as string | undefined,
+    timestamp: router.query.timestamp,
+  });
 
   // Live handle on the peeked trace id: an in-flight delete that resolves after
   // K/J-navigation reads the CURRENT peek here (not the stale value captured
   // when the delete was fired), so it only closes the peek it actually deleted.
-  const peekIdRef = useRef(peekId);
-  peekIdRef.current = peekId;
+  const peekIdRef = useRef(traceId);
+  peekIdRef.current = traceId;
 
   const trace = usePeekData({
     projectId,
-    traceId: peekId,
+    traceId,
     timestamp,
   });
 
@@ -57,7 +61,7 @@ export const TablePeekViewTraceDetail = (
   return (
     <TablePeekView
       {...props}
-      title={traceDetailTitle(trace.data, peekId)}
+      title={traceDetailTitle(trace.data, traceId)}
       actions={
         actionProps ? <TraceDetailActions {...actionProps} /> : undefined
       }

--- a/web/src/components/table/peek/resolvePeekTraceParams.clienttest.ts
+++ b/web/src/components/table/peek/resolvePeekTraceParams.clienttest.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePeekTraceParams } from "@/src/components/table/peek/resolvePeekTraceParams";
+
+// The two peek URL dialects (LFE-11041):
+// - v3 TracesTable:  peek=<trace id>, timestamp=<trace timestamp>
+// - v4 EventsTable:  peek=<observation id>, traceId=<trace id>,
+//                    timestamp=<observation startTime>
+// Each reader must accept the other dialect's URLs, since links cross the
+// v4-beta boundary between users.
+
+const TRACE_ID = "gist_service_8944222577377194128";
+const OBSERVATION_ID = "2df44465-3d61-43b3-8f92-b9580395c8a1";
+const TIMESTAMP = "2026-07-14T19:47:57.703Z";
+
+describe("resolvePeekTraceParams", () => {
+  describe("trace reader (v3 TracesTable peek)", () => {
+    it("native v3 URL: uses peek as trace id and keeps the timestamp", () => {
+      const result = resolvePeekTraceParams({
+        reader: "trace",
+        peek: TRACE_ID,
+        timestamp: TIMESTAMP,
+      });
+      expect(result.traceId).toBe(TRACE_ID);
+      expect(result.timestamp?.toISOString()).toBe(TIMESTAMP);
+    });
+
+    it("v4-generated URL: prefers the traceId param over peek", () => {
+      const result = resolvePeekTraceParams({
+        reader: "trace",
+        peek: OBSERVATION_ID,
+        traceId: TRACE_ID,
+        timestamp: TIMESTAMP,
+      });
+      expect(result.traceId).toBe(TRACE_ID);
+    });
+
+    it("v4-generated URL: drops the timestamp (it is an observation startTime, not the trace timestamp)", () => {
+      const result = resolvePeekTraceParams({
+        reader: "trace",
+        peek: OBSERVATION_ID,
+        traceId: TRACE_ID,
+        timestamp: TIMESTAMP,
+      });
+      expect(result.timestamp).toBeUndefined();
+    });
+  });
+
+  describe("observation reader (v4 EventsTable peek)", () => {
+    it("native v4 URL: uses the traceId param and keeps the timestamp", () => {
+      const result = resolvePeekTraceParams({
+        reader: "observation",
+        peek: OBSERVATION_ID,
+        traceId: TRACE_ID,
+        timestamp: TIMESTAMP,
+      });
+      expect(result.traceId).toBe(TRACE_ID);
+      expect(result.timestamp?.toISOString()).toBe(TIMESTAMP);
+    });
+
+    it("empty traceId param (v4 row without a trace): stays empty so the query remains disabled, no peek fallback", () => {
+      // All v4 writers set traceId to "" when the row has no trace
+      // (`row.traceId || ""`). Falling back to peek here would query an
+      // observation id as a trace id inside a native v4 flow.
+      const result = resolvePeekTraceParams({
+        reader: "observation",
+        peek: OBSERVATION_ID,
+        traceId: "",
+        timestamp: TIMESTAMP,
+      });
+      expect(result.traceId).toBe("");
+    });
+
+    it("v3-generated URL (no traceId param): falls back to peek as trace id, keeps the trace timestamp", () => {
+      const result = resolvePeekTraceParams({
+        reader: "observation",
+        peek: TRACE_ID,
+        timestamp: TIMESTAMP,
+      });
+      expect(result.traceId).toBe(TRACE_ID);
+      expect(result.timestamp?.toISOString()).toBe(TIMESTAMP);
+    });
+  });
+
+  it("decodes URL-encoded timestamps", () => {
+    const result = resolvePeekTraceParams({
+      reader: "trace",
+      peek: TRACE_ID,
+      timestamp: encodeURIComponent(TIMESTAMP),
+    });
+    expect(result.timestamp?.toISOString()).toBe(TIMESTAMP);
+  });
+
+  it("returns undefined trace id when neither param is present", () => {
+    const result = resolvePeekTraceParams({ reader: "trace" });
+    expect(result.traceId).toBeUndefined();
+    expect(result.timestamp).toBeUndefined();
+  });
+});

--- a/web/src/components/table/peek/resolvePeekTraceParams.ts
+++ b/web/src/components/table/peek/resolvePeekTraceParams.ts
@@ -1,0 +1,42 @@
+import { parseTraceTimestampFromQuery } from "@/src/utils/parseTraceTimestampFromQuery";
+
+/**
+ * The trace-peek URL comes in two dialects, and links cross the v4-beta
+ * boundary between users (LFE-11041):
+ *
+ * - v3 `TracesTable`:  `peek=<trace id>`, `timestamp=<trace timestamp>`
+ * - v4 `EventsTable`:  `peek=<observation id>`, `traceId=<trace id>`,
+ *                      `timestamp=<observation startTime>`
+ *
+ * Both peek readers resolve their query input through this one helper so each
+ * accepts the other dialect's URLs:
+ *
+ * - trace reader (v3): a `traceId` param marks a v4-generated URL — prefer it
+ *   over `peek`, and drop the timestamp: it is an observation startTime, and
+ *   `traces.byIdWithObservationsAndScores` would use it as the trace-timestamp
+ *   filter, 404ing long traces (same class as LFE-10947).
+ * - observation reader (v4): a missing `traceId` param marks a v3-generated
+ *   URL — fall back to `peek` as the trace id. The v3 timestamp is the trace
+ *   timestamp, a safe lookup anchor, so it is kept in both cases.
+ */
+export function resolvePeekTraceParams({
+  reader,
+  peek,
+  traceId,
+  timestamp,
+}: {
+  reader: "trace" | "observation";
+  peek?: string;
+  traceId?: string;
+  timestamp?: string | string[];
+}): { traceId?: string; timestamp?: Date } {
+  // A `traceId` param on the trace reader marks a v4-generated URL.
+  const dropTimestamp = reader === "trace" && !!traceId;
+
+  return {
+    traceId: traceId ?? peek,
+    timestamp: dropTimestamp
+      ? undefined
+      : parseTraceTimestampFromQuery(timestamp),
+  };
+}

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1322,12 +1322,16 @@ export default function TracesTable({
   );
 
   const peekNavigationProps = usePeekNavigation({
-    queryParams: ["observation", "display", "timestamp"],
+    // traceId is not written by this table but arrives on v4-dialect shared
+    // URLs (LFE-11041); listing it clears it on open/navigate/close so it
+    // cannot pin the peek to the originally shared trace.
+    queryParams: ["observation", "display", "timestamp", "traceId"],
     extractParamsValuesFromRow: (row: TracesTableRow) => ({
       timestamp: row.timestamp?.toISOString() || "",
     }),
     expandConfig: {
       basePath: `/project/${projectId}/traces`,
+      pathParam: "traceId",
     },
   });
 

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1332,6 +1332,7 @@ export default function TracesTable({
     expandConfig: {
       basePath: `/project/${projectId}/traces`,
       pathParam: "traceId",
+      reader: "trace",
     },
   });
 

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -107,7 +107,10 @@ function DatasetCompareRunsTableInternal(props: {
   }, [datasetItemsWithRunData.isSuccess, datasetItemsWithRunData.data]);
 
   const { closePeek, expandPeek } = usePeekNavigation({
-    queryParams: ["observation", "display", "timestamp"],
+    // traceId: not written here, but cleared (and preferred by the trace
+    // reader) so a stray param cannot pin the peek to a foreign trace
+    // (LFE-11041).
+    queryParams: ["observation", "display", "timestamp", "traceId"],
     expandConfig: {
       basePath: `/project/${props.projectId}/traces`,
     },

--- a/web/src/features/evals/components/code-eval-test-run-card.tsx
+++ b/web/src/features/evals/components/code-eval-test-run-card.tsx
@@ -74,7 +74,10 @@ export function CodeEvalTestRunCard({
     useEventsTable: isBetaEnabled,
   });
   const peekNavigationProps = usePeekNavigation({
-    queryParams: ["observation", "display", "timestamp"],
+    // traceId: not written here, but cleared (and preferred by the trace
+    // reader) so a stray param cannot pin the peek to a foreign trace
+    // (LFE-11041).
+    queryParams: ["observation", "display", "timestamp", "traceId"],
     expandConfig: {
       basePath: `/project/${projectId}/traces`,
     },


### PR DESCRIPTION
## What does this PR do?

Fixes cross-view trace-peek links (LFE-11041, surfaced via LFE-10929 / Taboola).

The `peek` query param on `/project/:id/traces` means different things depending on the viewer's v4 beta state:

| View | `peek` contains | trace id read from |
| --- | --- | --- |
| v3 `TracesTable` | trace id | `peek` |
| v4 `EventsTable` | observation id | separate `traceId` param |

Links crossing the beta boundary therefore break in both directions: a v4-generated URL opened by a v3 user looks up the observation UUID as a trace id → 404 "Trace not found"; a v3-generated URL opened by a v4 user has no `traceId` param → silently empty peek pane.

Both peek readers now resolve their query input through one shared, unit-tested helper (`resolvePeekTraceParams`):

- v3 reader: prefers the `traceId` param when present (v4-generated URL). The URL's `timestamp` is dropped in that case — it is an observation `startTime`, and using it as the trace-timestamp filter 404s long traces (same class as LFE-10947).
- v4 reader: falls back to `peek` as the trace id when `traceId` is absent (v3-generated URL). The v3 timestamp is the trace timestamp, a safe lookup anchor, so it is kept.

Native URLs of each dialect are unaffected.

Note for review: verified via unit tests (7 new) + existing peek/trace-detail client suites; please double-check the cross-dialect flows once the PR preview is up (open a v4-view peek URL as a beta-off user and vice versa).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `resolvePeekTraceParams` helper that normalises the two peek URL dialects (v3 `TracesTable`: `peek=traceId,timestamp=traceTimestamp` and v4 `EventsTable`: `peek=obsId,traceId=traceId,timestamp=obsStartTime`) so each reader correctly handles links generated by the other. The core fix drops the `timestamp` when the trace reader encounters a v4 URL, preventing the observation startTime from being used as a trace-level filter (which caused 404s on long traces, LFE-10947 class).

- **`resolvePeekTraceParams.ts`** — new helper with a single `dropTimestamp` flag that targets precisely the trace-reader + v4-URL case; both readers now fall back gracefully when served the other's URL format.
- **`peek-trace-detail.tsx` / `peek-observation-detail.tsx`** — inline decoding logic replaced by the helper, removing duplication; `peekIdRef` in the trace reader now tracks the resolved `traceId` (functionally correct but the name was left stale).
- **`resolvePeekTraceParams.clienttest.ts`** — covers native and cross-dialect URLs for both readers, including URL-encoded timestamps and the no-param edge case.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the logic change is well-scoped and covered by tests, with only a minor naming inconsistency left in the trace detail component.

The helper correctly handles all four dialect-reader combinations and the tests validate them. The only issue is the `peekIdRef` variable name that was not updated to `traceIdRef` after the refactor — it tracks the resolved `traceId` now, so the delete guard works correctly, but the name misleads future readers of that code path.

web/src/components/table/peek/peek-trace-detail.tsx — the `peekIdRef` variable name should be updated to reflect that it now tracks the resolved trace ID.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant TraceReader as "Trace Reader (v3)"
    participant ObsReader as "Obs Reader (v4)"
    participant Helper as "resolvePeekTraceParams"
    participant usePeekData

    Note over User,usePeekData: v4 URL opened in trace reader
    User->>TraceReader: "peek=obsId, traceId=traceId, timestamp=obsStartTime"
    TraceReader->>Helper: "reader=trace, peek=obsId, traceId=traceId, timestamp=obsStartTime"
    Note over Helper: dropTimestamp=true (traceId present)
    Helper-->>TraceReader: "traceId=traceId, timestamp=undefined"
    TraceReader->>usePeekData: "traceId, no timestamp filter"

    Note over User,usePeekData: v3 URL opened in obs reader
    User->>ObsReader: "peek=traceId, timestamp=traceTimestamp"
    ObsReader->>Helper: "reader=observation, peek=traceId, timestamp=traceTimestamp"
    Note over Helper: no traceId param, fallback to peek
    Helper-->>ObsReader: "traceId=peek, timestamp=traceTimestamp"
    ObsReader->>usePeekData: "traceId, traceTimestamp"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant TraceReader as "Trace Reader (v3)"
    participant ObsReader as "Obs Reader (v4)"
    participant Helper as "resolvePeekTraceParams"
    participant usePeekData

    Note over User,usePeekData: v4 URL opened in trace reader
    User->>TraceReader: "peek=obsId, traceId=traceId, timestamp=obsStartTime"
    TraceReader->>Helper: "reader=trace, peek=obsId, traceId=traceId, timestamp=obsStartTime"
    Note over Helper: dropTimestamp=true (traceId present)
    Helper-->>TraceReader: "traceId=traceId, timestamp=undefined"
    TraceReader->>usePeekData: "traceId, no timestamp filter"

    Note over User,usePeekData: v3 URL opened in obs reader
    User->>ObsReader: "peek=traceId, timestamp=traceTimestamp"
    ObsReader->>Helper: "reader=observation, peek=traceId, timestamp=traceTimestamp"
    Note over Helper: no traceId param, fallback to peek
    Helper-->>ObsReader: "traceId=peek, timestamp=traceTimestamp"
    ObsReader->>usePeekData: "traceId, traceTimestamp"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/table/peek/peek-trace-detail.tsx:36-37
**Stale `peekIdRef` name after refactor** — the ref was previously tracking `peekId` (the raw `peek` query param), but now tracks the resolved `traceId`. The variable name `peekIdRef` no longer matches its contents, which could confuse readers of the delete-guard logic on line 54. Consider renaming to `traceIdRef` to match the analogous pattern in `peek-observation-detail.tsx`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): resolve peek trace id across v3..."](https://github.com/langfuse/langfuse/commit/ede263e1ff6cc951dfa66b58c9054f0227bfa048) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45098617)</sub>

<!-- /greptile_comment -->