### PR TITLE
refactor(agent): upgrade @ag-ui/mastra to 1.1.1 and remove custom chunk parsing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,7 @@ overrides:
   ip-address@10.1.0: 10.2.0
   '@ai-sdk/provider-utils@<=4.0.26': 4.0.27
   '@ai-sdk/provider-utils-v5': npm:@ai-sdk/provider-utils@4.0.27
+  '@ai-sdk/ui-utils>@ai-sdk/provider-utils': 2.2.8
   '@copilotkit/runtime@0.0.0-mme-ag-ui-0-0-46-20260227141603>@ag-ui/langgraph': 0.0.29
   '@anthropic-ai/vertex-sdk>@anthropic-ai/sdk': 0.104.1
   next-auth>nodemailer: ^9.0.3
@@ -419,8 +420,8 @@ importers:
         specifier: ^0.0.52
         version: 0.0.52
       '@ag-ui/mastra':
-        specifier: 1.0.3
-        version: 1.0.3(@ag-ui/client@0.0.52)(@ag-ui/core@0.0.52)(@copilotkit/runtime@0.0.0-mme-ag-ui-0-0-46-20260227141603(8a42fcd90342b5e5e0a318760eda49df))(@mastra/client-js@1.21.1(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(effect@3.21.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(rxjs@7.8.1)(zod@4.3.6))(@mastra/core@1.46.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(express@5.2.1)(rxjs@7.8.1)(zod@4.3.6))(zod@4.3.6)
+        specifier: 1.1.1
+        version: 1.1.1(@ag-ui/client@0.0.52)(@ag-ui/core@0.0.52)(@copilotkit/runtime@0.0.0-mme-ag-ui-0-0-46-20260227141603(8a42fcd90342b5e5e0a318760eda49df))(@mastra/client-js@1.21.1(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(effect@3.21.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(rxjs@7.8.1)(zod@4.3.6))(@mastra/core@1.46.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(express@5.2.1)(rxjs@7.8.1)(zod@4.3.6))
       '@ai-sdk/amazon-bedrock':
         specifier: 4.0.81
         version: 4.0.81(zod@4.3.6)
@@ -1147,6 +1148,9 @@ packages:
   '@adobe/css-tools@4.4.0':
     resolution: {integrity: sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==}
 
+  '@ag-ui/a2ui-toolkit@0.0.4':
+    resolution: {integrity: sha512-9VPmgpCAsFVICk7z23kh+Kp/BwYMxw0D0KGjOiKXhm1MAH+Wid2iC3yKsXso+q7UZZiyhWgeDUSgaAkltyLmGg==}
+
   '@ag-ui/client@0.0.46':
     resolution: {integrity: sha512-9Bl6GN6N3NWa3Ewqgl8E3nJzo88prIB2LS50bTNgw35h5BxC1UY21c0SImqQWZ+VV5kbhs6AUrriypKEBB7F5A==}
 
@@ -1171,14 +1175,14 @@ packages:
       '@ag-ui/client': '>=0.0.42'
       '@ag-ui/core': '>=0.0.42'
 
-  '@ag-ui/mastra@1.0.3':
-    resolution: {integrity: sha512-KiUEg+m04afE6uw1M/SdldnMOxP9+E8tE2bAOhRBKxrWoUKIuVUOJoVkNxzRLmIDLG3bQFJti2ljpRyIJvnFNA==}
+  '@ag-ui/mastra@1.1.1':
+    resolution: {integrity: sha512-6j+3msihWB+b6sc1N+6APR6UM57n0ONR+YCfB7e1twCoyuINJ97z3MEYA5YY9SynTLpfJk58+Yk1wxckJL4v6g==}
     peerDependencies:
       '@ag-ui/client': '>=0.0.44'
       '@ag-ui/core': '>=0.0.44'
-      '@copilotkit/runtime': 0.0.0-mme-ag-ui-0-0-46-20260227141603
+      '@copilotkit/runtime': ^1.60.1
       '@mastra/client-js': '>=1.0.0-0 <2.0.0-0'
-      '@mastra/core': '>=1.0.0-0 <2.0.0-0'
+      '@mastra/core': '>=1.29.0 <2.0.0-0'
 
   '@ag-ui/proto@0.0.46':
     resolution: {integrity: sha512-+FfVhB1OP5A1+5BrEccQnwfODTbfBRWT3+NVnbW4RDFUDVmO9EUA+XPuO1ZxWcDfziTvQriwm0vNyaXGidSIhw==}
@@ -1279,6 +1283,12 @@ packages:
   '@ai-sdk/openai@4.0.5':
     resolution: {integrity: sha512-a9cYQNAKAbkMTt6bHAvDuLv3klwtJT9m0A6x7s8EZlf1ebcxadg/1CONaYh1GA80ZRA9UQHJUS2wHoOphkQQkg==}
     engines: {node: '>=22'}
+    peerDependencies:
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
     peerDependencies:
       zod: 4.3.6
 
@@ -11652,6 +11662,8 @@ snapshots:
 
   '@adobe/css-tools@4.4.0': {}
 
+  '@ag-ui/a2ui-toolkit@0.0.4': {}
+
   '@ag-ui/client@0.0.46':
     dependencies:
       '@ag-ui/core': 0.0.46
@@ -11718,17 +11730,18 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/mastra@1.0.3(@ag-ui/client@0.0.52)(@ag-ui/core@0.0.52)(@copilotkit/runtime@0.0.0-mme-ag-ui-0-0-46-20260227141603(8a42fcd90342b5e5e0a318760eda49df))(@mastra/client-js@1.21.1(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(effect@3.21.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(rxjs@7.8.1)(zod@4.3.6))(@mastra/core@1.46.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(express@5.2.1)(rxjs@7.8.1)(zod@4.3.6))(zod@4.3.6)':
+  '@ag-ui/mastra@1.1.1(@ag-ui/client@0.0.52)(@ag-ui/core@0.0.52)(@copilotkit/runtime@0.0.0-mme-ag-ui-0-0-46-20260227141603(8a42fcd90342b5e5e0a318760eda49df))(@mastra/client-js@1.21.1(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(effect@3.21.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(rxjs@7.8.1)(zod@4.3.6))(@mastra/core@1.46.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(express@5.2.1)(rxjs@7.8.1)(zod@4.3.6))':
     dependencies:
+      '@ag-ui/a2ui-toolkit': 0.0.4
       '@ag-ui/client': 0.0.52
       '@ag-ui/core': 0.0.52
       '@ai-sdk/ui-utils': 1.2.11(zod@4.3.6)
       '@copilotkit/runtime': 0.0.0-mme-ag-ui-0-0-46-20260227141603(8a42fcd90342b5e5e0a318760eda49df)
       '@mastra/client-js': 1.21.1(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(effect@3.21.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(rxjs@7.8.1)(zod@4.3.6)
       '@mastra/core': 1.46.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(express@5.2.1)(rxjs@7.8.1)(zod@4.3.6)
+      fast-json-patch: 3.1.1
       rxjs: 7.8.1
-    transitivePeerDependencies:
-      - zod
+      zod: 4.3.6
 
   '@ag-ui/proto@0.0.46':
     dependencies:
@@ -11858,6 +11871,13 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.3(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@2.2.8(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.12
+      secure-json-parse: 2.7.0
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -11908,7 +11928,7 @@ snapshots:
   '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
       zod: 4.3.6
       zod-to-json-schema: 3.25.2(zod@4.3.6)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,6 +58,10 @@ overrides:
   ip-address@10.1.0: 10.2.0
   "@ai-sdk/provider-utils@<=4.0.26": 4.0.27
   "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@4.0.27"
+  # @ag-ui/mastra imports parsePartialJson from @ai-sdk/ui-utils, whose module
+  # evaluation needs exports (validatorSymbol) that only exist in its own
+  # provider-utils 2.x line — exempt it from the blanket 4.0.27 lift above.
+  "@ai-sdk/ui-utils>@ai-sdk/provider-utils": 2.2.8
   "@copilotkit/runtime@0.0.0-mme-ag-ui-0-0-46-20260227141603>@ag-ui/langgraph": 0.0.29
   # Keep Anthropic's Vertex client on an SDK version that emits Vertex rawPredict URLs.
   # Remove once @langchain/anthropic allows the same SDK range.

--- a/web/package.json
+++ b/web/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@ag-ui/client": "^0.0.52",
     "@ag-ui/core": "^0.0.52",
-    "@ag-ui/mastra": "1.0.3",
+    "@ag-ui/mastra": "1.1.1",
     "@ai-sdk/amazon-bedrock": "4.0.81",
     "@appsignal/opentelemetry-instrumentation-bullmq": "^0.8.0",
     "@astral-sh/ruff-wasm-web": "0.15.13",

--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -10,7 +10,7 @@ import {
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
   IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE,
 } from "@/src/ee/features/in-app-agent/constants";
-import { patchMastraToolCallInputStreaming } from "@/src/ee/features/in-app-agent/server/agent";
+import { patchMastraApprovalChunks } from "@/src/ee/features/in-app-agent/server/agent";
 import {
   createInAppAgentSandbox,
   type SandboxProvider,
@@ -275,305 +275,21 @@ const createPatchedChunkProcessor = () => {
     })),
   };
 
-  patchMastraToolCallInputStreaming(adapter as unknown as MastraAgent);
+  patchMastraApprovalChunks(adapter as unknown as MastraAgent);
 
   const processor = adapter.createChunkProcessor({ onError });
 
   return { forwardedChunks, onError, processor, flush };
 };
 
-describe("patchMastraToolCallInputStreaming", () => {
-  it("converts streamed tool-call input chunks to one native tool-call", () => {
-    const { forwardedChunks, onError, processor } =
-      createPatchedChunkProcessor();
-
-    processor.handleChunk({
-      type: "tool-call-input-streaming-start",
-      payload: {
-        toolCallId: "tool-call-1",
-        toolName: "langfuseDocs_search",
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-delta",
-      payload: {
-        toolCallId: "tool-call-1",
-        argsTextDelta: '{"query":"invite',
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-delta",
-      payload: {
-        toolCallId: "tool-call-1",
-        argsTextDelta: ' users"}',
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-input-streaming-end",
-      payload: { toolCallId: "tool-call-1" },
-    });
-
-    expect(onError).not.toHaveBeenCalled();
-    expect(forwardedChunks).toEqual([
-      {
-        type: "tool-call",
-        payload: {
-          toolCallId: "tool-call-1",
-          toolName: "langfuseDocs_search",
-          args: { query: "invite users" },
-        },
-      },
-    ]);
-  });
-
-  it("uses empty args when streamed tool-call input is malformed JSON", () => {
-    const { forwardedChunks, onError, processor } =
-      createPatchedChunkProcessor();
-
-    processor.handleChunk({
-      type: "tool-call-input-streaming-start",
-      payload: {
-        toolCallId: "tool-call-1",
-        toolName: "langfuseDocs_search",
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-delta",
-      payload: {
-        toolCallId: "tool-call-1",
-        argsTextDelta: '{"query":"invite users"',
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-input-streaming-end",
-      payload: { toolCallId: "tool-call-1" },
-    });
-
-    expect(onError).not.toHaveBeenCalled();
-    expect(forwardedChunks).toEqual([
-      {
-        type: "tool-call",
-        payload: {
-          toolCallId: "tool-call-1",
-          toolName: "langfuseDocs_search",
-          args: {},
-        },
-      },
-    ]);
-  });
-
-  it("suppresses one duplicate native tool-call after synthesizing it", () => {
-    const { forwardedChunks, processor } = createPatchedChunkProcessor();
-
-    processor.handleChunk({
-      type: "tool-call-input-streaming-start",
-      payload: {
-        toolCallId: "tool-call-1",
-        toolName: "langfuseDocs_search",
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-delta",
-      payload: {
-        toolCallId: "tool-call-1",
-        argsTextDelta: '{"query":"invite users"}',
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-input-streaming-end",
-      payload: { toolCallId: "tool-call-1" },
-    });
-    processor.handleChunk({
-      type: "tool-call",
-      payload: {
-        toolCallId: "tool-call-1",
-        toolName: "langfuseDocs_search",
-        args: { query: "invite users" },
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call",
-      payload: {
-        toolCallId: "tool-call-2",
-        toolName: "langfuse_search",
-        args: { traceId: "trace-1" },
-      },
-    });
-
-    expect(forwardedChunks).toEqual([
-      {
-        type: "tool-call",
-        payload: {
-          toolCallId: "tool-call-1",
-          toolName: "langfuseDocs_search",
-          args: { query: "invite users" },
-        },
-      },
-      {
-        type: "tool-call",
-        payload: {
-          toolCallId: "tool-call-2",
-          toolName: "langfuse_search",
-          args: { traceId: "trace-1" },
-        },
-      },
-    ]);
-  });
-
-  it("passes non-tool streaming chunks through unchanged", () => {
-    const { forwardedChunks, onError, processor } =
-      createPatchedChunkProcessor();
-
-    processor.handleChunk({
-      type: "step-start",
-      payload: {},
-    });
-    processor.handleChunk({
-      type: "text-start",
-      payload: { textMessageId: "assistant-1" },
-    });
-    processor.handleChunk({
-      type: "text-delta",
-      payload: {
-        textMessageId: "assistant-1",
-        textDelta: "Investigating...",
-      },
-    });
-    processor.handleChunk({
-      type: "tool-result",
-      payload: {
-        toolCallId: "tool-call-1",
-        toolName: "langfuseDocs_search",
-        result: { ok: true },
-      },
-    });
-    processor.handleChunk({
-      type: "step-finish",
-      payload: {},
-    });
-
-    expect(onError).not.toHaveBeenCalled();
-    expect(forwardedChunks).toEqual([
-      {
-        type: "step-start",
-        payload: {},
-      },
-      {
-        type: "text-start",
-        payload: { textMessageId: "assistant-1" },
-      },
-      {
-        type: "text-delta",
-        payload: {
-          textMessageId: "assistant-1",
-          textDelta: "Investigating...",
-        },
-      },
-      {
-        type: "tool-result",
-        payload: {
-          toolCallId: "tool-call-1",
-          toolName: "langfuseDocs_search",
-          result: { ok: true },
-        },
-      },
-      {
-        type: "step-finish",
-        payload: {},
-      },
-    ]);
-  });
-
-  it("passes through native tool-calls that were not synthesized", () => {
-    const { forwardedChunks, processor } = createPatchedChunkProcessor();
-
-    processor.handleChunk({
-      type: "tool-call",
-      payload: {
-        toolCallId: "tool-call-1",
-        toolName: "langfuse_search",
-        args: { query: "errors" },
-      },
-    });
-
-    expect(forwardedChunks).toEqual([
-      {
-        type: "tool-call",
-        payload: {
-          toolCallId: "tool-call-1",
-          toolName: "langfuse_search",
-          args: { query: "errors" },
-        },
-      },
-    ]);
-  });
-
-  it("keeps suppressing the duplicate native tool-call after a tool-result arrives", () => {
-    const { forwardedChunks, onError, processor } =
-      createPatchedChunkProcessor();
-
-    processor.handleChunk({
-      type: "tool-call-input-streaming-start",
-      payload: {
-        toolCallId: "tool-call-1",
-        toolName: "bash",
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-delta",
-      payload: {
-        toolCallId: "tool-call-1",
-        argsTextDelta: '{"command":"date"}',
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-input-streaming-end",
-      payload: { toolCallId: "tool-call-1" },
-    });
-    processor.handleChunk({
-      type: "tool-result",
-      payload: {
-        toolCallId: "tool-call-1",
-        toolName: "bash",
-        result: "Wed Jul 08 2026",
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call",
-      payload: {
-        toolCallId: "tool-call-1",
-        toolName: "bash",
-        args: { command: "date" },
-      },
-    });
-
-    expect(onError).not.toHaveBeenCalled();
-    expect(forwardedChunks).toEqual([
-      {
-        type: "tool-call",
-        payload: {
-          toolCallId: "tool-call-1",
-          toolName: "bash",
-          args: { command: "date" },
-        },
-      },
-      {
-        type: "tool-result",
-        payload: {
-          toolCallId: "tool-call-1",
-          toolName: "bash",
-          result: "Wed Jul 08 2026",
-        },
-      },
-    ]);
-  });
-
+describe("patchMastraApprovalChunks", () => {
   it("converts tool-call approval chunks to suspended tool calls", () => {
     const { forwardedChunks, onError, processor } =
       createPatchedChunkProcessor();
 
     processor.handleChunk({
       type: "tool-call-approval",
+      runId: "run-1",
       payload: {
         toolCallId: "tool-call-1",
         toolName: "langfuse_createScoreConfig",
@@ -591,6 +307,7 @@ describe("patchMastraToolCallInputStreaming", () => {
     expect(forwardedChunks).toEqual([
       {
         type: "tool-call-suspended",
+        runId: "run-1",
         payload: {
           toolCallId: "tool-call-1",
           toolName: "langfuse_createScoreConfig",
@@ -617,61 +334,6 @@ describe("patchMastraToolCallInputStreaming", () => {
     ]);
   });
 
-  it("drops streamed tool-call args when the tool call becomes an approval", () => {
-    const { forwardedChunks, onError, processor } =
-      createPatchedChunkProcessor();
-
-    processor.handleChunk({
-      type: "tool-call-input-streaming-start",
-      payload: {
-        toolCallId: "tool-call-1",
-        toolName: "langfuse_createScoreConfig",
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-delta",
-      payload: {
-        toolCallId: "tool-call-1",
-        argsTextDelta:
-          '{"name":"readiness","dataType":"NUMERIC","numericMinValue":0,"numericMaxValue":1}',
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-approval",
-      payload: {
-        toolCallId: "tool-call-1",
-        toolName: "langfuse_createScoreConfig",
-        args: {
-          name: "readiness",
-          dataType: "NUMERIC",
-          numericMinValue: 0,
-          numericMaxValue: 1,
-        },
-      },
-    });
-    processor.handleChunk({
-      type: "tool-call-input-streaming-end",
-      payload: { toolCallId: "tool-call-1" },
-    });
-
-    expect(onError).not.toHaveBeenCalled();
-    expect(forwardedChunks).toEqual([
-      {
-        type: "tool-call-suspended",
-        payload: expect.objectContaining({
-          toolCallId: "tool-call-1",
-          toolName: "langfuse_createScoreConfig",
-          args: {
-            name: "readiness",
-            dataType: "NUMERIC",
-            numericMinValue: 0,
-            numericMaxValue: 1,
-          },
-        }),
-      },
-    ]);
-  });
-
   it("reports malformed tool-call approvals", () => {
     const { forwardedChunks, onError, processor } =
       createPatchedChunkProcessor();
@@ -693,123 +355,6 @@ describe("patchMastraToolCallInputStreaming", () => {
     expect(forwardedChunks).toEqual([]);
   });
 
-  it("reports malformed tool-call deltas with no known tool name", () => {
-    const { forwardedChunks, onError, processor } =
-      createPatchedChunkProcessor();
-
-    const shouldStop = processor.handleChunk({
-      type: "tool-call-delta",
-      payload: {
-        toolCallId: "tool-call-1",
-        argsTextDelta: '{"query":"invite users"}',
-      },
-    });
-
-    expect(shouldStop).toBe(true);
-    expect(onError).toHaveBeenCalledWith(
-      new Error(
-        "Malformed tool-call-delta: missing toolName for unknown toolCallId in payload",
-      ),
-    );
-    expect(forwardedChunks).toEqual([]);
-  });
-
-  it("passes through text streaming chunks", () => {
-    const { forwardedChunks, onError, processor } =
-      createPatchedChunkProcessor();
-
-    processor.handleChunk({
-      type: "text-start",
-      payload: { textMessageId: "message-1" },
-    });
-    processor.handleChunk({
-      type: "text-delta",
-      payload: { textMessageId: "message-1", textDelta: "hello" },
-    });
-    processor.handleChunk({
-      type: "text-end",
-      payload: { textMessageId: "message-1" },
-    });
-
-    expect(onError).not.toHaveBeenCalled();
-    expect(forwardedChunks).toEqual([
-      {
-        type: "text-start",
-        payload: { textMessageId: "message-1" },
-      },
-      {
-        type: "text-delta",
-        payload: { textMessageId: "message-1", textDelta: "hello" },
-      },
-      {
-        type: "text-end",
-        payload: { textMessageId: "message-1" },
-      },
-    ]);
-  });
-
-  it("passes lifecycle chunks through unchanged", () => {
-    const { forwardedChunks, onError, processor } =
-      createPatchedChunkProcessor();
-
-    processor.handleChunk({
-      type: "start",
-      runId: "run-1",
-      from: "AGENT",
-      payload: { id: "langfuse-in-app-assistant", messageId: "message-1" },
-    });
-    processor.handleChunk({
-      type: "step-start",
-      runId: "run-1",
-      from: "AGENT",
-      payload: { request: {}, warnings: [], messageId: "message-1" },
-    });
-    processor.handleChunk({
-      type: "step-finish",
-      runId: "run-1",
-      from: "AGENT",
-      payload: {
-        messageId: "message-1",
-        stepResult: { reason: "tool-calls", isContinued: true },
-      },
-    });
-
-    expect(onError).not.toHaveBeenCalled();
-    expect(forwardedChunks).toEqual([
-      {
-        type: "start",
-        from: "AGENT",
-        runId: "run-1",
-        payload: {
-          id: "langfuse-in-app-assistant",
-          messageId: "message-1",
-        },
-      },
-      {
-        type: "step-start",
-        from: "AGENT",
-        runId: "run-1",
-        payload: {
-          messageId: "message-1",
-          request: {},
-          warnings: [],
-        },
-      },
-      {
-        type: "step-finish",
-        from: "AGENT",
-        runId: "run-1",
-        payload: {
-          messageId: "message-1",
-          stepResult: {
-            isContinued: true,
-            reason: "tool-calls",
-          },
-        },
-      },
-    ]);
-  });
-
   it("converts tool-error chunks to tool-result error chunks", () => {
     const { forwardedChunks, onError, processor } =
       createPatchedChunkProcessor();
@@ -817,7 +362,6 @@ describe("patchMastraToolCallInputStreaming", () => {
     processor.handleChunk({
       type: "tool-error",
       runId: "run-1",
-      from: "AGENT",
       payload: {
         toolCallId: "tool-call-1",
         toolName: "bash",
@@ -832,6 +376,7 @@ describe("patchMastraToolCallInputStreaming", () => {
     expect(forwardedChunks).toEqual([
       {
         type: "tool-result",
+        runId: "run-1",
         payload: {
           toolCallId: "tool-call-1",
           toolName: "bash",
@@ -849,24 +394,18 @@ describe("patchMastraToolCallInputStreaming", () => {
     ]);
   });
 
-  it("reports malformed tool-error chunks", () => {
+  it("passes other chunks through unchanged", () => {
     const { forwardedChunks, onError, processor } =
       createPatchedChunkProcessor();
+    const streamingChunk = {
+      type: "tool-call-delta",
+      payload: { toolCallId: "tool-call-1", argsTextDelta: '{"query":' },
+    };
 
-    const shouldStop = processor.handleChunk({
-      type: "tool-error",
-      payload: {
-        error: { message: "boom" },
-      },
-    });
+    processor.handleChunk(streamingChunk);
 
-    expect(shouldStop).toBe(true);
-    expect(onError).toHaveBeenCalledWith(
-      new Error(
-        "Malformed tool-error: missing toolCallId or toolName in payload",
-      ),
-    );
-    expect(forwardedChunks).toEqual([]);
+    expect(onError).not.toHaveBeenCalled();
+    expect(forwardedChunks).toEqual([streamingChunk]);
   });
 });
 

--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -382,13 +382,7 @@ describe("patchMastraApprovalChunks", () => {
           toolName: "bash",
           args: { command: "date" },
           isError: true,
-          result: JSON.stringify(
-            {
-              error: "Error: Region is missing",
-            },
-            null,
-            2,
-          ),
+          result: { error: "Error: Region is missing" },
         },
       },
     ]);

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -34,7 +34,6 @@ import { DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS } from "@/src/features/filters/cons
 import { logger } from "@langfuse/shared/src/server";
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
 import { IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER } from "@/src/ee/features/in-app-agent/constants";
-import { assertUnreachable } from "@/src/utils/types";
 
 const ASSISTANT_TITLE = "Langfuse Assistant";
 const IN_APP_AGENT_SYSTEM_PROMPT_NAME = "in-app-agent-system-prompt";
@@ -819,10 +818,12 @@ async function createMastraAdapter(params: {
     const adapter = new MastraAgent({
       agent,
       resourceId: params.input.threadId,
+      // The structured RUN_FINISHED interrupt outcome targets CopilotKit
+      // >= 1.61.2 clients; ours consumes the legacy on_interrupt CUSTOM
+      // events, so keep the pre-flag behavior.
+      emitInterruptOutcome: false,
     });
-    // @ag-ui/mastra@1.0.3 does not understand Mastra's newer streaming
-    // tool-call chunks yet, so translate them locally to avoid warning noise.
-    patchMastraToolCallInputStreaming(adapter);
+    patchMastraApprovalChunks(adapter);
 
     return {
       adapter,
@@ -894,31 +895,16 @@ type MastraStreamCallbacks = {
 };
 
 type PatchableMastraAgent = {
-  createChunkProcessor?: (
-    callbacks: MastraStreamCallbacks,
-  ) => MastraChunkProcessor;
+  createChunkProcessor?: (...args: unknown[]) => MastraChunkProcessor;
 };
 
-type MastraStreamChunk = {
-  type?:
-    | "start"
-    | "step-start"
-    | "step-finish"
-    | "text-start"
-    | "text-delta"
-    | "text-end"
-    | "tool-call-input-streaming-start"
-    | "tool-call-delta"
-    | "tool-call-input-streaming-end"
-    | "tool-call"
-    | "tool-result"
-    | "tool-error"
-    | "tool-call-approval"
-    | "tool-call-suspended";
+type MastraApprovalStreamChunk = {
+  type?: string;
+  runId?: string;
   payload?: {
-    text?: string;
-    textDelta?: string;
-    textMessageId?: string;
+    toolCallId?: string;
+    toolName?: string;
+    args?: unknown;
     error?: {
       message?: string;
       cause?: {
@@ -928,70 +914,18 @@ type MastraStreamChunk = {
         errorMessage?: string;
       };
     };
-    toolCallId?: string;
-    toolName?: string;
-    argsTextDelta?: string;
-    args?: unknown;
-    result?: unknown;
-    isError?: boolean;
-    resumeSchema?: unknown;
-    suspendPayload?: unknown;
   };
 };
 
-type MastraStreamChunkType = NonNullable<MastraStreamChunk["type"]>;
-
-const MASTRA_STREAM_CHUNK_TYPES = [
-  "start",
-  "step-start",
-  "step-finish",
-  "text-start",
-  "text-delta",
-  "text-end",
-  "tool-call-input-streaming-start",
-  "tool-call-delta",
-  "tool-call-input-streaming-end",
-  "tool-call",
-  "tool-result",
-  "tool-error",
-  "tool-call-approval",
-  "tool-call-suspended",
-] as const satisfies readonly MastraStreamChunkType[];
-
-function isMastraStreamChunkType(type: unknown): type is MastraStreamChunkType {
-  return (
-    typeof type === "string" &&
-    MASTRA_STREAM_CHUNK_TYPES.some((chunkType) => chunkType === type)
-  );
-}
-
-function isMastraStreamChunk(chunk: unknown): chunk is MastraStreamChunk {
-  if (typeof chunk !== "object" || chunk === null) {
-    return false;
-  }
-
-  if (!("type" in chunk) || chunk.type === undefined) {
-    return true;
-  }
-
-  if (!isMastraStreamChunkType(chunk.type)) {
-    return false;
-  }
-
-  if (!("payload" in chunk) || chunk.payload === undefined) {
-    return true;
-  }
-
-  return typeof chunk.payload === "object" && chunk.payload !== null;
-}
-
-type StreamingToolCall = {
-  toolCallId: string;
-  toolName: string;
-  argsText: string;
-};
-
-export function patchMastraToolCallInputStreaming(adapter: MastraAgent) {
+// @ag-ui/mastra handles Mastra's suspend()-based interrupts natively
+// (tool-call-suspended), but not the requireApproval flow used by
+// withInAppAgentToolApproval: Mastra emits a tool-call-approval chunk for
+// those tools and the bridge has no case for it, so approvals would never
+// surface as on_interrupt events. Map approvals onto the suspend protocol.
+// Non-background tool-error chunks are likewise swallowed by the bridge, so
+// convert them to error tool results to keep the failure visible in the
+// transcript and to the model.
+export function patchMastraApprovalChunks(adapter: MastraAgent) {
   const patchableAdapter = adapter as unknown as PatchableMastraAgent;
   const createChunkProcessor = patchableAdapter.createChunkProcessor;
 
@@ -1001,175 +935,21 @@ export function patchMastraToolCallInputStreaming(adapter: MastraAgent) {
 
   patchableAdapter.createChunkProcessor = function patchedCreateChunkProcessor(
     this: PatchableMastraAgent,
-    callbacks: MastraStreamCallbacks,
+    ...args: unknown[]
   ) {
-    const processor = createChunkProcessor.call(this, callbacks);
-    const streamingToolCalls = new Map<string, StreamingToolCall>();
-    const synthesizedToolCallIds = new Set<string>();
-
-    const parseStreamingToolCallArgs = (argsText: string): unknown => {
-      try {
-        return JSON.parse(argsText || "{}");
-      } catch {
-        return {};
-      }
-    };
+    const processor = createChunkProcessor.apply(this, args);
+    const callbacks = args[0] as MastraStreamCallbacks;
 
     return {
       handleChunk(chunk: unknown) {
-        if (!isMastraStreamChunk(chunk)) {
-          logger.warn(
-            "Received unknown Mastra chunk while patching tool-call input streaming",
-            chunk,
-          );
+        const mastraChunk = chunk as MastraApprovalStreamChunk;
 
-          return processor.handleChunk(chunk);
-        }
-
-        const mastraChunk = chunk;
-
-        if (mastraChunk.type === undefined) {
-          return processor.handleChunk(chunk);
-        }
-
-        if (mastraChunk.type === "tool-call-input-streaming-start") {
-          const { toolCallId, toolName } = mastraChunk.payload ?? {};
-          if (!toolCallId || !toolName) {
-            callbacks.onError(
-              new Error(
-                "Malformed tool-call-input-streaming-start: missing toolCallId or toolName in payload",
-              ),
-            );
-            return true;
-          }
-
-          streamingToolCalls.set(toolCallId, {
+        if (mastraChunk?.type === "tool-call-approval") {
+          const {
             toolCallId,
             toolName,
-            argsText: "",
-          });
-          return false;
-        }
-
-        if (mastraChunk.type === "tool-call-delta") {
-          const { toolCallId, toolName, argsTextDelta } =
-            mastraChunk.payload ?? {};
-          if (!toolCallId) {
-            callbacks.onError(
-              new Error(
-                "Malformed tool-call-delta: missing toolCallId in payload",
-              ),
-            );
-            return true;
-          }
-
-          let streamingToolCall = streamingToolCalls.get(toolCallId);
-          if (!streamingToolCall) {
-            if (!toolName) {
-              callbacks.onError(
-                new Error(
-                  "Malformed tool-call-delta: missing toolName for unknown toolCallId in payload",
-                ),
-              );
-              return true;
-            }
-
-            streamingToolCall = { toolCallId, toolName, argsText: "" };
-            streamingToolCalls.set(toolCallId, streamingToolCall);
-          }
-
-          streamingToolCall.argsText += argsTextDelta ?? "";
-          return false;
-        }
-
-        if (mastraChunk.type === "tool-call-input-streaming-end") {
-          const { toolCallId } = mastraChunk.payload ?? {};
-          const streamingToolCall = toolCallId
-            ? streamingToolCalls.get(toolCallId)
-            : undefined;
-          if (streamingToolCall) {
-            synthesizedToolCallIds.add(streamingToolCall.toolCallId);
-            const shouldStop = processor.handleChunk({
-              type: "tool-call",
-              payload: {
-                toolCallId: streamingToolCall.toolCallId,
-                toolName: streamingToolCall.toolName,
-                args: parseStreamingToolCallArgs(streamingToolCall.argsText),
-              },
-            });
-            streamingToolCalls.delete(streamingToolCall.toolCallId);
-            return shouldStop;
-          }
-          return false;
-        }
-
-        if (mastraChunk.type === "tool-call") {
-          const { toolCallId } = mastraChunk.payload ?? {};
-          if (toolCallId && synthesizedToolCallIds.has(toolCallId)) {
-            synthesizedToolCallIds.delete(toolCallId);
-            return false;
-          }
-
-          return processor.handleChunk(chunk);
-        }
-
-        if (mastraChunk.type === "tool-error") {
-          const { toolCallId, toolName, args } = mastraChunk.payload ?? {};
-          if (!toolCallId || !toolName) {
-            callbacks.onError(
-              new Error(
-                "Malformed tool-error: missing toolCallId or toolName in payload",
-              ),
-            );
-            return true;
-          }
-
-          streamingToolCalls.delete(toolCallId);
-          synthesizedToolCallIds.delete(toolCallId);
-
-          return processor.handleChunk({
-            type: "tool-result",
-            payload: {
-              toolCallId,
-              toolName,
-              args,
-              isError: true,
-              result: JSON.stringify(
-                {
-                  error: ((): string => {
-                    if (
-                      typeof mastraChunk.payload?.error?.details
-                        ?.errorMessage === "string"
-                    ) {
-                      return mastraChunk.payload.error.details.errorMessage;
-                    }
-
-                    if (
-                      typeof mastraChunk.payload?.error?.cause?.message ===
-                      "string"
-                    ) {
-                      return mastraChunk.payload.error.cause.message;
-                    }
-
-                    if (
-                      typeof mastraChunk.payload?.error?.message === "string"
-                    ) {
-                      return mastraChunk.payload.error.message;
-                    }
-
-                    return "Unknown tool error";
-                  })(),
-                },
-                null,
-                2,
-              ),
-            },
-          });
-        }
-
-        if (mastraChunk.type === "tool-call-approval") {
-          const { toolCallId, toolName, args, resumeSchema } =
-            mastraChunk.payload ?? {};
+            args: toolArgs,
+          } = mastraChunk.payload ?? {};
           if (!toolCallId || !toolName) {
             callbacks.onError(
               new Error(
@@ -1179,54 +959,78 @@ export function patchMastraToolCallInputStreaming(adapter: MastraAgent) {
             return true;
           }
 
-          streamingToolCalls.delete(toolCallId);
-          synthesizedToolCallIds.delete(toolCallId);
-
           return processor.handleChunk({
+            ...mastraChunk,
             type: "tool-call-suspended",
             payload: {
-              toolCallId,
-              toolName,
-              args,
-              resumeSchema,
+              ...mastraChunk.payload,
               suspendPayload: {
                 type: "approval",
                 toolCallId,
                 toolName,
-                args,
+                args: toolArgs,
               },
             },
           });
         }
 
-        if (mastraChunk.type === "tool-call-suspended") {
-          const { toolCallId } = mastraChunk.payload ?? {};
-          if (toolCallId) {
-            streamingToolCalls.delete(toolCallId);
-            synthesizedToolCallIds.delete(toolCallId);
+        if (mastraChunk?.type === "tool-error") {
+          const {
+            toolCallId,
+            toolName,
+            args: toolArgs,
+          } = mastraChunk.payload ?? {};
+          if (!toolCallId || !toolName) {
+            callbacks.onError(
+              new Error(
+                "Malformed tool-error: missing toolCallId or toolName in payload",
+              ),
+            );
+            return true;
           }
-          return processor.handleChunk(chunk);
+
+          return processor.handleChunk({
+            ...mastraChunk,
+            type: "tool-result",
+            payload: {
+              toolCallId,
+              toolName,
+              args: toolArgs,
+              isError: true,
+              result: JSON.stringify(
+                { error: getToolErrorMessage(mastraChunk) },
+                null,
+                2,
+              ),
+            },
+          });
         }
 
-        if (
-          mastraChunk.type === "start" ||
-          mastraChunk.type === "step-start" ||
-          mastraChunk.type === "step-finish" ||
-          mastraChunk.type === "text-start" ||
-          mastraChunk.type === "text-delta" ||
-          mastraChunk.type === "text-end" ||
-          mastraChunk.type === "tool-result"
-        ) {
-          return processor.handleChunk(chunk);
-        }
-
-        return assertUnreachable(mastraChunk.type);
+        return processor.handleChunk(chunk);
       },
       flush() {
         processor.flush();
       },
     };
   };
+}
+
+function getToolErrorMessage(chunk: MastraApprovalStreamChunk): string {
+  const error = chunk.payload?.error;
+
+  if (typeof error?.details?.errorMessage === "string") {
+    return error.details.errorMessage;
+  }
+
+  if (typeof error?.cause?.message === "string") {
+    return error.cause.message;
+  }
+
+  if (typeof error?.message === "string") {
+    return error.message;
+  }
+
+  return "Unknown tool error";
 }
 
 async function getSystemPromptInstructions(params: {

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -895,7 +895,10 @@ type MastraStreamCallbacks = {
 };
 
 type PatchableMastraAgent = {
-  createChunkProcessor?: (...args: unknown[]) => MastraChunkProcessor;
+  createChunkProcessor?: (
+    callbacks: MastraStreamCallbacks,
+    ...rest: unknown[]
+  ) => MastraChunkProcessor;
 };
 
 type MastraApprovalStreamChunk = {
@@ -923,8 +926,11 @@ type MastraApprovalStreamChunk = {
 // those tools and the bridge has no case for it, so approvals would never
 // surface as on_interrupt events. Map approvals onto the suspend protocol.
 // Non-background tool-error chunks are likewise swallowed by the bridge, so
-// convert them to error tool results to keep the failure visible in the
-// transcript and to the model.
+// convert them to tool results carrying the error message as content. Note:
+// the bridge emits TOOL_CALL_RESULT without a top-level `error` field, so the
+// failure renders with the error message in the result body but a "succeeded"
+// status; the model is unaffected (Mastra's loop feeds it the real error).
+// Status fidelity is tracked as a follow-up.
 export function patchMastraApprovalChunks(adapter: MastraAgent) {
   const patchableAdapter = adapter as unknown as PatchableMastraAgent;
   const createChunkProcessor = patchableAdapter.createChunkProcessor;
@@ -935,10 +941,10 @@ export function patchMastraApprovalChunks(adapter: MastraAgent) {
 
   patchableAdapter.createChunkProcessor = function patchedCreateChunkProcessor(
     this: PatchableMastraAgent,
-    ...args: unknown[]
+    callbacks: MastraStreamCallbacks,
+    ...rest: unknown[]
   ) {
-    const processor = createChunkProcessor.apply(this, args);
-    const callbacks = args[0] as MastraStreamCallbacks;
+    const processor = createChunkProcessor.call(this, callbacks, ...rest);
 
     return {
       handleChunk(chunk: unknown) {
@@ -997,11 +1003,10 @@ export function patchMastraApprovalChunks(adapter: MastraAgent) {
               toolName,
               args: toolArgs,
               isError: true,
-              result: JSON.stringify(
-                { error: getToolErrorMessage(mastraChunk) },
-                null,
-                2,
-              ),
+              // Raw object, not pre-stringified: the bridge JSON-stringifies
+              // payload.result into the event content, so a string here would
+              // double-encode.
+              result: { error: getToolErrorMessage(mastraChunk) },
             },
           });
         }


### PR DESCRIPTION
## What does this PR do?

Closes [LFE-10973](https://linear.app/clickhouse/issue/LFE-10973/upgrade-ag-uimastra-to-remove-custom-chunk-parsinghandling).

Upgrades `@ag-ui/mastra` 1.0.3 → 1.1.1 and removes the ~240-line `patchMastraToolCallInputStreaming` chunk processor. The new bridge natively handles Mastra's streaming tool-call chunks (`tool-call-input-streaming-start/-delta/-end`) and — importantly — suppresses the TOOL_CALL_* lifecycle of suspended tool calls, so approval-gated tools no longer leak orphaned tool-call events into the stream.

What remains is a minimal, stateless shim (`patchMastraApprovalChunks`) for the two chunk types the bridge (still) has no case for:

- `tool-call-approval` (Mastra's `requireApproval: true` flow, which our `withInAppAgentToolApproval` uses) is mapped onto the suspend protocol (`tool-call-suspended`), so approvals keep surfacing as `on_interrupt` events;
- non-background `tool-error` is converted to an error `TOOL_CALL_RESULT` so tool failures stay visible in the transcript and to the model (1.1.1 swallows these).

Supporting changes:

- `emitInterruptOutcome: false` on the `MastraAgent` — the new structured `RUN_FINISHED.outcome` interrupt path targets CopilotKit ≥ 1.61.2 clients; ours consumes the legacy `on_interrupt` CUSTOM events, and the outcome would list all suspends, bypassing approval serialization on the live stream.
- Scoped pnpm override `"@ai-sdk/ui-utils>@ai-sdk/provider-utils": 2.2.8`: `@ag-ui/mastra@1.1.1` imports `parsePartialJson` from `@ai-sdk/ui-utils`, whose module evaluation needs exports (`validatorSymbol`) that only exist in its own provider-utils 2.x line — the existing blanket `<=4.0.26 → 4.0.27` lift broke the build once the bridge started importing it.

### Relation to #15229 (LFE-11033, serialize tool approvals)

This upgrade removes the orphan-lifecycle leak at the source: suspended tool calls no longer emit stray `TOOL_CALL_START/ARGS/END`. The fixes in #15229 remain relevant — 1.1.1 still emits one `on_interrupt` per suspended tool (so the one-interrupt-per-run filter is still needed to keep at most one resumable approval), and approval resumes still synthesize the tool-call lifecycle (so the client tool-call-ID dedup still covers the duplicate-render case, observed again during this PR's browser validation). After this merges, we should rebase/re-evaluate #15229 — its two fixes compose with this upgrade rather than being replaced by it.

Impacted packages: `web` (+ root `pnpm-workspace.yaml`, lockfile)

## Validation

- `pnpm --filter web run test src/__tests__/server/in-app-agent-stream.servertest.ts`
  - `Tests 14 passed (14)` (old patch tests removed; 4 focused shim tests added)
- `pnpm run lint`
  - `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck`
  - exited successfully
- Local browser regression of core flows (per ticket requirement), all via the new native chunk processor:
  - thinking/reasoning block renders;
  - read-only tool call (`langfuse_listPrompts: succeeded`) with correct answer;
  - docs tool with Sources extraction;
  - approval flow: card with correct args → approve → tool executed exactly once → `succeeded`;
  - approval flow: reject → tool not executed, renders `denied` (from persisted state);
  - parallel two-approval request: one approval card at a time, second surfaced after resolving the first, **no orphaned/failed chips** for the deferred call;
  - redirect action button renders and navigates.
  - Server logs clean: no unknown-chunk warnings, no event validation errors.
- Notes from validation (pre-existing, not caused by this PR): live (pre-reload) tool messages lose the `error` field because `@ag-ui/client@0.0.52` builds tool messages from `TOOL_CALL_RESULT` without it, so a just-rejected call briefly shows `succeeded` until reload; duplicate rendering of an approved call's tool chip is the LFE-11033 duplicate class addressed by #15229's client dedup.

## Type of change

- [x] Refactor (non-breaking change that only restructures code)

## Mandatory Tasks

- [x] Self-reviewed the code; scoped to the bridge upgrade, the residual shim, and its tests.

## Documentation

No documentation update required; no public API or behavior contract changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves streamed tool-call handling into the upgraded Mastra bridge. The main changes are:

- Upgrades `@ag-ui/mastra` from 1.0.3 to 1.1.1.
- Replaces custom chunk parsing with approval and tool-error conversions.
- Disables structured interrupt outcomes for the legacy client.
- Restores the provider-utils version required by `@ai-sdk/ui-utils`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The bridge upgrade needs runtime compatibility aligned before merging.

- The resolved CopilotKit runtime does not satisfy the upgraded bridge's peer contract.
- The chunk wrapper assumes an unchecked callback argument position on malformed-event paths.
- The provider-utils override matches the dependency expected by `@ai-sdk/ui-utils`.

web/package.json, pnpm-lock.yaml, and web/src/ee/features/in-app-agent/server/agent.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/package.json:35
**Runtime Peer Contract Mismatch**

`@ag-ui/mastra@1.1.1` requires `@copilotkit/runtime ^1.60.1`, but the lockfile resolves the older `0.0.0-mme-ag-ui-0-0-46-20260227141603` fork. When the upgraded bridge reaches an API absent from that fork, agent stream initialization or interrupt handling can fail; align the runtime version or explicitly provide a compatible fork.

### Issue 2 of 2
web/src/ee/features/in-app-agent/server/agent.ts:940-941
**Unchecked Processor Callback Position**

The wrapper now accepts any argument list but assumes `args[0]` is always the callbacks object. If the upgraded bridge invokes `createChunkProcessor` without callbacks first, a malformed approval or tool-error reaches `callbacks.onError` and throws instead of reporting the stream error.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(agent): upgrade @ag-ui/mastra t..."](https://github.com/langfuse/langfuse/commit/58ba196dfedf15f5f1350f7239ee467b4b22ffc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45875318)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->