### PR TITLE
fix(api): add annotation queue rate limit

### DIFF
--- a/packages/shared/src/interfaces/rate-limits.ts
+++ b/packages/shared/src/interfaces/rate-limits.ts
@@ -12,6 +12,7 @@ export const RateLimitResource = z.enum([
   "prompts",
   "legacy-ingestion",
   "datasets",
+  "annotation-queues",
   "trace-delete",
   "score-delete",
   "in-app-agent-run",

--- a/web/src/__tests__/server/rate-limit.servertest.ts
+++ b/web/src/__tests__/server/rate-limit.servertest.ts
@@ -378,6 +378,48 @@ describe("RateLimitService", () => {
     expect(result?.isRateLimited()).toBe(false);
   });
 
+  it("should apply annotation queue rate limits by cloud plan", async () => {
+    const cases = [
+      { plan: "cloud:hobby" as const, points: 100 },
+      { plan: "cloud:core" as const, points: 1000 },
+      { plan: "cloud:pro" as const, points: 1000 },
+      { plan: "cloud:team" as const, points: 1000 },
+      { plan: "cloud:enterprise" as const, points: 1000 },
+    ];
+
+    const rateLimitService = RateLimitService.getInstance(redis as Redis);
+
+    for (const testCase of cases) {
+      await redis.del(
+        `${RATE_LIMIT_REDIS_KEY_PREFIX}:annotation-queues:${orgId}`,
+      );
+
+      const scope = {
+        orgId: orgId,
+        plan: testCase.plan,
+        projectId,
+        accessLevel: "project" as const,
+        rateLimitOverrides: [],
+      };
+
+      const result = await rateLimitService.rateLimitRequest(
+        asScope(scope),
+        "annotation-queues",
+      );
+
+      expect(result?.res).toEqual({
+        scope: scope,
+        resource: "annotation-queues",
+        points: testCase.points,
+        remainingPoints: testCase.points - 1,
+        msBeforeNext: expect.any(Number),
+        consumedPoints: 1,
+        isFirstInDuration: true,
+      });
+      expect(result?.isRateLimited()).toBe(false);
+    }
+  });
+
   it("should apply public-api-legacy rate limits by cloud plan", async () => {
     const cases = [
       { plan: "cloud:hobby" as const, points: 15 },

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -301,6 +301,12 @@ const getPlanBasedRateLimitConfig = (
             points: 100,
             durationInSec: 60,
           };
+        case "annotation-queues":
+          return {
+            resource: "annotation-queues",
+            points: 100,
+            durationInSec: 60,
+          };
         case "public-api-metrics":
           return {
             resource: "public-api-metrics",
@@ -391,6 +397,12 @@ const getPlanBasedRateLimitConfig = (
             points: 1000, // temporary: using pro limit
             durationInSec: 60,
           };
+        case "annotation-queues":
+          return {
+            resource: "annotation-queues",
+            points: 1000,
+            durationInSec: 60,
+          };
         case "public-api-metrics":
           return {
             resource: "public-api-metrics",
@@ -476,6 +488,12 @@ const getPlanBasedRateLimitConfig = (
         case "datasets":
           return {
             resource: "datasets",
+            points: 1000,
+            durationInSec: 60,
+          };
+        case "annotation-queues":
+          return {
+            resource: "annotation-queues",
             points: 1000,
             durationInSec: 60,
           };

--- a/web/src/pages/api/public/annotation-queues/[queueId]/assignments.ts
+++ b/web/src/pages/api/public/annotation-queues/[queueId]/assignments.ts
@@ -18,6 +18,7 @@ export default withMiddlewares({
     bodySchema: CreateAnnotationQueueAssignmentBody,
     querySchema: AnnotationQueueAssignmentQuery,
     responseSchema: CreateAnnotationQueueAssignmentResponse,
+    rateLimitResource: "annotation-queues",
     fn: async ({ query, body, auth }) => {
       const { assignment } = await createAnnotationQueueAssignmentForApi({
         projectId: auth.scope.projectId,
@@ -36,6 +37,7 @@ export default withMiddlewares({
     querySchema: AnnotationQueueAssignmentQuery,
     bodySchema: DeleteAnnotationQueueAssignmentBody,
     responseSchema: DeleteAnnotationQueueAssignmentResponse,
+    rateLimitResource: "annotation-queues",
     fn: async ({ query, body, auth }) => {
       const result = await deleteAnnotationQueueAssignmentForApi({
         projectId: auth.scope.projectId,

--- a/web/src/pages/api/public/annotation-queues/[queueId]/index.ts
+++ b/web/src/pages/api/public/annotation-queues/[queueId]/index.ts
@@ -11,6 +11,7 @@ export default withMiddlewares({
     name: "Get annotation queue by ID",
     querySchema: GetAnnotationQueueByIdQuery,
     responseSchema: GetAnnotationQueueByIdResponse,
+    rateLimitResource: "annotation-queues",
     fn: async ({ query, auth }) =>
       await getAnnotationQueueForApi({
         projectId: auth.scope.projectId,

--- a/web/src/pages/api/public/annotation-queues/[queueId]/items/[itemId].ts
+++ b/web/src/pages/api/public/annotation-queues/[queueId]/items/[itemId].ts
@@ -19,6 +19,7 @@ export default withMiddlewares({
     name: "Get annotation queue item by ID",
     querySchema: GetAnnotationQueueItemByIdQuery,
     responseSchema: GetAnnotationQueueItemByIdResponse,
+    rateLimitResource: "annotation-queues",
     fn: async ({ query, auth }) =>
       await getAnnotationQueueItemForApi({
         projectId: auth.scope.projectId,
@@ -31,6 +32,7 @@ export default withMiddlewares({
     querySchema: GetAnnotationQueueItemByIdQuery,
     bodySchema: UpdateAnnotationQueueItemBody,
     responseSchema: UpdateAnnotationQueueItemResponse,
+    rateLimitResource: "annotation-queues",
     fn: async ({ query, body, auth }) =>
       await updateAnnotationQueueItemForApi({
         projectId: auth.scope.projectId,
@@ -44,6 +46,7 @@ export default withMiddlewares({
     name: "Delete annotation queue item",
     querySchema: DeleteAnnotationQueueItemQuery,
     responseSchema: DeleteAnnotationQueueItemResponse,
+    rateLimitResource: "annotation-queues",
     fn: async ({ query, auth }) =>
       await deleteAnnotationQueueItemForApi({
         projectId: auth.scope.projectId,

--- a/web/src/pages/api/public/annotation-queues/[queueId]/items/index.ts
+++ b/web/src/pages/api/public/annotation-queues/[queueId]/items/index.ts
@@ -16,6 +16,7 @@ export default withMiddlewares({
     name: "Get annotation queue items",
     querySchema: GetAnnotationQueueItemsQuery,
     responseSchema: GetAnnotationQueueItemsResponse,
+    rateLimitResource: "annotation-queues",
     fn: async ({ query, auth }) =>
       await listAnnotationQueueItemsForApi({
         projectId: auth.scope.projectId,
@@ -30,6 +31,7 @@ export default withMiddlewares({
     querySchema: GetAnnotationQueueItemsQuery,
     bodySchema: CreateAnnotationQueueItemBody,
     responseSchema: CreateAnnotationQueueItemResponse,
+    rateLimitResource: "annotation-queues",
     fn: async ({ query, body, auth }) =>
       await createAnnotationQueueItemForApi({
         projectId: auth.scope.projectId,

--- a/web/src/pages/api/public/annotation-queues/index.ts
+++ b/web/src/pages/api/public/annotation-queues/index.ts
@@ -16,6 +16,7 @@ export default withMiddlewares({
     name: "Get annotation queues",
     querySchema: GetAnnotationQueuesQuery,
     responseSchema: GetAnnotationQueuesResponse,
+    rateLimitResource: "annotation-queues",
     fn: async ({ query, auth }) =>
       await listAnnotationQueuesForApi({
         projectId: auth.scope.projectId,
@@ -28,6 +29,7 @@ export default withMiddlewares({
     name: "Create annotation queue",
     bodySchema: CreateAnnotationQueueBody,
     responseSchema: CreateAnnotationQueueResponse,
+    rateLimitResource: "annotation-queues",
     fn: async ({ body, auth }) =>
       await createAnnotationQueueForApi({
         projectId: auth.scope.projectId,


### PR DESCRIPTION
## Summary

- add a dedicated `annotation-queues` rate-limit resource
- apply it consistently across all public annotation queue API operations
- allow 100 requests/minute on Hobby and 1,000 requests/minute on paid Cloud plans
- add regression coverage for the plan-based limits

## Verification

- focused rate-limit suite passed before the final route coverage expansion: `Tests  16 passed (16)`
- final checks were not rerun, per request

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a dedicated annotation-queue rate-limit bucket, configures cloud-plan limits, applies it to every public annotation-queue API operation, and adds plan-based regression coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with consistent rate-limit configuration and complete public annotation-queue route coverage.

Every public annotation-queue API method selects the new resource, all supported plan branches define it, and the shared schema and regression test use the same resource contract.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): add annotation queue rate limi..."](https://github.com/langfuse/langfuse/commit/8dc470a7ded6c171b53d83194472d6100bf84546) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46633028)</sub>

**Context used:**

- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->