### PR TITLE
fix(security): mask analytics integration credentials in get endpoints (LFE-14384)

### DIFF
--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -412,7 +412,10 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
         projectId: project.id,
       });
       expect(result.config).not.toHaveProperty("mixpanelProjectToken");
-      expect(result.config?.mixpanelProjectTokenDisplay).toContain("...");
+      // Last-4-only: leading characters of the token are real secret material.
+      expect(result.config?.mixpanelProjectTokenDisplay).toBe(
+        "..." + baseConfig.mixpanelProjectToken.slice(-4),
+      );
       expect(JSON.stringify(result)).not.toContain(
         baseConfig.mixpanelProjectToken,
       );

--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -4,6 +4,7 @@ import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import { LEGACY_BLOB_EXPORT_CUTOFF } from "@langfuse/shared";
+import { decrypt } from "@langfuse/shared/encryption";
 import { env } from "@/src/env.mjs";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -382,6 +383,71 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
         projectId: project.id,
       });
       expect(result.config?.exportSource).toBe("EVENTS");
+    });
+  });
+
+  // LFE-14384: the credential is write-only — get returns only a masked
+  // display value; a blank token on update keeps the persisted encrypted value.
+  describe("Mixpanel credential masking", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+
+    beforeEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+    });
+
+    afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+    });
+
+    it("get returns a masked display value, never the plaintext token", async () => {
+      const { caller, project } = await prepare();
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config).not.toHaveProperty("mixpanelProjectToken");
+      expect(result.config?.mixpanelProjectTokenDisplay).toContain("...");
+      expect(JSON.stringify(result)).not.toContain(
+        baseConfig.mixpanelProjectToken,
+      );
+    });
+
+    it("update with a blank token keeps the existing credential", async () => {
+      const { caller, project } = await prepare();
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        mixpanelProjectToken: "",
+        enabled: false,
+      });
+      const row = await prisma.mixpanelIntegration.findUniqueOrThrow({
+        where: { projectId: project.id },
+      });
+      expect(decrypt(row.encryptedMixpanelProjectToken)).toBe(
+        baseConfig.mixpanelProjectToken,
+      );
+      expect(row.enabled).toBe(false);
+    });
+
+    it("create with a blank token → BAD_REQUEST", async () => {
+      const { caller, project } = await prepare();
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          mixpanelProjectToken: "",
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     });
   });
 });

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -4,6 +4,7 @@ import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import { LEGACY_BLOB_EXPORT_CUTOFF } from "@langfuse/shared";
+import { decrypt } from "@langfuse/shared/encryption";
 import { env } from "@/src/env.mjs";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -426,6 +427,71 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         projectId: project.id,
       });
       expect(result.config?.exportSource).toBe("EVENTS");
+    });
+  });
+
+  // LFE-14384: the credential is write-only — get returns only a masked
+  // display value; a blank key on update keeps the persisted encrypted value.
+  describe("PostHog credential masking", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+
+    beforeEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+    });
+
+    afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+    });
+
+    it("get returns a masked display value, never the plaintext key", async () => {
+      const { caller, project } = await prepare();
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config).not.toHaveProperty("posthogApiKey");
+      expect(result.config?.posthogApiKeyDisplay).toContain("...");
+      expect(JSON.stringify(result)).not.toContain(
+        baseConfig.posthogProjectApiKey,
+      );
+    });
+
+    it("update with a blank key keeps the existing credential", async () => {
+      const { caller, project } = await prepare();
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        posthogProjectApiKey: "",
+        enabled: false,
+      });
+      const row = await prisma.posthogIntegration.findUniqueOrThrow({
+        where: { projectId: project.id },
+      });
+      expect(decrypt(row.encryptedPosthogApiKey)).toBe(
+        baseConfig.posthogProjectApiKey,
+      );
+      expect(row.enabled).toBe(false);
+    });
+
+    it("create with a blank key → BAD_REQUEST", async () => {
+      const { caller, project } = await prepare();
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          posthogProjectApiKey: "",
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     });
   });
 });

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -456,7 +456,10 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         projectId: project.id,
       });
       expect(result.config).not.toHaveProperty("posthogApiKey");
