### PR TITLE
fix(web): Resolve dropdown component issues introduced in a186a9d

### DIFF
--- a/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.stories.tsx
+++ b/web/src/components/ProjectDropdownMenu/ProjectDropdownMenu.stories.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps } from "react";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import preview from "../../../.storybook/preview";
 import {
   DropdownMenu,
@@ -74,5 +75,97 @@ export const WithoutCreation = meta.story({
 export const Loading = meta.story({
   args: {
     state: "loading",
+  },
+});
+
+// TODO: Move these regression tests to a generic dropdown component story once one exists.
+const getAnalyticsActions = async (canvasElement: HTMLElement) => {
+  const body = within(canvasElement.ownerDocument.body);
+  const primaryAction = await body.findByRole("link", { name: "Analytics" });
+  const secondaryAction = body.getByRole("link", {
+    name: "Go to settings for Analytics",
+  });
+  const menuItem = primaryAction.closest('[role="menuitem"]');
+
+  // Every primary action must be owned by a Radix menu item for keyboard navigation.
+  await expect(menuItem).not.toBeNull();
+  if (!(menuItem instanceof HTMLElement)) {
+    throw new Error("Expected Analytics to be rendered inside a menu item");
+  }
+
+  return { menuItem, primaryAction, secondaryAction };
+};
+
+export const TestSecondaryActionLayout = meta.story({
+  name: "(Test) Secondary action layout",
+  args: {
+    state: "loaded",
+    projects,
+  },
+  play: async ({ canvasElement }) => {
+    const { menuItem, secondaryAction } =
+      await getAnalyticsActions(canvasElement);
+
+    // Both actions must share one menu item so its highlight spans the full row.
+    await expect(menuItem).toContainElement(secondaryAction);
+
+    const menuItemRect = menuItem.getBoundingClientRect();
+    const secondaryActionRect = secondaryAction.getBoundingClientRect();
+    const centerDifference = Math.abs(
+      menuItemRect.top +
+        menuItemRect.height / 2 -
+        (secondaryActionRect.top + secondaryActionRect.height / 2),
+    );
+    // The secondary action must remain vertically centered in the row.
+    await expect(centerDifference).toBeLessThanOrEqual(1);
+
+    await userEvent.hover(secondaryAction);
+
+    // Hovering the secondary action must highlight the shared menu item.
+    await waitFor(() => expect(menuItem).toHaveAttribute("data-highlighted"));
+  },
+});
+
+export const TestActionsRemainIndependent = meta.story({
+  name: "(Test) Actions remain independent",
+  args: {
+    state: "loaded",
+    projects,
+  },
+  play: async ({ canvasElement }) => {
+    const { primaryAction, secondaryAction } =
+      await getAnalyticsActions(canvasElement);
+    const onPrimaryClick = fn((event: MouseEvent) => event.preventDefault());
+    const onSecondaryClick = fn((event: MouseEvent) => event.preventDefault());
+    primaryAction.addEventListener("click", onPrimaryClick);
+    secondaryAction.addEventListener("click", onSecondaryClick);
+
+    await userEvent.click(secondaryAction);
+
+    // The secondary action handles the click itself without triggering the primary link.
+    await expect(onSecondaryClick).toHaveBeenCalledOnce();
+    await expect(onPrimaryClick).not.toHaveBeenCalled();
+  },
+});
+
+export const TestKeyboardActivation = meta.story({
+  name: "(Test) Keyboard activation",
+  args: {
+    state: "loaded",
+    projects,
+  },
+  play: async ({ canvasElement }) => {
+    const { menuItem, primaryAction } =
+      await getAnalyticsActions(canvasElement);
+    const onPrimaryClick = fn((event: MouseEvent) => event.preventDefault());
+    primaryAction.addEventListener("click", onPrimaryClick);
+
+    menuItem.focus();
+    await userEvent.keyboard("{Enter}");
+    menuItem.focus();
+    await userEvent.keyboard(" ");
+
+    // Radix forwards both supported activation keys to the primary action exactly once.
+    await expect(onPrimaryClick).toHaveBeenCalledTimes(2);
   },
 });

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -191,9 +191,11 @@ const DropdownMenuContent = React.forwardRef<
     { children, className, header, sideOffset = 4, maxHeight, style, ...props },
     ref,
   ) => {
+    // The early return is intentional: the sticky header sits outside the padded
+    // body so its background and border span the full scroll container. Keep the
+    // header and headerless paths explicit rather than consolidating them through
+    // local variables.
     if (header != null) {
-      // The sticky header sits outside the padded body so its background and
-      // border cover the full width of the scroll container.
       return (
         <DropdownContentWrapper
           ref={ref}
@@ -310,6 +312,9 @@ const DropdownMenuItemWithSecondaryAction = (
   const secondaryAction = props.secondaryAction;
   const PrimaryActionIcon = props.icon;
   const SecondaryActionIcon = secondaryAction?.icon;
+  const primaryActionRef = React.useRef<HTMLAnchorElement | HTMLButtonElement>(
+    null,
+  );
   const primaryContent = (
     <>
       {PrimaryActionIcon && (
@@ -325,6 +330,8 @@ const DropdownMenuItemWithSecondaryAction = (
   );
   let secondaryActionContent: React.ReactNode = null;
 
+  // The secondary action is intentionally pointer-only and cannot be targeted
+  // with the keyboard; the parent remains the row's sole menu item.
   if (secondaryAction && SecondaryActionIcon) {
     if (secondaryAction.href !== undefined) {
       secondaryActionContent = (
@@ -365,41 +372,51 @@ const DropdownMenuItemWithSecondaryAction = (
   }
 
   return (
-    <div className="flex h-8">
+    <DropdownMenuItem
+      className="h-8 p-0"
+      onClick={(event) => {
+        if (event.target !== event.currentTarget) return;
+
+        event.preventDefault();
+        primaryActionRef.current?.click();
+      }}
+    >
       {props.href !== undefined ? (
-        <DropdownMenuItem asChild className="h-8 min-w-0 flex-1 p-0">
-          <Link
-            href={props.href}
-            className={dropdownMenuItemPrimaryActionVariants()}
-            onClick={() => {
+        <Link
+          ref={(element) => {
+            primaryActionRef.current = element;
+          }}
+          href={props.href}
+          className={dropdownMenuItemPrimaryActionVariants()}
+          onClick={() => {
+            props.onBeforeAction?.();
+          }}
+          onAuxClick={(event) => {
+            if (event.button === 1) {
               props.onBeforeAction?.();
-            }}
-            onAuxClick={(event) => {
-              if (event.button === 1) {
-                props.onBeforeAction?.();
-              }
-            }}
-          >
-            {primaryContent}
-          </Link>
-        </DropdownMenuItem>
+            }
+          }}
+        >
+          {primaryContent}
+        </Link>
       ) : (
-        <DropdownMenuItem asChild className="h-8 min-w-0 flex-1 p-0">
-          <button
-            type="button"
-            className={dropdownMenuItemPrimaryActionVariants()}
-            onClick={() => {
-              props.onBeforeAction?.();
-              props.onClick();
-            }}
-          >
-            {primaryContent}
-          </button>
-        </DropdownMenuItem>
+        <button
+          ref={(element) => {
+            primaryActionRef.current = element;
+          }}
+          type="button"
+          className={dropdownMenuItemPrimaryActionVariants()}
+          onClick={() => {
+            props.onBeforeAction?.();
+            props.onClick();
+          }}
+        >
+          {primaryContent}
+        </button>
       )}
 
       {secondaryActionContent}
-    </div>
+    </DropdownMenuItem>
   );
 };
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates dropdown rows with secondary actions and adds interaction tests. The main changes are:

- One Radix menu item now owns both row actions.
- Keyboard activation is forwarded to the primary action.
- Storybook tests cover layout, independent clicks, and primary keyboard activation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The secondary-action keyboard path needs a fix before merging.

- Secondary settings links no longer participate in keyboard focus.
- Enter and Space always activate the primary action.
- The new tests cover only pointer access to the secondary action.

web/src/components/ui/dropdown-menu.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/ui/dropdown-menu.tsx:333-334
**Secondary Action Loses Keyboard Access**

The secondary settings link was previously its own Radix menu item, but it is now intentionally pointer-only while Enter and Space always activate `primaryActionRef`. Keyboard users can no longer focus or open actions such as “Go to settings for Analytics,” so the updated row removes an existing navigation path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Resolve dropdown component iss..."](https://github.com/langfuse/langfuse/commit/23c13e9d9694deaed3b6eb471686b2d4cfca5e6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46018919)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->