### PR TITLE
fix(traces): clean up annotation queue items when their trace is deleted (#12852)

### DIFF
--- a/packages/shared/src/server/repositories/annotation-queue-items.ts
+++ b/packages/shared/src/server/repositories/annotation-queue-items.ts
@@ -1,0 +1,63 @@
+import { AnnotationQueueObjectType, prisma } from "../../db";
+import { getTraceIdsOlderThan } from "./traces";
+
+/**
+ * Delete annotation queue items that reference any of the given objects.
+ *
+ * Annotation queue items point at traces/observations via `objectId` with no
+ * foreign key to the underlying ClickHouse data. When that data is deleted
+ * (manual/batch trace deletion or data retention) the queue items would otherwise
+ * be left behind as orphans that render "Trace not found" in the review UI.
+ * Callers pass the ids that are being removed so the matching items are cleaned up
+ * in the same operation. See langfuse/langfuse#12852.
+ *
+ * @returns the number of deleted annotation queue items.
+ */
+export const deleteAnnotationQueueItemsByObjectIds = async ({
+  projectId,
+  objectType,
+  objectIds,
+}: {
+  projectId: string;
+  objectType: AnnotationQueueObjectType;
+  objectIds: string[];
+}): Promise<number> => {
+  if (objectIds.length === 0) return 0;
+
+  const { count } = await prisma.annotationQueueItem.deleteMany({
+    where: {
+      projectId,
+      objectType,
+      objectId: { in: objectIds },
+    },
+  });
+
+  return count;
+};
+
+/**
+ * Resolve which TRACE-type annotation queue items in a project reference traces
+ * older than `beforeDate` (i.e. traces about to be removed by data retention).
+ *
+ * Returns the expiring trace ids, which callers pass to
+ * `deleteAnnotationQueueItemsByObjectIds` AFTER the traces are deleted. It is
+ * resolved while the traces still exist so we never drop items for traces that
+ * survive the cutoff. Annotation queues are a small, curated set, so listing the
+ * referenced ids and filtering them by the cutoff stays cheap. Shared by the
+ * per-project retention job and the batch retention cleaner. See
+ * langfuse/langfuse#12852.
+ */
+export const getExpiredAnnotationQueueTraceIds = async (
+  projectId: string,
+  beforeDate: Date,
+): Promise<string[]> => {
+  const items = await prisma.annotationQueueItem.findMany({
+    where: { projectId, objectType: AnnotationQueueObjectType.TRACE },
+    select: { objectId: true },
+  });
+
+  const referencedTraceIds = [...new Set(items.map((item) => item.objectId))];
+  if (referencedTraceIds.length === 0) return [];
+
+  return getTraceIdsOlderThan(projectId, referencedTraceIds, beforeDate);
+};

--- a/packages/shared/src/server/repositories/index.ts
+++ b/packages/shared/src/server/repositories/index.ts
@@ -27,3 +27,4 @@ export * from "./job-executions";
 export * from "./daily-metrics";
 export * from "./dataset-runs";
 export * from "./score-configs";
+export * from "./annotation-queue-items";

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -918,6 +918,38 @@ export const hasAnyTraceOlderThan = async (
   return rows.length > 0;
 };
 
+/**
+ * Given a set of candidate trace ids, returns the subset whose trace timestamp is
+ * older than `beforeDate`. Used by data retention to find annotation queue items
+ * that reference traces about to be removed, so those items can be cleaned up
+ * instead of being left as orphans. See langfuse/langfuse#12852.
+ */
+export const getTraceIdsOlderThan = async (
+  projectId: string,
+  traceIds: string[],
+  beforeDate: Date,
+): Promise<string[]> => {
+  if (traceIds.length === 0) return [];
+
+  const rows = await queryClickhouse<{ id: string }>({
+    query: `
+      SELECT DISTINCT id
+      FROM traces
+      WHERE project_id = {projectId: String}
+      AND id IN ({traceIds: Array(String)})
+      AND timestamp < {cutoffDate: DateTime64(3)}
+    `,
+    params: {
+      projectId,
+      traceIds,
+      cutoffDate: convertDateToClickhouseDateTime(beforeDate),
+    },
+    tags: { projectId },
+  });
+
+  return rows.map((row) => row.id);
+};
+
 export const deleteTracesOlderThanDays = async (
   projectId: string,
   beforeDate: Date,

--- a/worker/src/__tests__/annotationQueueTraceDeletionCleanup.test.ts
+++ b/worker/src/__tests__/annotationQueueTraceDeletionCleanup.test.ts
@@ -1,0 +1,194 @@
+import { expect, describe, it } from "vitest";
+import { randomUUID } from "crypto";
+import { Job } from "bullmq";
+import {
+  createTrace,
+  createTracesCh,
+  createOrgProjectAndApiKey,
+} from "@langfuse/shared/src/server";
+import { AnnotationQueueObjectType, prisma } from "@langfuse/shared/src/db";
+import { processPostgresTraceDelete } from "../features/traces/processPostgresTraceDelete";
+import { handleDataRetentionProcessingJob } from "../ee/dataRetention/handleDataRetentionProcessingJob";
+import { BatchDataRetentionCleaner } from "../features/batch-data-retention-cleaner";
+
+/**
+ * Regression coverage for langfuse/langfuse#12852.
+ *
+ * Annotation queue items reference traces via `objectId` with no foreign key to
+ * ClickHouse. Deleting the referenced trace (manually or via data retention) used
+ * to leave the queue item behind, so opening it in the UI failed with
+ * "Trace not found". These tests assert the items are cleaned up with the trace
+ * across every trace-deletion path: manual/batch deletion, the per-project
+ * retention job, and the batch retention cleaner.
+ */
+describe("annotation queue cleanup on trace deletion (#12852)", () => {
+  const createQueueWithItem = async (
+    projectId: string,
+    objectId: string,
+    objectType: AnnotationQueueObjectType = AnnotationQueueObjectType.TRACE,
+  ) => {
+    const queueId = randomUUID();
+    await prisma.annotationQueue.create({
+      data: { id: queueId, projectId, name: `queue-${queueId}` },
+    });
+    const item = await prisma.annotationQueueItem.create({
+      data: { projectId, queueId, objectId, objectType },
+    });
+    return item.id;
+  };
+
+  const itemExists = async (id: string) =>
+    (await prisma.annotationQueueItem.findUnique({ where: { id } })) !== null;
+
+  describe("manual / batch trace deletion", () => {
+    it("deletes annotation queue items referencing the deleted traces", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+
+      const deletedTraceId = randomUUID();
+      const keptTraceId = randomUUID();
+      const deletedItemId = await createQueueWithItem(
+        projectId,
+        deletedTraceId,
+      );
+      const keptItemId = await createQueueWithItem(projectId, keptTraceId);
+
+      // When: only the first trace is deleted
+      await processPostgresTraceDelete(projectId, [deletedTraceId]);
+
+      // Then: the item for the deleted trace is gone, the other item remains
+      expect(await itemExists(deletedItemId)).toBe(false);
+      expect(await itemExists(keptItemId)).toBe(true);
+    });
+
+    it("removes every queue item referencing the same deleted trace", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+
+      const traceId = randomUUID();
+      // Same trace queued in two different queues -> two items, one objectId.
+      const itemA = await createQueueWithItem(projectId, traceId);
+      const itemB = await createQueueWithItem(projectId, traceId);
+
+      await processPostgresTraceDelete(projectId, [traceId]);
+
+      expect(await itemExists(itemA)).toBe(false);
+      expect(await itemExists(itemB)).toBe(false);
+    });
+
+    it("deletes only the referenced project's items, not another project's", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      const { projectId: otherProjectId } = await createOrgProjectAndApiKey();
+
+      const sharedTraceId = randomUUID();
+      const sameProjectItemId = await createQueueWithItem(
+        projectId,
+        sharedTraceId,
+      );
+      const otherProjectItemId = await createQueueWithItem(
+        otherProjectId,
+        sharedTraceId,
+      );
+
+      await processPostgresTraceDelete(projectId, [sharedTraceId]);
+
+      // The item in the deleted trace's project is removed...
+      expect(await itemExists(sameProjectItemId)).toBe(false);
+      // ...while an item with the same objectId in another project is untouched.
+      expect(await itemExists(otherProjectItemId)).toBe(true);
+    });
+
+    it("leaves OBSERVATION-type items untouched (cleanup is scoped to TRACE)", async () => {
+      // Documents the intentional scope: trace cleanup only removes TRACE-type
+      // items. OBSERVATION-type orphan handling is a separate follow-up.
+      const { projectId } = await createOrgProjectAndApiKey();
+
+      const traceId = randomUUID();
+      const observationItemId = await createQueueWithItem(
+        projectId,
+        traceId,
+        AnnotationQueueObjectType.OBSERVATION,
+      );
+
+      await processPostgresTraceDelete(projectId, [traceId]);
+
+      expect(await itemExists(observationItemId)).toBe(true);
+    });
+  });
+
+  describe("per-project data retention job", () => {
+    it("deletes items whose trace is expired, keeping recent ones", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      await prisma.project.update({
+        where: { id: projectId },
+        data: { retentionDays: 7 },
+      });
+
+      const oldTraceId = randomUUID();
+      const recentTraceId = randomUUID();
+      await createTracesCh([
+        createTrace({
+          id: oldTraceId,
+          project_id: projectId,
+          timestamp: Date.now() - 1000 * 60 * 60 * 24 * 30, // 30d ago -> expired
+        }),
+        createTrace({
+          id: recentTraceId,
+          project_id: projectId,
+          timestamp: Date.now(), // within retention -> kept
+        }),
+      ]);
+
+      const oldItemId = await createQueueWithItem(projectId, oldTraceId);
+      const recentItemId = await createQueueWithItem(projectId, recentTraceId);
+
+      await handleDataRetentionProcessingJob({
+        data: { payload: { projectId, retention: 7 } },
+      } as Job);
+
+      expect(await itemExists(oldItemId)).toBe(false);
+      expect(await itemExists(recentItemId)).toBe(true);
+
+      await prisma.project.update({
+        where: { id: projectId },
+        data: { retentionDays: null },
+      });
+    });
+  });
+
+  describe("batch data retention cleaner", () => {
+    it("deletes items whose trace is removed by the batch cleaner", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      await prisma.project.update({
+        where: { id: projectId },
+        data: { retentionDays: 7 },
+      });
+
+      const oldTraceId = randomUUID();
+      const recentTraceId = randomUUID();
+      await createTracesCh([
+        createTrace({
+          id: oldTraceId,
+          project_id: projectId,
+          timestamp: Date.now() - 1000 * 60 * 60 * 24 * 30, // 30d ago -> expired
+        }),
+        createTrace({
+          id: recentTraceId,
+          project_id: projectId,
+          timestamp: Date.now(), // within retention -> kept
+        }),
+      ]);
+
+      const oldItemId = await createQueueWithItem(projectId, oldTraceId);
+      const recentItemId = await createQueueWithItem(projectId, recentTraceId);
+
+      await new BatchDataRetentionCleaner("traces").processBatch();
+
+      expect(await itemExists(oldItemId)).toBe(false);
+      expect(await itemExists(recentItemId)).toBe(true);
+
+      await prisma.project.update({
+        where: { id: projectId },
+        data: { retentionDays: null },
+      });
+    });
+  });
+});

