### PR TITLE
feat(annotations): Support opening "Manage score configs" in a new tab

### DIFF
--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -270,7 +270,13 @@ const DropdownMenuItem = React.forwardRef<
 ));
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
-type DropdownMenuItemAction =
+type DropdownMenuItemAction = {
+  /**
+   * Use `onBeforeAction` to perform minor side effects such as capturing an event.
+   * Do not use `onBeforeAction` to perform the main action or prevent the default action.
+   */
+  onBeforeAction?: () => void;
+} & (
   | {
       href: React.ComponentProps<typeof Link>["href"];
       onClick?: never;
@@ -278,7 +284,8 @@ type DropdownMenuItemAction =
   | {
       href?: never;
       onClick: () => void;
-    };
+    }
+);
 
 type DropdownMenuItemWithSecondaryActionProps = {
   icon?: LucideIcon;
@@ -325,7 +332,10 @@ const DropdownMenuItemWithSecondaryAction = (
           href={secondaryAction.href}
           aria-label={secondaryAction.ariaLabel}
           className={dropdownMenuItemSecondaryActionVariants()}
-          onClick={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            secondaryAction.onBeforeAction?.();
+          }}
         >
           <SecondaryActionIcon size={12} />
         </Link>
@@ -338,6 +348,7 @@ const DropdownMenuItemWithSecondaryAction = (
           className={dropdownMenuItemSecondaryActionVariants()}
           onClick={(event) => {
             event.stopPropagation();
+            secondaryAction.onBeforeAction?.();
             secondaryAction.onClick();
           }}
         >
@@ -354,6 +365,9 @@ const DropdownMenuItemWithSecondaryAction = (
           <Link
             href={props.href}
             className={dropdownMenuItemPrimaryActionVariants()}
+            onClick={() => {
+              props.onBeforeAction?.();
+            }}
           >
             {primaryContent}
           </Link>
@@ -363,7 +377,10 @@ const DropdownMenuItemWithSecondaryAction = (
           <button
             type="button"
             className={dropdownMenuItemPrimaryActionVariants()}
-            onClick={props.onClick}
+            onClick={() => {
+              props.onBeforeAction?.();
+              props.onClick();
+            }}
           >
             {primaryContent}
           </button>

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -336,6 +336,12 @@ const DropdownMenuItemWithSecondaryAction = (
             event.stopPropagation();
             secondaryAction.onBeforeAction?.();
           }}
+          onAuxClick={(event) => {
+            event.stopPropagation();
+            if (event.button === 1) {
+              secondaryAction.onBeforeAction?.();
+            }
+          }}
         >
           <SecondaryActionIcon size={12} />
         </Link>
@@ -367,6 +373,11 @@ const DropdownMenuItemWithSecondaryAction = (
             className={dropdownMenuItemPrimaryActionVariants()}
             onClick={() => {
               props.onBeforeAction?.();
+            }}
+            onAuxClick={(event) => {
+              if (event.button === 1) {
+                props.onBeforeAction?.();
+              }
             }}
           >
             {primaryContent}

--- a/web/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton.tsx
+++ b/web/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton.tsx
@@ -32,12 +32,11 @@ import {
 } from "@langfuse/shared";
 import { api } from "@/src/utils/api";
 import { MultiSelectKeyValues } from "@/src/features/scores/components/multi-select-key-values";
-import { useRouter } from "next/router";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useEntitlementLimit } from "@/src/features/entitlements/hooks";
 import { ActionButton } from "@/src/components/ActionButton";
 import { IconOnlyButton } from "@/src/components/IconOnlyButton";
-import { DropdownMenuItem } from "@/src/components/ui/dropdown-menu";
+import { DropdownMenuItemWithSecondaryAction } from "@/src/components/ui/dropdown-menu";
 import { useUniqueNameValidation } from "@/src/hooks/useUniqueNameValidation";
 import {
   Collapsible,
@@ -73,7 +72,6 @@ export const CreateOrEditAnnotationQueueButton = ({
     scope: "annotationQueueAssignments:read",
   });
   const queueLimit = useEntitlementLimit("annotation-queue-count");
-  const router = useRouter();
   const capture = usePostHogClientCapture();
 
   const queueQuery = api.annotationQueues.byId.useQuery(
@@ -357,19 +355,16 @@ export const CreateOrEditAnnotationQueueButton = ({
                             };
                           })}
                           controlButtons={
-                            <DropdownMenuItem
-                              onSelect={() => {
+                            <DropdownMenuItemWithSecondaryAction
+                              onBeforeAction={() => {
                                 capture(
                                   "score_configs:manage_configs_item_click",
                                   { source: "AnnotationQueue" },
                                 );
-                                router.push(
-                                  `/project/${projectId}/settings/scores`,
-                                );
                               }}
-                            >
-                              Manage score configs
-                            </DropdownMenuItem>
+                              href={`/project/${projectId}/settings/scores`}
+                              title="Manage score configs"
+                            />
                           }
                         />
                       </FormControl>

--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -65,14 +65,13 @@ import { transformToAnnotationScores } from "@/src/features/scores/lib/transform
 import { v4 as uuid } from "uuid";
 import { useScoreMutations } from "@/src/features/scores/hooks/useScoreMutations";
 import { MultiSelectKeyValues } from "@/src/features/scores/components/multi-select-key-values";
-import { DropdownMenuItem } from "@/src/components/ui/dropdown-menu";
+import { DropdownMenuItemWithSecondaryAction } from "@/src/components/ui/dropdown-menu";
 import { useScoreConfigSelection } from "@/src/features/scores/hooks/useScoreConfigSelection";
 import { KeyboardShortcut } from "@/src/components/ui/keyboard-shortcut";
 import {
   hasBlockingOverlay,
   hasModifier,
 } from "@/src/features/scores/lib/keyboardShortcuts";
-import { useRouter } from "next/router";
 import { useAnnotationScoreConfigs } from "@/src/features/scores/hooks/useScoreConfigs";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
@@ -234,7 +233,6 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
   configControl,
 }: InnerAnnotationFormProps<Target>) {
   const capture = usePostHogClientCapture();
-  const router = useRouter();
   const { configs, allowManualSelection } = configControl;
 
   // Initialize form with initial data (never updates)
@@ -853,19 +851,16 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
                   }),
                 }))}
               controlButtons={
-                <DropdownMenuItem
-                  onSelect={() => {
+                <DropdownMenuItemWithSecondaryAction
+                  title="Manage score configs"
+                  href={`/project/${scoreMetadata.projectId}/settings/scores`}
+                  onBeforeAction={() => {
                     capture(
                       "score_configs:manage_configs_item_click",
                       analyticsData,
                     );
-                    router.push(
-                      `/project/${scoreMetadata.projectId}/settings/scores`,
-                    );
                   }}
-                >
-                  Manage score configs
-                </DropdownMenuItem>
+                />
               }
             />
           </div>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables native new-tab navigation for the “Manage score configs” action. The main changes are:

- Adds an optional pre-action callback to shared dropdown actions.
- Replaces programmatic score-settings navigation with links.
- Preserves analytics capture before navigation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(annotations): Support opening &quot;Mana..."](https://github.com/langfuse/langfuse/commit/5742baa813358693e675898dde1d59edff25bf05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45890510)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->