### PR TITLE
fix(in-app-agent): deliver approval guidance to the model via tool-result content

### DIFF
--- a/web/src/__tests__/server/unit/in-app-agent-manual-tool-approval.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-manual-tool-approval.servertest.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { EventType } from "@ag-ui/core";
+
+import type { AgUiRunAgentInput } from "@/src/ee/features/in-app-agent/schema";
+import { createManualToolApprovalRunInput } from "@/src/ee/features/in-app-agent/server/human-in-the-loop";
+
+// The AG-UI -> Mastra message conversion forwards only assistant/user/tool
+// roles, so guidance must travel inside the tool-result content (which also
+// persists it for replay). These tests pin that transport: no dropped roles
+// in the resume input, and in-memory message content identical to the
+// persisted TOOL_CALL_RESULT event content.
+
+function createResumeInput(approved: boolean): AgUiRunAgentInput {
+  return {
+    threadId: "thread-1",
+    runId: "run-2",
+    state: null,
+    messages: [],
+    tools: [],
+    context: [],
+    forwardedProps: {
+      command: {
+        resume: {
+          approved,
+          approvalRequest: {
+            type: "tool_approval_request",
+            toolCallId: "tool-call-1",
+            toolName: "langfuse_createTextPrompt",
+            args: { name: "test-prompt" },
+            runId: "run-1",
+          },
+        },
+      },
+    },
+  };
+}
+
+function getPersistedToolResultContent(
+  syntheticEvents: { type: EventType; content?: unknown }[],
+) {
+  const resultEvent = syntheticEvents.find(
+    (event) => event.type === EventType.TOOL_CALL_RESULT,
+  );
+  return resultEvent?.content;
+}
+
+describe("createManualToolApprovalRunInput", () => {
+  it("folds rejection guidance into the tool result and emits no model-invisible roles", async () => {
+    const runInput = await createManualToolApprovalRunInput({
+      input: createResumeInput(false),
+      executeToolCall: async () => {
+        throw new Error("must not execute rejected tool calls");
+      },
+    });
+
+    const roles = runInput.input.messages.map((message) => message.role);
+    expect(roles).toEqual(["assistant", "tool"]);
+
+    const toolMessage = runInput.input.messages.at(-1);
+    expect(toolMessage?.role).toBe("tool");
+    expect(toolMessage).toMatchObject({
+      content: expect.stringContaining("Tool call was not approved"),
+    });
+    expect(toolMessage).toMatchObject({
+      content: expect.stringContaining("Do not retry this tool call"),
+    });
+
+    expect(getPersistedToolResultContent(runInput.syntheticEvents)).toBe(
+      toolMessage && "content" in toolMessage ? toolMessage.content : undefined,
+    );
+  });
+
+  it("folds tool-error guidance into the tool result on failed approved execution", async () => {
+    const runInput = await createManualToolApprovalRunInput({
+      input: createResumeInput(true),
+      executeToolCall: async () => {
+        throw new Error("database exploded");
+      },
+    });
+
+    const roles = runInput.input.messages.map((message) => message.role);
+    expect(roles).toEqual(["assistant", "tool"]);
+
+    const toolMessage = runInput.input.messages.at(-1);
+    expect(toolMessage).toMatchObject({
+      role: "tool",
+      error: "database exploded",
+      content: expect.stringContaining("database exploded"),
+    });
+    expect(toolMessage).toMatchObject({
+      content: expect.stringContaining(
+        "Do not call the same tool again with identical arguments",
+      ),
+    });
+
+    expect(getPersistedToolResultContent(runInput.syntheticEvents)).toBe(
+      toolMessage && "content" in toolMessage ? toolMessage.content : undefined,
+    );
+  });
+});

--- a/web/src/ee/features/in-app-agent/server/human-in-the-loop.ts
+++ b/web/src/ee/features/in-app-agent/server/human-in-the-loop.ts
@@ -21,6 +21,16 @@ const MANUAL_TOOL_APPROVAL_REJECTION_ERROR = JSON.stringify({
   code: IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE,
   message: MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
 });
+// Guidance for the model travels inside the tool-result content: the
+// AG-UI -> Mastra message conversion forwards only assistant/user/tool roles
+// (a separate developer message would be dropped silently), and the tool
+// result is persisted, so the guidance survives replay on later turns.
+const MANUAL_TOOL_APPROVAL_REJECTION_CONTENT = [
+  MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
+  "The action was not completed.",
+  "Do not retry this tool call or attempt an equivalent action unless the user explicitly requests it.",
+  "Briefly acknowledge that the action was not completed and ask the user how they would like to continue.",
+].join("\n");
 
 export const IN_APP_AGENT_PENDING_TOOL_APPROVAL_TTL_SECONDS = 60 * 60;
 