--- a/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
+++ b/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
@@ -1,17 +1,19 @@
 import {
+  deleteAnnotationQueueItemsByObjectIds,
   deleteEventsOlderThanDays,
   deleteMediaFiles,
   deleteObservationsOlderThanDays,
   deleteScoresOlderThanDays,
   deleteTracesOlderThanDays,
   findExpiredMediaByProjectId,
+  getExpiredAnnotationQueueTraceIds,
   getS3MediaStorageClient,
   logger,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
   getCurrentSpan,
 } from "@langfuse/shared/src/server";
 import { Job } from "bullmq";
-import { prisma } from "@langfuse/shared/src/db";
+import { AnnotationQueueObjectType, prisma } from "@langfuse/shared/src/db";
 import { env, v4WritesToEventsTable } from "../../env";
 
 export const handleDataRetentionProcessingJob = async (job: Job) => {
@@ -80,6 +82,18 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
     );
   }
 
+  // Annotation queue items reference traces by objectId with no foreign key to
+  // ClickHouse, so age-based trace deletion would otherwise leave orphaned items
+  // that render "Trace not found" in the review UI. Resolve which referenced
+  // traces are expiring before the delete runs (while they still exist), then
+  // remove their queue items after the trace data is gone. See
+  // langfuse/langfuse#12852. NOTE: only TRACE-type items are handled here;
+  // OBSERVATION- and SESSION-type items are a documented follow-up.
+  const expiredReferencedTraceIds = await getExpiredAnnotationQueueTraceIds(
+    projectId,
+    cutoffDate,
+  );
+
   // Delete ClickHouse (TTL / Delete Queries)
   logger.info(
     `[Data Retention] Deleting ClickHouse and S3 data older than ${currentRetention} days for project ${projectId}`,
@@ -101,6 +115,18 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
   logger.info(
     `[Data Retention] Deleted ClickHouse and S3 data older than ${currentRetention} days for project ${projectId}`,
   );
+
+  // Clean up annotation queue items that referenced the traces we just deleted.
+  if (expiredReferencedTraceIds.length > 0) {
+    const deletedQueueItems = await deleteAnnotationQueueItemsByObjectIds({
+      projectId,
+      objectType: AnnotationQueueObjectType.TRACE,
+      objectIds: expiredReferencedTraceIds,
+    });
+    logger.info(
+      `[Data Retention] Deleted ${deletedQueueItems} annotation queue items referencing expired traces for project ${projectId}`,
+    );
+  }
 
   // Set S3 Lifecycle for deletion (Future)
 };

