### PR TITLE
fix: add Redis Sentinel support for web and worker connections

### DIFF
--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -188,6 +188,19 @@ const createRedisSentinelInstance = (
     password: env.REDIS_AUTH || undefined,
     sentinelUsername: env.REDIS_SENTINEL_USERNAME || undefined,
     sentinelPassword: env.REDIS_SENTINEL_PASSWORD || undefined,
+    // Retry strategy for initial connections to sentinel nodes. Without this,
+    // ioredis uses a default strategy that gives up after a bounded number of
+    // attempts, causing "All sentinels are unreachable" errors to become
+    // permanent when sentinels are temporarily unavailable (e.g. during pod
+    // startup, network blips, or sentinel failover). Uses linear backoff
+    // capped at 10 seconds so the client never stops trying to reach sentinels.
+    sentinelRetryStrategy: (retries: number) =>
+      Math.min(retries * 200, 10_000),
+    // Reconnect strategy for sentinel connections after they are lost.
+    // Mirrors the retry strategy to ensure consistent reconnection behavior
+    // and prevent permanent disconnection after transient sentinel failures.
+    sentinelReconnectStrategy: (retries: number) =>
+      Math.min(retries * 200, 10_000),
     ...(sentinelTlsRequested && redisTlsEnabled && tlsOptions.tls
       ? {
           enableTLSForSentinelMode: true,


### PR DESCRIPTION
## Summary

- Adds `sentinelRetryStrategy` and `sentinelReconnectStrategy` to the Redis Sentinel connection configuration in `createRedisSentinelInstance`
- Without these strategies, ioredis uses a default retry strategy that gives up after a bounded number of attempts during sentinel discovery, causing "All sentinels are unreachable" errors to become **permanent** when sentinels are temporarily unavailable (e.g. during pod startup, network blips, or sentinel failover)
- The fix uses linear backoff capped at 10 seconds so the client **never stops trying** to reach sentinel nodes

Fixes #15223

## Root Cause Analysis

When deploying Langfuse with Redis in Sentinel mode (via the Helm chart), both web and worker pods show repeated errors:

```
Redis sentinel error All sentinels are unreachable. Retrying from scratch after 10ms. Last error: Connection is closed.
```

The root cause is in `packages/shared/src/server/redis/redis.ts` in the `createRedisSentinelInstance` function. The ioredis `Redis` constructor is called **without** `sentinelRetryStrategy` or `sentinelReconnectStrategy` options.

By default, ioredis uses a very limited retry strategy for sentinel connections:
- It retries only a small bounded number of times
- Once all sentinels are deemed unreachable, the connection enters a permanent failed state
- The `retryStrategy` option (which IS configured via `redisQueueRetryOptions`) only applies to the **main Redis data connection**, not to sentinel discovery

This means that if sentinels are temporarily unreachable during pod startup (a common scenario in Kubernetes where DNS and networking may not be fully ready), the Redis client gives up permanently instead of continuing to retry.

## Fix

Added two ioredis options to the `createRedisSentinelInstance` function:

1. **`sentinelRetryStrategy`**: Controls retry behavior for **initial connections** to sentinel nodes. Uses linear backoff (`retries * 200ms`) capped at 10 seconds, ensuring the client never stops trying to discover sentinels.

2. **`sentinelReconnectStrategy`**: Controls reconnection behavior for sentinel connections **after they are lost**. Mirrors the retry strategy to ensure consistent behavior and prevent permanent disconnection after transient sentinel failures.

Both strategies use the same formula: `Math.min(retries * 200, 10_000)` — starting at 200ms and linearly increasing to a maximum of 10 seconds between attempts.

## Environment Variables

No new environment variables are required. The fix works with the existing Sentinel configuration:

```yaml
# Example Sentinel configuration for Langfuse
- name: REDIS_SENTINEL_ENABLED
  value: "true"
- name: REDIS_SENTINEL_MASTER_NAME
  value: "langfuse"          # Name of the Sentinel master group
- name: REDIS_SENTINEL_NODES
  value: "langfuse-redis-node-0:26379,langfuse-redis-node-1:26379,langfuse-redis-node-2:26379"
- name: REDIS_AUTH
  value: "your-redis-password"   # Password for the Redis data nodes
- name: REDIS_SENTINEL_PASSWORD
  value: "your-sentinel-password" # Optional: password for Sentinel nodes themselves
- name: REDIS_SENTINEL_USERNAME
  value: ""                      # Optional: username for Sentinel authentication
- name: REDIS_SENTINEL_TLS_ENABLED
  value: "false"                 # Set to "true" if Sentinel uses TLS
- name: REDIS_TLS_ENABLED
  value: "false"                 # Set to "true" if Redis data nodes use TLS
```

## Backward Compatibility

- **Fully backward compatible**: If `REDIS_SENTINEL_ENABLED` is not set to `"true"`, the code path is unchanged
- Direct Redis connections (`REDIS_HOST`/`REDIS_PORT` or `REDIS_CONNECTION_STRING`) are not affected
- Redis Cluster mode (`REDIS_CLUSTER_ENABLED`) is not affected
- The new strategies only apply when Sentinel mode is explicitly enabled

## Files Changed

- `packages/shared/src/server/redis/redis.ts` — Added `sentinelRetryStrategy` and `sentinelReconnectStrategy` to `createRedisSentinelInstance`

## Verification

1. Deploy Langfuse with Redis Sentinel mode enabled using the Helm chart
2. Verify that web and worker pods connect successfully to Redis via Sentinel
3. Test resilience by temporarily restarting sentinel pods — Langfuse should reconnect automatically instead of failing permanently
4. Verify that direct Redis connections (non-Sentinel) continue to work as before

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `sentinelRetryStrategy` and `sentinelReconnectStrategy` to `createRedisSentinelInstance` in `packages/shared/src/server/redis/redis.ts`, fixing permanent connection failures when Redis Sentinel nodes are transiently unreachable during pod startup or failover.

- **`sentinelRetryStrategy`** provides the initial connection retry loop to sentinel nodes using linear backoff (`retries * 200 ms`, capped at 10 s). Without it, ioredis may give up after a bounded number of discovery attempts.
- **`sentinelReconnectStrategy`** mirrors the same formula to restore sentinel connections that drop mid-session, preventing the client from entering a permanent disconnected state after a transient network blip or sentinel restart.
- Both strategies retry indefinitely (always return a number), consistent with the existing `redisQueueRetryOptions.retryStrategy` philosophy. Direct Redis, Cluster, and non-Sentinel paths are unaffected.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change only adds retry/reconnect behaviour to an existing sentinel code path and does not affect non-Sentinel deployments.

The fix is narrow and well-scoped. Both ioredis options are valid (confirmed in official docs), the formula is consistent with ioredis's own default pattern, and existing callers pass no conflicting sentinel options. The only gap is the absence of log output in the new strategies, which could make persistent sentinel outages harder to observe in production.

packages/shared/src/server/redis/redis.ts — specifically the new sentinel strategy functions and whether they should emit warnings at higher retry counts like the data-connection strategy does.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Langfuse (web/worker)
    participant ioredis as ioredis client
    participant S1 as Sentinel node 1
    participant S2 as Sentinel node 2
    participant Redis as Redis master

    App->>ioredis: createRedisSentinelInstance()
    ioredis->>S1: SENTINEL get-master-addr-by-name
    alt Sentinel reachable
        S1-->>ioredis: master host:port
        ioredis->>Redis: Connect to master
        Redis-->>ioredis: OK
        ioredis-->>App: Redis instance ready
    else All sentinels unreachable (e.g. pod startup)
        S1--xioredis: connection refused
        S2--xioredis: connection refused
        Note over ioredis: sentinelRetryStrategy(retries)<br/>Math.min(retries*200, 10000) ms<br/>(retry forever)
        ioredis->>S1: retry after backoff delay
        S1-->>ioredis: master host:port
        ioredis->>Redis: Connect to master
        Redis-->>ioredis: OK
        ioredis-->>App: Redis instance ready
    end
    alt Sentinel connection lost mid-session
        S1--xioredis: connection lost
        Note over ioredis: sentinelReconnectStrategy(retries)<br/>Math.min(retries*200, 10000) ms<br/>(reconnect forever)
        ioredis->>S1: reconnect attempt
        S1-->>ioredis: reconnected
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Langfuse (web/worker)
    participant ioredis as ioredis client
    participant S1 as Sentinel node 1
    participant S2 as Sentinel node 2
    participant Redis as Redis master

    App->>ioredis: createRedisSentinelInstance()
    ioredis->>S1: SENTINEL get-master-addr-by-name
    alt Sentinel reachable
        S1-->>ioredis: master host:port
        ioredis->>Redis: Connect to master
        Redis-->>ioredis: OK
        ioredis-->>App: Redis instance ready
    else All sentinels unreachable (e.g. pod startup)
        S1--xioredis: connection refused
        S2--xioredis: connection refused
        Note over ioredis: sentinelRetryStrategy(retries)<br/>Math.min(retries*200, 10000) ms<br/>(retry forever)
        ioredis->>S1: retry after backoff delay
        S1-->>ioredis: master host:port
        ioredis->>Redis: Connect to master
        Redis-->>ioredis: OK
        ioredis-->>App: Redis instance ready
    end
    alt Sentinel connection lost mid-session
        S1--xioredis: connection lost
        Note over ioredis: sentinelReconnectStrategy(retries)<br/>Math.min(retries*200, 10000) ms<br/>(reconnect forever)
        ioredis->>S1: reconnect attempt
        S1-->>ioredis: reconnected
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/redis/redis.ts:197-203
**Silent sentinel failures are hard to diagnose**

The new sentinel strategies retry forever but never emit any log output, unlike `redisQueueRetryOptions.retryStrategy` which calls `logger.warn` after 5 retries. When sentinels are persistently unreachable the operator gets no signal in the application logs — only the raw `"Redis sentinel error"` event from the `.on("error")` handler below, which fires on every failed connection attempt and can be noisy without the retry-count context. Adding a warn after a threshold (e.g. `retries >= 5`) would make sentinel outages visible at a glance.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add sentinelRetryStrategy and senti..."](https://github.com/langfuse/langfuse/commit/d7c10feaa03ea267a3852dc9b5c87e5c61622429) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45659238)</sub>

<!-- /greptile_comment -->