### PR TITLE
fix(ui): point annotation queue help links to annotation queues docs

### DIFF
--- a/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
@@ -468,7 +468,7 @@ export function AnnotationQueueItemsTable({
         help={{
           description:
             "Add traces and/or observations to your annotation queue to have them annotated by your team across predefined dimensions.",
-          href: "https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge",
+          href: "https://langfuse.com/docs/evaluation/evaluation-methods/annotation-queues",
         }}
         pagination={{
           totalCount: items.data?.totalItems ?? null,

--- a/web/src/features/annotation-queues/pages/AnnotationQueues.tsx
+++ b/web/src/features/annotation-queues/pages/AnnotationQueues.tsx
@@ -40,7 +40,7 @@ export default function AnnotationQueues() {
         help: {
           description:
             "Annotation queues are used to manage scoring workflows for your LLM projects. See docs to learn more.",
-          href: "https://langfuse.com/docs/evaluation/evaluation-methods/annotation",
+          href: "https://langfuse.com/docs/evaluation/evaluation-methods/annotation-queues",
         },
         actionButtonsRight: (
           <CreateOrEditAnnotationQueueButton


### PR DESCRIPTION
## What does this PR do?

Two help popups in the Annotation Queues feature link to the wrong docs pages:

- **Annotation Queues list page** (header ⓘ) → links to `/docs/evaluation/evaluation-methods/annotation`, which is the **Scores via UI** (manual annotation) page.
- **Queue items table** (empty-state ⓘ) → links to `/docs/evaluation/evaluation-methods/llm-as-a-judge`, a different feature entirely — and the empty state is exactly when a new user is looking for guidance on how to add items.

Both now point to the dedicated [Annotation Queues docs page](https://langfuse.com/docs/evaluation/evaluation-methods/annotation-queues).

Context: the list-page link dates from the docs-structure link sweep in #8552; the docs were restructured again afterwards, leaving these two behind. Other usages of the manual-annotation URL (`ScoreConfigSettings`, `AnnotationForm`) are correct for their context and left unchanged.

**Verify:** in the PR preview, open *Annotation Queues* → hover/click the header ⓘ; and open an empty queue → "No results." ⓘ.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two stale help-link URLs in the Annotation Queues feature that were pointing to unrelated docs pages (manual annotation UI and LLM-as-a-judge). Both now point to the dedicated Annotation Queues docs page at `/docs/evaluation/evaluation-methods/annotation-queues`, which was confirmed to be a live, correct page.

- **`AnnotationQueues.tsx`**: The page-header `ⓘ` help link now targets the Annotation Queues docs instead of the generic "Scores via UI" page.
- **`AnnotationQueueItemsTable.tsx`**: The empty-state `ⓘ` help link now targets the Annotation Queues docs instead of the LLM-as-a-judge page, which is a different feature entirely.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Two isolated string constant replacements with no logic changes — safe to merge.

Both changed URLs were verified to point to the correct, live Annotation Queues docs page. No functional code, state, or component logic was touched; the fix is narrowly scoped to two href strings in help-popup props.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Annotation Queues] --> B{Which UI element?}
    B --> C[Page header ⓘ icon]
    B --> D[Empty queue ⓘ icon]

    C --> |Before| E["❌ /docs/evaluation/evaluation-methods/annotation\n(Scores via UI page)"]
    C --> |After| F["✅ /docs/evaluation/evaluation-methods/annotation-queues\n(Annotation Queues page)"]

    D --> |Before| G["❌ /docs/evaluation/evaluation-methods/llm-as-a-judge\n(Wrong feature entirely)"]
    D --> |After| H["✅ /docs/evaluation/evaluation-methods/annotation-queues\n(Annotation Queues page)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User opens Annotation Queues] --> B{Which UI element?}
    B --> C[Page header ⓘ icon]
    B --> D[Empty queue ⓘ icon]

    C --> |Before| E["❌ /docs/evaluation/evaluation-methods/annotation\n(Scores via UI page)"]
    C --> |After| F["✅ /docs/evaluation/evaluation-methods/annotation-queues\n(Annotation Queues page)"]

    D --> |Before| G["❌ /docs/evaluation/evaluation-methods/llm-as-a-judge\n(Wrong feature entirely)"]
    D --> |After| H["✅ /docs/evaluation/evaluation-methods/annotation-queues\n(Annotation Queues page)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): point annotation queue help lin..."](https://github.com/langfuse/langfuse/commit/c52698aee8cab89d110ad36511668f911bbb7467) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45467703)</sub>

<!-- /greptile_comment -->