### PR TITLE
feat(layouts): real mobile hamburger for the sidebar trigger (LFE-11067)

### DIFF
--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -4,6 +4,7 @@ import BreadcrumbComponent from "@/src/components/layouts/breadcrumb";
 import { PageHeaderControlsSlotTarget } from "@/src/components/layouts/page-header-controls-slot";
 import { InAppAiAgentButton } from "@/src/components/nav/in-app-ai-agent-button";
 import { TopbarBrand } from "@/src/components/nav/topbar-brand";
+import { useHasAppSidebar } from "@/src/components/nav/sidebar-presence";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { SidebarTrigger } from "@/src/components/ui/sidebar";
 import {
@@ -78,6 +79,12 @@ const PageHeader = ({
   breadcrumbBadges,
 }: PageHeaderProps) => {
   const router = useRouter();
+  const hasAppSidebar = useHasAppSidebar();
+  // The sidebar trigger + brand mark only make sense where a real AppSidebar
+  // exists to toggle/mirror. On the sidebar-less MinimalLayout (public/shared
+  // trace and session views) show the page's own leadingControl instead — no
+  // hamburger opening an empty sheet, no orphaned brand mark.
+  const showSidebarChrome = showSidebarTrigger && hasAppSidebar;
   return (
     <div
       className={cn([
@@ -103,16 +110,12 @@ const PageHeader = ({
             )}
           >
             <div className="flex min-w-0 flex-wrap items-center gap-3">
-              {showSidebarTrigger ? (
+              {showSidebarChrome ? (
                 <>
                   <SidebarTrigger />
                   {/* Brand the app in the top bar while the sidebar (which
                       owns the logo) is off-canvas below `md`. Hidden on
-                      desktop where the sidebar logo is visible. Gated on the
-                      same condition as the trigger so it only appears where a
-                      sidebar actually exists to mirror — never on the
-                      sidebar-less MinimalLayout (e.g. the public/shared trace
-                      view, which supplies its own leadingControl). */}
+                      desktop where the sidebar logo is visible. */}
                   <TopbarBrand className="md:hidden" />
                 </>
               ) : (

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { type VariantProps, cva } from "class-variance-authority";
-import { PanelLeft } from "lucide-react";
+import { Menu, PanelLeft } from "lucide-react";
 import { useIsMobile } from "@/src/hooks/use-mobile";
 import useLocalStorage from "@/src/components/useLocalStorage";
 import { cn } from "@/src/utils/tailwind";
@@ -288,14 +288,20 @@ const SidebarTrigger = React.forwardRef<
       data-sidebar="trigger"
       variant="ghost"
       size="icon"
-      className={cn("h-5 w-5", className)}
+      // A real hamburger tap target on mobile (where it opens the off-canvas
+      // nav sheet); compact on desktop where it's just a panel-collapse toggle
+      // next to the docked sidebar.
+      className={cn("h-9 w-9 md:h-5 md:w-5", className)}
       onClick={(event) => {
         onClick?.(event);
         toggleSidebar();
       }}
       {...props}
     >
-      <PanelLeft />
+      {/* Hamburger below `md` (opens the sheet); panel-collapse glyph on
+          desktop (toggles the docked sidebar). */}
+      <Menu className="size-5 md:hidden" />
+      <PanelLeft className="hidden md:block" />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );


### PR DESCRIPTION
## TL;DR
On mobile the sidebar trigger *is* the menu button, but it showed the desktop panel-collapse glyph at a tiny 20px tap target. This turns it into a proper hamburger with a real tap target on mobile, and stops it (and the brand mark) from rendering on sidebar-less public-share pages. Second "base chrome" slice of the mobile revamp (LFE-11067).

## Why
Below `md` the trigger opens the off-canvas nav `Sheet` — that's a menu affordance, but it rendered `PanelLeft` (a panel-collapse glyph) at `h-5 w-5` (20px), a poor mobile target. Separately, on the sidebar-less `MinimalLayout` (public/shared trace **and** session views) the trigger opened an *empty* sheet — there's no `AppSidebar` there to toggle.

## What
- **Mobile hamburger:** below `md` the trigger renders `Menu` (☰) at a 36px tap target; desktop keeps the compact `PanelLeft` at 20px, pixel-identical to before.
- **Gate on real sidebar presence:** the trigger + brand mark now render only when `showSidebarTrigger && hasAppSidebar` (the `SidebarPresence` context added in the branding slice, provided only by `AuthenticatedLayout`). On `MinimalLayout` the page's own `leadingControl` takes that slot instead — no hamburger to an empty sheet, no orphaned brand.

## Result
Mobile: `[☰] [Langfuse mark] [breadcrumb] … [actions]` with a tappable hamburger that opens the nav sheet. Desktop unchanged. Public-share views no longer show sidebar chrome. Verified live at 375px (icon `lucide-menu`, button 36×36, sheet opens) and 1280px (icon `lucide-panel-left`, button 20×20, unchanged).

<details>
<summary>Verification & mechanism</summary>

- Measured via computed styles: at 375px the visible icon is `lucide-menu` in a 36×36 button; at 1280px it's `lucide-panel-left` in a 20×20 button. The two icons swap purely by CSS breakpoint (`md:hidden` / `hidden md:block`) — no `useIsMobile`, no hydration flash.
- Clicking the hamburger opens the mobile `Sheet` (nav + wordmark) — toggle behavior intact.
- `hasAppSidebar` defaults to `false` and is only provided by `AuthenticatedLayout`, so `MinimalLayout`-reachable routes (public shares, auth pages) get no trigger/brand by construction — the same layout-level guard the branding slice introduced, now extended to the trigger.
- The empty-sheet trigger on public-session mobile was a pre-existing issue flagged in review of the branding PR; this closes it.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the mobile experience for the sidebar trigger by replacing the `PanelLeft` (panel-collapse) icon with a proper hamburger (`Menu`) on mobile viewports, using a CSS breakpoint swap with no hydration flash. It also gates the trigger and `TopbarBrand` behind a `hasAppSidebar` context check, preventing them from rendering on `MinimalLayout` routes (public/shared trace and session views) where there is no `AppSidebar` to toggle.

- **Hamburger on mobile**: `SidebarTrigger` now renders `Menu` at 36×36 on mobile and `PanelLeft` at 20×20 on desktop via `md:hidden` / `hidden md:block`; the icon swap is pure CSS with no `useIsMobile` and no hydration flash.
- **`MinimalLayout` guard**: `showSidebarChrome = showSidebarTrigger && hasAppSidebar` ensures the trigger and brand mark only appear when `SidebarPresenceProvider` (mounted only by `AuthenticatedLayout`) is in the tree, so public-share pages no longer show a hamburger that would open an empty sheet.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The changes are scoped to two UI files and use pure-CSS breakpoint toggling with no runtime JS involved in the icon swap, so there is no hydration risk.

Both changed files are straightforward UI changes: one adds a second icon with a CSS visibility toggle, the other adds a context check that was already guarded by layout hierarchy. The `hasAppSidebar` guard correctly defaults to `false`, so pages outside `AuthenticatedLayout` automatically opt out. The desktop rendering is verified by the author to be pixel-identical to the pre-existing implementation.

No files require special attention. `sidebar.tsx` and `page-header.tsx` are the only changed files and both changes are well-contained.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Layout mounts] --> B{AuthenticatedLayout?}
    B -- Yes --> C[SidebarPresenceProvider value=true]
    B -- No --> D[No provider — context defaults to false]
    C --> E[PageHeader: useHasAppSidebar → true]
    D --> F[PageHeader: useHasAppSidebar → false]
    E --> G{showSidebarTrigger prop?}
    G -- true --> H[showSidebarChrome = true]
    G -- false --> I[showSidebarChrome = false]
    F --> I
    H --> J[Render SidebarTrigger + TopbarBrand]
    J --> K{Viewport}
    K -- below md --> L[Menu icon ☰, 36×36 button\nopens off-canvas Sheet]
    K -- md and above --> M[PanelLeft icon, 20×20 button\ntoggles docked sidebar]
    I --> N[Render leadingControl if provided]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Layout mounts] --> B{AuthenticatedLayout?}
    B -- Yes --> C[SidebarPresenceProvider value=true]
    B -- No --> D[No provider — context defaults to false]
    C --> E[PageHeader: useHasAppSidebar → true]
    D --> F[PageHeader: useHasAppSidebar → false]
    E --> G{showSidebarTrigger prop?}
    G -- true --> H[showSidebarChrome = true]
    G -- false --> I[showSidebarChrome = false]
    F --> I
    H --> J[Render SidebarTrigger + TopbarBrand]
    J --> K{Viewport}
    K -- below md --> L[Menu icon ☰, 36×36 button\nopens off-canvas Sheet]
    K -- md and above --> M[PanelLeft icon, 20×20 button\ntoggles docked sidebar]
    I --> N[Render leadingControl if provided]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/ui/sidebar.tsx:304
`PanelLeft` is missing an explicit `size-5` class to match the `Menu` icon. Without it, `PanelLeft` renders at the lucide-react default of 24px inside a 20×20 (desktop) button — a minor inconsistency introduced by making the icon sizing explicit for `Menu` but not its sibling. Desktop rendering was always this way (pre-existing), but since the PR adds an explicit `size-5` to `Menu`, applying the same to `PanelLeft` makes the intent clearer.

```suggestion
      <PanelLeft className="hidden size-5 md:block" />
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(layouts): real mobile hamburger for..."](https://github.com/langfuse/langfuse/commit/00bf9632ecfd9a17684a6aa26ff42dd862edbbb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45649440)</sub>

<!-- /greptile_comment -->