### PR TITLE
feat(observability): add reportError capture seam (LFE-10974)

### DIFF
--- a/web/src/utils/captureUnknownError.ts
+++ b/web/src/utils/captureUnknownError.ts
@@ -1,72 +1,28 @@
-import { captureException } from "@sentry/nextjs";
-
-/**
- * Turn an unknown thrown/logged value into a legible string.
- *
- * `String(value)` and template interpolation collapse most objects to the
- * useless `[object Object]` / `[object ErrorEvent]`. We try `JSON.stringify`
- * first, and when that yields nothing useful — `"{}"` for objects whose fields
- * live on the prototype (DOM `Event`s, `DOMException`), or a throw on circular
- * references — we fall back to a descriptor built from the value's constructor
- * name and own enumerable keys.
- */
-function safeStringify(value: unknown): string {
-  try {
-    const json = JSON.stringify(value);
-    if (json !== undefined && json !== "{}") {
-      return json;
-    }
-  } catch {
-    // circular reference or a throwing getter — fall through to describe()
-  }
-  return describeUnknown(value);
-}
-
-function describeUnknown(value: unknown): string {
-  if (value === null) return "null";
-  if (typeof value !== "object") return String(value);
-  const ctorName =
-    (value as { constructor?: { name?: string } }).constructor?.name ??
-    "Object";
-  const keys = Object.keys(value as Record<string, unknown>);
-  return keys.length > 0 ? `${ctorName} { ${keys.join(", ")} }` : ctorName;
-}
+import { reportError } from "@/src/utils/reportError";
 
 /**
  * Report an unknown (possibly non-Error) value to Sentry as a legible Error.
  *
- * `instrumentation-client.ts` enables
- * `captureConsoleIntegration({ levels: ["error"] })`, so every
- * `console.error(nonError)` also becomes an opaque Sentry event
- * (`[object Object]` / "Object captured as exception with keys …"). Route
- * caught-unknown values through here instead: real `Error`s pass through
- * untouched (stack preserved); anything else is synthesized into an `Error`
- * with a readable message. We log with `console.warn` (not `console.error`) so
- * the integration does not double-capture the same failure.
+ * Thin wrapper over the {@link reportError} seam kept for its existing call
+ * sites (playground/auth). It maps the legacy `(context, value, extra)` shape
+ * onto `reportError`, which owns the single unknown→`Error` coercion and the
+ * single `captureException` path:
+ * - real `Error`s pass through untouched (stack preserved);
+ * - anything else is synthesized into an `Error` with a readable `[context]`
+ *   message (never `[object Object]` / `[object ErrorEvent]`);
+ * - it tags `area: context` and logs via `console.warn` (not `console.error`,
+ *   which `captureConsoleIntegration` would double-capture).
+ *
+ * `context` is also mirrored into `extra` to preserve the exact payload legacy
+ * callers have always sent. Prefer `reportError` directly in new code.
  */
 export function captureUnknownError(
   context: string,
   value: unknown,
   extra?: Record<string, unknown>,
 ): void {
-  const err =
-    value instanceof Error
-      ? value
-      : new Error(
-          `[${context}] ${
-            typeof value === "string" ? value : safeStringify(value)
-          }`,
-        );
-  captureException(err, {
+  reportError(value, {
+    area: context,
     extra: { context, ...extra },
-    tags: { area: context },
   });
-  // warn, not error → captureConsoleIntegration only captures console.error,
-  // so this line does not create a second, opaque Sentry event. The
-  // synthesized (non-Error) message already carries the `[context]` prefix; a
-  // pass-through Error does not, so add it here only in that branch to keep the
-  // context present exactly once in both cases.
-  console.warn(
-    value instanceof Error ? `[${context}] ${err.message}` : err.message,
-  );
 }

--- a/web/src/utils/reportError.clienttest.ts
+++ b/web/src/utils/reportError.clienttest.ts
@@ -1,0 +1,110 @@
+import { reportError } from "@/src/utils/reportError";
+
+const { captureExceptionMock, addBreadcrumbMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+  addBreadcrumbMock: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: captureExceptionMock,
+  addBreadcrumb: addBreadcrumbMock,
+}));
+
+describe("reportError", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    captureExceptionMock.mockClear();
+    addBreadcrumbMock.mockClear();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  describe("expected: true", () => {
+    it("adds a breadcrumb and does NOT capture", () => {
+      reportError(new Error("member of another project"), {
+        area: "trpc.query",
+        expected: true,
+        extra: { code: "FORBIDDEN" },
+      });
+
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+      expect(addBreadcrumbMock).toHaveBeenCalledTimes(1);
+      const crumb = addBreadcrumbMock.mock.calls[0]![0];
+      expect(crumb.category).toBe("trpc.query");
+      expect(crumb.type).toBe("error");
+      expect(crumb.level).toBe("info");
+      expect(crumb.data).toEqual({ code: "FORBIDDEN" });
+    });
+
+    it("does not warn or error for an expected state", () => {
+      reportError("some expected state", {
+        area: "auth.session",
+        expected: true,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("unexpected (captured)", () => {
+    it("passes a real Error through untouched (same instance → stack preserved) with area tag", () => {
+      const original = new Error("boom");
+      reportError(original, { area: "io.parse", extra: { traceId: "abc" } });
+
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+      const [err, options] = captureExceptionMock.mock.calls[0]!;
+      expect(err).toBe(original); // same instance → original stack preserved
+      expect(options.tags.area).toBe("io.parse");
+      expect(options.extra).toEqual({ traceId: "abc" });
+      expect(addBreadcrumbMock).not.toHaveBeenCalled();
+    });
+
+    it("synthesizes a legible Error for a plain object (not [object Object])", () => {
+      reportError({ code: 42, reason: "bad" }, { area: "io.parse" });
+
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+      const [err] = captureExceptionMock.mock.calls[0]!;
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).not.toContain("[object Object]");
+      expect(err.message).toContain("code");
+      expect(err.message).toContain("42");
+      expect(err.message).toContain("io.parse");
+    });
+
+    it("synthesizes a legible Error for a string", () => {
+      reportError("something failed", { area: "io.parse" });
+
+      const [err] = captureExceptionMock.mock.calls[0]!;
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe("[io.parse] something failed");
+    });
+
+    it("logs via console.warn, never console.error (avoids captureConsole double-capture)", () => {
+      reportError(new Error("boom"), { area: "io.parse" });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("captures exactly once per call", () => {
+      reportError(new Error("once"), { area: "io.parse" });
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes undefined extra through when omitted", () => {
+      reportError(new Error("boom"), { area: "io.parse" });
+
+      const [, options] = captureExceptionMock.mock.calls[0]!;
+      expect(options.tags.area).toBe("io.parse");
+      expect(options.extra).toBeUndefined();
+    });
+  });
+});

--- a/web/src/utils/reportError.ts
+++ b/web/src/utils/reportError.ts
@@ -1,0 +1,108 @@
+import { addBreadcrumb, captureException } from "@sentry/nextjs";
+
+/**
+ * Turn an unknown thrown/logged value into a legible string.
+ *
+ * `String(value)` and template interpolation collapse most objects to the
+ * useless `[object Object]` / `[object ErrorEvent]`. We try `JSON.stringify`
+ * first, and when that yields nothing useful — `"{}"` for objects whose fields
+ * live on the prototype (DOM `Event`s, `DOMException`), or a throw on circular
+ * references — we fall back to a descriptor built from the value's constructor
+ * name and own enumerable keys.
+ */
+function safeStringify(value: unknown): string {
+  try {
+    const json = JSON.stringify(value);
+    if (json !== undefined && json !== "{}") {
+      return json;
+    }
+  } catch {
+    // circular reference or a throwing getter — fall through to describe()
+  }
+  return describeUnknown(value);
+}
+
+function describeUnknown(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value !== "object") return String(value);
+  const ctorName =
+    (value as { constructor?: { name?: string } }).constructor?.name ??
+    "Object";
+  const keys = Object.keys(value as Record<string, unknown>);
+  return keys.length > 0 ? `${ctorName} { ${keys.join(", ")} }` : ctorName;
+}
+
+/**
+ * Coerce any caught/unknown value into a legible real `Error`.
+ *
+ * This is the single unknown→`Error` coercion in the client codebase; both the
+ * generic {@link reportError} seam and the legacy `captureUnknownError` helper
+ * route through it. Real `Error`s pass through untouched so Sentry keeps the
+ * original stack; anything else is synthesized into an `Error` whose message is
+ * `[area] <readable value>` (never `[object Object]`), so the synthesized event
+ * both groups by `area` and stays diagnosable.
+ */
+export function coerceToError(area: string, value: unknown): Error {
+  return value instanceof Error
+    ? value
+    : new Error(
+        `[${area}] ${typeof value === "string" ? value : safeStringify(value)}`,
+      );
+}
+
+/**
+ * The single capture seam every future client error-report routes through.
+ *
+ * Why a seam: classification and tagging live in one place, so Sentry's
+ * `beforeSend` in `instrumentation-client.ts` can be a backstop rather than the
+ * strategy. Report through here instead of calling `captureException` directly.
+ *
+ * Behavior:
+ * - `expected: true` — the failure is the product working as designed (a state
+ *   the UI already renders: a missing/forbidden resource, invalid user input, an
+ *   offline/transport blip the server already owns). We do NOT capture — an event
+ *   in Sentry is a promise a human should act, and nobody acts on an expected
+ *   state. We drop a breadcrumb so the (unexpected) error that DOES get captured
+ *   later in the session still carries the trail of what happened before it.
+ * - otherwise — coerce to a real `Error` (see {@link coerceToError}),
+ *   `captureException` with an `area` tag (so issues route/group by surface) and
+ *   the caller's structured `extra`, then log a companion `console.warn`.
+ *
+ * `console.warn`, never `console.error`: `instrumentation-client.ts` enables
+ * `captureConsoleIntegration({ levels: ["error"] })`, so a `console.error` here
+ * would mint a second, opaque Sentry event for the same failure.
+ *
+ * PII: keep the message static and legible and never route user content
+ * (prompt/trace text, tokens, ids, share-link secrets) through it — a message
+ * that interpolates user data both leaks and shatters Sentry grouping. Keeping
+ * `extra` free of PII is the caller's responsibility; this seam does not scrub it.
+ */
+export function reportError(
+  error: unknown,
+  opts: { area: string; expected?: boolean; extra?: Record<string, unknown> },
+): void {
+  if (opts.expected === true) {
+    addBreadcrumb({
+      category: opts.area,
+      type: "error",
+      level: "info",
+      message: "Expected error (not captured)",
+      data: { ...opts.extra },
+    });
+    return;
+  }
+
+  const err = coerceToError(opts.area, error);
+  captureException(err, {
+    tags: { area: opts.area },
+    extra: opts.extra,
+  });
+  // warn, not error → captureConsoleIntegration only captures console.error, so
+  // this line does not create a second, opaque event. Show the `area` exactly
+  // once: a synthesized error already embeds `[area]` in its message
+  // (coerceToError), a pass-through real Error does not — so prefix only that
+  // branch to keep the surface legible in the console without duplicating it.
+  console.warn(
+    error instanceof Error ? `[${opts.area}] ${err.message}` : err.message,
+  );
+}


### PR DESCRIPTION
## TL;DR

Adds `web/src/utils/reportError.ts` — the **single client capture seam** every future error-report routes through. Classification and `area` tagging now live in one place, so Sentry's `beforeSend` can be a backstop rather than the strategy. `captureUnknownError` now delegates to it (one `captureException` path). **Core only** — no call-site migration, no ESLint ban; both are deliberate follow-ups (see below).

## Why

Client Sentry noise came from scattered, ad-hoc captures: raw `captureException(nonError)` collapsing to opaque `[object Object]` fingerprints, `console.error(object)` re-captured by `captureConsoleIntegration`, and expected states (a 404/forbidden the UI already renders) minting issues no human acts on. The sentry-instrumentation skill defines the contract — a Sentry event is a promise a human acts, so it must be a real `Error`, `area`-tagged, PII-free — but there was no one wrapper that enforced it. Every path had to remember the rules.

## What

One seam, `reportError(error, { area, expected?, extra? })`:

- **`expected: true`** → the product working as designed (missing/forbidden resource, invalid user input, an offline blip the server already owns). Drops an `addBreadcrumb` (so the *next* real capture keeps the trail) and **returns without capturing**.
- **otherwise** → coerce to a real `Error`, `captureException(err, { tags: { area }, extra })`, then `console.warn` (never `console.error` — that would be re-captured).

`coerceToError` is now the **single** unknown→`Error` coercion (`safeStringify` / `describeUnknown` moved into `reportError.ts`). `captureUnknownError` is a thin delegate over the seam with its **signature and behavior unchanged** — its existing tests still pass.

## Result

- New: `reportError.ts` (seam + coercion) and `reportError.clienttest.ts`.
- `captureUnknownError` shrinks to a delegate; single `captureException` path.
- Verified: `web typecheck` exit 0; client tests **18 passed** (8 reportError + 10 captureUnknownError); `web lint` / `turbo run lint` **7 successful, 7 total**; prettier clean.

## This is the CORE of the seam (§5.2). Deliberate FOLLOW-UP PRs:

1. **Call-site migration** — move existing raw `captureException` / `console.error` error paths onto `reportError`.
2. **ESLint `no-restricted-imports` ban** on raw `captureException` — **must land LAST**, after migration. CI lints with `--max-warnings 0`, so banning the raw import before the call sites are migrated would fail the build on existing calls.

<details>
<summary>Mechanism &amp; decisions</summary>

- **One coercion implementation.** The task allowed either exporting the coercion from `captureUnknownError.ts` or moving it into `reportError.ts`; the latter was chosen so the dependency is one-way (`captureUnknownError → reportError`) with no import cycle.
- **Console line.** The seam warns `err.message`, but keeps the `area` legible exactly once: a synthesized error already embeds `[area]` in its message via `coerceToError`, a pass-through real `Error` does not, so the prefix is added only in that branch. This preserves `captureUnknownError`'s prior console behavior byte-for-byte while capturing the *original* Error instance (stack preserved).
- **PII.** The message is kept static; user content (prompt/trace text, tokens, ids, share-link secrets) must never flow through it. Keeping `extra` PII-free is documented as the caller's responsibility — the seam does not scrub.
- **Tests:** `expected:true` → breadcrumb added, `captureException` not called; real `Error` → captured once, same instance, `tags.area` set; unknown non-Error (object/string) → synthesized legible message (never `[object Object]`); `console.warn` used, `console.error` not; plus the full existing `captureUnknownError` suite green post-delegation.
- **Untouched on purpose:** `instrumentation-client.ts` (separate PR editing it), `reportParserWorkerError`, `handleTrpcError`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a central client-side error-reporting seam. The main changes are:

- Classifies expected errors as breadcrumbs without capturing them.
- Coerces unexpected values into real `Error` instances and tags them by area.
- Routes the existing `captureUnknownError` helper through the new seam.
- Adds focused client tests for capture, breadcrumb, coercion, and console behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- Existing callers retain their capture payload and console behavior.
- The new expected-error and capture branches have focused tests.

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(observability): add reportError cap..."](https://github.com/langfuse/langfuse/commit/bf38e14f0344bbaf8d6eef1d92c0c06e846d12df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46037712)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->