### PR TITLE
feat(filters): block filter-sidebar facets unavailable in chart view (LFE-11040)

### DIFF
--- a/web/src/components/table/data-table-controls.clienttest.tsx
+++ b/web/src/components/table/data-table-controls.clienttest.tsx
@@ -599,3 +599,121 @@ describe("DataTableControls facet ordering", () => {
     expect(screen.getByText("All")).toBeInTheDocument();
   });
 });
+
+describe("DataTableControls blocked facets (LFE-11040)", () => {
+  const categoricalFilter = (
+    column: string,
+    label: string,
+    isActive: boolean,
+  ): CategoricalUIFilter => ({
+    type: "categorical",
+    column,
+    label,
+    loading: false,
+    expanded: false,
+    isActive,
+    isDisabled: false,
+    onReset: () => {},
+    value: isActive ? ["x"] : [],
+    options: ["x", "y"],
+    counts: new Map(),
+    onChange: () => {},
+  });
+
+  const queryFilter = (
+    filters: UIFilter[],
+    expanded: string[] = [],
+  ): QueryFilter => ({
+    filters,
+    expanded,
+    onExpandedChange: () => {},
+    clearAll: () => {},
+    isFiltered: filters.some((f) => f.isActive),
+    setFilterState: () => {},
+  });
+
+  const REASON = "Charts can't filter by this field at the moment.";
+
+  it("blocks an INACTIVE facet whose column the surface can't honour, while leaving a forwardable one live", () => {
+    // The core of LFE-11040: previously only an ACTIVE filter deactivated, so
+    // an empty facet on an unavailable column stayed usable. Now a column the
+    // surface can't honour blocks regardless of whether it holds a value.
+    const { container } = render(
+      <TooltipProvider>
+        <DataTableControls
+          queryFilter={queryFilter(
+            [
+              categoricalFilter("blocked", "Blocked", false),
+              categoricalFilter("forwardable", "Forwardable", false),
+            ],
+            // Expand both so each facet's fieldset is mounted and observable.
+            ["blocked", "forwardable"],
+          )}
+          blockedColumnReason={(column) =>
+            column === "blocked" ? REASON : null
+          }
+        />
+      </TooltipProvider>,
+    );
+
+    // The inactive-but-blocked facet's inputs are disabled (fieldset) even
+    // though it carries no value…
+    expect(
+      container.querySelector('[data-facet-column="blocked"] fieldset'),
+    ).toBeDisabled();
+    // …and its header reads blocked (dimmed + not-allowed cursor).
+    expect(screen.getByRole("button", { name: /Blocked/ }).className).toContain(
+      "cursor-not-allowed",
+    );
+
+    // A forwardable inactive facet (resolver returns null) stays interactive.
+    expect(
+      container.querySelector('[data-facet-column="forwardable"] fieldset'),
+    ).not.toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /Forwardable/ }).className,
+    ).not.toContain("cursor-not-allowed");
+  });
+
+  it("makes a blocked column non-addable in the Add-filter picker, carrying the reason as its title", () => {
+    // Active-only mode surfaces the rest of the catalog behind "Add filter".
+    localStorage.setItem("data-table-controls-active-only", "true");
+    try {
+      render(
+        <TooltipProvider>
+          <DataTableControls
+            queryFilter={queryFilter([
+              // One active facet so active-only mode has something to show
+              // and the picker (addable = the inactive rest) renders.
+              categoricalFilter("active", "Active", true),
+              categoricalFilter("blocked", "Blocked", false),
+              categoricalFilter("forwardable", "Forwardable", false),
+            ])}
+            blockedColumnReason={(column) =>
+              column === "blocked" ? REASON : null
+            }
+          />
+        </TooltipProvider>,
+      );
+
+      // Open the Add-filter dropdown. Radix opens the menu on the trigger's
+      // pointer-down, which jsdom doesn't synthesize reliably; the keyboard
+      // path (Enter) opens it without depending on PointerEvent support.
+      const addButton = screen.getByRole("button", { name: /Add filter/ });
+      fireEvent.keyDown(addButton, { key: "Enter" });
+
+      const blockedItem = screen.getByRole("menuitem", { name: "Blocked" });
+      const forwardableItem = screen.getByRole("menuitem", {
+        name: "Forwardable",
+      });
+      // Blocked column stays visible but is disabled, with the reason on hover.
+      expect(blockedItem).toHaveAttribute("aria-disabled", "true");
+      expect(blockedItem).toHaveAttribute("title", REASON);
+      // Forwardable column is addable as usual.
+      expect(forwardableItem).not.toHaveAttribute("aria-disabled", "true");
+      expect(forwardableItem).not.toHaveAttribute("title");
+    } finally {
+      localStorage.removeItem("data-table-controls-active-only");
+    }
+  });
+});

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -152,12 +152,14 @@ interface DataTableControlsProps {
   queryFilter: QueryFilter;
   filterWithAI?: boolean;
   /**
-   * Given a filter column, the reason an active filter on it is NOT applied on
-   * the current surface (e.g. the chart view can't filter on it), or null. When
-   * it returns a reason, that active facet renders deactivated (dimmed + the
-   * reason on hover); Clearing still works. Undefined leaves every filter live.
+   * Given a filter column, the reason a filter on it is blocked on the current
+   * surface (active or not) — e.g. the chart view can't filter on it (#15187 /
+   * #15049), and later an OR/bracket a surface can't honour — or null. When it
+   * returns a reason, that facet renders blocked (dimmed + the reason on hover)
+   * whether or not it holds a value; Clearing still works. Undefined leaves
+   * every filter live.
    */
-  deactivatedColumnReason?: (column: string) => string | null;
+  blockedColumnReason?: (column: string) => string | null;
 }
 
 // Module-stable initial value: a fresh {} per render would re-subscribe
