### PR TITLE
refactor(shared): extract analytics score trace-attribute CTE into swappable fragment (LFE-11009)

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2377,19 +2377,23 @@ export const getScoresForBlobStorageExportParquet = function (
   });
 };
 
-export const getScoresForAnalyticsIntegrations = async function* (
+/**
+ * Trace-attribute CTE for analytics-integration score exports. Pre-filters
+ * traces so the trace timestamp window prunes partitions directly, instead of
+ * living in an OR clause after the LEFT JOIN where the planner cannot push it
+ * down. Subtracts 7d from minTimestamp to keep scores whose trace was created
+ * before the score window started.
+ *
+ * Schema contract with the consuming query in
+ * getScoresForAnalyticsIntegrations: project_id, id, name, session_id,
+ * user_id, release, tags, posthog_session_id, mixpanel_session_id.
+ */
+const buildAnalyticsScoreTraceAttributesCte = (
   projectId: string,
-  projectName: string,
   minTimestamp: Date,
   maxTimestamp: Date,
-  options: { useGraceHash?: boolean } = {},
-) {
-  // Pre-filter traces in a CTE so the trace timestamp window prunes partitions
-  // directly, instead of living in an OR clause after the LEFT JOIN where the
-  // planner cannot push it down. Subtract 7d from minTimestamp to keep scores
-  // whose trace was created before the score window started.
-  const query = `
-    WITH selected_traces AS (
+): { query: string; params: Record<string, unknown> } => ({
+  query: `
       SELECT
         t.project_id as project_id,
         t.id as id,
@@ -2403,7 +2407,29 @@ export const getScoresForAnalyticsIntegrations = async function* (
       FROM traces t FINAL
       WHERE t.project_id = {projectId: String}
       AND t.timestamp >= {minTimestamp: DateTime64(3)} - INTERVAL 7 DAY
-      AND t.timestamp <= {maxTimestamp: DateTime64(3)}
+      AND t.timestamp <= {maxTimestamp: DateTime64(3)}`,
+  params: {
+    projectId,
+    minTimestamp: convertDateToClickhouseDateTime(minTimestamp),
+    maxTimestamp: convertDateToClickhouseDateTime(maxTimestamp),
+  },
+});
+
+export const getScoresForAnalyticsIntegrations = async function* (
+  projectId: string,
+  projectName: string,
+  minTimestamp: Date,
+  maxTimestamp: Date,
+  options: { useGraceHash?: boolean } = {},
+) {
+  const selectedTraces = buildAnalyticsScoreTraceAttributesCte(
+    projectId,
+    minTimestamp,
+    maxTimestamp,
+  );
+
+  const query = `
+    WITH selected_traces AS (${selectedTraces.query}
     )
 
     SELECT
@@ -2447,6 +2473,7 @@ export const getScoresForAnalyticsIntegrations = async function* (
       minTimestamp: convertDateToClickhouseDateTime(minTimestamp),
       maxTimestamp: convertDateToClickhouseDateTime(maxTimestamp),
       dataTypes: LISTABLE_SCORE_TYPES,
+      ...selectedTraces.params,
     },
     tags: { projectId },
     clickhouseConfigs: {


### PR DESCRIPTION
## What does this PR do?

Behavior-preserving prep for LFE-11009 (stacked: routing follows in #15298).

Extracts the `selected_traces` CTE construction in `getScoresForAnalyticsIntegrations` (PostHog/Mixpanel score exports) into a fragment function returning `{query, params}`. No SQL output change: same CTE body, same parameters. This makes the trace-attribute source swappable so the follow-up PR can route it by `LANGFUSE_MIGRATION_V4_WRITE_MODE` without touching the streaming query.

## Type of change

- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] Covered by the ClickHouse servertests added in #15298 (legacy-source path asserts unchanged enrichment behavior)
- [x] `pnpm turbo run lint typecheck --filter=@langfuse/shared` passes on this branch standalone

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts the analytics score trace CTE into a swappable query fragment. The main changes are:

- Moves trace selection SQL into a dedicated builder.
- Returns the fragment SQL together with its ClickHouse parameters.
- Composes the fragment into the existing analytics export query.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The generated SQL, projected columns, and timestamp filters remain unchanged.
- Overlapping query parameters resolve to the same values, so current behavior is preserved.

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(shared): extract analytics scor..."](https://github.com/langfuse/langfuse/commit/8c72d928e17d8343bc9d0721ca0a78392c9d89ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46261724)</sub>

<!-- /greptile_comment -->