--- a/worker/src/features/batch-data-retention-cleaner/index.ts
+++ b/worker/src/features/batch-data-retention-cleaner/index.ts
@@ -1,10 +1,12 @@
 import { createHash } from "crypto";
 import pLimit from "p-limit";
 
-import { prisma } from "@langfuse/shared/src/db";
+import { AnnotationQueueObjectType, prisma } from "@langfuse/shared/src/db";
 import {
   commandClickhouse,
   convertDateToClickhouseDateTime,
+  deleteAnnotationQueueItemsByObjectIds,
+  getExpiredAnnotationQueueTraceIds,
   logger,
   parseClickhouseUTCDateTimeFormat,
   queryClickhouse,
@@ -258,12 +260,35 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
             },
           );
 
+          // Annotation queue items reference traces by objectId with no foreign
+          // key to ClickHouse. Resolve which referenced traces are expiring for
+          // each project BEFORE the bulk delete removes them, so we can clean up
+          // the now-orphaned queue items afterwards (only relevant for the traces
+          // table). Scoped to selectedWorkloads because only those projects have
+          // their rows deleted in this pass. See langfuse/langfuse#12852.
+          const expiredAnnotationTraceIds =
+            this.tableName === "traces"
+              ? await Promise.all(
+                  selectedWorkloads.map(async (w) => ({
+                    projectId: w.projectId,
+                    traceIds: await getExpiredAnnotationQueueTraceIds(
+                      w.projectId,
+                      w.cutoffDate,
+                    ),
+                  })),
+                )
+              : [];
+
           await this.executeBatchDelete(timestampColumn, selectedWorkloads);
 
           logger.info(`${this.instanceName}: Batch deletion completed`, {
             table: this.tableName,
             projectsProcessed: selectedWorkloads.length,
           });
