### PR TITLE
fix(worker): wrap bare-boolean root metadata like other scalars (LFE-14344)

### DIFF
--- a/worker/src/services/IngestionService/tests/convertJsonSchemaToRecord.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/convertJsonSchemaToRecord.unit.test.ts
@@ -11,8 +11,9 @@ describe("convertJsonSchemaToRecord", () => {
     expect(convertJsonSchemaToRecord(true)).toEqual({ metadata: "true" });
   });
 
-  // Load-bearing: `false` is falsy — guards against a truthiness-based fix
-  // that would drop or mis-wrap it.
+  // Function-level contract only: callers currently short-circuit falsy
+  // metadata (false/0/"") via truthy guards, so false does not reach this
+  // branch end-to-end.
   it("wraps a bare boolean false as { metadata: 'false' }", () => {
     expect(convertJsonSchemaToRecord(false)).toEqual({ metadata: "false" });
   });

--- a/worker/src/services/IngestionService/tests/convertJsonSchemaToRecord.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/convertJsonSchemaToRecord.unit.test.ts
@@ -1,0 +1,48 @@
+import { convertJsonSchemaToRecord } from "../utils";
+import { expect, describe, it } from "vitest";
+
+// Spec (LFE-14344): bare-scalar root metadata must be wrapped under the
+// "metadata" key, mirroring convertPostgresJsonToMetadataRecord. Booleans
+// are the fix target; string/number/array/object pin existing behavior.
+describe("convertJsonSchemaToRecord", () => {
+  // Load-bearing: the acceptance criterion itself — bare `true` must not be
+  // raw-cast to Record<string, string>.
+  it("wraps a bare boolean true as { metadata: 'true' }", () => {
+    expect(convertJsonSchemaToRecord(true)).toEqual({ metadata: "true" });
+  });
+
+  // Load-bearing: `false` is falsy — guards against a truthiness-based fix
+  // that would drop or mis-wrap it.
+  it("wraps a bare boolean false as { metadata: 'false' }", () => {
+    expect(convertJsonSchemaToRecord(false)).toEqual({ metadata: "false" });
+  });
+
+  // Regressions: existing scalar/array/object wrapping must stay unchanged.
+  it("wraps a bare string under the metadata key", () => {
+    expect(convertJsonSchemaToRecord("hello")).toEqual({ metadata: "hello" });
+  });
+
+  it("wraps a bare number under the metadata key as a string", () => {
+    expect(convertJsonSchemaToRecord(42)).toEqual({ metadata: "42" });
+  });
+
+  it("wraps an array under the metadata key as JSON", () => {
+    expect(convertJsonSchemaToRecord([1, "a", true])).toEqual({
+      metadata: '[1,"a",true]',
+    });
+  });
+
+  // Pins CURRENT behavior per acceptance criteria ("object inputs
+  // unchanged"): objects pass through as-is. Note this deliberately does NOT
+  // mirror convertPostgresJsonToMetadataRecord, which stringifies non-string
+  // values — see AMBIGUITY finding in the test-author report.
+  it("passes object inputs through unchanged", () => {
+    expect(convertJsonSchemaToRecord({ a: "x", b: 2, c: { d: true } })).toEqual(
+      {
+        a: "x",
+        b: 2,
+        c: { d: true },
+      },
+    );
+  });
+});

--- a/worker/src/services/IngestionService/tests/convertJsonSchemaToRecord.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/convertJsonSchemaToRecord.unit.test.ts
@@ -35,7 +35,7 @@ describe("convertJsonSchemaToRecord", () => {
   // Pins CURRENT behavior per acceptance criteria ("object inputs
   // unchanged"): objects pass through as-is. Note this deliberately does NOT
   // mirror convertPostgresJsonToMetadataRecord, which stringifies non-string
-  // values — see AMBIGUITY finding in the test-author report.
+  // values.
   it("passes object inputs through unchanged", () => {
     expect(convertJsonSchemaToRecord({ a: "x", b: 2, c: { d: true } })).toEqual(
       {

--- a/worker/src/services/IngestionService/utils.ts
+++ b/worker/src/services/IngestionService/utils.ts
@@ -9,7 +9,11 @@ export const convertJsonSchemaToRecord = (
   const record: Record<string, string> = {};
 
   // if it's a literal, return the value with "metadata" prefix
-  if (typeof jsonSchema === "string" || typeof jsonSchema === "number") {
+  if (
+    typeof jsonSchema === "string" ||
+    typeof jsonSchema === "number" ||
+    typeof jsonSchema === "boolean"
+  ) {
     record["metadata"] = jsonSchema.toString();
     return record;
   }


### PR DESCRIPTION
## What does this PR do?

Fixes a silent metadata mangle in legacy ingestion: `convertJsonSchemaToRecord` handled `string`, `number`, and `Array` root metadata values but had no `boolean` branch, so a bare-boolean root metadata value (`metadata: true`) fell through to a raw cast and was reduced to `{}` downstream. It is now wrapped like every other scalar (`{ metadata: "true" }`), consistent with the sibling `convertPostgresJsonToMetadataRecord`.

Side benefit: pre-fix, the raw boolean leaking into a `Map(String, String)` insert could fail a shared ClickHouse writer batch; wrapping removes that failure trigger.

Scope note: callers still short-circuit falsy metadata (`false`/`0`/`""`) via pre-existing truthy guards (`metadata ? convert(...) : {}`), so `metadata: false` does not reach this branch end-to-end. This PR fixes the function-level contract; widening the caller guards would change behavior for `""`/`0` as well and is deliberately not part of this change (documented in the test).

Linear: LFE-14344

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have added tests that prove my fix is effective (`worker/src/services/IngestionService/tests/convertJsonSchemaToRecord.unit.test.ts`, 6 cases, red-first)
- New and existing unit tests pass locally (`Tests 6 passed (6)`; `utils.unit.test.ts` 7/7; `IngestionService.unit.test.ts` 6/6; lint + typecheck green)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates root metadata conversion to handle bare booleans like other scalars. The main changes are:

- Wrap bare booleans under the `metadata` key.
- Add unit coverage for booleans and existing input shapes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Bare `false` metadata is still lost on the main score, trace, and observation ingestion paths.

- The helper now converts both boolean values correctly.
- Existing caller truthiness guards skip the helper for `false` and store an empty object.
- The added tests cover the helper but not the affected ingestion paths.

worker/src/services/IngestionService/utils.ts and its callers in worker/src/services/IngestionService/index.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/services/IngestionService/utils.ts:15
**False Metadata Remains Dropped**

When score, trace, or observation metadata is bare `false`, the existing caller truthiness guards return `{}` without invoking this new boolean branch. Those ingestion paths therefore still discard the value instead of storing `{ metadata: "false" }`; the callers must distinguish absent metadata from `false`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): scope false-wrap test com..."](https://github.com/langfuse/langfuse/commit/9d58bb5cea1cc3af0d584639b605a66a2049858c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45952133)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->