### PR TITLE
fix(web): render selected cloud region in picker

### DIFF
--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -17,24 +17,31 @@ const SelectTrigger = React.forwardRef<
   React.ComponentRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
     hideDownIcon?: boolean;
+    disableValueLineClamp?: boolean;
   }
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "border-input bg-background ring-offset-background placeholder:text-foreground-tertiary focus:ring-ring disabled:bg-muted/50 flex h-8 w-full items-center justify-between gap-1 rounded-md border px-3 py-2 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
-      className,
-    )}
-    {...props}
-  >
-    {children}
-    {props.hideDownIcon ? null : (
-      <SelectPrimitive.Icon asChild>
-        <ChevronDown className="h-4 w-4 opacity-50" />
-      </SelectPrimitive.Icon>
-    )}
-  </SelectPrimitive.Trigger>
-));
+>(
+  (
+    { className, children, hideDownIcon, disableValueLineClamp, ...props },
+    ref,
+  ) => (
+    <SelectPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "border-input bg-background ring-offset-background placeholder:text-foreground-tertiary focus:ring-ring disabled:bg-muted/50 flex h-8 w-full items-center justify-between gap-1 rounded-md border px-3 py-2 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+        disableValueLineClamp ? null : "[&>span]:line-clamp-1",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {hideDownIcon ? null : (
+        <SelectPrimitive.Icon asChild>
+          <ChevronDown className="h-4 w-4 opacity-50" />
+        </SelectPrimitive.Icon>
+      )}
+    </SelectPrimitive.Trigger>
+  ),
+);
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
 const SelectScrollUpButton = React.forwardRef<

--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -1,23 +1,8 @@
 import { env } from "@/src/env.mjs";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
