### PR TITLE
chore(worker): emit per-queue DLQ oldest-job-age gauge (LFE-11064)

### DIFF
--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -326,7 +326,7 @@ const flushMetricsToCloudWatch = () => {
 
 // Metrics ending with these suffixes have their tags flattened into the
 // CloudWatch metric name (excluding "unit"). Other metrics are unaffected.
-const CW_TAG_FLATTENED_SUFFIXES = [".depth", ".rate"];
+const CW_TAG_FLATTENED_SUFFIXES = [".depth", ".rate", ".dlq_oldest_age"];
 
 function buildCloudWatchKey(
   stat: string,

--- a/worker/src/__tests__/workerManager.test.ts
+++ b/worker/src/__tests__/workerManager.test.ts
@@ -19,11 +19,10 @@ const extractProjectId = (data: unknown): string | undefined =>
   ).extractProjectId({ data });
 
 const computeDlqOldestAgeMs = (jobs: unknown[], nowMs: number): number =>
-  (
-    WorkerManager as unknown as {
-      computeDlqOldestAgeMs(jobs: unknown[], nowMs: number): number;
-    }
-  ).computeDlqOldestAgeMs(jobs, nowMs);
+  WorkerManager.computeDlqOldestAgeMs(
+    jobs as Parameters<typeof WorkerManager.computeDlqOldestAgeMs>[0],
+    nowMs,
+  );
 
 const resolveMetricInfo = (queueName: QueueName) =>
   (

--- a/worker/src/__tests__/workerManager.test.ts
+++ b/worker/src/__tests__/workerManager.test.ts
@@ -1,6 +1,14 @@
+import { randomUUID } from "crypto";
+
+import { Queue, Worker } from "bullmq";
 import { describe, expect, it } from "vitest";
 
-import { QueueName } from "@langfuse/shared/src/server";
+import {
+  createNewRedisInstance,
+  getQueuePrefix,
+  QueueName,
+  redisQueueRetryOptions,
+} from "@langfuse/shared/src/server";
 import { WorkerManager } from "../queues/workerManager";
 
 const extractProjectId = (data: unknown): string | undefined =>
@@ -9,6 +17,13 @@ const extractProjectId = (data: unknown): string | undefined =>
       extractProjectId(job: { data: unknown }): string | undefined;
     }
   ).extractProjectId({ data });
+
+const computeDlqOldestAgeMs = (jobs: unknown[], nowMs: number): number =>
+  (
+    WorkerManager as unknown as {
+      computeDlqOldestAgeMs(jobs: unknown[], nowMs: number): number;
+    }
+  ).computeDlqOldestAgeMs(jobs, nowMs);
 
 const resolveMetricInfo = (queueName: QueueName) =>
   (
@@ -73,5 +88,85 @@ describe("WorkerManager", () => {
           .baseMetric,
       ).toBe("langfuse.queue.ingestion");
     });