@@ -167,7 +169,7 @@ const EMPTY_RECENCY: Record<string, number> = {};
 export function DataTableControls({
   queryFilter,
   filterWithAI,
-  deactivatedColumnReason,
+  blockedColumnReason,
 }: DataTableControlsProps) {
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const { setOpen, tableName } = useDataTableControls();
@@ -339,15 +341,16 @@ export function DataTableControls({
   const promotedFacetCount = displayedFilters.filter(isPromoted).length;
 
   const renderFacet = (filter: UIFilter) => {
-    // "Not applied on this surface" (e.g. the chart can't filter on this
-    // column — #15187). Only an ACTIVE filter deactivates — an empty facet
-    // stays usable. Overrides isDisabled/disabledReason so the facet dims
-    // and explains on hover while Clear still works.
-    const deactivatedReason = filter.isActive
-      ? (deactivatedColumnReason?.(filter.column) ?? null)
-      : null;
-    const facetDisabled = filter.isDisabled || deactivatedReason !== null;
-    const facetDisabledReason = deactivatedReason ?? filter.disabledReason;
+    // A column the current surface can't honour blocks the facet whether or
+    // not it holds a value: the chart view can't filter on it (#15187 /
+    // #15049), and later an OR/bracket a surface can't apply. (An empty facet
+    // used to stay usable; blocking it regardless is the point of LFE-11040 —
+    // adding a value it can't honour would only mislead.) Overrides
+    // isDisabled/disabledReason so the facet dims and explains on hover while
+    // Clear still works.
+    const blockedReason = blockedColumnReason?.(filter.column) ?? null;
+    const facetDisabled = filter.isDisabled || blockedReason !== null;
+    const facetDisabledReason = blockedReason ?? filter.disabledReason;
     if (filter.type === "categorical") {
       const summaryValue = getFacetSummaryValue(filter);
       return (
@@ -837,15 +840,25 @@ export function DataTableControls({
                     align="start"
                     className="max-h-72 w-56 overflow-y-auto"
                   >
-                    {addableFilters.map((filter) => (
-                      <DropdownMenuItem
-                        key={filter.column}
-                        onClick={() => handleAddFilter(filter.column)}
-                        className="cursor-pointer"
-                      >
-                        {filter.label}
-                      </DropdownMenuItem>
-                    ))}
+                    {addableFilters.map((filter) => {
+                      // A column the surface can't honour stays visible but is
+                      // not addable — adding it would only land a facet that
+                      // immediately reads blocked (chart view — #15187 /
+                      // #15049). Same reason on hover.
+                      const reason =
+                        blockedColumnReason?.(filter.column) ?? null;
+                      return (
+                        <DropdownMenuItem
+                          key={filter.column}
+                          disabled={!!reason}
+                          title={reason ?? undefined}
+                          onClick={() => handleAddFilter(filter.column)}
+                          className="cursor-pointer"
+                        >
+                          {filter.label}
+                        </DropdownMenuItem>
+                      );
+                    })}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -2050,9 +2050,10 @@ export default function ObservationsEventsTable({
               // In bar mode AI filtering lives in the search bar; only offer the
               // sidebar wand on non-bar surfaces (embedded scoped tables).
               filterWithAI={!searchBarMode}
-              // In chart mode, dim active filters the chart can't apply (+ hover
-              // reason). Stateless per-column resolver — matches the search bar.
-              deactivatedColumnReason={
+              // In chart mode, block filters the chart can't apply — active or
+              // not — dimmed + hover reason. Stateless per-column resolver,
+              // matching the search bar.
+              blockedColumnReason={
                 chartActive ? chartFilterExclusionReason : undefined
               }
             />


### PR DESCRIPTION
## TL;DR

Follow-up to "any view is a chart": when the events/observations table is in **chart view**, the filter **sidebar** now dims and blocks the facets a chart can't filter by (latency, cost, tokens, scores, comments, metadata, structural columns…) — matching how the search bar already disables them — with a hover tooltip explaining why. It reuses the per-column reason resolver from #15187 and the blocked-facet visual from #15049; the change is essentially removing a guard that had limited blocking to *active* filters only. Live-verified (Chrome), 18/18 client tests, typecheck clean.

## Why

#15187 ("any view is a chart") made the filter/search **bar** disable items a chart can't honour. The **sidebar** was left out — its facets stayed fully usable in chart view even for columns a chart can't filter, which is misleading. This closes that gap and gives the sidebar a generic "blocked" state to reuse for the upcoming OR/brackets work.

## What

- **Core:** in `renderFacet` (`data-table-controls.tsx`), a facet now blocks whenever the surface's `blockedColumnReason(column)` returns a reason — previously that was restricted to *active* filters, so empty facets on unavailable columns stayed live. The existing blocked visual from #15049 (dimmed + `cursor-not-allowed` + hover-tooltip reason + disabled inputs) does the rest.
- **Add-filter picker:** blocked columns stay visible but non-addable (`disabled`), so you can't add a filter the chart can't honour.
- **Generalized the seam:** renamed the prop `deactivatedColumnReason` → `blockedColumnReason` (+ broadened its doc) so it reads as a generic "blocked on this surface" reason rather than chart-specific — ready for OR/brackets to supply their own resolver.
- **Tests:** inactive blocked facet renders disabled; forwardable inactive facet stays live; picker disables a blocked column.

## Result

In chart view, exactly the columns `chartFilterExclusionReason` marks unavailable render blocked (verified 23 blocked / 16 forwardable on observations), each explaining itself on hover; back in table view all facets are live. Blast radius is contained: **only the events/observations table passes the resolver**, so every other table (traces, sessions, prompts, evals, monitors, experiments, scores) is byte-identical to before.

<details>
<summary>Verification + one known nit</summary>

- `pnpm --filter=web run typecheck` (tsgo) clean; ESLint/prettier clean; **18/18 client tests** (incl. new ones, confirmed non-tautological — they fail against the pre-change guard).
- Live (Chrome, observations): Table → 0 blocked; Chart → unavailable facets (latency/TTFT, input/output/total tokens + cost, all scores, commentCount/Content, metadata, structural: isRootObservation/modelId/statusMessage/traceId/toolDefinitions/toolCalls) blocked with reason on hover; forwardable facets (environment, type, name, level, providedModelName, traceName, userId, sessionId, version, promptName, traceTags, toolNames, calledToolNames, experiment*) stay live. Active filters on blocked columns keep their value + Clear button (no data loss).
- **Known minor nit:** on the *add-filter dropdown* (shown only in "show only active" mode), a blocked item is dimmed + non-addable, but its native `title` tooltip isn't reachable on hover (a Radix disabled item is `pointer-events:none`), so only the dimming conveys "blocked" there. The primary surface — the sidebar facet header — uses a real Radix tooltip that works. Optional follow-up: swap the `title` for a Radix tooltip on the dropdown item.

Files: `data-table-controls.tsx`, `EventsTable.tsx`, `data-table-controls.clienttest.tsx`.
</details>

LFE-11040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes the gap left by #15187: when the observations/events table is in chart view, the **filter sidebar** now blocks facets for columns the chart can't honour (latency, tokens, cost, scores, metadata, etc.) — not just the search bar. It removes the guard that restricted blocking to *active* filters only, so empty facets on unavailable columns are no longer misleadingly interactive.

- **Core change** (`data-table-controls.tsx`): `renderFacet` now calls `blockedColumnReason` unconditionally (renamed from `deactivatedColumnReason`); blocked facets render dimmed + `cursor-not-allowed` + hover tooltip whether or not they hold a value.
- **Add-filter picker**: blocked columns stay in the dropdown (visible) but are marked `disabled` with the reason as a `title`, preventing new filters from being added on chart-incompatible columns.
- **Blast radius is narrow**: only `EventsTable` passes a resolver; all other tables remain byte-identical to before.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is narrowly scoped to the filter sidebar, only EventsTable passes a resolver, and all other tables are unaffected.

The core logic change is small and well-tested. Two minor issues: the 'Add filter' button remains enabled even when every addable filter is blocked (opening an all-disabled dropdown), and `cursor-pointer` is applied to disabled Radix items where `pointer-events: none` makes it a no-op. Neither affects correctness or data integrity.

The Add-filter dropdown section in `data-table-controls.tsx` around the button disabled check (line 833) and the `DropdownMenuItem` className could use a second look.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DataTableControls renders] --> B{blockedColumnReason\nprovided?}
    B -- No --> C[All facets render live]
    B -- Yes --> D[renderFacet per filter]
    D --> E{resolver returns\nreason string?}
    E -- No --> F[Facet live\nuses filter.isDisabled]
    E -- Yes --> G[facetDisabled=true\nDimmed + cursor-not-allowed\n+ hover tooltip]
    G --> H{filter.isActive?}
    H -- Yes --> I[Blocked with value visible\nClear still works]
    H -- No --> J[Blocked and empty\nnot interactive]

    A --> K{showOnlyActive mode?}
    K -- Yes --> L[addableFilters in dropdown]
    L --> M{resolver returns\nreason string?}
    M -- No --> N[DropdownMenuItem enabled]
    M -- Yes --> O[DropdownMenuItem disabled\ntitle equals reason]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[DataTableControls renders] --> B{blockedColumnReason\nprovided?}
    B -- No --> C[All facets render live]
    B -- Yes --> D[renderFacet per filter]
    D --> E{resolver returns\nreason string?}
    E -- No --> F[Facet live\nuses filter.isDisabled]
    E -- Yes --> G[facetDisabled=true\nDimmed + cursor-not-allowed\n+ hover tooltip]
    G --> H{filter.isActive?}
    H -- Yes --> I[Blocked with value visible\nClear still works]
    H -- No --> J[Blocked and empty\nnot interactive]

    A --> K{showOnlyActive mode?}
    K -- Yes --> L[addableFilters in dropdown]
    L --> M{resolver returns\nreason string?}
    M -- No --> N[DropdownMenuItem enabled]
    M -- Yes --> O[DropdownMenuItem disabled\ntitle equals reason]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/table/data-table-controls.tsx:833
**"Add filter" button stays enabled when all addable filters are blocked**

`addableFilters` now includes blocked columns (they're kept visible but disabled), so `addableFilters.length` remains non-zero even when every item is blocked. The button won't be disabled, and clicking it opens a dropdown where all entries are non-interactive — which is confusing. Consider also disabling the button when every filter in `addableFilters` has a non-null `blockedColumnReason`.

### Issue 2 of 2
web/src/components/table/data-table-controls.tsx:851-857
`cursor-pointer` has no effect on a disabled Radix `DropdownMenuItem` because Radix applies `pointer-events: none` which overrides the cursor style. This is a no-op and slightly misleading. Conditionally apply the class only for non-blocked items.

```suggestion
                        <DropdownMenuItem
                          key={filter.column}
                          disabled={!!reason}
                          title={reason ?? undefined}
                          onClick={() => handleAddFilter(filter.column)}
                          className={reason ? undefined : "cursor-pointer"}
                        >
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(filters): block filter-sidebar face..."](https://github.com/langfuse/langfuse/commit/80f521ed08584c72d5b7676035e430e7778c9a64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45130000)</sub>

<!-- /greptile_comment -->