### PR TITLE
feat(seeder): agentic seeder entrypoint for PR previews (@seeder comments)

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -88,7 +88,8 @@
     "ch:reset": "pnpm run ch:down && pnpm run ch:up && pnpm run ch:seed && pnpm run ch:dev-tables",
     "ch:seed": "dotenv -e ../../.env -- tsx scripts/seeder/seed-clickhouse.ts",
     "load:setup": "dotenv -e ../../.env -- tsx scripts/seeder/load-seed-clickhouse.ts",
-    "seed:scenario": "dotenv -e ../../.env -- tsx scripts/seeder/cli.ts"
+    "seed:scenario": "dotenv -e ../../.env -- tsx scripts/seeder/cli.ts",
+    "seed:agent": "dotenv -e ../../.env -- tsx scripts/seeder/agent.ts"
   },
   "prisma": {
     "seed": "dotenv -e ../../.env -- tsx scripts/seeder/seed-postgres.ts"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -102,7 +102,6 @@
     "@ai-sdk/google-vertex": "^5.0.8",
     "@ai-sdk/openai": "^4.0.0",
     "@ai-sdk/openai-compatible": "^3.0.3",
-    "@anthropic-ai/sdk": "^0.111.0",
     "@aws-sdk/client-cloudwatch": "catalog:",
     "@aws-sdk/client-lambda": "catalog:",
     "@aws-sdk/client-s3": "catalog:",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -101,6 +101,7 @@
     "@ai-sdk/google-vertex": "^5.0.8",
     "@ai-sdk/openai": "^4.0.0",
     "@ai-sdk/openai-compatible": "^3.0.3",
+    "@anthropic-ai/sdk": "^0.111.0",
     "@aws-sdk/client-cloudwatch": "catalog:",
     "@aws-sdk/client-lambda": "catalog:",
     "@aws-sdk/client-s3": "catalog:",

--- a/packages/shared/scripts/seeder/AGENTS.md
+++ b/packages/shared/scripts/seeder/AGENTS.md
@@ -34,14 +34,20 @@ progress output. Full usage and the need→command table live in the
   `event-mirror.ts` (v3 observation → v4 `events_full` row), `verify.ts`
 - `seed-postgres.ts`, `seed-clickhouse.ts`, `utils/` — the pre-existing
   `pnpm run dx` seed path (unchanged by the CLI)
-- `agent.ts` — PR-preview agentic seeder entrypoint: an Anthropic-powered
-  agent that drives this CLI (as a subprocess, same public contract) inside
-  a preview environment when someone comments `@seeder <prompt>` on a
-  preview-labeled PR. Dispatch, credentials, and result posting live in
-  langfuse/infrastructure (`k8s/preview/README.md`, "Agentic seeder"); the
-  env contract is documented in the file header. Runtime-only and
-  preview-only — it needs `ANTHROPIC_API_KEY` at runtime, but no scenario
-  or fixture may ever depend on a model provider key (rule below stands).
+- `agent.ts` / `agent-main.ts` — PR-preview agentic seeder: an agent that
+  drives this CLI (as a subprocess, same public contract) inside a preview
+  environment when someone comments `@seeder <prompt>` on a preview-labeled
+  PR. `agent.ts` is a thin bootstrap (imports nothing from `src/`, emits the
+  result block on any failure) that dynamically loads `agent-main.ts` — the
+  same split as `cli.ts`/`cli-main.ts`, so an env-schema failure still
+  reports cleanly. The LLM runs through `@langfuse/shared`'s own
+  `generateLLMText` (the AI SDK boundary that also backs LLM-as-a-judge) —
+  the repo's single Anthropic path, not a separate SDK. Dispatch,
+  credentials, and result posting live in langfuse/infrastructure
+  (`k8s/preview/README.md`, "Agentic seeder"); the env contract is in the
+  `agent-main.ts` header. Runtime-only and preview-only — it needs
+  `ANTHROPIC_API_KEY` at runtime, but no scenario or fixture may ever depend
+  on a model provider key (rule below stands).
 - `README.md` — design rationale, contract, and roadmap
 
 ## Rules for changes

--- a/packages/shared/scripts/seeder/AGENTS.md
+++ b/packages/shared/scripts/seeder/AGENTS.md
@@ -34,6 +34,14 @@ progress output. Full usage and the need→command table live in the
   `event-mirror.ts` (v3 observation → v4 `events_full` row), `verify.ts`
 - `seed-postgres.ts`, `seed-clickhouse.ts`, `utils/` — the pre-existing
   `pnpm run dx` seed path (unchanged by the CLI)
+- `agent.ts` — PR-preview agentic seeder entrypoint: an Anthropic-powered
+  agent that drives this CLI (as a subprocess, same public contract) inside
+  a preview environment when someone comments `@seeder <prompt>` on a
+  preview-labeled PR. Dispatch, credentials, and result posting live in
+  langfuse/infrastructure (`k8s/preview/README.md`, "Agentic seeder"); the
+  env contract is documented in the file header. Runtime-only and
+  preview-only — it needs `ANTHROPIC_API_KEY` at runtime, but no scenario
+  or fixture may ever depend on a model provider key (rule below stands).
 - `README.md` — design rationale, contract, and roadmap
 
 ## Rules for changes

--- a/packages/shared/scripts/seeder/agent-main.ts
+++ b/packages/shared/scripts/seeder/agent-main.ts
@@ -1,0 +1,366 @@
+/**
+ * Agentic seeder — implementation (loaded dynamically by agent.ts).
+ *
+ * Kept separate from agent.ts for the same reason cli-main.ts is separate from
+ * cli.ts: importing `../../src/server` parses the shared env schema at module
+ * load, which throws on a missing env before any result block can be emitted.
+ * agent.ts prechecks nothing itself — it wraps the dynamic import of this file
+ * in a try/catch that turns any load- or run-time failure into a result block.
+ *
+ * The LLM is driven through @langfuse/shared's own `generateLLMText`
+ * (the AI SDK v7 boundary that also backs the worker's LLM-as-a-judge), so the
+ * seeder reuses the repo's single Anthropic path — model construction,
+ * tracing, timeout, and retry — rather than a second SDK. `generateLLMText`
+ * deliberately rejects tool `execute` functions ("a completion cannot silently
+ * become an agent loop"), so the multi-turn loop lives here: declare tools,
+ * read `toolCalls`, run them, feed `tool` messages back, repeat.
+ *
+ * Env contract (keep in sync with k8s/preview/README.md "Agentic seeder" in
+ * langfuse/infrastructure):
+ *   SEEDER_AGENT_PROMPT_FILE  path to the reviewer's prompt (required)
+ *   SEEDER_PR_NUMBER          PR number (for fetch_pr_diff)
+ *   SEEDER_COMMENT_ID         triggering comment id (informational)
+ *   LANGFUSE_PREVIEW_URL      public base URL of this preview (deep links)
+ *   LANGFUSE_WEB_URL          in-cluster web URL (informational)
+ *   ANTHROPIC_API_KEY         seeder-agent Anthropic key
+ *   ENCRYPTION_KEY            already required by the seed CLI; used here to
+ *                             encrypt the key into the LLMConnection shape
+ *   + the datastore env the seed CLI needs (DATABASE_URL, CLICKHOUSE_*)
+ */
+import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { promisify } from "node:util";
+
+import { prisma } from "../../src/db";
+import { encrypt } from "../../src/encryption";
+import {
+  createLLMToolSet,
+  generateLLMText,
+  LLMAdapter,
+  redis,
+  type LLMModelMessage,
+  type LLMToolDefinition,
+} from "../../src/server";
+
+// Job entrypoint env, not a turbo task — read directly. Full contract above.
+/* eslint-disable turbo/no-undeclared-env-vars */
+const ENV = {
+  promptFile: process.env.SEEDER_AGENT_PROMPT_FILE,
+  prNumber: process.env.SEEDER_PR_NUMBER,
+  previewUrl: process.env.LANGFUSE_PREVIEW_URL,
+  nextauthUrl: process.env.NEXTAUTH_URL,
+  model: process.env.SEEDER_AGENT_MODEL,
+  anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+};
+/* eslint-enable turbo/no-undeclared-env-vars */
+
+const MODEL = ENV.model ?? "claude-opus-4-8";
+const MAX_ITERATIONS = 24; // agent turns; the Job's activeDeadlineSeconds is the hard stop
+const MAX_OUTPUT_TOKENS = 16_000;
+const CLI_TIMEOUT_MS = 6 * 60 * 1000; // per seed run; several must fit in one Job
+const MAX_TOOL_RESULT_CHARS = 20_000;
+const MAX_DIFF_CHARS = 80_000;
+
+const execFileAsync = promisify(execFile);
+
+/** run() outcome — agent.ts owns emitting the marker block and the exit code. */
+export type SeederResult = { markdown: string; ok: boolean };
+
+const truncate = (text: string, max: number): string =>
+  text.length > max ? `${text.slice(0, max)}\n… [truncated]` : text;
+
+/**
+ * Run the compiled seed CLI (dist/scripts/seeder/cli.js, sibling of this
+ * file). No shell — args go straight to execFile. NEXTAUTH_URL is pointed at
+ * the preview's public URL so the CLI's JSON-summary `links` are directly
+ * postable to the PR.
+ */
+const runSeedCli = async (
+  args: string[],
+): Promise<{ ok: boolean; output: string }> => {
+  const cliPath = path.join(__dirname, "cli.js");
+  const env = {
+    ...process.env,
+    NEXTAUTH_URL: ENV.previewUrl ?? ENV.nextauthUrl,
+    LANGFUSE_LOG_LEVEL: "error",
+  };
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      [cliPath, ...args],
+      { env, timeout: CLI_TIMEOUT_MS, maxBuffer: 32 * 1024 * 1024 },
+    );
+    // With --json the last stdout line is the machine-readable summary; keep
+    // the whole (truncated) output anyway so the model sees doctor/list text.
+    const output = [stdout.trim(), stderr.trim()]
+      .filter(Boolean)
+      .join("\n--- stderr ---\n");
+    return { ok: true, output: truncate(output, MAX_TOOL_RESULT_CHARS) };
+  } catch (error) {
+    const e = error as { stdout?: string; stderr?: string; message?: string };
+    const output = [e.message, e.stdout?.trim(), e.stderr?.trim()]
+      .filter(Boolean)
+      .join("\n");
+    return { ok: false, output: truncate(output, MAX_TOOL_RESULT_CHARS) };
+  }
+};
+
+// Flag/scenario tokens the CLI accepts; excludes whitespace and anything that
+// needs quoting so tool inputs stay auditable in logs.
+const SAFE_ARG = /^[A-Za-z0-9@._:/=-]+$/;
+
+// LLMToolDefinition[] (name/description/parameters JSON Schema) — converted to
+// an AI SDK ToolSet by createLLMToolSet below. No `execute`: the loop is ours.
+const TOOL_DEFINITIONS: LLMToolDefinition[] = [
+  {
+    name: "list_scenarios",
+    description:
+      "List the available seed scenarios with their flags and descriptions. " +
+      "Call this first to learn what can be seeded and which flags exist.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "seed_doctor",
+    description:
+      "Diagnose the seeding stack (Postgres/ClickHouse connectivity, seed " +
+      "project). Use when a seed run fails for unclear reasons.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "run_seed_scenario",
+    description:
+      "Run one seed scenario against this preview's datastores. Equivalent to " +
+      "`pnpm run seed -- <scenario> <args...> --json`. The result ends with a " +
+      "JSON summary containing counts, ids, `verified`, and UI deep `links`. " +
+      "Prefer `--dry-run` first when unsure about volume. Keep volumes " +
+      "bounded — this is a single-node preview, not production.",
+    parameters: {
+      type: "object",
+      properties: {
+        scenario: {
+          type: "string",
+          description: "Scenario name exactly as shown by list_scenarios",
+        },
+        args: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            'Flags and values as separate tokens, e.g. ["--observations", "1000", "--v4"]. Do not pass --json (added automatically).',
+        },
+      },
+      required: ["scenario", "args"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "fetch_pr_diff",
+    description:
+      "Fetch this PR's unified diff from GitHub. Use when asked to seed data " +
+      "that exercises the changes in this PR, to decide what to seed.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+];
+
+const executeTool = async (
+  name: string,
+  input: unknown,
+): Promise<{ content: string; isError: boolean }> => {
+  if (name === "list_scenarios") {
+    const r = await runSeedCli(["list", "--json"]);
+    return { content: r.output, isError: !r.ok };
+  }
+  if (name === "seed_doctor") {
+    const r = await runSeedCli(["doctor", "--json"]);
+    // doctor exits non-zero on FAIL items; its report is still the answer
+    return { content: r.output, isError: false };
+  }
+  if (name === "run_seed_scenario") {
+    const { scenario, args } = (input ?? {}) as {
+      scenario?: string;
+      args?: string[];
+    };
+    if (!scenario) {
+      return {
+        content: "run_seed_scenario requires a scenario",
+        isError: true,
+      };
+    }
+    const tokens = [scenario, ...(args ?? [])];
+    const invalid = tokens.filter((t) => !SAFE_ARG.test(t));
+    if (invalid.length > 0) {
+      return {
+        content: `invalid argument token(s): ${invalid.join(", ")} — tokens must match ${SAFE_ARG}`,
+        isError: true,
+      };
+    }
+    const withJson = tokens.includes("--json") ? tokens : [...tokens, "--json"];
+    const r = await runSeedCli(withJson);
+    return { content: r.output, isError: !r.ok };
+  }
+  if (name === "fetch_pr_diff") {
+    const pr = ENV.prNumber;
+    if (!pr || !/^\d+$/.test(pr)) {
+      return { content: "SEEDER_PR_NUMBER is not set", isError: true };
+    }
+    const url = `https://github.com/langfuse/langfuse/pull/${pr}.diff`;
+    try {
+      const response = await fetch(url, { redirect: "follow" });
+      if (!response.ok) {
+        return { content: `GET ${url} -> ${response.status}`, isError: true };
+      }
+      return {
+        content: truncate(await response.text(), MAX_DIFF_CHARS),
+        isError: false,
+      };
+    } catch (error) {
+      return {
+        content: `GET ${url} failed: ${error instanceof Error ? error.message : String(error)}`,
+        isError: true,
+      };
+    }
+  }
+  return { content: `unknown tool: ${name}`, isError: true };
+};
+
+const buildSystemPrompt = (): string => {
+  const previewUrl = ENV.previewUrl ?? "(unknown)";
+  const prNumber = ENV.prNumber ?? "(unknown)";
+  return [
+    "You are the Langfuse preview seeder agent. You run inside the ephemeral",
+    `preview environment for langfuse/langfuse PR #${prNumber} (public URL:`,
+    `${previewUrl}). A reviewer asked you, via a PR comment, to seed test data`,
+    "into this preview so they can inspect something in the UI.",
+    "",
+    "Environment facts:",
+    "- The seed CLI writes directly to this preview's own Postgres and",
+    "  single-node ClickHouse; nothing you do here touches production.",
+    "- Reviewers log in at the preview URL as demo@langfuse.com (password",
+    '  "password"); the seeded data lands in the seed project ("llm-app")',
+    "  unless a scenario says otherwise.",
+    "- Keep volumes preview-sized: prefer the smallest data set that lets the",
+    "  reviewer see what they asked for. Do not exceed roughly 100k rows",
+    "  unless the request explicitly demands more.",
+    "",
+    "Method:",
+    "- Start with list_scenarios to see what exists; pick the scenario(s) that",
+    "  match the request instead of improvising.",
+    '- If the request is about "this PR\'s changes", call fetch_pr_diff and',
+    "  choose scenarios that exercise the touched surfaces.",
+    "- After seeding, use the JSON summary's `verified` and `links` fields;",
+    "  if a run fails, try seed_doctor once and adjust.",
+    "",
+    "Your final message is posted to the PR verbatim as a comment. Write it",
+    "as concise markdown for the reviewer: lead with what you seeded (counts,",
+    "project), then the deep links from the summaries, then one or two lines",
+    "on what to look at. If you could not fulfil the request, say what you",
+    "tried and why it failed. No preamble, no meta-commentary.",
+  ].join("\n");
+};
+
+// One assistant turn's tool calls, in the AI SDK v7 shape (`input`, not `args`).
+type ToolCall = { toolCallId: string; toolName: string; input: unknown };
+
+const execute = async (): Promise<SeederResult> => {
+  if (!ENV.promptFile) {
+    throw new Error("SEEDER_AGENT_PROMPT_FILE is not set");
+  }
+  const prompt = readFileSync(ENV.promptFile, "utf8").trim();
+  if (prompt.length === 0) {
+    throw new Error(`prompt file ${ENV.promptFile} is empty`);
+  }
+  if (!ENV.anthropicApiKey) {
+    throw new Error("ANTHROPIC_API_KEY is not set");
+  }
+
+  const tools = createLLMToolSet(TOOL_DEFINITIONS);
+  // The shared boundary expects an LLMConnection whose secret is encrypted;
+  // it decrypts inside the call. Synthesize a minimal Anthropic connection
+  // from the env key (encrypt uses ENCRYPTION_KEY, present in the Job env).
+  const connection = {
+    secretKey: encrypt(ENV.anthropicApiKey),
+    baseURL: null,
+    extraHeaders: null,
+    config: null,
+  };
+
+  const messages: LLMModelMessage[] = [
+    { role: "system", content: buildSystemPrompt() },
+    { role: "user", content: prompt },
+  ];
+
+  let finalText = "";
+  let finishReason = "";
+  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+    const result = await generateLLMText({
+      model: { adapter: LLMAdapter.Anthropic, id: MODEL },
+      connection,
+      messages,
+      tools,
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      maxRetries: 2,
+    });
+
+    // Append the assistant turn (incl. tool-call parts) verbatim so the next
+    // request is a valid continuation. Each call is a single step (no tool
+    // `execute` at this boundary), so finalStep carries this turn's messages.
+    messages.push(...(result.finalStep.response.messages as LLMModelMessage[]));
+    finalText = (result.text ?? "").trim();
+    finishReason = result.finishReason;
+
+    const toolCalls = (result.toolCalls ?? []) as ToolCall[];
+    if (toolCalls.length === 0) break; // clean stop (or length) — no more tools
+
+    const toolResults = [];
+    for (const call of toolCalls) {
+      console.error(
+        `tool ${call.toolName} ${JSON.stringify(call.input).slice(0, 500)}`,
+      );
+      const res = await executeTool(call.toolName, call.input);
+      toolResults.push({
+        type: "tool-result" as const,
+        toolCallId: call.toolCallId,
+        toolName: call.toolName,
+        output: res.isError
+          ? { type: "error-text" as const, value: res.content }
+          : { type: "text" as const, value: res.content },
+      });
+    }
+    // All results for this turn go back in a single tool message.
+    messages.push({ role: "tool", content: toolResults });
+  }
+
+  if (finalText.length === 0) {
+    throw new Error("the agent produced no final answer");
+  }
+  if (finishReason !== "stop") {
+    // Ran out of turns while still calling tools, or hit the output cap: what
+    // we have is mid-work narration or a truncated message, not a completed
+    // answer. Never present it as success — mark it partial (ok: false) so the
+    // dispatcher uses its "did not finish cleanly" framing.
+    const why =
+      finishReason === "tool-calls"
+        ? `hit the ${MAX_ITERATIONS}-turn limit while still working`
+        : `finish reason: ${finishReason || "unknown"}`;
+    return {
+      ok: false,
+      markdown:
+        `⚠️ The seeder agent stopped before finishing (${why}). Data may be ` +
+        `partially seeded. Last status:\n\n${finalText}`,
+    };
+  }
+  return { ok: true, markdown: finalText };
+};
+
+export const run = async (): Promise<SeederResult> => {
+  try {
+    return await execute();
+  } finally {
+    // Importing the shared server barrel opens a Redis client (and Prisma)
+    // whose reconnect loop would otherwise pin the event loop and hang the
+    // Job to its activeDeadlineSeconds. Disconnect both so the process exits
+    // cleanly after the result block is emitted — mirrors cli-main.ts.
+    await prisma.$disconnect().catch(() => {});
+    redis?.disconnect();
+  }
+};

--- a/packages/shared/scripts/seeder/agent.ts
+++ b/packages/shared/scripts/seeder/agent.ts
@@ -3,355 +3,46 @@
  *
  * Runs as a one-shot Job inside a preview namespace when an allowlisted author
  * comments `@seeder <prompt>` on a preview-labeled PR (dispatch + result
- * posting live in langfuse/infrastructure, k8s/preview). An Anthropic-powered
- * agent drives the seed CLI (cli.ts, same contract as `pnpm run seed`) against
- * THIS preview's datastores, then reports back.
+ * posting live in langfuse/infrastructure, k8s/preview). An agent drives the
+ * seed CLI (cli.ts, same contract as `pnpm run seed`) against THIS preview's
+ * datastores, then reports back — driven through @langfuse/shared's own
+ * `generateLLMText` (the AI SDK boundary that also backs LLM-as-a-judge), so
+ * the seeder reuses the repo's single Anthropic path rather than a second SDK.
  *
- * Contract with the infrastructure job (keep in sync with
- * k8s/preview/README.md "Agentic seeder" in langfuse/infrastructure):
- *   input env:
- *     SEEDER_AGENT_PROMPT_FILE  path to the user's prompt (required)
- *     SEEDER_PR_NUMBER          PR number (for fetch_pr_diff)
- *     SEEDER_COMMENT_ID         triggering comment id (informational)
- *     LANGFUSE_PREVIEW_URL      public base URL of this preview (deep links)
- *     LANGFUSE_WEB_URL          in-cluster web URL (informational)
- *     ANTHROPIC_API_KEY         read by the SDK
- *     + the same datastore env the seed CLI needs (DATABASE_URL, CLICKHOUSE_*)
- *   output: the markdown between the marker lines below is posted VERBATIM to
- *     the PR; everything else on stdout/stderr stays in the pod logs. Always
- *     emit exactly one result block, success or failure.
+ * Output contract with the infrastructure job (keep in sync with
+ * k8s/preview/README.md "Agentic seeder"): the markdown between the marker
+ * lines below is posted VERBATIM to the PR; everything else on stdout/stderr
+ * stays in the pod logs. Exactly one result block is emitted, success or
+ * failure, and a non-clean finish exits non-zero so the dispatcher uses its
+ * "did not finish cleanly" framing.
  *
- * Like cli.ts, this file must not import from src/ at module load (the shared
- * env schema would throw before we can emit a result block) — all seeding goes
- * through the compiled cli.js as a subprocess, which also keeps the agent on
- * the CLI's public scenario/flag/JSON-summary contract.
+ * This bootstrap imports nothing from src/ (importing the shared server barrel
+ * parses the env schema, which throws on a missing env before a result block
+ * can be emitted). It dynamically loads ./agent-main.js — mirroring
+ * cli.ts/cli-main.ts — inside a try/catch that turns any load- or run-time
+ * failure into a result block. The env contract lives in agent-main.ts.
  */
-import { execFile } from "node:child_process";
-import { readFileSync } from "node:fs";
-import * as path from "node:path";
-import { promisify } from "node:util";
-
-import Anthropic from "@anthropic-ai/sdk";
-
 const BEGIN_MARK = "-----BEGIN SEEDER RESULT-----";
 const END_MARK = "-----END SEEDER RESULT-----";
-
-// Job entrypoint, not a turbo task — reads its env contract directly. The
-// full contract is documented in the header comment above.
-/* eslint-disable turbo/no-undeclared-env-vars */
-const ENV = {
-  promptFile: process.env.SEEDER_AGENT_PROMPT_FILE,
-  prNumber: process.env.SEEDER_PR_NUMBER,
-  previewUrl: process.env.LANGFUSE_PREVIEW_URL,
-  nextauthUrl: process.env.NEXTAUTH_URL,
-  model: process.env.SEEDER_AGENT_MODEL,
-  anthropicApiKey: process.env.ANTHROPIC_API_KEY,
-};
-/* eslint-enable turbo/no-undeclared-env-vars */
-
-const MODEL = ENV.model ?? "claude-opus-4-8";
-const MAX_ITERATIONS = 24; // agent turns; the Job's activeDeadlineSeconds is the hard stop
-const CLI_TIMEOUT_MS = 6 * 60 * 1000; // per seed run; several must fit in one Job
-const MAX_TOOL_RESULT_CHARS = 20_000;
-const MAX_DIFF_CHARS = 80_000;
-
-const execFileAsync = promisify(execFile);
 
 const emitResult = (markdown: string): void => {
   console.log(`${BEGIN_MARK}\n${markdown.trim()}\n${END_MARK}`);
 };
 
-const truncate = (text: string, max: number): string =>
-  text.length > max ? `${text.slice(0, max)}\n… [truncated]` : text;
-
-/**
- * Run the compiled seed CLI (dist/scripts/seeder/cli.js, sibling of this
- * file). No shell — args go straight to execFile. NEXTAUTH_URL is pointed at
- * the preview's public URL so the CLI's JSON-summary `links` are directly
- * postable to the PR.
- */
-const runSeedCli = async (
-  args: string[],
-): Promise<{ ok: boolean; output: string }> => {
-  const cliPath = path.join(__dirname, "cli.js");
-  const env = {
-    ...process.env,
-    NEXTAUTH_URL: ENV.previewUrl ?? ENV.nextauthUrl,
-    LANGFUSE_LOG_LEVEL: "error",
-  };
-  try {
-    const { stdout, stderr } = await execFileAsync(
-      process.execPath,
-      [cliPath, ...args],
-      { env, timeout: CLI_TIMEOUT_MS, maxBuffer: 32 * 1024 * 1024 },
-    );
-    // With --json the last stdout line is the machine-readable summary; keep
-    // the whole (truncated) output anyway so the model sees doctor/list text.
-    const output = [stdout.trim(), stderr.trim()]
-      .filter(Boolean)
-      .join("\n--- stderr ---\n");
-    return { ok: true, output: truncate(output, MAX_TOOL_RESULT_CHARS) };
-  } catch (error) {
-    const e = error as { stdout?: string; stderr?: string; message?: string };
-    const output = [e.message, e.stdout?.trim(), e.stderr?.trim()]
-      .filter(Boolean)
-      .join("\n");
-    return { ok: false, output: truncate(output, MAX_TOOL_RESULT_CHARS) };
-  }
+const boot = async (): Promise<void> => {
+  // Dynamic import: agent-main pulls in @langfuse/shared/src/server (env-schema
+  // parse), so any failure there must land in the catch below, not at load.
+  const agentMain = await import("./agent-main.js");
+  const { markdown, ok } = await agentMain.run();
+  emitResult(markdown);
+  if (!ok) process.exitCode = 1;
 };
 
-// Flag/scenario tokens the CLI accepts; excludes whitespace and anything that
-// needs quoting so tool inputs stay auditable in logs.
-const SAFE_ARG = /^[A-Za-z0-9@._:/=-]+$/;
-
-const TOOLS: Anthropic.Tool[] = [
-  {
-    name: "list_scenarios",
-    description:
-      "List the available seed scenarios with their flags and descriptions. " +
-      "Call this first to learn what can be seeded and which flags exist.",
-    input_schema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-  },
-  {
-    name: "seed_doctor",
-    description:
-      "Diagnose the seeding stack (Postgres/ClickHouse connectivity, seed " +
-      "project). Use when a seed run fails for unclear reasons.",
-    input_schema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-  },
-  {
-    name: "run_seed_scenario",
-    description:
-      "Run one seed scenario against this preview's datastores. Equivalent to " +
-      "`pnpm run seed -- <scenario> <args...> --json`. The result ends with a " +
-      "JSON summary containing counts, ids, `verified`, and UI deep `links`. " +
-      "Prefer `--dry-run` first when unsure about volume. Keep volumes " +
-      "bounded — this is a single-node preview, not production.",
-    input_schema: {
-      type: "object",
-      properties: {
-        scenario: {
-          type: "string",
-          description: "Scenario name exactly as shown by list_scenarios",
-        },
-        args: {
-          type: "array",
-          items: { type: "string" },
-          description:
-            'Flags and values as separate tokens, e.g. ["--observations", "1000", "--v4"]. Do not pass --json (added automatically).',
-        },
-      },
-      required: ["scenario", "args"],
-      additionalProperties: false,
-    },
-  },
-  {
-    name: "fetch_pr_diff",
-    description:
-      "Fetch this PR's unified diff from GitHub. Use when asked to seed data " +
-      "that exercises the changes in this PR, to decide what to seed.",
-    input_schema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-  },
-];
-
-const executeTool = async (
-  name: string,
-  input: unknown,
-): Promise<{ content: string; isError: boolean }> => {
-  if (name === "list_scenarios") {
-    const r = await runSeedCli(["list", "--json"]);
-    return { content: r.output, isError: !r.ok };
-  }
-  if (name === "seed_doctor") {
-    const r = await runSeedCli(["doctor", "--json"]);
-    // doctor exits non-zero on FAIL items; its report is still the answer
-    return { content: r.output, isError: false };
-  }
-  if (name === "run_seed_scenario") {
-    const { scenario, args } = input as { scenario: string; args: string[] };
-    const tokens = [scenario, ...(args ?? [])];
-    const invalid = tokens.filter((t) => !SAFE_ARG.test(t));
-    if (invalid.length > 0) {
-      return {
-        content: `invalid argument token(s): ${invalid.join(", ")} — tokens must match ${SAFE_ARG}`,
-        isError: true,
-      };
-    }
-    const withJson = tokens.includes("--json") ? tokens : [...tokens, "--json"];
-    const r = await runSeedCli(withJson);
-    return { content: r.output, isError: !r.ok };
-  }
-  if (name === "fetch_pr_diff") {
-    const pr = ENV.prNumber;
-    if (!pr || !/^\d+$/.test(pr)) {
-      return { content: "SEEDER_PR_NUMBER is not set", isError: true };
-    }
-    const url = `https://github.com/langfuse/langfuse/pull/${pr}.diff`;
-    try {
-      const response = await fetch(url, { redirect: "follow" });
-      if (!response.ok) {
-        return {
-          content: `GET ${url} -> ${response.status}`,
-          isError: true,
-        };
-      }
-      return {
-        content: truncate(await response.text(), MAX_DIFF_CHARS),
-        isError: false,
-      };
-    } catch (error) {
-      return {
-        content: `GET ${url} failed: ${error instanceof Error ? error.message : String(error)}`,
-        isError: true,
-      };
-    }
-  }
-  return { content: `unknown tool: ${name}`, isError: true };
-};
-
-const buildSystemPrompt = (): string => {
-  const previewUrl = ENV.previewUrl ?? "(unknown)";
-  const prNumber = ENV.prNumber ?? "(unknown)";
-  return [
-    "You are the Langfuse preview seeder agent. You run inside the ephemeral",
-    `preview environment for langfuse/langfuse PR #${prNumber} (public URL:`,
-    `${previewUrl}). A reviewer asked you, via a PR comment, to seed test data`,
-    "into this preview so they can inspect something in the UI.",
-    "",
-    "Environment facts:",
-    "- The seed CLI writes directly to this preview's own Postgres and",
-    "  single-node ClickHouse; nothing you do here touches production.",
-    "- Reviewers log in at the preview URL as demo@langfuse.com (password",
-    '  "password"); the seeded data lands in the seed project ("llm-app")',
-    "  unless a scenario says otherwise.",
-    "- Keep volumes preview-sized: prefer the smallest data set that lets the",
-    "  reviewer see what they asked for. Do not exceed roughly 100k rows",
-    "  unless the request explicitly demands more.",
-    "",
-    "Method:",
-    "- Start with list_scenarios to see what exists; pick the scenario(s) that",
-    "  match the request instead of improvising.",
-    '- If the request is about "this PR\'s changes", call fetch_pr_diff and',
-    "  choose scenarios that exercise the touched surfaces.",
-    "- After seeding, use the JSON summary's `verified` and `links` fields;",
-    "  if a run fails, try seed_doctor once and adjust.",
-    "",
-    "Your final message is posted to the PR verbatim as a comment. Write it",
-    "as concise markdown for the reviewer: lead with what you seeded (counts,",
-    "project), then the deep links from the summaries, then one or two lines",
-    "on what to look at. If you could not fulfil the request, say what you",
-    "tried and why it failed. No preamble, no meta-commentary.",
-  ].join("\n");
-};
-
-const main = async (): Promise<void> => {
-  if (!ENV.promptFile) {
-    throw new Error("SEEDER_AGENT_PROMPT_FILE is not set");
-  }
-  const prompt = readFileSync(ENV.promptFile, "utf8").trim();
-  if (prompt.length === 0) {
-    throw new Error(`prompt file ${ENV.promptFile} is empty`);
-  }
-  if (!ENV.anthropicApiKey) {
-    throw new Error("ANTHROPIC_API_KEY is not set");
-  }
-
-  const client = new Anthropic();
-  const messages: Anthropic.MessageParam[] = [
-    { role: "user", content: prompt },
-  ];
-
-  let finalText = "";
-  let lastStopReason: string | null = null;
-  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
-    const response = await client.messages.create({
-      model: MODEL,
-      max_tokens: 16000,
-      thinking: { type: "adaptive" },
-      system: buildSystemPrompt(),
-      tools: TOOLS,
-      messages,
-    });
-
-    // Echo the full content back (thinking blocks included, unchanged) so the
-    // next turn is valid; collect text as the running candidate result.
-    messages.push({ role: "assistant", content: response.content });
-    finalText = response.content
-      .filter((b): b is Anthropic.TextBlock => b.type === "text")
-      .map((b) => b.text)
-      .join("\n")
-      .trim();
-
-    lastStopReason = response.stop_reason;
-    if (response.stop_reason !== "tool_use") {
-      if (response.stop_reason !== "end_turn") {
-        console.error(`stopping on stop_reason=${response.stop_reason}`);
-      }
-      break;
-    }
-
-    const toolResults: Anthropic.ToolResultBlockParam[] = [];
-    for (const block of response.content) {
-      if (block.type !== "tool_use") continue;
-      console.error(
-        `tool ${block.name} ${JSON.stringify(block.input).slice(0, 500)}`,
-      );
-      const result = await executeTool(block.name, block.input);
-      toolResults.push({
-        type: "tool_result",
-        tool_use_id: block.id,
-        content: result.content,
-        is_error: result.isError,
-      });
-    }
-    // All results for this turn go back in a single user message.
-    messages.push({ role: "user", content: toolResults });
-  }
-
-  if (finalText.length === 0) {
-    throw new Error("the agent produced no final answer");
-  }
-  if (lastStopReason !== "end_turn") {
-    // Ran out of turns while still calling tools, or hit max_tokens: what we
-    // have is mid-work narration or a truncated message, not a completed
-    // answer. Never present it as a success — mark it and exit non-zero so
-    // the dispatcher uses its "did not finish cleanly" framing.
-    const why =
-      lastStopReason === "tool_use"
-        ? `hit the ${MAX_ITERATIONS}-turn limit while still working`
-        : `stop reason: ${String(lastStopReason)}`;
-    emitResult(
-      `⚠️ The seeder agent stopped before finishing (${why}). Data may be ` +
-        `partially seeded. Last status:\n\n${finalText}`,
-    );
-    process.exitCode = 1;
-    return;
-  }
-  emitResult(finalText);
-};
-
-main().catch((error: unknown) => {
+boot().catch((error: unknown) => {
   // Always emit a result block — the dispatcher posts ONLY this block, so a
   // bare crash would otherwise surface as an unexplained failure on the PR.
-  let detail: string;
-  if (error instanceof Anthropic.APIError) {
-    detail = `Anthropic API error (${error.status ?? "network"}): ${error.message}`;
-  } else {
-    detail = error instanceof Error ? error.message : String(error);
-  }
   console.error(error);
+  const detail = error instanceof Error ? error.message : String(error);
   emitResult(
     `⚠️ The seeder agent hit an error before finishing: ${detail}\n\n` +
       "Check the job logs in the preview cluster, then re-post the comment to retry.",

--- a/packages/shared/scripts/seeder/agent.ts
+++ b/packages/shared/scripts/seeder/agent.ts
@@ -1,0 +1,342 @@
+/**
+ * Agentic seeder entrypoint for PR preview environments.
+ *
+ * Runs as a one-shot Job inside a preview namespace when an allowlisted author
+ * comments `@seeder <prompt>` on a preview-labeled PR (dispatch + result
+ * posting live in langfuse/infrastructure, k8s/preview). An Anthropic-powered
+ * agent drives the seed CLI (cli.ts, same contract as `pnpm run seed`) against
+ * THIS preview's datastores, then reports back.
+ *
+ * Contract with the infrastructure job (keep in sync with
+ * k8s/preview/README.md "Agentic seeder" in langfuse/infrastructure):
+ *   input env:
+ *     SEEDER_AGENT_PROMPT_FILE  path to the user's prompt (required)
+ *     SEEDER_PR_NUMBER          PR number (for fetch_pr_diff)
+ *     SEEDER_COMMENT_ID         triggering comment id (informational)
+ *     LANGFUSE_PREVIEW_URL      public base URL of this preview (deep links)
+ *     LANGFUSE_WEB_URL          in-cluster web URL (informational)
+ *     ANTHROPIC_API_KEY         read by the SDK
+ *     + the same datastore env the seed CLI needs (DATABASE_URL, CLICKHOUSE_*)
+ *   output: the markdown between the marker lines below is posted VERBATIM to
+ *     the PR; everything else on stdout/stderr stays in the pod logs. Always
+ *     emit exactly one result block, success or failure.
+ *
+ * Like cli.ts, this file must not import from src/ at module load (the shared
+ * env schema would throw before we can emit a result block) — all seeding goes
+ * through the compiled cli.js as a subprocess, which also keeps the agent on
+ * the CLI's public scenario/flag/JSON-summary contract.
+ */
+import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { promisify } from "node:util";
+
+import Anthropic from "@anthropic-ai/sdk";
+
+const BEGIN_MARK = "-----BEGIN SEEDER RESULT-----";
+const END_MARK = "-----END SEEDER RESULT-----";
+
+// Job entrypoint, not a turbo task — reads its env contract directly. The
+// full contract is documented in the header comment above.
+/* eslint-disable turbo/no-undeclared-env-vars */
+const ENV = {
+  promptFile: process.env.SEEDER_AGENT_PROMPT_FILE,
+  prNumber: process.env.SEEDER_PR_NUMBER,
+  previewUrl: process.env.LANGFUSE_PREVIEW_URL,
+  nextauthUrl: process.env.NEXTAUTH_URL,
+  model: process.env.SEEDER_AGENT_MODEL,
+  anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+};
+/* eslint-enable turbo/no-undeclared-env-vars */
+
+const MODEL = ENV.model ?? "claude-opus-4-8";
+const MAX_ITERATIONS = 24; // agent turns; the Job's activeDeadlineSeconds is the hard stop
+const CLI_TIMEOUT_MS = 6 * 60 * 1000; // per seed run; several must fit in one Job
+const MAX_TOOL_RESULT_CHARS = 20_000;
+const MAX_DIFF_CHARS = 80_000;
+
+const execFileAsync = promisify(execFile);
+
+const emitResult = (markdown: string): void => {
+  console.log(`${BEGIN_MARK}\n${markdown.trim()}\n${END_MARK}`);
+};
+
+const truncate = (text: string, max: number): string =>
+  text.length > max ? `${text.slice(0, max)}\n… [truncated]` : text;
+
+/**
+ * Run the compiled seed CLI (dist/scripts/seeder/cli.js, sibling of this
+ * file). No shell — args go straight to execFile. NEXTAUTH_URL is pointed at
+ * the preview's public URL so the CLI's JSON-summary `links` are directly
+ * postable to the PR.
+ */
+const runSeedCli = async (
+  args: string[],
+): Promise<{ ok: boolean; output: string }> => {
+  const cliPath = path.join(__dirname, "cli.js");
+  const env = {
+    ...process.env,
+    NEXTAUTH_URL: ENV.previewUrl ?? ENV.nextauthUrl,
+    LANGFUSE_LOG_LEVEL: "error",
+  };
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      [cliPath, ...args],
+      { env, timeout: CLI_TIMEOUT_MS, maxBuffer: 32 * 1024 * 1024 },
+    );
+    // With --json the last stdout line is the machine-readable summary; keep
+    // the whole (truncated) output anyway so the model sees doctor/list text.
+    const output = [stdout.trim(), stderr.trim()]
+      .filter(Boolean)
+      .join("\n--- stderr ---\n");
+    return { ok: true, output: truncate(output, MAX_TOOL_RESULT_CHARS) };
+  } catch (error) {
+    const e = error as { stdout?: string; stderr?: string; message?: string };
+    const output = [e.message, e.stdout?.trim(), e.stderr?.trim()]
+      .filter(Boolean)
+      .join("\n");
+    return { ok: false, output: truncate(output, MAX_TOOL_RESULT_CHARS) };
+  }
+};
+
+// Flag/scenario tokens the CLI accepts; excludes whitespace and anything that
+// needs quoting so tool inputs stay auditable in logs.
+const SAFE_ARG = /^[A-Za-z0-9@._:/=-]+$/;
+
+const TOOLS: Anthropic.Tool[] = [
+  {
+    name: "list_scenarios",
+    description:
+      "List the available seed scenarios with their flags and descriptions. " +
+      "Call this first to learn what can be seeded and which flags exist.",
+    input_schema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "seed_doctor",
+    description:
+      "Diagnose the seeding stack (Postgres/ClickHouse connectivity, seed " +
+      "project). Use when a seed run fails for unclear reasons.",
+    input_schema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "run_seed_scenario",
+    description:
+      "Run one seed scenario against this preview's datastores. Equivalent to " +
+      "`pnpm run seed -- <scenario> <args...> --json`. The result ends with a " +
+      "JSON summary containing counts, ids, `verified`, and UI deep `links`. " +
+      "Prefer `--dry-run` first when unsure about volume. Keep volumes " +
+      "bounded — this is a single-node preview, not production.",
+    input_schema: {
+      type: "object",
+      properties: {
+        scenario: {
+          type: "string",
+          description: "Scenario name exactly as shown by list_scenarios",
+        },
+        args: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            'Flags and values as separate tokens, e.g. ["--observations", "1000", "--v4"]. Do not pass --json (added automatically).',
+        },
+      },
+      required: ["scenario", "args"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "fetch_pr_diff",
+    description:
+      "Fetch this PR's unified diff from GitHub. Use when asked to seed data " +
+      "that exercises the changes in this PR, to decide what to seed.",
+    input_schema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+];
+
+const executeTool = async (
+  name: string,
+  input: unknown,
+): Promise<{ content: string; isError: boolean }> => {
+  if (name === "list_scenarios") {
+    const r = await runSeedCli(["list", "--json"]);
+    return { content: r.output, isError: !r.ok };
+  }
+  if (name === "seed_doctor") {
+    const r = await runSeedCli(["doctor", "--json"]);
+    // doctor exits non-zero on FAIL items; its report is still the answer
+    return { content: r.output, isError: false };
+  }
+  if (name === "run_seed_scenario") {
+    const { scenario, args } = input as { scenario: string; args: string[] };
+    const tokens = [scenario, ...(args ?? [])];
+    const invalid = tokens.filter((t) => !SAFE_ARG.test(t));
+    if (invalid.length > 0) {
+      return {
+        content: `invalid argument token(s): ${invalid.join(", ")} — tokens must match ${SAFE_ARG}`,
+        isError: true,
+      };
+    }
+    const withJson = tokens.includes("--json") ? tokens : [...tokens, "--json"];
+    const r = await runSeedCli(withJson);
+    return { content: r.output, isError: !r.ok };
+  }
+  if (name === "fetch_pr_diff") {
+    const pr = ENV.prNumber;
+    if (!pr || !/^\d+$/.test(pr)) {
+      return { content: "SEEDER_PR_NUMBER is not set", isError: true };
+    }
+    const url = `https://github.com/langfuse/langfuse/pull/${pr}.diff`;
+    try {
+      const response = await fetch(url, { redirect: "follow" });
+      if (!response.ok) {
+        return {
+          content: `GET ${url} -> ${response.status}`,
+          isError: true,
+        };
+      }
+      return {
+        content: truncate(await response.text(), MAX_DIFF_CHARS),
+        isError: false,
+      };
+    } catch (error) {
+      return {
+        content: `GET ${url} failed: ${error instanceof Error ? error.message : String(error)}`,
+        isError: true,
+      };
+    }
+  }
+  return { content: `unknown tool: ${name}`, isError: true };
+};
+
+const buildSystemPrompt = (): string => {
+  const previewUrl = ENV.previewUrl ?? "(unknown)";
+  const prNumber = ENV.prNumber ?? "(unknown)";
+  return [
+    "You are the Langfuse preview seeder agent. You run inside the ephemeral",
+    `preview environment for langfuse/langfuse PR #${prNumber} (public URL:`,
+    `${previewUrl}). A reviewer asked you, via a PR comment, to seed test data`,
+    "into this preview so they can inspect something in the UI.",
+    "",
+    "Environment facts:",
+    "- The seed CLI writes directly to this preview's own Postgres and",
+    "  single-node ClickHouse; nothing you do here touches production.",
+    "- Reviewers log in at the preview URL as demo@langfuse.com (password",
+    '  "password"); the seeded data lands in the seed project ("llm-app")',
+    "  unless a scenario says otherwise.",
+    "- Keep volumes preview-sized: prefer the smallest data set that lets the",
+    "  reviewer see what they asked for. Do not exceed roughly 100k rows",
+    "  unless the request explicitly demands more.",
+    "",
+    "Method:",
+    "- Start with list_scenarios to see what exists; pick the scenario(s) that",
+    "  match the request instead of improvising.",
+    '- If the request is about "this PR\'s changes", call fetch_pr_diff and',
+    "  choose scenarios that exercise the touched surfaces.",
+    "- After seeding, use the JSON summary's `verified` and `links` fields;",
+    "  if a run fails, try seed_doctor once and adjust.",
+    "",
+    "Your final message is posted to the PR verbatim as a comment. Write it",
+    "as concise markdown for the reviewer: lead with what you seeded (counts,",
+    "project), then the deep links from the summaries, then one or two lines",
+    "on what to look at. If you could not fulfil the request, say what you",
+    "tried and why it failed. No preamble, no meta-commentary.",
+  ].join("\n");
+};
+
+const main = async (): Promise<void> => {
+  if (!ENV.promptFile) {
+    throw new Error("SEEDER_AGENT_PROMPT_FILE is not set");
+  }
+  const prompt = readFileSync(ENV.promptFile, "utf8").trim();
+  if (prompt.length === 0) {
+    throw new Error(`prompt file ${ENV.promptFile} is empty`);
+  }
+  if (!ENV.anthropicApiKey) {
+    throw new Error("ANTHROPIC_API_KEY is not set");
+  }
+
+  const client = new Anthropic();
+  const messages: Anthropic.MessageParam[] = [
+    { role: "user", content: prompt },
+  ];
+
+  let finalText = "";
+  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+    const response = await client.messages.create({
+      model: MODEL,
+      max_tokens: 16000,
+      thinking: { type: "adaptive" },
+      system: buildSystemPrompt(),
+      tools: TOOLS,
+      messages,
+    });
+
+    // Echo the full content back (thinking blocks included, unchanged) so the
+    // next turn is valid; collect text as the running candidate result.
+    messages.push({ role: "assistant", content: response.content });
+    finalText = response.content
+      .filter((b): b is Anthropic.TextBlock => b.type === "text")
+      .map((b) => b.text)
+      .join("\n")
+      .trim();
+
+    if (response.stop_reason !== "tool_use") {
+      if (response.stop_reason !== "end_turn") {
+        console.error(`stopping on stop_reason=${response.stop_reason}`);
+      }
+      break;
+    }
+
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    for (const block of response.content) {
+      if (block.type !== "tool_use") continue;
+      console.error(
+        `tool ${block.name} ${JSON.stringify(block.input).slice(0, 500)}`,
+      );
+      const result = await executeTool(block.name, block.input);
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: block.id,
+        content: result.content,
+        is_error: result.isError,
+      });
+    }
+    // All results for this turn go back in a single user message.
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  if (finalText.length === 0) {
+    throw new Error("the agent produced no final answer");
+  }
+  emitResult(finalText);
+};
+
+main().catch((error: unknown) => {
+  // Always emit a result block — the dispatcher posts ONLY this block, so a
+  // bare crash would otherwise surface as an unexplained failure on the PR.
+  let detail: string;
+  if (error instanceof Anthropic.APIError) {
+    detail = `Anthropic API error (${error.status ?? "network"}): ${error.message}`;
+  } else {
+    detail = error instanceof Error ? error.message : String(error);
+  }
+  console.error(error);
+  emitResult(
+    `⚠️ The seeder agent hit an error before finishing: ${detail}\n\n` +
+      "Check the job logs in the preview cluster, then re-post the comment to retry.",
+  );
+  process.exitCode = 1;
+});

--- a/packages/shared/scripts/seeder/agent.ts
+++ b/packages/shared/scripts/seeder/agent.ts
@@ -274,6 +274,7 @@ const main = async (): Promise<void> => {
   ];
 
   let finalText = "";
+  let lastStopReason: string | null = null;
   for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
     const response = await client.messages.create({
       model: MODEL,
@@ -293,6 +294,7 @@ const main = async (): Promise<void> => {
       .join("\n")
       .trim();
 
+    lastStopReason = response.stop_reason;
     if (response.stop_reason !== "tool_use") {
       if (response.stop_reason !== "end_turn") {
         console.error(`stopping on stop_reason=${response.stop_reason}`);
@@ -320,6 +322,22 @@ const main = async (): Promise<void> => {
 
   if (finalText.length === 0) {
     throw new Error("the agent produced no final answer");
+  }
+  if (lastStopReason !== "end_turn") {
+    // Ran out of turns while still calling tools, or hit max_tokens: what we
+    // have is mid-work narration or a truncated message, not a completed
+    // answer. Never present it as a success — mark it and exit non-zero so
+    // the dispatcher uses its "did not finish cleanly" framing.
+    const why =
+      lastStopReason === "tool_use"
+        ? `hit the ${MAX_ITERATIONS}-turn limit while still working`
+        : `stop reason: ${String(lastStopReason)}`;
+    emitResult(
+      `⚠️ The seeder agent stopped before finishing (${why}). Data may be ` +
+        `partially seeded. Last status:\n\n${finalText}`,
+    );
+    process.exitCode = 1;
+    return;
   }
   emitResult(finalText);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,9 +222,6 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: ^3.0.3
         version: 3.0.3(zod@4.3.6)
-      '@anthropic-ai/sdk':
-        specifier: ^0.111.0
-        version: 0.111.0(zod@4.3.6)
       '@aws-sdk/client-cloudwatch':
         specifier: 'catalog:'
         version: 3.1074.0
@@ -1339,15 +1336,6 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
-
-  '@anthropic-ai/sdk@0.111.0':
-    resolution: {integrity: sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==}
-    hasBin: true
-    peerDependencies:
-      zod: 4.3.6
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@anthropic-ai/tokenizer@0.0.4':
     resolution: {integrity: sha512-EHRKbxlxlc8W4KCBEseByJ7YwyYCmgu9OyN59H9+IYIGPoKv8tXyQXinkeGDI+cI8Tiuz9wk2jZb/kK7AyvL7g==}
@@ -5089,9 +5077,6 @@ packages:
     resolution: {integrity: sha512-ZS7Y5X8mU9qRSsqwOeGKw86WWtPsRxa396kX2HyhYwADRqFHJ0cb3p2uFk6QnFF3BluUUBHTZJpPA9QuEl0tlg==}
     engines: {node: '>=18.0.0'}
 
-  '@stablelib/base64@1.0.1':
-    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
-
   '@standard-community/standard-json@0.3.5':
     resolution: {integrity: sha512-4+ZPorwDRt47i+O7RjyuaxHRK/37QY/LmgxlGrRrSTLYoFatEOzvqIc85GTlM18SFZ5E91C+v0o/M37wZPpUHA==}
     peerDependencies:
@@ -7774,9 +7759,6 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-sha256@1.3.0:
-    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
-
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -8669,10 +8651,6 @@ packages:
   json-schema-faker@0.6.1:
     resolution: {integrity: sha512-IMF9QGFn/j7sys1LxgYpt/+0LUozFE8R/yUav4D7NqsHnh5L0mbJZOiU724nlJ3g+ZZo6NykVtTeJLoVcOP6Xw==}
     hasBin: true
-
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
 
   json-schema-to-zod@2.8.1:
     resolution: {integrity: sha512-fRr1mHgZ7hboLKBUdR428gd9dIHUFGivUqOeiDcSmyXkNZCtB1uGaZLvsjZ4GaN5pwBIs+TGIOf6s+Rp5/R/zA==}
@@ -10650,9 +10628,6 @@ packages:
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
-  standardwebhooks@1.0.0:
-    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
-
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -11009,9 +10984,6 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
-
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -11946,13 +11918,6 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
-
-  '@anthropic-ai/sdk@0.111.0(zod@4.3.6)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-      standardwebhooks: 1.0.0
-    optionalDependencies:
-      zod: 4.3.6
 
   '@anthropic-ai/tokenizer@0.0.4':
     dependencies:
@@ -16272,8 +16237,6 @@ snapshots:
       '@smithy/core': 3.29.3
       tslib: 2.8.1
 
-  '@stablelib/base64@1.0.1': {}
-
   '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -19315,8 +19278,6 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-sha256@1.3.0: {}
-
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -20305,11 +20266,6 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-faker@0.6.1: {}
-
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
-      ts-algebra: 2.0.0
 
   json-schema-to-zod@2.8.1: {}
 
@@ -22746,11 +22702,6 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
-  standardwebhooks@1.0.0:
-    dependencies:
-      '@stablelib/base64': 1.0.1
-      fast-sha256: 1.3.0
-
   statuses@2.0.2: {}
 
   std-env@4.0.0: {}
@@ -23108,8 +23059,6 @@ snapshots:
   triple-beam@1.4.1: {}
 
   trough@2.2.0: {}
-
-  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: ^3.0.3
         version: 3.0.3(zod@4.3.6)
+      '@anthropic-ai/sdk':
+        specifier: ^0.111.0
+        version: 0.111.0(zod@4.3.6)
       '@aws-sdk/client-cloudwatch':
         specifier: 'catalog:'
         version: 3.1074.0
@@ -1336,6 +1339,15 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@anthropic-ai/sdk@0.111.0':
+    resolution: {integrity: sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==}
+    hasBin: true
+    peerDependencies:
+      zod: 4.3.6
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@anthropic-ai/tokenizer@0.0.4':
     resolution: {integrity: sha512-EHRKbxlxlc8W4KCBEseByJ7YwyYCmgu9OyN59H9+IYIGPoKv8tXyQXinkeGDI+cI8Tiuz9wk2jZb/kK7AyvL7g==}
@@ -5077,6 +5089,9 @@ packages:
     resolution: {integrity: sha512-ZS7Y5X8mU9qRSsqwOeGKw86WWtPsRxa396kX2HyhYwADRqFHJ0cb3p2uFk6QnFF3BluUUBHTZJpPA9QuEl0tlg==}
     engines: {node: '>=18.0.0'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-community/standard-json@0.3.5':
     resolution: {integrity: sha512-4+ZPorwDRt47i+O7RjyuaxHRK/37QY/LmgxlGrRrSTLYoFatEOzvqIc85GTlM18SFZ5E91C+v0o/M37wZPpUHA==}
     peerDependencies:
@@ -7759,6 +7774,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -8651,6 +8669,10 @@ packages:
   json-schema-faker@0.6.1:
     resolution: {integrity: sha512-IMF9QGFn/j7sys1LxgYpt/+0LUozFE8R/yUav4D7NqsHnh5L0mbJZOiU724nlJ3g+ZZo6NykVtTeJLoVcOP6Xw==}
     hasBin: true
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-to-zod@2.8.1:
     resolution: {integrity: sha512-fRr1mHgZ7hboLKBUdR428gd9dIHUFGivUqOeiDcSmyXkNZCtB1uGaZLvsjZ4GaN5pwBIs+TGIOf6s+Rp5/R/zA==}
@@ -10628,6 +10650,9 @@ packages:
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -10984,6 +11009,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -11918,6 +11946,13 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
+
+  '@anthropic-ai/sdk@0.111.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.3.6
 
   '@anthropic-ai/tokenizer@0.0.4':
     dependencies:
@@ -16237,6 +16272,8 @@ snapshots:
       '@smithy/core': 3.29.3
       tslib: 2.8.1
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -19278,6 +19315,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -20266,6 +20305,11 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-faker@0.6.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
 
   json-schema-to-zod@2.8.1: {}
 
@@ -22702,6 +22746,11 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@4.0.0: {}
@@ -23059,6 +23108,8 @@ snapshots:
   triple-beam@1.4.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `agent.ts`, a one-shot Anthropic-powered agent that runs as a Kubernetes Job in PR preview environments, seeding test data by driving the existing `cli.ts` seed CLI as a subprocess in response to `@seeder <prompt>` PR comments. It also adds `@anthropic-ai/sdk@^0.111.0` as a dependency and documents the new file in `AGENTS.md`.

- **Agent loop**: Uses adaptive thinking with up to 24 turns, dispatching four tools (`list_scenarios`, `seed_doctor`, `run_seed_scenario`, `fetch_pr_diff`). Input tokens are validated via a `SAFE_ARG` regex before reaching `execFile`, and the result is posted back to the PR as a delimited markdown block.
- **Default model string** is `claude-opus-4-8`, which does not match any known model alias and looks like a typo of `claude-opus-4-6`; every invocation will 404 if the string is wrong.
- **Context management is absent**: the messages array accumulates all turns including adaptive-thinking blocks without trimming or compaction, making context-window exhaustion nearly certain for sessions longer than ~8-10 turns.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge only after verifying/correcting the model ID and adding context management — as written, the agent will likely fail on every run or hit context limits mid-job.

The model string `claude-opus-4-8` doesn't match any known model alias and looks like a typo; if wrong, the agent fails immediately with a 404 before doing any work. Separately, the messages array accumulates every assistant turn (including adaptive-thinking blocks) with no trimming or compaction, so any non-trivial multi-step session will exhaust the 200K context window mid-run and surface as a generic error with no visibility into partial seeding state. Both issues affect the core agentic loop on every real invocation.

packages/shared/scripts/seeder/agent.ts — the default model ID and the unbounded context accumulation in the main loop both need attention before this is deployed.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub PR
    participant Infra as k8s Job (infrastructure)
    participant Agent as agent.ts
    participant Anthropic as Anthropic API
    participant CLI as seed CLI (cli.js)

    GH->>Infra: "@seeder prompt comment (allowlisted author)"
    Infra->>Agent: spawn Job with env contract
    Agent->>Agent: readFileSync(promptFile)
    loop Up to 24 turns
        Agent->>Anthropic: messages.create(model, thinking:adaptive, tools, messages)
        Anthropic-->>Agent: response (text + optional tool_use blocks)
        alt "stop_reason == end_turn"
            Agent->>Agent: emitResult(finalText)
        else "stop_reason == tool_use"
            loop for each tool_use block
                alt list_scenarios / seed_doctor / run_seed_scenario
                    Agent->>CLI: execFile(node, cli.js, args)
                    CLI-->>Agent: stdout/stderr
                else fetch_pr_diff
                    Agent->>GH: GET /pull/pr.diff
                    GH-->>Agent: unified diff
                end
            end
            Agent->>Anthropic: next turn with tool_results
        end
    end
    Agent->>GH: BEGIN/END SEEDER RESULT block (posted by Infra)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub PR
    participant Infra as k8s Job (infrastructure)
    participant Agent as agent.ts
    participant Anthropic as Anthropic API
    participant CLI as seed CLI (cli.js)

    GH->>Infra: "@seeder prompt comment (allowlisted author)"
    Infra->>Agent: spawn Job with env contract
    Agent->>Agent: readFileSync(promptFile)
    loop Up to 24 turns
        Agent->>Anthropic: messages.create(model, thinking:adaptive, tools, messages)
        Anthropic-->>Agent: response (text + optional tool_use blocks)
        alt "stop_reason == end_turn"
            Agent->>Agent: emitResult(finalText)
        else "stop_reason == tool_use"
            loop for each tool_use block
                alt list_scenarios / seed_doctor / run_seed_scenario
                    Agent->>CLI: execFile(node, cli.js, args)
                    CLI-->>Agent: stdout/stderr
                else fetch_pr_diff
                    Agent->>GH: GET /pull/pr.diff
                    GH-->>Agent: unified diff
                end
            end
            Agent->>Anthropic: next turn with tool_results
        end
    end
    Agent->>GH: BEGIN/END SEEDER RESULT block (posted by Infra)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/shared/scripts/seeder/agent.ts:272-321
**Context window exhaustion across iterations**

The `messages` array accumulates every turn's full content — including adaptive-thinking blocks (which can be tens of thousands of tokens each) plus tool results up to `MAX_TOOL_RESULT_CHARS` characters — without any trimming or compaction. Over 24 iterations, a realistic session with tool calls and thinking blocks will almost certainly exceed the 200K context limit, causing a mid-run `400 invalid_request_error`. The error is caught by the outer `.catch()` handler, so the PR comment will show a generic failure with no indication of how much seeding was completed.

The Anthropic SDK supports server-side compaction (`compact-2026-01-12` beta header with `context_management: { edits: [{ type: "compact_20260112" }] }`) exactly for this pattern — long multi-turn agent loops that risk filling the context window.

### Issue 2 of 3
packages/shared/scripts/seeder/agent.ts:52
The default model string `claude-opus-4-8` doesn't appear in the current Anthropic model catalog. The most recent Claude Opus 4 model identifier is `claude-opus-4-6`. This looks like a typo (`8` instead of `6`); if the agent runs with an invalid model ID, every invocation will fail immediately with a 404 before any seeding work is done.

```suggestion
const MODEL = ENV.model ?? "claude-opus-4-6";
```

### Issue 3 of 3
packages/shared/scripts/seeder/agent.ts:152-155
The `args` field is listed in `required`, but the executor immediately falls back to `args ?? []`. If `args` is always expected to be provided (even as an empty array), the nullish-coalescing fallback is dead code. If it is genuinely optional, it should be removed from `required` so the model is not forced to emit `"args": []` for scenarios with no flags.

```suggestion
      required: ["scenario"],
      additionalProperties: false,
    },
  },
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(seeder): add seed:agent script so ..."](https://github.com/langfuse/langfuse/commit/22efa7128ff9b4ebfbcefb7233a71d1c165481b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45323190)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->