### PR TITLE
docs(previews): update debugging guide

### DIFF
--- a/.agents/skills/langfuse-previews/SKILL.md
+++ b/.agents/skills/langfuse-previews/SKILL.md
@@ -117,7 +117,7 @@ kubectl annotate ns $NS downscaler/force-uptime-                   # undo later 
 ### Symptom → fix
 | Symptom | Likely cause / fix |
 |---|---|
-| My preview environment is not available | Check that all CI checks pass. The PR's preview image is built only after they succeed. |
+| My preview environment is not available | Check for the `preview` label and inspect the **AWS preview build** workflow. If the PR opened with merge conflicts, resolve them; the next update adds the label. Other CI checks do not gate the preview build. |
 | 🟢 build comment posted, but the URL 404s | PR author not on the **deploy allowlist** — the image built, nothing deployed. Add yourself (see Getting access). |
 | URL not ready right after building | Build still finishing (~5 min) or a transient `ImagePullBackOff` — it self-heals. |
 | Unresponsive at night / on a weekend | Asleep off-hours — wake it (above). |

--- a/.agents/skills/langfuse-previews/SKILL.md
+++ b/.agents/skills/langfuse-previews/SKILL.md
@@ -117,6 +117,7 @@ kubectl annotate ns $NS downscaler/force-uptime-                   # undo later 
 ### Symptom → fix
 | Symptom | Likely cause / fix |
 |---|---|
+| My preview environment is not available | Check that all CI checks pass. The PR's preview image is built only after they succeed. |
 | 🟢 build comment posted, but the URL 404s | PR author not on the **deploy allowlist** — the image built, nothing deployed. Add yourself (see Getting access). |
 | URL not ready right after building | Build still finishing (~5 min) or a transient `ImagePullBackOff` — it self-heals. |
 | Unresponsive at night / on a weekend | Asleep off-hours — wake it (above). |
@@ -129,18 +130,15 @@ kubectl annotate ns $NS downscaler/force-uptime-                   # undo later 
   selector in `k8s/preview/bootstrap/applicationset.yaml` (repo
   `langfuse/infrastructure`), open a PR, and merge to `main`. Argo re-syncs and
   your labeled PRs deploy — no admin needed.
-- **Cluster access — needs an admin** (only to debug with `kubectl`, not to
-  *use* a preview). Ask an admin to add you to the preview-cluster role in AWS
-  IAM Identity Center. Then set up local access — the `~/.aws/config` profile
-  block and its exact values (AWS account id, SSO start URL, cluster name,
-  region) are in the internal Langfuse doc:
+- **Cluster access — available to all Langfuse engineers** (only needed to
+  debug with `kubectl`, not to *use* a preview). Set up local access using the
+  `~/.aws/config` profile block from the internal Langfuse doc:
   https://linear.app/langfuse/document/connect-to-aws-instances-aurora-redis-from-local-machine-896fe46ff797
   1. Open `~/.aws/config` and add the `[sso-session langfuse]` + `[profile preview]`
      blocks from that doc (keep any `[sso-session langfuse]` you already have).
   2. `aws sso login --profile preview`
-  3. `aws eks update-kubeconfig --name <cluster> --region <region> --profile preview`
-     (name + region are in the doc; no `--role-arn` — the role has its own EKS
-     access entry).
+  3. `aws eks update-kubeconfig --name langfuse-preview --region eu-west-1 --profile preview`
+     (no `--role-arn` — the role has its own EKS access entry).
 
 ---
 

--- a/.github/workflows/preview-autolabel.yml
+++ b/.github/workflows/preview-autolabel.yml
@@ -1,8 +1,11 @@
 name: AWS preview auto-label
 
-# Auto-apply the `preview` label to same-repo PRs on open, so the Argo CD
-# ApplicationSet (in the infrastructure repo) picks them up and builds a
-# preview. Anyone with write access can also apply the label by hand.
+# Auto-apply the `preview` label to same-repo PRs on open or update, so the Argo
+# CD ApplicationSet (in the infrastructure repo) picks them up and builds a
+# preview. Including synchronize recovers PRs that opened with merge conflicts:
+# GitHub skips pull_request workflows until the conflict is resolved. It also
+# reactivates a stale or manually removed preview when development resumes.
+# Anyone with write access can also apply the label by hand.
 #
 # Trust boundary is WRITE access, not a per-author allowlist: opening a
 # same-repo PR requires push access, so labeling every same-repo PR is exactly
@@ -14,7 +17,7 @@ name: AWS preview auto-label
 # stays off zizmor's dangerous-triggers list.
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

- Document the concrete preview EKS cluster name and AWS region so engineers can configure kubectl without placeholders.
- Simplify cluster-access guidance now that all Langfuse engineers are authorized.
- Add troubleshooting guidance to confirm CI passes before expecting the preview image to build.

## Linear

- None

## Review Focus

- Confirm the documented cluster access assumptions and CI prerequisite match the current preview infrastructure.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the preview debugging guide with concrete operational details. The main changes are:

- Adds a CI-related troubleshooting entry for unavailable previews.
- States that cluster access is available to all Langfuse engineers.
- Documents the preview EKS cluster name and AWS region.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The troubleshooting guidance can misdiagnose preview failures, and the cluster-access section may leave unassigned engineers blocked.

- The preview build runs independently of the aggregate CI result.
- The updated access text removes the administrator fallback for accounts without the required IAM assignment.
- The concrete cluster command is otherwise consistent with the intended documentation change.

.agents/skills/langfuse-previews/SKILL.md
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.agents/skills/langfuse-previews/SKILL.md:120
**Preview Build Is Not CI-Gated**

The preview workflow starts independently on pull-request events and does not depend on the aggregate CI result. When an unrelated check fails, this row incorrectly tells engineers that no preview image was built, sending them away from the preview-build workflow that contains the relevant failure.

### Issue 2 of 2
.agents/skills/langfuse-previews/SKILL.md:132-134
**Access Escalation Path Removed**

If a new engineer has not yet been assigned the preview-cluster permission in IAM Identity Center, `aws sso login --profile preview` cannot provide cluster access. The updated text removes the previous instruction to contact an administrator, leaving that engineer blocked with no access-request path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(previews): update debugging guide"](https://github.com/langfuse/langfuse/commit/8b43058bee25541d29bec7e5640f9da02e718f4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46293859)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->