-      expect(result.config?.posthogApiKeyDisplay).toContain("...");
+      // Last-4-only: leading characters of the key are real secret material.
+      expect(result.config?.posthogApiKeyDisplay).toBe(
+        "..." + baseConfig.posthogProjectApiKey.slice(-4),
+      );
       expect(JSON.stringify(result)).not.toContain(
         baseConfig.posthogProjectApiKey,
       );

--- a/web/src/features/analytics-integrations/server/displayCredential.ts
+++ b/web/src/features/analytics-integrations/server/displayCredential.ts
@@ -1,0 +1,5 @@
+// Masking for arbitrary third-party credentials: reveal only the last 4
+// characters. getDisplaySecretKey (shared apiKeys.ts) also reveals the first
+// 6, which is safe only for Langfuse keys with a public prefix (LFE-14384).
+export const getDisplayCredential = (secret: string): string =>
+  "..." + secret.slice(-4);

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -11,6 +11,7 @@ import { decrypt, encrypt } from "@langfuse/shared/encryption";
 import { mixpanelIntegrationFormSchema } from "@/src/features/mixpanel-integration/types";
 import { TRPCError } from "@trpc/server";
 import { env } from "@/src/env.mjs";
+import { getDisplaySecretKey } from "@langfuse/shared/src/server";
 import {
   AnalyticsIntegrationExportSource,
   areLegacyWritesActive,
@@ -45,11 +46,14 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         const { encryptedMixpanelProjectToken, exportSource, ...config } =
           dbConfig;
 
+        // Write-only credential: never return the plaintext token (LFE-14384).
         return {
           config: {
             ...config,
             exportSource,
-            mixpanelProjectToken: decrypt(encryptedMixpanelProjectToken),
+            mixpanelProjectTokenDisplay: getDisplaySecretKey(
+              decrypt(encryptedMixpanelProjectToken),
+            ),
           },
           legacyWritesActive,
         };
@@ -101,8 +105,24 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
       const existingIntegration =
         await ctx.prisma.mixpanelIntegration.findUnique({
           where: { projectId: input.projectId },
-          select: { exportSource: true, createdAt: true },
+          select: {
+            exportSource: true,
+            createdAt: true,
+            encryptedMixpanelProjectToken: true,
+          },
         });
+
+      // Write-only credential: blank/omitted keeps the persisted encrypted
+      // value (LFE-14384).
+      const encryptedMixpanelProjectToken = input.mixpanelProjectToken
+        ? encrypt(input.mixpanelProjectToken)
+        : existingIntegration?.encryptedMixpanelProjectToken;
+      if (!encryptedMixpanelProjectToken) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Mixpanel Project Token is required",
+        });
+      }
       const createDefaultExportSource = legacyWritesActive
         ? AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
         : AnalyticsIntegrationExportSource.EVENTS;
@@ -136,9 +156,7 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         resourceType: "mixpanelIntegration",
         resourceId: input.projectId,
       });
