### PR TITLE
fix(worker): stabilize data retention lag metrics

### DIFF
--- a/worker/src/__tests__/batchDataRetentionCleaner.test.ts
+++ b/worker/src/__tests__/batchDataRetentionCleaner.test.ts
@@ -22,6 +22,7 @@ import { env } from "../env";
 
 const integrationHooks = vi.hoisted(() => ({
   failExactEnrichmentForProjectId: null as string | null,
+  omitExactEnrichmentForProjectId: null as string | null,
   failCandidateStreamAfterFirstRow: false,
   activeCandidateStreams: 0,
   candidateHttpTimeouts: [] as Array<{ send: number; receive: number }>,
@@ -64,7 +65,14 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
       ) {
         throw new Error("forced exact enrichment failure");
       }
-      return actual.queryClickhouse<T>(opts);
+      const result = await actual.queryClickhouse<T>(opts);
+      return integrationHooks.omitExactEnrichmentForProjectId === null
+        ? result
+        : result.filter(
+            (row) =>
+              (row as { project_id?: string }).project_id !==
+              integrationHooks.omitExactEnrichmentForProjectId,
+          );
     },
     queryClickhouseStream: async function* <T>(
       opts: Parameters<typeof actual.queryClickhouseStream>[0],
@@ -491,6 +499,7 @@ describe("BatchDataRetentionCleaner", () => {
         env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT;
       timestampColumns[tableName] = "start_time";
       integrationHooks.failExactEnrichmentForProjectId = null;
+      integrationHooks.omitExactEnrichmentForProjectId = null;
       integrationHooks.failCandidateStreamAfterFirstRow = false;
       integrationHooks.activeCandidateStreams = 0;
       integrationHooks.candidateHttpTimeouts = [];
@@ -676,6 +685,38 @@ describe("BatchDataRetentionCleaner", () => {
           "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
         ),
       ).toBe(0);
+    });
+
+    it("keeps sibling enrichment when a candidate disappears", async () => {
+      const [staleProjectId, siblingProjectId] =
+        await createProjectsWithRetention(2);
+      const dayMs = 24 * 60 * 60 * 1000;
+      await insertRetentionTestRows(
+        tableName,
+        [staleProjectId!, siblingProjectId!].map((projectId) => ({
+          projectId,
+          startTime: Date.now() - 10 * dayMs,
+        })),
+      );
+      integrationHooks.omitExactEnrichmentForProjectId = staleProjectId!;
+
+      await new BatchDataRetentionCleaner(table).processBatch();
+
+      expect(
+        await getRetentionTestProjectCount(tableName, siblingProjectId!),
+      ).toBe(0);
+      expect(
+        integrationHooks.incrementCalls.some(
+          ([name]) =>
+            name ===
+            "langfuse.batch_data_retention_cleaner.enrichment_query_failures",
+        ),
+      ).toBe(false);
+      expect(
+        getLastGaugeValue(
+          "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
+        ),
+      ).toBeGreaterThan(2 * (dayMs / 1000));
     });
   });
 });

--- a/worker/src/__tests__/batchDataRetentionCleaner.test.ts
+++ b/worker/src/__tests__/batchDataRetentionCleaner.test.ts
@@ -25,6 +25,11 @@ const integrationHooks = vi.hoisted(() => ({
   failCandidateStreamAfterFirstRow: false,
   activeCandidateStreams: 0,
   candidateHttpTimeouts: [] as Array<{ send: number; receive: number }>,
+  exactEnrichmentRequests: [] as Array<{
+    projectIds: string[];
+    preferredClickhouseService: string | undefined;
+    requestTimeout: number | undefined;
+  }>,
   gaugeCalls: [] as Array<[stat: string, value: number | undefined]>,
   incrementCalls: [] as Array<[stat: string, value: number | undefined]>,
 }));
