### PR TITLE
fix(trace): restore persisted raw/markdown toggle for trace and observation IO content

### DIFF
--- a/web/src/components/trace/components/IOPreview/components/ChatMessage.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ChatMessage.tsx
@@ -139,6 +139,7 @@ export function ChatMessage({
       <div className="hover:bg-muted transition-colors">
         <MarkdownJsonViewHeader
           title={title}
+          canEnableMarkdown={false}
           handleOnValueChange={() => {}}
           handleOnCopy={() => {
             const rawText = JSON.stringify(message, null, 2);

--- a/web/src/components/ui/MarkdownJsonView.clienttest.tsx
+++ b/web/src/components/ui/MarkdownJsonView.clienttest.tsx
@@ -1,0 +1,120 @@
+/**
+ * Trace/observation IO cards auto-render string message content as markdown.
+ * CommonMark mangles line-oriented content (numbered rule lists become <ol>,
+ * pseudo-XML wrappers like <injected-rules> are swallowed as HTML blocks), and
+ * users had no override (#14778). These tests pin the restored Raw/Markdown
+ * toggle: it renders raw content as preformatted text with real line breaks
+ * and persists the choice via the global markdown preference.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { MarkdownJsonView } from "./MarkdownJsonView";
+import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+  };
+}
+
+// Line-oriented content that markdown rendering visibly restructures: the
+// numbered lines collapse into a single <ol> instead of staying as lines.
+const lineOrientedContent = [
+  "Injected rules:",
+  "1. Always do X.",
+  "2. Never do Y.",
+].join("\n");
+
+function renderView(content: unknown) {
+  return render(
+    <MarkdownContextProvider>
+      <MarkdownJsonView title="user" content={content} />
+    </MarkdownContextProvider>,
+  );
+}
+
+const rawToggle = () =>
+  screen.queryByRole("button", { name: /view as plain text/i });
+const markdownToggle = () =>
+  screen.queryByRole("button", { name: /render markdown/i });
+
+describe("MarkdownJsonView raw/markdown toggle (#14778)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createMemoryStorage());
+    vi.stubGlobal("sessionStorage", createMemoryStorage());
+  });
+
+  it("renders markdown by default and offers the plain-text toggle", () => {
+    renderView(lineOrientedContent);
+
+    // numbered lines were restructured into a list by the markdown renderer
+    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(rawToggle()).toBeInTheDocument();
+    expect(markdownToggle()).not.toBeInTheDocument();
+  });
+
+  it("switches to preformatted text with real line breaks and persists the choice", () => {
+    const { container } = renderView(lineOrientedContent);
+
+    fireEvent.click(rawToggle()!);
+
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    const pre = container.querySelector("pre");
+    expect(pre?.textContent).toBe(lineOrientedContent);
+    expect(localStorage.getItem("shouldRenderMarkdown")).toBe("false");
+    expect(markdownToggle()).toBeInTheDocument();
+  });
+
+  it("honors a persisted raw preference on mount and can switch back", () => {
+    localStorage.setItem("shouldRenderMarkdown", "false");
+
+    const { container } = renderView(lineOrientedContent);
+
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    expect(container.querySelector("pre")?.textContent).toBe(
+      lineOrientedContent,
+    );
+
+    fireEvent.click(markdownToggle()!);
+
+    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(localStorage.getItem("shouldRenderMarkdown")).toBe("true");
+  });
+
+  it("preserves line breaks for content sent as OpenAI text content parts", () => {
+    localStorage.setItem("shouldRenderMarkdown", "false");
+
+    const { container } = renderView([
+      { type: "text", text: lineOrientedContent },
+    ]);
+
+    expect(container.querySelector("pre")?.textContent).toBe(
+      lineOrientedContent,
+    );
+  });
+
+  it("offers no toggle for non-markdown-capable content", () => {
+    renderView({ nested: { foo: "bar" } });
+
+    expect(rawToggle()).not.toBeInTheDocument();
+    expect(markdownToggle()).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/ui/MarkdownJsonView.tsx
+++ b/web/src/components/ui/MarkdownJsonView.tsx
@@ -6,7 +6,8 @@ import { Button } from "@/src/components/ui/button";
 import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
 import { MarkdownView } from "@/src/components/ui/MarkdownViewer";
 import { type MediaReturnType } from "@/src/features/media/validation";
-import { Check, Copy } from "lucide-react";
+import { useMarkdownContext } from "@/src/features/theming/useMarkdownContext";
+import { Check, Copy, LetterText, RemoveFormatting } from "lucide-react";
 import { useMemo, useState } from "react";
 import { type z } from "zod";
 import { MARKDOWN_RENDER_CHARACTER_LIMIT } from "@/src/utils/constants";
@@ -23,12 +24,13 @@ type MarkdownJsonViewHeaderProps = {
 export function MarkdownJsonViewHeader({
   title,
   titleIcon,
-  handleOnValueChange: _handleOnValueChange,
+  handleOnValueChange,
   handleOnCopy,
-  canEnableMarkdown: _canEnableMarkdown = true,
+  canEnableMarkdown = true,
   controlButtons,
 }: MarkdownJsonViewHeaderProps) {
   const [isCopied, setIsCopied] = useState(false);
+  const { isMarkdownEnabled } = useMarkdownContext();
 
   return (
     <div className="io-message-header group-hover:bg-muted/80 flex flex-row items-center justify-between px-1 py-1 text-sm font-medium capitalize transition-colors">
@@ -38,6 +40,22 @@ export function MarkdownJsonViewHeader({
       </div>
       <div className="mr-1 flex min-w-0 shrink flex-row items-center gap-1">
         {controlButtons}
+        {canEnableMarkdown && (
+          <Button
+            title={isMarkdownEnabled ? "View as plain text" : "Render markdown"}
+            variant="ghost"
+            size="icon-xs"
+            type="button"
+            onClick={handleOnValueChange}
+            className="hover:bg-border"
+          >
+            {isMarkdownEnabled ? (
+              <RemoveFormatting className="h-3 w-3" />
+            ) : (
+              <LetterText className="h-3 w-3" />
+            )}
+          </Button>
+        )}
         <Button
           title="Copy to clipboard"
           variant="ghost"
@@ -76,8 +94,10 @@ const isSupportedMarkdownFormat = (
   return true;
 };
 
-// MarkdownJsonView will render markdown if `isMarkdownEnabled` (global context) is true and the content is valid markdown
-// otherwise, if content is valid markdown will render JSON with switch to enable markdown globally
+// MarkdownJsonView renders markdown-capable content via MarkdownView: as
+// markdown when `isMarkdownEnabled` (global, persisted context) is true,
+// otherwise as preformatted plain text with a header toggle between the two
+// (#14778). Non-markdown-capable content falls back to PrettyJsonView.
 export function MarkdownJsonView({
   content,
   title,
@@ -108,6 +128,7 @@ export function MarkdownJsonView({
     () => OpenAIContentSchema.safeParse(content),
     [content],
   );
+  const { isMarkdownEnabled } = useMarkdownContext();
 
   const canEnableMarkdown = isSupportedMarkdownFormat(
     content,
@@ -121,6 +142,7 @@ export function MarkdownJsonView({
           markdown={
             validatedOpenAIContent.success ? validatedOpenAIContent.data : null
           }
+          renderMarkdown={isMarkdownEnabled}
           title={title}
           titleIcon={titleIcon}
           customCodeHeaderClassName={customCodeHeaderClassName}

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -493,7 +493,7 @@ export function MarkdownView({
 }) {
   const capture = usePostHogClientCapture();
   const { resolvedTheme: theme } = useTheme();
-  const { setIsMarkdownEnabled } = useMarkdownContext();
+  const { isMarkdownEnabled, setIsMarkdownEnabled } = useMarkdownContext();
 
   const markdownContent =
     typeof markdown === "string" ? markdown : parseOpenAIContentParts(markdown);
@@ -524,10 +524,13 @@ export function MarkdownView({
     copyTextToClipboard(markdownContent);
   };
 
+  // Toggle relative to the context value, not the `renderMarkdown` prop: the
+  // header icon reads the context, so this keeps icon and action consistent
+  // even for a caller that passes a static `renderMarkdown`.
   const handleOnValueChange = () => {
-    setIsMarkdownEnabled(!renderMarkdown);
+    setIsMarkdownEnabled(!isMarkdownEnabled);
     capture("trace_detail:io_pretty_format_toggle_group", {
-      renderMarkdown: !renderMarkdown,
+      renderMarkdown: !isMarkdownEnabled,
     });
   };
 

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -205,11 +205,15 @@ function MarkdownRenderer({
   theme,
   className,
   customCodeHeaderClassName,
+  renderMarkdown = true,
 }: {
   markdown: string;
   theme?: string;
   className?: string;
   customCodeHeaderClassName?: string;
+  /** When false, render preformatted plain text with real line breaks
+      instead of markdown — the user-facing raw view (#14778). */
+  renderMarkdown?: boolean;
 }) {
   const promptReferenceProjectId = usePromptReferenceProjectId();
 
@@ -221,6 +225,16 @@ function MarkdownRenderer({
     () => exceedsMarkdownRenderLimits(markdown),
     [markdown],
   );
+
+  if (!renderMarkdown) {
+    return (
+      <div className={cn("space-y-2 overflow-x-auto text-sm", className)}>
+        <pre className="text-sm break-words whitespace-pre-wrap">
+          {markdown}
+        </pre>
+      </div>
+    );
+  }
 
   if (tooLargeOrDeep) {
     return (
@@ -456,6 +470,7 @@ export function MarkdownView({
   controlButtons,
   afterHeader,
   isSystemPrompt,
+  renderMarkdown = true,
 }: {
   markdown: string | z.infer<typeof OpenAIContentSchema>;
   title?: string;
@@ -471,6 +486,10 @@ export function MarkdownView({
       (`role === "system"`) — the title can be a message `name` instead of the
       role. Falls back to matching the title for callers without role data. */
   isSystemPrompt?: boolean;
+  /** When false, text content renders as preformatted plain text with real
+      line breaks instead of markdown; the header toggle flips the persisted
+      global preference (#14778). */
+  renderMarkdown?: boolean;
 }) {
   const capture = usePostHogClientCapture();
   const { resolvedTheme: theme } = useTheme();
@@ -506,9 +525,9 @@ export function MarkdownView({
   };
 
   const handleOnValueChange = () => {
-    setIsMarkdownEnabled(false);
+    setIsMarkdownEnabled(!renderMarkdown);
     capture("trace_detail:io_pretty_format_toggle_group", {
-      renderMarkdown: false,
+      renderMarkdown: !renderMarkdown,
     });
   };
 
@@ -572,6 +591,7 @@ export function MarkdownView({
                 markdown={isCollapsed ? truncatedContent : markdown}
                 theme={theme}
                 customCodeHeaderClassName={customCodeHeaderClassName}
+                renderMarkdown={renderMarkdown}
               />
               {collapseToggle}
             </>
@@ -584,6 +604,7 @@ export function MarkdownView({
                 markdown={truncatedContent}
                 theme={theme}
                 customCodeHeaderClassName={customCodeHeaderClassName}
+                renderMarkdown={renderMarkdown}
               />
             ) : (
               (markdown ?? []).map((content, index) => {
@@ -594,6 +615,7 @@ export function MarkdownView({
                       markdown={content.text}
                       theme={theme}
                       customCodeHeaderClassName={customCodeHeaderClassName}
+                      renderMarkdown={renderMarkdown}
                     />
                   );
                 }
@@ -643,6 +665,7 @@ export function MarkdownView({
               markdown={audio.transcript ? "[Audio] \n" + audio.transcript : ""}
               theme={theme}
               customCodeHeaderClassName={customCodeHeaderClassName}
+              renderMarkdown={renderMarkdown}
             />
             <LangfuseMediaView
               mediaReferenceString={audio.data.referenceString}

--- a/web/src/components/ui/PrettyJsonView.gate.clienttest.tsx
+++ b/web/src/components/ui/PrettyJsonView.gate.clienttest.tsx
@@ -6,6 +6,7 @@
  * normal small string still mounts the viewer.
  */
 import { render, screen } from "@testing-library/react";
+import { type ReactElement } from "react";
 import type * as CodeJsonViewerModule from "@/src/components/ui/CodeJsonViewer";
 
 // LargeStringFallback's only provider-bound dependency — stub it so the test
@@ -29,11 +30,18 @@ vi.mock("@/src/components/ui/CodeJsonViewer", async (importOriginal) => {
 
 import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
 import { LARGE_STRING_RENDER_CHAR_LIMIT } from "@/src/components/ui/largeStringGate";
+import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
+
+// PrettyJsonView reads the global markdown preference (raw/markdown toggle).
+const renderWithProviders = (ui: ReactElement) =>
+  render(<MarkdownContextProvider>{ui}</MarkdownContextProvider>);
 
 describe("PrettyJsonView large-string gate (LFE-10991)", () => {
   it("renders the bounded fallback and mounts neither the JSON viewer nor the table for an over-limit string", () => {
     const huge = "x".repeat(LARGE_STRING_RENDER_CHAR_LIMIT + 1);
-    const { container } = render(<PrettyJsonView json={huge} title="Input" />);
+    const { container } = renderWithProviders(
+      <PrettyJsonView json={huge} title="Input" />,
+    );
 
     // Bounded fallback + download affordance are shown...
     expect(screen.getByText(/Large string —/i)).toBeInTheDocument();
@@ -50,7 +58,9 @@ describe("PrettyJsonView large-string gate (LFE-10991)", () => {
   });
 
   it("renders normally (JSON viewer mounted, no fallback) for small I/O", () => {
-    render(<PrettyJsonView json={{ foo: "bar", n: 1 }} title="Input" />);
+    renderWithProviders(
+      <PrettyJsonView json={{ foo: "bar", n: 1 }} title="Input" />,
+    );
 
     expect(screen.queryByText(/Large string —/i)).not.toBeInTheDocument();
     expect(screen.getByTestId("json-view")).toBeInTheDocument();
@@ -66,7 +76,7 @@ describe("PrettyJsonView large-string gate (LFE-10991)", () => {
     });
     expect(hugeRawJson.length).toBeGreaterThan(LARGE_STRING_RENDER_CHAR_LIMIT);
 
-    render(
+    renderWithProviders(
       <PrettyJsonView
         json={hugeRawJson}
         parsedJson={undefined}
@@ -85,7 +95,7 @@ describe("PrettyJsonView large-string gate (LFE-10991)", () => {
 
   it("still gates a genuinely huge SETTLED top-level string (parse finished)", () => {
     const hugePlainString = "z".repeat(LARGE_STRING_RENDER_CHAR_LIMIT + 1);
-    render(
+    renderWithProviders(
       <PrettyJsonView
         json="ignored-raw"
         parsedJson={hugePlainString}

--- a/web/src/components/ui/PrettyJsonView.markdown-toggle.clienttest.tsx
+++ b/web/src/components/ui/PrettyJsonView.markdown-toggle.clienttest.tsx
@@ -1,0 +1,97 @@
+/**
+ * PrettyJsonView's markdown mode (bare markdown-like strings outside the
+ * ChatML path) auto-rendered markdown with no user override (#14778). These
+ * tests pin the header toggle: raw mode renders preformatted text with real
+ * line breaks, and non-markdown content never shows the toggle.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
+import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+  };
+}
+
+// A bare string with markdown structure: heading + numbered lines.
+const markdownString = [
+  "# Call summary",
+  "1. Greeted the customer.",
+  "2. Resolved the issue.",
+].join("\n");
+
+function renderView(json: unknown) {
+  return render(
+    <MarkdownContextProvider>
+      <PrettyJsonView title="Input" json={json} currentView="pretty" />
+    </MarkdownContextProvider>,
+  );
+}
+
+const rawToggle = () =>
+  screen.queryByRole("button", { name: /view as plain text/i });
+const markdownToggle = () =>
+  screen.queryByRole("button", { name: /render markdown/i });
+
+describe("PrettyJsonView markdown-mode raw/markdown toggle (#14778)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createMemoryStorage());
+    vi.stubGlobal("sessionStorage", createMemoryStorage());
+  });
+
+  it("renders markdown by default and offers the plain-text toggle", () => {
+    renderView(markdownString);
+
+    expect(
+      screen.getByRole("heading", { name: /call summary/i }),
+    ).toBeInTheDocument();
+    expect(rawToggle()).toBeInTheDocument();
+  });
+
+  it("switches to preformatted text with real line breaks and persists the choice", () => {
+    const { container } = renderView(markdownString);
+
+    fireEvent.click(rawToggle()!);
+
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+    expect(container.querySelector("pre")?.textContent).toBe(markdownString);
+    expect(localStorage.getItem("shouldRenderMarkdown")).toBe("false");
+    expect(markdownToggle()).toBeInTheDocument();
+  });
+
+  it("honors a persisted raw preference on mount", () => {
+    localStorage.setItem("shouldRenderMarkdown", "false");
+
+    const { container } = renderView(markdownString);
+
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+    expect(container.querySelector("pre")?.textContent).toBe(markdownString);
+  });
+
+  it("offers no toggle for non-markdown JSON content", () => {
+    renderView({ foo: "bar", n: 1 });
+
+    expect(rawToggle()).not.toBeInTheDocument();
+    expect(markdownToggle()).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -47,6 +47,8 @@ import {
   StringOrMarkdownSchema,
   containsAnyMarkdown,
 } from "@/src/components/schemas/MarkdownSchema";
+import { useMarkdownContext } from "@/src/features/theming/useMarkdownContext";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { MARKDOWN_RENDER_CHARACTER_LIMIT } from "@/src/utils/constants";
 import {
   convertRowIdToKeyPath,
@@ -907,6 +909,8 @@ export function PrettyJsonView(props: {
     useState<LangfuseExpandedState>({});
 
   const isChatML = useMemo(() => isChatMLFormat(parsedJson), [parsedJson]);
+  const { isMarkdownEnabled, setIsMarkdownEnabled } = useMarkdownContext();
+  const capture = usePostHogClientCapture();
   const { isMarkdown, content: markdownContent } = useMemo(
     // Skip the markdown probe for gated large strings: isMarkdownContent runs
     // `JSON.stringify` on the whole value, an O(n) pass over the multi-MB string.
@@ -1326,6 +1330,7 @@ export function PrettyJsonView(props: {
               markdown={markdownContent || ""}
               media={props.media}
               isSystemPrompt={props.isSystemPrompt}
+              renderMarkdown={isMarkdownEnabled}
             />
           )}
         </div>
@@ -1444,8 +1449,13 @@ export function PrettyJsonView(props: {
         <MarkdownJsonViewHeader
           title={props.title}
           titleIcon={props.titleIcon}
-          canEnableMarkdown={false}
-          handleOnValueChange={() => {}} // No-op, parent handles state
+          canEnableMarkdown={isMarkdownMode}
+          handleOnValueChange={() => {
+            setIsMarkdownEnabled(!isMarkdownEnabled);
+            capture("trace_detail:io_pretty_format_toggle_group", {
+              renderMarkdown: !isMarkdownEnabled,
+            });
+          }}
           handleOnCopy={handleOnCopy}
           controlButtons={
             <>


### PR DESCRIPTION
Fixes langfuse/langfuse#14778

The trace preview renders string message content as markdown with no way to turn it off. Line-oriented content gets mangled — numbered rule lists collapse into a single `<ol>`, and pseudo-XML wrappers like `<injected-rules>` are swallowed as HTML blocks. The JSON tab isn't a real fallback because newlines show up as escaped `\n`.

While digging into this I found the toggle used to exist: the persisted `shouldRenderMarkdown` preference is still there (`MarkdownContext`, mounted in `_app.tsx`), and both handlers still call `setIsMarkdownEnabled` including the posthog event — the header button that invoked them was disconnected in the [#7938](<https://github.com/langfuse/langfuse/issues/7938>) rework and has been dead code since. So this mostly rewires what's already there:

* `MarkdownJsonViewHeader` renders the toggle again when the content is markdown-capable, reading the persisted preference for its state
* raw mode is a plain `<pre>` with real line breaks (new `renderMarkdown` prop on `MarkdownView`/`MarkdownRenderer`, default `true`), not the JSON-escaped view
* covers both paths: chat messages via `MarkdownJsonView`, and bare markdown strings via `PrettyJsonView`'s markdown mode
* comments and other markdown surfaces are untouched (`CommentList` has no title so no header; the prop defaults to `true`), and tool-call-only headers don't show the toggle

Markdown auto-detection stays the default; the choice persists and syncs across tabs like before.

**Tests:** 9 new client tests across both paths (written failing-first), covering the switch in both directions, persistence across mount, and content parts. `PrettyJsonView.gate.clienttest.tsx` now mounts inside `MarkdownContextProvider`. `test-client`, `typecheck`, and `lint` all pass.

Fork PRs don't get preview environments, so I verified in the browser through Storybook. Markdown (left) vs raw (right):

**Chat message path** — system prompt with `<injected-rules>`:

<img src="https://raw.githubusercontent.com/MatthewSynthia/langfuse/assets-pr-14778/chatml-1-markdown.png " alt="" width="400" />

<img src="https://raw.githubusercontent.com/MatthewSynthia/langfuse/assets-pr-14778/chatml-2-raw.png " alt="" width="400" />

**Bare string path** — the timestamp column alignment survives raw mode:

<img src="https://raw.githubusercontent.com/MatthewSynthia/langfuse/assets-pr-14778/barestring-1-markdown.png " alt="" width="400" />

<img src="https://raw.githubusercontent.com/MatthewSynthia/langfuse/assets-pr-14778/barestring-2-raw.png " alt="" width="400" />

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

<details><summary>Greptile Summary</summary>

This PR restores the persisted raw/markdown toggle for trace and observation IO content, fixing a regression introduced in PR [#7938](<https://github.com/langfuse/langfuse/issues/7938>) where the header toggle button was disconnected. The `MarkdownJsonViewHeader` now renders the toggle when content is markdown-capable, and a new `renderMarkdown` prop on `MarkdownRenderer`/`MarkdownView` renders preformatted `<pre>` text with real line breaks instead of parsed markdown.

* **MarkdownJsonView path**: `MarkdownView` (called with a title) now shows the toggle button and passes `renderMarkdown={isMarkdownEnabled}` from global context down through `MarkdownRenderer`, covering the ChatML/OpenAI content format path.
* **PrettyJsonView path**: The component's own `MarkdownJsonViewHeader` gains `canEnableMarkdown={isMarkdownMode}` and a toggle handler that calls `setIsMarkdownEnabled`; the nested `MarkdownView` receives `renderMarkdown={isMarkdownEnabled}` covering bare markdown strings.
* **Tests**: Nine new client tests across both paths (toggle in both directions, persistence across mount, content parts) are added along with provider-wrapping fixes to the existing gate test file.

</details>

<details><summary>Confidence Score: 4/5</summary>

Safe to merge. The toggle logic is correct for all current callers, tests pass, and no regressions to existing surfaces (comments, tool-only headers) were introduced.

The two paths for restoring the toggle (ChatML via MarkdownJsonView/MarkdownView and bare strings via PrettyJsonView) both correctly wire context state to rendering and to the handler. The only actionable concern is that handleOnValueChange in MarkdownView reads the renderMarkdown prop rather than the isMarkdownEnabled context value it already holds — both are identical today, but the coupling is fragile for future callers. Test coverage for the toggle logic is thorough. The createMemoryStorage duplication is a minor quality note.

web/src/components/ui/MarkdownViewer.tsx — the handleOnValueChange handler coupling between the renderMarkdown prop and context value.

</details>

<details><summary>Prompt To Fix All With AI</summary>

```markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/components/ui/MarkdownViewer.tsx:496
Since `MarkdownView` already calls `useMarkdownContext()` to obtain `setIsMarkdownEnabled`, destructuring `isMarkdownEnabled` from the same call and using it in the handler removes the dependency on the `renderMarkdown` prop being identical to the context value. Currently they always agree, but using the prop creates an implicit coupling that a future caller could violate silently.

```suggestion
  const { isMarkdownEnabled, setIsMarkdownEnabled } = useMarkdownContext();
```

### Issue 2 of 3
web/src/components/ui/MarkdownViewer.tsx:527-532
**Toggle handler uses prop instead of context value**

`handleOnValueChange` calls `setIsMarkdownEnabled(!renderMarkdown)`, where `renderMarkdown` is a prop. But `MarkdownView` already holds `setIsMarkdownEnabled` from context — it could just as easily read `isMarkdownEnabled` from the same call and use `!isMarkdownEnabled` directly. The current approach relies on an implicit invariant that every caller passes `renderMarkdown={isMarkdownEnabled}` from context. If a future caller provides a static/hardcoded `renderMarkdown` value, the toggle will silently become a no-op. With `isMarkdownEnabled` destructured from context (see companion suggestion on line 496), the handler can use it directly.

```suggestion
  const handleOnValueChange = () => {
    setIsMarkdownEnabled(!isMarkdownEnabled);
    capture("trace_detail:io_pretty_format_toggle_group", {
      renderMarkdown: !isMarkdownEnabled,
    });
  };
```

### Issue 3 of 3
web/src/components/ui/MarkdownJsonView.clienttest.tsx:20-35
**`createMemoryStorage` duplicated across two test files**

This exact helper is defined identically in `PrettyJsonView.markdown-toggle.clienttest.tsx`. Extracting it to a shared test utility (e.g., `web/src/test-utils/createMemoryStorage.ts`) would eliminate the duplication and make future changes to the stub easier to maintain.
```

</details>

Reviews (1): Last reviewed commit: ["feat(trace): restore raw/markdown toggle..."](<https://github.com/langfuse/langfuse/commit/07b26467caaaeccf67a22be229a435c83ccaad9c>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=45268550>)

> Greptile also left **1 inline comment** on this PR.