### PR TITLE
chore(deploy): tag dd-trace telemetry with ECS task_arn via DD_TAGS (LFE-11028)

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -129,7 +129,7 @@ fi
 # with task_id.  Best-effort: on any failure DD_TAGS is left untouched and
 # startup proceeds.
 if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
-    _task_arn=$(wget -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    _task_arn=$(wget -T 2 -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
     _task_id="${_task_arn##*/}"
     if [ -n "$_task_id" ]; then
         export DD_TAGS="${DD_TAGS:+${DD_TAGS},}task_id:${_task_id}"

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -124,21 +124,22 @@ if [ $status -ne 0 ]; then
     exit $status
 fi
 
-# On ECS, resolve the task id from the container metadata endpoint and append
+# On ECS, resolve the task ARN from the container metadata endpoint and append
 # it to DD_TAGS so dd-trace stamps tracer telemetry (runtime metrics, spans)
-# with task_id.  Reuses the separator DD_TAGS already uses (comma or space).
-# Best-effort, bounded to ~2s total: on any failure DD_TAGS is left untouched
-# and startup proceeds — this block never fails boot.
+# with task_arn.  The full ARN exact-match joins with EventBridge's taskArn
+# field and Datadog's ECS task_arn tag convention.  Reuses the separator
+# DD_TAGS already uses (comma or space).  Best-effort, bounded to ~2s total:
+# on any failure DD_TAGS is left untouched and startup proceeds — this block
+# never fails boot.
 if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
     _task_arn=$(timeout 2 wget -T 2 -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-    _task_id="${_task_arn##*/}"
-    if [ -n "$_task_id" ]; then
+    if [ -n "$_task_arn" ]; then
         case "$DD_TAGS" in
             *,*) _sep="," ;;
             *" "*) _sep=" " ;;
             *) _sep="," ;;
         esac
-        export DD_TAGS="${DD_TAGS:+${DD_TAGS}${_sep}}task_id:${_task_id}"
+        export DD_TAGS="${DD_TAGS:+${DD_TAGS}${_sep}}task_arn:${_task_arn}"
     fi
 fi
 

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -124,5 +124,17 @@ if [ $status -ne 0 ]; then
     exit $status
 fi
 
+# On ECS, resolve the task id from the container metadata endpoint and append
+# it to DD_TAGS so dd-trace stamps tracer telemetry (runtime metrics, spans)
+# with task_id.  Best-effort: on any failure DD_TAGS is left untouched and
+# startup proceeds.
+if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
+    _task_arn=$(wget -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    _task_id="${_task_arn##*/}"
+    if [ -n "$_task_id" ]; then
+        export DD_TAGS="${DD_TAGS:+${DD_TAGS},}task_id:${_task_id}"
+    fi
+fi
+
 # Run the command passed to the docker image on start
 exec "$@"

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -126,13 +126,19 @@ fi
 
 # On ECS, resolve the task id from the container metadata endpoint and append
 # it to DD_TAGS so dd-trace stamps tracer telemetry (runtime metrics, spans)
-# with task_id.  Best-effort: on any failure DD_TAGS is left untouched and
-# startup proceeds.
+# with task_id.  Reuses the separator DD_TAGS already uses (comma or space).
+# Best-effort, bounded to ~2s total: on any failure DD_TAGS is left untouched
+# and startup proceeds — this block never fails boot.
 if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
-    _task_arn=$(wget -T 2 -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    _task_arn=$(timeout 2 wget -T 2 -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
     _task_id="${_task_arn##*/}"
     if [ -n "$_task_id" ]; then
-        export DD_TAGS="${DD_TAGS:+${DD_TAGS},}task_id:${_task_id}"
+        case "$DD_TAGS" in
+            *,*) _sep="," ;;
+            *" "*) _sep=" " ;;
+            *) _sep="," ;;
+        esac
+        export DD_TAGS="${DD_TAGS:+${DD_TAGS}${_sep}}task_id:${_task_id}"
     fi
 fi
 

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -19,13 +19,18 @@ if [ -z "$DATABASE_URL" ]; then
     fi
 fi
 
-# On ECS, append task_id:<id> from the container metadata endpoint to DD_TAGS
-# (best-effort; never blocks startup)
+# On ECS, append task_id:<id> from the container metadata endpoint to DD_TAGS,
+# reusing its existing separator (bounded ~2s total; never fails boot)
 if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
-    _task_arn=$(wget -T 2 -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    _task_arn=$(timeout 2 wget -T 2 -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
     _task_id="${_task_arn##*/}"
     if [ -n "$_task_id" ]; then
-        export DD_TAGS="${DD_TAGS:+${DD_TAGS},}task_id:${_task_id}"
+        case "$DD_TAGS" in
+            *,*) _sep="," ;;
+            *" "*) _sep=" " ;;
+            *) _sep="," ;;
+        esac
+        export DD_TAGS="${DD_TAGS:+${DD_TAGS}${_sep}}task_id:${_task_id}"
     fi
 fi
 

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -22,7 +22,7 @@ fi
 # On ECS, append task_id:<id> from the container metadata endpoint to DD_TAGS
 # (best-effort; never blocks startup)
 if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
