### PR TITLE
feat(onboarding): track tracing api key creation click

### DIFF
--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -228,6 +228,7 @@ export const events = {
   onboarding: [
     "code_example_tab_switch",
     "tracing_check_active",
+    "tracing_api_key_create_clicked",
     "tracing_agent_prompt_copy_clicked",
     "tracing_manual_docs_link_clicked",
   ],

--- a/web/src/features/setup/components/TracesSetupOnboardingCard.tsx
+++ b/web/src/features/setup/components/TracesSetupOnboardingCard.tsx
@@ -80,6 +80,8 @@ export function TracesSetupOnboardingCard({
   });
 
   const createApiKey = async () => {
+    capture("onboarding:tracing_api_key_create_clicked");
+
     try {
       await mutCreateApiKey.mutateAsync({ projectId });
     } catch (error) {

--- a/web/src/features/setup/components/TracesSetupOnboardingCard.tsx
+++ b/web/src/features/setup/components/TracesSetupOnboardingCard.tsx
@@ -80,11 +80,7 @@ export function TracesSetupOnboardingCard({
   });
 
   const createApiKey = async () => {
-    try {
-      capture("onboarding:tracing_api_key_create_clicked");
-    } catch (error) {
-      console.error("Error capturing API key creation click:", error);
-    }
+    capture("onboarding:tracing_api_key_create_clicked");
 
     try {
       await mutCreateApiKey.mutateAsync({ projectId });

--- a/web/src/features/setup/components/TracesSetupOnboardingCard.tsx
+++ b/web/src/features/setup/components/TracesSetupOnboardingCard.tsx
@@ -80,7 +80,11 @@ export function TracesSetupOnboardingCard({
   });
 
   const createApiKey = async () => {
-    capture("onboarding:tracing_api_key_create_clicked");
+    try {
+      capture("onboarding:tracing_api_key_create_clicked");
+    } catch (error) {
+      console.error("Error capturing API key creation click:", error);
+    }
 
     try {
       await mutCreateApiKey.mutateAsync({ projectId });


### PR DESCRIPTION
## Summary

- Add a typed PostHog event for tracing onboarding API-key creation clicks.
- Capture `onboarding:tracing_api_key_create_clicked` from the tracing onboarding “Create new API key” button before the create-key mutation starts.
- Keep the event metadata-only: no API keys, project IDs, or raw values are sent.

## Impacted packages

- `web`

## Verification

- `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli` - `All matched files use Prettier code style!`
- `turbo run lint` - `Tasks:    7 successful, 7 total`
- `fnm exec --using=24 pnpm --filter web run lint` - completed with exit 0
- `fnm exec --using=24 pnpm --filter web exec tsc -p tsconfig.json --noEmit --skipLibCheck --incremental false` - completed with exit 0
- `git diff --check` - completed with exit 0

Note: `fnm exec --using=24 pnpm --filter web run typecheck` was attempted, but the repo's `tsgo` typecheck currently fails on unrelated broad `@langfuse/shared`/Prisma export errors. Prisma generation and `@langfuse/shared` build were refreshed successfully; plain `tsc` for `web` passed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tracks API-key creation clicks during tracing onboarding. The main changes are:

- Adds a typed PostHog event for the click.
- Captures the event before starting the create-key mutation.
- Sends no API-key or project metadata.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is mergeable after isolating API-key creation from analytics failures.

- The event name is registered in the typed event catalog.
- The click handler sends no sensitive properties.
- A synchronous analytics error can prevent the mutation from starting.

web/src/features/setup/components/TracesSetupOnboardingCard.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/setup/components/TracesSetupOnboardingCard.tsx:83
**Analytics Failure Blocks Key Creation**

`capture` runs before the mutation and outside its error handling. If the analytics client throws during a click, `createApiKey` exits immediately and the requested API key is never created, so telemetry availability can break the onboarding action.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(onboarding): track tracing api key ..."](https://github.com/langfuse/langfuse/commit/8300575e2afb0a68b50e5c4bb6b074bd23fc4a75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45935932)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->