### PR TITLE
feat(layouts): show Langfuse brand mark in the mobile top bar (LFE-11067)

### DIFF
--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -9,6 +9,7 @@ import Head from "next/head";
 import { useRouter, type NextRouter } from "next/router";
 import { SidebarProvider, SidebarInset } from "@/src/components/ui/sidebar";
 import { AppSidebar } from "@/src/components/nav/app-sidebar";
+import { SidebarPresenceProvider } from "@/src/components/nav/sidebar-presence";
 import { Toaster } from "@/src/components/ui/sonner";
 import { Layer } from "@/src/components/ui/layer";
 import { TopBannerProvider } from "@/src/features/top-banner";
@@ -169,42 +170,44 @@ export function AuthenticatedLayout({
       </Head>
 
       <TopBannerProvider>
-        <SidebarProvider>
-          <div className="flex h-dvh w-full flex-col">
-            <PaymentBanner />
-            <div className="pt-banner-offset flex min-h-0 flex-1">
-              <AppSidebar
-                navItems={navigation.mainNavigation}
-                secondaryNavItems={navigation.secondaryNavigation}
-                userNavProps={userNavProps}
-              />
-              <SidebarInset className="h-screen-with-banner max-w-full md:peer-data-[state=collapsed]:w-[calc(100vw-var(--sidebar-width-icon))] md:peer-data-[state=expanded]:w-[calc(100vw-var(--sidebar-width))]">
-                <AppContentWithRightDrawer>
-                  {children}
-                </AppContentWithRightDrawer>
-                {/* Toasts render in the `toast` overlay layer — the last layer
-                    in LAYER_ORDER — so they paint above every overlay (incl. a
-                    non-modal peek) by DOM order alone, no z-index. Sonner's
-                    Toaster is position:fixed, so nesting it in the fixed
-                    full-screen layer container is positionally identical. */}
-                <Layer name="toast">
-                  <Toaster visibleToasts={1} />
-                </Layer>
-                <CommandMenu mainNavigation={navigation.navigation} />
-                {/* Assistant window host lives here (not in PageHeader with
-                    its launcher button) so the open window and its geometry
-                    survive route changes. */}
-                <InAppAgentWindowHost />
-              </SidebarInset>
+        <SidebarPresenceProvider>
+          <SidebarProvider>
+            <div className="flex h-dvh w-full flex-col">
+              <PaymentBanner />
+              <div className="pt-banner-offset flex min-h-0 flex-1">
+                <AppSidebar
+                  navItems={navigation.mainNavigation}
+                  secondaryNavItems={navigation.secondaryNavigation}
+                  userNavProps={userNavProps}
+                />
+                <SidebarInset className="h-screen-with-banner max-w-full md:peer-data-[state=collapsed]:w-[calc(100vw-var(--sidebar-width-icon))] md:peer-data-[state=expanded]:w-[calc(100vw-var(--sidebar-width))]">
+                  <AppContentWithRightDrawer>
+                    {children}
+                  </AppContentWithRightDrawer>
+                  {/* Toasts render in the `toast` overlay layer — the last layer
+                      in LAYER_ORDER — so they paint above every overlay (incl. a
+                      non-modal peek) by DOM order alone, no z-index. Sonner's
+                      Toaster is position:fixed, so nesting it in the fixed
+                      full-screen layer container is positionally identical. */}
+                  <Layer name="toast">
+                    <Toaster visibleToasts={1} />
+                  </Layer>
+                  <CommandMenu mainNavigation={navigation.navigation} />
+                  {/* Assistant window host lives here (not in PageHeader with
+                      its launcher button) so the open window and its geometry
+                      survive route changes. */}
+                  <InAppAgentWindowHost />
+                </SidebarInset>
+              </div>
+              {hasFeaturePreviews ? (
+                <ControlledFeaturePreviewModal
+                  open={featurePreviewOpen}
+                  onOpenChange={setFeaturePreviewOpen}
+                />
+              ) : null}
             </div>
-            {hasFeaturePreviews ? (
-              <ControlledFeaturePreviewModal
-                open={featurePreviewOpen}
-                onOpenChange={setFeaturePreviewOpen}
-              />
-            ) : null}
-          </div>
-        </SidebarProvider>
+          </SidebarProvider>
+        </SidebarPresenceProvider>
       </TopBannerProvider>
     </>
   );

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -104,16 +104,22 @@ const PageHeader = ({
           >
             <div className="flex min-w-0 flex-wrap items-center gap-3">
               {showSidebarTrigger ? (
-                <SidebarTrigger />
+                <>
+                  <SidebarTrigger />
+                  {/* Brand the app in the top bar while the sidebar (which
+                      owns the logo) is off-canvas below `md`. Hidden on
+                      desktop where the sidebar logo is visible. Gated on the
+                      same condition as the trigger so it only appears where a
+                      sidebar actually exists to mirror — never on the
+                      sidebar-less MinimalLayout (e.g. the public/shared trace
+                      view, which supplies its own leadingControl). */}
+                  <TopbarBrand className="md:hidden" />
+                </>
               ) : (
                 leadingControl && (
                   <div className="flex items-center">{leadingControl}</div>
                 )
               )}
-              {/* Brand the app in the top bar while the sidebar (which owns the
-                  logo) is off-canvas below `md`. Hidden on desktop where the
-                  sidebar logo is visible. */}
-              <TopbarBrand className="md:hidden" />
               <div>
                 <EnvLabel />
               </div>

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -3,6 +3,7 @@ import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
 import BreadcrumbComponent from "@/src/components/layouts/breadcrumb";
 import { PageHeaderControlsSlotTarget } from "@/src/components/layouts/page-header-controls-slot";
 import { InAppAiAgentButton } from "@/src/components/nav/in-app-ai-agent-button";
+import { TopbarBrand } from "@/src/components/nav/topbar-brand";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { SidebarTrigger } from "@/src/components/ui/sidebar";
 import {
@@ -109,6 +110,10 @@ const PageHeader = ({
                   <div className="flex items-center">{leadingControl}</div>
                 )
               )}
+              {/* Brand the app in the top bar while the sidebar (which owns the
+                  logo) is off-canvas below `md`. Hidden on desktop where the
+                  sidebar logo is visible. */}
+              <TopbarBrand className="md:hidden" />
               <div>
                 <EnvLabel />
               </div>

--- a/web/src/components/nav/sidebar-presence.tsx
+++ b/web/src/components/nav/sidebar-presence.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+/**
+ * Signals whether the real app navigation sidebar (`AppSidebar`) is mounted in
+ * the current layout.
+ *
+ * Only `AuthenticatedLayout` mounts `AppSidebar`. The sidebar-less
+ * `MinimalLayout` / `UnauthenticatedLayout` (public share views, auth pages)
+ * leave this at its default `false`.
+ *
+ * Top-bar chrome that exists purely to mirror the sidebar — e.g. the mobile
+ * `TopbarBrand` — reads this so it never renders on a page that has no sidebar
+ * to mirror, regardless of which `PageHeader` props a given route happens to
+ * set. That keeps the invariant in one place instead of relying on every
+ * MinimalLayout-reachable caller to opt out.
+ */
+const SidebarPresenceContext = createContext(false);
+
+export const SidebarPresenceProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => (
+  <SidebarPresenceContext.Provider value={true}>
+    {children}
+  </SidebarPresenceContext.Provider>
+);
+
+export const useHasAppSidebar = () => useContext(SidebarPresenceContext);

--- a/web/src/components/nav/topbar-brand.tsx
+++ b/web/src/components/nav/topbar-brand.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@/src/utils/tailwind";
+import Link from "next/link";
+import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
+import { PlusIcon } from "lucide-react";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
+
+/**
+ * Compact Langfuse brand mark for the top bar.
+ *
+ * The primary brand lives in the sidebar header. Once the sidebar goes
+ * off-canvas (below `md`, where it collapses into a Sheet) nothing brands the
+ * app, so the page header renders this compact mark instead — mirroring the
+ * icon the sidebar itself shows when collapsed.
+ *
+ * Respects the self-host UI-customization logo entitlement, same as
+ * `LangfuseLogo`, and links to `/` like the sidebar logo.
+ */
+export const TopbarBrand = ({ className }: { className?: string }) => {
+  const uiCustomization = useUiCustomization();
+  const logoLight = uiCustomization?.logoLightModeHref;
+  const logoDark = uiCustomization?.logoDarkModeHref;
+
+  return (
+    <Link
+      href="/"
+      aria-label="Langfuse home"
+      className={cn("flex shrink-0 items-center gap-1", className)}
+    >
+      {logoLight && logoDark ? (
+        // Custom logo (max aspect ratio 1:3 per docs) + the Langfuse mark,
+        // matching LangfuseLogo's customized layout.
+        <>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={logoLight}
+            alt="Logo"
+            className="max-h-5 max-w-16 dark:hidden"
+          />
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={logoDark}
+            alt="Logo"
+            className="hidden max-h-5 max-w-16 dark:block"
+          />
+          <PlusIcon size={8} className="text-muted-foreground" />
+          <LangfuseIcon size={16} />
+        </>
+      ) : (
+        <LangfuseIcon size={28} />
+      )}
+    </Link>
+  );
+};

--- a/web/src/components/nav/topbar-brand.tsx
+++ b/web/src/components/nav/topbar-brand.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
 import { PlusIcon } from "lucide-react";
 import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
+import { useHasAppSidebar } from "@/src/components/nav/sidebar-presence";
 
 /**
  * Compact Langfuse brand mark for the top bar.
@@ -16,9 +17,15 @@ import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/Langfu
  * `LangfuseLogo`, and links to `/` like the sidebar logo.
  */
 export const TopbarBrand = ({ className }: { className?: string }) => {
+  const hasAppSidebar = useHasAppSidebar();
   const uiCustomization = useUiCustomization();
   const logoLight = uiCustomization?.logoLightModeHref;
   const logoDark = uiCustomization?.logoDarkModeHref;
+
+  // Nothing to mirror when there is no sidebar (sidebar-less MinimalLayout,
+  // e.g. public/shared trace and session views). Guarding here keeps the
+  // brand off every such route without each caller having to opt out.
+  if (!hasAppSidebar) return null;
 
   return (
     <Link


### PR DESCRIPTION
## TL;DR
On mobile, the Langfuse logo disappears — it lives only in the sidebar, which is off-canvas below `md`. This adds a compact, customization-aware Langfuse brand mark to the top bar so the app is always branded. First "base chrome" slice of the mobile revamp (LFE-11067).

## Why
The logo renders **only** in the sidebar header (`LangfuseLogo` in `app-sidebar.tsx`). Below the `md` breakpoint the sidebar collapses into an off-canvas `Sheet`, so once it's closed nothing tells you you're in Langfuse. The mobile top bar is just a hamburger + breadcrumb.

## What
- New `TopbarBrand` component: a compact brand mark that mirrors the icon the sidebar shows when collapsed. It respects the self-host UI-customization logo entitlement via the same `useUiCustomization` path as `LangfuseLogo`, and links to `/` like the sidebar logo.
- Rendered in the page-header top row right after the sidebar trigger, shown only while the sidebar is off-canvas (`md:hidden`). On desktop the sidebar owns the logo, so the top-bar mark is hidden — no duplication.
- Uses a CSS breakpoint (`md:hidden`) rather than the JS `useIsMobile` hook, so there's no hydration flash.

## Result
`[☰] [Langfuse mark] [breadcrumb] … [actions]` on mobile; unchanged on desktop. Verified live at 1280 (hidden), 767 (appears exactly as the sidebar goes off-canvas), 375, and 320px (no horizontal overflow); custom-logo path preserved.

<details>
<summary>Verification & mechanism</summary>

- The `md:hidden` visibility and the sidebar's own `hidden md:block` / `useIsMobile` (< 768) boundary align: at 767px the sidebar becomes a Sheet **and** the brand mark appears; at 768px+ the sidebar is docked **and** the mark hides. No gap or overlap.
- `useUiCustomization` is gated behind `self-host-ui-customization` entitlement and is already fetched by the sidebar logo on every page (react-query cached, `refetchOnMount:false`), so no extra network cost.
- Default (no custom logo) → the standalone Langfuse icon at 28px. Custom-logo tenants → customer logo + Langfuse icon, matching `LangfuseLogo`'s customized layout.
- Checked the sidebar Sheet still opens from the trigger and shows the full "langfuse" wordmark + nav — the icon-in-bar → wordmark-in-menu story is coherent.
- Non-user-facing wrapping of the controls/agent slot onto a second line on very narrow phones is pre-existing; those controls move into the bottom bar in later slices of the epic.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `TopbarBrand` component that renders a compact Langfuse icon in the page-header top bar on mobile (hidden via `md:hidden`), filling the branding gap that occurs when the sidebar collapses into an off-canvas Sheet below the `md` breakpoint. The component mirrors the customization-aware logic already used in `LangfuseLogo`, uses CSS breakpoints instead of the JS `useIsMobile` hook to avoid hydration flashes, and carries no extra network cost since `useUiCustomization` is already cached by the sidebar logo.

- `topbar-brand.tsx`: new component that shows the Langfuse icon by default, or the custom-logo pair + Langfuse mark for self-host tenants with the `self-host-ui-customization` entitlement.
- `page-header.tsx`: mounts `TopbarBrand` right after the sidebar trigger with `md:hidden`, so it's invisible on desktop but fills the brand gap on mobile.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, CSS-only visibility control, and the new component follows an established pattern already used by the sidebar logo.

The component correctly reuses the useUiCustomization hook (same cache, same entitlement gate), the md:hidden breakpoint aligns precisely with the sidebar's 768px collapse threshold, and the fallback to the default icon when customization data is absent or loading mirrors the sidebar's own behavior. No new network requests, no hydration risk from using a CSS class instead of the useIsMobile hook, and the custom-logo code path is a straightforward copy of the existing LangfuseLogo layout.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant PageHeader
    participant TopbarBrand
    participant useUiCustomization
    participant SidebarLogo as LangfuseLogo (Sidebar)

    Browser->>PageHeader: render (any breakpoint)
    PageHeader->>TopbarBrand: "render (className="md:hidden")"
    TopbarBrand->>useUiCustomization: check entitlement + fetch customization
    alt No entitlement / no custom logo
        useUiCustomization-->>TopbarBrand: null
        TopbarBrand-->>PageHeader: "LangfuseIcon size=28 (only visible below md)"
    else Custom logo present (both light + dark)
        useUiCustomization-->>TopbarBrand: "{ logoLightModeHref, logoDarkModeHref }"
        TopbarBrand-->>PageHeader: "img light + img dark + PlusIcon + LangfuseIcon size=16"
    end

    Note over PageHeader,TopbarBrand: Below md (< 768px): TopbarBrand visible, Sidebar Sheet closed
    Note over SidebarLogo: Above md (>= 768px): Sidebar docked + LangfuseLogo visible, TopbarBrand hidden
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant PageHeader
    participant TopbarBrand
    participant useUiCustomization
    participant SidebarLogo as LangfuseLogo (Sidebar)

    Browser->>PageHeader: render (any breakpoint)
    PageHeader->>TopbarBrand: "render (className="md:hidden")"
    TopbarBrand->>useUiCustomization: check entitlement + fetch customization
    alt No entitlement / no custom logo
        useUiCustomization-->>TopbarBrand: null
        TopbarBrand-->>PageHeader: "LangfuseIcon size=28 (only visible below md)"
    else Custom logo present (both light + dark)
        useUiCustomization-->>TopbarBrand: "{ logoLightModeHref, logoDarkModeHref }"
        TopbarBrand-->>PageHeader: "img light + img dark + PlusIcon + LangfuseIcon size=16"
    end

    Note over PageHeader,TopbarBrand: Below md (< 768px): TopbarBrand visible, Sidebar Sheet closed
    Note over SidebarLogo: Above md (>= 768px): Sidebar docked + LangfuseLogo visible, TopbarBrand hidden
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(layouts): show Langfuse brand mark ..."](https://github.com/langfuse/langfuse/commit/94069404e3f88c160e9a4689806407453d5ec588) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45597746)</sub>

<!-- /greptile_comment -->