### PR TITLE
fix(agent): Set user agent header in MCP requests

### DIFF
--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { AgUiEvent } from "@/src/ee/features/in-app-agent/schema";
 import {
   IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER,
+  IN_APP_AGENT_MCP_USER_AGENT,
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
   IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE,
 } from "@/src/ee/features/in-app-agent/constants";
@@ -947,7 +948,15 @@ describe("createAgUiStream", () => {
           requestInit: {
             headers: expect.objectContaining({
               Authorization: expect.stringContaining("Basic "),
+              "User-Agent": IN_APP_AGENT_MCP_USER_AGENT,
               [IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER]: "run-override",
+            }),
+          },
+        },
+        langfuseDocs: {
+          requestInit: {
+            headers: expect.objectContaining({
+              "User-Agent": IN_APP_AGENT_MCP_USER_AGENT,
             }),
           },
         },
@@ -958,13 +967,24 @@ describe("createAgUiStream", () => {
       servers: {
         langfuse: {
           requestInit: {
-            headers: expect.not.objectContaining({
-              [IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER]: expect.anything(),
+            headers: expect.objectContaining({
+              "User-Agent": IN_APP_AGENT_MCP_USER_AGENT,
+            }),
+          },
+        },
+        langfuseDocs: {
+          requestInit: {
+            headers: expect.objectContaining({
+              "User-Agent": IN_APP_AGENT_MCP_USER_AGENT,
             }),
           },
         },
       },
     });
+    expect(
+      vi.mocked(MCPClient).mock.calls[1]?.[0].servers.langfuse.requestInit
+        ?.headers,
+    ).not.toHaveProperty(IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER);
     expect(persistedEvents).toEqual([
       {
         type: EventType.RUN_STARTED,

--- a/web/src/ee/features/in-app-agent/constants.ts
+++ b/web/src/ee/features/in-app-agent/constants.ts
@@ -3,6 +3,8 @@ export const IN_APP_AGENT_REDIRECT_TOOL_NAME = "langfuse_proposeRedirect";
 
 export const IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE = "tool_call_rejected";
 
+export const IN_APP_AGENT_MCP_USER_AGENT = "langfuse-in-app-agent";
+
 // Header used only by Langfuse's server-side in-app agent when it calls the
 // Langfuse MCP endpoint with a temporary in-app-agent API key and run override.
 export const IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER =

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -32,8 +32,11 @@ import { LANGFUSE_IN_APP_AGENT_SKILLS } from "@/src/ee/features/in-app-agent/ser
 import type { InAppAgentSandbox } from "@/src/ee/features/in-app-agent/server/sandbox";
 import { DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS } from "@/src/features/filters/constants/internal-environments";
 import { logger } from "@langfuse/shared/src/server";
-import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
-import { IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER } from "@/src/ee/features/in-app-agent/constants";
+import {
+  IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER,
+  IN_APP_AGENT_MCP_USER_AGENT,
+  IN_APP_AGENT_REDIRECT_TOOL_NAME,
+} from "@/src/ee/features/in-app-agent/constants";
 
 const ASSISTANT_TITLE = "Langfuse Assistant";
 const IN_APP_AGENT_SYSTEM_PROMPT_NAME = "in-app-agent-system-prompt";
@@ -737,6 +740,7 @@ async function createMastraAdapter(params: {
         requestInit: {
           headers: {
             Authorization: params.langfuseMcpAuthHeader,
+            "User-Agent": IN_APP_AGENT_MCP_USER_AGENT,
             ...(params.options.langfuseMcp.runOverride
               ? {
                   [IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER]:
@@ -748,6 +752,11 @@ async function createMastraAdapter(params: {
       },
       langfuseDocs: {
         url: new URL(LANGFUSE_DOCS_MCP_URL),
+        requestInit: {
+          headers: {
+            "User-Agent": IN_APP_AGENT_MCP_USER_AGENT,
+          },
+        },
       },
     },
   });


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR identifies MCP requests from the in-app agent with a dedicated User-Agent header. The main changes are:

- Adds a shared `langfuse-in-app-agent` User-Agent constant.
- Sends the header to the Langfuse and documentation MCP servers.
- Tests the new header and verifies continuation requests omit the tool-override header.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The continuation test now directly checks that the privileged override header is absent.
- The new header is applied consistently to both MCP server configurations.
- No blocking issues were found in the changed code.

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agent): Set user agent header in MCP..."](https://github.com/langfuse/langfuse/commit/d4c42690db80b40f55f7f28dc85e4652dc9fea21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45965007)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->