+
+          await this.cleanupOrphanedAnnotationQueueItems(
+            expiredAnnotationTraceIds,
+          );
         } else {
           logger.info(
             `${this.instanceName}: No projects with retention and data to delete`,
@@ -684,6 +709,32 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
           })),
           complete: false,
         };
+      }
+    }
+  }
+
+  /**
+   * Remove annotation queue items that referenced the traces we just deleted, so
+   * they don't become orphans that render "Trace not found" in the review UI.
+   * The expiring trace ids are resolved before the bulk delete (while the traces
+   * still exist); this runs after it, once the trace data is gone. Only TRACE-type
+   * items are handled — OBSERVATION- and SESSION-type items are a documented
+   * follow-up. See langfuse/langfuse#12852.
+   */
+  private async cleanupOrphanedAnnotationQueueItems(
+    expiredByProject: Array<{ projectId: string; traceIds: string[] }>,
+  ): Promise<void> {
+    for (const { projectId, traceIds } of expiredByProject) {
+      const deletedQueueItems = await deleteAnnotationQueueItemsByObjectIds({
+        projectId,
+        objectType: AnnotationQueueObjectType.TRACE,
+        objectIds: traceIds,
+      });
+      if (deletedQueueItems > 0) {
+        logger.info(
+          `${this.instanceName}: Deleted ${deletedQueueItems} annotation queue items referencing expired traces`,
+          { table: this.tableName, projectId },
+        );
       }
     }
   }