-      const { mixpanelProjectToken, ...config } = input;
-
-      const encryptedMixpanelProjectToken = encrypt(mixpanelProjectToken);
+      const { mixpanelProjectToken: _mixpanelProjectToken, ...config } = input;
 
       await ctx.prisma.$transaction(async (tx) => {
         const result = await tx.mixpanelIntegration.upsert({

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -11,7 +11,7 @@ import { decrypt, encrypt } from "@langfuse/shared/encryption";
 import { mixpanelIntegrationFormSchema } from "@/src/features/mixpanel-integration/types";
 import { TRPCError } from "@trpc/server";
 import { env } from "@/src/env.mjs";
-import { getDisplaySecretKey } from "@langfuse/shared/src/server";
+import { getDisplayCredential } from "@/src/features/analytics-integrations/server/displayCredential";
 import {
   AnalyticsIntegrationExportSource,
   areLegacyWritesActive,
@@ -51,7 +51,7 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
           config: {
             ...config,
             exportSource,
-            mixpanelProjectTokenDisplay: getDisplaySecretKey(
+            mixpanelProjectTokenDisplay: getDisplayCredential(
               decrypt(encryptedMixpanelProjectToken),
             ),
           },

--- a/web/src/features/mixpanel-integration/types.ts
+++ b/web/src/features/mixpanel-integration/types.ts
@@ -20,13 +20,9 @@ export type MixpanelRegion = (typeof MIXPANEL_REGIONS)[number]["subdomain"];
 
 export const mixpanelIntegrationFormSchema = z.object({
   mixpanelRegion: z.enum(MIXPANEL_REGIONS.map((r) => r.subdomain)),
-  mixpanelProjectToken: z
-    .string()
-    .min(1, "Project Token is required")
-    .refine(
-      (v) => v.length > 0,
-      "Mixpanel Project Token is required. You can find it in your Mixpanel project settings.",
-    ),
+  // Write-only: blank keeps the persisted credential (required on create,
+  // enforced server-side and via page-level superRefine).
+  mixpanelProjectToken: z.string().optional(),
   enabled: z.boolean(),
   exportSource: z
     .enum(AnalyticsIntegrationExportSource)

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -11,7 +11,10 @@ import { decrypt, encrypt } from "@langfuse/shared/encryption";
 import { posthogIntegrationFormSchema } from "@/src/features/posthog-integration/types";
 import { TRPCError } from "@trpc/server";
 import { env } from "@/src/env.mjs";
-import { validateWebhookURL } from "@langfuse/shared/src/server";
+import {
+  getDisplaySecretKey,
+  validateWebhookURL,
+} from "@langfuse/shared/src/server";
 import {
   AnalyticsIntegrationExportSource,
   areLegacyWritesActive,
@@ -45,11 +48,14 @@ export const posthogIntegrationRouter = createTRPCRouter({
 
         const { encryptedPosthogApiKey, exportSource, ...config } = dbConfig;
 
+        // Write-only credential: never return the plaintext key (LFE-14384).
         return {
           config: {
             ...config,
             exportSource,
-            posthogApiKey: decrypt(encryptedPosthogApiKey),
+            posthogApiKeyDisplay: getDisplaySecretKey(
+              decrypt(encryptedPosthogApiKey),
+            ),
           },
           legacyWritesActive,
         };
@@ -114,8 +120,24 @@ export const posthogIntegrationRouter = createTRPCRouter({
       const existingIntegration =
         await ctx.prisma.posthogIntegration.findUnique({
           where: { projectId: input.projectId },
-          select: { exportSource: true, createdAt: true },
+          select: {
+            exportSource: true,
+            createdAt: true,
+            encryptedPosthogApiKey: true,
+          },
         });
+
+      // Write-only credential: blank/omitted keeps the persisted encrypted
+      // value (LFE-14384).
+      const encryptedPosthogApiKey = input.posthogProjectApiKey
+        ? encrypt(input.posthogProjectApiKey)
+        : existingIntegration?.encryptedPosthogApiKey;
+      if (!encryptedPosthogApiKey) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "PostHog Project API Key is required",
+        });
+      }
       const createDefaultExportSource = legacyWritesActive
         ? AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
         : AnalyticsIntegrationExportSource.EVENTS;
@@ -149,9 +171,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
         resourceType: "posthogIntegration",
         resourceId: input.projectId,
       });
-      const { posthogProjectApiKey, ...config } = input;
-
-      const encryptedPosthogApiKey = encrypt(posthogProjectApiKey);
+      const { posthogProjectApiKey: _posthogProjectApiKey, ...config } = input;
 
       await ctx.prisma.$transaction(async (tx) => {
         const result = await tx.posthogIntegration.upsert({

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -11,10 +11,8 @@ import { decrypt, encrypt } from "@langfuse/shared/encryption";
 import { posthogIntegrationFormSchema } from "@/src/features/posthog-integration/types";
 import { TRPCError } from "@trpc/server";
 import { env } from "@/src/env.mjs";
-import {
-  getDisplaySecretKey,
-  validateWebhookURL,
-} from "@langfuse/shared/src/server";
+import { validateWebhookURL } from "@langfuse/shared/src/server";
+import { getDisplayCredential } from "@/src/features/analytics-integrations/server/displayCredential";
 import {
   AnalyticsIntegrationExportSource,
   areLegacyWritesActive,
@@ -53,7 +51,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
           config: {
             ...config,
             exportSource,
-            posthogApiKeyDisplay: getDisplaySecretKey(
+            posthogApiKeyDisplay: getDisplayCredential(
               decrypt(encryptedPosthogApiKey),
             ),
           },

--- a/web/src/features/posthog-integration/types.ts
+++ b/web/src/features/posthog-integration/types.ts
@@ -3,10 +3,15 @@ import { z } from "zod";
 
 export const posthogIntegrationFormSchema = z.object({
   posthogHostname: z.url().transform((v) => new URL(v).href),
-  posthogProjectApiKey: z.string().refine((v) => v.startsWith("phc_"), {
-    message:
-      "PostHog 'Project API Key' must start with 'phc_'. You can find it in the PostHog project settings.",
-  }),
+  // Write-only: blank keeps the persisted credential (required on create,
+  // enforced server-side and via page-level superRefine).
+  posthogProjectApiKey: z
+    .string()
+    .refine((v) => v === "" || v.startsWith("phc_"), {
+      message:
+        "PostHog 'Project API Key' must start with 'phc_'. You can find it in the PostHog project settings.",
+    })
+    .optional(),
   enabled: z.boolean(),
   exportSource: z
     .enum(AnalyticsIntegrationExportSource)

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -201,6 +201,15 @@ const MixpanelIntegrationSettingsForm = ({
   const formSchema = useMemo(
     () =>
       mixpanelIntegrationFormSchema.superRefine((data, ctx) => {
+        // The credential is write-only: blank keeps the saved token, so it is
+        // only required when no integration exists yet (LFE-14384).
+        if (!state && !data.mixpanelProjectToken) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["mixpanelProjectToken"],
+            message: "Mixpanel Project Token is required",
+          });
+        }
         if (!isExportSourceSelectable(data.exportSource, exportSourceCtx)) {
           ctx.addIssue({
             code: "custom",
@@ -210,7 +219,7 @@ const MixpanelIntegrationSettingsForm = ({
           });
         }
       }),
-    [exportSourceCtx],
+    [exportSourceCtx, state],
   );
 
   const defaultExportSource = isPostCutoffCloud
@@ -226,7 +235,7 @@ const MixpanelIntegrationSettingsForm = ({
       mixpanelRegion:
         (state?.mixpanelRegion as MixpanelRegion) ??
         MIXPANEL_REGIONS[0].subdomain,
-      mixpanelProjectToken: state?.mixpanelProjectToken ?? "",
+      mixpanelProjectToken: "",
       enabled: state?.enabled ?? false,
       exportSource: defaultExportSource,
     },
@@ -238,7 +247,7 @@ const MixpanelIntegrationSettingsForm = ({
       mixpanelRegion:
         (state?.mixpanelRegion as MixpanelRegion) ??
         MIXPANEL_REGIONS[0].subdomain,
-      mixpanelProjectToken: state?.mixpanelProjectToken ?? "",
+      mixpanelProjectToken: "",
       enabled: state?.enabled ?? false,
       exportSource: defaultExportSource,
     });
@@ -313,11 +322,15 @@ const MixpanelIntegrationSettingsForm = ({
             <FormItem>
               <FormLabel>Mixpanel Project Token</FormLabel>
               <FormControl>
-                <PasswordInput {...field} />
+                <PasswordInput
+                  {...field}
+                  placeholder={state?.mixpanelProjectTokenDisplay}
+                />
               </FormControl>
               <FormDescription>
-                You can find your Project Token in your Mixpanel project
-                settings
+                {state
+                  ? "Leave blank to keep the current token."
+                  : "You can find your Project Token in your Mixpanel project settings"}
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -198,6 +198,15 @@ const PostHogIntegrationSettings = ({
   const formSchema = useMemo(
     () =>
       posthogIntegrationFormSchema.superRefine((data, ctx) => {
+        // The credential is write-only: blank keeps the saved key, so it is
+        // only required when no integration exists yet (LFE-14384).
+        if (!state && !data.posthogProjectApiKey) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["posthogProjectApiKey"],
+            message: "PostHog Project API Key is required",
+          });
+        }
         if (!isExportSourceSelectable(data.exportSource, exportSourceCtx)) {
           ctx.addIssue({
             code: "custom",
@@ -207,7 +216,7 @@ const PostHogIntegrationSettings = ({
           });
         }
       }),
-    [exportSourceCtx],
+    [exportSourceCtx, state],
   );
 
   const defaultExportSource = isPostCutoffCloud
@@ -221,7 +230,7 @@ const PostHogIntegrationSettings = ({
     resolver: zodResolver(formSchema),
     defaultValues: {
       posthogHostname: state?.posthogHostName ?? "",
-      posthogProjectApiKey: state?.posthogApiKey ?? "",
+      posthogProjectApiKey: "",
       enabled: state?.enabled ?? false,
       exportSource: defaultExportSource,
     },
@@ -231,7 +240,7 @@ const PostHogIntegrationSettings = ({
   useEffect(() => {
     posthogForm.reset({
       posthogHostname: state?.posthogHostName ?? "",
-      posthogProjectApiKey: state?.posthogApiKey ?? "",
+      posthogProjectApiKey: "",
       enabled: state?.enabled ?? false,
       exportSource: defaultExportSource,
     });
@@ -293,8 +302,16 @@ const PostHogIntegrationSettings = ({
             <FormItem>
               <FormLabel>Posthog Project API Key</FormLabel>
               <FormControl>
-                <PasswordInput {...field} />
+                <PasswordInput
+                  {...field}
+                  placeholder={state?.posthogApiKeyDisplay}
+                />
               </FormControl>
+              {state && (
+                <FormDescription>
+                  Leave blank to keep the current API key.
+                </FormDescription>
+              )}
               <FormMessage />
             </FormItem>
           )}


### PR DESCRIPTION
## What does this PR do?

`posthogIntegration.get` and `mixpanelIntegration.get` returned the decrypted PostHog Project API Key / Mixpanel Project Token to any project member with the `integrations:CRUD` scope, and the settings pages pre-filled the plaintext credential into the form.

Following the blob-storage pattern, the credential is now write-only:

- `get` returns only a masked display value (`posthogApiKeyDisplay` / `mixpanelProjectTokenDisplay`, via `getDisplaySecretKey`) — the plaintext never leaves the server.
- `update` accepts a blank/omitted credential and keeps the persisted encrypted value; creating an integration without a credential is rejected with `BAD_REQUEST`.
- The settings forms start with an empty password field showing the masked value as placeholder, with a "leave blank to keep" hint; the credential is only required when no integration exists yet.

Fixes LFE-14384

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes Mixpanel and PostHog integration credentials write-only. The main changes are:

- Masks credentials returned by integration GET endpoints.
- Preserves stored encrypted credentials when updates leave the credential blank.
- Shows masked placeholders in the integration settings forms.
- Adds tests for masking, blank updates, and credential-less creation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The server, form, and test changes consistently enforce write-only credentials.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): mask analytics integratio..."](https://github.com/langfuse/langfuse/commit/0d4cd2fb5ecde728ee7252917c8d1a1e58b55d0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46252906)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->