-import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import {
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/src/components/ui/dialog";
-import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
+import { CloudRegionPicker } from "@/src/features/auth/components/CloudRegionPicker";
 import { getAvailableCloudRegionOptions } from "@/src/features/organizations/cloudRegions";
+import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 export function CloudRegionSwitch({
   isSignUpPage,
@@ -35,143 +20,26 @@ export function CloudRegionSwitch({
   const currentRegion = regions.find((region) => region.name === cloudRegion);
 
   return (
-    <div className="bg-card mt-8 -mb-10 rounded-lg px-6 py-6 text-sm sm:mx-auto sm:w-full sm:max-w-[480px] sm:rounded-lg sm:px-10">
-      <div className="flex w-full flex-col gap-2">
-        <div>
-          <span className="text-sm leading-none font-bold">
-            Data Region
-            <DataRegionInfo />
-          </span>
-          {isSignUpPage && cloudRegion === "HIPAA" ? (
-            <p className="text-muted-foreground text-xs">
-              Demo project is not available in the HIPAA data region.
-            </p>
-          ) : null}
-        </div>
-        <Select
-          value={currentRegion?.name}
-          onValueChange={(value) => {
-            const region = regions.find((region) => region.name === value);
-            if (!region) return;
-            capture(
-              "sign_in:cloud_region_switch",
-              {
-                region: region.name,
-              },
-              {
-                send_instantly: true,
-              },
-            );
-            if (region.hostname) {
-              window.location.hostname = region.hostname;
-            }
-          }}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {regions.map((region) => (
-              <SelectItem key={region.name} value={region.name}>
-                <span className="flex items-center gap-2">
-                  <span
-                    className={
-                      // The HIPAA symbol glyph sits lower than flag emojis in the same font.
-                      region.name === "HIPAA"
-                        ? "translate-y-[-3px] text-xl leading-none"
-                        : "-translate-y-px text-xl leading-none"
-                    }
-                  >
-                    {region.flag}
-                  </span>
-                  <span>{region.name}</span>
-                </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        {cloudRegion === "HIPAA" && (
-          <div className="bg-muted/50 text-muted-foreground mt-2 rounded-md p-3 text-xs">
-            <p>
-              The Business Associate Agreement (BAA) is only effective on the
-              Cloud Pro and Teams plans.{" "}
-              <a
-                href="https://langfuse.com/security/hipaa"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-link hover:text-link-hover underline"
-              >
-                Learn more about HIPAA compliance →
-              </a>
-            </p>
-          </div>
-        )}
-      </div>
-    </div>
+    <CloudRegionPicker
+      regions={regions}
+      selectedRegion={currentRegion}
+      onValueChange={(value) => {
+        const region = regions.find((region) => region.name === value);
+        if (!region) return;
+        capture(
+          "sign_in:cloud_region_switch",
+          {
+            region: region.name,
+          },
+          {
+            send_instantly: true,
+          },
+        );
+        if (region.hostname) {
+          window.location.hostname = region.hostname;
+        }
+      }}
+      isSignUpPage={isSignUpPage}
+    />
   );
 }
-
-const DataRegionInfo = () => (
-  <Dialog>
-    <DialogTrigger asChild>
-      <a
-        href="#"
-        className="text-link hover:text-link-hover ml-1 text-xs"
-        title="What is this?"
-        tabIndex={-1}
-      >
-        (what is this?)
-      </a>
-    </DialogTrigger>
-    <DialogContent>
-      <DialogHeader>
-        <DialogTitle>Data Regions</DialogTitle>
-      </DialogHeader>
-      <DialogBody>
-        <DialogDescription className="flex flex-col gap-2">
-          <p>Langfuse Cloud is available in four data regions:</p>
-          <ul className="list-disc pl-5">
-            <li>US: Oregon (AWS us-west-2)</li>
-            <li>EU: Ireland (AWS eu-west-1)</li>
-            <li>JP: Tokyo (AWS ap-northeast-1)</li>
-            <li>
-              HIPAA: Oregon (AWS us-west-2) - HIPAA-compliant region (available
-              with Pro and Teams plans)
-            </li>
-          </ul>
-          <p>
-            Regions are strictly separated, and no data is shared across
-            regions. Choosing a region close to you can help improve speed and
-            comply with local data residency laws and privacy regulations.
-          </p>
-          <p>
-            You can have accounts in multiple regions. Each region requires a
-            separate subscription.
-          </p>
-          <p>
-            Learn more about{" "}
-            <a
-              href="https://langfuse.com/security/data-regions"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-link hover:text-link-hover underline"
-            >
-              data regions
-            </a>{" "}
-            and{" "}
-            <a
-              href="https://langfuse.com/docs/data-security-privacy"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-link hover:text-link-hover underline"
-            >
-              data security & privacy
-            </a>
-            .
-          </p>
-        </DialogDescription>
-      </DialogBody>
-    </DialogContent>
-  </Dialog>
-);

--- a/web/src/features/auth/components/CloudRegionPicker.stories.tsx
+++ b/web/src/features/auth/components/CloudRegionPicker.stories.tsx
@@ -1,0 +1,40 @@
+import preview from "../../../../.storybook/preview";
+import { getAvailableCloudRegionOptions } from "@/src/features/organizations/cloudRegions";
+import { useState } from "react";
+import { CloudRegionPicker } from "./CloudRegionPicker";
+
+const regions = getAvailableCloudRegionOptions();
+
+const meta = preview.meta({
+  component: CloudRegionPicker,
+});
+
+function StatefulCloudRegionPicker({
+  initialRegion,
+  isSignUpPage,
+}: {
+  initialRegion: (typeof regions)[number]["name"];
+  isSignUpPage?: boolean;
+}) {
+  const [regionName, setRegionName] = useState(initialRegion);
+  const selectedRegion = regions.find((region) => region.name === regionName);
+
+  return (
+    <CloudRegionPicker
+      regions={regions}
+      selectedRegion={selectedRegion}
+      onValueChange={setRegionName}
+      isSignUpPage={isSignUpPage}
+    />
+  );
+}
+
+export const Default = meta.story({
+  render: () => <StatefulCloudRegionPicker initialRegion="EU" />,
+});
+
+export const HipaaSignUp = meta.story({
+  render: () => (
+    <StatefulCloudRegionPicker initialRegion="HIPAA" isSignUpPage />
+  ),
+});

--- a/web/src/features/auth/components/CloudRegionPicker.tsx
+++ b/web/src/features/auth/components/CloudRegionPicker.tsx
@@ -43,6 +43,7 @@ export function CloudRegionPicker({
         <Select value={selectedRegion?.name} onValueChange={onValueChange}>
           <SelectTrigger
             className="w-full"
+            disableValueLineClamp
             aria-label={
               selectedRegion ? `${selectedRegion.name} data region` : undefined
             }
@@ -83,7 +84,7 @@ export function CloudRegionPicker({
 
 function CloudRegionLabel({ region }: { region: CloudRegion }) {
   return (
-    <span className="!flex items-center gap-2">
+    <span className="flex items-center gap-2">
       <span
         className={
           region.name === "HIPAA"

--- a/web/src/features/auth/components/CloudRegionPicker.tsx
+++ b/web/src/features/auth/components/CloudRegionPicker.tsx
@@ -12,7 +12,6 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
 } from "@/src/components/ui/select";
 import type { CloudRegion } from "@/src/features/organizations/cloudRegions";
 
@@ -48,11 +47,9 @@ export function CloudRegionPicker({
               selectedRegion ? `${selectedRegion.name} data region` : undefined
             }
           >
-            <SelectValue>
-              {selectedRegion ? (
-                <CloudRegionLabel region={selectedRegion} />
-              ) : null}
-            </SelectValue>
+            {selectedRegion ? (
+              <CloudRegionLabel region={selectedRegion} />
+            ) : null}
           </SelectTrigger>
           <SelectContent>
             {regions.map((region) => (
@@ -86,10 +83,9 @@ export function CloudRegionPicker({
 
 function CloudRegionLabel({ region }: { region: CloudRegion }) {
   return (
-    <span className="flex items-center gap-2">
+    <span className="!flex items-center gap-2">
       <span
         className={
-          // The HIPAA symbol glyph sits lower than flag emojis in the same font.
           region.name === "HIPAA"
             ? "translate-y-[-3px] text-xl leading-none"
             : "-translate-y-px text-xl leading-none"

--- a/web/src/features/auth/components/CloudRegionPicker.tsx
+++ b/web/src/features/auth/components/CloudRegionPicker.tsx
@@ -1,0 +1,167 @@
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/src/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/src/components/ui/select";
+import type { CloudRegion } from "@/src/features/organizations/cloudRegions";
+
+export function CloudRegionPicker({
+  regions,
+  selectedRegion,
+  onValueChange,
+  isSignUpPage,
+}: {
+  regions: CloudRegion[];
+  selectedRegion?: CloudRegion;
+  onValueChange: (value: CloudRegion["name"]) => void;
+  isSignUpPage?: boolean;
+}) {
+  return (
+    <div className="bg-card mt-8 -mb-10 rounded-lg px-6 py-6 text-sm sm:mx-auto sm:w-full sm:max-w-[480px] sm:rounded-lg sm:px-10">
+      <div className="flex w-full flex-col gap-2">
+        <div>
+          <span className="text-sm leading-none font-bold">
+            Data Region
+            <DataRegionInfo />
+          </span>
+          {isSignUpPage && selectedRegion?.name === "HIPAA" ? (
+            <p className="text-muted-foreground text-xs">
+              Demo project is not available in the HIPAA data region.
+            </p>
+          ) : null}
+        </div>
+        <Select value={selectedRegion?.name} onValueChange={onValueChange}>
+          <SelectTrigger
+            className="w-full"
+            aria-label={
+              selectedRegion ? `${selectedRegion.name} data region` : undefined
+            }
+          >
+            <SelectValue>
+              {selectedRegion ? (
+                <CloudRegionLabel region={selectedRegion} />
+              ) : null}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {regions.map((region) => (
+              <SelectItem key={region.name} value={region.name}>
+                <CloudRegionLabel region={region} />
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {selectedRegion?.name === "HIPAA" && (
+          <div className="bg-muted/50 text-muted-foreground mt-2 rounded-md p-3 text-xs">
+            <p>
+              The Business Associate Agreement (BAA) is only effective on the
+              Cloud Pro and Teams plans.{" "}
+              <a
+                href="https://langfuse.com/security/hipaa"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-link hover:text-link-hover underline"
+              >
+                Learn more about HIPAA compliance →
+              </a>
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CloudRegionLabel({ region }: { region: CloudRegion }) {
+  return (
+    <span className="flex items-center gap-2">
+      <span
+        className={
+          // The HIPAA symbol glyph sits lower than flag emojis in the same font.
+          region.name === "HIPAA"
+            ? "translate-y-[-3px] text-xl leading-none"
+            : "-translate-y-px text-xl leading-none"
+        }
+      >
+        {region.flag}
+      </span>
+      <span>{region.name}</span>
+    </span>
+  );
+}
+
+const DataRegionInfo = () => (
+  <Dialog>
+    <DialogTrigger asChild>
+      <a
+        href="#"
+        className="text-link hover:text-link-hover ml-1 text-xs"
+        title="What is this?"
+        tabIndex={-1}
+      >
+        (what is this?)
+      </a>
+    </DialogTrigger>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Data Regions</DialogTitle>
+      </DialogHeader>
+      <DialogBody>
+        <DialogDescription className="flex flex-col gap-2">
+          <p>Langfuse Cloud is available in four data regions:</p>
+          <ul className="list-disc pl-5">
+            <li>US: Oregon (AWS us-west-2)</li>
+            <li>EU: Ireland (AWS eu-west-1)</li>
+            <li>JP: Tokyo (AWS ap-northeast-1)</li>
+            <li>
+              HIPAA: Oregon (AWS us-west-2) - HIPAA-compliant region (available
+              with Pro and Teams plans)
+            </li>
+          </ul>
+          <p>
+            Regions are strictly separated, and no data is shared across
+            regions. Choosing a region close to you can help improve speed and
+            comply with local data residency laws and privacy regulations.
+          </p>
+          <p>
+            You can have accounts in multiple regions. Each region requires a
+            separate subscription.
+          </p>
+          <p>
+            Learn more about{" "}
+            <a
+              href="https://langfuse.com/security/data-regions"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-link hover:text-link-hover underline"
+            >
+              data regions
+            </a>{" "}
+            and{" "}
+            <a
+              href="https://langfuse.com/docs/data-security-privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-link hover:text-link-hover underline"
+            >
+              data security & privacy
+            </a>
+            .
+          </p>
+        </DialogDescription>
+      </DialogBody>
+    </DialogContent>
+  </Dialog>
+);

--- a/web/src/features/organizations/cloudRegions.ts
+++ b/web/src/features/organizations/cloudRegions.ts
@@ -43,6 +43,8 @@ const cloudRegions = [
   },
 ] as const;
 
+export type CloudRegion = (typeof cloudRegions)[number];
+
 const availableRegionsByCurrentRegion = {
   STAGING: ["STAGING"],
   DEV: ["DEV"],


### PR DESCRIPTION
## Summary

- Extracts the auth cloud region selector into a reusable `CloudRegionPicker` component so the sign-in region switch and Storybook coverage share the same presentational UI.
- Renders the selected region label directly in the trigger to keep the picker display stable after the select value handling changed.
- Adds Storybook coverage for the default and HIPAA sign-up states.

After:
<img width="557" height="220" alt="CleanShot 2026-07-20 at 12 32 38" src="https://github.com/user-attachments/assets/09f132c9-339f-43f8-9363-768e25d0f2b6" />

Before:
<img width="625" height="197" alt="CleanShot 2026-07-20 at 12 25 32" src="https://github.com/user-attachments/assets/c5b50b7d-45f5-43f6-b325-fa571ed28e8c" />


## Linear

- None

## Major Decisions

- Kept the existing HIPAA behavior on Safari unchanged for now; this PR only fixes the picker rendering/refactor scope.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the cloud region selection UI by extracting a reusable `CloudRegionPicker` component from `AuthCloudRegionSwitch`, and fixes the picker's display by rendering the selected region label directly inside the `SelectTrigger` instead of relying on `<SelectValue />` (which had stopped rendering correctly).

- **Component extraction**: All presentational logic (region label, HIPAA notice, data-region info dialog) is moved from `AuthCloudRegionSwitch` into the new `CloudRegionPicker` component. `AuthCloudRegionSwitch` now acts as a thin behavioral wrapper that supplies the PostHog capture call and navigation side-effect.
- **Trigger rendering fix**: `<SelectValue />` is replaced with a directly rendered `<CloudRegionLabel>` in the trigger; the `!flex` Tailwind important modifier ensures the flex layout isn't overridden by Radix UI's trigger styles.
- **Storybook coverage**: Two new stories (`Default` and `HipaaSignUp`) exercise the component with stateful region selection.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a focused UI refactor and rendering fix with no changes to auth logic, data handling, or API calls. The behavioral side-effects (PostHog capture and hostname navigation) are preserved unchanged in AuthCloudRegionSwitch.

The change correctly moves presentational code into a dedicated component and fixes the picker by rendering the region label directly in the trigger. The only edge case worth noting — an empty trigger when no region matches — is unlikely in production and was equally unhandled in the original code.

No files require special attention. CloudRegionPicker.tsx is the core new file and reads straightforwardly.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User on Langfuse Cloud page] --> B[AuthCloudRegionSwitch]
    B --> C[useLangfuseCloudRegion]
    C --> D{cloudRegion found in available regions?}
    D -- Yes --> E[selectedRegion = CloudRegion object]
    D -- No --> F[selectedRegion = undefined, Empty trigger rendered]
    E --> G[CloudRegionPicker rendered with selectedRegion]
    G --> H[SelectTrigger shows CloudRegionLabel flag + name]
    G --> I[User changes region]
    I --> J[onValueChange callback]
    J --> K[PostHog capture event]
    J --> L{region.hostname?}
    L -- Yes --> M[window.location.hostname = region.hostname]
    L -- No --> N[No navigation - DEV region]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User on Langfuse Cloud page] --> B[AuthCloudRegionSwitch]
    B --> C[useLangfuseCloudRegion]
    C --> D{cloudRegion found in available regions?}
    D -- Yes --> E[selectedRegion = CloudRegion object]
    D -- No --> F[selectedRegion = undefined, Empty trigger rendered]
    E --> G[CloudRegionPicker rendered with selectedRegion]
    G --> H[SelectTrigger shows CloudRegionLabel flag + name]
    G --> I[User changes region]
    I --> J[onValueChange callback]
    J --> K[PostHog capture event]
    J --> L{region.hostname?}
    L -- Yes --> M[window.location.hostname = region.hostname]
    L -- No --> N[No navigation - DEV region]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/auth/components/CloudRegionPicker.tsx:49-53
**Empty trigger when `selectedRegion` is undefined**

When `selectedRegion` is `undefined` (e.g., `useLangfuseCloudRegion()` returns a value not present in the available regions list), the `SelectTrigger` renders no content at all — no label, no placeholder. In the original code, `<SelectValue />` would at least render a blank placeholder affordance. Consider adding a fallback such as `"Select region"` so the picker remains discoverable in that edge state.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): render cloud region trigger la..."](https://github.com/langfuse/langfuse/commit/2af6c1c0770227437a9d0e9080b9401882ac39e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45597920)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->