--- a/worker/src/features/traces/processPostgresTraceDelete.ts
+++ b/worker/src/features/traces/processPostgresTraceDelete.ts
@@ -1,5 +1,9 @@
-import { prisma } from "@langfuse/shared/src/db";
-import { logger, traceException } from "@langfuse/shared/src/server";
+import { AnnotationQueueObjectType, prisma } from "@langfuse/shared/src/db";
+import {
+  deleteAnnotationQueueItemsByObjectIds,
+  logger,
+  traceException,
+} from "@langfuse/shared/src/server";
 
 export const processPostgresTraceDelete = async (
   projectId: string,
@@ -17,6 +21,20 @@ export const processPostgresTraceDelete = async (
         projectId: projectId,
       },
     });
+
+    // Annotation queue items reference traces by objectId with no foreign key to
+    // ClickHouse, so deleting the trace would otherwise leave orphaned items that
+    // render "Trace not found" in the review UI. See langfuse/langfuse#12852.
+    const deletedQueueItems = await deleteAnnotationQueueItemsByObjectIds({
+      projectId,
+      objectType: AnnotationQueueObjectType.TRACE,
+      objectIds: traceIds,
+    });
+    if (deletedQueueItems > 0) {
+      logger.info(
+        `Deleted ${deletedQueueItems} annotation queue items referencing deleted traces in project ${projectId}`,
+      );
+    }
   } catch (e) {
     logger.error(
       `Error deleting trace ${JSON.stringify(traceIds)} in project ${projectId} from Postgres`,


### PR DESCRIPTION
## What does this PR do?

Annotation queue items reference traces via `objectId` with **no foreign key** to the ClickHouse traces they point at. When a trace is deleted, nothing removes the referencing `AnnotationQueueItem` rows, so they become orphans pointing at data that no longer exists. Opening such an item in the review UI fails with:

> **Trace not found** — Path: `traces.byIdWithObservationsAndScores`

Tracing the deletion code, **three** separate paths delete traces and all of them leak queue items:

1. **Per-project data retention (TTL)** — the reported issue. `handleDataRetentionProcessingJob` deletes traces older than the cutoff purely by age and never touches the referencing queue items.
2. **Manual / batch trace deletion** — `processPostgresTraceDelete` already cleans up `jobExecution` rows for the deleted traces, but not annotation queue items, so single/batch/cleaner deletions orphan items too.
3. **Batch retention cleaner** — `BatchDataRetentionCleaner` (opt-in) bulk-deletes expired traces straight from ClickHouse and touches no Postgres at all.

### Fix

Cascade-delete the `AnnotationQueueItem` rows that reference a trace whenever that trace is deleted, across all three paths, via two small shared helpers in `packages/shared/src/server/repositories`:

- `deleteAnnotationQueueItemsByObjectIds({ projectId, objectType, objectIds })` — the Postgres delete.
- `getExpiredAnnotationQueueTraceIds(projectId, beforeDate)` — resolves which of a project's queue-referenced traces are past the cutoff (annotation queues are a small, curated set, so this stays cheap), built on a new `getTraceIdsOlderThan` ClickHouse query.

Wiring:

- **Manual path** (`processPostgresTraceDelete`): delete queue items for the exact trace ids being removed.
- **Per-project TTL** (`handleDataRetentionProcessingJob`) and **batch cleaner** (`BatchDataRetentionCleaner`): resolve the expiring referenced trace ids **before** the ClickHouse delete removes them, then delete the queue items **after** the trace data is gone — so a failed ClickHouse delete never prematurely drops still-valid items.

### Tests

`worker/src/__tests__/annotationQueueTraceDeletionCleanup.test.ts` covers all three paths:

- Manual deletion removes the referencing item and leaves unrelated items intact.
- Every item referencing the same deleted trace is removed (multiple queues).
- Deletion is project-scoped: a same-`objectId` item in another project is untouched, while the same-project item is removed.
- OBSERVATION-type items are left untouched (documents the intentional scope).
- Per-project TTL and the batch cleaner each remove items whose trace is expired while keeping items whose trace is still within retention.

### Scope / follow-ups

Scoped to `TRACE`-type queue items — the reported case and the dominant usage. Two same-class gaps are called out in code comments as deliberate follow-ups rather than bundled here:

- **`OBSERVATION`-type items**: trace deletion also deletes the trace's observations, so observation-referencing items can orphan the same way. Handling them needs an observation → trace resolution the manual path doesn't currently have.
- **`SESSION`-type items**: a session is derived from its traces (no ClickHouse `sessions` table), so it only "disappears" once *all* its traces are deleted — a different liveness check.

Project deletion already cascades queue items via the Postgres FK (`onDelete: Cascade`), so that path is unaffected.

Fixes #12852

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Added tests that prove the fix is effective (`annotationQueueTraceDeletionCleanup.test.ts`, covering all three deletion paths).
- [x] Commented the non-obvious areas (ordering rationale, scope boundaries).
- [x] No documentation changes required.
- [ ] Lint and the full test suite are validated by CI on this PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds cascade-delete logic for `AnnotationQueueItem` rows that reference traces deleted via any of three paths: manual/batch deletion, per-project data retention TTL, and the batch retention cleaner. Two shared helpers (`deleteAnnotationQueueItemsByObjectIds` and `getExpiredAnnotationQueueTraceIds`) are introduced and wired into each path.

- The manual-deletion path (`processPostgresTraceDelete`) correctly deletes queue items for the explicit trace IDs being removed and is safe on retry.
- The TTL path (`handleDataRetentionProcessingJob`) and batch cleaner (`BatchDataRetentionCleaner`) use a pre-compute/post-delete strategy: queue trace IDs are resolved before ClickHouse deletion, then the queue items are removed after. However, in both places the secondary lookup is not wrapped in error handling — a failure there can block the primary trace deletion, and a failure in the post-delete cleanup creates permanently unrecoverable orphans on retry (because `getTraceIdsOlderThan` returns empty for already-deleted traces).
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Merging is risky for the TTL and batch-cleaner paths: a transient Prisma error during the pre-deletion lookup can block all trace deletion for a project, and a failure in the post-deletion queue cleanup leaves queue items permanently orphaned after the traces are already gone.

The manual-deletion path is clean and correctly implemented. The retention paths place a new Prisma query in the critical path of ClickHouse trace deletion without error handling, and the post-delete queue cleanup cannot be recovered on retry once traces have been removed from ClickHouse.

worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts and worker/src/features/batch-data-retention-cleaner/index.ts both need try/catch around the annotation queue lookup and the subsequent delete so failures are logged rather than propagated.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Job as Retention Job / Batch Cleaner
    participant PG as PostgreSQL (Prisma)
    participant CH as ClickHouse

    Note over Job,CH: Pre-deletion: resolve expiring queue trace IDs
    Job->>PG: getExpiredAnnotationQueueTraceIds()
    PG-->>Job: referencedTraceIds[]
    Job->>CH: getTraceIdsOlderThan(referencedTraceIds, cutoff)
    CH-->>Job: expiredTraceIds[]

    Note over Job,CH: Primary deletion
    Job->>CH: deleteTracesOlderThanDays / executeBatchDelete
    CH-->>Job: OK

    Note over Job,PG: Post-deletion cleanup
    Job->>PG: deleteAnnotationQueueItemsByObjectIds(expiredTraceIds)
    PG-->>Job: deletedCount

    Note over Job,CH: Manual path (processPostgresTraceDelete)
    Job->>PG: jobExecution.deleteMany(traceIds)
    Job->>PG: deleteAnnotationQueueItemsByObjectIds(traceIds)
    Job->>CH: processClickhouseTraceDelete(traceIds)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Job as Retention Job / Batch Cleaner
    participant PG as PostgreSQL (Prisma)
    participant CH as ClickHouse

    Note over Job,CH: Pre-deletion: resolve expiring queue trace IDs
    Job->>PG: getExpiredAnnotationQueueTraceIds()
    PG-->>Job: referencedTraceIds[]
    Job->>CH: getTraceIdsOlderThan(referencedTraceIds, cutoff)
    CH-->>Job: expiredTraceIds[]

    Note over Job,CH: Primary deletion
    Job->>CH: deleteTracesOlderThanDays / executeBatchDelete
    CH-->>Job: OK

    Note over Job,PG: Post-deletion cleanup
    Job->>PG: deleteAnnotationQueueItemsByObjectIds(expiredTraceIds)
    PG-->>Job: deletedCount

    Note over Job,CH: Manual path (processPostgresTraceDelete)
    Job->>PG: jobExecution.deleteMany(traceIds)
    Job->>PG: deleteAnnotationQueueItemsByObjectIds(traceIds)
    Job->>CH: processClickhouseTraceDelete(traceIds)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts:92-95
**Secondary lookup blocks primary trace deletion**

`getExpiredAnnotationQueueTraceIds` issues a Prisma query before any traces are deleted. If that query fails (transient DB overload, connection pool exhaustion, etc.), the entire job throws and the primary ClickHouse deletion at line 101 never runs. Repeated failures on the next retry cycle could delay retention indefinitely for the affected project. Because the annotation queue cleanup is best-effort relative to the main deletion, this lookup should not block it — wrap the lookup and the subsequent delete in a `try`/`catch` that logs but does not re-throw.

### Issue 2 of 4
worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts:119-130
**Queue-item delete failure after ClickHouse delete creates permanent orphans**

If `deleteAnnotationQueueItemsByObjectIds` throws after ClickHouse traces have already been removed (line 101–114), the job fails and BullMQ retries. On the retry, `getExpiredAnnotationQueueTraceIds` calls `getTraceIdsOlderThan`, which queries ClickHouse for those trace IDs — but they no longer exist, so it returns `[]`. The `if (expiredReferencedTraceIds.length > 0)` guard is never entered, and the queue items are permanently orphaned — the exact bug this PR aims to fix. Wrapping lines 120–129 in a `try`/`catch` that only logs (and does not re-throw) prevents the job from failing and avoids this unrecoverable state.

### Issue 3 of 4
worker/src/features/batch-data-retention-cleaner/index.ts:214-225
**`Promise.all` over per-project lookups blocks `executeBatchDelete`**

If `getExpiredAnnotationQueueTraceIds` rejects for any project in the `workloads` list, the `await Promise.all(...)` at line 216 rejects, and `executeBatchDelete` at line 227 never runs for any project. A single project's Prisma issue therefore prevents batch trace deletion across all projects in this run. The queue cleanup should be best-effort — wrapping this block (and the subsequent `cleanupOrphanedAnnotationQueueItems` call) in a `try`/`catch` that logs but continues keeps the primary deletion path independent of the secondary cleanup.

### Issue 4 of 4
worker/src/features/batch-data-retention-cleaner/index.ts:234-236
**`cleanupOrphanedAnnotationQueueItems` failure after batch delete causes unrecoverable orphans**

If `cleanupOrphanedAnnotationQueueItems` throws after `executeBatchDelete` has already removed the traces, the `PeriodicExclusiveRunner` schedules a fresh execution. On the next run, `getExpiredAnnotationQueueTraceIds` returns `[]` for those projects because their traces are gone, so the cleanup is never reattempted and the queue items remain orphaned permanently. Catching the error inside `cleanupOrphanedAnnotationQueueItems` per-project (or around the entire call here) and logging rather than propagating avoids this unrecoverable state.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(traces): clean up annotation queue i..."](https://github.com/langfuse/langfuse/commit/699aa59591e5788e6998bf5845c6867303bdb9b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45112235)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->