### PR TITLE
feat(web): banner to prompt reload on a new deploy (LFE-10978)

### DIFF
--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -13,6 +13,7 @@ import { SidebarPresenceProvider } from "@/src/components/nav/sidebar-presence";
 import { Toaster } from "@/src/components/ui/sonner";
 import { Layer } from "@/src/components/ui/layer";
 import { TopBannerProvider } from "@/src/features/top-banner";
+import { VersionUpdateBanner } from "@/src/features/version-update";
 import { AppContentWithRightDrawer } from "../right-drawer/AppContentWithRightDrawer";
 import { ThemeToggle } from "@/src/features/theming/ThemeToggle";
 import {
@@ -173,6 +174,7 @@ export function AuthenticatedLayout({
           <SidebarProvider>
             <div className="flex h-dvh w-full flex-col">
               <PaymentBanner />
+              <VersionUpdateBanner />
               <div className="pt-banner-offset flex min-h-0 flex-1">
                 <AppSidebar
                   navItems={navigation.mainNavigation}

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -232,6 +232,10 @@ export const events = {
     "compare_run_added",
     "compare_run_removed",
   ],
+  // Version-update reload notification (LFE-10978). `banner_shown` fires once
+  // per appearance; the two actions measure the reload-vs-dismiss split. No
+  // props carry user content.
+  version_update: ["banner_shown", "reload_clicked", "dismissed"],
   notification: ["click_link", "dismiss_notification"],
   toast: ["report_issue", "dismiss"],
   tag: [

--- a/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
@@ -1,16 +1,35 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { TopBannerProvider } from "@/src/features/top-banner";
 import { VersionUpdateBanner } from "./VersionUpdateBanner";
 import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
-import { versionUpdateStore } from "./versionUpdateStore";
+
+// Shared mutable mock state (hoisted above the vi.mock factories).
+const h = vi.hoisted(() => ({
+  capture: vi.fn(),
+  dismiss: vi.fn(),
+  visible: true,
+}));
+
+// The connected banner portals into the top-most overlay layer, whose DOM
+// container only exists via _document.tsx; render children inline for the test.
+vi.mock("@/src/components/ui/layer", () => ({
+  Layer: ({ children }: { children?: unknown }) => children,
+}));
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => h.capture,
+}));
+vi.mock("./versionUpdateStore", () => ({
+  versionUpdateStore: { dismiss: h.dismiss },
+}));
+vi.mock("./useVersionUpdateAvailable", () => ({
+  useVersionUpdateAvailable: () => h.visible,
+}));
 
 describe("VersionUpdateBannerView", () => {
   it("renders a reload and a dismiss control", () => {
     render(
       <VersionUpdateBannerView onReload={() => {}} onDismiss={() => {}} />,
     );
-
     expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
   });
@@ -32,41 +51,51 @@ describe("VersionUpdateBannerView", () => {
 
 describe("VersionUpdateBanner (connected)", () => {
   beforeEach(() => {
-    // The running build id the tab loaded; a differing observed id is the
-    // trigger. ResizeObserver is used by the shared top-banner registration and
-    // is not implemented in jsdom.
-    vi.stubEnv("NEXT_PUBLIC_BUILD_ID", "running-build");
-    vi.stubGlobal(
-      "ResizeObserver",
-      class {
-        observe() {}
-        unobserve() {}
-        disconnect() {}
-      },
-    );
+    h.capture.mockClear();
+    h.dismiss.mockClear();
+    h.visible = true;
+    // Reload is invoked on the Reload click; stub it so jsdom doesn't complain.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { reload: vi.fn() },
+    });
   });
 
   afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
-  it("appears when a newer build is observed and hides on dismiss", () => {
-    // A newer build was deployed while the tab stayed open.
-    versionUpdateStore.reportObservedBuildId("deployed-build");
-
-    render(
-      <TopBannerProvider>
-        <VersionUpdateBanner />
-      </TopBannerProvider>,
-    );
-
+  it("reports banner_shown once when it appears", () => {
+    render(<VersionUpdateBanner />);
     expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+    expect(h.capture).toHaveBeenCalledWith("version_update:banner_shown");
+    expect(
+      h.capture.mock.calls.filter(
+        (c) => c[0] === "version_update:banner_shown",
+      ),
+    ).toHaveLength(1);
+  });
 
+  it("captures reload_clicked and reloads on Reload", () => {
+    render(<VersionUpdateBanner />);
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+    expect(h.capture).toHaveBeenCalledWith("version_update:reload_clicked");
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures dismissed and calls the store on Dismiss", () => {
+    render(<VersionUpdateBanner />);
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(h.capture).toHaveBeenCalledWith("version_update:dismissed");
+    expect(h.dismiss).toHaveBeenCalledTimes(1);
+  });
 
+  it("renders nothing when no update is available", () => {
+    h.visible = false;
+    render(<VersionUpdateBanner />);
     expect(
       screen.queryByRole("button", { name: "Reload" }),
     ).not.toBeInTheDocument();
+    expect(h.capture).not.toHaveBeenCalled();
   });
 });

--- a/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VersionUpdateBanner } from "./VersionUpdateBanner";
 import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
@@ -7,7 +7,9 @@ import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
 const h = vi.hoisted(() => ({
   capture: vi.fn(),
   dismiss: vi.fn(),
-  visible: true,
+  markShownReported: vi.fn(() => true),
+  available: true,
+  settled: true,
 }));
 
 // The connected banner portals into the top-most overlay layer, whose DOM
@@ -19,10 +21,16 @@ vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
   usePostHogClientCapture: () => h.capture,
 }));
 vi.mock("./versionUpdateStore", () => ({
-  versionUpdateStore: { dismiss: h.dismiss },
+  versionUpdateStore: {
+    dismiss: h.dismiss,
+    markShownReported: h.markShownReported,
+  },
 }));
 vi.mock("./useVersionUpdateAvailable", () => ({
-  useVersionUpdateAvailable: () => h.visible,
+  useVersionUpdateAvailable: () => h.available,
+}));
+vi.mock("./useAppSettled", () => ({
+  useAppSettled: () => h.settled,
 }));
 
 describe("VersionUpdateBannerView", () => {
@@ -51,12 +59,12 @@ describe("VersionUpdateBannerView", () => {
 
 describe("VersionUpdateBanner (connected)", () => {
   beforeEach(() => {
-    // The banner is gated behind a startup grace period (setTimeout); fake
-    // timers let us fast-forward past it deterministically.
-    vi.useFakeTimers();
     h.capture.mockClear();
     h.dismiss.mockClear();
-    h.visible = true;
+    h.markShownReported.mockClear();
+    h.markShownReported.mockReturnValue(true);
+    h.available = true;
+    h.settled = true;
     // Reload is invoked on the Reload click; stub it so jsdom doesn't complain.
     Object.defineProperty(window, "location", {
       configurable: true,
@@ -65,30 +73,11 @@ describe("VersionUpdateBanner (connected)", () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  // Advance past the app-settle grace period so the banner is allowed to render.
-  const settle = () =>
-    act(() => {
-      vi.advanceTimersByTime(5000);
-    });
-
-  it("stays hidden during the startup grace period, then appears", () => {
+  it("shows and reports banner_shown when an update is available and the app has settled", () => {
     render(<VersionUpdateBanner />);
-    expect(
-      screen.queryByRole("button", { name: "Reload" }),
-    ).not.toBeInTheDocument();
-    expect(h.capture).not.toHaveBeenCalled();
-
-    settle();
-    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
-  });
-
-  it("reports banner_shown once when it appears", () => {
-    render(<VersionUpdateBanner />);
-    settle();
     expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
     expect(h.capture).toHaveBeenCalledWith("version_update:banner_shown");
     expect(
@@ -98,9 +87,35 @@ describe("VersionUpdateBanner (connected)", () => {
     ).toHaveLength(1);
   });
 
+  it("delegates the once-per-appearance guard to the store (no banner_shown when it returns false)", () => {
+    // Simulates a remount for an appearance the store already reported.
+    h.markShownReported.mockReturnValue(false);
+    render(<VersionUpdateBanner />);
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+    expect(h.capture).not.toHaveBeenCalledWith("version_update:banner_shown");
+  });
+
+  it("stays hidden until the app has settled", () => {
+    h.settled = false;
+    render(<VersionUpdateBanner />);
+    expect(
+      screen.queryByRole("button", { name: "Reload" }),
+    ).not.toBeInTheDocument();
+    expect(h.capture).not.toHaveBeenCalled();
+    expect(h.markShownReported).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when no update is available", () => {
+    h.available = false;
+    render(<VersionUpdateBanner />);
+    expect(
+      screen.queryByRole("button", { name: "Reload" }),
+    ).not.toBeInTheDocument();
+    expect(h.capture).not.toHaveBeenCalled();
+  });
+
   it("captures reload_clicked and reloads on Reload", () => {
     render(<VersionUpdateBanner />);
-    settle();
     fireEvent.click(screen.getByRole("button", { name: "Reload" }));
     expect(h.capture).toHaveBeenCalledWith("version_update:reload_clicked");
     expect(window.location.reload).toHaveBeenCalledTimes(1);
@@ -108,19 +123,8 @@ describe("VersionUpdateBanner (connected)", () => {
 
   it("captures dismissed and calls the store on Dismiss", () => {
     render(<VersionUpdateBanner />);
-    settle();
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
     expect(h.capture).toHaveBeenCalledWith("version_update:dismissed");
     expect(h.dismiss).toHaveBeenCalledTimes(1);
-  });
-
-  it("renders nothing when no update is available", () => {
-    h.visible = false;
-    render(<VersionUpdateBanner />);
-    settle();
-    expect(
-      screen.queryByRole("button", { name: "Reload" }),
-    ).not.toBeInTheDocument();
-    expect(h.capture).not.toHaveBeenCalled();
   });
 });

--- a/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TopBannerProvider } from "@/src/features/top-banner";
+import { VersionUpdateBanner } from "./VersionUpdateBanner";
+import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
+import { versionUpdateStore } from "./versionUpdateStore";
+
+describe("VersionUpdateBannerView", () => {
+  it("renders a reload and a dismiss control", () => {
+    render(
+      <VersionUpdateBannerView onReload={() => {}} onDismiss={() => {}} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
+  });
+
+  it("invokes the callbacks when the controls are clicked", () => {
+    const onReload = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <VersionUpdateBannerView onReload={onReload} onDismiss={onDismiss} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+    expect(onReload).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("VersionUpdateBanner (connected)", () => {
+  beforeEach(() => {
+    // The running build id the tab loaded; a differing observed id is the
+    // trigger. ResizeObserver is used by the shared top-banner registration and
+    // is not implemented in jsdom.
+    vi.stubEnv("NEXT_PUBLIC_BUILD_ID", "running-build");
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("appears when a newer build is observed and hides on dismiss", () => {
+    // A newer build was deployed while the tab stayed open.
+    versionUpdateStore.reportObservedBuildId("deployed-build");
+
+    render(
+      <TopBannerProvider>
+        <VersionUpdateBanner />
+      </TopBannerProvider>,
+    );
+
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(
+      screen.queryByRole("button", { name: "Reload" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VersionUpdateBanner } from "./VersionUpdateBanner";
 import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
@@ -51,6 +51,9 @@ describe("VersionUpdateBannerView", () => {
 
 describe("VersionUpdateBanner (connected)", () => {
   beforeEach(() => {
+    // The banner is gated behind a startup grace period (setTimeout); fake
+    // timers let us fast-forward past it deterministically.
+    vi.useFakeTimers();
     h.capture.mockClear();
     h.dismiss.mockClear();
     h.visible = true;
@@ -62,11 +65,30 @@ describe("VersionUpdateBanner (connected)", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  // Advance past the app-settle grace period so the banner is allowed to render.
+  const settle = () =>
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+  it("stays hidden during the startup grace period, then appears", () => {
+    render(<VersionUpdateBanner />);
+    expect(
+      screen.queryByRole("button", { name: "Reload" }),
+    ).not.toBeInTheDocument();
+    expect(h.capture).not.toHaveBeenCalled();
+
+    settle();
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
   });
 
   it("reports banner_shown once when it appears", () => {
     render(<VersionUpdateBanner />);
+    settle();
     expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
     expect(h.capture).toHaveBeenCalledWith("version_update:banner_shown");
     expect(
@@ -78,6 +100,7 @@ describe("VersionUpdateBanner (connected)", () => {
 
   it("captures reload_clicked and reloads on Reload", () => {
     render(<VersionUpdateBanner />);
+    settle();
     fireEvent.click(screen.getByRole("button", { name: "Reload" }));
     expect(h.capture).toHaveBeenCalledWith("version_update:reload_clicked");
     expect(window.location.reload).toHaveBeenCalledTimes(1);
@@ -85,6 +108,7 @@ describe("VersionUpdateBanner (connected)", () => {
 
   it("captures dismissed and calls the store on Dismiss", () => {
     render(<VersionUpdateBanner />);
+    settle();
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
     expect(h.capture).toHaveBeenCalledWith("version_update:dismissed");
     expect(h.dismiss).toHaveBeenCalledTimes(1);
@@ -93,6 +117,7 @@ describe("VersionUpdateBanner (connected)", () => {
   it("renders nothing when no update is available", () => {
     h.visible = false;
     render(<VersionUpdateBanner />);
+    settle();
     expect(
       screen.queryByRole("button", { name: "Reload" }),
     ).not.toBeInTheDocument();

--- a/web/src/features/version-update/VersionUpdateBanner.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.tsx
@@ -1,9 +1,33 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Layer } from "@/src/components/ui/layer";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { versionUpdateStore } from "./versionUpdateStore";
 import { useVersionUpdateAvailable } from "./useVersionUpdateAvailable";
 import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
+
+// Hold the banner back until the app has settled after first render. During the
+// initial mount/hydration window the layout flickers and React StrictMode
+// double-invokes mounts — and because the banner renders through an overlay
+// portal, a mount during that churn gets torn down and recreated, replaying the
+// entrance animation (a visible "jump"/double-start). Appearing only after the
+// app is quiet means the banner mounts exactly once, cleanly. It also reads
+// better: no banner flashing in during startup. A build-id mismatch seen later
+// (a deploy while the tab is open) still shows immediately — the gate has long
+// since opened.
+const APP_SETTLE_DELAY_MS = 5000;
+
+/**
+ * `false` until {@link APP_SETTLE_DELAY_MS} after mount, then `true`. The timer
+ * is the external system this effect owns (setup starts it, cleanup clears it).
+ */
+function useAppSettled(): boolean {
+  const [settled, setSettled] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setSettled(true), APP_SETTLE_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+  return settled;
+}
 
 /**
  * App-wide notification prompting the user to reload when a newer build has
@@ -16,7 +40,13 @@ import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
  * appearance, plus the reload / dismiss actions.
  */
 export function VersionUpdateBanner() {
-  const isVisible = useVersionUpdateAvailable();
+  // Show only once a build mismatch exists AND the app has settled after first
+  // render — the grace period keeps the banner out of the noisy startup window
+  // so its entrance plays cleanly (see `useAppSettled`). Both hooks run
+  // unconditionally; the gate is the boolean AND of their results.
+  const updateAvailable = useVersionUpdateAvailable();
+  const appSettled = useAppSettled();
+  const isVisible = updateAvailable && appSettled;
   const capture = usePostHogClientCapture();
 
   // Analytics side-effect (external system = PostHog): report `banner_shown`

--- a/web/src/features/version-update/VersionUpdateBanner.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.tsx
@@ -1,0 +1,45 @@
+import { useRef } from "react";
+import {
+  useTopBanner,
+  useTopBannerRegistration,
+} from "@/src/features/top-banner";
+import { versionUpdateStore } from "./versionUpdateStore";
+import { useVersionUpdateAvailable } from "./useVersionUpdateAvailable";
+import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
+
+const VERSION_UPDATE_BANNER_ID = "version-update-banner";
+// After the payment banner (order 10) so the two stack cleanly if both show.
+const VERSION_UPDATE_BANNER_ORDER = 20;
+
+/**
+ * App-wide banner prompting the user to reload when a newer build has been
+ * deployed while their tab stayed open (LFE-10978, §4.9). Visibility is derived
+ * from the version-update store — fed by the tRPC `buildIdLink` on every
+ * response — via `useSyncExternalStore`, with no effect-driven state sync.
+ *
+ * Participates in the shared top-banner offset system so page chrome shifts
+ * down instead of being overlapped, and offsets below any earlier banner.
+ */
+export function VersionUpdateBanner() {
+  const isVisible = useVersionUpdateAvailable();
+  const bannerRef = useRef<HTMLDivElement>(null);
+  const { getTopBannerOffset } = useTopBanner();
+
+  useTopBannerRegistration({
+    bannerId: VERSION_UPDATE_BANNER_ID,
+    order: VERSION_UPDATE_BANNER_ORDER,
+    isVisible,
+    elementRef: bannerRef,
+  });
+
+  if (!isVisible) return null;
+
+  return (
+    <VersionUpdateBannerView
+      ref={bannerRef}
+      style={{ top: getTopBannerOffset(VERSION_UPDATE_BANNER_ORDER) }}
+      onReload={() => window.location.reload()}
+      onDismiss={() => versionUpdateStore.dismiss()}
+    />
+  );
+}

--- a/web/src/features/version-update/VersionUpdateBanner.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.tsx
@@ -1,45 +1,53 @@
-import { useRef } from "react";
-import {
-  useTopBanner,
-  useTopBannerRegistration,
-} from "@/src/features/top-banner";
+import { useEffect, useRef } from "react";
+import { Layer } from "@/src/components/ui/layer";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { versionUpdateStore } from "./versionUpdateStore";
 import { useVersionUpdateAvailable } from "./useVersionUpdateAvailable";
 import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
 
-const VERSION_UPDATE_BANNER_ID = "version-update-banner";
-// After the payment banner (order 10) so the two stack cleanly if both show.
-const VERSION_UPDATE_BANNER_ORDER = 20;
-
 /**
- * App-wide banner prompting the user to reload when a newer build has been
- * deployed while their tab stayed open (LFE-10978, §4.9). Visibility is derived
- * from the version-update store — fed by the tRPC `buildIdLink` on every
+ * App-wide notification prompting the user to reload when a newer build has
+ * been deployed while their tab stayed open (LFE-10978, §4.9). Visibility is
+ * derived from the version-update store — fed by the tRPC `buildIdLink` on every
  * response — via `useSyncExternalStore`, with no effect-driven state sync.
  *
- * Participates in the shared top-banner offset system so page chrome shifts
- * down instead of being overlapped, and offsets below any earlier banner.
+ * Renders into the top-most overlay layer (`toast`) so it floats above content
+ * rather than pushing page chrome down. Analytics: `banner_shown` once per
+ * appearance, plus the reload / dismiss actions.
  */
 export function VersionUpdateBanner() {
   const isVisible = useVersionUpdateAvailable();
-  const bannerRef = useRef<HTMLDivElement>(null);
-  const { getTopBannerOffset } = useTopBanner();
+  const capture = usePostHogClientCapture();
 
-  useTopBannerRegistration({
-    bannerId: VERSION_UPDATE_BANNER_ID,
-    order: VERSION_UPDATE_BANNER_ORDER,
-    isVisible,
-    elementRef: bannerRef,
-  });
+  // Analytics side-effect (external system = PostHog): report `banner_shown`
+  // once each time the notification appears. Guarded against StrictMode
+  // double-mount; reset when it hides so a genuinely new build later counts as
+  // a fresh appearance. This does not derive render state — visibility comes
+  // from the store — it only reports the appearance.
+  const reportedShown = useRef(false);
+  useEffect(() => {
+    if (isVisible && !reportedShown.current) {
+      reportedShown.current = true;
+      capture("version_update:banner_shown");
+    } else if (!isVisible) {
+      reportedShown.current = false;
+    }
+  }, [isVisible, capture]);
 
   if (!isVisible) return null;
 
   return (
-    <VersionUpdateBannerView
-      ref={bannerRef}
-      style={{ top: getTopBannerOffset(VERSION_UPDATE_BANNER_ORDER) }}
-      onReload={() => window.location.reload()}
-      onDismiss={() => versionUpdateStore.dismiss()}
-    />
+    <Layer name="toast">
+      <VersionUpdateBannerView
+        onReload={() => {
+          capture("version_update:reload_clicked");
+          window.location.reload();
+        }}
+        onDismiss={() => {
+          capture("version_update:dismissed");
+          versionUpdateStore.dismiss();
+        }}
+      />
+    </Layer>
   );
 }

--- a/web/src/features/version-update/VersionUpdateBanner.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.tsx
@@ -1,66 +1,40 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import { Layer } from "@/src/components/ui/layer";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { versionUpdateStore } from "./versionUpdateStore";
 import { useVersionUpdateAvailable } from "./useVersionUpdateAvailable";
+import { useAppSettled } from "./useAppSettled";
 import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
-
-// Hold the banner back until the app has settled after first render. During the
-// initial mount/hydration window the layout flickers and React StrictMode
-// double-invokes mounts — and because the banner renders through an overlay
-// portal, a mount during that churn gets torn down and recreated, replaying the
-// entrance animation (a visible "jump"/double-start). Appearing only after the
-// app is quiet means the banner mounts exactly once, cleanly. It also reads
-// better: no banner flashing in during startup. A build-id mismatch seen later
-// (a deploy while the tab is open) still shows immediately — the gate has long
-// since opened.
-const APP_SETTLE_DELAY_MS = 5000;
-
-/**
- * `false` until {@link APP_SETTLE_DELAY_MS} after mount, then `true`. The timer
- * is the external system this effect owns (setup starts it, cleanup clears it).
- */
-function useAppSettled(): boolean {
-  const [settled, setSettled] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => setSettled(true), APP_SETTLE_DELAY_MS);
-    return () => clearTimeout(timer);
-  }, []);
-  return settled;
-}
 
 /**
  * App-wide notification prompting the user to reload when a newer build has
- * been deployed while their tab stayed open (LFE-10978, §4.9). Visibility is
- * derived from the version-update store — fed by the tRPC `buildIdLink` on every
- * response — via `useSyncExternalStore`, with no effect-driven state sync.
+ * been deployed while their tab stayed open (LFE-10978, §4.9).
+ *
+ * Visibility is `updateAvailable && appSettled` — both read from module-level
+ * external stores via `useSyncExternalStore` (no effect-driven state sync).
+ * `updateAvailable` comes from {@link versionUpdateStore} (fed by the tRPC
+ * `buildIdLink`); {@link useAppSettled} holds the banner out of the noisy
+ * startup window. Keeping both in module scope means the state survives banner
+ * remounts (e.g. AppLayout switching between AuthenticatedLayout and
+ * MinimalLayout) rather than re-hiding for the grace period each time.
  *
  * Renders into the top-most overlay layer (`toast`) so it floats above content
  * rather than pushing page chrome down. Analytics: `banner_shown` once per
  * appearance, plus the reload / dismiss actions.
  */
 export function VersionUpdateBanner() {
-  // Show only once a build mismatch exists AND the app has settled after first
-  // render — the grace period keeps the banner out of the noisy startup window
-  // so its entrance plays cleanly (see `useAppSettled`). Both hooks run
-  // unconditionally; the gate is the boolean AND of their results.
   const updateAvailable = useVersionUpdateAvailable();
   const appSettled = useAppSettled();
   const isVisible = updateAvailable && appSettled;
   const capture = usePostHogClientCapture();
 
   // Analytics side-effect (external system = PostHog): report `banner_shown`
-  // once each time the notification appears. Guarded against StrictMode
-  // double-mount; reset when it hides so a genuinely new build later counts as
-  // a fresh appearance. This does not derive render state — visibility comes
-  // from the store — it only reports the appearance.
-  const reportedShown = useRef(false);
+  // once per appearance. The once-guard lives in the store, so a banner remount
+  // cannot double-count one continuous appearance and a StrictMode-double-
+  // invoked effect still fires the event only once.
   useEffect(() => {
-    if (isVisible && !reportedShown.current) {
-      reportedShown.current = true;
+    if (isVisible && versionUpdateStore.markShownReported()) {
       capture("version_update:banner_shown");
-    } else if (!isVisible) {
-      reportedShown.current = false;
     }
   }, [isVisible, capture]);
 

--- a/web/src/features/version-update/VersionUpdateBannerView.stories.tsx
+++ b/web/src/features/version-update/VersionUpdateBannerView.stories.tsx
@@ -1,0 +1,18 @@
+import { fn } from "storybook/test";
+import preview from "../../../.storybook/preview";
+import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
+
+const meta = preview.meta({
+  component: VersionUpdateBannerView,
+  args: {
+    onReload: fn(),
+    onDismiss: fn(),
+  },
+});
+
+/**
+ * The banner only exists in its "a new version is available" state — it renders
+ * nothing otherwise — so this default IS that state. It pins to the top of the
+ * viewport (as in the app) and offers Reload plus a dismiss control.
+ */
+export const Default = meta.story({});

--- a/web/src/features/version-update/VersionUpdateBannerView.tsx
+++ b/web/src/features/version-update/VersionUpdateBannerView.tsx
@@ -1,4 +1,3 @@
-import { forwardRef, type CSSProperties } from "react";
 import { RotateCw, Sparkles, X } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
@@ -6,61 +5,63 @@ import { cn } from "@/src/utils/tailwind";
 export type VersionUpdateBannerViewProps = {
   /** Reload the tab to pick up the new build. */
   onReload: () => void;
-  /** Hide the banner for this session. */
+  /** Hide the notification for this session. */
   onDismiss: () => void;
-  /** Inline styles (used by the connected banner to offset below other banners). */
-  style?: CSSProperties;
   className?: string;
 };
 
 /**
- * Presentational "a new version is available — reload" banner. Purely
- * props-driven (no store, no context, no data fetching) so it renders in
- * isolation — see `VersionUpdateBannerView.stories.tsx`. The connected
- * {@link VersionUpdateBanner} wires it to the version-update store and the
- * top-banner offset system.
+ * Presentational "Langfuse just got an update" notification — a floating,
+ * frosted-glass pill pinned center-top, NOT a layout-pushing top bar. It sits
+ * over the content (the connected banner renders it into the top-most overlay
+ * layer), so it may cover whatever is directly behind it; the rest of the app
+ * stays interactive (there is no backdrop).
  *
- * We prompt rather than auto-reload on purpose: reloading would discard unsaved
- * work (open annotations, editors). The user reloads when it is safe for them.
+ * Purely props-driven (no store/context/data) so it renders in isolation — see
+ * `VersionUpdateBannerView.stories.tsx`. The connected {@link VersionUpdateBanner}
+ * wires it to the store, the overlay layer, and analytics.
+ *
+ * We prompt rather than auto-reload: reloading would discard unsaved work (open
+ * annotations, editors); the user reloads when it is safe for them.
  */
-export const VersionUpdateBannerView = forwardRef<
-  HTMLDivElement,
-  VersionUpdateBannerViewProps
->(function VersionUpdateBannerView(
-  { onReload, onDismiss, style, className },
-  ref,
-) {
+export function VersionUpdateBannerView({
+  onReload,
+  onDismiss,
+  className,
+}: VersionUpdateBannerViewProps) {
   return (
     <div
-      ref={ref}
-      className={cn(
-        "bg-foreground text-background fixed top-0 z-51 flex w-full items-center justify-between gap-4 px-4 py-1",
-        className,
-      )}
-      style={style}
       role="status"
       aria-live="polite"
+      className={cn(
+        // Float center-top, a little below the edge — over content, not pushing it.
+        "fixed top-4 left-1/2 -translate-x-1/2",
+        // Frosted-glass pill: translucent + blurred, with a soft glow.
+        "flex items-center gap-3 rounded-full py-1.5 pr-1.5 pl-4",
+        "border-border/60 bg-background/80 border shadow-xl ring-1 ring-black/5 backdrop-blur-xl dark:ring-white/10",
+        // Beautiful entrance: fade in + slide down from the top + a gentle zoom.
+        "animate-in fade-in-0 slide-in-from-top-4 zoom-in-95 duration-500 ease-out",
+        className,
+      )}
     >
-      <div className="flex items-center gap-3">
-        <Sparkles className="h-4 w-4 shrink-0" />
-        <span className="text-sm">A new version of Langfuse is available.</span>
-      </div>
-
-      <div className="flex items-center gap-1">
-        <Button size="sm" variant="ghost" onClick={onReload}>
-          <RotateCw className="mr-2 h-4 w-4" />
-          Reload
-        </Button>
-        <Button
-          size="icon-sm"
-          variant="ghost"
-          onClick={onDismiss}
-          aria-label="Dismiss"
-          title="Dismiss"
-        >
-          <X className="h-4 w-4" />
-        </Button>
-      </div>
+      <Sparkles className="text-primary h-4 w-4 shrink-0" />
+      <span className="text-foreground text-sm whitespace-nowrap">
+        Langfuse just got an update
+      </span>
+      <Button size="sm" className="rounded-full" onClick={onReload}>
+        <RotateCw className="mr-1.5 h-3.5 w-3.5" />
+        Reload
+      </Button>
+      <Button
+        size="icon-sm"
+        variant="ghost"
+        className="text-muted-foreground rounded-full"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        title="Dismiss"
+      >
+        <X className="h-4 w-4" />
+      </Button>
     </div>
   );
-});
+}

--- a/web/src/features/version-update/VersionUpdateBannerView.tsx
+++ b/web/src/features/version-update/VersionUpdateBannerView.tsx
@@ -13,9 +13,11 @@ export type VersionUpdateBannerViewProps = {
 /**
  * Presentational "Langfuse just got an update" notification — a floating,
  * frosted-glass pill pinned center-top, NOT a layout-pushing top bar. It sits
- * over the content (the connected banner renders it into the top-most overlay
+ * over page content (the connected banner renders it into the top-most overlay
  * layer), so it may cover whatever is directly behind it; the rest of the app
- * stays interactive (there is no backdrop).
+ * stays interactive (there is no backdrop). It does respect the top-banner
+ * offset, so it drops below a full-width top banner (e.g. the payment banner)
+ * instead of overlapping it.
  *
  * Purely props-driven (no store/context/data) so it renders in isolation — see
  * `VersionUpdateBannerView.stories.tsx`. The connected {@link VersionUpdateBanner}
@@ -34,7 +36,11 @@ export function VersionUpdateBannerView({
       role="status"
       aria-live="polite"
       className={cn(
-        "fixed top-4 left-1/2 -translate-x-1/2",
+        // `top-banner-offset` = safe-area + any registered top banner's height,
+        // so the pill sits below a full-width top banner (e.g. PaymentBanner)
+        // rather than overlapping it; `mt-4` keeps a 16px gap (and, with no top
+        // banner, places it ~16px from the viewport top).
+        "top-banner-offset fixed left-1/2 mt-4 -translate-x-1/2",
         "flex items-center gap-3 rounded-full py-1.5 pr-1.5 pl-4",
         "border-border/60 bg-background/80 border shadow-xl ring-1 ring-black/5 backdrop-blur-xl dark:ring-white/10",
         // `fill-mode-both` holds the entrance keyframes' start state on the

--- a/web/src/features/version-update/VersionUpdateBannerView.tsx
+++ b/web/src/features/version-update/VersionUpdateBannerView.tsx
@@ -1,0 +1,66 @@
+import { forwardRef, type CSSProperties } from "react";
+import { RotateCw, Sparkles, X } from "lucide-react";
+import { Button } from "@/src/components/ui/button";
+import { cn } from "@/src/utils/tailwind";
+
+export type VersionUpdateBannerViewProps = {
+  /** Reload the tab to pick up the new build. */
+  onReload: () => void;
+  /** Hide the banner for this session. */
+  onDismiss: () => void;
+  /** Inline styles (used by the connected banner to offset below other banners). */
+  style?: CSSProperties;
+  className?: string;
+};
+
+/**
+ * Presentational "a new version is available — reload" banner. Purely
+ * props-driven (no store, no context, no data fetching) so it renders in
+ * isolation — see `VersionUpdateBannerView.stories.tsx`. The connected
+ * {@link VersionUpdateBanner} wires it to the version-update store and the
+ * top-banner offset system.
+ *
+ * We prompt rather than auto-reload on purpose: reloading would discard unsaved
+ * work (open annotations, editors). The user reloads when it is safe for them.
+ */
+export const VersionUpdateBannerView = forwardRef<
+  HTMLDivElement,
+  VersionUpdateBannerViewProps
+>(function VersionUpdateBannerView(
+  { onReload, onDismiss, style, className },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "bg-foreground text-background fixed top-0 z-51 flex w-full items-center justify-between gap-4 px-4 py-1",
+        className,
+      )}
+      style={style}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-3">
+        <Sparkles className="h-4 w-4 shrink-0" />
+        <span className="text-sm">A new version of Langfuse is available.</span>
+      </div>
+
+      <div className="flex items-center gap-1">
+        <Button size="sm" variant="ghost" onClick={onReload}>
+          <RotateCw className="mr-2 h-4 w-4" />
+          Reload
+        </Button>
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          title="Dismiss"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+});

--- a/web/src/features/version-update/VersionUpdateBannerView.tsx
+++ b/web/src/features/version-update/VersionUpdateBannerView.tsx
@@ -34,13 +34,14 @@ export function VersionUpdateBannerView({
       role="status"
       aria-live="polite"
       className={cn(
-        // Float center-top, a little below the edge — over content, not pushing it.
         "fixed top-4 left-1/2 -translate-x-1/2",
-        // Frosted-glass pill: translucent + blurred, with a soft glow.
         "flex items-center gap-3 rounded-full py-1.5 pr-1.5 pl-4",
         "border-border/60 bg-background/80 border shadow-xl ring-1 ring-black/5 backdrop-blur-xl dark:ring-white/10",
-        // Beautiful entrance: fade in + slide down from the top + a gentle zoom.
-        "animate-in fade-in-0 slide-in-from-top-4 zoom-in-95 duration-500 ease-out",
+        // `fill-mode-both` holds the entrance keyframes' start state on the
+        // mount frame, before the animation's first tick — without it the pill
+        // can paint one frame at its final position/opacity and then snap back
+        // to animate (a flash that reads as a "jump"; Firefox is most prone).
+        "animate-in fade-in-0 slide-in-from-top-4 zoom-in-95 fill-mode-both duration-500 ease-out",
         className,
       )}
     >

--- a/web/src/features/version-update/index.ts
+++ b/web/src/features/version-update/index.ts
@@ -1,0 +1,8 @@
+export { VersionUpdateBanner } from "./VersionUpdateBanner";
+export { useVersionUpdateAvailable } from "./useVersionUpdateAvailable";
+export {
+  versionUpdateStore,
+  createVersionUpdateStore,
+  isVersionMismatch,
+  type VersionUpdateStore,
+} from "./versionUpdateStore";

--- a/web/src/features/version-update/useAppSettled.clienttest.ts
+++ b/web/src/features/version-update/useAppSettled.clienttest.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createAppSettledGate } from "./useAppSettled";
+
+describe("createAppSettledGate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts unsettled and settles after the delay once subscribed", () => {
+    const gate = createAppSettledGate(5000);
+    expect(gate.getSnapshot()).toBe(false);
+
+    const listener = vi.fn();
+    gate.subscribe(listener);
+    expect(gate.getSnapshot()).toBe(false);
+
+    vi.advanceTimersByTime(4999);
+    expect(gate.getSnapshot()).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(gate.getSnapshot()).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start the timer until the first subscription", () => {
+    const gate = createAppSettledGate(5000);
+    // No subscriber yet → timer never started, so time passing does nothing.
+    vi.advanceTimersByTime(10000);
+    expect(gate.getSnapshot()).toBe(false);
+
+    gate.subscribe(vi.fn());
+    vi.advanceTimersByTime(5000);
+    expect(gate.getSnapshot()).toBe(true);
+  });
+
+  it("starts the timer once across subscribe/unsubscribe/resubscribe (StrictMode) and remounts", () => {
+    const gate = createAppSettledGate(5000);
+
+    // StrictMode mounts, unmounts, remounts synchronously before the timer.
+    const unsub = gate.subscribe(vi.fn());
+    unsub();
+    gate.subscribe(vi.fn());
+
+    vi.advanceTimersByTime(5000);
+    expect(gate.getSnapshot()).toBe(true);
+  });
+
+  it("reports settled immediately to a subscriber that mounts after settling (remount survives)", () => {
+    const gate = createAppSettledGate(5000);
+    const first = gate.subscribe(vi.fn());
+    vi.advanceTimersByTime(5000);
+    expect(gate.getSnapshot()).toBe(true);
+
+    // The component unmounts (e.g. AuthenticatedLayout -> MinimalLayout) and a
+    // fresh one mounts later — it must see the already-settled value, not reset.
+    first();
+    const listener = vi.fn();
+    gate.subscribe(listener);
+    expect(gate.getSnapshot()).toBe(true);
+    // Already settled → no further timer, no extra notification needed.
+    vi.advanceTimersByTime(5000);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("has a server snapshot that is always false", () => {
+    const gate = createAppSettledGate(5000);
+    gate.subscribe(vi.fn());
+    vi.advanceTimersByTime(5000);
+    expect(gate.getSnapshot()).toBe(true);
+    expect(gate.getServerSnapshot()).toBe(false);
+  });
+});

--- a/web/src/features/version-update/useAppSettled.ts
+++ b/web/src/features/version-update/useAppSettled.ts
@@ -1,0 +1,72 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * How long after the app first mounts before the version-update banner is
+ * allowed to appear. During the initial mount/hydration window the layout
+ * flickers and React StrictMode double-invokes mounts; because the banner
+ * renders through an overlay portal, a mount landing in that churn is torn down
+ * and recreated, replaying its entrance animation (a visible "jump"). Holding it
+ * back until the app is quiet means it mounts exactly once, cleanly — and reads
+ * better (no banner flashing in during startup).
+ */
+export const APP_SETTLE_DELAY_MS = 5000;
+
+/**
+ * A one-shot "the app has settled after first render" gate as an external store.
+ *
+ * It is module-scoped (a singleton below), NOT component state, so the settled
+ * flag survives banner unmount/remount — e.g. when `AppLayout` switches between
+ * `AuthenticatedLayout` and `MinimalLayout` (navigating to `/onboarding`,
+ * `/auth/*`, `/public/*` and back). A component-local timer would restart the
+ * grace period on every such remount, re-hiding an already-acknowledged banner
+ * for another {@link APP_SETTLE_DELAY_MS}. Once settled it stays settled, so
+ * later mounts see `true` immediately.
+ *
+ * Exposed as a factory for deterministic testing; the app uses the singleton.
+ */
+export function createAppSettledGate(delayMs = APP_SETTLE_DELAY_MS) {
+  let settled = false;
+  let timerStarted = false;
+  const listeners = new Set<() => void>();
+
+  // The timer is the external system this store owns. Start it once, on first
+  // subscription (the app's first client mount); it is idempotent across the
+  // StrictMode subscribe/unsubscribe/subscribe cycle and across remounts.
+  const startTimer = () => {
+    if (timerStarted || settled) return;
+    timerStarted = true;
+    setTimeout(() => {
+      settled = true;
+      for (const listener of listeners) listener();
+    }, delayMs);
+  };
+
+  return {
+    subscribe(listener: () => void) {
+      startTimer();
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getSnapshot: () => settled,
+    // Never settled on the server; the banner only exists in a live tab.
+    getServerSnapshot: () => false,
+  };
+}
+
+const appSettledGate = createAppSettledGate();
+
+/**
+ * `true` once the app has settled after first render (see
+ * {@link createAppSettledGate}). Read via `useSyncExternalStore` — no
+ * effect-driven state, and the value is shared across all consumers and
+ * survives component remounts.
+ */
+export function useAppSettled(): boolean {
+  return useSyncExternalStore(
+    appSettledGate.subscribe,
+    appSettledGate.getSnapshot,
+    appSettledGate.getServerSnapshot,
+  );
+}

--- a/web/src/features/version-update/useVersionUpdateAvailable.ts
+++ b/web/src/features/version-update/useVersionUpdateAvailable.ts
@@ -1,0 +1,15 @@
+import { useSyncExternalStore } from "react";
+import { versionUpdateStore } from "./versionUpdateStore";
+
+/**
+ * `true` when a newer app build has been deployed while this tab stayed open and
+ * the user has not dismissed the prompt for it. Reads the module-level
+ * {@link versionUpdateStore} via `useSyncExternalStore` — no effect, no polling.
+ */
+export function useVersionUpdateAvailable(): boolean {
+  return useSyncExternalStore(
+    versionUpdateStore.subscribe,
+    versionUpdateStore.getSnapshot,
+    versionUpdateStore.getServerSnapshot,
+  );
+}

--- a/web/src/features/version-update/versionUpdateStore.clienttest.ts
+++ b/web/src/features/version-update/versionUpdateStore.clienttest.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createVersionUpdateStore,
+  isVersionMismatch,
+} from "./versionUpdateStore";
+
+describe("isVersionMismatch", () => {
+  it("is true only when both ids are present and differ", () => {
+    expect(isVersionMismatch("build-a", "build-b")).toBe(true);
+  });
+
+  it("is false when the ids are equal", () => {
+    expect(isVersionMismatch("build-a", "build-a")).toBe(false);
+  });
+
+  it("is false when either id is missing", () => {
+    // running missing
+    expect(isVersionMismatch(null, "build-b")).toBe(false);
+    expect(isVersionMismatch(undefined, "build-b")).toBe(false);
+    expect(isVersionMismatch("", "build-b")).toBe(false);
+    // observed missing
+    expect(isVersionMismatch("build-a", null)).toBe(false);
+    expect(isVersionMismatch("build-a", undefined)).toBe(false);
+    expect(isVersionMismatch("build-a", "")).toBe(false);
+    // both missing
+    expect(isVersionMismatch(null, null)).toBe(false);
+    expect(isVersionMismatch(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("versionUpdateStore", () => {
+  it("starts with no update available", () => {
+    const store = createVersionUpdateStore(() => "running");
+    expect(store.getSnapshot()).toBe(false);
+  });
+
+  it("stays silent when the observed build matches the running build", () => {
+    const store = createVersionUpdateStore(() => "running");
+    store.reportObservedBuildId("running");
+    expect(store.getSnapshot()).toBe(false);
+  });
+
+  it("becomes available when a differing build id is observed", () => {
+    const store = createVersionUpdateStore(() => "running");
+    store.reportObservedBuildId("deployed");
+    expect(store.getSnapshot()).toBe(true);
+  });
+
+  it("stays silent when the running build id is unknown", () => {
+    const store = createVersionUpdateStore(() => undefined);
+    store.reportObservedBuildId("deployed");
+    expect(store.getSnapshot()).toBe(false);
+  });
+
+  it("ignores empty/absent observed build ids", () => {
+    const store = createVersionUpdateStore(() => "running");
+    store.reportObservedBuildId(null);
+    store.reportObservedBuildId(undefined);
+    store.reportObservedBuildId("");
+    expect(store.getSnapshot()).toBe(false);
+  });
+
+  it("hides after dismiss and re-shows only when an even newer build arrives", () => {
+    const store = createVersionUpdateStore(() => "running");
+
+    store.reportObservedBuildId("deployed-1");
+    expect(store.getSnapshot()).toBe(true);
+
+    store.dismiss();
+    expect(store.getSnapshot()).toBe(false);
+
+    // The same build id must not re-trigger the banner after dismissal.
+    store.reportObservedBuildId("deployed-1");
+    expect(store.getSnapshot()).toBe(false);
+
+    // An even newer build the user has not seen re-shows it.
+    store.reportObservedBuildId("deployed-2");
+    expect(store.getSnapshot()).toBe(true);
+  });
+
+  it("notifies subscribers when the snapshot changes and after unsubscribe stops", () => {
+    const store = createVersionUpdateStore(() => "running");
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+
+    store.reportObservedBuildId("deployed");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // No snapshot change → no extra notification.
+    store.reportObservedBuildId("deployed");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    store.dismiss();
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    store.reportObservedBuildId("deployed-next");
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("has a server snapshot that is always false", () => {
+    const store = createVersionUpdateStore(() => "running");
+    store.reportObservedBuildId("deployed");
+    expect(store.getServerSnapshot()).toBe(false);
+  });
+});

--- a/web/src/features/version-update/versionUpdateStore.clienttest.ts
+++ b/web/src/features/version-update/versionUpdateStore.clienttest.ts
@@ -60,7 +60,7 @@ describe("versionUpdateStore", () => {
     expect(store.getSnapshot()).toBe(false);
   });
 
-  it("hides after dismiss and re-shows only when an even newer build arrives", () => {
+  it("hides after dismiss and re-shows only when a not-yet-seen build arrives", () => {
     const store = createVersionUpdateStore(() => "running");
 
     store.reportObservedBuildId("deployed-1");
@@ -73,9 +73,57 @@ describe("versionUpdateStore", () => {
     store.reportObservedBuildId("deployed-1");
     expect(store.getSnapshot()).toBe(false);
 
-    // An even newer build the user has not seen re-shows it.
+    // A build id the user has not seen re-shows it.
     store.reportObservedBuildId("deployed-2");
     expect(store.getSnapshot()).toBe(true);
+  });
+
+  // Rolling deploy: one tab sees responses from BOTH old and new pods, in any
+  // order, and build ids are opaque (no orderable newer/older). These guard the
+  // three failure modes flagged in review.
+  describe("rolling deploy robustness", () => {
+    it("stays available once a differing build is seen — a later old-pod response cannot suppress it", () => {
+      const store = createVersionUpdateStore(() => "running");
+
+      store.reportObservedBuildId("deployed"); // new pod
+      expect(store.getSnapshot()).toBe(true);
+
+      // Old pod still serving the running build id — must NOT clear the banner.
+      store.reportObservedBuildId("running");
+      expect(store.getSnapshot()).toBe(true);
+
+      // Alternating pods likewise keep it sticky.
+      store.reportObservedBuildId("deployed");
+      store.reportObservedBuildId("running");
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("does not reopen a dismissed banner when an already-seen build re-appears (old pod)", () => {
+      const store = createVersionUpdateStore(() => "running");
+
+      store.reportObservedBuildId("deployed");
+      store.dismiss();
+      expect(store.getSnapshot()).toBe(false);
+
+      // Old pods keep alternating: re-observing the running id or the
+      // already-seen deployed id must not reopen the dismissed banner.
+      store.reportObservedBuildId("running");
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(false);
+    });
+
+    it("re-observing an already-seen build never flaps the snapshot (no extra notifications)", () => {
+      const store = createVersionUpdateStore(() => "running");
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.reportObservedBuildId("deployed"); // 1 change: false→true
+      store.reportObservedBuildId("deployed"); // seen → no-op
+      store.reportObservedBuildId("running"); // matches running → no-op
+      store.reportObservedBuildId("deployed"); // seen → no-op
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(store.getSnapshot()).toBe(true);
+    });
   });
 
   it("notifies subscribers when the snapshot changes and after unsubscribe stops", () => {

--- a/web/src/features/version-update/versionUpdateStore.clienttest.ts
+++ b/web/src/features/version-update/versionUpdateStore.clienttest.ts
@@ -151,4 +151,44 @@ describe("versionUpdateStore", () => {
     store.reportObservedBuildId("deployed");
     expect(store.getServerSnapshot()).toBe(false);
   });
+
+  // `banner_shown` fires once per appearance; the guard lives here (not in
+  // component state) so a banner remount cannot double-count one appearance.
+  describe("markShownReported (banner_shown once-per-appearance guard)", () => {
+    it("returns true once per appearance, then false", () => {
+      const store = createVersionUpdateStore(() => "running");
+      store.reportObservedBuildId("deployed");
+
+      expect(store.markShownReported()).toBe(true);
+      // A remount / StrictMode-double-invoked effect calls it again for the same
+      // appearance — must not count twice.
+      expect(store.markShownReported()).toBe(false);
+      expect(store.markShownReported()).toBe(false);
+    });
+
+    it("resets for a genuinely new build id (a fresh appearance)", () => {
+      const store = createVersionUpdateStore(() => "running");
+
+      store.reportObservedBuildId("deployed-1");
+      expect(store.markShownReported()).toBe(true);
+      expect(store.markShownReported()).toBe(false);
+
+      // A new, never-seen build id is a new appearance → report again.
+      store.reportObservedBuildId("deployed-2");
+      expect(store.markShownReported()).toBe(true);
+      expect(store.markShownReported()).toBe(false);
+    });
+
+    it("does not reset when an already-seen build id is re-observed", () => {
+      const store = createVersionUpdateStore(() => "running");
+
+      store.reportObservedBuildId("deployed");
+      expect(store.markShownReported()).toBe(true);
+
+      // Re-observing the same (or the running) id is a no-op — no new appearance.
+      store.reportObservedBuildId("deployed");
+      store.reportObservedBuildId("running");
+      expect(store.markShownReported()).toBe(false);
+    });
+  });
 });

--- a/web/src/features/version-update/versionUpdateStore.ts
+++ b/web/src/features/version-update/versionUpdateStore.ts
@@ -50,6 +50,16 @@ export type VersionUpdateStore = {
    * already-seen build (an old pod during a rolling deploy).
    */
   dismiss: () => void;
+  /**
+   * Returns `true` exactly once per appearance, `false` afterwards; the flag
+   * resets when a genuinely new build id arrives (a fresh appearance). Kept in
+   * the store — not in component state — so the `banner_shown` analytics event
+   * fires once per logical appearance even if the banner component unmounts and
+   * remounts in between (e.g. AppLayout switching between AuthenticatedLayout
+   * and MinimalLayout), and once (not twice) under a StrictMode double-invoked
+   * effect.
+   */
+  markShownReported: () => boolean;
 };
 
 /**
@@ -80,6 +90,9 @@ export function createVersionUpdateStore(
   // Sticky: set true the first time a differing build id is seen, never unset.
   let updateAvailable = false;
   let dismissed = false;
+  // `banner_shown` analytics guard — true once the current appearance has been
+  // reported. Reset when a genuinely new build id arrives (new appearance).
+  let shownReported = false;
 
   const compute = (): boolean => updateAvailable && !dismissed;
 
@@ -117,13 +130,20 @@ export function createVersionUpdateStore(
       seenDifferingBuildIds.add(observedBuildId);
       updateAvailable = true; // sticky
       // A genuinely new (never-seen) differing build → worth re-prompting even
-      // if the user dismissed an earlier one.
+      // if the user dismissed an earlier one, and worth counting as a fresh
+      // appearance for analytics.
       dismissed = false;
+      shownReported = false;
       emitChange();
     },
     dismiss() {
       dismissed = true;
       emitChange();
+    },
+    markShownReported() {
+      if (shownReported) return false;
+      shownReported = true;
+      return true;
     },
   };
 }

--- a/web/src/features/version-update/versionUpdateStore.ts
+++ b/web/src/features/version-update/versionUpdateStore.ts
@@ -38,13 +38,16 @@ export type VersionUpdateStore = {
   getServerSnapshot: () => boolean;
   /**
    * Record a build id observed from a server response. Safe to call on every
-   * tRPC response with any value; it only changes the snapshot when it reveals a
-   * genuinely newer build than the one already seen.
+   * tRPC response with any value. Once a build id different from the running one
+   * has been seen, "update available" is STICKY — later responses (including an
+   * old pod still serving the running build during a rolling deploy) can never
+   * clear it.
    */
   reportObservedBuildId: (observedBuildId: string | null | undefined) => void;
   /**
-   * Dismiss the banner for the current session. It re-shows only if an even
-   * newer build id arrives later (the user has already seen this one).
+   * Dismiss the banner for the current session. It re-shows only when a build id
+   * that has NOT been seen before arrives — never on a re-observation of an
+   * already-seen build (an old pod during a rolling deploy).
    */
   dismiss: () => void;
 };
@@ -53,17 +56,32 @@ export type VersionUpdateStore = {
  * Builds a version-update store. `getRunningBuildId` returns the build id of the
  * bundle this tab is running; injecting it (rather than reading the module-level
  * env directly) keeps the store deterministic and testable.
+ *
+ * Rolling-deploy correctness: during a rollout, one tab sees responses from
+ * BOTH the old and new pods, in any order, and build ids are opaque hashes with
+ * no orderable "newer/older". So the store cannot ask "is the observed build
+ * newer?" — it asks only "have we ever seen a build id ≠ ours?". That makes the
+ * signal:
+ *  - **sticky** — a subsequent old-pod response carrying the running build id
+ *    cannot flip the banner back off; and
+ *  - **flap-free** — re-observing an already-seen build id does nothing, so the
+ *    banner does not blink or reopen as responses alternate between pods.
+ * Reloading always converges the tab to whatever build is currently served, so
+ * "a build ≠ yours exists → offer reload" is the right action even though we
+ * can't prove the other build is strictly newer.
  */
 export function createVersionUpdateStore(
   getRunningBuildId: () => string | null | undefined,
 ): VersionUpdateStore {
   const listeners = new Set<() => void>();
-  let latestBuildId: string | null = null;
-  let dismissedBuildId: string | null = null;
+  // Every build id observed that differs from the running one. Membership is
+  // what makes re-observation a no-op (no flapping) and dismiss durable.
+  const seenDifferingBuildIds = new Set<string>();
+  // Sticky: set true the first time a differing build id is seen, never unset.
+  let updateAvailable = false;
+  let dismissed = false;
 
-  const compute = (): boolean =>
-    isVersionMismatch(getRunningBuildId(), latestBuildId) &&
-    latestBuildId !== dismissedBuildId;
+  const compute = (): boolean => updateAvailable && !dismissed;
 
   // Cache the snapshot so `getSnapshot` returns a referentially stable value
   // between changes — `useSyncExternalStore` requires this to avoid re-render
@@ -91,12 +109,20 @@ export function createVersionUpdateStore(
       return false;
     },
     reportObservedBuildId(observedBuildId) {
-      if (!observedBuildId || observedBuildId === latestBuildId) return;
-      latestBuildId = observedBuildId;
+      if (!observedBuildId) return;
+      if (!isVersionMismatch(getRunningBuildId(), observedBuildId)) return;
+      // A differing build id. If we've already seen this exact one, do nothing —
+      // re-observation (old pod re-serving it) must not flap or reopen a dismiss.
+      if (seenDifferingBuildIds.has(observedBuildId)) return;
+      seenDifferingBuildIds.add(observedBuildId);
+      updateAvailable = true; // sticky
+      // A genuinely new (never-seen) differing build → worth re-prompting even
+      // if the user dismissed an earlier one.
+      dismissed = false;
       emitChange();
     },
     dismiss() {
-      dismissedBuildId = latestBuildId;
+      dismissed = true;
       emitChange();
     },
   };

--- a/web/src/features/version-update/versionUpdateStore.ts
+++ b/web/src/features/version-update/versionUpdateStore.ts
@@ -1,0 +1,112 @@
+/**
+ * External store tracking whether a newer app build has been deployed while the
+ * current tab stayed open.
+ *
+ * Frequent deploys + long-lived tabs leave a tab running a stale JS bundle,
+ * which then 404s on code-split chunks and mints stale-fingerprint Sentry noise
+ * (LFE-10978, §4.9). This store powers a persistent "reload to update" banner so
+ * the user can refresh on their own terms — we NEVER auto-reload (that would
+ * throw away unsaved work: open annotations, editors, ...).
+ *
+ * It is fed imperatively from the tRPC `buildIdLink` (see `src/utils/api.ts`),
+ * which captures the `x-build-id` response header on every tRPC response. React
+ * reads it via {@link useVersionUpdateAvailable} (a `useSyncExternalStore` hook)
+ * — no polling, no effect-driven state sync.
+ */
+
+/**
+ * True only when both build ids are present and they differ. When either id is
+ * missing we cannot conclude anything (a self-hosted build without
+ * `NEXT_PUBLIC_BUILD_ID`, or a response that carried no `x-build-id`), so we
+ * stay silent rather than nag on a false positive.
+ */
+export function isVersionMismatch(
+  runningBuildId: string | null | undefined,
+  observedBuildId: string | null | undefined,
+): boolean {
+  return (
+    !!runningBuildId && !!observedBuildId && runningBuildId !== observedBuildId
+  );
+}
+
+export type VersionUpdateStore = {
+  /** Subscribe to snapshot changes (for `useSyncExternalStore`). */
+  subscribe: (listener: () => void) => () => void;
+  /** Current snapshot: is an update available and not yet dismissed? */
+  getSnapshot: () => boolean;
+  /** SSR snapshot — always `false`; the mismatch only exists in a live tab. */
+  getServerSnapshot: () => boolean;
+  /**
+   * Record a build id observed from a server response. Safe to call on every
+   * tRPC response with any value; it only changes the snapshot when it reveals a
+   * genuinely newer build than the one already seen.
+   */
+  reportObservedBuildId: (observedBuildId: string | null | undefined) => void;
+  /**
+   * Dismiss the banner for the current session. It re-shows only if an even
+   * newer build id arrives later (the user has already seen this one).
+   */
+  dismiss: () => void;
+};
+
+/**
+ * Builds a version-update store. `getRunningBuildId` returns the build id of the
+ * bundle this tab is running; injecting it (rather than reading the module-level
+ * env directly) keeps the store deterministic and testable.
+ */
+export function createVersionUpdateStore(
+  getRunningBuildId: () => string | null | undefined,
+): VersionUpdateStore {
+  const listeners = new Set<() => void>();
+  let latestBuildId: string | null = null;
+  let dismissedBuildId: string | null = null;
+
+  const compute = (): boolean =>
+    isVersionMismatch(getRunningBuildId(), latestBuildId) &&
+    latestBuildId !== dismissedBuildId;
+
+  // Cache the snapshot so `getSnapshot` returns a referentially stable value
+  // between changes — `useSyncExternalStore` requires this to avoid re-render
+  // loops (it compares snapshots with `Object.is`).
+  let snapshot = compute();
+
+  const emitChange = () => {
+    const next = compute();
+    if (next === snapshot) return;
+    snapshot = next;
+    for (const listener of listeners) listener();
+  };
+
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getSnapshot() {
+      return snapshot;
+    },
+    getServerSnapshot() {
+      return false;
+    },
+    reportObservedBuildId(observedBuildId) {
+      if (!observedBuildId || observedBuildId === latestBuildId) return;
+      latestBuildId = observedBuildId;
+      emitChange();
+    },
+    dismiss() {
+      dismissedBuildId = latestBuildId;
+      emitChange();
+    },
+  };
+}
+
+/**
+ * App-wide singleton, wired to the running build id. `NEXT_PUBLIC_BUILD_ID` is
+ * inlined into the client bundle at build time, so this reflects the exact
+ * bundle the tab loaded.
+ */
+export const versionUpdateStore = createVersionUpdateStore(
+  () => process.env.NEXT_PUBLIC_BUILD_ID,
+);

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -24,6 +24,7 @@ import { observable } from "@trpc/server/observable";
 import superjson from "superjson";
 import { env } from "@/src/env.mjs";
 import { showVersionUpdateToast } from "@/src/features/notifications/showVersionUpdateToast";
+import { versionUpdateStore } from "@/src/features/version-update/versionUpdateStore";
 import { type AppRouter } from "@/src/server/api/root";
 import { setUpSuperjson } from "@/src/utils/superjson";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
@@ -276,22 +277,33 @@ const handleTrpcError = (error: unknown, shouldSilenceError = false) => {
   }
 };
 
-// onError update build id to compare versions
+// Reads the `x-build-id` response header (the build id serving this response)
+// and records it: the module-level `buildId` still drives the legacy
+// stale-cache toast, and the version-update store drives the persistent reload
+// banner (see src/features/version-update). Called on EVERY response — success
+// and error — so a mismatch is detected on the first response after a deploy,
+// not only when a stale chunk 404s.
+const captureBuildId = (response: unknown) => {
+  if (!(response instanceof Response)) return;
+  const observed = response.headers.get("x-build-id");
+  if (!observed) return;
+  buildId = observed;
+  versionUpdateStore.reportObservedBuildId(observed);
+};
+
+// Track the build id serving tRPC responses to compare against the running one.
 const buildIdLink = (): TRPCLink<AppRouter> => () => {
   return ({ next, op }) => {
     return observable((observer) => {
       const unsubscribe = next(op).subscribe({
         next(value) {
+          captureBuildId(value.context?.response);
           observer.next(value);
         },
         error(err) {
-          if (
-            err.meta &&
-            err.meta.response &&
-            err.meta.response instanceof Response
-          ) {
-            buildId = err.meta.response.headers.get("x-build-id");
-          }
+          captureBuildId(
+            err.meta && err.meta.response ? err.meta.response : undefined,
+          );
           observer.error(err);
         },
         complete() {


### PR DESCRIPTION
## TL;DR
A persistent, dismissible **"Langfuse just got an update — Reload"** notification that appears when a tab has been open across a deploy. It's a floating, frosted-glass pill (center-top, Apple-notification style), not a layout-pushing bar. Users refresh on their own terms; we never auto-reload. This is **§4.9 part 1 (banner)** of the Sentry-noise workstream; chunk-load / worker-retry resilience is a deliberate sibling follow-up.

## Why
Frequent deploys + long-lived tabs leave users running a stale JS bundle. When the app then tries to load a code-split chunk that no longer exists, it 404s and mints stale-fingerprint error-tracker noise — plus a broken experience. A visible "reload to update" prompt shrinks both. (Infra can't retain old chunks server-side, so the banner *is* the mitigation, not a nicety.)

## What
- **Detection reuses the existing seam.** The tRPC `buildIdLink` now records the `x-build-id` response header on **every** response (success and error, not just the 404 path) into a small external store read via `useSyncExternalStore` — no polling, no effect state-sync.
- **Conservative mismatch predicate:** "update available" only when both the running build id (`NEXT_PUBLIC_BUILD_ID`) and the observed one are present **and differ**. Either missing (e.g. a self-hosted build with no build id) stays silent.
- **Rolling-deploy robust:** during a rollout a tab sees responses from both old and new pods, in any order, with opaque build hashes. The store asks only "have we ever seen a build id ≠ ours?" — so the signal is **sticky** (an old-pod response can't flip it back off) and **flap-free** (re-observing a seen id does nothing).
- **Floating pill, not a bar:** renders into the top-most overlay `toast` layer, floating center-top over content (no chrome shift). It **offsets below** any full-width top banner (e.g. the payment banner) via `top-banner-offset`, so it doesn't overlap.
- **Clean, single entrance:** a grace period holds the banner out of the app's startup churn (hydration flicker + StrictMode double-mount) so its animation plays exactly once; `fill-mode-both` prevents a start-frame flash. Both the settle-gate and the once-per-appearance analytics guard live in module scope, so the banner survives remounts (e.g. AppLayout ↔ MinimalLayout) without re-hiding or double-counting.
- **Never auto-reloads** (would discard unsaved work — open annotations, editors). Dismiss hides it for the session; a genuinely newer build id re-shows it.
- **Analytics:** `version_update:banner_shown` (once per appearance) + `reload_clicked` / `dismissed`.

## How to see it
- **Storybook:** story `Default` in `VersionUpdateBannerView.stories.tsx` renders the pill in isolation (Reload + dismiss ×).
- **Live:** keep the app open on one build, deploy another (responses start returning a different `x-build-id`) — the pill appears ~5s after the page settles. Locally, force it by serving a build id from the tRPC seam different from `NEXT_PUBLIC_BUILD_ID`.

<details>
<summary>Files, design decisions & verification</summary>

**Feature module** `web/src/features/version-update/`:
- `versionUpdateStore.ts` — `isVersionMismatch(running, observed)` predicate + `createVersionUpdateStore(getRunningBuildId)` factory (injected running id → testable) + the app-wide singleton wired to `process.env.NEXT_PUBLIC_BUILD_ID`. Sticky `updateAvailable`, `dismissed`, a seen-ids set (flap-free), and `markShownReported()` (banner_shown once-per-appearance guard, module-level so it survives remounts). Cached boolean snapshot for `useSyncExternalStore`; `getServerSnapshot` always `false`.
- `useAppSettled.ts` — module-level startup grace-period gate (factory + singleton external store); the settled flag survives banner remounts so the grace period never restarts.
- `useVersionUpdateAvailable.ts` — the store hook.
- `VersionUpdateBannerView.tsx` — presentational, props-only (`onReload`/`onDismiss`) → renders in isolation. Frosted-glass pill, `top-banner-offset`, entrance animation with `fill-mode-both`.
- `VersionUpdateBanner.tsx` — connected: `isVisible = updateAvailable && appSettled`, portals into the `toast` layer, reports analytics, wires reload/dismiss.

**Wiring:** `api.ts` `buildIdLink` feeds the store on every response; `AuthenticatedLayout.tsx` mounts `<VersionUpdateBanner />`.

**Verification:** typecheck + lint clean; **30 client tests pass** (predicate, store report/dismiss/sticky/flap + markShownReported, the settle gate, and connected-banner render/analytics/gating). Entrance animation verified in Chrome + Firefox (single clean play); the remount + offset fixes address the two review nits.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
