### PR TITLE
feat(agent): batch tool approvals

### DIFF
--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -298,6 +298,70 @@ describe("in-app agent public API route auth", () => {
     }
   });
 
+  it("consumes batch decisions all-or-nothing", async () => {
+    await withInAppAgentCloudEnv(async () => {
+      const { project, userId } = await setupInAppAgentProjectSession();
+      const conversationId = `conversation-${randomUUID()}`;
+      const seededApproval =
+        createResumeForwardedProps().command.resume.approvalRequest;
+      const forgedApproval =
+        createResumeForwardedProps().command.resume.approvalRequest;
+
+      await seedPendingToolApproval({
+        projectId: project.id,
+        conversationId,
+        userId,
+        approvalRequest: seededApproval,
+      });
+
+      const { default: handler } =
+        await import("@/src/ee/features/in-app-agent/server/handler");
+      const response = await handler(
+        new Request("http://localhost/api/in-app-agent", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            threadId: conversationId,
+            runId: "client-run-1",
+            messages: [],
+            tools: [],
+            context: [],
+            state: {
+              type: "existingConversation",
+              projectId: project.id,
+              conversationId,
+            },
+            forwardedProps: {
+              command: {
+                resume: {
+                  decisions: [
+                    { approved: true, approvalRequest: seededApproval },
+                    { approved: true, approvalRequest: forgedApproval },
+                  ],
+                },
+              },
+            },
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "Invalid forwarded props",
+      });
+      // The forged decision invalidates the whole batch: the seeded approval
+      // must survive untouched so the user can retry.
+      await expect(
+        pendingToolApprovalExists({
+          projectId: project.id,
+          conversationId,
+          toolCallId: seededApproval.toolCallId,
+        }),
+      ).resolves.toBe(true);
+      expect(agentMocks.createAgUiStream).not.toHaveBeenCalled();
+    });
+  });
+
   it("rejects forged resume forwarded props without a pending approval", async () => {
     await withInAppAgentCloudEnv(async () => {
       const { project } = await setupInAppAgentProjectSession();

--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -261,7 +261,11 @@ vi.mock("@/src/ee/features/in-app-agent/server/instrumentation", () => ({
     instrumentationMocks.createInAppAgentInstrumentation,
 }));
 
-const createPatchedChunkProcessor = () => {
+const createPatchedChunkProcessor = (
+  approvalGatedToolNames: ReadonlySet<string> = new Set([
+    "langfuse_createScoreConfig",
+  ]),
+) => {
   const forwardedChunks: unknown[] = [];
   const onError = vi.fn();
   const flush = vi.fn();
@@ -275,7 +279,10 @@ const createPatchedChunkProcessor = () => {
     })),
   };
 
-  patchMastraApprovalChunks(adapter as unknown as MastraAgent);
+  patchMastraApprovalChunks(
+    adapter as unknown as MastraAgent,
+    approvalGatedToolNames,
+  );
 
   const processor = adapter.createChunkProcessor({ onError });
 
@@ -332,6 +339,73 @@ describe("patchMastraApprovalChunks", () => {
         },
       },
     ]);
+  });
+
+  it("suspends every proposed approval-gated tool call", () => {
+    // Mastra raises at most one approval per run: parallel siblings never
+    // reach their execution step. Their tool-call chunks must still surface
+    // as suspensions so all proposed calls get an approval card.
+    const { forwardedChunks, onError, processor } =
+      createPatchedChunkProcessor();
+
+    processor.handleChunk({
+      type: "tool-call",
+      payload: {
+        toolCallId: "tool-call-1",
+        toolName: "langfuse_createScoreConfig",
+        args: { name: "sibling-a" },
+      },
+    });
+    processor.handleChunk({
+      type: "tool-call",
+      payload: {
+        toolCallId: "tool-call-2",
+        toolName: "langfuse_createScoreConfig",
+        args: { name: "sibling-b" },
+      },
+    });
+    // The call Mastra does execute also emits its approval chunk; it must not
+    // suspend twice.
+    processor.handleChunk({
+      type: "tool-call-approval",
+      payload: {
+        toolCallId: "tool-call-1",
+        toolName: "langfuse_createScoreConfig",
+        args: { name: "sibling-a" },
+      },
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(
+      forwardedChunks.map((chunk) => {
+        const { type, payload } = chunk as {
+          type: string;
+          payload: { toolCallId: string };
+        };
+        return { type, toolCallId: payload.toolCallId };
+      }),
+    ).toEqual([
+      { type: "tool-call-suspended", toolCallId: "tool-call-1" },
+      { type: "tool-call-suspended", toolCallId: "tool-call-2" },
+    ]);
+  });
+
+  it("passes tool calls without approval gating through unchanged", () => {
+    const { forwardedChunks, onError, processor } =
+      createPatchedChunkProcessor();
+    const readToolCall = {
+      type: "tool-call",
+      payload: {
+        toolCallId: "tool-call-1",
+        toolName: "langfuse_listPrompts",
+        args: {},
+      },
+    };
+
+    processor.handleChunk(readToolCall);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(forwardedChunks).toEqual([readToolCall]);
   });
 
   it("reports malformed tool-call approvals", () => {

--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -1030,6 +1030,116 @@ describe("createAgUiStream", () => {
     );
   });
 
+  it("resolves a batch of decisions in one continuation run", async () => {
+    const { createAgUiStream } =
+      await import("@/src/ee/features/in-app-agent/server/agent");
+    const base = createToolApprovalResumeInput(true);
+    const approvedRequest = base.forwardedProps.command.resume.approvalRequest;
+    const rejectedRequest = {
+      type: "tool_approval_request" as const,
+      toolCallId: "tool-call-2",
+      toolName: "langfuse_upsertDataset",
+      args: { name: "Rejected dataset" },
+      runId: "interrupted-run-1",
+    };
+    const input = {
+      ...base,
+      forwardedProps: {
+        command: {
+          resume: {
+            decisions: [
+              { approved: true, approvalRequest: approvedRequest },
+              { approved: false, approvalRequest: rejectedRequest },
+            ],
+          },
+        },
+      },
+    };
+    adapterEvents.inputs = [];
+    adapterEvents.items = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+    ];
+    const persistedEvents: AgUiEvent[] = [];
+
+    const stream = await createAgUiStream({
+      input,
+      signal: new AbortController().signal,
+      options: {
+        onEvent: (event) => {
+          persistedEvents.push(event);
+        },
+        awsBedrock: { modelId: "test-model" },
+        langfuseMcp: {
+          url: "https://example.com/api/public/mcp",
+          publicKey: "pk",
+          secretKey: "sk",
+          userAccess: defaultInAppAgentUserAccess,
+          runOverride: "run-override",
+        },
+        redirectAction: {
+          projectId: "project-1",
+          isV4Enabled: false,
+        },
+        langfuseClient: {
+          getPrompt: promptMocks.getPrompt,
+        } as unknown as Langfuse,
+        useLocalPrompt: false,
+      },
+    });
+    await readStream(stream);
+
+    // One continuation run receives both resolutions in decision order.
+    expect(adapterEvents.inputs).toHaveLength(1);
+    expect(adapterEvents.inputs[0]).toMatchObject({
+      forwardedProps: {},
+      messages: expect.arrayContaining([
+        expect.objectContaining({
+          id: "tool-call-1-approval-tool-result",
+          role: "tool",
+          toolCallId: "tool-call-1",
+          content: JSON.stringify({
+            id: "score-config-1",
+            name: "readiness",
+            dataType: "NUMERIC",
+          }),
+        }),
+        expect.objectContaining({
+          id: "tool-call-2-approval-tool-result",
+          role: "tool",
+          toolCallId: "tool-call-2",
+          content: "Tool call was not approved by the user.",
+          error: expect.stringContaining("tool_call_rejected"),
+        }),
+      ]),
+    });
+
+    // The approved tool executed exactly once; the rejected one never ran.
+    expect(adapterEvents.createScoreConfigExecute).toHaveBeenCalledTimes(1);
+
+    const persistedResults = persistedEvents.filter(
+      (event) => event.type === EventType.TOOL_CALL_RESULT,
+    );
+    expect(persistedResults).toEqual([
+      expect.objectContaining({
+        toolCallId: "tool-call-1",
+        content: JSON.stringify({
+          id: "score-config-1",
+          name: "readiness",
+          dataType: "NUMERIC",
+        }),
+      }),
+      expect.objectContaining({
+        toolCallId: "tool-call-2",
+        content: "Tool call was not approved by the user.",
+        error: expect.stringContaining("tool_call_rejected"),
+      }),
+    ]);
+  });
+
   it("continues approved tools with a tool error result when execution fails", async () => {
     const { createAgUiStream } =
       await import("@/src/ee/features/in-app-agent/server/agent");

--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -204,8 +204,8 @@ describe("MCP public API tools", () => {
   it("resolves only the overridden mutating tool for in-app agent keys", async () => {
     const context = mockServerContext({
       inAppAgent: {
-        permissions: "single-tool-override",
-        allowedToolName: "upsertDataset",
+        permissions: "tool-override",
+        allowedToolNames: ["upsertDataset"],
       },
     });
 
@@ -223,8 +223,8 @@ describe("MCP public API tools", () => {
   it("resolves the dashboard widget creation override for in-app agent keys", async () => {
     const context = mockServerContext({
       inAppAgent: {
-        permissions: "single-tool-override",
-        allowedToolName: "createDashboardWidget",
+        permissions: "tool-override",
+        allowedToolNames: ["createDashboardWidget"],
       },
     });
 

--- a/web/src/__tests__/server/unit/in-app-agent-mcp-run-override.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-mcp-run-override.servertest.ts
@@ -4,9 +4,9 @@ import {
 } from "@/src/ee/features/in-app-agent/server/human-in-the-loop";
 
 describe("in-app agent MCP run override", () => {
-  it("serializes the override as plain JSON", async () => {
+  it("serializes a single-tool override in the legacy shape", async () => {
     const token = await createInAppAgentMcpRunOverride({
-      toolName: "upsertDataset",
+      toolNames: ["upsertDataset"],
     });
 
     expect(JSON.parse(token)).toEqual({
@@ -14,9 +14,19 @@ describe("in-app agent MCP run override", () => {
     });
   });
 
+  it("serializes a multi-tool override as a tool name list", async () => {
+    const token = await createInAppAgentMcpRunOverride({
+      toolNames: ["upsertDataset", "createDashboardWidget"],
+    });
+
+    expect(JSON.parse(token)).toEqual({
+      toolNames: ["upsertDataset", "createDashboardWidget"],
+    });
+  });
+
   it("accepts a matching plain JSON override", async () => {
     const token = await createInAppAgentMcpRunOverride({
-      toolName: "upsertDataset",
+      toolNames: ["upsertDataset"],
     });
 
     expect(InAppAgentMcpRunOverrideSchema.safeParse(JSON.parse(token))).toEqual(

--- a/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
@@ -47,20 +47,34 @@ describe("MCP route in-app-agent context", () => {
     });
   });
 
-  it("returns a single-tool override for valid override headers", async () => {
+  it("returns a tool override for valid override headers", async () => {
     const overrideHeader = await createInAppAgentMcpRunOverride({
-      toolName: "upsertDataset",
+      toolNames: ["upsertDataset"],
     });
     const req = createRequest(overrideHeader);
 
+    // Single-tool overrides are minted in the legacy shape so web instances
+    // that predate the batch contract still parse them during rolling deploys.
     expect(
       InAppAgentMcpRunOverrideSchema.parse(JSON.parse(overrideHeader)),
     ).toEqual({
       toolName: "upsertDataset",
     });
     expect(getInAppAgentContext(req, true)).toEqual({
-      permissions: "single-tool-override",
-      allowedToolName: "upsertDataset",
+      permissions: "tool-override",
+      allowedToolNames: ["upsertDataset"],
+    });
+  });
+
+  it("returns a tool override listing every approved tool", async () => {
+    const overrideHeader = await createInAppAgentMcpRunOverride({
+      toolNames: ["upsertDataset", "createDashboardWidget"],
+    });
+    const req = createRequest(overrideHeader);
+
+    expect(getInAppAgentContext(req, true)).toEqual({
+      permissions: "tool-override",
+      allowedToolNames: ["upsertDataset", "createDashboardWidget"],
     });
   });
 });

--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -59,7 +59,6 @@ export function ControlledInAppAgentWindow(
     selectedConversationIsWriteLocked,
     submit,
     submitFeedback,
-    approveAllToolCalls,
   } = useInAppAiAgent();
   const {
     isAnimating,
@@ -151,7 +150,6 @@ export function ControlledInAppAgentWindow(
       onSubmit={submit}
       onApproveToolCall={approveToolCall}
       onRejectToolCall={rejectToolCall}
-      onApproveAllToolCalls={approveAllToolCalls}
       onSubmitFeedback={submitFeedback}
       {...closeButtonProps}
     />

--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -59,6 +59,7 @@ export function ControlledInAppAgentWindow(
     selectedConversationIsWriteLocked,
     submit,
     submitFeedback,
+    approveAllToolCalls,
   } = useInAppAiAgent();
   const {
     isAnimating,
@@ -150,6 +151,7 @@ export function ControlledInAppAgentWindow(
       onSubmit={submit}
       onApproveToolCall={approveToolCall}
       onRejectToolCall={rejectToolCall}
+      onApproveAllToolCalls={approveAllToolCalls}
       onSubmitFeedback={submitFeedback}
       {...closeButtonProps}
     />

--- a/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.stories.tsx
@@ -64,6 +64,56 @@ export const ApprovalRequired = meta.story({
   },
 });
 
+export const ApprovalApproved = meta.story({
+  args: {
+    isCompact: true,
+    tool: {
+      type: "tool",
+      name: "langfuse_upsertDataset",
+      status: "running",
+      args: JSON.stringify(
+        {
+          name: "regression-examples",
+          description: "Examples used for release regression tests",
+        },
+        null,
+        2,
+      ),
+      approval: {
+        id: "approval-1",
+        status: "approved",
+      },
+    },
+    onApproveToolCall: fn(),
+    onRejectToolCall: fn(),
+  },
+});
+
+export const ApprovalRejected = meta.story({
+  args: {
+    isCompact: true,
+    tool: {
+      type: "tool",
+      name: "langfuse_upsertDataset",
+      status: "running",
+      args: JSON.stringify(
+        {
+          name: "regression-examples",
+          description: "Examples used for release regression tests",
+        },
+        null,
+        2,
+      ),
+      approval: {
+        id: "approval-1",
+        status: "rejected",
+      },
+    },
+    onApproveToolCall: fn(),
+    onRejectToolCall: fn(),
+  },
+});
+
 export const ApprovalSubmitting = meta.story({
   args: {
     isCompact: true,

--- a/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentToolCallCard.tsx
@@ -23,6 +23,10 @@ export function InAppAgentToolCallCard({
   const approval = tool.approval;
   const isApprovalPending = approval?.status === "pending";
   const isApprovalSubmitting = approval?.status === "submitting";
+  const decision =
+    approval?.status === "approved" || approval?.status === "rejected"
+      ? approval.status
+      : null;
   const approveLabel = `Approve ${tool.name}?`;
   const usedLabel = `Used ${tool.name}`;
 
@@ -59,7 +63,10 @@ export function InAppAgentToolCallCard({
                 variant="outline-success"
                 className="h-7"
                 disabled={
-                  isDisabled || isApprovalSubmitting || !onApproveToolCall
+                  isDisabled ||
+                  isApprovalSubmitting ||
+                  decision !== null ||
+                  !onApproveToolCall
                 }
                 onClick={() => {
                   if (isApprovalPending) {
@@ -72,7 +79,7 @@ export function InAppAgentToolCallCard({
                 ) : (
                   <Check className="mr-1 size-3" />
                 )}
-                Confirm
+                {decision === "approved" ? "Approved" : "Confirm"}
               </Button>
               <Button
                 type="button"
@@ -80,7 +87,10 @@ export function InAppAgentToolCallCard({
                 variant="outline"
                 className="h-7"
                 disabled={
-                  isDisabled || isApprovalSubmitting || !onRejectToolCall
+                  isDisabled ||
+                  isApprovalSubmitting ||
+                  decision !== null ||
+                  !onRejectToolCall
                 }
                 onClick={() => {
                   if (isApprovalPending) {
@@ -88,8 +98,13 @@ export function InAppAgentToolCallCard({
                   }
                 }}
               >
-                Reject
+                {decision === "rejected" ? "Rejected" : "Reject"}
               </Button>
+              {decision !== null && !isApprovalSubmitting ? (
+                <span className="text-muted-foreground text-xs">
+                  Waiting for the remaining decisions…
+                </span>
+              ) : null}
             </div>
           </div>
         </div>

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -146,7 +146,7 @@ describe("InAppAgentWindow quick actions", () => {
 
 describe("InAppAgentWindow tool approvals", () => {
   const approvalToolGroupMessage = (
-    tools: Array<{ id: string; status: "pending" | "approved" }>,
+    tools: Array<{ id: string; status: "pending" | "approved" | "submitting" }>,
   ) =>
     ({
       id: "tools",
@@ -197,5 +197,23 @@ describe("InAppAgentWindow tool approvals", () => {
     fireEvent.click(screen.getByRole("button", { name: /Confirm/ }));
     expect(onApproveToolCall).toHaveBeenCalledWith("tool-call-1");
     expect(screen.getByText(/tool-call-2/)).toBeInTheDocument();
+  });
+
+  it("closes the pager once the batch is submitting", () => {
+    render(
+      windowElement({
+        messages: [
+          approvalToolGroupMessage([
+            { id: "tool-call-1", status: "submitting" },
+            { id: "tool-call-2", status: "submitting" },
+          ]),
+        ],
+      }),
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /Confirm/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/awaiting review/)).not.toBeInTheDocument();
   });
 });

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -30,7 +30,6 @@ function windowElement(
     isLoadingMoreConversations: false,
     messages: [],
     onApproveToolCall: vi.fn(),
-    onApproveAllToolCalls: vi.fn(),
     onDeleteConversation: vi.fn(),
     onExpandedChange: vi.fn(),
     onLoadMoreConversations: vi.fn(),
@@ -164,9 +163,9 @@ describe("InAppAgentWindow tool approvals", () => {
       },
     }) as const;
 
-  it("offers approve-all only while several cards are undecided", () => {
-    const onApproveAllToolCalls = vi.fn().mockResolvedValue(undefined);
-    const { rerender } = render(
+  it("pages through approvals one card at a time and advances on decision", () => {
+    const onApproveToolCall = vi.fn().mockResolvedValue(undefined);
+    render(
       windowElement({
         messages: [
           approvalToolGroupMessage([
@@ -174,27 +173,29 @@ describe("InAppAgentWindow tool approvals", () => {
             { id: "tool-call-2", status: "pending" },
           ]),
         ],
-        onApproveAllToolCalls,
+        onApproveToolCall,
       }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Approve all" }));
-    expect(onApproveAllToolCalls).toHaveBeenCalledTimes(1);
-
-    // One remaining undecided card no longer needs the shortcut.
-    rerender(
-      windowElement({
-        messages: [
-          approvalToolGroupMessage([
-            { id: "tool-call-1", status: "approved" },
-            { id: "tool-call-2", status: "pending" },
-          ]),
-        ],
-        onApproveAllToolCalls,
-      }),
-    );
+    // Only the active card renders.
+    expect(screen.getAllByRole("button", { name: /Confirm/ })).toHaveLength(1);
     expect(
-      screen.queryByRole("button", { name: "Approve all" }),
-    ).not.toBeInTheDocument();
+      screen.getByText("Tool call 1 of 2 awaiting review"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/tool-call-1/)).toBeInTheDocument();
+
+    // Manual navigation reaches the sibling card.
+    fireEvent.click(screen.getByRole("button", { name: "Next tool call" }));
+    expect(
+      screen.getByText("Tool call 2 of 2 awaiting review"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/tool-call-2/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Previous tool call" }));
+    expect(screen.getByText(/tool-call-1/)).toBeInTheDocument();
+
+    // Deciding records the decision and advances to the next undecided card.
+    fireEvent.click(screen.getByRole("button", { name: /Confirm/ }));
+    expect(onApproveToolCall).toHaveBeenCalledWith("tool-call-1");
+    expect(screen.getByText(/tool-call-2/)).toBeInTheDocument();
   });
 });

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -155,10 +155,10 @@ describe("InAppAgentWindow tool approvals", () => {
       content: {
         type: "toolGroup",
         tools: tools.map(({ id, status }) => ({
-          type: "tool",
+          type: "tool" as const,
           name: `langfuse_createTextPrompt`,
           args: JSON.stringify({ name: id }),
-          status: "running",
+          status: "running" as const,
           approval: { id, status },
         })),
       },

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -30,6 +30,7 @@ function windowElement(
     isLoadingMoreConversations: false,
     messages: [],
     onApproveToolCall: vi.fn(),
+    onApproveAllToolCalls: vi.fn(),
     onDeleteConversation: vi.fn(),
     onExpandedChange: vi.fn(),
     onLoadMoreConversations: vi.fn(),
@@ -141,5 +142,59 @@ describe("InAppAgentWindow quick actions", () => {
     expect(
       screen.getByRole("button", { name: /^Create a prompt/ }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("InAppAgentWindow tool approvals", () => {
+  const approvalToolGroupMessage = (
+    tools: Array<{ id: string; status: "pending" | "approved" }>,
+  ) =>
+    ({
+      id: "tools",
+      role: "assistant",
+      content: {
+        type: "toolGroup",
+        tools: tools.map(({ id, status }) => ({
+          type: "tool",
+          name: `langfuse_createTextPrompt`,
+          args: JSON.stringify({ name: id }),
+          status: "running",
+          approval: { id, status },
+        })),
+      },
+    }) as const;
+
+  it("offers approve-all only while several cards are undecided", () => {
+    const onApproveAllToolCalls = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = render(
+      windowElement({
+        messages: [
+          approvalToolGroupMessage([
+            { id: "tool-call-1", status: "pending" },
+            { id: "tool-call-2", status: "pending" },
+          ]),
+        ],
+        onApproveAllToolCalls,
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve all" }));
+    expect(onApproveAllToolCalls).toHaveBeenCalledTimes(1);
+
+    // One remaining undecided card no longer needs the shortcut.
+    rerender(
+      windowElement({
+        messages: [
+          approvalToolGroupMessage([
+            { id: "tool-call-1", status: "approved" },
+            { id: "tool-call-2", status: "pending" },
+          ]),
+        ],
+        onApproveAllToolCalls,
+      }),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Approve all" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -654,6 +654,51 @@ export const ToolApprovalRequired = meta.story({
   },
 });
 
+// The batch state cannot be reached casually in the app (the model must
+// propose several approval-gated calls in one turn), so this story is the
+// reference for the pager: one card at a time with prev/next navigation.
+export const ToolApprovalBatch = meta.story({
+  args: {
+    isAssistantTurnInProgress: true,
+    isInputDisabled: true,
+    selectedConversationId: "conversation-1",
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        content: {
+          type: "text",
+          text: "Create three prompts in parallel with draft content.",
+        },
+      },
+      {
+        id: "approvals",
+        role: "assistant",
+        content: {
+          type: "toolGroup",
+          tools: [1, 2, 3].map((index) => ({
+            type: "tool",
+            name: "langfuse_createTextPrompt",
+            status: "running",
+            args: JSON.stringify(
+              {
+                name: `prompt-${index}`,
+                prompt: `You are draft assistant ${index}: {{input}}`,
+              },
+              null,
+              2,
+            ),
+            approval: {
+              id: `approval-${index}`,
+              status: "pending",
+            },
+          })),
+        },
+      },
+    ],
+  },
+});
+
 export const Empty = meta.story({
   args: {
     messages: [],
@@ -1215,5 +1260,36 @@ export const RefocusAfterSubmit = meta.story({
     await waitFor(() => {
       expect(textarea).toHaveFocus();
     });
+  },
+});
+
+export const ToolApprovalPagerNavigation = meta.story({
+  name: "(Test) Tool Approval Pager Navigation",
+  args: {
+    ...ToolApprovalBatch.input.args,
+    onApproveToolCall: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByText("Tool call 1 of 3 awaiting review"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText(/prompt-1/)).toBeInTheDocument();
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Next tool call" }),
+    );
+    await expect(
+      canvas.getByText("Tool call 2 of 3 awaiting review"),
+    ).toBeInTheDocument();
+
+    // Deciding a card records the decision and advances to the next
+    // undecided one.
+    await userEvent.click(canvas.getByRole("button", { name: "Confirm" }));
+    await expect(args.onApproveToolCall).toHaveBeenCalledWith("approval-2");
+    await expect(
+      canvas.getByText("Tool call 3 of 3 awaiting review"),
+    ).toBeInTheDocument();
   },
 });

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -600,6 +600,7 @@ const meta = preview.meta({
     onOpenConversationHistory: fn(),
     onNewConversation: fn(),
     onApproveToolCall: fn(),
+    onApproveAllToolCalls: fn(),
     onRejectToolCall: fn(),
     onSelectConversation: fn(),
     onClose: fn(),

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -600,7 +600,6 @@ const meta = preview.meta({
     onOpenConversationHistory: fn(),
     onNewConversation: fn(),
     onApproveToolCall: fn(),
-    onApproveAllToolCalls: fn(),
     onRejectToolCall: fn(),
     onSelectConversation: fn(),
     onClose: fn(),

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -492,9 +492,15 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const [isConversationHistoryOpen, setIsConversationHistoryOpen] =
     useState(false);
   const hasUserMessage = messages.some((message) => message.role === "user");
+  // Submitting approvals are excluded: once the last decision is made the
+  // batch is committed and nothing is actionable — the pager closes and the
+  // streaming continuation is the feedback. On failure the statuses revert to
+  // "pending" and the pager reappears.
   const pendingToolCalls = messages.flatMap((message) =>
     message.content.type === "toolGroup"
-      ? message.content.tools.filter((tool) => tool.approval)
+      ? message.content.tools.filter(
+          (tool) => tool.approval && tool.approval.status !== "submitting",
+        )
       : [],
   );
   const visibleMessages = messages

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -10,7 +10,8 @@ import {
 import {
   ArrowRight,
   BotMessageSquare,
-  Check,
+  ChevronLeft,
+  ChevronRight,
   History,
   Info,
   Maximize2,
@@ -46,6 +47,7 @@ import type { InAppAgentScreenContextDescription } from "@/src/ee/features/in-ap
 import { InAppAgentToolCallCard } from "@/src/ee/features/in-app-agent/components/InAppAgentToolCallCard";
 import {
   type InAppAgentError,
+  type InAppAgentToolCallContent,
   isInAppAgentRateLimited,
 } from "@/src/ee/features/in-app-agent/components/utils/utils";
 import styles from "./InAppAgentWindow.module.css";
@@ -173,6 +175,99 @@ function InAppAgentQuickActionPicker({
   );
 }
 
+// One approval card at a time: several cards stacked in the pinned section
+// take over the whole window. The pager shows the active card with prev/next
+// navigation and jumps to the next undecided card after each decision; the
+// batch resume still fires once every card is decided.
+function InAppAgentToolApprovalPager({
+  pendingToolCalls,
+  isExpanded,
+  isDisabled,
+  onApproveToolCall,
+  onRejectToolCall,
+}: {
+  pendingToolCalls: InAppAgentToolCallContent[];
+  isExpanded: boolean;
+  isDisabled: boolean;
+  onApproveToolCall: (approvalId: string) => Promise<void>;
+  onRejectToolCall: (approvalId: string) => Promise<void>;
+}) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const cardCount = pendingToolCalls.length;
+  const safeIndex = Math.min(activeIndex, cardCount - 1);
+  const activeTool = pendingToolCalls[safeIndex];
+
+  if (!activeTool) {
+    return null;
+  }
+
+  // The just-decided card's status only flips after the provider processes the
+  // decision, so search forward from it (wrapping) for the next undecided one.
+  const advanceToNextPending = () => {
+    for (let offset = 1; offset < cardCount; offset += 1) {
+      const index = (safeIndex + offset) % cardCount;
+      if (pendingToolCalls[index]?.approval?.status === "pending") {
+        setActiveIndex(index);
+        return;
+      }
+    }
+  };
+
+  return (
+    <div
+      className={cn("flex flex-col gap-1.5", isExpanded && "mx-auto max-w-3xl")}
+    >
+      {cardCount > 1 ? (
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-muted-foreground text-xs">
+            Tool call {safeIndex + 1} of {cardCount} awaiting review
+          </span>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="size-7 p-0"
+              aria-label="Previous tool call"
+              onClick={() => {
+                setActiveIndex((safeIndex - 1 + cardCount) % cardCount);
+              }}
+            >
+              <ChevronLeft className="size-3.5" />
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="size-7 p-0"
+              aria-label="Next tool call"
+              onClick={() => {
+                setActiveIndex((safeIndex + 1) % cardCount);
+              }}
+            >
+              <ChevronRight className="size-3.5" />
+            </Button>
+          </div>
+        </div>
+      ) : null}
+      <InAppAgentToolCallCard
+        key={activeTool.approval?.id ?? activeTool.name}
+        tool={activeTool}
+        isCompact={!isExpanded}
+        isDisabled={isDisabled}
+        onApproveToolCall={(approvalId) => {
+          advanceToNextPending();
+          return onApproveToolCall(approvalId);
+        }}
+        onRejectToolCall={(approvalId) => {
+          advanceToNextPending();
+          return onRejectToolCall(approvalId);
+        }}
+      />
+    </div>
+  );
+}
+
 function formatScreenContextNotice(
   description: InAppAgentScreenContextDescription,
 ) {
@@ -271,7 +366,6 @@ export type InAppAgentWindowProps = {
   onNewConversation: () => void;
   onApproveToolCall: (approvalId: string) => Promise<void>;
   onRejectToolCall: (approvalId: string) => Promise<void>;
-  onApproveAllToolCalls: () => Promise<void>;
   onOpenConversationHistory: () => void;
   onSelectConversation: (conversationId: string) => void;
   onSubmit: (
@@ -373,7 +467,6 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     onNewConversation,
     onApproveToolCall,
     onRejectToolCall,
-    onApproveAllToolCalls,
     onOpenConversationHistory,
     onSelectConversation,
     onSubmit,
@@ -802,49 +895,18 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
               isExpanded ? "px-1.5 pb-2" : "px-3 pb-2",
             )}
           >
-            <div
-              className={cn(
-                "flex flex-col gap-2",
-                isExpanded && "mx-auto max-w-3xl",
-              )}
-            >
-              {pendingToolCalls.filter(
-                (tool) => tool.approval?.status === "pending",
-              ).length > 1 ? (
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-muted-foreground text-xs">
-                    {pendingToolCalls.length} tool calls awaiting review
-                  </span>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline-success"
-                    className="h-7"
-                    disabled={
-                      isRateLimited || disablePendingToolApprovalActions
-                    }
-                    onClick={() => {
-                      onApproveAllToolCalls().catch(() => undefined);
-                    }}
-                  >
-                    <Check className="mr-1 size-3" />
-                    Approve all
-                  </Button>
-                </div>
-              ) : null}
-              {pendingToolCalls.map((tool, index) => (
-                <InAppAgentToolCallCard
-                  key={`${tool.approval?.id ?? tool.name}-${index}`}
-                  tool={tool}
-                  isCompact={!isExpanded}
-                  isDisabled={
-                    isRateLimited || disablePendingToolApprovalActions
-                  }
-                  onApproveToolCall={onApproveToolCall}
-                  onRejectToolCall={onRejectToolCall}
-                />
-              ))}
-            </div>
+            <InAppAgentToolApprovalPager
+              // Remount (and reset the pager position) when the set of open
+              // approvals changes, but not when a card's status changes.
+              key={pendingToolCalls
+                .map((tool) => tool.approval?.id ?? tool.name)
+                .join(",")}
+              pendingToolCalls={pendingToolCalls}
+              isExpanded={isExpanded}
+              isDisabled={isRateLimited || disablePendingToolApprovalActions}
+              onApproveToolCall={onApproveToolCall}
+              onRejectToolCall={onRejectToolCall}
+            />
           </div>
         ) : null}
         <div

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -10,6 +10,7 @@ import {
 import {
   ArrowRight,
   BotMessageSquare,
+  Check,
   History,
   Info,
   Maximize2,
@@ -270,6 +271,7 @@ export type InAppAgentWindowProps = {
   onNewConversation: () => void;
   onApproveToolCall: (approvalId: string) => Promise<void>;
   onRejectToolCall: (approvalId: string) => Promise<void>;
+  onApproveAllToolCalls: () => Promise<void>;
   onOpenConversationHistory: () => void;
   onSelectConversation: (conversationId: string) => void;
   onSubmit: (
@@ -371,6 +373,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     onNewConversation,
     onApproveToolCall,
     onRejectToolCall,
+    onApproveAllToolCalls,
     onOpenConversationHistory,
     onSelectConversation,
     onSubmit,
@@ -805,6 +808,30 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 isExpanded && "mx-auto max-w-3xl",
               )}
             >
+              {pendingToolCalls.filter(
+                (tool) => tool.approval?.status === "pending",
+              ).length > 1 ? (
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-muted-foreground text-xs">
+                    {pendingToolCalls.length} tool calls awaiting review
+                  </span>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline-success"
+                    className="h-7"
+                    disabled={
+                      isRateLimited || disablePendingToolApprovalActions
+                    }
+                    onClick={() => {
+                      onApproveAllToolCalls().catch(() => undefined);
+                    }}
+                  >
+                    <Check className="mr-1 size-3" />
+                    Approve all
+                  </Button>
+                </div>
+              ) : null}
               {pendingToolCalls.map((tool, index) => (
                 <InAppAgentToolCallCard
                   key={`${tool.approval?.id ?? tool.name}-${index}`}

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -1055,12 +1055,19 @@ function InAppAiAgentProviderInner({
       approved: approval.status === "approved",
       approvalRequest: approval.approvalRequest,
     }));
+    // The continuation run can raise NEW approval interrupts while this batch
+    // is in flight; every state update below must touch only the submitted
+    // approvals so a freshly arrived card is not wiped or reverted.
+    const submittedApprovalIds = new Set(
+      approvals.map((approval) => approval.id),
+    );
 
     updatePendingToolApprovals((currentApprovals) =>
-      currentApprovals.map((currentApproval) => ({
-        ...currentApproval,
-        status: "submitting" as const,
-      })),
+      currentApprovals.map((currentApproval) =>
+        submittedApprovalIds.has(currentApproval.id)
+          ? { ...currentApproval, status: "submitting" as const }
+          : currentApproval,
+      ),
     );
     setError(null);
 
@@ -1077,21 +1084,30 @@ function InAppAiAgentProviderInner({
 
       if (!completed) {
         updatePendingToolApprovals((currentApprovals) =>
-          currentApprovals.map((currentApproval) => ({
-            ...currentApproval,
-            status: "pending" as const,
-          })),
+          currentApprovals.map((currentApproval) =>
+            submittedApprovalIds.has(currentApproval.id)
+              ? { ...currentApproval, status: "pending" as const }
+              : currentApproval,
+          ),
         );
         return;
       }
 
-      updatePendingToolApprovals(() => []);
+      updatePendingToolApprovals((currentApprovals) =>
+        currentApprovals.filter(
+          (currentApproval) => !submittedApprovalIds.has(currentApproval.id),
+        ),
+      );
     } catch (error) {
       const errorMessage = getAgentErrorMessage(error);
       if (errorMessage === "Invalid forwarded props") {
         // The batch is consumed all-or-nothing, so a stale entry invalidates
-        // the whole set.
-        updatePendingToolApprovals(() => []);
+        // the whole submitted set.
+        updatePendingToolApprovals((currentApprovals) =>
+          currentApprovals.filter(
+            (currentApproval) => !submittedApprovalIds.has(currentApproval.id),
+          ),
+        );
         setError({
           type: "generic",
           message:
@@ -1102,10 +1118,11 @@ function InAppAiAgentProviderInner({
       }
 
       updatePendingToolApprovals((currentApprovals) =>
-        currentApprovals.map((currentApproval) => ({
-          ...currentApproval,
-          status: "pending" as const,
-        })),
+        currentApprovals.map((currentApproval) =>
+          submittedApprovalIds.has(currentApproval.id)
+            ? { ...currentApproval, status: "pending" as const }
+            : currentApproval,
+        ),
       );
       setError(getInAppAgentError(error));
       console.error("Failed to resume in-app agent tool calls", error);

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -113,6 +113,7 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
   submit: async () => false,
   approveToolCall: async () => undefined,
   rejectToolCall: async () => undefined,
+  approveAllToolCalls: async () => undefined,
   submitFeedback: async () => undefined,
 };
 
@@ -124,7 +125,12 @@ type InAppAiAgentFeedbackByConversationId = Record<
 export type InAppAgentPendingToolApproval = {
   id: string;
   approvalRequest: InAppAgentToolApprovalRequest;
-  status: "pending" | "submitting";
+  /**
+   * pending: awaiting the user's decision. approved/rejected: decided locally,
+   * waiting for the remaining cards — the batch resume fires once none are
+   * pending. submitting: the batch resume is in flight.
+   */
+  status: "pending" | "approved" | "rejected" | "submitting";
 };
 
 export type InAppAiAgentConversation = {
@@ -166,6 +172,7 @@ type InAppAiAgentContextType = {
   ) => Promise<boolean>;
   approveToolCall: (approvalId: string) => Promise<void>;
   rejectToolCall: (approvalId: string) => Promise<void>;
+  approveAllToolCalls: () => Promise<void>;
   submitFeedback: (params: {
     messageId: string;
     runId: string;
@@ -1016,126 +1023,189 @@ function InAppAiAgentProviderInner({
     [capture, organization, setAgentOpen],
   );
 
-  const resumeToolApproval = useCallback(
-    async (approvalId: string, approved: boolean) => {
-      if (selectedConversationIsWriteLocked) {
-        setError({
-          type: "generic",
-          message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
-        });
+  // Fires the single batch resume once every card is decided; all decisions
+  // travel in one continuation run.
+  const submitToolApprovalDecisions = useCallback(async () => {
+    const approvals = pendingToolApprovalsRef.current;
+
+    if (
+      approvals.length === 0 ||
+      approvals.some(
+        (approval) =>
+          approval.status === "pending" || approval.status === "submitting",
+      )
+    ) {
+      return;
+    }
+
+    if (!selectedConversationId) {
+      return;
+    }
+
+    const agent = agentRef.current;
+    if (!agent || agent.threadId !== selectedConversationId) {
+      showErrorToast(
+        "Failed to resume tool calls",
+        "The interrupted assistant run is no longer available.",
+      );
+      return;
+    }
+
+    const decisions = approvals.map((approval) => ({
+      approved: approval.status === "approved",
+      approvalRequest: approval.approvalRequest,
+    }));
+
+    updatePendingToolApprovals((currentApprovals) =>
+      currentApprovals.map((currentApproval) => ({
+        ...currentApproval,
+        status: "submitting" as const,
+      })),
+    );
+    setError(null);
+
+    try {
+      ensureSubscription(agent);
+      const completed = await runAgent(agent, selectedConversationId, {
+        runId: createInAppAgentRunId(),
+        forwardedProps: {
+          command: {
+            resume: { decisions },
+          },
+        },
+      });
+
+      if (!completed) {
+        updatePendingToolApprovals((currentApprovals) =>
+          currentApprovals.map((currentApproval) => ({
+            ...currentApproval,
+            status: "pending" as const,
+          })),
+        );
         return;
       }
 
-      const approval = pendingToolApprovals.find(
+      updatePendingToolApprovals(() => []);
+    } catch (error) {
+      const errorMessage = getAgentErrorMessage(error);
+      if (errorMessage === "Invalid forwarded props") {
+        // The batch is consumed all-or-nothing, so a stale entry invalidates
+        // the whole set.
+        updatePendingToolApprovals(() => []);
+        setError({
+          type: "generic",
+          message:
+            "These tool approvals are no longer valid. Please try again.",
+        });
+        console.error("Failed to resume in-app agent tool calls", error);
+        return;
+      }
+
+      updatePendingToolApprovals((currentApprovals) =>
+        currentApprovals.map((currentApproval) => ({
+          ...currentApproval,
+          status: "pending" as const,
+        })),
+      );
+      setError(getInAppAgentError(error));
+      console.error("Failed to resume in-app agent tool calls", error);
+    }
+  }, [
+    ensureSubscription,
+    runAgent,
+    selectedConversationId,
+    updatePendingToolApprovals,
+  ]);
+
+  const canDecideToolApprovals = useCallback(() => {
+    if (selectedConversationIsWriteLocked) {
+      setError({
+        type: "generic",
+        message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+      });
+      return false;
+    }
+
+    return (
+      Boolean(selectedConversationId) &&
+      !isRunning &&
+      !runInFlightRef.current &&
+      !isInAppAgentRateLimited(error) &&
+      !pendingToolApprovalsRef.current.some(
+        (approval) => approval.status === "submitting",
+      )
+    );
+  }, [
+    error,
+    isRunning,
+    selectedConversationId,
+    selectedConversationIsWriteLocked,
+  ]);
+
+  const recordToolApprovalDecision = useCallback(
+    async (approvalId: string, approved: boolean) => {
+      const approval = pendingToolApprovalsRef.current.find(
         (approval) => approval.id === approvalId,
       );
 
-      if (
-        !approval ||
-        !selectedConversationId ||
-        isRunning ||
-        runInFlightRef.current ||
-        isInAppAgentRateLimited(error)
-      ) {
-        return;
-      }
-
-      const agent = agentRef.current;
-      if (!agent || agent.threadId !== selectedConversationId) {
-        showErrorToast(
-          "Failed to resume tool call",
-          "The interrupted assistant run is no longer available.",
-        );
+      if (!approval || !canDecideToolApprovals()) {
         return;
       }
 
       updatePendingToolApprovals((currentApprovals) =>
         currentApprovals.map((currentApproval) =>
           currentApproval.id === approvalId
-            ? { ...currentApproval, status: "submitting" }
+            ? {
+                ...currentApproval,
+                status: approved
+                  ? ("approved" as const)
+                  : ("rejected" as const),
+              }
             : currentApproval,
         ),
       );
-      setError(null);
 
-      try {
-        ensureSubscription(agent);
-        const completed = await runAgent(agent, selectedConversationId, {
-          runId: createInAppAgentRunId(),
-          forwardedProps: {
-            command: {
-              resume: {
-                approved,
-                approvalRequest: approval.approvalRequest,
-              },
-            },
-          },
-        });
-
-        if (!completed) {
-          updatePendingToolApprovals((currentApprovals) =>
-            currentApprovals.map((currentApproval) =>
-              currentApproval.id === approvalId
-                ? { ...currentApproval, status: "pending" }
-                : currentApproval,
-            ),
-          );
-          return;
-        }
-
-        updatePendingToolApprovals((currentApprovals) =>
-          currentApprovals.filter(
-            (currentApproval) => currentApproval.id !== approvalId,
-          ),
-        );
-      } catch (error) {
-        const errorMessage = getAgentErrorMessage(error);
-        if (errorMessage === "Invalid forwarded props") {
-          updatePendingToolApprovals((currentApprovals) =>
-            currentApprovals.filter(
-              (currentApproval) => currentApproval.id !== approvalId,
-            ),
-          );
-          setError({
-            type: "generic",
-            message: "This tool approval is no longer valid. Please try again.",
-          });
-          console.error("Failed to resume in-app agent tool call", error);
-          return;
-        }
-
-        updatePendingToolApprovals((currentApprovals) =>
-          currentApprovals.map((currentApproval) =>
-            currentApproval.id === approvalId
-              ? { ...currentApproval, status: "pending" }
-              : currentApproval,
-          ),
-        );
-        setError(getInAppAgentError(error));
-        console.error("Failed to resume in-app agent tool call", error);
-      }
+      await submitToolApprovalDecisions();
     },
     [
-      ensureSubscription,
-      error,
-      isRunning,
-      pendingToolApprovals,
-      runAgent,
-      selectedConversationId,
-      selectedConversationIsWriteLocked,
+      canDecideToolApprovals,
+      submitToolApprovalDecisions,
       updatePendingToolApprovals,
     ],
   );
 
   const approveToolCall = useCallback(
-    (approvalId: string) => resumeToolApproval(approvalId, true),
-    [resumeToolApproval],
+    (approvalId: string) => recordToolApprovalDecision(approvalId, true),
+    [recordToolApprovalDecision],
   );
 
   const rejectToolCall = useCallback(
-    (approvalId: string) => resumeToolApproval(approvalId, false),
-    [resumeToolApproval],
+    (approvalId: string) => recordToolApprovalDecision(approvalId, false),
+    [recordToolApprovalDecision],
   );
+
+  const approveAllToolCalls = useCallback(async () => {
+    if (
+      pendingToolApprovalsRef.current.length === 0 ||
+      !canDecideToolApprovals()
+    ) {
+      return;
+    }
+
+    updatePendingToolApprovals((currentApprovals) =>
+      currentApprovals.map((currentApproval) =>
+        currentApproval.status === "pending"
+          ? { ...currentApproval, status: "approved" as const }
+          : currentApproval,
+      ),
+    );
+
+    await submitToolApprovalDecisions();
+  }, [
+    canDecideToolApprovals,
+    submitToolApprovalDecisions,
+    updatePendingToolApprovals,
+  ]);
 
   const value = useMemo<InAppAiAgentContextType>(
     () => ({
@@ -1166,10 +1236,12 @@ function InAppAiAgentProviderInner({
       submit,
       approveToolCall,
       rejectToolCall,
+      approveAllToolCalls,
       submitFeedback,
     }),
     [
       approveToolCall,
+      approveAllToolCalls,
       isExpanded,
       conversations,
       error,

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -113,7 +113,6 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
   submit: async () => false,
   approveToolCall: async () => undefined,
   rejectToolCall: async () => undefined,
-  approveAllToolCalls: async () => undefined,
   submitFeedback: async () => undefined,
 };
 
@@ -172,7 +171,6 @@ type InAppAiAgentContextType = {
   ) => Promise<boolean>;
   approveToolCall: (approvalId: string) => Promise<void>;
   rejectToolCall: (approvalId: string) => Promise<void>;
-  approveAllToolCalls: () => Promise<void>;
   submitFeedback: (params: {
     messageId: string;
     runId: string;
@@ -1201,29 +1199,6 @@ function InAppAiAgentProviderInner({
     [recordToolApprovalDecision],
   );
 
-  const approveAllToolCalls = useCallback(async () => {
-    if (
-      pendingToolApprovalsRef.current.length === 0 ||
-      !canDecideToolApprovals()
-    ) {
-      return;
-    }
-
-    updatePendingToolApprovals((currentApprovals) =>
-      currentApprovals.map((currentApproval) =>
-        currentApproval.status === "pending"
-          ? { ...currentApproval, status: "approved" as const }
-          : currentApproval,
-      ),
-    );
-
-    await submitToolApprovalDecisions();
-  }, [
-    canDecideToolApprovals,
-    submitToolApprovalDecisions,
-    updatePendingToolApprovals,
-  ]);
-
   const value = useMemo<InAppAiAgentContextType>(
     () => ({
       isAvailable: true,
@@ -1253,12 +1228,10 @@ function InAppAiAgentProviderInner({
       submit,
       approveToolCall,
       rejectToolCall,
-      approveAllToolCalls,
       submitFeedback,
     }),
     [
       approveToolCall,
-      approveAllToolCalls,
       isExpanded,
       conversations,
       error,

--- a/web/src/ee/features/in-app-agent/components/useSmoothStreamingMessages.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/useSmoothStreamingMessages.clienttest.tsx
@@ -685,6 +685,37 @@ describe("useSmoothStreamingMessages", () => {
     );
   });
 
+  it("shows an approval that arrives after its tool call is already visible", () => {
+    // Tool-call events stream before the interrupt that carries the approval,
+    // so the tool's appearance transition runs while no approval exists yet.
+    const { rerender } = render(
+      <TestConsumer liveMessageVersion={0} messages={[userMessage]} />,
+    );
+
+    rerender(
+      <TestConsumer
+        liveMessageVersion={1}
+        messages={[userMessage, assistantToolMessage(["tool-call-1"], true)]}
+      />,
+    );
+    runAllAnimationFrames();
+
+    expect(screen.getByTestId("tool-call-ids")).toHaveTextContent(
+      "tool-call-1",
+    );
+    expect(screen.getByTestId("approval-ids")).toBeEmptyDOMElement();
+
+    rerender(
+      <TestConsumer
+        liveMessageVersion={1}
+        messages={[userMessage, assistantToolMessage(["tool-call-1"], true)]}
+        pendingToolApprovals={[pendingToolApproval("tool-call-1", "pending")]}
+      />,
+    );
+
+    expect(screen.getByTestId("approval-ids")).toHaveTextContent("tool-call-1");
+  });
+
   it("does not animate for reduced-motion users", () => {
     prefersReducedMotion = true;
     const content =

--- a/web/src/ee/features/in-app-agent/components/useSmoothStreamingMessages.ts
+++ b/web/src/ee/features/in-app-agent/components/useSmoothStreamingMessages.ts
@@ -232,6 +232,7 @@ function enqueueStreamingUpdate(
     displayedToolApprovals: mergeDisplayedToolApprovals(
       state.displayedToolApprovals,
       action.pendingToolApprovals,
+      state.toolDisplayById,
     ),
     nowMs: action.publishedAtMs,
     textPacingByMessageId: isLivePublication
@@ -592,14 +593,29 @@ function applyNextToolTransition(state: SmoothStreamingState, nowMs: number) {
 function mergeDisplayedToolApprovals(
   displayedApprovals: InAppAgentPendingToolApproval[],
   targetApprovals: InAppAgentPendingToolApproval[],
+  toolDisplayById: ToolDisplayState,
 ) {
   const targetApprovalsById = new Map(
     targetApprovals.map((approval) => [approval.id, approval]),
   );
-
-  return displayedApprovals.map(
-    (approval) => targetApprovalsById.get(approval.id) ?? approval,
+  const displayedApprovalIds = new Set(
+    displayedApprovals.map((approval) => approval.id),
   );
+  // An approval can arrive after its tool call's appearance transition has
+  // already run: the TOOL_CALL_* events stream well before the interrupt that
+  // carries the approval. No later transition surfaces it (appearance only
+  // fires once per tool), so attach it as soon as its tool is visible.
+  // Approvals for tools that are not visible yet keep waiting for their
+  // appearance transition.
+  const lateApprovals = targetApprovals.filter(
+    (approval) =>
+      !displayedApprovalIds.has(approval.id) &&
+      toolDisplayById[approval.id] !== undefined,
+  );
+
+  return displayedApprovals
+    .map((approval) => targetApprovalsById.get(approval.id) ?? approval)
+    .concat(lateApprovals);
 }
 
 function areToolApprovalsEqual(

--- a/web/src/ee/features/in-app-agent/components/utils/utils.clienttest.ts
+++ b/web/src/ee/features/in-app-agent/components/utils/utils.clienttest.ts
@@ -1068,4 +1068,63 @@ describe("getDrawerMessages", () => {
       expect(toolGroup.content.tools[0]).not.toHaveProperty("approval");
     }
   });
+
+  it("renders a resumed tool call only once when its id is duplicated", () => {
+    const mappedMessages = getDrawerMessages({
+      error: null,
+      isRunning: false,
+      messages: [
+        {
+          id: "interrupted-run-assistant",
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tool-call-1",
+              type: "function",
+              function: {
+                name: "langfuse_deleteDashboardWidget",
+                arguments: JSON.stringify({ widgetId: "widget-1" }),
+              },
+            },
+          ],
+        },
+        {
+          id: "resumed-run-assistant",
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tool-call-1",
+              type: "function",
+              function: {
+                name: "langfuse_deleteDashboardWidget",
+                arguments: JSON.stringify({ widgetId: "widget-1" }),
+              },
+            },
+          ],
+        },
+        {
+          id: "tool-result-1",
+          role: "tool",
+          toolCallId: "tool-call-1",
+          content: JSON.stringify({
+            message: "Dashboard widget successfully deleted",
+          }),
+        },
+      ] satisfies InAppAiAgentMessage[],
+    });
+
+    const renderedTools = mappedMessages.flatMap((message) =>
+      message.content.type === "toolGroup" ? message.content.tools : [],
+    );
+
+    expect(renderedTools).toHaveLength(1);
+    expect(renderedTools[0]).toMatchObject({
+      name: "langfuse_deleteDashboardWidget",
+      result: JSON.stringify({
+        message: "Dashboard widget successfully deleted",
+      }),
+    });
+  });
 });

--- a/web/src/ee/features/in-app-agent/components/utils/utils.ts
+++ b/web/src/ee/features/in-app-agent/components/utils/utils.ts
@@ -36,7 +36,7 @@ export type InAppAgentToolCallContent = {
   error?: string;
   approval?: {
     id: string;
-    status: "pending" | "submitting";
+    status: "pending" | "approved" | "rejected" | "submitting";
   };
 };
 

--- a/web/src/ee/features/in-app-agent/components/utils/utils.ts
+++ b/web/src/ee/features/in-app-agent/components/utils/utils.ts
@@ -216,6 +216,7 @@ export function getDrawerMessages({
     ? new Set(runningToolCallIds)
     : null;
   const mappedPendingApprovalIds = new Set<string>();
+  const mappedToolCallIds = new Set<string>();
 
   const mappedMessages: InAppAgentWindowMessage[] = [];
   let pendingTools: InAppAgentToolCallContent[] = [];
@@ -324,6 +325,11 @@ export function getDrawerMessages({
       message.role === "assistant"
         ? (message.toolCalls?.flatMap(
             (toolCall): InAppAgentToolCallContent[] => {
+              if (mappedToolCallIds.has(toolCall.id)) {
+                return [];
+              }
+              mappedToolCallIds.add(toolCall.id);
+
               if (toolCall.function.name === IN_APP_AGENT_REDIRECT_TOOL_NAME) {
                 return [];
               }

--- a/web/src/ee/features/in-app-agent/schema.ts
+++ b/web/src/ee/features/in-app-agent/schema.ts
@@ -237,16 +237,37 @@ export type InAppAgentToolApprovalRequest = z.infer<
   typeof InAppAgentToolApprovalRequestSchema
 >;
 
+export const InAppAgentToolApprovalDecisionSchema = z.object({
+  approved: z.boolean(),
+  approvalRequest: InAppAgentToolApprovalRequestSchema,
+});
+
+export type InAppAgentToolApprovalDecision = z.infer<
+  typeof InAppAgentToolApprovalDecisionSchema
+>;
+
 export const ResumeForwardedPropsSchema = z.object({
   command: z.object({
-    resume: z.object({
-      approved: z.boolean(),
-      approvalRequest: InAppAgentToolApprovalRequestSchema,
-    }),
+    resume: z.union([
+      z.object({
+        decisions: z.array(InAppAgentToolApprovalDecisionSchema).min(1),
+      }),
+      // Legacy single-decision shape, kept for browser tabs that stay open
+      // across a deploy. Normalize via getResumeDecisions.
+      InAppAgentToolApprovalDecisionSchema,
+    ]),
   }),
 });
 
 export type ResumeForwardedProps = z.infer<typeof ResumeForwardedPropsSchema>;
+
+export function getResumeDecisions(
+  forwardedProps: ResumeForwardedProps,
+): InAppAgentToolApprovalDecision[] {
+  const resume = forwardedProps.command.resume;
+
+  return "decisions" in resume ? resume.decisions : [resume];
+}
 
 export const InAppAgentRuntimeStateSchema = z.discriminatedUnion("type", [
   z.object({

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -829,7 +829,14 @@ async function createMastraAdapter(params: {
       // events, so keep the pre-flag behavior.
       emitInterruptOutcome: false,
     });
-    patchMastraApprovalChunks(adapter);
+    const approvalGatedToolNames = new Set(
+      Object.entries(tools).flatMap(([toolName, tool]) =>
+        (tool as { requireApproval?: boolean }).requireApproval === true
+          ? [toolName]
+          : [],
+      ),
+    );
+    patchMastraApprovalChunks(adapter, approvalGatedToolNames);
 
     return {
       adapter,
@@ -931,13 +938,27 @@ type MastraApprovalStreamChunk = {
 // withInAppAgentToolApproval: Mastra emits a tool-call-approval chunk for
 // those tools and the bridge has no case for it, so approvals would never
 // surface as on_interrupt events. Map approvals onto the suspend protocol.
+//
+// Mastra also raises at most ONE approval per run: when the model proposes
+// several approval-gated calls in parallel, only the first reaches its
+// execution step before the run suspends — the siblings never execute, never
+// get an approval chunk, and their streamed lifecycles dangle. Since the
+// approval resume executes approved calls manually from (toolCallId, toolName,
+// args) and never touches Mastra's suspension state, a synthesized suspension
+// is exactly as good as a real one: every approval-gated `tool-call` chunk is
+// mapped onto the suspend protocol directly, so all proposed calls surface as
+// approval cards in the same run and resolve in one batch continuation.
+//
 // Non-background tool-error chunks are likewise swallowed by the bridge, so
 // convert them to tool results carrying the error message as content. Note:
 // the bridge emits TOOL_CALL_RESULT without a top-level `error` field, so the
 // failure renders with the error message in the result body but a "succeeded"
 // status; the model is unaffected (Mastra's loop feeds it the real error).
 // Status fidelity is tracked as a follow-up.
-export function patchMastraApprovalChunks(adapter: MastraAgent) {
+export function patchMastraApprovalChunks(
+  adapter: MastraAgent,
+  approvalGatedToolNames: ReadonlySet<string>,
+) {
   const patchableAdapter = adapter as unknown as PatchableMastraAgent;
   const createChunkProcessor = patchableAdapter.createChunkProcessor;
 
@@ -951,10 +972,53 @@ export function patchMastraApprovalChunks(adapter: MastraAgent) {
     ...rest: unknown[]
   ) {
     const processor = createChunkProcessor.call(this, callbacks, ...rest);
+    // The call that Mastra does execute emits BOTH a tool-call chunk and a
+    // tool-call-approval chunk; suspend it once.
+    const suspendedToolCallIds = new Set<string>();
+
+    const suspendToolCall = (
+      mastraChunk: MastraApprovalStreamChunk,
+      toolCallId: string,
+      toolName: string,
+      toolArgs: unknown,
+    ) => {
+      if (suspendedToolCallIds.has(toolCallId)) {
+        return false;
+      }
+
+      suspendedToolCallIds.add(toolCallId);
+      return processor.handleChunk({
+        ...mastraChunk,
+        type: "tool-call-suspended",
+        payload: {
+          ...mastraChunk.payload,
+          suspendPayload: {
+            type: "approval",
+            toolCallId,
+            toolName,
+            args: toolArgs,
+          },
+        },
+      });
+    };
 
     return {
       handleChunk(chunk: unknown) {
         const mastraChunk = chunk as MastraApprovalStreamChunk;
+
+        if (
+          mastraChunk?.type === "tool-call" &&
+          typeof mastraChunk.payload?.toolName === "string" &&
+          approvalGatedToolNames.has(mastraChunk.payload.toolName) &&
+          typeof mastraChunk.payload.toolCallId === "string"
+        ) {
+          return suspendToolCall(
+            mastraChunk,
+            mastraChunk.payload.toolCallId,
+            mastraChunk.payload.toolName,
+            mastraChunk.payload.args,
+          );
+        }
 
         if (mastraChunk?.type === "tool-call-approval") {
           const {
@@ -971,19 +1035,7 @@ export function patchMastraApprovalChunks(adapter: MastraAgent) {
             return true;
           }
 
-          return processor.handleChunk({
-            ...mastraChunk,
-            type: "tool-call-suspended",
-            payload: {
-              ...mastraChunk.payload,
-              suspendPayload: {
-                type: "approval",
-                toolCallId,
-                toolName,
-                args: toolArgs,
-              },
-            },
-          });
+          return suspendToolCall(mastraChunk, toolCallId, toolName, toolArgs);
         }
 
         if (mastraChunk?.type === "tool-error") {

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -10,6 +10,7 @@ import { MCPClient } from "@mastra/mcp";
 import type { Langfuse } from "langfuse";
 
 import {
+  getResumeDecisions,
   type AgUiEvent,
   type AgUiRunAgentInput,
   type InAppAgentToolApprovalRequest,
@@ -155,7 +156,7 @@ export function getBedrockReasoningProviderOptions(modelId: string) {
 
 type CreateAgUiStreamOptions = {
   onEvent?: (event: AgUiEvent) => void | Promise<void>;
-  onApprovedToolCallExecuted?: () => void | Promise<void>;
+  onApprovedToolCallExecuted?: (toolCallId: string) => void | Promise<void>;
   onComplete?: () => void | Promise<void>;
   onAbort?: () => void | Promise<void>;
   onError?: (error: unknown) => void | Promise<void>;
@@ -493,13 +494,18 @@ export async function createAgUiStream(params: {
               params.options.onApprovedToolCallExecuted,
           });
           const pendingSyntheticEvents = [...runInput.syntheticEvents];
+          const hasApprovedResumeDecision =
+            forwardedProps?.command?.resume !== undefined &&
+            getResumeDecisions(forwardedProps).some(
+              (decision) => decision.approved,
+            );
 
           if (
-            forwardedProps?.command?.resume?.approved === true &&
+            hasApprovedResumeDecision &&
             params.options.langfuseMcp.runOverride
           ) {
             // The override is intentionally single-use: execute the approved
-            // mutating MCP tool with the first client, then rebuild the MCP
+            // mutating MCP tools with the first client, then rebuild the MCP
             // client without the override so the continuation returns to the
             // normal read-only in-app-agent policy.
 
@@ -575,9 +581,9 @@ export async function createAgUiStream(params: {
                   agUiEvent.type === EventType.RUN_STARTED &&
                   pendingSyntheticEvents.length > 0
                 ) {
-                  instrumentation?.recordToolCallApproval(
-                    runInput.toolCallApproval,
-                  );
+                  for (const toolCallApproval of runInput.toolCallApprovals) {
+                    instrumentation?.recordToolCallApproval(toolCallApproval);
+                  }
                   instrumentation?.recordEvents(pendingSyntheticEvents);
                   for (const syntheticEvent of pendingSyntheticEvents) {
                     enqueueEvent(syntheticEvent);

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -17,6 +17,7 @@ import {
   AgUiRunAgentInputSchema,
   type AgUiRunAgentInput,
   type AgUiEvent,
+  getResumeDecisions,
   InAppAgentRuntimeStateSchema,
   type AgUiMessage,
   ResumeForwardedPropsSchema,
@@ -293,9 +294,9 @@ export default async function handler(request: Request) {
       sanitizedInput,
       conversationMessages,
     );
-    const resumeApprovalRequest = isResumeAgentInput(sanitizedInput)
-      ? sanitizedInput.forwardedProps.command.resume.approvalRequest
-      : undefined;
+    const resumeDecisions = isResumeAgentInput(sanitizedInput)
+      ? getResumeDecisions(sanitizedInput.forwardedProps)
+      : [];
     const sandboxProviderType = getDefaultInAppAgentSandboxProviderType();
     const sandboxProvider =
       await getInAppAgentSandboxProvider(sandboxProviderType);
@@ -321,41 +322,55 @@ export default async function handler(request: Request) {
         })
       : undefined;
 
-    const approvedResumeApprovalRequest =
-      isResumeAgentInput(sanitizedInput) &&
-      sanitizedInput.forwardedProps.command.resume.approved
-        ? sanitizedInput.forwardedProps.command.resume.approvalRequest
-        : undefined;
+    const approvedResumeDecisions = resumeDecisions.filter(
+      (decision) => decision.approved,
+    );
+    const approvedResumeToolCallIds = new Set(
+      approvedResumeDecisions.map(
+        (decision) => decision.approvalRequest.toolCallId,
+      ),
+    );
 
     return await withInAppAgentMcpApiKeyCleanup(
       {
         projectId,
         runId: sanitizedInput.runId,
         userId,
-        toolName: getInAppAgentMcpRegistryToolName(
-          approvedResumeApprovalRequest?.toolName,
-        ),
+        toolNames: approvedResumeDecisions.flatMap((decision) => {
+          const registryToolName = getInAppAgentMcpRegistryToolName(
+            decision.approvalRequest.toolName,
+          );
+          return registryToolName ? [registryToolName] : [];
+        }),
       },
       async (mcpApiKey, runOverride, cleanupMcpApiKey) => {
         let runCreated = false;
         let pendingToolApprovalConsumed = false;
         let streamCreated = false;
-        let approvedToolResultPersisted = false;
+        const executedApprovedToolCallIds = new Set<string>();
 
-        const restorePendingToolApprovalIfRetryable = () => {
-          if (
-            !pendingToolApprovalConsumed ||
-            !approvedResumeApprovalRequest ||
-            approvedToolResultPersisted
-          ) {
+        // Rejected decisions are never restored (matching the pre-batch
+        // behavior); an approved decision is restored only while its tool has
+        // not executed — an executed call must never become resumable again.
+        const restorePendingToolApprovalIfRetryable = async () => {
+          if (!pendingToolApprovalConsumed) {
             return;
           }
 
-          return storePendingToolApproval({
-            projectId,
-            conversationId: conversation.id,
-            approvalRequest: approvedResumeApprovalRequest,
-          });
+          const restorableDecisions = approvedResumeDecisions.filter(
+            (decision) =>
+              !executedApprovedToolCallIds.has(
+                decision.approvalRequest.toolCallId,
+              ),
+          );
+
+          for (const decision of restorableDecisions) {
+            await storePendingToolApproval({
+              projectId,
+              conversationId: conversation.id,
+              approvalRequest: decision.approvalRequest,
+            });
+          }
         };
 
         try {
@@ -442,10 +457,10 @@ export default async function handler(request: Request) {
 
                 if (
                   persistedEvent.type === EventType.TOOL_CALL_RESULT &&
-                  persistedEvent.toolCallId ===
-                    resumeApprovalRequest?.toolCallId
+                  typeof persistedEvent.toolCallId === "string" &&
+                  approvedResumeToolCallIds.has(persistedEvent.toolCallId)
                 ) {
-                  approvedToolResultPersisted = true;
+                  executedApprovedToolCallIds.add(persistedEvent.toolCallId);
                 }
 
                 persistedEvents.push(persistedEvent);
@@ -456,8 +471,8 @@ export default async function handler(request: Request) {
 
                 return replacePersistedRunEvents();
               },
-              onApprovedToolCallExecuted: () => {
-                approvedToolResultPersisted = true;
+              onApprovedToolCallExecuted: (toolCallId) => {
+                executedApprovedToolCallIds.add(toolCallId);
               },
               onComplete: () =>
                 replacePersistedRunEvents()
@@ -763,7 +778,7 @@ async function withInAppAgentMcpApiKeyCleanup<T>(
     projectId: string;
     runId: string;
     userId: string;
-    toolName?: McpToolName;
+    toolNames: McpToolName[];
   },
   createResponse: (
     mcpApiKey: Awaited<ReturnType<typeof createInAppAgentMcpApiKey>>,
@@ -772,7 +787,7 @@ async function withInAppAgentMcpApiKeyCleanup<T>(
   ) => T | Promise<T>,
 ): Promise<T> {
   // Each run gets a temporary in-app-agent API key. Approved MCP resumes also
-  // get a tool-scoped run override for the single mutating registry tool.
+  // get a tool-scoped run override for the approved mutating registry tools.
   const mcpApiKey = await createInAppAgentMcpApiKey(
     params.projectId,
     params.userId,
@@ -794,11 +809,12 @@ async function withInAppAgentMcpApiKeyCleanup<T>(
   };
 
   try {
-    const runOverride = params.toolName
-      ? await createInAppAgentMcpRunOverride({
-          toolName: params.toolName,
-        })
-      : undefined;
+    const runOverride =
+      params.toolNames.length > 0
+        ? await createInAppAgentMcpRunOverride({
+            toolNames: params.toolNames,
+          })
+        : undefined;
 
     return await createResponse(mcpApiKey, runOverride, cleanupMcpApiKey);
   } catch (err) {

--- a/web/src/ee/features/in-app-agent/server/human-in-the-loop.ts
+++ b/web/src/ee/features/in-app-agent/server/human-in-the-loop.ts
@@ -8,9 +8,11 @@ import { IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE } from "@/src/ee/features/in-app
 import { IN_APP_AGENT_LANGFUSE_MCP_TOOL_NAMES } from "@/src/ee/features/in-app-agent/server/tools";
 import { safeJsonParse, stableJsonStringify } from "@/src/utils/json";
 import {
+  getResumeDecisions,
   type AgUiEvent,
   type AgUiMessage,
   type AgUiRunAgentInput,
+  type InAppAgentToolApprovalDecision,
   type InAppAgentToolApprovalRequest,
   type ResumeForwardedProps,
 } from "@/src/ee/features/in-app-agent/schema";
@@ -38,9 +40,22 @@ const McpToolNameSchema = z.custom<McpToolName>(
   { message: "Invalid MCP tool name" },
 );
 
-export const InAppAgentMcpRunOverrideSchema = z.object({
-  toolName: McpToolNameSchema,
-});
+export const InAppAgentMcpRunOverrideSchema = z.union([
+  z.object({ toolNames: z.array(McpToolNameSchema).min(1) }),
+  // Legacy single-tool shape, still minted for single-tool overrides and
+  // parsed for rolling-deploy compatibility.
+  z.object({ toolName: McpToolNameSchema }),
+]);
+
+export type InAppAgentMcpRunOverride = z.infer<
+  typeof InAppAgentMcpRunOverrideSchema
+>;
+
+export function getInAppAgentMcpOverrideToolNames(
+  override: InAppAgentMcpRunOverride,
+): McpToolName[] {
+  return "toolNames" in override ? override.toolNames : [override.toolName];
+}
 
 const MastraSuspendEventSchema = z.object({
   type: z.literal("mastra_suspend"),
@@ -84,6 +99,33 @@ export async function storePendingToolApproval(params: {
   });
 }
 
+// Every decision must reference a distinct pending approval; a duplicated
+// toolCallId would let one row satisfy two decisions in the count checks below.
+function getValidatedDecisions(forwardedProps: ResumeForwardedProps) {
+  const decisions = getResumeDecisions(forwardedProps);
+  const toolCallIds = new Set(
+    decisions.map((decision) => decision.approvalRequest.toolCallId),
+  );
+
+  if (toolCallIds.size !== decisions.length) {
+    throw new InvalidRequestError("Invalid forwarded props");
+  }
+
+  return decisions;
+}
+
+function createPendingToolApprovalConditions(
+  decisions: InAppAgentToolApprovalDecision[],
+) {
+  const now = new Date();
+
+  return decisions.map(({ approvalRequest }) => ({
+    toolCallId: approvalRequest.toolCallId,
+    approvalFingerprint: createPendingToolApprovalFingerprint(approvalRequest),
+    expiresAt: { gt: now },
+  }));
+}
+
 // Check early, before stream setup, so malformed or forged resume payloads fail
 // without starting another model/tool execution attempt.
 export async function validatePendingToolApproval(params: {
@@ -91,54 +133,55 @@ export async function validatePendingToolApproval(params: {
   conversationId: string;
   forwardedProps: ResumeForwardedProps;
 }) {
-  const approvalRequest = params.forwardedProps.command.resume.approvalRequest;
-  const pendingApproval = await prisma.inAppAgentPendingToolApproval.findFirst({
+  const decisions = getValidatedDecisions(params.forwardedProps);
+  const pendingCount = await prisma.inAppAgentPendingToolApproval.count({
     where: {
       projectId: params.projectId,
       conversationId: params.conversationId,
-      toolCallId: approvalRequest.toolCallId,
-      approvalFingerprint:
-        createPendingToolApprovalFingerprint(approvalRequest),
-      expiresAt: { gt: new Date() },
+      OR: createPendingToolApprovalConditions(decisions),
     },
-    select: { toolCallId: true },
   });
 
-  if (!pendingApproval) {
+  if (pendingCount !== decisions.length) {
     throw new InvalidRequestError("Invalid forwarded props");
   }
 }
 
-// Atomically consume before stream setup so a pending approval can start at most
-// one resumed tool call attempt.
+// Atomically consume before stream setup so every pending approval can start at
+// most one resumed tool call attempt. All-or-nothing: if any decision does not
+// match a live pending approval, nothing is consumed.
 export async function consumeAndValidatePendingToolApproval(params: {
   projectId: string;
   conversationId: string;
   forwardedProps: ResumeForwardedProps;
 }) {
-  const approvalRequest = params.forwardedProps.command.resume.approvalRequest;
-  const consumeResult = await prisma.inAppAgentPendingToolApproval.deleteMany({
-    where: {
-      projectId: params.projectId,
-      conversationId: params.conversationId,
-      toolCallId: approvalRequest.toolCallId,
-      approvalFingerprint:
-        createPendingToolApprovalFingerprint(approvalRequest),
-      expiresAt: { gt: new Date() },
-    },
-  });
+  const decisions = getValidatedDecisions(params.forwardedProps);
 
-  if (consumeResult.count !== 1) {
-    throw new InvalidRequestError("Invalid forwarded props");
-  }
+  await prisma.$transaction(async (tx) => {
+    const consumeResult = await tx.inAppAgentPendingToolApproval.deleteMany({
+      where: {
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+        OR: createPendingToolApprovalConditions(decisions),
+      },
+    });
+
+    if (consumeResult.count !== decisions.length) {
+      throw new InvalidRequestError("Invalid forwarded props");
+    }
+  });
 }
 
 export async function createInAppAgentMcpRunOverride(params: {
-  toolName: McpToolName;
+  toolNames: McpToolName[];
 }) {
-  return JSON.stringify({
-    toolName: params.toolName,
-  });
+  // Single-tool overrides keep the legacy shape so web instances that predate
+  // the batch contract still parse them during a rolling deploy.
+  return JSON.stringify(
+    params.toolNames.length === 1
+      ? { toolName: params.toolNames[0] }
+      : { toolNames: params.toolNames },
+  );
 }
 
 export function parseInAppAgentInterruptEvent(
@@ -161,10 +204,10 @@ export function parseInAppAgentInterruptEvent(
 export type ManualToolApprovalRunInput = {
   input: AgUiRunAgentInput;
   syntheticEvents: AgUiEvent[];
-  toolCallApproval?: {
+  toolCallApprovals: Array<{
     toolCallId: string;
     status: "approved" | "rejected";
-  };
+  }>;
 };
 
 export async function createManualToolApprovalRunInput(params: {
@@ -172,93 +215,90 @@ export async function createManualToolApprovalRunInput(params: {
   executeToolCall: (
     approvalRequest: InAppAgentToolApprovalRequest,
   ) => Promise<unknown>;
-  onApprovedToolCallExecuted?: () => void | Promise<void>;
+  onApprovedToolCallExecuted?: (toolCallId: string) => void | Promise<void>;
 }): Promise<ManualToolApprovalRunInput> {
   const forwardedProps = getResumeForwardedProps(params.input);
 
   if (!forwardedProps) {
-    return { input: params.input, syntheticEvents: [] };
+    return { input: params.input, syntheticEvents: [], toolCallApprovals: [] };
   }
 
-  const { approved, approvalRequest } = forwardedProps.command.resume;
-  if (!approved) {
-    const assistantMessage =
-      createManualToolCallAssistantMessage(approvalRequest);
-    const toolMessage: AgUiMessage = {
-      id: createManualToolResultMessageId(approvalRequest),
-      role: "tool",
-      content: MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
-      toolCallId: approvalRequest.toolCallId,
-      error: MANUAL_TOOL_APPROVAL_REJECTION_ERROR,
-    };
+  const decisions = getResumeDecisions(forwardedProps);
+  const messages: AgUiMessage[] = [...params.input.messages];
+  const syntheticEvents: AgUiEvent[] = [];
+  const toolCallApprovals: ManualToolApprovalRunInput["toolCallApprovals"] = [];
 
-    return {
-      input: {
-        ...params.input,
-        messages: [
-          ...params.input.messages,
-          assistantMessage,
-          toolMessage,
-          createToolRejectionGuidanceMessage(approvalRequest),
-        ],
-        forwardedProps: {},
-      },
-      syntheticEvents: createManualToolApprovalEvents({
-        approvalRequest,
-        toolResultContent: MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
-        toolError: MANUAL_TOOL_APPROVAL_REJECTION_ERROR,
-      }),
-      toolCallApproval: {
+  // Decision order is the order the tool calls were proposed in; approved
+  // calls execute sequentially so their effects and transcript entries match
+  // what the user reviewed.
+  for (const { approved, approvalRequest } of decisions) {
+    if (!approved) {
+      messages.push(
+        createManualToolCallAssistantMessage(approvalRequest),
+        {
+          id: createManualToolResultMessageId(approvalRequest),
+          role: "tool",
+          content: MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
+          toolCallId: approvalRequest.toolCallId,
+          error: MANUAL_TOOL_APPROVAL_REJECTION_ERROR,
+        },
+        createToolRejectionGuidanceMessage(approvalRequest),
+      );
+      syntheticEvents.push(
+        ...createManualToolApprovalEvents({
+          approvalRequest,
+          toolResultContent: MANUAL_TOOL_APPROVAL_REJECTION_MESSAGE,
+          toolError: MANUAL_TOOL_APPROVAL_REJECTION_ERROR,
+        }),
+      );
+      toolCallApprovals.push({
         toolCallId: approvalRequest.toolCallId,
         status: "rejected",
-      },
-    };
-  }
+      });
+      continue;
+    }
 
-  const { toolResult, toolError } = await executeApprovedToolCall({
-    approvalRequest,
-    executeToolCall: params.executeToolCall,
-  });
-  await params.onApprovedToolCallExecuted?.();
-  const toolResultContent = serializeToolResultContent(toolResult);
-  const assistantMessage =
-    createManualToolCallAssistantMessage(approvalRequest);
-  const toolMessage: AgUiMessage = {
-    id: createManualToolResultMessageId(approvalRequest),
-    role: "tool",
-    content: toolResultContent,
-    toolCallId: approvalRequest.toolCallId,
-    ...(toolError ? { error: toolError } : {}),
-  };
-  const syntheticEvents = createManualToolApprovalEvents({
-    approvalRequest,
-    toolResultContent,
-    toolError,
-  });
+    const { toolResult, toolError } = await executeApprovedToolCall({
+      approvalRequest,
+      executeToolCall: params.executeToolCall,
+    });
+    await params.onApprovedToolCallExecuted?.(approvalRequest.toolCallId);
+    const toolResultContent = serializeToolResultContent(toolResult);
+
+    messages.push(
+      createManualToolCallAssistantMessage(approvalRequest),
+      {
+        id: createManualToolResultMessageId(approvalRequest),
+        role: "tool",
+        content: toolResultContent,
+        toolCallId: approvalRequest.toolCallId,
+        ...(toolError ? { error: toolError } : {}),
+      },
+      ...(toolError
+        ? [createToolExecutionErrorGuidanceMessage(approvalRequest, toolError)]
+        : []),
+    );
+    syntheticEvents.push(
+      ...createManualToolApprovalEvents({
+        approvalRequest,
+        toolResultContent,
+        toolError,
+      }),
+    );
+    toolCallApprovals.push({
+      toolCallId: approvalRequest.toolCallId,
+      status: "approved",
+    });
+  }
 
   return {
     input: {
       ...params.input,
-      messages: [
-        ...params.input.messages,
-        assistantMessage,
-        toolMessage,
-        ...(toolError
-          ? [
-              createToolExecutionErrorGuidanceMessage(
-                approvalRequest,
-                toolError,
-              ),
-            ]
-          : []),
-      ],
+      messages,
       forwardedProps: {},
     },
     syntheticEvents,
-    toolCallApproval: {
-      toolCallId: approvalRequest.toolCallId,
-      status: "approved",
-    },
+    toolCallApprovals,
   };
 }
 

--- a/web/src/features/mcp/server/registry.ts
+++ b/web/src/features/mcp/server/registry.ts
@@ -176,8 +176,10 @@ class ToolRegistry {
       return tool.definition.annotations?.readOnlyHint === true;
     }
 
-    if (context.inAppAgent.permissions === "single-tool-override") {
-      return context.inAppAgent.allowedToolName === tool.definition.name;
+    if (context.inAppAgent.permissions === "tool-override") {
+      return context.inAppAgent.allowedToolNames.some(
+        (allowedToolName) => allowedToolName === tool.definition.name,
+      );
     }
 
     return false;

--- a/web/src/features/mcp/types.ts
+++ b/web/src/features/mcp/types.ts
@@ -60,7 +60,7 @@ export interface ServerContext {
 
 /**
  * In-app-agent MCP access is explicit: `read` allows only tools annotated with `readOnlyHint`.
- * To allow mutating operations, `single-tool-override` can include a specific MCP registry tool name that the in-app agent is allowed to invoke.
+ * To allow mutating operations, `tool-override` names the MCP registry tools the in-app agent is allowed to invoke — one entry per individually approved tool call.
  * Human approval is enforced earlier in the in-app agent runtime before any override is minted.
  */
 export type InAppAgentContext =
@@ -68,6 +68,6 @@ export type InAppAgentContext =
       permissions: "read";
     }
   | {
-      permissions: "single-tool-override";
-      allowedToolName: McpToolName;
+      permissions: "tool-override";
+      allowedToolNames: McpToolName[];
     };

--- a/web/src/pages/api/public/mcp/index.ts
+++ b/web/src/pages/api/public/mcp/index.ts
@@ -41,7 +41,10 @@ import { BaseError, UnauthorizedError, ForbiddenError } from "@langfuse/shared";
 import { ZodError } from "zod";
 import { isUserInputError } from "@/src/features/mcp/core/errors";
 import { IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER } from "@/src/ee/features/in-app-agent/constants";
-import { InAppAgentMcpRunOverrideSchema } from "@/src/ee/features/in-app-agent/server/human-in-the-loop";
+import {
+  getInAppAgentMcpOverrideToolNames,
+  InAppAgentMcpRunOverrideSchema,
+} from "@/src/ee/features/in-app-agent/server/human-in-the-loop";
 import { safeJsonParse } from "@/src/utils/json";
 
 // Bootstrap MCP features - registers all tools at module load time
@@ -204,8 +207,10 @@ export function getInAppAgentContext(
 
   return parsedOverride.success
     ? {
-        permissions: "single-tool-override",
-        allowedToolName: parsedOverride.data.toolName,
+        permissions: "tool-override",
+        allowedToolNames: getInAppAgentMcpOverrideToolNames(
+          parsedOverride.data,
+        ),
       }
     : { permissions: "read" };
 }


### PR DESCRIPTION
## What does this PR do?

Closes [LFE-11033](https://linear.app/langfuse/issue/LFE-11033/if-one-turn-requires-multiple-tool-approvals-we-dont-have-an-approve). Supersedes #15229.

Pivots the approval contract from **serialize** (#15229: one interrupt per run, each approval costing a full model continuation) to **batch**: all of a run's approval interrupts surface as cards, the user decides each (with an "Approve all" shortcut when several are open), and a **single** continuation run executes every approved call and synthesizes every rejection. Compared to #15229 this removes the need for interrupt filtering and stale-approval pruning entirely — sibling calls get real decisions instead of being superseded and cleaned up.

### Server

- `ResumeForwardedPropsSchema` accepts a `decisions` array; the legacy single-decision shape still parses and normalizes to a one-element list (open browser tabs across a deploy keep working).
- Pending approvals are validated and consumed **all-or-nothing** in one transaction: any stale/forged decision rejects the whole batch with nothing consumed.
- `createManualToolApprovalRunInput` loops the existing per-request helpers: approved calls execute sequentially in decision order, rejections synthesize their transcript entries, all synthetic events ride one continuation run.
- The MCP run override carries every approved registry tool (`tool-override` context with `allowedToolNames`); single-tool overrides keep the legacy header shape for rolling deploys.
- Retry restoration is per decision: an executed call can never become resumable again; rejected decisions are never restored (matching pre-batch behavior).
- **Every proposed approval-gated call becomes a card.** Mastra raises at most one approval per run (parallel siblings never reach their execution step; their lifecycles previously dangled as failed-looking chips while the model re-proposed them run after run). Since the resume executes approved calls manually and never touches Mastra's suspension state, the shim maps every approval-gated `tool-call` chunk onto the suspend protocol directly (deduped against the executing call's own approval chunk) — all proposed calls surface in the same run and resolve in one continuation.

### Client

- Approval cards record local approve/reject decisions; the batch resume fires automatically when the last open card is decided. Cards render **one at a time in a pager** ("Tool call N of M awaiting review" with prev/next navigation) — stacked cards took over the whole window — and the pager jumps to the next undecided card after each decision, closing immediately once the last decision commits the batch (a failed submission reverts to pending and reopens it). An "Approve all" shortcut was built and then removed per review; it can be reintroduced inside the pager header if wanted.
- State updates after submit touch only the submitted approval ids, so an interrupt raised by the continuation run surfaces as a fresh card instead of being wiped (bug found and fixed during browser validation).
- Ports two fixes from #15229 that remain necessary: the smooth-streaming late-approval display fix (#15118 regression — cards never rendered when the interrupt arrived after its tool chip) and transcript tool-call-ID dedup.



Impacted package: `web`

## Validation

- `pnpm --filter web run test src/__tests__/server/in-app-agent-stream.servertest.ts` — `Tests 17 passed (17)` (includes the batch-continuation test and the proposed-call suspension tests)
- `pnpm --filter web run test src/__tests__/server/in-app-agent-api-route-auth.servertest.ts` — `Tests 20 passed (20)` (includes all-or-nothing consumption)
- `pnpm --filter web run test src/__tests__/server/unit` — `Tests 503 passed` pre-change baseline; touched override/context suites re-run green (`Tests 9 passed (9)`)
- `pnpm --filter web run test-client src/ee/features/in-app-agent` — `Tests 73 passed (73)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`; `pnpm --filter web run typecheck` — exited successfully
- Browser (local dev stack, seeded project):
  - **full batch flow**: "create 3 prompts in parallel" → three approvals in the pager ("Tool call 1 of 3 awaiting review", prev/next navigation and wrap-around verified) → approve 2, reject 1 with auto-advance between decisions → single continuation (2 runs total for the whole request): both approved prompts created, the rejection acknowledged, transcript shows one "Called 3 tools" group with no dangling chips;
  - single-approval regression: card → approve → one continuation → tool executed once, rendered once;
  - rejection through the new contract: approve mix-a, reject mix-b → mix-a created, mix-b not created, model acknowledges the decline;
  - late-arrival flow: an interrupt raised by a continuation surfaces as a fresh card while the submitted batch clears;
  - transcript clean throughout; test artifacts cleaned up afterwards.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Self-reviewed the code; scoped to the approval contract, its UI, and regression coverage.

## Documentation

No documentation update required; the approval flow remains an internal in-app-agent behavior without public API changes.



