### PR TITLE
docs(agents): add sentry-instrumentation skill (LFE-10974)

### DIFF
--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: sentry-instrumentation
+description: |
+  Capture errors in Langfuse with Sentry deliberately, and decide whether a new
+  error path should report at all. Use when (1) adding or touching any
+  `captureException`, `console.error`, error boundary, `catch` block, Worker
+  `onerror`, or tRPC/REST error handler in `web/**` — pause and decide capture
+  before finishing; (2) adding or reviewing a Sentry `beforeSend` filter,
+  denylist rule, `ignoreErrors`, `denyUrls`, or any noise-suppression change
+  (MANDATORY here — the review question is "does this rule hide a real
+  error?"); (3) asked to reduce Sentry noise, triage a Sentry issue, or answer
+  "why is X / isn't X in Sentry"; (4) rendering user-supplied content (URLs,
+  hrefs) through a framework primitive that may reject it and log an error.
+---
+
+# Sentry Instrumentation
+
+**One idea:** an event in Sentry is a **promise that a human should act.** If
+nobody would act on it, do not send it. If you send it, make it **legible** (a
+real `Error` with a stack — never a string/object/SyntheticEvent) and
+**routable** (an `area` tag, a message stable enough to group). Sentry is not a
+log sink; the server-side observability stack is where firehose logs live.
+
+## Decide capture when adding an error path
+
+When adding or changing an error path in `web/**`, decide explicitly whether it
+should reach Sentry — do not `captureException` (or `console.error`) reflexively.
+Run the decision tree, then say in one line what you chose and why (in the plan
+or PR description). The three outcomes:
+
+| The failure is… | Do | Never |
+|---|---|---|
+| an **expected user-facing state** — a missing/forbidden resource, expired session, invalid user input, a malformed URL in user content | render the UX (error page / toast / plain text) | capture — it is the product working as designed |
+| a **transport / offline / infra** failure — fetch failed, a 5xx on a poll, an LB blip | let the UI degrade; the server owns this signal | capture client-side — it is an amplified, lower-fidelity copy of a server truth |
+| **our code failed** — an invariant broke, a parse threw, a worker failed to load | `captureException` a **real `Error`** with an `area` tag via the shared helpers | pass a raw string/object/`Event` |
+
+**`console.error` is a capture API here.** `instrumentation-client.ts` enables
+`captureConsoleIntegration({ levels: ["error"] })`, so **every `console.error`
+becomes a Sentry event.** Logging an object yields an opaque `[object Object]`
+fingerprint; logging non-actionable info still mints an issue. For
+non-actionable logging use `console.warn`; to report a real failure, capture it
+properly (below).
+
+## The Langfuse pattern (match it exactly)
+
+- **Report caught unknowns through the shared helpers, not raw
+  `captureException`:**
+  - [`captureUnknownError(context, value, extra?)`](../../../web/src/utils/captureUnknownError.ts)
+    — turns any caught value into a legible `Error` (real `Error`s pass through
+    with their stack; everything else is synthesized), tags `area`, and logs via
+    `console.warn` so the console integration does not double-capture.
+  - [`reportParserWorkerError(hook, event)`](../../../web/src/hooks/parserWorkerError.ts)
+    — extracts the real fields from a Worker `ErrorEvent` (message/filename/lineno)
+    instead of stringifying it to `[object ErrorEvent]`.
+- **All Sentry config is reviewed code in one place:**
+  [`web/src/utils/sentryFilters.ts`](../../../web/src/utils/sentryFilters.ts)
+  (documented, unit-tested filter predicates) called from `beforeSend` in
+  [`web/instrumentation-client.ts`](../../../web/instrumentation-client.ts) (the
+  only `Sentry.init` in the codebase — `beforeSend`, `captureConsoleIntegration`,
+  `denyUrls`, replay masking). Add a filter as a named predicate here, never as
+  an ad-hoc inline check.
+- **Classify tRPC errors at the seam,** not per call site: `handleTrpcError`
+  ([`web/src/utils/api.ts`](../../../web/src/utils/api.ts)) drops expected codes
+  and tags the rest — every query/mutation error flows through it.
+- **Tag `area`, keep the message static.** `captureException(err, { tags: { area },
+  extra })`. Fingerprints group on the message, so put variable IDs in `extra`,
+  never in the message string.
+
+## The rules (each earned the hard way — cited to shipped PRs)
+
+1. **An event is a promise a human acts — expected states are not events.**
+   A `NOT_FOUND` / `FORBIDDEN` / `UNAUTHORIZED` the UI already renders is not a
+   regression. ⚠ `TRPCClientError: Trace not found` was the #2 issue by volume
+   (~30k events); the tRPC seam now drops those (PR #15243). "Project Not Found"
+   captured on every mount until it rendered the non-capturing `ErrorPage`.
+
+2. **Capture a REAL `Error`, never a string / object / `SyntheticEvent` /
+   `ErrorEvent`.** Those collapse to opaque `[object Object]` / `[object
+   ErrorEvent]` fingerprints with no stack. ⚠ The 5EX cluster (opaque non-Error
+   captures, PR #15175) and the parse-worker `[object ErrorEvent]` family (PR
+   #15173) were exactly this. Route unknowns through `captureUnknownError` /
+   `reportParserWorkerError`.
+
+3. **`console.error` mints a Sentry event — pick the level deliberately.** Use
+   `console.warn` for non-actionable logs (the #15173 pattern); use
+   `captureException` for real failures. Never `console.error(someObject)`.
+
+4. **Client transport failure ≠ app bug — do not amplify server/infra state.**
+   One LB 502 or a poll blip becomes thousands of browser events. ⚠ The 418
+   `HTTP Client Error` saga (~44k events → 8/24h after scoping the httpClient
+   integration, PR #15145) and the next-auth `CLIENT_FETCH_ERROR` /
+   `Failed to fetch` families (denylist, PR #15238). The real outage is visible
+   server-side; the client copy is noise.
+
+5. **Root-cause at the source beats a filter.** Prefer eliminating the emission
+   over suppressing the event. ⚠ User-content markdown URLs rendered through a
+   Next.js `<Link>` logged `Invalid href … passed to next/router` (~40k events);
+   a native `<a>` (which never runs the router's href validation) removed the
+   family at the source (PR #15245) — no filter needed.
+
+6. **Every `beforeSend` / denylist rule: narrow signature + written rationale +
+   a NEGATIVE fixture proving a real error still passes.** This is the MANDATORY
+   review gate — for any suppression change, answer "does this rule hide a real
+   error?" in the PR, and add a test asserting a real 5xx / unknown code / thrown
+   error is NOT dropped (the `sentryFilters.clienttest.ts` pattern from #15145 /
+   #15238). ⚠ **Read the right event field:** message-type events (console
+   captures, benign strings) carry their text on `event.message` /
+   `event.logentry.message`, NOT `event.exception.values[0].value` — a filter
+   that only reads the exception value silently never fires on them (the reason
+   the original invalid-href filter never worked).
+
+7. **PII — never put user content in a message, `extra`, or tag.** No prompt
+   text, trace content, tokens, share-link secrets, user/session ids. Respect
+   the replay masking already configured for HIPAA/regions in
+   `instrumentation-client.ts`. A message that interpolates user data both leaks
+   and shatters grouping (Rule 5).
+
+8. **VERIFY in the environment that actually fires the error.** Router/console
+   validations run only in the **real client runtime, not jsdom** — a green unit
+   test does NOT prove the console error is gone. Reproduce it in a browser
+   against the running app (Playwright), do an A/B, and confirm the event
+   disappears. ⚠ The #15245 invalid-href fix was verified this way (old `<Link>`
+   fired the error ×12; new `<a>` fired 0). Unit tests lock the *contract*; the
+   browser proves the *noise removal*.
+
+## Workflow
+
+1. **Classify (tiny).** For the error path, name the outcome — expected /
+   transport / our-code — and write the one-line decision. That IS the PR note.
+2. **Wire it.** Expected → render UX (no capture). Transport → degrade (no
+   capture). Real → `captureException` a real `Error` via the helpers, with an
+   `area` tag, static message, structured `extra`, no PII.
+3. **If suppressing:** add a named predicate in `sentryFilters.ts` reading the
+   right event field, with a written rationale and a negative fixture (Rule 6).
+   Prefer root-causing the emission instead (Rule 5).
+4. **Verify** — unit test for the contract; **browser A/B** for the actual
+   event removal (Rule 8).
+5. **PR** with the decision note; for suppression changes, the explicit
+   "does this hide a real error?" answer + the negative-fixture test.
+
+## Anti-patterns
+
+- Capturing an expected 404 / permission / validation / malformed-user-input
+  state (Rule 1).
+- `captureException(nonError)` or `console.error(object)` → opaque fingerprint
+  (Rules 2, 3).
+- Re-reporting transport/infra failures the server already owns (Rule 4).
+- Adding a `beforeSend` filter with no rationale, no negative fixture, or one
+  that reads the wrong event field (Rule 6).
+- Interpolating ids/user data into the message → PII + grouping explosion
+  (Rules 5, 7).
+- Trusting a green jsdom test as proof the noise is gone (Rule 8).
+- An ad-hoc inline `beforeSend` check instead of a named, tested predicate in
+  `sentryFilters.ts`.
+
+## References
+
+- [references/sentry-capture-contract.md](references/sentry-capture-contract.md)
+  — the capture contract in depth: the shared-helper APIs, the beforeSend /
+  denylist authoring protocol (field-reading, negative fixtures), fingerprinting
+  and `area` tagging, the known noise families, and the shipped-PR case studies
+  (#15145 / #15173 / #15174 / #15175 / #15238 / #15243 / #15245). Read when
+  authoring a suppression rule, hardening a capture path, or triaging a family.

--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -72,9 +72,9 @@ properly (below).
 
 ## The rules (each earned the hard way — cited to workstream PRs)
 
-> PR references name the **lever** that establishes each pattern; some are
-> in-flight (not yet on `main`). Treat them as "the PR that does X," and verify
-> against the current tree before assuming a symbol or swap already exists.
+> PR references name the **lever** that established each pattern. Verify a cited
+> symbol or swap against the current tree before relying on it — the code, not
+> this doc, is the source of truth.
 
 1. **An event is a promise a human acts — expected states are not events.**
    A `NOT_FOUND` / `FORBIDDEN` / `UNAUTHORIZED` the UI already renders is not a

--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -70,13 +70,18 @@ properly (below).
   extra })`. Fingerprints group on the message, so put variable IDs in `extra`,
   never in the message string.
 
-## The rules (each earned the hard way — cited to shipped PRs)
+## The rules (each earned the hard way — cited to workstream PRs)
+
+> PR references name the **lever** that establishes each pattern; some are
+> in-flight (not yet on `main`). Treat them as "the PR that does X," and verify
+> against the current tree before assuming a symbol or swap already exists.
 
 1. **An event is a promise a human acts — expected states are not events.**
    A `NOT_FOUND` / `FORBIDDEN` / `UNAUTHORIZED` the UI already renders is not a
    regression. ⚠ `TRPCClientError: Trace not found` was the #2 issue by volume
-   (~30k events); PR #15243 drops those at the tRPC seam. "Project Not Found"
-   captured on every mount until it was switched to the non-capturing `ErrorPage`.
+   (~30k events); PR #15243 drops those at the tRPC seam and switches the
+   "Project Not Found" state (which captured on every mount via
+   `ErrorPageWithSentry`) to the non-capturing `ErrorPage`.
 
 2. **Capture a REAL `Error`, never a string / object / `SyntheticEvent` /
    `ErrorEvent`.** Those collapse to opaque `[object Object]` / `[object
@@ -98,11 +103,14 @@ properly (below).
 
 5. **Root-cause at the source beats a filter.** Prefer eliminating the emission
    over suppressing the event. ⚠ User-content markdown URLs rendered through a
-   Next.js `<Link>` logged `Invalid href … passed to next/router` (~40k events);
-   a native `<a>` (which never runs the router's href validation) removes the
-   family at the source (PR #15245) — no new filter needed. (The older inline
-   `beforeSend` invalid-href check is now redundant and never fired anyway — it
-   read the wrong field, Rule 6 — so it can be retired.)
+   Next.js `<Link>` logged `Invalid href … passed to next/router` (~40k events)
+   — note `getSafeLinkUrl` does NOT prevent this: a malformed-but-parseable URL
+   (a second `https://` → repeated `//`) passes validation and `<Link>`'s router
+   still rejects it. PR #15245 renders these as a native `<a>` (which never runs
+   the router's href validation), removing the family at the source — no new
+   filter needed. (The older inline `beforeSend` invalid-href check is redundant
+   and never fired anyway — it read the wrong field, Rule 6 — so it can be
+   retired.)
 
 6. **Every `beforeSend` / denylist rule: narrow signature + written rationale +
    a NEGATIVE fixture proving a real error still passes.** This is the MANDATORY
@@ -125,8 +133,8 @@ properly (below).
    validations run only in the **real client runtime, not jsdom** — a green unit
    test does NOT prove the console error is gone. Reproduce it in a browser
    against the running app (Playwright), do an A/B, and confirm the event
-   disappears. ⚠ The #15245 invalid-href fix was verified this way (old `<Link>`
-   fired the error ×12; new `<a>` fired 0). Unit tests lock the *contract*; the
+   disappears. ⚠ PR #15245 was verified this way — its native `<a>` fired 0
+   where the prior `<Link>` fired the error ×12. Unit tests lock the *contract*; the
    browser proves the *noise removal*.
 
 ## Workflow

--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -52,16 +52,20 @@ properly (below).
   - [`reportParserWorkerError(hook, event)`](../../../web/src/hooks/parserWorkerError.ts)
     — extracts the real fields from a Worker `ErrorEvent` (message/filename/lineno)
     instead of stringifying it to `[object ErrorEvent]`.
-- **All Sentry config is reviewed code in one place:**
-  [`web/src/utils/sentryFilters.ts`](../../../web/src/utils/sentryFilters.ts)
-  (documented, unit-tested filter predicates) called from `beforeSend` in
+- **Filter predicates belong in
+  [`web/src/utils/sentryFilters.ts`](../../../web/src/utils/sentryFilters.ts)**
+  (documented, unit-tested), called from `beforeSend` in
   [`web/instrumentation-client.ts`](../../../web/instrumentation-client.ts) (the
-  only `Sentry.init` in the codebase — `beforeSend`, `captureConsoleIntegration`,
-  `denyUrls`, replay masking). Add a filter as a named predicate here, never as
-  an ad-hoc inline check.
+  only `Sentry.init` in the codebase — `beforeSend`,
+  `captureConsoleIntegration`, `denyUrls`, replay masking). Add every new filter
+  as a named predicate there, never as an ad-hoc inline check. `beforeSend`
+  still carries a couple of legacy inline checks (invalid-href, React-devtools)
+  that predate this convention and read only the exception value — migrate those
+  into named, all-field predicates; do not add more inline checks.
 - **Classify tRPC errors at the seam,** not per call site: `handleTrpcError`
-  ([`web/src/utils/api.ts`](../../../web/src/utils/api.ts)) drops expected codes
-  and tags the rest — every query/mutation error flows through it.
+  ([`web/src/utils/api.ts`](../../../web/src/utils/api.ts)) is the single
+  chokepoint every query/mutation error flows through — the place to drop
+  expected codes and tag the rest (the seam-classification lever, PR #15243).
 - **Tag `area`, keep the message static.** `captureException(err, { tags: { area },
   extra })`. Fingerprints group on the message, so put variable IDs in `extra`,
   never in the message string.
@@ -71,8 +75,8 @@ properly (below).
 1. **An event is a promise a human acts — expected states are not events.**
    A `NOT_FOUND` / `FORBIDDEN` / `UNAUTHORIZED` the UI already renders is not a
    regression. ⚠ `TRPCClientError: Trace not found` was the #2 issue by volume
-   (~30k events); the tRPC seam now drops those (PR #15243). "Project Not Found"
-   captured on every mount until it rendered the non-capturing `ErrorPage`.
+   (~30k events); PR #15243 drops those at the tRPC seam. "Project Not Found"
+   captured on every mount until it was switched to the non-capturing `ErrorPage`.
 
 2. **Capture a REAL `Error`, never a string / object / `SyntheticEvent` /
    `ErrorEvent`.** Those collapse to opaque `[object Object]` / `[object
@@ -95,8 +99,10 @@ properly (below).
 5. **Root-cause at the source beats a filter.** Prefer eliminating the emission
    over suppressing the event. ⚠ User-content markdown URLs rendered through a
    Next.js `<Link>` logged `Invalid href … passed to next/router` (~40k events);
-   a native `<a>` (which never runs the router's href validation) removed the
-   family at the source (PR #15245) — no filter needed.
+   a native `<a>` (which never runs the router's href validation) removes the
+   family at the source (PR #15245) — no new filter needed. (The older inline
+   `beforeSend` invalid-href check is now redundant and never fired anyway — it
+   read the wrong field, Rule 6 — so it can be retired.)
 
 6. **Every `beforeSend` / denylist rule: narrow signature + written rationale +
    a NEGATIVE fixture proving a real error still passes.** This is the MANDATORY

--- a/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
+++ b/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
@@ -24,11 +24,15 @@ the detail behind its rules.
   reaches Sentry; it does not. (Treat "Sentry = frontend-only" until a decision
   says otherwise.)
 - **Filter predicates** live in [`web/src/utils/sentryFilters.ts`](../../../../web/src/utils/sentryFilters.ts)
-  with unit tests in `sentryFilters.clienttest.ts`. `beforeSend` calls them; it
-  holds no ad-hoc logic of its own.
+  with unit tests in `sentryFilters.clienttest.ts`; `beforeSend` calls them.
+  `beforeSend` also still carries two legacy inline checks (invalid-href,
+  React-devtools) that predate this convention and read only
+  `event.exception.values[0].value` — a known gap to migrate into named,
+  all-field predicates. Add new filters only as predicates here, never inline.
 - **The tRPC seam** is `handleTrpcError` in [`web/src/utils/api.ts`](../../../../web/src/utils/api.ts):
-  every query/mutation error flows through it. It drops expected `data.code`s
-  (`NOT_FOUND` / `FORBIDDEN` / `UNAUTHORIZED`) with a breadcrumb and tags the rest
+  every query/mutation error flows through it — the single place to classify.
+  PR #15243 drops expected `data.code`s (`NOT_FOUND` / `FORBIDDEN` /
+  `UNAUTHORIZED`) there with a breadcrumb and tags the rest
   (`trpc.code` / `trpc.path`).
 
 ## The shared capture helpers
@@ -112,7 +116,7 @@ The recurring shapes and their correct disposition:
 | #15173 | parse-worker `[object ErrorEvent]` | `reportParserWorkerError` (real Error) |
 | #15174 | JSON-viewer meta-root offsets (456) | fingerprint/render fix |
 | #15175 | opaque non-Error captures (5EX) | `captureUnknownError` (real Error) |
-| #15238 | transport / next-auth / benign (~1.9k/24h) | `isDenylistedNoiseEvent` (reads all fields, negative fixtures) |
+| #15238 | transport / next-auth / benign (~1.9k/24h) | `beforeSend` denylist predicate — reads all event fields, negative fixtures |
 | #15243 | expected tRPC codes (54F #2, ~30k) | `handleTrpcError` classify + breadcrumb + tags |
 | #15245 | `Invalid href` (5DZ/5EA/5ER, ~40k) | native `<a>` at the source |
 

--- a/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
+++ b/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
@@ -11,7 +11,7 @@ the detail behind its rules.
 - [beforeSend / denylist authoring protocol](#beforesend--denylist-authoring-protocol)
 - [Fingerprinting, tagging, messages](#fingerprinting-tagging-messages)
 - [Known noise families](#known-noise-families)
-- [Shipped-PR case studies](#shipped-pr-case-studies)
+- [Workstream levers (case studies)](#workstream-levers-case-studies)
 
 ## Where Sentry is wired
 
@@ -108,7 +108,10 @@ The recurring shapes and their correct disposition:
 - **Stale-deploy** — chunk 404s, `importScripts` failures, version-skew. → a
   reload-on-new-version prompt + release-aware handling (open work).
 
-## Shipped-PR case studies
+## Workstream levers (case studies)
+
+Each row names the PR that establishes the pattern; some are in-flight, not yet
+on `main` — verify against the current tree before assuming a swap/symbol exists.
 
 | PR | Family | Lever |
 |---|---|---|

--- a/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
+++ b/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
@@ -1,0 +1,120 @@
+# Sentry capture contract — depth reference
+
+Load when authoring a `beforeSend`/denylist rule, hardening a capture path, or
+triaging a noise family. Read the [SKILL.md](../SKILL.md) first — this file is
+the detail behind its rules.
+
+## Contents
+
+- [Where Sentry is wired](#where-sentry-is-wired)
+- [The shared capture helpers](#the-shared-capture-helpers)
+- [beforeSend / denylist authoring protocol](#beforesend--denylist-authoring-protocol)
+- [Fingerprinting, tagging, messages](#fingerprinting-tagging-messages)
+- [Known noise families](#known-noise-families)
+- [Shipped-PR case studies](#shipped-pr-case-studies)
+
+## Where Sentry is wired
+
+- **The only `Sentry.init`** is [`web/instrumentation-client.ts`](../../../../web/instrumentation-client.ts)
+  — client-side only. It configures `beforeSend`, `captureConsoleIntegration({ levels: ["error"] })`,
+  `httpClientIntegration()`, `replayIntegration(...)` (masking gated on region/HIPAA),
+  and `denyUrls` (browser-extension origins).
+- **The worker and web server have no Sentry SDK** — backend signal lives in the
+  server-side observability/APM stack, not Sentry. Do not assume a backend error
+  reaches Sentry; it does not. (Treat "Sentry = frontend-only" until a decision
+  says otherwise.)
+- **Filter predicates** live in [`web/src/utils/sentryFilters.ts`](../../../../web/src/utils/sentryFilters.ts)
+  with unit tests in `sentryFilters.clienttest.ts`. `beforeSend` calls them; it
+  holds no ad-hoc logic of its own.
+- **The tRPC seam** is `handleTrpcError` in [`web/src/utils/api.ts`](../../../../web/src/utils/api.ts):
+  every query/mutation error flows through it. It drops expected `data.code`s
+  (`NOT_FOUND` / `FORBIDDEN` / `UNAUTHORIZED`) with a breadcrumb and tags the rest
+  (`trpc.code` / `trpc.path`).
+
+## The shared capture helpers
+
+Prefer these over a raw `captureException`:
+
+```ts
+// A caught value of unknown shape (catch block, rejected promise, event handler).
+captureUnknownError("io-parse", value, { traceId }); // real Error passes through; else synthesized. tags:{area}, warns (no double-capture)
+
+// A Web Worker onerror ErrorEvent (script failed to load / threw during init).
+reportParserWorkerError("useJsonParse", event); // extracts message/filename/lineno; tags:{area:"io-parse-worker"}
+```
+
+Both log via `console.warn` (not `console.error`) on purpose — `console.error`
+would be re-captured by `captureConsoleIntegration` as a second, opaque event.
+
+If you must capture directly: pass a real `Error`, add `{ tags: { area }, extra }`,
+keep the message static, and log any companion console line at `warn`.
+
+## beforeSend / denylist authoring protocol
+
+A suppression rule is a loaded gun aimed at your own signal. Every rule:
+
+1. **Is a named predicate in `sentryFilters.ts`** (e.g. `isNoisyHttpClientPollEvent`),
+   never an inline check in `beforeSend`.
+2. **Keys on an unambiguous signature** — the Sentry-set exception `mechanism.type`,
+   a whole-message match, or a `startsWith`-anchored prefix. Never a loose
+   `includes` that could match a real error.
+3. **Reads the right event field.** Exception events carry text on
+   `event.exception.values[0].value`; **message events (console captures, benign
+   strings, `[next-auth]` logs, `Invalid href …`) carry it on `event.message` or
+   `event.logentry.message`.** A predicate must coalesce all three
+   (`exception value ?? event.message ?? event.logentry?.message`) or it silently
+   never fires on message events — the exact bug that left the original
+   invalid-href filter dead.
+4. **Has a written rationale** in a comment: why this signature cannot represent
+   a real, actionable error, and where the real signal still lives (usually
+   server-side).
+5. **Has a NEGATIVE fixture** in `sentryFilters.clienttest.ts` proving a real
+   error still passes — a 5xx / unknown code / genuine thrown Error must return
+   `false` from the predicate.
+
+Prefer **root-causing the emission** over a filter whenever the source is a
+small, identifiable set of call sites (see Rule 5 / the invalid-href case).
+
+## Fingerprinting, tagging, messages
+
+- **Static message → correct grouping.** Sentry groups by message; an
+  interpolated id (`Trace ${id} not found`) mints a new fingerprint per id.
+  Keep the message constant; put variability in `extra`.
+- **`area` tag** on every real capture (`tags: { area: "io-parse-worker" }`) so
+  issues route/group by surface. The tRPC seam adds `trpc.code` / `trpc.path`.
+- **Explicit `fingerprint`** only when a message legitimately must vary and you
+  still want one group — set it on the scope; do not rely on the default.
+
+## Known noise families
+
+The recurring shapes and their correct disposition:
+
+- **Expected tRPC codes** — `Trace not found` (NOT_FOUND), `not a member`
+  (FORBIDDEN), expired session (UNAUTHORIZED). → dropped at the seam (#15243).
+- **Transport / next-auth** — `Failed to fetch`, `[next-auth] CLIENT_FETCH_ERROR`,
+  poll 5xx. → server owns the signal; scoped/denylisted (#15145, #15238).
+- **Opaque non-Error captures** — `[object Object]`, `[object ErrorEvent]`,
+  "Object captured as exception". → capture a real Error via the helpers
+  (#15173, #15175).
+- **User-content URL validation** — `Invalid href … passed to next/router`. →
+  render user URLs as native `<a>`, not a framework `<Link>` (#15245).
+- **Perf detectors / third-party** — N+1, HTTP-overhead `info` issues, browser
+  extensions, crawlers. → Sentry project settings (inbound filters, detectors),
+  not code.
+- **Stale-deploy** — chunk 404s, `importScripts` failures, version-skew. → a
+  reload-on-new-version prompt + release-aware handling (open work).
+
+## Shipped-PR case studies
+
+| PR | Family | Lever |
+|---|---|---|
+| #15145 | 418 httpClient poll 5xx (~44k→8/24h) | `isNoisyHttpClientPollEvent` (mechanism + path) |
+| #15173 | parse-worker `[object ErrorEvent]` | `reportParserWorkerError` (real Error) |
+| #15174 | JSON-viewer meta-root offsets (456) | fingerprint/render fix |
+| #15175 | opaque non-Error captures (5EX) | `captureUnknownError` (real Error) |
+| #15238 | transport / next-auth / benign (~1.9k/24h) | `isDenylistedNoiseEvent` (reads all fields, negative fixtures) |
+| #15243 | expected tRPC codes (54F #2, ~30k) | `handleTrpcError` classify + breadcrumb + tags |
+| #15245 | `Invalid href` (5DZ/5EA/5ER, ~40k) | native `<a>` at the source |
+
+Each is a worked example of one rule: prefer real Errors, prefer root-cause over
+filter, read the right field, keep a negative fixture, verify in the browser.

--- a/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
+++ b/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
@@ -110,8 +110,8 @@ The recurring shapes and their correct disposition:
 
 ## Workstream levers (case studies)
 
-Each row names the PR that establishes the pattern; some are in-flight, not yet
-on `main` — verify against the current tree before assuming a swap/symbol exists.
+Each row names the PR that established the pattern; verify a cited symbol/swap
+against the current tree before relying on it.
 
 | PR | Family | Lever |
 |---|---|---|
@@ -119,7 +119,7 @@ on `main` — verify against the current tree before assuming a swap/symbol exis
 | #15173 | parse-worker `[object ErrorEvent]` | `reportParserWorkerError` (real Error) |
 | #15174 | JSON-viewer meta-root offsets (456) | fingerprint/render fix |
 | #15175 | opaque non-Error captures (5EX) | `captureUnknownError` (real Error) |
-| #15238 | transport / next-auth / benign (~1.9k/24h) | `beforeSend` denylist predicate — reads all event fields, negative fixtures |
+| #15238 | transport / next-auth / benign (~1.9k/24h) | `isDenylistedNoiseEvent` in `sentryFilters.ts` — reads all event fields, negative fixtures |
 | #15243 | expected tRPC codes (54F #2, ~30k) | `handleTrpcError` classify + breadcrumb + tags |
 | #15245 | `Invalid href` (5DZ/5EA/5ER, ~40k) | native `<a>` at the source |
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -73,6 +73,8 @@ Use root [AGENTS.md](../AGENTS.md) for monorepo-level rules.
   [`web/.agents/skills/vercel-react-best-practices/SKILL.md`](.agents/skills/vercel-react-best-practices/SKILL.md)
 - PostHog product analytics — when and how to instrument user actions:
   [`../.agents/skills/posthog-instrumentation/SKILL.md`](../.agents/skills/posthog-instrumentation/SKILL.md)
+- Sentry error capture — whether and how an error path should report:
+  [`../.agents/skills/sentry-instrumentation/SKILL.md`](../.agents/skills/sentry-instrumentation/SKILL.md)
 
 Read these package-local skills before substantial frontend refactors when the
 task involves component composition, reusable component APIs, rendering
@@ -83,7 +85,11 @@ from loaded data, read the frontend-large-feature-architecture skill first —
 most effects that derive or sync state should not exist. When adding a
 meaningful user action (button, handler, form, mutation, feature surface),
 read the PostHog instrumentation skill and decide explicitly whether the
-action should emit an analytics event.
+action should emit an analytics event. When adding or touching an error path —
+a `captureException` or `console.error` call, an error boundary, a `catch`
+block, a Worker `onerror`, or a Sentry `beforeSend`/denylist filter — read the
+Sentry instrumentation skill first and decide whether it should capture at all
+(and, for any suppression change, answer "does this rule hide a real error?").
 
 ## Web Conventions
 


### PR DESCRIPTION
## TL;DR

A repo skill — `.agents/skills/sentry-instrumentation/` — that encodes the capture contract behind the Sentry-noise cleanup, so the error stream **stays** clean without nightly triage. Every agent (and human reviewer) touching an error path now has one rule: *an event in Sentry is a promise that a human should act.* Mirrors the proven `posthog-instrumentation` skill.

## Why

The noise cleanup keeps re-litigating the same lessons per issue — capture a real `Error` not a string, don't re-report transport failures, read the right event field in a `beforeSend` filter, verify in the browser. Those are a *contract*, not per-issue triage. Codifying it as a skill turns error hygiene into something applied by default (the same move that made `posthog-instrumentation` stick), and doubles as a reviewer prompt for any PR that touches a capture path.

## What

- **`SKILL.md`** — the one idea, the capture **decision tree** (expected state → render UX; transport/offline → server owns it; our-code failure → `captureException` a real `Error` via the shared helpers), the fact that **`console.error` is a capture API here** (`captureConsoleIntegration`), and 8 rules each cited to a shipped noise-reduction PR. Includes the MANDATORY suppression-review gate ("does this rule hide a real error?" + a negative fixture) and the verify-in-the-browser rule.
- **`references/sentry-capture-contract.md`** — depth: where Sentry is wired, the shared-helper APIs, the `beforeSend`/denylist authoring protocol (including *read the right event field* — message events carry text on `event.message`, not `event.exception.value`), fingerprint/`area`-tag discipline, the known noise families, and a shipped-PR case-study table.

## Result

A durable, teachable artifact. The description triggers it whenever an agent adds/reviews a `captureException`, `console.error`, error boundary, catch block, or `beforeSend`/denylist rule — so new work self-polices instead of minting the next noise family.

<details>
<summary>Grounding & verification</summary>

- Every rule is cited to a real, shipped lever: #15145 (httpClient poll scope), #15173 (parse-worker real Error), #15174 (fingerprint), #15175 (`captureUnknownError`), #15238 (denylist + negative fixtures), #15243 (tRPC-seam classify), #15245 (native `<a>` at the source).
- `pnpm run agents:sync` + `pnpm run agents:check` → clean (skill linked, no shim drift). The generated provider shims under `.claude/` / `.cursor/` / `.codex/` / `.vscode/` / `.mcp.json` are gitignored local artifacts and are not part of this diff.
- Forward-tested with a fresh agent on a realistic error-path task to confirm the guidance transfers.
</details>

Part of the Sentry-noise workstream (LFE-10974) — the structural layer that keeps the stream clean. Sibling PRs: #15243, #15245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a repository skill for consistent Sentry error handling. The main changes are:

- A capture decision tree for expected, transport, and application errors.
- Rules for helpers, tags, filtering, privacy, and browser verification.
- A detailed reference covering Sentry wiring and prior noise-reduction patterns.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The new skill describes filtering and tRPC behavior that the current application does not implement.

- Expected tRPC codes are documented as dropped but are still captured.
- Active inline filters contradict the stated centralization contract.
- A documented denylist predicate is not present or wired into Sentry.

.agents/skills/sentry-instrumentation/SKILL.md and .agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md:29-32
**tRPC Contract Describes Missing Behavior**

`handleTrpcError` currently captures `TRPCClientError`s without dropping `NOT_FOUND`, `FORBIDDEN`, or `UNAUTHORIZED`, and it does not add the documented `trpc.code` or `trpc.path` tags. An agent following this contract can leave expected errors flowing to Sentry while assuming they are already filtered and routed.

### Issue 2 of 3
.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md:26-27
**Filters Are Not Fully Centralized**

The active `beforeSend` still contains inline checks for invalid href and React devtool events, while this contract says it contains no ad-hoc logic. The invalid-href check also reads only the exception value, so agents relying on this document can miss the active message-event filter and add overlapping or ineffective suppression.

### Issue 3 of 3
.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md:113
**Referenced Denylist Is Absent**

This lists `isDenylistedNoiseEvent` as the shipped lever for transport and next-auth noise, but that predicate is absent from the current tree and `beforeSend` does not call it. A reader can therefore assume these message events are already suppressed or try to reuse an API that does not exist.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): add sentry-instrumentation..."](https://github.com/langfuse/langfuse/commit/f7f820d80bd208b969f1c2a2d4073dbdec5159f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45910306)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->