+  });
+
+  describe("computeDlqOldestAgeMs", () => {
+    it("returns 0 for an empty failed set", () => {
+      expect(computeDlqOldestAgeMs([], 5_000)).toBe(0);
+    });
+
+    it("measures age from the first job's finishedOn", () => {
+      expect(
+        computeDlqOldestAgeMs([{ finishedOn: 1_000, timestamp: 500 }], 4_000),
+      ).toBe(3_000);
+    });
+
+    it("falls back to timestamp when finishedOn is missing", () => {
+      expect(computeDlqOldestAgeMs([{ timestamp: 500 }], 4_000)).toBe(3_500);
+    });
+
+    it("skips undefined entries from stale job ids", () => {
+      expect(
+        computeDlqOldestAgeMs([undefined, { finishedOn: 1_000 }], 4_000),
+      ).toBe(3_000);
+    });
+  });
+
+  describe("dlq oldest job lookup", () => {
+    it("getFailed returns newest-first, so index -1 is the oldest job", async () => {
+      const queueName = `dlq-oldest-age-${randomUUID()}`;
+      const redis = createNewRedisInstance({
+        enableOfflineQueue: false,
+        ...redisQueueRetryOptions,
+      });
+      if (!redis) throw new Error("Failed to create redis instance");
+
+      const queue = new Queue(queueName, {
+        connection: redis,
+        prefix: getQueuePrefix(queueName),
+      });
+      const worker = new Worker(
+        queueName,
+        async () => {
+          throw new Error("always fails");
+        },
+        { connection: redis, prefix: getQueuePrefix(queueName) },
+      );
+
+      const waitForFailedCount = async (expected: number) => {
+        const deadline = Date.now() + 15_000;
+        while ((await queue.getFailedCount()) < expected) {
+          if (Date.now() > deadline) {
+            throw new Error(`Timed out waiting for ${expected} failed jobs`);
+          }
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+      };
+
+      try {
+        await queue.add("job", { order: "oldest" });
+        await waitForFailedCount(1);
+        // Failure timestamps have ms resolution; keep them distinct.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        await queue.add("job", { order: "newest" });
+        await waitForFailedCount(2);
+
+        const newestFirst = await queue.getFailed();
+        expect(newestFirst.map((job) => job.data.order)).toEqual([
+          "newest",
+          "oldest",
+        ]);
+
+        const [oldest] = await queue.getFailed(-1, -1);
+        expect(oldest.data.order).toBe("oldest");
+        expect(oldest.finishedOn).toBeDefined();
+        expect(oldest.finishedOn!).toBeLessThan(newestFirst[0].finishedOn!);
+      } finally {
+        await worker.close();
+        await queue.obliterate({ force: true });
+        await queue.close();
+        redis.disconnect();
+      }
+    }, 30_000);
   });
 });

