### PR TITLE
fix(trace): gate oversized fields in the JSON Beta IO viewer (LFE-10847)

### DIFF
--- a/web/src/components/trace/components/IOPreview/IOPreviewJSON.clienttest.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewJSON.clienttest.tsx
@@ -101,11 +101,34 @@ describe("IOPreviewJSON node-count gating", () => {
       screen.getByRole("button", { name: /Download Input/i }),
     ).toBeInTheDocument();
     // ...and its section carries NO data, so the viewer builds no tree for it.
-    expect(screen.getByTestId("section-input")).toHaveAttribute(
+    // The gated section uses a collapse-isolated key (`__oversized`), never the
+    // plain field key, so it cannot inherit a persisted collapsed state.
+    expect(screen.getByTestId("section-input__oversized")).toHaveAttribute(
       "data-hide-data",
       "true",
     );
     expect(screen.queryByTestId("data-input")).not.toBeInTheDocument();
+  });
+
+  it("gates under a collapse-isolated key, not the plain field key", () => {
+    // The fallback's download escape hatch lives in the section footer, which
+    // the viewer hides when the section is collapsed and persists that collapse
+    // per section key. Reusing the plain field key would let a collapse from an
+    // earlier trace (where the field rendered normally) silently hide the
+    // fallback here. A distinct `__oversized` key keeps the two states separate.
+    render(
+      <IOPreviewJSON
+        input={manyRows()}
+        hideOutput
+        hideIfNull
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    expect(screen.getByTestId("section-input__oversized")).toBeInTheDocument();
+    expect(screen.queryByTestId("section-input")).not.toBeInTheDocument();
   });
 
   it("reports the node/row count as the reason, not a character count", () => {
@@ -165,7 +188,7 @@ describe("IOPreviewJSON node-count gating", () => {
     expect(
       screen.getByRole("button", { name: /Download Input/i }),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("section-input")).toHaveAttribute(
+    expect(screen.getByTestId("section-input__oversized")).toHaveAttribute(
       "data-hide-data",
       "true",
     );
@@ -173,7 +196,7 @@ describe("IOPreviewJSON node-count gating", () => {
     expect(screen.getByTestId("data-output")).toBeInTheDocument();
     const sections = screen.getAllByTestId(/^section-/);
     expect(sections.map((el) => el.getAttribute("data-testid"))).toEqual([
-      "section-input",
+      "section-input__oversized",
       "section-output",
     ]);
   });

--- a/web/src/components/trace/components/IOPreview/IOPreviewJSON.clienttest.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewJSON.clienttest.tsx
@@ -2,20 +2,37 @@
  * The JSON Beta viewer virtualizes the DOM but still builds the full node tree
  * on the main thread, so a field with too many nodes (a large conversation /
  * deeply nested JSON) freezes the tab even here (LFE-10847). These tests pin the
- * node-count gate in IOPreviewJSON: over-limit fields render the bounded
- * fallback and are NEVER handed to MultiSectionJsonViewer, while normal fields
- * (including a huge single string, which is only one node) render as before.
+ * node-count gate in IOPreviewJSON: over-limit fields render as a `hideData`
+ * section (so the viewer builds no tree) whose footer is the bounded fallback,
+ * while normal fields (including a huge single string, which is only one node)
+ * render with their data as before.
  */
 import { render, screen } from "@testing-library/react";
 
-// MultiSectionJsonViewer is the tree-building path we must NOT reach for
-// over-limit fields — mock it and expose the section keys it receives.
+// Mock MultiSectionJsonViewer: expose each section's key, whether it carries
+// data (hideData=false) vs. is gated (hideData=true, tree never built), and
+// render its footer so the fallback is observable.
 vi.mock(
   "@/src/components/ui/AdvancedJsonViewer/MultiSectionJsonViewer",
   () => ({
-    MultiSectionJsonViewer: (props: { sections: { key: string }[] }) => (
+    MultiSectionJsonViewer: (props: {
+      sections: {
+        key: string;
+        hideData?: boolean;
+        renderFooter?: (ctx: unknown) => React.ReactNode;
+      }[];
+    }) => (
       <div data-testid="multi-section-viewer">
-        {props.sections.map((s) => s.key).join(",")}
+        {props.sections.map((s) => (
+          <div
+            key={s.key}
+            data-testid={`section-${s.key}`}
+            data-hide-data={String(!!s.hideData)}
+          >
+            {!s.hideData && <span data-testid={`data-${s.key}`}>data</span>}
+            {s.renderFooter ? s.renderFooter({}) : null}
+          </div>
+        ))}
       </div>
     ),
   }),
@@ -66,7 +83,7 @@ const manyRows = () =>
   Array.from({ length: JSON_VIEW_RENDER_ROW_LIMIT }, (_, i) => i);
 
 describe("IOPreviewJSON node-count gating", () => {
-  it("renders the fallback and never mounts the viewer for an over-limit field", () => {
+  it("renders an over-limit field as a hideData section with the fallback footer", () => {
     render(
       <IOPreviewJSON
         input={manyRows()}
@@ -78,17 +95,38 @@ describe("IOPreviewJSON node-count gating", () => {
       />,
     );
 
+    // Fallback (with download) shown for the gated field...
     expect(screen.getByText(FALLBACK_TEXT)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /Download Input/i }),
     ).toBeInTheDocument();
-    // The over-limit field was never handed to the tree-building viewer.
+    // ...and its section carries NO data, so the viewer builds no tree for it.
+    expect(screen.getByTestId("section-input")).toHaveAttribute(
+      "data-hide-data",
+      "true",
+    );
+    expect(screen.queryByTestId("data-input")).not.toBeInTheDocument();
+  });
+
+  it("reports the node/row count as the reason, not a character count", () => {
+    render(
+      <IOPreviewJSON
+        input={manyRows()}
+        hideOutput
+        hideIfNull
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+    // Node-count gate → the summary names rows, not characters.
+    expect(screen.getByText(/rows — too large to render/i)).toBeInTheDocument();
     expect(
-      screen.queryByTestId("multi-section-viewer"),
+      screen.queryByText(/characters — too large to render/i),
     ).not.toBeInTheDocument();
   });
 
-  it("lets a huge single STRING through (one node) — no fallback, viewer renders it", () => {
+  it("lets a huge single STRING through (one node) — no fallback, data rendered", () => {
     // A 20 MB base64-style string is a single node: cheap for the virtualized
     // viewer (renders as a media chip). A char-based gate would wrongly gate it.
     const hugeString = "A".repeat(20_000_000);
@@ -104,11 +142,14 @@ describe("IOPreviewJSON node-count gating", () => {
     );
 
     expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
-    const viewer = screen.getByTestId("multi-section-viewer");
-    expect(viewer).toHaveTextContent("input");
+    expect(screen.getByTestId("section-input")).toHaveAttribute(
+      "data-hide-data",
+      "false",
+    );
+    expect(screen.getByTestId("data-input")).toBeInTheDocument();
   });
 
-  it("gates only the over-limit field, keeping the rest in the viewer", () => {
+  it("gates only the over-limit field and keeps its position among sections", () => {
     render(
       <IOPreviewJSON
         input={manyRows()}
@@ -120,17 +161,24 @@ describe("IOPreviewJSON node-count gating", () => {
       />,
     );
 
-    // Input fallback shown...
+    // Input fallback shown, input section is gated (no data)...
     expect(
       screen.getByRole("button", { name: /Download Input/i }),
     ).toBeInTheDocument();
-    // ...and the viewer still renders, with output but NOT input.
-    const viewer = screen.getByTestId("multi-section-viewer");
-    expect(viewer).toHaveTextContent("output");
-    expect(viewer).not.toHaveTextContent("input");
+    expect(screen.getByTestId("section-input")).toHaveAttribute(
+      "data-hide-data",
+      "true",
+    );
+    // ...output still renders its data, and Input precedes Output (order kept).
+    expect(screen.getByTestId("data-output")).toBeInTheDocument();
+    const sections = screen.getAllByTestId(/^section-/);
+    expect(sections.map((el) => el.getAttribute("data-testid"))).toEqual([
+      "section-input",
+      "section-output",
+    ]);
   });
 
-  it("renders the viewer (no fallback) for normal small I/O", () => {
+  it("renders normal small I/O with its data and no fallback", () => {
     render(
       <IOPreviewJSON
         input={{ messages: [{ role: "user", content: "hi" }] }}
@@ -143,8 +191,6 @@ describe("IOPreviewJSON node-count gating", () => {
     );
 
     expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
-    expect(screen.getByTestId("multi-section-viewer")).toHaveTextContent(
-      "input",
-    );
+    expect(screen.getByTestId("data-input")).toBeInTheDocument();
   });
 });

--- a/web/src/components/trace/components/IOPreview/IOPreviewJSON.clienttest.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewJSON.clienttest.tsx
@@ -1,0 +1,150 @@
+/**
+ * The JSON Beta viewer virtualizes the DOM but still builds the full node tree
+ * on the main thread, so a field with too many nodes (a large conversation /
+ * deeply nested JSON) freezes the tab even here (LFE-10847). These tests pin the
+ * node-count gate in IOPreviewJSON: over-limit fields render the bounded
+ * fallback and are NEVER handed to MultiSectionJsonViewer, while normal fields
+ * (including a huge single string, which is only one node) render as before.
+ */
+import { render, screen } from "@testing-library/react";
+
+// MultiSectionJsonViewer is the tree-building path we must NOT reach for
+// over-limit fields — mock it and expose the section keys it receives.
+vi.mock(
+  "@/src/components/ui/AdvancedJsonViewer/MultiSectionJsonViewer",
+  () => ({
+    MultiSectionJsonViewer: (props: { sections: { key: string }[] }) => (
+      <div data-testid="multi-section-viewer">
+        {props.sections.map((s) => s.key).join(",")}
+      </div>
+    ),
+  }),
+);
+
+vi.mock("./components/CorrectedOutputField", () => ({
+  CorrectedOutputField: () => <div data-testid="corrected-output" />,
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+vi.mock(
+  "@/src/components/ui/AdvancedJsonViewer/hooks/useJsonViewPreferences",
+  () => ({
+    useJsonViewPreferences: () => ({
+      stringWrapMode: "truncate",
+      setStringWrapMode: vi.fn(),
+    }),
+  }),
+);
+
+// deepParseJson is the only runtime import from the shared barrel here; stub it
+// to identity so the test stays light and deterministic.
+vi.mock("@langfuse/shared", () => ({
+  deepParseJson: (value: unknown) => value,
+}));
+
+// Unicode decoding is orthogonal to the size gate under test; identity keeps
+// the test focused (and avoids pulling shared's decode helper through the mock).
+vi.mock("@/src/utils/decodeUnicodeInJson", () => ({
+  decodeUnicodeInJson: (value: unknown) => value,
+}));
+
+import { IOPreviewJSON } from "./IOPreviewJSON";
+import { JSON_VIEW_RENDER_ROW_LIMIT } from "./lib/jsonViewSizeGate";
+
+const FALLBACK_TEXT = /too large to render in JSON view/i;
+
+// An array of N primitives is N+1 rows (array node + N elements) and is cheap
+// to build — no giant nested object needed to cross the node limit.
+const manyRows = () =>
+  Array.from({ length: JSON_VIEW_RENDER_ROW_LIMIT }, (_, i) => i);
+
+describe("IOPreviewJSON node-count gating", () => {
+  it("renders the fallback and never mounts the viewer for an over-limit field", () => {
+    render(
+      <IOPreviewJSON
+        input={manyRows()}
+        hideOutput
+        hideIfNull
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    expect(screen.getByText(FALLBACK_TEXT)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Download Input/i }),
+    ).toBeInTheDocument();
+    // The over-limit field was never handed to the tree-building viewer.
+    expect(
+      screen.queryByTestId("multi-section-viewer"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("lets a huge single STRING through (one node) — no fallback, viewer renders it", () => {
+    // A 20 MB base64-style string is a single node: cheap for the virtualized
+    // viewer (renders as a media chip). A char-based gate would wrongly gate it.
+    const hugeString = "A".repeat(20_000_000);
+    render(
+      <IOPreviewJSON
+        input={hugeString}
+        hideOutput
+        hideIfNull
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
+    const viewer = screen.getByTestId("multi-section-viewer");
+    expect(viewer).toHaveTextContent("input");
+  });
+
+  it("gates only the over-limit field, keeping the rest in the viewer", () => {
+    render(
+      <IOPreviewJSON
+        input={manyRows()}
+        output={{ answer: "ok" }}
+        hideIfNull
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    // Input fallback shown...
+    expect(
+      screen.getByRole("button", { name: /Download Input/i }),
+    ).toBeInTheDocument();
+    // ...and the viewer still renders, with output but NOT input.
+    const viewer = screen.getByTestId("multi-section-viewer");
+    expect(viewer).toHaveTextContent("output");
+    expect(viewer).not.toHaveTextContent("input");
+  });
+
+  it("renders the viewer (no fallback) for normal small I/O", () => {
+    render(
+      <IOPreviewJSON
+        input={{ messages: [{ role: "user", content: "hi" }] }}
+        hideOutput
+        hideIfNull
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
+    expect(screen.getByTestId("multi-section-viewer")).toHaveTextContent(
+      "input",
+    );
+  });
+});

--- a/web/src/components/trace/components/IOPreview/IOPreviewJSON.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewJSON.tsx
@@ -347,13 +347,18 @@ function IOPreviewJSONInner({
   // header shows the field name, so the fallback hides its own title.
   const sections = useMemo(() => {
     const gatedSection = (
-      key: string,
+      fieldKey: string,
       title: string,
       backgroundColor: string,
       probe: ReturnType<typeof probeJsonField> | null,
       rowCount: number,
     ) => ({
-      key,
+      // Use a key distinct from the field's normal section key so the fallback
+      // does not inherit a persisted collapsed state from an earlier trace
+      // where the same field rendered normally — that would silently hide the
+      // download escape hatch (its collapse persists per section key). A gated
+      // field gets its own key, so it always defaults to expanded.
+      key: `${fieldKey}__oversized`,
       title,
       data: null,
       hideData: true,
@@ -368,7 +373,7 @@ function IOPreviewJSONInner({
             isString={probe.isString}
             charCount={probe.size}
             rowCount={rowCount}
-            downloadFileBase={`${key}-${downloadName}`}
+            downloadFileBase={`${fieldKey}-${downloadName}`}
           />
         ) : null,
     });
@@ -418,6 +423,7 @@ function IOPreviewJSONInner({
         renderFooter: () => (
           <CorrectedOutputField
             actualOutput={effectiveOutput}
+            actualOutputTooLarge={outputTooLarge}
             existingCorrection={outputCorrection}
             observationId={observationId}
             projectId={projectId}

--- a/web/src/components/trace/components/IOPreview/IOPreviewJSON.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewJSON.tsx
@@ -187,17 +187,21 @@ function IOPreviewJSONInner({
   );
 
   // Probe over-limit fields once for the bounded fallback (preview + download).
+  // Probe the PARSED value — the same value the row-count gate ran on — so the
+  // preview, download and reported size all reflect what tripped the gate (a
+  // string field that deep-parses into a large tree would otherwise show its
+  // short raw length).
   const inputProbe = useMemo(
-    () => (inputTooLarge ? probeJsonField(input) : null),
-    [input, inputTooLarge],
+    () => (inputTooLarge ? probeJsonField(inputParsed) : null),
+    [inputParsed, inputTooLarge],
   );
   const outputProbe = useMemo(
-    () => (outputTooLarge ? probeJsonField(output) : null),
-    [output, outputTooLarge],
+    () => (outputTooLarge ? probeJsonField(outputParsed) : null),
+    [outputParsed, outputTooLarge],
   );
   const metadataProbe = useMemo(
-    () => (metadataTooLarge ? probeJsonField(metadata) : null),
-    [metadata, metadataTooLarge],
+    () => (metadataTooLarge ? probeJsonField(metadataParsed) : null),
+    [metadataParsed, metadataTooLarge],
   );
 
   // A gated field parses to undefined above but is not empty — it is too big.
@@ -299,16 +303,25 @@ function IOPreviewJSONInner({
   }, []);
 
   const handleCopy = useCallback(() => {
+    // Gated fields have no materialized value (effective* is undefined), so
+    // copy a placeholder rather than silently dropping the key — the field is
+    // visibly present on screen (fallback + download), it just can't be inlined.
+    const TOO_LARGE = "<omitted: too large to render — use the field download>";
     const dataObj: Record<string, unknown> = {};
-    if (showInput) dataObj.input = effectiveInput;
-    if (showOutput) dataObj.output = effectiveOutput;
-    if (showMetadata) dataObj.metadata = effectiveMetadata;
+    if (showInput) dataObj.input = inputTooLarge ? TOO_LARGE : effectiveInput;
+    if (showOutput)
+      dataObj.output = outputTooLarge ? TOO_LARGE : effectiveOutput;
+    if (showMetadata)
+      dataObj.metadata = metadataTooLarge ? TOO_LARGE : effectiveMetadata;
     const jsonString = JSON.stringify(dataObj, null, 2);
     navigator.clipboard.writeText(jsonString);
   }, [
     showInput,
     showOutput,
     showMetadata,
+    inputTooLarge,
+    outputTooLarge,
+    metadataTooLarge,
     effectiveInput,
     effectiveOutput,
     effectiveMetadata,
@@ -326,28 +339,72 @@ function IOPreviewJSONInner({
     [stringWrapMode],
   );
 
-  // Build sections - memoized to prevent re-creation. Over-limit fields are
-  // NOT added here: they render as a bounded fallback outside the viewer, so
-  // the viewer never builds a tree for them.
+  // Build sections - memoized to prevent re-creation. A gated field renders as
+  // a section with no data (hideData → the viewer builds no tree for it, so it
+  // can't freeze) whose footer is the bounded fallback. Keeping it a section —
+  // rather than a block outside the viewer — preserves the natural
+  // Input → Output → Metadata order and the shared search/scroll. The section
+  // header shows the field name, so the fallback hides its own title.
   const sections = useMemo(() => {
+    const gatedSection = (
+      key: string,
+      title: string,
+      backgroundColor: string,
+      probe: ReturnType<typeof probeJsonField> | null,
+      rowCount: number,
+    ) => ({
+      key,
+      title,
+      data: null,
+      hideData: true,
+      backgroundColor,
+      minHeight: "4px",
+      renderFooter: () =>
+        probe ? (
+          <LargeJsonFieldFallback
+            title={title}
+            hideTitle
+            serialized={probe.serialized}
+            isString={probe.isString}
+            charCount={probe.size}
+            rowCount={rowCount}
+            downloadFileBase={`${key}-${downloadName}`}
+          />
+        ) : null,
+    });
+
     const result = [];
-    if (showInput && !inputTooLarge) {
-      result.push({
-        key: "input",
-        title: "Input",
-        data: effectiveInput,
-        backgroundColor: inputBgColor,
-        minHeight: "200px",
-      });
+    if (showInput) {
+      result.push(
+        inputTooLarge
+          ? gatedSection("input", "Input", inputBgColor, inputProbe, inputRows)
+          : {
+              key: "input",
+              title: "Input",
+              data: effectiveInput,
+              backgroundColor: inputBgColor,
+              minHeight: "200px",
+            },
+      );
     }
-    if (showOutput && !outputTooLarge) {
-      result.push({
-        key: "output",
-        title: "Output",
-        data: effectiveOutput,
-        backgroundColor: outputBgColor,
-        minHeight: "200px",
-      });
+    if (showOutput) {
+      result.push(
+        outputTooLarge
+          ? gatedSection(
+              "output",
+              "Output",
+              outputBgColor,
+              outputProbe,
+              outputRows,
+            )
+          : {
+              key: "output",
+              title: "Output",
+              data: effectiveOutput,
+              backgroundColor: outputBgColor,
+              minHeight: "200px",
+            },
+      );
     }
     if (showCorrections) {
       result.push({
@@ -371,14 +428,24 @@ function IOPreviewJSONInner({
         ),
       });
     }
-    if (showMetadata && !metadataTooLarge) {
-      result.push({
-        key: "metadata",
-        title: "Metadata",
-        data: effectiveMetadata,
-        backgroundColor: metadataBgColor,
-        minHeight: "200px",
-      });
+    if (showMetadata) {
+      result.push(
+        metadataTooLarge
+          ? gatedSection(
+              "metadata",
+              "Metadata",
+              metadataBgColor,
+              metadataProbe,
+              metadataRows,
+            )
+          : {
+              key: "metadata",
+              title: "Metadata",
+              data: effectiveMetadata,
+              backgroundColor: metadataBgColor,
+              minHeight: "200px",
+            },
+      );
     }
     return result;
   }, [
@@ -391,6 +458,13 @@ function IOPreviewJSONInner({
     effectiveInput,
     effectiveOutput,
     effectiveMetadata,
+    inputProbe,
+    outputProbe,
+    metadataProbe,
+    inputRows,
+    outputRows,
+    metadataRows,
+    downloadName,
     inputBgColor,
     outputBgColor,
     metadataBgColor,
@@ -401,43 +475,6 @@ function IOPreviewJSONInner({
     traceId,
     environment,
   ]);
-
-  // Bounded fallbacks for over-limit fields (rendered outside the viewer, in
-  // field order). Preview + raw download; the full payload also renders in the
-  // lazy Formatted view.
-  const largeFieldFallbacks = (
-    <>
-      {showInput && inputTooLarge && inputProbe && (
-        <LargeJsonFieldFallback
-          title="Input"
-          serialized={inputProbe.serialized}
-          isString={inputProbe.isString}
-          charCount={inputProbe.size}
-          downloadFileBase={`input-${downloadName}`}
-        />
-      )}
-      {showOutput && outputTooLarge && outputProbe && (
-        <LargeJsonFieldFallback
-          title="Output"
-          serialized={outputProbe.serialized}
-          isString={outputProbe.isString}
-          charCount={outputProbe.size}
-          downloadFileBase={`output-${downloadName}`}
-        />
-      )}
-      {showMetadata && metadataTooLarge && metadataProbe && (
-        <LargeJsonFieldFallback
-          title="Metadata"
-          serialized={metadataProbe.serialized}
-          isString={metadataProbe.isString}
-          charCount={metadataProbe.size}
-          downloadFileBase={`metadata-${downloadName}`}
-        />
-      )}
-    </>
-  );
-
-  const hasViewerSections = sections.length > 0;
 
   // Wait for parsing to complete before rendering to avoid flicker
   if (isParsing) {
@@ -483,143 +520,135 @@ function IOPreviewJSONInner({
         <InlineCommentBubble onAddComment={handleAddComment} />
       )}
 
-      {/* Header + nav are only meaningful when the viewer renders sections; a
-          fully-gated view shows just the fallbacks below. */}
-      {hasViewerSections && (
-        <div className="bg-background flex h-9 shrink-0 items-center gap-1.5 border-b px-2">
-          {/* Search input - expands to fill available width */}
-          <Command className="flex-1 rounded-none border-0 bg-transparent">
-            <CommandInput
-              showBorder={false}
-              placeholder="Search across all sections..."
-              className="h-7 border-0 focus:ring-0"
-              value={searchQuery}
-              onValueChange={setSearchQuery}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  if (e.shiftKey) {
-                    handlePreviousMatch();
-                  } else {
-                    handleNextMatch();
-                  }
-                } else if (e.key === "Escape") {
-                  handleClearSearch();
+      {/* Header - matches LogViewToolbar styling */}
+      <div className="bg-background flex h-9 shrink-0 items-center gap-1.5 border-b px-2">
+        {/* Search input - expands to fill available width */}
+        <Command className="flex-1 rounded-none border-0 bg-transparent">
+          <CommandInput
+            showBorder={false}
+            placeholder="Search across all sections..."
+            className="h-7 border-0 focus:ring-0"
+            value={searchQuery}
+            onValueChange={setSearchQuery}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                if (e.shiftKey) {
+                  handlePreviousMatch();
+                } else {
+                  handleNextMatch();
                 }
-              }}
-            />
-          </Command>
+              } else if (e.key === "Escape") {
+                handleClearSearch();
+              }
+            }}
+          />
+        </Command>
 
-          {/* Match counter - inline text (only when searching) */}
-          {searchQuery && (
-            <span className="text-muted-foreground text-xs whitespace-nowrap">
-              {searchMatchCount > 0
-                ? `${currentMatchIndex + 1} of ${searchMatchCount}`
-                : "No matches"}
-            </span>
-          )}
+        {/* Match counter - inline text (only when searching) */}
+        {searchQuery && (
+          <span className="text-muted-foreground text-xs whitespace-nowrap">
+            {searchMatchCount > 0
+              ? `${currentMatchIndex + 1} of ${searchMatchCount}`
+              : "No matches"}
+          </span>
+        )}
 
-          {/* Navigation buttons (only when matches exist) */}
-          {searchQuery && searchMatchCount > 0 && (
-            <>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={handlePreviousMatch}
-                title="Previous match (Shift+Enter)"
-              >
-                <ChevronUp className="h-3.5 w-3.5" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={handleNextMatch}
-                title="Next match (Enter)"
-              >
-                <ChevronDown className="h-3.5 w-3.5" />
-              </Button>
-            </>
-          )}
+        {/* Navigation buttons (only when matches exist) */}
+        {searchQuery && searchMatchCount > 0 && (
+          <>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={handlePreviousMatch}
+              title="Previous match (Shift+Enter)"
+            >
+              <ChevronUp className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={handleNextMatch}
+              title="Next match (Enter)"
+            >
+              <ChevronDown className="h-3.5 w-3.5" />
+            </Button>
+          </>
+        )}
 
-          {/* Wrap mode toggle */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            onClick={handleCycleWrapMode}
-            title={`String wrap mode: ${stringWrapMode}`}
-          >
-            {wrapIcon}
-          </Button>
+        {/* Wrap mode toggle */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={handleCycleWrapMode}
+          title={`String wrap mode: ${stringWrapMode}`}
+        >
+          {wrapIcon}
+        </Button>
 
-          {/* Copy button */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            onClick={handleCopy}
-            title="Copy to clipboard"
-          >
-            <Copy className="h-3.5 w-3.5" />
-          </Button>
-        </div>
-      )}
+        {/* Copy button */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={handleCopy}
+          title="Copy to clipboard"
+        >
+          <Copy className="h-3.5 w-3.5" />
+        </Button>
+      </div>
 
       {/* Section navigation hint bar */}
-      {hasViewerSections && (
-        <div className="bg-background flex h-6 shrink-0 items-center gap-1.5 border-b px-2">
-          <span className="text-muted-foreground text-xs">Jump to:</span>
-          {sections.map((section, index) => (
-            <span key={section.key} className="flex items-center">
-              <button
-                onClick={() => handleScrollToSection(section.key)}
-                className="text-primary cursor-pointer text-xs hover:underline"
-              >
-                {section.title}
-              </button>
-              {index < sections.length - 1 && (
-                <span className="text-muted-foreground text-xs">,&nbsp;</span>
-              )}
-            </span>
-          ))}
-          {needsVirtualization && (
-            <HoverCard>
-              <HoverCardTrigger asChild>
-                <span className="bg-muted text-muted-foreground ml-auto cursor-help rounded px-1.5 py-px text-[10px] font-bold">
-                  Virtualized
-                </span>
-              </HoverCardTrigger>
-              <HoverCardContent className="w-80" side="bottom" align="end">
-                <div className="space-y-2">
-                  <p className="text-sm font-bold">Virtualized View</p>
-                  <p className="text-muted-foreground text-xs">
-                    This view is using virtualization due to a large number of
-                    keys ({rowCounts.input.toLocaleString()} input,{" "}
-                    {rowCounts.output.toLocaleString()} output,{" "}
-                    {rowCounts.metadata.toLocaleString()} metadata). Only
-                    visible rows are rendered for optimal performance.
-                  </p>
-                </div>
-              </HoverCardContent>
-            </HoverCard>
-          )}
-        </div>
-      )}
+      <div className="bg-background flex h-6 shrink-0 items-center gap-1.5 border-b px-2">
+        <span className="text-muted-foreground text-xs">Jump to:</span>
+        {sections.map((section, index) => (
+          <span key={section.key} className="flex items-center">
+            <button
+              onClick={() => handleScrollToSection(section.key)}
+              className="text-primary cursor-pointer text-xs hover:underline"
+            >
+              {section.title}
+            </button>
+            {index < sections.length - 1 && (
+              <span className="text-muted-foreground text-xs">,&nbsp;</span>
+            )}
+          </span>
+        ))}
+        {needsVirtualization && (
+          <HoverCard>
+            <HoverCardTrigger asChild>
+              <span className="bg-muted text-muted-foreground ml-auto cursor-help rounded px-1.5 py-px text-[10px] font-bold">
+                Virtualized
+              </span>
+            </HoverCardTrigger>
+            <HoverCardContent className="w-80" side="bottom" align="end">
+              <div className="space-y-2">
+                <p className="text-sm font-bold">Virtualized View</p>
+                <p className="text-muted-foreground text-xs">
+                  This view is using virtualization due to a large number of
+                  keys ({rowCounts.input.toLocaleString()} input,{" "}
+                  {rowCounts.output.toLocaleString()} output,{" "}
+                  {rowCounts.metadata.toLocaleString()} metadata). Only visible
+                  rows are rendered for optimal performance.
+                </p>
+              </div>
+            </HoverCardContent>
+          </HoverCard>
+        )}
+      </div>
 
-      {/* Body: bounded fallbacks for over-limit fields, then the viewer for the
-          remaining sections (if any). Both scroll together. */}
+      {/* Body with MultiSectionJsonViewer */}
       <div className="min-h-0 flex-1 overflow-auto" ref={scrollContainerRef}>
-        {largeFieldFallbacks}
-        {hasViewerSections &&
-          (enableInlineComments ? (
-            <CommentableJsonView enabled={enableInlineComments}>
-              {viewerContent}
-            </CommentableJsonView>
-          ) : (
-            viewerContent
-          ))}
+        {enableInlineComments ? (
+          <CommentableJsonView enabled={enableInlineComments}>
+            {viewerContent}
+          </CommentableJsonView>
+        ) : (
+          viewerContent
+        )}
       </div>
     </div>
   );

--- a/web/src/components/trace/components/IOPreview/IOPreviewJSON.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewJSON.tsx
@@ -364,6 +364,17 @@ function IOPreviewJSONInner({
       hideData: true,
       backgroundColor,
       minHeight: "4px",
+      // A gated field has no tree to expand/collapse — only the download escape
+      // hatch below. Render a header WITHOUT a collapse toggle, so the section
+      // can never be collapsed: its collapse is therefore never persisted, and
+      // the download can't be hidden — not silently (inherited state) and not
+      // by a user collapsing one gated field then viewing another of the same
+      // name (the gated→gated leak the plain key still allowed).
+      renderHeader: () => (
+        <div className="flex items-center px-2 py-1.5">
+          <span className="text-xs font-bold">{title}</span>
+        </div>
+      ),
       renderFooter: () =>
         probe ? (
           <LargeJsonFieldFallback

--- a/web/src/components/trace/components/IOPreview/IOPreviewJSON.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewJSON.tsx
@@ -27,6 +27,11 @@ import { type ExpansionState } from "@/src/components/ui/AdvancedJsonViewer/type
 import { type Prisma, type ScoreDomain, deepParseJson } from "@langfuse/shared";
 import { decodeUnicodeInJson } from "@/src/utils/decodeUnicodeInJson";
 import { CorrectedOutputField } from "./components/CorrectedOutputField";
+import { LargeJsonFieldFallback } from "./components/LargeJsonFieldFallback";
+import {
+  JSON_VIEW_RENDER_ROW_LIMIT,
+  probeJsonField,
+} from "./lib/jsonViewSizeGate";
 
 const VIRTUALIZATION_THRESHOLD = 3333;
 
@@ -122,40 +127,109 @@ function IOPreviewJSONInner({
   );
 
   // Fall back to raw values when caller does not provide pre-parsed fields
-  // (e.g. session events rows in v4 mode).
+  // (e.g. session events rows in v4 mode). Parse once here, BEFORE the decode
+  // and tree-build, so the node-count gate below can act on the parsed shape.
+  const inputParsed = useMemo(
+    () => (isParsing ? undefined : (parsedInput ?? deepParseJson(input))),
+    [parsedInput, input, isParsing],
+  );
+  const outputParsed = useMemo(
+    () => (isParsing ? undefined : (parsedOutput ?? deepParseJson(output))),
+    [parsedOutput, output, isParsing],
+  );
+  const metadataParsed = useMemo(
+    () => (isParsing ? undefined : (parsedMetadata ?? deepParseJson(metadata))),
+    [parsedMetadata, metadata, isParsing],
+  );
+
+  // Node-count gate (LFE-10847): the Beta viewer virtualizes the DOM but still
+  // builds the full node tree on the main thread, so a field with too many
+  // nodes (a large conversation / deeply nested JSON) freezes the tab even
+  // here. Count rows once per field — cheap (~integer add per node) and, unlike
+  // a char limit, correctly lets a huge single string (one node, e.g. a base64
+  // data-URI) through while gating million-node payloads. `countJsonRows` also
+  // feeds the virtualization decision below, so a gated field contributes 0.
+  const inputRows = useMemo(() => countJsonRows(inputParsed), [inputParsed]);
+  const outputRows = useMemo(() => countJsonRows(outputParsed), [outputParsed]);
+  const metadataRows = useMemo(
+    () => countJsonRows(metadataParsed),
+    [metadataParsed],
+  );
+
+  const inputTooLarge = inputRows > JSON_VIEW_RENDER_ROW_LIMIT;
+  const outputTooLarge = outputRows > JSON_VIEW_RENDER_ROW_LIMIT;
+  const metadataTooLarge = metadataRows > JSON_VIEW_RENDER_ROW_LIMIT;
+
   // Decode \uXXXX escapes (e.g. Japanese ingested with Python
   // ensure_ascii=True) at the data source so that search-match offsets, comment
   // ranges, rendering and copy-to-clipboard all operate on the same decoded
   // strings. Decoding at the leaf renderer instead would desync highlight
-  // offsets. Already-decoded strings are a no-op.
-  const effectiveInput = useMemo(() => {
-    if (isParsing) return undefined;
-    return decodeUnicodeInJson(parsedInput ?? deepParseJson(input));
-  }, [parsedInput, input, isParsing]);
+  // offsets. Already-decoded strings are a no-op. Over-limit fields skip decode
+  // and the tree entirely — they render the bounded fallback instead.
+  const effectiveInput = useMemo(
+    () =>
+      isParsing || inputTooLarge ? undefined : decodeUnicodeInJson(inputParsed),
+    [inputParsed, isParsing, inputTooLarge],
+  );
+  const effectiveOutput = useMemo(
+    () =>
+      isParsing || outputTooLarge
+        ? undefined
+        : decodeUnicodeInJson(outputParsed),
+    [outputParsed, isParsing, outputTooLarge],
+  );
+  const effectiveMetadata = useMemo(
+    () =>
+      isParsing || metadataTooLarge
+        ? undefined
+        : decodeUnicodeInJson(metadataParsed),
+    [metadataParsed, isParsing, metadataTooLarge],
+  );
 
-  const effectiveOutput = useMemo(() => {
-    if (isParsing) return undefined;
-    return decodeUnicodeInJson(parsedOutput ?? deepParseJson(output));
-  }, [parsedOutput, output, isParsing]);
+  // Probe over-limit fields once for the bounded fallback (preview + download).
+  const inputProbe = useMemo(
+    () => (inputTooLarge ? probeJsonField(input) : null),
+    [input, inputTooLarge],
+  );
+  const outputProbe = useMemo(
+    () => (outputTooLarge ? probeJsonField(output) : null),
+    [output, outputTooLarge],
+  );
+  const metadataProbe = useMemo(
+    () => (metadataTooLarge ? probeJsonField(metadata) : null),
+    [metadata, metadataTooLarge],
+  );
 
-  const effectiveMetadata = useMemo(() => {
-    if (isParsing) return undefined;
-    return decodeUnicodeInJson(parsedMetadata ?? deepParseJson(metadata));
-  }, [parsedMetadata, metadata, isParsing]);
-
-  const showInput = !hideInput && !(hideIfNull && effectiveInput === undefined);
+  // A gated field parses to undefined above but is not empty — it is too big.
+  // Treat it as present so hideIfNull callers still show the fallback instead
+  // of silently dropping the field.
+  const showInput =
+    !hideInput &&
+    (inputTooLarge || !(hideIfNull && effectiveInput === undefined));
   const showOutput =
-    !hideOutput && !(hideIfNull && effectiveOutput === undefined);
-  const showMetadata = !(hideIfNull && effectiveMetadata === undefined);
+    !hideOutput &&
+    (outputTooLarge || !(hideIfNull && effectiveOutput === undefined));
+  const showMetadata =
+    metadataTooLarge || !(hideIfNull && effectiveMetadata === undefined);
 
-  // Count rows for each section to determine if virtualization is needed
+  const downloadName = observationId ?? traceId;
+
+  // Row counts drive the virtualization decision. Gated fields render as a
+  // fallback (not inside the viewer), so they contribute 0.
   const rowCounts = useMemo(() => {
     return {
-      input: countJsonRows(effectiveInput),
-      output: countJsonRows(effectiveOutput),
-      metadata: countJsonRows(effectiveMetadata),
+      input: inputTooLarge ? 0 : inputRows,
+      output: outputTooLarge ? 0 : outputRows,
+      metadata: metadataTooLarge ? 0 : metadataRows,
     };
-  }, [effectiveInput, effectiveOutput, effectiveMetadata]);
+  }, [
+    inputTooLarge,
+    outputTooLarge,
+    metadataTooLarge,
+    inputRows,
+    outputRows,
+    metadataRows,
+  ]);
 
   // Determine if virtualization is needed based on threshold
   const needsVirtualization = useMemo(() => {
@@ -252,10 +326,12 @@ function IOPreviewJSONInner({
     [stringWrapMode],
   );
 
-  // Build sections - memoized to prevent re-creation
+  // Build sections - memoized to prevent re-creation. Over-limit fields are
+  // NOT added here: they render as a bounded fallback outside the viewer, so
+  // the viewer never builds a tree for them.
   const sections = useMemo(() => {
     const result = [];
-    if (showInput) {
+    if (showInput && !inputTooLarge) {
       result.push({
         key: "input",
         title: "Input",
@@ -264,7 +340,7 @@ function IOPreviewJSONInner({
         minHeight: "200px",
       });
     }
-    if (showOutput) {
+    if (showOutput && !outputTooLarge) {
       result.push({
         key: "output",
         title: "Output",
@@ -295,7 +371,7 @@ function IOPreviewJSONInner({
         ),
       });
     }
-    if (showMetadata) {
+    if (showMetadata && !metadataTooLarge) {
       result.push({
         key: "metadata",
         title: "Metadata",
@@ -309,6 +385,9 @@ function IOPreviewJSONInner({
     showInput,
     showOutput,
     showMetadata,
+    inputTooLarge,
+    outputTooLarge,
+    metadataTooLarge,
     effectiveInput,
     effectiveOutput,
     effectiveMetadata,
@@ -322,6 +401,43 @@ function IOPreviewJSONInner({
     traceId,
     environment,
   ]);
+
+  // Bounded fallbacks for over-limit fields (rendered outside the viewer, in
+  // field order). Preview + raw download; the full payload also renders in the
+  // lazy Formatted view.
+  const largeFieldFallbacks = (
+    <>
+      {showInput && inputTooLarge && inputProbe && (
+        <LargeJsonFieldFallback
+          title="Input"
+          serialized={inputProbe.serialized}
+          isString={inputProbe.isString}
+          charCount={inputProbe.size}
+          downloadFileBase={`input-${downloadName}`}
+        />
+      )}
+      {showOutput && outputTooLarge && outputProbe && (
+        <LargeJsonFieldFallback
+          title="Output"
+          serialized={outputProbe.serialized}
+          isString={outputProbe.isString}
+          charCount={outputProbe.size}
+          downloadFileBase={`output-${downloadName}`}
+        />
+      )}
+      {showMetadata && metadataTooLarge && metadataProbe && (
+        <LargeJsonFieldFallback
+          title="Metadata"
+          serialized={metadataProbe.serialized}
+          isString={metadataProbe.isString}
+          charCount={metadataProbe.size}
+          downloadFileBase={`metadata-${downloadName}`}
+        />
+      )}
+    </>
+  );
+
+  const hasViewerSections = sections.length > 0;
 
   // Wait for parsing to complete before rendering to avoid flicker
   if (isParsing) {
@@ -367,135 +483,143 @@ function IOPreviewJSONInner({
         <InlineCommentBubble onAddComment={handleAddComment} />
       )}
 
-      {/* Header - matches LogViewToolbar styling */}
-      <div className="bg-background flex h-9 shrink-0 items-center gap-1.5 border-b px-2">
-        {/* Search input - expands to fill available width */}
-        <Command className="flex-1 rounded-none border-0 bg-transparent">
-          <CommandInput
-            showBorder={false}
-            placeholder="Search across all sections..."
-            className="h-7 border-0 focus:ring-0"
-            value={searchQuery}
-            onValueChange={setSearchQuery}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                if (e.shiftKey) {
-                  handlePreviousMatch();
-                } else {
-                  handleNextMatch();
+      {/* Header + nav are only meaningful when the viewer renders sections; a
+          fully-gated view shows just the fallbacks below. */}
+      {hasViewerSections && (
+        <div className="bg-background flex h-9 shrink-0 items-center gap-1.5 border-b px-2">
+          {/* Search input - expands to fill available width */}
+          <Command className="flex-1 rounded-none border-0 bg-transparent">
+            <CommandInput
+              showBorder={false}
+              placeholder="Search across all sections..."
+              className="h-7 border-0 focus:ring-0"
+              value={searchQuery}
+              onValueChange={setSearchQuery}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  if (e.shiftKey) {
+                    handlePreviousMatch();
+                  } else {
+                    handleNextMatch();
+                  }
+                } else if (e.key === "Escape") {
+                  handleClearSearch();
                 }
-              } else if (e.key === "Escape") {
-                handleClearSearch();
-              }
-            }}
-          />
-        </Command>
+              }}
+            />
+          </Command>
 
-        {/* Match counter - inline text (only when searching) */}
-        {searchQuery && (
-          <span className="text-muted-foreground text-xs whitespace-nowrap">
-            {searchMatchCount > 0
-              ? `${currentMatchIndex + 1} of ${searchMatchCount}`
-              : "No matches"}
-          </span>
-        )}
+          {/* Match counter - inline text (only when searching) */}
+          {searchQuery && (
+            <span className="text-muted-foreground text-xs whitespace-nowrap">
+              {searchMatchCount > 0
+                ? `${currentMatchIndex + 1} of ${searchMatchCount}`
+                : "No matches"}
+            </span>
+          )}
 
-        {/* Navigation buttons (only when matches exist) */}
-        {searchQuery && searchMatchCount > 0 && (
-          <>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7"
-              onClick={handlePreviousMatch}
-              title="Previous match (Shift+Enter)"
-            >
-              <ChevronUp className="h-3.5 w-3.5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7"
-              onClick={handleNextMatch}
-              title="Next match (Enter)"
-            >
-              <ChevronDown className="h-3.5 w-3.5" />
-            </Button>
-          </>
-        )}
+          {/* Navigation buttons (only when matches exist) */}
+          {searchQuery && searchMatchCount > 0 && (
+            <>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={handlePreviousMatch}
+                title="Previous match (Shift+Enter)"
+              >
+                <ChevronUp className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={handleNextMatch}
+                title="Next match (Enter)"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+              </Button>
+            </>
+          )}
 
-        {/* Wrap mode toggle */}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          onClick={handleCycleWrapMode}
-          title={`String wrap mode: ${stringWrapMode}`}
-        >
-          {wrapIcon}
-        </Button>
+          {/* Wrap mode toggle */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={handleCycleWrapMode}
+            title={`String wrap mode: ${stringWrapMode}`}
+          >
+            {wrapIcon}
+          </Button>
 
-        {/* Copy button */}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          onClick={handleCopy}
-          title="Copy to clipboard"
-        >
-          <Copy className="h-3.5 w-3.5" />
-        </Button>
-      </div>
+          {/* Copy button */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={handleCopy}
+            title="Copy to clipboard"
+          >
+            <Copy className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      )}
 
       {/* Section navigation hint bar */}
-      <div className="bg-background flex h-6 shrink-0 items-center gap-1.5 border-b px-2">
-        <span className="text-muted-foreground text-xs">Jump to:</span>
-        {sections.map((section, index) => (
-          <span key={section.key} className="flex items-center">
-            <button
-              onClick={() => handleScrollToSection(section.key)}
-              className="text-primary cursor-pointer text-xs hover:underline"
-            >
-              {section.title}
-            </button>
-            {index < sections.length - 1 && (
-              <span className="text-muted-foreground text-xs">,&nbsp;</span>
-            )}
-          </span>
-        ))}
-        {needsVirtualization && (
-          <HoverCard>
-            <HoverCardTrigger asChild>
-              <span className="bg-muted text-muted-foreground ml-auto cursor-help rounded px-1.5 py-px text-[10px] font-bold">
-                Virtualized
-              </span>
-            </HoverCardTrigger>
-            <HoverCardContent className="w-80" side="bottom" align="end">
-              <div className="space-y-2">
-                <p className="text-sm font-bold">Virtualized View</p>
-                <p className="text-muted-foreground text-xs">
-                  This view is using virtualization due to a large number of
-                  keys ({rowCounts.input.toLocaleString()} input,{" "}
-                  {rowCounts.output.toLocaleString()} output,{" "}
-                  {rowCounts.metadata.toLocaleString()} metadata). Only visible
-                  rows are rendered for optimal performance.
-                </p>
-              </div>
-            </HoverCardContent>
-          </HoverCard>
-        )}
-      </div>
+      {hasViewerSections && (
+        <div className="bg-background flex h-6 shrink-0 items-center gap-1.5 border-b px-2">
+          <span className="text-muted-foreground text-xs">Jump to:</span>
+          {sections.map((section, index) => (
+            <span key={section.key} className="flex items-center">
+              <button
+                onClick={() => handleScrollToSection(section.key)}
+                className="text-primary cursor-pointer text-xs hover:underline"
+              >
+                {section.title}
+              </button>
+              {index < sections.length - 1 && (
+                <span className="text-muted-foreground text-xs">,&nbsp;</span>
+              )}
+            </span>
+          ))}
+          {needsVirtualization && (
+            <HoverCard>
+              <HoverCardTrigger asChild>
+                <span className="bg-muted text-muted-foreground ml-auto cursor-help rounded px-1.5 py-px text-[10px] font-bold">
+                  Virtualized
+                </span>
+              </HoverCardTrigger>
+              <HoverCardContent className="w-80" side="bottom" align="end">
+                <div className="space-y-2">
+                  <p className="text-sm font-bold">Virtualized View</p>
+                  <p className="text-muted-foreground text-xs">
+                    This view is using virtualization due to a large number of
+                    keys ({rowCounts.input.toLocaleString()} input,{" "}
+                    {rowCounts.output.toLocaleString()} output,{" "}
+                    {rowCounts.metadata.toLocaleString()} metadata). Only
+                    visible rows are rendered for optimal performance.
+                  </p>
+                </div>
+              </HoverCardContent>
+            </HoverCard>
+          )}
+        </div>
+      )}
 
-      {/* Body with MultiSectionJsonViewer */}
+      {/* Body: bounded fallbacks for over-limit fields, then the viewer for the
+          remaining sections (if any). Both scroll together. */}
       <div className="min-h-0 flex-1 overflow-auto" ref={scrollContainerRef}>
-        {enableInlineComments ? (
-          <CommentableJsonView enabled={enableInlineComments}>
-            {viewerContent}
-          </CommentableJsonView>
-        ) : (
-          viewerContent
-        )}
+        {largeFieldFallbacks}
+        {hasViewerSections &&
+          (enableInlineComments ? (
+            <CommentableJsonView enabled={enableInlineComments}>
+              {viewerContent}
+            </CommentableJsonView>
+          ) : (
+            viewerContent
+          ))}
       </div>
     </div>
   );

--- a/web/src/components/trace/components/IOPreview/IOPreviewJSONSimple.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewJSONSimple.tsx
@@ -184,10 +184,13 @@ export function IOPreviewJSONSimple({
         ))}
       {/* When the output is over-limit, effectiveOutput is undefined, so the
           correction editor opens without a baseline actual-output to diff
-          against — an acceptable degradation for payloads too large to render. */}
+          against — an acceptable degradation for payloads too large to render.
+          We flag it as too-large so the diff dialog says so, rather than
+          reporting "no original output". */}
       {showCorrections && (
         <CorrectedOutputField
           actualOutput={effectiveOutput}
+          actualOutputTooLarge={outputTooLarge}
           existingCorrection={outputCorrection}
           observationId={observationId}
           projectId={projectId}

--- a/web/src/components/trace/components/IOPreview/components/CorrectedOutputDiffDialog.clienttest.tsx
+++ b/web/src/components/trace/components/IOPreview/components/CorrectedOutputDiffDialog.clienttest.tsx
@@ -1,0 +1,102 @@
+/**
+ * The output-correction diff dialog has three states, and gated (too-large)
+ * output must not be conflated with genuinely-absent output (LFE-10847 review):
+ * - `actualOutputTooLarge` → the original exists but was gated out of the view,
+ *   so we say it is too large to diff (NOT "no original output").
+ * - original output null/undefined and not gated → "No original output".
+ * - original output present → render the diff.
+ *
+ * The Dialog primitives (Radix portal + layer container) and DiffViewer are
+ * stubbed to inline renders so these tests pin the branch logic, not the
+ * overlay plumbing.
+ */
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/src/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogBody: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
+}));
+
+vi.mock("@/src/components/DiffViewer", () => ({
+  default: (props: { oldString: string; newString: string }) => (
+    <div
+      data-testid="diff-viewer"
+      data-old={props.oldString}
+      data-new={props.newString}
+    />
+  ),
+}));
+
+import { CorrectedOutputDiffDialog } from "./CorrectedOutputDiffDialog";
+
+const noop = () => {};
+
+describe("CorrectedOutputDiffDialog original-output state", () => {
+  it("reports too-large output as such, not as missing", () => {
+    render(
+      <CorrectedOutputDiffDialog
+        isOpen
+        setIsOpen={noop}
+        actualOutput={undefined}
+        actualOutputTooLarge
+        correctedOutput='{"answer":"fixed"}'
+        strictJsonMode={false}
+      />,
+    );
+
+    expect(screen.getByText(/too large to diff/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^No original output$/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("diff-viewer")).not.toBeInTheDocument();
+  });
+
+  it("reports genuinely-absent output as 'No original output'", () => {
+    render(
+      <CorrectedOutputDiffDialog
+        isOpen
+        setIsOpen={noop}
+        actualOutput={undefined}
+        correctedOutput='{"answer":"fixed"}'
+        strictJsonMode={false}
+      />,
+    );
+
+    expect(screen.getByText(/^No original output$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/too large to diff/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("diff-viewer")).not.toBeInTheDocument();
+  });
+
+  it("renders the diff when an original output is present", () => {
+    render(
+      <CorrectedOutputDiffDialog
+        isOpen
+        setIsOpen={noop}
+        actualOutput="original"
+        correctedOutput="corrected"
+        strictJsonMode={false}
+      />,
+    );
+
+    expect(screen.getByTestId("diff-viewer")).toBeInTheDocument();
+    expect(screen.queryByText(/No original output/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/too large to diff/i)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/trace/components/IOPreview/components/CorrectedOutputDiffDialog.tsx
+++ b/web/src/components/trace/components/IOPreview/components/CorrectedOutputDiffDialog.tsx
@@ -17,6 +17,11 @@ type CorrectedOutputDiffDialogProps = {
   actualOutput?: unknown;
   correctedOutput: string;
   strictJsonMode: boolean;
+  /**
+   * True when the original output exists but was too large to load into the
+   * view (gated). Distinguishes "too large to diff" from "no output at all".
+   */
+  actualOutputTooLarge?: boolean;
 };
 
 /**
@@ -55,7 +60,14 @@ const formatOutputForDiff = (
 
 export const CorrectedOutputDiffDialog: React.FC<
   CorrectedOutputDiffDialogProps
-> = ({ isOpen, setIsOpen, actualOutput, correctedOutput, strictJsonMode }) => {
+> = ({
+  isOpen,
+  setIsOpen,
+  actualOutput,
+  correctedOutput,
+  strictJsonMode,
+  actualOutputTooLarge = false,
+}) => {
   // Format both outputs for comparison
   const formattedActualOutput = formatOutputForDiff(
     actualOutput,
@@ -66,9 +78,12 @@ export const CorrectedOutputDiffDialog: React.FC<
     strictJsonMode,
   );
 
-  // Check if there's no original output to compare
+  // Check if there's no original output to compare. When the output exists but
+  // was too large to load into the view, we cannot diff it — but that is not
+  // the same as there being no original output.
   const hasNoOriginalOutput =
-    actualOutput === null || actualOutput === undefined;
+    !actualOutputTooLarge &&
+    (actualOutput === null || actualOutput === undefined);
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -81,7 +96,20 @@ export const CorrectedOutputDiffDialog: React.FC<
         </DialogHeader>
 
         <DialogBody>
-          {hasNoOriginalOutput ? (
+          {actualOutputTooLarge ? (
+            <div className="flex flex-col items-center justify-center p-8 text-center">
+              <div className="text-muted-foreground">
+                <p className="text-lg font-bold">
+                  Original output too large to diff
+                </p>
+                <p className="mt-2 text-sm">
+                  The original output is too large to load here, so it cannot be
+                  compared side by side. Your correction is shown below and will
+                  be saved as-is.
+                </p>
+              </div>
+            </div>
+          ) : hasNoOriginalOutput ? (
             <div className="flex flex-col items-center justify-center p-8 text-center">
               <div className="text-muted-foreground">
                 <p className="text-lg font-bold">No original output</p>

--- a/web/src/components/trace/components/IOPreview/components/CorrectedOutputDiffDialog.tsx
+++ b/web/src/components/trace/components/IOPreview/components/CorrectedOutputDiffDialog.tsx
@@ -97,16 +97,22 @@ export const CorrectedOutputDiffDialog: React.FC<
 
         <DialogBody>
           {actualOutputTooLarge ? (
-            <div className="flex flex-col items-center justify-center p-8 text-center">
-              <div className="text-muted-foreground">
-                <p className="text-lg font-bold">
+            <div className="space-y-4">
+              <div className="text-muted-foreground rounded-md border border-dashed p-4 text-sm">
+                <p className="text-foreground font-bold">
                   Original output too large to diff
                 </p>
-                <p className="mt-2 text-sm">
+                <p className="mt-1">
                   The original output is too large to load here, so it cannot be
                   compared side by side. Your correction is shown below and will
                   be saved as-is.
                 </p>
+              </div>
+              <div>
+                <p className="mb-1 text-sm font-bold">Corrected Output</p>
+                <pre className="bg-muted/30 max-h-[50vh] overflow-auto rounded-md border p-3 text-xs break-words whitespace-pre-wrap">
+                  {formattedCorrectedOutput}
+                </pre>
               </div>
             </div>
           ) : hasNoOriginalOutput ? (

--- a/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
+++ b/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
@@ -24,6 +24,12 @@ interface CorrectedOutputFieldProps {
   traceId: string;
   environment: string;
   actualOutput?: unknown;
+  /**
+   * True when the original output exists but was gated out of the view for
+   * being too large. It is then unavailable as `actualOutput`, but that must
+   * not be reported to the user as "no original output".
+   */
+  actualOutputTooLarge?: boolean;
   existingCorrection?: ScoreDomain | null;
   observationId?: string;
   compact?: boolean; // Use smaller font size for JSON Beta view
@@ -31,6 +37,7 @@ interface CorrectedOutputFieldProps {
 
 export function CorrectedOutputField({
   actualOutput,
+  actualOutputTooLarge = false,
   existingCorrection,
   observationId,
   projectId,
@@ -154,6 +161,7 @@ export function CorrectedOutputField({
         isOpen={isDiffDialogOpen}
         setIsOpen={setIsDiffDialogOpen}
         actualOutput={actualOutput}
+        actualOutputTooLarge={actualOutputTooLarge}
         correctedOutput={value}
         strictJsonMode={strictJsonMode}
       />

--- a/web/src/components/trace/components/IOPreview/components/LargeJsonFieldFallback.tsx
+++ b/web/src/components/trace/components/IOPreview/components/LargeJsonFieldFallback.tsx
@@ -10,11 +10,13 @@ const PREVIEW_DISPLAY_CHARS = 4_000;
 
 /**
  * Fallback for a single JSON-view field (Input / Output / Metadata) whose
- * payload is too large to render in the unvirtualized react18-json-view
- * (LFE-10989). Instead of parsing + rendering the full tree on the main thread
- * — which freezes for seconds and crashes the renderer around ~20 MB — it
- * shows a bounded preview head plus escape hatches: a raw download, and a
- * pointer to the Formatted (lazy) and JSON Beta (virtualized) views that scale.
+ * payload is too large to render. Used by both JSON views: the plain view when
+ * a field exceeds the char limit (unvirtualized react18-json-view, LFE-10989),
+ * and the Beta viewer when a field exceeds the node/row limit (its O(N)
+ * tree-build freezes the tab even though the DOM is virtualized, LFE-10847).
+ * Instead of building the full tree on the main thread — which freezes for
+ * seconds and crashes the renderer — it shows a bounded preview head plus
+ * escape hatches: a raw download, and a pointer to the Formatted (lazy) view.
  *
  * This component never serializes the payload: the caller's size probe already
  * did that once and passes the `serialized` string in, reused here for both the
@@ -72,8 +74,7 @@ export function LargeJsonFieldFallback({
         </div>
         <p className="text-muted-foreground text-xs">
           Rendering this much JSON at once freezes the tab. Use the{" "}
-          <span className="font-bold">Formatted</span> or{" "}
-          <span className="font-bold">JSON Beta</span> view for the full
+          <span className="font-bold">Formatted</span> view for the full
           payload, or download it below.
         </p>
         <pre className="bg-muted/50 max-h-40 overflow-hidden rounded-md border p-2 font-mono text-xs break-all whitespace-pre-wrap">

--- a/web/src/components/trace/components/IOPreview/components/LargeJsonFieldFallback.tsx
+++ b/web/src/components/trace/components/IOPreview/components/LargeJsonFieldFallback.tsx
@@ -28,7 +28,9 @@ export function LargeJsonFieldFallback({
   serialized,
   isString,
   charCount,
+  rowCount,
   downloadFileBase,
+  hideTitle = false,
 }: {
   title: string;
   /** Pre-serialized content: raw text for string fields, compact JSON for
@@ -38,10 +40,24 @@ export function LargeJsonFieldFallback({
    *  base64/plain payloads are not quote/escape-wrapped; objects use .json. */
   isString: boolean;
   charCount: number;
+  /** When set, the field was gated on node/row count (JSON Beta viewer), so the
+   *  summary names rows — the actual trigger — instead of characters. Omit for
+   *  the plain view's char-based gate. */
+  rowCount?: number;
   /** File name without extension. */
   downloadFileBase: string;
+  /** Omit the field-name heading — used when the surrounding section already
+   *  renders the title (JSON Beta section footer). */
+  hideTitle?: boolean;
 }) {
   const capture = usePostHogClientCapture();
+
+  // Name the metric that actually tripped the gate: rows for the virtualized
+  // Beta viewer (node/tree-build cost), characters for the plain view.
+  const sizeSummary =
+    rowCount != null
+      ? `${compactNumberFormatter(rowCount, 1)} rows`
+      : `${compactNumberFormatter(charCount, 1)} characters`;
 
   const previewText = useMemo(
     () =>
@@ -66,11 +82,10 @@ export function LargeJsonFieldFallback({
     <div className="io-message-content">
       <div className="my-2 flex flex-col gap-2 rounded-sm border border-dashed p-3">
         <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-xs">
-          <span className="text-foreground font-bold">{title}</span>
-          <span>
-            {compactNumberFormatter(charCount, 1)} characters — too large to
-            render in JSON view
-          </span>
+          {!hideTitle && (
+            <span className="text-foreground font-bold">{title}</span>
+          )}
+          <span>{sizeSummary} — too large to render in JSON view</span>
         </div>
         <p className="text-muted-foreground text-xs">
           Rendering this much JSON at once freezes the tab. Use the{" "}

--- a/web/src/components/trace/components/IOPreview/lib/jsonViewSizeGate.ts
+++ b/web/src/components/trace/components/IOPreview/lib/jsonViewSizeGate.ts
@@ -37,6 +37,27 @@
  */
 export const JSON_VIEW_RENDER_CHAR_LIMIT = 2_000_000;
 
+/**
+ * Node ceiling for rendering a field in the *virtualized* JSON Beta viewer
+ * (AdvancedJsonViewer). Measured in fully-expanded rows (`countJsonRows`), NOT
+ * chars — the Beta viewer virtualizes the DOM, so its cost is the O(N)
+ * tree-build (`buildMultiSectionTree` materializes every node) + row-count, not
+ * the visible DOM. A char limit is the wrong metric here: a 20 MB single string
+ * (e.g. a base64 data-URI) is one node and renders instantly as a media chip,
+ * while 20 MB of nested JSON is ~1M nodes and freezes the tab building the tree
+ * (LFE-10847 — matches the "freezes switching to JSON view on large
+ * conversations" report). Above this limit the field renders the same bounded
+ * preview + download fallback the plain JSON view uses.
+ *
+ * 50k is chosen deliberately:
+ * - 15× the viewer's own `VIRTUALIZATION_THRESHOLD` (3333), so ordinary large
+ *   traces (a few thousand rows) are never gated and keep rendering.
+ * - Far below the measured ~1M-node freeze; a 50k-node tree builds in tens of
+ *   ms and virtualizes fine.
+ * Users keep full access via the Formatted (lazy) view and the raw download.
+ */
+export const JSON_VIEW_RENDER_ROW_LIMIT = 50_000;
+
 export interface JsonFieldProbe {
   /** Serialized length in UTF-16 chars; drives the gating decision. */
   size: number;

--- a/web/src/components/ui/AdvancedJsonViewer/utils/rowCount.clienttest.ts
+++ b/web/src/components/ui/AdvancedJsonViewer/utils/rowCount.clienttest.ts
@@ -1,0 +1,37 @@
+/**
+ * countJsonRows feeds the JSON-view size gate (LFE-10847): it decides whether a
+ * field is too large to render. It must therefore never itself crash on the
+ * payloads the gate exists to catch — in particular a deeply *nested* payload
+ * (a single-branch chain thousands of levels deep), which overflows the call
+ * stack under plain recursion (worse in Firefox, cf. the deep-chain shapes in
+ * LFE-10959). These tests pin the counts and the deep-nesting safety.
+ */
+import { countJsonRows, exceedsRowThreshold } from "./rowCount";
+
+describe("countJsonRows", () => {
+  it("counts primitives, objects, and arrays per the node model", () => {
+    expect(countJsonRows(null)).toBe(0);
+    expect(countJsonRows(undefined)).toBe(0);
+    expect(countJsonRows("hello")).toBe(1);
+    expect(countJsonRows(42)).toBe(1);
+    expect(countJsonRows(true)).toBe(1);
+    expect(countJsonRows({ a: 1, b: 2 })).toBe(3); // object + 2 props
+    expect(countJsonRows([1, 2, 3])).toBe(4); // array + 3 elements
+    expect(countJsonRows({ a: { b: { c: 1 } } })).toBe(4); // 3 objects + 1 number
+    expect(countJsonRows([])).toBe(1);
+    expect(countJsonRows({})).toBe(1);
+  });
+
+  it("does not stack-overflow on a deeply nested chain", () => {
+    const depth = 200_000;
+    let deep: unknown = 1;
+    for (let i = 0; i < depth; i++) deep = { next: deep };
+    // depth objects + the leaf primitive.
+    expect(countJsonRows(deep)).toBe(depth + 1);
+  });
+
+  it("exceedsRowThreshold compares the total against the limit", () => {
+    expect(exceedsRowThreshold([1, 2, 3], 2)).toBe(true);
+    expect(exceedsRowThreshold([1, 2, 3], 10)).toBe(false);
+  });
+});

--- a/web/src/components/ui/AdvancedJsonViewer/utils/rowCount.ts
+++ b/web/src/components/ui/AdvancedJsonViewer/utils/rowCount.ts
@@ -21,42 +21,55 @@
  * countJsonRows({ a: { b: { c: 1 } } }) // 4 (3 objects + 1 number)
  */
 export function countJsonRows(data: unknown): number {
-  // null/undefined → no rows
-  if (data === null || data === undefined) {
-    return 0;
-  }
+  // Iterative DFS with an explicit stack — NOT plain recursion. A deeply nested
+  // payload (a single-branch chain thousands of levels deep) is exactly the
+  // shape this gate exists to catch, and one JS call frame per level would
+  // stack-overflow the counter itself (worse in Firefox). The counts are
+  // identical to the node model: null/undefined → 0, primitive → 1,
+  // array/object → 1 + children.
+  let count = 0;
+  const stack: unknown[] = [data];
 
-  // Primitives (string, number, boolean) → 1 row
-  const type = typeof data;
-  if (type === "string" || type === "number" || type === "boolean") {
-    return 1;
-  }
+  while (stack.length > 0) {
+    const node = stack.pop();
 
-  // Arrays
-  if (Array.isArray(data)) {
-    // 1 for array itself + sum of all elements
-    let count = 1;
-    for (const element of data) {
-      count += countJsonRows(element);
+    // null/undefined → no rows
+    if (node === null || node === undefined) {
+      continue;
     }
-    return count;
-  }
 
-  // Objects
-  if (type === "object" && data !== null) {
-    // 1 for object itself + sum of all properties
-    let count = 1;
-    const obj = data as Record<string, unknown>;
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        count += countJsonRows(obj[key]);
+    const type = typeof node;
+    if (type === "string" || type === "number" || type === "boolean") {
+      count += 1;
+      continue;
+    }
+
+    if (Array.isArray(node)) {
+      // 1 for the array itself + each element (pushed for later counting).
+      count += 1;
+      for (let i = 0; i < node.length; i++) {
+        stack.push(node[i]);
       }
+      continue;
     }
-    return count;
+
+    if (type === "object") {
+      // 1 for the object itself + each own property.
+      count += 1;
+      const obj = node as Record<string, unknown>;
+      for (const key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          stack.push(obj[key]);
+        }
+      }
+      continue;
+    }
+
+    // Fallback for other types (functions, symbols, etc.) → 1 row
+    count += 1;
   }
 
-  // Fallback for other types (functions, symbols, etc.) → 1 row
-  return 1;
+  return count;
 }
 
 /**


### PR DESCRIPTION
## TL;DR
Large traces could still freeze the tab in the **JSON Beta** IO viewer. It virtualizes the DOM but builds the full node tree on the main thread first, so a payload with ~1M nodes (a big conversation / deeply nested JSON) wedges the browser before virtualization helps. This gates oversized fields on **node count** — over-limit fields show the same bounded preview + download fallback the plain JSON view already uses, so the trace still opens and the tab never freezes.

## Why
A customer reported a trace that crashes the browser (part of the large-traces resilience epic, LFE-10152). Digging in on the reproduction:

- The **plain JSON** view is already gated by *character count* (LFE-10989) and the **Formatted** view lazy-collapses, so both survive today.
- The **JSON Beta** viewer is the remaining gap: it has **no size gate**. It renders only visible rows, but `buildMultiSectionTree` still materializes *every* node on the main thread up front. A ~20 MB structured-JSON field is ~1M nodes → the tab wedges. This matches user reports of freezing when switching to the JSON view on large conversations.
- A character limit is the wrong metric for this viewer: a multi-MB *single string* (e.g. a base64 data-URI) is a single node and renders instantly as a media chip — a char gate would wrongly hide it.

## What
- Gate the Beta viewer on **node count** (`countJsonRows > JSON_VIEW_RENDER_ROW_LIMIT`, 50k). Over-limit fields skip the parse/decode/tree-build entirely and render the existing bounded `LargeJsonFieldFallback` (4k-char preview + raw download); everything else renders exactly as before.
- Fix the fallback guidance, which pointed users at the JSON Beta view that could itself freeze — it now points only at the lazy **Formatted** view.

## Result
Verified locally against seeded 20 MB payloads (v4):

| Field | Nodes | JSON Beta before | JSON Beta after |
|---|---|---|---|
| Structured JSON | ~1,000,000 | tab freezes | bounded fallback + download, no freeze |
| base64 data-URI | ~15 | renders (media chip) | renders (media chip) — unchanged |

`countJsonRows` on the 1M-node payload is ~23 ms, so the gate itself is cheap; the freeze was the tree build it now skips.

<details>
<summary>Mechanism, scope & verification</summary>

**Root cause.** `IOPreviewJSON` fed each field straight into `MultiSectionJsonViewer`, whose eager `buildMultiSectionTree` is O(node count) on the main thread. Virtualization bounds the *DOM*, not the *build*, so node count — not payload size — is what freezes the tab.

**Fix shape.** Per field: parse once, `countJsonRows`, and if over the limit render the fallback and exclude the field from the viewer's `sections` (so the tree builder never sees it). Non-gated fields keep the shared viewer (search, jump-to, virtualization). The header/nav are hidden when every field is gated. Reuses the existing `probeJsonField` + `LargeJsonFieldFallback` from the plain-view gate — one fallback UI, two size metrics (chars for the unvirtualized view, nodes for the virtualized one).

**Threshold.** 50k rows = 15× the viewer's own virtualization threshold (3333), far below the measured ~1M-node freeze; a 50k-node tree builds in tens of ms and virtualizes fine. Ordinary large traces are never gated.

**Tests.** New `IOPreviewJSON.clienttest.tsx` pins the branch selection: over-limit field → fallback and never handed to the viewer; huge single string → not gated (one node); mixed → only the over-limit field is gated; normal I/O → viewer as before. Confirmed the two gate assertions fail without the change.

**Verification.** `pnpm --filter web run typecheck` clean; `turbo run lint` 7/7; new + sibling gate tests 18 passed. Browser-checked both payloads in all three IO views on a local dev server.

**Scope.** Frontend resilience only — the complementary backend cap on how much IO is sent to the client is tracked separately.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a browser-freeze gap in the **JSON Beta** IO viewer by adding a node-count gate (`JSON_VIEW_RENDER_ROW_LIMIT = 50 000`). Fields that exceed the limit are diverted to the existing `LargeJsonFieldFallback` (preview + download) before the O(N) tree-build in `MultiSectionJsonViewer` ever runs, preventing tab freezes on million-node payloads.

- Parses each field once with `deepParseJson`, counts rows via `countJsonRows`, and gates before the Unicode-decode and tree-build steps; non-gated fields continue through the existing viewer path unchanged.
- Hides the search/nav toolbar when all fields are gated (no viewer sections), and updates the fallback guidance to remove the now-incorrect pointer to \"JSON Beta.\"
- Adds four focused client tests that pin the gate logic: over-limit → fallback only; huge single string (one node) → viewer; mixed → only gated field uses fallback; normal I/O → viewer.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix prevents a real browser freeze with no regressions to the normal rendering path.

The gate logic is correct and well-tested. Two minor issues exist: the Copy button in mixed mode silently omits gated fields from the clipboard payload, and `probeJsonField` receives the raw prop rather than the deeply-parsed value so the character count shown in the fallback can be misleading for double-encoded JSON strings.

The copy handler and the `probeJsonField` call site in `IOPreviewJSON.tsx` are worth a second look.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Field received input/output/metadata] --> B[deepParseJson → parsedValue]
    B --> C[countJsonRows on parsedValue]
    C --> D{rows > 50k?}
    D -- Yes --> E[inputTooLarge = true]
    D -- No --> F[inputTooLarge = false]
    E --> G[effectiveField = undefined]
    E --> H[probeJsonField on raw input]
    H --> I[LargeJsonFieldFallback - preview + download]
    F --> J[decodeUnicodeInJson → effectiveField]
    J --> K[Add to MultiSectionJsonViewer sections]
    K --> L{sections.length > 0?}
    L -- Yes --> M[Render header/nav + viewer]
    L -- No --> N[Render fallbacks only, no header/nav]
    I --> N
    I --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Field received input/output/metadata] --> B[deepParseJson → parsedValue]
    B --> C[countJsonRows on parsedValue]
    C --> D{rows > 50k?}
    D -- Yes --> E[inputTooLarge = true]
    D -- No --> F[inputTooLarge = false]
    E --> G[effectiveField = undefined]
    E --> H[probeJsonField on raw input]
    H --> I[LargeJsonFieldFallback - preview + download]
    F --> J[decodeUnicodeInJson → effectiveField]
    J --> K[Add to MultiSectionJsonViewer sections]
    K --> L{sections.length > 0?}
    L -- Yes --> M[Render header/nav + viewer]
    L -- No --> N[Render fallbacks only, no header/nav]
    I --> N
    I --> M
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/trace/components/IOPreview/IOPreviewJSON.tsx:301-315
**Copy silently omits gated fields in mixed rendering mode**

When at least one field is under the row limit (so `hasViewerSections` is `true` and the toolbar renders), the Copy button is shown. But over-limit fields have `effectiveInput/Output/Metadata === undefined`, and `JSON.stringify({ input: undefined })` omits those keys entirely — so the copied JSON is silently incomplete. A user pasting it elsewhere won't see the gated fields at all. At minimum the button tooltip could reflect this ("Copy visible sections"), or gated fields could be included from their probe serialization.

### Issue 2 of 2
web/src/components/trace/components/IOPreview/IOPreviewJSON.tsx:189-201
**`probeJsonField` serializes the raw prop, but the row-count gate runs on the deeply-parsed value**

`countJsonRows` is called on `inputParsed` (`deepParseJson(input)`), which expands any embedded JSON strings into their full object trees. `probeJsonField` is then called with the original raw `input` prop. When a field is a string containing valid JSON (the "v4 session events" case mentioned in the comment), `deepParseJson` can turn it into a large object tree that trips the gate, while `probeJsonField` sees a short string and reports its `isString: true` length. The fallback would then display, for example, "100 characters — too large to render in JSON view" even though the actual content is tens of thousands of nodes. Passing `inputParsed` to `probeJsonField` instead would keep the node-count and the displayed size consistent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): gate oversized fields in the..."](https://github.com/langfuse/langfuse/commit/7098a2a6ae225baa7d9c3287c9fbf41f5a31f2d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45627775)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->