### PR TITLE
feat(clickhouse): add created_at minmax skip indexes to observations, traces, scores

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0037_add_created_at_indexes.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0037_add_created_at_indexes.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE observations ON CLUSTER default DROP INDEX IF EXISTS idx_created_at;
+ALTER TABLE traces ON CLUSTER default DROP INDEX IF EXISTS idx_created_at;
+ALTER TABLE scores ON CLUSTER default DROP INDEX IF EXISTS idx_created_at;

--- a/packages/shared/clickhouse/migrations/clustered/0037_add_created_at_indexes.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0037_add_created_at_indexes.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE observations ON CLUSTER default ADD INDEX IF NOT EXISTS idx_created_at created_at TYPE minmax GRANULARITY 1 SETTINGS alter_sync = 2;
+ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_created_at SETTINGS mutations_sync = 2;
+ALTER TABLE traces ON CLUSTER default ADD INDEX IF NOT EXISTS idx_created_at created_at TYPE minmax GRANULARITY 1 SETTINGS alter_sync = 2;
+ALTER TABLE traces ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_created_at SETTINGS mutations_sync = 2;
+ALTER TABLE scores ON CLUSTER default ADD INDEX IF NOT EXISTS idx_created_at created_at TYPE minmax GRANULARITY 1 SETTINGS alter_sync = 2;
+ALTER TABLE scores ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_created_at SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/clustered/0037_add_created_at_indexes.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0037_add_created_at_indexes.up.sql
@@ -1,6 +1,6 @@
 ALTER TABLE observations ON CLUSTER default ADD INDEX IF NOT EXISTS idx_created_at created_at TYPE minmax GRANULARITY 1 SETTINGS alter_sync = 2;
-ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_created_at SETTINGS mutations_sync = 2;
+ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_created_at;
 ALTER TABLE traces ON CLUSTER default ADD INDEX IF NOT EXISTS idx_created_at created_at TYPE minmax GRANULARITY 1 SETTINGS alter_sync = 2;
-ALTER TABLE traces ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_created_at SETTINGS mutations_sync = 2;
+ALTER TABLE traces ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_created_at;
 ALTER TABLE scores ON CLUSTER default ADD INDEX IF NOT EXISTS idx_created_at created_at TYPE minmax GRANULARITY 1 SETTINGS alter_sync = 2;
-ALTER TABLE scores ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_created_at SETTINGS mutations_sync = 2;
+ALTER TABLE scores ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_created_at;

--- a/packages/shared/clickhouse/migrations/unclustered/0037_add_created_at_indexes.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0037_add_created_at_indexes.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE observations DROP INDEX IF EXISTS idx_created_at;
+ALTER TABLE traces DROP INDEX IF EXISTS idx_created_at;
+ALTER TABLE scores DROP INDEX IF EXISTS idx_created_at;

--- a/packages/shared/clickhouse/migrations/unclustered/0037_add_created_at_indexes.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0037_add_created_at_indexes.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE observations ADD INDEX IF NOT EXISTS idx_created_at created_at TYPE minmax GRANULARITY 1;
+ALTER TABLE observations MATERIALIZE INDEX IF EXISTS idx_created_at;
+ALTER TABLE traces ADD INDEX IF NOT EXISTS idx_created_at created_at TYPE minmax GRANULARITY 1;
+ALTER TABLE traces MATERIALIZE INDEX IF EXISTS idx_created_at;
+ALTER TABLE scores ADD INDEX IF NOT EXISTS idx_created_at created_at TYPE minmax GRANULARITY 1;
+ALTER TABLE scores MATERIALIZE INDEX IF EXISTS idx_created_at;


### PR DESCRIPTION
Codifies the manual DDL applied to Langfuse Cloud (LFE-10886) as a regular migration. The hourly cloud usage metering job counts rows per project filtered by created_at, which is not part of any sort key — without an index each count is a full scan that grows with table size. A minmax skip index at GRANULARITY 1 prunes these scans to the granules of the metered hour.

ADD INDEX IF NOT EXISTS and MATERIALIZE INDEX IF EXISTS make the migration a no-op re-materialization on environments where the index was already applied manually.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This migration codifies the manual DDL already applied to Langfuse Cloud by adding a `minmax` skip index on `created_at` to the `observations`, `traces`, and `scores` tables. The index targets the hourly cloud usage metering job, which filters by `created_at` but that column is absent from any table's sort key, causing full-granule scans that grow linearly with data.

- **Idempotent design**: `ADD INDEX IF NOT EXISTS` + `MATERIALIZE INDEX IF EXISTS` means the migration is safe to run on both fresh installs and Cloud environments where the index already exists from a prior manual DDL.
- **Clustered vs unclustered asymmetry**: The clustered migration materializes indexes synchronously (`mutations_sync = 2`), which can block the migration runner for hours on large tables; the unclustered migration materializes asynchronously (no `mutations_sync`), completing quickly but leaving the index building in the background.
- **Re-materialization on Cloud**: On environments where the index was already manually applied and built, `MATERIALIZE INDEX IF EXISTS` unconditionally triggers a full re-materialization, imposing additional I/O load — this appears to be a deliberate trade-off rather than a bug.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the migration is idempotent and functionally correct, with the main operational risk being a potentially long-running synchronous mutation on large clustered self-hosted deployments.

All three tables are very large in production. The clustered MATERIALIZE INDEX blocks synchronously until every replica is done — for observations and traces this could take hours and time out deployment tooling. The unclustered path returns immediately, leaving the index building in the background so a metering job run right after migration may not yet benefit. Neither is a functional bug, but both carry real operational implications for self-hosted users.

Both up.sql files warrant a second look: clustered/0037_add_created_at_indexes.up.sql for the synchronous-block risk, and unclustered/0037_add_created_at_indexes.up.sql for the async-completion gap.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/clickhouse/migrations/clustered/0037_add_created_at_indexes.up.sql:2
**Synchronous materialization blocks migration runner on large tables**

`MATERIALIZE INDEX … SETTINGS mutations_sync = 2` holds the migration runner thread until every replica confirms the mutation is done. For `observations` and `traces`, which are the largest tables in large-scale self-hosted clustered deployments, this can take hours and may cause the deployment orchestrator (k8s init-container, CI gate, etc.) to time out. Consider whether the migration runner has an appropriate deadline, and document this expectation. The unclustered variant (no `mutations_sync`) runs asynchronously and does not have this risk.

### Issue 2 of 2
packages/shared/clickhouse/migrations/unclustered/0037_add_created_at_indexes.up.sql:2
**`MATERIALIZE INDEX` runs asynchronously in unclustered mode**

Without `SETTINGS mutations_sync = 1`, `MATERIALIZE INDEX IF EXISTS idx_created_at` enqueues the mutation and returns immediately. The migration is marked complete before the index is actually built, so a metering job that runs right after the migration may still perform full-granule scans until the background mutation finishes. This is in contrast to the clustered variant which waits synchronously. If the migration is intended to be "ready to use" on completion for both paths, consider adding `SETTINGS mutations_sync = 1`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(clickhouse): add created\_at minmax ..."](https://github.com/langfuse/langfuse/commit/38ee222184980fb015c0cf20110984e3a6cda8a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45624978)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->