@@ -39,8 +44,18 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
       opts: Parameters<typeof actual.queryClickhouse>[0],
     ) => {
       const candidateProjectIds = opts.params?.candidateProjectIds;
+      if (!opts.query.includes("AS oldest_timestamp")) {
+        return actual.queryClickhouse<T>(opts);
+      }
+
+      integrationHooks.exactEnrichmentRequests.push({
+        projectIds: Array.isArray(candidateProjectIds)
+          ? candidateProjectIds.map(String)
+          : [],
+        preferredClickhouseService: opts.preferredClickhouseService,
+        requestTimeout: opts.clickhouseConfigs?.request_timeout,
+      });
       if (
-        opts.query.includes("AS oldest_timestamp") &&
         integrationHooks.failExactEnrichmentForProjectId !== null &&
         Array.isArray(candidateProjectIds) &&
         candidateProjectIds.includes(
@@ -461,7 +476,7 @@ describe("BatchDataRetentionCleaner", () => {
     });
   });
 
-  describe("candidate discovery and fallback queries", () => {
+  describe("candidate discovery and enrichment", () => {
     const timestampColumns = TIMESTAMP_COLUMN_MAP as Record<string, string>;
     let tableName: string;
     let table: BatchDataRetentionTable;
@@ -479,6 +494,7 @@ describe("BatchDataRetentionCleaner", () => {
       integrationHooks.failCandidateStreamAfterFirstRow = false;
       integrationHooks.activeCandidateStreams = 0;
       integrationHooks.candidateHttpTimeouts = [];
+      integrationHooks.exactEnrichmentRequests = [];
       integrationHooks.gaugeCalls = [];
       integrationHooks.incrementCalls = [];
       await createRetentionTestTable(tableName);
@@ -604,42 +620,62 @@ describe("BatchDataRetentionCleaner", () => {
         "langfuse.batch_data_retention_cleaner.candidate_query_failures",
         1,
       ]);
+      expect(
+        getLastGaugeValue(
+          "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
+        ),
+      ).toBe(0);
     });
 
-    it("uses partition lag when exact enrichment fails", async () => {
-      const [fallbackProjectId] = await createProjectsWithRetention(1);
-      await insertRetentionTestRows(tableName, [
-        {
-          projectId: fallbackProjectId!,
-          startTime: new Date("2020-03-15T00:00:00.000Z").getTime(),
-        },
-        {
-          projectId: fallbackProjectId!,
+    it("continues other chunks after one enrichment exhausts its retry", async () => {
+      const [failedProjectId, successfulProjectId] =
+        await createProjectsWithRetention(2);
+      await insertRetentionTestRows(
+        tableName,
+        [failedProjectId!, successfulProjectId!].map((projectId) => ({
+          projectId,
           startTime: new Date("2020-01-15T00:00:00.000Z").getTime(),
-        },
-      ]);
-      integrationHooks.failExactEnrichmentForProjectId = fallbackProjectId!;
-      const beforeRun = Date.now();
+        })),
+      );
+      integrationHooks.failExactEnrichmentForProjectId = failedProjectId!;
+      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CHUNK_SIZE = 1;
 
       await new BatchDataRetentionCleaner(table).processBatch();
 
-      const afterRun = Date.now();
+      expect(await getRetentionTestRowCount(tableName)).toBe(0);
+      const failedProjectRequests =
+        integrationHooks.exactEnrichmentRequests.filter((request) =>
+          request.projectIds.includes(failedProjectId!),
+        );
       expect(
-        await getRetentionTestProjectCount(tableName, fallbackProjectId!),
+        failedProjectRequests.map(
+          (request) => request.preferredClickhouseService,
+        ),
+      ).toEqual([undefined, "ReadOnly"]);
+      expect(
+        integrationHooks.exactEnrichmentRequests.filter((request) =>
+          request.projectIds.includes(successfulProjectId!),
+        ),
+      ).toHaveLength(1);
+      expect(
+        integrationHooks.exactEnrichmentRequests.every(
+          (request) =>
+            request.requestTimeout ===
+            env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CANDIDATE_QUERY_TIMEOUT_MS,
+        ),
+      ).toBe(true);
+      expect(
+        integrationHooks.incrementCalls.filter(
+          ([name]) =>
+            name ===
+            "langfuse.batch_data_retention_cleaner.enrichment_query_failures",
+        ),
+      ).toHaveLength(1);
+      expect(
+        getLastGaugeValue(
+          "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
+        ),
       ).toBe(0);
-
-      const lagValue = getLastGaugeValue(
-        "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
-      );
-      const partitionStart = new Date("2020-01-01T00:00:00.000Z").getTime();
-      const retentionMs = 7 * 24 * 60 * 60 * 1000;
-
-      expect(lagValue).toBeGreaterThanOrEqual(
-        (beforeRun - retentionMs - partitionStart) / 1000,
-      );
-      expect(lagValue).toBeLessThanOrEqual(
-        (afterRun - retentionMs - partitionStart) / 1000,
-      );
     });
   });
 });

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -427,11 +427,16 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(100), // Chunk size for counting projects in ClickHouse
+  LANGFUSE_BATCH_DATA_RETENTION_CLEANER_QUERY_CONCURRENCY: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(2), // Max concurrent query pipelines per table cleaner
   LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CANDIDATE_QUERY_TIMEOUT_MS: z.coerce
     .number()
     .int()
     .positive()
-    .default(180_000), // 3 minutes for candidate discovery queries
+    .default(180_000), // 3 minutes for candidate and enrichment queries
   LANGFUSE_BATCH_DATA_RETENTION_CLEANER_DELETE_TIMEOUT_MS: z.coerce
     .number()
     .positive()

--- a/worker/src/features/batch-data-retention-cleaner/index.ts
+++ b/worker/src/features/batch-data-retention-cleaner/index.ts
@@ -1,4 +1,5 @@
 import { createHash } from "crypto";
+import pLimit from "p-limit";
 
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -61,52 +62,17 @@ interface ProjectWorkload extends ProjectRetention {
 interface ProjectWorkloadSelection {
   observedWorkloads: ProjectWorkload[];
   selectedWorkloads: ProjectWorkload[];
+  lagMeasurementComplete: boolean;
 }
 
-function parseMonthlyPartitionStart(partitionId: string): Date | null {
-  if (!/^\d{6}$/.test(partitionId)) {
-    return null;
-  }
-
-  const year = Number(partitionId.slice(0, 4));
-  const month = Number(partitionId.slice(4, 6));
-  if (year < 100 || month < 1 || month > 12) {
-    return null;
-  }
-
-  return new Date(Date.UTC(year, month - 1, 1));
+interface CandidateDiscoveryResult {
+  candidates: ProjectRetention[];
+  complete: boolean;
 }
 
-async function getOldestProjectPartitionStarts(
-  tableName: BatchDataRetentionTable,
-  projectIds: string[],
-): Promise<Map<string, Date | null>> {
-  if (projectIds.length === 0) {
-    return new Map();
-  }
-
-  const result = await queryClickhouse<{
-    project_id: string;
-    oldest_expired_partition: string;
-  }>({
-    query: `
-      SELECT
-        project_id,
-        min(_partition_id) AS oldest_expired_partition
-      FROM ${tableName}
-      PREWHERE project_id IN ({candidateProjectIds: Array(String)})
-      GROUP BY project_id
-    `,
-    params: { candidateProjectIds: projectIds },
-    useMultipartParamsAuto: true,
-  });
-
-  return new Map(
-    result.map((row) => [
-      row.project_id,
-      parseMonthlyPartitionStart(row.oldest_expired_partition),
-    ]),
-  );
+interface EnrichmentResult {
+  workloads: ProjectWorkload[];
+  complete: boolean;
 }
 
 /**
@@ -217,6 +183,8 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
     logger.info(`Starting ${this.instanceName}`, {
       intervalMs: env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_INTERVAL_MS,
       projectLimit: env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT,
+      queryConcurrency:
+        env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_QUERY_CONCURRENCY,
       candidateQueryTimeoutMs:
         env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CANDIDATE_QUERY_TIMEOUT_MS,
       deleteTimeoutMs:
@@ -281,7 +249,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
         this.lastLockExtensionAt = 0;
 
         // Step 1: Get project workloads (streamed CH candidates + PG config)
-        const { observedWorkloads, selectedWorkloads } =
+        const { observedWorkloads, selectedWorkloads, lagMeasurementComplete } =
           await this.getProjectWorkloads();
 
         recordGauge(
@@ -295,7 +263,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
         // Retention cutoffs come from Postgres and are frozen once per run.
         // Fold the per-project results here to preserve one maximum across all
         // bounded ClickHouse queries.
-        const maxSecondsPastCutoff = observedWorkloads.reduce(
+        const observedMaxSecondsPastCutoff = observedWorkloads.reduce(
           (maximum, workload) =>
             workload.secondsPastCutoff === null
               ? maximum
@@ -303,13 +271,15 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
           0,
         );
 
-        recordGauge(
-          `${METRIC_PREFIX}.seconds_past_cutoff`,
-          maxSecondsPastCutoff,
-          {
-            table: this.tableName,
-          },
-        );
+        if (lagMeasurementComplete) {
+          recordGauge(
+            `${METRIC_PREFIX}.seconds_past_cutoff`,
+            observedMaxSecondsPastCutoff,
+            {
+              table: this.tableName,
+            },
+          );
+        }
 
         // Step 2: Execute DELETE
         if (selectedWorkloads.length > 0) {
@@ -320,7 +290,8 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
                 (workload) => workload.projectId,
               ),
               pendingProjectsSeen: observedWorkloads.length,
-              maxSecondsPastCutoff,
+              observedMaxSecondsPastCutoff,
+              lagMeasurementComplete,
             },
           );
 
@@ -377,7 +348,11 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
     });
 
     if (projectsWithRetention.length === 0) {
-      return { observedWorkloads: [], selectedWorkloads: [] };
+      return {
+        observedWorkloads: [],
+        selectedWorkloads: [],
+        lagMeasurementComplete: true,
+      };
     }
 
     // Step 2: Calculate cutoffs for all projects upfront
@@ -409,16 +384,58 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
     // count breaks ties, but deletion must not depend on this grouped query
     // succeeding. Keep enrichment per input chunk so its parameters remain
     // bounded too.
-    const chunkWorkloads = await Promise.all(
-      projectChunks.map(async (projectChunk) => {
-        const candidates = await this.findExpiredProjectCandidates(
-          timestampColumn,
-          projectChunk,
-        );
-        return this.enrichProjectCandidates(timestampColumn, candidates);
-      }),
+    const limitRetentionQuery = pLimit(
+      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_QUERY_CONCURRENCY,
     );
-    const workloads = chunkWorkloads.flat();
+    let leaseLost = false;
+    // Wait for every limited pipeline so no queued query outlives the lock.
+    const settledChunkResults = await Promise.allSettled(
+      projectChunks.map((projectChunk) =>
+        limitRetentionQuery(async () => {
+          if (leaseLost) {
+            return null;
+          }
+
+          try {
+            const discovery = await this.findExpiredProjectCandidates(
+              timestampColumn,
+              projectChunk,
+            );
+            if (leaseLost) {
+              return null;
+            }
+
+            const enrichment = await this.enrichProjectCandidates(
+              timestampColumn,
+              discovery.candidates,
+            );
+            return {
+              workloads: enrichment.workloads,
+              complete: discovery.complete && enrichment.complete,
+            };
+          } catch (error) {
+            if (error instanceof BatchDataRetentionCleanerLeaseLostError) {
+              leaseLost = true;
+            }
+            throw error;
+          }
+        }),
+      ),
+    );
+
+    const failedChunk = settledChunkResults.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (failedChunk) {
+      throw failedChunk.reason;
+    }
+
+    const chunkResults = settledChunkResults.flatMap((result) =>
+      result.status === "fulfilled" && result.value !== null
+        ? [result.value]
+        : [],
+    );
+    const workloads = chunkResults.flatMap((result) => result.workloads);
 
     // Prioritize the projects furthest behind their cutoff. A failed lag or
     // count estimate can indicate a particularly large workload, so keep
@@ -452,6 +469,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
         0,
         env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT,
       ),
+      lagMeasurementComplete: chunkResults.every((result) => result.complete),
     };
   }
 
@@ -462,9 +480,9 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
   private async findExpiredProjectCandidates(
     timestampColumn: string,
     projects: ProjectRetention[],
-  ): Promise<ProjectRetention[]> {
+  ): Promise<CandidateDiscoveryResult> {
     if (projects.length === 0) {
-      return [];
+      return { candidates: [], complete: true };
     }
 
     const { conditions, params } = buildRetentionConditions(
@@ -480,6 +498,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
     `;
 
     const candidatesById = new Map<string, ProjectRetention>();
+    let complete = true;
     const projectsById = new Map(
       projects.map((project) => [project.projectId, project]),
     );
@@ -515,6 +534,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       if (error instanceof BatchDataRetentionCleanerLeaseLostError) {
         throw error;
       }
+      complete = false;
       recordIncrement(`${METRIC_PREFIX}.candidate_query_failures`, 1, {
         table: this.tableName,
       });
@@ -527,22 +547,26 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
     // A completed query is progress even when it did not yield a candidate.
     await this.extendLockOnProgress();
 
-    return Array.from(candidatesById.values());
+    return {
+      candidates: Array.from(candidatesById.values()),
+      complete,
+    };
   }
 
   /**
    * Best-effort total count and oldest retention timestamp for discovered
    * candidates. The query deliberately filters only on project_id. Retention
    * cutoffs come from Postgres and are frozen once per run, so they are applied
-   * after the result is returned. If this query fails, estimate the oldest
-   * timestamp from the monthly partition instead.
+   * after the result is returned. A failed primary query is retried once on a
+   * read-only pool. If both attempts fail, candidates remain eligible for
+   * deletion without publishing a partial lag maximum.
    */
   private async enrichProjectCandidates(
     timestampColumn: string,
     candidates: ProjectRetention[],
-  ): Promise<ProjectWorkload[]> {
+  ): Promise<EnrichmentResult> {
     if (candidates.length === 0) {
-      return [];
+      return { workloads: [], complete: true };
     }
 
     const query = `
@@ -555,7 +579,9 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       GROUP BY project_id
     `;
 
-    try {
+    const queryExactWorkloads = async (
+      preferredClickhouseService?: "ReadOnly" | "EventsReadOnly",
+    ): Promise<ProjectWorkload[]> => {
       const result = await queryClickhouse<{
         project_id: string;
         row_count: number;
@@ -568,6 +594,15 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
           ),
         },
         useMultipartParamsAuto: true,
+        preferredClickhouseService,
+        clickhouseConfigs: {
+          request_timeout:
+            env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_CANDIDATE_QUERY_TIMEOUT_MS,
+          clickhouse_settings: {
+            http_send_timeout: this.candidateQueryHttpTimeoutSeconds,
+            http_receive_timeout: this.candidateQueryHttpTimeoutSeconds,
+          },
+        },
       });
 
       const resultByProjectId = new Map(
@@ -591,97 +626,81 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
         }),
       );
 
-      await this.extendLockOnProgress();
-
-      return candidates.flatMap((candidate) => {
+      return candidates.map((candidate) => {
         const resultForProject = resultByProjectId.get(candidate.projectId);
         if (
           !resultForProject ||
           resultForProject.oldestTimestamp.getTime() >=
             candidate.cutoffDate.getTime()
         ) {
-          return [];
+          throw new Error(
+            `Exact enrichment did not find expired data for project ${candidate.projectId}`,
+          );
         }
 
-        return [
-          {
-            ...candidate,
-            rowCount: resultForProject.rowCount,
-            secondsPastCutoff:
-              (candidate.cutoffDate.getTime() -
-                resultForProject.oldestTimestamp.getTime()) /
-              1000,
-          },
-        ];
-      });
-    } catch (error) {
-      if (error instanceof BatchDataRetentionCleanerLeaseLostError) {
-        throw error;
-      }
-      recordIncrement(`${METRIC_PREFIX}.enrichment_query_failures`, 1, {
-        table: this.tableName,
-      });
-      logger.warn(`${this.instanceName}: Candidate enrichment failed`, {
-        error,
-        candidatesFound: candidates.length,
-      });
-
-      await this.extendLockOnProgress();
-      return this.enrichCandidatesFromOldestPartition(candidates);
-    }
-  }
-
-  /**
-   * Estimate each candidate's lag from its oldest monthly partition. The
-   * partition start is an upper bound on how far the oldest row is past the
-   * fixed project cutoff. If this query also fails, retain the candidates
-   * without metrics.
-   */
-  private async enrichCandidatesFromOldestPartition(
-    candidates: ProjectRetention[],
-  ): Promise<ProjectWorkload[]> {
-    try {
-      const partitionStartByProjectId = await getOldestProjectPartitionStarts(
-        this.tableName,
-        candidates.map((candidate) => candidate.projectId),
-      );
-
-      await this.extendLockOnProgress();
-
-      return candidates.map((candidate) => {
-        const partitionStart = partitionStartByProjectId.get(
-          candidate.projectId,
-        );
         return {
           ...candidate,
-          rowCount: null,
-          secondsPastCutoff: partitionStart
-            ? Math.max(
-                (candidate.cutoffDate.getTime() - partitionStart.getTime()) /
-                  1000,
-                0,
-              )
-            : null,
+          rowCount: resultForProject.rowCount,
+          secondsPastCutoff:
+            (candidate.cutoffDate.getTime() -
+              resultForProject.oldestTimestamp.getTime()) /
+            1000,
         };
       });
+    };
+
+    try {
+      const workloads = await queryExactWorkloads();
+      await this.extendLockOnProgress();
+      return { workloads, complete: true };
     } catch (error) {
       if (error instanceof BatchDataRetentionCleanerLeaseLostError) {
         throw error;
       }
-      recordIncrement(`${METRIC_PREFIX}.partition_fallback_query_failures`, 1, {
-        table: this.tableName,
-      });
-      logger.warn(`${this.instanceName}: Partition fallback query failed`, {
-        error,
-        candidatesFound: candidates.length,
-      });
+      logger.warn(
+        `${this.instanceName}: Candidate enrichment failed; retrying on read-only`,
+        {
+          error,
+          candidatesFound: candidates.length,
+        },
+      );
 
-      await this.extendLockOnProgress();
-      return candidates.map((candidate) => ({
-        ...candidate,
-        rowCount: null,
-        secondsPastCutoff: null,
-      }));
+      // Reset the lease before another potentially long exact query.
+      await this.extendLockOnProgress(true);
+
+      const preferredClickhouseService =
+        this.tableName === "events_full" || this.tableName === "events_core"
+          ? "EventsReadOnly"
+          : "ReadOnly";
+
+      try {
+        const workloads = await queryExactWorkloads(preferredClickhouseService);
+        await this.extendLockOnProgress();
+        return { workloads, complete: true };
+      } catch (retryError) {
+        if (retryError instanceof BatchDataRetentionCleanerLeaseLostError) {
+          throw retryError;
+        }
+
+        recordIncrement(`${METRIC_PREFIX}.enrichment_query_failures`, 1, {
+          table: this.tableName,
+        });
+        logger.warn(`${this.instanceName}: Candidate enrichment failed`, {
+          error: retryError,
+          primaryError: error,
+          candidatesFound: candidates.length,
+        });
+
+        await this.extendLockOnProgress();
+        return {
+          workloads: candidates.map((candidate) => ({
+            ...candidate,
+            rowCount: null,
+            secondsPastCutoff: null,
+          })),
+          complete: false,
+        };
+      }
     }
   }
 

--- a/worker/src/features/batch-data-retention-cleaner/index.ts
+++ b/worker/src/features/batch-data-retention-cleaner/index.ts
@@ -626,26 +626,26 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
         }),
       );
 
-      return candidates.map((candidate) => {
+      return candidates.flatMap((candidate) => {
         const resultForProject = resultByProjectId.get(candidate.projectId);
         if (
           !resultForProject ||
           resultForProject.oldestTimestamp.getTime() >=
             candidate.cutoffDate.getTime()
         ) {
-          throw new Error(
-            `Exact enrichment did not find expired data for project ${candidate.projectId}`,
-          );
+          return [];
         }
 
-        return {
-          ...candidate,
-          rowCount: resultForProject.rowCount,
-          secondsPastCutoff:
-            (candidate.cutoffDate.getTime() -
-              resultForProject.oldestTimestamp.getTime()) /
-            1000,
-        };
+        return [
+          {
+            ...candidate,
+            rowCount: resultForProject.rowCount,
+            secondsPastCutoff:
+              (candidate.cutoffDate.getTime() -
+                resultForProject.oldestTimestamp.getTime()) /
+              1000,
+          },
+        ];
       });
     };
 


### PR DESCRIPTION
## What does this PR do?

The batch data-retention cleaner previously ran every project-chunk enrichment pipeline concurrently. When exact enrichment timed out, it fell back to the monthly ClickHouse partition start, so transient query pressure could turn the existing `seconds_past_cutoff` gauge into a coarse upper bound and produce large zig-zags. Incomplete sweeps could also publish a maximum based on only the chunks that succeeded.

This change:

- limits candidate/enrichment pipelines per table cleaner with `LANGFUSE_BATCH_DATA_RETENTION_CLEANER_QUERY_CONCURRENCY` (default `2`);
- retries failed exact enrichment once on the read-only pool (`EventsReadOnly` for event tables);
- removes the monthly partition fallback while keeping unenriched candidates eligible for deletion;
- increments the existing `enrichment_query_failures` counter only after both exact attempts fail; and
- avoids overwriting `seconds_past_cutoff` with partial results when discovery or enrichment is incomplete.

## Impacted packages

- `worker`: retention-cleaner orchestration, environment configuration, and integration coverage.

No API, schema, or user-facing configuration changes are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

- `pnpm --filter worker run test batchDataRetentionCleaner.test.ts` — `Tests 12 passed (12)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter worker run typecheck` — passed
- `git diff --check` — passed

## Mandatory Tasks

- [x] Self-reviewed the code

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes retention-cleaner lag reporting and limits ClickHouse query pressure. The main changes are:

- Limits concurrent discovery and enrichment pipelines per table.
- Retries failed exact enrichment through a read-only ClickHouse service.
- Removes monthly-partition lag estimates after enrichment failures.
- Suppresses lag updates when a sweep is incomplete.
- Adds integration coverage for retries and partial sweeps.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The lag publication and stale-candidate enrichment paths need fixes before merging.

- Incomplete sweeps leave the gauge at the earlier zero reset instead of preserving the last complete value.
- One candidate that disappears between queries can discard valid enrichment results for its whole chunk.
- The delete query still checks each project's retention cutoff.

worker/src/features/batch-data-retention-cleaner/index.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Reset lag gauge to zero] --> B[Discover candidates]
  B --> C[Run exact enrichment]
  C -->|Success| D[Collect exact workloads]
  C -->|Failure or absent candidate| E[Retry on read-only service]
  E -->|Success| D
  E -->|Failure| F[Keep workloads with null metrics]
  D --> G{All chunks complete?}
  F --> G
  G -->|Yes| H[Publish maximum lag]
  G -->|No| I[Skip update; zero remains]
  D --> J[Delete rows before each cutoff]
  F --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Reset lag gauge to zero] --> B[Discover candidates]
  B --> C[Run exact enrichment]
  C -->|Success| D[Collect exact workloads]
  C -->|Failure or absent candidate| E[Retry on read-only service]
  E -->|Success| D
  E -->|Failure| F[Keep workloads with null metrics]
  D --> G{All chunks complete?}
  F --> G
  G -->|Yes| H[Publish maximum lag]
  G -->|No| I[Skip update; zero remains]
  D --> J[Delete rows before each cutoff]
  F --> J
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/batch-data-retention-cleaner/index.ts:274-282
**Incomplete Sweep Publishes Zero Lag**

When discovery or enrichment is incomplete, this branch skips the final gauge update, but `execute()` has already reset `seconds_past_cutoff` to zero. A transient query failure therefore replaces the last complete measurement with zero instead of preserving it, causing the same misleading metric drop this change is intended to prevent.

### Issue 2 of 2
worker/src/features/batch-data-retention-cleaner/index.ts:629-639
**Stale Candidate Invalidates Whole Chunk**

If expired rows disappear between discovery and enrichment, the grouped query legitimately omits that project. Throwing here retries the whole chunk and then discards valid measurements for every other project when the candidate is still absent, which increments the failure counter and suppresses the run's lag gauge. The absent or no-longer-expired candidate should be omitted without converting successful results for its siblings into a query failure.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): stabilize data retention la..."](https://github.com/langfuse/langfuse/commit/504a0c5427e2d83f6e153497ac5af44029980658) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45972344)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->