### PR TITLE
perf(worker): prioritize retention cleanup by expiry lag

### DIFF
--- a/worker/src/__tests__/batchDataRetentionCleaner.test.ts
+++ b/worker/src/__tests__/batchDataRetentionCleaner.test.ts
@@ -38,10 +38,12 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
     queryClickhouse: async <T>(
       opts: Parameters<typeof actual.queryClickhouse>[0],
     ) => {
+      const candidateProjectIds = opts.params?.candidateProjectIds;
       if (
-        opts.query.includes("AS oldest_age_seconds") &&
+        opts.query.includes("AS oldest_timestamp") &&
         integrationHooks.failExactEnrichmentForProjectId !== null &&
-        Object.values(opts.params ?? {}).includes(
+        Array.isArray(candidateProjectIds) &&
+        candidateProjectIds.includes(
           integrationHooks.failExactEnrichmentForProjectId,
         )
       ) {
@@ -138,7 +140,7 @@ async function insertRetentionTestRows(
     values: rows.map((row) => ({
       project_id: row.projectId,
       start_time: row.startTime,
-      event_ts: row.startTime,
+      event_ts: Date.now(),
     })),
   });
 }
@@ -166,6 +168,13 @@ async function getRetentionTestProjectCount(
     params: { projectId },
   });
   return Number(result[0]?.count ?? 0);
