### PR TITLE
fix(feature-previews): allow enabling previews on self-hosted deploys

### DIFF
--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -114,7 +114,7 @@ export function AuthenticatedLayout({
     }),
   );
 
-  const hasFeaturePreviews = isLangfuseCloud;
+  const hasFeaturePreviews = isLangfuseCloud || user.v4BetaEnabled === true;
 
   // User navigation items for sidebar dropdown
   const userNavProps = {

--- a/web/src/server/api/routers/userAccount.ts
+++ b/web/src/server/api/routers/userAccount.ts
@@ -110,11 +110,15 @@ export const userAccountRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const userId = ctx.session.user.id;
 
-      if (input.enabled && !env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
+      const canEnableFeaturePreviews =
+        Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) ||
+        ctx.session.user.v4BetaEnabled === true;
+
+      if (input.enabled && !canEnableFeaturePreviews) {
         throw new TRPCError({
           code: "PRECONDITION_FAILED",
           message:
-            "Feature previews are not available in self-hosted deployments.",
+            "Feature previews require Fast (Preview) on self-hosted deployments.",
         });
       }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR allows Fast Preview users to access feature previews on self-hosted deployments. The main changes are:

- Show feature-preview controls when `v4BetaEnabled` is true.
- Permit the feature-preview mutation for matching self-hosted sessions.
- Update the self-hosted precondition message.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The self-hosted server gate should validate current Fast Preview eligibility before merging.

- Existing JWT sessions can retain `v4BetaEnabled` after the deployment disables Fast Preview.
- The changed mutation trusts that stale value and can enable previews against the current configuration.

web/src/server/api/routers/userAccount.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/server/api/routers/userAccount.ts:113-115
**Stale Session Bypasses Preview Gate**

When a self-hosted deployment disables Fast Preview or changes back to legacy mode, existing JWT sessions can still contain `v4BetaEnabled: true`. This gate then allows those sessions to enable feature previews until the session is refreshed or expires, even though the current deployment configuration no longer permits Fast Preview.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(feature-previews): allow enabling pr..."](https://github.com/langfuse/langfuse/commit/79324fb60261526919acc9078d3eca43d8b11408) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46273833)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->