### PR TITLE
feat(api): state the concrete v3 sunset date, November 16, 2026 (LFE-10895)

### DIFF
--- a/fern/apis/server/definition/dataset-run-items.yml
+++ b/fern/apis/server/definition/dataset-run-items.yml
@@ -9,7 +9,7 @@ service:
     create:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, create experiment data via the SDK experiment runner or the OpenTelemetry endpoint at POST /api/public/otel/v1/traces."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, create experiment data via the SDK experiment runner or the OpenTelemetry endpoint at POST /api/public/otel/v1/traces."
       method: POST
       docs: Create a dataset run item
       path: /dataset-run-items
@@ -18,7 +18,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, dataset run items are replaced by experiment items; use GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, dataset run items are replaced by experiment items; use GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to> instead."
       method: GET
       docs: List dataset run items
       path: /dataset-run-items

--- a/fern/apis/server/definition/dataset-run-items.yml
+++ b/fern/apis/server/definition/dataset-run-items.yml
@@ -9,7 +9,7 @@ service:
     create:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, create experiment data via the SDK experiment runner or the OpenTelemetry endpoint at POST /api/public/otel/v1/traces."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, create experiment data via the SDK experiment runner or the OpenTelemetry endpoint at POST /api/public/otel/v1/traces."
       method: POST
       docs: Create a dataset run item
       path: /dataset-run-items
@@ -18,7 +18,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, dataset run items are replaced by experiment items; use `GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>` instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset run items are replaced by experiment items; use `GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>` instead."
       method: GET
       docs: List dataset run items
       path: /dataset-run-items

--- a/fern/apis/server/definition/dataset-run-items.yml
+++ b/fern/apis/server/definition/dataset-run-items.yml
@@ -9,7 +9,7 @@ service:
     create:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, create experiment data via the SDK experiment runner or the OpenTelemetry endpoint at POST /api/public/otel/v1/traces."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, create experiment data via the SDK experiment runner or the OpenTelemetry endpoint at POST /api/public/otel/v1/traces."
       method: POST
       docs: Create a dataset run item
       path: /dataset-run-items
@@ -18,7 +18,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, dataset run items are replaced by experiment items; use `GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>` instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, dataset run items are replaced by experiment items; use `GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>` instead."
       method: GET
       docs: List dataset run items
       path: /dataset-run-items

--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -36,7 +36,7 @@ service:
     getRun:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
       method: GET
       docs: Get a dataset run and its items
       path: /datasets/{datasetName}/runs/{runName}
@@ -47,7 +47,7 @@ service:
     deleteRun:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, dataset runs are replaced by experiments."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, dataset runs are replaced by experiments."
       method: DELETE
       docs: Delete a dataset run and all its run items. This action is irreversible.
       path: /datasets/{datasetName}/runs/{runName}
@@ -58,7 +58,7 @@ service:
     getRuns:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
       method: GET
       docs: Get dataset runs
       path: /datasets/{datasetName}/runs

--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -36,7 +36,7 @@ service:
     getRun:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
       method: GET
       docs: Get a dataset run and its items
       path: /datasets/{datasetName}/runs/{runName}
@@ -47,7 +47,7 @@ service:
     deleteRun:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, dataset runs are replaced by experiments."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset runs are replaced by experiments."
       method: DELETE
       docs: Delete a dataset run and all its run items. This action is irreversible.
       path: /datasets/{datasetName}/runs/{runName}
@@ -58,7 +58,7 @@ service:
     getRuns:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
       method: GET
       docs: Get dataset runs
       path: /datasets/{datasetName}/runs

--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -9,7 +9,7 @@ service:
     batch:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Send data via the OpenTelemetry endpoint at POST /api/public/otel/v1/traces instead. Learn more: https://langfuse.com/integrations/native/opentelemetry"
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Send data via the OpenTelemetry endpoint at POST /api/public/otel/v1/traces instead. Learn more: https://langfuse.com/integrations/native/opentelemetry"
       docs: |
         **Legacy endpoint for batch ingestion for Langfuse Observability.**
 

