### PR TITLE
fix(worker): throttle PostHog integration exports

### DIFF
--- a/worker/src/__tests__/posthogIntegrationProjectJob.test.ts
+++ b/worker/src/__tests__/posthogIntegrationProjectJob.test.ts
@@ -1,19 +1,53 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 /**
- * Unit tests for the PostHog integration project job's events_only legacy
- * guard (LFE-10148): a persisted legacy export source on an events_only
- * deployment reads the v3 traces/observations tables, which are no longer
- * written — the job must fail loudly before exporting empty data and
- * advancing lastSyncAt. Mocked in the same style as
- * mixpanelIntegrationProjectJob.test.ts.
+ * Unit tests for the PostHog integration project job:
+ *
+ * 1. The events_only legacy guard (LFE-10148): a persisted legacy export
+ *    source on an events_only deployment reads the v3 traces/observations
+ *    tables, which are no longer written — the job must fail loudly before
+ *    exporting empty data and advancing lastSyncAt.
+ *
+ * 2. Export throttling (issue #12786): the original implementation built one
+ *    PostHog client per stream and ran all streams concurrently via
+ *    Promise.all, producing an unbounded export burst that overwhelmed the
+ *    target. This mirrors the Mixpanel fix (PR #13958):
+ *      a. a single reused client per job,
+ *      b. sequential stream execution (max concurrency 1), and
+ *      c. a configurable inter-flush delay (LANGFUSE_POSTHOG_FLUSH_DELAY_MS).
+ *    Unlike the custom MixpanelClient, posthog-node keeps a background flush
+ *    timer, so the job must also shutdown() the client exactly once — even
+ *    when a stream fails — to avoid leaking timers in the worker process.
+ *
+ * Mocked in the same style as mixpanelIntegrationProjectJob.test.ts.
  */
 
 // vi.mock factories are hoisted above module scope, so all shared mutable
 // state the factories touch must live inside vi.hoisted().
 const h = vi.hoisted(() => {
-  async function* fakeStream(label: string) {
-    yield { langfuse_id: `${label}-1` };
+  const timeline: string[] = [];
+  const constructed: { shutdown: unknown }[] = [];
+  const state = { activeStreams: 0, maxConcurrentStreams: 0 };
+
+  // A fake async stream that records start/end on the shared timeline and
+  // tracks concurrency with a yield point in between, so concurrent
+  // (Promise.all) execution would interleave and trip the max-concurrency
+  // assertion.
+  function fakeStream(label: string) {
+    return (async function* () {
+      state.activeStreams++;
+      state.maxConcurrentStreams = Math.max(
+        state.maxConcurrentStreams,
+        state.activeStreams,
+      );
+      timeline.push(`${label}:start`);
+      await Promise.resolve();
+      yield { langfuse_id: `${label}-1` };
+      await Promise.resolve();
+      yield { langfuse_id: `${label}-2` };
+      timeline.push(`${label}:end`);
+      state.activeStreams--;
+    })();
   }
 
   const posthogIntegrationUpdate = vi.fn();
@@ -37,6 +71,9 @@ const h = vi.hoisted(() => {
   const db = { integration: defaultIntegration() as Record<string, unknown> };
 
   return {
+    timeline,
+    constructed,
+    state,
     posthogIntegrationUpdate,
     getTraces,
     getGenerations,
@@ -82,15 +119,25 @@ vi.mock("@langfuse/shared/encryption", () => ({
 vi.mock("posthog-node", () => ({
   PostHog: class {
     capture = vi.fn();
-    flush = vi.fn(async () => {});
+    flush = vi.fn(async () => {
+      h.timeline.push("flush");
+    });
     on = vi.fn();
+    shutdown = vi.fn(async () => {});
+    constructor() {
+      h.constructed.push(this as unknown as { shutdown: unknown });
+    }
   },
 }));
 
 // Path is relative to this test file -> resolves to worker/src/env (the
-// module the exportWriteModeGuard reads its write mode from).
+// module the exportWriteModeGuard reads its write mode from). Keep the
+// throttle delay at 0 to keep the unit tests fast (real default is 100ms).
 vi.mock("../env", () => ({
-  env: { LANGFUSE_MIGRATION_V4_WRITE_MODE: "legacy" },
+  env: {
+    LANGFUSE_MIGRATION_V4_WRITE_MODE: "legacy",
+    LANGFUSE_POSTHOG_FLUSH_DELAY_MS: 0,
+  },
 }));
 
 // Import after mocks are registered.
@@ -104,16 +151,22 @@ function makeJob() {
   } as unknown as Parameters<typeof handlePostHogIntegrationProjectJob>[0];
 }
 
+function resetSharedState() {
+  h.timeline.length = 0;
+  h.constructed.length = 0;
+  h.state.activeStreams = 0;
+  h.state.maxConcurrentStreams = 0;
+  h.posthogIntegrationUpdate.mockClear();
+  h.getTraces.mockClear();
+  h.getGenerations.mockClear();
+  h.getScores.mockClear();
+  h.getEvents.mockClear();
+  h.db.integration = h.defaultIntegration();
+  (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+}
+
 describe("handlePostHogIntegrationProjectJob events_only legacy guard (LFE-10148)", () => {
-  beforeEach(() => {
-    h.posthogIntegrationUpdate.mockClear();
-    h.getTraces.mockClear();
-    h.getGenerations.mockClear();
-    h.getScores.mockClear();
-    h.getEvents.mockClear();
-    h.db.integration = h.defaultIntegration();
-    (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
-  });
+  beforeEach(resetSharedState);
 
   it("throws before export and does not advance lastSyncAt on events_only + legacy source", async () => {
     (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
@@ -156,5 +209,57 @@ describe("handlePostHogIntegrationProjectJob events_only legacy guard (LFE-10148
 
     expect(h.getTraces).toHaveBeenCalledTimes(1);
     expect(h.posthogIntegrationUpdate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handlePostHogIntegrationProjectJob throttling (issue #12786)", () => {
+  beforeEach(() => {
+    resetSharedState();
+    h.db.integration = {
+      ...h.defaultIntegration(),
+      exportSource: "TRACES_OBSERVATIONS_EVENTS",
+    };
+  });
+
+  it("reuses a single PostHog client for the whole job", async () => {
+    await handlePostHogIntegrationProjectJob(makeJob());
+    expect(h.constructed.length).toBe(1);
+  });
+
+  it("runs export streams sequentially (no concurrent streams)", async () => {
+    await handlePostHogIntegrationProjectJob(makeJob());
+    // Each stream must fully finish before the next starts.
+    expect(h.state.maxConcurrentStreams).toBe(1);
+    // Timeline never has two starts without an intervening end.
+    let open = 0;
+    for (const entry of h.timeline) {
+      if (entry.endsWith(":start")) open++;
+      if (entry.endsWith(":end")) open--;
+      expect(open).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("shuts the client down exactly once on success", async () => {
+    await handlePostHogIntegrationProjectJob(makeJob());
+    expect(h.constructed.length).toBe(1);
+    expect(h.constructed[0].shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("shuts the client down when a stream fails", async () => {
+    h.getScores.mockImplementationOnce(() =>
+      (async function* (): AsyncGenerator<{ langfuse_id: string }> {
+        yield { langfuse_id: "scores-1" };
+        throw new Error("stream failed");
+      })(),
+    );
+
+    await expect(handlePostHogIntegrationProjectJob(makeJob())).rejects.toThrow(
+      "stream failed",
+    );
+
+    expect(h.constructed.length).toBe(1);
+    expect(h.constructed[0].shutdown).toHaveBeenCalledTimes(1);
+    // A failed run must not advance lastSyncAt.
+    expect(h.posthogIntegrationUpdate).not.toHaveBeenCalled();
   });
 });

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -133,6 +133,9 @@ const EnvSchema = z.object({
   // Delay (ms) inserted after each Mixpanel flush to throttle analytics exports
   // and avoid overwhelming the target instance (see issue #12786).
   LANGFUSE_MIXPANEL_FLUSH_DELAY_MS: z.coerce.number().min(0).default(100),
+  // Delay (ms) inserted after each PostHog flush to throttle analytics exports
+  // and avoid overwhelming the target instance (see issue #12786).
+  LANGFUSE_POSTHOG_FLUSH_DELAY_MS: z.coerce.number().min(0).default(100),
   LANGFUSE_DATASET_DELETE_CONCURRENCY: z.coerce.number().positive().default(1),
   LANGFUSE_PROJECT_DELETE_CONCURRENCY: z.coerce.number().positive().default(1),
   LANGFUSE_EVAL_EXECUTION_WORKER_CONCURRENCY: z.coerce

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -21,6 +21,7 @@ import { decrypt } from "@langfuse/shared/encryption";
 import { PostHog } from "posthog-node";
 import { recordExportVolume } from "../../services/exportVolumeMetric";
 import { assertLegacyExportSourceWritable } from "../exportWriteModeGuard";
+import { env } from "../../env";
 
 type PostHogExecutionConfig = {
   projectId: string;
@@ -36,10 +37,30 @@ type PostHogExecutionConfig = {
   // Shared accumulator for gzipped on-wire upload volume, written by the
   // fetch wrapper on each client and read once the run succeeds.
   volume: { bytes: number };
+  // Last error emitted by the shared PostHog client; checked inside the export
+  // loops so a failing stream aborts the job instead of silently continuing.
+  sendError: { current?: Error };
 };
 
 const postHogSettings = {
   flushAt: 1000,
+};
+
+const sleep = (ms: number) =>
+  ms > 0
+    ? new Promise((resolve) => setTimeout(resolve, ms))
+    : Promise.resolve();
+
+// Throttle exports after each flush so a single project sync cannot burst the
+// target PostHog instance with an unbounded event rate (issue #12786).
+// `hadEvents` must be tracked by the caller since posthog-node does not expose
+// its internal queue size; flush() is a no-op on an empty batch, so skipping
+// the delay then avoids a wasted wait on the terminal flush.
+const flushWithDelay = async (posthog: PostHog, hadEvents: boolean) => {
+  await posthog.flush();
+  if (hadEvents) {
+    await sleep(env.LANGFUSE_POSTHOG_FLUSH_DELAY_MS);
+  }
 };
 
 type PostHogClientOptions = NonNullable<
@@ -70,7 +91,10 @@ export const countingFetch =
     return globalThis.fetch(url, options as RequestInit);
   };
 
-const processPostHogTraces = async (config: PostHogExecutionConfig) => {
+const processPostHogTraces = async (
+  posthog: PostHog,
+  config: PostHogExecutionConfig,
+) => {
   const traces = getTracesForAnalyticsIntegrations(
     config.projectId,
     config.projectName,
@@ -83,43 +107,31 @@ const processPostHogTraces = async (config: PostHogExecutionConfig) => {
     `[POSTHOG] Sending traces for project ${config.projectId} to PostHog`,
   );
 
-  // Send each via PostHog SDK
-  const posthog = new PostHog(config.decryptedPostHogApiKey, {
-    host: config.postHogHost,
-    ...postHogSettings,
-    fetch: countingFetch(config.volume),
-  });
-
-  let sendError: Error | undefined;
-  posthog.on("error", (error) => {
-    logger.error(
-      `[POSTHOG] Error sending traces to PostHog for project ${config.projectId}: ${error}`,
-    );
-    sendError = error instanceof Error ? error : new Error(String(error));
-  });
-
   let count = 0;
   for await (const trace of traces) {
-    if (sendError) throw sendError;
+    if (config.sendError.current) throw config.sendError.current;
     count++;
     const event = transformTraceForPostHog(trace, config.projectId);
     posthog.capture(event);
-    if (count % 10000 === 0) {
-      await posthog.flush();
-      if (sendError) throw sendError;
+    if (count % postHogSettings.flushAt === 0) {
+      await flushWithDelay(posthog, true);
+      if (config.sendError.current) throw config.sendError.current;
       logger.info(
         `[POSTHOG] Sent ${count} traces to PostHog for project ${config.projectId}`,
       );
     }
   }
-  await posthog.flush();
-  if (sendError) throw sendError;
+  await flushWithDelay(posthog, count % postHogSettings.flushAt !== 0);
+  if (config.sendError.current) throw config.sendError.current;
   logger.info(
     `[POSTHOG] Sent ${count} traces to PostHog for project ${config.projectId}`,
   );
 };
 
-const processPostHogGenerations = async (config: PostHogExecutionConfig) => {
+const processPostHogGenerations = async (
+  posthog: PostHog,
+  config: PostHogExecutionConfig,
+) => {
   const generations = getGenerationsForAnalyticsIntegrations(
     config.projectId,
     config.projectName,
@@ -132,43 +144,31 @@ const processPostHogGenerations = async (config: PostHogExecutionConfig) => {
     `[POSTHOG] Sending generations for project ${config.projectId} to PostHog`,
   );
 
-  // Send each via PostHog SDK
-  const posthog = new PostHog(config.decryptedPostHogApiKey, {
-    host: config.postHogHost,
-    ...postHogSettings,
-    fetch: countingFetch(config.volume),
-  });
-
-  let sendError: Error | undefined;
-  posthog.on("error", (error) => {
-    logger.error(
-      `[POSTHOG] Error sending generations to PostHog for project ${config.projectId}: ${error}`,
-    );
-    sendError = error instanceof Error ? error : new Error(String(error));
-  });
-
   let count = 0;
   for await (const generation of generations) {
-    if (sendError) throw sendError;
+    if (config.sendError.current) throw config.sendError.current;
     count++;
     const event = transformGenerationForPostHog(generation, config.projectId);
     posthog.capture(event);
-    if (count % 10000 === 0) {
-      await posthog.flush();
-      if (sendError) throw sendError;
+    if (count % postHogSettings.flushAt === 0) {
+      await flushWithDelay(posthog, true);
+      if (config.sendError.current) throw config.sendError.current;
       logger.info(
         `[POSTHOG] Sent ${count} generations to PostHog for project ${config.projectId}`,
       );
     }
   }
-  await posthog.flush();
-  if (sendError) throw sendError;
+  await flushWithDelay(posthog, count % postHogSettings.flushAt !== 0);
+  if (config.sendError.current) throw config.sendError.current;
   logger.info(
     `[POSTHOG] Sent ${count} generations to PostHog for project ${config.projectId}`,
   );
 };
 
-const processPostHogScores = async (config: PostHogExecutionConfig) => {
+const processPostHogScores = async (
+  posthog: PostHog,
+  config: PostHogExecutionConfig,
+) => {
   const scores = getScoresForAnalyticsIntegrations(
     config.projectId,
     config.projectName,
@@ -181,43 +181,31 @@ const processPostHogScores = async (config: PostHogExecutionConfig) => {
     `[POSTHOG] Sending scores for project ${config.projectId} to PostHog`,
   );
 
-  // Send each via PostHog SDK
-  const posthog = new PostHog(config.decryptedPostHogApiKey, {
-    host: config.postHogHost,
-    ...postHogSettings,
-    fetch: countingFetch(config.volume),
-  });
-
-  let sendError: Error | undefined;
-  posthog.on("error", (error) => {
-    logger.error(
-      `[POSTHOG] Error sending scores to PostHog for project ${config.projectId}: ${error}`,
-    );
-    sendError = error instanceof Error ? error : new Error(String(error));
-  });
-
   let count = 0;
   for await (const score of scores) {
-    if (sendError) throw sendError;
+    if (config.sendError.current) throw config.sendError.current;
     count++;
     const event = transformScoreForPostHog(score, config.projectId);
     posthog.capture(event);
-    if (count % 10000 === 0) {
-      await posthog.flush();
-      if (sendError) throw sendError;
+    if (count % postHogSettings.flushAt === 0) {
+      await flushWithDelay(posthog, true);
+      if (config.sendError.current) throw config.sendError.current;
       logger.info(
         `[POSTHOG] Sent ${count} scores to PostHog for project ${config.projectId}`,
       );
     }
   }
-  await posthog.flush();
-  if (sendError) throw sendError;
+  await flushWithDelay(posthog, count % postHogSettings.flushAt !== 0);
+  if (config.sendError.current) throw config.sendError.current;
   logger.info(
     `[POSTHOG] Sent ${count} scores to PostHog for project ${config.projectId}`,
   );
 };
 
-const processPostHogEvents = async (config: PostHogExecutionConfig) => {
+const processPostHogEvents = async (
+  posthog: PostHog,
+  config: PostHogExecutionConfig,
+) => {
   const events = getEventsForAnalyticsIntegrations(
     config.projectId,
     config.projectName,
@@ -229,36 +217,22 @@ const processPostHogEvents = async (config: PostHogExecutionConfig) => {
     `[POSTHOG] Sending events for project ${config.projectId} to PostHog`,
   );
 
-  // Send each via PostHog SDK
-  const posthog = new PostHog(config.decryptedPostHogApiKey, {
-    host: config.postHogHost,
-    ...postHogSettings,
-    fetch: countingFetch(config.volume),
-  });
-
-  let sendError: Error | undefined;
-  posthog.on("error", (error) => {
-    logger.error(
-      `[POSTHOG] Error sending events to PostHog for project ${config.projectId}: ${error}`,
-    );
-    sendError = error instanceof Error ? error : new Error(String(error));
-  });
-
   let count = 0;
   for await (const analyticsEvent of events) {
-    if (sendError) throw sendError;
+    if (config.sendError.current) throw config.sendError.current;
     count++;
     const event = transformEventForPostHog(analyticsEvent, config.projectId);
     posthog.capture(event);
-    if (count % 10000 === 0) {
-      await posthog.flush();
+    if (count % postHogSettings.flushAt === 0) {
+      await flushWithDelay(posthog, true);
+      if (config.sendError.current) throw config.sendError.current;
       logger.info(
         `[POSTHOG] Sent ${count} events to PostHog for project ${config.projectId}`,
       );
     }
   }
-  await posthog.flush();
-  if (sendError) throw sendError;
+  await flushWithDelay(posthog, count % postHogSettings.flushAt !== 0);
+  if (config.sendError.current) throw config.sendError.current;
   logger.info(
     `[POSTHOG] Sent ${count} events to PostHog for project ${config.projectId}`,
   );
@@ -362,6 +336,7 @@ export const handlePostHogIntegrationProjectJob = async (
     postHogHost: postHogIntegration.posthogHostName,
     useGraceHash: job.attemptsMade > 0,
     volume: { bytes: 0 },
+    sendError: {},
   };
 
   try {
@@ -372,31 +347,48 @@ export const handlePostHogIntegrationProjectJob = async (
       "Select the enriched observations export source in the PostHog integration settings.",
     );
 
-    const processPromises: Promise<void>[] = [];
+    // Reuse a single client and run streams sequentially so the per-job export
+    // rate stays bounded. Running the streams in parallel with one client each
+    // produced an unbounded burst that overwhelmed the target (issue #12786).
+    const posthog = new PostHog(executionConfig.decryptedPostHogApiKey, {
+      host: executionConfig.postHogHost,
+      ...postHogSettings,
+      fetch: countingFetch(executionConfig.volume),
+    });
 
-    // Always include scores
-    processPromises.push(processPostHogScores(executionConfig));
-
-    // Traces and observations - for TRACES_OBSERVATIONS and TRACES_OBSERVATIONS_EVENTS
-    if (
-      postHogIntegration.exportSource === "TRACES_OBSERVATIONS" ||
-      postHogIntegration.exportSource === "TRACES_OBSERVATIONS_EVENTS"
-    ) {
-      processPromises.push(
-        processPostHogTraces(executionConfig),
-        processPostHogGenerations(executionConfig),
+    posthog.on("error", (error) => {
+      logger.error(
+        `[POSTHOG] Error sending events to PostHog for project ${projectId}: ${error}`,
       );
-    }
+      executionConfig.sendError.current =
+        error instanceof Error ? error : new Error(String(error));
+    });
 
-    // Events - for EVENTS and TRACES_OBSERVATIONS_EVENTS
-    if (
-      postHogIntegration.exportSource === "EVENTS" ||
-      postHogIntegration.exportSource === "TRACES_OBSERVATIONS_EVENTS"
-    ) {
-      processPromises.push(processPostHogEvents(executionConfig));
-    }
+    try {
+      // Always include scores
+      await processPostHogScores(posthog, executionConfig);
 
-    await Promise.all(processPromises);
+      // Traces and observations - for TRACES_OBSERVATIONS and TRACES_OBSERVATIONS_EVENTS
+      if (
+        postHogIntegration.exportSource === "TRACES_OBSERVATIONS" ||
+        postHogIntegration.exportSource === "TRACES_OBSERVATIONS_EVENTS"
+      ) {
+        await processPostHogTraces(posthog, executionConfig);
+        await processPostHogGenerations(posthog, executionConfig);
+      }
+
+      // Events - for EVENTS and TRACES_OBSERVATIONS_EVENTS
+      if (
+        postHogIntegration.exportSource === "EVENTS" ||
+        postHogIntegration.exportSource === "TRACES_OBSERVATIONS_EVENTS"
+      ) {
+        await processPostHogEvents(posthog, executionConfig);
+      }
+    } finally {
+      // Flush remaining events and stop the SDK's background flush timer so
+      // nothing leaks per job in the long-running worker process.
+      await posthog.shutdown();
+    }
 
     // Update the last run information for the postHogIntegration record.
     await prisma.posthogIntegration.update({


### PR DESCRIPTION
## What does this PR do?

Fixes the PostHog half of #12786: the PostHog integration export ran all streams (scores, traces, generations, events) concurrently via `Promise.all`, each with its own `posthog-node` client and no throttling, which produced unbounded export bursts (~18k events/sec observed in production) that overwhelmed target PostHog instances.

This ports the already-merged Mixpanel fix (#13958) to the PostHog integration:

- **Single reused client per job** instead of one client per stream.
- **Sequential stream execution** (scores -> traces -> generations -> events) instead of `Promise.all`.
- **Configurable inter-flush delay** via `LANGFUSE_POSTHOG_FLUSH_DELAY_MS` (default 100ms, matching `LANGFUSE_MIXPANEL_FLUSH_DELAY_MS`), applied on every 1000-event flush (aligned with the SDK's `flushAt: 1000`).
- **`posthog.shutdown()` in a `finally` block** so the SDK's background flush timer and connections are cleaned up per job, even when a stream fails. This addresses the unresolved review finding on #13773, which this PR supersedes (that PR has been inactive since June 9).

The single client also means the shared `on(error)` handler now covers all streams, fixing a missed error check after flush in the events stream.

Fixes #12786

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project (`pnpm run format`)
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings (eslint `--max-warnings 0` passes on changed files)
- I have added tests that prove my fix is effective (single client, sequential streams, shutdown on success and on stream failure) while keeping the existing LFE-10148 guard tests green
- New and existing unit tests pass locally (`posthogIntegrationProjectJob`, `mixpanelIntegrationProjectJob`, `posthogExportVolume`; worker typecheck clean)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes unbounded export bursts in the PostHog integration (issue #12786) by mirroring the previously merged Mixpanel throttling fix. The original code created one `PostHog` client per stream and ran all four streams concurrently via `Promise.all`, which could produce ~18k events/sec bursts.

- Replaces per-stream `PostHog` clients with a single shared client constructed once per job; all four streams now run sequentially (`scores → traces → generations → events`), and flush-induced bursts are throttled by a configurable `LANGFUSE_POSTHOG_FLUSH_DELAY_MS` delay (default 100 ms, matching the Mixpanel setting).
- Adds `posthog.shutdown()` in a `finally` block so the SDK's background flush timer is always cleaned up per job, even when a stream fails mid-export.
- Adds a comprehensive test suite covering single-client reuse, sequential execution (via concurrency tracking), and shutdown on both success and failure paths.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The throttling change is well-scoped, closely mirrors the already-shipped Mixpanel fix, and is covered by targeted unit tests.

The only issue found is a log message that says 'sending events' when the shared error handler now covers all four stream types — misleading in production when a trace or score flush fails. All logic around sequential execution, shutdown-in-finally, and the configurable flush delay is correct and well-tested.

handlePostHogIntegrationProjectJob.ts — the on('error') log message wording.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as handlePostHogIntegrationProjectJob
    participant PH as PostHog Client (single)
    participant DB as Prisma DB

    Job->>Handler: execute(job)
    Handler->>DB: findFirst(posthogIntegration)
    Handler->>Handler: assertLegacyExportSourceWritable()
    Handler->>PH: "new PostHog(apiKey, {flushAt:1000})"
    Handler->>PH: on(error, handler)

    Note over Handler,PH: Inner try block (sequential)
    Handler->>PH: processPostHogScores() await
    loop every 1000 scores
        Handler->>PH: capture(event)
        Handler->>PH: flush() + sleep(FLUSH_DELAY_MS)
    end
    Handler->>PH: terminal flush()
    Handler->>PH: processPostHogTraces() await
    Handler->>PH: processPostHogGenerations() await
    Handler->>PH: processPostHogEvents() await

    Note over Handler,PH: finally (always runs)
    Handler->>PH: shutdown()

    Handler->>DB: update(lastSyncAt)
    Handler->>Job: done
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as handlePostHogIntegrationProjectJob
    participant PH as PostHog Client (single)
    participant DB as Prisma DB

    Job->>Handler: execute(job)
    Handler->>DB: findFirst(posthogIntegration)
    Handler->>Handler: assertLegacyExportSourceWritable()
    Handler->>PH: "new PostHog(apiKey, {flushAt:1000})"
    Handler->>PH: on(error, handler)

    Note over Handler,PH: Inner try block (sequential)
    Handler->>PH: processPostHogScores() await
    loop every 1000 scores
        Handler->>PH: capture(event)
        Handler->>PH: flush() + sleep(FLUSH_DELAY_MS)
    end
    Handler->>PH: terminal flush()
    Handler->>PH: processPostHogTraces() await
    Handler->>PH: processPostHogGenerations() await
    Handler->>PH: processPostHogEvents() await

    Note over Handler,PH: finally (always runs)
    Handler->>PH: shutdown()

    Handler->>DB: update(lastSyncAt)
    Handler->>Job: done
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts:359-362
The consolidated `on("error")` handler message hardcodes "sending events" even though the handler now covers all four stream types (scores, traces, generations, and events). When a flush error originates from the scores or traces stream, the log will say "sending events", which will mislead anyone debugging from production logs.

```suggestion
    posthog.on("error", (error) => {
      logger.error(
        `[POSTHOG] Error sending data to PostHog for project ${projectId}: ${error}`,
      );
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): throttle PostHog integratio..."](https://github.com/langfuse/langfuse/commit/a368bc0e385a9c828b69bdc3a9cd46f2b1a2568f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45427741)</sub>

<!-- /greptile_comment -->