### PR TITLE
fix(assistant): guard undefined event.key in shortcut handler

### DIFF
--- a/web/src/components/nav/in-app-ai-agent-button.clienttest.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.clienttest.tsx
@@ -77,4 +77,35 @@ describe("InAppAiAgentButton", () => {
     expect(mocks.openAssistant).toHaveBeenCalledTimes(1);
     expect(mocks.setOpen).toHaveBeenCalledWith(false);
   });
+
+  it("no-ops without throwing when event.key is undefined", () => {
+    render(<InAppAiAgentButton />);
+
+    // Synthetic / autofill keydown events can arrive without a `key`
+    // (undefined); jsdom otherwise defaults it to "". The handler must not
+    // call `.toLowerCase()` on undefined. dispatchEvent does not rethrow a
+    // listener exception — it reports it as a global error event — so assert
+    // on that as well as the direct throw.
+    const onError = vi.fn();
+    window.addEventListener("error", onError);
+
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+    });
+    Object.defineProperty(event, "key", {
+      value: undefined,
+      configurable: true,
+    });
+
+    expect(() => fireEvent(document, event)).not.toThrow();
+
+    window.removeEventListener("error", onError);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+    expect(mocks.openAssistant).not.toHaveBeenCalled();
+    expect(mocks.setOpen).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -37,7 +37,7 @@ export const InAppAiAgentButton = () => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.repeat ||
-        event.key.toLowerCase() !== "i" ||
+        event.key?.toLowerCase() !== "i" ||
         (!event.metaKey && !event.ctrlKey) ||
         event.altKey ||
         event.shiftKey


### PR DESCRIPTION
**TL;DR** — The assistant keyboard-shortcut listener crashed with `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` on keydown events that have no `key`. One-character guard (optional chaining) fixes it; the shortcut still works. Regression from #15160.

**Why** — A client error observed in production: some synthetic / browser-autofill keydown events fire with `event.key === undefined`. The global listener added for the top-nav assistant shortcut called `event.key.toLowerCase()` unconditionally, so those events threw for any user on a page with the assistant available.

**What** — Optional-chain the read: `event.key?.toLowerCase()`. When `key` is absent the comparison is `undefined !== "i"`, so the handler no-ops and falls through to its early return. Real Cmd/Ctrl+I behavior is untouched. Extended the existing key-handler unit test with an undefined-key case.

**Result** — No more crash on keyless keydown events; Cmd/Ctrl+I still opens/closes the assistant. `web` typecheck + lint clean; component test green (verified it fails against the pre-fix code).

<details><summary>Detail</summary>

Regression from the top-nav assistant shortcut work (#15160), `web/src/components/nav/in-app-ai-agent-button.tsx`. The test dispatches a real keydown with `event.key` forced to `undefined` and asserts no global error event fires (note: `dispatchEvent` reports listener exceptions as a global error event rather than rethrowing, so the test asserts on the `window` `error` event — verified to fail pre-fix, pass post-fix).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR guards against a `TypeError` crash in the global keydown listener on `in-app-ai-agent-button.tsx` by adding optional chaining to `event.key?.toLowerCase()`. The crash affected any user on a page with the assistant available when a synthetic or browser-autofill keydown event fired without a `key` property.

- **Fix** (`in-app-ai-agent-button.tsx`): One-character change — `event.key.toLowerCase()` → `event.key?.toLowerCase()`. When `key` is `undefined` the comparison becomes `undefined !== "i"`, the guard condition is truthy, and the handler returns early with no side effects.
- **Test** (`in-app-ai-agent-button.clienttest.tsx`): Adds a case that constructs a `KeyboardEvent` with `key` forced to `undefined` via `Object.defineProperty`, then dispatches it and asserts no global `error` event fired and no assistant actions were triggered.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-character optional-chain guard on a single comparison in an event listener, with no effect on the happy path.

The fix is minimal and precise: optional chaining on `event.key` means undefined-key events silently no-op while normal Cmd/Ctrl+I behavior is completely unchanged. The new test correctly exercises the crash path using `Object.defineProperty` to force `key` to `undefined` and validates via the global `error` event, which is the right approach for `dispatchEvent` in jsdom. No logic regressions are plausible from this change.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as Browser / Autofill
    participant Doc as document (keydown)
    participant Handler as handleKeyDown
    participant Toggle as toggleAssistant

    Browser->>Doc: "KeyboardEvent (key = undefined, metaKey = true)"
    Doc->>Handler: handleKeyDown(event)

    Note over Handler: event.key?.toLowerCase() → undefined
    Note over Handler: undefined !== "i" → true (guard fires)
    Handler-->>Doc: return (no-op, no crash)

    Browser->>Doc: "KeyboardEvent (key = "i", metaKey = true)"
    Doc->>Handler: handleKeyDown(event)

    Note over Handler: event.key?.toLowerCase() → "i"
    Note over Handler: "i" !== "i" → false (guard skips)
    Handler->>Handler: event.preventDefault()
    Handler->>Toggle: toggleAssistant("keyboard_shortcut")
    Toggle-->>Handler: assistant opened / closed
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as Browser / Autofill
    participant Doc as document (keydown)
    participant Handler as handleKeyDown
    participant Toggle as toggleAssistant

    Browser->>Doc: "KeyboardEvent (key = undefined, metaKey = true)"
    Doc->>Handler: handleKeyDown(event)

    Note over Handler: event.key?.toLowerCase() → undefined
    Note over Handler: undefined !== "i" → true (guard fires)
    Handler-->>Doc: return (no-op, no crash)

    Browser->>Doc: "KeyboardEvent (key = "i", metaKey = true)"
    Doc->>Handler: handleKeyDown(event)

    Note over Handler: event.key?.toLowerCase() → "i"
    Note over Handler: "i" !== "i" → false (guard skips)
    Handler->>Handler: event.preventDefault()
    Handler->>Toggle: toggleAssistant("keyboard_shortcut")
    Toggle-->>Handler: assistant opened / closed
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(assistant): guard undefined event.ke..."](https://github.com/langfuse/langfuse/commit/21b3c4cf8169b7072bdff6cc30d162f77551b76a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45670547)</sub>

<!-- /greptile_comment -->