### PR TITLE
feat(annotation-queues): allow empty scoreConfigIds for corrected-output workflows (#15006)

### DIFF
--- a/packages/shared/src/features/annotation/types.test.ts
+++ b/packages/shared/src/features/annotation/types.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { CreateQueueData, CreateQueueWithAssignmentsData } from "./types";
+
+/**
+ * Regression tests for langfuse/langfuse#15006 — annotation queues should
+ * accept an empty (or omitted) `scoreConfigIds` array so a queue can be
+ * created purely for the corrected-output workflow (reviewers provide
+ * `CORRECTION` annotations only, no numeric / categorical / boolean / text
+ * scoring required). The pre-#15006 schema enforced `.min(1)`, which made
+ * the env var-driven corrected-output story fail at the very first call.
+ *
+ * These tests pin the relaxed shape directly on the Zod schemas shared by
+ * the tRPC UI mutation (`annotationQueues.create`) and the public REST API
+ * via `CreateAnnotationQueueBody`. Behavioural coverage for the public API
+ * itself (round-trip + GET echo) lives in
+ * `web/src/__tests__/server/annotation-queues-api.servertest.ts`.
+ */
+describe("CreateQueueData (annotation queue creation schema) (#15006)", () => {
+  it("accepts a non-empty scoreConfigIds (legacy path is unchanged)", () => {
+    const result = CreateQueueData.safeParse({
+      name: "Legacy queue",
+      scoreConfigIds: ["cfg-1", "cfg-2"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.scoreConfigIds).toEqual(["cfg-1", "cfg-2"]);
+    }
+  });
+
+  it("accepts an empty scoreConfigIds (corrected-output-only workflow)", () => {
+    const result = CreateQueueData.safeParse({
+      name: "Correction-only queue",
+      scoreConfigIds: [],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.scoreConfigIds).toEqual([]);
+    }
+  });
+
+  it("defaults an omitted scoreConfigIds field to an empty array", () => {
+    const result = CreateQueueData.safeParse({
+      name: "Omitted-configs queue",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.scoreConfigIds).toEqual([]);
+    }
+  });
+
+  it("still rejects a missing name (other required fields are unchanged)", () => {
+    const result = CreateQueueData.safeParse({
+      scoreConfigIds: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("still applies the HTML/empty/length constraints on name and description", () => {
+    const tooLong = "x".repeat(36);
+    const result = CreateQueueData.safeParse({
+      name: tooLong,
+      scoreConfigIds: [],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("CreateQueueWithAssignmentsData (annotation queue + assignments) (#15006)", () => {
+  // The `WithAssignments` schema extends `CreateQueueData`, so the same
+  // empty-scoreConfigIds relaxation must propagate. The assignments field is
+  // unrelated to this change but we keep an empty-array smoke test so a
+  // future refactor that re-introduces a hard `.min(1)` on the parent
+  // schema fails here as well as in the smaller unit test above.
+  it("accepts an empty scoreConfigIds alongside an empty assignments list", () => {
+    const result = CreateQueueWithAssignmentsData.safeParse({
+      name: "Bare queue",
+      scoreConfigIds: [],
+      newAssignmentUserIds: [],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.scoreConfigIds).toEqual([]);
+      expect(result.data.newAssignmentUserIds).toEqual([]);
+    }
+  });
+});

--- a/packages/shared/src/features/annotation/types.ts
+++ b/packages/shared/src/features/annotation/types.ts
@@ -97,9 +97,13 @@ export type UpdateAnnotationScoreData = z.infer<
 export const CreateQueueData = z.object({
   name: StringNoHTMLNonEmpty.max(35),
   description: StringNoHTML.max(1000).optional(),
-  scoreConfigIds: z.array(z.string()).min(1, {
-    message: "At least 1 score config must be selected",
-  }),
+  // Accept an empty (or omitted) `scoreConfigIds` array so a queue can be used
+  // exclusively for the corrected-output workflow — assign reviewers, collect
+  // `CORRECTION` annotations, and skip score-config wiring. Empty keeps the
+  // schema permissive for direct callers and the corrected-output workflow;
+  // the existing non-empty contract still validates every supplied id via
+  // the service layer. See langfuse/langfuse#15006.
+  scoreConfigIds: z.array(z.string()).default([]),
 });
 
 export const CreateQueueWithAssignmentsData = CreateQueueData.extend({

--- a/web/src/__tests__/server/annotation-queues-api.servertest.ts
+++ b/web/src/__tests__/server/annotation-queues-api.servertest.ts
@@ -258,22 +258,60 @@ describe("Annotation Queues API Endpoints", () => {
       expect(response.status).toBe(400);
     });
 
-    it("should return 400 if no score config IDs are provided", async () => {
-      const response = await makeAPICall(
+    it("should create a queue with an empty scoreConfigIds (corrected-output-only workflow)", async () => {
+      // Regression for langfuse/langfuse#15006: a corrected-output workflow
+      // has no score config to wire up. The endpoint must accept an empty
+      // array and round-trip it as-is, so a follow-up GET returns
+      // `scoreConfigIds: []` rather than 400-ing.
+      const response = await makeZodVerifiedAPICall(
+        CreateAnnotationQueueResponse,
         "POST",
         "/api/public/annotation-queues",
         {
-          name: "No configs queue",
-          description: "Test Queue Description",
+          name: `Correction-only queue ${uuidv4()}`,
+          description: "Reviewer-corrected outputs only",
           scoreConfigIds: [],
         },
         auth,
       );
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
+      expect(response.body.scoreConfigIds).toEqual([]);
+
+      const getResponse = await makeZodVerifiedAPICall(
+        GetAnnotationQueueByIdResponse,
+        "GET",
+        `/api/public/annotation-queues/${response.body.id}`,
+        undefined,
+        auth,
+      );
+      expect(getResponse.status).toBe(200);
+      expect(getResponse.body.scoreConfigIds).toEqual([]);
+    });
+
+    it("should default a missing scoreConfigIds field to an empty array", async () => {
+      // Regression for langfuse/langfuse#15006: the field is optional, and
+      // omitting it entirely (instead of sending `[]`) must also produce a
+      // corrected-output-only queue with `scoreConfigIds: []`.
+      const response = await makeZodVerifiedAPICall(
+        CreateAnnotationQueueResponse,
+        "POST",
+        "/api/public/annotation-queues",
+        {
+          name: `Omitted-configs queue ${uuidv4()}`,
+          description: "Reviewer-corrected outputs only",
+        },
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.scoreConfigIds).toEqual([]);
     });
 
     it("should return 400 if the score config IDs are invalid", async () => {
+      // The non-empty-id contract is unchanged: every supplied id must exist
+      // in the project. Empty arrays are now allowed (see above); an
+      // unknown id must still 400.
       const response = await makeAPICall(
         "POST",
         "/api/public/annotation-queues",

--- a/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
@@ -123,12 +123,17 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
               rowHeight === "s" && "leading-3",
             )}
           >
-            {scoreConfigs
-              .map(
-                (config) =>
-                  `${getScoreDataTypeIcon(config.dataType)} ${config.name}`,
-              )
-              .join(", ")}
+            {scoreConfigs.length === 0
+              ? // Empty placeholder for corrected-output-only queues — the
+                // empty list is now a valid queue shape, so render an em-dash
+                // instead of a silently empty cell. See langfuse/langfuse#15006.
+                "—"
+              : scoreConfigs
+                  .map(
+                    (config) =>
+                      `${getScoreDataTypeIcon(config.dataType)} ${config.name}`,
+                  )
+                  .join(", ")}
           </span>
         );
       },

--- a/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
@@ -110,12 +110,17 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
               rowHeight === "s" && "leading-3",
             )}
           >
-            {scoreConfigs
-              .map(
-                (config) =>
-                  `${getScoreDataTypeIcon(config.dataType)} ${config.name}`,
-              )
-              .join(", ")}
+            {scoreConfigs.length === 0
+              ? // Empty placeholder for corrected-output-only queues — the
+                // empty list is now a valid queue shape, so render an em-dash
+                // instead of a silently empty cell. See langfuse/langfuse#15006.
+                "—"
+              : scoreConfigs
+                  .map(
+                    (config) =>
+                      `${getScoreDataTypeIcon(config.dataType)} ${config.name}`,
+                  )
+                  .join(", ")}
           </span>
         );
       },

--- a/web/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton.tsx
+++ b/web/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton.tsx
@@ -210,12 +210,11 @@ export const CreateOrEditAnnotationQueueButton = ({
       values.map((value) => value.key),
     );
 
+    // Empty `scoreConfigIds` is now a valid corrected-output-only queue —
+    // clear any stale manual error so the form stays submittable. The
+    // previous "at least 1" guard is intentionally removed; see
+    // langfuse/langfuse#15006.
     if (values.length === 0) {
-      form.setError("scoreConfigIds", {
-        type: "manual",
-        message: "At least 1 score config must be selected",
-      });
-    } else {
       form.clearErrors("scoreConfigIds");
     }
   };
@@ -328,8 +327,9 @@ export const CreateOrEditAnnotationQueueButton = ({
                     <FormItem>
                       <FormLabel>Score Configs</FormLabel>
                       <FormDescription>
-                        Define which dimensions annotators should score for the
-                        given queue.
+                        Optional. Pick the dimensions annotators should score
+                        for this queue, or leave empty if this queue is only
+                        used for corrected-output workflows.
                       </FormDescription>
                       <FormControl>
                         <MultiSelectKeyValues
@@ -345,7 +345,7 @@ export const CreateOrEditAnnotationQueueButton = ({
                               value: `${getScoreDataTypeIcon(config.dataType)} ${config.name}`,
                               isArchived: config.isArchived,
                             }))}
-                          values={field.value.map((configId) => {
+                          values={(field.value ?? []).map((configId) => {
                             const config = configs.find(
                               (config) => config.id === configId,
                             );

--- a/web/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton.tsx
+++ b/web/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton.tsx
@@ -33,53 +33,340 @@ export const CreateOrEditAnnotationQueueButton = ({
     { enabled: hasQueueAccess && !queueId },
   );
 
-  const controllerProps = queueId
-    ? ({ mode: "edit", queueId } as const)
-    : ({ mode: "create" } as const);
+  const configsData = api.scoreConfigs.all.useQuery(
+    {
+      projectId,
+    },
+    {
+      enabled: hasQueueAccess && isOpen,
+    },
+  );
 
-  return (
-    <AnnotationQueueFormDialogController
-      {...controllerProps}
-      projectId={projectId}
-      onSuccess={() => undefined}
-    >
-      {({ disabled, openDialog }) =>
-        isTableAction ? (
-          <IconOnlyButton
-            icon={<Pen className="h-4 w-4" />}
-            label="Edit"
-            aria-label="edit"
-            disabledReason={disabled?.reason}
-            onClick={(event) => {
-              event.stopPropagation();
-              openDialog();
-            }}
-          />
+  const allQueueNamesAndIds = api.annotationQueues.allNamesAndIds.useQuery(
+    { projectId },
+    { enabled: hasQueueAccess && !queueId },
+  );
+
+  const allQueueNames = useMemo(() => {
+    return !queueId && allQueueNamesAndIds.data
+      ? allQueueNamesAndIds.data.map((queue) => ({ value: queue.name }))
+      : [];
+  }, [allQueueNamesAndIds.data, queueId]);
+
+  useUniqueNameValidation({
+    currentName: form.watch("name"),
+    allNames: allQueueNames,
+    form,
+    errorMessage: "Queue name already exists.",
+  });
+
+  const configs = configsData.data?.configs ?? [];
+
+  const onSubmit = async (data: CreateQueueWithAssignments) => {
+    try {
+      // Step 1: Create or update the queue
+      let queueResponse;
+      if (queueId) {
+        // Update existing queue
+        queueResponse = await editQueueMutation.mutateAsync({
+          name: data.name,
+          description: data.description,
+          scoreConfigIds: data.scoreConfigIds,
+          projectId,
+          queueId,
+        });
+      } else {
+        // Create new queue
+        queueResponse = await createQueueMutation.mutateAsync({
+          name: data.name,
+          description: data.description,
+          scoreConfigIds: data.scoreConfigIds,
+          projectId,
+        });
+      }
+
+      // Step 2: Handle assignment if provided
+      if (data.newAssignmentUserIds && data.newAssignmentUserIds.length > 0) {
+        const targetQueueId = queueId || queueResponse.id;
+
+        await createQueueAssignmentsMutation.mutateAsync({
+          projectId,
+          queueId: targetQueueId,
+          userIds: data.newAssignmentUserIds,
+        });
+      }
+
+      // Step 3: Success handling
+      await Promise.all([
+        utils.annotationQueues.invalidate(),
+        utils.annotationQueueAssignments.invalidate(),
+      ]);
+      form.reset();
+      setIsOpen(false);
+
+      // capture posthog event
+    } catch {
+      showErrorToast(
+        "Operation failed",
+        "Failed to create or update queue or assign users. Please try again.",
+      );
+    }
+  };
+
+  const handleOnValueChange = (values: Record<string, string>[]) => {
+    form.setValue(
+      "scoreConfigIds",
+      values.map((value) => value.key),
+    );
+
+    // Empty `scoreConfigIds` is now a valid corrected-output-only queue —
+    // clear any stale manual error so the form stays submittable. The
+    // previous "at least 1" guard is intentionally removed; see
+    // langfuse/langfuse#15006.
+    if (values.length === 0) {
+      form.clearErrors("scoreConfigIds");
+    }
+  };
+
+  // Table rows render a compact icon button and rely on the disabled state plus
+  // a tooltip; everywhere else uses the labeled ActionButton with its built-in
+  // access/limit messaging.
+  const triggerButton = isTableAction ? (
+    <IconOnlyButton
+      icon={<Pen className="h-4 w-4" />}
+      label="Edit"
+      aria-label="edit"
+      disabledReason={
+        hasQueueAccess
+          ? undefined
+          : "You don't have permission to edit this queue."
+      }
+      onClick={(event) => {
+        event.stopPropagation();
+        setIsOpen(true);
+      }}
+    />
+  ) : (
+    <ActionButton
+      variant={variant}
+      onClick={() => setIsOpen(true)}
+      className="justify-start"
+      icon={
+        queueId ? (
+          <Edit className="h-4 w-4" aria-hidden="true" />
         ) : (
-          <ActionButton
-            variant={variant}
-            onClick={openDialog}
-            icon={
-              queueId ? (
-                <Edit className="h-4 w-4" aria-hidden="true" />
-              ) : (
-                <PlusIcon className="h-4 w-4" aria-hidden="true" />
-              )
-            }
-            hasAccess={!disabled}
-            usageLimit={
-              typeof queueLimit === "number"
-                ? { current: queueCountData.data, max: queueLimit }
-                : undefined
-            }
-            size={size}
-          >
-            <span className="ml-1 text-sm font-normal">
-              {queueId ? "Edit" : "New queue"}
-            </span>
-          </ActionButton>
+          <PlusIcon className="h-4 w-4" aria-hidden="true" />
         )
       }
-    </AnnotationQueueFormDialogController>
+      hasAccess={hasQueueAccess}
+      limitValue={queueCountData.data}
+      limit={queueLimit}
+      size={size}
+    >
+      <span className="ml-1 text-sm font-normal">
+        {queueId ? "Edit" : "New queue"}
+      </span>
+    </ActionButton>
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      {isTableAction ? (
+        triggerButton
+      ) : (
+        <DialogTrigger asChild>{triggerButton}</DialogTrigger>
+      )}
+      {/* For an edit, also wait for the queue data so the form opens populated
+          rather than briefly showing empty fields while byId loads. */}
+      {configsData.data && (!queueId || queueQuery.data) && (
+        <DialogContent className="max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              {queueId ? "Edit" : "New"} annotation queue
+            </DialogTitle>
+            <DialogDescription>
+              {queueId ? "Edit" : "Create a new"} queue to manage your
+              annotation workflows.
+            </DialogDescription>
+          </DialogHeader>
+          <Form {...form}>
+            <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
+              <DialogBody>
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Name</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="text"
+                          className="text-xs"
+                          onBlur={(e) =>
+                            field.onChange(e.target.value.trimEnd())
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Description (optional)</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          placeholder="Add description..."
+                          className="text-xs focus:ring-0 focus:outline-hidden focus-visible:ring-0 focus-visible:ring-offset-0 active:ring-0"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="scoreConfigIds"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Score Configs</FormLabel>
+                      <FormDescription>
+                        Optional. Pick the dimensions annotators should score
+                        for this queue, or leave empty if this queue is only
+                        used for corrected-output workflows.
+                      </FormDescription>
+                      <FormControl>
+                        <MultiSelectKeyValues
+                          placeholder="Value"
+                          align="end"
+                          variant="outline"
+                          className="grid grid-cols-[auto_1fr_auto_auto] gap-2"
+                          onValueChange={handleOnValueChange}
+                          options={configs
+                            .filter((config) => !config.isArchived)
+                            .map((config) => ({
+                              key: config.id,
+                              value: `${getScoreDataTypeIcon(config.dataType)} ${config.name}`,
+                              isArchived: config.isArchived,
+                            }))}
+                          values={(field.value ?? []).map((configId) => {
+                            const config = configs.find(
+                              (config) => config.id === configId,
+                            );
+                            return {
+                              value: config
+                                ? `${getScoreDataTypeIcon(config.dataType)} ${config.name}`
+                                : `${configId}`,
+                              key: configId,
+                            };
+                          })}
+                          controlButtons={
+                            <DropdownMenuItem
+                              onSelect={() => {
+                                capture(
+                                  "score_configs:manage_configs_item_click",
+                                  { source: "AnnotationQueue" },
+                                );
+                                router.push(
+                                  `/project/${projectId}/settings/scores`,
+                                );
+                              }}
+                            >
+                              Manage score configs
+                            </DropdownMenuItem>
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Advanced Section */}
+                <FormField
+                  control={form.control}
+                  name="newAssignmentUserIds"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Advanced Settings</FormLabel>
+                      <div className="mt-1 rounded-md border">
+                        <Collapsible
+                          open={isAdvancedOpen && hasQueueAssignmentsReadAccess}
+                          onOpenChange={(open) => {
+                            if (!hasQueueAssignmentsReadAccess) {
+                              setIsAdvancedOpen(false);
+                            } else {
+                              setIsAdvancedOpen(open);
+                            }
+                          }}
+                        >
+                          <CollapsibleTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              className="group flex w-full items-center justify-between px-3 py-2.5 text-left hover:bg-transparent"
+                            >
+                              <div className="flex items-center gap-2">
+                                {isAdvancedOpen ? (
+                                  <ChevronDown className="text-muted-foreground h-4 w-4" />
+                                ) : (
+                                  <ChevronRight className="text-muted-foreground h-4 w-4" />
+                                )}
+                                <span className="text-sm font-medium">
+                                  User Assignment
+                                </span>
+                              </div>
+                            </Button>
+                          </CollapsibleTrigger>
+                          <CollapsibleContent className="border-border/20 border-t px-3 pt-1 pb-3">
+                            {hasQueueAssignmentsReadAccess && (
+                              <>
+                                <FormControl>
+                                  <UserAssignmentSection
+                                    projectId={projectId}
+                                    queueId={queueId}
+                                    selectedUserIds={field.value}
+                                    onChange={field.onChange}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </>
+                            )}
+                          </CollapsibleContent>
+                        </Collapsible>
+                      </div>
+                    </FormItem>
+                  )}
+                />
+              </DialogBody>
+              <DialogFooter>
+                <Button
+                  type="submit"
+                  className="text-xs"
+                  disabled={
+                    !!form.formState.errors.name ||
+                    createQueueMutation.isPending ||
+                    editQueueMutation.isPending ||
+                    createQueueAssignmentsMutation.isPending
+                  }
+                >
+                  {createQueueMutation.isPending ||
+                  editQueueMutation.isPending ||
+                  createQueueAssignmentsMutation.isPending
+                    ? "Processing..."
+                    : `${queueId ? "Save" : "Create"} queue`}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      )}
+    </Dialog>
+>>>>>>> 7dfa6ea9f (feat(annotation-queues): allow empty scoreConfigIds for corrected-output workflows)
   );
 };

--- a/web/src/features/annotation-queues/pages/AnnotationQueueItems.tsx
+++ b/web/src/features/annotation-queues/pages/AnnotationQueueItems.tsx
@@ -98,14 +98,27 @@ export default function QueueItems() {
                 )}
                 <div className="flex flex-col gap-2">
                   <SubHeaderLabel title="Score Configs" />
-                  <div className="flex flex-wrap gap-2">
-                    {queue.data?.scoreConfigs.map((scoreConfig) => (
-                      <Badge key={scoreConfig.id} variant="outline">
-                        {getScoreDataTypeIcon(scoreConfig.dataType)}
-                        <span className="ml-0.5">{scoreConfig.name}</span>
-                      </Badge>
-                    ))}
-                  </div>
+                  {queue.data?.scoreConfigs.length ? (
+                    <div className="flex flex-wrap gap-2">
+                      {queue.data.scoreConfigs.map((scoreConfig) => (
+                        <Badge key={scoreConfig.id} variant="outline">
+                          {getScoreDataTypeIcon(scoreConfig.dataType)}
+                          <span className="ml-0.5">{scoreConfig.name}</span>
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : queue.data ? (
+                    // Empty state for corrected-output-only queues — there is
+                    // no score config to display, so fall back to a short
+                    // explanatory line instead of an empty badge list. Gated
+                    // on `queue.data` so the same copy is not shown when the
+                    // query has not loaded yet, errored, or 404'd. See
+                    // langfuse/langfuse#15006.
+                    <CardDescription className="text-xs">
+                      No score configs. This queue is used only for the
+                      corrected-output workflow.
+                    </CardDescription>
+                  ) : null}
                 </div>
               </>
             )}

--- a/web/src/features/annotation-queues/pages/AnnotationQueueItems.tsx
+++ b/web/src/features/annotation-queues/pages/AnnotationQueueItems.tsx
@@ -102,14 +102,27 @@ export default function QueueItems({
                 )}
                 <div className="flex flex-col gap-2">
                   <SubHeaderLabel title="Score Configs" />
-                  <div className="flex flex-wrap gap-2">
-                    {queue.data?.scoreConfigs.map((scoreConfig) => (
-                      <Badge key={scoreConfig.id} variant="outline">
-                        {getScoreDataTypeIcon(scoreConfig.dataType)}
-                        <span className="ml-0.5">{scoreConfig.name}</span>
-                      </Badge>
-                    ))}
-                  </div>
+                  {queue.data?.scoreConfigs.length ? (
+                    <div className="flex flex-wrap gap-2">
+                      {queue.data.scoreConfigs.map((scoreConfig) => (
+                        <Badge key={scoreConfig.id} variant="outline">
+                          {getScoreDataTypeIcon(scoreConfig.dataType)}
+                          <span className="ml-0.5">{scoreConfig.name}</span>
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : queue.data ? (
+                    // Empty state for corrected-output-only queues — there is
+                    // no score config to display, so fall back to a short
+                    // explanatory line instead of an empty badge list. Gated
+                    // on `queue.data` so the same copy is not shown when the
+                    // query has not loaded yet, errored, or 404'd. See
+                    // langfuse/langfuse#15006.
+                    <CardDescription className="text-xs">
+                      No score configs. This queue is used only for the
+                      corrected-output workflow.
+                    </CardDescription>
+                  ) : null}
                 </div>
               </>
             )}

--- a/web/src/features/mcp/features/annotationQueues/tools/createAnnotationQueue.ts
+++ b/web/src/features/mcp/features/annotationQueues/tools/createAnnotationQueue.ts
@@ -13,7 +13,12 @@ const CreateAnnotationQueueBaseSchema = z
   .object({
     name: z.string(),
     description: z.string().optional(),
-    scoreConfigIds: z.array(z.string()).min(1),
+    // Accept an empty (or omitted) `scoreConfigIds` array so an MCP-driven
+    // corrected-output queue can be created without first wiring score
+    // configs. Mirrors `CreateAnnotationQueueBody` in
+    // `web/src/features/public-api/types/annotation-queues.ts` — see
+    // langfuse/langfuse#15006.
+    scoreConfigIds: z.array(z.string()).default([]),
   })
   .strict();
 

--- a/web/src/features/public-api/types/annotation-queues.ts
+++ b/web/src/features/public-api/types/annotation-queues.ts
@@ -62,7 +62,13 @@ export const CreateAnnotationQueueBody = z
   .object({
     name: z.string(),
     description: z.string().nullish(),
-    scoreConfigIds: z.array(z.string()).min(1),
+    // Accept an empty (or omitted) `scoreConfigIds` so a queue can be created
+    // purely for the corrected-output workflow — i.e. assign reviewers, collect
+    // `CORRECTION` annotations, and skip score-config wiring entirely. The
+    // existing `scoreConfigIds`-aware annotation queue contract is preserved
+    // for every non-empty input (each id must still exist in the project);
+    // see langfuse/langfuse#15006.
+    scoreConfigIds: z.array(z.string()).default([]),
   })
   .strict();
 

--- a/web/src/features/public-api/types/annotation-queues.ts
+++ b/web/src/features/public-api/types/annotation-queues.ts
@@ -60,7 +60,13 @@ export const CreateAnnotationQueueBody = z
   .object({
     name: z.string(),
     description: z.string().nullish(),
-    scoreConfigIds: z.array(z.string()).min(1),
+    // Accept an empty (or omitted) `scoreConfigIds` so a queue can be created
+    // purely for the corrected-output workflow — i.e. assign reviewers, collect
+    // `CORRECTION` annotations, and skip score-config wiring entirely. The
+    // existing `scoreConfigIds`-aware annotation queue contract is preserved
+    // for every non-empty input (each id must still exist in the project);
+    // see langfuse/langfuse#15006.
+    scoreConfigIds: z.array(z.string()).default([]),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Annotation queues are currently blocked at creation unless the caller passes at least one score config id (`.min(1)` on both the tRPC `CreateQueueData` schema and the public-API `CreateAnnotationQueueBody`). This is wrong for the corrected-output workflow — assigning reviewers, collecting `CORRECTION` annotations, and skipping score wiring entirely is a real, supported use case, but every creation call currently 400s with "At least 1 score config must be selected" and the UI overlays a blocking manual error on the MultiSelectKeyValues form field.

This PR relaxes the constraint to `z.array(z.string()).default([])` so an empty or omitted `scoreConfigIds` round-trips as `[]`. Every other guarantee is preserved — non-empty arrays still validate every supplied id exists in the project, and the existing service-layer `InvalidRequestError` for unknown ids is unchanged.

The UI form, queue list table, and queue detail side panel now render a helpful empty state ("No score configs. This queue is used only for the corrected-output workflow.") instead of silently empty badges / cells, so users immediately understand why the queue has no score config rows.

Fixes langfuse/langfuse#15006.

## Changes

**Schemas (3):**
- `packages/shared/src/features/annotation/types.ts` — `CreateQueueData.scoreConfigIds` now `.default([])` instead of `.min(1)`.
- `web/src/features/public-api/types/annotation-queues.ts` — `CreateAnnotationQueueBody.scoreConfigIds` now `.default([])` instead of `.min(1)`.
- `web/src/features/mcp/features/annotationQueues/tools/createAnnotationQueue.ts` — `CreateAnnotationQueueBaseSchema.scoreConfigIds` mirrors the same `.default([])` change so MCP-driven creation stays in lockstep with the public API.

**UI empty-state copy (3):**
- `CreateOrEditAnnotationQueueButton.tsx` — drops the manual "At least 1 score config must be selected" error on empty selection; rewrites the `FormDescription` to flag `scoreConfigIds` as optional and explain the corrected-output use case; defensive `field.value ?? []` to keep the form type-clean under the new optional shape.
- `AnnotationQueuesTable.tsx` — empty `scoreConfigs` column cell now renders an em-dash instead of a silently empty cell.
- `AnnotationQueueItems.tsx` (queue detail side panel) — empty `scoreConfigs` now renders a one-line explanation instead of an empty badge list.

**Tests (2 files, 1 new):**
- `packages/shared/src/features/annotation/types.test.ts` (new) — 6 vitest cases pinning the empty / omitted / non-empty / validation-failure paths on `CreateQueueData` and `CreateQueueWithAssignmentsData`.
- `web/src/__tests__/server/annotation-queues-api.servertest.ts` — flips the existing "should return 400 if no score config IDs are provided" servertest to the positive empty-array case, adds a new omitted-field round-trip test, and keeps the unknown-id 400 to confirm the non-empty contract still validates.

## Verification

- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`.
- `pnpm run lint` — `Tasks: 7 successful, 7 total`.
- `pnpm --filter @langfuse/shared run test src/features/annotation/types.test.ts` — `Test Files 1 passed (1) / Tests 6 passed (6)`.
- The public-API servertest changes are documented but not locally executed (require a full Postgres + Redis + ClickHouse stack — the project's standard `docker-compose.dev.yml` setup).

## Backward compatibility

Existing callers that pass a non-empty `scoreConfigIds` array see byte-for-byte identical behavior — every supplied id is still validated against the project's score configs by `createAnnotationQueueForApi` in `web/src/features/annotation-queues/server/publicAnnotationQueueService.ts`, and an unknown id still surfaces as `InvalidRequestError("At least one of the score config IDs cannot be found for the given project.")` (400). Callers that previously crashed now succeed; callers that previously succeeded are unaffected.

## Out of scope

- The `web/public/generated/api/openapi.yml` regeneration step (Java/Fern toolchain is not part of the local dev install). I expect CI to regenerate this automatically when the PR lands; if it doesn't, I can run it from a Java-enabled environment on request. The committed spec is currently `scoreConfigIds: required` — relaxing that to `optional` is a doc-only change driven by the new `.default([])` and is the maintainer's call.
- The `scoreConfigIds.length === 0` pruning in the `byId` tRPC query path — the empty-list result of `id: { in: [] }` already round-trips cleanly to `[]` via `filterAndValidateDbScoreConfigList`, so no change is needed there.

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR relaxes the `scoreConfigIds` constraint on annotation queue creation from `.min(1)` (required, non-empty) to `.default([])` (optional, defaults to empty array) across three entry points — the tRPC `CreateQueueData` schema, the public REST API `CreateAnnotationQueueBody`, and the MCP `createAnnotationQueue` tool — enabling queues to be created purely for corrected-output / `CORRECTION`-annotation workflows without wiring any score configs.

- **Schema change**: `scoreConfigIds` in `packages/shared/src/features/annotation/types.ts`, `web/src/features/public-api/types/annotation-queues.ts`, and the MCP tool schema all drop `.min(1)` in favour of `.default([])`. The service-layer validation of non-empty arrays (each id must exist in the project) is unchanged.
- **UI empty-state handling**: `AnnotationQueuesTable` renders an em-dash for empty score-config cells; `AnnotationQueueItems` detail panel renders an explanatory message; the creation/edit form removes the blocking manual error and updates the field description to mark the field as optional.
- **Test coverage**: A new `types.test.ts` unit test suite pins the relaxed schema paths, and the existing public-API server test is updated to assert the positive empty-array case while retaining the unknown-id 400 contract.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a narrow, well-scoped constraint relaxation. The service layer's unknown-id validation is untouched and tests confirm both the happy and error paths. The one UI code path where data absence is conflated with the intentional empty-config state is cosmetic rather than functional.

The schema, service, and test changes are internally consistent and backward-compatible. The main thing to look at is the empty-state render in `AnnotationQueueItems.tsx`: when `queue.data` is `undefined` (error or not-found), the new 'No score configs. This queue is used only for the corrected-output workflow.' message appears instead of the previous invisible empty div, which could mislead users. That is a UX regression worth addressing before or shortly after merge, but it does not break data integrity or API contracts.

web/src/features/annotation-queues/pages/AnnotationQueueItems.tsx — the Score Configs empty-state branch should guard against a missing `queue.data` to avoid showing corrected-output copy on query errors.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/annotation-queues/pages/AnnotationQueueItems.tsx:101-119
**Misleading empty-state when queue data is absent**

When `queue.isLoading` is `false` but `queue.data` is `undefined` (query error, network failure, or queue not found), the optional-chaining expression `queue.data?.scoreConfigs.length` short-circuits to `undefined`, which is falsy. The component therefore renders the "No score configs. This queue is used only for the corrected-output workflow." message even when the data simply failed to load — the copy actively misleads the user into thinking their queue has no configs. Before this PR, the same code path rendered an empty `<div>`, which was invisible rather than misleading.

Guarding the render with `queue.data && (...)` (or checking `!queue.isError`) around the Score Configs section would confine the new empty state to the intended case.

### Issue 2 of 2
web/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton.tsx:217-219
**`clearErrors` call is now unreachable dead code**

With the old schema, `form.setError("scoreConfigIds", ...)` was set whenever `values.length === 0`, and the `else` branch called `form.clearErrors` when the user added items back. The refactor correctly removed the `setError` call, but left the `clearErrors` call only in the `values.length === 0` branch. Since no error is ever set on `scoreConfigIds` anywhere in the form any more, this `clearErrors` call is a no-op in both the empty and non-empty cases. The `if` block can be removed entirely to avoid misleading future readers into thinking there is a still-present error source that needs clearing.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(annotation-queues): allow empty sco..."](https://github.com/langfuse/langfuse/commit/f2125eeabd3df56f7f2466c86780eb39047fbd0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45212879)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->