### PR TITLE
fix(worker): bound media retention cleanup batches

### DIFF
--- a/packages/shared/src/server/media-deletion.ts
+++ b/packages/shared/src/server/media-deletion.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import chunk from "lodash/chunk";
 
 import { prisma } from "../db";
@@ -8,6 +9,42 @@ interface MediaFileRef {
   id: string;
   bucketPath: string;
 }
+
+export interface MediaRetentionProject {
+  projectId: string;
+  retentionDays: number;
+  cutoffDate: Date;
+  secondsPastCutoff: number;
+}
+
+const expiredMediaWorkCondition = (params: {
+  projectId: Prisma.Sql;
+  cutoffDate: Prisma.Sql;
+}) => Prisma.sql`
+  m.project_id = ${params.projectId}
+  AND m.created_at <= ${params.cutoffDate}
+  AND (
+    NOT EXISTS (
+      SELECT 1
+      FROM dataset_item_media dim
+      WHERE dim.project_id = ${params.projectId}
+        AND dim.media_id = m.id
+        AND dim.dataset_item_valid_from IS NOT NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM trace_media tm
+      WHERE tm.project_id = ${params.projectId}
+        AND tm.media_id = m.id
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM observation_media om
+      WHERE om.project_id = ${params.projectId}
+        AND om.media_id = m.id
+    )
+  )
+`;
 
 /**
  * Find all media files for a project (for complete project deletion).
@@ -38,6 +75,65 @@ export async function findExpiredMediaByProjectId(params: {
       createdAt: { lte: params.cutoffDate },
     },
   });
+}
+
+/**
+ * Find the oldest bounded retention batch. Each returned row either deletes
+ * media or removes stale trace/observation links, so every batch progresses.
+ */
+export async function findExpiredMediaBatchByProjectId(params: {
+  projectId: string;
+  cutoffDate: Date;
+  limit: number;
+}): Promise<MediaFileRef[]> {
+  const condition = expiredMediaWorkCondition({
+    projectId: Prisma.sql`${params.projectId}`,
+    cutoffDate: Prisma.sql`${params.cutoffDate}`,
+  });
+
+  return prisma.$queryRaw<MediaFileRef[]>(Prisma.sql`
+    SELECT m.id, m.bucket_path AS "bucketPath"
+    FROM media m
+    WHERE ${condition}
+    ORDER BY m.created_at ASC, m.id ASC
+    LIMIT ${params.limit}
+  `);
+}
+
+/**
+ * Find the project whose oldest actionable media is furthest past retention.
+ * The lateral lookup stops at the first actionable row per project.
+ */
+export async function findNextMediaRetentionProject(): Promise<MediaRetentionProject | null> {
+  const cutoffDate = Prisma.sql`
+    NOW() - p.retention_days * INTERVAL '1 day'
+  `;
+  const condition = expiredMediaWorkCondition({
+    projectId: Prisma.sql`p.id`,
+    cutoffDate,
+  });
+  const rows = await prisma.$queryRaw<MediaRetentionProject[]>(Prisma.sql`
+    SELECT
+      p.id AS "projectId",
+      p.retention_days AS "retentionDays",
+      ${cutoffDate} AS "cutoffDate",
+      EXTRACT(EPOCH FROM (${cutoffDate} - oldest.created_at))::int
+        AS "secondsPastCutoff"
+    FROM projects p
+    CROSS JOIN LATERAL (
+      SELECT m.created_at
+      FROM media m
+      WHERE ${condition}
+      ORDER BY m.created_at ASC
+      LIMIT 1
+    ) oldest
+    WHERE p.retention_days > 0
+      AND p.deleted_at IS NULL
+    ORDER BY "secondsPastCutoff" DESC, p.id ASC
+    LIMIT 1
+  `);
+
+  return rows[0] ?? null;
 }
 
 export interface StorageClient {

--- a/packages/shared/src/server/media-deletion.ts
+++ b/packages/shared/src/server/media-deletion.ts
@@ -17,18 +17,32 @@ export interface MediaRetentionProject {
   secondsPastCutoff: number;
 }
 
-const expiredDeletableMediaCondition = (params: {
+const expiredMediaWorkCondition = (params: {
   projectId: Prisma.Sql;
   cutoffDate: Prisma.Sql;
 }) => Prisma.sql`
   m.project_id = ${params.projectId}
   AND m.created_at <= ${params.cutoffDate}
-  AND NOT EXISTS (
-    SELECT 1
-    FROM dataset_item_media dim
-    WHERE dim.project_id = ${params.projectId}
-      AND dim.media_id = m.id
-      AND dim.dataset_item_valid_from IS NOT NULL
+  AND (
+    NOT EXISTS (
+      SELECT 1
+      FROM dataset_item_media dim
+      WHERE dim.project_id = ${params.projectId}
+        AND dim.media_id = m.id
+        AND dim.dataset_item_valid_from IS NOT NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM trace_media tm
+      WHERE tm.project_id = ${params.projectId}
+        AND tm.media_id = m.id
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM observation_media om
+      WHERE om.project_id = ${params.projectId}
+        AND om.media_id = m.id
+    )
   )
 `;
 
@@ -64,15 +78,15 @@ export async function findExpiredMediaByProjectId(params: {
 }
 
 /**
- * Find the oldest bounded retention batch. Claimed dataset media is excluded
- * before applying the limit so every returned row can be deleted.
+ * Find the oldest bounded retention batch. Each returned row either deletes
+ * media or removes stale trace/observation links, so every batch progresses.
  */
 export async function findExpiredMediaBatchByProjectId(params: {
   projectId: string;
   cutoffDate: Date;
   limit: number;
 }): Promise<MediaFileRef[]> {
-  const condition = expiredDeletableMediaCondition({
+  const condition = expiredMediaWorkCondition({
     projectId: Prisma.sql`${params.projectId}`,
     cutoffDate: Prisma.sql`${params.cutoffDate}`,
   });
@@ -87,14 +101,14 @@ export async function findExpiredMediaBatchByProjectId(params: {
 }
 
 /**
- * Find the project whose oldest deletable media is furthest past retention.
- * The lateral lookup stops at the first deletable row per project.
+ * Find the project whose oldest actionable media is furthest past retention.
+ * The lateral lookup stops at the first actionable row per project.
  */
 export async function findNextMediaRetentionProject(): Promise<MediaRetentionProject | null> {
   const cutoffDate = Prisma.sql`
     NOW() - p.retention_days * INTERVAL '1 day'
   `;
-  const condition = expiredDeletableMediaCondition({
+  const condition = expiredMediaWorkCondition({
     projectId: Prisma.sql`p.id`,
     cutoffDate,
   });
@@ -197,20 +211,26 @@ export async function deleteMediaFiles(params: {
     );
     const deletableMediaIds = deletableBatch.map((f) => f.id);
 
+    // Trace/observation links are cleaned up even for an all-protected batch, so
+    // only the S3 delete is skipped when nothing is deletable.
     if (deletableBatch.length > 0) {
       await storageClient.deleteFiles(deletableBatch.map((f) => f.bucketPath));
     }
     await prisma.$transaction([
+      // Trace/observation links are removed for every media in the batch, not
+      // just the deletable ones: their traces/observations are deleted by the
+      // same retention job, so the links go even when the media itself is kept
+      // for a dataset item.
       prisma.traceMedia.deleteMany({
         where: {
           projectId,
-          mediaId: { in: deletableMediaIds },
+          mediaId: { in: mediaIds },
         },
       }),
       prisma.observationMedia.deleteMany({
         where: {
           projectId,
-          mediaId: { in: deletableMediaIds },
+          mediaId: { in: mediaIds },
         },
       }),
       // Sweep leftover pending rows for the deleted media (claimed rows can't

--- a/packages/shared/src/server/media-deletion.ts
+++ b/packages/shared/src/server/media-deletion.ts
@@ -17,32 +17,18 @@ export interface MediaRetentionProject {
   secondsPastCutoff: number;
 }
 
-const expiredMediaWorkCondition = (params: {
+const expiredDeletableMediaCondition = (params: {
   projectId: Prisma.Sql;
   cutoffDate: Prisma.Sql;
 }) => Prisma.sql`
   m.project_id = ${params.projectId}
   AND m.created_at <= ${params.cutoffDate}
-  AND (
-    NOT EXISTS (
-      SELECT 1
-      FROM dataset_item_media dim
-      WHERE dim.project_id = ${params.projectId}
-        AND dim.media_id = m.id
-        AND dim.dataset_item_valid_from IS NOT NULL
-    )
-    OR EXISTS (
-      SELECT 1
-      FROM trace_media tm
-      WHERE tm.project_id = ${params.projectId}
-        AND tm.media_id = m.id
-    )
-    OR EXISTS (
-      SELECT 1
-      FROM observation_media om
-      WHERE om.project_id = ${params.projectId}
-        AND om.media_id = m.id
-    )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM dataset_item_media dim
+    WHERE dim.project_id = ${params.projectId}
+      AND dim.media_id = m.id
+      AND dim.dataset_item_valid_from IS NOT NULL
   )
 `;
 
@@ -78,15 +64,15 @@ export async function findExpiredMediaByProjectId(params: {
 }
 
 /**
- * Find the oldest bounded retention batch. Each returned row either deletes
- * media or removes stale trace/observation links, so every batch progresses.
+ * Find the oldest bounded retention batch. Claimed dataset media is excluded
+ * before applying the limit so every returned row can be deleted.
  */
 export async function findExpiredMediaBatchByProjectId(params: {
   projectId: string;
   cutoffDate: Date;
   limit: number;
 }): Promise<MediaFileRef[]> {
-  const condition = expiredMediaWorkCondition({
+  const condition = expiredDeletableMediaCondition({
     projectId: Prisma.sql`${params.projectId}`,
     cutoffDate: Prisma.sql`${params.cutoffDate}`,
   });
@@ -101,14 +87,14 @@ export async function findExpiredMediaBatchByProjectId(params: {
 }
 
 /**
- * Find the project whose oldest actionable media is furthest past retention.
- * The lateral lookup stops at the first actionable row per project.
+ * Find the project whose oldest deletable media is furthest past retention.
+ * The lateral lookup stops at the first deletable row per project.
  */
 export async function findNextMediaRetentionProject(): Promise<MediaRetentionProject | null> {
   const cutoffDate = Prisma.sql`
     NOW() - p.retention_days * INTERVAL '1 day'
   `;
-  const condition = expiredMediaWorkCondition({
+  const condition = expiredDeletableMediaCondition({
     projectId: Prisma.sql`p.id`,
     cutoffDate,
   });
@@ -211,26 +197,20 @@ export async function deleteMediaFiles(params: {
     );
     const deletableMediaIds = deletableBatch.map((f) => f.id);
 
-    // Trace/observation links are cleaned up even for an all-protected batch, so
-    // only the S3 delete is skipped when nothing is deletable.
     if (deletableBatch.length > 0) {
       await storageClient.deleteFiles(deletableBatch.map((f) => f.bucketPath));
     }
     await prisma.$transaction([
-      // Trace/observation links are removed for every media in the batch, not
-      // just the deletable ones: their traces/observations are deleted by the
-      // same retention job, so the links go even when the media itself is kept
-      // for a dataset item.
       prisma.traceMedia.deleteMany({
         where: {
           projectId,
-          mediaId: { in: mediaIds },
+          mediaId: { in: deletableMediaIds },
         },
       }),
       prisma.observationMedia.deleteMany({
         where: {
           projectId,
-          mediaId: { in: mediaIds },
+          mediaId: { in: deletableMediaIds },
         },
       }),
       // Sweep leftover pending rows for the deleted media (claimed rows can't

--- a/packages/shared/src/server/media-deletion.ts
+++ b/packages/shared/src/server/media-deletion.ts
@@ -36,12 +36,14 @@ const expiredMediaWorkCondition = (params: {
       FROM trace_media tm
       WHERE tm.project_id = ${params.projectId}
         AND tm.media_id = m.id
+        AND tm.created_at <= ${params.cutoffDate}
     )
     OR EXISTS (
       SELECT 1
       FROM observation_media om
       WHERE om.project_id = ${params.projectId}
         AND om.media_id = m.id
+        AND om.created_at <= ${params.cutoffDate}
     )
   )
 `;
@@ -79,7 +81,7 @@ export async function findExpiredMediaByProjectId(params: {
 
 /**
  * Find the oldest bounded retention batch. Each returned row either deletes
- * media or removes stale trace/observation links, so every batch progresses.
+ * media or removes expired trace/observation links, so every batch progresses.
  */
 export async function findExpiredMediaBatchByProjectId(params: {
   projectId: string;
@@ -170,14 +172,17 @@ export async function deleteMediaLinkRowsByProjectId(params: {
 /**
  * Delete media files from S3 first, then from PostgreSQL.
  * S3 is deleted first to avoid orphaned files if PG deletion succeeds but S3 fails.
+ * A link cutoff preserves recent links when retention keeps dataset-protected media.
  * Returns the number of media files deleted.
  */
 export async function deleteMediaFiles(params: {
   projectId: string;
   mediaFiles: MediaFileRef[];
   storageClient: StorageClient;
+  linkCleanupCutoffDate?: Date;
 }): Promise<number> {
-  const { projectId, mediaFiles, storageClient } = params;
+  const { projectId, mediaFiles, storageClient, linkCleanupCutoffDate } =
+    params;
 
   if (mediaFiles.length === 0) {
     return 0;
@@ -210,27 +215,31 @@ export async function deleteMediaFiles(params: {
       (f) => !datasetAssociatedMediaIds.has(f.id),
     );
     const deletableMediaIds = deletableBatch.map((f) => f.id);
+    const linkCleanupFilter = linkCleanupCutoffDate
+      ? {
+          OR: [
+            { mediaId: { in: deletableMediaIds } },
+            { createdAt: { lte: linkCleanupCutoffDate } },
+          ],
+        }
+      : {};
 
-    // Trace/observation links are cleaned up even for an all-protected batch, so
-    // only the S3 delete is skipped when nothing is deletable.
     if (deletableBatch.length > 0) {
       await storageClient.deleteFiles(deletableBatch.map((f) => f.bucketPath));
     }
     await prisma.$transaction([
-      // Trace/observation links are removed for every media in the batch, not
-      // just the deletable ones: their traces/observations are deleted by the
-      // same retention job, so the links go even when the media itself is kept
-      // for a dataset item.
       prisma.traceMedia.deleteMany({
         where: {
           projectId,
           mediaId: { in: mediaIds },
+          ...linkCleanupFilter,
         },
       }),
       prisma.observationMedia.deleteMany({
         where: {
           projectId,
           mediaId: { in: mediaIds },
+          ...linkCleanupFilter,
         },
       }),
       // Sweep leftover pending rows for the deleted media (claimed rows can't

--- a/web/src/__tests__/server/repositories/dataset-item-media-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/dataset-item-media-repository.servertest.ts
@@ -559,26 +559,6 @@ describe("Dataset Item Media Associations", () => {
       const pendingMedia = await createMediaRow(); // pending row only -> deleted
 
       await createItemWithMedia(datasetId, associatedMedia.referenceString);
-      const reusedTraceId = v4();
-      await prisma.traceMedia.create({
-        data: {
-          id: v4(),
-          projectId,
-          mediaId: associatedMedia.mediaId,
-          traceId: reusedTraceId,
-          field: "input",
-        },
-      });
-      await prisma.observationMedia.create({
-        data: {
-          id: v4(),
-          projectId,
-          mediaId: associatedMedia.mediaId,
-          traceId: reusedTraceId,
-          observationId: v4(),
-          field: "input",
-        },
-      });
       // A pending association: declared at upload, the item was never written.
       await prisma.datasetItemMedia.create({
         data: {
@@ -642,16 +622,6 @@ describe("Dataset Item Media Associations", () => {
           where: { projectId_id: { projectId, id: associatedMedia.mediaId } },
         }),
       ).resolves.not.toBeNull();
-      await expect(
-        prisma.traceMedia.count({
-          where: { projectId, mediaId: associatedMedia.mediaId },
-        }),
-      ).resolves.toBe(1);
-      await expect(
-        prisma.observationMedia.count({
-          where: { projectId, mediaId: associatedMedia.mediaId },
-        }),
-      ).resolves.toBe(1);
       await expect(
         prisma.media.findUnique({
           where: { projectId_id: { projectId, id: unassociatedMedia.mediaId } },

--- a/web/src/__tests__/server/repositories/dataset-item-media-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/dataset-item-media-repository.servertest.ts
@@ -559,6 +559,26 @@ describe("Dataset Item Media Associations", () => {
       const pendingMedia = await createMediaRow(); // pending row only -> deleted
 
       await createItemWithMedia(datasetId, associatedMedia.referenceString);
+      const reusedTraceId = v4();
+      await prisma.traceMedia.create({
+        data: {
+          id: v4(),
+          projectId,
+          mediaId: associatedMedia.mediaId,
+          traceId: reusedTraceId,
+          field: "input",
+        },
+      });
+      await prisma.observationMedia.create({
+        data: {
+          id: v4(),
+          projectId,
+          mediaId: associatedMedia.mediaId,
+          traceId: reusedTraceId,
+          observationId: v4(),
+          field: "input",
+        },
+      });
       // A pending association: declared at upload, the item was never written.
       await prisma.datasetItemMedia.create({
         data: {
@@ -622,6 +642,16 @@ describe("Dataset Item Media Associations", () => {
           where: { projectId_id: { projectId, id: associatedMedia.mediaId } },
         }),
       ).resolves.not.toBeNull();
+      await expect(
+        prisma.traceMedia.count({
+          where: { projectId, mediaId: associatedMedia.mediaId },
+        }),
+      ).resolves.toBe(1);
+      await expect(
+        prisma.observationMedia.count({
+          where: { projectId, mediaId: associatedMedia.mediaId },
+        }),
+      ).resolves.toBe(1);
       await expect(
         prisma.media.findUnique({
           where: { projectId_id: { projectId, id: unassociatedMedia.mediaId } },

--- a/worker/src/__tests__/mediaRetentionCleaner.test.ts
+++ b/worker/src/__tests__/mediaRetentionCleaner.test.ts
@@ -18,13 +18,14 @@ vi.mock("@langfuse/shared/src/server", async () => {
 });
 
 // Mock the env module to enable S3 bucket
-vi.mock("../../env", async () => {
-  const actual = await vi.importActual("../../env");
+vi.mock("../env", async () => {
+  const actual = await vi.importActual("../env");
   return {
     env: {
       ...(actual as { env: object }).env,
       LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: "test-bucket",
       LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG: "false",
+      LANGFUSE_MEDIA_RETENTION_CLEANER_ITEM_LIMIT: 2,
     },
   };
 });
@@ -202,6 +203,119 @@ describe("MediaRetentionCleaner", () => {
           where: { projectId, datasetItemValidFrom: null },
         }),
       ).resolves.toBe(0);
+    });
+
+    it("continues an over-limit project and cleans claimed media links", async () => {
+      await drainExpiredMedia();
+      mockDeleteFiles.mockClear();
+
+      const now = Date.now();
+      const daysAgo = (days: number) =>
+        new Date(now - days * 24 * 60 * 60 * 1000);
+
+      const { projectId } = await createOrgProjectAndApiKey();
+      await prisma.project.update({
+        where: { id: projectId },
+        data: { retentionDays: 7 },
+      });
+
+      // Claimed media remains stored, but its stale links must stop consuming
+      // the limited selection so later runs reach deletable media.
+      const protectedMediaIds: string[] = [];
+      for (const ageInDays of [300, 299]) {
+        const protectedMedia = await createTestMedia(
+          projectId,
+          daysAgo(ageInDays),
+        );
+        protectedMediaIds.push(protectedMedia.id);
+        const traceId = randomUUID();
+        await prisma.datasetItemMedia.create({
+          data: {
+            id: randomUUID(),
+            projectId,
+            datasetId: randomUUID(),
+            datasetItemId: randomUUID(),
+            datasetItemValidFrom: new Date(),
+            mediaId: protectedMedia.id,
+            field: "input",
+            jsonPath: "$['image']",
+            referenceString: `@@@langfuseMedia:type=image/png|id=${protectedMedia.id}|source=base64@@@`,
+          },
+        });
+        await prisma.traceMedia.create({
+          data: {
+            id: randomUUID(),
+            projectId,
+            mediaId: protectedMedia.id,
+            traceId,
+            field: "input",
+          },
+        });
+        await prisma.observationMedia.create({
+          data: {
+            id: randomUUID(),
+            projectId,
+            mediaId: protectedMedia.id,
+            traceId,
+            observationId: randomUUID(),
+            field: "input",
+          },
+        });
+      }
+
+      const deletableMedia = await Promise.all([
+        createTestMedia(projectId, daysAgo(200)),
+        createTestMedia(projectId, daysAgo(199)),
+        createTestMedia(projectId, daysAgo(198)),
+      ]);
+
+      const firstCleaner = new MediaRetentionCleaner();
+      await firstCleaner.processBatch();
+
+      expect(mockDeleteFiles).not.toHaveBeenCalled();
+      await expect(
+        prisma.traceMedia.count({
+          where: { projectId, mediaId: { in: protectedMediaIds } },
+        }),
+      ).resolves.toBe(0);
+      await expect(
+        prisma.observationMedia.count({
+          where: { projectId, mediaId: { in: protectedMediaIds } },
+        }),
+      ).resolves.toBe(0);
+      await expect(
+        prisma.media.count({
+          where: {
+            projectId,
+            id: { in: deletableMedia.map((media) => media.id) },
+          },
+        }),
+      ).resolves.toBe(3);
+
+      const secondCleaner = new MediaRetentionCleaner();
+      await secondCleaner.processBatch();
+
+      expect(mockDeleteFiles).toHaveBeenCalledTimes(1);
+      expect(mockDeleteFiles).toHaveBeenLastCalledWith(
+        deletableMedia.slice(0, 2).map((media) => media.bucketPath),
+      );
+      await expect(
+        prisma.media.count({
+          where: {
+            projectId,
+            id: { in: deletableMedia.map((media) => media.id) },
+          },
+        }),
+      ).resolves.toBe(1);
+
+      const thirdCleaner = new MediaRetentionCleaner();
+      await thirdCleaner.processBatch();
+
+      expect(mockDeleteFiles).toHaveBeenCalledTimes(2);
+      expect(mockDeleteFiles).toHaveBeenLastCalledWith([
+        deletableMedia[2].bucketPath,
+      ]);
+      await expect(getMediaCount(projectId)).resolves.toBe(2);
     });
 
     it("should NOT delete media within retention period", async () => {

--- a/worker/src/__tests__/mediaRetentionCleaner.test.ts
+++ b/worker/src/__tests__/mediaRetentionCleaner.test.ts
@@ -2,6 +2,7 @@ import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
 import { randomUUID } from "crypto";
 import {
   createOrgProjectAndApiKey,
+  findNextMediaRetentionProject,
   getS3MediaStorageClient,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
@@ -85,12 +86,9 @@ async function processUntilProjectComplete(
  */
 async function drainExpiredMedia(maxIterations = 20): Promise<void> {
   for (let i = 0; i < maxIterations; i++) {
-    const countBefore = mockDeleteFiles.mock.calls.length;
+    if (!(await findNextMediaRetentionProject())) return;
     const cleaner = new MediaRetentionCleaner();
     await cleaner.processBatch();
-    const countAfter = mockDeleteFiles.mock.calls.length;
-    // No new deletions means no more work
-    if (countAfter === countBefore) return;
   }
 }
 
@@ -135,10 +133,12 @@ describe("MediaRetentionCleaner", () => {
       expect(allDeletedPaths).toContain(media.bucketPath);
     });
 
-    it("protects claimed-associated media but sweeps pending associations", async () => {
+    it("cleans claimed media links and continues an over-limit project", async () => {
       await drainExpiredMedia();
+      mockDeleteFiles.mockClear();
       const now = Date.now();
-      const tenDaysAgo = new Date(now - 10 * 24 * 60 * 60 * 1000);
+      const daysAgo = (days: number) =>
+        new Date(now - days * 24 * 60 * 60 * 1000);
 
       const { projectId } = await createOrgProjectAndApiKey();
       await prisma.project.update({
@@ -147,7 +147,7 @@ describe("MediaRetentionCleaner", () => {
       });
 
       // Claimed association (validFrom set) protects its media from retention.
-      const claimedMedia = await createTestMedia(projectId, tenDaysAgo);
+      const claimedMedia = await createTestMedia(projectId, daysAgo(12));
       await prisma.datasetItemMedia.create({
         data: {
           id: randomUUID(),
@@ -161,11 +161,31 @@ describe("MediaRetentionCleaner", () => {
           referenceString: `@@@langfuseMedia:type=image/png|id=${claimedMedia.id}|source=base64@@@`,
         },
       });
+      const traceId = randomUUID();
+      await prisma.traceMedia.create({
+        data: {
+          id: randomUUID(),
+          projectId,
+          mediaId: claimedMedia.id,
+          traceId,
+          field: "input",
+        },
+      });
+      await prisma.observationMedia.create({
+        data: {
+          id: randomUUID(),
+          projectId,
+          mediaId: claimedMedia.id,
+          traceId,
+          observationId: randomUUID(),
+          field: "input",
+        },
+      });
 
       // Pending association (null validFrom): an abandoned upload that never
       // claimed an item. It must not shield the project from the picker, and is
       // swept along with its media.
-      const pendingMedia = await createTestMedia(projectId, tenDaysAgo);
+      const pendingMedia = await createTestMedia(projectId, daysAgo(11));
       await prisma.datasetItemMedia.create({
         data: {
           id: randomUUID(),
@@ -179,8 +199,34 @@ describe("MediaRetentionCleaner", () => {
           referenceString: null,
         },
       });
+      const unassociatedMedia = await createTestMedia(projectId, daysAgo(10));
 
-      await processUntilProjectComplete(projectId);
+      await new MediaRetentionCleaner().processBatch();
+
+      expect(mockDeleteFiles).toHaveBeenCalledWith([pendingMedia.bucketPath]);
+      await expect(
+        prisma.traceMedia.count({
+          where: { projectId, mediaId: claimedMedia.id },
+        }),
+      ).resolves.toBe(0);
+      await expect(
+        prisma.observationMedia.count({
+          where: { projectId, mediaId: claimedMedia.id },
+        }),
+      ).resolves.toBe(0);
+      await expect(
+        prisma.media.findUnique({
+          where: {
+            projectId_id: { projectId, id: unassociatedMedia.id },
+          },
+        }),
+      ).resolves.not.toBeNull();
+
+      await new MediaRetentionCleaner().processBatch();
+
+      expect(mockDeleteFiles).toHaveBeenLastCalledWith([
+        unassociatedMedia.bucketPath,
+      ]);
 
       // Claimed media (and its row) survive; pending media (and its row) are gone.
       await expect(
@@ -194,6 +240,13 @@ describe("MediaRetentionCleaner", () => {
         }),
       ).resolves.toBeNull();
       await expect(
+        prisma.media.findUnique({
+          where: {
+            projectId_id: { projectId, id: unassociatedMedia.id },
+          },
+        }),
+      ).resolves.toBeNull();
+      await expect(
         prisma.datasetItemMedia.count({
           where: { projectId, datasetItemValidFrom: { not: null } },
         }),
@@ -203,106 +256,6 @@ describe("MediaRetentionCleaner", () => {
           where: { projectId, datasetItemValidFrom: null },
         }),
       ).resolves.toBe(0);
-    });
-
-    it("skips claimed media without consuming the batch limit", async () => {
-      await drainExpiredMedia();
-      mockDeleteFiles.mockClear();
-
-      const now = Date.now();
-      const daysAgo = (days: number) =>
-        new Date(now - days * 24 * 60 * 60 * 1000);
-
-      const { projectId } = await createOrgProjectAndApiKey();
-      await prisma.project.update({
-        where: { id: projectId },
-        data: { retentionDays: 7 },
-      });
-
-      // Claimed media remains stored and may be reused by recent traces. It
-      // must not consume the limit or lose those links.
-      const protectedMediaIds: string[] = [];
-      for (const ageInDays of [300, 299]) {
-        const protectedMedia = await createTestMedia(
-          projectId,
-          daysAgo(ageInDays),
-        );
-        protectedMediaIds.push(protectedMedia.id);
-        const traceId = randomUUID();
-        await prisma.datasetItemMedia.create({
-          data: {
-            id: randomUUID(),
-            projectId,
-            datasetId: randomUUID(),
-            datasetItemId: randomUUID(),
-            datasetItemValidFrom: new Date(),
-            mediaId: protectedMedia.id,
-            field: "input",
-            jsonPath: "$['image']",
-            referenceString: `@@@langfuseMedia:type=image/png|id=${protectedMedia.id}|source=base64@@@`,
-          },
-        });
-        await prisma.traceMedia.create({
-          data: {
-            id: randomUUID(),
-            projectId,
-            mediaId: protectedMedia.id,
-            traceId,
-            field: "input",
-          },
-        });
-        await prisma.observationMedia.create({
-          data: {
-            id: randomUUID(),
-            projectId,
-            mediaId: protectedMedia.id,
-            traceId,
-            observationId: randomUUID(),
-            field: "input",
-          },
-        });
-      }
-
-      const deletableMedia = await Promise.all([
-        createTestMedia(projectId, daysAgo(200)),
-        createTestMedia(projectId, daysAgo(199)),
-        createTestMedia(projectId, daysAgo(198)),
-      ]);
-
-      const firstCleaner = new MediaRetentionCleaner();
-      await firstCleaner.processBatch();
-
-      expect(mockDeleteFiles).toHaveBeenCalledTimes(1);
-      expect(mockDeleteFiles).toHaveBeenLastCalledWith(
-        deletableMedia.slice(0, 2).map((media) => media.bucketPath),
-      );
-      await expect(
-        prisma.traceMedia.count({
-          where: { projectId, mediaId: { in: protectedMediaIds } },
-        }),
-      ).resolves.toBe(2);
-      await expect(
-        prisma.observationMedia.count({
-          where: { projectId, mediaId: { in: protectedMediaIds } },
-        }),
-      ).resolves.toBe(2);
-      await expect(
-        prisma.media.count({
-          where: {
-            projectId,
-            id: { in: deletableMedia.map((media) => media.id) },
-          },
-        }),
-      ).resolves.toBe(1);
-
-      const secondCleaner = new MediaRetentionCleaner();
-      await secondCleaner.processBatch();
-
-      expect(mockDeleteFiles).toHaveBeenCalledTimes(2);
-      expect(mockDeleteFiles).toHaveBeenLastCalledWith([
-        deletableMedia[2].bucketPath,
-      ]);
-      await expect(getMediaCount(projectId)).resolves.toBe(2);
     });
 
     it("should NOT delete media within retention period", async () => {

--- a/worker/src/__tests__/mediaRetentionCleaner.test.ts
+++ b/worker/src/__tests__/mediaRetentionCleaner.test.ts
@@ -205,7 +205,7 @@ describe("MediaRetentionCleaner", () => {
       ).resolves.toBe(0);
     });
 
-    it("continues an over-limit project and cleans claimed media links", async () => {
+    it("skips claimed media without consuming the batch limit", async () => {
       await drainExpiredMedia();
       mockDeleteFiles.mockClear();
 
@@ -219,8 +219,8 @@ describe("MediaRetentionCleaner", () => {
         data: { retentionDays: 7 },
       });
 
-      // Claimed media remains stored, but its stale links must stop consuming
-      // the limited selection so later runs reach deletable media.
+      // Claimed media remains stored and may be reused by recent traces. It
+      // must not consume the limit or lose those links.
       const protectedMediaIds: string[] = [];
       for (const ageInDays of [300, 299]) {
         const protectedMedia = await createTestMedia(
@@ -272,33 +272,20 @@ describe("MediaRetentionCleaner", () => {
       const firstCleaner = new MediaRetentionCleaner();
       await firstCleaner.processBatch();
 
-      expect(mockDeleteFiles).not.toHaveBeenCalled();
-      await expect(
-        prisma.traceMedia.count({
-          where: { projectId, mediaId: { in: protectedMediaIds } },
-        }),
-      ).resolves.toBe(0);
-      await expect(
-        prisma.observationMedia.count({
-          where: { projectId, mediaId: { in: protectedMediaIds } },
-        }),
-      ).resolves.toBe(0);
-      await expect(
-        prisma.media.count({
-          where: {
-            projectId,
-            id: { in: deletableMedia.map((media) => media.id) },
-          },
-        }),
-      ).resolves.toBe(3);
-
-      const secondCleaner = new MediaRetentionCleaner();
-      await secondCleaner.processBatch();
-
       expect(mockDeleteFiles).toHaveBeenCalledTimes(1);
       expect(mockDeleteFiles).toHaveBeenLastCalledWith(
         deletableMedia.slice(0, 2).map((media) => media.bucketPath),
       );
+      await expect(
+        prisma.traceMedia.count({
+          where: { projectId, mediaId: { in: protectedMediaIds } },
+        }),
+      ).resolves.toBe(2);
+      await expect(
+        prisma.observationMedia.count({
+          where: { projectId, mediaId: { in: protectedMediaIds } },
+        }),
+      ).resolves.toBe(2);
       await expect(
         prisma.media.count({
           where: {
@@ -308,8 +295,8 @@ describe("MediaRetentionCleaner", () => {
         }),
       ).resolves.toBe(1);
 
-      const thirdCleaner = new MediaRetentionCleaner();
-      await thirdCleaner.processBatch();
+      const secondCleaner = new MediaRetentionCleaner();
+      await secondCleaner.processBatch();
 
       expect(mockDeleteFiles).toHaveBeenCalledTimes(2);
       expect(mockDeleteFiles).toHaveBeenLastCalledWith([

--- a/worker/src/__tests__/mediaRetentionCleaner.test.ts
+++ b/worker/src/__tests__/mediaRetentionCleaner.test.ts
@@ -2,6 +2,7 @@ import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
 import { randomUUID } from "crypto";
 import {
   createOrgProjectAndApiKey,
+  findExpiredMediaBatchByProjectId,
   findNextMediaRetentionProject,
   getS3MediaStorageClient,
 } from "@langfuse/shared/src/server";
@@ -133,7 +134,7 @@ describe("MediaRetentionCleaner", () => {
       expect(allDeletedPaths).toContain(media.bucketPath);
     });
 
-    it("cleans claimed media links and continues an over-limit project", async () => {
+    it("cleans expired links, preserves recent links, and drains the project", async () => {
       await drainExpiredMedia();
       mockDeleteFiles.mockClear();
       const now = Date.now();
@@ -161,13 +162,35 @@ describe("MediaRetentionCleaner", () => {
           referenceString: `@@@langfuseMedia:type=image/png|id=${claimedMedia.id}|source=base64@@@`,
         },
       });
-      const traceId = randomUUID();
+      const expiredTraceId = randomUUID();
       await prisma.traceMedia.create({
         data: {
           id: randomUUID(),
           projectId,
           mediaId: claimedMedia.id,
-          traceId,
+          traceId: expiredTraceId,
+          field: "input",
+          createdAt: daysAgo(11),
+        },
+      });
+      await prisma.observationMedia.create({
+        data: {
+          id: randomUUID(),
+          projectId,
+          mediaId: claimedMedia.id,
+          traceId: expiredTraceId,
+          observationId: randomUUID(),
+          field: "input",
+          createdAt: daysAgo(11),
+        },
+      });
+      const recentTraceId = randomUUID();
+      await prisma.traceMedia.create({
+        data: {
+          id: randomUUID(),
+          projectId,
+          mediaId: claimedMedia.id,
+          traceId: recentTraceId,
           field: "input",
         },
       });
@@ -176,7 +199,7 @@ describe("MediaRetentionCleaner", () => {
           id: randomUUID(),
           projectId,
           mediaId: claimedMedia.id,
-          traceId,
+          traceId: recentTraceId,
           observationId: randomUUID(),
           field: "input",
         },
@@ -199,33 +222,46 @@ describe("MediaRetentionCleaner", () => {
           referenceString: null,
         },
       });
-      const unassociatedMedia = await createTestMedia(projectId, daysAgo(10));
+      const firstUnassociatedMedia = await createTestMedia(
+        projectId,
+        daysAgo(10),
+      );
+      const secondUnassociatedMedia = await createTestMedia(
+        projectId,
+        daysAgo(9),
+      );
 
       await new MediaRetentionCleaner().processBatch();
 
       expect(mockDeleteFiles).toHaveBeenCalledWith([pendingMedia.bucketPath]);
       await expect(
-        prisma.traceMedia.count({
+        prisma.traceMedia.findMany({
+          select: { traceId: true },
           where: { projectId, mediaId: claimedMedia.id },
         }),
-      ).resolves.toBe(0);
+      ).resolves.toEqual([{ traceId: recentTraceId }]);
       await expect(
-        prisma.observationMedia.count({
+        prisma.observationMedia.findMany({
+          select: { traceId: true },
           where: { projectId, mediaId: claimedMedia.id },
         }),
-      ).resolves.toBe(0);
+      ).resolves.toEqual([{ traceId: recentTraceId }]);
       await expect(
-        prisma.media.findUnique({
+        prisma.media.count({
           where: {
-            projectId_id: { projectId, id: unassociatedMedia.id },
+            projectId,
+            id: {
+              in: [firstUnassociatedMedia.id, secondUnassociatedMedia.id],
+            },
           },
         }),
-      ).resolves.not.toBeNull();
+      ).resolves.toBe(2);
 
       await new MediaRetentionCleaner().processBatch();
 
       expect(mockDeleteFiles).toHaveBeenLastCalledWith([
-        unassociatedMedia.bucketPath,
+        firstUnassociatedMedia.bucketPath,
+        secondUnassociatedMedia.bucketPath,
       ]);
 
       // Claimed media (and its row) survive; pending media (and its row) are gone.
@@ -240,12 +276,15 @@ describe("MediaRetentionCleaner", () => {
         }),
       ).resolves.toBeNull();
       await expect(
-        prisma.media.findUnique({
+        prisma.media.count({
           where: {
-            projectId_id: { projectId, id: unassociatedMedia.id },
+            projectId,
+            id: {
+              in: [firstUnassociatedMedia.id, secondUnassociatedMedia.id],
+            },
           },
         }),
-      ).resolves.toBeNull();
+      ).resolves.toBe(0);
       await expect(
         prisma.datasetItemMedia.count({
           where: { projectId, datasetItemValidFrom: { not: null } },
@@ -256,6 +295,13 @@ describe("MediaRetentionCleaner", () => {
           where: { projectId, datasetItemValidFrom: null },
         }),
       ).resolves.toBe(0);
+      await expect(
+        findExpiredMediaBatchByProjectId({
+          projectId,
+          cutoffDate: daysAgo(7),
+          limit: 2,
+        }),
+      ).resolves.toEqual([]);
     });
 
     it("should NOT delete media within retention period", async () => {

--- a/worker/src/__tests__/mediaRetentionCleaner.test.ts
+++ b/worker/src/__tests__/mediaRetentionCleaner.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { MediaRetentionCleaner } from "../features/media-retention-cleaner";
+import { env } from "../env";
 
 // Mock S3 and blob storage functions
 vi.mock("@langfuse/shared/src/server", async () => {
@@ -27,6 +28,7 @@ vi.mock("../env", async () => {
       ...(actual as { env: object }).env,
       LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: "test-bucket",
       LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG: "false",
+      LANGFUSE_MEDIA_RETENTION_CLEANER_INTERVAL_MS: 600_000,
       LANGFUSE_MEDIA_RETENTION_CLEANER_ITEM_LIMIT: 2,
     },
   };
@@ -104,6 +106,27 @@ describe("MediaRetentionCleaner", () => {
   });
 
   describe("processBatch", () => {
+    it("runs again immediately after work and waits when empty", async () => {
+      await drainExpiredMedia();
+
+      const { projectId } = await createOrgProjectAndApiKey();
+      await prisma.project.update({
+        where: { id: projectId },
+        data: { retentionDays: 7 },
+      });
+      await createTestMedia(
+        projectId,
+        new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+      );
+
+      const cleaner = new MediaRetentionCleaner();
+      await expect(cleaner.processBatch()).resolves.toBe(0);
+      await expect(getMediaCount(projectId)).resolves.toBe(0);
+      await expect(cleaner.processBatch()).resolves.toBe(
+        env.LANGFUSE_MEDIA_RETENTION_CLEANER_INTERVAL_MS,
+      );
+    });
+
     it("should delete media files older than project retention", async () => {
       const now = Date.now();
       const tenDaysAgo = new Date(now - 10 * 24 * 60 * 60 * 1000);

--- a/worker/src/features/media-retention-cleaner/index.ts
+++ b/worker/src/features/media-retention-cleaner/index.ts
@@ -146,6 +146,7 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
       storageClient: getS3MediaStorageClient(
         env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET!,
       ),
+      linkCleanupCutoffDate: workload.cutoffDate,
     });
 
     // Record successful deletion metrics

--- a/worker/src/features/media-retention-cleaner/index.ts
+++ b/worker/src/features/media-retention-cleaner/index.ts
@@ -1,16 +1,16 @@
-import { prisma } from "@langfuse/shared/src/db";
 import {
   deleteMediaFiles,
-  findExpiredMediaByProjectId,
+  findExpiredMediaBatchByProjectId,
+  findNextMediaRetentionProject,
   getS3MediaStorageClient,
   logger,
+  type MediaRetentionProject,
   recordGauge,
   recordIncrement,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
   traceException,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
-import { getRetentionCutoffDate } from "../utils";
 import { PeriodicExclusiveRunner } from "../../utils/PeriodicExclusiveRunner";
 
 const METRIC_PREFIX = "langfuse.media_retention_cleaner";
@@ -18,18 +18,11 @@ const METRIC_PREFIX = "langfuse.media_retention_cleaner";
 export const MEDIA_RETENTION_CLEANER_LOCK_KEY =
   "langfuse:media-retention-cleaner";
 
-interface ProjectWorkload {
-  projectId: string;
-  retentionDays: number;
-  cutoffDate: Date;
-  secondsPastCutoff: number | null;
-}
-
 /**
  * MediaRetentionCleaner handles periodic deletion of media files and blob storage
  * entries based on project retention settings.
  *
- * Processes one project per iteration (most work first) for simplicity.
+ * Processes one project per iteration (oldest actionable media first).
  * Run frequently to process all projects over time.
  */
 export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
@@ -62,7 +55,7 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
   }
 
   /**
-   * Process expired media for the project with most work.
+   * Process expired media for the project furthest past its cutoff.
    * Preflight and deletion are both under lock to avoid redundant expensive queries.
    */
   protected async execute(): Promise<void> {
@@ -72,10 +65,10 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
 
     await this.withLock(
       async () => {
-        // Get the project with most expired media (single project per iteration)
-        let workload: ProjectWorkload | null;
+        // Get the most overdue project (single project per iteration)
+        let workload: MediaRetentionProject | null;
         try {
-          workload = await this.getTopProjectWorkload();
+          workload = await findNextMediaRetentionProject();
         } catch (error) {
           logger.error(`${this.name}: Failed to query project workload`, {
             error,
@@ -109,60 +102,7 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
     );
   }
 
-  /**
-   * Get the project with the most expired media (single query via Prisma).
-   * Returns null if no projects have expired media.
-   */
-  private async getTopProjectWorkload(): Promise<ProjectWorkload | null> {
-    const now = new Date();
-
-    // Single query: join projects with media, filter by retention cutoff, order by count, limit 1
-    // Using raw SQL for the complex per-project cutoff logic
-    const result = await prisma.$queryRaw<
-      Array<{
-        project_id: string;
-        retention_days: number;
-        seconds_past_cutoff: number;
-      }>
-    >`
-      SELECT
-        p.id as project_id,
-        p.retention_days,
-        EXTRACT(EPOCH FROM (
-          (NOW() - (p.retention_days || ' days')::interval) - MIN(m.created_at)
-        ))::int as seconds_past_cutoff
-      FROM projects p
-      INNER JOIN media m ON m.project_id = p.id
-      -- Only a claimed association (validFrom set) protects media; pending rows
-      -- (null validFrom) are sweepable, matching deleteMediaFiles. Counting them
-      -- here would hide projects whose only expired media is abandoned uploads.
-      LEFT JOIN dataset_item_media dim
-        ON dim.project_id = m.project_id
-        AND dim.media_id = m.id
-        AND dim.dataset_item_valid_from IS NOT NULL
-      WHERE p.retention_days > 0
-        AND p.deleted_at IS NULL
-        AND m.created_at <= NOW() - (p.retention_days || ' days')::interval
-        AND dim.media_id IS NULL
-      GROUP BY p.id, p.retention_days
-      ORDER BY seconds_past_cutoff DESC
-      LIMIT 1
-    `;
-
-    if (result.length === 0) {
-      return null;
-    }
-
-    const row = result[0];
-    return {
-      projectId: row.project_id,
-      retentionDays: row.retention_days,
-      cutoffDate: getRetentionCutoffDate(row.retention_days, now),
-      secondsPastCutoff: row.seconds_past_cutoff,
-    };
-  }
-
-  private async processProject(workload: ProjectWorkload): Promise<void> {
+  private async processProject(workload: MediaRetentionProject): Promise<void> {
     // Delete media files (S3 + PostgreSQL)
     if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
       await this.deleteExpiredMedia(workload);
@@ -182,10 +122,13 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
     });
   }
 
-  private async deleteExpiredMedia(workload: ProjectWorkload): Promise<void> {
-    const mediaFiles = await findExpiredMediaByProjectId({
+  private async deleteExpiredMedia(
+    workload: MediaRetentionProject,
+  ): Promise<void> {
+    const mediaFiles = await findExpiredMediaBatchByProjectId({
       projectId: workload.projectId,
       cutoffDate: workload.cutoffDate,
+      limit: env.LANGFUSE_MEDIA_RETENTION_CLEANER_ITEM_LIMIT,
     });
 
     // Record gauge for observed work

--- a/worker/src/features/media-retention-cleaner/index.ts
+++ b/worker/src/features/media-retention-cleaner/index.ts
@@ -58,12 +58,12 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
    * Process expired media for the project furthest past its cutoff.
    * Preflight and deletion are both under lock to avoid redundant expensive queries.
    */
-  protected async execute(): Promise<void> {
+  protected async execute(): Promise<number> {
     // Reset gauge before attempting lock - ensures it doesn't appear stuck
     // if another worker holds the lock
     recordGauge(`${METRIC_PREFIX}.seconds_past_cutoff`, 0);
 
-    await this.withLock(
+    const nextDelayMs = await this.withLock(
       async () => {
         // Get the most overdue project (single project per iteration)
         let workload: MediaRetentionProject | null;
@@ -92,14 +92,21 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
 
           await this.processProject(workload);
           recordIncrement(`${METRIC_PREFIX}.projects_processed`, 1);
-        } else {
-          logger.info(`${this.name}: No expired media to clean up`);
+          // Without media storage, this workload cannot make progress.
+          return env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET
+            ? 0
+            : this.defaultIntervalMs;
         }
+
+        logger.info(`${this.name}: No expired media to clean up`);
+        return this.defaultIntervalMs;
       },
       () => {
         recordIncrement(`${METRIC_PREFIX}.project_failures`, 1);
       },
     );
+
+    return nextDelayMs ?? this.defaultIntervalMs;
   }
 
   private async processProject(workload: MediaRetentionProject): Promise<void> {


### PR DESCRIPTION
## What changed

- apply `LANGFUSE_MEDIA_RETENTION_CLEANER_ITEM_LIMIT` in PostgreSQL before media rows cross the Prisma/N-API boundary
- select only actionable expired media: deletable media, or dataset-protected media with trace/observation links created before the captured retention cutoff
- pass that same cutoff into `deleteMediaFiles`, deleting all links for deletable media but only expired links for protected media
- share the actionable-media predicate between the bounded batch selector and project picker
- replace the global media aggregation with an indexed lateral lookup per retention-enabled project
- immediately schedule the next bounded batch after productive media work, while retaining the configured interval for idle, failed, contended, or storage-less runs

Every stable selected row makes progress: its media is deleted, or its expired links are removed and it no longer matches the picker. The periodic runner therefore continues immediately through projects whose backlog exceeds the configured limit, then returns to the normal interval once the picker is empty. Fresh links created when an old dataset-protected media object is deduplicated are neither selected nor deleted.

## Root cause

The cleaner logged `LANGFUSE_MEDIA_RETENTION_CLEANER_ITEM_LIMIT`, but fetched every expired media row with an unbounded Prisma `findMany`. Large project backlogs could cross the Prisma Rust-to-NAPI string conversion boundary in one result and fail before deletion began.

Compared with `main`, unprotected-media cleanup is unchanged. Protected-media cleanup is safer: links newer than the retention cutoff survive, while expired links are still removed. Existing `ON CONFLICT DO NOTHING` link-insertion semantics remain unchanged.

## Impacted packages

- `@langfuse/shared`
- `worker`

## Verification

- shared build: `tsc`
- worker media retention suite: `Tests 12 passed (12)`
- web dataset media repository suite: `Tests 13 passed (13)`
- lint: `Tasks: 7 successful, 7 total`
- typecheck: `Tasks: 7 successful, 7 total`
- format check: `All matched files use Prettier code style!`
- `git diff --check`
- PostgreSQL `EXPLAIN ANALYZE`: bounded selector starts from `media_project_id_created_at_idx`; local execution `0.117 ms`