-    _task_arn=$(wget -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    _task_arn=$(wget -T 2 -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
     _task_id="${_task_arn##*/}"
     if [ -n "$_task_id" ]; then
         export DD_TAGS="${DD_TAGS:+${DD_TAGS},}task_id:${_task_id}"

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -19,5 +19,15 @@ if [ -z "$DATABASE_URL" ]; then
     fi
 fi
 
+# On ECS, append task_id:<id> from the container metadata endpoint to DD_TAGS
+# (best-effort; never blocks startup)
+if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
+    _task_arn=$(wget -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    _task_id="${_task_arn##*/}"
+    if [ -n "$_task_id" ]; then
+        export DD_TAGS="${DD_TAGS:+${DD_TAGS},}task_id:${_task_id}"
+    fi
+fi
+
 # Run the command passed to the docker image on start
 exec "$@"

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -19,18 +19,19 @@ if [ -z "$DATABASE_URL" ]; then
     fi
 fi
 
-# On ECS, append task_id:<id> from the container metadata endpoint to DD_TAGS,
-# reusing its existing separator (bounded ~2s total; never fails boot)
+# On ECS, append task_arn:<full TaskARN> from the container metadata endpoint
+# to DD_TAGS, reusing its existing separator (bounded ~2s total; never fails
+# boot).  Full ARN exact-match joins with EventBridge taskArn / Datadog's ECS
+# task_arn tag convention.
 if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
     _task_arn=$(timeout 2 wget -T 2 -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-    _task_id="${_task_arn##*/}"
-    if [ -n "$_task_id" ]; then
+    if [ -n "$_task_arn" ]; then
         case "$DD_TAGS" in
             *,*) _sep="," ;;
             *" "*) _sep=" " ;;
             *) _sep="," ;;
         esac
-        export DD_TAGS="${DD_TAGS:+${DD_TAGS}${_sep}}task_id:${_task_id}"
+        export DD_TAGS="${DD_TAGS:+${DD_TAGS}${_sep}}task_arn:${_task_arn}"
     fi
 fi
 


### PR DESCRIPTION
## What does this PR do?

Tags dd-trace telemetry (Node runtime metrics + APM spans) with the ECS task id, so per-task attribution (exact-match joins with EventBridge `taskArn`, per Datadog ECS tag convention) — boot spike vs. stalled container, metric ↔ log ↔ span joins on one stable key — no longer requires manual IP joins against EventBridge task-state events.

On ECS (detected via `ECS_CONTAINER_METADATA_URI_V4`), the web and worker image entrypoints resolve `TaskARN` from the container metadata endpoint and append `task_arn:<full TaskARN>` to `DD_TAGS` before the final `exec`. dd-trace applies tracer tags to both runtime metrics and spans; `langfuse.*` custom-metric cardinality is unaffected (deliberately not using `DD_DOGSTATSD_TAG_CARDINALITY`).

Guards:
- Strict no-op when the ECS metadata env var is absent — self-hosted images behave identically.
- Fetch bounded by a hard 2s total deadline (`timeout 2`, BusyBox applet verified in the `node:24-alpine` runtime image) plus a 2s per-read bound (`wget -T 2`); endpoint failure or garbage responses are tolerated silently — this block can never fail or hang boot.
- Separator-aware append: preserves comma- or space-separated `DD_TAGS` dialects (mixing them makes dd-trace's parser mis-split tags).
- POSIX sh, `wget`/`sed` only (no jq in the image); helper variables not exported.

Verified by a stub harness executing both real entrypoints end-to-end across 12 scenarios (no env / happy path / append to comma- and space-separated `DD_TAGS` / endpoint failure / garbage / byte-dripping endpoint under the deadline), plus `sh -n` and lint.

Follow-up (operational, not in this repo): create the Datadog span facet for `task_arn` and confirm custom-metric cardinality is unchanged after rollout; if any prod task definition overrides the image entrypoint, the block won't run there.

Linear: LFE-11028

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tags Datadog telemetry with the current ECS task ID. The main changes are:

- Fetches the task ARN from the ECS container metadata endpoint.
- Appends the extracted task ID to `DD_TAGS` in both entrypoints.
- Preserves existing comma- or space-separated Datadog tags.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Metadata lookup failures leave `DD_TAGS` unchanged and do not stop startup.
- Empty and existing tag values are handled without adding a leading separator.
- No blocking issues found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deploy): separator-aware DD\_TAGS a..."](https://github.com/langfuse/langfuse/commit/1c9238247f4b06c81ea1ac9ae2efd28dba6ca5df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46210873)</sub>

<!-- /greptile_comment -->
