### PR TITLE
feat(api): stream trace observation IO as bytes (LFE-11081)

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2537,6 +2537,95 @@ export const getObservationsBatchIOFromEventsTable = async <
 };
 
 /**
+ * The single observation IO fields that {@link streamObservationIOFieldFromEventsTable}
+ * can serve. `input`/`output` are raw `String` columns; `metadata` is
+ * reconstructed from the `metadata_names`/`metadata_values` arrays.
+ */
+export const OBSERVATION_IO_STREAM_FIELDS = [
+  "input",
+  "output",
+  "metadata",
+] as const;
+
+export type ObservationIoStreamField =
+  (typeof OBSERVATION_IO_STREAM_FIELDS)[number];
+
+/**
+ * Stream ONE observation's single IO field (input | output | metadata) straight
+ * from ClickHouse to the caller as raw bytes, WITHOUT materializing the whole
+ * value in the Node process. Uses `FORMAT RawBLOB`, so ClickHouse emits exactly
+ * the field's bytes (no JSONEachRow envelope) and {@link queryClickhouseExecRaw}
+ * hands back the live HTTP body as a `Readable` for the caller to pipe onward.
+ * This is the transport primitive behind the lazy/streaming large-JSON viewer
+ * (LFE-11081): the browser can fetch a multi-hundred-MB field as a byte stream
+ * instead of forcing the server to buffer + JSON-serialize it in one shot.
+ *
+ * SECURITY: strictly tenant-scoped. The read is pinned to a single
+ * (project_id, trace_id, span_id) via parameterized predicates, so it can only
+ * ever return bytes for that one observation inside that one project — a wrong
+ * projectId yields zero rows (zero bytes). `field` is NOT interpolated user
+ * input: it selects from a fixed, closed set of SQL expressions. Callers MUST
+ * still authorize the (projectId, traceId) pair before calling — this function
+ * performs data isolation, not request authorization.
+ *
+ * The ±1s window around `startTime` only prunes the primary key
+ * (project_id, toStartOfMinute(start_time), xxHash32(trace_id)); it is a
+ * performance hint, never an authorization control.
+ */
+export const streamObservationIOFieldFromEventsTable = (opts: {
+  projectId: string;
+  traceId: string;
+  observationId: string;
+  field: ObservationIoStreamField;
+  /** The observation's startTime; bounds the read for primary-key pruning. */
+  startTime: Date;
+}) => {
+  const minTimestamp = new Date(opts.startTime.getTime() - 1000);
+  const maxTimestamp = new Date(opts.startTime.getTime() + 1000);
+
+  // Closed set of SQL expressions keyed by the validated `field` enum — never
+  // string-interpolated user input. input/output are raw String columns;
+  // metadata is rebuilt into a JSON object string so it streams as one column.
+  const fieldSelect: Record<ObservationIoStreamField, string> = {
+    input: "e.input",
+    output: "e.output",
+    metadata:
+      "toJSONString(mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values)))",
+  };
+
+  const query = `
+    SELECT ${fieldSelect[opts.field]} AS field
+    FROM events_full e
+    WHERE e.project_id = {projectId: String}
+      AND e.trace_id = {traceId: String}
+      AND e.span_id = {observationId: String}
+      AND e.start_time >= {minTimestamp: DateTime64(3)}
+      AND e.start_time <= {maxTimestamp: DateTime64(3)}
+    ORDER BY e.event_ts DESC
+    LIMIT 1
+  `;
+
+  // FORMAT RawBLOB emits the selected String column's bytes with no escaping or
+  // delimiters; with LIMIT 1 that is exactly this observation's field value.
+  return queryClickhouseExecRaw({
+    query,
+    format: "RawBLOB",
+    params: {
+      projectId: opts.projectId,
+      traceId: opts.traceId,
+      observationId: opts.observationId,
+      minTimestamp: convertDateToClickhouseDateTime(minTimestamp),
+      maxTimestamp: convertDateToClickhouseDateTime(maxTimestamp),
+    },
+    tags: {
+      projectId: opts.projectId,
+      route: "observation-io-stream",
+    },
+    preferredClickhouseService: "EventsReadOnly",
+  });
+};
+
+/**
  * Full raw I/O + metadata for ONE observation, scoped to a session (the
  * session-detail download fallback for payloads too large to render inline,
  * LFE-10958). Callers are session-authorized (public sessions included), so

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2537,9 +2537,14 @@ export const getObservationsBatchIOFromEventsTable = async <
 };
 
 /**
- * The single observation IO fields that {@link streamObservationIOFieldFromEventsTable}
- * can serve. `input`/`output` are raw `String` columns; `metadata` is
- * reconstructed from the `metadata_names`/`metadata_values` arrays.
+ * The single observation IO fields the stream/length helpers below can serve.
+ * `input`/`output` are raw `String` columns streamed as-is — note they may be a
+ * bare, unquoted string (not JSON) for plain-text prompts/completions, so the
+ * route serves them as opaque bytes, not `application/json`. `metadata` is
+ * reconstructed from the `metadata_names`/`metadata_values` `Map(String,String)`
+ * columns, so **every metadata value is emitted JSON-string-encoded** (a nested
+ * object comes out as an escaped string). Consumers must unwrap one level, exactly
+ * as the existing metadata read path does (`parseMetadataCHRecordToDomain`).
  */
 export const OBSERVATION_IO_STREAM_FIELDS = [
   "input",
@@ -2549,6 +2554,83 @@ export const OBSERVATION_IO_STREAM_FIELDS = [
 
 export type ObservationIoStreamField =
   (typeof OBSERVATION_IO_STREAM_FIELDS)[number];
+
+// Closed set of SQL expressions keyed by the validated `field` enum — never
+// string-interpolated user input. The length pre-query and the byte stream share
+// this map + the WHERE/params below so they can never drift; a mismatch would
+// make the route's Content-Length integrity check wrong.
+const OBSERVATION_IO_FIELD_SELECT: Record<ObservationIoStreamField, string> = {
+  input: "e.input",
+  output: "e.output",
+  metadata:
+    "toJSONString(mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values)))",
+};
+
+// The ±1s window around `startTime` only prunes the primary key
+// (project_id, toStartOfMinute(start_time), xxHash32(trace_id)); it is a
+// performance hint, never an authorization control.
+const OBSERVATION_IO_WHERE = `
+    WHERE e.project_id = {projectId: String}
+      AND e.trace_id = {traceId: String}
+      AND e.span_id = {observationId: String}
+      AND e.start_time >= {minTimestamp: DateTime64(3)}
+      AND e.start_time <= {maxTimestamp: DateTime64(3)}`;
+
+interface ObservationIOReadOpts {
+  projectId: string;
+  traceId: string;
+  observationId: string;
+  field: ObservationIoStreamField;
+  /** The observation's startTime; bounds the read for primary-key pruning. */
+  startTime: Date;
+}
+
+function observationIOReadParams(opts: ObservationIOReadOpts) {
+  return {
+    projectId: opts.projectId,
+    traceId: opts.traceId,
+    observationId: opts.observationId,
+    minTimestamp: convertDateToClickhouseDateTime(
+      new Date(opts.startTime.getTime() - 1000),
+    ),
+    maxTimestamp: convertDateToClickhouseDateTime(
+      new Date(opts.startTime.getTime() + 1000),
+    ),
+  };
+}
+
+/**
+ * Byte length of one observation IO field — a cheap pre-query the streaming
+ * route runs BEFORE committing headers. It does two jobs the raw stream can't:
+ *  - distinguishes "not found" (no row → `null` → the route 404s) from "present
+ *    but empty" (row with 0 → empty 200), so a stale/skewed `startTime` yields a
+ *    diagnosable 404 rather than a misleading empty body; and
+ *  - gives the exact byte count for a `Content-Length` header, so a mid-stream
+ *    ClickHouse failure (truncated body) is detectable at the HTTP layer on ANY
+ *    ClickHouse version — independent of the `x-clickhouse-exception-tag` header
+ *    that raw-passthrough failure detection needs (≥25.11 only).
+ * Uses the SAME field expression + WHERE as the stream, so the length matches the
+ * bytes streamed. `length()` on a ClickHouse `String` is its byte count.
+ */
+export const getObservationIOFieldByteLengthFromEventsTable = async (
+  opts: ObservationIOReadOpts,
+): Promise<number | null> => {
+  const query = `
+    SELECT length(${OBSERVATION_IO_FIELD_SELECT[opts.field]}) AS len
+    FROM events_full e
+    ${OBSERVATION_IO_WHERE}
+    ORDER BY e.event_ts DESC
+    LIMIT 1
+  `;
+  const rows = await queryClickhouse<{ len: string }>({
+    query,
+    params: observationIOReadParams(opts),
+    tags: { projectId: opts.projectId, route: "observation-io-stream-length" },
+    preferredClickhouseService: "EventsReadOnly",
+  });
+  const first = rows[0];
+  return first ? Number(first.len) : null;
+};
 
 /**
  * Stream ONE observation's single IO field (input | output | metadata) straight
@@ -2567,40 +2649,14 @@ export type ObservationIoStreamField =
  * input: it selects from a fixed, closed set of SQL expressions. Callers MUST
  * still authorize the (projectId, traceId) pair before calling — this function
  * performs data isolation, not request authorization.
- *
- * The ±1s window around `startTime` only prunes the primary key
- * (project_id, toStartOfMinute(start_time), xxHash32(trace_id)); it is a
- * performance hint, never an authorization control.
  */
-export const streamObservationIOFieldFromEventsTable = (opts: {
-  projectId: string;
-  traceId: string;
-  observationId: string;
-  field: ObservationIoStreamField;
-  /** The observation's startTime; bounds the read for primary-key pruning. */
-  startTime: Date;
-}) => {
-  const minTimestamp = new Date(opts.startTime.getTime() - 1000);
-  const maxTimestamp = new Date(opts.startTime.getTime() + 1000);
-
-  // Closed set of SQL expressions keyed by the validated `field` enum — never
-  // string-interpolated user input. input/output are raw String columns;
-  // metadata is rebuilt into a JSON object string so it streams as one column.
-  const fieldSelect: Record<ObservationIoStreamField, string> = {
-    input: "e.input",
-    output: "e.output",
-    metadata:
-      "toJSONString(mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values)))",
-  };
-
+export const streamObservationIOFieldFromEventsTable = (
+  opts: ObservationIOReadOpts,
+) => {
   const query = `
-    SELECT ${fieldSelect[opts.field]} AS field
+    SELECT ${OBSERVATION_IO_FIELD_SELECT[opts.field]} AS field
     FROM events_full e
-    WHERE e.project_id = {projectId: String}
-      AND e.trace_id = {traceId: String}
-      AND e.span_id = {observationId: String}
-      AND e.start_time >= {minTimestamp: DateTime64(3)}
-      AND e.start_time <= {maxTimestamp: DateTime64(3)}
+    ${OBSERVATION_IO_WHERE}
     ORDER BY e.event_ts DESC
     LIMIT 1
   `;
@@ -2610,13 +2666,7 @@ export const streamObservationIOFieldFromEventsTable = (opts: {
   return queryClickhouseExecRaw({
     query,
     format: "RawBLOB",
-    params: {
-      projectId: opts.projectId,
-      traceId: opts.traceId,
-      observationId: opts.observationId,
-      minTimestamp: convertDateToClickhouseDateTime(minTimestamp),
-      maxTimestamp: convertDateToClickhouseDateTime(maxTimestamp),
-    },
+    params: observationIOReadParams(opts),
     tags: {
       projectId: opts.projectId,
       route: "observation-io-stream",

--- a/web/src/__tests__/server/repositories/stream-observation-io-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/stream-observation-io-repository.servertest.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from "crypto";
+import { describe, expect } from "vitest";
+import {
+  createEvent,
+  createEventsCh,
+  streamObservationIOFieldFromEventsTable,
+} from "@langfuse/shared/src/server";
+import { env } from "@/src/env.mjs";
+
+// Reads the v4 events table (events_full), so gate on the same preview opt-in as
+// the rest of the events-repository suite.
+const maybe =
+  env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+    ? describe
+    : describe.skip;
+
+async function collectStream(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+maybe("streamObservationIOFieldFromEventsTable", () => {
+  it("streams each raw IO field for the scoped observation", async () => {
+    const projectId = randomUUID();
+    const traceId = randomUUID();
+    const observationId = randomUUID();
+    const startMs = Date.now();
+
+    const input = JSON.stringify({ prompt: "hello 🌍", n: 42 });
+    const output = JSON.stringify([{ role: "assistant", content: "hi" }]);
+
+    await createEventsCh([
+      createEvent({
+        id: observationId,
+        span_id: observationId,
+        project_id: projectId,
+        trace_id: traceId,
+        input,
+        output,
+        metadata_names: ["k1", "k2"],
+        metadata_values: ["v1", "v2"],
+        start_time: startMs * 1000, // micros
+      }),
+    ]);
+
+    const startTime = new Date(startMs);
+
+    const inputText = await streamObservationIOFieldFromEventsTable({
+      projectId,
+      traceId,
+      observationId,
+      field: "input",
+      startTime,
+    }).then((r) => collectStream(r.stream));
+    expect(inputText).toBe(input);
+
+    const outputText = await streamObservationIOFieldFromEventsTable({
+      projectId,
+      traceId,
+      observationId,
+      field: "output",
+      startTime,
+    }).then((r) => collectStream(r.stream));
+    expect(outputText).toBe(output);
+
+    const metadataText = await streamObservationIOFieldFromEventsTable({
+      projectId,
+      traceId,
+      observationId,
+      field: "metadata",
+      startTime,
+    }).then((r) => collectStream(r.stream));
+    expect(JSON.parse(metadataText)).toMatchObject({ k1: "v1", k2: "v2" });
+  });
+
+  it("returns zero bytes for a different project (tenant isolation)", async () => {
+    const projectId = randomUUID();
+    const traceId = randomUUID();
+    const observationId = randomUUID();
+    const startMs = Date.now();
+
+    await createEventsCh([
+      createEvent({
+        id: observationId,
+        span_id: observationId,
+        project_id: projectId,
+        trace_id: traceId,
+        input: "secret tenant data",
+        start_time: startMs * 1000,
+      }),
+    ]);
+
+    // Same trace/observation ids, but a foreign projectId must never match.
+    const crossProject = await streamObservationIOFieldFromEventsTable({
+      projectId: randomUUID(),
+      traceId,
+      observationId,
+      field: "input",
+      startTime: new Date(startMs),
+    }).then((r) => collectStream(r.stream));
+
+    expect(crossProject).toBe("");
+  });
+});

--- a/web/src/__tests__/server/repositories/stream-observation-io-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/stream-observation-io-repository.servertest.ts
@@ -3,6 +3,7 @@ import { describe, expect } from "vitest";
 import {
   createEvent,
   createEventsCh,
+  getObservationIOFieldByteLengthFromEventsTable,
   streamObservationIOFieldFromEventsTable,
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
@@ -103,5 +104,46 @@ maybe("streamObservationIOFieldFromEventsTable", () => {
     }).then((r) => collectStream(r.stream));
 
     expect(crossProject).toBe("");
+  });
+
+  it("byte length is the field's UTF-8 byte count, and null for a foreign project", async () => {
+    const projectId = randomUUID();
+    const traceId = randomUUID();
+    const observationId = randomUUID();
+    const startMs = Date.now();
+    // Contains a 4-byte emoji, so byte length > character length: verifies
+    // ClickHouse `length()` counts bytes (what Content-Length needs).
+    const input = JSON.stringify({ prompt: "hello 🌍", n: 42 });
+
+    await createEventsCh([
+      createEvent({
+        id: observationId,
+        span_id: observationId,
+        project_id: projectId,
+        trace_id: traceId,
+        input,
+        start_time: startMs * 1000,
+      }),
+    ]);
+    const startTime = new Date(startMs);
+
+    const len = await getObservationIOFieldByteLengthFromEventsTable({
+      projectId,
+      traceId,
+      observationId,
+      field: "input",
+      startTime,
+    });
+    expect(len).toBe(Buffer.byteLength(input, "utf8"));
+
+    // No matching row → null (the route turns this into a 404, not empty 200).
+    const missing = await getObservationIOFieldByteLengthFromEventsTable({
+      projectId: randomUUID(),
+      traceId,
+      observationId,
+      field: "input",
+      startTime,
+    });
+    expect(missing).toBeNull();
   });
 });

--- a/web/src/__tests__/server/stream-observation-io-api.servertest.ts
+++ b/web/src/__tests__/server/stream-observation-io-api.servertest.ts
@@ -1,0 +1,180 @@
+/** @vitest-environment node */
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Readable } from "stream";
+import { createMocks } from "node-mocks-http";
+import { LangfuseNotFoundError, UnauthorizedError } from "@langfuse/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import handler from "../../pages/api/traces/[traceId]/observations/[observationId]/io/[field]";
+
+const { mockGetServerAuthSession, mockGetAuthorizedTrace, mockStreamIOField } =
+  vi.hoisted(() => ({
+    mockGetServerAuthSession: vi.fn(),
+    mockGetAuthorizedTrace: vi.fn(),
+    mockStreamIOField: vi.fn(),
+  }));
+
+vi.mock("../../server/auth", () => ({
+  getServerAuthSession: (...args: unknown[]) =>
+    mockGetServerAuthSession(...args),
+}));
+
+// Override only the trace authorizer; keep the rest of the module real.
+vi.mock("../../features/traces/server/buildTraceExport", async () => ({
+  ...(await vi.importActual("../../features/traces/server/buildTraceExport")),
+  getAuthorizedTrace: (...args: unknown[]) => mockGetAuthorizedTrace(...args),
+}));
+
+// Override only the ClickHouse streaming read; keep logger, the field enum, and
+// everything withMiddlewares needs from the barrel intact.
+vi.mock("@langfuse/shared/src/server", async () => ({
+  ...(await vi.importActual("@langfuse/shared/src/server")),
+  streamObservationIOFieldFromEventsTable: (...args: unknown[]) =>
+    mockStreamIOField(...args),
+}));
+
+const projectId = "project-1";
+const traceId = "trace-1";
+const observationId = "obs-1";
+const startTime = "2024-06-15T12:00:00.000Z";
+
+const createGetMocks = (query: Record<string, string | string[] | undefined>) =>
+  createMocks<NextApiRequest, NextApiResponse>({ method: "GET", query });
+
+const validQuery = {
+  traceId,
+  observationId,
+  field: "input",
+  projectId,
+  startTime,
+};
+
+describe("GET /api/traces/[traceId]/observations/[observationId]/io/[field]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerAuthSession.mockResolvedValue({
+      user: {
+        email: "test@example.com",
+        admin: false,
+        organizations: [{ projects: [{ id: projectId }] }],
+      },
+    });
+    mockGetAuthorizedTrace.mockResolvedValue({
+      id: traceId,
+      timestamp: new Date(startTime),
+    });
+    mockStreamIOField.mockResolvedValue({
+      stream: Readable.from(['{"hello":', '"world"}']),
+    });
+  });
+
+  it("streams the field bytes with a JSON content type for an authorized member", async () => {
+    const { req, res } = createGetMocks(validQuery);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader("Content-Type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(res.getHeader("Cache-Control")).toBe("private, no-store");
+    expect(res.getHeader("Accept-Ranges")).toBe("none");
+    expect(res._getData()).toBe('{"hello":"world"}');
+
+    // The ClickHouse read is pinned to exactly this tenant/trace/observation.
+    expect(mockStreamIOField).toHaveBeenCalledWith({
+      projectId,
+      traceId,
+      observationId,
+      field: "input",
+      startTime: new Date(startTime),
+    });
+  });
+
+  it("serves each supported field", async () => {
+    for (const field of ["input", "output", "metadata"] as const) {
+      vi.clearAllMocks();
+      mockGetServerAuthSession.mockResolvedValue({
+        user: {
+          email: "test@example.com",
+          admin: false,
+          organizations: [{ projects: [{ id: projectId }] }],
+        },
+      });
+      mockGetAuthorizedTrace.mockResolvedValue({ id: traceId });
+      mockStreamIOField.mockResolvedValue({ stream: Readable.from(["x"]) });
+
+      const { req, res } = createGetMocks({ ...validQuery, field });
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockStreamIOField).toHaveBeenCalledWith(
+        expect.objectContaining({ field }),
+      );
+    }
+  });
+
+  it("returns 401 and never reads IO when the caller is not authorized (cross-project/tenant)", async () => {
+    // A user from another project: getAuthorizedTrace rejects for a
+    // non-public trace they cannot access.
+    mockGetAuthorizedTrace.mockRejectedValue(
+      new UnauthorizedError(
+        "User is not a member of this project and this trace is not public",
+      ),
+    );
+    const { req, res } = createGetMocks(validQuery);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    // Authorization gates data access: the ClickHouse read is never issued.
+    expect(mockStreamIOField).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the trace does not exist", async () => {
+    mockGetAuthorizedTrace.mockRejectedValue(
+      new LangfuseNotFoundError("Trace not found"),
+    );
+    const { req, res } = createGetMocks(validQuery);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(mockStreamIOField).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an unsupported field", async () => {
+    const { req, res } = createGetMocks({ ...validQuery, field: "secrets" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockGetAuthorizedTrace).not.toHaveBeenCalled();
+    expect(mockStreamIOField).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when projectId is missing", async () => {
+    const { req, res } = createGetMocks({
+      traceId,
+      observationId,
+      field: "input",
+      startTime,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockGetAuthorizedTrace).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an unparseable startTime", async () => {
+    const { req, res } = createGetMocks({
+      ...validQuery,
+      startTime: "not-a-date",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockStreamIOField).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/server/stream-observation-io-api.servertest.ts
+++ b/web/src/__tests__/server/stream-observation-io-api.servertest.ts
@@ -6,12 +6,17 @@ import { LangfuseNotFoundError, UnauthorizedError } from "@langfuse/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import handler from "../../pages/api/traces/[traceId]/observations/[observationId]/io/[field]";
 
-const { mockGetServerAuthSession, mockGetAuthorizedTrace, mockStreamIOField } =
-  vi.hoisted(() => ({
-    mockGetServerAuthSession: vi.fn(),
-    mockGetAuthorizedTrace: vi.fn(),
-    mockStreamIOField: vi.fn(),
-  }));
+const {
+  mockGetServerAuthSession,
+  mockGetAuthorizedTrace,
+  mockStreamIOField,
+  mockByteLength,
+} = vi.hoisted(() => ({
+  mockGetServerAuthSession: vi.fn(),
+  mockGetAuthorizedTrace: vi.fn(),
+  mockStreamIOField: vi.fn(),
+  mockByteLength: vi.fn(),
+}));
 
 vi.mock("../../server/auth", () => ({
   getServerAuthSession: (...args: unknown[]) =>
@@ -28,6 +33,8 @@ vi.mock("../../features/traces/server/buildTraceExport", async () => ({
 // everything withMiddlewares needs from the barrel intact.
 vi.mock("@langfuse/shared/src/server", async () => ({
   ...(await vi.importActual("@langfuse/shared/src/server")),
+  getObservationIOFieldByteLengthFromEventsTable: (...args: unknown[]) =>
+    mockByteLength(...args),
   streamObservationIOFieldFromEventsTable: (...args: unknown[]) =>
     mockStreamIOField(...args),
 }));
@@ -62,20 +69,23 @@ describe("GET /api/traces/[traceId]/observations/[observationId]/io/[field]", ()
       id: traceId,
       timestamp: new Date(startTime),
     });
+    // Byte length matches the streamed body ('{"hello":"world"}' = 17 bytes).
+    mockByteLength.mockResolvedValue(17);
     mockStreamIOField.mockResolvedValue({
       stream: Readable.from(['{"hello":', '"world"}']),
     });
   });
 
-  it("streams the field bytes with a JSON content type for an authorized member", async () => {
+  it("streams the field as opaque bytes with a Content-Length for an authorized member", async () => {
     const { req, res } = createGetMocks(validQuery);
 
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(res.getHeader("Content-Type")).toBe(
-      "application/json; charset=utf-8",
-    );
+    // Opaque bytes, not application/json (input/output may be a bare string).
+    expect(res.getHeader("Content-Type")).toBe("application/octet-stream");
+    // Exact byte count → the client can detect a truncated body.
+    expect(res.getHeader("Content-Length")).toBe("17");
     expect(res.getHeader("Cache-Control")).toBe("private, no-store");
     expect(res.getHeader("Accept-Ranges")).toBe("none");
     expect(res._getData()).toBe('{"hello":"world"}');
@@ -90,6 +100,30 @@ describe("GET /api/traces/[traceId]/observations/[observationId]/io/[field]", ()
     });
   });
 
+  it("returns 404 (not a misleading empty 200) when the field/observation is not found", async () => {
+    // No matching row (e.g. a stale/skewed startTime) → the length pre-query
+    // returns null → clean 404, and the stream is never opened.
+    mockByteLength.mockResolvedValue(null);
+    const { req, res } = createGetMocks(validQuery);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(mockStreamIOField).not.toHaveBeenCalled();
+  });
+
+  it("serves a genuinely empty field as 200 with Content-Length 0", async () => {
+    mockByteLength.mockResolvedValue(0);
+    mockStreamIOField.mockResolvedValue({ stream: Readable.from([]) });
+    const { req, res } = createGetMocks(validQuery);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader("Content-Length")).toBe("0");
+    expect(res._getData()).toBe("");
+  });
+
   it("serves each supported field", async () => {
     for (const field of ["input", "output", "metadata"] as const) {
       vi.clearAllMocks();
@@ -101,6 +135,7 @@ describe("GET /api/traces/[traceId]/observations/[observationId]/io/[field]", ()
         },
       });
       mockGetAuthorizedTrace.mockResolvedValue({ id: traceId });
+      mockByteLength.mockResolvedValue(1);
       mockStreamIOField.mockResolvedValue({ stream: Readable.from(["x"]) });
 
       const { req, res } = createGetMocks({ ...validQuery, field });

--- a/web/src/__tests__/server/stream-observation-io-api.servertest.ts
+++ b/web/src/__tests__/server/stream-observation-io-api.servertest.ts
@@ -76,7 +76,7 @@ describe("GET /api/traces/[traceId]/observations/[observationId]/io/[field]", ()
     });
   });
 
-  it("streams the field as opaque bytes with a Content-Length for an authorized member", async () => {
+  it("streams the field as opaque bytes for an authorized member", async () => {
     const { req, res } = createGetMocks(validQuery);
 
     await handler(req, res);
@@ -84,8 +84,9 @@ describe("GET /api/traces/[traceId]/observations/[observationId]/io/[field]", ()
     expect(res._getStatusCode()).toBe(200);
     // Opaque bytes, not application/json (input/output may be a bare string).
     expect(res.getHeader("Content-Type")).toBe("application/octet-stream");
-    // Exact byte count → the client can detect a truncated body.
-    expect(res.getHeader("Content-Length")).toBe("17");
+    // No Content-Length: the body streams chunked, so its size is never derived
+    // from a second read that could diverge from it.
+    expect(res.getHeader("Content-Length")).toBeUndefined();
     expect(res.getHeader("Cache-Control")).toBe("private, no-store");
     expect(res.getHeader("Accept-Ranges")).toBe("none");
     expect(res._getData()).toBe('{"hello":"world"}');
@@ -112,7 +113,7 @@ describe("GET /api/traces/[traceId]/observations/[observationId]/io/[field]", ()
     expect(mockStreamIOField).not.toHaveBeenCalled();
   });
 
-  it("serves a genuinely empty field as 200 with Content-Length 0", async () => {
+  it("serves a genuinely empty field (length 0, row exists) as an empty 200", async () => {
     mockByteLength.mockResolvedValue(0);
     mockStreamIOField.mockResolvedValue({ stream: Readable.from([]) });
     const { req, res } = createGetMocks(validQuery);
@@ -120,7 +121,6 @@ describe("GET /api/traces/[traceId]/observations/[observationId]/io/[field]", ()
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(res.getHeader("Content-Length")).toBe("0");
     expect(res._getData()).toBe("");
   });
 
@@ -201,7 +201,7 @@ describe("GET /api/traces/[traceId]/observations/[observationId]/io/[field]", ()
     expect(mockGetAuthorizedTrace).not.toHaveBeenCalled();
   });
 
-  it("returns 400 for an unparseable startTime", async () => {
+  it("returns 400 for an unparsable startTime", async () => {
     const { req, res } = createGetMocks({
       ...validQuery,
       startTime: "not-a-date",

--- a/web/src/features/traces/server/buildTraceExport.ts
+++ b/web/src/features/traces/server/buildTraceExport.ts
@@ -92,7 +92,16 @@ const getObservationRecordCountForTrace = async (params: {
   });
 };
 
-async function getAuthorizedTrace(params: {
+/**
+ * Canonical trace read-authorization used by the session-authed trace download
+ * routes: grants access when the trace (or its session) is public, the user is
+ * an admin, or the user is a member of the project — and fires the admin-access
+ * webhook for admins. Reused by the observation IO streaming route (LFE-11081)
+ * so authorization stays in one place rather than being re-derived per route.
+ * Returns the authorized trace (its `timestamp` bounds downstream ClickHouse
+ * reads); throws `LangfuseNotFoundError` / `UnauthorizedError` otherwise.
+ */
+export async function getAuthorizedTrace(params: {
   traceId: string;
   projectId: string;
   session: TraceExportAccessSession;

--- a/web/src/pages/api/traces/[traceId]/observations/[observationId]/io/[field].ts
+++ b/web/src/pages/api/traces/[traceId]/observations/[observationId]/io/[field].ts
@@ -1,7 +1,12 @@
-import { once } from "events";
+import { once } from "node:events";
 import { z } from "zod";
-import { InvalidRequestError, UnauthorizedError } from "@langfuse/shared";
 import {
+  InvalidRequestError,
+  LangfuseNotFoundError,
+  UnauthorizedError,
+} from "@langfuse/shared";
+import {
+  getObservationIOFieldByteLengthFromEventsTable,
   logger,
   OBSERVATION_IO_STREAM_FIELDS,
   streamObservationIOFieldFromEventsTable,
@@ -98,6 +103,23 @@ export default withMiddlewares({
     );
     await getAuthorizedTrace({ traceId, projectId, session });
 
+    // Cheap pre-query BEFORE any bytes: the exact field byte length. Two jobs —
+    // (1) a null (no matching row, e.g. a stale/skewed startTime) becomes a clean
+    // 404 instead of a misleading empty 200; (2) the length drives a
+    // Content-Length header so a truncated body is detectable at the HTTP layer.
+    const byteLength = await getObservationIOFieldByteLengthFromEventsTable({
+      projectId,
+      traceId,
+      observationId,
+      field,
+      startTime,
+    });
+    if (byteLength === null) {
+      throw new LangfuseNotFoundError(
+        "Observation IO field not found for the given trace/observation/startTime",
+      );
+    }
+
     // Resolves once ClickHouse has returned response headers; an immediate query
     // failure rejects here (pre-headers) and is handled by withMiddlewares.
     const { stream } = await streamObservationIOFieldFromEventsTable({
@@ -110,7 +132,13 @@ export default withMiddlewares({
 
     // --- Headers committed below; from here we must not throw into
     // withMiddlewares (headers are already sent). ---
-    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    // Opaque field bytes: input/output may be a bare (unquoted) string rather
+    // than JSON, so we do NOT claim application/json. The consumer knows it is an
+    // IO field and parses accordingly.
+    res.setHeader("Content-Type", "application/octet-stream");
+    // Exact byte count: lets the client detect a truncated body (mid-stream
+    // ClickHouse failure) at the HTTP layer, on any ClickHouse version.
+    res.setHeader("Content-Length", String(byteLength));
     // Tenant data: never cache in shared/proxy caches.
     res.setHeader("Cache-Control", "private, no-store");
     res.setHeader("X-Content-Type-Options", "nosniff");
@@ -119,21 +147,33 @@ export default withMiddlewares({
     res.setHeader("Accept-Ranges", "none");
     res.status(200);
 
+    // Tear down the ClickHouse read if the client disconnects (mirrors
+    // execute-query-stream.ts). Without this, a disconnect under backpressure
+    // would hang the handler forever and leak the CH connection.
+    let clientClosed = false;
+    const closed = once(res, "close");
+    req.on("close", () => {
+      clientClosed = true;
+      stream.destroy();
+    });
+
     try {
-      // Pull one chunk at a time (source backpressure) and honor sink
-      // backpressure via drain — the field never fully materializes in Node.
+      // One chunk at a time (source backpressure); honor sink backpressure via
+      // drain — but race drain against `close`, or a disconnect mid-drain would
+      // never settle (`once(res,"drain")` alone hangs on socket close).
       for await (const chunk of stream) {
-        // write() returns false only when the sink buffer is full; wait for
-        // drain before resuming so a slow client can't balloon memory.
+        if (clientClosed) break;
         if (res.write(chunk) === false) {
-          await once(res, "drain");
+          await Promise.race([once(res, "drain"), closed]);
+          if (clientClosed) break;
         }
       }
-      res.end();
+      if (!clientClosed) res.end();
     } catch (error) {
-      // A mid-stream ClickHouse/transport failure after headers were sent: the
-      // client sees a truncated body. Log, tear down, and do not rethrow (that
-      // would collide with withMiddlewares' already-sent headers).
+      // Mid-stream ClickHouse/transport failure after headers were sent. Abort
+      // the socket (not a clean end) so the body ends SHORT of the declared
+      // Content-Length → the client's fetch errors, instead of a clean truncated
+      // 200 that looks like success. Do not rethrow (headers already sent).
       logger.error("[stream-observation-io] mid-stream failure", {
         error: error instanceof Error ? error.message : String(error),
         projectId,
@@ -142,7 +182,9 @@ export default withMiddlewares({
         field,
       });
       stream.destroy();
-      if (!res.writableEnded) res.end();
+      if (!res.writableEnded && !clientClosed) {
+        res.destroy(error instanceof Error ? error : new Error(String(error)));
+      }
     }
   },
 });

--- a/web/src/pages/api/traces/[traceId]/observations/[observationId]/io/[field].ts
+++ b/web/src/pages/api/traces/[traceId]/observations/[observationId]/io/[field].ts
@@ -103,10 +103,12 @@ export default withMiddlewares({
     );
     await getAuthorizedTrace({ traceId, projectId, session });
 
-    // Cheap pre-query BEFORE any bytes: the exact field byte length. Two jobs —
-    // (1) a null (no matching row, e.g. a stale/skewed startTime) becomes a clean
-    // 404 instead of a misleading empty 200; (2) the length drives a
-    // Content-Length header so a truncated body is detectable at the HTTP layer.
+    // Cheap existence pre-query BEFORE any bytes: a null (no matching row, e.g.
+    // a stale/skewed startTime) becomes a clean 404 instead of a misleading
+    // empty 200. We deliberately do NOT derive a Content-Length from it: the
+    // body is streamed from a *separate* read, and a new event landing between
+    // the two would make a length-vs-body mismatch (truncation is instead
+    // signaled by aborting the socket in the catch below — see there).
     const byteLength = await getObservationIOFieldByteLengthFromEventsTable({
       projectId,
       traceId,
@@ -136,9 +138,11 @@ export default withMiddlewares({
     // than JSON, so we do NOT claim application/json. The consumer knows it is an
     // IO field and parses accordingly.
     res.setHeader("Content-Type", "application/octet-stream");
-    // Exact byte count: lets the client detect a truncated body (mid-stream
-    // ClickHouse failure) at the HTTP layer, on any ClickHouse version.
-    res.setHeader("Content-Length", String(byteLength));
+    // No Content-Length: the exact size would have to come from a second,
+    // independent read that can diverge from the body under concurrent
+    // ingestion. Streamed with chunked transfer-encoding instead; a truncated
+    // body is signaled by a socket abort (catch below), which fails the
+    // client's fetch — no false "clean" short read.
     // Tenant data: never cache in shared/proxy caches.
     res.setHeader("Cache-Control", "private, no-store");
     res.setHeader("X-Content-Type-Options", "nosniff");
@@ -171,9 +175,9 @@ export default withMiddlewares({
       if (!clientClosed) res.end();
     } catch (error) {
       // Mid-stream ClickHouse/transport failure after headers were sent. Abort
-      // the socket (not a clean end) so the body ends SHORT of the declared
-      // Content-Length → the client's fetch errors, instead of a clean truncated
-      // 200 that looks like success. Do not rethrow (headers already sent).
+      // the socket (res.destroy, not a clean res.end) so the client's fetch
+      // rejects with a connection error instead of seeing a clean 200 whose
+      // body was silently truncated. Do not rethrow (headers already sent).
       logger.error("[stream-observation-io] mid-stream failure", {
         error: error instanceof Error ? error.message : String(error),
         projectId,

--- a/web/src/pages/api/traces/[traceId]/observations/[observationId]/io/[field].ts
+++ b/web/src/pages/api/traces/[traceId]/observations/[observationId]/io/[field].ts
@@ -1,0 +1,148 @@
+import { once } from "events";
+import { z } from "zod";
+import { InvalidRequestError, UnauthorizedError } from "@langfuse/shared";
+import {
+  logger,
+  OBSERVATION_IO_STREAM_FIELDS,
+  streamObservationIOFieldFromEventsTable,
+} from "@langfuse/shared/src/server";
+import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import {
+  getAuthorizedTrace,
+  type TraceExportAccessSession,
+} from "@/src/features/traces/server/buildTraceExport";
+import { getServerAuthSession } from "@/src/server/auth";
+
+/**
+ * GET /api/traces/:traceId/observations/:observationId/io/:field
+ *   ?projectId=...&startTime=<ISO-8601>
+ *
+ * Streams ONE observation's raw IO field (input | output | metadata) as bytes,
+ * piping the ClickHouse response body straight to the client without buffering
+ * the whole value in the Node process. This is the transport enabler for the
+ * lazy/streaming large-JSON viewer (LFE-11081, seeded by LFE-10847 / LFE-10152:
+ * huge single-field payloads crash the browser when fetched+parsed in one shot).
+ *
+ * SECURITY: session-authed and strictly project-scoped. Authorization reuses the
+ * canonical `getAuthorizedTrace` (project membership, public trace/session, or
+ * admin) — identical to the trace download route — and the underlying query is
+ * pinned to (projectId, traceId, observationId), so a caller can never read
+ * another project's or trace's observation IO.
+ *
+ * v4/events-only: reads `events_full`, matching the events.batchIO read path.
+ */
+
+// traceId / observationId / field are path segments; projectId / startTime are
+// query-string params. All are validated before any data access.
+const querySchema = z.object({
+  traceId: z.string().min(1),
+  observationId: z.string().min(1),
+  field: z.enum(OBSERVATION_IO_STREAM_FIELDS),
+  projectId: z.string().min(1),
+  // The observation's startTime (ISO-8601). Prunes the ClickHouse primary key;
+  // not a security control — the tenant scoping above is.
+  startTime: z.coerce.date(),
+});
+
+/**
+ * Shape the NextAuth session into the access-session `getAuthorizedTrace`
+ * expects. Mirrors the trace download route (`/api/traces/[traceId]/download`):
+ * a missing session stays `null` (only public traces are then readable); a
+ * malformed session is rejected.
+ */
+function toTraceAccessSession(
+  session: Awaited<ReturnType<typeof getServerAuthSession>>,
+): TraceExportAccessSession {
+  if (!session) {
+    return null;
+  }
+
+  const { user } = session;
+  if (
+    !user ||
+    typeof user.email !== "string" ||
+    !Array.isArray(user.organizations)
+  ) {
+    throw new UnauthorizedError("Unauthorized");
+  }
+
+  return {
+    user: {
+      email: user.email,
+      admin: user.admin,
+      organizations: user.organizations,
+    },
+  };
+}
+
+export default withMiddlewares({
+  GET: async (req, res) => {
+    // --- Everything that can fail cleanly happens BEFORE any bytes are sent,
+    // so withMiddlewares can still translate errors into a JSON response. ---
+
+    const parsed = querySchema.safeParse({
+      traceId: req.query.traceId,
+      observationId: req.query.observationId,
+      field: req.query.field,
+      projectId: req.query.projectId,
+      startTime: req.query.startTime,
+    });
+    if (!parsed.success) {
+      throw new InvalidRequestError(parsed.error.message);
+    }
+    const { traceId, observationId, field, projectId, startTime } = parsed.data;
+
+    // Authorize the (projectId, traceId) pair. Throws 401/404 before we stream.
+    const session = toTraceAccessSession(
+      await getServerAuthSession({ req, res }),
+    );
+    await getAuthorizedTrace({ traceId, projectId, session });
+
+    // Resolves once ClickHouse has returned response headers; an immediate query
+    // failure rejects here (pre-headers) and is handled by withMiddlewares.
+    const { stream } = await streamObservationIOFieldFromEventsTable({
+      projectId,
+      traceId,
+      observationId,
+      field,
+      startTime,
+    });
+
+    // --- Headers committed below; from here we must not throw into
+    // withMiddlewares (headers are already sent). ---
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    // Tenant data: never cache in shared/proxy caches.
+    res.setHeader("Cache-Control", "private, no-store");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    // Range paging is a documented follow-up (see PR); advertise it as
+    // unsupported for now rather than silently ignoring a Range header.
+    res.setHeader("Accept-Ranges", "none");
+    res.status(200);
+
+    try {
+      // Pull one chunk at a time (source backpressure) and honor sink
+      // backpressure via drain — the field never fully materializes in Node.
+      for await (const chunk of stream) {
+        // write() returns false only when the sink buffer is full; wait for
+        // drain before resuming so a slow client can't balloon memory.
+        if (res.write(chunk) === false) {
+          await once(res, "drain");
+        }
+      }
+      res.end();
+    } catch (error) {
+      // A mid-stream ClickHouse/transport failure after headers were sent: the
+      // client sees a truncated body. Log, tear down, and do not rethrow (that
+      // would collide with withMiddlewares' already-sent headers).
+      logger.error("[stream-observation-io] mid-stream failure", {
+        error: error instanceof Error ? error.message : String(error),
+        projectId,
+        traceId,
+        observationId,
+        field,
+      });
+      stream.destroy();
+      if (!res.writableEnded) res.end();
+    }
+  },
+});


### PR DESCRIPTION
## TL;DR

Adds one additive, backend-only endpoint that streams a **single** trace-observation IO field (`input` | `output` | `metadata`) to the browser **as raw bytes**, piping ClickHouse's response body straight through without buffering the whole value in Node. This is the **transport primitive** for a future lazy/streaming large-JSON viewer. Purely additive; no existing endpoint or behavior changes. Spike/RFC-grade.

## Why

Very large single fields (multi-hundred-MB `input`/`output`) crash the browser today: the current read path materializes the field and the client fetches + `JSON.parse`s it in one shot (seed context: **LFE-10847** big-trace browser crashes, **LFE-10152** large-trace findings). The viewer we want (**LFE-11081**) needs to pull a field as a *byte stream* it can page/parse incrementally. That requires a byte-oriented transport first — this PR — before any UI work.

## What

**New endpoint (session-authed, project-scoped):**

```
GET /api/traces/:traceId/observations/:observationId/io/:field?projectId=...&startTime=<ISO-8601>
```

- `field` ∈ `input | output | metadata`. Responds `Content-Type: application/json; charset=utf-8`.
- Sits next to the existing `GET /api/traces/:traceId/download` route and reuses its **exact** authorization.

**Where the IO comes from:** v4 observation IO lives in the ClickHouse `events_full` table as raw `String` columns (`input`, `output`); `metadata` is reconstructed from the `metadata_names`/`metadata_values` arrays. This is the same source the `events.batchIO` read path uses. It is **not** offloaded to S3 — the field bytes are in ClickHouse — so we can stream straight from CH.

**How it streams:** a new repository fn `streamObservationIOFieldFromEventsTable` selects the one field with `FORMAT RawBLOB` and hands back ClickHouse's live HTTP body as a `Readable` (via the existing `queryClickhouseExecRaw`, the same machinery the Parquet blob-export uses). The route pipes that stream to the response with backpressure — **the field never fully materializes in the Node process**.

## Security model (the #1 review concern)

- **Authenticated + strictly project-scoped.** Authorization reuses the canonical `getAuthorizedTrace` (project membership, public trace, public session, or admin + admin-access webhook) — identical to the trace download route. No new auth surface is invented.
- **Tenant isolation in the query itself (defense in depth).** The read is pinned to a single `(project_id, trace_id, span_id)` via parameterized predicates, so even setting auth aside a caller can only ever get bytes for that one observation in that one project. A foreign `projectId` returns **zero rows / zero bytes** (verified by test against real ClickHouse).
- **No SQL injection.** `field` is validated by a Zod enum and used only as a key into a fixed, closed set of SQL expressions — never string-interpolated. Every user-supplied value goes through CH `{param: String}` binding.
- `startTime` is a primary-key pruning hint only, never an authorization control.
- Response is `Cache-Control: private, no-store` + `X-Content-Type-Options: nosniff`.

## Implemented vs. deferred

| | Status |
|---|---|
| Full-field byte streaming (CH → response, no Node buffering) | ✅ implemented (true source-streaming via `FORMAT RawBLOB`) |
| Strict project scoping + auth + input validation | ✅ implemented |
| Server tests (auth enforced, happy-path stream, cross-project denied) | ✅ implemented |
| `Range: bytes=a-b` / `Accept-Ranges: bytes` paged fetch | ⏸️ **deferred** — advertised `Accept-Ranges: none` for now. Straightforward follow-up via CH `substring`/`length`. |
| Observation-existence 404 | ⏸️ deferred — a missing observation yields an empty 200 body (trace-level auth is enforced; the FE only requests IO for observations it already knows exist). |

<details>
<summary>Mechanism, verification & notes</summary>

**Files**
- `packages/shared/src/server/repositories/events.ts` — `streamObservationIOFieldFromEventsTable` + `OBSERVATION_IO_STREAM_FIELDS` (additive).
- `web/src/pages/api/traces/[traceId]/observations/[observationId]/io/[field].ts` — the route.
- `web/src/features/traces/server/buildTraceExport.ts` — one additive `export` on `getAuthorizedTrace` so the authorizer is reused, not re-derived. No behavior change; existing callers unaffected.
- Two tests: a mocked route test (auth 401/404, invalid-input 400, happy-path streams the field + Content-Type) and a gated ClickHouse integration test (real byte streaming for all three fields + cross-project isolation).

**Error handling.** All fallible work (validation, authorization, awaiting the CH query start) happens before any bytes are written, so failures become clean JSON errors via `withMiddlewares`. A mid-stream CH/transport failure (after headers) is logged and torn down without a double-send.

**Verification (local)**
- Route test: `Tests  7 passed (7)`
- Repo integration test (v4 flag on, live ClickHouse): `Tests  2 passed (2)`
- Typecheck: web + `@langfuse/shared` clean
- Lint (pre-commit `turbo run lint`): `Tasks: 7 successful, 7 total`
- Also validated the `RawBLOB` query directly against local ClickHouse: `input` → raw bytes, `metadata` → valid JSON, foreign `projectId` → 0 bytes.

**Follow-ups.** Range support; per-request authorization is a trace read each call (fine for a spike; cacheable later).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcwTfEAu1Xi7CZko7Y9V8p

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new session-authenticated streaming endpoint (`GET /api/traces/:traceId/observations/:observationId/io/:field`) that pipes a single observation IO field (`input`, `output`, or `metadata`) as raw bytes directly from ClickHouse to the browser, without buffering the field in Node. It is purely additive and shares the existing `getAuthorizedTrace` authorization with the trace-download route.

- **Repository layer** (`events.ts`): new `streamObservationIOFieldFromEventsTable` using `FORMAT RawBLOB` with fully parameterized predicates; `field` is a closed enum, never interpolated.
- **Route** (`io/[field].ts`): validates all inputs with Zod before any auth or data access, writes headers only after CH confirms query startup, and implements per-chunk backpressure via `res.write` + `once(res, 'drain')`.
- **`buildTraceExport.ts`**: `getAuthorizedTrace` is exported (additive only); no behavior change to existing callers.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge as a spike — purely additive, no existing endpoint or behavior is changed. The one concern worth addressing before wider adoption is the drain-wait hang on client disconnect.

The backpressure loop uses `await once(res, 'drain')` without a concurrent guard on socket close. When a slow client disconnects while the response buffer is full, `res` emits `'close'` rather than `'drain'` or `'error'`, so the await never settles. This holds the ClickHouse connection open and pins the request handler until an outer timeout fires — a resource-leak path that is reachable whenever any client drops mid-stream under load. All other aspects of the implementation — tenant scoping, parameterized queries, pre-stream auth, and mid-stream error teardown — are correct.

web/src/pages/api/traces/[traceId]/observations/[observationId]/io/[field].ts — specifically the backpressure loop around lines 128–130
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Route as Route io/[field]
    participant Auth as getAuthorizedTrace
    participant CH as ClickHouse events_full

    Client->>Route: "GET ?projectId&startTime&field=input"
    Route->>Route: Zod parse all inputs
    alt validation fails
        Route-->>Client: 400 InvalidRequestError
    end
    Route->>Auth: getAuthorizedTrace(traceId, projectId, session)
    alt not found
        Auth-->>Route: throw LangfuseNotFoundError
        Route-->>Client: 404
    else unauthorized
        Auth-->>Route: throw UnauthorizedError
        Route-->>Client: 401
    end
    Auth-->>Route: authorized trace
    Route->>CH: SELECT field FORMAT RawBLOB LIMIT 1
    Note over Route,CH: Pinned to project_id + trace_id + span_id within startTime +-1s
    CH-->>Route: Readable stream opened
    Route-->>Client: 200 + Content-Type application/json
    loop for each chunk with backpressure
        CH-->>Route: chunk bytes
        Route-->>Client: res.write(chunk)
        opt write returns false
            Route->>Route: await once(res, drain)
        end
    end
    Route-->>Client: res.end()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Route as Route io/[field]
    participant Auth as getAuthorizedTrace
    participant CH as ClickHouse events_full

    Client->>Route: "GET ?projectId&startTime&field=input"
    Route->>Route: Zod parse all inputs
    alt validation fails
        Route-->>Client: 400 InvalidRequestError
    end
    Route->>Auth: getAuthorizedTrace(traceId, projectId, session)
    alt not found
        Auth-->>Route: throw LangfuseNotFoundError
        Route-->>Client: 404
    else unauthorized
        Auth-->>Route: throw UnauthorizedError
        Route-->>Client: 401
    end
    Auth-->>Route: authorized trace
    Route->>CH: SELECT field FORMAT RawBLOB LIMIT 1
    Note over Route,CH: Pinned to project_id + trace_id + span_id within startTime +-1s
    CH-->>Route: Readable stream opened
    Route-->>Client: 200 + Content-Type application/json
    loop for each chunk with backpressure
        CH-->>Route: chunk bytes
        Route-->>Client: res.write(chunk)
        opt write returns false
            Route->>Route: await once(res, drain)
        end
    end
    Route-->>Client: res.end()
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/api/traces/[traceId]/observations/[observationId]/io/[field].ts:128-130
**Hanging await when client disconnects under backpressure**

`once(res, 'drain')` only resolves on `'drain'` or rejects on `'error'`. In Node.js HTTP, a client disconnect (graceful FIN) causes the underlying socket to emit `'close'`, but this is not automatically forwarded as an `'error'` on `res`. If the response buffer is full at the moment the client drops the connection, the `await once(res, 'drain')` will never settle — the ClickHouse streaming connection stays open and the request handler is pinned until an outer function/process timeout. A `Promise.race` against `once(res, 'close')` (or listening on `req.socket` destroy) is the conventional guard here.

### Issue 2 of 2
packages/shared/src/server/repositories/events.ts:2583-2584
**Narrow ±1 s window silently yields an empty 200 on time skew**

The `minTimestamp`/`maxTimestamp` window is only 2 seconds wide. If the client supplies a `startTime` that differs from the stored `e.start_time` by more than 1 second (clock rounding, truncated ISO-string, or a bug in the caller), the query returns zero rows and the HTTP response is an empty body with status 200 — indistinguishable from a legitimately empty field. There is no feedback to help callers diagnose the mismatch. Since the observation's actual startTime is available from `getAuthorizedTrace` (it's on the returned trace), the route could widen the window or at least warn in the response headers when zero bytes are written.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api): stream trace observation IO a..."](https://github.com/langfuse/langfuse/commit/eb59456c2ed79dfb2452843e86fe6554bc172c9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45681935)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->