### PR TITLE
fix(auth): redirect authenticated users off enterprise-sso-required

### DIFF
--- a/web/src/components/layouts/app-layout/utils/pathClassification.ts
+++ b/web/src/components/layouts/app-layout/utils/pathClassification.ts
@@ -13,6 +13,7 @@ export const PATH_CONSTANTS = {
     "/auth/sign-in",
     "/auth/sign-up",
     "/auth/sso-initiate",
+    "/auth/enterprise-sso-required",
     "/auth/error",
     "/auth/hf-spaces",
   ] as const,

--- a/web/src/pages/auth/enterprise-sso-required.tsx
+++ b/web/src/pages/auth/enterprise-sso-required.tsx
@@ -141,7 +141,7 @@ export default function EnterpriseSsoRequiredPage() {
       <Head>
         <title>Enterprise SSO Required | Langfuse</title>
       </Head>
-      <div className="min-h-screen-with-banner bg-background flex flex-col justify-center px-6 py-12 lg:px-8">
+      <div className="flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
           <div className="mx-auto w-fit">
             <LangfuseIcon />


### PR DESCRIPTION
## Summary

After a user completes the enforced-SSO flow, the `/auth/enterprise-sso-required` page stays visible inside the app instead of sending the now-authenticated user home (as reported by @marcklingen in LFE-9331).

To achieve this we:
- Classified `/auth/enterprise-sso-required` as an unauthenticated route so the app-layout auth guard redirects authenticated users to `/` (or the `targetPath` still in the URL), matching sign-in/sign-up.
- Fixed the page's root container to live inside the shared unauthenticated layout instead of assuming it owns the full viewport, removing the off-white inset border.

Fixes [LFE-9331](https://linear.app/langfuse/issue/LFE-9331/enterprise-sso-required-should-not-be-visible-once-logged-in)

## Verification

- [x] `pnpm --filter web run lint`
- [ ] Browser review of the enforced-SSO flow

## Test plan

- [ ] With SSO enforced, sign in with a non-SSO provider, complete the enterprise SSO flow, and confirm you land on `/` rather than the enterprise-sso-required page.
- [ ] Navigate directly to `/auth/enterprise-sso-required` while logged in and confirm you are redirected home.
- [ ] Visit `/auth/enterprise-sso-required` while logged out and confirm the page still renders with no inset border.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR redirects authenticated users away from the enterprise SSO requirement page and aligns its styling with the shared authentication layout. The main changes are:

- Classifies `/auth/enterprise-sso-required` as an unauthenticated route.
- Uses the shared layout for page height, background, and spacing.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The redirect uses the existing safe authenticated-user guard.
- The container styling matches sibling authentication pages.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): redirect authenticated users ..."](https://github.com/langfuse/langfuse/commit/c4ce7d232d3e6511fab2533e1a2d8c8a3b181e88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45925651)</sub>

<!-- /greptile_comment -->