+}
+
+function getLastGaugeValue(stat: string): number {
+  return (
+    integrationHooks.gaugeCalls.findLast(([name]) => name === stat)?.[1] ??
+    Number.NaN
+  );
 }
 
 describe("BatchDataRetentionCleaner", () => {
@@ -483,43 +492,66 @@ describe("BatchDataRetentionCleaner", () => {
       await commandClickhouse({ query: `DROP TABLE IF EXISTS ${tableName}` });
     });
 
-    it("discovers expired projects across every configured project chunk", async () => {
-      const projectIds = await createProjectsWithRetention(3);
+    it("prioritizes lag, breaks ties by total rows, and reports maximum lag", async () => {
+      const [
+        smallerTieProjectId,
+        largerTieProjectId,
+        olderButLessLateProjectId,
+      ] = await createProjectsWithRetention(3);
+      await prisma.project.update({
+        where: { id: olderButLessLateProjectId! },
+        data: { retentionDays: 59 },
+      });
+
+      const now = Date.now();
+      const dayMs = 24 * 60 * 60 * 1000;
+      const rowsAtDaysAgo = (projectId: string, daysAgo: number[]) =>
+        daysAgo.map((days) => ({
+          projectId,
+          startTime: now - days * dayMs,
+        }));
       await insertRetentionTestRows(
         tableName,
-        projectIds.map((projectId) => ({
-          projectId,
-          startTime: Date.now() - 10 * 24 * 60 * 60 * 1000,
-        })),
+        rowsAtDaysAgo(smallerTieProjectId!, [10, 9]).concat(
+          rowsAtDaysAgo(largerTieProjectId!, [10, 2, 1]),
+          rowsAtDaysAgo(olderButLessLateProjectId!, [60]),
+        ),
       );
       env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CHUNK_SIZE = 2;
-      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT = 3;
+      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT = 1;
 
       await new BatchDataRetentionCleaner(table).processBatch();
 
-      expect(await getRetentionTestRowCount(tableName)).toBe(0);
-      expect(integrationHooks.incrementCalls).toContainEqual([
-        "langfuse.batch_data_retention_cleaner.rows_matched_before_delete",
-        3,
-      ]);
-      expect(integrationHooks.candidateHttpTimeouts.length).toBeGreaterThan(0);
-      for (const timeouts of integrationHooks.candidateHttpTimeouts) {
-        const expectedTimeoutSeconds = Math.ceil(
-          env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CANDIDATE_QUERY_TIMEOUT_MS /
-            1000,
-        );
-        expect(timeouts).toEqual({
-          send: expectedTimeoutSeconds,
-          receive: expectedTimeoutSeconds,
-        });
-      }
       expect(
-        integrationHooks.gaugeCalls.findLast(
-          ([stat]) =>
-            stat ===
-            "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
-        )?.[1],
-      ).toBeGreaterThan(0);
+        await Promise.all(
+          [
+            smallerTieProjectId!,
+            largerTieProjectId!,
+            olderButLessLateProjectId!,
+          ].map((projectId) =>
+            getRetentionTestProjectCount(tableName, projectId),
+          ),
+        ),
+      ).toEqual([2, 2, 1]);
+      const expectedTimeoutSeconds = Math.ceil(
+        env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CANDIDATE_QUERY_TIMEOUT_MS /
+          1000,
+      );
+      expect(integrationHooks.candidateHttpTimeouts[0]).toEqual({
+        send: expectedTimeoutSeconds,
+        receive: expectedTimeoutSeconds,
+      });
+      expect(
+        getLastGaugeValue(
+          "langfuse.batch_data_retention_cleaner.pending_projects",
+        ),
+      ).toBe(3);
+
+      const lagValue = getLastGaugeValue(
+        "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
+      );
+      expect(lagValue).toBeGreaterThan(2 * (dayMs / 1000));
+      expect(lagValue).toBeLessThan(4 * (dayMs / 1000));
     });
 
     it("renews on progress and aborts when the final lease renewal fails", async () => {
@@ -574,10 +606,8 @@ describe("BatchDataRetentionCleaner", () => {
       ]);
     });
 
-    it("prioritizes unenriched candidates and estimates lag from their oldest partition", async () => {
-      const [fallbackProjectId, exactProjectId] =
-        await createProjectsWithRetention(2);
-      const exactExpiredAt = Date.now() - 10 * 24 * 60 * 60 * 1000;
+    it("uses partition lag when exact enrichment fails", async () => {
+      const [fallbackProjectId] = await createProjectsWithRetention(1);
       await insertRetentionTestRows(tableName, [
         {
           projectId: fallbackProjectId!,
@@ -587,12 +617,7 @@ describe("BatchDataRetentionCleaner", () => {
           projectId: fallbackProjectId!,
           startTime: new Date("2020-01-15T00:00:00.000Z").getTime(),
         },
-        { projectId: exactProjectId!, startTime: exactExpiredAt },
-        { projectId: exactProjectId!, startTime: exactExpiredAt - 1 },
-        { projectId: exactProjectId!, startTime: exactExpiredAt - 2 },
       ]);
-      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CHUNK_SIZE = 1;
-      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT = 1;
       integrationHooks.failExactEnrichmentForProjectId = fallbackProjectId!;
       const beforeRun = Date.now();
 
@@ -602,17 +627,12 @@ describe("BatchDataRetentionCleaner", () => {
       expect(
         await getRetentionTestProjectCount(tableName, fallbackProjectId!),
       ).toBe(0);
-      expect(
-        await getRetentionTestProjectCount(tableName, exactProjectId!),
-      ).toBe(3);
 
-      const lagGauge = integrationHooks.gaugeCalls.findLast(
-        ([stat]) =>
-          stat === "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
+      const lagValue = getLastGaugeValue(
+        "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
       );
       const partitionStart = new Date("2020-01-01T00:00:00.000Z").getTime();
       const retentionMs = 7 * 24 * 60 * 60 * 1000;
-      const lagValue = lagGauge?.[1] ?? Number.NaN;
 
       expect(lagValue).toBeGreaterThanOrEqual(
         (beforeRun - retentionMs - partitionStart) / 1000,
@@ -620,10 +640,6 @@ describe("BatchDataRetentionCleaner", () => {
       expect(lagValue).toBeLessThanOrEqual(
         (afterRun - retentionMs - partitionStart) / 1000,
       );
-      expect(integrationHooks.incrementCalls).toContainEqual([
-        "langfuse.batch_data_retention_cleaner.row_count_unavailable",
-        1,
-      ]);
     });
   });
 });

--- a/worker/src/features/batch-data-retention-cleaner/index.ts
+++ b/worker/src/features/batch-data-retention-cleaner/index.ts
@@ -1,11 +1,11 @@
 import { createHash } from "crypto";
 
-import { percentile } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   commandClickhouse,
   convertDateToClickhouseDateTime,
   logger,
+  parseClickhouseUTCDateTimeFormat,
   queryClickhouse,
   queryClickhouseStream,
   recordGauge,
@@ -54,8 +54,13 @@ interface ProjectRetention {
 }
 
 interface ProjectWorkload extends ProjectRetention {
-  expiredRowCount: number | null;
-  oldestAgeSeconds: number | null;
+  rowCount: number | null;
+  secondsPastCutoff: number | null;
+}
+
+interface ProjectWorkloadSelection {
+  observedWorkloads: ProjectWorkload[];
+  selectedWorkloads: ProjectWorkload[];
 }
 
 function parseMonthlyPartitionStart(partitionId: string): Date | null {
@@ -113,7 +118,7 @@ function toParamKey(projectId: string): string {
 
 /**
  * Build OR conditions for project-specific cutoffs.
- * Used by both count and delete queries.
+ * Used by candidate discovery and delete queries.
  * Uses hashed projectId keys to prevent index mismatch bugs.
  */
 function buildRetentionConditions(
@@ -164,8 +169,8 @@ function buildRetentionConditions(
  * 1. Query PG for all projects with retentionDays > 0
  * 2. Calculate retention cutoff dates for each project
  * 3. Stream projects with expired rows from bounded project chunks
- * 4. Best-effort enrich candidates with exact count and oldest timestamp
- * 5. Sort by expired count DESC when enrichment is available
+ * 4. Best-effort enrich candidates with total row count and oldest timestamp
+ * 5. Sort by lag past cutoff DESC, using total row count as a tie-breaker
  * 6. Execute a single batch DELETE with OR conditions
  */
 export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
@@ -276,75 +281,54 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
         this.lastLockExtensionAt = 0;
 
         // Step 1: Get project workloads (streamed CH candidates + PG config)
-        const workloads = await this.getProjectWorkloads();
+        const { observedWorkloads, selectedWorkloads } =
+          await this.getProjectWorkloads();
 
-        recordGauge(`${METRIC_PREFIX}.pending_projects`, workloads.length, {
-          table: this.tableName,
-        });
+        recordGauge(
+          `${METRIC_PREFIX}.pending_projects`,
+          observedWorkloads.length,
+          {
+            table: this.tableName,
+          },
+        );
 
-        const SECONDS_PER_DAY = 86400;
-        const secondsPastCutoffByProject = workloads
-          .filter((workload) => workload.oldestAgeSeconds !== null)
-          .map((workload) => ({
-            projectId: workload.projectId,
-            secondsPastCutoff:
-              workload.oldestAgeSeconds! -
-              workload.retentionDays * SECONDS_PER_DAY,
-          }));
-
-        // Compute p90 for the gauge metric (0 when no pending work)
-        const p90SecondsPastCutoff = percentile(
-          secondsPastCutoffByProject.map((project) =>
-            Math.max(project.secondsPastCutoff, 0),
-          ),
-          0.9,
+        // Retention cutoffs come from Postgres and are frozen once per run.
+        // Fold the per-project results here to preserve one maximum across all
+        // bounded ClickHouse queries.
+        const maxSecondsPastCutoff = observedWorkloads.reduce(
+          (maximum, workload) =>
+            workload.secondsPastCutoff === null
+              ? maximum
+              : Math.max(maximum, workload.secondsPastCutoff),
+          0,
         );
 
         recordGauge(
           `${METRIC_PREFIX}.seconds_past_cutoff`,
-          Math.max(p90SecondsPastCutoff, 0),
+          maxSecondsPastCutoff,
           {
             table: this.tableName,
           },
         );
 
         // Step 2: Execute DELETE
-        if (workloads.length >= 0) {
+        if (selectedWorkloads.length > 0) {
           logger.info(
-            `${this.instanceName}: Processing ${workloads.length} projects`,
+            `${this.instanceName}: Processing ${selectedWorkloads.length} projects`,
             {
-              projectIds: workloads.map((workload) => workload.projectId),
-              secondsPastCutoffByProject,
+              projectIds: selectedWorkloads.map(
+                (workload) => workload.projectId,
+              ),
+              pendingProjectsSeen: observedWorkloads.length,
+              maxSecondsPastCutoff,
             },
           );
 
-          await this.executeBatchDelete(timestampColumn, workloads);
-
-          if (workloads.length > 0) {
-            const matchedRows = workloads.reduce<number | null>(
-              (sum, workload) =>
-                sum === null || workload.expiredRowCount === null
-                  ? null
-                  : sum + workload.expiredRowCount,
-              0,
-            );
-
-            if (matchedRows === null) {
-              recordIncrement(`${METRIC_PREFIX}.row_count_unavailable`, 1, {
-                table: this.tableName,
-              });
-            } else {
-              recordIncrement(
-                `${METRIC_PREFIX}.rows_matched_before_delete`,
-                matchedRows,
-                { table: this.tableName },
-              );
-            }
-          }
+          await this.executeBatchDelete(timestampColumn, selectedWorkloads);
 
           logger.info(`${this.instanceName}: Batch deletion completed`, {
             table: this.tableName,
-            projectsProcessed: workloads.length,
+            projectsProcessed: selectedWorkloads.length,
           });
         } else {
           logger.info(
@@ -358,7 +342,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
         });
         recordIncrement(
           `${METRIC_PREFIX}.projects_processed`,
-          workloads.length,
+          selectedWorkloads.length,
           {
             table: this.tableName,
           },
@@ -377,10 +361,10 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
    * 1. PostgreSQL: Get all projects with retention enabled
    * 2. Calculate cutoffs for all projects
    * 3. Stream projects with expired data from each CHUNK_SIZE project chunk
-   * 4. Best-effort enrich each chunk's candidates with count/min
-   * 5. Sort by count when available and select top PROJECT_LIMIT
+   * 4. Best-effort enrich each chunk's candidates with total count/min
+   * 5. Sort by lag, then total count, and select top PROJECT_LIMIT
    */
-  private async getProjectWorkloads(): Promise<ProjectWorkload[]> {
+  private async getProjectWorkloads(): Promise<ProjectWorkloadSelection> {
     const timestampColumn = TIMESTAMP_COLUMN_MAP[this.tableName];
 
     // Step 1: Get all projects with retention from PostgreSQL
@@ -393,7 +377,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
     });
 
     if (projectsWithRetention.length === 0) {
-      return [];
+      return { observedWorkloads: [], selectedWorkloads: [] };
     }
 
     // Step 2: Calculate cutoffs for all projects upfront
@@ -421,9 +405,10 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       );
     }
 
-    // Step 4: Exact count/min is useful for global ordering and metrics, but
-    // deletion must not depend on this more expensive grouped query succeeding.
-    // Keep enrichment per input chunk so its parameters remain bounded too.
+    // Step 4: Oldest timestamp provides the main ordering signal and total
+    // count breaks ties, but deletion must not depend on this grouped query
+    // succeeding. Keep enrichment per input chunk so its parameters remain
+    // bounded too.
     const chunkWorkloads = await Promise.all(
       projectChunks.map(async (projectChunk) => {
         const candidates = await this.findExpiredProjectCandidates(
@@ -435,22 +420,39 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
     );
     const workloads = chunkWorkloads.flat();
 
-    // A failed count can indicate a particularly large workload. Prioritize
-    // unknown counts ahead of exact counts instead of treating them as empty.
+    // Prioritize the projects furthest behind their cutoff. A failed lag or
+    // count estimate can indicate a particularly large workload, so keep
+    // unknown values ahead of known ones to avoid starvation.
     workloads.sort((left, right) => {
-      if (left.expiredRowCount === null) {
-        return right.expiredRowCount === null ? 0 : -1;
+      if (left.secondsPastCutoff === null) {
+        if (right.secondsPastCutoff !== null) {
+          return -1;
+        }
+      } else if (right.secondsPastCutoff === null) {
+        return 1;
+      } else {
+        const lagDifference = right.secondsPastCutoff - left.secondsPastCutoff;
+        if (lagDifference !== 0) {
+          return lagDifference;
+        }
       }
-      if (right.expiredRowCount === null) {
+
+      if (left.rowCount === null) {
+        return right.rowCount === null ? 0 : -1;
+      }
+      if (right.rowCount === null) {
         return 1;
       }
-      return right.expiredRowCount - left.expiredRowCount;
+      return right.rowCount - left.rowCount;
     });
 
-    return workloads.slice(
-      0,
-      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT,
-    );
+    return {
+      observedWorkloads: workloads,
+      selectedWorkloads: workloads.slice(
+        0,
+        env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT,
+      ),
+    };
   }
 
   /**
@@ -529,8 +531,11 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
   }
 
   /**
-   * Best-effort exact count and oldest age for discovered candidates. If this
-   * query fails, estimate the oldest age from the monthly partition instead.
+   * Best-effort total count and oldest retention timestamp for discovered
+   * candidates. The query deliberately filters only on project_id. Retention
+   * cutoffs come from Postgres and are frozen once per run, so they are applied
+   * after the result is returned. If this query fails, estimate the oldest
+   * timestamp from the monthly partition instead.
    */
   private async enrichProjectCandidates(
     timestampColumn: string,
@@ -540,42 +545,47 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       return [];
     }
 
-    const { conditions, params } = buildRetentionConditions(
-      timestampColumn,
-      candidates,
-    );
     const query = `
       SELECT
         project_id,
-        count() AS count,
-        dateDiff('second', min(event_ts), now()) AS oldest_age_seconds
+        count() AS row_count,
+        min(${timestampColumn}) AS oldest_timestamp
       FROM ${this.tableName}
-      PREWHERE ${conditions}
+      PREWHERE project_id IN ({candidateProjectIds: Array(String)})
       GROUP BY project_id
     `;
 
     try {
       const result = await queryClickhouse<{
         project_id: string;
-        count: number;
-        oldest_age_seconds: number;
+        row_count: number;
+        oldest_timestamp: string;
       }>({
         query,
-        params,
+        params: {
+          candidateProjectIds: candidates.map(
+            (candidate) => candidate.projectId,
+          ),
+        },
         useMultipartParamsAuto: true,
       });
 
       const resultByProjectId = new Map(
         result.map((row) => {
-          const oldestAgeSeconds = Number(row.oldest_age_seconds);
+          const oldestTimestamp = parseClickhouseUTCDateTimeFormat(
+            row.oldest_timestamp,
+          );
+          if (Number.isNaN(oldestTimestamp.getTime())) {
+            throw new Error(
+              `Invalid oldest timestamp for project ${row.project_id}`,
+            );
+          }
 
           return [
             row.project_id,
             {
-              count: Number(row.count),
-              oldestAgeSeconds: Number.isFinite(oldestAgeSeconds)
-                ? oldestAgeSeconds
-                : null,
+              rowCount: Number(row.row_count),
+              oldestTimestamp,
             },
           ] as const;
         }),
@@ -583,13 +593,26 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
 
       await this.extendLockOnProgress();
 
-      return candidates.map((candidate) => {
+      return candidates.flatMap((candidate) => {
         const resultForProject = resultByProjectId.get(candidate.projectId);
-        return {
-          ...candidate,
-          expiredRowCount: resultForProject?.count ?? null,
-          oldestAgeSeconds: resultForProject?.oldestAgeSeconds ?? null,
-        };
+        if (
+          !resultForProject ||
+          resultForProject.oldestTimestamp.getTime() >=
+            candidate.cutoffDate.getTime()
+        ) {
+          return [];
+        }
+
+        return [
+          {
+            ...candidate,
+            rowCount: resultForProject.rowCount,
+            secondsPastCutoff:
+              (candidate.cutoffDate.getTime() -
+                resultForProject.oldestTimestamp.getTime()) /
+              1000,
+          },
+        ];
       });
     } catch (error) {
       if (error instanceof BatchDataRetentionCleanerLeaseLostError) {
@@ -609,9 +632,10 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
   }
 
   /**
-   * Estimate each candidate's oldest age from its oldest monthly partition.
-   * The partition start is an upper bound on how far the oldest row is past
-   * cutoff. If this query also fails, retain the candidates without metrics.
+   * Estimate each candidate's lag from its oldest monthly partition. The
+   * partition start is an upper bound on how far the oldest row is past the
+   * fixed project cutoff. If this query also fails, retain the candidates
+   * without metrics.
    */
   private async enrichCandidatesFromOldestPartition(
     candidates: ProjectRetention[],
@@ -624,16 +648,19 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
 
       await this.extendLockOnProgress();
 
-      const now = Date.now();
       return candidates.map((candidate) => {
         const partitionStart = partitionStartByProjectId.get(
           candidate.projectId,
         );
         return {
           ...candidate,
-          expiredRowCount: null,
-          oldestAgeSeconds: partitionStart
-            ? (now - partitionStart.getTime()) / 1000
+          rowCount: null,
+          secondsPastCutoff: partitionStart
+            ? Math.max(
+                (candidate.cutoffDate.getTime() - partitionStart.getTime()) /
+                  1000,
+                0,
+              )
             : null,
         };
       });
@@ -652,8 +679,8 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       await this.extendLockOnProgress();
       return candidates.map((candidate) => ({
         ...candidate,
-        expiredRowCount: null,
-        oldestAgeSeconds: null,
+        rowCount: null,
+        secondsPastCutoff: null,
       }));
     }
   }


### PR DESCRIPTION
## What does this PR do?

Improves batch data-retention candidate enrichment and prioritization:

- queries ClickHouse by candidate project IDs without the slower per-project timestamp predicates
- compares each project's oldest timestamp against its PostgreSQL retention cutoff in the worker
- prioritizes projects by lag past expiry, using total row count as a tie-breaker
- reports the maximum lag across all workloads observed during the run
- preserves the monthly-partition lag fallback when exact enrichment fails

This keeps the final deletion constrained by each project's retention policy while avoiding the substantially slower cutoff-bounded aggregation.

Impacted package: `worker`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code

## Verification

- [x] `pnpm run lint` — `Tasks: 7 successful, 7 total`
- [x] `pnpm --filter worker run typecheck`
- [x] `pnpm --filter worker run test batchDataRetentionCleaner.test.ts` — `Tests 12 passed (12)`
- [x] pre-commit Prettier check — `All matched files use Prettier code style!`
- [x] `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the `BatchDataRetentionCleaner` enrichment phase to drop the per-project cutoff predicates from ClickHouse, instead querying each candidate project's total row count and minimum timestamp without a cutoff filter, then computing lag in the worker by comparing against the Postgres-derived cutoff date.

- **Prioritization rewrite**: workloads are now sorted by `secondsPastCutoff` descending (lag past the project's cutoff), with total `rowCount` as a tie-breaker; unknown values continue to sort first to avoid starvation.
- **Metric changes**: the old p90 `seconds_past_cutoff` gauge is replaced by the maximum across all observed workloads; `rows_matched_before_delete` and `row_count_unavailable` counters are removed entirely.
- **Bug fix**: the always-true guard `workloads.length >= 0` is correctly replaced by `selectedWorkloads.length > 0`, fixing a misleading log path when no work is pending.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the delete query itself is unchanged and still uses per-project cutoff conditions, so no data outside each project's retention window is at risk of removal.

The enrichment phase now silently drops discovered candidates that lack a confirmed result from ClickHouse (no metric, no fallback, no log), and the deletion-volume metrics (rows_matched_before_delete) are gone with no direct replacement. Both are unlikely to manifest as visible failures in normal operation, but reduce diagnosability if the enrichment path behaves unexpectedly.

worker/src/features/batch-data-retention-cleaner/index.ts — specifically the candidates.flatMap block in enrichProjectCandidates (silent drop path) and the execute method where deletion-volume counters were removed.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W as Worker (processBatch)
    participant PG as PostgreSQL
    participant CH as ClickHouse

    W->>PG: "findMany(retentionDays > 0, deletedAt null)"
    PG-->>W: projectsWithRetention (id, retentionDays)
    W->>W: compute cutoffDate per project

    loop per CHUNK_SIZE slice
        W->>CH: SELECT DISTINCT project_id PREWHERE per-project cutoffs LIMIT chunkSize
        CH-->>W: candidate project IDs (streaming)

        alt enrichment succeeds
            W->>CH: SELECT project_id, count(), min(timestampCol) PREWHERE project_id IN candidates
            CH-->>W: rowCount + oldestTimestamp per project
            W->>W: "filter oldestTimestamp >= cutoffDate, compute secondsPastCutoff"
        else enrichment query throws
            W->>CH: SELECT project_id, min(_partition_id) PREWHERE project_id IN candidates
            CH-->>W: oldest partition per project
            W->>W: estimate secondsPastCutoff from partition start
        end
    end

    W->>W: sort secondsPastCutoff DESC then rowCount DESC, slice top PROJECT_LIMIT
    W->>W: recordGauge pending_projects and max seconds_past_cutoff
    W->>CH: DELETE FROM table WHERE per-project cutoff conditions
    CH-->>W: OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W as Worker (processBatch)
    participant PG as PostgreSQL
    participant CH as ClickHouse

    W->>PG: "findMany(retentionDays > 0, deletedAt null)"
    PG-->>W: projectsWithRetention (id, retentionDays)
    W->>W: compute cutoffDate per project

    loop per CHUNK_SIZE slice
        W->>CH: SELECT DISTINCT project_id PREWHERE per-project cutoffs LIMIT chunkSize
        CH-->>W: candidate project IDs (streaming)

        alt enrichment succeeds
            W->>CH: SELECT project_id, count(), min(timestampCol) PREWHERE project_id IN candidates
            CH-->>W: rowCount + oldestTimestamp per project
            W->>W: "filter oldestTimestamp >= cutoffDate, compute secondsPastCutoff"
        else enrichment query throws
            W->>CH: SELECT project_id, min(_partition_id) PREWHERE project_id IN candidates
            CH-->>W: oldest partition per project
            W->>W: estimate secondsPastCutoff from partition start
        end
    end

    W->>W: sort secondsPastCutoff DESC then rowCount DESC, slice top PROJECT_LIMIT
    W->>W: recordGauge pending_projects and max seconds_past_cutoff
    W->>CH: DELETE FROM table WHERE per-project cutoff conditions
    CH-->>W: OK
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/batch-data-retention-cleaner/index.ts:596-604
**Silent candidate drop bypasses partition fallback**

When `enrichProjectCandidates` succeeds (no exception) but a specific candidate is missing from the result — or has `oldestTimestamp >= cutoffDate` — the candidate is silently dropped with no log, no metric, and no fallback to `enrichCandidatesFromOldestPartition`. The partition fallback is only triggered on a full query failure.

Under the old code, missing enrichment data still produced a workload entry (with null metrics) that would proceed to deletion. Here, a project discovered by `findExpiredProjectCandidates` can be silently skipped until the next cycle. If this happens systematically (e.g., a ClickHouse replica serves stale data for the enrichment query), there's no signal in telemetry to diagnose it.

### Issue 2 of 2
worker/src/features/batch-data-retention-cleaner/index.ts:327-348
**Deletion volume is no longer observable from worker telemetry**

The `rows_matched_before_delete` and `row_count_unavailable` metrics were removed without replacement. Previously these gave direct visibility into how many rows were selected for deletion each run, which was useful for capacity planning and detecting anomalies (e.g., a sudden drop in matched rows indicating a misconfigured cutoff).

The new `rowCount` field counts all rows for a project (not just expired ones), so it can't be summed to recreate the old metric. There's currently no worker-emitted counter that tracks the size of the actual delete workload. Consider incrementing a counter from `selectedWorkloads` using the per-project `rowCount`, or at least logging the aggregate before `executeBatchDelete`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(worker): prioritize retention clean..."](https://github.com/langfuse/langfuse/commit/430678441a34c70b452374ecac1c64ad925dfa3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45593285)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->