### PR TITLE
feat(web): serve browser source maps in production (LFE-10974)

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -62,6 +62,14 @@ const reportToHeader = {
 
 /** @type {import("next").NextConfig} */
 const nextConfig = {
+  // Emit and SERVE browser source maps in production. Langfuse is open source,
+  // so there is nothing to hide by shipping maps — and doing so makes every
+  // client stack legible: browser devtools de-minify automatically, and Sentry
+  // symbolicates by fetching the public map from each bundle's sourceMappingURL
+  // (no upload step, no auth token, no Sentry-specific magic). This is why the
+  // Sentry plugin's own source-map upload stays disabled (see `sourcemaps` in
+  // withSentryConfig below).
+  productionBrowserSourceMaps: true,
   // Allow building to alternate directory for parallel build checks while dev server runs
   distDir: process.env.NEXT_DIST_DIR || ".next",
   typescript: {
@@ -278,7 +286,10 @@ const sentryConfig = withSentryConfig(nextConfig, {
   // side errors will fail.
   // tunnelRoute: "/api/monitoring-tunnel",
 
-  // Hides source maps from generated client bundles
+  // Keep the Sentry plugin's own source-map generation/upload OFF. We serve
+  // browser source maps publicly instead (`productionBrowserSourceMaps: true`
+  // above); Sentry fetches them from the public sourceMappingURL, so uploading
+  // a second copy (with an auth token + build-time upload) is redundant here.
   sourcemaps: {
     disable: true,
   },


### PR DESCRIPTION
## TL;DR

Enable `productionBrowserSourceMaps` so prod client bundles ship **served** `.map` files. Every client stack becomes legible again — browser devtools de-minify automatically, and Sentry symbolicates by fetching the public map from each bundle's `sourceMappingURL`. No upload step, no auth token, no Sentry-specific magic.

## Why

Prod bundles are minified, so Sentry issues are born with unreadable stacks (`h.find`, `e` culprits) — several past issues stalled purely because nobody could read them. Langfuse is **open source**, so there's nothing to hide by serving source maps; the "delete-after-upload to Sentry" dance only makes sense for closed source. Serving them is the honest default and also gives self-hosters + anyone in devtools legible stacks for free.

## What

- `productionBrowserSourceMaps: true` in `next.config.mjs` — Next emits and serves browser source maps.
- The Sentry plugin's own `sourcemaps.disable: true` **stays** — we don't upload a second copy; Sentry fetches the public one. (The now-inert upload apparatus — `authToken`, `widenClientFileUpload` — can be pruned in a follow-up.)

## Result

All future Sentry issues have de-minified stacks; a force-multiplier for the whole noise-cleanup effort.

<details>
<summary>Verification / caveats</summary>

- **Build-time delta** — source-map generation adds to the client compile; the real number will show in this PR's **"Build and push web"** CI check vs main. If it turns out prohibitive, the fallback is upload-with-delete, but for an OSS app serving is preferred.
- **Sentry symbolication** — confirm on a post-merge test event that stacks de-minify (Sentry resolves public artifacts from the `sourceMappingURL`); if the project needs "Enable JavaScript source fetching", that's a one-time project setting.
- **Artifact size** — the deploy serves `.map` files (larger static output); harmless disk/bandwidth.

Part of the Sentry-noise workstream (LFE-10974).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables public production browser source maps for the web app. The main changes are:

- Enables `productionBrowserSourceMaps` in the Next.js configuration.
- Keeps Sentry-managed source-map generation and upload disabled.
- Documents that Sentry should fetch maps from public bundle URLs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The production image copies the complete Next.js static output, including generated source maps.
- Sentry upload being disabled does not prevent Next.js from generating or serving those maps.
- No blocking issues were found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): serve browser source maps in ..."](https://github.com/langfuse/langfuse/commit/1a50f001edb0115bbbfe79057b972d326e98acec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46035206)</sub>

<!-- /greptile_comment -->