### PR TITLE
feat(preview): enable cloud AI features on PR previews

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -152,7 +152,10 @@ jobs:
             image: ${{ needs.meta.outputs.web_image }}
             dockerfile: web/Dockerfile
             # web disables sign-up on previews; worker has no such arg.
-            extra_build_args: --build-arg NEXT_PUBLIC_SIGN_UP_DISABLED=true
+            # The cloud region must be baked at build time (NEXT_PUBLIC_* is
+            # inlined into the client bundle) so previews render the cloud-only
+            # AI features; the worker reads it from runtime env instead.
+            extra_build_args: --build-arg NEXT_PUBLIC_SIGN_UP_DISABLED=true --build-arg NEXT_PUBLIC_LANGFUSE_CLOUD_REGION=DEV
           - target: worker
             image: ${{ needs.meta.outputs.worker_image }}
             dockerfile: worker/Dockerfile

--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -108,6 +108,7 @@ async function main() {
     where: { id: seedOrgId },
     update: {
       name: "Seed Org",
+      aiFeaturesEnabled: true,
       cloudConfig: {
         plan: "Team",
       },
@@ -136,6 +137,7 @@ async function main() {
   });
 
   await upsertInAppAgentSystemPrompt(project1.id);
+  await upsertNaturalLanguageFilterPrompt(project1.id);
 
   // Realistic support chat scenario
   await createSupportChatSession(project1);
@@ -828,6 +830,42 @@ async function upsertInAppAgentSystemPrompt(projectId: string) {
       prompt: inAppAgentSystemPrompt,
       type: "text",
       labels: ["production", "latest"],
+    },
+  });
+}
+
+// The legacy natural-language filter feature fetches this prompt from the
+// AI-features project at runtime; on self-referential deployments (previews)
+// that project is llm-app, so it must exist on the default seed path too.
+const NATURAL_LANGUAGE_FILTER_PROMPT_NAME = "get-filter-conditions-from-query";
+
+async function upsertNaturalLanguageFilterPrompt(projectId: string) {
+  const seedPrompt = SEED_PROMPT_VERSIONS.find(
+    (p) => p.name === NATURAL_LANGUAGE_FILTER_PROMPT_NAME,
+  );
+  if (!seedPrompt) return;
+
+  await prisma.prompt.upsert({
+    where: {
+      projectId_name_version: {
+        projectId,
+        name: seedPrompt.name,
+        version: seedPrompt.version,
+      },
+    },
+    create: {
+      projectId,
+      createdBy: seedPrompt.createdBy,
+      prompt: seedPrompt.prompt,
+      name: seedPrompt.name,
+      type: seedPrompt.type ?? "text",
+      version: seedPrompt.version,
+      labels: seedPrompt.labels,
+    },
+    update: {
+      prompt: seedPrompt.prompt,
+      type: seedPrompt.type ?? "text",
+      labels: seedPrompt.labels,
     },
   });
 }

--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -137,7 +137,12 @@ async function main() {
   });
 
   await upsertInAppAgentSystemPrompt(project1.id);
-  await upsertNaturalLanguageFilterPrompt(project1.id);
+  // Skip on examples/load: those paths seed this prompt via generatePrompts
+  // (SEED_PROMPT_VERSIONS), whose upsert takes the create branch against a
+  // pre-existing row and violates the (projectId, name, version) constraint.
+  if (environment !== "examples" && environment !== "load") {
+    await upsertNaturalLanguageFilterPrompt(project1.id);
+  }
 
   // Realistic support chat scenario
   await createSupportChatSession(project1);

--- a/web/src/features/natural-language-filters/server/utils.ts
+++ b/web/src/features/natural-language-filters/server/utils.ts
@@ -1,6 +1,7 @@
 import { Langfuse } from "langfuse";
 import { type FilterCondition, singleFilter } from "@langfuse/shared";
 import { z } from "zod";
+import { getProductBaseUrl } from "@/src/utils/base-url";
 
 let langfuseClient: Langfuse | null = null;
 
@@ -43,7 +44,10 @@ export function getLangfuseClient(
     langfuseClient = new Langfuse({
       publicKey,
       secretKey,
-      baseUrl,
+      // Without LANGFUSE_AI_FEATURES_HOST the SDK would default to
+      // cloud.langfuse.com; self-referential deployments (e.g. PR previews)
+      // must talk to themselves instead.
+      baseUrl: baseUrl ?? getProductBaseUrl().toString(),
       enabled: enabled ?? true,
     });
   }


### PR DESCRIPTION
## Summary

