### PR TITLE
fix(agent): Minor Assistant styling issues

### DIFF
--- a/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -324,12 +324,7 @@ function InAppAgentReasoningBlock({
         isCompact ? "text-[0.775rem]" : "text-sm",
       )}
     >
-      <summary
-        className={cn(
-          "hover:text-foreground focus-visible:ring-ring flex w-fit cursor-pointer list-none items-center gap-1.5 rounded-md px-1 py-0.5 text-xs leading-none font-bold outline-none focus-visible:ring-2 focus-visible:ring-offset-2 [&::-webkit-details-marker]:hidden",
-          isCompact && "px-0.5",
-        )}
-      >
+      <summary className="hover:text-foreground focus-visible:ring-ring flex w-fit cursor-pointer list-none items-center gap-1.5 rounded-md px-1 py-0.5 text-xs leading-none font-bold outline-none focus-visible:ring-2 focus-visible:ring-offset-2 [&::-webkit-details-marker]:hidden">
         <span
           className={cn(
             "min-w-0 flex-1",

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -671,7 +671,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
           ) : null}
         </div>
       </header>
-      <div className="flex min-h-0 flex-1 flex-col">
+      <div className="relative flex min-h-0 flex-1 flex-col">
         <div
           ref={viewportRef}
           className="min-h-0 flex-1 overflow-y-auto"
@@ -829,7 +829,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
               : "max-h-40 opacity-100",
           )}
         >
-          <div className="p-2">
+          <div className="mb-2 px-2">
             <div
               className={cn(
                 "flex w-full flex-col gap-1.5",


### PR DESCRIPTION
Fixes two minor issues with the Assistant UI:

1. Messages being cut off by empty space above the screen context banner:
<img width="1280" height="140" alt="image" src="https://github.com/user-attachments/assets/6eec19a5-8b79-480f-a27b-946f1b9df48d" />

2. The Reasoning element not being aligned with the Tool groups (few px off)
<img width="1144" height="706" alt="image" src="https://github.com/user-attachments/assets/82e0e383-9ee1-453c-8340-bea32405b87d" />

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adjusts spacing and alignment in the Assistant UI. The main changes are:

- Aligns the reasoning summary with tool groups.
- Removes excess space above the screen-context banner.
- Establishes the message-area wrapper as a positioning container.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Minor in-app agent styling i..."](https://github.com/langfuse/langfuse/commit/d5659dabb902c654717e95bf6daa209c3ac24a8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45952195)</sub>

<!-- /greptile_comment -->