### PR TITLE
fix(observability): render markdown links as native anchors (LFE-10977)

### DIFF
--- a/web/src/components/ui/MarkdownViewer.clienttest.tsx
+++ b/web/src/components/ui/MarkdownViewer.clienttest.tsx
@@ -1,0 +1,59 @@
+import { render } from "@testing-library/react";
+import { MarkdownView } from "@/src/components/ui/MarkdownViewer";
+import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ query: {} }),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+const renderMarkdown = (markdown: string) =>
+  render(
+    <MarkdownContextProvider>
+      <MarkdownView markdown={markdown} />
+    </MarkdownContextProvider>,
+  );
+
+describe("MarkdownView link rendering", () => {
+  it("renders an external link as a native anchor opening in a new tab", () => {
+    const { container } = renderMarkdown("[example](https://example.com/page)");
+
+    const anchor = container.querySelector("a");
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute("href")).toBe("https://example.com/page");
+    expect(anchor?.getAttribute("target")).toBe("_blank");
+    expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  // Regression guard for the Sentry "Invalid href '…' passed to next/router"
+  // noise family (LANGFUSE-5DZ / 5EA / 5ER, ~40k lifetime events): user-content
+  // markdown embeds URLs that a Next.js <Link> rejects (repeated `//` from an
+  // embedded second `https://`, etc.). A native <a> never runs the router's
+  // href validation, so such a link must render without throwing — a
+  // regression to <Link> would throw here.
+  it("renders a malformed user URL as an anchor without throwing", () => {
+    const malformed =
+      "https://www.example.com/a%22,%22thumb%22:%22https://assets.example.com/b";
+
+    expect(() => renderMarkdown(`[bad](${malformed})`)).not.toThrow();
+
+    const { container } = renderMarkdown(`[bad](${malformed})`);
+    const anchor = container.querySelector("a");
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute("target")).toBe("_blank");
+  });
+
+  it("renders an unsafe-protocol link as plain text, not an anchor", () => {
+    const { container } = renderMarkdown("[x](javascript:alert(1))");
+
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toContain("x");
+  });
+});

--- a/web/src/components/ui/MarkdownViewer.clienttest.tsx
+++ b/web/src/components/ui/MarkdownViewer.clienttest.tsx
@@ -1,5 +1,8 @@
 import { render } from "@testing-library/react";
-import { MarkdownView } from "@/src/components/ui/MarkdownViewer";
+import {
+  MarkdownView,
+  prependBasePathToInternalHref,
+} from "@/src/components/ui/MarkdownViewer";
 import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
 
 vi.mock("next/router", () => ({
@@ -55,5 +58,39 @@ describe("MarkdownView link rendering", () => {
 
     expect(container.querySelector("a")).toBeNull();
     expect(container.textContent).toContain("x");
+  });
+});
+
+describe("prependBasePathToInternalHref", () => {
+  // A native <a> loses the NEXT_PUBLIC_BASE_PATH that <Link> used to prepend to
+  // root-relative internal hrefs; this helper restores it for subpath deploys.
+  it("prepends the base path to a root-relative internal href", () => {
+    expect(
+      prependBasePathToInternalHref("/project/abc/traces/def", "/lf"),
+    ).toBe("/lf/project/abc/traces/def");
+  });
+
+  it("is a no-op when no base path is configured", () => {
+    expect(prependBasePathToInternalHref("/project/abc", "")).toBe(
+      "/project/abc",
+    );
+  });
+
+  it("leaves absolute URLs untouched", () => {
+    expect(
+      prependBasePathToInternalHref("https://example.com/page", "/lf"),
+    ).toBe("https://example.com/page");
+    expect(prependBasePathToInternalHref("mailto:a@b.com", "/lf")).toBe(
+      "mailto:a@b.com",
+    );
+  });
+
+  it("leaves protocol-relative, hash, search and dot-relative refs untouched", () => {
+    expect(prependBasePathToInternalHref("//evil.example.com", "/lf")).toBe(
+      "//evil.example.com",
+    );
+    expect(prependBasePathToInternalHref("#section", "/lf")).toBe("#section");
+    expect(prependBasePathToInternalHref("?tab=io", "/lf")).toBe("?tab=io");
+    expect(prependBasePathToInternalHref("./sibling", "/lf")).toBe("./sibling");
   });
 });

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -39,6 +39,7 @@ import { MENTION_USER_PREFIX } from "@/src/features/comments/lib/mentionParser";
 import { useCollapsibleSystemPrompt } from "@/src/hooks/useCollapsibleSystemPrompt";
 import { Button } from "@/src/components/ui/button";
 import { getSafeImageUrl, getSafeLinkUrl } from "@/src/components/ui/safe-url";
+import { env } from "@/src/env.mjs";
 import {
   getPromptReferenceMarkdownHref,
   getPromptReferenceMarkdownLabel,
@@ -88,6 +89,23 @@ const transformListItemChildren = (children: ReactNode) =>
         })
       : child,
   );
+
+/**
+ * A Next.js `<Link>` auto-prepends the configured `NEXT_PUBLIC_BASE_PATH` to
+ * root-relative internal hrefs (`/project/...`); a native `<a>` does not. Since
+ * markdown links now render as native anchors, replicate that so a hand-authored
+ * internal link still resolves under the base path on subpath deployments.
+ * Only root-relative paths are rewritten — absolute URLs (with a scheme),
+ * protocol-relative (`//`), hash (`#`), search (`?`), and `./`/`../` refs are
+ * left untouched (Next's `<Link>` did not prepend the base path to those either).
+ */
+export const prependBasePathToInternalHref = (
+  href: string,
+  basePath: string,
+): string =>
+  basePath && href.startsWith("/") && !href.startsWith("//")
+    ? `${basePath}${href}`
+    : href;
 
 const isImageNode = (node?: ReactMarkdownNode): boolean =>
   !!node &&