--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -9,7 +9,7 @@ service:
     batch:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Send data via the OpenTelemetry endpoint at `POST /api/public/otel/v1/traces` instead, see the [OpenTelemetry integration docs](https://langfuse.com/integrations/native/opentelemetry)."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. Send data via the OpenTelemetry endpoint at `POST /api/public/otel/v1/traces` instead, see the [OpenTelemetry integration docs](https://langfuse.com/integrations/native/opentelemetry)."
       docs: |
         **Legacy endpoint for batch ingestion for Langfuse Observability.**
 

--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -9,7 +9,7 @@ service:
     batch:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Send data via the OpenTelemetry endpoint at `POST /api/public/otel/v1/traces` instead, see the [OpenTelemetry integration docs](https://langfuse.com/integrations/native/opentelemetry)."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Send data via the OpenTelemetry endpoint at `POST /api/public/otel/v1/traces` instead, see the [OpenTelemetry integration docs](https://langfuse.com/integrations/native/opentelemetry)."
       docs: |
         **Legacy endpoint for batch ingestion for Langfuse Observability.**
 

--- a/fern/apis/server/definition/legacy/metrics-v1.yml
+++ b/fern/apis/server/definition/legacy/metrics-v1.yml
@@ -9,7 +9,7 @@ service:
     metrics:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/metrics?query=<urlencoded json query> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v2/metrics?query=<urlencoded json query> instead."
       docs: |
         Get metrics from the Langfuse project using a query object.
 

--- a/fern/apis/server/definition/legacy/metrics-v1.yml
+++ b/fern/apis/server/definition/legacy/metrics-v1.yml
@@ -9,7 +9,7 @@ service:
     metrics:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use `GET /api/public/v2/metrics?query=<urlencoded json query>` instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use `GET /api/public/v2/metrics?query=<urlencoded json query>` instead."
       docs: |
         Get metrics from the Langfuse project using a query object.
 

--- a/fern/apis/server/definition/legacy/metrics-v1.yml
+++ b/fern/apis/server/definition/legacy/metrics-v1.yml
@@ -9,7 +9,7 @@ service:
     metrics:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use `GET /api/public/v2/metrics?query=<urlencoded json query>` instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. Use `GET /api/public/v2/metrics?query=<urlencoded json query>` instead."
       docs: |
         Get metrics from the Langfuse project using a query object.
 

--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
       docs: Get a observation
       method: GET
       path: /observations/{observationId}
@@ -21,7 +21,7 @@ service:
     getMany:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
       docs: |
         Get a list of observations.
 

--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
       docs: Get a observation
       method: GET
       path: /observations/{observationId}
@@ -21,7 +21,7 @@ service:
     getMany:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
       docs: |
         Get a list of observations.
 

--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
       docs: Get a observation
       method: GET
       path: /observations/{observationId}
@@ -21,7 +21,7 @@ service:
     getMany:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
       docs: |
         Get a list of observations.
 

--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -9,7 +9,7 @@ service:
     get-many:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v3/scores instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v3/scores instead."
       docs: |
         **Deprecated.** Use `GET /api/public/v3/scores` instead. This endpoint
         is no longer available on Langfuse v4 and later.
@@ -94,7 +94,7 @@ service:
     get-by-id:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v3/scores with the id filter instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. Use GET /api/public/v3/scores with the id filter instead."
       docs: |
         **Deprecated.** Use `GET /api/public/v3/scores` with the `id` filter
         instead. This endpoint is no longer available on Langfuse v4 and later.

--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -15,7 +15,7 @@ service:
     get-many:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed on October 31, 2026. Use `GET /api/public/v3/scores` instead."
+        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed on November 16, 2026. Use `GET /api/public/v3/scores` instead."
       docs: Get a list of scores (supports both trace and session scores)
       method: GET
       path: /v2/scores
@@ -96,7 +96,7 @@ service:
     get-by-id:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed on October 31, 2026. Use `GET /api/public/v3/scores` with the `id` filter instead."
+        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed on November 16, 2026. Use `GET /api/public/v3/scores` with the `id` filter instead."
       docs: Get a score (supports both trace and session scores)
       method: GET
       path: /v2/scores/{scoreId}

--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -15,7 +15,7 @@ service:
     get-many:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed in a future release. Use `GET /api/public/v3/scores` instead."
+        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed on October 31, 2026. Use `GET /api/public/v3/scores` instead."
       docs: Get a list of scores (supports both trace and session scores)
       method: GET
       path: /v2/scores
@@ -96,7 +96,7 @@ service:
     get-by-id:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed in a future release. Use `GET /api/public/v3/scores` with the `id` filter instead."
+        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed on October 31, 2026. Use `GET /api/public/v3/scores` with the `id` filter instead."
       docs: Get a score (supports both trace and session scores)
       method: GET
       path: /v2/scores/{scoreId}

--- a/fern/apis/server/definition/sessions.yml
+++ b/fern/apis/server/definition/sessions.yml
@@ -9,7 +9,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
       docs: |
         Get sessions.
 
@@ -42,7 +42,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
       docs: |
         Get a session.
 

--- a/fern/apis/server/definition/sessions.yml
+++ b/fern/apis/server/definition/sessions.yml
@@ -9,7 +9,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
       docs: |
         Get sessions.
 
@@ -42,7 +42,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
       docs: |
         Get a session.
 

--- a/fern/apis/server/definition/sessions.yml
+++ b/fern/apis/server/definition/sessions.yml
@@ -9,7 +9,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
       docs: |
         Get sessions.
 
@@ -42,7 +42,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
       docs: |
         Get a session.
 

--- a/fern/apis/server/definition/trace.yml
+++ b/fern/apis/server/definition/trace.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
       docs: Get a specific trace
       method: GET
       path: /traces/{traceId}
@@ -36,7 +36,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
       docs: Get list of traces
       method: GET
       path: /traces

--- a/fern/apis/server/definition/trace.yml
+++ b/fern/apis/server/definition/trace.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
       docs: Get a specific trace
       method: GET
       path: /traces/{traceId}
@@ -36,7 +36,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
       docs: Get list of traces
       method: GET
       path: /traces

--- a/fern/apis/server/definition/trace.yml
+++ b/fern/apis/server/definition/trace.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
       docs: Get a specific trace
       method: GET
       path: /traces/{traceId}
@@ -36,7 +36,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on October 31, 2026. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
       docs: Get list of traces
       method: GET
       path: /traces

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1135,7 +1135,7 @@ paths:
     post:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. In Langfuse v4, create experiment data via the SDK
+        on November 16, 2026. In Langfuse v4, create experiment data via the SDK
         experiment runner or the OpenTelemetry endpoint at POST
         /api/public/otel/v1/traces. See the [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
@@ -1189,7 +1189,7 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. In Langfuse v4, dataset run items are replaced by
+        on November 16, 2026. In Langfuse v4, dataset run items are replaced by
         experiment items; use `GET
         /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>`
         instead. See the [Langfuse v3 to v4 upgrade
@@ -1407,7 +1407,7 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. In Langfuse v4, dataset runs are replaced by
+        on November 16, 2026. In Langfuse v4, dataset runs are replaced by
         experiments; use GET /api/public/experiments instead. See the [Langfuse
         v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
@@ -1465,7 +1465,7 @@ paths:
     delete:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. In Langfuse v4, dataset runs are replaced by
+        on November 16, 2026. In Langfuse v4, dataset runs are replaced by
         experiments. See the [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
@@ -1523,7 +1523,7 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. In Langfuse v4, dataset runs are replaced by
+        on November 16, 2026. In Langfuse v4, dataset runs are replaced by
         experiments; use GET /api/public/experiments instead. See the [Langfuse
         v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
@@ -1935,7 +1935,7 @@ paths:
     post:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. Send data via the OpenTelemetry endpoint at `POST
+        on November 16, 2026. Send data via the OpenTelemetry endpoint at `POST
         /api/public/otel/v1/traces` instead, see the [OpenTelemetry integration
         docs](https://langfuse.com/integrations/native/opentelemetry). See the
         [Langfuse v3 to v4 upgrade
@@ -2041,7 +2041,7 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. Use `GET /api/public/v2/metrics?query=<urlencoded
+        on November 16, 2026. Use `GET /api/public/v2/metrics?query=<urlencoded
         json query>` instead. See the [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
@@ -2149,7 +2149,7 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. Use `GET
+        on November 16, 2026. Use `GET
         /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`
         instead. See the [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
@@ -2206,7 +2206,7 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. Use `GET
+        on November 16, 2026. Use `GET
         /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`
         instead. See the [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
@@ -5833,9 +5833,9 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint is not
-        available on Langfuse v4 and later and will be removed in a future
-        release. Use `GET /api/public/v3/scores` instead. See the [Langfuse v3
-        to v4 upgrade
+        available on Langfuse v4 and later and will be removed on November 16,
+        2026. Use `GET /api/public/v3/scores` instead. See the [Langfuse v3 to
+        v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -6063,9 +6063,9 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint is not
-        available on Langfuse v4 and later and will be removed in a future
-        release. Use `GET /api/public/v3/scores` with the `id` filter instead.
-        See the [Langfuse v3 to v4 upgrade
+        available on Langfuse v4 and later and will be removed on November 16,
+        2026. Use `GET /api/public/v3/scores` with the `id` filter instead. See
+        the [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -6118,7 +6118,7 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. In Langfuse v4, read session data via `GET
+        on November 16, 2026. In Langfuse v4, read session data via `GET
         /api/public/v2/observations?filter=<urlencoded sessionId
         filter>&fromStartTime=<from>&toStartTime=<to>`. See the [Langfuse v3 to
         v4 upgrade
@@ -6226,7 +6226,7 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. In Langfuse v4, read session data via `GET
+        on November 16, 2026. In Langfuse v4, read session data via `GET
         /api/public/v2/observations?filter=<urlencoded sessionId
         filter>&fromStartTime=<from>&toStartTime=<to>`. See the [Langfuse v3 to
         v4 upgrade
@@ -6293,7 +6293,7 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. In Langfuse v4, read span and trace data via `GET
+        on November 16, 2026. In Langfuse v4, read span and trace data via `GET
         /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`. See
         the [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
@@ -6406,7 +6406,7 @@ paths:
     get:
       description: >-
         **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        in a future release. In Langfuse v4, read span and trace data via `GET
+        on November 16, 2026. In Langfuse v4, read span and trace data via `GET
         /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`. See
         the [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).

--- a/web/src/__tests__/server/deprecation-signal.servertest.ts
+++ b/web/src/__tests__/server/deprecation-signal.servertest.ts
@@ -19,6 +19,7 @@ import {
   SCORES_DEPRECATION,
   SESSIONS_DEPRECATION,
   TRACES_DEPRECATION,
+  V3_SUNSET_DATE,
 } from "@/src/features/public-api/server/deprecations";
 import { OBSERVATIONS_API_V2_DOCS_URL } from "@/src/features/public-api/server/rateLimitUpgradePaths";
 import { env } from "@/src/env.mjs";
@@ -61,7 +62,7 @@ maybeDescribe("public API deprecation signal", () => {
     );
   });
 
-  it("carries the docs URL", async () => {
+  it("carries the docs URL and the committed sunset date", async () => {
     const response = await makeZodVerifiedAPICall(
       GetObservationsV1Response,
       "GET",
@@ -74,6 +75,8 @@ maybeDescribe("public API deprecation signal", () => {
     expect(response.body._deprecation?.docsUrl).toBe(
       OBSERVATIONS_API_V2_DOCS_URL,
     );
+    // sunsetAt is committed → present.
+    expect(response.body._deprecation?.sunsetAt).toBe(V3_SUNSET_DATE);
   });
 
   // Single-item response: `_deprecation` is added via `.extend()` at the

--- a/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
+++ b/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
@@ -11,6 +11,10 @@ import {
   deprecationNotice,
   stampDeprecations,
 } from "../../../../scripts/openapi/stamp-deprecations";
+import {
+  V3_SUNSET_DATE,
+  V3_SUNSET_HUMAN,
+} from "@/src/features/public-api/server/deprecations";
 
 type OpenApiOperation = {
   deprecated?: boolean;
@@ -116,6 +120,27 @@ describe("OpenAPI deprecations", () => {
         `${method.toUpperCase()} ${endpointPath}`,
       ).toContain(deprecationNotice(message));
     }
+  });
+
+  it("states the runtime sunset date in every Fern deprecation message", () => {
+    for (const { method, endpointPath, message } of getFernDeprecatedOperations(
+      definitionDirectory,
+    )) {
+      expect(message, `${method.toUpperCase()} ${endpointPath}`).toContain(
+        `will be removed on ${V3_SUNSET_HUMAN}.`,
+      );
+    }
+  });
+
+  it("keeps the human-readable sunset date in sync with the machine-readable one", () => {
+    expect(
+      new Date(`${V3_SUNSET_DATE}T00:00:00Z`).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        timeZone: "UTC",
+      }),
+    ).toBe(V3_SUNSET_HUMAN);
   });
 
   it("supports deprecated endpoints at a service base path", () => {

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -5,9 +5,14 @@ import { OBSERVATIONS_API_V2_DOCS_URL } from "./rateLimitUpgradePaths";
 // endpoints. Attach one via the `deprecation` route-config field; the response
 // gets a top-level `_deprecation` key.
 
+// Sunset date for the legacy v3 public API — single source of truth. Set to the
+// end of October 2026; update both constants together if the date moves.
+export const V3_SUNSET_DATE = "2026-10-31";
+const V3_SUNSET_HUMAN = "October 31, 2026";
+
 // Shared deprecation reason — references the deprecated Langfuse v3 system
 // version (not an API version). Customer-facing wording lives here — edit once.
-const V3_NOTICE = `Langfuse v3 is deprecated; this endpoint will be removed in a future release.`;
+const V3_NOTICE = `Langfuse v3 is deprecated; this endpoint will be removed on ${V3_SUNSET_HUMAN}.`;
 
 // v4 replacement endpoints, referenced by both the message and `replacement`.
 // Placeholder style matches rateLimitUpgradePaths (<from>, <to>, filters).
@@ -39,6 +44,7 @@ export const OBSERVATIONS_V1_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Use ${REPLACEMENT.observationsV2} instead.`,
   replacement: REPLACEMENT.observationsV2,
   docsUrl: DOCS.observationsV2,
+  sunsetAt: V3_SUNSET_DATE,
 };
 
 // Traces have no drop-in successor; observations v2 is the closest v4 read surface.
@@ -46,6 +52,7 @@ export const TRACES_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} In Langfuse v4, read span and trace data via ${REPLACEMENT.observationsV2}.`,
   replacement: REPLACEMENT.observationsV2,
   docsUrl: DOCS.observationsV2,
+  sunsetAt: V3_SUNSET_DATE,
 };
 
 // Sessions have no drop-in successor; filter observations v2 by session instead.
@@ -53,18 +60,21 @@ export const SESSIONS_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} In Langfuse v4, read session data via ${REPLACEMENT.observationsV2BySession}.`,
   replacement: REPLACEMENT.observationsV2BySession,
   docsUrl: DOCS.observationsV2,
+  sunsetAt: V3_SUNSET_DATE,
 };
 
 export const SCORES_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Use ${REPLACEMENT.scoresV3} instead.`,
   replacement: REPLACEMENT.scoresV3,
   docsUrl: DOCS.scoresV3,
+  sunsetAt: V3_SUNSET_DATE,
 };
 
 export const METRICS_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} Use ${REPLACEMENT.metricsV2} instead.`,
   replacement: REPLACEMENT.metricsV2,
   docsUrl: DOCS.metricsV2,
+  sunsetAt: V3_SUNSET_DATE,
 };
 
 // Legacy dataset-run-items reads → experiment items (dataset runs are replaced
@@ -73,6 +83,7 @@ export const DATASET_RUN_ITEMS_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} In Langfuse v4, dataset run items are replaced by experiment items; use ${REPLACEMENT.experimentItems} instead.`,
   replacement: REPLACEMENT.experimentItems,
   docsUrl: DOCS.compatibility,
+  sunsetAt: V3_SUNSET_DATE,
 };
 
 // Legacy dataset-run reads → experiments (dataset runs are replaced by
@@ -81,6 +92,7 @@ export const DATASET_RUNS_DEPRECATION: ApiDeprecationInfo = {
   message: `${V3_NOTICE} In Langfuse v4, dataset runs are replaced by experiments; use ${REPLACEMENT.experiments} instead.`,
   replacement: REPLACEMENT.experiments,
   docsUrl: DOCS.compatibility,
+  sunsetAt: V3_SUNSET_DATE,
 };
 
 // Stamp a deprecation signal onto a JSON response body as the top-level

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -5,10 +5,11 @@ import { OBSERVATIONS_API_V2_DOCS_URL } from "./rateLimitUpgradePaths";
 // endpoints. Attach one via the `deprecation` route-config field; the response
 // gets a top-level `_deprecation` key.
 
-// Sunset date for the legacy v3 public API — single source of truth. Set to
-// mid-November 2026; update both constants together if the date moves.
+// Sunset date for the legacy v3 public API — single source of truth. If the
+// date moves, update both constants and every Fern availability message;
+// openapi-deprecations.servertest.ts fails on any drift between the three.
 export const V3_SUNSET_DATE = "2026-11-16";
-const V3_SUNSET_HUMAN = "November 16, 2026";
+export const V3_SUNSET_HUMAN = "November 16, 2026";
 
 // Shared deprecation reason — references the deprecated Langfuse v3 system
 // version (not an API version). Customer-facing wording lives here — edit once.

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -5,10 +5,10 @@ import { OBSERVATIONS_API_V2_DOCS_URL } from "./rateLimitUpgradePaths";
 // endpoints. Attach one via the `deprecation` route-config field; the response
 // gets a top-level `_deprecation` key.
 
-// Sunset date for the legacy v3 public API — single source of truth. Set to the
-// end of October 2026; update both constants together if the date moves.
-export const V3_SUNSET_DATE = "2026-10-31";
-const V3_SUNSET_HUMAN = "October 31, 2026";
+// Sunset date for the legacy v3 public API — single source of truth. Set to
+// mid-November 2026; update both constants together if the date moves.
+export const V3_SUNSET_DATE = "2026-11-16";
+const V3_SUNSET_HUMAN = "November 16, 2026";
 
 // Shared deprecation reason — references the deprecated Langfuse v3 system
 // version (not an API version). Customer-facing wording lives here — edit once.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15270.preview.langfuse.com](https://pr-15270.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Publishes the concrete sunset date for the legacy Langfuse v3 public API endpoints. The agent-friendly deprecation responses themselves already shipped in #15168; this follow-up re-adds the concrete date that was deliberately deferred there.

- Restores the single-source `V3_SUNSET_DATE` (`2026-11-16`) and `V3_SUNSET_HUMAN` (`November 16, 2026`) constants in `deprecations.ts`.
- `V3_NOTICE` and every runtime `_deprecation.sunsetAt` now state the concrete date instead of "a future release".
- Updates the Fern `availability` messages on the legacy endpoints to name the same date.
- Server test asserts the machine-readable `sunsetAt` on a legacy response.

## Remaining concern: only the sunset date

The deprecation mechanism itself — the `_deprecation` response shape, the runtime signals, and the Fern markers — already merged in #15168 and is not in question here. The **only** open item in this PR is the sunset date:

- **Value** — is `2026-11-16` / "November 16, 2026" the date we want to commit to publicly?
- **Single source of truth** — the runtime is single-sourced through `V3_SUNSET_DATE` / `V3_SUNSET_HUMAN`, but the human-readable date is still repeated inline across the Fern `availability` messages. If the date moves and only the runtime constants are updated, the generated docs and SDK notices will keep advertising the old date until the Fern strings are changed too. (This is the source-of-truth point raised in review.)

Everything else is unchanged from the already-reviewed base work.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] My changes generate no new warnings (`pnpm run lint`).
- [x] I added a test that proves the machine-readable `sunsetAt` is present on a legacy response.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Publishes November 16, 2026 as the sunset date for legacy Langfuse v3 public API endpoints.
- Adds shared runtime constants for the machine-readable and human-readable sunset date.
- Includes the date in runtime deprecation messages and `_deprecation.sunsetAt` fields.
- Updates Fern availability notices and adds a server assertion for `sunsetAt`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(api): move the v3 sunset date to No..."](https://github.com/langfuse/langfuse/commit/e017f6a754c182959624bd7ba38a9d2cd4f58a83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45974297)</sub>

<!-- /greptile_comment -->