### PR TITLE
fix(web): Improve Project & Organization Dropdowns

### DIFF
--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.stories.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.stories.tsx
@@ -27,6 +27,10 @@ const organizations = [
   createOrganization("org-acme", "Acme Inc."),
   createOrganization("org-globex", "Globex Corporation"),
   createOrganization("org-initech", "Initech"),
+  createOrganization(
+    "org-long-name",
+    "An organization name that is too long to fit in the menu",
+  ),
 ];
 
 const meta = preview.meta({
@@ -37,7 +41,7 @@ const meta = preview.meta({
   },
   render: (args) => (
     <DropdownMenu defaultOpen>
-      <DropdownMenuTrigger>Current organization</DropdownMenuTrigger>
+      <DropdownMenuTrigger>Trigger</DropdownMenuTrigger>
       <OrganizationDropdownMenu {...args} />
     </DropdownMenu>
   ),
@@ -50,7 +54,7 @@ export const Default = meta.story({
   },
 });
 
-export const Scrollable = meta.story({
+export const Many = meta.story({
   args: {
     state: "loaded",
     organizations: Array.from({ length: 10 }, (_, index) =>
@@ -64,19 +68,6 @@ export const WithoutCreation = meta.story({
     state: "loaded",
     organizations,
     canCreateOrganizations: false,
-  },
-});
-
-export const WithLongName = meta.story({
-  args: {
-    state: "loaded",
-    organizations: [
-      createOrganization(
-        "org-long-name",
-        "An organization name that is too long to fit in the menu",
-      ),
-      ...organizations,
-    ],
   },
 });
 

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.stories.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.stories.tsx
@@ -1,0 +1,89 @@
+import type { ComponentProps } from "react";
+import { fn } from "storybook/test";
+import preview from "../../../.storybook/preview";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import { OrganizationDropdownMenu } from "./OrganizationDropdownMenu";
+
+type Organization = Extract<
+  ComponentProps<typeof OrganizationDropdownMenu>,
+  { state: "loaded" }
+>["organizations"][number];
+
+const createOrganization = (id: string, name: string): Organization => ({
+  id,
+  name,
+  role: "OWNER",
+  cloudConfig: undefined,
+  plan: "cloud:hobby",
+  metadata: {},
+  aiFeaturesEnabled: false,
+  aiTelemetryEnabled: false,
+  projects: [],
+});
+
+const organizations = [
+  createOrganization("org-acme", "Acme Inc."),
+  createOrganization("org-globex", "Globex Corporation"),
+  createOrganization("org-initech", "Initech"),
+];
+
+const meta = preview.meta({
+  component: OrganizationDropdownMenu,
+  args: {
+    canCreateOrganizations: true,
+    getOrgPath: (organizationId) => `/organization/${organizationId}`,
+    onGoToOrganizationSettings: fn(),
+  },
+  render: (args) => (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger>Current organization</DropdownMenuTrigger>
+      <OrganizationDropdownMenu {...args} />
+    </DropdownMenu>
+  ),
+});
+
+export const Default = meta.story({
+  args: {
+    state: "loaded",
+    organizations,
+  },
+});
+
+export const Scrollable = meta.story({
+  args: {
+    state: "loaded",
+    organizations: Array.from({ length: 10 }, (_, index) =>
+      createOrganization(`org-${index + 1}`, `Organization ${index + 1}`),
+    ),
+  },
+});
+
+export const WithoutCreation = meta.story({
+  args: {
+    state: "loaded",
+    organizations,
+    canCreateOrganizations: false,
+  },
+});
+
+export const WithLongName = meta.story({
+  args: {
+    state: "loaded",
+    organizations: [
+      createOrganization(
+        "org-long-name",
+        "An organization name that is too long to fit in the menu",
+      ),
+      ...organizations,
+    ],
+  },
+});
+
+export const Loading = meta.story({
+  args: {
+    state: "loading",
+  },
+});

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.stories.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.stories.tsx
@@ -1,5 +1,4 @@
 import type { ComponentProps } from "react";
-import { fn } from "storybook/test";
 import preview from "../../../.storybook/preview";
 import {
   DropdownMenu,
@@ -35,7 +34,6 @@ const meta = preview.meta({
   args: {
     canCreateOrganizations: true,
     getOrgPath: (organizationId) => `/organization/${organizationId}`,
-    onGoToOrganizationSettings: fn(),
   },
   render: (args) => (
     <DropdownMenu defaultOpen>

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
@@ -102,17 +102,10 @@ export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
         <>
           <DropdownMenuSeparator />
           <DropdownMenuItem asChild>
-            <Button
-              variant="ghost"
-              size="xs"
-              className="h-8 w-full text-sm font-normal"
-              asChild
-            >
-              <Link href={createOrganizationRoute}>
-                <PlusIcon className="mr-1.5 h-4 w-4" aria-hidden="true" />
-                New Organization
-              </Link>
-            </Button>
+            <Link href={createOrganizationRoute}>
+              <PlusIcon className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              New Organization
+            </Link>
           </DropdownMenuItem>
         </>
       )}

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
@@ -1,10 +1,10 @@
-import Spinner from "@/src/components/design-system/Spinner/Spinner";
 import { Button } from "@/src/components/ui/button";
 import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuLoadingItem,
 } from "@/src/components/ui/dropdown-menu";
 import { PlusIcon, Settings } from "lucide-react";
 import { type Session } from "next-auth";
@@ -25,17 +25,6 @@ type OrganizationDropdownMenuProps = {
       state: "loaded";
       organizations: Organization[];
     }
-);
-
-// TODO: This is duplicated in /web/src/components/layouts/breadcrumb.tsx
-// Should this be a shared utility component?
-const LoadingMenuItem = () => (
-  <DropdownMenuItem>
-    <span className="mr-1.5 inline-flex">
-      <Spinner size="sm" />
-    </span>
-    Loading...
-  </DropdownMenuItem>
 );
 
 export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
@@ -94,7 +83,7 @@ export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
               </Fragment>
             ))
         ) : (
-          <LoadingMenuItem />
+          <DropdownMenuLoadingItem />
         )}
       </div>
 

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
@@ -29,7 +29,7 @@ export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
   return (
     <DropdownMenuContent align="start" header="Organizations" maxHeight="15rem">
       {props.state === "loaded" ? (
-        props.organizations
+        [...props.organizations]
           .sort((a, b) => {
             // sort demo org to the bottom
             const isDemoA = env.NEXT_PUBLIC_DEMO_ORG_ID === a.id;

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
@@ -1,6 +1,5 @@
 import {
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuItemWithSecondaryAction,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -8,7 +7,6 @@ import {
 } from "@/src/components/ui/dropdown-menu";
 import { PlusIcon, Settings } from "lucide-react";
 import { type Session } from "next-auth";
-import Link from "next/link";
 import { Fragment } from "react";
 import { env } from "@/src/env.mjs";
 import { createOrganizationRoute } from "@/src/features/setup/setupRoutes";
@@ -66,12 +64,11 @@ export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
       {canCreateOrganizations && (
         <>
           <DropdownMenuSeparator />
-          <DropdownMenuItem asChild>
-            <Link href={createOrganizationRoute}>
-              <PlusIcon className="mr-1.5 h-4 w-4" aria-hidden="true" />
-              New Organization
-            </Link>
-          </DropdownMenuItem>
+          <DropdownMenuItemWithSecondaryAction
+            title="New Organization"
+            href={createOrganizationRoute}
+            icon={PlusIcon}
+          />
         </>
       )}
     </DropdownMenuContent>

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
@@ -29,52 +29,50 @@ export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
   const { canCreateOrganizations, getOrgPath } = props;
 
   return (
-    <DropdownMenuContent align="start">
+    <DropdownMenuContent align="start" maxHeight="15rem">
       <DropdownMenuLabel>Organizations</DropdownMenuLabel>
       <DropdownMenuSeparator />
-      <div className="max-h-36 overflow-y-auto">
-        {props.state === "loaded" ? (
-          props.organizations
-            .sort((a, b) => {
-              // sort demo org to the bottom
-              const isDemoA = env.NEXT_PUBLIC_DEMO_ORG_ID === a.id;
-              const isDemoB = env.NEXT_PUBLIC_DEMO_ORG_ID === b.id;
-              if (isDemoA) return 1;
-              if (isDemoB) return -1;
-              return 0;
-            })
-            .map((dropdownOrg) => (
-              <Fragment key={dropdownOrg.id}>
-                {env.NEXT_PUBLIC_DEMO_ORG_ID === dropdownOrg.id && (
-                  <DropdownMenuSeparator />
-                )}
-                <DropdownMenuItem className="p-0">
-                  <Link
-                    href={getOrgPath(dropdownOrg.id)}
-                    className="flex min-w-0 flex-1 cursor-pointer px-2 py-1.5"
+      {props.state === "loaded" ? (
+        props.organizations
+          .sort((a, b) => {
+            // sort demo org to the bottom
+            const isDemoA = env.NEXT_PUBLIC_DEMO_ORG_ID === a.id;
+            const isDemoB = env.NEXT_PUBLIC_DEMO_ORG_ID === b.id;
+            if (isDemoA) return 1;
+            if (isDemoB) return -1;
+            return 0;
+          })
+          .map((dropdownOrg) => (
+            <Fragment key={dropdownOrg.id}>
+              {env.NEXT_PUBLIC_DEMO_ORG_ID === dropdownOrg.id && (
+                <DropdownMenuSeparator />
+              )}
+              <DropdownMenuItem className="p-0">
+                <Link
+                  href={getOrgPath(dropdownOrg.id)}
+                  className="flex min-w-0 flex-1 cursor-pointer px-2 py-1.5"
+                >
+                  <span
+                    className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
+                    title={dropdownOrg.name}
                   >
-                    <span
-                      className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
-                      title={dropdownOrg.name}
-                    >
-                      {dropdownOrg.name}
-                    </span>
-                  </Link>
-                  <Link
-                    href={`/organization/${dropdownOrg.id}/settings`}
-                    aria-label={`Go to settings for ${dropdownOrg.name}`}
-                    className="hover:bg-background flex size-8 shrink-0 cursor-pointer items-center justify-center"
-                    onClick={(event) => event.stopPropagation()}
-                  >
-                    <Settings size={12} />
-                  </Link>
-                </DropdownMenuItem>
-              </Fragment>
-            ))
-        ) : (
-          <DropdownMenuLoadingItem />
-        )}
-      </div>
+                    {dropdownOrg.name}
+                  </span>
+                </Link>
+                <Link
+                  href={`/organization/${dropdownOrg.id}/settings`}
+                  aria-label={`Go to settings for ${dropdownOrg.name}`}
+                  className="hover:bg-background flex size-8 shrink-0 cursor-pointer items-center justify-center"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <Settings size={12} />
+                </Link>
+              </DropdownMenuItem>
+            </Fragment>
+          ))
+      ) : (
+        <DropdownMenuLoadingItem />
+      )}
 
       {canCreateOrganizations && (
         <>

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
@@ -1,6 +1,7 @@
 import {
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuItemWithSecondaryAction,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuLoadingItem,
@@ -47,27 +48,15 @@ export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
               {env.NEXT_PUBLIC_DEMO_ORG_ID === dropdownOrg.id && (
                 <DropdownMenuSeparator />
               )}
-              <DropdownMenuItem className="p-0">
-                <Link
-                  href={getOrgPath(dropdownOrg.id)}
-                  className="flex min-w-0 flex-1 cursor-pointer px-2 py-1.5"
-                >
-                  <span
-                    className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
-                    title={dropdownOrg.name}
-                  >
-                    {dropdownOrg.name}
-                  </span>
-                </Link>
-                <Link
-                  href={`/organization/${dropdownOrg.id}/settings`}
-                  aria-label={`Go to settings for ${dropdownOrg.name}`}
-                  className="hover:bg-background flex size-8 shrink-0 cursor-pointer items-center justify-center"
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  <Settings size={12} />
-                </Link>
-              </DropdownMenuItem>
+              <DropdownMenuItemWithSecondaryAction
+                title={dropdownOrg.name}
+                href={getOrgPath(dropdownOrg.id)}
+                secondaryAction={{
+                  href: `/organization/${dropdownOrg.id}/settings`,
+                  ariaLabel: `Go to settings for ${dropdownOrg.name}`,
+                  icon: Settings,
+                }}
+              />
             </Fragment>
           ))
       ) : (

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
@@ -1,7 +1,6 @@
 import {
   DropdownMenuContent,
   DropdownMenuItemWithSecondaryAction,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuLoadingItem,
 } from "@/src/components/ui/dropdown-menu";
@@ -28,9 +27,7 @@ export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
   const { canCreateOrganizations, getOrgPath } = props;
 
   return (
-    <DropdownMenuContent align="start" maxHeight="15rem">
-      <DropdownMenuLabel>Organizations</DropdownMenuLabel>
-      <DropdownMenuSeparator />
+    <DropdownMenuContent align="start" header="Organizations" maxHeight="15rem">
       {props.state === "loaded" ? (
         props.organizations
           .sort((a, b) => {

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@/src/components/ui/button";
 import {
   DropdownMenuContent,
   DropdownMenuItem,
@@ -18,7 +17,6 @@ type Organization = NonNullable<Session["user"]>["organizations"][number];
 type OrganizationDropdownMenuProps = {
   canCreateOrganizations: boolean;
   getOrgPath: (organizationId: string) => string;
-  onGoToOrganizationSettings: (organizationId: string) => void;
 } & (
   | { state: "loading" }
   | {
@@ -28,8 +26,7 @@ type OrganizationDropdownMenuProps = {
 );
 
 export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
-  const { canCreateOrganizations, getOrgPath, onGoToOrganizationSettings } =
-    props;
+  const { canCreateOrganizations, getOrgPath } = props;
 
   return (
     <DropdownMenuContent align="start">
@@ -51,10 +48,10 @@ export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
                 {env.NEXT_PUBLIC_DEMO_ORG_ID === dropdownOrg.id && (
                   <DropdownMenuSeparator />
                 )}
-                <DropdownMenuItem asChild>
+                <DropdownMenuItem className="p-0">
                   <Link
                     href={getOrgPath(dropdownOrg.id)}
-                    className="flex cursor-pointer justify-between"
+                    className="flex min-w-0 flex-1 cursor-pointer px-2 py-1.5"
                   >
                     <span
                       className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
@@ -62,22 +59,14 @@ export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
                     >
                       {dropdownOrg.name}
                     </span>
-                    <Button
-                      asChild
-                      variant="ghost"
-                      size="xs"
-                      className="hover:bg-background -my-1 ml-4"
-                    >
-                      <div
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          onGoToOrganizationSettings(dropdownOrg.id);
-                        }}
-                      >
-                        <Settings size={12} />
-                      </div>
-                    </Button>
+                  </Link>
+                  <Link
+                    href={`/organization/${dropdownOrg.id}/settings`}
+                    aria-label={`Go to settings for ${dropdownOrg.name}`}
+                    className="hover:bg-background flex size-8 shrink-0 cursor-pointer items-center justify-center"
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    <Settings size={12} />
                   </Link>
                 </DropdownMenuItem>
               </Fragment>

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
@@ -1,0 +1,124 @@
+import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { Button } from "@/src/components/ui/button";
+import {
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/src/components/ui/dropdown-menu";
+import { PlusIcon, Settings } from "lucide-react";
+import { type Session } from "next-auth";
+import Link from "next/link";
+import { Fragment } from "react";
+import { env } from "@/src/env.mjs";
+import { createOrganizationRoute } from "@/src/features/setup/setupRoutes";
+
+type Organization = NonNullable<Session["user"]>["organizations"][number];
+
+type OrganizationDropdownMenuProps = {
+  canCreateOrganizations: boolean;
+  getOrgPath: (organizationId: string) => string;
+  onGoToOrganizationSettings: (organizationId: string) => void;
+} & (
+  | { state: "loading" }
+  | {
+      state: "loaded";
+      organizations: Organization[];
+    }
+);
+
+// TODO: This is duplicated in /web/src/components/layouts/breadcrumb.tsx
+// Should this be a shared utility component?
+const LoadingMenuItem = () => (
+  <DropdownMenuItem>
+    <span className="mr-1.5 inline-flex">
+      <Spinner size="sm" />
+    </span>
+    Loading...
+  </DropdownMenuItem>
+);
+
+export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
+  const { canCreateOrganizations, getOrgPath, onGoToOrganizationSettings } =
+    props;
+
+  return (
+    <DropdownMenuContent align="start">
+      <DropdownMenuItem className="font-bold" asChild>
+        <Link href="/" className="cursor-pointer">
+          Organizations
+        </Link>
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <div className="max-h-36 overflow-y-auto">
+        {props.state === "loaded" ? (
+          props.organizations
+            .sort((a, b) => {
+              // sort demo org to the bottom
+              const isDemoA = env.NEXT_PUBLIC_DEMO_ORG_ID === a.id;
+              const isDemoB = env.NEXT_PUBLIC_DEMO_ORG_ID === b.id;
+              if (isDemoA) return 1;
+              if (isDemoB) return -1;
+              return 0;
+            })
+            .map((dropdownOrg) => (
+              <Fragment key={dropdownOrg.id}>
+                {env.NEXT_PUBLIC_DEMO_ORG_ID === dropdownOrg.id && (
+                  <DropdownMenuSeparator />
+                )}
+                <DropdownMenuItem asChild>
+                  <Link
+                    href={getOrgPath(dropdownOrg.id)}
+                    className="flex cursor-pointer justify-between"
+                  >
+                    <span
+                      className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
+                      title={dropdownOrg.name}
+                    >
+                      {dropdownOrg.name}
+                    </span>
+                    <Button
+                      asChild
+                      variant="ghost"
+                      size="xs"
+                      className="hover:bg-background -my-1 ml-4"
+                    >
+                      <div
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          onGoToOrganizationSettings(dropdownOrg.id);
+                        }}
+                      >
+                        <Settings size={12} />
+                      </div>
+                    </Button>
+                  </Link>
+                </DropdownMenuItem>
+              </Fragment>
+            ))
+        ) : (
+          <LoadingMenuItem />
+        )}
+      </div>
+
+      {canCreateOrganizations && (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem asChild>
+            <Button
+              variant="ghost"
+              size="xs"
+              className="h-8 w-full text-sm font-normal"
+              asChild
+            >
+              <Link href={createOrganizationRoute}>
+                <PlusIcon className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                New Organization
+              </Link>
+            </Button>
+          </DropdownMenuItem>
+        </>
+      )}
+    </DropdownMenuContent>
+  );
+}

--- a/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
+++ b/web/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/src/components/ui/button";
 import {
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/src/components/ui/dropdown-menu";
 import { PlusIcon, Settings } from "lucide-react";
@@ -43,11 +44,7 @@ export function OrganizationDropdownMenu(props: OrganizationDropdownMenuProps) {
 
   return (
     <DropdownMenuContent align="start">
-      <DropdownMenuItem className="font-bold" asChild>
-        <Link href="/" className="cursor-pointer">
-          Organizations
-        </Link>
-      </DropdownMenuItem>
+      <DropdownMenuLabel>Organizations</DropdownMenuLabel>
       <DropdownMenuSeparator />
       <div className="max-h-36 overflow-y-auto">
         {props.state === "loaded" ? (

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.stories.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.stories.tsx
@@ -1,0 +1,89 @@
+import type { ComponentProps } from "react";
+import { fn } from "storybook/test";
+import preview from "../../../.storybook/preview";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import { ProjectDropdownMenu } from "./ProjectDropdownMenu";
+
+type Project = Extract<
+  ComponentProps<typeof ProjectDropdownMenu>,
+  { state: "loaded" }
+>["projects"][number];
+
+const createProject = (id: string, name: string): Project => ({
+  id,
+  name,
+  role: "ADMIN",
+  deletedAt: null,
+  retentionDays: null,
+  hasTraces: false,
+  metadata: {},
+  createdAt: new Date().toISOString(),
+});
+
+const projects = [
+  createProject("project-analytics", "Analytics"),
+  createProject("project-production", "Production"),
+  createProject("project-staging", "Staging"),
+];
+
+const meta = preview.meta({
+  component: ProjectDropdownMenu,
+  args: {
+    organizationId: "org-acme",
+    canCreateProjects: true,
+    getProjectPath: (projectId) => `/project/${projectId}`,
+    onGoToProjectSettings: fn(),
+  },
+  render: (args) => (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger>Current project</DropdownMenuTrigger>
+      <ProjectDropdownMenu {...args} />
+    </DropdownMenu>
+  ),
+});
+
+export const Default = meta.story({
+  args: {
+    state: "loaded",
+    projects,
+  },
+});
+
+export const Scrollable = meta.story({
+  args: {
+    state: "loaded",
+    projects: Array.from({ length: 10 }, (_, index) =>
+      createProject(`project-${index + 1}`, `Project ${index + 1}`),
+    ),
+  },
+});
+
+export const WithoutCreation = meta.story({
+  args: {
+    state: "loaded",
+    projects,
+    canCreateProjects: false,
+  },
+});
+
+export const WithLongName = meta.story({
+  args: {
+    state: "loaded",
+    projects: [
+      createProject(
+        "project-long-name",
+        "A project name that is too long to fit in the menu",
+      ),
+      ...projects,
+    ],
+  },
+});
+
+export const Loading = meta.story({
+  args: {
+    state: "loading",
+  },
+});

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.stories.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.stories.tsx
@@ -26,6 +26,10 @@ const projects = [
   createProject("project-analytics", "Analytics"),
   createProject("project-production", "Production"),
   createProject("project-staging", "Staging"),
+  createProject(
+    "project-long-name",
+    "A project name that is too long to fit in the menu",
+  ),
 ];
 
 const meta = preview.meta({
@@ -37,7 +41,7 @@ const meta = preview.meta({
   },
   render: (args) => (
     <DropdownMenu defaultOpen>
-      <DropdownMenuTrigger>Current project</DropdownMenuTrigger>
+      <DropdownMenuTrigger>Trigger</DropdownMenuTrigger>
       <ProjectDropdownMenu {...args} />
     </DropdownMenu>
   ),
@@ -50,7 +54,7 @@ export const Default = meta.story({
   },
 });
 
-export const Scrollable = meta.story({
+export const Many = meta.story({
   args: {
     state: "loaded",
     projects: Array.from({ length: 10 }, (_, index) =>
@@ -64,19 +68,6 @@ export const WithoutCreation = meta.story({
     state: "loaded",
     projects,
     canCreateProjects: false,
-  },
-});
-
-export const WithLongName = meta.story({
-  args: {
-    state: "loaded",
-    projects: [
-      createProject(
-        "project-long-name",
-        "A project name that is too long to fit in the menu",
-      ),
-      ...projects,
-    ],
   },
 });
 

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.stories.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.stories.tsx
@@ -1,5 +1,4 @@
 import type { ComponentProps } from "react";
-import { fn } from "storybook/test";
 import preview from "../../../.storybook/preview";
 import {
   DropdownMenu,
@@ -35,7 +34,6 @@ const meta = preview.meta({
     organizationId: "org-acme",
     canCreateProjects: true,
     getProjectPath: (projectId) => `/project/${projectId}`,
-    onGoToProjectSettings: fn(),
   },
   render: (args) => (
     <DropdownMenu defaultOpen>

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
@@ -1,10 +1,10 @@
-import Spinner from "@/src/components/design-system/Spinner/Spinner";
 import { Button } from "@/src/components/ui/button";
 import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuLoadingItem,
 } from "@/src/components/ui/dropdown-menu";
 import { createProjectRoute } from "@/src/features/setup/setupRoutes";
 import { PlusIcon, Settings } from "lucide-react";
@@ -26,15 +26,6 @@ type ProjectDropdownMenuProps = {
       state: "loaded";
       projects: Project[];
     }
-);
-
-const LoadingMenuItem = () => (
-  <DropdownMenuItem>
-    <span className="mr-1.5 inline-flex">
-      <Spinner size="sm" />
-    </span>
-    Loading...
-  </DropdownMenuItem>
 );
 
 export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
@@ -83,7 +74,11 @@ export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
             </DropdownMenuItem>
           ))
         ) : (
-          <LoadingMenuItem />
+          <>
+            <DropdownMenuLoadingItem />
+            <DropdownMenuLoadingItem />
+            <DropdownMenuLoadingItem />
+          </>
         )}
       </div>
 

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
@@ -1,7 +1,6 @@
 import {
   DropdownMenuContent,
   DropdownMenuItemWithSecondaryAction,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuLoadingItem,
 } from "@/src/components/ui/dropdown-menu";
@@ -29,9 +28,7 @@ export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
   const { organizationId, canCreateProjects, getProjectPath } = props;
 
   return (
-    <DropdownMenuContent align="start" maxHeight="15rem">
-      <DropdownMenuLabel>Projects</DropdownMenuLabel>
-      <DropdownMenuSeparator />
+    <DropdownMenuContent align="start" header="Projects" maxHeight="15rem">
       {props.state === "loaded" ? (
         props.projects.map((dropdownProject) => (
           <DropdownMenuItemWithSecondaryAction

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
@@ -1,6 +1,7 @@
 import {
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuItemWithSecondaryAction,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuLoadingItem,
@@ -35,27 +36,16 @@ export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
       <DropdownMenuSeparator />
       {props.state === "loaded" ? (
         props.projects.map((dropdownProject) => (
-          <DropdownMenuItem key={dropdownProject.id} className="p-0">
-            <Link
-              href={getProjectPath(dropdownProject.id)}
-              className="flex min-w-0 flex-1 cursor-pointer px-2 py-1.5"
-            >
-              <span
-                className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
-                title={dropdownProject.name}
-              >
-                {dropdownProject.name}
-              </span>
-            </Link>
-            <Link
-              href={`/project/${dropdownProject.id}/settings`}
-              aria-label={`Go to settings for ${dropdownProject.name}`}
-              className="hover:bg-background flex size-8 shrink-0 cursor-pointer items-center justify-center"
-              onClick={(event) => event.stopPropagation()}
-            >
-              <Settings size={12} />
-            </Link>
-          </DropdownMenuItem>
+          <DropdownMenuItemWithSecondaryAction
+            key={dropdownProject.id}
+            title={dropdownProject.name}
+            href={getProjectPath(dropdownProject.id)}
+            secondaryAction={{
+              href: `/project/${dropdownProject.id}/settings`,
+              ariaLabel: `Go to settings for ${dropdownProject.name}`,
+              icon: Settings,
+            }}
+          />
         ))
       ) : (
         <>

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
@@ -1,6 +1,5 @@
 import {
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuItemWithSecondaryAction,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -9,7 +8,6 @@ import {
 import { createProjectRoute } from "@/src/features/setup/setupRoutes";
 import { PlusIcon, Settings } from "lucide-react";
 import { type Session } from "next-auth";
-import Link from "next/link";
 
 type Project = NonNullable<
   Session["user"]
@@ -58,12 +56,11 @@ export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
       {canCreateProjects && (
         <>
           <DropdownMenuSeparator />
-          <DropdownMenuItem asChild>
-            <Link href={createProjectRoute(organizationId)}>
-              <PlusIcon className="mr-1.5 h-4 w-4" aria-hidden="true" />
-              New Project
-            </Link>
-          </DropdownMenuItem>
+          <DropdownMenuItemWithSecondaryAction
+            title="New Project"
+            href={createProjectRoute(organizationId)}
+            icon={PlusIcon}
+          />
         </>
       )}
     </DropdownMenuContent>

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
@@ -30,42 +30,40 @@ export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
   const { organizationId, canCreateProjects, getProjectPath } = props;
 
   return (
-    <DropdownMenuContent align="start">
+    <DropdownMenuContent align="start" maxHeight="15rem">
       <DropdownMenuLabel>Projects</DropdownMenuLabel>
       <DropdownMenuSeparator />
-      <div className="max-h-36 overflow-y-auto">
-        {props.state === "loaded" ? (
-          props.projects.map((dropdownProject) => (
-            <DropdownMenuItem key={dropdownProject.id} className="p-0">
-              <Link
-                href={getProjectPath(dropdownProject.id)}
-                className="flex min-w-0 flex-1 cursor-pointer px-2 py-1.5"
+      {props.state === "loaded" ? (
+        props.projects.map((dropdownProject) => (
+          <DropdownMenuItem key={dropdownProject.id} className="p-0">
+            <Link
+              href={getProjectPath(dropdownProject.id)}
+              className="flex min-w-0 flex-1 cursor-pointer px-2 py-1.5"
+            >
+              <span
+                className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
+                title={dropdownProject.name}
               >
-                <span
-                  className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
-                  title={dropdownProject.name}
-                >
-                  {dropdownProject.name}
-                </span>
-              </Link>
-              <Link
-                href={`/project/${dropdownProject.id}/settings`}
-                aria-label={`Go to settings for ${dropdownProject.name}`}
-                className="hover:bg-background flex size-8 shrink-0 cursor-pointer items-center justify-center"
-                onClick={(event) => event.stopPropagation()}
-              >
-                <Settings size={12} />
-              </Link>
-            </DropdownMenuItem>
-          ))
-        ) : (
-          <>
-            <DropdownMenuLoadingItem />
-            <DropdownMenuLoadingItem />
-            <DropdownMenuLoadingItem />
-          </>
-        )}
-      </div>
+                {dropdownProject.name}
+              </span>
+            </Link>
+            <Link
+              href={`/project/${dropdownProject.id}/settings`}
+              aria-label={`Go to settings for ${dropdownProject.name}`}
+              className="hover:bg-background flex size-8 shrink-0 cursor-pointer items-center justify-center"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <Settings size={12} />
+            </Link>
+          </DropdownMenuItem>
+        ))
+      ) : (
+        <>
+          <DropdownMenuLoadingItem />
+          <DropdownMenuLoadingItem />
+          <DropdownMenuLoadingItem />
+        </>
+      )}
 
       {canCreateProjects && (
         <>

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@/src/components/ui/button";
 import {
   DropdownMenuContent,
   DropdownMenuItem,
@@ -19,7 +18,6 @@ type ProjectDropdownMenuProps = {
   organizationId: string;
   canCreateProjects: boolean;
   getProjectPath: (projectId: string) => string;
-  onGoToProjectSettings: (projectId: string) => void;
 } & (
   | { state: "loading" }
   | {
@@ -29,12 +27,7 @@ type ProjectDropdownMenuProps = {
 );
 
 export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
-  const {
-    organizationId,
-    canCreateProjects,
-    getProjectPath,
-    onGoToProjectSettings,
-  } = props;
+  const { organizationId, canCreateProjects, getProjectPath } = props;
 
   return (
     <DropdownMenuContent align="start">
@@ -43,10 +36,10 @@ export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
       <div className="max-h-36 overflow-y-auto">
         {props.state === "loaded" ? (
           props.projects.map((dropdownProject) => (
-            <DropdownMenuItem key={dropdownProject.id} asChild>
+            <DropdownMenuItem key={dropdownProject.id} className="p-0">
               <Link
                 href={getProjectPath(dropdownProject.id)}
-                className="flex cursor-pointer justify-between"
+                className="flex min-w-0 flex-1 cursor-pointer px-2 py-1.5"
               >
                 <span
                   className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
@@ -54,22 +47,14 @@ export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
                 >
                   {dropdownProject.name}
                 </span>
-                <Button
-                  asChild
-                  variant="ghost"
-                  size="xs"
-                  className="hover:bg-background -my-1 ml-4"
-                >
-                  <div
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      onGoToProjectSettings(dropdownProject.id);
-                    }}
-                  >
-                    <Settings size={12} />
-                  </div>
-                </Button>
+              </Link>
+              <Link
+                href={`/project/${dropdownProject.id}/settings`}
+                aria-label={`Go to settings for ${dropdownProject.name}`}
+                className="hover:bg-background flex size-8 shrink-0 cursor-pointer items-center justify-center"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <Settings size={12} />
               </Link>
             </DropdownMenuItem>
           ))

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
@@ -91,17 +91,10 @@ export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
         <>
           <DropdownMenuSeparator />
           <DropdownMenuItem asChild>
-            <Button
-              variant="ghost"
-              size="xs"
-              className="h-8 w-full text-sm font-normal"
-              asChild
-            >
-              <Link href={createProjectRoute(organizationId)}>
-                <PlusIcon className="mr-1.5 h-4 w-4" aria-hidden="true" />
-                New Project
-              </Link>
-            </Button>
+            <Link href={createProjectRoute(organizationId)}>
+              <PlusIcon className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              New Project
+            </Link>
           </DropdownMenuItem>
         </>
       )}

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
@@ -1,0 +1,116 @@
+import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { Button } from "@/src/components/ui/button";
+import {
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/src/components/ui/dropdown-menu";
+import { createProjectRoute } from "@/src/features/setup/setupRoutes";
+import { PlusIcon, Settings } from "lucide-react";
+import { type Session } from "next-auth";
+import Link from "next/link";
+
+type Project = NonNullable<
+  Session["user"]
+>["organizations"][number]["projects"][number];
+
+type ProjectDropdownMenuProps = {
+  organizationId: string;
+  canCreateProjects: boolean;
+  getProjectPath: (projectId: string) => string;
+  onGoToProjectSettings: (projectId: string) => void;
+} & (
+  | { state: "loading" }
+  | {
+      state: "loaded";
+      projects: Project[];
+    }
+);
+
+const LoadingMenuItem = () => (
+  <DropdownMenuItem>
+    <span className="mr-1.5 inline-flex">
+      <Spinner size="sm" />
+    </span>
+    Loading...
+  </DropdownMenuItem>
+);
+
+export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
+  const {
+    organizationId,
+    canCreateProjects,
+    getProjectPath,
+    onGoToProjectSettings,
+  } = props;
+
+  return (
+    <DropdownMenuContent align="start">
+      <DropdownMenuItem asChild className="font-bold">
+        <Link
+          href={`/organization/${organizationId}`}
+          className="cursor-pointer"
+        >
+          Projects
+        </Link>
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <div className="max-h-36 overflow-y-auto">
+        {props.state === "loaded" ? (
+          props.projects.map((dropdownProject) => (
+            <DropdownMenuItem key={dropdownProject.id} asChild>
+              <Link
+                href={getProjectPath(dropdownProject.id)}
+                className="flex cursor-pointer justify-between"
+              >
+                <span
+                  className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
+                  title={dropdownProject.name}
+                >
+                  {dropdownProject.name}
+                </span>
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="xs"
+                  className="hover:bg-background -my-1 ml-4"
+                >
+                  <div
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onGoToProjectSettings(dropdownProject.id);
+                    }}
+                  >
+                    <Settings size={12} />
+                  </div>
+                </Button>
+              </Link>
+            </DropdownMenuItem>
+          ))
+        ) : (
+          <LoadingMenuItem />
+        )}
+      </div>
+
+      {canCreateProjects && (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem asChild>
+            <Button
+              variant="ghost"
+              size="xs"
+              className="h-8 w-full text-sm font-normal"
+              asChild
+            >
+              <Link href={createProjectRoute(organizationId)}>
+                <PlusIcon className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                New Project
+              </Link>
+            </Button>
+          </DropdownMenuItem>
+        </>
+      )}
+    </DropdownMenuContent>
+  );
+}

--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/src/components/ui/button";
 import {
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/src/components/ui/dropdown-menu";
 import { createProjectRoute } from "@/src/features/setup/setupRoutes";
@@ -46,14 +47,7 @@ export function ProjectDropdownMenu(props: ProjectDropdownMenuProps) {
 
   return (
     <DropdownMenuContent align="start">
-      <DropdownMenuItem asChild className="font-bold">
-        <Link
-          href={`/organization/${organizationId}`}
-          className="cursor-pointer"
-        >
-          Projects
-        </Link>
-      </DropdownMenuItem>
+      <DropdownMenuLabel>Projects</DropdownMenuLabel>
       <DropdownMenuSeparator />
       <div className="max-h-36 overflow-y-auto">
         {props.state === "loaded" ? (

--- a/web/src/components/layouts/breadcrumb.tsx
+++ b/web/src/components/layouts/breadcrumb.tsx
@@ -8,35 +8,19 @@ import {
 import { Fragment } from "react";
 import {
   DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
-import { ChevronDownIcon, PlusIcon, Settings, Slash } from "lucide-react";
-import Spinner from "@/src/components/design-system/Spinner/Spinner";
-import { Button } from "@/src/components/ui/button";
+import { ChevronDownIcon, Slash } from "lucide-react";
 import { env } from "@/src/env.mjs";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
-import {
-  createOrganizationRoute,
-  createProjectRoute,
-} from "@/src/features/setup/setupRoutes";
 import { isCloudPlan, planLabels } from "@langfuse/shared";
 import Link from "next/link";
 import { Badge } from "@/src/components/ui/badge";
-
-const LoadingMenuItem = () => (
-  <DropdownMenuItem>
-    <span className="mr-1.5 inline-flex">
-      <Spinner size="sm" />
-    </span>
-    Loading...
-  </DropdownMenuItem>
-);
+import { OrganizationDropdownMenu } from "@/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu";
+import { ProjectDropdownMenu } from "@/src/components/ProjectDropdownMenu/ProjectDropdownMenu";
 
 const BreadcrumbComponent = ({
   items,
@@ -108,89 +92,16 @@ const BreadcrumbComponent = ({
                 )}
               <ChevronDownIcon className="h-4 w-4" />
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
-              <DropdownMenuItem className="font-bold" asChild>
-                <Link href="/" className="cursor-pointer">
-                  Organizations
-                </Link>
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <div className="max-h-36 overflow-y-auto">
-                {organizations ? (
-                  organizations
-                    .sort((a, b) => {
-                      // sort demo org to the bottom
-                      const isDemoA = env.NEXT_PUBLIC_DEMO_ORG_ID === a.id;
-                      const isDemoB = env.NEXT_PUBLIC_DEMO_ORG_ID === b.id;
-                      if (isDemoA) return 1;
-                      if (isDemoB) return -1;
-                      return 0;
-                    })
-                    .map((dropdownOrg) => (
-                      <Fragment key={dropdownOrg.id}>
-                        {env.NEXT_PUBLIC_DEMO_ORG_ID === dropdownOrg.id && (
-                          <DropdownMenuSeparator />
-                        )}
-                        <DropdownMenuItem asChild>
-                          <Link
-                            href={getOrgPath(dropdownOrg.id)}
-                            className="flex cursor-pointer justify-between"
-                          >
-                            <span
-                              className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
-                              title={dropdownOrg.name}
-                            >
-                              {dropdownOrg.name}
-                            </span>
-                            <Button
-                              asChild
-                              variant="ghost"
-                              size="xs"
-                              className="hover:bg-background -my-1 ml-4"
-                            >
-                              <div
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  e.stopPropagation();
-                                  router.push(
-                                    `/organization/${dropdownOrg.id}/settings`,
-                                  );
-                                }}
-                              >
-                                <Settings size={12} />
-                              </div>
-                            </Button>
-                          </Link>
-                        </DropdownMenuItem>
-                      </Fragment>
-                    ))
-                ) : (
-                  <LoadingMenuItem />
-                )}
-              </div>
-
-              {canCreateOrganizations && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem asChild>
-                    <Button
-                      variant="ghost"
-                      size="xs"
-                      className="h-8 w-full text-sm font-normal"
-                      asChild
-                    >
-                      <Link href={createOrganizationRoute}>
-                        <PlusIcon
-                          className="mr-1.5 h-4 w-4"
-                          aria-hidden="true"
-                        />
-                        New Organization
-                      </Link>
-                    </Button>
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
+            <OrganizationDropdownMenu
+              {...(organizations
+                ? { state: "loaded", organizations }
+                : { state: "loading" })}
+              canCreateOrganizations={!!canCreateOrganizations}
+              getOrgPath={getOrgPath}
+              onGoToOrganizationSettings={(orgId) => {
+                return router.push(`/organization/${orgId}/settings`);
+              }}
+            />
           </DropdownMenu>
         )}
         {organization && project && (
@@ -203,80 +114,22 @@ const BreadcrumbComponent = ({
                 {project?.name ?? "Project"}
                 <ChevronDownIcon className="h-4 w-4" />
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="start">
-                <DropdownMenuItem asChild className="font-bold">
-                  <Link
-                    href={`/organization/${organization.id}`}
-                    className="cursor-pointer"
-                  >
-                    Projects
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <div className="max-h-36 overflow-y-auto">
-                  {organizations ? (
-                    organizations
-                      .find((org) => org.id === organization.id)
-                      ?.projects.map((dropdownProject) => (
-                        <DropdownMenuItem key={dropdownProject.id} asChild>
-                          <Link
-                            href={getProjectPath(dropdownProject.id)}
-                            className="flex cursor-pointer justify-between"
-                          >
-                            <span
-                              className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
-                              title={dropdownProject.name}
-                            >
-                              {dropdownProject.name}
-                            </span>
-                            <Button
-                              asChild
-                              variant="ghost"
-                              size="xs"
-                              className="hover:bg-background -my-1 ml-4"
-                            >
-                              <div
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  e.stopPropagation();
-                                  router.push(
-                                    `/project/${dropdownProject.id}/settings`,
-                                  );
-                                }}
-                              >
-                                <Settings size={12} />
-                              </div>
-                            </Button>
-                          </Link>
-                        </DropdownMenuItem>
-                      ))
-                  ) : (
-                    <LoadingMenuItem />
-                  )}
-                </div>
-
-                {canCreateProjects && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem asChild>
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        className="h-8 w-full text-sm font-normal"
-                        asChild
-                      >
-                        <Link href={createProjectRoute(organization.id)}>
-                          <PlusIcon
-                            className="mr-1.5 h-4 w-4"
-                            aria-hidden="true"
-                          />
-                          New Project
-                        </Link>
-                      </Button>
-                    </DropdownMenuItem>
-                  </>
-                )}
-              </DropdownMenuContent>
+              <ProjectDropdownMenu
+                organizationId={organization.id}
+                {...(organizations
+                  ? {
+                      state: "loaded",
+                      projects:
+                        organizations.find((org) => org.id === organization.id)
+                          ?.projects ?? [],
+                    }
+                  : { state: "loading" })}
+                canCreateProjects={!!canCreateProjects}
+                getProjectPath={getProjectPath}
+                onGoToProjectSettings={(projectId) => {
+                  return router.push(`/project/${projectId}/settings`);
+                }}
+              />
             </DropdownMenu>
           </>
         )}

--- a/web/src/components/layouts/breadcrumb.tsx
+++ b/web/src/components/layouts/breadcrumb.tsx
@@ -98,9 +98,6 @@ const BreadcrumbComponent = ({
                 : { state: "loading" })}
               canCreateOrganizations={!!canCreateOrganizations}
               getOrgPath={getOrgPath}
-              onGoToOrganizationSettings={(orgId) => {
-                return router.push(`/organization/${orgId}/settings`);
-              }}
             />
           </DropdownMenu>
         )}
@@ -126,9 +123,6 @@ const BreadcrumbComponent = ({
                   : { state: "loading" })}
                 canCreateProjects={!!canCreateProjects}
                 getProjectPath={getProjectPath}
-                onGoToProjectSettings={(projectId) => {
-                  return router.push(`/project/${projectId}/settings`);
-                }}
               />
             </DropdownMenu>
           </>

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -70,8 +70,10 @@ DropdownMenuSubContent.displayName =
 
 const DropdownMenuContent = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
+    maxHeight?: React.CSSProperties["maxHeight"];
+  }
+>(({ className, sideOffset = 4, maxHeight, style, ...props }, ref) => {
   // Route into the `popover` overlay layer (above `modal`). null until mounted
   // → falls back to <body>, SSR-parity. Layer order, not z-index, stacks it.
   const container = useLayerContainer("popover");
@@ -84,6 +86,11 @@ const DropdownMenuContent = React.forwardRef<
           "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-32 overflow-hidden rounded-md border p-1 shadow-md",
           className,
         )}
+        style={
+          maxHeight === undefined
+            ? style
+            : { ...style, maxHeight, overflowY: "auto" }
+        }
         {...props}
       />
     </DropdownMenuPrimitive.Portal>

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -15,6 +15,7 @@ import Link from "next/link";
 import { cn } from "@/src/utils/tailwind";
 import { useLayerContainer } from "@/src/components/ui/layer";
 import { Skeleton } from "@/src/components/ui/skeleton";
+import { useScrollGradients } from "@/src/hooks/useScrollGradients";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
@@ -92,6 +93,26 @@ const dropdownMenuContentVariants = cva(
   },
 );
 
+const dropdownMenuScrollGradientVariants = cva(
+  "before:pointer-events-none before:sticky before:z-2 before:-mx-1 before:-mb-6 before:block before:h-6 before:bg-linear-to-b before:from-popover before:to-transparent before:content-[''] after:pointer-events-none after:sticky after:bottom-0 after:z-2 after:-mx-1 after:-mt-6 after:block after:h-6 after:bg-linear-to-t after:from-popover after:to-transparent after:content-['']",
+  {
+    variants: {
+      hasHeader: {
+        true: "before:top-[calc(2.5rem-1px)]",
+        false: "before:top-0",
+      },
+      showTopGradient: {
+        true: "before:opacity-100",
+        false: "before:opacity-0",
+      },
+      showBottomGradient: {
+        true: "after:opacity-100",
+        false: "after:opacity-0",
+      },
+    },
+  },
+);
+
 const DropdownMenuContent = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
@@ -110,64 +131,98 @@ const DropdownMenuContent = React.forwardRef<
     const DropdownContentWrapper = React.useCallback(
       function DropdownContentWrapper({
         children: wrapperChildren,
-        className,
-      }: React.PropsWithChildren<{
-        className?: string;
-      }>) {
+      }: {
+        children:
+          | React.ReactNode
+          | ((gradients: { top: boolean; bottom: boolean }) => React.ReactNode);
+      }) {
+        const { register, recompute, top, bottom } = useScrollGradients<
+          React.ComponentRef<typeof DropdownMenuPrimitive.Content>
+        >(maxHeight !== undefined);
+        const content =
+          typeof wrapperChildren === "function"
+            ? wrapperChildren({ top, bottom })
+            : wrapperChildren;
+
         return (
           <DropdownMenuPrimitive.Portal container={container}>
             <DropdownMenuPrimitive.Content
-              ref={ref}
+              ref={(element) => {
+                register(element);
+                if (typeof ref === "function") {
+                  ref(element);
+                } else if (ref) {
+                  ref.current = element;
+                }
+              }}
               sideOffset={sideOffset}
-              className={className}
+              className={cn(
+                dropdownMenuContentVariants({
+                  hasHeader: header != null,
+                  className,
+                }),
+                maxHeight !== undefined &&
+                  header == null &&
+                  dropdownMenuScrollGradientVariants({
+                    hasHeader: false,
+                    showTopGradient: top,
+                    showBottomGradient: bottom,
+                  }),
+              )}
               style={
                 maxHeight === undefined
                   ? style
                   : { ...style, maxHeight, overflowY: "auto" }
               }
               {...props}
+              onScroll={(event) => {
+                recompute();
+                props.onScroll?.(event);
+              }}
             >
-              {wrapperChildren}
+              {content}
             </DropdownMenuPrimitive.Content>
           </DropdownMenuPrimitive.Portal>
         );
       },
-      [container, maxHeight, props, ref, sideOffset, style],
+      [className, container, header, maxHeight, props, ref, sideOffset, style],
     );
 
     if (header != null) {
       // The sticky header sits outside the padded body so its background and
       // border cover the full width of the scroll container.
       return (
-        <DropdownContentWrapper
-          className={dropdownMenuContentVariants({
-            hasHeader: true,
-            className,
-          })}
-        >
-          <div
-            className={cn(
-              dropdownMenuLabelVariants(),
-              "border-border bg-popover sticky top-0 z-1 border-b px-3 py-2.5",
-            )}
-          >
-            {header}
-          </div>
-          <div className="p-1">{children}</div>
+        <DropdownContentWrapper>
+          {({ top, bottom }) => (
+            <>
+              <div
+                className={cn(
+                  dropdownMenuLabelVariants(),
+                  "border-border bg-popover sticky top-0 z-1 border-b px-3 py-2.5",
+                )}
+              >
+                {header}
+              </div>
+              <div
+                className={cn(
+                  "p-1",
+                  maxHeight !== undefined &&
+                    dropdownMenuScrollGradientVariants({
+                      hasHeader: true,
+                      showTopGradient: top,
+                      showBottomGradient: bottom,
+                    }),
+                )}
+              >
+                {children}
+              </div>
+            </>
+          )}
         </DropdownContentWrapper>
       );
     }
 
-    return (
-      <DropdownContentWrapper
-        className={dropdownMenuContentVariants({
-          hasHeader: false,
-          className,
-        })}
-      >
-        {children}
-      </DropdownContentWrapper>
-    );
+    return <DropdownContentWrapper>{children}</DropdownContentWrapper>;
   },
 );
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -182,7 +182,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("bg-muted -mx-1 my-1 h-px", className)}
+    className={cn("bg-border -mx-1 my-1 h-px", className)}
     {...props}
   />
 ));

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -227,6 +227,9 @@ const DropdownMenuContent = React.forwardRef<
 );
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
+/**
+ * Prefer `DropdownMenuItemWithSecondaryAction` for items that do not require JSX content.
+ */
 const DropdownMenuItem = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -2,7 +2,15 @@
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { Check, ChevronRight, Circle, Minus } from "lucide-react";
+import { cva } from "class-variance-authority";
+import {
+  Check,
+  ChevronRight,
+  Circle,
+  Minus,
+  type LucideIcon,
+} from "lucide-react";
+import Link from "next/link";
 
 import { cn } from "@/src/utils/tailwind";
 import { useLayerContainer } from "@/src/components/ui/layer";
@@ -116,6 +124,91 @@ const DropdownMenuItem = React.forwardRef<
 ));
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
+type DropdownMenuItemAction =
+  | {
+      href: React.ComponentProps<typeof Link>["href"];
+      onClick?: never;
+    }
+  | {
+      href?: never;
+      onClick: () => void;
+    };
+
+type DropdownMenuItemWithSecondaryActionProps = {
+  title: string;
+  secondaryAction: DropdownMenuItemAction & {
+    ariaLabel?: string;
+    icon: LucideIcon;
+  };
+} & DropdownMenuItemAction;
+
+const dropdownMenuItemPrimaryActionVariants = cva(
+  "flex min-w-0 flex-1 cursor-pointer px-2 py-1.5",
+);
+
+const dropdownMenuItemSecondaryActionVariants = cva(
+  "hover:bg-border dark:hover:bg-white/10 flex size-6 shrink-0 cursor-pointer items-center justify-center rounded mr-1",
+);
+
+const DropdownMenuItemWithSecondaryAction = (
+  props: DropdownMenuItemWithSecondaryActionProps,
+) => {
+  const secondaryAction = props.secondaryAction;
+  const SecondaryActionIcon = secondaryAction.icon;
+  const primaryContent = (
+    <span
+      className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
+      title={props.title}
+    >
+      {props.title}
+    </span>
+  );
+
+  return (
+    <DropdownMenuItem className="p-0">
+      {props.href !== undefined ? (
+        <Link
+          href={props.href}
+          className={dropdownMenuItemPrimaryActionVariants()}
+        >
+          {primaryContent}
+        </Link>
+      ) : (
+        <button
+          type="button"
+          className={dropdownMenuItemPrimaryActionVariants()}
+          onClick={props.onClick}
+        >
+          {primaryContent}
+        </button>
+      )}
+
+      {secondaryAction.href !== undefined ? (
+        <Link
+          href={secondaryAction.href}
+          aria-label={secondaryAction.ariaLabel}
+          className={dropdownMenuItemSecondaryActionVariants()}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <SecondaryActionIcon size={12} />
+        </Link>
+      ) : (
+        <button
+          type="button"
+          aria-label={secondaryAction.ariaLabel}
+          className={dropdownMenuItemSecondaryActionVariants()}
+          onClick={(event) => {
+            event.stopPropagation();
+            secondaryAction.onClick();
+          }}
+        >
+          <SecondaryActionIcon size={12} />
+        </button>
+      )}
+    </DropdownMenuItem>
+  );
+};
+
 const DropdownMenuLoadingItem = () => (
   <DropdownMenuItem disabled aria-label="Loading">
     <Skeleton variant="contrast" className="h-4 w-24" />
@@ -213,6 +306,7 @@ export {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuItemWithSecondaryAction,
   DropdownMenuLoadingItem,
   DropdownMenuCheckboxItem,
   DropdownMenuRadioItem,

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -202,7 +202,7 @@ const DropdownMenuItemWithSecondaryAction = (
   }
 
   return (
-    <DropdownMenuItem className="p-0">
+    <DropdownMenuItem className="h-8 p-0">
       {props.href !== undefined ? (
         <Link
           href={props.href}

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -76,34 +76,100 @@ const DropdownMenuSubContent = React.forwardRef<
 DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName;
 
+const dropdownMenuLabelVariants = cva("px-2 py-1.5 text-sm font-bold");
+
+const dropdownMenuContentVariants = cva(
+  "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-32 overflow-hidden rounded-md border shadow-md",
+  {
+    variants: {
+      // Header content provides its own full-width header and padded body.
+      // Headerless content needs the default padding on the Radix container.
+      hasHeader: {
+        true: null,
+        false: "p-1",
+      },
+    },
+  },
+);
+
 const DropdownMenuContent = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
+    header?: React.ReactNode;
     maxHeight?: React.CSSProperties["maxHeight"];
   }
->(({ className, sideOffset = 4, maxHeight, style, ...props }, ref) => {
-  // Route into the `popover` overlay layer (above `modal`). null until mounted
-  // → falls back to <body>, SSR-parity. Layer order, not z-index, stacks it.
-  const container = useLayerContainer("popover");
-  return (
-    <DropdownMenuPrimitive.Portal container={container}>
-      <DropdownMenuPrimitive.Content
-        ref={ref}
-        sideOffset={sideOffset}
-        className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-32 overflow-hidden rounded-md border p-1 shadow-md",
+>(
+  (
+    { children, className, header, sideOffset = 4, maxHeight, style, ...props },
+    ref,
+  ) => {
+    // Route into the `popover` overlay layer (above `modal`). null until mounted
+    // → falls back to <body>, SSR-parity. Layer order, not z-index, stacks it.
+    const container = useLayerContainer("popover");
+
+    const DropdownContentWrapper = React.useCallback(
+      function DropdownContentWrapper({
+        children: wrapperChildren,
+        className,
+      }: React.PropsWithChildren<{
+        className?: string;
+      }>) {
+        return (
+          <DropdownMenuPrimitive.Portal container={container}>
+            <DropdownMenuPrimitive.Content
+              ref={ref}
+              sideOffset={sideOffset}
+              className={className}
+              style={
+                maxHeight === undefined
+                  ? style
+                  : { ...style, maxHeight, overflowY: "auto" }
+              }
+              {...props}
+            >
+              {wrapperChildren}
+            </DropdownMenuPrimitive.Content>
+          </DropdownMenuPrimitive.Portal>
+        );
+      },
+      [container, maxHeight, props, ref, sideOffset, style],
+    );
+
+    if (header != null) {
+      // The sticky header sits outside the padded body so its background and
+      // border cover the full width of the scroll container.
+      return (
+        <DropdownContentWrapper
+          className={dropdownMenuContentVariants({
+            hasHeader: true,
+            className,
+          })}
+        >
+          <div
+            className={cn(
+              dropdownMenuLabelVariants(),
+              "border-border bg-popover sticky top-0 z-1 border-b px-3 py-2.5",
+            )}
+          >
+            {header}
+          </div>
+          <div className="p-1">{children}</div>
+        </DropdownContentWrapper>
+      );
+    }
+
+    return (
+      <DropdownContentWrapper
+        className={dropdownMenuContentVariants({
+          hasHeader: false,
           className,
-        )}
-        style={
-          maxHeight === undefined
-            ? style
-            : { ...style, maxHeight, overflowY: "auto" }
-        }
-        {...props}
-      />
-    </DropdownMenuPrimitive.Portal>
-  );
-});
+        })}
+      >
+        {children}
+      </DropdownContentWrapper>
+    );
+  },
+);
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<
@@ -286,7 +352,7 @@ const DropdownMenuLabel = React.forwardRef<
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
     ref={ref}
-    className={cn("px-2 py-1.5 text-sm font-bold", inset && "pl-8", className)}
+    className={cn(dropdownMenuLabelVariants(), inset && "pl-8", className)}
     {...props}
   />
 ));

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -113,86 +113,97 @@ const dropdownMenuScrollGradientVariants = cva(
   },
 );
 
-const DropdownMenuContent = React.forwardRef<
+type DropdownMenuContentProps = React.ComponentPropsWithoutRef<
+  typeof DropdownMenuPrimitive.Content
+> & {
+  header?: React.ReactNode;
+  maxHeight?: React.CSSProperties["maxHeight"];
+};
+
+const DropdownContentWrapper = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
-    header?: React.ReactNode;
-    maxHeight?: React.CSSProperties["maxHeight"];
+  Omit<DropdownMenuContentProps, "children"> & {
+    children:
+      | React.ReactNode
+      | ((gradients: { top: boolean; bottom: boolean }) => React.ReactNode);
   }
 >(
   (
     { children, className, header, sideOffset = 4, maxHeight, style, ...props },
     ref,
   ) => {
-    // Route into the `popover` overlay layer (above `modal`). null until mounted
-    // → falls back to <body>, SSR-parity. Layer order, not z-index, stacks it.
     const container = useLayerContainer("popover");
+    const { register, recompute, top, bottom } = useScrollGradients<
+      React.ComponentRef<typeof DropdownMenuPrimitive.Content>
+    >(maxHeight !== undefined);
+    const content =
+      typeof children === "function" ? children({ top, bottom }) : children;
 
-    const DropdownContentWrapper = React.useCallback(
-      function DropdownContentWrapper({
-        children: wrapperChildren,
-      }: {
-        children:
-          | React.ReactNode
-          | ((gradients: { top: boolean; bottom: boolean }) => React.ReactNode);
-      }) {
-        const { register, recompute, top, bottom } = useScrollGradients<
-          React.ComponentRef<typeof DropdownMenuPrimitive.Content>
-        >(maxHeight !== undefined);
-        const content =
-          typeof wrapperChildren === "function"
-            ? wrapperChildren({ top, bottom })
-            : wrapperChildren;
-
-        return (
-          <DropdownMenuPrimitive.Portal container={container}>
-            <DropdownMenuPrimitive.Content
-              ref={(element) => {
-                register(element);
-                if (typeof ref === "function") {
-                  ref(element);
-                } else if (ref) {
-                  ref.current = element;
-                }
-              }}
-              sideOffset={sideOffset}
-              className={cn(
-                dropdownMenuContentVariants({
-                  hasHeader: header != null,
-                  className,
-                }),
-                maxHeight !== undefined &&
-                  header == null &&
-                  dropdownMenuScrollGradientVariants({
-                    hasHeader: false,
-                    showTopGradient: top,
-                    showBottomGradient: bottom,
-                  }),
-              )}
-              style={
-                maxHeight === undefined
-                  ? style
-                  : { ...style, maxHeight, overflowY: "auto" }
-              }
-              {...props}
-              onScroll={(event) => {
-                recompute();
-                props.onScroll?.(event);
-              }}
-            >
-              {content}
-            </DropdownMenuPrimitive.Content>
-          </DropdownMenuPrimitive.Portal>
-        );
-      },
-      [className, container, header, maxHeight, props, ref, sideOffset, style],
+    return (
+      <DropdownMenuPrimitive.Portal container={container}>
+        <DropdownMenuPrimitive.Content
+          ref={(element) => {
+            register(element);
+            if (typeof ref === "function") {
+              ref(element);
+            } else if (ref) {
+              ref.current = element;
+            }
+          }}
+          sideOffset={sideOffset}
+          className={cn(
+            dropdownMenuContentVariants({
+              hasHeader: header != null,
+              className,
+            }),
+            maxHeight !== undefined &&
+              header == null &&
+              dropdownMenuScrollGradientVariants({
+                hasHeader: false,
+                showTopGradient: top,
+                showBottomGradient: bottom,
+              }),
+          )}
+          style={
+            maxHeight === undefined
+              ? style
+              : { ...style, maxHeight, overflowY: "auto" }
+          }
+          {...props}
+          onScroll={(event) => {
+            recompute();
+            props.onScroll?.(event);
+          }}
+        >
+          {content}
+        </DropdownMenuPrimitive.Content>
+      </DropdownMenuPrimitive.Portal>
     );
+  },
+);
+DropdownContentWrapper.displayName = "DropdownContentWrapper";
 
+const DropdownMenuContent = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
+  DropdownMenuContentProps
+>(
+  (
+    { children, className, header, sideOffset = 4, maxHeight, style, ...props },
+    ref,
+  ) => {
     if (header != null) {
       // The sticky header sits outside the padded body so its background and
       // border cover the full width of the scroll container.
       return (
-        <DropdownContentWrapper>
+        <DropdownContentWrapper
+          ref={ref}
+          className={className}
+          header={header}
+          sideOffset={sideOffset}
+          maxHeight={maxHeight}
+          style={style}
+          {...props}
+        >
           {({ top, bottom }) => (
             <>
               <div
@@ -222,7 +233,18 @@ const DropdownMenuContent = React.forwardRef<
       );
     }
 
-    return <DropdownContentWrapper>{children}</DropdownContentWrapper>;
+    return (
+      <DropdownContentWrapper
+        ref={ref}
+        className={className}
+        sideOffset={sideOffset}
+        maxHeight={maxHeight}
+        style={style}
+        {...props}
+      >
+        {children}
+      </DropdownContentWrapper>
+    );
   },
 );
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
@@ -326,26 +348,30 @@ const DropdownMenuItemWithSecondaryAction = (
   }
 
   return (
-    <DropdownMenuItem className="h-8 p-0">
+    <div className="flex h-8">
       {props.href !== undefined ? (
-        <Link
-          href={props.href}
-          className={dropdownMenuItemPrimaryActionVariants()}
-        >
-          {primaryContent}
-        </Link>
+        <DropdownMenuItem asChild className="h-8 min-w-0 flex-1 p-0">
+          <Link
+            href={props.href}
+            className={dropdownMenuItemPrimaryActionVariants()}
+          >
+            {primaryContent}
+          </Link>
+        </DropdownMenuItem>
       ) : (
-        <button
-          type="button"
-          className={dropdownMenuItemPrimaryActionVariants()}
-          onClick={props.onClick}
-        >
-          {primaryContent}
-        </button>
+        <DropdownMenuItem asChild className="h-8 min-w-0 flex-1 p-0">
+          <button
+            type="button"
+            className={dropdownMenuItemPrimaryActionVariants()}
+            onClick={props.onClick}
+          >
+            {primaryContent}
+          </button>
+        </DropdownMenuItem>
       )}
 
       {secondaryActionContent}
-    </DropdownMenuItem>
+    </div>
   );
 };
 

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -6,6 +6,7 @@ import { Check, ChevronRight, Circle, Minus } from "lucide-react";
 
 import { cn } from "@/src/utils/tailwind";
 import { useLayerContainer } from "@/src/components/ui/layer";
+import { Skeleton } from "@/src/components/ui/skeleton";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
@@ -108,6 +109,12 @@ const DropdownMenuItem = React.forwardRef<
 ));
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
+const DropdownMenuLoadingItem = () => (
+  <DropdownMenuItem disabled aria-label="Loading">
+    <Skeleton variant="contrast" className="h-4 w-24" />
+  </DropdownMenuItem>
+);
+
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
@@ -199,6 +206,7 @@ export {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLoadingItem,
   DropdownMenuCheckboxItem,
   DropdownMenuRadioItem,
   DropdownMenuLabel,

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -135,15 +135,16 @@ type DropdownMenuItemAction =
     };
 
 type DropdownMenuItemWithSecondaryActionProps = {
+  icon?: LucideIcon;
   title: string;
-  secondaryAction: DropdownMenuItemAction & {
+  secondaryAction?: DropdownMenuItemAction & {
     ariaLabel?: string;
     icon: LucideIcon;
   };
 } & DropdownMenuItemAction;
 
 const dropdownMenuItemPrimaryActionVariants = cva(
-  "flex min-w-0 flex-1 cursor-pointer px-2 py-1.5",
+  "flex min-w-0 flex-1 cursor-pointer items-center px-2 py-1.5",
 );
 
 const dropdownMenuItemSecondaryActionVariants = cva(
@@ -154,15 +155,51 @@ const DropdownMenuItemWithSecondaryAction = (
   props: DropdownMenuItemWithSecondaryActionProps,
 ) => {
   const secondaryAction = props.secondaryAction;
-  const SecondaryActionIcon = secondaryAction.icon;
+  const PrimaryActionIcon = props.icon;
+  const SecondaryActionIcon = secondaryAction?.icon;
   const primaryContent = (
-    <span
-      className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
-      title={props.title}
-    >
-      {props.title}
-    </span>
+    <>
+      {PrimaryActionIcon && (
+        <PrimaryActionIcon className="mr-1.5 size-4" aria-hidden="true" />
+      )}
+      <span
+        className="max-w-36 overflow-hidden text-ellipsis whitespace-nowrap"
+        title={props.title}
+      >
+        {props.title}
+      </span>
+    </>
   );
+  let secondaryActionContent: React.ReactNode = null;
+
+  if (secondaryAction && SecondaryActionIcon) {
+    if (secondaryAction.href !== undefined) {
+      secondaryActionContent = (
+        <Link
+          href={secondaryAction.href}
+          aria-label={secondaryAction.ariaLabel}
+          className={dropdownMenuItemSecondaryActionVariants()}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <SecondaryActionIcon size={12} />
+        </Link>
+      );
+    } else {
+      secondaryActionContent = (
+        <button
+          type="button"
+          aria-label={secondaryAction.ariaLabel}
+          className={dropdownMenuItemSecondaryActionVariants()}
+          onClick={(event) => {
+            event.stopPropagation();
+            secondaryAction.onClick();
+          }}
+        >
+          <SecondaryActionIcon size={12} />
+        </button>
+      );
+    }
+  }
 
   return (
     <DropdownMenuItem className="p-0">
@@ -183,28 +220,7 @@ const DropdownMenuItemWithSecondaryAction = (
         </button>
       )}
 
-      {secondaryAction.href !== undefined ? (
-        <Link
-          href={secondaryAction.href}
-          aria-label={secondaryAction.ariaLabel}
-          className={dropdownMenuItemSecondaryActionVariants()}
-          onClick={(event) => event.stopPropagation()}
-        >
-          <SecondaryActionIcon size={12} />
-        </Link>
-      ) : (
-        <button
-          type="button"
-          aria-label={secondaryAction.ariaLabel}
-          className={dropdownMenuItemSecondaryActionVariants()}
-          onClick={(event) => {
-            event.stopPropagation();
-            secondaryAction.onClick();
-          }}
-        >
-          <SecondaryActionIcon size={12} />
-        </button>
-      )}
+      {secondaryActionContent}
     </DropdownMenuItem>
   );
 };

--- a/web/src/components/ui/skeleton.tsx
+++ b/web/src/components/ui/skeleton.tsx
@@ -1,14 +1,27 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
 import { cn } from "@/src/utils/tailwind";
+
+const skeletonVariants = cva("animate-pulse rounded-md", {
+  variants: {
+    variant: {
+      default: "bg-muted",
+      contrast: "bg-border-contrast",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
 
 function Skeleton({
   className,
+  variant,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
+}: React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof skeletonVariants>) {
   return (
-    <div
-      className={cn("bg-muted animate-pulse rounded-md", className)}
-      {...props}
-    />
+    <div className={cn(skeletonVariants({ variant }), className)} {...props} />
   );
 }
 

--- a/web/src/hooks/useScrollGradients.ts
+++ b/web/src/hooks/useScrollGradients.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Tracks whether a scroll container has hidden content above or below it.
+ * Re-measures when the container resizes or its DOM content changes so callers
+ * can render scroll affordances at the active edges.
+ */
+export function useScrollGradients<TElement extends HTMLElement>(
+  enabled: boolean,
+) {
+  const contentRef = useRef<TElement>(null);
+  const [{ top, bottom }, setScrollGradients] = useState({
+    top: false,
+    bottom: false,
+  });
+  const register = useCallback((element: TElement | null) => {
+    contentRef.current = element;
+  }, []);
+  const recompute = useCallback(() => {
+    const element = contentRef.current;
+    if (!element || !enabled) return;
+
+    const maxScrollTop = element.scrollHeight - element.clientHeight;
+    const nextTop = maxScrollTop > 1 && element.scrollTop > 1;
+    const nextBottom = maxScrollTop > 1 && element.scrollTop < maxScrollTop - 1;
+
+    setScrollGradients((current) => {
+      if (current.top === nextTop && current.bottom === nextBottom) {
+        return current;
+      }
+      return { top: nextTop, bottom: nextBottom };
+    });
+  }, [enabled]);
+
+  useEffect(() => {
+    const element = contentRef.current;
+    if (!element || !enabled) return;
+
+    const update = () => recompute();
+    update();
+
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(element);
+    const mutationObserver = new MutationObserver(update);
+    mutationObserver.observe(element, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, [enabled, recompute]);
+
+  return { register, recompute, top, bottom };
+}

--- a/web/src/hooks/useScrollGradients.ts
+++ b/web/src/hooks/useScrollGradients.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+const SCROLL_EDGE_THRESHOLD_PX = 10;
+
 /**
  * Tracks whether a scroll container has hidden content above or below it.
  * Re-measures when the container resizes or its DOM content changes so callers
@@ -21,8 +23,12 @@ export function useScrollGradients<TElement extends HTMLElement>(
     if (!element || !enabled) return;
 
     const maxScrollTop = element.scrollHeight - element.clientHeight;
-    const nextTop = maxScrollTop > 1 && element.scrollTop > 1;
-    const nextBottom = maxScrollTop > 1 && element.scrollTop < maxScrollTop - 1;
+    const nextTop =
+      maxScrollTop > SCROLL_EDGE_THRESHOLD_PX &&
+      element.scrollTop > SCROLL_EDGE_THRESHOLD_PX;
+    const nextBottom =
+      maxScrollTop > SCROLL_EDGE_THRESHOLD_PX &&
+      element.scrollTop < maxScrollTop - SCROLL_EDGE_THRESHOLD_PX;
 
     setScrollGradients((current) => {
       if (current.top === nextTop && current.bottom === nextBottom) {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the project and organization breadcrumb dropdowns by extracting them into dedicated `OrganizationDropdownMenu` and `ProjectDropdownMenu` components, and extends the shared `DropdownMenuContent` with sticky-header, `maxHeight`, and scroll-gradient support.

- The new `DropdownContentWrapper` is correctly defined at module scope as a stable `forwardRef` component, fixing the previous render-identity issue.
- `OrganizationDropdownMenu` uses a spread copy (`[...props.organizations].sort(...)`) to avoid mutating the session array, addressing the previously noted in-place mutation bug.
- The new `DropdownMenuItemWithSecondaryAction` exposes an `onClick` secondary-action variant; clicking an `onClick`-based secondary button won't auto-close the dropdown (only `href`-based navigation implicitly closes it via page change), which could be a latent UX issue if the `onClick` variant is adopted.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The refactoring cleanly extracts dropdown components and fixes previously noted mutation and component-identity bugs.

All changes are UI-layer refactoring with no data mutations, API calls, or auth logic. The previous known issues (in-place array sort mutation, unstable component identity in DropdownMenuContent) are both addressed. The one latent concern — onClick-based secondary actions not auto-closing the dropdown — is not exercised by any current callsite.

web/src/components/ui/dropdown-menu.tsx — the new DropdownMenuItemWithSecondaryAction component, specifically its onClick secondary-action path, deserves attention if that variant is adopted in future callsites.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant BC as breadcrumb.tsx
    participant ODM as OrganizationDropdownMenu
    participant PDM as ProjectDropdownMenu
    participant DMC as DropdownMenuContent
    participant DCW as DropdownContentWrapper
    participant SG as useScrollGradients

    BC->>ODM: "state=loaded|loading, organizations, getOrgPath"
    ODM->>DMC: "header="Organizations", maxHeight="15rem""
    DMC->>DCW: children as render prop fn
    DCW->>SG: register(element), recompute on scroll/resize
    SG-->>DCW: top/bottom gradient flags
    DCW-->>DMC: renders Content with gradient classes
    DMC-->>ODM: renders items via DropdownMenuItemWithSecondaryAction
    BC->>PDM: "state=loaded|loading, projects, organizationId"
    PDM->>DMC: "header="Projects", maxHeight="15rem""
    DMC->>DCW: children as render prop fn
    DCW->>SG: register(element), recompute on scroll/resize
    SG-->>DCW: top/bottom gradient flags
    DCW-->>PDM: renders items via DropdownMenuItemWithSecondaryAction
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant BC as breadcrumb.tsx
    participant ODM as OrganizationDropdownMenu
    participant PDM as ProjectDropdownMenu
    participant DMC as DropdownMenuContent
    participant DCW as DropdownContentWrapper
    participant SG as useScrollGradients

    BC->>ODM: "state=loaded|loading, organizations, getOrgPath"
    ODM->>DMC: "header="Organizations", maxHeight="15rem""
    DMC->>DCW: children as render prop fn
    DCW->>SG: register(element), recompute on scroll/resize
    SG-->>DCW: top/bottom gradient flags
    DCW-->>DMC: renders Content with gradient classes
    DMC-->>ODM: renders items via DropdownMenuItemWithSecondaryAction
    BC->>PDM: "state=loaded|loading, projects, organizationId"
    PDM->>DMC: "header="Projects", maxHeight="15rem""
    DMC->>DCW: children as render prop fn
    DCW->>SG: register(element), recompute on scroll/resize
    SG-->>DCW: top/bottom gradient flags
    DCW-->>PDM: renders items via DropdownMenuItemWithSecondaryAction
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address PR comments"](https://github.com/langfuse/langfuse/commit/a186a9d7162e3cea3f2f9caa56834dbc5cfe2b4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45626660)</sub>

<!-- /greptile_comment -->