### PR TITLE
fix(chatml): render Google ADK invocation root spans as chat messages

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/gemini.ts
+++ b/packages/shared/src/utils/chatml/adapters/gemini.ts
@@ -35,6 +35,15 @@ const GeminiADKOutputSchema = z.looseObject({
   }),
 });
 
+// ADK invocation input format (root span of the OpenInference ADK
+// instrumentation): {user_id, session_id, new_message: {parts, role}, run_config}
+const GeminiADKInvocationInputSchema = z.looseObject({
+  new_message: z.looseObject({
+    parts: z.array(z.any()),
+    role: z.string().optional(),
+  }),
+});
+
 // ADK input format: {config: {tools, system_instruction}, contents: [...]}
 const GeminiADKInputSchema = z.looseObject({
   config: z.looseObject({
@@ -378,7 +387,20 @@ function preprocessData(data: unknown): unknown {
   }
 
   // ========================================
-  // STEP 3: Handle ADK input format
+  // STEP 3: Unwrap ADK invocation input format (root invocation span)
+  // ========================================
+  // {new_message: {parts, role}, user_id, session_id, run_config, ...} → [{parts, role}]
+  if (GeminiADKInvocationInputSchema.safeParse(data).success) {
+    const obj = data as Record<string, unknown>;
+    const newMessage = obj.new_message as Record<string, unknown>;
+    if ("parts" in newMessage && Array.isArray(newMessage.parts)) {
+      // new_message is the user's request to the agent; default the role
+      return normalizeMessages([{ role: "user", ...newMessage }]);
+    }
+  }
+
+  // ========================================
+  // STEP 4: Handle ADK input format
   // ========================================
   // {config: {tools, system_instruction}, contents: [...]}
   if (GeminiADKInputSchema.safeParse(data).success) {
@@ -424,7 +446,7 @@ function preprocessData(data: unknown): unknown {
   }
 
   // ========================================
-  // STEP 4: Handle simple request format
+  // STEP 5: Handle simple request format
   // ========================================
   // {contents: [{parts, role}], model: "..."}
   if (GeminiRequestSchema.safeParse(data).success) {
@@ -433,14 +455,14 @@ function preprocessData(data: unknown): unknown {
   }
 
   // ========================================
-  // STEP 5: Handle arrays
+  // STEP 6: Handle arrays
   // ========================================
   if (Array.isArray(data)) {
     return normalizeMessages(data);
   }
 
   // ========================================
-  // STEP 6: Handle messages wrapper
+  // STEP 7: Handle messages wrapper
   // ========================================
   if (typeof data === "object" && "messages" in data) {
     const obj = data as Record<string, unknown>;
@@ -494,12 +516,15 @@ export const geminiAdapter: ProviderAdapter = {
     // STRUCTURAL: Schema-based detection on metadata (check metadata first for performance)
     if (GeminiRequestSchema.safeParse(ctx.metadata).success) return true;
     if (GeminiADKInputSchema.safeParse(ctx.metadata).success) return true;
+    if (GeminiADKInvocationInputSchema.safeParse(ctx.metadata).success)
+      return true;
     if (GeminiRawAPISchema.safeParse(ctx.metadata).success) return true;
     if (GeminiADKOutputSchema.safeParse(ctx.metadata).success) return true;
 
     // Schema-based detection on data (slower, do last)
     if (GeminiRequestSchema.safeParse(ctx.data).success) return true;
     if (GeminiADKInputSchema.safeParse(ctx.data).success) return true;
+    if (GeminiADKInvocationInputSchema.safeParse(ctx.data).success) return true;
     if (GeminiRawAPISchema.safeParse(ctx.data).success) return true;
     if (GeminiADKOutputSchema.safeParse(ctx.data).success) return true;
 

--- a/packages/shared/src/utils/chatml/adapters/gemini.ts
+++ b/packages/shared/src/utils/chatml/adapters/gemini.ts
@@ -38,6 +38,8 @@ const GeminiADKOutputSchema = z.looseObject({
 // ADK invocation input format (root span of the OpenInference ADK
 // instrumentation): {user_id, session_id, new_message: {parts, role}, run_config}
 const GeminiADKInvocationInputSchema = z.looseObject({
+  user_id: z.string(),
+  session_id: z.string(),
   new_message: z.looseObject({
     parts: z.array(z.any()),
     role: z.string().optional(),

--- a/worker/src/__tests__/chatml/adapters/gemini.test.ts
+++ b/worker/src/__tests__/chatml/adapters/gemini.test.ts
@@ -3,6 +3,9 @@ import {
   geminiAdapter,
   selectAdapter,
   SimpleChatMlArraySchema,
+  normalizeInput as chatmlNormalizeInput,
+  normalizeOutput as chatmlNormalizeOutput,
+  combineInputOutputMessages,
   type NormalizerContext,
 } from "@langfuse/shared";
 
@@ -268,5 +271,124 @@ describe("geminiAdapter", () => {
       expect(result.data?.[3].role).toBe("user");
       expect(result.data?.[3].content).toBeDefined();
     });
+  });
+});
+
+// Real payloads from a Google ADK invocation root span
+// (openinference-instrumentation-google-adk 0.1.17, google-adk 2.4.0).
+// Regression tests for https://github.com/langfuse/langfuse/issues/13292
+describe("geminiAdapter: Google ADK invocation root span", () => {
+  const invocationInput = {
+    user_id: "demo-user",
+    session_id: "demo-session",
+    invocation_id: null,
+    new_message: {
+      parts: [
+        {
+          text: "hi",
+        },
+      ],
+      role: "user",
+    },
+    state_delta: null,
+    run_config: {
+      save_input_blobs_as_artifacts: false,
+      support_cfc: false,
+      streaming_mode: "StreamingMode.NONE",
+      output_audio_transcription: {},
+      input_audio_transcription: {},
+      save_live_blob: false,
+      save_live_audio: false,
+      max_llm_calls: 500,
+    },
+    yield_user_message: false,
+  };
+
+  const invocationOutput = {
+    model_version: "gemini-3.1-flash-lite",
+    content: {
+      parts: [
+        {
+          text: "Hello! How can I help you today?",
+          thought_signature:
+            "EjQKMgERTTIP4vHbi_GtaO9Rcz5K7VC1uJkE5IsctGfJn7xqR9usflAYTBhwqAuJMyGmdnsy",
+        },
+      ],
+      role: "model",
+    },
+    finish_reason: "STOP",
+    usage_metadata: {
+      candidates_token_count: 9,
+      prompt_token_count: 62,
+      prompt_tokens_details: [
+        {
+          modality: "TEXT",
+          token_count: 62,
+        },
+      ],
+      total_token_count: 71,
+    },
+    invocation_id: "e-db33baf0-bb57-4b21-a6f7-a222364a4309",
+    author: "hello_agent",
+    actions: {
+      state_delta: {},
+      artifact_delta: {},
+      requested_auth_configs: {},
+      requested_tool_confirmations: {},
+    },
+    node_info: {
+      path: "hello_agent@1",
+    },
+    id: "8f01c045-0d98-421a-848f-cf25fc4fe1d3",
+    timestamp: 1784663909.934617,
+  };
+
+  const observationMetadata = {
+    attributes: {
+      "langfuse.internal.is_app_root": "true",
+      "input.mime_type": "application/json",
+      "user.id": "demo-user",
+      "session.id": "demo-session",
+      "output.mime_type": "application/json",
+      "openinference.span.kind": "CHAIN",
+    },
+    resourceAttributes: {
+      "telemetry.sdk.language": "python",
+      "telemetry.sdk.name": "opentelemetry",
+      "telemetry.sdk.version": "1.42.1",
+      "service.name": "unknown_service",
+    },
+    scope: {
+      name: "openinference.instrumentation.google_adk",
+      version: "0.1.17",
+      attributes: {},
+    },
+  };
+
+  // ctx exactly as parseChatML (useChatMLParser.ts) builds it
+  const ctx: NormalizerContext = {
+    metadata: observationMetadata,
+    observationName: "invocation [hello_app]",
+  };
+
+  it("normalizes the invocation input envelope into a user message", () => {
+    const res = chatmlNormalizeInput(invocationInput, ctx);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.data).toHaveLength(1);
+    expect(res.data[0].role).toBe("user");
+    expect(res.data[0].content).toBe("hi");
+  });
+
+  it("combines invocation input and output so the trace renders as chat", () => {
+    const inResult = chatmlNormalizeInput(invocationInput, ctx);
+    const outResult = chatmlNormalizeOutput(invocationOutput, ctx);
+    const messages = combineInputOutputMessages(
+      inResult,
+      outResult,
+      invocationOutput,
+    );
+    expect(messages).toHaveLength(2);
+    expect(messages[1].role).toBe("model");
   });
 });

--- a/worker/src/__tests__/chatml/adapters/generic.test.ts
+++ b/worker/src/__tests__/chatml/adapters/generic.test.ts
@@ -44,21 +44,20 @@ describe("Generic Adapter", () => {
 
   it("should not display non-ChatML formats as chat", () => {
     const input = {
-      new_message: {
-        parts: [{ text: "hi" }],
-        role: "user",
+      job_request: {
+        steps: [{ name: "fetch" }],
+        priority: "high",
       },
-      run_config: {
-        streaming_mode: "StreamingMode.NONE",
+      retry_policy: {
+        max_attempts: 3,
       },
     };
 
     const output = {
-      content: {
-        parts: [{ text: "Hello!" }],
-        role: "model",
+      status: "completed",
+      metrics: {
+        duration_ms: 12,
       },
-      finish_reason: "STOP",
     };
 
     const inResult = normalizeInput(input);

--- a/worker/src/__tests__/chatml/framework-traces/google-adk-2025-08-28.chatml.json
+++ b/worker/src/__tests__/chatml/framework-traces/google-adk-2025-08-28.chatml.json
@@ -41,11 +41,13 @@
   },
   "86cd4912944ddc41": {
     "input": {
-      "success": false,
-      "error": {
-        "name": "ZodError",
-        "message": "[\n  {\n    \"expected\": \"array\",\n    \"code\": \"invalid_type\",\n    \"path\": [],\n    \"message\": \"Invalid input: expected array, received object\"\n  }\n]"
-      }
+      "success": true,
+      "data": [
+        {
+          "role": "user",
+          "content": "hi"
+        }
+      ]
     },
     "output": {
       "success": true,


### PR DESCRIPTION
## What does this PR do?

Fixes langfuse/langfuse#13292

Google ADK traces (instrumented via `openinference-instrumentation-google-adk`)  <br>rendered their root `invocation` span as raw JSON instead of a readable chat  <br>conversation.

### Root cause

The invocation span's input is the serialized argument envelope of ADK's  <br>`Runner.run_async` call, i.e. `{user_id, session_id, new_message, run_config, ...}`.  <br>No ChatML adapter recognized this shape, so `normalizeInput` failed. Because  <br>`combineInputOutputMessages` returns an empty list whenever the input fails to  <br>parse, the successfully parsed output was discarded as well, `canDisplayAsChat`  <br>stayed false, and the UI fell back to the JSON tree for both input and output.

### Changes

* Add `GeminiADKInvocationInputSchema` to the gemini adapter. The  <br>`new_message.parts` fingerprint mirrors the public `Runner.run_async`  <br>signature and is unique across all 20 framework seed traces in the repo.
* Add the matching detect checks and a preprocess step that unwraps  <br>`new_message` into a single user message, with the role defaulting to `user`.
* Replace the specimen in the non-ChatML rendering test with a  <br>framework-neutral payload. The previous specimen was this exact ADK envelope.
* Regenerate the ADK seed-trace snapshot. Only the invocation observation  <br>changes, from a stored ZodError to a parsed user message.

The change is read-time display logic only, so it applies retroactively to  <br>already ingested traces. Envelope fields such as `user_id`, `session_id` and  <br>`run_config` stay visible via Additional Input and the JSON view, and  <br>user/session are already first-class Langfuse fields.

### Verification

* Two regression tests with real ADK 2.4.0 payloads in `gemini.test.ts`,  <br>red before the fix and green after. Worker chatml suite: `Tests 122 passed (122)`
* Lint via pre-commit on every commit: `Tasks: 7 successful, 7 total`
* End-to-end on a local stack: ran the Google ADK cookbook unchanged against  <br>this branch, all four example traces render as user/model conversations.

<details><summary>Greptile Summary</summary>

This PR renders Google ADK invocation root spans as chat messages. The main changes are:

* Adds a schema and preprocessing path for ADK invocation envelopes.
* Adds normalization and message-combination tests using ADK payloads.
* Updates the ADK trace snapshot and generic non-chat fixture.

</details>

<details><summary>Confidence Score: 4/5</summary>

The new adapter detection can misclassify unrelated message envelopes and needs a narrower discriminator.

* The intended ADK input and output path is covered by tests.
* The new schema accepts any nested `new_message.parts` array, so unrelated inputs can be rendered with the wrong adapter.

packages/shared/src/utils/chatml/adapters/gemini.ts

</details>

<details><summary>Prompt To Fix All With AI</summary>

```markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/utils/chatml/adapters/gemini.ts:40-45
**Broad Envelope Misclassifies Other Inputs**

Any input shaped like `{ new_message: { parts: [...] } }` now selects the Gemini adapter, even without an ADK-specific field or instrumentation marker. A non-ADK application using this common envelope is therefore unwrapped as a user message instead of retaining its original representation; require a stable ADK discriminator before claiming it.
```

</details>

Reviews (1): Last reviewed commit: ["test(chatml): add ADK invocation envelop..."](<https://github.com/langfuse/langfuse/commit/d851391ba8b6c2131754da596b88c01c21aa3cf5>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=46261882>)

> Greptile also left **1 inline comment** on this PR.

**Context used:**

* Rule used - Move imports to the top of the module instead of p... ([source](<https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12>))

**Learned From**  <br>[langfuse/langfuse-python#1387](<https://github.com/langfuse/langfuse-python/pull/1387>)