### PR TITLE
chore(clickhouse): propagate query_id to streaming queries and log_comment to all queries (LFE-11043)

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -471,8 +471,16 @@ export async function queryClickhouseExecRaw(
     );
 
     // The span outlives this function (it covers the consumer's read). Forward
-    // source errors so the consumer sees them.
-    res.stream.on("error", (error) => guardedStream.destroy(error));
+    // source errors (e.g. mid-transfer connection resets) so the consumer sees
+    // them, enriched like the other error paths of this function.
+    res.stream.on("error", (error) =>
+      guardedStream.destroy(
+        ClickHouseResourceError.wrapIfResourceError(
+          enrichWithQueryId(error, queryId),
+          normalizedTags,
+        ),
+      ),
+    );
     // `.pipe()` only wires src→dest, so destroying guardedStream (e.g. the
     // worker's pipeline aborting on an upload failure) would leave the live CH
     // body streaming into an unread socket — pinning a connection slot and query

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -264,14 +264,17 @@ export async function* queryClickhouseStream<T>(
     kind: SpanKind.CLIENT,
   });
 
-  let queryId: string | undefined;
+  // Client-generated so failures before/without a response still carry a
+  // query_id on errors and spans; system.query_log stays pollable by id.
+  const queryId = randomUUID();
 
   try {
     setSpanQueryAttributes(span, opts.query);
+    span.setAttribute("ch.queryId", queryId);
 
     const res = await context
       .with(trace.setSpan(context.active(), span), () =>
-        sendClickhouseQuery({ ...opts, format: "JSONEachRow", span }),
+        sendClickhouseQuery({ ...opts, format: "JSONEachRow", span, queryId }),
       )
       .catch((error) => {
         throw ClickHouseResourceError.wrapIfResourceError(
@@ -279,9 +282,6 @@ export async function* queryClickhouseStream<T>(
           normalizedTags,
         );
       });
-
-    queryId = res.query_id;
-    span.setAttribute("ch.queryId", queryId);
 
     for await (const rows of res.stream<T>()) {
       for (const row of rows) {
@@ -335,14 +335,17 @@ export async function* queryClickhouseStreamRawText(
     kind: SpanKind.CLIENT,
   });
 
-  let queryId: string | undefined;
+  // Client-generated so failures before/without a response still carry a
+  // query_id on errors and spans; system.query_log stays pollable by id.
+  const queryId = randomUUID();
 
   try {
     setSpanQueryAttributes(span, opts.query);
+    span.setAttribute("ch.queryId", queryId);
 
     const res = await context
       .with(trace.setSpan(context.active(), span), () =>
-        sendClickhouseQuery({ ...opts, format: "JSONEachRow", span }),
+        sendClickhouseQuery({ ...opts, format: "JSONEachRow", span, queryId }),
       )
       .catch((error) => {
         throw ClickHouseResourceError.wrapIfResourceError(
@@ -350,9 +353,6 @@ export async function* queryClickhouseStreamRawText(
           normalizedTags,
         );
       });
-
-    queryId = res.query_id;
-    span.setAttribute("ch.queryId", queryId);
 
     for await (const rows of res.stream()) {
       for (const row of rows) {
@@ -420,11 +420,14 @@ export async function queryClickhouseExecRaw(
     kind: SpanKind.CLIENT,
   });
 
-  let queryId: string | undefined;
+  // Client-generated so failures before/without a response still carry a
+  // query_id on errors and spans; system.query_log stays pollable by id.
+  const queryId = randomUUID();
 
   try {
     const queryWithFormat = `${opts.query}\nFORMAT ${opts.format}`;
     setSpanQueryAttributes(span, queryWithFormat);
+    span.setAttribute("ch.queryId", queryId);
 
     const res = await context
       .with(trace.setSpan(context.active(), span), () =>
@@ -435,6 +438,7 @@ export async function queryClickhouseExecRaw(
           query: queryWithFormat,
           query_params: opts.params,
           use_multipart_params_auto: opts.useMultipartParamsAuto,
+          query_id: queryId,
           clickhouse_settings: {
             ...opts.clickhouseSettings,
             log_comment: JSON.stringify(normalizedTags),
@@ -447,9 +451,6 @@ export async function queryClickhouseExecRaw(
           normalizedTags,
         );
       });
-
-    queryId = res.query_id;
-    span.setAttribute("ch.queryId", queryId);
     for (const [key, value] of Object.entries(normalizedTags)) {
       span.setAttribute(`ch.tag.${key}`, value);
     }
@@ -597,6 +598,7 @@ async function sendClickhouseQuery<F extends DataFormat>(opts: {
   clickhouseSettings?: ClickHouseSettings;
   format: F;
   span: Span;
+  queryId?: string;
 }) {
   const normalizedTags = normalizeClickHouseQueryTags(opts.tags);
   const res = await clickhouseClient(
@@ -607,6 +609,7 @@ async function sendClickhouseQuery<F extends DataFormat>(opts: {
     format: opts.format,
     query_params: opts.params,
     use_multipart_params_auto: opts.useMultipartParamsAuto,
+    ...(opts.queryId ? { query_id: opts.queryId } : {}),
     clickhouse_settings: {
       ...opts.clickhouseSettings,
       log_comment: JSON.stringify(normalizedTags),

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -723,8 +723,13 @@ export async function* queryClickhouseWithProgress<T>(
     kind: SpanKind.CLIENT,
   });
 
+  // Client-generated so failures before/without a response still carry a
+  // query_id on errors and spans; system.query_log stays pollable by id.
+  const queryId = randomUUID();
+
   try {
     setSpanQueryAttributes(span, opts.query);
+    span.setAttribute("ch.queryId", queryId);
 
     const res = await context
       .with(trace.setSpan(context.active(), span), () =>
@@ -737,6 +742,7 @@ export async function* queryClickhouseWithProgress<T>(
           },
           format: "JSONEachRowWithProgress",
           span,
+          queryId,
         }),
       )
       .catch((error) => {
@@ -752,9 +758,18 @@ export async function* queryClickhouseWithProgress<T>(
       }
     }
   } catch (error) {
-    if (error instanceof ClickHouseResourceError) throw error;
+    if (error instanceof ClickHouseResourceError) {
+      const enriched = enrichWithQueryId(error, queryId);
+      throw enriched === error
+        ? error
+        : new ClickHouseResourceError(
+            error.errorType,
+            enriched,
+            normalizedTags,
+          );
+    }
     throw ClickHouseResourceError.wrapIfResourceError(
-      error as Error,
+      enrichWithQueryId(error as Error, queryId),
       normalizedTags,
     );
   } finally {

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -429,28 +429,23 @@ export async function queryClickhouseExecRaw(
     setSpanQueryAttributes(span, queryWithFormat);
     span.setAttribute("ch.queryId", queryId);
 
-    const res = await context
-      .with(trace.setSpan(context.active(), span), () =>
-        clickhouseClient(
-          opts.clickhouseConfigs,
-          opts.preferredClickhouseService,
-        ).exec({
-          query: queryWithFormat,
-          query_params: opts.params,
-          use_multipart_params_auto: opts.useMultipartParamsAuto,
-          query_id: queryId,
-          clickhouse_settings: {
-            ...opts.clickhouseSettings,
-            log_comment: JSON.stringify(normalizedTags),
-          },
-        }),
-      )
-      .catch((error) => {
-        throw ClickHouseResourceError.wrapIfResourceError(
-          enrichWithQueryId(error as Error, queryId),
-          normalizedTags,
-        );
-      });
+    // Failures reject into the outer catch, which enriches with the query_id
+    // and wraps resource errors exactly once.
+    const res = await context.with(trace.setSpan(context.active(), span), () =>
+      clickhouseClient(
+        opts.clickhouseConfigs,
+        opts.preferredClickhouseService,
+      ).exec({
+        query: queryWithFormat,
+        query_params: opts.params,
+        use_multipart_params_auto: opts.useMultipartParamsAuto,
+        query_id: queryId,
+        clickhouse_settings: {
+          ...opts.clickhouseSettings,
+          log_comment: JSON.stringify(normalizedTags),
+        },
+      }),
+    );
     for (const [key, value] of Object.entries(normalizedTags)) {
       span.setAttribute(`ch.tag.${key}`, value);
     }

--- a/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
+++ b/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
@@ -1,9 +1,13 @@
 import {
   queryClickhouse,
   queryClickhouseStream,
+  queryClickhouseStreamRawText,
   ClickHouseResourceError,
 } from "@langfuse/shared/src/server";
 import { fail } from "assert";
+
+const QUERY_ID_PATTERN =
+  /\[query_id: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\]/;
 
 describe("ClickHouse Resource Error Handling", () => {
   describe("queryClickhouse", () => {
@@ -132,6 +136,60 @@ describe("ClickHouse Resource Error Handling", () => {
         expect(results.length).toBe(3);
         expect(results[0]).toHaveProperty("number");
       });
+    });
+
+    describe("query_id propagation (LFE-11043)", () => {
+      it("should include query_id in errors thrown mid-stream", async () => {
+        const generator = queryClickhouseStream({
+          query: `SELECT throwIf(number = 2, 'memory limit exceeded: would use 10.23 GiB') as V FROM numbers(10)`,
+          clickhouseSettings: { max_block_size: "1" },
+        });
+
+        const rows: unknown[] = [];
+        try {
+          for await (const item of generator) {
+            rows.push(item);
+          }
+          fail("Should have thrown an error");
+        } catch (error: any) {
+          expect(error).toBeInstanceOf(ClickHouseResourceError);
+          expect(error.message).toMatch(QUERY_ID_PATTERN);
+        }
+      });
+
+      it("should include query_id in errors thrown before streaming starts", async () => {
+        const generator = queryClickhouseStream({
+          query: `SELECT * FROM non_existent_table_xyz123`,
+        });
+
+        const rows: unknown[] = [];
+        try {
+          for await (const item of generator) {
+            rows.push(item);
+          }
+          fail("Should have thrown an error");
+        } catch (error: any) {
+          expect(error.message).toMatch(QUERY_ID_PATTERN);
+        }
+      });
+    });
+  });
+
+  describe("queryClickhouseStreamRawText", () => {
+    it("should include query_id in errors thrown before streaming starts", async () => {
+      const generator = queryClickhouseStreamRawText({
+        query: `SELECT * FROM non_existent_table_xyz123`,
+      });
+
+      const rows: string[] = [];
+      try {
+        for await (const item of generator) {
+          rows.push(item);
+        }
+        fail("Should have thrown an error");
+      } catch (error: any) {
+        expect(error.message).toMatch(QUERY_ID_PATTERN);
+      }
     });
   });
 

--- a/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
+++ b/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
@@ -2,6 +2,7 @@ import {
   queryClickhouse,
   queryClickhouseStream,
   queryClickhouseStreamRawText,
+  queryClickhouseExecRaw,
   ClickHouseResourceError,
 } from "@langfuse/shared/src/server";
 import { fail } from "assert";
@@ -170,6 +171,7 @@ describe("ClickHouse Resource Error Handling", () => {
           fail("Should have thrown an error");
         } catch (error: any) {
           expect(error.message).toMatch(QUERY_ID_PATTERN);
+          expect(error.message.match(/\[query_id:/g)).toHaveLength(1);
         }
       });
     });
@@ -189,6 +191,22 @@ describe("ClickHouse Resource Error Handling", () => {
         fail("Should have thrown an error");
       } catch (error: any) {
         expect(error.message).toMatch(QUERY_ID_PATTERN);
+        expect(error.message.match(/\[query_id:/g)).toHaveLength(1);
+      }
+    });
+  });
+
+  describe("queryClickhouseExecRaw", () => {
+    it("should include query_id exactly once in errors thrown before streaming", async () => {
+      try {
+        await queryClickhouseExecRaw({
+          query: `SELECT * FROM non_existent_table_xyz123`,
+          format: "Parquet",
+        });
+        fail("Should have thrown an error");
+      } catch (error: any) {
+        expect(error.message).toMatch(QUERY_ID_PATTERN);
+        expect(error.message.match(/\[query_id:/g)).toHaveLength(1);
       }
     });
   });

--- a/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
+++ b/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
@@ -3,6 +3,7 @@ import {
   queryClickhouseStream,
   queryClickhouseStreamRawText,
   queryClickhouseExecRaw,
+  queryClickhouseWithProgress,
   ClickHouseResourceError,
 } from "@langfuse/shared/src/server";
 import { fail } from "assert";
@@ -184,6 +185,25 @@ describe("ClickHouse Resource Error Handling", () => {
       });
 
       const rows: string[] = [];
+      try {
+        for await (const item of generator) {
+          rows.push(item);
+        }
+        fail("Should have thrown an error");
+      } catch (error: any) {
+        expect(error.message).toMatch(QUERY_ID_PATTERN);
+        expect(error.message.match(/\[query_id:/g)).toHaveLength(1);
+      }
+    });
+  });
+
+  describe("queryClickhouseWithProgress", () => {
+    it("should include query_id exactly once in errors thrown before streaming starts", async () => {
+      const generator = queryClickhouseWithProgress({
+        query: `SELECT * FROM non_existent_table_xyz123`,
+      });
+
+      const rows: unknown[] = [];
       try {
         for await (const item of generator) {
           rows.push(item);

--- a/worker/src/backgroundMigrations/backfillEventsFullFromDatasetRunItems.ts
+++ b/worker/src/backgroundMigrations/backfillEventsFullFromDatasetRunItems.ts
@@ -570,7 +570,15 @@ export default class BackfillEventsFullFromDatasetRunItems implements IBackgroun
       return predecessor;
     }
 
-    const tables = await clickhouseClient().query({ query: "SHOW TABLES" });
+    const tables = await clickhouseClient().query({
+      query: "SHOW TABLES",
+      clickhouse_settings: {
+        log_comment: buildClickHouseLogComment({
+          surface: "worker",
+          route: "background-migration.backfillEventsFullFromDatasetRunItems",
+        }),
+      },
+    });
     const tableNames = (await tables.json()).data as { name: string }[];
 
     const requiredTables = [

--- a/worker/src/backgroundMigrations/migrateDatasetRunItemsFromPostgresToClickhouseRmt.ts
+++ b/worker/src/backgroundMigrations/migrateDatasetRunItemsFromPostgresToClickhouseRmt.ts
@@ -1,5 +1,6 @@
 import { IBackgroundMigration } from "./IBackgroundMigration";
 import {
+  buildClickHouseLogComment,
   clickhouseClient,
   convertPostgresDatasetRunItemToInsert,
   logger,
@@ -35,6 +36,13 @@ export default class MigrateDatasetRunItemsFromPostgresToClickhouseRmt implement
     // Check if ClickHouse dataset_run_items_rmt table exists
     const tables = await clickhouseClient().query({
       query: "SHOW TABLES",
+      clickhouse_settings: {
+        log_comment: buildClickHouseLogComment({
+          surface: "worker",
+          route:
+            "background-migration.migrateDatasetRunItemsFromPostgresToClickhouseRmt",
+        }),
+      },
     });
     const tableNames = (await tables.json()).data as { name: string }[];
     if (!tableNames.some((r) => r.name === "dataset_run_items_rmt")) {
@@ -162,6 +170,13 @@ export default class MigrateDatasetRunItemsFromPostgresToClickhouseRmt implement
         table: "dataset_run_items_rmt",
         values: datasetRunItems.map(convertPostgresDatasetRunItemToInsert),
         format: "JSONEachRow",
+        clickhouse_settings: {
+          log_comment: buildClickHouseLogComment({
+            surface: "worker",
+            route:
+              "background-migration.migrateDatasetRunItemsFromPostgresToClickhouseRmt",
+          }),
+        },
       });
 
       logger.info(

--- a/worker/src/backgroundMigrations/migrateEventLogToBlobStorageRefTable.ts
+++ b/worker/src/backgroundMigrations/migrateEventLogToBlobStorageRefTable.ts
@@ -1,5 +1,6 @@
 import { IBackgroundMigration } from "./IBackgroundMigration";
 import {
+  buildClickHouseLogComment,
   clickhouseClient,
   findS3RefsByPrimaryKey,
   getLastEventLogPrimaryKey,
@@ -42,6 +43,12 @@ export default class MigrateEventLogToBlobStorageRefTable implements IBackground
     // Check if ClickHouse traces table exists
     const tables = await clickhouseClient().query({
       query: "SHOW TABLES",
+      clickhouse_settings: {
+        log_comment: buildClickHouseLogComment({
+          surface: "worker",
+          route: "background-migration.migrateEventLogToBlobStorageRefTable",
+        }),
+      },
     });
     const tableNames = (await tables.json()).data as { name: string }[];
     if (

--- a/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
@@ -1,5 +1,6 @@
 import { IBackgroundMigration } from "./IBackgroundMigration";
 import {
+  buildClickHouseLogComment,
   clickhouseClient,
   convertPostgresObservationToInsert,
   logger,
@@ -70,6 +71,13 @@ export default class MigrateObservationsFromPostgresToClickhouse implements IBac
     // Check if ClickHouse observations table exists
     const tables = await clickhouseClient().query({
       query: "SHOW TABLES",
+      clickhouse_settings: {
+        log_comment: buildClickHouseLogComment({
+          surface: "worker",
+          route:
+            "background-migration.migrateObservationsFromPostgresToClickhouse",
+        }),
+      },
     });
     const tableNames = (await tables.json()).data as { name: string }[];
     if (!tableNames.some((r) => r.name === "observations")) {
@@ -143,6 +151,13 @@ export default class MigrateObservationsFromPostgresToClickhouse implements IBac
         table: "observations",
         values: observations.map(convertPostgresObservationToInsert),
         format: "JSONEachRow",
+        clickhouse_settings: {
+          log_comment: buildClickHouseLogComment({
+            surface: "worker",
+            route:
+              "background-migration.migrateObservationsFromPostgresToClickhouse",
+          }),
+        },
       });
 
       logger.info(

--- a/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
@@ -1,5 +1,6 @@
 import { IBackgroundMigration } from "./IBackgroundMigration";
 import {
+  buildClickHouseLogComment,
   clickhouseClient,
   convertPostgresScoreToInsert,
   logger,
@@ -35,6 +36,12 @@ export default class MigrateScoresFromPostgresToClickhouse implements IBackgroun
     // Check if ClickHouse scores table exists
     const tables = await clickhouseClient().query({
       query: "SHOW TABLES",
+      clickhouse_settings: {
+        log_comment: buildClickHouseLogComment({
+          surface: "worker",
+          route: "background-migration.migrateScoresFromPostgresToClickhouse",
+        }),
+      },
     });
     const tableNames = (await tables.json()).data as { name: string }[];
     if (!tableNames.some((r) => r.name === "scores")) {
@@ -120,6 +127,12 @@ export default class MigrateScoresFromPostgresToClickhouse implements IBackgroun
         table: "scores",
         values: scores.map(convertPostgresScoreToInsert),
         format: "JSONEachRow",
+        clickhouse_settings: {
+          log_comment: buildClickHouseLogComment({
+            surface: "worker",
+            route: "background-migration.migrateScoresFromPostgresToClickhouse",
+          }),
+        },
       });
 
       logger.info(

--- a/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
@@ -1,5 +1,6 @@
 import { IBackgroundMigration } from "./IBackgroundMigration";
 import {
+  buildClickHouseLogComment,
   clickhouseClient,
   convertPostgresTraceToInsert,
   logger,
@@ -35,6 +36,12 @@ export default class MigrateTracesFromPostgresToClickhouse implements IBackgroun
     // Check if ClickHouse traces table exists
     const tables = await clickhouseClient().query({
       query: "SHOW TABLES",
+      clickhouse_settings: {
+        log_comment: buildClickHouseLogComment({
+          surface: "worker",
+          route: "background-migration.migrateTracesFromPostgresToClickhouse",
+        }),
+      },
     });
     const tableNames = (await tables.json()).data as { name: string }[];
     if (!tableNames.some((r) => r.name === "traces")) {
@@ -120,6 +127,12 @@ export default class MigrateTracesFromPostgresToClickhouse implements IBackgroun
         table: "traces",
         values: traces.map(convertPostgresTraceToInsert),
         format: "JSONEachRow",
+        clickhouse_settings: {
+          log_comment: buildClickHouseLogComment({
+            surface: "worker",
+            route: "background-migration.migrateTracesFromPostgresToClickhouse",
+          }),
+        },
       });
 
       logger.info(

--- a/worker/src/backgroundMigrations/utils/backfillBase.ts
+++ b/worker/src/backgroundMigrations/utils/backfillBase.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { parseArgs } from "node:util";
 import {
+  buildClickHouseLogComment,
   clickhouseClient,
   commandClickhouse,
   getQueryError,
@@ -570,7 +571,15 @@ export abstract class ChunkedClickhouseBackfillMigration<
   }
 
   private async findFirstMissingTable(): Promise<string | null> {
-    const tables = await clickhouseClient().query({ query: "SHOW TABLES" });
+    const tables = await clickhouseClient().query({
+      query: "SHOW TABLES",
+      clickhouse_settings: {
+        log_comment: buildClickHouseLogComment({
+          surface: "worker",
+          route: `background-migration.${this.constructor.name}`,
+        }),
+      },
+    });
     const tableNames = (await tables.json()).data as { name: string }[];
     return (
       this.requiredTables.find(


### PR DESCRIPTION
## What does this PR do?

Brings the streaming ClickHouse query path to parity with the blob exporter for query attribution (LFE-11043), and closes the remaining `log_comment` gaps so every ClickHouse query carries attribution.

**query_id propagation** — `queryClickhouseStream`, `queryClickhouseStreamRawText`, `queryClickhouseWithProgress`, and `queryClickhouseExecRaw` now generate the `query_id` client-side (`randomUUID()`) and pass it to the ClickHouse client, instead of only reading it from the response:

- Errors thrown **before or without a response** (e.g. a query killed at start by the memory OvercommitTracker) now carry `[query_id: …]` in the message — previously the id was only known after a successful response, so exactly the failures that needed it lost it. In `queryClickhouseExecRaw` the pre-response `enrichWithQueryId` call referenced a `queryId` that was always `undefined` at that point; enrichment now happens exactly once, in the outer catch.
- `ch.queryId` is set on the query span up front, so failed-query spans carry it too.
- `system.query_log` / `system.processes` stay pollable by a known id for the whole query lifetime.

Batch export failure logs (`[BATCH EXPORT] Getting data from DB and transform failed`) include the error message, so the query id is now recoverable from Datadog even after `system.query_log` retention expires.

**log_comment coverage** — the last raw `clickhouseClient()` calls without attribution now set `log_comment` via `buildClickHouseLogComment` (`surface: worker`, `route: background-migration.<name>`): the `SHOW TABLES` validation guards and the Postgres→ClickHouse migration inserts in `worker/src/backgroundMigrations/**`.

Fixes [LFE-11043](https://linear.app/langfuse/issue/LFE-11043)

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves ClickHouse observability by generating a `query_id` client-side (via `randomUUID()`) before each streaming query so that span attributes and error messages always carry a stable ID — even when a request fails before ClickHouse returns a response. It also backfills `log_comment` on raw `clickhouseClient()` calls in background migration classes that were bypassing the shared wrapper.

- `queryClickhouseStream`, `queryClickhouseStreamRawText`, and `queryClickhouseExecRaw` now generate and forward `query_id` to ClickHouse, set `ch.queryId` on the span upfront, and append `[query_id: <uuid>]` to thrown errors via the new `enrichWithQueryId` helper.
- Background migration files (`migrateTracesFromPostgresToClickhouse`, `migrateObservationsFromPostgresToClickhouse`, `migrateScoresFromPostgresToClickhouse`, `migrateDatasetRunItemsFromPostgresToClickhouseRmt`, `migrateEventLogToBlobStorageRefTable`, `backfillEventsFullFromDatasetRunItems`, and `backfillBase`) now include `log_comment` on their direct `SHOW TABLES` and `insert` calls.
- New server tests verify that both pre-stream and mid-stream errors from `queryClickhouseStream` and `queryClickhouseStreamRawText` expose a UUID-shaped `[query_id: ...]` in the thrown error message.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the changes are additive observability improvements with no risk to query execution or data integrity.

The core change — moving `query_id` assignment before the request — is correct and well-tested for the three streaming functions it targets. Two gaps are worth a follow-up: `queryClickhouseWithProgress` was not updated to the same pattern, and `queryClickhouseExecRaw` can produce double `[query_id: ...]` in non-resource error messages because both the inner `.catch` and the outer `catch` call `enrichWithQueryId` for non-resource errors. Neither affects production behavior beyond slightly noisy error strings.

`packages/shared/src/server/repositories/clickhouse.ts` — the `queryClickhouseWithProgress` function and the double-enrichment path in `queryClickhouseExecRaw` warrant a second look.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/repositories/clickhouse.ts:716-764
**`queryClickhouseWithProgress` skipped in query_id propagation**

`queryClickhouseWithProgress` is a streaming async generator with the same error surface as `queryClickhouseStream`, but it was not updated in this PR. It still uses a server-assigned `query_id` (set after the response via `sendClickhouseQuery`), so if a request fails before ClickHouse responds, the span attribute `ch.queryId` is never set and errors are not enriched with `[query_id: ...]`. The same client-generated UUID pattern applied to the other streaming functions should be applied here.

### Issue 2 of 2
packages/shared/src/server/repositories/clickhouse.ts:447-501
**Double `[query_id: ...]` appended for non-resource errors in `queryClickhouseExecRaw`**

The inner `.catch` on the `exec()` call already calls `enrichWithQueryId(error, queryId)` and then `wrapIfResourceError`. For resource errors (memory limit, timeout, etc.), `wrapIfResourceError` returns a `ClickHouseResourceError`, which the outer `catch` re-throws immediately via `if (error instanceof ClickHouseResourceError) throw error` — so only one enrichment. But for non-resource errors (e.g. table-not-found, connection reset), `wrapIfResourceError` returns the plain enriched error, which the outer `catch` then passes through `enrichWithQueryId` a second time, producing messages like `"...table not found [query_id: abc] [query_id: abc]"`. The other streaming functions (`queryClickhouseStream`, `queryClickhouseStreamRawText`) avoid this by not calling `enrichWithQueryId` in the inner `.catch` — only in the outer one.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(clickhouse): propagate query\_id to..."](https://github.com/langfuse/langfuse/commit/11d18206cc96f0e0aa7243769dbecf9ef05eed01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45111520)</sub>

<!-- /greptile_comment -->