@@ -187,7 +197,7 @@ export async function createManualToolApprovalRunInput(params: {
     const toolMessage: AgUiMessage = {
       id: createManualToolResultMessageId(approvalRequest),
       role: "tool",
-      content: MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
+      content: MANUAL_TOOL_APPROVAL_REJECTION_CONTENT,
       toolCallId: approvalRequest.toolCallId,
       error: MANUAL_TOOL_APPROVAL_REJECTION_ERROR,
     };
@@ -195,17 +205,12 @@ export async function createManualToolApprovalRunInput(params: {
     return {
       input: {
         ...params.input,
-        messages: [
-          ...params.input.messages,
-          assistantMessage,
-          toolMessage,
-          createToolRejectionGuidanceMessage(approvalRequest),
-        ],
+        messages: [...params.input.messages, assistantMessage, toolMessage],
         forwardedProps: {},
       },
       syntheticEvents: createManualToolApprovalEvents({
         approvalRequest,
-        toolResultContent: MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
+        toolResultContent: MANUAL_TOOL_APPROVAL_REJECTION_CONTENT,
         toolError: MANUAL_TOOL_APPROVAL_REJECTION_ERROR,
       }),
       toolCallApproval: {
@@ -220,7 +225,9 @@ export async function createManualToolApprovalRunInput(params: {
     executeToolCall: params.executeToolCall,
   });
   await params.onApprovedToolCallExecuted?.();
-  const toolResultContent = serializeToolResultContent(toolResult);
+  const toolResultContent = toolError
+    ? createToolExecutionErrorContent(approvalRequest, toolError)
+    : serializeToolResultContent(toolResult);
   const assistantMessage =
     createManualToolCallAssistantMessage(approvalRequest);
   const toolMessage: AgUiMessage = {
@@ -239,19 +246,7 @@ export async function createManualToolApprovalRunInput(params: {
   return {
     input: {
       ...params.input,
-      messages: [
-        ...params.input.messages,
-        assistantMessage,
-        toolMessage,
-        ...(toolError
-          ? [
-              createToolExecutionErrorGuidanceMessage(
-                approvalRequest,
-                toolError,
-              ),
-            ]
-          : []),
-      ],
+      messages: [...params.input.messages, assistantMessage, toolMessage],
       forwardedProps: {},
     },
     syntheticEvents,
@@ -259,21 +254,6 @@ export async function createManualToolApprovalRunInput(params: {
       toolCallId: approvalRequest.toolCallId,
       status: "approved",
     },
-  };
-}
-
-function createToolRejectionGuidanceMessage(
-  approvalRequest: InAppAgentToolApprovalRequest,
-): AgUiMessage {
-  return {
-    id: `${approvalRequest.toolCallId}-approval-rejection-guidance`,
-    role: "developer",
-    content: [
-      `The user declined the proposed tool call ${approvalRequest.toolName}.`,
-      "The action was not completed.",
-      "Do not retry this tool call or attempt an equivalent action unless the user explicitly requests it.",
-      "Briefly acknowledge that the action was not completed and ask the user how they would like to continue.",
-    ].join("\n"),
   };
 }
 
@@ -326,23 +306,16 @@ export function createManualToolCallAssistantMessage(
   };
 }
 
-function createToolExecutionErrorGuidanceMessage(
+function createToolExecutionErrorContent(
   approvalRequest: InAppAgentToolApprovalRequest,
   toolError: string,
-): AgUiMessage {
-  const args = serializeToolCallArgs(approvalRequest.args);
-
-  return {
-    id: `${approvalRequest.toolCallId}-approval-tool-error-guidance`,
-    role: "developer",
-    content: [
-      `The approved tool call ${approvalRequest.toolName} failed during execution.`,
-      `Rejected arguments: ${args}`,
-      `Tool error: ${toolError}`,
-      "Do not call the same tool again with identical arguments.",
-      "Correct the arguments based on the tool error and retry only if a valid correction is clear. If you cannot infer a valid correction, ask the user for clarification or explain why the action could not be completed.",
-    ].join("\n"),
-  };
+): string {
+  return [
+    `The approved tool call ${approvalRequest.toolName} failed during execution.`,
+    `Tool error: ${toolError}`,
+    "Do not call the same tool again with identical arguments.",
+    "Correct the arguments based on the tool error and retry only if a valid correction is clear. If you cannot infer a valid correction, ask the user for clarification or explain why the action could not be completed.",
+  ].join("\n");
 }
 
 export function createManualToolApprovalEvents(params: {


### PR DESCRIPTION
## Problem

The `developer`-role guidance messages injected on approval **reject** ("do not retry this tool call…") and on **failed approved tool execution** never reached the model: the `@ag-ui/mastra` AG-UI→Mastra message conversion forwards only `assistant`/`user`/`tool` roles and silently drops `developer` messages. Runtime-verified by dumping the exact Bedrock prompt of a rejection continuation — no guidance message anywhere; the model only saw the bare tool-result string. The guidance was also never persisted as an event, so it could not survive into later turns either.

## Fix

Fold the guidance into the synthetic tool-result `content` — the transport that demonstrably works and persists for free via the `TOOL_CALL_RESULT` event — and delete the dead `developer`-message builders. The structured rejection `error` field is unchanged, so the drawer's denied/failed status detection (which keys off `error`, not content) is unaffected.

## Impacted packages

- `web` only (`src/ee/features/in-app-agent/server/human-in-the-loop.ts` + new unit servertest)

## Verification

- New test written red-first (failed on old code with an extra `developer` role in the resume input), then green after the fix: `Tests  2 passed (2)` — pins that the resume input contains no roles the bridge drops, and that in-memory tool-message content equals the persisted `TOOL_CALL_RESULT` content.
- `pnpm --filter web run test src/__tests__/server/unit/in-app-agent-mcp-run-override.servertest.ts` → `Tests  3 passed (3)`
- `pnpm --filter web run lint` → exit 0 (also re-run by pre-commit: `Tasks: 7 successful, 7 total`)
- Live browser check on local dev: rejected a `createTextPrompt` approval — tool chip still renders `denied`, and the model's reply now visibly follows the folded guidance ("…the action was rejected. How would you like to continue?").

🤖 Generated with [Claude Code](https://claude.com/claude-code)