@@ -291,11 +309,16 @@ function MarkdownRenderer({
               // a second `https://`). That was a top Sentry noise family
               // (LANGFUSE-5DZ / 5EA / 5ER, ~40k lifetime events). getSafeLinkUrl
               // already gates the protocol/shape; a native <a> never validates.
+              // Re-apply NEXT_PUBLIC_BASE_PATH for root-relative internal hrefs,
+              // which <Link> used to prepend automatically (subpath deploys).
               const safeHref = getSafeLinkUrl(href);
               if (safeHref) {
                 return (
                   <a
-                    href={safeHref}
+                    href={prependBasePathToInternalHref(
+                      safeHref,
+                      env.NEXT_PUBLIC_BASE_PATH ?? "",
+                    )}
                     className="underline"
                     target="_blank"
                     rel="noopener noreferrer"

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -10,7 +10,6 @@ import {
   createElement,
 } from "react";
 import ReactMarkdown, { type Options } from "react-markdown";
-import Link from "next/link";
 import remarkGfm from "remark-gfm";
 import { CodeBlock } from "@/src/components/ui/Codeblock";
 import { useTheme } from "next-themes";
@@ -283,18 +282,26 @@ function MarkdownRenderer({
                 );
               }
 
-              // Handle regular links
+              // Handle regular links. These are user-content URLs opened in a
+              // new tab (target="_blank"), so a native <a> is correct: a Next.js
+              // <Link> gives no client-routing benefit for an external new-tab
+              // navigation, but it DOES run the router's href validation, which
+              // throws "Invalid href '…' passed to next/router" for the many
+              // malformed URLs embedded in trace content (e.g. a URL containing
+              // a second `https://`). That was a top Sentry noise family
+              // (LANGFUSE-5DZ / 5EA / 5ER, ~40k lifetime events). getSafeLinkUrl
+              // already gates the protocol/shape; a native <a> never validates.
               const safeHref = getSafeLinkUrl(href);
               if (safeHref) {
                 return (
-                  <Link
+                  <a
                     href={safeHref}
                     className="underline"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
                     {children}
-                  </Link>
+                  </a>
                 );
               }
               return (


### PR DESCRIPTION
## TL;DR

Trace/comment markdown links were rendered through a Next.js `<Link>`, whose router validates the href and logs `Invalid href '…' passed to next/router` for the many malformed URLs embedded in user content. `captureConsoleIntegration` turned each into a Sentry event — a top noise family (**LANGFUSE-5DZ / 5EA / 5ER, ~40k lifetime events, ~330/24h**). These links open in a new tab, so `<Link>` buys nothing anyway: render a native `<a>`, which never runs that validation.

## Why

The URLs come from trace content (e.g. an LLM output embedding `https://a.com/x":"https://b.com/y` — a second `https://` produces repeated `//`, which Next.js rejects). `getSafeLinkUrl` accepts it as a valid https URL, then `<Link>` throws on the normalized form. Nobody acts on "a user's content contained a weird URL" — it's pure noise, and it's born from using `<Link>` for something that isn't internal navigation. Part of the Sentry-noise workstream (LFE-10974).

## What

In `MarkdownViewer`'s markdown-link (`a`) renderer, replace the Next.js `<Link>` with a native `<a>` (same `href`/`className`/`target="_blank"`/`rel`). `getSafeLinkUrl` still gates protocol and shape, so the safety posture is unchanged; the link renders and opens identically. Removed the now-unused `next/link` import.

## Result

Eliminates the `Invalid href … passed to next/router` family at the source. No user-facing change — links render and open exactly as before.

<details>
<summary>Verification (browser A/B on a real trace)</summary>

Added a comment `…[bad link](https://www.example.com/a%22:%22https://assets.example.com/b)` (an embedded second `https://`, the production shape) to a local trace and opened the comment drawer:

- **Before (`<Link>`):** console fires
  `Invalid href 'https://www.example.com/a%22:%22https://assets.example.com/b' passed to next/router in page: '/project/[projectId]/traces/[traceId]'. Repeated forward-slashes (//) or backslashes \ are not valid in the href.`
  — repeated ~12× (each a Sentry event via `captureConsoleIntegration`).
- **After (`<a>`):** **0** "Invalid href" errors; the link renders as `<a href="…" target="_blank" rel="noopener noreferrer">` and is clickable.

The router's href validation only runs in the real client runtime (not jsdom), so the unit tests (`MarkdownViewer.clienttest.tsx`) lock the rendering contract as a regression guard: external links render as a native `<a>` (correct `href`/`target`/`rel`), a malformed URL renders without throwing, and an unsafe-protocol (`javascript:`) link still renders as plain text (not an anchor).

`pnpm --filter web run test-client src/components/ui/MarkdownViewer.clienttest.tsx` → 3 passed · typecheck clean · lint clean.
</details>

Part of the Sentry-noise workstream (LFE-10974). Sibling PR: #15243 (expected tRPC codes). Related shipped levers: #15145, #15238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR renders sanitized markdown links as native browser anchors. The main changes are:

- Replaces Next.js `Link` with `<a>` for links opened in a new tab.
- Removes the unused `next/link` import.
- Adds tests for external, malformed, and unsafe-protocol links.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- URL sanitization and new-tab protections remain in place.
- Native anchors avoid router validation without changing the intended navigation.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(observability): render markdown link..."](https://github.com/langfuse/langfuse/commit/fd210cee2a8f8d196d11ded51d79627c10d11301) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45889964)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->