### PR TITLE
docs(agents): Add instructions on when to create storybook stories

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -21,8 +21,8 @@ evaluating, and debugging AI applications.
   real browser before signoff. Prefill the data the flow needs with the seed
   CLI (`pnpm run seed -- list` shows scenarios; runs print UI deep links) —
   never with ad-hoc scripts or raw ClickHouse inserts.
-- When fixing an isolated styling issue in an individual component, read the
-  `storybook` skill and create or update a component story following its
+- When fixing an isolated styling issue in an individual component, read
+  `.agents/skills/storybook/SKILL.md` create or update a component story following its
   guidance first.
 - Every PR auto-builds (via GitHub Actions) a disposable, full-stack preview at
   `pr-<N>.preview.langfuse.com` — nothing to spin up. Use the `langfuse-previews`

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -21,6 +21,9 @@ evaluating, and debugging AI applications.
   real browser before signoff. Prefill the data the flow needs with the seed
   CLI (`pnpm run seed -- list` shows scenarios; runs print UI deep links) —
   never with ad-hoc scripts or raw ClickHouse inserts.
+- When fixing an isolated styling issue in an individual component, read the
+  `storybook` skill and create or update a component story following its
+  guidance first.
 - Every PR auto-builds (via GitHub Actions) a disposable, full-stack preview at
   `pr-<N>.preview.langfuse.com` — nothing to spin up. Use the `langfuse-previews`
   skill to use or debug one, e.g. read a preview's web/worker error logs with


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Storybook guidance for isolated component styling fixes. The main change is:

- Requires agents to read the `storybook` skill and create or update a component story first.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The new styling workflow references a required skill that is unavailable in the repository.

- Agents cannot follow the required `storybook` skill step.
- The workflow can continue without the intended story guidance or stop at a missing resource.

.agents/AGENTS.md
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.agents/AGENTS.md:24-26
**Required Storybook Skill Is Missing**

An agent handling an isolated component styling fix is now required to read the `storybook` skill, but no shared or package-local skill with that name is available through the repository's skill discovery paths. The required workflow therefore stops at a missing resource or proceeds without the promised guidance, so the styling change may not receive the required story.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): Add instructions on when t..."](https://github.com/langfuse/langfuse/commit/e5de32c37309ebd954ee63030d149c5621447920) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46224475)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->