--- a/worker/src/features/queue-metrics-runner/index.ts
+++ b/worker/src/features/queue-metrics-runner/index.ts
@@ -144,6 +144,48 @@ export class QueueMetricsRunner extends PeriodicRunner {
 
       const metricBase = convertQueueNameToMetricName(config.baseQueueName);
 
+      const agePromises = shardNames.map((shardName) => {
+        const queue = config.getInstance(shardName);
+        if (!queue) return Promise.resolve(null);
+
+        return queue
+          .getFailed(-1, -1)
+          .then((jobs) => {
+            const age = WorkerManager.computeDlqOldestAgeMs(jobs, Date.now());
+            recordGauge(metricBase + ".dlq_oldest_age", age, {
+              shard: shardName,
+              unit: "milliseconds",
+            });
+            return age;
+          })
+          .catch((err) => {
+            logger.error(
+              `Queue metrics: failed to collect dlq oldest age for ${shardName}`,
+              err,
+            );
+            return null;
+          });
+      });
+
+      // Aggregate is the max across shards (the oldest job overall); unlike
+      // depth there is nothing to extrapolate for failed shards.
+      promises.push(
+        Promise.allSettled(agePromises).then((results) => {
+          const ages: number[] = [];
+          for (const result of results) {
+            if (result.status === "fulfilled" && result.value !== null) {
+              ages.push(result.value);
+            }
+          }
+          if (ages.length === 0) return;
+
+          recordGauge(metricBase + ".dlq_oldest_age", Math.max(...ages), {
+            shard: "all",
+            unit: "milliseconds",
+          });
+        }),
+      );
+
       const shardPromises = shardNames.map((shardName) => {
         const queue = config.getInstance(shardName);
         if (!queue) return Promise.resolve(null);

--- a/worker/src/features/queue-metrics-runner/index.ts
+++ b/worker/src/features/queue-metrics-runner/index.ts
@@ -89,6 +89,24 @@ export class QueueMetricsRunner extends PeriodicRunner {
       const metricBase = convertQueueNameToMetricName(queueName);
 
       promises.push(
+        queue
+          .getFailed(-1, -1)
+          .then((jobs) => {
+            recordGauge(
+              metricBase + ".dlq_oldest_age",
+              WorkerManager.computeDlqOldestAgeMs(jobs, Date.now()),
+              { unit: "milliseconds" },
+            );
+          })
+          .catch((err) => {
+            logger.error(
+              `Queue metrics: failed to collect dlq oldest age for ${queueName}`,
+              err,
+            );
+          }),
+      );
+
+      promises.push(
         collectDepth(queue)
           .then((depths) => {
             if (depths) {

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -60,7 +60,7 @@ export class WorkerManager {
 
   // Empty failed set emits 0 so monitors see the gauge reset after a DLQ
   // drain.
-  private static computeDlqOldestAgeMs(
+  public static computeDlqOldestAgeMs(
     jobs: (Job | undefined)[],
     nowMs: number,
   ): number {

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -58,6 +58,16 @@ export class WorkerManager {
     };
   }
 
+  // Empty failed set emits 0 so monitors see the gauge reset after a DLQ
+  // drain.
+  private static computeDlqOldestAgeMs(
+    jobs: (Job | undefined)[],
+    nowMs: number,
+  ): number {
+    const oldest = jobs.find(Boolean);
+    return oldest ? nowMs - (oldest.finishedOn ?? oldest.timestamp) : 0;
+  }
+
   private static metricWrapper(
     processor: Processor,
     queueName: QueueName,
@@ -113,6 +123,15 @@ export class WorkerManager {
             recordGauge(oldMetric + ".dlq_length", count, {
               unit: "records",
             });
+          }),
+          // getFailed returns newest-first (ZREVRANGE on failure time), so
+          // index -1 is the oldest job.
+          queue?.getFailed(-1, -1).then((jobs) => {
+            recordGauge(
+              oldMetric + ".dlq_oldest_age",
+              WorkerManager.computeDlqOldestAgeMs(jobs, Date.now()),
+              { unit: "milliseconds" },
+            );
           }),
           queue?.getActiveCount().then((count) => {
             recordGauge(oldMetric + ".active", count, {


### PR DESCRIPTION
## What does this PR do?

Emits a new gauge `langfuse.queue.<queue>.dlq_oldest_age` (milliseconds) = now − failure time of the oldest job in each queue's BullMQ failed set, from two emission paths mirroring `dlq_length`:

1. `WorkerManager.metricWrapper` on job processing (same sample-rate gating as the sibling gauges, one extra Redis call per sampled job).
2. `QueueMetricsRunner` on the periodic `LANGFUSE_QUEUE_METRICS_INTERVAL_MS` interval for all queues with registered workers — non-sharded queues under the plain metric name, sharded queues per shard with a `shard` tag plus a `shard:"all"` max aggregate (the oldest job overall) — so the gauge keeps advancing for idle queues/shards with a static pile of failed jobs, which is exactly the scenario age-based alerting exists for.

DLQ depth alone can't distinguish a static corpse pile from an active failure bleed, and says nothing about whether jobs are still replayable before the events-bucket lifecycle expires them. Age is the canonical DLQ alerting signal (cf. SQS `ApproximateAgeOfOldestMessage`) and enables migrating DLQ monitors from absolute-depth thresholds to age/growth-based conditions.

Details:
- BullMQ's `getFailed()` returns jobs newest-first (`ZREVRANGE` on failure time), so the oldest job is fetched via `getFailed(-1, -1)` — pinned by a Redis-backed test.
- Failure time = `finishedOn`, falling back to `timestamp`.
- Empty failed set emits 0, so monitors see the gauge reset after a DLQ drain.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have added tests that prove my feature works (`worker/src/__tests__/workerManager.test.ts`)
- New and existing unit tests pass locally with my changes (`Tests  11 passed (11)`)
- Lint and typecheck pass (`pnpm turbo run lint|typecheck --filter=worker`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
