### PR TITLE
feat(layouts): expandable mobile bottom action bar (LFE-11067)

### DIFF
--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -12,6 +12,8 @@ import { AppSidebar } from "@/src/components/nav/app-sidebar";
 import { SidebarPresenceProvider } from "@/src/components/nav/sidebar-presence";
 import { Toaster } from "@/src/components/ui/sonner";
 import { Layer } from "@/src/components/ui/layer";
+import { MobileBottomBar } from "@/src/components/layouts/mobile-bottom-bar/MobileBottomBar";
+import { MobileBottomBarProvider } from "@/src/components/layouts/mobile-bottom-bar/mobile-bottom-bar-context";
 import { TopBannerProvider } from "@/src/features/top-banner";
 import { AppContentWithRightDrawer } from "../right-drawer/AppContentWithRightDrawer";
 import { ThemeToggle } from "@/src/features/theming/ThemeToggle";
@@ -171,40 +173,47 @@ export function AuthenticatedLayout({
       <TopBannerProvider>
         <SidebarPresenceProvider>
           <SidebarProvider>
-            <div className="flex h-dvh w-full flex-col">
-              <PaymentBanner />
-              <div className="pt-banner-offset flex min-h-0 flex-1">
-                <AppSidebar
-                  navItems={navigation.mainNavigation}
-                  secondaryNavItems={navigation.secondaryNavigation}
-                  userNavProps={userNavProps}
-                />
-                <SidebarInset className="h-screen-with-banner max-w-full md:peer-data-[state=collapsed]:w-[calc(100vw-var(--sidebar-width-icon))] md:peer-data-[state=expanded]:w-[calc(100vw-var(--sidebar-width))]">
-                  <AppContentWithRightDrawer>
-                    {children}
-                  </AppContentWithRightDrawer>
-                  {/* Toasts render in the `toast` overlay layer — the last layer
+            {/* Mobile bottom-bar shell. The provider wraps both the page tree
+                (so any page can portal controls into the bar via the seam) and
+                the bar itself; MobileBottomBar renders only below `md` and
+                portals through the `panel` overlay layer. */}
+            <MobileBottomBarProvider>
+              <div className="flex h-dvh w-full flex-col">
+                <PaymentBanner />
+                <div className="pt-banner-offset flex min-h-0 flex-1">
+                  <AppSidebar
+                    navItems={navigation.mainNavigation}
+                    secondaryNavItems={navigation.secondaryNavigation}
+                    userNavProps={userNavProps}
+                  />
+                  <SidebarInset className="h-screen-with-banner max-w-full md:peer-data-[state=collapsed]:w-[calc(100vw-var(--sidebar-width-icon))] md:peer-data-[state=expanded]:w-[calc(100vw-var(--sidebar-width))]">
+                    <AppContentWithRightDrawer>
+                      {children}
+                    </AppContentWithRightDrawer>
+                    {/* Toasts render in the `toast` overlay layer — the last layer
                       in LAYER_ORDER — so they paint above every overlay (incl. a
                       non-modal peek) by DOM order alone, no z-index. Sonner's
                       Toaster is position:fixed, so nesting it in the fixed
                       full-screen layer container is positionally identical. */}
-                  <Layer name="toast">
-                    <Toaster visibleToasts={1} />
-                  </Layer>
-                  <CommandMenu mainNavigation={navigation.navigation} />
-                  {/* Assistant window host lives here (not in PageHeader with
+                    <Layer name="toast">
+                      <Toaster visibleToasts={1} />
+                    </Layer>
+                    <CommandMenu mainNavigation={navigation.navigation} />
+                    {/* Assistant window host lives here (not in PageHeader with
                       its launcher button) so the open window and its geometry
                       survive route changes. */}
-                  <InAppAgentWindowHost />
-                </SidebarInset>
+                    <InAppAgentWindowHost />
+                  </SidebarInset>
+                </div>
+                {hasFeaturePreviews ? (
+                  <ControlledFeaturePreviewModal
+                    open={featurePreviewOpen}
+                    onOpenChange={setFeaturePreviewOpen}
+                  />
+                ) : null}
               </div>
-              {hasFeaturePreviews ? (
-                <ControlledFeaturePreviewModal
-                  open={featurePreviewOpen}
-                  onOpenChange={setFeaturePreviewOpen}
-                />
-              ) : null}
-            </div>
+              <MobileBottomBar />
+            </MobileBottomBarProvider>
           </SidebarProvider>
         </SidebarPresenceProvider>
       </TopBannerProvider>

--- a/web/src/components/layouts/mobile-bottom-bar/MobileBottomBar.stories.tsx
+++ b/web/src/components/layouts/mobile-bottom-bar/MobileBottomBar.stories.tsx
@@ -10,13 +10,17 @@ import {
 
 /**
  * `MobileBottomBar` is the app-shell mobile action bar (below `md`). Stories
- * force `visibility="always"` so the bar shows at any Storybook canvas width;
- * in the app it is gated to mobile by a CSS breakpoint. The bar and its
- * expanded sheet are `position: fixed`, so they anchor to the bottom of the
- * canvas viewport (exactly as in the app).
+ * default the `visibility` arg to `"always"` so the bar shows at any Storybook
+ * canvas width; in the app it defaults to `"responsive"` (mobile-only). Flip the
+ * `visibility` control (or `&args=visibility:responsive` in the URL) and load
+ * the story in `iframe.html` to exercise the real mobile gate: below 768px the
+ * pill shows and the sheet can open; at/above 768px the pill hides and an open
+ * sheet auto-closes. The bar and its expanded sheet are `position: fixed`, so
+ * they anchor to the bottom of the canvas viewport (exactly as in the app).
  */
 const meta = preview.meta({
   component: MobileBottomBar,
+  args: { visibility: "always" },
 });
 
 /** Icon-first quick actions for the collapsed pill (the `"bar"` region). */
@@ -71,10 +75,9 @@ function SampleSheetActions() {
 
 /** Collapsed pill with two sample quick actions + the expand handle. */
 export const Collapsed = meta.story({
-  parameters: { controls: { disable: true } },
-  render: () => (
+  render: (args) => (
     <MobileBottomBarProvider>
-      <MobileBottomBar visibility="always" />
+      <MobileBottomBar {...args} />
       <SampleBarActions />
       <SampleSheetActions />
     </MobileBottomBarProvider>
@@ -83,10 +86,9 @@ export const Collapsed = meta.story({
 
 /** Expanded bottom sheet (opened on mount) with the fuller action set. */
 export const Expanded = meta.story({
-  parameters: { controls: { disable: true } },
-  render: () => (
+  render: (args) => (
     <MobileBottomBarProvider defaultExpanded>
-      <MobileBottomBar visibility="always" />
+      <MobileBottomBar {...args} />
       <SampleBarActions />
       <SampleSheetActions />
     </MobileBottomBarProvider>
@@ -96,10 +98,9 @@ export const Expanded = meta.story({
 /** The shell chrome with no page actions registered — just the expand handle,
  * and an empty sheet. Documents the "nothing to show" baseline. */
 export const NoActions = meta.story({
-  parameters: { controls: { disable: true } },
-  render: () => (
+  render: (args) => (
     <MobileBottomBarProvider>
-      <MobileBottomBar visibility="always" />
+      <MobileBottomBar {...args} />
     </MobileBottomBarProvider>
   ),
 });

--- a/web/src/components/layouts/mobile-bottom-bar/MobileBottomBar.stories.tsx
+++ b/web/src/components/layouts/mobile-bottom-bar/MobileBottomBar.stories.tsx
@@ -1,0 +1,105 @@
+import { BotMessageSquare, ListFilter, RefreshCw, Clock } from "lucide-react";
+import preview from "../../../../.storybook/preview";
+import { Button } from "@/src/components/ui/button";
+import { MobileBottomBar } from "@/src/components/layouts/mobile-bottom-bar/MobileBottomBar";
+import {
+  MobileBottomBarPortal,
+  MobileBottomBarProvider,
+  useMobileBottomBar,
+} from "@/src/components/layouts/mobile-bottom-bar/mobile-bottom-bar-context";
+
+/**
+ * `MobileBottomBar` is the app-shell mobile action bar (below `md`). Stories
+ * force `visibility="always"` so the bar shows at any Storybook canvas width;
+ * in the app it is gated to mobile by a CSS breakpoint. The bar and its
+ * expanded sheet are `position: fixed`, so they anchor to the bottom of the
+ * canvas viewport (exactly as in the app).
+ */
+const meta = preview.meta({
+  component: MobileBottomBar,
+});
+
+/** Icon-first quick actions for the collapsed pill (the `"bar"` region). */
+function SampleBarActions() {
+  const ctx = useMobileBottomBar();
+  return (
+    <MobileBottomBarPortal region="bar">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="rounded-full"
+        aria-label="Ask AI"
+      >
+        <BotMessageSquare className="h-5 w-5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="rounded-full"
+        aria-label="Filters"
+        onClick={() => ctx?.setExpanded(true)}
+      >
+        <ListFilter className="h-5 w-5" />
+      </Button>
+    </MobileBottomBarPortal>
+  );
+}
+
+/** Labelled control set for the expanded sheet (the `"sheet"` region). */
+function SampleSheetActions() {
+  return (
+    <MobileBottomBarPortal region="sheet">
+      <Button variant="default" className="w-full justify-start gap-2">
+        <BotMessageSquare className="h-4 w-4" />
+        Ask Langfuse AI
+      </Button>
+      <Button variant="outline" className="w-full justify-start gap-2">
+        <ListFilter className="h-4 w-4" />
+        Filters
+      </Button>
+      <Button variant="outline" className="w-full justify-start gap-2">
+        <Clock className="h-4 w-4" />
+        Time range
+      </Button>
+      <Button variant="outline" className="w-full justify-start gap-2">
+        <RefreshCw className="h-4 w-4" />
+        Refresh
+      </Button>
+    </MobileBottomBarPortal>
+  );
+}
+
+/** Collapsed pill with two sample quick actions + the expand handle. */
+export const Collapsed = meta.story({
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <MobileBottomBarProvider>
+      <MobileBottomBar visibility="always" />
+      <SampleBarActions />
+      <SampleSheetActions />
+    </MobileBottomBarProvider>
+  ),
+});
+
+/** Expanded bottom sheet (opened on mount) with the fuller action set. */
+export const Expanded = meta.story({
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <MobileBottomBarProvider defaultExpanded>
+      <MobileBottomBar visibility="always" />
+      <SampleBarActions />
+      <SampleSheetActions />
+    </MobileBottomBarProvider>
+  ),
+});
+
+/** The shell chrome with no page actions registered — just the expand handle,
+ * and an empty sheet. Documents the "nothing to show" baseline. */
+export const NoActions = meta.story({
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <MobileBottomBarProvider>
+      <MobileBottomBar visibility="always" />
+    </MobileBottomBarProvider>
+  ),
+});

--- a/web/src/components/layouts/mobile-bottom-bar/MobileBottomBar.tsx
+++ b/web/src/components/layouts/mobile-bottom-bar/MobileBottomBar.tsx
@@ -1,0 +1,121 @@
+import { ChevronUp } from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { Button } from "@/src/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/src/components/ui/drawer";
+import { Layer } from "@/src/components/ui/layer";
+import { cn } from "@/src/utils/tailwind";
+import {
+  MobileBottomBarSlotTarget,
+  useMobileBottomBar,
+} from "@/src/components/layouts/mobile-bottom-bar/mobile-bottom-bar-context";
+
+// Safe-area-aware bottom padding: honour the notch/home-indicator inset but
+// keep a comfortable floor so the pill never hugs the very edge.
+const SAFE_BOTTOM = "pb-[max(0.75rem,env(safe-area-inset-bottom))]";
+
+const wrapperVariants = cva(
+  // pointer-events-none so taps pass THROUGH the empty gutter around the pill;
+  // only the pill itself (pointer-events-auto) catches events.
+  "pointer-events-none fixed inset-x-0 bottom-0 flex justify-center px-3",
+  {
+    variants: {
+      visibility: {
+        // Real app: mobile-only. CSS breakpoint (not the JS useIsMobile hook)
+        // so there is no hydration flash of the bar on desktop.
+        responsive: "md:hidden",
+        // Storybook / previews: force it on regardless of viewport width.
+        always: "",
+      },
+    },
+    defaultVariants: { visibility: "responsive" },
+  },
+);
+
+type MobileBottomBarProps = VariantProps<typeof wrapperVariants> & {
+  className?: string;
+};
+
+/**
+ * Expandable mobile bottom action bar — the app-shell home for per-page
+ * controls on mobile. Collapsed, it is a compact floating pill pinned to the
+ * bottom of the viewport (safe-area aware). Its expand handle opens a bottom
+ * sheet (the shared `vaul` {@link Drawer}) that hosts the fuller control set.
+ *
+ * Pages fill it through the {@link MobileBottomBarPortal} seam (regions `"bar"`
+ * and `"sheet"`); this component owns only the chrome. Both surfaces portal
+ * through the app overlay `panel` layer — the collapsed pill via {@link Layer},
+ * the sheet via the Drawer's own layer-routed portal — so no raw z-index is
+ * used to escape the app shell.
+ */
+export function MobileBottomBar({
+  visibility,
+  className,
+}: MobileBottomBarProps) {
+  const ctx = useMobileBottomBar();
+  if (!ctx) return null;
+  const { expanded, setExpanded } = ctx;
+
+  return (
+    <>
+      {/* Collapsed pill. Bespoke fixed content → portal through the `panel`
+          layer with <Layer>. It stays mounted while the sheet is open (the
+          sheet's overlay, appended later into the same layer, paints over it),
+          so the `bar` slot target — and any content a page portals into it —
+          keeps a stable DOM home. */}
+      <Layer name="panel">
+        <div className={cn(wrapperVariants({ visibility }), SAFE_BOTTOM)}>
+          <div
+            className={cn(
+              "border-border-contrast bg-background/85 pointer-events-auto flex items-center gap-1 rounded-full border p-1.5 shadow-lg backdrop-blur-md",
+              className,
+            )}
+          >
+            <MobileBottomBarSlotTarget region="bar" />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="rounded-full"
+              aria-label="More actions"
+              aria-expanded={expanded}
+              onClick={() => setExpanded(true)}
+            >
+              <ChevronUp className="h-5 w-5" />
+            </Button>
+          </div>
+        </div>
+      </Layer>
+
+      {/* Expanded bottom sheet. The Drawer routes its portal into the `panel`
+          layer itself (see ui/drawer.tsx) and handles focus trap / Escape /
+          aria-modal; we only supply the content. h-auto lets it fit content up
+          to a max, with the body scrolling past that. */}
+      <Drawer
+        open={expanded}
+        onOpenChange={setExpanded}
+        forceDirection="bottom"
+      >
+        <DrawerContent
+          className={cn("h-auto max-h-[85svh] rounded-t-2xl", SAFE_BOTTOM)}
+        >
+          <div
+            aria-hidden
+            className="bg-muted mx-auto mt-3 h-1.5 w-10 shrink-0 rounded-full"
+          />
+          <DrawerHeader className="pb-2 text-left">
+            <DrawerTitle>Actions</DrawerTitle>
+          </DrawerHeader>
+          <div className="flex flex-col gap-2 overflow-y-auto px-4 pb-2">
+            <MobileBottomBarSlotTarget region="sheet" />
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+}

--- a/web/src/components/layouts/mobile-bottom-bar/MobileBottomBar.tsx
+++ b/web/src/components/layouts/mobile-bottom-bar/MobileBottomBar.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 import { ChevronUp } from "lucide-react";
 import { cva, type VariantProps } from "class-variance-authority";
 
@@ -9,6 +11,7 @@ import {
   DrawerTitle,
 } from "@/src/components/ui/drawer";
 import { Layer } from "@/src/components/ui/layer";
+import { useIsMobile } from "@/src/hooks/use-mobile";
 import { cn } from "@/src/utils/tailwind";
 import {
   MobileBottomBarSlotTarget,
@@ -58,8 +61,35 @@ export function MobileBottomBar({
   className,
 }: MobileBottomBarProps) {
   const ctx = useMobileBottomBar();
+  const isMobile = useIsMobile();
+  const router = useRouter();
+  const forceVisible = visibility === "always";
+  // useState setters are referentially stable, so this is a stable dep for the
+  // route-change effect below even though the surrounding context value object
+  // is not.
+  const setExpanded = ctx?.setExpanded;
+
+  // External system: Pages Router navigation. The provider lives in the
+  // persistent app shell, so without this the ~85svh sheet would stay open on
+  // the next page after a navigation (incl. a back-nav). Close it when a route
+  // change starts.
+  useEffect(() => {
+    const events = router.events;
+    const closeSheet = () => setExpanded?.(false);
+    events.on("routeChangeStart", closeSheet);
+    return () => events.off("routeChangeStart", closeSheet);
+  }, [router.events, setExpanded]);
+
   if (!ctx) return null;
-  const { expanded, setExpanded } = ctx;
+  const { expanded } = ctx;
+  // Gate the sheet to mobile. The collapsed pill is CSS-gated (`md:hidden`), but
+  // the vaul sheet is a portal that ignores that class — so without this a sheet
+  // opened on a small device and then rotated/resized across the `md` (768px)
+  // breakpoint would strand a full-width sheet over the desktop layout with no
+  // desktop control to close it. Folding `isMobile` into `open` auto-closes it
+  // the moment the viewport is desktop-width. `forceVisible` (Storybook) opts
+  // out so the Expanded story stays open at any canvas width.
+  const mobileActive = forceVisible || isMobile;
 
   return (
     <>
@@ -84,7 +114,7 @@ export function MobileBottomBar({
               className="rounded-full"
               aria-label="More actions"
               aria-expanded={expanded}
-              onClick={() => setExpanded(true)}
+              onClick={() => setExpanded?.(true)}
             >
               <ChevronUp className="h-5 w-5" />
             </Button>
@@ -97,7 +127,7 @@ export function MobileBottomBar({
           aria-modal; we only supply the content. h-auto lets it fit content up
           to a max, with the body scrolling past that. */}
       <Drawer
-        open={expanded}
+        open={expanded && mobileActive}
         onOpenChange={setExpanded}
         forceDirection="bottom"
       >

--- a/web/src/components/layouts/mobile-bottom-bar/MobileBottomBarDemoActions.tsx
+++ b/web/src/components/layouts/mobile-bottom-bar/MobileBottomBarDemoActions.tsx
@@ -1,0 +1,115 @@
+import { BotMessageSquare, ListFilter, RefreshCw, Clock } from "lucide-react";
+
+import { Button } from "@/src/components/ui/button";
+import {
+  MobileBottomBarPortal,
+  useMobileBottomBar,
+} from "@/src/components/layouts/mobile-bottom-bar/mobile-bottom-bar-context";
+import {
+  useCanUseInAppAgent,
+  useInAppAiAgent,
+} from "@/src/ee/features/in-app-agent/components/InAppAiAgentProvider";
+
+/**
+ * Demo action set for the LFE-11067 mobile bottom bar (decision surface).
+ *
+ * Wires the real in-app agent into the bar via the {@link MobileBottomBarPortal}
+ * seam (the "Ask AI" action opens the live assistant), alongside placeholder
+ * Filters / Time range / Refresh actions that stand in for the per-page controls
+ * a later slice will migrate here from the top bar. Mounted from the traces page;
+ * the whole thing is only ever visible below `md`, where the bar renders.
+ */
+export function MobileBottomBarDemoActions() {
+  const ctx = useMobileBottomBar();
+  const canUseAgent = useCanUseInAppAgent();
+  const { openAssistant } = useInAppAiAgent();
+
+  const openAgent = () => {
+    ctx?.setExpanded(false);
+    openAssistant("mobile_bottom_bar");
+  };
+
+  return (
+    <>
+      {/* Collapsed pill: 1-2 icon-first quick actions + the shell's expand
+          handle. "Ask AI" is live; "Filters" opens the sheet where the fuller
+          control set lives. */}
+      <MobileBottomBarPortal region="bar">
+        {canUseAgent ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="rounded-full"
+            aria-label="Ask Langfuse AI"
+            onClick={openAgent}
+          >
+            <BotMessageSquare className="h-5 w-5" />
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="rounded-full"
+          aria-label="Filters"
+          onClick={() => ctx?.setExpanded(true)}
+        >
+          <ListFilter className="h-5 w-5" />
+        </Button>
+      </MobileBottomBarPortal>
+
+      {/* Expanded sheet: the fuller, labelled action set. */}
+      <MobileBottomBarPortal region="sheet">
+        {canUseAgent ? (
+          <Button
+            type="button"
+            variant="default"
+            className="w-full justify-start gap-2"
+            onClick={openAgent}
+          >
+            <BotMessageSquare className="h-4 w-4" />
+            Ask Langfuse AI
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full justify-start gap-2"
+          onClick={() => {
+            /* placeholder — the per-table filter UI migrates here in a later slice */
+          }}
+        >
+          <ListFilter className="h-4 w-4" />
+          Filters
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full justify-start gap-2"
+          onClick={() => {
+            /* placeholder — time-range picker migrates here in a later slice */
+          }}
+        >
+          <Clock className="h-4 w-4" />
+          Time range
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full justify-start gap-2"
+          onClick={() => {
+            /* placeholder — refresh handler migrates here in a later slice */
+          }}
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </Button>
+        <p className="text-muted-foreground px-1 pt-1 text-xs">
+          Filters, time range and refresh are placeholders for this preview —
+          per-page controls move here in a later slice.
+        </p>
+      </MobileBottomBarPortal>
+    </>
+  );
+}

--- a/web/src/components/layouts/mobile-bottom-bar/MobileBottomBarDemoActions.tsx
+++ b/web/src/components/layouts/mobile-bottom-bar/MobileBottomBarDemoActions.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from "react";
 import { BotMessageSquare, ListFilter, RefreshCw, Clock } from "lucide-react";
 
 import { Button } from "@/src/components/ui/button";
@@ -59,7 +60,11 @@ export function MobileBottomBarDemoActions() {
         </Button>
       </MobileBottomBarPortal>
 
-      {/* Expanded sheet: the fuller, labelled action set. */}
+      {/* Expanded sheet: the fuller, labelled action set. "Ask AI" is live; the
+          rest are disabled placeholders for the per-page controls a later slice
+          migrates here — rendered as visibly `disabled` with a "Soon" badge so a
+          mobile user never taps a live-looking button that silently does
+          nothing. */}
       <MobileBottomBarPortal region="sheet">
         {canUseAgent ? (
           <Button
@@ -72,44 +77,41 @@ export function MobileBottomBarDemoActions() {
             Ask Langfuse AI
           </Button>
         ) : null}
-        <Button
-          type="button"
-          variant="outline"
-          className="w-full justify-start gap-2"
-          onClick={() => {
-            /* placeholder — the per-table filter UI migrates here in a later slice */
-          }}
-        >
-          <ListFilter className="h-4 w-4" />
+        <PlaceholderAction icon={<ListFilter className="h-4 w-4" />}>
           Filters
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          className="w-full justify-start gap-2"
-          onClick={() => {
-            /* placeholder — time-range picker migrates here in a later slice */
-          }}
-        >
-          <Clock className="h-4 w-4" />
+        </PlaceholderAction>
+        <PlaceholderAction icon={<Clock className="h-4 w-4" />}>
           Time range
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          className="w-full justify-start gap-2"
-          onClick={() => {
-            /* placeholder — refresh handler migrates here in a later slice */
-          }}
-        >
-          <RefreshCw className="h-4 w-4" />
+        </PlaceholderAction>
+        <PlaceholderAction icon={<RefreshCw className="h-4 w-4" />}>
           Refresh
-        </Button>
-        <p className="text-muted-foreground px-1 pt-1 text-xs">
-          Filters, time range and refresh are placeholders for this preview —
-          per-page controls move here in a later slice.
-        </p>
+        </PlaceholderAction>
       </MobileBottomBarPortal>
     </>
+  );
+}
+
+/** A not-yet-wired sheet action: visibly disabled with a "Soon" badge so it
+ * reads as upcoming rather than broken, and cannot be tapped to a no-op. */
+function PlaceholderAction({
+  icon,
+  children,
+}: {
+  icon: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      className="w-full justify-start gap-2"
+      disabled
+    >
+      {icon}
+      {children}
+      <span className="bg-muted text-muted-foreground ml-auto rounded-full px-2 py-0.5 text-xs">
+        Soon
+      </span>
+    </Button>
   );
 }

--- a/web/src/components/layouts/mobile-bottom-bar/index.ts
+++ b/web/src/components/layouts/mobile-bottom-bar/index.ts
@@ -1,0 +1,6 @@
+export { MobileBottomBar } from "@/src/components/layouts/mobile-bottom-bar/MobileBottomBar";
+export {
+  MobileBottomBarProvider,
+  MobileBottomBarPortal,
+  useMobileBottomBar,
+} from "@/src/components/layouts/mobile-bottom-bar/mobile-bottom-bar-context";

--- a/web/src/components/layouts/mobile-bottom-bar/mobile-bottom-bar-context.tsx
+++ b/web/src/components/layouts/mobile-bottom-bar/mobile-bottom-bar-context.tsx
@@ -1,0 +1,110 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Mobile bottom-bar seam — the app-shell-level home for per-page controls on
+ * mobile (below the `md` breakpoint), mirroring the header controls slot
+ * ({@link ../page-header-controls-slot}).
+ *
+ * The shell {@link MobileBottomBar} renders two slot targets and exposes them
+ * through this context. A page portals its own controls/actions into the bar
+ * from anywhere in its subtree via {@link MobileBottomBarPortal} — the state
+ * stays wherever it already lives (e.g. a table owns its filter handlers); only
+ * the rendered DOM moves into the shell bar. Two regions:
+ *
+ * - `"bar"`   — the always-visible collapsed pill. Use for 1-3 compact,
+ *   icon-first quick actions (the most important per-page affordances).
+ * - `"sheet"` — the expanded bottom sheet body. Use for the fuller,
+ *   labelled control set (filters, time range, refresh, page actions).
+ *
+ * The provider also owns the low-frequency expanded (open) state so the bar's
+ * expand handle and the sheet stay in sync and a page could open it
+ * programmatically later.
+ */
+type MobileBottomBarRegion = "bar" | "sheet";
+
+type MobileBottomBarContextValue = {
+  barSlot: HTMLDivElement | null;
+  setBarSlot: (node: HTMLDivElement | null) => void;
+  sheetSlot: HTMLDivElement | null;
+  setSheetSlot: (node: HTMLDivElement | null) => void;
+  expanded: boolean;
+  setExpanded: (open: boolean) => void;
+};
+
+const MobileBottomBarContext =
+  createContext<MobileBottomBarContextValue | null>(null);
+
+export function MobileBottomBarProvider({
+  children,
+  defaultExpanded = false,
+}: {
+  children: ReactNode;
+  /** Initial expanded state. Defaults to collapsed; stories pass `true`. */
+  defaultExpanded?: boolean;
+}) {
+  const [barSlot, setBarSlot] = useState<HTMLDivElement | null>(null);
+  const [sheetSlot, setSheetSlot] = useState<HTMLDivElement | null>(null);
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const value = useMemo(
+    () => ({
+      barSlot,
+      setBarSlot,
+      sheetSlot,
+      setSheetSlot,
+      expanded,
+      setExpanded,
+    }),
+    [barSlot, sheetSlot, expanded],
+  );
+  return (
+    <MobileBottomBarContext.Provider value={value}>
+      {children}
+    </MobileBottomBarContext.Provider>
+  );
+}
+
+export function useMobileBottomBar() {
+  return useContext(MobileBottomBarContext);
+}
+
+/**
+ * Rendered by {@link MobileBottomBar} for each region. Uses `display: contents`
+ * so the empty target adds no layout box; portaled children become direct
+ * children (flex items) of the surrounding cluster.
+ */
+export function MobileBottomBarSlotTarget({
+  region,
+}: {
+  region: MobileBottomBarRegion;
+}) {
+  const ctx = useContext(MobileBottomBarContext);
+  if (!ctx) return null;
+  const setSlot = region === "bar" ? ctx.setBarSlot : ctx.setSheetSlot;
+  return <div className="contents" ref={setSlot} />;
+}
+
+/**
+ * Portals its children into the mobile bottom bar. Renders nothing when there
+ * is no target yet — e.g. outside {@link MobileBottomBarProvider}, or, for the
+ * `"sheet"` region, while the sheet is collapsed (its target only exists in the
+ * DOM once the sheet is open).
+ */
+export function MobileBottomBarPortal({
+  region = "sheet",
+  children,
+}: {
+  region?: MobileBottomBarRegion;
+  children: ReactNode;
+}) {
+  const ctx = useContext(MobileBottomBarContext);
+  const slot = region === "bar" ? ctx?.barSlot : ctx?.sheetSlot;
+  if (!slot) return null;
+  return createPortal(children, slot);
+}

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -68,7 +68,8 @@ const EMPTY_MESSAGES: AgUiMessage[] = [];
 export type InAppAgentEntryPoint =
   | "top_nav"
   | "keyboard_shortcut"
-  | "dashboard_widget";
+  | "dashboard_widget"
+  | "mobile_bottom_bar";
 
 const MastraSuspendEventSchema = z.object({
   type: z.literal("mastra_suspend"),

--- a/web/src/pages/project/[projectId]/traces/index.tsx
+++ b/web/src/pages/project/[projectId]/traces/index.tsx
@@ -10,6 +10,7 @@ import {
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import ObservationsEventsTable from "@/src/features/events/components/EventsTable";
 import { useQueryProject } from "@/src/features/projects/hooks";
+import { MobileBottomBarDemoActions } from "@/src/components/layouts/mobile-bottom-bar/MobileBottomBarDemoActions";
 
 export default function Traces() {
   const router = useRouter();
@@ -87,6 +88,9 @@ export default function Traces() {
               },
       }}
     >
+      {/* LFE-11067 demo: portal page actions into the mobile bottom bar.
+          Renders nothing itself — only visible below `md`, inside the bar. */}
+      <MobileBottomBarDemoActions />
       {isInitializing ? (
         <>
           {/* Wait for the beta flag before mounting either table. Otherwise the


### PR DESCRIPTION
## TL;DR
Adds an **expandable mobile bottom action bar** — a compact floating pill pinned to the bottom of the viewport below `md` that expands into a bottom sheet. It's the app-shell home where per-page controls (in-app agent, filters, time range, refresh, page actions) will live on mobile. This PR ships the **shell + the reusable portal seam + a live demo on the traces page + Storybook**; the risky per-table filter-state migration is intentionally deferred to a later slice.

Part of the **LFE-11067 mobile interface revamp** epic (alongside the top-bar brand mark #15224 and the mobile hamburger #15232). The epic explicitly calls for "a pattern of bottom bar, we make it expandable, we move page-related actions like agent and filters there" — this is that pillar.

## Why
On mobile the sidebar collapses off-canvas and per-page controls (agent launcher, filters, time range) get cramped into the top bar. The bottom bar gives those actions a thumb-reachable, modern home and a single seam every page can plug into.

## What
- **`MobileBottomBar` shell** — collapsed = a safe-area-aware floating pill; its expand handle opens a bottom sheet built on the shared `vaul` `Drawer`. Rendered only below `md` via a **CSS breakpoint** (no `useIsMobile` → no hydration flash). Both surfaces portal through the **`panel` overlay layer** (pill via `<Layer>`, sheet via the Drawer's layer-routed portal) — no raw z-index.
- **Portal seam** mirroring `page-header-controls-slot`: a page-scoped provider + two typed slot targets — `"bar"` (compact quick actions) and `"sheet"` (fuller labelled controls). Any page portals its own controls in via `MobileBottomBarPortal`; state stays where it already lives.
- **Mounted in `AuthenticatedLayout` only** (the sole layout with a real sidebar), inside the existing `SidebarPresenceProvider` tree. Not on Minimal/Unauthenticated layouts.
- **Live demo on the traces page** — the real in-app agent ("Ask AI") wired through the seam, plus placeholder Filters / Time range / Refresh actions that stand in for the controls a later slice migrates here.
- **Storybook** stories (collapsed, expanded, no-actions) so the states are viewable without the full app.

## Result
Typecheck + lint clean; all three stories render (collapsed pill, expanded sheet) in both light and dark themes, verified in Storybook via Playwright.

<details>
<summary>Design, mechanism, verification & open questions</summary>

### Architecture
- **Effect-free / one-way data flow.** The provider owns two slot refs (set via ref callbacks) + low-frequency expanded state; no `useEffect` to derive or sync anything. Portaling reuses the proven `createPortal`-into-a-registered-node pattern from `page-header-controls-slot`.
- **New primitive, kept clean.** `MobileBottomBar` uses `cva` + `cn`, theme tokens (`bg-background`, `border-border-contrast`, `bg-muted`), and the shared `Button`/`Drawer`. A `visibility` variant (`responsive` | `always`) lets Storybook force it on at any width while the app stays mobile-gated.
- **Safe area:** `pb-[max(0.75rem,env(safe-area-inset-bottom))]` on both the pill wrapper and the sheet.
- **Accessibility:** the expand handle carries `aria-label` + `aria-expanded`; the sheet is a `vaul` Drawer (focus trap / Escape / `aria-modal`) with a visible `DrawerTitle`. Pill buttons expose accessible names ("Ask AI", "Filters", "More actions").
- One-line, semantically-correct addition of a `"mobile_bottom_bar"` in-app-agent entry point for analytics attribution.

### Verification
- `pnpm --filter web run typecheck` — zero errors in touched files (the repo's local full typecheck has a pre-existing baseline of unrelated errors in `scores`/`slack`/`*.clienttest`/prisma-generated drift, present on `main`).
- `pnpm turbo run lint --filter=web` — `Tasks: 4 successful, 4 total`, zero warnings.
- Storybook + Playwright at a mobile viewport: collapsed pill and expanded sheet render correctly in light **and** dark.

### Explicitly out of scope (later slices)
- Migrating real per-table filter state into the bar (riskiest; separate PR).
- Removing controls from the top bar; any desktop change.

### Open design questions
- **Collapsed contents:** which 1–3 quick actions belong in the pill by default (agent only? agent + filters?), and should the pill hide entirely on pages that register no actions (today it shows just the expand handle)?
- **Snap heights:** sheet is `h-auto` up to `max-h-[85svh]` — do we want fixed vaul snap points instead?
- **Content padding:** the pill is a fixed overlay; a later slice may add bottom padding so it never covers the last row of scrolled content.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces an expandable mobile bottom action bar — a floating pill pinned to the bottom viewport edge (below `md`) that opens into a `vaul` bottom sheet. It ships the shell, a context/portal seam mirroring `page-header-controls-slot`, and a live demo wired to the in-app agent on the traces page.

- **`MobileBottomBarProvider` + `MobileBottomBarPortal`** — a ref-based portal seam with two typed regions (`"bar"` for the collapsed pill, `"sheet"` for the expanded drawer body); pages portal their own controls without lifting state.
- **`MobileBottomBar`** — CSS-breakpoint-gated (`md:hidden`, no `useIsMobile` JS hook) chrome component that routes both surfaces through the `panel` overlay layer to avoid raw z-index.
- **`MobileBottomBarDemoActions`** — a demo component mounted on the traces page that wires the live AI agent and ships Filters / Time range / Refresh as acknowledged placeholder no-ops; the per-table filter migration is explicitly deferred to a later slice.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The new shell, context/portal seam, and layout wiring are sound — the bar is CSS-gated to mobile, provider placement correctly covers both the page tree and the bar itself, and the pattern mirrors the existing header-controls slot.

The architecture is clean and the Storybook verification matches the described behavior. The non-functional placeholder buttons visible on the traces page produce no response when tapped, with the only explanation being small disclaimer text at the bottom of the sheet. The missing `aria-controls` on the expand handle is a minor accessibility gap. Neither concern blocks the PR, but the placeholder UX is worth addressing before this pattern is copied to additional pages.

MobileBottomBarDemoActions.tsx — the no-op Filters/Time range/Refresh buttons are the only thing that ships a potentially confusing experience to real users in this diff.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Page as Traces Page
    participant Provider as MobileBottomBarProvider
    participant Bar as MobileBottomBar (pill)
    participant Sheet as Drawer (sheet)
    participant Portal as MobileBottomBarPortal

    Note over Provider: expanded=false, barSlot=null, sheetSlot=null

    Provider->>Bar: renders (inside provider)
    Bar->>Provider: SlotTarget "bar" mounts → setBarSlot(node)
    Note over Provider: barSlot = DOM node

    Page->>Portal: "MobileBottomBarPortal region="bar""
    Portal->>Provider: "ctx.barSlot != null"
    Portal->>Bar: createPortal(children, barSlot)
    Note over Bar: pill shows AI + Filters buttons

    Note over Sheet: DrawerContent not yet in DOM (open=false)
    Page->>Portal: "MobileBottomBarPortal region="sheet""
    Portal->>Provider: "ctx.sheetSlot == null → returns null"
    Note over Page: sheet portal silently inactive

    Bar->>Provider: user taps expand → setExpanded(true)
    Provider->>Sheet: "Drawer open=true → DrawerContent mounts"
    Sheet->>Provider: SlotTarget "sheet" mounts → setSheetSlot(node)
    Note over Provider: sheetSlot = DOM node

    Page->>Portal: "MobileBottomBarPortal region="sheet" re-renders"
    Portal->>Sheet: createPortal(children, sheetSlot)
    Note over Sheet: sheet shows AI / Filters / Time range / Refresh

    Bar->>Provider: user taps "Ask AI" → setExpanded(false), openAssistant()
    Provider->>Sheet: "Drawer open=false → DrawerContent animates out"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Page as Traces Page
    participant Provider as MobileBottomBarProvider
    participant Bar as MobileBottomBar (pill)
    participant Sheet as Drawer (sheet)
    participant Portal as MobileBottomBarPortal

    Note over Provider: expanded=false, barSlot=null, sheetSlot=null

    Provider->>Bar: renders (inside provider)
    Bar->>Provider: SlotTarget "bar" mounts → setBarSlot(node)
    Note over Provider: barSlot = DOM node

    Page->>Portal: "MobileBottomBarPortal region="bar""
    Portal->>Provider: "ctx.barSlot != null"
    Portal->>Bar: createPortal(children, barSlot)
    Note over Bar: pill shows AI + Filters buttons

    Note over Sheet: DrawerContent not yet in DOM (open=false)
    Page->>Portal: "MobileBottomBarPortal region="sheet""
    Portal->>Provider: "ctx.sheetSlot == null → returns null"
    Note over Page: sheet portal silently inactive

    Bar->>Provider: user taps expand → setExpanded(true)
    Provider->>Sheet: "Drawer open=true → DrawerContent mounts"
    Sheet->>Provider: SlotTarget "sheet" mounts → setSheetSlot(node)
    Note over Provider: sheetSlot = DOM node

    Page->>Portal: "MobileBottomBarPortal region="sheet" re-renders"
    Portal->>Sheet: createPortal(children, sheetSlot)
    Note over Sheet: sheet shows AI / Filters / Time range / Refresh

    Bar->>Provider: user taps "Ask AI" → setExpanded(false), openAssistant()
    Provider->>Sheet: "Drawer open=false → DrawerContent animates out"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/layouts/mobile-bottom-bar/MobileBottomBarDemoActions.tsx:75-113
**Placeholder buttons ship silently non-functional to production**

The Filters, Time range, and Refresh buttons are rendered on the live traces page for every mobile user, but their `onClick` handlers are no-ops. The only hint is a disclaimer in small `text-xs` text at the very bottom of the sheet — only visible after a user has already opened the sheet and tapped one of these buttons. A mobile user who taps "Filters" and gets zero response has no feedback explaining why. Consider disabling these three buttons (`disabled` prop) or rendering them with a visual "coming soon" affordance so the no-op is communicated at interaction time, not via a prose footnote they may never read.

### Issue 2 of 2
web/src/components/layouts/mobile-bottom-bar/MobileBottomBar.tsx:80-91
**`aria-controls` missing on expand handle**

The expand button correctly carries `aria-expanded` to signal its toggle state, but without `aria-controls` pointing to the drawer region's ID, the button-to-content relationship is incomplete for assistive technology. Screen readers can announce that something is expanded without knowing *what* is being expanded. Adding `aria-controls="mobile-bottom-bar-sheet"` (and a matching `id` on the `DrawerContent`) would complete the ARIA pattern for `aria-haspopup`/`aria-expanded` toggle buttons.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(layouts): expandable mobile bottom ..."](https://github.com/langfuse/langfuse/commit/2457dc598e9326e76cccb4269f01415f87676642) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45671314)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->