### PR TITLE
fix(observability): filter known-benign client noise before Sentry capture (LFE-10976)

### DIFF
--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -1,5 +1,8 @@
 import * as Sentry from "@sentry/nextjs";
-import { isNoisyHttpClientPollEvent } from "@/src/utils/sentryFilters";
+import {
+  isDenylistedNoiseEvent,
+  isNoisyHttpClientPollEvent,
+} from "@/src/utils/sentryFilters";
 
 const isEuOrUsRegionNonHipaa =
   process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined
@@ -38,6 +41,17 @@ Sentry.init({
     // session outage is still observable server-side via request tracing/APM
     // spans and application logs.
     if (isNoisyHttpClientPollEvent(event)) {
+      return null;
+    }
+
+    // Drop known-benign client-side noise: browser/transport failures (offline,
+    // flaky network, CORS, proxy/infra HTML error pages), transient
+    // framework/vendor poll logs (NextAuth CLIENT_FETCH_ERROR, PostHog notices),
+    // and expected browser artifacts (clipboard permission denials, intentional
+    // request cancellations). Each signature is narrow and cannot represent a
+    // real Langfuse app bug; real errors that merely quote a phrase still flow
+    // to Sentry. See isDenylistedNoiseEvent for the per-rule rationale.
+    if (isDenylistedNoiseEvent(event)) {
       return null;
     }
 

--- a/web/src/utils/sentryFilters.clienttest.ts
+++ b/web/src/utils/sentryFilters.clienttest.ts
@@ -217,6 +217,22 @@ describe("isDenylistedNoiseEvent", () => {
       );
     });
 
+    it("drops Chrome 'Failed to fetch (hostname)' (trailing parenthetical)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("Failed to fetch (cloud.langfuse.com)"),
+        ),
+      ).toBe(true);
+      // also when wrapped by TRPCClientError
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "TRPCClientError: Failed to fetch (cloud.langfuse.com)",
+          ),
+        ),
+      ).toBe(true);
+    });
+
     it("drops Firefox 'NetworkError when attempting to fetch resource' (with trailing period)", () => {
       expect(
         isDenylistedNoiseEvent(
@@ -308,8 +324,8 @@ describe("isDenylistedNoiseEvent", () => {
       ).toBe(true);
     });
 
-    // PostHog and the Next.js artifact also arrive as MESSAGE events (string
-    // console.error), so assert against that production shape.
+    // PostHog logs a string via console.error, so it arrives as a MESSAGE event
+    // (captureConsoleIntegration) — assert against that production shape.
     it("drops a third-party [PostHog.js] notice (message event)", () => {
       expect(
         isDenylistedNoiseEvent(
@@ -318,12 +334,17 @@ describe("isDenylistedNoiseEvent", () => {
       ).toBe(true);
     });
 
-    it("drops the Next.js '_error.js called with falsy error' artifact (message event)", () => {
+    it("drops the @sentry/nextjs '_error.js called with falsy error (…)' artifact", () => {
+      // Real shape: captureException(`_error.js called with falsy error (${err})`)
+      // → exception event whose value STARTS with the prefix.
       expect(
         isDenylistedNoiseEvent(
-          messageEvent(
-            "The default export is not a React Component in page: /_error.js called with falsy error",
-          ),
+          exceptionEvent("_error.js called with falsy error (undefined)"),
+        ),
+      ).toBe(true);
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("_error.js called with falsy error (null)"),
         ),
       ).toBe(true);
     });
@@ -384,6 +405,14 @@ describe("isDenylistedNoiseEvent", () => {
       expect(
         isDenylistedNoiseEvent(
           exceptionEvent("Load failed for dataset export job 42"),
+        ),
+      ).toBe(false);
+      // Ends in a parenthetical, but the non-parenthetical part is longer than a
+      // bare transport phrase, so stripping the trailing `(…)` still leaves a
+      // non-matching whole message — must survive.
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("Failed to fetch traces (batch 3 of 5)"),
         ),
       ).toBe(false);
     });

--- a/web/src/utils/sentryFilters.clienttest.ts
+++ b/web/src/utils/sentryFilters.clienttest.ts
@@ -193,6 +193,22 @@ function exceptionEvent(value: string, type = "Error"): ErrorEvent {
   } as ErrorEvent;
 }
 
+/**
+ * Build the shape `captureConsoleIntegration` produces for a string
+ * `console.error(...)` with `attachStacktrace` unset (the default): a MESSAGE
+ * event with `event.message` and NO `event.exception`. This is how the biggest
+ * console-origin families (NextAuth CLIENT_FETCH_ERROR, PostHog notices, the
+ * Next.js `_error.js` artifact) actually reach `beforeSend` in production.
+ */
+function messageEvent(message: string): ErrorEvent {
+  return { message } as ErrorEvent;
+}
+
+/** Same, but the text lives on `event.logentry.message` (defensive fallback). */
+function logentryEvent(message: string): ErrorEvent {
+  return { logentry: { message } } as ErrorEvent;
+}
+
 describe("isDenylistedNoiseEvent", () => {
   describe("A. drops browser/transport failures (whole-message match)", () => {
     it("drops Chrome 'Failed to fetch'", () => {
@@ -244,11 +260,23 @@ describe("isDenylistedNoiseEvent", () => {
   });
 
   describe("B. drops NextAuth session-poll CLIENT_FETCH_ERROR", () => {
-    it("drops the [next-auth][error][CLIENT_FETCH_ERROR] log", () => {
+    // NextAuth logs a STRING via console.error, so this arrives as a MESSAGE
+    // event (no exception) — the shape captureConsoleIntegration produces.
+    it("drops the [next-auth][error][CLIENT_FETCH_ERROR] log (message event)", () => {
       expect(
         isDenylistedNoiseEvent(
-          exceptionEvent(
+          messageEvent(
             "[next-auth][error][CLIENT_FETCH_ERROR] https://cloud.langfuse.com/api/auth/session Failed to fetch",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops it when the text lives on event.logentry.message", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          logentryEvent(
+            "[next-auth][error][CLIENT_FETCH_ERROR] https://cloud.langfuse.com/api/auth/session Load failed",
           ),
         ),
       ).toBe(true);
@@ -280,19 +308,39 @@ describe("isDenylistedNoiseEvent", () => {
       ).toBe(true);
     });
 
-    it("drops a third-party [PostHog.js] notice", () => {
+    // PostHog and the Next.js artifact also arrive as MESSAGE events (string
+    // console.error), so assert against that production shape.
+    it("drops a third-party [PostHog.js] notice (message event)", () => {
       expect(
         isDenylistedNoiseEvent(
-          exceptionEvent("[PostHog.js] was already loaded elsewhere."),
+          messageEvent("[PostHog.js] was already loaded elsewhere."),
         ),
       ).toBe(true);
     });
 
-    it("drops the Next.js '_error.js called with falsy error' artifact", () => {
+    it("drops the Next.js '_error.js called with falsy error' artifact (message event)", () => {
       expect(
         isDenylistedNoiseEvent(
-          exceptionEvent(
+          messageEvent(
             "The default export is not a React Component in page: /_error.js called with falsy error",
+          ),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("A. transport failures also drop when they arrive as message events", () => {
+    it("drops a message-event 'Failed to fetch'", () => {
+      expect(isDenylistedNoiseEvent(messageEvent("Failed to fetch"))).toBe(
+        true,
+      );
+    });
+
+    it("drops a message-event HTML-parsed-as-JSON error", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          messageEvent(
+            `Unexpected token '<', "<html>\n<head>"... is not valid JSON`,
           ),
         ),
       ).toBe(true);
@@ -410,7 +458,27 @@ describe("isDenylistedNoiseEvent", () => {
     it("keeps a different next-auth error (only CLIENT_FETCH_ERROR is dropped)", () => {
       expect(
         isDenylistedNoiseEvent(
-          exceptionEvent("[next-auth][error][SIGNIN_OAUTH_ERROR] boom"),
+          messageEvent("[next-auth][error][SIGNIN_OAUTH_ERROR] boom"),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps a phrase-quoting app error delivered as a MESSAGE event", () => {
+      // Same safety contract on the message-event path: whole-message equality
+      // means a longer app message is not caught even without an exception.
+      expect(
+        isDenylistedNoiseEvent(messageEvent("Failed to fetch created model")),
+      ).toBe(false);
+    });
+
+    it("keeps the generic prod error-boundary string as a MESSAGE event (still excluded)", () => {
+      // captureConsoleIntegration delivers this 1MY string as a message event;
+      // it must survive on that path too, not just the exception path.
+      expect(
+        isDenylistedNoiseEvent(
+          messageEvent(
+            "A client-side exception has occurred while loading cloud.langfuse.com, see the browser console for more information.",
+          ),
         ),
       ).toBe(false);
     });

--- a/web/src/utils/sentryFilters.clienttest.ts
+++ b/web/src/utils/sentryFilters.clienttest.ts
@@ -1,6 +1,9 @@
 import { type ErrorEvent } from "@sentry/nextjs";
 
-import { isNoisyHttpClientPollEvent } from "@/src/utils/sentryFilters";
+import {
+  isDenylistedNoiseEvent,
+  isNoisyHttpClientPollEvent,
+} from "@/src/utils/sentryFilters";
 
 /**
  * Build an event shaped exactly like the ones `httpClientIntegration` emits:
@@ -174,6 +177,263 @@ describe("isNoisyHttpClientPollEvent", () => {
         },
       } as ErrorEvent;
       expect(isNoisyHttpClientPollEvent(event)).toBe(false);
+    });
+  });
+});
+
+/**
+ * Build an event carrying a single exception value (type + value), the shape
+ * `captureConsoleIntegration` / global error handlers emit.
+ */
+function exceptionEvent(value: string, type = "Error"): ErrorEvent {
+  return {
+    exception: {
+      values: [{ type, value, mechanism: { type: "generic", handled: false } }],
+    },
+  } as ErrorEvent;
+}
+
+describe("isDenylistedNoiseEvent", () => {
+  describe("A. drops browser/transport failures (whole-message match)", () => {
+    it("drops Chrome 'Failed to fetch'", () => {
+      expect(isDenylistedNoiseEvent(exceptionEvent("Failed to fetch"))).toBe(
+        true,
+      );
+    });
+
+    it("drops Firefox 'NetworkError when attempting to fetch resource' (with trailing period)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("NetworkError when attempting to fetch resource."),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops Safari/WebKit 'Load failed'", () => {
+      expect(isDenylistedNoiseEvent(exceptionEvent("Load failed"))).toBe(true);
+    });
+
+    it("drops the transport failure when wrapped by TRPCClientError", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("TRPCClientError: Failed to fetch"),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops Response.json() on a non-JSON body", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "Failed to execute 'json' on 'Response': Unexpected end of JSON input",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops an HTML error page parsed as JSON (json-parse signature + <html)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            `Unexpected token '<', "<html>\n<head>"... is not valid JSON`,
+            "SyntaxError",
+          ),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("B. drops NextAuth session-poll CLIENT_FETCH_ERROR", () => {
+    it("drops the [next-auth][error][CLIENT_FETCH_ERROR] log", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "[next-auth][error][CLIENT_FETCH_ERROR] https://cloud.langfuse.com/api/auth/session Failed to fetch",
+          ),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("C. drops expected browser-benign / vendor artifacts", () => {
+    it("drops a clipboard permission denial (NotAllowedError + writeText)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "Failed to execute 'writeText' on 'Clipboard': Write permission denied.",
+            "NotAllowedError",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops an intentional request cancellation (AbortError)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("signal is aborted without reason", "AbortError"),
+        ),
+      ).toBe(true);
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("The operation was aborted.", "AbortError"),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops a third-party [PostHog.js] notice", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("[PostHog.js] was already loaded elsewhere."),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops the Next.js '_error.js called with falsy error' artifact", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "The default export is not a React Component in page: /_error.js called with falsy error",
+          ),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  // The heart of the safety contract: prove that real / similar-looking errors
+  // are NOT dropped. If any of these regress to `true`, a real bug would be
+  // hidden from Sentry.
+  describe("KEEPS real errors (never masks a genuine app error)", () => {
+    it("keeps a real tRPC error carrying the server's message", () => {
+      expect(
+        isDenylistedNoiseEvent(exceptionEvent("TRPCClientError: UNAUTHORIZED")),
+      ).toBe(false);
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "TRPCClientError: You are not a member of this organization",
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps an app error that merely QUOTES a transport phrase", () => {
+      // Real messages seen in the codebase — must survive.
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "Failed to fetch created model",
+            "InvalidRequestError",
+          ),
+        ),
+      ).toBe(false);
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "Failed to fetch channels. Please check your Slack connection and try again.",
+          ),
+        ),
+      ).toBe(false);
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("Load failed for dataset export job 42"),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps a genuine SyntaxError with no <html (not an HTML-as-JSON artifact)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("Unexpected end of JSON input", "SyntaxError"),
+        ),
+      ).toBe(false);
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            `Unexpected token 'x', "xyz" is not valid JSON`,
+            "SyntaxError",
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps the chunk-load / stale-deploy SyntaxError (handled separately, not dropped)", () => {
+      // Script parsing an HTML page: has `Unexpected token '<'` and `<html` but
+      // NOT the JSON-parse `is not valid JSON` suffix, so A5 must not catch it.
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "Unexpected token '<'\n<html><body>502 Bad Gateway</body></html>",
+            "SyntaxError",
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps a real thrown TypeError", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "Cannot read properties of undefined (reading 'map')",
+            "TypeError",
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps a non-clipboard NotAllowedError (autoplay/fullscreen)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "play() failed because the user didn't interact with the document first",
+            "NotAllowedError",
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps the generic prod error-boundary string (LANGFUSE-1MY, deliberately not dropped)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "A client-side exception has occurred while loading cloud.langfuse.com, see the browser console for more information.",
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps an OAuthCallback sign-in error (deliberately not dropped)", () => {
+      expect(
+        isDenylistedNoiseEvent(exceptionEvent("OAuthCallback error", "Error")),
+      ).toBe(false);
+    });
+
+    it("keeps a different next-auth error (only CLIENT_FETCH_ERROR is dropped)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("[next-auth][error][SIGNIN_OAUTH_ERROR] boom"),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps auth/permission and query-timeout errors (routed to UX, not dropped)", () => {
+      expect(isDenylistedNoiseEvent(exceptionEvent("UNAUTHORIZED"))).toBe(
+        false,
+      );
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent("Query could not be completed within the time limit"),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps an event with no exception values", () => {
+      expect(
+        isDenylistedNoiseEvent({ message: "some message" } as ErrorEvent),
+      ).toBe(false);
+    });
+
+    it("keeps an event with an empty exception value", () => {
+      expect(isDenylistedNoiseEvent(exceptionEvent(""))).toBe(false);
     });
   });
 });

--- a/web/src/utils/sentryFilters.ts
+++ b/web/src/utils/sentryFilters.ts
@@ -108,6 +108,11 @@ const NOISE_MESSAGE_PREFIXES: readonly string[] = [
   // JSON was expected). This is the response not being ours-as-JSON, i.e. a
   // transport/infra artifact, not app logic.
   "Failed to execute 'json' on 'Response'",
+  // `@sentry/nextjs`'s own pages-router `_error` instrumentation calls
+  // `captureException(err || `_error.js called with falsy error (${err})`)`, so
+  // the fallback message always STARTS with this literal (`(undefined)`,
+  // `(null)`, ...). It is a framework artifact with no real error attached.
+  "_error.js called with falsy error",
 ];
 
 /**
@@ -123,9 +128,19 @@ function coreMessage(value: string): string {
   const withoutWrapper = value.startsWith(TRPC_CLIENT_ERROR_PREFIX)
     ? value.slice(TRPC_CLIENT_ERROR_PREFIX.length)
     : value;
-  // Normalize a single trailing period (Firefox appends one to its transport
-  // message) so the whole-message comparison stays exact but engine-agnostic.
-  return withoutWrapper.trim().replace(/\.$/, "");
+  // Strip engine-specific decorations so the whole-message comparison stays
+  // exact yet engine-agnostic:
+  //  - a trailing ` (host)` parenthetical Chrome appends, e.g.
+  //    `Failed to fetch (cloud.langfuse.com)` -> `Failed to fetch`;
+  //  - a single trailing period Firefox appends to its transport message.
+  // Only a WHOLE trailing parenthetical/period is removed, so a real app error
+  // that merely quotes a phrase (`Failed to fetch created model`) is untouched
+  // and still fails the exact-equality match.
+  return withoutWrapper
+    .trim()
+    .replace(/\s*\([^()]*\)$/, "")
+    .replace(/\.$/, "")
+    .trim();
 }
 
 /**
@@ -180,7 +195,9 @@ export function isDenylistedNoiseEvent(event: ErrorEvent): boolean {
     // --- A. Transport / connectivity (whole-message match after unwrapping) ---
     if (TRANSPORT_FAILURE_MESSAGES.includes(core)) return true;
 
-    // --- A + B + C(vendor). Unambiguous framework/vendor/transport prefixes. ---
+    // --- A + B + C. Unambiguous framework/vendor/transport prefixes (incl.
+    // NextAuth, PostHog, non-JSON Response.json(), and the Next.js `_error.js`
+    // falsy-error artifact). Anchored with startsWith, never a loose includes. ---
     if (NOISE_MESSAGE_PREFIXES.some((prefix) => core.startsWith(prefix))) {
       return true;
     }
@@ -197,9 +214,6 @@ export function isDenylistedNoiseEvent(event: ErrorEvent): boolean {
     ) {
       return true;
     }
-
-    // --- C. Next.js internal artifact: error boundary handed a falsy error. ---
-    if (messageText.includes("_error.js called with falsy error")) return true;
   }
 
   // --- C. `type`-guarded rules — exception events only (message events carry

--- a/web/src/utils/sentryFilters.ts
+++ b/web/src/utils/sentryFilters.ts
@@ -141,6 +141,14 @@ function coreMessage(value: string): string {
  * signature is left out. Real outages behind these client amplifications remain
  * observable server-side (request tracing / logs).
  *
+ * Event shape: message-signature rules are checked against the exception value
+ * AND the message-event fields (`event.message` / `event.logentry.message`),
+ * because console-origin noise (NextAuth `CLIENT_FETCH_ERROR`, PostHog notices,
+ * the Next.js `_error.js` artifact) is captured by `captureConsoleIntegration`
+ * as a MESSAGE event with NO `event.exception` (no stacktrace is attached by
+ * default). The `type`-guarded rules stay exception-only — message events carry
+ * no exception `type`, and those artifacts always arrive as thrown exceptions.
+ *
  * DELIBERATELY NOT dropped here (needs separate, verified handling — do not add
  * without confirming the real error is still captured elsewhere):
  *  - the generic prod error-boundary string `A client-side exception has
@@ -154,53 +162,69 @@ function coreMessage(value: string): string {
  */
 export function isDenylistedNoiseEvent(event: ErrorEvent): boolean {
   const exception = event.exception?.values?.[0];
-  const value = exception?.value;
-  if (typeof value !== "string" || value.length === 0) return false;
-  const type = exception?.type;
+  const exceptionType = exception?.type;
+  const exceptionValue = exception?.value;
+  const hasExceptionValue =
+    typeof exceptionValue === "string" && exceptionValue.length > 0;
 
-  // --- A. Transport / connectivity (whole-message match after unwrapping) ---
-  const core = coreMessage(value);
-  if (TRANSPORT_FAILURE_MESSAGES.includes(core)) return true;
+  // The message-signature rules run against the exception value when present,
+  // otherwise the message-event text (console-origin noise has no exception).
+  const messageText =
+    (hasExceptionValue ? exceptionValue : undefined) ??
+    event.message ??
+    event.logentry?.message;
 
-  // --- A + B + C(vendor). Unambiguous framework/vendor/transport prefixes. ---
-  if (NOISE_MESSAGE_PREFIXES.some((prefix) => core.startsWith(prefix))) {
-    return true;
+  if (typeof messageText === "string" && messageText.length > 0) {
+    const core = coreMessage(messageText);
+
+    // --- A. Transport / connectivity (whole-message match after unwrapping) ---
+    if (TRANSPORT_FAILURE_MESSAGES.includes(core)) return true;
+
+    // --- A + B + C(vendor). Unambiguous framework/vendor/transport prefixes. ---
+    if (NOISE_MESSAGE_PREFIXES.some((prefix) => core.startsWith(prefix))) {
+      return true;
+    }
+
+    // --- A. Server returned an HTML error page where JSON was expected. ---
+    // Requires the JSON-parse signature (`is not valid JSON`) AND an HTML body
+    // marker, so it stays a "parsed an HTML error page as JSON" transport
+    // artifact and does NOT overlap the chunk-load / stale-deploy `SyntaxError`
+    // family (script parsing an HTML page), which is handled separately.
+    if (
+      messageText.includes("Unexpected token '<'") &&
+      messageText.includes("<html") &&
+      messageText.includes("is not valid JSON")
+    ) {
+      return true;
+    }
+
+    // --- C. Next.js internal artifact: error boundary handed a falsy error. ---
+    if (messageText.includes("_error.js called with falsy error")) return true;
   }
 
-  // --- A. Server returned an HTML error page where JSON was expected. ---
-  // Requires the JSON-parse signature (`is not valid JSON`) AND an HTML body
-  // marker, so it stays a "parsed an HTML error page as JSON" transport artifact
-  // and does NOT overlap the chunk-load / stale-deploy `SyntaxError` family
-  // (script parsing an HTML page), which is handled separately, not dropped.
-  if (
-    value.includes("Unexpected token '<'") &&
-    value.includes("<html") &&
-    value.includes("is not valid JSON")
-  ) {
-    return true;
-  }
+  // --- C. `type`-guarded rules — exception events only (message events carry
+  // no exception `type`; these artifacts always arrive as thrown exceptions). ---
+  if (typeof exceptionValue === "string") {
+    // Expected clipboard permission denial (we already fall back). The generic
+    // `NotAllowedError` type (autoplay, fullscreen, ...) REQUIRES a clipboard
+    // marker alongside it.
+    if (
+      exceptionType === "NotAllowedError" &&
+      (exceptionValue.includes("Clipboard") ||
+        exceptionValue.includes("writeText"))
+    ) {
+      return true;
+    }
 
-  // --- C. Expected clipboard permission denial (we already fall back). ---
-  // `NotAllowedError` is generic (autoplay, fullscreen, ...), so a clipboard
-  // marker is REQUIRED alongside the type.
-  if (
-    type === "NotAllowedError" &&
-    (value.includes("Clipboard") || value.includes("writeText"))
-  ) {
-    return true;
+    // Intentional request cancellation (nav away / superseded query).
+    if (
+      exceptionType === "AbortError" &&
+      (exceptionValue.includes("signal is aborted") ||
+        exceptionValue.includes("The operation was aborted"))
+    ) {
+      return true;
+    }
   }
-
-  // --- C. Intentional request cancellation (nav away / superseded query). ---
-  if (
-    type === "AbortError" &&
-    (value.includes("signal is aborted") ||
-      value.includes("The operation was aborted"))
-  ) {
-    return true;
-  }
-
-  // --- C. Next.js internal artifact: error boundary handed a falsy error. ---
-  if (value.includes("_error.js called with falsy error")) return true;
 
   return false;
 }

--- a/web/src/utils/sentryFilters.ts
+++ b/web/src/utils/sentryFilters.ts
@@ -67,3 +67,140 @@ export function isNoisyHttpClientPollEvent(event: ErrorEvent): boolean {
 
   return HTTP_CLIENT_NOISE_PATHS.some((noisePath) => path.endsWith(noisePath));
 }
+
+/**
+ * Browser/transport messages that mean the client could not complete a network
+ * request at the transport layer: offline, flaky wifi, a throttled/backgrounded
+ * tab, a CORS rejection, or a proxy/infra 5xx that returned an HTML page. Each
+ * is just one engine's name for "the fetch never completed" — none is Langfuse
+ * application logic.
+ *
+ * Matched as the WHOLE (normalized) exception message, never as a substring: a
+ * genuine failure does not surface as one of these bare strings. Real API
+ * failures surface server-side (request tracing / logs) and, on the client, as
+ * a *handled* error carrying the server's real message (e.g. `UNAUTHORIZED`).
+ * App code that merely quotes a phrase — e.g. `Failed to fetch created model`,
+ * `Failed to fetch channels. Please check your Slack connection` — is longer
+ * than the bare string and is therefore KEPT. See the negative fixtures in
+ * `sentryFilters.clienttest.ts`.
+ */
+const TRANSPORT_FAILURE_MESSAGES: readonly string[] = [
+  "Failed to fetch", // Chrome / Chromium fetch network failure
+  "NetworkError when attempting to fetch resource", // Firefox fetch network failure
+  "Load failed", // Safari / WebKit fetch network failure
+];
+
+/**
+ * Message prefixes emitted by non-Langfuse code (framework / vendor). These are
+ * unambiguous, vendor-namespaced strings that our own code cannot produce, so
+ * matching them by prefix cannot swallow a real app error.
+ */
+const NOISE_MESSAGE_PREFIXES: readonly string[] = [
+  // NextAuth's client `SessionProvider` logs this via `console.error` (picked up
+  // by `captureConsoleIntegration`) when its 5-min / on-focus session poll fails
+  // transiently — same transient root as the httpClient poll already filtered by
+  // `isNoisyHttpClientPollEvent`. The `[next-auth]` namespace can only come from
+  // the library, never from app code.
+  "[next-auth][error][CLIENT_FETCH_ERROR]",
+  // PostHog analytics SDK notices / client-side rate-limit logs. Third-party.
+  "[PostHog.js]",
+  // `Response.json()` on a non-JSON body (a 5xx / HTML proxy page returned where
+  // JSON was expected). This is the response not being ours-as-JSON, i.e. a
+  // transport/infra artifact, not app logic.
+  "Failed to execute 'json' on 'Response'",
+];
+
+/**
+ * A `TRPCClientError` re-wraps its cause's message. Depending on capture path
+ * the Sentry `value` may be the bare cause message (`Failed to fetch`) or carry
+ * the wrapper prefix (`TRPCClientError: Failed to fetch`). We strip ONLY this
+ * one known wrapper prefix and match the inner phrase, because the raw
+ * `TRPCClientError:` prefix also fronts real, must-keep errors.
+ */
+const TRPC_CLIENT_ERROR_PREFIX = "TRPCClientError: ";
+
+function coreMessage(value: string): string {
+  const withoutWrapper = value.startsWith(TRPC_CLIENT_ERROR_PREFIX)
+    ? value.slice(TRPC_CLIENT_ERROR_PREFIX.length)
+    : value;
+  // Normalize a single trailing period (Firefox appends one to its transport
+  // message) so the whole-message comparison stays exact but engine-agnostic.
+  return withoutWrapper.trim().replace(/\.$/, "");
+}
+
+/**
+ * True for known-benign CLIENT-side noise that cannot be a real Langfuse app
+ * bug: browser-level network/transport failures, transient framework/vendor
+ * poll logs, and expected browser-permission / cancellation artifacts. Returning
+ * `true` drops the event in `beforeSend`.
+ *
+ * Design rule (safety first): only signatures that CANNOT represent a real app
+ * error are listed, each keyed on an unambiguous signature (whole-message match,
+ * vendor-namespaced prefix, or exception `type` + a required message guard) so a
+ * real error that merely quotes a phrase still flows to Sentry. When in doubt, a
+ * signature is left out. Real outages behind these client amplifications remain
+ * observable server-side (request tracing / logs).
+ *
+ * DELIBERATELY NOT dropped here (needs separate, verified handling — do not add
+ * without confirming the real error is still captured elsewhere):
+ *  - the generic prod error-boundary string `A client-side exception has
+ *    occurred` — it aggregates real exceptions with no stack; hard-dropping it
+ *    could blind us if the underlying exceptions are not captured separately.
+ *  - `OAuthCallback` sign-in errors — could be a genuine auth-config break.
+ *  - auth/permission (`UNAUTHORIZED`, not-a-member), query-timeout,
+ *    chunk-load / stale-deploy `SyntaxError`, and Sentry perf detectors /
+ *    third-party scripts — handled as UX or in Sentry project settings, not by a
+ *    blind client-side drop.
+ */
+export function isDenylistedNoiseEvent(event: ErrorEvent): boolean {
+  const exception = event.exception?.values?.[0];
+  const value = exception?.value;
+  if (typeof value !== "string" || value.length === 0) return false;
+  const type = exception?.type;
+
+  // --- A. Transport / connectivity (whole-message match after unwrapping) ---
+  const core = coreMessage(value);
+  if (TRANSPORT_FAILURE_MESSAGES.includes(core)) return true;
+
+  // --- A + B + C(vendor). Unambiguous framework/vendor/transport prefixes. ---
+  if (NOISE_MESSAGE_PREFIXES.some((prefix) => core.startsWith(prefix))) {
+    return true;
+  }
+
+  // --- A. Server returned an HTML error page where JSON was expected. ---
+  // Requires the JSON-parse signature (`is not valid JSON`) AND an HTML body
+  // marker, so it stays a "parsed an HTML error page as JSON" transport artifact
+  // and does NOT overlap the chunk-load / stale-deploy `SyntaxError` family
+  // (script parsing an HTML page), which is handled separately, not dropped.
+  if (
+    value.includes("Unexpected token '<'") &&
+    value.includes("<html") &&
+    value.includes("is not valid JSON")
+  ) {
+    return true;
+  }
+
+  // --- C. Expected clipboard permission denial (we already fall back). ---
+  // `NotAllowedError` is generic (autoplay, fullscreen, ...), so a clipboard
+  // marker is REQUIRED alongside the type.
+  if (
+    type === "NotAllowedError" &&
+    (value.includes("Clipboard") || value.includes("writeText"))
+  ) {
+    return true;
+  }
+
+  // --- C. Intentional request cancellation (nav away / superseded query). ---
+  if (
+    type === "AbortError" &&
+    (value.includes("signal is aborted") ||
+      value.includes("The operation was aborted"))
+  ) {
+    return true;
+  }
+
+  // --- C. Next.js internal artifact: error boundary handed a falsy error. ---
+  if (value.includes("_error.js called with falsy error")) return true;
+
+  return false;
+}


### PR DESCRIPTION
**TL;DR** — Extend the client-side Sentry `beforeSend` denylist to drop known-benign browser noise (network/transport failures, transient framework/vendor poll logs, expected browser artifacts) that cannot be a real app bug. Every rule is a narrow signature with a negative-fixture test proving real errors still reach Sentry. Removes a large share of client noise so Sentry becomes alert-able again. Extends #15145. Closes LFE-10976.

**Why** — The client Sentry stream is dominated by events that are not actionable app errors: a browser that couldn't complete a fetch (offline, flaky wifi, backgrounded tab, a proxy 5xx returning an HTML page), a transient next-auth session-poll log, third-party analytics notices, and expected browser artifacts (clipboard-permission denials, intentionally cancelled requests). These bury the real issues and make alerting impossible. #15145 fixed the single worst offender (the httpClient session-poll 5xx); this continues that cleanup for the message-signature families.

**What** — A new `isDenylistedNoiseEvent` in `web/src/utils/sentryFilters.ts`, called from the existing `beforeSend`. Safety-first: only signatures that cannot represent a real Langfuse error, each keyed on an unambiguous match — whole-message equality (after unwrapping a `TRPCClientError:` prefix), a vendor-namespaced prefix, or an exception `type` plus a required message guard. Deliberately anchored, never loose `includes`, so an app error that merely quotes a phrase (e.g. `Failed to fetch created model`) still flows through.

The message-signature rules are matched against both the exception value **and** the message-event fields (`event.message` / `event.logentry.message`) — because console-origin noise (next-auth `CLIENT_FETCH_ERROR`, PostHog notices, the Next.js `_error.js` artifact) is captured as a message event with no `event.exception`. The `type`-guarded rules (clipboard `NotAllowedError`, `AbortError`) stay exception-only. Risky/ambiguous families (the generic prod error-boundary aggregate string, OAuthCallback sign-in errors, auth/query-timeout, chunk-load `SyntaxError`, perf detectors) are explicitly left out and documented for separate handling.

**Result** — Removes a large, well-defined chunk of pure client noise at ingestion with zero risk to real-error visibility (real outages remain observable server-side). 40 unit tests pass, including negative fixtures — both exception- and message-shaped — that are the safety contract.

<details><summary>Rules, safety, and verification</summary>

- **Transport (A):** `Failed to fetch` / `NetworkError when attempting to fetch resource` / `Load failed` as the whole message (after unwrapping `TRPCClientError:` + trailing-period normalize); `Failed to execute 'json' on 'Response'` by prefix; HTML-page-parsed-as-JSON via `Unexpected token '<'` + `<html` + `is not valid JSON` (the JSON-parse suffix keeps it from overlapping the separately-handled chunk-load `SyntaxError` family).
- **next-auth (B):** prefix `[next-auth][error][CLIENT_FETCH_ERROR]` (the SessionProvider poll; library-namespaced).
- **Browser-benign (C):** `[PostHog.js]` prefix; `_error.js called with falsy error`; `NotAllowedError` + clipboard marker; `AbortError` + intentional-cancel message (last two exception-only).
- **Deliberately excluded** (needs verification the underlying error is captured elsewhere first): the generic `A client-side exception has occurred` aggregate, `OAuthCallback`, auth/permission, query-timeout, chunk-load, and perf detectors.
- **Event-shape correctness:** rules match both the exception value and message-event fields, so console-captured noise (message-only events) is actually dropped, not just thrown-exception shapes.
- **Tests:** positive fixtures per rule in both exception and message shapes + negative fixtures (real tRPC messages, phrase-quoting app errors, genuine `SyntaxError`, chunk-load `SyntaxError`, real `TypeError`, non-clipboard `NotAllowedError`, the excluded strings incl. the generic boundary string as a message event, UNAUTHORIZED/query-timeout, no-exception/empty events). Typecheck + full lint clean.
</details>

Extends #15145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the Sentry `beforeSend` denylist to suppress a broad class of known-benign client-side noise: browser transport failures (Chrome/Firefox/WebKit fetch errors), NextAuth session-poll console logs, PostHog notices, clipboard permission denials, and intentional request abortions. The filter is implemented as a new `isDenylistedNoiseEvent` function in `sentryFilters.ts` called in the existing `beforeSend` chain.

- **`isDenylistedNoiseEvent`**: uses whole-message equality for transport failures, vendor-namespaced prefix matching for framework logs, and exception-type guards for clipboard/abort artifacts; checks both exception values and message-event fields so console-origin noise (captured by `captureConsoleIntegration`) is also dropped.
- **Test coverage**: 40 tests with positive (drop) and negative (keep) fixtures for each rule in both exception-event and message-event shapes; the negative fixtures form the safety contract proving real app errors still reach Sentry.
- One inconsistency: the `_error.js called with falsy error` rule uses an unconstrained `includes()` substring match rather than whole-message equality, contrary to the documented "never loose includes" design rule, and has no corresponding negative fixture — though in practice the string is Next.js-internal and the false-positive risk is negligible.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all rules are narrow, real errors remain observable server-side, and no functional regressions are expected.

The filter logic is well-structured and the negative fixtures provide a strong safety contract. The only notable gap is the _error.js rule using an unconstrained substring match inconsistent with the documented design, and lacking a negative fixture — but the string itself is so Next.js-internal that masking a real app error is practically impossible.

web/src/utils/sentryFilters.ts — specifically the _error.js check at line 202.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/utils/sentryFilters.ts:202
**`_error.js` check uses loose `includes()` — inconsistent with stated design rule**

The PR description says "Deliberately anchored, never loose `includes`", and the transport failure rules enforce whole-message equality via `TRANSPORT_FAILURE_MESSAGES.includes(core)`. However, this rule uses an unconstrained substring match (`messageText.includes("_error.js called with falsy error")`) with no exception-type guard and no outer whole-message boundary. An app error message that happens to contain this phrase in any position would be silently dropped. There is also no corresponding negative fixture (e.g., a message like `"Error rendering page: _error.js called with falsy error in my custom handler"`) proving that longer app messages still pass through, unlike the analogous negative fixtures for transport phrases (`"Failed to fetch created model"`, etc.). In practice the risk is negligible because the string is Next.js-internal, but it breaks the safety contract that other rules rely on.

### Issue 2 of 2
web/src/utils/sentryFilters.clienttest.ts:340-356
**Duplicate `"A."` describe label produces ambiguous test output**

There are two `describe` blocks both labeled `"A. …"` — the first (`"A. drops browser/transport failures (whole-message match)"`) covers exception events, while this second one (`"A. transport failures also drop when they arrive as message events"`) covers the message-event path. Jest output will show two identical-looking `"A."` headings side by side, making it hard to distinguish which suite a failing test belongs to when reading CI logs. A label like `"A. (message-event shape) transport failures are also dropped"` would disambiguate them.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(observability): match console-origin..."](https://github.com/langfuse/langfuse/commit/106f536148e96a69b12a0f3f249991c34d5c1c38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45675566)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->