PR previews (`pr-N.preview.langfuse.com`) will run as cloud region **`DEV`** so the two Langfuse-managed AI features work there: the **search-bar AI filter** and the **in-app agent**. Both are wired self-referentially against the preview's own seeded **Seed Org / llm-app** project. This PR is the app half; the Bedrock IRSA role and preview chart env land in the infrastructure repo: langfuse/infrastructure#1161.

### Changes

- **`.github/workflows/preview-build.yml`** — bake `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION=DEV` into the preview **web** image via `--build-arg`. This must be build-time: `NEXT_PUBLIC_*` is inlined into the client bundle, and the AI UI gates client-side via `useLangfuseCloudRegion()` — runtime env alone would enable the server routes but hide every AI affordance. (The worker gets the region from runtime env via the preview chart instead.)
- **`web/src/features/natural-language-filters/server/utils.ts`** — when `LANGFUSE_AI_FEATURES_HOST` is unset, `getLangfuseClient` now falls back to `getProductBaseUrl()` (NEXTAUTH_URL-derived) instead of the SDK's `cloud.langfuse.com` default. Cloud is unaffected: all ECS environments set the HOST unconditionally.
- **`packages/shared/scripts/seeder/seed-postgres.ts`** —
  - add `aiFeaturesEnabled: true` to the Seed Org upsert's **update** block (the create block already sets it since #14033; re-seeded orgs previously stayed AI-off)
  - seed the legacy `get-filter-conditions-from-query` prompt on the **default** path (previously only `examples`/`load`). Once the region gate opens, the legacy filter-with-AI buttons surface and their router fetches this prompt via the SDK — without it they 500.

### Why DEV and not PREVIEW?

- Decisive: the region value is validated against a strict zod enum at `next build`, and preview images build from the **raw PR head** — a new `PREVIEW` enum value would fail the build for every branch predating the enum commit. `DEV` is accepted on any branch.
- It also reuses the existing enum/registry — zero region-registration changes (a full `PREVIEW` region was scoped at ~13–16 files / ~60–100 lines plus a permanent keep-in-sync tax on every `=== "DEV"` branch).
- Accepted downsides:
  - `@langfuse.com` users see the green **DEV** badge/favicon on previews.
  - Telemetry tags previews `langfuse_cloud_region: DEV`, same as localhost — filter by hostname if needed.
  - Session cookies are namespaced `.DEV` (still host-isolated per preview).
  - Two latent DEV posture gaps, both inert on previews: relaxed blob-storage SSRF validation (`blobStorageEndpointValidation.ts`, backstopped by the preview NetworkPolicies) and admin API allowed on DEV (`adminApiAuth.ts`, previews ship no `ADMIN_API_KEY`).
- Non-goals: no change to local dev's use of `DEV`; previews are not a product-level cloud region. A first-class `PREVIEW` region stays a follow-up if the telemetry conflation becomes painful.

### Verification

- `eslint` on the touched web file, `tsc --noEmit` on `@langfuse/shared` (seeder included), `prettier --check`, workflow YAML parse — all pass (pre-commit hook also ran repo-wide prettier + turbo lint).
- SDK trailing-slash concern checked: `langfuse-core` normalizes `baseUrl` at construction (`removeTrailingSlash`), so `getProductBaseUrl().toString()` is safe.
- End-to-end behavior is verified on a live preview after the infrastructure PR lands (search-bar filter, agent conversation, traces in llm-app).

Tests added: 0 — the changes are env/config wiring plus two idempotent seeder upserts and a one-line URL fallback; the existing `in-app-agent-api-route-auth.servertest.ts` mocks `getLangfuseClient` with an unchanged signature, and behavior is exercised end-to-end on a live preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables Langfuse-managed AI features on PR previews. The main changes are:

- Bakes the `DEV` cloud region into preview web images.
- Falls back to the deployment URL for AI-feature SDK requests.
- Enables AI features when the Seed Org is updated.
- Seeds the legacy natural-language-filter prompt on the default path.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The examples/load seeding path can fail on a duplicate prompt insert.

- The new default-path upsert runs before the existing bulk prompt generator.
- Both paths target the same prompt identity but can use different row IDs.
- The resulting uniqueness error can abort the seed workflow.

packages/shared/scripts/seeder/seed-postgres.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/scripts/seeder/seed-postgres.ts:140
**Duplicate Prompt Upsert Conflicts**

On `examples` or `load` runs, this call creates the filter prompt before `generatePromptsForProject` upserts the same `(projectId, name, version)` with a different generated `id`. The later selector does not match the first row, so Prisma can attempt a second insert and fail on the composite unique constraint, aborting the seed run.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(preview): enable cloud AI features ..."](https://github.com/langfuse/langfuse/commit/bbb7ef938b96fdd787f3d4ae6130ebe1110d5282) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45958540)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->