### PR TITLE
fix(evals): scrollable evaluator list in "Evaluate observations" dialog

### DIFF
--- a/web/src/features/batch-actions/components/RunEvaluationDialog/EvaluatorSelectionStep.tsx
+++ b/web/src/features/batch-actions/components/RunEvaluationDialog/EvaluatorSelectionStep.tsx
@@ -92,8 +92,8 @@ export function EvaluatorSelectionStep(props: EvaluatorSelectionStepProps) {
   };
 
   return (
-    <div className="flex h-full flex-col gap-2">
-      <div className="min-h-0 flex-1">
+    <div className="flex h-full min-h-0 flex-col gap-2">
+      <div className="flex min-h-0 flex-1 flex-col">
         {isQueryLoading ? (
           <p className="text-muted-foreground text-sm">Loading evaluators...</p>
         ) : isQueryError ? (


### PR DESCRIPTION
**TL;DR** — The evaluator list in the "Evaluate {count} observations" dialog overflowed and was clipped with no scrollbar when a project had many evaluators configured. Two Tailwind classes on the selection step's wrapper chain restore the intended in-dialog scroll. Fixes [LFE-11053](https://linear.app/langfuse/issue/LFE-11053).

**Why** — `DialogContent` is a bounded `max-h-[62vh]` flex column and its `DialogBody` is correctly clipped, but `EvaluatorSelectionStep`'s own wrapper chain broke the bounded height before it reached the inner scroll list, so a long list grew past the dialog and got clipped instead of scrolling — leaving no way to reach evaluators below the fold.

**What** — Two classes on the step's wrapper chain:
- add `min-h-0` to the step root so it can shrink below its content instead of overflowing the body;
- make the intermediate content wrapper a flex column so its child's `h-full` height resolves.

The list's own `min-h-0 flex-1 overflow-y-auto` was already correct; it just never received a bounded parent.

**Result** — Long evaluator lists scroll inside the dialog with the footer pinned and visible; short lists are unchanged (no spurious scrollbar).

<details><summary>Verification</summary>

Verified live in the browser with 30 evaluators: the list scrolls internally (`scrollTop` 0 → max), the footer stays visible, and the list stays within the dialog bounds; a computed-style walk confirms every wrapper from `DialogContent` down to the list is now height-bounded (`scrollHeight === clientHeight` at each level except the intended scroll container). Filtered to a single evaluator: no scrollbar, dialog shrinks, footer visible. An independent review confirmed the loading / error / empty states are unaffected (they render a single top-aligned child that was already inside a `flex-1` wrapper). Typecheck + lint pass.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a CSS flexbox layout bug where the evaluator list in the "Evaluate observations" dialog overflowed the bounded `DialogContent` instead of scrolling. The root cause was a missing `min-h-0` on the step's root element (preventing shrink below content height) and a missing `flex flex-col` on its intermediate wrapper (preventing the child's `h-full` from resolving).

- Adds `min-h-0` to the step root `div` so the flex child can compress within the dialog's `max-h-[62vh]` bound.
- Adds `flex flex-col` to the intermediate wrapper so the inner scroll container's `flex-1` / `h-full` resolves correctly, making the list scrollable inside the dialog with the footer pinned.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is two additive Tailwind classes with no logic or API surface touched.

Both changes are well-understood flexbox layout fixes: min-h-0 on the step root lets it compress inside the bounded dialog, and flex flex-col on the intermediate wrapper gives the inner scroll container a proper flex parent so its flex-1 resolves. Short evaluator lists and the loading/error/empty states are unaffected because those children render at their natural height inside the same flex-1 wrapper. No logic, state, or API surface is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    DC["DialogContent\nmax-h-[62vh] · flex · flex-col"]
    DB["DialogBody\nflex-1 · overflow-hidden"]
    ESS["EvaluatorSelectionStep root\nflex · flex-col · h-full\n+ min-h-0 NEW"]
    IW["Intermediate wrapper\nflex-1\n+ flex · flex-col NEW\n(min-h-0 already present)"]
    states["Loading / Error / Empty states\n(single child, unaffected)"]
    innerFlex["Inner flex column\nflex · flex-col · h-full · gap-2\n(min-h-0 already present)"]
    search["Search input\n(static height)"]
    badges["Selected badges row\n(static height)"]
    list["Evaluator list\nmin-h-0 · flex-1 · overflow-y-auto\n(was correct — needed bounded parent)"]
    footer["Create new Evaluator button\n(always visible)"]

    DC --> DB
    DB --> ESS
    ESS --> IW
    ESS --> footer
    IW --> states
    IW --> innerFlex
    innerFlex --> search
    innerFlex --> badges
    innerFlex --> list
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    DC["DialogContent\nmax-h-[62vh] · flex · flex-col"]
    DB["DialogBody\nflex-1 · overflow-hidden"]
    ESS["EvaluatorSelectionStep root\nflex · flex-col · h-full\n+ min-h-0 NEW"]
    IW["Intermediate wrapper\nflex-1\n+ flex · flex-col NEW\n(min-h-0 already present)"]
    states["Loading / Error / Empty states\n(single child, unaffected)"]
    innerFlex["Inner flex column\nflex · flex-col · h-full · gap-2\n(min-h-0 already present)"]
    search["Search input\n(static height)"]
    badges["Selected badges row\n(static height)"]
    list["Evaluator list\nmin-h-0 · flex-1 · overflow-y-auto\n(was correct — needed bounded parent)"]
    footer["Create new Evaluator button\n(always visible)"]

    DC --> DB
    DB --> ESS
    ESS --> IW
    ESS --> footer
    IW --> states
    IW --> innerFlex
    innerFlex --> search
    innerFlex --> badges
    innerFlex --> list
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): scrollable evaluator list in..."](https://github.com/langfuse/langfuse/commit/67d73dc8c0a4e24d202a7475cb70bb69a1208f17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45581265)</sub>

<!-- /greptile_comment -->