### PR TITLE
feat(components): one-line self-measuring OverflowActionBar (LFE-11067)

### DIFF
--- a/web/src/components/OverflowActionBar.stories.tsx
+++ b/web/src/components/OverflowActionBar.stories.tsx
@@ -1,0 +1,159 @@
+import { fn } from "storybook/test";
+import {
+  BarChart3,
+  Bookmark,
+  Columns3,
+  Download,
+  Filter,
+  RefreshCw,
+  Sparkles,
+  Table,
+} from "lucide-react";
+
+import preview from "../../.storybook/preview";
+import { Button } from "@/src/components/ui/button";
+import { OverflowActionBar, type OverflowAction } from "./OverflowActionBar";
+
+const meta = preview.meta({
+  component: OverflowActionBar,
+});
+
+/** A realistic Traces-page action set: date range, refresh, view toggle,
+ *  filters (with a count), views, columns, export, and a pinned "Ask AI". */
+const sampleActions = (): OverflowAction[] => {
+  const barButton = (label: string, icon: React.ReactNode) => (
+    <Button variant="outline" size="sm" className="gap-1.5" onClick={fn()}>
+      {icon}
+      {label}
+    </Button>
+  );
+  return [
+    {
+      key: "date",
+      content: barButton("Past 1 day", null),
+      overflowLabel: "Past 1 day",
+      onSelect: fn(),
+    },
+    {
+      key: "refresh",
+      content: barButton("Off", <RefreshCw className="size-3.5" />),
+      overflowLabel: (
+        <>
+          <RefreshCw className="size-4" /> Auto-refresh
+        </>
+      ),
+      onSelect: fn(),
+    },
+    {
+      key: "view",
+      content: barButton("Table", <Table className="size-3.5" />),
+      overflowLabel: (
+        <>
+          <BarChart3 className="size-4" /> Chart view
+        </>
+      ),
+      onSelect: fn(),
+    },
+    {
+      key: "filters",
+      content: (
+        <Button variant="outline" size="sm" className="gap-1.5" onClick={fn()}>
+          <Filter className="size-3.5" />
+          Filters
+          <span className="bg-primary text-primary-foreground ml-0.5 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[0.625rem] leading-none">
+            2
+          </span>
+        </Button>
+      ),
+      overflowLabel: (
+        <>
+          <Filter className="size-4" /> Filters (2)
+        </>
+      ),
+      onSelect: fn(),
+    },
+    {
+      key: "views",
+      content: barButton("My Views", <Bookmark className="size-3.5" />),
+      overflowLabel: (
+        <>
+          <Bookmark className="size-4" /> My Views
+        </>
+      ),
+      onSelect: fn(),
+    },
+    {
+      key: "columns",
+      content: barButton("Columns", <Columns3 className="size-3.5" />),
+      overflowLabel: (
+        <>
+          <Columns3 className="size-4" /> Columns
+        </>
+      ),
+      onSelect: fn(),
+    },
+    {
+      key: "export",
+      content: barButton("Export", <Download className="size-3.5" />),
+      overflowLabel: (
+        <>
+          <Download className="size-4" /> Export
+        </>
+      ),
+      onSelect: fn(),
+    },
+    {
+      key: "ask-ai",
+      pinned: true,
+      content: (
+        <Button size="sm" className="gap-1.5" onClick={fn()}>
+          <Sparkles className="size-3.5" />
+          Ask AI
+        </Button>
+      ),
+      overflowLabel: "Ask AI",
+    },
+  ];
+};
+
+// Wide enough that every action fits on one line — no overflow trigger.
+export const Default = meta.story({
+  args: { actions: sampleActions() },
+  render: (args) => (
+    <div className="w-[640px] max-w-full rounded-md border p-2">
+      <OverflowActionBar {...args} />
+    </div>
+  ),
+});
+
+// Phone width: most actions spill into the "⋯" menu; the pinned "Ask AI" and
+// the count badge stay put.
+export const Overflowing = meta.story({
+  args: { actions: sampleActions() },
+  render: (args) => (
+    <div className="w-[360px] max-w-full rounded-md border p-2">
+      <OverflowActionBar {...args} />
+    </div>
+  ),
+});
+
+// The mechanic at a glance: the same bar at shrinking widths. As space drops,
+// trailing actions move into "⋯ (n)"; "Ask AI" never leaves the row.
+export const AcrossWidths = meta.story({
+  args: { actions: sampleActions() },
+  render: (args) => (
+    <div className="flex flex-col gap-4">
+      {[680, 520, 400, 300, 240].map((w) => (
+        <div key={w} className="flex flex-col gap-1">
+          <span className="text-muted-foreground text-xs">{w}px</span>
+          <div
+            className="rounded-md border p-2"
+            style={{ width: w, maxWidth: "100%" }}
+          >
+            <OverflowActionBar {...args} />
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+});

--- a/web/src/components/OverflowActionBar.tsx
+++ b/web/src/components/OverflowActionBar.tsx
@@ -27,7 +27,7 @@ export type OverflowAction = {
 };
 
 const GAP_PX = 8; // matches gap-2
-const TRIGGER_WIDTH_PX = 40; // the "⋯" trigger + its gap budget
+const TRIGGER_WIDTH_PX = 52; // the "⋯ n" trigger + its gap budget
 
 /**
  * A single-line action bar that stays exactly one line: it measures itself and
@@ -109,7 +109,7 @@ export const OverflowActionBar = ({
       role="toolbar"
       aria-label={ariaLabel}
       className={cn(
-        "flex min-w-0 items-center gap-2 overflow-hidden",
+        "flex min-w-0 items-center gap-2",
         // Hide the row until the first measurement lands so users never see a
         // flash of the un-trimmed set.
         visibleCount === null && "invisible",
@@ -127,14 +127,12 @@ export const OverflowActionBar = ({
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              size="icon"
-              className="relative shrink-0"
+              size="sm"
+              className="shrink-0 gap-1"
               aria-label={`${overflowItems.length} more action${overflowItems.length === 1 ? "" : "s"}`}
             >
               <MoreHorizontal className="size-4" />
-              <span className="bg-primary text-primary-foreground absolute -top-1.5 -right-1.5 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[0.625rem] leading-none font-bold">
-                {overflowItems.length}
-              </span>
+              {overflowItems.length}
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">

--- a/web/src/components/OverflowActionBar.tsx
+++ b/web/src/components/OverflowActionBar.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import * as React from "react";
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/src/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import { useElementSize } from "@/src/hooks/useElementSize";
+import { cn } from "@/src/utils/tailwind";
+
+export type OverflowAction = {
+  /** Stable identity across renders. */
+  key: string;
+  /** Inline rendering when the action fits on the row (a button/control). */
+  content: React.ReactNode;
+  /** Representation inside the overflow "⋯" menu when the action doesn't fit. */
+  overflowLabel: React.ReactNode;
+  /** Invoked when the action is chosen from the overflow menu. Omit for actions
+   *  that can't sensibly live in a menu (keep those `pinned`). */
+  onSelect?: () => void;
+  /** Never overflows — always rendered inline (e.g. the primary "Ask AI"). */
+  pinned?: boolean;
+};
+
+const GAP_PX = 8; // matches gap-2
+const TRIGGER_WIDTH_PX = 40; // the "⋯" trigger + its gap budget
+
+/**
+ * A single-line action bar that stays exactly one line: it measures itself and
+ * spills whatever doesn't fit into a badge-counted "⋯" overflow menu, pulling
+ * items back inline as space grows. Pinned actions never overflow.
+ *
+ * Measurement is container-relative (ResizeObserver via {@link useElementSize}),
+ * so the bar reacts to its actual available width — e.g. when a filter sidebar
+ * opens — not just the viewport size.
+ */
+export const OverflowActionBar = ({
+  actions,
+  className,
+  "aria-label": ariaLabel = "Page actions",
+}: {
+  actions: OverflowAction[];
+  className?: string;
+  "aria-label"?: string;
+}) => {
+  const [containerRef, size] = useElementSize<HTMLDivElement>();
+  const containerWidth = size?.width ?? 0;
+
+  // Hidden measurement row keeps every item's natural width on hand so overflow
+  // is computed from real geometry, not guesses.
+  const measureRefs = React.useRef<Map<string, HTMLSpanElement>>(new Map());
+  const [visibleCount, setVisibleCount] = React.useState<number | null>(null);
+
+  const pinned = React.useMemo(
+    () => actions.filter((a) => a.pinned),
+    [actions],
+  );
+  const flexible = React.useMemo(
+    () => actions.filter((a) => !a.pinned),
+    [actions],
+  );
+
+  // Serialized key list so the layout effect recomputes when the set changes.
+  const actionKeys = actions.map((a) => a.key).join("|");
+
+  React.useLayoutEffect(() => {
+    if (!containerWidth) return;
+    const widthOf = (key: string) =>
+      measureRefs.current.get(key)?.getBoundingClientRect().width ?? 0;
+
+    const pinnedWidth = pinned.reduce(
+      (sum, a) => sum + widthOf(a.key) + GAP_PX,
+      0,
+    );
+    const flexibleWidth = flexible.reduce(
+      (sum, a) => sum + widthOf(a.key) + GAP_PX,
+      0,
+    );
+
+    // Everything fits with room to spare → no trigger, show all.
+    if (flexibleWidth <= containerWidth - pinnedWidth) {
+      setVisibleCount(flexible.length);
+      return;
+    }
+
+    // Reserve space for the "⋯" trigger and fill the prefix that fits.
+    const budget = containerWidth - pinnedWidth - TRIGGER_WIDTH_PX;
+    let used = 0;
+    let count = 0;
+    for (const a of flexible) {
+      used += widthOf(a.key) + GAP_PX;
+      if (used > budget) break;
+      count += 1;
+    }
+    setVisibleCount(count);
+  }, [containerWidth, actionKeys, pinned, flexible]);
+
+  const resolvedVisible = visibleCount ?? flexible.length;
+  const visibleItems = flexible.slice(0, resolvedVisible);
+  const overflowItems = flexible.slice(resolvedVisible);
+
+  return (
+    <div
+      ref={containerRef}
+      role="toolbar"
+      aria-label={ariaLabel}
+      className={cn(
+        "flex min-w-0 items-center gap-2 overflow-hidden",
+        // Hide the row until the first measurement lands so users never see a
+        // flash of the un-trimmed set.
+        visibleCount === null && "invisible",
+        className,
+      )}
+    >
+      {visibleItems.map((a) => (
+        <div key={a.key} className="flex shrink-0 items-center">
+          {a.content}
+        </div>
+      ))}
+
+      {overflowItems.length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              className="relative shrink-0"
+              aria-label={`${overflowItems.length} more action${overflowItems.length === 1 ? "" : "s"}`}
+            >
+              <MoreHorizontal className="size-4" />
+              <span className="bg-primary text-primary-foreground absolute -top-1.5 -right-1.5 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[0.625rem] leading-none font-bold">
+                {overflowItems.length}
+              </span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {overflowItems.map((a) => (
+              <DropdownMenuItem
+                key={a.key}
+                onSelect={() => a.onSelect?.()}
+                className="gap-2"
+              >
+                {a.overflowLabel}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+
+      {pinned.map((a) => (
+        <div key={a.key} className="flex shrink-0 items-center">
+          {a.content}
+        </div>
+      ))}
+
+      {/* Hidden measurement row: renders every item once to capture natural
+          widths. Absolutely positioned + aria-hidden so it never affects
+          layout, hit-testing, or the accessibility tree. */}
+      <div
+        aria-hidden
+        className="pointer-events-none invisible absolute flex flex-nowrap gap-2"
+      >
+        {actions.map((a) => (
+          <span
+            key={a.key}
+            ref={(el) => {
+              if (el) measureRefs.current.set(a.key, el);
+              else measureRefs.current.delete(a.key);
+            }}
+            className="flex shrink-0 items-center"
+          >
+            {a.content}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## TL;DR
The engine for the mobile "second top bar" you picked: a **one-line action bar that measures itself and spills overflow into a badge-counted `⋯` menu**, growing items back as space allows. Pinned actions (Ask AI) never overflow. This PR is the reusable primitive + Storybook; wiring it into the mobile shell (and hoisting each page's toolbar into it) is the next slice.

## Why
The mobile top was overloaded because page actions (time range, refresh, view toggle, filters, columns, export, Ask AI, …) just wrap onto several rows. We want them on exactly one line, with the rest one tap away — the pattern Grafana/Superset/Sentry all converge on (measured overflow into a "More" menu).

## What
`OverflowActionBar` takes an ordered list of actions and:
- renders the prefix that fits, spills the rest into a `⋯` dropdown with a **count badge**;
- **grows items back inline** when width increases (bidirectional);
- keeps `pinned` actions (Ask AI) always inline;
- measures **container width** (ResizeObserver), not the viewport — so it reacts when the filter sidebar opens.

## Result
Strictly one line at every width. Verified in Storybook across 240–680px: actions progressively move into `⋯(n)`, Ask AI stays put, the `Filters (2)` badge shows inline then moves into the menu. Typecheck + lint green.

<details>
<summary>Mechanism & notes</summary>

- A hidden, `aria-hidden`, absolutely-positioned measurement row renders every item once to capture natural widths; a `useLayoutEffect` computes the fitting prefix (reserving space for the trigger + pinned items) and sets `visibleCount`. The visible row is `invisible` until the first measurement lands, so there's no flash of the un-trimmed set.
- Filters intentionally are **not** a special case here — they're just another action (a `Filters (n)` button) that can overflow; where the filter *panel* itself lives on mobile is a separate decision.
- Overflowed actions expose an `overflowLabel` + `onSelect` for their menu representation. Complex controls (e.g. the date picker) would stay pinned or open their own modal — the research-backed "date picker → modal on phone" refinement lands with integration.
- Not yet wired into a page — that's deliberate (validate the mechanic in isolation first). Stories: `Default`, `Overflowing`, `AcrossWidths`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a self-measuring one-line action bar for mobile toolbars. The main changes are:

- A reusable component that moves trailing actions into a counted overflow menu.
- Support for pinned actions that remain inline.
- Container-based resize measurement for growing actions back into the row.
- Storybook examples across desktop and mobile widths.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Dynamic and effectful actions can behave incorrectly and need fixes before production integration.

- The hidden measurement row mounts action controls twice.
- Width changes inside an action can leave the overflow state stale.
- Overflowable actions without handlers become enabled no-op menu entries.

web/src/components/OverflowActionBar.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
web/src/components/OverflowActionBar.tsx:176
**Hidden Controls Mount Twice**

The measurement row mounts every supplied `content` node in addition to its visible instance. When an action contains a date picker, dialog, or another effectful control, the hidden copy can duplicate IDs, subscriptions, requests, and portals because `aria-hidden` and `invisible` only hide DOM output.

### Issue 2 of 4
web/src/components/OverflowActionBar.tsx:70
**Content Changes Keep Stale Widths**

This calculation does not rerun when an action changes width without changing the container or `actions` references. A stateful date label, growing count badge, or newly loaded font can therefore leave too many items inline, and `overflow-hidden` clips the row instead of moving the item into the menu.

### Issue 3 of 4
web/src/components/OverflowActionBar.tsx:144
**Overflow Action Becomes Inert**

A non-pinned action may omit `onSelect`, but this path still renders it as an enabled menu item. At widths where that action overflows, selecting it closes the menu without invoking the working inline control, so the action silently stops functioning.

### Issue 4 of 4
web/src/components/OverflowActionBar.tsx:68
**Serialized Keys Hide Action Changes**

Joining keys with `|` makes distinct lists such as `['view|table', 'export']` and `['view', 'table|export']` share the same effect dependency. If a caller switches between those valid key sets while preserving the array partition references, the overflow calculation can keep the previous visible count and show the wrong action set.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(components): OverflowActionBar — on..."](https://github.com/langfuse/langfuse/commit/ed9872213e5ce11a33fd5c48b16075663c9b8013) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46290157)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->