### PR TITLE
fix(otel): persist post-media event bytes

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -95,6 +95,18 @@ type MergeAndWriteParams = {
   attribution: IngestionAttribution;
 };
 
+/**
+ * Returns the UTF-8 size of the final JSONEachRow event payload, excluding the
+ * self-referential `event_bytes` accounting field.
+ */
+function getSerializedEventByteLength(
+  eventRecord: EventRecordInsertType,
+): number {
+  const { event_bytes: _eventBytes, ...eventWithoutSize } = eventRecord;
+
+  return Buffer.byteLength(JSON.stringify(eventWithoutSize), "utf8");
+}
+
 const immutableEntityKeys: {
   [TableName.Traces]: (keyof TraceRecordInsertType)[];
   [TableName.Scores]: (keyof ScoreRecordInsertType)[];
@@ -416,9 +428,14 @@ export class IngestionService {
    * A materialized view auto-populates events_core from events_full.
    * Use createEventRecord() first to get the record, then call this to write.
    *
+   * Mutates `eventRecord.event_bytes` immediately before enqueueing so the
+   * persisted value describes the final normalized event rather than the raw
+   * OTEL span measured before media processing.
+   *
    * @param eventRecord - The event record to write
    */
   public writeEventRecord(eventRecord: EventRecordInsertType): void {
+    eventRecord.event_bytes = getSerializedEventByteLength(eventRecord);
     this.clickHouseWriter.addToQueue(TableName.EventsFull, eventRecord);
   }
 

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -96,15 +96,19 @@ type MergeAndWriteParams = {
 };
 
 /**
- * Returns the UTF-8 size of the final JSONEachRow event payload, excluding the
- * self-referential `event_bytes` accounting field.
+ * Returns a new event record whose `event_bytes` value is the UTF-8 size of
+ * the final JSONEachRow payload, excluding the self-referential accounting
+ * field. The supplied record is not mutated.
  */
-function getSerializedEventByteLength(
+function withSerializedEventByteLength(
   eventRecord: EventRecordInsertType,
-): number {
+): EventRecordInsertType {
   const { event_bytes: _eventBytes, ...eventWithoutSize } = eventRecord;
 
-  return Buffer.byteLength(JSON.stringify(eventWithoutSize), "utf8");
+  return {
+    ...eventWithoutSize,
+    event_bytes: Buffer.byteLength(JSON.stringify(eventWithoutSize), "utf8"),
+  };
 }
 
 const immutableEntityKeys: {
@@ -428,15 +432,17 @@ export class IngestionService {
    * A materialized view auto-populates events_core from events_full.
    * Use createEventRecord() first to get the record, then call this to write.
    *
-   * Mutates `eventRecord.event_bytes` immediately before enqueueing so the
-   * persisted value describes the final normalized event rather than the raw
-   * OTEL span measured before media processing.
+   * Enqueues a new record whose `event_bytes` describes the final normalized
+   * event rather than the raw OTEL span measured before media processing. The
+   * supplied record is not mutated.
    *
    * @param eventRecord - The event record to write
    */
   public writeEventRecord(eventRecord: EventRecordInsertType): void {
-    eventRecord.event_bytes = getSerializedEventByteLength(eventRecord);
-    this.clickHouseWriter.addToQueue(TableName.EventsFull, eventRecord);
+    this.clickHouseWriter.addToQueue(
+      TableName.EventsFull,
+      withSerializedEventByteLength(eventRecord),
+    );
   }
 
   private async processDatasetRunItemEventList(params: {

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -46,6 +46,8 @@ describe("IngestionService unit tests", () => {
     const queuedRecord = addToQueue.mock.calls[0]?.[1];
     const { event_bytes: eventBytes, ...eventWithoutSize } = queuedRecord;
 
+    expect(queuedRecord).not.toBe(eventRecord);
+    expect(eventRecord.event_bytes).toBe(rawOtelSpanBytes);
     expect(eventBytes).toBe(
       Buffer.byteLength(JSON.stringify(eventWithoutSize), "utf8"),
     );

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -9,6 +9,49 @@ import {
 import { TableName } from "../../ClickhouseWriter";
 
 describe("IngestionService unit tests", () => {
+  it("writes the final serialized event size instead of the raw OTEL span size", async () => {
+    const addToQueue = vi.fn();
+    const ingestionService = new IngestionService(
+      {} as any,
+      {} as any,
+      { addToQueue } as any,
+      {} as any,
+    );
+    const rawOtelSpanBytes = 10_000_000;
+    const eventRecord = await ingestionService.createEventRecord(
+      {
+        projectId: "project-id",
+        traceId: "trace-id",
+        spanId: "observation-id",
+        parentSpanId: "",
+        name: "post-media-size",
+        type: "SPAN",
+        environment: "default",
+        startTimeISO: "2026-07-22T00:00:00.000Z",
+        endTimeISO: "2026-07-22T00:00:01.000Z",
+        input: "@@@langfuseMedia:type=image/png|id=media-id|source=bytes@@@",
+        output: "multibyte 🔥 output",
+        metadata: { nested: { value: "metadata" } },
+        source: "otel",
+        eventBytes: rawOtelSpanBytes,
+      },
+      "otel/project-id/raw-event.json",
+    );
+
+    expect(eventRecord.event_bytes).toBe(rawOtelSpanBytes);
+
+    ingestionService.writeEventRecord(eventRecord);
+
+    expect(addToQueue).toHaveBeenCalledOnce();
+    const queuedRecord = addToQueue.mock.calls[0]?.[1];
+    const { event_bytes: eventBytes, ...eventWithoutSize } = queuedRecord;
+
+    expect(eventBytes).toBe(
+      Buffer.byteLength(JSON.stringify(eventWithoutSize), "utf8"),
+    );
+    expect(eventBytes).toBeLessThan(rawOtelSpanBytes);
+  });
+
   it("correctly sorts events in ascending order by timestamp", async () => {
     const firstTrace = { timestamp: 1, type: "observation-create" };
     const secondTrace = { timestamp: 1, type: "observation-update" };


### PR DESCRIPTION
## Motivation

`events_full.event_bytes` currently copies the raw OTEL span byte count captured before normalization and media extraction. After inline media is replaced with a compact reference, ClickHouse therefore retains the much larger pre-media value instead of the size of the final event it stores.

Linear: [LFE-14366](https://linear.app/clickhouse/issue/LFE-14366/persist-post-media-clickhouse-event-size-for-direct-otel-writes)

Follow-up to #15120.

## Approach

- Preserve the existing raw OTEL `eventBytes` value for ingress metrics and oversized-span detection.
- At the `writeEventRecord()` persistence boundary, derive a new record whose `event_bytes` is the UTF-8 byte length of the final JSONEachRow event payload.
- Exclude `event_bytes` itself from the calculation to avoid a self-referential size definition.
- Leave the supplied event record unchanged; only the derived record is enqueued for `events_full`.
- Cover post-media references, multibyte content, a deliberately stale 10 MB raw-span value, and the non-mutation contract in a focused unit test.

## Scope

Impacted package:

- `worker`: final direct-event sizing at the ClickHouse write boundary.

Non-goals:

- Physical compressed ClickHouse bytes.
- Schema or materialized-column changes.
- Generic ClickHouse writer serialization changes.
- Historical backfill.

## Verification

- `pnpm --filter worker run test IngestionService.unit.test.ts` — `Tests  7 passed (7)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- Focused Prettier check — all matched files use Prettier code style.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR records the size of the final normalized event at the ClickHouse write boundary. The main changes are:

- Computes the UTF-8 byte length after removing `event_bytes` from the serialized value.
- Enqueues a derived record without mutating the caller's record.
- Adds coverage for media references, multibyte text, stale ingress sizes, and non-mutation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into hassiebbot/lfe-..."](https://github.com/langfuse/langfuse/commit/c3e8bab2bb43c96220c12d78fa3a7c89d2163c1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46220254)</sub>

<!-- /greptile_comment -->