### PR TITLE
fix(api-keys): Close modal when clicking backdrop

### DIFF
--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -78,12 +78,15 @@ const dialogContentVariants = cva(
 
 const DialogContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
-    closeOnInteractionOutside?: boolean;
-    confirmCloseOnEscape?: string;
-    overlayMode?: DialogOverlayMode;
-    stopPropagationOnEnterSpace?: boolean;
-  } & VariantProps<typeof dialogContentVariants>
+  Omit<
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+      closeOnInteractionOutside?: boolean;
+      confirmCloseOnEscape?: string;
+      overlayMode?: DialogOverlayMode;
+      stopPropagationOnEnterSpace?: boolean;
+    } & VariantProps<typeof dialogContentVariants>,
+    "onPointerDownOutside" | "onInteractOutside"
+  >
 >(
   (
     {

--- a/web/src/features/prompts/components/PromptVersionDiffDialog.tsx
+++ b/web/src/features/prompts/components/PromptVersionDiffDialog.tsx
@@ -87,10 +87,7 @@ export const PromptVersionDiffDialog: React.FC<PromptVersionDiffDialogProps> = (
         size="xl"
         // prevent event bubbling up and triggering the row's click handler
         onClick={(event) => event.stopPropagation()}
-        onPointerDownOutside={(e) => {
-          setIsOpen(false);
-          e.stopPropagation();
-        }}
+        closeOnInteractionOutside
       >
         <DialogHeader>
           <DialogTitle>

--- a/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
+++ b/web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx
@@ -38,7 +38,7 @@ export function ApiKeyCreateDialogContent(
     const { secretKey, publicKey, baseUrl } = props;
 
     return (
-      <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
+      <DialogContent closeOnInteractionOutside>
         <DialogHeader>
           <DialogTitle>API Keys</DialogTitle>
         </DialogHeader>
@@ -58,7 +58,7 @@ export function ApiKeyCreateDialogContent(
   const { note, onNoteChange, onSubmit, isPending } = props;
 
   return (
-    <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
+    <DialogContent closeOnInteractionOutside>
       <DialogHeader>
         <DialogTitle>Create API Keys</DialogTitle>
       </DialogHeader>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralises outside-interaction handling in the shared `DialogContent` component by introducing a `closeOnInteractionOutside` boolean prop and omitting `onPointerDownOutside`/`onInteractOutside` from the public prop surface. Callers are migrated from ad-hoc event handlers to the new flag.

- **`dialog.tsx`**: Hardcodes both Radix outside-interaction handlers internally; when `closeOnInteractionOutside` is `false` (default) they call `e.preventDefault()`, otherwise they are no-ops and Radix closes the dialog naturally.
- **`PromptVersionDiffDialog.tsx`**: Correctly replaced the manual `setIsOpen(false)` callback with `closeOnInteractionOutside`; parent state stays in sync via `onOpenChange`.
- **`ApiKeyCreateDialogContent.tsx`**: Both the `form` and `detail` views now close on backdrop click — the `detail` branch shows a one-time-only secret key, so enabling backdrop dismiss risks unrecoverable key loss on an accidental click outside the modal.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for the prompt diff and dialog infrastructure changes, but the API key detail view now closes on backdrop click, making the one-time secret key unrecoverable on an accidental dismiss.

The `dialog.tsx` and `PromptVersionDiffDialog` changes are clean and functionally equivalent. The concern is in `ApiKeyCreateDialogContent`: the `detail` branch, which renders the newly generated secret key that can only be seen once, now allows the user to accidentally close it with a backdrop click — permanently losing access to the key without being warned. The original `e.preventDefault()` on that branch was deliberate safety behaviour, and it appears to have been removed as a side effect of the uniform migration rather than as an intentional UX decision.

web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx — specifically the `detail` branch around line 37–55
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Backdrop as Backdrop (DialogOverlay)
    participant Radix as Radix DialogPrimitive
    participant DialogContent

    Note over DialogContent: closeOnInteractionOutside = false (default)
    User->>Backdrop: pointer down
    Backdrop->>Radix: onPointerDownOutside fires
    Radix->>DialogContent: onPointerDownOutside handler
    DialogContent->>Radix: e.preventDefault()
    Note over Radix: Dialog stays open

    Note over DialogContent: closeOnInteractionOutside = true
    User->>Backdrop: pointer down
    Backdrop->>Radix: onPointerDownOutside fires
    Radix->>DialogContent: onPointerDownOutside handler (no-op)
    Radix-->>DialogContent: closes dialog (default behavior)
    Radix-->>User: onOpenChange(false) called
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Backdrop as Backdrop (DialogOverlay)
    participant Radix as Radix DialogPrimitive
    participant DialogContent

    Note over DialogContent: closeOnInteractionOutside = false (default)
    User->>Backdrop: pointer down
    Backdrop->>Radix: onPointerDownOutside fires
    Radix->>DialogContent: onPointerDownOutside handler
    DialogContent->>Radix: e.preventDefault()
    Note over Radix: Dialog stays open

    Note over DialogContent: closeOnInteractionOutside = true
    User->>Backdrop: pointer down
    Backdrop->>Radix: onPointerDownOutside fires
    Radix->>DialogContent: onPointerDownOutside handler (no-op)
    Radix-->>DialogContent: closes dialog (default behavior)
    Radix-->>User: onOpenChange(false) called
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/public-api/components/ApiKeyCreateDialogContent.tsx:37-55
**Secret key lost on accidental backdrop click**

The `detail` view renders the newly generated secret API key, which is only displayed once. With `closeOnInteractionOutside` now enabled, a click anywhere on the backdrop will silently close the dialog — if the user hasn't yet copied the secret key, it is unrecoverable without deleting the key and recreating it. The old `onPointerDownOutside={(e) => e.preventDefault()}` was intentional protection against exactly this scenario. The `form` view (line 61) is fine to close on outside click, but the `detail` branch warrants keeping the backdrop-close prevention or adding a confirmation step.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Clean up \`DialogContent\` props"](https://github.com/langfuse/langfuse/commit/53ec90491e678a34949d711fb64e40baf35ed742) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45674516)</sub>

<!-- /greptile_comment -->