### PR TITLE
fix(filters): match unicode-escaped stored IO in input/output string filters

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -13,6 +13,7 @@ import {
   isFtsTextField,
   isFtsTextTarget,
 } from "./fts";
+import { toJsonUnicodeEscaped } from "./json-unicode-escape";
 
 export type ClickhouseOperator =
   | (typeof filterOperators)[keyof typeof filterOperators][number]
@@ -82,6 +83,18 @@ export class StringFilter implements Filter {
       }
     }
 
+    // input/output can hold JSON written by an `ensure_ascii=True` serializer,
+    // where non-ASCII text is stored as literal `\uXXXX` escapes. Substring
+    // filters on the raw value would never match those rows, so also match the
+    // escaped form — same recovery the free-text search path applies (see
+    // json-unicode-escape.ts, issues #11538 / #15072). ASCII values escape to
+    // themselves and keep the single-variant query.
+    const escapedValue = isFtsTextField(this.field)
+      ? toJsonUnicodeEscaped(this.value)
+      : this.value;
+    const escapedVarName = `${varName}Escaped`;
+    const hasEscapedVariant = escapedValue !== this.value;
+
     let query: string;
     switch (this.operator) {
       case "=":
@@ -95,16 +108,24 @@ export class StringFilter implements Filter {
         }
         break;
       case "contains":
-        query = `position(${fieldWithPrefix}, {${varName}: String}) > 0`;
+        query = hasEscapedVariant
+          ? `(position(${fieldWithPrefix}, {${varName}: String}) > 0 OR position(${fieldWithPrefix}, {${escapedVarName}: String}) > 0)`
+          : `position(${fieldWithPrefix}, {${varName}: String}) > 0`;
         break;
       case "does not contain":
-        query = `position(${fieldWithPrefix}, {${varName}: String}) = 0`;
+        query = hasEscapedVariant
+          ? `(position(${fieldWithPrefix}, {${varName}: String}) = 0 AND position(${fieldWithPrefix}, {${escapedVarName}: String}) = 0)`
+          : `position(${fieldWithPrefix}, {${varName}: String}) = 0`;
         break;
       case "starts with":
-        query = `startsWith(${fieldWithPrefix}, {${varName}: String})`;
+        query = hasEscapedVariant
+          ? `(startsWith(${fieldWithPrefix}, {${varName}: String}) OR startsWith(${fieldWithPrefix}, {${escapedVarName}: String}))`
+          : `startsWith(${fieldWithPrefix}, {${varName}: String})`;
         break;
       case "ends with":
-        query = `endsWith(${fieldWithPrefix}, {${varName}: String})`;
+        query = hasEscapedVariant
+          ? `(endsWith(${fieldWithPrefix}, {${varName}: String}) OR endsWith(${fieldWithPrefix}, {${escapedVarName}: String}))`
+          : `endsWith(${fieldWithPrefix}, {${varName}: String})`;
         break;
       case FTS_MATCH_OPERATOR:
         assertValidFtsMatchFilter({
@@ -130,9 +151,19 @@ export class StringFilter implements Filter {
       query = `(${fieldWithPrefix} != '' AND ${query})`;
     }
 
+    const usesEscapedParam =
+      hasEscapedVariant &&
+      (this.operator === "contains" ||
+        this.operator === "does not contain" ||
+        this.operator === "starts with" ||
+        this.operator === "ends with");
+
     return {
       query: query,
-      params: { [varName]: this.value },
+      params: {
+        [varName]: this.value,
+        ...(usesEscapedParam ? { [escapedVarName]: escapedValue } : {}),
+      },
     };
   }
 }

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.unicode.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.unicode.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Non-ASCII values in input/output string filters must also match payloads
+ * persisted in the `\uXXXX`-escaped form written by `ensure_ascii=True` JSON
+ * serializers (Python SDK / OTel ingestion). The free-text search path already
+ * does this (see search.ts, issue #11538); these tests pin the same behavior
+ * for the column filters the search bar and table filters lower to
+ * (issue #15072: `position(e.input, '内部') > 0` never matches escaped
+ * storage).
+ */
+import { describe, expect, it } from "vitest";
+
+import { StringFilter } from "./clickhouse-filter";
+
+const applyFilter = (
+  overrides: Partial<ConstructorParameters<typeof StringFilter>[0]> = {},
+) =>
+  new StringFilter({
+    clickhouseTable: "events_core",
+    field: "input",
+    operator: "contains",
+    value: "内部",
+    tablePrefix: "e",
+    ...overrides,
+  }).apply();
+
+const paramValues = (params: Record<string, unknown>) => Object.values(params);
+
+describe("StringFilter unicode-escaped variant for IO fields (#15072)", () => {
+  it("contains on input with non-ASCII value matches raw and escaped forms", () => {
+    const { query, params } = applyFilter();
+
+    expect(query).toMatch(
+      /^\(position\(e\.input, \{stringFilter\w+: String\}\) > 0 OR position\(e\.input, \{stringFilter\w+Escaped: String\}\) > 0\)$/,
+    );
+    expect(paramValues(params)).toEqual(
+      expect.arrayContaining(["内部", "\\u5185\\u90e8"]),
+    );
+  });
+
+  it("does not contain must exclude both forms (AND, not OR)", () => {
+    const { query, params } = applyFilter({ operator: "does not contain" });
+
+    expect(query).toMatch(
+      /^\(position\(e\.input, \{stringFilter\w+: String\}\) = 0 AND position\(e\.input, \{stringFilter\w+Escaped: String\}\) = 0\)$/,
+    );
+    expect(paramValues(params)).toEqual(
+      expect.arrayContaining(["内部", "\\u5185\\u90e8"]),
+    );
+  });
+
+  it("starts with / ends with match either form", () => {
+    const startsWith = applyFilter({ operator: "starts with" });
+    expect(startsWith.query).toMatch(
+      /^\(startsWith\(e\.input, \{stringFilter\w+: String\}\) OR startsWith\(e\.input, \{stringFilter\w+Escaped: String\}\)\)$/,
+    );
+
+    const endsWith = applyFilter({ operator: "ends with", field: "output" });
+    expect(endsWith.query).toMatch(
+      /^\(endsWith\(e\.output, \{stringFilter\w+: String\}\) OR endsWith\(e\.output, \{stringFilter\w+Escaped: String\}\)\)$/,
+    );
+  });
+
+  it("ASCII values keep the single-variant query and params", () => {
+    const { query, params } = applyFilter({ value: "internal" });
+
+    expect(query).toMatch(
+      /^position\(e\.input, \{stringFilter\w+: String\}\) > 0$/,
+    );
+    expect(paramValues(params)).toEqual(["internal"]);
+  });
+
+  it("non-IO fields are unaffected even with non-ASCII values", () => {
+    const { query, params } = applyFilter({
+      clickhouseTable: "traces",
+      field: "user_id",
+      tablePrefix: "t",
+    });
+
+    expect(query).toMatch(
+      /^position\(t\.user_id, \{stringFilter\w+: String\}\) > 0$/,
+    );
+    expect(paramValues(params)).toEqual(["内部"]);
+  });
+
+  it("astral code points escape as surrogate pairs", () => {
+    const { params } = applyFilter({ value: "🍜" });
+
+    expect(paramValues(params)).toEqual(
+      expect.arrayContaining(["🍜", "\\ud83c\\udf5c"]),
+    );
+  });
+});

--- a/packages/shared/src/server/queries/clickhouse-sql/json-unicode-escape.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/json-unicode-escape.ts
@@ -1,0 +1,30 @@
+/**
+ * Re-encodes a string the way a JSON serializer with `ensure_ascii=True` does (e.g. Python's
+ * `json.dumps`, used by the Langfuse Python SDK's EventSerializer / the OpenTelemetry ingestion
+ * path): every code point >= U+0080 becomes a `\uXXXX` escape (astral code points become a
+ * UTF-16 surrogate pair). ASCII is left untouched.
+ *
+ * Trace / observation `input` and `output` ingested through that path is persisted in ClickHouse
+ * verbatim in this escaped form (e.g. `你好` is stored as the literal `\u4f60\u597d`), so a
+ * substring search for the raw, human-readable text would never match it. By also searching for
+ * this escaped form we recover full-text search for non-English content. See issues #11538 and #15072.
+ */
+export const toJsonUnicodeEscaped = (value: string): string => {
+  let out = "";
+  for (const ch of value) {
+    const cp = ch.codePointAt(0)!;
+    if (cp < 0x80) {
+      out += ch;
+    } else if (cp <= 0xffff) {
+      out += "\\u" + cp.toString(16).padStart(4, "0");
+    } else {
+      const v = cp - 0x10000;
+      out +=
+        "\\u" +
+        (0xd800 + (v >> 10)).toString(16).padStart(4, "0") +
+        "\\u" +
+        (0xdc00 + (v & 0x3ff)).toString(16).padStart(4, "0");
+    }
+  }
+  return out;
+};

--- a/packages/shared/src/server/queries/clickhouse-sql/search.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/search.ts
@@ -1,38 +1,8 @@
 import { TracingSearchType } from "../../../interfaces/search";
 import { ftsTextTokenConjunct } from "./fts";
+import { toJsonUnicodeEscaped } from "./json-unicode-escape";
 
 const regexIndefiniteCharacters = "%";
-
-/**
- * Re-encodes a string the way a JSON serializer with `ensure_ascii=True` does (e.g. Python's
- * `json.dumps`, used by the Langfuse Python SDK's EventSerializer / the OpenTelemetry ingestion
- * path): every code point >= U+0080 becomes a `\uXXXX` escape (astral code points become a
- * UTF-16 surrogate pair). ASCII is left untouched.
- *
- * Trace / observation `input` and `output` ingested through that path is persisted in ClickHouse
- * verbatim in this escaped form (e.g. `你好` is stored as the literal `\u4f60\u597d`), so a
- * substring search for the raw, human-readable text would never match it. By also searching for
- * this escaped form we recover full-text search for non-English content. See issue #11538.
- */
-const toJsonUnicodeEscaped = (value: string): string => {
-  let out = "";
-  for (const ch of value) {
-    const cp = ch.codePointAt(0)!;
-    if (cp < 0x80) {
-      out += ch;
-    } else if (cp <= 0xffff) {
-      out += "\\u" + cp.toString(16).padStart(4, "0");
-    } else {
-      const v = cp - 0x10000;
-      out +=
-        "\\u" +
-        (0xd800 + (v >> 10)).toString(16).padStart(4, "0") +
-        "\\u" +
-        (0xdc00 + (v & 0x3ff)).toString(16).padStart(4, "0");
-    }
-  }
-  return out;
-};
 
 export type ClickhouseSearchConditionOptions = {
   query?: string;
@@ -76,7 +46,7 @@ export const clickhouseSearchCondition = ({
   // For input/output (which can hold JSON written by an `ensure_ascii=True` serializer), also
   // match the `\uXXXX`-escaped form of the query. ASCII-only queries are unaffected: the escaped
   // form is identical, so no extra parameter or clause is emitted (keeps existing behaviour and
-  // query plans for the common case). See issue #11538 and `toJsonUnicodeEscaped` above.
+  // query plans for the common case). See issue #11538 and `toJsonUnicodeEscaped`.
   const escapedQuery = query ? toJsonUnicodeEscaped(query) : undefined;
   const hasEscapedVariant = !!query && escapedQuery !== query;
 


### PR DESCRIPTION
Fixes the backend half of #15072 (issue 1, "Unicode is not supported").

The SQL in the issue screenshot shows why the search finds nothing: `position(e.input, '内部') > 0` compares against the raw stored value, but payloads ingested through `ensure_ascii=True` serializers (Python SDK, the OTel path) store non-ASCII text as literal `\uXXXX` escapes — `内部` is on disk as `\u5185\u90e8`, so the filter can never match. This hits the search bar's `input:`/`output:` filters and the classic table IO filters alike, for any CJK/Cyrillic/emoji value.

The free-text search path already solved exactly this in #11538 by also matching the escaped form. This PR applies the same recovery to `StringFilter`: for `input`/`output` fields whose value escapes to a different string, `contains`/`starts with`/`ends with` become an OR of the raw and escaped variants, and `does not contain` becomes an AND so both forms are excluded. ASCII values escape to themselves and keep the exact same query and params as before. `toJsonUnicodeEscaped` moves unchanged from `search.ts` into a shared module so both call sites use one copy.

Not covered here: issue 2 in #15072 (the search-bar composer doubling IME input, `内部` → `内部内部`) is a frontend composition bug in `SearchComposer` and is independent of this fix.

**Tests:** 6 new unit tests pinning the generated SQL and params (written failing-first): both variants for contains, the AND shape for does-not-contain, starts/ends-with, ASCII staying single-variant, non-IO fields untouched, and surrogate-pair escaping. All 28 existing query-layer tests and the web filter unit tests pass; full `typecheck` and shared `lint` are green. The escaped-vs-stored matching semantics are the ones already exercised end-to-end against ClickHouse by the #11538 fixtures in `clickhouseSearchCondition.servertest.ts` (`input-match-escaped-cjk` etc.) — this change reuses that exact escaping function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes unicode substring filtering for `input`/`output` ClickHouse columns by applying the same `\uXXXX`-escaped dual-variant query strategy that the free-text search path (`search.ts`) already uses. Non-ASCII text ingested through `ensure_ascii=True` serializers (Python SDK, OTel) is stored as literal escape sequences, so a plain `position(e.input, '内部')` would never match; the fix emits an OR of both forms for `contains`/`starts with`/`ends with` and an AND for `does not contain`.

- **`json-unicode-escape.ts`**: Extracts the `toJsonUnicodeEscaped` helper from `search.ts` into a shared module so both call sites use one copy — no functional change to the existing search path.
- **`clickhouse-filter.ts`**: `StringFilter.apply()` now checks `isFtsTextField` and, for non-ASCII values, generates dual-parameter queries for the four substring operators; ASCII values escape to themselves and keep the single-variant query unchanged.
- **`clickhouse-filter.unicode.test.ts`**: Six new unit tests pin the generated SQL shape and parameter values for all fixed operators, ASCII passthrough, non-IO field isolation, and surrogate-pair escaping."
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The change is additive — ASCII values produce identical queries to before, and the new dual-variant path is gated behind a field-name check that only activates for input/output.

The fix is well-scoped and the logic is correct for the four substring operators. The one gap worth noting is that the = operator on input/output fields still doesn't match unicode-escaped rows, which could surprise callers who apply exact-match filters with non-ASCII values. The tests are thorough for the intended change, and the ASCII passthrough path is unchanged.

The = operator branch in clickhouse-filter.ts (lines 100–109) is the one place that doesn't apply the escaped-variant treatment; worth revisiting if exact-match filters on input/output with non-ASCII values become a use case.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as UI Filter
    participant SF as StringFilter.apply()
    participant FTS as isFtsTextField()
    participant UE as toJsonUnicodeEscaped()
    participant CH as ClickHouse

    UI->>SF: "operator="contains", field="input", value="内部""
    SF->>FTS: isFtsTextField("input")
    FTS-->>SF: true
    SF->>UE: toJsonUnicodeEscaped("内部")
    UE-->>SF: "\\u5185\\u90e8" (≠ "内部")
    Note over SF: hasEscapedVariant = true
    SF-->>CH: "(position(e.input, {v}) > 0 OR position(e.input, {vEscaped}) > 0)"
    CH-->>UI: rows matching either raw or escaped form

    UI->>SF: "operator="contains", field="user_id", value="内部""
    SF->>FTS: isFtsTextField("user_id")
    FTS-->>SF: false
    Note over SF: hasEscapedVariant = false
    SF-->>CH: "position(t.user_id, {v}) > 0"

    UI->>SF: "operator="contains", field="input", value="hello""
    SF->>FTS: isFtsTextField("input")
    FTS-->>SF: true
    SF->>UE: toJsonUnicodeEscaped("hello")
    UE-->>SF: "hello" (ASCII, unchanged)
    Note over SF: hasEscapedVariant = false
    SF-->>CH: "position(e.input, {v}) > 0 (single variant)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as UI Filter
    participant SF as StringFilter.apply()
    participant FTS as isFtsTextField()
    participant UE as toJsonUnicodeEscaped()
    participant CH as ClickHouse

    UI->>SF: "operator="contains", field="input", value="内部""
    SF->>FTS: isFtsTextField("input")
    FTS-->>SF: true
    SF->>UE: toJsonUnicodeEscaped("内部")
    UE-->>SF: "\\u5185\\u90e8" (≠ "内部")
    Note over SF: hasEscapedVariant = true
    SF-->>CH: "(position(e.input, {v}) > 0 OR position(e.input, {vEscaped}) > 0)"
    CH-->>UI: rows matching either raw or escaped form

    UI->>SF: "operator="contains", field="user_id", value="内部""
    SF->>FTS: isFtsTextField("user_id")
    FTS-->>SF: false
    Note over SF: hasEscapedVariant = false
    SF-->>CH: "position(t.user_id, {v}) > 0"

    UI->>SF: "operator="contains", field="input", value="hello""
    SF->>FTS: isFtsTextField("input")
    FTS-->>SF: true
    SF->>UE: toJsonUnicodeEscaped("hello")
    UE-->>SF: "hello" (ASCII, unchanged)
    Note over SF: hasEscapedVariant = false
    SF-->>CH: "position(e.input, {v}) > 0 (single variant)"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts:99-109
**`=` operator silently misses unicode-escaped rows**

The `=` case generates `fieldWithPrefix = {varName: String}` using only the raw value, so an exact-match filter like `input = '内部'` will never match rows where the value was persisted as `\u5185\u90e8`. `hasEscapedVariant` is correctly computed before the switch and could be used here the same way it is for `contains`. In practice exact-match on a full JSON blob field is unusual, but it is a reachable operator through the filter system and the inconsistency with the substring operators could surprise callers who use the `"="` operator on these fields.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(filters): match unicode-escaped stor..."](https://github.com/langfuse/langfuse/commit/df1dd6c720aa4191f3d7e7df852db11691ce0246) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45303632)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->