### PR TITLE
fix(observability): stop capturing expected tRPC errors as Sentry issues (LFE-10977)

### DIFF
--- a/web/src/components/layouts/app-layout/index.tsx
+++ b/web/src/components/layouts/app-layout/index.tsx
@@ -15,7 +15,7 @@ import { signOut } from "next-auth/react";
 import posthog from "posthog-js";
 import { env } from "@/src/env.mjs";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { ErrorPageWithSentry } from "@/src/components/error-page";
+import { ErrorPage } from "@/src/components/error-page";
 
 // Layout variants
 import { LoadingLayout } from "./variants/LoadingLayout";
@@ -89,9 +89,13 @@ export function AppLayout(props: PropsWithChildren) {
       return <MinimalLayout>{props.children}</MinimalLayout>;
     }
 
-    // For non-publishable paths, show error page
+    // For non-publishable paths, show error page. This is an EXPECTED state (an
+    // authenticated user opened a project they can't access or that no longer
+    // exists) that the UI already renders — so use the non-capturing ErrorPage
+    // rather than ErrorPageWithSentry, which otherwise mints a Sentry issue on
+    // every mount (thousands of events / hundreds of users of pure noise).
     return (
-      <ErrorPageWithSentry
+      <ErrorPage
         title="Project Not Found"
         message="The project you are trying to access does not exist or you do not have access to it."
         additionalButton={{

--- a/web/src/utils/api.clienttest.ts
+++ b/web/src/utils/api.clienttest.ts
@@ -1,5 +1,30 @@
 import { TRPCClientError } from "@trpc/client";
-import { isNetworkConnectivityError } from "@/src/utils/api";
+import {
+  EXPECTED_TRPC_ERROR_CODES,
+  getTrpcErrorCode,
+  getTrpcErrorPath,
+  isExpectedTrpcClientError,
+  isNetworkConnectivityError,
+} from "@/src/utils/api";
+
+/** Builds a TRPCClientError with the given server error shape (code/path). */
+const trpcServerError = (opts: {
+  code: string;
+  httpStatus: number;
+  path?: string;
+  message?: string;
+}) =>
+  TRPCClientError.from({
+    error: {
+      code: -32600,
+      message: opts.message ?? opts.code,
+      data: {
+        code: opts.code,
+        httpStatus: opts.httpStatus,
+        ...(opts.path !== undefined ? { path: opts.path } : {}),
+      },
+    },
+  });
 
 describe("isNetworkConnectivityError", () => {
   it("detects the reported failed fetch error without a response", () => {
@@ -52,5 +77,93 @@ describe("isNetworkConnectivityError", () => {
     expect(isNetworkConnectivityError(new TypeError("Failed to fetch"))).toBe(
       false,
     );
+  });
+});
+
+describe("getTrpcErrorCode / getTrpcErrorPath", () => {
+  it("extracts the code and path from a tRPC server error", () => {
+    const error = trpcServerError({
+      code: "NOT_FOUND",
+      httpStatus: 404,
+      path: "traces.byId",
+    });
+
+    expect(getTrpcErrorCode(error)).toBe("NOT_FOUND");
+    expect(getTrpcErrorPath(error)).toBe("traces.byId");
+  });
+
+  it("returns undefined for non-tRPC errors", () => {
+    expect(getTrpcErrorCode(new Error("boom"))).toBeUndefined();
+    expect(getTrpcErrorPath(new Error("boom"))).toBeUndefined();
+    expect(getTrpcErrorCode("nope")).toBeUndefined();
+    expect(getTrpcErrorPath(null)).toBeUndefined();
+  });
+
+  it("returns undefined path when the server shape omits it", () => {
+    const error = trpcServerError({ code: "FORBIDDEN", httpStatus: 403 });
+
+    expect(getTrpcErrorCode(error)).toBe("FORBIDDEN");
+    expect(getTrpcErrorPath(error)).toBeUndefined();
+  });
+});
+
+describe("isExpectedTrpcClientError", () => {
+  // Expected, user-facing states — must be suppressed (not captured to Sentry).
+  it.each(EXPECTED_TRPC_ERROR_CODES)(
+    "treats %s as an expected client error",
+    (code) => {
+      const httpStatus =
+        code === "NOT_FOUND" ? 404 : code === "FORBIDDEN" ? 403 : 401;
+      const error = trpcServerError({ code, httpStatus, path: "traces.byId" });
+
+      expect(isExpectedTrpcClientError(error)).toBe(true);
+    },
+  );
+
+  // Negative fixtures: real errors MUST still flow to Sentry. If any of these
+  // start returning true, the suppression rule has grown a hole that hides a
+  // genuine bug.
+  it("does not suppress server (5xx) errors", () => {
+    const error = trpcServerError({
+      code: "INTERNAL_SERVER_ERROR",
+      httpStatus: 500,
+      path: "events.all",
+    });
+
+    expect(isExpectedTrpcClientError(error)).toBe(false);
+  });
+
+  it("does not suppress client validation errors (BAD_REQUEST / CONFLICT)", () => {
+    expect(
+      isExpectedTrpcClientError(
+        trpcServerError({ code: "BAD_REQUEST", httpStatus: 400 }),
+      ),
+    ).toBe(false);
+    expect(
+      isExpectedTrpcClientError(
+        trpcServerError({ code: "CONFLICT", httpStatus: 409 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not suppress an unrecognized tRPC code", () => {
+    const error = trpcServerError({
+      code: "TEAPOT",
+      httpStatus: 418,
+    });
+
+    expect(isExpectedTrpcClientError(error)).toBe(false);
+  });
+
+  it("does not suppress non-tRPC errors or non-errors", () => {
+    expect(isExpectedTrpcClientError(new Error("boom"))).toBe(false);
+    expect(isExpectedTrpcClientError(new TypeError("Failed to fetch"))).toBe(
+      false,
+    );
+    expect(isExpectedTrpcClientError({ data: { code: "NOT_FOUND" } })).toBe(
+      false,
+    );
+    expect(isExpectedTrpcClientError(null)).toBe(false);
+    expect(isExpectedTrpcClientError(undefined)).toBe(false);
   });
 });

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -5,7 +5,7 @@
  * We also create a few inference helpers for input and output types.
  */
 
-import { captureException } from "@sentry/nextjs";
+import { addBreadcrumb, captureException } from "@sentry/nextjs";
 import {
   createTRPCProxyClient,
   httpBatchLink,
@@ -96,6 +96,71 @@ export const isNetworkConnectivityError = (error: unknown): boolean => {
 };
 
 /**
+ * tRPC error codes that represent EXPECTED, user-facing product states rather
+ * than actionable application errors:
+ *  - NOT_FOUND     — a missing/deleted/never-existed resource (opening a trace
+ *                    URL that no longer resolves)
+ *  - FORBIDDEN     — the signed-in user may not access this resource (a trace in
+ *                    another org, a project they are not a member of)
+ *  - UNAUTHORIZED  — the session expired or the user is not signed in
+ *
+ * The UI already renders each of these as an error page or toast — it is the
+ * product working as designed, not a regression a human should act on. Sending
+ * them to Sentry turns the error tracker into a log of ordinary navigation
+ * (`Trace not found` alone is the #2 issue by volume, ~30k events / ~3.3k
+ * users) and drowns real signal.
+ *
+ * Suppressing capture here does NOT blind us to real authz/lookup regressions:
+ * the server owns that signal — a genuine regression surfaces as a 4xx-rate
+ * anomaly server-side and as user reports, whereas the client Sentry event is
+ * only an amplified, lower-fidelity copy. The server itself already logs
+ * NOT_FOUND / UNAUTHORIZED as non-errors (`web/src/server/api/trpc.ts`), and
+ * `handleTrpcError` leaves a breadcrumb for each suppressed error so its path +
+ * code stay in the trail of any real event captured later in the session.
+ *
+ * Deliberately narrow: only these codes on an actual `TRPCClientError`. A 5xx
+ * (`INTERNAL_SERVER_ERROR`), a `BAD_REQUEST`, an unrecognized code, or any
+ * non-tRPC error is not expected and keeps flowing to Sentry unchanged.
+ */
+export const EXPECTED_TRPC_ERROR_CODES = [
+  "NOT_FOUND",
+  "FORBIDDEN",
+  "UNAUTHORIZED",
+] as const;
+
+const getTrpcErrorData = (
+  error: unknown,
+): { code?: unknown; path?: unknown } | undefined =>
+  error instanceof TRPCClientError
+    ? (error.data as { code?: unknown; path?: unknown } | undefined)
+    : undefined;
+
+/** The tRPC error code (`data.code`) when `error` is a TRPCClientError. */
+export const getTrpcErrorCode = (error: unknown): string | undefined => {
+  const code = getTrpcErrorData(error)?.code;
+  return typeof code === "string" ? code : undefined;
+};
+
+/** The tRPC procedure path (`data.path`) when available — used as a Sentry tag. */
+export const getTrpcErrorPath = (error: unknown): string | undefined => {
+  const path = getTrpcErrorData(error)?.path;
+  return typeof path === "string" ? path : undefined;
+};
+
+/**
+ * True when `error` is a TRPCClientError whose code is an EXPECTED, user-facing
+ * state that should not be captured to Sentry.
+ * See {@link EXPECTED_TRPC_ERROR_CODES}.
+ */
+export const isExpectedTrpcClientError = (error: unknown): boolean => {
+  const code = getTrpcErrorCode(error);
+  return (
+    code !== undefined &&
+    (EXPECTED_TRPC_ERROR_CODES as readonly string[]).includes(code)
+  );
+};
+
+/**
  * tRPC serializes query input into the GET URL. For reads whose input scales with
  * the number of rows (the `*.batchIO` I/O fetches), that URL grows large (~6KB at
  * 50 rows, ~12KB at 100) and — together with per-user cookies (NextAuth session
@@ -174,7 +239,33 @@ const handleTrpcError = (error: unknown, shouldSilenceError = false) => {
       }
     }
 
-    captureException(error);
+    if (isExpectedTrpcClientError(error)) {
+      // Expected, user-facing states (a missing/forbidden resource, an expired
+      // session) are the product working as designed — don't mint a Sentry
+      // issue for them. Leave a breadcrumb so the path + code stay in the trail
+      // of any real event captured later this session; the server owns the real
+      // authz/lookup-regression signal. See `isExpectedTrpcClientError`.
+      addBreadcrumb({
+        category: "trpc",
+        type: "http",
+        level: "info",
+        message: "Suppressed expected tRPC error (not sent to Sentry)",
+        data: {
+          code: getTrpcErrorCode(error),
+          path: getTrpcErrorPath(error),
+          httpStatus,
+        },
+      });
+    } else {
+      // Real tRPC errors keep flowing to Sentry, now tagged by procedure/code
+      // so they group and route instead of collapsing into one opaque bucket.
+      captureException(error, {
+        tags: {
+          "trpc.code": getTrpcErrorCode(error),
+          "trpc.path": getTrpcErrorPath(error),
+        },
+      });
+    }
   } else {
     // For non-TRPC errors, still send to Sentry
     captureException(error);


### PR DESCRIPTION
## TL;DR

Stop turning **expected, user-facing tRPC states** into Sentry issues. `handleTrpcError` captured *every* `TRPCClientError`, so ordinary navigation — opening a trace that was deleted, a project you're not a member of, a session that expired — minted error events. `Trace not found` (54F) alone is the **#2 issue by volume (~30k events / ~3.3k users)**. This classifies at the tRPC client seam: expected codes (`NOT_FOUND` / `FORBIDDEN` / `UNAUTHORIZED`) are no longer captured; everything else keeps flowing, now tagged.

## Why

The tRPC global error handler `captureException`s unconditionally — the single biggest deliberate inflow to Sentry (~14.5k/7d "generic" captures). Most of that volume isn't crashes; it's the product working as designed being logged as errors, which drowns real signal. Dozens of views *already* handle these codes (`error.data?.code === "NOT_FOUND"` → render a not-found view), but the error still reached Sentry through the global `handleTrpcError` — so even correctly-handled UX was minting issues. This closes that gap at the single seam every tRPC error flows through. Part of the "make Sentry signal, not noise" workstream (LFE-10974).

## What

- **`handleTrpcError` classifies** (`web/src/utils/api.ts`): a `TRPCClientError` whose `data.code` is `NOT_FOUND` / `FORBIDDEN` / `UNAUTHORIZED` leaves a **breadcrumb** instead of capturing. All other tRPC errors (5xx, `BAD_REQUEST`, unknown codes) and all non-tRPC errors are captured unchanged — now **tagged** `trpc.code` / `trpc.path` so they group and route by procedure instead of collapsing into one opaque bucket.
- **`ErrorPage` for the expected "Project Not Found / no access" layout state** (`app-layout`): it rendered `ErrorPageWithSentry`, which captured a Sentry issue on *every mount* (4DX). The two genuine auth-error pages (`auth/error`, `auth/sso-initiate`) are left capturing.

## Result

Removes today's #2 issue (54F) plus the "not a member" (5GM), expired-session (`UNAUTHORIZED`), and "Project Not Found" (4DX) families from the stream, and enriches the real tRPC errors that remain. No user-facing change — toasts and error pages render exactly as before.

<details>
<summary>Safety: does this hide a real error?</summary>

Suppressing capture for these three codes does **not** blind us to real authz/lookup regressions:

- **The server owns that signal.** A genuine regression (a broken lookup wrongly 404ing, an RBAC bug wrongly 403ing legitimate users) surfaces as a **4xx-rate anomaly server-side** and as user reports. The client Sentry event was only an amplified, lower-fidelity copy of a signal that already lives server-side.
- **The server already treats these as non-errors** when it logs (`web/src/server/api/trpc.ts` downgrades `NOT_FOUND` / `UNAUTHORIZED`).
- **The trail survives.** Each suppressed error leaves a Sentry **breadcrumb** (code + path + status), so if a *real* event is captured later in the same session, the expected-error context is right there.
- **Deliberately narrow.** Only those three codes on an actual `TRPCClientError`. A 5xx, a `BAD_REQUEST`, an unrecognized code, or any non-tRPC error is not expected and keeps flowing to Sentry unchanged.

**Tests** (`web/src/utils/api.clienttest.ts`): negative fixtures assert `INTERNAL_SERVER_ERROR`, `BAD_REQUEST`, `CONFLICT`, unknown codes, and non-tRPC errors all still return `false` from the classifier — i.e. still reach Sentry. If the suppression rule ever grows a hole, those tests fail.

**Verification:** `pnpm --filter web run typecheck` clean · `pnpm --filter web run lint` clean · `pnpm --filter web run test-client src/utils/api.clienttest.ts` → 16 passed.
</details>

The seam catches every expected tRPC error comprehensively; the remaining per-surface audit in LFE-10977 (individual not-found / permission components) can follow as smaller cleanups. Part of the Sentry-noise workstream (LFE-10974). Related shipped levers: #15145 (httpClient poll scope), #15238 (beforeSend denylist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces Sentry noise from expected client-side tRPC states. The main changes are:

- Records `NOT_FOUND`, `FORBIDDEN`, and `UNAUTHORIZED` responses as breadcrumbs instead of issues.
- Adds procedure and error-code tags to captured tRPC errors.
- Uses the non-capturing project access error page in the app layout.
- Adds tests for tRPC metadata extraction and classification.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- Unexpected tRPC errors and non-tRPC errors still reach Sentry.
- The app-layout change preserves the existing error-page content and actions.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(observability): stop capturing expec..."](https://github.com/langfuse/langfuse/commit/e57f4a7447801985ef2bcc837a6b4617ba16721c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45884784)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->