### PR TITLE
refactor(observability): move beforeSend checks into named predicates (LFE-10974)

### DIFF
--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -59,9 +59,9 @@ properly (below).
   only `Sentry.init` in the codebase — `beforeSend`,
   `captureConsoleIntegration`, `denyUrls`, replay masking). Add every new filter
   as a named predicate there, never as an ad-hoc inline check. `beforeSend`
-  still carries a couple of legacy inline checks (invalid-href, React-devtools)
-  that predate this convention and read only the exception value — migrate those
-  into named, all-field predicates; do not add more inline checks.
+  now holds NO inline checks — every filter routes through a named predicate
+  (`isNoisyHttpClientPollEvent`, `isDenylistedNoiseEvent`,
+  `isReactDevtoolsInternalEvent`). Keep it that way.
 - **Classify tRPC errors at the seam,** not per call site: `handleTrpcError`
   ([`web/src/utils/api.ts`](../../../web/src/utils/api.ts)) is the single
   chokepoint every query/mutation error flows through — the place to drop
@@ -108,9 +108,8 @@ properly (below).
    (a second `https://` → repeated `//`) passes validation and `<Link>`'s router
    still rejects it. PR #15245 renders these as a native `<a>` (which never runs
    the router's href validation), removing the family at the source — no new
-   filter needed. (The older inline `beforeSend` invalid-href check is redundant
-   and never fired anyway — it read the wrong field, Rule 6 — so it can be
-   retired.)
+   filter needed. (The older inline `beforeSend` invalid-href check — which
+   never fired anyway, wrong field, Rule 6 — was removed in #15276.)
 
 6. **Every `beforeSend` / denylist rule: narrow signature + written rationale +
    a NEGATIVE fixture proving a real error still passes.** This is the MANDATORY

--- a/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
+++ b/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
@@ -24,11 +24,11 @@ the detail behind its rules.
   reaches Sentry; it does not. (Treat "Sentry = frontend-only" until a decision
   says otherwise.)
 - **Filter predicates** live in [`web/src/utils/sentryFilters.ts`](../../../../web/src/utils/sentryFilters.ts)
-  with unit tests in `sentryFilters.clienttest.ts`; `beforeSend` calls them.
-  `beforeSend` also still carries two legacy inline checks (invalid-href,
-  React-devtools) that predate this convention and read only
-  `event.exception.values[0].value` — a known gap to migrate into named,
-  all-field predicates. Add new filters only as predicates here, never inline.
+  with unit tests in `sentryFilters.clienttest.ts`; `beforeSend` only calls
+  these named predicates and holds no inline checks (the former invalid-href
+  and React-devtools inline checks were removed / migrated to
+  `isReactDevtoolsInternalEvent` in #15276). Add new filters only as predicates
+  here, never inline.
 - **The tRPC seam** is `handleTrpcError` in [`web/src/utils/api.ts`](../../../../web/src/utils/api.ts):
   every query/mutation error flows through it — the single place to classify.
   PR #15243 drops expected `data.code`s (`NOT_FOUND` / `FORBIDDEN` /

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 import {
   isDenylistedNoiseEvent,
   isNoisyHttpClientPollEvent,
+  isReactDevtoolsInternalEvent,
 } from "@/src/utils/sentryFilters";
 
 const isEuOrUsRegionNonHipaa =
@@ -15,21 +16,10 @@ Sentry.init({
   release: process.env.NEXT_PUBLIC_BUILD_ID,
 
   beforeSend(event) {
-    // const error = hint.originalException;
-    const errorValue = event.exception?.values?.[0]?.value || "";
-
-    // Filter invalid href errors - these are from user-inputted data containing malformed URLs
-    // The Next.js router correctly rejects them, no need to log as errors
-    if (
-      errorValue.includes("Invalid href") &&
-      errorValue.includes("passed to next/router")
-    ) {
-      return null;
-    }
-
-    // Filter React DevTools internal errors - these are benign errors from DevTools
-    // trying to access internal React properties
-    if (errorValue.includes("__reactContextDevtoolDebugId")) {
+    // Drop React DevTools' internal probes against React's private fiber
+    // properties - benign, DevTools-only noise. See isReactDevtoolsInternalEvent
+    // for the rationale.
+    if (isReactDevtoolsInternalEvent(event)) {
       return null;
     }
 

--- a/web/src/utils/sentryFilters.clienttest.ts
+++ b/web/src/utils/sentryFilters.clienttest.ts
@@ -3,6 +3,7 @@ import { type ErrorEvent } from "@sentry/nextjs";
 import {
   isDenylistedNoiseEvent,
   isNoisyHttpClientPollEvent,
+  isReactDevtoolsInternalEvent,
 } from "@/src/utils/sentryFilters";
 
 /**
@@ -531,6 +532,62 @@ describe("isDenylistedNoiseEvent", () => {
 
     it("keeps an event with an empty exception value", () => {
       expect(isDenylistedNoiseEvent(exceptionEvent(""))).toBe(false);
+    });
+  });
+});
+
+describe("isReactDevtoolsInternalEvent", () => {
+  describe("drops React DevTools internal probes", () => {
+    it("drops a message-event probe", () => {
+      expect(
+        isReactDevtoolsInternalEvent(
+          messageEvent(
+            "Cannot read properties of undefined (reading '__reactContextDevtoolDebugId')",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops an exception-value variant", () => {
+      expect(
+        isReactDevtoolsInternalEvent(
+          exceptionEvent(
+            "Cannot read properties of undefined (reading '__reactContextDevtoolDebugId')",
+            "TypeError",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops it when the text lives on event.logentry.message", () => {
+      expect(
+        isReactDevtoolsInternalEvent(
+          logentryEvent(
+            "Cannot read properties of null (reading '__reactContextDevtoolDebugId')",
+          ),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  // The safety contract: a suppression predicate must not swallow real errors.
+  describe("KEEPS real errors (never masks a genuine app error)", () => {
+    it("keeps a real thrown TypeError unrelated to DevTools", () => {
+      expect(
+        isReactDevtoolsInternalEvent(
+          exceptionEvent("TypeError: cannot read x", "TypeError"),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps an unrelated message event", () => {
+      expect(
+        isReactDevtoolsInternalEvent(messageEvent("some unrelated message")),
+      ).toBe(false);
+    });
+
+    it("keeps an event with no exception/message/logentry text", () => {
+      expect(isReactDevtoolsInternalEvent({} as ErrorEvent)).toBe(false);
     });
   });
 });

--- a/web/src/utils/sentryFilters.clienttest.ts
+++ b/web/src/utils/sentryFilters.clienttest.ts
@@ -568,6 +568,19 @@ describe("isReactDevtoolsInternalEvent", () => {
         ),
       ).toBe(true);
     });
+
+    it("drops a mixed event: EMPTY exception value but text on message", () => {
+      // An empty-string exception value is not nullish, so a naive `??` chain
+      // would keep it and never look at `message`. `eventText` treats it as
+      // absent, so this still matches.
+      expect(
+        isReactDevtoolsInternalEvent({
+          exception: { values: [{ value: "" }] },
+          message:
+            "Cannot read properties of undefined (reading '__reactContextDevtoolDebugId')",
+        } as unknown as Parameters<typeof isReactDevtoolsInternalEvent>[0]),
+      ).toBe(true);
+    });
   });
 
   // The safety contract: a suppression predicate must not swallow real errors.

--- a/web/src/utils/sentryFilters.ts
+++ b/web/src/utils/sentryFilters.ts
@@ -154,16 +154,27 @@ function coreMessage(value: string): string {
  * the `logentry` fallback) because these can arrive as either an exception or
  * a message event depending on how DevTools triggers the failure.
  */
-export function isReactDevtoolsInternalEvent(event: ErrorEvent): boolean {
-  const messageText =
-    event.exception?.values?.[0]?.value ??
-    event.message ??
-    event.logentry?.message;
-
+/**
+ * The event's first NON-EMPTY text field — the exception value, else the
+ * message-event text, else the `logentry` fallback. An empty-string exception
+ * value is treated as absent (not nullish, so `??` alone would keep it), so a
+ * "mixed" event — empty exception value but real text on `message` — still
+ * matches on the message rather than being silently skipped.
+ */
+function eventText(event: ErrorEvent): string {
+  const exceptionValue = event.exception?.values?.[0]?.value;
   return (
-    typeof messageText === "string" &&
-    messageText.includes("__reactContextDevtoolDebugId")
+    (typeof exceptionValue === "string" && exceptionValue.length > 0
+      ? exceptionValue
+      : undefined) ??
+    event.message ??
+    event.logentry?.message ??
+    ""
   );
+}
+
+export function isReactDevtoolsInternalEvent(event: ErrorEvent): boolean {
+  return eventText(event).includes("__reactContextDevtoolDebugId");
 }
 
 /**
@@ -202,17 +213,13 @@ export function isDenylistedNoiseEvent(event: ErrorEvent): boolean {
   const exception = event.exception?.values?.[0];
   const exceptionType = exception?.type;
   const exceptionValue = exception?.value;
-  const hasExceptionValue =
-    typeof exceptionValue === "string" && exceptionValue.length > 0;
 
-  // The message-signature rules run against the exception value when present,
-  // otherwise the message-event text (console-origin noise has no exception).
-  const messageText =
-    (hasExceptionValue ? exceptionValue : undefined) ??
-    event.message ??
-    event.logentry?.message;
+  // Message-signature rules run against the first non-empty text field
+  // (exception value → message → logentry); `eventText` treats an empty
+  // exception value as absent so mixed events still match on the message.
+  const messageText = eventText(event);
 
-  if (typeof messageText === "string" && messageText.length > 0) {
+  if (messageText.length > 0) {
     const core = coreMessage(messageText);
 
     // --- A. Transport / connectivity (whole-message match after unwrapping) ---

--- a/web/src/utils/sentryFilters.ts
+++ b/web/src/utils/sentryFilters.ts
@@ -144,6 +144,29 @@ function coreMessage(value: string): string {
 }
 
 /**
+ * True for React DevTools' internal probes against React's private fiber
+ * properties (`__reactContextDevtoolDebugId` and similar). These are benign:
+ * DevTools reads properties React does not guarantee exist, and the resulting
+ * failure is DevTools' own instrumentation, not a Langfuse app bug — it fires
+ * only when the extension is attached and installs its own probes.
+ *
+ * Matched against ALL text fields (exception value, message-event text, and
+ * the `logentry` fallback) because these can arrive as either an exception or
+ * a message event depending on how DevTools triggers the failure.
+ */
+export function isReactDevtoolsInternalEvent(event: ErrorEvent): boolean {
+  const messageText =
+    event.exception?.values?.[0]?.value ??
+    event.message ??
+    event.logentry?.message;
+
+  return (
+    typeof messageText === "string" &&
+    messageText.includes("__reactContextDevtoolDebugId")
+  );
+}
+
+/**
  * True for known-benign CLIENT-side noise that cannot be a real Langfuse app
  * bug: browser-level network/transport failures, transient framework/vendor
  * poll logs, and expected browser-permission / cancellation artifacts. Returning


### PR DESCRIPTION
## TL;DR
Cleans up the last two hardcoded inline checks in Sentry's `beforeSend` (LFE-10974): deletes a dead "Invalid href" branch, and moves the React-DevTools noise check into a named, tested predicate — no behavior change for real errors.

## Why
`web/instrumentation-client.ts`'s `beforeSend` had two inline checks that predate the repo's filter-predicate convention (named, tested functions in `sentryFilters.ts`, see `isNoisyHttpClientPollEvent` / `isDenylistedNoiseEvent`). Both only read `event.exception?.values?.[0]?.value`, but the events they were meant to catch arrive as **message events** (console-captured, text on `event.message`), so neither ever actually fired in production.

## What
1. **Removed the inline "Invalid href … passed to next/router" check.** It's dead code — wrong field, so it never fired — and the underlying source was already root-caused in #15245 (markdown links render as a native `<a>`, so the router's href validation never runs). Deleting it changes nothing at runtime; if `Invalid href` ever recurs from a different source, it will surface (correctly) and should be root-caused there, per the sentry-instrumentation skill.
2. **Moved the React-DevTools check into `isReactDevtoolsInternalEvent`** in `sentryFilters.ts`, matching `__reactContextDevtoolDebugId` against all text fields (exception value, `event.message`, `event.logentry.message`) — mirroring how `isDenylistedNoiseEvent` reads fields. `beforeSend` now calls the predicate instead of inlining the check.

## Skeptic: does this hide a real error?
No.
- The invalid-href removal deletes a branch that never matched anything (wrong field) — nothing that used to be dropped is now sent, because nothing was ever dropped by it. Its source is independently root-caused.
- The React-DevTools predicate preserves the exact prior match signature (`__reactContextDevtoolDebugId`), only reading additional fields so it actually fires on the message-event shape these arrive as. A negative fixture (`isReactDevtoolsInternalEvent` on a real `TypeError` / unrelated message) proves real errors still pass through.

<details>
<summary>Verification</summary>

```
$ pnpm --filter web run typecheck
(clean, no errors)

$ pnpm --filter web run test-client src/utils/sentryFilters.clienttest.ts
 Test Files  1 passed (1)
      Tests  47 passed (47)

$ pnpm --filter @repo/eslint-plugin run build && pnpm --filter web run lint
(clean, no errors/warnings)
```

Pre-commit hook (prettier + turbo lint) also passed on commit: `Tasks: 7 successful, 7 total`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves React DevTools noise filtering into a named Sentry predicate. The main changes are:

- Removes the inline invalid-href filter.
- Adds a reusable React DevTools event predicate.
- Adds client tests for exception, message, and log-entry shapes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks mergeable after a small fix to mixed-field event filtering.

- The import and predicate integration are consistent.
- Events with multiple populated text fields can bypass the intended noise filter.
- The issue affects observability noise rather than application behavior.

web/src/utils/sentryFilters.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/utils/sentryFilters.ts:158-166
**Mixed Event Fields Bypass Filter**

When an event has an empty or unrelated exception value but its `message` or `logentry.message` contains the DevTools marker, the first non-nullish value wins and the marker is never checked. That event reaches Sentry even though this predicate is intended to inspect all text fields.

```suggestion
  const messageTexts = [
    event.exception?.values?.[0]?.value,
    event.message,
    event.logentry?.message,
  ];

  return messageTexts.some(
    (messageText) =>
      typeof messageText === "string" &&
      messageText.includes("__reactContextDevtoolDebugId"),
  );
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(observability): move beforeSend..."](https://github.com/langfuse/langfuse/commit/0e42ddacd0f9811faa2489f04dca93ac61f5497e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46031979)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->