### PR TITLE
feat(assistant): support concurrent conversations and queued follow-ups

### DIFF
--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -59,9 +59,9 @@ properly (below).
   only `Sentry.init` in the codebase — `beforeSend`,
   `captureConsoleIntegration`, `denyUrls`, replay masking). Add every new filter
   as a named predicate there, never as an ad-hoc inline check. `beforeSend`
-  still carries a couple of legacy inline checks (invalid-href, React-devtools)
-  that predate this convention and read only the exception value — migrate those
-  into named, all-field predicates; do not add more inline checks.
+  now holds NO inline checks — every filter routes through a named predicate
+  (`isNoisyHttpClientPollEvent`, `isDenylistedNoiseEvent`,
+  `isReactDevtoolsInternalEvent`). Keep it that way.
 - **Classify tRPC errors at the seam,** not per call site: `handleTrpcError`
   ([`web/src/utils/api.ts`](../../../web/src/utils/api.ts)) is the single
   chokepoint every query/mutation error flows through — the place to drop
@@ -108,9 +108,8 @@ properly (below).
    (a second `https://` → repeated `//`) passes validation and `<Link>`'s router
    still rejects it. PR #15245 renders these as a native `<a>` (which never runs
    the router's href validation), removing the family at the source — no new
-   filter needed. (The older inline `beforeSend` invalid-href check is redundant
-   and never fired anyway — it read the wrong field, Rule 6 — so it can be
-   retired.)
+   filter needed. (The older inline `beforeSend` invalid-href check — which
+   never fired anyway, wrong field, Rule 6 — was removed in #15276.)
 
 6. **Every `beforeSend` / denylist rule: narrow signature + written rationale +
    a NEGATIVE fixture proving a real error still passes.** This is the MANDATORY

--- a/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
+++ b/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
@@ -24,11 +24,11 @@ the detail behind its rules.
   reaches Sentry; it does not. (Treat "Sentry = frontend-only" until a decision
   says otherwise.)
 - **Filter predicates** live in [`web/src/utils/sentryFilters.ts`](../../../../web/src/utils/sentryFilters.ts)
-  with unit tests in `sentryFilters.clienttest.ts`; `beforeSend` calls them.
-  `beforeSend` also still carries two legacy inline checks (invalid-href,
-  React-devtools) that predate this convention and read only
-  `event.exception.values[0].value` — a known gap to migrate into named,
-  all-field predicates. Add new filters only as predicates here, never inline.
+  with unit tests in `sentryFilters.clienttest.ts`; `beforeSend` only calls
+  these named predicates and holds no inline checks (the former invalid-href
+  and React-devtools inline checks were removed / migrated to
+  `isReactDevtoolsInternalEvent` in #15276). Add new filters only as predicates
+  here, never inline.
 - **The tRPC seam** is `handleTrpcError` in [`web/src/utils/api.ts`](../../../../web/src/utils/api.ts):
   every query/mutation error flows through it — the single place to classify.
   PR #15243 drops expected `data.code`s (`NOT_FOUND` / `FORBIDDEN` /

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 import {
   isDenylistedNoiseEvent,
   isNoisyHttpClientPollEvent,
+  isReactDevtoolsInternalEvent,
 } from "@/src/utils/sentryFilters";
 
 const isEuOrUsRegionNonHipaa =
@@ -15,21 +16,10 @@ Sentry.init({
   release: process.env.NEXT_PUBLIC_BUILD_ID,
 
   beforeSend(event) {
-    // const error = hint.originalException;
-    const errorValue = event.exception?.values?.[0]?.value || "";
-
-    // Filter invalid href errors - these are from user-inputted data containing malformed URLs
-    // The Next.js router correctly rejects them, no need to log as errors
-    if (
-      errorValue.includes("Invalid href") &&
-      errorValue.includes("passed to next/router")
-    ) {
-      return null;
-    }
-
-    // Filter React DevTools internal errors - these are benign errors from DevTools
-    // trying to access internal React properties
-    if (errorValue.includes("__reactContextDevtoolDebugId")) {
+    // Drop React DevTools' internal probes against React's private fiber
+    // properties - benign, DevTools-only noise. See isReactDevtoolsInternalEvent
+    // for the rationale.
+    if (isReactDevtoolsInternalEvent(event)) {
       return null;
     }
 

--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.clienttest.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+
+import { ControlledInAppAgentWindow } from "./ControlledInAppAgentWindow";
+import type { AgUiMessage } from "@/src/ee/features/in-app-agent/schema";
+
+const mocks = vi.hoisted(() => ({
+  agent: {} as Record<string, unknown>,
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ asPath: "/project/project-1/traces" }),
+}));
+
+vi.mock("./InAppAiAgentProvider", () => ({
+  useInAppAiAgent: () => mocks.agent,
+}));
+
+vi.mock("./InAppAgentWindow", () => ({
+  InAppAgentWindow: ({
+    messages,
+  }: {
+    messages: Array<{ content: { type: string; text?: string } }>;
+  }) => <span data-testid="content">{messages.at(-1)?.content.text}</span>,
+}));
+
+const assistantMessage = (id: string, content: string) =>
+  ({ id, role: "assistant", content }) satisfies AgUiMessage;
+
+function setConversation(
+  selectedConversationId: string,
+  liveMessageVersion: number,
+  messages: AgUiMessage[],
+) {
+  mocks.agent = {
+    conversations: [],
+    error: null,
+    isRunning: true,
+    liveMessageVersion,
+    messages,
+    pendingToolApprovals: [],
+    queuedMessages: [],
+    selectedConversationId,
+  };
+}
+
+describe("ControlledInAppAgentWindow", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: false })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows accumulated streaming progress immediately after switching back", () => {
+    setConversation("conversation-a", 1, [
+      assistantMessage("assistant-a", "Conversation A started streaming."),
+    ]);
+    const { rerender } = render(
+      <ControlledInAppAgentWindow
+        isExpanded={false}
+        onDeleteConversation={vi.fn()}
+        onExpandedChange={vi.fn()}
+        showCloseButton={false}
+      />,
+    );
+
+    setConversation("conversation-b", 1, [
+      assistantMessage("assistant-b", "Conversation B is also streaming."),
+    ]);
+    rerender(
+      <ControlledInAppAgentWindow
+        isExpanded={false}
+        onDeleteConversation={vi.fn()}
+        onExpandedChange={vi.fn()}
+        showCloseButton={false}
+      />,
+    );
+
+    const accumulatedContent =
+      "Conversation A started streaming and made substantial progress while unselected.";
+    setConversation("conversation-a", 7, [
+      assistantMessage("assistant-a", accumulatedContent),
+    ]);
+    rerender(
+      <ControlledInAppAgentWindow
+        isExpanded={false}
+        onDeleteConversation={vi.fn()}
+        onExpandedChange={vi.fn()}
+        showCloseButton={false}
+      />,
+    );
+
+    expect(screen.getByTestId("content")).toHaveTextContent(accumulatedContent);
+  });
+});

--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -41,22 +41,26 @@ export function ControlledInAppAgentWindow(
   const router = useRouter();
   const {
     conversations,
+    deleteQueuedMessage,
+    draft,
+    editQueuedMessage,
     error,
     hasMoreConversations,
     isLoadingMoreConversations,
     isRunning,
     isSelectedConversationHydrating,
-    isSubmitting,
     invalidateConversations,
     loadMoreConversations,
     liveMessageVersion,
     messages,
     pendingToolApprovals,
+    queuedMessages,
     approveToolCall,
     rejectToolCall,
     selectConversation,
     selectedConversationId,
     selectedConversationIsWriteLocked,
+    setDraft,
     submit,
     submitFeedback,
   } = useInAppAiAgent();
@@ -72,12 +76,7 @@ export function ControlledInAppAgentWindow(
     shouldFlush: error !== null,
   });
   const isInputDisabled =
-    isRunning ||
-    isAnimating ||
-    isSubmitting ||
-    selectedConversationIsWriteLocked ||
-    isSelectedConversationHydrating ||
-    pendingToolApprovals.length > 0;
+    selectedConversationIsWriteLocked || isSelectedConversationHydrating;
   const displayError = selectedConversationIsWriteLocked
     ? ({
         type: "generic",
@@ -131,6 +130,8 @@ export function ControlledInAppAgentWindow(
       isInputDisabled={isInputDisabled}
       disablePendingToolApprovalActions={selectedConversationIsWriteLocked}
       messages={drawerMessages}
+      draft={draft}
+      queuedMessages={queuedMessages}
       quickActionContext={quickActionContext}
       focusedQuickActions={focusedQuickActions}
       quickActionResetKey={quickActionResetKey}
@@ -148,6 +149,9 @@ export function ControlledInAppAgentWindow(
       }}
       onExpandedChange={props.onExpandedChange}
       onSubmit={submit}
+      onDraftChange={setDraft}
+      onEditQueuedMessage={editQueuedMessage}
+      onDeleteQueuedMessage={deleteQueuedMessage}
       onApproveToolCall={approveToolCall}
       onRejectToolCall={rejectToolCall}
       onSubmitFeedback={submitFeedback}

--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -38,6 +38,17 @@ type ControlledInAppAgentWindowProps = ControlledInAppAgentWindowBaseProps &
 export function ControlledInAppAgentWindow(
   props: ControlledInAppAgentWindowProps,
 ) {
+  const { selectedConversationId } = useInAppAiAgent();
+
+  return (
+    <SelectedConversationWindow
+      key={selectedConversationId ?? "new-conversation"}
+      {...props}
+    />
+  );
+}
+
+function SelectedConversationWindow(props: ControlledInAppAgentWindowProps) {
   const router = useRouter();
   const {
     conversations,
@@ -55,7 +66,6 @@ export function ControlledInAppAgentWindow(
     messages,
     pendingToolApprovals,
     queuedMessages,
-    reorderQueuedMessage,
     approveToolCall,
     rejectToolCall,
     selectConversation,
@@ -153,7 +163,6 @@ export function ControlledInAppAgentWindow(
       onDraftChange={setDraft}
       onEditQueuedMessage={editQueuedMessage}
       onDeleteQueuedMessage={deleteQueuedMessage}
-      onReorderQueuedMessage={reorderQueuedMessage}
       onApproveToolCall={approveToolCall}
       onRejectToolCall={rejectToolCall}
       onSubmitFeedback={submitFeedback}

--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -55,6 +55,7 @@ export function ControlledInAppAgentWindow(
     messages,
     pendingToolApprovals,
     queuedMessages,
+    reorderQueuedMessage,
     approveToolCall,
     rejectToolCall,
     selectConversation,
@@ -152,6 +153,7 @@ export function ControlledInAppAgentWindow(
       onDraftChange={setDraft}
       onEditQueuedMessage={editQueuedMessage}
       onDeleteQueuedMessage={deleteQueuedMessage}
+      onReorderQueuedMessage={reorderQueuedMessage}
       onApproveToolCall={approveToolCall}
       onRejectToolCall={rejectToolCall}
       onSubmitFeedback={submitFeedback}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.stories.tsx
@@ -1,0 +1,118 @@
+import { useState, type ComponentProps } from "react";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import preview from "../../../../../.storybook/preview";
+import {
+  InAppAgentQueuedMessages,
+  type InAppAgentQueuedMessageItem,
+} from "./InAppAgentQueuedMessages";
+
+const messages: InAppAgentQueuedMessageItem[] = [
+  { id: "queued-1", content: "Compare this against the previous week." },
+  {
+    id: "queued-2",
+    content:
+      "Then break the result down by model.\nCall out any regressions that are larger than 10%.",
+  },
+];
+
+const meta = preview.meta({
+  component: InAppAgentQueuedMessages,
+  args: {
+    messages,
+    onEdit: fn(),
+    onDelete: fn(),
+  },
+});
+
+export const QueuedFollowUps = meta.story({});
+
+export const Collapsed = meta.story({
+  args: { defaultExpanded: false },
+});
+
+function EditableQueueStory(
+  args: ComponentProps<typeof InAppAgentQueuedMessages>,
+) {
+  const [queuedMessages, setQueuedMessages] = useState(args.messages);
+  return (
+    <InAppAgentQueuedMessages
+      {...args}
+      messages={queuedMessages}
+      onEdit={(messageId, content) => {
+        args.onEdit(messageId, content);
+        setQueuedMessages((current) =>
+          current.map((message) =>
+            message.id === messageId ? { ...message, content } : message,
+          ),
+        );
+      }}
+      onDelete={(messageId) => {
+        args.onDelete(messageId);
+        setQueuedMessages((current) =>
+          current.filter((message) => message.id !== messageId),
+        );
+      }}
+    />
+  );
+}
+
+export const TestEditsAndDeletesFollowUps = meta.story({
+  name: "(Test) Edits And Deletes Follow-Ups",
+  render: (args) => <EditableQueueStory {...args} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Edit queued message 1" }),
+    );
+    const firstEditor = canvas.getByRole("textbox", {
+      name: "Edit queued message 1",
+    });
+    await userEvent.clear(firstEditor);
+    await userEvent.type(firstEditor, "Edited with Save");
+    await userEvent.click(canvas.getByRole("button", { name: "Save" }));
+    await expect(args.onEdit).toHaveBeenCalledWith(
+      "queued-1",
+      "Edited with Save",
+    );
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Edit queued message 2" }),
+    );
+    const secondEditor = canvas.getByRole("textbox", {
+      name: "Edit queued message 2",
+    });
+    await userEvent.type(secondEditor, "{enter}temporary line");
+    await expect(secondEditor).toHaveValue(
+      `${messages[1]?.content}\ntemporary line`,
+    );
+    await userEvent.click(canvas.getByRole("button", { name: "Cancel" }));
+    await expect(args.onEdit).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Edit queued message 1" }),
+    );
+    const keyboardEditor = canvas.getByRole("textbox", {
+      name: "Edit queued message 1",
+    });
+    await userEvent.clear(keyboardEditor);
+    await userEvent.type(keyboardEditor, "Saved from keyboard");
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+    await expect(args.onEdit).toHaveBeenLastCalledWith(
+      "queued-1",
+      "Saved from keyboard",
+    );
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Edit queued message 2" }),
+    );
+    await userEvent.keyboard("{Escape}");
+    await expect(canvas.queryByRole("textbox")).not.toBeInTheDocument();
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Delete queued message 2" }),
+    );
+    await expect(args.onDelete).toHaveBeenCalledWith("queued-2");
+  },
+});

--- a/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.stories.tsx
@@ -1,4 +1,5 @@
 import { useState, type ComponentProps } from "react";
+import { arrayMove } from "@dnd-kit/sortable";
 import { expect, fn, userEvent, within } from "storybook/test";
 
 import preview from "../../../../../.storybook/preview";
@@ -22,36 +23,44 @@ const meta = preview.meta({
     messages,
     onEdit: fn(),
     onDelete: fn(),
+    onReorder: fn(),
   },
 });
 
-export const QueuedFollowUps = meta.story({});
+export const QueuedFollowUps = meta.story({
+  render: (args) => <ReorderableQueueStory {...args} />,
+});
 
 export const Collapsed = meta.story({
   args: { defaultExpanded: false },
+  render: (args) => <ReorderableQueueStory {...args} />,
 });
 
-function EditableQueueStory(
+function ReorderableQueueStory(
   args: ComponentProps<typeof InAppAgentQueuedMessages>,
 ) {
-  const [queuedMessages, setQueuedMessages] = useState(args.messages);
+  const [queuedMessages, setQueuedMessages] = useState(() =>
+    Array.from(args.messages),
+  );
   return (
     <InAppAgentQueuedMessages
       {...args}
       messages={queuedMessages}
-      onEdit={(messageId, content) => {
-        args.onEdit(messageId, content);
-        setQueuedMessages((current) =>
-          current.map((message) =>
-            message.id === messageId ? { ...message, content } : message,
-          ),
-        );
-      }}
       onDelete={(messageId) => {
         args.onDelete(messageId);
         setQueuedMessages((current) =>
-          current.filter((message) => message.id !== messageId),
+          current.filter(({ id }) => id !== messageId),
         );
+      }}
+      onReorder={(messageId, targetMessageId) => {
+        args.onReorder?.(messageId, targetMessageId);
+        setQueuedMessages((current) => {
+          const fromIndex = current.findIndex(({ id }) => id === messageId);
+          const toIndex = current.findIndex(({ id }) => id === targetMessageId);
+          return fromIndex < 0 || toIndex < 0
+            ? current
+            : arrayMove(current, fromIndex, toIndex);
+        });
       }}
     />
   );
@@ -59,56 +68,14 @@ function EditableQueueStory(
 
 export const TestEditsAndDeletesFollowUps = meta.story({
   name: "(Test) Edits And Deletes Follow-Ups",
-  render: (args) => <EditableQueueStory {...args} />,
+  render: (args) => <ReorderableQueueStory {...args} />,
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
     await userEvent.click(
       canvas.getByRole("button", { name: "Edit queued message 1" }),
     );
-    const firstEditor = canvas.getByRole("textbox", {
-      name: "Edit queued message 1",
-    });
-    await userEvent.clear(firstEditor);
-    await userEvent.type(firstEditor, "Edited with Save");
-    await userEvent.click(canvas.getByRole("button", { name: "Save" }));
-    await expect(args.onEdit).toHaveBeenCalledWith(
-      "queued-1",
-      "Edited with Save",
-    );
-
-    await userEvent.click(
-      canvas.getByRole("button", { name: "Edit queued message 2" }),
-    );
-    const secondEditor = canvas.getByRole("textbox", {
-      name: "Edit queued message 2",
-    });
-    await userEvent.type(secondEditor, "{enter}temporary line");
-    await expect(secondEditor).toHaveValue(
-      `${messages[1]?.content}\ntemporary line`,
-    );
-    await userEvent.click(canvas.getByRole("button", { name: "Cancel" }));
-    await expect(args.onEdit).toHaveBeenCalledTimes(1);
-
-    await userEvent.click(
-      canvas.getByRole("button", { name: "Edit queued message 1" }),
-    );
-    const keyboardEditor = canvas.getByRole("textbox", {
-      name: "Edit queued message 1",
-    });
-    await userEvent.clear(keyboardEditor);
-    await userEvent.type(keyboardEditor, "Saved from keyboard");
-    await userEvent.keyboard("{Control>}{Enter}{/Control}");
-    await expect(args.onEdit).toHaveBeenLastCalledWith(
-      "queued-1",
-      "Saved from keyboard",
-    );
-
-    await userEvent.click(
-      canvas.getByRole("button", { name: "Edit queued message 2" }),
-    );
-    await userEvent.keyboard("{Escape}");
-    await expect(canvas.queryByRole("textbox")).not.toBeInTheDocument();
+    await expect(args.onEdit).toHaveBeenCalledWith("queued-1");
 
     await userEvent.click(
       canvas.getByRole("button", { name: "Delete queued message 2" }),

--- a/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.stories.tsx
@@ -1,5 +1,4 @@
 import { useState, type ComponentProps } from "react";
-import { arrayMove } from "@dnd-kit/sortable";
 import { expect, fn, userEvent, within } from "storybook/test";
 
 import preview from "../../../../../.storybook/preview";
@@ -23,7 +22,6 @@ const meta = preview.meta({
     messages,
     onEdit: fn(),
     onDelete: fn(),
-    onReorder: fn(),
   },
 });
 
@@ -51,16 +49,6 @@ function ReorderableQueueStory(
         setQueuedMessages((current) =>
           current.filter(({ id }) => id !== messageId),
         );
-      }}
-      onReorder={(messageId, targetMessageId) => {
-        args.onReorder?.(messageId, targetMessageId);
-        setQueuedMessages((current) => {
-          const fromIndex = current.findIndex(({ id }) => id === messageId);
-          const toIndex = current.findIndex(({ id }) => id === targetMessageId);
-          return fromIndex < 0 || toIndex < 0
-            ? current
-            : arrayMove(current, fromIndex, toIndex);
-        });
       }}
     />
   );

--- a/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.tsx
@@ -1,29 +1,5 @@
 import { useState } from "react";
-import {
-  closestCenter,
-  DndContext,
-  KeyboardSensor,
-  MouseSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from "@dnd-kit/core";
-import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import {
-  ChevronDown,
-  CornerDownRight,
-  GripVertical,
-  Pencil,
-  Trash2,
-} from "lucide-react";
+import { ChevronDown, CornerDownRight, Pencil, Trash2 } from "lucide-react";
 
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
@@ -38,34 +14,13 @@ export function InAppAgentQueuedMessages({
   defaultExpanded = true,
   onEdit,
   onDelete,
-  onReorder,
 }: {
   messages: readonly InAppAgentQueuedMessageItem[];
   defaultExpanded?: boolean;
   onEdit: (messageId: string) => void;
   onDelete: (messageId: string) => void;
-  onReorder?: (messageId: string, targetMessageId: string) => void;
 }) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
-  const sensors = useSensors(
-    useSensor(MouseSensor),
-    useSensor(TouchSensor),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
-  );
-
-  const handleDragEnd = ({ active, over }: DragEndEvent) => {
-    if (
-      onReorder &&
-      over &&
-      active.id !== over.id &&
-      typeof active.id === "string" &&
-      typeof over.id === "string"
-    ) {
-      onReorder(active.id, over.id);
-    }
-  };
 
   return (
     <div className="border-border bg-card overflow-hidden rounded-md border">
@@ -87,84 +42,40 @@ export function InAppAgentQueuedMessages({
         {messages.length} queued
       </button>
       {isExpanded ? (
-        <DndContext
-          collisionDetection={closestCenter}
-          modifiers={[restrictToVerticalAxis]}
-          sensors={sensors}
-          onDragEnd={handleDragEnd}
-        >
-          <SortableContext
-            items={messages.map(({ id }) => id)}
-            strategy={verticalListSortingStrategy}
-          >
-            <ol className="border-border divide-y border-t">
-              {messages.map((message, index) => (
-                <SortableQueuedMessage
-                  key={message.id}
-                  message={message}
-                  index={index}
-                  canReorder={Boolean(onReorder)}
-                  onEdit={onEdit}
-                  onDelete={onDelete}
-                />
-              ))}
-            </ol>
-          </SortableContext>
-        </DndContext>
+        <ol className="border-border divide-y border-t">
+          {messages.map((message, index) => (
+            <QueuedMessage
+              key={message.id}
+              message={message}
+              index={index}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))}
+        </ol>
       ) : null}
     </div>
   );
 }
 
-function SortableQueuedMessage({
+function QueuedMessage({
   message,
   index,
-  canReorder,
   onEdit,
   onDelete,
 }: {
   message: InAppAgentQueuedMessageItem;
   index: number;
-  canReorder: boolean;
   onEdit: (messageId: string) => void;
   onDelete: (messageId: string) => void;
 }) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: message.id, disabled: !canReorder });
-
   return (
-    <li
-      ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
-      className={cn(
-        "bg-card flex gap-2 px-2 py-2",
-        isDragging && "relative z-10 opacity-70 shadow-sm",
-      )}
-    >
+    <li className="bg-card flex gap-2 px-2 py-2">
       <CornerDownRight className="text-muted-foreground mt-0.5 size-4 shrink-0" />
       <p className="min-w-0 flex-1 text-xs leading-5 wrap-break-word whitespace-pre-wrap">
         {message.content}
       </p>
       <div className="flex shrink-0 items-start gap-0.5">
-        {canReorder ? (
-          <Button
-            {...attributes}
-            {...listeners}
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            className="cursor-grab active:cursor-grabbing"
-            aria-label={`Reorder queued message ${index + 1}`}
-          >
-            <GripVertical className="size-3" />
-          </Button>
-        ) : null}
         <Button
           type="button"
           variant="ghost"

--- a/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.tsx
@@ -1,8 +1,31 @@
-import { useState, type KeyboardEvent } from "react";
-import { ChevronDown, Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  ChevronDown,
+  CornerDownRight,
+  GripVertical,
+  Pencil,
+  Trash2,
+} from "lucide-react";
 
 import { Button } from "@/src/components/ui/button";
-import { Textarea } from "@/src/components/ui/textarea";
 import { cn } from "@/src/utils/tailwind";
 
 export type InAppAgentQueuedMessageItem = {
@@ -15,35 +38,32 @@ export function InAppAgentQueuedMessages({
   defaultExpanded = true,
   onEdit,
   onDelete,
+  onReorder,
 }: {
   messages: readonly InAppAgentQueuedMessageItem[];
   defaultExpanded?: boolean;
-  onEdit: (messageId: string, content: string) => void;
+  onEdit: (messageId: string) => void;
   onDelete: (messageId: string) => void;
+  onReorder?: (messageId: string, targetMessageId: string) => void;
 }) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
-  const [editing, setEditing] = useState<{
-    messageId: string;
-    content: string;
-  } | null>(null);
+  const sensors = useSensors(
+    useSensor(MouseSensor),
+    useSensor(TouchSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
 
-  const saveEdit = () => {
-    const content = editing?.content.trim();
-    if (!editing || !content) {
-      return;
-    }
-    onEdit(editing.messageId, content);
-    setEditing(null);
-  };
-  const handleEditKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      setEditing(null);
-      return;
-    }
-    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-      event.preventDefault();
-      saveEdit();
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (
+      onReorder &&
+      over &&
+      active.id !== over.id &&
+      typeof active.id === "string" &&
+      typeof over.id === "string"
+    ) {
+      onReorder(active.id, over.id);
     }
   };
 
@@ -67,96 +87,108 @@ export function InAppAgentQueuedMessages({
         {messages.length} queued
       </button>
       {isExpanded ? (
-        <ol className="border-border divide-y border-t">
-          {messages.map((message, index) => {
-            const isEditing = editing?.messageId === message.id;
-            return (
-              <li key={message.id} className="flex gap-2 px-2 py-2">
-                <span className="bg-muted text-muted-foreground mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full text-[0.6875rem] font-bold">
-                  {index + 1}
-                </span>
-                {isEditing ? (
-                  <div className="min-w-0 flex-1 space-y-1.5">
-                    <Textarea
-                      autoFocus
-                      aria-label={`Edit queued message ${index + 1}`}
-                      rows={2}
-                      value={editing.content}
-                      onChange={(event) => {
-                        setEditing({
-                          messageId: message.id,
-                          content: event.target.value,
-                        });
-                      }}
-                      onKeyDown={handleEditKeyDown}
-                      className="max-h-32 min-h-14 resize-y text-xs"
-                    />
-                    <div className="flex justify-end gap-1">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-xs"
-                        onClick={() => {
-                          setEditing(null);
-                        }}
-                      >
-                        Cancel
-                      </Button>
-                      <Button
-                        type="button"
-                        size="sm"
-                        className="h-7 px-2 text-xs"
-                        disabled={!editing.content.trim()}
-                        onClick={saveEdit}
-                      >
-                        Save
-                      </Button>
-                    </div>
-                  </div>
-                ) : (
-                  <>
-                    <p className="min-w-0 flex-1 text-xs leading-5 wrap-break-word whitespace-pre-wrap">
-                      {message.content}
-                    </p>
-                    <div className="flex shrink-0 items-start gap-0.5">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-xs"
-                        aria-label={`Edit queued message ${index + 1}`}
-                        onClick={() => {
-                          setEditing({
-                            messageId: message.id,
-                            content: message.content,
-                          });
-                        }}
-                      >
-                        <Pencil className="size-3" />
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-xs"
-                        className="hover:text-destructive"
-                        aria-label={`Delete queued message ${index + 1}`}
-                        onClick={() => {
-                          if (editing?.messageId === message.id) {
-                            setEditing(null);
-                          }
-                          onDelete(message.id);
-                        }}
-                      >
-                        <Trash2 className="size-3" />
-                      </Button>
-                    </div>
-                  </>
-                )}
-              </li>
-            );
-          })}
-        </ol>
+        <DndContext
+          collisionDetection={closestCenter}
+          modifiers={[restrictToVerticalAxis]}
+          sensors={sensors}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={messages.map(({ id }) => id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ol className="border-border divide-y border-t">
+              {messages.map((message, index) => (
+                <SortableQueuedMessage
+                  key={message.id}
+                  message={message}
+                  index={index}
+                  canReorder={Boolean(onReorder)}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                />
+              ))}
+            </ol>
+          </SortableContext>
+        </DndContext>
       ) : null}
     </div>
+  );
+}
+
+function SortableQueuedMessage({
+  message,
+  index,
+  canReorder,
+  onEdit,
+  onDelete,
+}: {
+  message: InAppAgentQueuedMessageItem;
+  index: number;
+  canReorder: boolean;
+  onEdit: (messageId: string) => void;
+  onDelete: (messageId: string) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: message.id, disabled: !canReorder });
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        "bg-card flex gap-2 px-2 py-2",
+        isDragging && "relative z-10 opacity-70 shadow-sm",
+      )}
+    >
+      <CornerDownRight className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+      <p className="min-w-0 flex-1 text-xs leading-5 wrap-break-word whitespace-pre-wrap">
+        {message.content}
+      </p>
+      <div className="flex shrink-0 items-start gap-0.5">
+        {canReorder ? (
+          <Button
+            {...attributes}
+            {...listeners}
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="cursor-grab active:cursor-grabbing"
+            aria-label={`Reorder queued message ${index + 1}`}
+          >
+            <GripVertical className="size-3" />
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={`Edit queued message ${index + 1}`}
+          onClick={() => {
+            onEdit(message.id);
+          }}
+        >
+          <Pencil className="size-3" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="hover:text-destructive"
+          aria-label={`Delete queued message ${index + 1}`}
+          onClick={() => {
+            onDelete(message.id);
+          }}
+        >
+          <Trash2 className="size-3" />
+        </Button>
+      </div>
+    </li>
   );
 }

--- a/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.tsx
@@ -1,0 +1,162 @@
+import { useState, type KeyboardEvent } from "react";
+import { ChevronDown, Pencil, Trash2 } from "lucide-react";
+
+import { Button } from "@/src/components/ui/button";
+import { Textarea } from "@/src/components/ui/textarea";
+import { cn } from "@/src/utils/tailwind";
+
+export type InAppAgentQueuedMessageItem = {
+  id: string;
+  content: string;
+};
+
+export function InAppAgentQueuedMessages({
+  messages,
+  defaultExpanded = true,
+  onEdit,
+  onDelete,
+}: {
+  messages: readonly InAppAgentQueuedMessageItem[];
+  defaultExpanded?: boolean;
+  onEdit: (messageId: string, content: string) => void;
+  onDelete: (messageId: string) => void;
+}) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const [editing, setEditing] = useState<{
+    messageId: string;
+    content: string;
+  } | null>(null);
+
+  const saveEdit = () => {
+    const content = editing?.content.trim();
+    if (!editing || !content) {
+      return;
+    }
+    onEdit(editing.messageId, content);
+    setEditing(null);
+  };
+  const handleEditKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setEditing(null);
+      return;
+    }
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      saveEdit();
+    }
+  };
+
+  return (
+    <div className="border-border bg-card overflow-hidden rounded-md border">
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        className="hover:bg-muted/60 flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-xs font-bold"
+        onClick={() => {
+          setIsExpanded((current) => !current);
+        }}
+      >
+        <ChevronDown
+          aria-hidden="true"
+          className={cn(
+            "size-3.5 transition-transform",
+            !isExpanded && "-rotate-90",
+          )}
+        />
+        {messages.length} queued
+      </button>
+      {isExpanded ? (
+        <ol className="border-border divide-y border-t">
+          {messages.map((message, index) => {
+            const isEditing = editing?.messageId === message.id;
+            return (
+              <li key={message.id} className="flex gap-2 px-2 py-2">
+                <span className="bg-muted text-muted-foreground mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full text-[0.6875rem] font-bold">
+                  {index + 1}
+                </span>
+                {isEditing ? (
+                  <div className="min-w-0 flex-1 space-y-1.5">
+                    <Textarea
+                      autoFocus
+                      aria-label={`Edit queued message ${index + 1}`}
+                      rows={2}
+                      value={editing.content}
+                      onChange={(event) => {
+                        setEditing({
+                          messageId: message.id,
+                          content: event.target.value,
+                        });
+                      }}
+                      onKeyDown={handleEditKeyDown}
+                      className="max-h-32 min-h-14 resize-y text-xs"
+                    />
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2 text-xs"
+                        onClick={() => {
+                          setEditing(null);
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        className="h-7 px-2 text-xs"
+                        disabled={!editing.content.trim()}
+                        onClick={saveEdit}
+                      >
+                        Save
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <p className="min-w-0 flex-1 text-xs leading-5 wrap-break-word whitespace-pre-wrap">
+                      {message.content}
+                    </p>
+                    <div className="flex shrink-0 items-start gap-0.5">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        aria-label={`Edit queued message ${index + 1}`}
+                        onClick={() => {
+                          setEditing({
+                            messageId: message.id,
+                            content: message.content,
+                          });
+                        }}
+                      >
+                        <Pencil className="size-3" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        className="hover:text-destructive"
+                        aria-label={`Delete queued message ${index + 1}`}
+                        onClick={() => {
+                          if (editing?.messageId === message.id) {
+                            setEditing(null);
+                          }
+                          onDelete(message.id);
+                        }}
+                      >
+                        <Trash2 className="size-3" />
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWidgetComposer.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWidgetComposer.tsx
@@ -1,4 +1,9 @@
-import { type KeyboardEvent, type SyntheticEvent, useState } from "react";
+import {
+  type KeyboardEvent,
+  type SyntheticEvent,
+  useRef,
+  useState,
+} from "react";
 import { SendHorizontal, Sparkles } from "lucide-react";
 
 import { Button } from "@/src/components/ui/button";
@@ -26,9 +31,10 @@ export function InAppAgentWidgetComposer({
 }: {
   onSubmitted: () => void;
 }) {
-  const { isAvailable, isRunning, isSubmitting, openAssistant, submit } =
-    useInAppAiAgent();
+  const { isAvailable, openAssistant, submit } = useInAppAiAgent();
   const [request, setRequest] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const submitInFlightRef = useRef(false);
 
   if (!isAvailable) {
     return null;
@@ -38,7 +44,7 @@ export function InAppAgentWidgetComposer({
     event.preventDefault();
     const trimmedRequest = request.trim();
 
-    if (!trimmedRequest || isRunning || isSubmitting) {
+    if (!trimmedRequest || submitInFlightRef.current) {
       return;
     }
 
@@ -46,14 +52,21 @@ export function InAppAgentWidgetComposer({
       return;
     }
 
-    const started = await submit(getWidgetCreationPrompt(trimmedRequest), {
-      newConversation: true,
-      entryPoint: "add-widget-modal",
-    });
+    submitInFlightRef.current = true;
+    setIsSubmitting(true);
+    try {
+      const started = await submit(getWidgetCreationPrompt(trimmedRequest), {
+        newConversation: true,
+        entryPoint: "add-widget-modal",
+      });
 
-    if (started) {
-      setRequest("");
-      onSubmitted();
+      if (started) {
+        setRequest("");
+        onSubmitted();
+      }
+    } finally {
+      submitInFlightRef.current = false;
+      setIsSubmitting(false);
     }
   };
 
@@ -102,7 +115,7 @@ export function InAppAgentWidgetComposer({
           className="h-8 w-8 shrink-0 rounded-md border"
           variant="outline"
           aria-label="Add with Langfuse Assistant"
-          disabled={!request.trim() || isRunning || isSubmitting}
+          disabled={!request.trim() || isSubmitting}
         >
           <SendHorizontal className="h-4 w-4" />
         </Button>

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -142,4 +142,45 @@ describe("InAppAgentWindow quick actions", () => {
       screen.getByRole("button", { name: /^Create a prompt/ }),
     ).toBeInTheDocument();
   });
+
+  it("keeps follow-up, new conversation, history, and switching controls available while running", async () => {
+    const onNewConversation = vi.fn();
+    const onSelectConversation = vi.fn();
+
+    render(
+      windowElement({
+        conversations: [
+          {
+            id: "conversation-1",
+            title: "Running conversation",
+            updatedAt: new Date(),
+          },
+        ],
+        isAssistantTurnInProgress: true,
+        isInputDisabled: false,
+        messages: [
+          {
+            id: "message-1",
+            role: "user",
+            content: { type: "text", text: "First" },
+          },
+        ],
+        onNewConversation,
+        onSelectConversation,
+      }),
+    );
+
+    expect(screen.getByLabelText("Message the assistant")).toBeEnabled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Start new conversation" }),
+    );
+    fireEvent.keyDown(
+      screen.getByRole("button", { name: "Conversation history" }),
+      { key: "ArrowDown" },
+    );
+    fireEvent.click(await screen.findByText("Running conversation"));
+
+    expect(onNewConversation).toHaveBeenCalledOnce();
+    expect(onSelectConversation).toHaveBeenCalledWith("conversation-1");
+  });
 });

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -146,6 +146,7 @@ describe("InAppAgentWindow quick actions", () => {
   it("keeps follow-up, new conversation, history, and switching controls available while running", async () => {
     const onNewConversation = vi.fn();
     const onSelectConversation = vi.fn();
+    const onEditQueuedMessage = vi.fn();
 
     render(
       windowElement({
@@ -158,6 +159,8 @@ describe("InAppAgentWindow quick actions", () => {
         ],
         isAssistantTurnInProgress: true,
         isInputDisabled: false,
+        draft: "Unsent draft",
+        queuedMessages: [{ id: "queued-1", content: "Queued follow-up" }],
         messages: [
           {
             id: "message-1",
@@ -167,10 +170,30 @@ describe("InAppAgentWindow quick actions", () => {
         ],
         onNewConversation,
         onSelectConversation,
+        onEditQueuedMessage,
+        onDeleteQueuedMessage: vi.fn(),
       }),
     );
 
     expect(screen.getByLabelText("Message the assistant")).toBeEnabled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit queued message 1" }),
+    );
+    const editor = screen.getByRole("textbox", {
+      name: "Edit queued message",
+    });
+    expect(editor).toHaveValue("Queued follow-up");
+    fireEvent.change(editor, { target: { value: "Edited follow-up" } });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save queued message" }),
+    );
+    expect(onEditQueuedMessage).toHaveBeenCalledWith(
+      "queued-1",
+      "Edited follow-up",
+    );
+    expect(screen.getByLabelText("Message the assistant")).toHaveValue(
+      "Unsent draft",
+    );
     fireEvent.click(
       screen.getByRole("button", { name: "Start new conversation" }),
     );

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1,4 +1,5 @@
 import preview from "../../../../../.storybook/preview";
+import { arrayMove } from "@dnd-kit/sortable";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import {
@@ -54,6 +55,46 @@ function StatefulInAppAgentWindow(args: InAppAgentWindowProps) {
         />
       )}
     </InAppAgentWindowStoryShell>
+  );
+}
+
+function StatefulQueuedInAppAgentWindow(args: InAppAgentWindowProps) {
+  const [draft, setDraft] = useState(args.draft ?? "");
+  const [queuedMessages, setQueuedMessages] = useState(() =>
+    Array.from(args.queuedMessages ?? []),
+  );
+
+  return (
+    <StatefulInAppAgentWindow
+      {...args}
+      draft={draft}
+      queuedMessages={queuedMessages}
+      onDraftChange={setDraft}
+      onEditQueuedMessage={(messageId, content) => {
+        args.onEditQueuedMessage?.(messageId, content);
+        setQueuedMessages((current) =>
+          current.map((message) =>
+            message.id === messageId ? { ...message, content } : message,
+          ),
+        );
+      }}
+      onDeleteQueuedMessage={(messageId) => {
+        args.onDeleteQueuedMessage?.(messageId);
+        setQueuedMessages((current) =>
+          current.filter(({ id }) => id !== messageId),
+        );
+      }}
+      onReorderQueuedMessage={(messageId, targetMessageId) => {
+        args.onReorderQueuedMessage?.(messageId, targetMessageId);
+        setQueuedMessages((current) => {
+          const fromIndex = current.findIndex(({ id }) => id === messageId);
+          const toIndex = current.findIndex(({ id }) => id === targetMessageId);
+          return fromIndex < 0 || toIndex < 0
+            ? current
+            : arrayMove(current, fromIndex, toIndex);
+        });
+      }}
+    />
   );
 }
 
@@ -655,6 +696,7 @@ export const ToolApprovalRequired = meta.story({
 });
 
 export const RunningWithQueuedFollowUps = meta.story({
+  render: (args) => <StatefulQueuedInAppAgentWindow {...args} />,
   args: {
     isAssistantTurnInProgress: true,
     isInputDisabled: false,
@@ -671,6 +713,7 @@ export const RunningWithQueuedFollowUps = meta.story({
     onDraftChange: fn(),
     onEditQueuedMessage: fn(),
     onDeleteQueuedMessage: fn(),
+    onReorderQueuedMessage: fn(),
     messages: [
       {
         id: "user-1",
@@ -1171,10 +1214,10 @@ export const RateLimited = meta.story({
     await expect(canvas.getByRole("button", { name: "Reject" })).toBeDisabled();
     await expect(
       canvas.getByRole("button", { name: "Start new conversation" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
     await expect(
       canvas.getByRole("button", { name: "Conversation history" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
   },
 });
 

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1017,11 +1017,11 @@ export const LoadingAfterToolCall = meta.story({
 });
 
 export const FeedbackControlsWaitForTurnEnd = meta.story({
-  name: "(Test) Feedback Controls Wait For Turn End",
+  name: "(Test) Feedback Controls Stay During Queued Handoff",
   args: {
     selectedConversationId: "conversation-1",
-    isInputDisabled: true,
-    isAssistantTurnInProgress: true,
+    isInputDisabled: false,
+    isAssistantTurnInProgress: false,
     onSubmitFeedback: fn(),
     messages: [
       {
@@ -1034,11 +1034,18 @@ export const FeedbackControlsWaitForTurnEnd = meta.story({
       },
       {
         id: "assistant-1",
-        runId: "run-1",
         role: "assistant",
         content: {
           type: "text",
           text: "I found a cluster of ingestion errors around malformed JSON payloads",
+        },
+      },
+      {
+        id: "user-2",
+        role: "user",
+        content: {
+          type: "text",
+          text: "Which payloads were affected?",
         },
       },
     ],
@@ -1050,14 +1057,12 @@ export const FeedbackControlsWaitForTurnEnd = meta.story({
       "I found a cluster of ingestion errors around malformed JSON payloads",
     );
 
-    await waitFor(() => {
-      expect(
-        canvas.queryByRole("button", { name: "Good response" }),
-      ).not.toBeInTheDocument();
-      expect(
-        canvas.queryByRole("button", { name: "Bad response" }),
-      ).not.toBeInTheDocument();
-    });
+    await expect(
+      canvas.findByRole("button", { name: "Good response" }),
+    ).resolves.toBeDisabled();
+    await expect(
+      canvas.findByRole("button", { name: "Bad response" }),
+    ).resolves.toBeDisabled();
   },
 });
 

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1,5 +1,4 @@
 import preview from "../../../../../.storybook/preview";
-import { arrayMove } from "@dnd-kit/sortable";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import {
@@ -83,16 +82,6 @@ function StatefulQueuedInAppAgentWindow(args: InAppAgentWindowProps) {
         setQueuedMessages((current) =>
           current.filter(({ id }) => id !== messageId),
         );
-      }}
-      onReorderQueuedMessage={(messageId, targetMessageId) => {
-        args.onReorderQueuedMessage?.(messageId, targetMessageId);
-        setQueuedMessages((current) => {
-          const fromIndex = current.findIndex(({ id }) => id === messageId);
-          const toIndex = current.findIndex(({ id }) => id === targetMessageId);
-          return fromIndex < 0 || toIndex < 0
-            ? current
-            : arrayMove(current, fromIndex, toIndex);
-        });
       }}
     />
   );
@@ -713,7 +702,6 @@ export const RunningWithQueuedFollowUps = meta.story({
     onDraftChange: fn(),
     onEditQueuedMessage: fn(),
     onDeleteQueuedMessage: fn(),
-    onReorderQueuedMessage: fn(),
     messages: [
       {
         id: "user-1",

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -654,6 +654,42 @@ export const ToolApprovalRequired = meta.story({
   },
 });
 
+export const RunningWithQueuedFollowUps = meta.story({
+  args: {
+    isAssistantTurnInProgress: true,
+    isInputDisabled: false,
+    selectedConversationId: "conversation-1",
+    draft: "A third follow-up can still be composed",
+    queuedMessages: [
+      { id: "queued-1", content: "Compare this with last week." },
+      {
+        id: "queued-2",
+        content:
+          "Break down the result by model.\nHighlight regressions above 10%.",
+      },
+    ],
+    onDraftChange: fn(),
+    onEditQueuedMessage: fn(),
+    onDeleteQueuedMessage: fn(),
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        content: { type: "text", text: "Investigate today's latency spike." },
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: {
+          type: "reasoning",
+          text: "Inspecting slow traces and comparing model latency.",
+          isStreaming: true,
+        },
+      },
+    ],
+  },
+});
+
 export const Empty = meta.story({
   args: {
     messages: [],

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -61,6 +61,7 @@ import {
 } from "@/src/ee/features/in-app-agent/quickActions";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
+import { InAppAgentQueuedMessages } from "./InAppAgentQueuedMessages";
 
 const AUTO_SCROLL_THRESHOLD_PX = 50;
 const SCROLL_DIRECTION_TOLERANCE_PX = 1;
@@ -241,6 +242,12 @@ export type InAppAgentWindowConversation = {
   id: string;
   title: string | null;
   updatedAt: Date;
+  activity?: {
+    isRunning: boolean;
+    requiresApproval: boolean;
+    queuedCount: number;
+    unreadOutcome: "completed" | "failed" | null;
+  };
 };
 
 type InAppAgentWindowCloseButtonProps =
@@ -264,6 +271,8 @@ export type InAppAgentWindowProps = {
   isInputDisabled: boolean;
   isLoadingMoreConversations: boolean;
   messages: InAppAgentWindowMessage[];
+  draft?: string;
+  queuedMessages?: readonly { id: string; content: string }[];
   onExpandedChange: (isExpanded: boolean) => void;
   onDeleteConversation: (conversation: InAppAgentWindowConversation) => void;
   onLoadMoreConversations: () => void;
@@ -282,6 +291,9 @@ export type InAppAgentWindowProps = {
     value: InAppAgentMessageFeedbackValue | null;
     comment?: string | null;
   }) => Promise<void>;
+  onDraftChange?: (draft: string) => void;
+  onEditQueuedMessage?: (messageId: string, content: string) => void;
+  onDeleteQueuedMessage?: (messageId: string) => void;
   screenContextDescription: InAppAgentScreenContextDescription;
   quickActionContext: InAppAgentQuickActionContext;
   focusedQuickActions?: readonly InAppAgentQuickAction[];
@@ -365,6 +377,8 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     isInputDisabled: baseIsInputDisabled,
     isLoadingMoreConversations,
     messages,
+    draft,
+    queuedMessages = [],
     onDeleteConversation,
     onExpandedChange,
     onLoadMoreConversations,
@@ -375,6 +389,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     onSelectConversation,
     onSubmit,
     onSubmitFeedback,
+    onDraftChange,
+    onEditQueuedMessage,
+    onDeleteQueuedMessage,
     focusedQuickActions,
     quickActionContext,
     quickActionResetKey,
@@ -392,7 +409,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const previousScrollTopRef = useRef(0);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const previousIsInputDisabledRef = useRef(isInputDisabled);
-  const [input, setInput] = useState("");
+  const [localInput, setLocalInput] = useState("");
+  const input = draft ?? localInput;
+  const setInput = onDraftChange ?? setLocalInput;
   const [isConversationHistoryOpen, setIsConversationHistoryOpen] =
     useState(false);
   const hasUserMessage = messages.some((message) => message.role === "user");
@@ -437,9 +456,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
         if (submitted) {
           isAutoScrollAttachedRef.current = true;
 
-          setInput((currentInput) =>
-            currentInput.trim() === trimmedContent ? "" : currentInput,
-          );
+          if (inputRef.current?.value.trim() === trimmedContent) {
+            setInput("");
+          }
 
           window.requestAnimationFrame(() => {
             scrollViewportToBottom(viewportRef.current);
@@ -528,7 +547,6 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 size="icon"
                 className="size-6 shrink-0"
                 onClick={onNewConversation}
-                disabled={baseIsInputDisabled}
                 aria-label="Start new conversation"
               >
                 <Plus className="size-3" />
@@ -554,7 +572,6 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                     variant="ghost"
                     size="icon"
                     className="size-6 shrink-0"
-                    disabled={baseIsInputDisabled}
                     aria-label="Conversation history"
                   >
                     <History className="size-3" />
@@ -596,12 +613,48 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                       >
                         {conversationTitle}
                       </span>
+                      {conversation.activity?.requiresApproval ? (
+                        <span className="shrink-0 text-[0.625rem] font-bold text-amber-600 dark:text-amber-400">
+                          Approval
+                        </span>
+                      ) : conversation.activity?.isRunning ? (
+                        <span className="text-muted-foreground shrink-0 text-[0.625rem]">
+                          Running
+                        </span>
+                      ) : conversation.activity?.queuedCount ? (
+                        <span className="text-muted-foreground shrink-0 text-[0.625rem]">
+                          {conversation.activity.queuedCount} queued
+                        </span>
+                      ) : conversation.activity?.unreadOutcome ? (
+                        <span
+                          aria-label={
+                            conversation.activity.unreadOutcome === "failed"
+                              ? "Failed while unviewed"
+                              : "Completed while unviewed"
+                          }
+                          className={cn(
+                            "size-2 shrink-0 rounded-full",
+                            conversation.activity.unreadOutcome === "failed"
+                              ? "bg-destructive"
+                              : "bg-primary-accent",
+                          )}
+                          title={
+                            conversation.activity.unreadOutcome === "failed"
+                              ? "Failed while unviewed"
+                              : "Completed while unviewed"
+                          }
+                        />
+                      ) : null}
                       <Button
                         type="button"
                         variant="ghost"
                         size="icon-xs"
                         className="text-muted-foreground hover:text-destructive -mr-1.5 shrink-0"
-                        disabled={baseIsInputDisabled}
+                        disabled={
+                          conversation.activity?.isRunning ||
+                          conversation.activity?.requiresApproval ||
+                          Boolean(conversation.activity?.queuedCount)
+                        }
                         aria-label="Delete conversation"
                         onClick={(event) => {
                           event.preventDefault();
@@ -886,6 +939,23 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 </>
               )}
             </div>
+          </div>
+        ) : null}
+        {queuedMessages.length > 0 &&
+        onEditQueuedMessage &&
+        onDeleteQueuedMessage ? (
+          <div
+            className={cn(
+              "shrink-0 px-1.5 pt-1.5",
+              isExpanded && "mx-auto w-full max-w-3xl",
+            )}
+          >
+            <InAppAgentQueuedMessages
+              key={selectedConversationId ?? "new"}
+              messages={queuedMessages}
+              onEdit={onEditQueuedMessage}
+              onDelete={onDeleteQueuedMessage}
+            />
           </div>
         ) : null}
         <div

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -808,13 +808,13 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 const isLastMessageOfTurn = visibleMessages
                   .slice(index + 1, nextTurnStartIndex)
                   .every((nextMessage) => nextMessage.role !== "assistant");
-                const feedbackRunId =
+                const shouldShowFeedback =
                   message.role === "assistant" &&
                   message.content.type === "text" &&
-                  !isCurrentTurnInProgress &&
-                  isLastMessageOfTurn
-                    ? message.runId
-                    : undefined;
+                  isLastMessageOfTurn;
+                const feedbackRunId = shouldShowFeedback
+                  ? message.runId
+                  : undefined;
 
                 return (
                   <li
@@ -829,15 +829,21 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                       role={message.role}
                       content={message.content}
                       isCompact={!isExpanded}
-                      isFeedbackDisabled={baseIsInputDisabled}
+                      isFeedbackDisabled={
+                        baseIsInputDisabled ||
+                        isCurrentTurnInProgress ||
+                        !feedbackRunId
+                      }
                       onSubmitFeedback={
-                        feedbackRunId
+                        shouldShowFeedback
                           ? (params) =>
-                              onSubmitFeedback({
-                                messageId: message.id,
-                                runId: feedbackRunId,
-                                ...params,
-                              })
+                              feedbackRunId
+                                ? onSubmitFeedback({
+                                    messageId: message.id,
+                                    runId: feedbackRunId,
+                                    ...params,
+                                  })
+                                : Promise.resolve()
                           : undefined
                       }
                     />

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -246,7 +246,6 @@ export type InAppAgentWindowConversation = {
     isRunning: boolean;
     requiresApproval: boolean;
     queuedCount: number;
-    unreadOutcome: "completed" | "failed" | null;
   };
 };
 
@@ -294,7 +293,6 @@ export type InAppAgentWindowProps = {
   onDraftChange?: (draft: string) => void;
   onEditQueuedMessage?: (messageId: string, content: string) => void;
   onDeleteQueuedMessage?: (messageId: string) => void;
-  onReorderQueuedMessage?: (messageId: string, targetMessageId: string) => void;
   screenContextDescription: InAppAgentScreenContextDescription;
   quickActionContext: InAppAgentQuickActionContext;
   focusedQuickActions?: readonly InAppAgentQuickAction[];
@@ -393,7 +391,6 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     onDraftChange,
     onEditQueuedMessage,
     onDeleteQueuedMessage,
-    onReorderQueuedMessage,
     focusedQuickActions,
     quickActionContext,
     quickActionResetKey,
@@ -653,25 +650,6 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                         <span className="text-muted-foreground shrink-0 text-[0.625rem]">
                           {conversation.activity.queuedCount} queued
                         </span>
-                      ) : conversation.activity?.unreadOutcome ? (
-                        <span
-                          aria-label={
-                            conversation.activity.unreadOutcome === "failed"
-                              ? "Failed while unviewed"
-                              : "Completed while unviewed"
-                          }
-                          className={cn(
-                            "size-2 shrink-0 rounded-full",
-                            conversation.activity.unreadOutcome === "failed"
-                              ? "bg-destructive"
-                              : "bg-primary-accent",
-                          )}
-                          title={
-                            conversation.activity.unreadOutcome === "failed"
-                              ? "Failed while unviewed"
-                              : "Completed while unviewed"
-                          }
-                        />
                       ) : null}
                       <Button
                         type="button"
@@ -1003,7 +981,6 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 }
                 onDeleteQueuedMessage(messageId);
               }}
-              onReorder={onReorderQueuedMessage}
             />
           </div>
         ) : null}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -294,6 +294,7 @@ export type InAppAgentWindowProps = {
   onDraftChange?: (draft: string) => void;
   onEditQueuedMessage?: (messageId: string, content: string) => void;
   onDeleteQueuedMessage?: (messageId: string) => void;
+  onReorderQueuedMessage?: (messageId: string, targetMessageId: string) => void;
   screenContextDescription: InAppAgentScreenContextDescription;
   quickActionContext: InAppAgentQuickActionContext;
   focusedQuickActions?: readonly InAppAgentQuickAction[];
@@ -392,6 +393,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     onDraftChange,
     onEditQueuedMessage,
     onDeleteQueuedMessage,
+    onReorderQueuedMessage,
     focusedQuickActions,
     quickActionContext,
     quickActionResetKey,
@@ -412,6 +414,25 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const [localInput, setLocalInput] = useState("");
   const input = draft ?? localInput;
   const setInput = onDraftChange ?? setLocalInput;
+  const [queuedMessageEdit, setQueuedMessageEdit] = useState<{
+    conversationId: string | undefined;
+    messageId: string;
+    content: string;
+  } | null>(null);
+  const [editConversationId, setEditConversationId] = useState(
+    selectedConversationId,
+  );
+  if (editConversationId !== selectedConversationId) {
+    setEditConversationId(selectedConversationId);
+    setQueuedMessageEdit(null);
+  }
+  const activeQueuedMessageEdit =
+    queuedMessageEdit !== null &&
+    queuedMessageEdit.conversationId === selectedConversationId &&
+    queuedMessages.some(({ id }) => id === queuedMessageEdit.messageId)
+      ? queuedMessageEdit
+      : null;
+  const composerInput = activeQueuedMessageEdit?.content ?? input;
   const [isConversationHistoryOpen, setIsConversationHistoryOpen] =
     useState(false);
   const hasUserMessage = messages.some((message) => message.role === "user");
@@ -448,6 +469,13 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     const trimmedContent = content.trim();
 
     if (!trimmedContent || isInputDisabled) {
+      return;
+    }
+
+    if (activeQueuedMessageEdit && onEditQueuedMessage) {
+      onEditQueuedMessage(activeQueuedMessageEdit.messageId, trimmedContent);
+      setQueuedMessageEdit(null);
+      inputRef.current?.focus();
       return;
     }
 
@@ -511,7 +539,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
 
     input.style.height = "auto";
     input.style.height = `${Math.min(input.scrollHeight, 160)}px`;
-  }, [input]);
+  }, [composerInput]);
 
   return (
     <section
@@ -953,8 +981,29 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
             <InAppAgentQueuedMessages
               key={selectedConversationId ?? "new"}
               messages={queuedMessages}
-              onEdit={onEditQueuedMessage}
-              onDelete={onDeleteQueuedMessage}
+              onEdit={(messageId) => {
+                const message = queuedMessages.find(
+                  ({ id }) => id === messageId,
+                );
+                if (!message) {
+                  return;
+                }
+                setQueuedMessageEdit({
+                  conversationId: selectedConversationId,
+                  messageId,
+                  content: message.content,
+                });
+                window.requestAnimationFrame(() => {
+                  inputRef.current?.focus();
+                });
+              }}
+              onDelete={(messageId) => {
+                if (activeQueuedMessageEdit?.messageId === messageId) {
+                  setQueuedMessageEdit(null);
+                }
+                onDeleteQueuedMessage(messageId);
+              }}
+              onReorder={onReorderQueuedMessage}
             />
           </div>
         ) : null}
@@ -967,9 +1016,10 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
         >
           <form
             className={cn(
-              "relative flex w-full items-end gap-2 rounded-md",
-              isExpanded &&
-                "mx-auto max-w-3xl cursor-text flex-col border focus-within:ring focus-within:ring-blue-500 focus-within:ring-offset-0",
+              "relative flex w-full flex-col rounded-md",
+              (isExpanded || activeQueuedMessageEdit) &&
+                "cursor-text border focus-within:ring focus-within:ring-blue-500 focus-within:ring-offset-0",
+              isExpanded && "mx-auto max-w-3xl",
             )}
             onClick={() => {
               if (isExpanded) {
@@ -978,62 +1028,109 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
             }}
             onSubmit={(event) => {
               event.preventDefault();
-              submitInput(input);
+              submitInput(composerInput);
             }}
           >
-            <textarea
-              autoFocus={!isExpanded}
-              ref={setInputRef}
-              value={input}
-              onChange={(event) => {
-                setInput(event.target.value);
-              }}
-              onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
-                if (
-                  event.key === "Enter" &&
-                  !event.shiftKey &&
-                  !event.nativeEvent.isComposing
-                ) {
-                  event.preventDefault();
-                  event.currentTarget.form?.requestSubmit();
+            {activeQueuedMessageEdit ? (
+              <div className="border-border flex w-full items-center justify-between border-b px-3 py-2 text-xs font-bold">
+                <span>Editing queued message</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-1.5 text-xs"
+                  onClick={() => {
+                    setQueuedMessageEdit(null);
+                    inputRef.current?.focus();
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            ) : null}
+            <div className="flex w-full items-end gap-2">
+              <textarea
+                autoFocus={!isExpanded}
+                ref={setInputRef}
+                value={composerInput}
+                onChange={(event) => {
+                  if (activeQueuedMessageEdit) {
+                    setQueuedMessageEdit({
+                      ...activeQueuedMessageEdit,
+                      content: event.target.value,
+                    });
+                  } else {
+                    setInput(event.target.value);
+                  }
+                }}
+                onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
+                  if (event.key === "Escape" && activeQueuedMessageEdit) {
+                    event.preventDefault();
+                    setQueuedMessageEdit(null);
+                    return;
+                  }
+                  if (
+                    event.key === "Enter" &&
+                    !event.shiftKey &&
+                    !event.nativeEvent.isComposing
+                  ) {
+                    event.preventDefault();
+                    event.currentTarget.form?.requestSubmit();
+                  }
+                }}
+                disabled={isInputDisabled}
+                aria-label={
+                  activeQueuedMessageEdit
+                    ? "Edit queued message"
+                    : "Message the assistant"
                 }
-              }}
-              disabled={isInputDisabled}
-              aria-label="Message the assistant"
-              placeholder="Let me know what I can do for you..."
-              rows={1}
-              className={cn(
-                "bg-background placeholder:text-foreground-tertiary w-full flex-1 resize-none overflow-y-auto rounded-md text-sm leading-5 disabled:cursor-not-allowed disabled:opacity-60",
-                isExpanded
-                  ? "max-h-40 min-h-14 border-none ring-0"
-                  : "border-input max-h-40 min-h-8 px-3 py-1",
+                placeholder="Let me know what I can do for you..."
+                rows={1}
+                className={cn(
+                  "bg-background placeholder:text-foreground-tertiary w-full flex-1 resize-none overflow-y-auto rounded-md text-sm leading-5 disabled:cursor-not-allowed disabled:opacity-60",
+                  isExpanded || activeQueuedMessageEdit
+                    ? "max-h-40 min-h-14 border-none px-3 py-2 ring-0"
+                    : "border-input max-h-40 min-h-8 px-3 py-1",
+                )}
+              />
+              {!isExpanded && (
+                <Button
+                  type="submit"
+                  size="icon"
+                  className={cn(
+                    "h-8 w-8 shrink-0 rounded-md border",
+                    activeQueuedMessageEdit && "m-1",
+                  )}
+                  aria-label={
+                    activeQueuedMessageEdit
+                      ? "Save queued message"
+                      : "Send message"
+                  }
+                  variant="outline"
+                  disabled={isInputDisabled || !composerInput.trim()}
+                >
+                  <SendHorizontal className="h-4 w-4" />
+                </Button>
               )}
-            />
-            {!isExpanded && (
-              <Button
-                type="submit"
-                size="icon"
-                className="h-8 w-8 rounded-md border"
-                aria-label="Send message"
-                variant="outline"
-                disabled={isInputDisabled || !input.trim()}
-              >
-                <SendHorizontal className="h-4 w-4" />
-              </Button>
-            )}
+            </div>
 
             {isExpanded && (
               <div className="flex w-full justify-end p-1">
                 <Button
                   type="submit"
                   className="h-8 w-fit rounded-md px-3"
-                  aria-label="Send message"
-                  disabled={isInputDisabled || !input.trim()}
+                  aria-label={
+                    activeQueuedMessageEdit
+                      ? "Save queued message"
+                      : "Send message"
+                  }
+                  disabled={isInputDisabled || !composerInput.trim()}
                   onClick={(e) => {
                     e.stopPropagation();
                   }}
                 >
-                  Send <SendHorizontal className="ml-2 h-4 w-4" />
+                  {activeQueuedMessageEdit ? "Save" : "Send"}{" "}
+                  <SendHorizontal className="ml-2 h-4 w-4" />
                 </Button>
               </div>
             )}

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.clienttest.tsx
@@ -193,17 +193,6 @@ function Harness() {
           Open {conversation.title}
         </button>
       ))}
-      <button
-        onClick={() => {
-          const first = agent.queuedMessages[0];
-          const last = agent.queuedMessages.at(-1);
-          if (first && last) {
-            agent.reorderQueuedMessage(last.id, first.id);
-          }
-        }}
-      >
-        Move last first
-      </button>
       {agent.queuedMessages.map((message) => (
         <div key={message.id}>
           <span>{message.content}</span>
@@ -310,7 +299,7 @@ describe("InAppAiAgentProvider concurrent conversations and queue", () => {
     });
   });
 
-  it("edits, deletes, and reorders pending messages before dispatch", async () => {
+  it("edits and deletes pending messages without changing FIFO order", async () => {
     renderProvider();
 
     fireEvent.click(screen.getByText("Submit first"));
@@ -336,19 +325,18 @@ describe("InAppAiAgentProvider concurrent conversations and queue", () => {
     }
     fireEvent.click(editButton);
     fireEvent.click(deleteButton);
-    fireEvent.click(screen.getByText("Move last first"));
 
     act(() => {
       agent.finishNextRun();
     });
     await waitFor(() => {
-      expect(agent.userMessages).toEqual(["first", "fourth"]);
+      expect(agent.userMessages).toEqual(["first", "edited"]);
     });
     act(() => {
       agent.finishNextRun();
     });
     await waitFor(() => {
-      expect(agent.userMessages).toEqual(["first", "fourth", "edited"]);
+      expect(agent.userMessages).toEqual(["first", "edited", "fourth"]);
     });
   });
 });

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.clienttest.tsx
@@ -1,0 +1,342 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type * as AgUiClient from "@ag-ui/client";
+
+import { InAppAiAgentProvider, useInAppAiAgent } from "./InAppAiAgentProvider";
+
+const mocks = vi.hoisted(() => {
+  type Subscriber = {
+    onCustomEvent?: (payload: { event: unknown }) => void;
+    onMessagesChanged?: (payload: { messages: unknown[] }) => void;
+  };
+  class MockHttpAgent {
+    readonly threadId: string;
+    messages: unknown[];
+    isRunning = false;
+    readonly abortRun = vi.fn();
+    readonly runAgent = vi.fn();
+    private subscriber: Subscriber | undefined;
+    private pendingRuns: Array<() => void> = [];
+
+    constructor(options: { threadId: string; initialMessages?: unknown[] }) {
+      this.threadId = options.threadId;
+      this.messages = [...(options.initialMessages ?? [])];
+      this.runAgent.mockImplementation(() => {
+        this.isRunning = true;
+        return new Promise<void>((resolve) => {
+          this.pendingRuns.push(() => {
+            this.isRunning = false;
+            resolve();
+          });
+        });
+      });
+      agents.push(this);
+    }
+
+    addMessage(message: unknown) {
+      this.messages.push(message);
+      this.subscriber?.onMessagesChanged?.({ messages: this.messages });
+    }
+
+    subscribe(subscriber: Subscriber) {
+      this.subscriber = subscriber;
+      return { unsubscribe: vi.fn() };
+    }
+
+    finishNextRun() {
+      const finish = this.pendingRuns.shift();
+      if (!finish) {
+        throw new Error("No run to finish");
+      }
+      finish();
+    }
+
+    requestApproval() {
+      this.subscriber?.onCustomEvent?.({
+        event: {
+          name: "on_interrupt",
+          value: {
+            type: "mastra_suspend",
+            toolCallId: "approval-1",
+            toolName: "createDashboardWidget",
+            runId: "run-1",
+          },
+        },
+      });
+    }
+
+    get userMessages() {
+      return this.messages
+        .filter(
+          (message): message is { role: string; content: string } =>
+            typeof message === "object" &&
+            message !== null &&
+            "role" in message &&
+            message.role === "user" &&
+            "content" in message &&
+            typeof message.content === "string",
+        )
+        .map((message) => message.content);
+    }
+  }
+
+  const agents: MockHttpAgent[] = [];
+  return { agents, capture: vi.fn(), MockHttpAgent };
+});
+
+vi.mock("@ag-ui/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof AgUiClient>();
+  return { ...actual, HttpAgent: mocks.MockHttpAgent };
+});
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    asPath: "/project/project-1/traces",
+    query: { projectId: "project-1" },
+  }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { name: "Ada" } } }),
+}));
+
+vi.mock("@/src/features/entitlements/hooks", () => ({
+  useHasEntitlement: () => true,
+}));
+
+vi.mock("@/src/features/organizations/hooks", () => ({
+  useLangfuseCloudRegion: () => ({ isLangfuseCloud: true }),
+}));
+
+vi.mock("@/src/features/projects/hooks", () => ({
+  useQueryProjectOrOrganization: () => ({
+    organization: { id: "org-1", aiFeaturesEnabled: true },
+  }),
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => mocks.capture,
+}));
+
+vi.mock(
+  "@/src/ee/features/in-app-agent/components/InAppAgentDisabledDialog",
+  () => ({
+    InAppAgentDisabledDialog: () => null,
+  }),
+);
+
+vi.mock("@/src/utils/api", () => {
+  const invalidate = vi.fn().mockResolvedValue(undefined);
+  return {
+    api: {
+      useUtils: () => ({
+        inAppAgent: {
+          getConversation: { invalidate },
+          listConversations: { invalidate },
+        },
+      }),
+      inAppAgent: {
+        listConversations: {
+          useInfiniteQuery: () => ({
+            data: { pages: [{ conversations: [] }] },
+            error: null,
+            fetchNextPage: vi.fn(),
+            hasNextPage: false,
+            isFetchingNextPage: false,
+          }),
+        },
+        getConversation: {
+          useQuery: () => ({ data: undefined, error: null, isLoading: false }),
+        },
+        deleteConversation: {
+          useMutation: () => ({ mutateAsync: vi.fn() }),
+        },
+        submitFeedback: {
+          useMutation: () => ({ mutateAsync: vi.fn() }),
+        },
+      },
+    },
+  };
+});
+
+function Harness() {
+  const agent = useInAppAiAgent();
+
+  return (
+    <>
+      <button onClick={() => agent.submit("first")}>Submit first</button>
+      <button onClick={() => agent.submit("second")}>Submit second</button>
+      <button onClick={() => agent.submit("third")}>Submit third</button>
+      <button onClick={() => agent.submit("fourth")}>Submit fourth</button>
+      <button
+        onClick={() => {
+          agent.selectConversation(null);
+        }}
+      >
+        New
+      </button>
+      <button onClick={() => agent.approveToolCall("approval-1")}>
+        Approve
+      </button>
+      {agent.conversations.map((conversation) => (
+        <button
+          key={conversation.id}
+          onClick={() => {
+            agent.selectConversation(conversation.id);
+          }}
+        >
+          Open {conversation.title}
+        </button>
+      ))}
+      {agent.queuedMessages.map((message) => (
+        <div key={message.id}>
+          <span>{message.content}</span>
+          <button
+            onClick={() => {
+              agent.editQueuedMessage(message.id, "edited");
+            }}
+          >
+            Edit
+          </button>
+          <button
+            onClick={() => {
+              agent.deleteQueuedMessage(message.id);
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <InAppAiAgentProvider defaultOpen>
+      <Harness />
+    </InAppAiAgentProvider>,
+  );
+}
+
+describe("InAppAiAgentProvider concurrent conversations and queue", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    mocks.agents.length = 0;
+    mocks.capture.mockClear();
+  });
+
+  it("runs separate conversations independently without aborting on switch", async () => {
+    renderProvider();
+
+    fireEvent.click(screen.getByText("Submit first"));
+    await waitFor(() => {
+      expect(mocks.agents).toHaveLength(1);
+    });
+
+    fireEvent.click(screen.getByText("New"));
+    fireEvent.click(screen.getByText("Submit second"));
+    await waitFor(() => {
+      expect(mocks.agents).toHaveLength(2);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Open first" }));
+
+    expect(mocks.agents[0]?.runAgent).toHaveBeenCalledOnce();
+    expect(mocks.agents[1]?.runAgent).toHaveBeenCalledOnce();
+    expect(mocks.agents[0]?.abortRun).not.toHaveBeenCalled();
+    expect(mocks.agents[1]?.abortRun).not.toHaveBeenCalled();
+  });
+
+  it("dispatches queued follow-ups in FIFO order only after approval continuation finishes", async () => {
+    renderProvider();
+
+    fireEvent.click(screen.getByText("Submit first"));
+    await waitFor(() => {
+      expect(mocks.agents).toHaveLength(1);
+    });
+    const agent = mocks.agents[0];
+    if (!agent) {
+      throw new Error("Expected the first conversation agent");
+    }
+
+    fireEvent.click(screen.getByText("Submit second"));
+    fireEvent.click(screen.getByText("Submit third"));
+    act(() => {
+      agent.requestApproval();
+    });
+    act(() => {
+      agent.finishNextRun();
+    });
+
+    await waitFor(() => {
+      expect(agent.runAgent).toHaveBeenCalledOnce();
+    });
+    expect(agent.userMessages).toEqual(["first"]);
+
+    fireEvent.click(screen.getByText("Approve"));
+    await waitFor(() => {
+      expect(agent.runAgent).toHaveBeenCalledTimes(2);
+    });
+    act(() => {
+      agent.finishNextRun();
+    });
+
+    await waitFor(() => {
+      expect(agent.userMessages).toEqual(["first", "second"]);
+    });
+    expect(agent.runAgent).toHaveBeenCalledTimes(3);
+    act(() => {
+      agent.finishNextRun();
+    });
+
+    await waitFor(() => {
+      expect(agent.userMessages).toEqual(["first", "second", "third"]);
+    });
+  });
+
+  it("edits and deletes pending messages before dispatch without changing their order", async () => {
+    renderProvider();
+
+    fireEvent.click(screen.getByText("Submit first"));
+    await waitFor(() => {
+      expect(mocks.agents).toHaveLength(1);
+    });
+    const agent = mocks.agents[0];
+    if (!agent) {
+      throw new Error("Expected the first conversation agent");
+    }
+
+    fireEvent.click(screen.getByText("Submit second"));
+    fireEvent.click(screen.getByText("Submit third"));
+    fireEvent.click(screen.getByText("Submit fourth"));
+    const editButton = (
+      await screen.findAllByRole("button", { name: "Edit" })
+    ).at(1);
+    const deleteButton = screen
+      .getAllByRole("button", { name: "Delete" })
+      .at(0);
+    if (!editButton || !deleteButton) {
+      throw new Error("Expected queued message actions");
+    }
+    fireEvent.click(editButton);
+    fireEvent.click(deleteButton);
+
+    act(() => {
+      agent.finishNextRun();
+    });
+    await waitFor(() => {
+      expect(agent.userMessages).toEqual(["first", "edited"]);
+    });
+    act(() => {
+      agent.finishNextRun();
+    });
+    await waitFor(() => {
+      expect(agent.userMessages).toEqual(["first", "edited", "fourth"]);
+    });
+  });
+});

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.clienttest.tsx
@@ -193,6 +193,17 @@ function Harness() {
           Open {conversation.title}
         </button>
       ))}
+      <button
+        onClick={() => {
+          const first = agent.queuedMessages[0];
+          const last = agent.queuedMessages.at(-1);
+          if (first && last) {
+            agent.reorderQueuedMessage(last.id, first.id);
+          }
+        }}
+      >
+        Move last first
+      </button>
       {agent.queuedMessages.map((message) => (
         <div key={message.id}>
           <span>{message.content}</span>
@@ -299,7 +310,7 @@ describe("InAppAiAgentProvider concurrent conversations and queue", () => {
     });
   });
 
-  it("edits and deletes pending messages before dispatch without changing their order", async () => {
+  it("edits, deletes, and reorders pending messages before dispatch", async () => {
     renderProvider();
 
     fireEvent.click(screen.getByText("Submit first"));
@@ -325,18 +336,19 @@ describe("InAppAiAgentProvider concurrent conversations and queue", () => {
     }
     fireEvent.click(editButton);
     fireEvent.click(deleteButton);
+    fireEvent.click(screen.getByText("Move last first"));
 
     act(() => {
       agent.finishNextRun();
     });
     await waitFor(() => {
-      expect(agent.userMessages).toEqual(["first", "edited"]);
+      expect(agent.userMessages).toEqual(["first", "fourth"]);
     });
     act(() => {
       agent.finishNextRun();
     });
     await waitFor(() => {
-      expect(agent.userMessages).toEqual(["first", "edited", "fourth"]);
+      expect(agent.userMessages).toEqual(["first", "fourth", "edited"]);
     });
   });
 });

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -6,56 +6,59 @@ import {
   useMemo,
   useRef,
   useState,
-  type PropsWithChildren,
   type Dispatch,
+  type PropsWithChildren,
   type SetStateAction,
 } from "react";
 import { EventType, HttpAgent } from "@ag-ui/client";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { z } from "zod";
+import { useStore } from "zustand";
 
 import useSessionStorage from "@/src/components/useSessionStorage";
 import { env } from "@/src/env.mjs";
+import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "../constants";
 import {
   createInAppAgentConversationId,
   createInAppAgentMessageId,
   createInAppAgentRunId,
-} from "@/src/ee/features/in-app-agent/ids";
-import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
+} from "../ids";
 import {
   AgUiMessageSchema,
   type AgUiMessage,
   type InAppAgentMessageFeedback,
   type InAppAgentMessageFeedbackValue,
   type InAppAgentRuntimeState,
-  type InAppAgentToolApprovalRequest,
-} from "@/src/ee/features/in-app-agent/schema";
-import type { InAppAgentError } from "@/src/ee/features/in-app-agent/components/utils/utils";
-import { useHasEntitlement } from "@/src/features/entitlements/hooks";
-import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
-import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { api } from "@/src/utils/api";
+} from "../schema";
 import {
   createInAppAgentMessageEntryPointContext,
   createInAppAgentQuickActionAttributionContext,
   createInAppAgentScreenContext,
   createInAppAgentUserContext,
-  type InAppAgentMessageEntryPoint,
-} from "@/src/ee/features/in-app-agent/context";
-import type {
-  InAppAgentQuickActionAttribution,
-  InAppAgentSubmitOptions,
-} from "@/src/ee/features/in-app-agent/quickActions";
-import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+} from "../context";
+import type { InAppAgentSubmitOptions } from "../quickActions";
+import {
+  EMPTY_IN_APP_AGENT_CONVERSATION_STATE,
+  NEW_CONVERSATION_DRAFT_KEY,
+  createInAppAgentClientStore,
+  type InAppAgentPendingToolApproval,
+  type InAppAgentQueuedMessage,
+} from "./inAppAgentClientStore";
 import {
   getInAppAgentError,
   isInAppAgentRateLimited,
+  type InAppAgentError,
   type InAppAiAgentMessage,
-} from "@/src/ee/features/in-app-agent/components/utils/utils";
+} from "./utils/utils";
+import { InAppAgentDisabledDialog } from "./InAppAgentDisabledDialog";
+import { useHasEntitlement } from "@/src/features/entitlements/hooks";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
+import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { api } from "@/src/utils/api";
 import { evaluateSetStateAction } from "@/src/utils/evaluate-set-state-action";
-import { InAppAgentDisabledDialog } from "@/src/ee/features/in-app-agent/components/InAppAgentDisabledDialog";
 
 const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";
@@ -87,66 +90,38 @@ const getConversationAgentState = (
     ? { type: "newConversation", projectId }
     : { type: "existingConversation", projectId, conversationId };
 
-const NOOP_CONTEXT: InAppAiAgentContextType = {
-  isAvailable: false,
-  open: false,
-  setOpen: () => undefined,
-  openAssistant: () => false,
-  isExpanded: false,
-  setIsExpanded: () => undefined,
-  isRunning: false,
-  isSubmitting: false,
-  pendingToolApprovals: [],
-  isSelectedConversationHydrating: false,
-  error: null,
-  messages: [],
-  liveMessageVersion: 0,
-  conversations: [],
-  hasMoreConversations: false,
-  isLoadingMoreConversations: false,
-  selectedConversationId: undefined,
-  selectedConversationIsWriteLocked: false,
-  loadMoreConversations: () => undefined,
-  invalidateConversations: () => undefined,
-  selectConversation: () => undefined,
-  deleteConversation: async () => undefined,
-  submit: async () => false,
-  approveToolCall: async () => undefined,
-  rejectToolCall: async () => undefined,
-  submitFeedback: async () => undefined,
-};
-
 type InAppAiAgentFeedbackByConversationId = Record<
   string,
   Record<string, InAppAgentMessageFeedback>
 >;
 
-export type InAppAgentPendingToolApproval = {
-  id: string;
-  approvalRequest: InAppAgentToolApprovalRequest;
-  status: "pending" | "submitting";
-};
+export type { InAppAgentPendingToolApproval, InAppAgentQueuedMessage };
 
 export type InAppAiAgentConversation = {
   id: string;
   title: string | null;
   updatedAt: Date;
   isWriteLocked: boolean;
+  activity?: {
+    isRunning: boolean;
+    requiresApproval: boolean;
+    queuedCount: number;
+    unreadOutcome: "completed" | "failed" | null;
+  };
 };
 
 type InAppAiAgentContextType = {
   isAvailable: boolean;
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
-  /** Open the assistant from an entrypoint. Owns the AI-features gate: shows
-   * the disabled dialog and returns false when the organization has AI
-   * features turned off. */
   openAssistant: (source: InAppAgentEntryPoint) => boolean;
   isExpanded: boolean;
   setIsExpanded: Dispatch<SetStateAction<boolean>>;
   isRunning: boolean;
   isSubmitting: boolean;
   pendingToolApprovals: InAppAgentPendingToolApproval[];
+  queuedMessages: InAppAgentQueuedMessage[];
+  draft: string;
   isSelectedConversationHydrating: boolean;
   error: InAppAgentError | null;
   messages: InAppAiAgentMessage[];
@@ -160,6 +135,9 @@ type InAppAiAgentContextType = {
   invalidateConversations: () => void;
   selectConversation: (conversationId: string | null) => void;
   deleteConversation: (conversationId: string) => Promise<void>;
+  setDraft: (draft: string) => void;
+  editQueuedMessage: (messageId: string, content: string) => void;
+  deleteQueuedMessage: (messageId: string) => void;
   submit: (
     content: string,
     options?: InAppAgentSubmitOptions,
@@ -172,6 +150,40 @@ type InAppAiAgentContextType = {
     value: InAppAgentMessageFeedbackValue | null;
     comment?: string | null;
   }) => Promise<void>;
+};
+
+const NOOP_CONTEXT: InAppAiAgentContextType = {
+  isAvailable: false,
+  open: false,
+  setOpen: () => undefined,
+  openAssistant: () => false,
+  isExpanded: false,
+  setIsExpanded: () => undefined,
+  isRunning: false,
+  isSubmitting: false,
+  pendingToolApprovals: [],
+  queuedMessages: [],
+  draft: "",
+  isSelectedConversationHydrating: false,
+  error: null,
+  messages: [],
+  liveMessageVersion: 0,
+  conversations: [],
+  hasMoreConversations: false,
+  isLoadingMoreConversations: false,
+  selectedConversationId: undefined,
+  selectedConversationIsWriteLocked: false,
+  loadMoreConversations: () => undefined,
+  invalidateConversations: () => undefined,
+  selectConversation: () => undefined,
+  deleteConversation: async () => undefined,
+  setDraft: () => undefined,
+  editQueuedMessage: () => undefined,
+  deleteQueuedMessage: () => undefined,
+  submit: async () => false,
+  approveToolCall: async () => undefined,
+  rejectToolCall: async () => undefined,
+  submitFeedback: async () => undefined,
 };
 
 const InAppAiAgentContext = createContext<InAppAiAgentContextType | null>(null);
@@ -209,42 +221,51 @@ function InAppAiAgentProjectProvider({
   children,
   projectId,
   defaultOpen,
-}: InAppAiAgentProviderProps & {
-  projectId: string;
-}) {
+}: InAppAiAgentProviderProps & { projectId: string }) {
   const [open, setOpen] = useSessionStorage<boolean>(
     `${OPEN_STORAGE_KEY_PREFIX}:${projectId}`,
     defaultOpen ?? false,
   );
+  const [clientStore] = useState(createInAppAgentClientStore);
 
   return (
     <InAppAiAgentProviderInner
       projectId={projectId}
       open={open}
       setOpen={setOpen}
+      clientStore={clientStore}
     >
       {children}
     </InAppAiAgentProviderInner>
   );
 }
 
-type InAppAiAgentProviderInnerProps = PropsWithChildren<{
-  projectId: string;
-  open: boolean;
-  setOpen: Dispatch<SetStateAction<boolean>>;
-}>;
+type AgentRuntime = {
+  agent: HttpAgent;
+  subscription: ReturnType<HttpAgent["subscribe"]> | null;
+  activeRunId: string | null;
+};
+
+type RunResult = "completed" | "failed" | "rate_limited";
 
 function InAppAiAgentProviderInner({
   children,
   projectId,
   open,
   setOpen,
-}: InAppAiAgentProviderInnerProps) {
+  clientStore,
+}: PropsWithChildren<{
+  projectId: string;
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+  clientStore: ReturnType<typeof createInAppAgentClientStore>;
+}>) {
   const utils = api.useUtils();
   const capture = usePostHogClientCapture();
   const session = useSession();
   const { organization } = useQueryProjectOrOrganization();
   const [enableDialogOpen, setEnableDialogOpen] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [_selectedConversationId, setSelectedConversationId] =
     useSessionStorage<string | null>(
       `${SELECTED_CONVERSATION_STORAGE_KEY_PREFIX}:${projectId}`,
@@ -255,29 +276,29 @@ function InAppAiAgentProviderInner({
       `${FEEDBACK_STORAGE_KEY_PREFIX}:${projectId}`,
       {},
     );
-  const [messages, setMessages] = useState<AgUiMessage[]>([]);
-  // Only live AG-UI publications increment this version. The display smoother
-  // uses it to distinguish stream updates from history hydration, including
-  // updates where the agent mutates message objects in place.
-  const [liveMessageVersion, setLiveMessageVersion] = useState(0);
-  const [pendingToolApprovals, setPendingToolApprovals] = useState<
-    InAppAgentPendingToolApproval[]
-  >([]);
-  const pendingToolApprovalsRef = useRef<InAppAgentPendingToolApproval[]>([]);
-  const [isRunning, setIsRunning] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [loadingEventIds, setLoadingEventIds] = useState<ReadonlySet<string>>(
-    () => new Set(),
+  const runtimesRef = useRef(new Map<string, AgentRuntime>());
+  const selectedConversationIdRef = useRef<string | null>(null);
+  const pumpConversationRef = useRef<(conversationId: string) => void>(
+    () => undefined,
   );
-  const [error, setError] = useState<InAppAgentError | null>(null);
-  const agentRef = useRef<HttpAgent | null>(null);
-  const activeRunIdRef = useRef<string | null>(null);
-  const intentionalAbortRef = useRef(false);
-  const submitInFlightRef = useRef(false);
-  const runInFlightRef = useRef(false);
-  const subscriptionRef = useRef<ReturnType<HttpAgent["subscribe"]> | null>(
-    null,
+  const executeRunRef = useRef<
+    (
+      conversationId: string,
+      runtime: AgentRuntime,
+      context: InAppAgentQueuedMessage["context"],
+      parameters?: Parameters<HttpAgent["runAgent"]>[0],
+      retryOnRateLimit?: boolean,
+      throwOnFailure?: boolean,
+    ) => Promise<RunResult>
+  >(async () => "failed");
+  const actions = clientStore.getState().actions;
+  const allClientConversations = useStore(
+    clientStore,
+    (state) => state.conversations,
+  );
+  const localConversations = useStore(
+    clientStore,
+    (state) => state.localConversations,
   );
 
   const conversationListQuery =
@@ -288,60 +309,86 @@ function InAppAiAgentProviderInner({
         getNextPageParam: (lastPage) => lastPage.nextCursor,
       },
     );
+  const remoteConversations = useMemo(
+    () =>
+      conversationListQuery.data?.pages.flatMap((page) => page.conversations) ??
+      [],
+    [conversationListQuery.data?.pages],
+  );
+  const selectedClientKey =
+    _selectedConversationId ?? NEW_CONVERSATION_DRAFT_KEY;
+  const selectedClientState = useStore(
+    clientStore,
+    (state) =>
+      state.conversations[selectedClientKey] ??
+      EMPTY_IN_APP_AGENT_CONVERSATION_STATE,
+  );
   const conversationQuery = api.inAppAgent.getConversation.useQuery(
+    { projectId, conversationId: _selectedConversationId ?? "" },
     {
-      projectId,
-      conversationId: _selectedConversationId ?? "",
-    },
-    {
-      enabled: open && Boolean(_selectedConversationId) && !isSubmitting,
+      enabled:
+        open &&
+        Boolean(_selectedConversationId) &&
+        !selectedClientState.isSubmitting,
     },
   );
   const deleteConversationMutation =
     api.inAppAgent.deleteConversation.useMutation();
   const feedbackMutation = api.inAppAgent.submitFeedback.useMutation();
   const isSelectedConversationNotFound =
-    conversationQuery.error?.data?.code === "NOT_FOUND";
+    conversationQuery.error?.data?.code === "NOT_FOUND" &&
+    !localConversations[_selectedConversationId ?? ""];
   const selectedConversationId = isSelectedConversationNotFound
     ? null
     : _selectedConversationId;
+  selectedConversationIdRef.current = selectedConversationId;
 
-  const conversations = useMemo(
-    () =>
-      conversationListQuery.data?.pages.flatMap((page) => page.conversations) ??
-      [],
-    [conversationListQuery.data?.pages],
-  );
+  const conversations = useMemo<InAppAiAgentConversation[]>(() => {
+    const remoteIds = new Set(remoteConversations.map(({ id }) => id));
+    const localOnlyConversations: InAppAiAgentConversation[] = Object.values(
+      localConversations,
+    ).filter(({ id }) => !remoteIds.has(id));
+    const merged = localOnlyConversations.concat(remoteConversations);
+
+    return merged.map((conversation) => {
+      const state = allClientConversations[conversation.id];
+      return {
+        ...conversation,
+        activity: state
+          ? {
+              isRunning: state.isRunning || state.isSubmitting,
+              requiresApproval: state.pendingToolApprovals.length > 0,
+              queuedCount: state.queuedMessages.length,
+              unreadOutcome: state.unreadOutcome,
+            }
+          : undefined,
+      };
+    });
+  }, [allClientConversations, localConversations, remoteConversations]);
+  const selectedConversationIsWriteLocked =
+    conversationQuery.data?.conversation.isWriteLocked ??
+    conversations.find(({ id }) => id === selectedConversationId)
+      ?.isWriteLocked ??
+    false;
   const hasMoreConversations = conversationListQuery.hasNextPage === true;
   const isLoadingMoreConversations = conversationListQuery.isFetchingNextPage;
-  const selectedConversationIsWriteLocked =
-    conversationQuery.data?.conversation.isWriteLocked ?? false;
-  const currentMessages = useMemo(() => {
-    if (isSelectedConversationNotFound) {
-      return EMPTY_MESSAGES;
-    }
+  const isSelectedConversationHydrating =
+    Boolean(selectedConversationId) &&
+    !localConversations[selectedConversationId ?? ""] &&
+    conversationQuery.isLoading &&
+    !conversationQuery.data;
 
-    const storedMessages =
-      conversationQuery.data?.conversation.id === selectedConversationId
-        ? conversationQuery.data.messages.filter(isAgentConversationMessage)
-        : undefined;
-
-    if (
-      !isRunning &&
-      storedMessages &&
-      messages.length <= storedMessages.length
-    ) {
-      return storedMessages;
-    }
-
-    return messages;
-  }, [
-    conversationQuery.data,
-    isRunning,
-    isSelectedConversationNotFound,
-    messages,
-    selectedConversationId,
-  ]);
+  const storedMessages =
+    conversationQuery.data?.conversation.id === selectedConversationId
+      ? conversationQuery.data.messages.filter(isAgentConversationMessage)
+      : undefined;
+  const currentMessages = isSelectedConversationNotFound
+    ? EMPTY_MESSAGES
+    : !selectedClientState.isRunning &&
+        storedMessages &&
+        selectedClientState.messages.length <= storedMessages.length
+      ? storedMessages
+      : selectedClientState.messages;
   const messagesWithUiState = useMemo(() => {
     const messagesWithFeedback = mergeMessagesWithFeedback(
       currentMessages,
@@ -352,291 +399,107 @@ function InAppAiAgentProviderInner({
 
     return messagesWithFeedback.map((message) => {
       if (message.role === "reasoning") {
-        return { ...message, isLoading: loadingEventIds.has(message.id) };
+        return {
+          ...message,
+          isLoading: selectedClientState.loadingEventIds.has(message.id),
+        };
       }
-
       if (message.role !== "assistant") {
         return message;
       }
-
       return {
         ...message,
         isLoading:
-          loadingEventIds.has(message.id) ||
+          selectedClientState.loadingEventIds.has(message.id) ||
           (message.toolCalls?.some(
             (toolCall) =>
               toolCall.function.name !== IN_APP_AGENT_REDIRECT_TOOL_NAME &&
-              loadingEventIds.has(toolCall.id),
+              selectedClientState.loadingEventIds.has(toolCall.id),
           ) ??
             false),
       };
     });
   }, [
-    feedbackByConversationId,
     currentMessages,
-    loadingEventIds,
+    feedbackByConversationId,
+    selectedClientState.loadingEventIds,
     selectedConversationId,
   ]);
-  const fetchNextConversationsPage = conversationListQuery.fetchNextPage;
-  const loadMoreConversations = useCallback(() => {
-    if (!hasMoreConversations || isLoadingMoreConversations) {
-      return;
-    }
 
-    fetchNextConversationsPage().catch((error) => {
-      const errorMessage = getAgentErrorMessage(error);
-      showErrorToast("Failed to load conversations", errorMessage);
-      console.error("Failed to load in-app agent conversations", error);
-    });
-  }, [
-    fetchNextConversationsPage,
-    hasMoreConversations,
-    isLoadingMoreConversations,
-  ]);
-  const invalidateConversations = useCallback(
-    () => utils.inAppAgent.listConversations.invalidate({ projectId }),
-    [projectId, utils.inAppAgent.listConversations],
-  );
-
-  useEffect(() => {
-    if (!conversationListQuery.error) {
-      return;
-    }
-
-    const errorMessage = getAgentErrorMessage(conversationListQuery.error);
-    showErrorToast("Failed to load conversations", errorMessage);
-    console.error("Failed to load in-app agent conversations", {
-      error: conversationListQuery.error,
-      projectId,
-    });
-  }, [conversationListQuery.error, projectId]);
-
-  const isSelectedConversationHydrating =
-    Boolean(selectedConversationId) &&
-    conversationQuery.isLoading &&
-    !conversationQuery.data;
-  const updatePendingToolApprovals = useCallback(
+  const updateConversation = useCallback(
     (
-      updater: (
-        currentApprovals: InAppAgentPendingToolApproval[],
-      ) => InAppAgentPendingToolApproval[],
+      conversationId: string,
+      update: Parameters<typeof actions.updateConversation>[1],
     ) => {
-      const nextApprovals = updater(pendingToolApprovalsRef.current);
-      pendingToolApprovalsRef.current = nextApprovals;
-      setPendingToolApprovals(nextApprovals);
+      actions.updateConversation(conversationId, update);
     },
-    [],
+    [actions],
   );
+
+  const buildContext = useCallback(
+    (options?: InAppAgentSubmitOptions) =>
+      createInAppAgentScreenContext({
+        currentUrl: window.location.href,
+      }).concat(
+        createInAppAgentUserContext({
+          userName: session.data?.user?.name,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          languages:
+            navigator.languages.length > 0
+              ? Array.from(navigator.languages)
+              : [navigator.language],
+        }),
+        options?.quickAction
+          ? createInAppAgentQuickActionAttributionContext(options.quickAction)
+          : [],
+        createInAppAgentMessageEntryPointContext(options?.entryPoint ?? "chat"),
+      ),
+    [session.data?.user?.name],
+  );
+
   const updateLoadingEvent = useCallback(
-    (eventId: string, isLoading: boolean) => {
-      setLoadingEventIds((currentIds) => {
-        if (currentIds.has(eventId) === isLoading) {
-          return currentIds;
+    (conversationId: string, eventId: string, isLoading: boolean) => {
+      updateConversation(conversationId, (current) => {
+        if (current.loadingEventIds.has(eventId) === isLoading) {
+          return current;
         }
-
-        const nextIds = new Set(currentIds);
+        const loadingEventIds = new Set(current.loadingEventIds);
         if (isLoading) {
-          nextIds.add(eventId);
+          loadingEventIds.add(eventId);
         } else {
-          nextIds.delete(eventId);
+          loadingEventIds.delete(eventId);
         }
-        return nextIds;
+        return { ...current, loadingEventIds };
       });
     },
-    [],
+    [updateConversation],
   );
-  const clearLoadingEvents = useCallback(() => {
-    setLoadingEventIds((currentIds) =>
-      currentIds.size > 0 ? new Set() : currentIds,
-    );
-  }, []);
-  const publishLiveMessages = useCallback((messages: AgUiMessage[]) => {
-    setMessages(messages);
-    setLiveMessageVersion((currentVersion) => currentVersion + 1);
-  }, []);
 
-  const resetAgent = useCallback(() => {
-    if (agentRef.current?.isRunning) {
-      intentionalAbortRef.current = true;
-    }
-
-    subscriptionRef.current?.unsubscribe();
-    subscriptionRef.current = null;
-    agentRef.current?.abortRun();
-    agentRef.current = null;
-    activeRunIdRef.current = null;
-    pendingToolApprovalsRef.current = [];
-    setPendingToolApprovals([]);
-    clearLoadingEvents();
-  }, [clearLoadingEvents]);
-
-  useEffect(() => {
-    return () => {
-      resetAgent();
-    };
-  }, [resetAgent]);
-
-  const rateLimitRetryAt = error?.type === "rate_limit" ? error.retryAt : null;
-
-  useEffect(() => {
-    if (rateLimitRetryAt === null) {
-      return;
-    }
-
-    const timeout = window.setTimeout(
-      () => {
-        setError((currentError) => {
-          if (
-            currentError?.type !== "rate_limit" ||
-            currentError.retryAt !== rateLimitRetryAt
-          ) {
-            return currentError;
-          }
-
-          return null;
-        });
-      },
-      Math.max(0, rateLimitRetryAt - Date.now()),
-    );
-
-    return () => {
-      window.clearTimeout(timeout);
-    };
-  }, [rateLimitRetryAt]);
-
-  const ensureSubscription = useCallback(
-    (agent: HttpAgent) => {
-      if (subscriptionRef.current) {
-        return;
-      }
-
-      subscriptionRef.current = agent.subscribe({
-        onRunStartedEvent: (payload: { event: unknown }) => {
-          if (
-            typeof payload.event === "object" &&
-            payload.event !== null &&
-            "runId" in payload.event &&
-            typeof payload.event.runId === "string"
-          ) {
-            activeRunIdRef.current = payload.event.runId;
-          }
-        },
-        onEvent: ({ event }) => {
-          if (
-            event.type === EventType.REASONING_MESSAGE_START ||
-            event.type === EventType.TEXT_MESSAGE_START
-          ) {
-            updateLoadingEvent(event.messageId, true);
-            return;
-          }
-
-          if (
-            event.type === EventType.REASONING_MESSAGE_END ||
-            event.type === EventType.TEXT_MESSAGE_END
-          ) {
-            updateLoadingEvent(event.messageId, false);
-            return;
-          }
-
-          if (event.type === EventType.TOOL_CALL_START) {
-            updateLoadingEvent(event.toolCallId, true);
-            return;
-          }
-
-          // TOOL_CALL_END only finishes argument streaming. The tool remains
-          // active until its result arrives.
-          if (event.type === EventType.TOOL_CALL_RESULT) {
-            updateLoadingEvent(event.toolCallId, false);
-            return;
-          }
-
-          if (
-            event.type === EventType.RUN_FINISHED ||
-            event.type === EventType.RUN_ERROR
-          ) {
-            clearLoadingEvents();
-          }
-        },
-        onCustomEvent: ({ event }) => {
-          const approvalRequest = parseInAppAgentInterruptEvent(event);
-
-          if (!approvalRequest) {
-            return;
-          }
-
-          const approval: InAppAgentPendingToolApproval = {
-            id: approvalRequest.toolCallId,
-            approvalRequest,
-            status: "pending",
-          };
-
-          updatePendingToolApprovals((currentApprovals) => {
-            const existingIndex = currentApprovals.findIndex(
-              (currentApproval) => currentApproval.id === approval.id,
-            );
-
-            if (existingIndex === -1) {
-              return [...currentApprovals, approval];
-            }
-
-            const nextApprovals = [...currentApprovals];
-            nextApprovals[existingIndex] = approval;
-            return nextApprovals;
-          });
-        },
-        onToolCallResultEvent: ({ event }) => {
-          updatePendingToolApprovals((currentApprovals) =>
-            currentApprovals.filter(
-              (approval) =>
-                approval.approvalRequest.toolCallId !== event.toolCallId,
-            ),
-          );
-        },
-        onRunErrorEvent: ({ event }) => {
-          if (intentionalAbortRef.current) {
-            return;
-          }
-
-          setError(getInAppAgentError(event));
-          console.error("In-app agent drawer run error", event);
-        },
-        onMessagesChanged: ({ messages }) => {
-          publishLiveMessages(
-            attachActiveRunIdToAssistantMessages(
-              messages.filter(isAgentConversationMessage),
-              activeRunIdRef.current,
-            ),
-          );
-        },
-        onStateChanged: ({ messages }) => {
-          publishLiveMessages(
-            attachActiveRunIdToAssistantMessages(
-              messages.filter(isAgentConversationMessage),
-              activeRunIdRef.current,
-            ),
-          );
-        },
-      });
+  const publishLiveMessages = useCallback(
+    (
+      conversationId: string,
+      messages: AgUiMessage[],
+      activeRunId: string | null,
+    ) => {
+      updateConversation(conversationId, (current) => ({
+        ...current,
+        messages: attachActiveRunIdToAssistantMessages(messages, activeRunId),
+        liveMessageVersion: current.liveMessageVersion + 1,
+      }));
     },
-    [
-      clearLoadingEvents,
-      publishLiveMessages,
-      updateLoadingEvent,
-      updatePendingToolApprovals,
-    ],
+    [updateConversation],
   );
 
-  const getOrCreateAgent = useCallback(
+  const getOrCreateRuntime = useCallback(
     (
       conversationId: string,
       initialMessages: AgUiMessage[],
       isNewConversation: boolean,
     ) => {
-      if (agentRef.current?.threadId === conversationId) {
-        return agentRef.current;
+      const existing = runtimesRef.current.get(conversationId);
+      if (existing) {
+        return existing;
       }
-
-      resetAgent();
 
       const agent = new HttpAgent({
         url: getInAppAgentUrl(),
@@ -648,149 +511,515 @@ function InAppAiAgentProviderInner({
           isNewConversation,
         ),
       });
-
-      agentRef.current = agent;
-
-      return agent;
+      const runtime: AgentRuntime = {
+        agent,
+        activeRunId: null,
+        subscription: null,
+      };
+      runtime.subscription = agent.subscribe({
+        onRunStartedEvent: ({ event }) => {
+          const parsedEvent = z.object({ runId: z.string() }).safeParse(event);
+          if (parsedEvent.success) {
+            runtime.activeRunId = parsedEvent.data.runId;
+          }
+        },
+        onEvent: ({ event }) => {
+          if (
+            event.type === EventType.REASONING_MESSAGE_START ||
+            event.type === EventType.TEXT_MESSAGE_START
+          ) {
+            updateLoadingEvent(conversationId, event.messageId, true);
+          } else if (
+            event.type === EventType.REASONING_MESSAGE_END ||
+            event.type === EventType.TEXT_MESSAGE_END
+          ) {
+            updateLoadingEvent(conversationId, event.messageId, false);
+          } else if (event.type === EventType.TOOL_CALL_START) {
+            updateLoadingEvent(conversationId, event.toolCallId, true);
+          } else if (event.type === EventType.TOOL_CALL_RESULT) {
+            updateLoadingEvent(conversationId, event.toolCallId, false);
+          } else if (
+            event.type === EventType.RUN_FINISHED ||
+            event.type === EventType.RUN_ERROR
+          ) {
+            updateConversation(conversationId, (current) => ({
+              ...current,
+              loadingEventIds: new Set(),
+            }));
+          }
+        },
+        onCustomEvent: ({ event }) => {
+          const approvalRequest = parseInAppAgentInterruptEvent(event);
+          if (!approvalRequest) {
+            return;
+          }
+          const approval: InAppAgentPendingToolApproval = {
+            id: approvalRequest.toolCallId,
+            approvalRequest,
+            status: "pending",
+          };
+          updateConversation(conversationId, (current) => ({
+            ...current,
+            pendingToolApprovals: replaceApproval(
+              current.pendingToolApprovals,
+              approval,
+            ),
+          }));
+        },
+        onToolCallResultEvent: ({ event }) => {
+          updateConversation(conversationId, (current) => ({
+            ...current,
+            pendingToolApprovals: current.pendingToolApprovals.filter(
+              ({ approvalRequest }) =>
+                approvalRequest.toolCallId !== event.toolCallId,
+            ),
+          }));
+        },
+        onRunErrorEvent: ({ event }) => {
+          updateConversation(conversationId, (current) => ({
+            ...current,
+            error: getInAppAgentError(event),
+          }));
+          console.warn("In-app agent drawer run error", event);
+        },
+        onMessagesChanged: ({ messages }) => {
+          publishLiveMessages(
+            conversationId,
+            messages.filter(isAgentConversationMessage),
+            runtime.activeRunId,
+          );
+        },
+        onStateChanged: ({ messages }) => {
+          publishLiveMessages(
+            conversationId,
+            messages.filter(isAgentConversationMessage),
+            runtime.activeRunId,
+          );
+        },
+      });
+      runtimesRef.current.set(conversationId, runtime);
+      return runtime;
     },
-    [projectId, resetAgent],
+    [projectId, publishLiveMessages, updateConversation, updateLoadingEvent],
   );
 
-  const releaseSubmitLock = useCallback(() => {
-    submitInFlightRef.current = false;
-    setIsSubmitting(false);
-  }, []);
-
-  const runAgent = useCallback(
-    (
-      agent: HttpAgent,
+  const executeRun = useCallback(
+    async (
       conversationId: string,
-      runParameters?: Parameters<HttpAgent["runAgent"]>[0],
-      quickActionAttribution?: InAppAgentQuickActionAttribution,
-      messageEntryPoint?: InAppAgentMessageEntryPoint,
-    ) => {
-      if (runInFlightRef.current) {
-        return Promise.resolve(false);
-      }
+      runtime: AgentRuntime,
+      context: InAppAgentQueuedMessage["context"],
+      parameters?: Parameters<HttpAgent["runAgent"]>[0],
+      retryOnRateLimit = false,
+      throwOnFailure = false,
+    ): Promise<RunResult> => {
+      updateConversation(conversationId, (current) => ({
+        ...current,
+        error: null,
+        isRunning: true,
+        isSubmitting: false,
+        loadingEventIds: new Set(),
+      }));
+      let result: RunResult = "completed";
 
-      runInFlightRef.current = true;
-      clearLoadingEvents();
-      setIsRunning(true);
-      return (async () => {
-        try {
-          await agent.runAgent({
-            ...runParameters,
-            context: createInAppAgentScreenContext({
-              currentUrl: window.location.href,
-            }).concat(
-              createInAppAgentUserContext({
-                userName: session.data?.user?.name,
-                timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                languages:
-                  navigator.languages.length > 0
-                    ? Array.from(navigator.languages)
-                    : [navigator.language],
-              }),
-              quickActionAttribution
-                ? createInAppAgentQuickActionAttributionContext(
-                    quickActionAttribution,
-                  )
-                : [],
-              messageEntryPoint
-                ? createInAppAgentMessageEntryPointContext(messageEntryPoint)
-                : [],
-            ),
-          });
-          return true;
-        } catch (error) {
-          if (intentionalAbortRef.current) {
-            return false;
-          }
+      try {
+        await runtime.agent.runAgent({ ...parameters, context });
+      } catch (error) {
+        const agentError = getInAppAgentError(error);
+        const retryAt =
+          agentError.type === "rate_limit" ? agentError.retryAt : null;
+        result = retryAt === null ? "failed" : "rate_limited";
+        updateConversation(conversationId, (current) => ({
+          ...current,
+          error: agentError,
+        }));
+        console.warn("In-app agent drawer error", error);
 
-          if (runParameters?.forwardedProps?.command?.resume) {
-            throw error;
-          }
-
-          setError(getInAppAgentError(error));
-          console.error("In-app agent drawer error", error);
-          return false;
-        } finally {
-          const runId = activeRunIdRef.current;
-          clearLoadingEvents();
-          setIsRunning(false);
-          publishLiveMessages(
-            attachActiveRunIdToAssistantMessages(
-              agent.messages.filter(isAgentConversationMessage),
-              runId,
-            ),
+        if (retryAt !== null && retryOnRateLimit) {
+          window.setTimeout(
+            () => {
+              updateConversation(conversationId, (current) => ({
+                ...current,
+                error: null,
+              }));
+              executeRunRef
+                .current(conversationId, runtime, context, parameters, true)
+                .then((retryResult) => {
+                  if (retryResult !== "rate_limited") {
+                    pumpConversationRef.current(conversationId);
+                  }
+                })
+                .catch((error: unknown) => {
+                  console.warn("Failed to retry in-app agent run", error);
+                });
+            },
+            Math.max(0, retryAt - Date.now()),
           );
-          utils.inAppAgent.listConversations.invalidate({ projectId });
+        }
+        if (throwOnFailure) {
+          throw error;
+        }
+      } finally {
+        const activeRunId = runtime.activeRunId;
+        runtime.activeRunId = null;
+        const failed = result === "failed";
+        updateConversation(conversationId, (current) => ({
+          ...current,
+          isRunning: false,
+          isSubmitting: false,
+          loadingEventIds: new Set(),
+          messages: attachActiveRunIdToAssistantMessages(
+            runtime.agent.messages.filter(isAgentConversationMessage),
+            activeRunId,
+          ),
+          unreadOutcome:
+            selectedConversationIdRef.current !== conversationId &&
+            current.pendingToolApprovals.length === 0 &&
+            result !== "rate_limited"
+              ? failed
+                ? "failed"
+                : "completed"
+              : current.unreadOutcome,
+        }));
+        Promise.all([
+          utils.inAppAgent.listConversations.invalidate({ projectId }),
           utils.inAppAgent.getConversation.invalidate({
             projectId,
             conversationId,
-          });
-          releaseSubmitLock();
-          activeRunIdRef.current = null;
-          intentionalAbortRef.current = false;
-          runInFlightRef.current = false;
-        }
-      })();
+          }),
+        ]).catch((error: unknown) => {
+          console.warn("Failed to refresh in-app agent conversation", error);
+        });
+      }
+
+      return result;
     },
     [
       projectId,
-      clearLoadingEvents,
-      publishLiveMessages,
-      releaseSubmitLock,
-      session.data?.user?.name,
+      updateConversation,
       utils.inAppAgent.getConversation,
       utils.inAppAgent.listConversations,
     ],
   );
+  executeRunRef.current = executeRun;
 
-  const selectConversation = useCallback(
-    (conversationId: string | null) => {
-      if (isRunning || conversationId === _selectedConversationId) {
+  const dispatchNextQueuedMessage = useCallback(
+    async (conversationId: string) => {
+      const before =
+        clientStore.getState().conversations[conversationId] ??
+        EMPTY_IN_APP_AGENT_CONVERSATION_STATE;
+      const queuedMessage = before.queuedMessages[0];
+      if (!queuedMessage) {
         return;
       }
 
-      setError((currentError) =>
-        isInAppAgentRateLimited(currentError) ? currentError : null,
-      );
-      resetAgent();
-      setMessages([]);
-      setSelectedConversationId(conversationId);
+      updateConversation(conversationId, (current) => ({
+        ...current,
+        isSubmitting: true,
+        queuedMessages: current.queuedMessages.slice(1),
+      }));
+
+      try {
+        const initialMessages = before.messages.length
+          ? before.messages
+          : conversationQuery.data?.conversation.id === conversationId
+            ? conversationQuery.data.messages.filter(isAgentConversationMessage)
+            : [];
+        const runtime = getOrCreateRuntime(
+          conversationId,
+          initialMessages,
+          Boolean(localConversations[conversationId]) &&
+            initialMessages.length === 0,
+        );
+        const userMessage = {
+          id: createInAppAgentMessageId(),
+          role: "user",
+          content: queuedMessage.content,
+        } satisfies AgUiMessage;
+        runtime.agent.addMessage(userMessage);
+        updateConversation(conversationId, (current) => ({
+          ...current,
+          messages: runtime.agent.messages.filter(isAgentConversationMessage),
+        }));
+
+        const entryPoint = queuedMessage.options?.entryPoint ?? "chat";
+        if (
+          localConversations[conversationId] &&
+          initialMessages.length === 0
+        ) {
+          capture("in_app_agent:new_chat_started", { entryPoint });
+        }
+        capture("in_app_agent:new_chat_turn", { entryPoint });
+        const result = await executeRun(
+          conversationId,
+          runtime,
+          queuedMessage.context,
+          undefined,
+          true,
+        );
+        if (result !== "rate_limited") {
+          pumpConversationRef.current(conversationId);
+        }
+      } catch (error) {
+        updateConversation(conversationId, (current) => ({
+          ...current,
+          error: getInAppAgentError(error),
+          isSubmitting: false,
+          queuedMessages: [queuedMessage].concat(current.queuedMessages),
+        }));
+        console.warn("Failed to start in-app agent conversation", error);
+      }
     },
-    [_selectedConversationId, isRunning, resetAgent, setSelectedConversationId],
+    [
+      capture,
+      clientStore,
+      conversationQuery.data,
+      executeRun,
+      getOrCreateRuntime,
+      localConversations,
+      updateConversation,
+    ],
+  );
+
+  const pumpConversation = useCallback(
+    (conversationId: string) => {
+      const state =
+        clientStore.getState().conversations[conversationId] ??
+        EMPTY_IN_APP_AGENT_CONVERSATION_STATE;
+      const isBusy =
+        state.isRunning ||
+        state.isSubmitting ||
+        state.pendingToolApprovals.length > 0 ||
+        isInAppAgentRateLimited(state.error);
+      if (!isBusy && state.queuedMessages.length > 0) {
+        dispatchNextQueuedMessage(conversationId).catch((error: unknown) => {
+          console.warn("Failed to dispatch queued in-app agent message", error);
+        });
+      }
+    },
+    [clientStore, dispatchNextQueuedMessage],
+  );
+  pumpConversationRef.current = pumpConversation;
+
+  useEffect(() => {
+    const runtimes = runtimesRef.current;
+    return () => {
+      for (const { agent, subscription } of runtimes.values()) {
+        subscription?.unsubscribe();
+        agent.abortRun();
+      }
+      runtimes.clear();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!conversationListQuery.error) {
+      return;
+    }
+    const errorMessage = getAgentErrorMessage(conversationListQuery.error);
+    showErrorToast("Failed to load conversations", errorMessage);
+    console.warn("Failed to load in-app agent conversations", {
+      error: conversationListQuery.error,
+      projectId,
+    });
+  }, [conversationListQuery.error, projectId]);
+
+  const loadMoreConversations = useCallback(() => {
+    if (!hasMoreConversations || isLoadingMoreConversations) {
+      return;
+    }
+    conversationListQuery.fetchNextPage().catch((error) => {
+      showErrorToast(
+        "Failed to load conversations",
+        getAgentErrorMessage(error),
+      );
+      console.warn("Failed to load in-app agent conversations", error);
+    });
+  }, [conversationListQuery, hasMoreConversations, isLoadingMoreConversations]);
+  const invalidateConversations = useCallback(
+    () => utils.inAppAgent.listConversations.invalidate({ projectId }),
+    [projectId, utils.inAppAgent.listConversations],
+  );
+
+  const selectConversation = useCallback(
+    (conversationId: string | null) => {
+      if (conversationId === _selectedConversationId) {
+        return;
+      }
+      selectedConversationIdRef.current = conversationId;
+      setSelectedConversationId(conversationId);
+      if (conversationId) {
+        updateConversation(conversationId, (current) => ({
+          ...current,
+          unreadOutcome: null,
+        }));
+      }
+    },
+    [_selectedConversationId, setSelectedConversationId, updateConversation],
+  );
+
+  const setDraft = useCallback(
+    (draft: string) => {
+      updateConversation(selectedClientKey, (current) => ({
+        ...current,
+        draft,
+      }));
+    },
+    [selectedClientKey, updateConversation],
+  );
+  const editQueuedMessage = useCallback(
+    (messageId: string, content: string) => {
+      const trimmedContent = content.trim();
+      if (!selectedConversationId || !trimmedContent) {
+        return;
+      }
+      updateConversation(selectedConversationId, (current) => ({
+        ...current,
+        queuedMessages: current.queuedMessages.map((message) =>
+          message.id === messageId
+            ? { ...message, content: trimmedContent }
+            : message,
+        ),
+      }));
+    },
+    [selectedConversationId, updateConversation],
+  );
+  const deleteQueuedMessage = useCallback(
+    (messageId: string) => {
+      if (!selectedConversationId) {
+        return;
+      }
+      updateConversation(selectedConversationId, (current) => ({
+        ...current,
+        queuedMessages: current.queuedMessages.filter(
+          (message) => message.id !== messageId,
+        ),
+      }));
+    },
+    [selectedConversationId, updateConversation],
+  );
+
+  const submit = useCallback(
+    async (content: string, options?: InAppAgentSubmitOptions) => {
+      const trimmedContent = content.trim();
+      if (!trimmedContent) {
+        return false;
+      }
+      const isNewConversation =
+        options?.newConversation === true || !selectedConversationId;
+      if (!isNewConversation && isSelectedConversationHydrating) {
+        return false;
+      }
+      if (
+        !isNewConversation &&
+        selectedConversationId &&
+        selectedConversationIsWriteLocked
+      ) {
+        updateConversation(selectedConversationId, (current) => ({
+          ...current,
+          error: {
+            type: "generic",
+            message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+          },
+        }));
+        return false;
+      }
+
+      const conversationId = isNewConversation
+        ? createInAppAgentConversationId()
+        : selectedConversationId;
+      if (!conversationId) {
+        return false;
+      }
+      const current =
+        clientStore.getState().conversations[conversationId] ??
+        EMPTY_IN_APP_AGENT_CONVERSATION_STATE;
+      if (isInAppAgentRateLimited(current.error)) {
+        return false;
+      }
+
+      if (isNewConversation) {
+        actions.rememberLocalConversation(
+          conversationId,
+          trimmedContent.slice(0, 80),
+        );
+        actions.updateConversation(
+          NEW_CONVERSATION_DRAFT_KEY,
+          (draftState) => ({
+            ...draftState,
+            draft: "",
+          }),
+        );
+        selectedConversationIdRef.current = conversationId;
+        setSelectedConversationId(conversationId);
+      }
+
+      const queuedMessage: InAppAgentQueuedMessage = {
+        id: createInAppAgentMessageId(),
+        content: trimmedContent,
+        context: buildContext(options),
+        options,
+      };
+      const isBusy =
+        current.isRunning ||
+        current.isSubmitting ||
+        current.pendingToolApprovals.length > 0 ||
+        runtimesRef.current.get(conversationId)?.agent.isRunning === true;
+      updateConversation(conversationId, (state) => ({
+        ...state,
+        error: null,
+        draft: "",
+        queuedMessages: state.queuedMessages.concat(queuedMessage),
+      }));
+      if (isBusy) {
+        capture("in_app_agent:message_queued", {
+          queueDepth: current.queuedMessages.length + 1,
+        });
+      }
+      pumpConversationRef.current(conversationId);
+      return true;
+    },
+    [
+      actions,
+      buildContext,
+      capture,
+      clientStore,
+      isSelectedConversationHydrating,
+      selectedConversationId,
+      selectedConversationIsWriteLocked,
+      setSelectedConversationId,
+      updateConversation,
+    ],
   );
 
   const deleteConversation = useCallback(
     async (conversationId: string) => {
-      if (isRunning) {
+      const state = allClientConversations[conversationId];
+      if (
+        state &&
+        (state.isRunning ||
+          state.isSubmitting ||
+          state.pendingToolApprovals.length > 0 ||
+          state.queuedMessages.length > 0)
+      ) {
         return;
       }
-
       try {
         await deleteConversationMutation.mutateAsync({
           projectId,
           conversationId,
         });
-
         if (conversationId === selectedConversationId) {
-          resetAgent();
-          setMessages([]);
           setSelectedConversationId(null);
         }
-
+        actions.removeConversation(conversationId);
         setFeedbackByConversationId((currentFeedback) => {
           if (!currentFeedback[conversationId]) {
             return currentFeedback;
           }
-
           const nextFeedback = { ...currentFeedback };
           delete nextFeedback[conversationId];
           return nextFeedback;
         });
-
         await Promise.all([
           utils.inAppAgent.listConversations.invalidate({ projectId }),
           utils.inAppAgent.getConversation.invalidate({
@@ -799,17 +1028,19 @@ function InAppAiAgentProviderInner({
           }),
         ]);
       } catch (error) {
-        const errorMessage = getAgentErrorMessage(error);
-        showErrorToast("Failed to delete conversation", errorMessage);
-        console.error("Failed to delete in-app agent conversation", error);
+        showErrorToast(
+          "Failed to delete conversation",
+          getAgentErrorMessage(error),
+        );
+        console.warn("Failed to delete in-app agent conversation", error);
         throw error;
       }
     },
     [
+      actions,
+      allClientConversations,
       deleteConversationMutation,
-      isRunning,
       projectId,
-      resetAgent,
       selectedConversationId,
       setFeedbackByConversationId,
       setSelectedConversationId,
@@ -818,117 +1049,98 @@ function InAppAiAgentProviderInner({
     ],
   );
 
-  const submit = useCallback(
-    async (content: string, options?: InAppAgentSubmitOptions) => {
-      if (
-        !content ||
-        isRunning ||
-        isInAppAgentRateLimited(error) ||
-        (options?.newConversation !== true &&
-          isSelectedConversationHydrating) ||
-        submitInFlightRef.current ||
-        runInFlightRef.current
-      ) {
-        return false;
+  const resumeToolApproval = useCallback(
+    async (approvalId: string, approved: boolean) => {
+      if (!selectedConversationId || selectedConversationIsWriteLocked) {
+        return;
       }
+      const state =
+        clientStore.getState().conversations[selectedConversationId] ??
+        EMPTY_IN_APP_AGENT_CONVERSATION_STATE;
+      const approval = state.pendingToolApprovals.find(
+        ({ id }) => id === approvalId,
+      );
+      const runtime = runtimesRef.current.get(selectedConversationId);
+      if (
+        !approval ||
+        !runtime ||
+        state.isRunning ||
+        isInAppAgentRateLimited(state.error)
+      ) {
+        return;
+      }
+      updateConversation(selectedConversationId, (current) => ({
+        ...current,
+        pendingToolApprovals: current.pendingToolApprovals.map((item) =>
+          item.id === approvalId ? { ...item, status: "submitting" } : item,
+        ),
+      }));
 
-      submitInFlightRef.current = true;
-      setIsSubmitting(true);
-      setError(null);
-
-      let startedRun = false;
       try {
-        const isNewConversation =
-          options?.newConversation === true || !selectedConversationId;
-
-        if (!isNewConversation && selectedConversationIsWriteLocked) {
-          setError({
-            type: "generic",
-            message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
-          });
-          return false;
-        }
-
-        const conversationId = isNewConversation
-          ? createInAppAgentConversationId()
-          : selectedConversationId;
-
-        if (!conversationId) {
-          return false;
-        }
-
-        if (isNewConversation) {
-          setSelectedConversationId(conversationId);
-        }
-
-        const storedMessages =
-          conversationQuery.data?.conversation.id === conversationId
-            ? conversationQuery.data.messages
-            : undefined;
-        const initialMessages = !isNewConversation
-          ? getHydratedMessages(messages, storedMessages)
-          : [];
-        // TODO: Avoid hydrating the full history once the agent client can send
-        // only the latest user turn; the server rebuilds history from persistence.
-        const agent = getOrCreateAgent(
-          conversationId,
-          initialMessages,
-          isNewConversation,
+        await executeRun(
+          selectedConversationId,
+          runtime,
+          buildContext(),
+          {
+            runId: createInAppAgentRunId(),
+            forwardedProps: {
+              command: {
+                resume: {
+                  approved,
+                  approvalRequest: approval.approvalRequest,
+                },
+              },
+            },
+          },
+          false,
+          true,
         );
-
-        if (agent.isRunning) {
-          return false;
-        }
-
-        ensureSubscription(agent);
-
-        const userMessage = {
-          id: createInAppAgentMessageId(),
-          role: "user",
-          content,
-        } satisfies AgUiMessage;
-
-        agent.addMessage(userMessage);
-        setMessages(agent.messages.filter(isAgentConversationMessage));
-        const entryPoint = options?.entryPoint ?? "chat";
-        if (isNewConversation) {
-          capture("in_app_agent:new_chat_started", { entryPoint });
-        }
-        capture("in_app_agent:new_chat_turn", { entryPoint });
-        startedRun = true;
-        runAgent(
-          agent,
-          conversationId,
-          undefined,
-          options?.quickAction,
-          entryPoint,
-        );
-        return true;
+        updateConversation(selectedConversationId, (current) => ({
+          ...current,
+          pendingToolApprovals: current.pendingToolApprovals.filter(
+            ({ id }) => id !== approvalId,
+          ),
+        }));
+        pumpConversationRef.current(selectedConversationId);
       } catch (error) {
-        setError(getInAppAgentError(error));
-        console.error("Failed to start in-app agent conversation", error);
-        return false;
-      } finally {
-        if (!startedRun) {
-          releaseSubmitLock();
+        const isStaleApproval =
+          getAgentErrorMessage(error) === "Invalid forwarded props";
+        updateConversation(selectedConversationId, (current) => ({
+          ...current,
+          error: isStaleApproval
+            ? {
+                type: "generic",
+                message:
+                  "This tool approval is no longer valid. Please try again.",
+              }
+            : current.error,
+          pendingToolApprovals: isStaleApproval
+            ? current.pendingToolApprovals.filter(({ id }) => id !== approvalId)
+            : current.pendingToolApprovals.map((item) =>
+                item.id === approvalId ? { ...item, status: "pending" } : item,
+              ),
+        }));
+        if (isStaleApproval) {
+          pumpConversationRef.current(selectedConversationId);
         }
       }
     },
     [
-      conversationQuery.data,
-      capture,
-      ensureSubscription,
-      error,
-      getOrCreateAgent,
-      isSelectedConversationHydrating,
-      isRunning,
-      messages,
-      releaseSubmitLock,
-      runAgent,
+      buildContext,
+      clientStore,
+      executeRun,
       selectedConversationId,
       selectedConversationIsWriteLocked,
-      setSelectedConversationId,
+      updateConversation,
     ],
+  );
+  const approveToolCall = useCallback(
+    (approvalId: string) => resumeToolApproval(approvalId, true),
+    [resumeToolApproval],
+  );
+  const rejectToolCall = useCallback(
+    (approvalId: string) => resumeToolApproval(approvalId, false),
+    [resumeToolApproval],
   );
 
   const submitFeedback = useCallback(
@@ -941,7 +1153,6 @@ function InAppAiAgentProviderInner({
       if (!selectedConversationId) {
         return;
       }
-
       try {
         const result = await feedbackMutation.mutateAsync({
           projectId,
@@ -951,31 +1162,26 @@ function InAppAiAgentProviderInner({
           value: params.value,
           comment: params.comment ?? null,
         });
-
         setFeedbackByConversationId((currentFeedback) => {
           const nextFeedback = { ...currentFeedback };
           const conversationFeedback = {
             ...(nextFeedback[selectedConversationId] ?? {}),
           };
-
           if (result.feedback) {
             conversationFeedback[params.messageId] = result.feedback;
           } else {
             delete conversationFeedback[params.messageId];
           }
-
-          if (Object.keys(conversationFeedback).length > 0) {
+          if (Object.keys(conversationFeedback).length) {
             nextFeedback[selectedConversationId] = conversationFeedback;
           } else {
             delete nextFeedback[selectedConversationId];
           }
-
           return nextFeedback;
         });
       } catch (error) {
-        const errorMessage = getAgentErrorMessage(error);
-        showErrorToast("Failed to save feedback", errorMessage);
-        console.error("Failed to save in-app agent feedback", error);
+        showErrorToast("Failed to save feedback", getAgentErrorMessage(error));
+        console.warn("Failed to save in-app agent feedback", error);
         throw error;
       }
     },
@@ -990,151 +1196,24 @@ function InAppAiAgentProviderInner({
   const setAgentOpen = useCallback<Dispatch<SetStateAction<boolean>>>(
     (action) => {
       const nextOpen = evaluateSetStateAction(action, open);
-
       if (!nextOpen) {
-        // Collapse the drawer when closing
         setIsExpanded(false);
       }
-
       setOpen(nextOpen);
     },
     [open, setOpen],
   );
-
   const openAssistant = useCallback(
     (source: InAppAgentEntryPoint) => {
       capture("in_app_agent:entry_point_click", { source });
-
       if (organization && !organization.aiFeaturesEnabled) {
         setEnableDialogOpen(true);
         return false;
       }
-
       setAgentOpen(true);
       return true;
     },
     [capture, organization, setAgentOpen],
-  );
-
-  const resumeToolApproval = useCallback(
-    async (approvalId: string, approved: boolean) => {
-      if (selectedConversationIsWriteLocked) {
-        setError({
-          type: "generic",
-          message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
-        });
-        return;
-      }
-
-      const approval = pendingToolApprovals.find(
-        (approval) => approval.id === approvalId,
-      );
-
-      if (
-        !approval ||
-        !selectedConversationId ||
-        isRunning ||
-        runInFlightRef.current ||
-        isInAppAgentRateLimited(error)
-      ) {
-        return;
-      }
-
-      const agent = agentRef.current;
-      if (!agent || agent.threadId !== selectedConversationId) {
-        showErrorToast(
-          "Failed to resume tool call",
-          "The interrupted assistant run is no longer available.",
-        );
-        return;
-      }
-
-      updatePendingToolApprovals((currentApprovals) =>
-        currentApprovals.map((currentApproval) =>
-          currentApproval.id === approvalId
-            ? { ...currentApproval, status: "submitting" }
-            : currentApproval,
-        ),
-      );
-      setError(null);
-
-      try {
-        ensureSubscription(agent);
-        const completed = await runAgent(agent, selectedConversationId, {
-          runId: createInAppAgentRunId(),
-          forwardedProps: {
-            command: {
-              resume: {
-                approved,
-                approvalRequest: approval.approvalRequest,
-              },
-            },
-          },
-        });
-
-        if (!completed) {
-          updatePendingToolApprovals((currentApprovals) =>
-            currentApprovals.map((currentApproval) =>
-              currentApproval.id === approvalId
-                ? { ...currentApproval, status: "pending" }
-                : currentApproval,
-            ),
-          );
-          return;
-        }
-
-        updatePendingToolApprovals((currentApprovals) =>
-          currentApprovals.filter(
-            (currentApproval) => currentApproval.id !== approvalId,
-          ),
-        );
-      } catch (error) {
-        const errorMessage = getAgentErrorMessage(error);
-        if (errorMessage === "Invalid forwarded props") {
-          updatePendingToolApprovals((currentApprovals) =>
-            currentApprovals.filter(
-              (currentApproval) => currentApproval.id !== approvalId,
-            ),
-          );
-          setError({
-            type: "generic",
-            message: "This tool approval is no longer valid. Please try again.",
-          });
-          console.error("Failed to resume in-app agent tool call", error);
-          return;
-        }
-
-        updatePendingToolApprovals((currentApprovals) =>
-          currentApprovals.map((currentApproval) =>
-            currentApproval.id === approvalId
-              ? { ...currentApproval, status: "pending" }
-              : currentApproval,
-          ),
-        );
-        setError(getInAppAgentError(error));
-        console.error("Failed to resume in-app agent tool call", error);
-      }
-    },
-    [
-      ensureSubscription,
-      error,
-      isRunning,
-      pendingToolApprovals,
-      runAgent,
-      selectedConversationId,
-      selectedConversationIsWriteLocked,
-      updatePendingToolApprovals,
-    ],
-  );
-
-  const approveToolCall = useCallback(
-    (approvalId: string) => resumeToolApproval(approvalId, true),
-    [resumeToolApproval],
-  );
-
-  const rejectToolCall = useCallback(
-    (approvalId: string) => resumeToolApproval(approvalId, false),
-    [resumeToolApproval],
   );
 
   const value = useMemo<InAppAiAgentContextType>(
@@ -1145,15 +1224,17 @@ function InAppAiAgentProviderInner({
       openAssistant,
       isExpanded,
       setIsExpanded,
-      isRunning,
-      isSubmitting,
+      isRunning: selectedClientState.isRunning,
+      isSubmitting: selectedClientState.isSubmitting,
       pendingToolApprovals: isSelectedConversationNotFound
         ? []
-        : pendingToolApprovals,
+        : selectedClientState.pendingToolApprovals,
+      queuedMessages: selectedClientState.queuedMessages,
+      draft: selectedClientState.draft,
       isSelectedConversationHydrating,
-      error,
+      error: selectedClientState.error,
       messages: messagesWithUiState,
-      liveMessageVersion,
+      liveMessageVersion: selectedClientState.liveMessageVersion,
       conversations,
       hasMoreConversations,
       isLoadingMoreConversations,
@@ -1163,6 +1244,9 @@ function InAppAiAgentProviderInner({
       invalidateConversations,
       selectConversation,
       deleteConversation,
+      setDraft,
+      editQueuedMessage,
+      deleteQueuedMessage,
       submit,
       approveToolCall,
       rejectToolCall,
@@ -1170,28 +1254,27 @@ function InAppAiAgentProviderInner({
     }),
     [
       approveToolCall,
-      isExpanded,
       conversations,
-      error,
-      hasMoreConversations,
-      isLoadingMoreConversations,
-      isRunning,
-      isSelectedConversationHydrating,
-      selectedConversationIsWriteLocked,
-      isSubmitting,
-      isSelectedConversationNotFound,
       deleteConversation,
+      deleteQueuedMessage,
+      editQueuedMessage,
+      hasMoreConversations,
+      invalidateConversations,
+      isExpanded,
+      isLoadingMoreConversations,
+      isSelectedConversationHydrating,
+      isSelectedConversationNotFound,
       loadMoreConversations,
-      liveMessageVersion,
       messagesWithUiState,
       open,
       openAssistant,
-      pendingToolApprovals,
       rejectToolCall,
-      setAgentOpen,
-      invalidateConversations,
       selectConversation,
+      selectedClientState,
       selectedConversationId,
+      selectedConversationIsWriteLocked,
+      setAgentOpen,
+      setDraft,
       submit,
       submitFeedback,
     ],
@@ -1210,20 +1293,7 @@ function InAppAiAgentProviderInner({
 }
 
 function isAgentConversationMessage(message: unknown): message is AgUiMessage {
-  const result = AgUiMessageSchema.safeParse(message);
-
-  return result.success;
-}
-
-function getHydratedMessages(
-  localMessages: AgUiMessage[],
-  storedMessages: readonly unknown[] | undefined,
-): AgUiMessage[] {
-  if (localMessages.length > 0) {
-    return localMessages;
-  }
-
-  return storedMessages?.filter(isAgentConversationMessage) ?? [];
+  return AgUiMessageSchema.safeParse(message).success;
 }
 
 function mergeMessagesWithFeedback(
@@ -1233,19 +1303,11 @@ function mergeMessagesWithFeedback(
   if (!feedbackByMessageId || Object.keys(feedbackByMessageId).length === 0) {
     return messages;
   }
-
-  return messages.map((message) => {
-    if (message.role !== "assistant") {
-      return message;
-    }
-
-    const feedback = feedbackByMessageId[message.id];
-    if (!feedback) {
-      return message;
-    }
-
-    return { ...message, feedback };
-  });
+  return messages.map((message) =>
+    message.role === "assistant" && feedbackByMessageId[message.id]
+      ? { ...message, feedback: feedbackByMessageId[message.id] }
+      : message,
+  );
 }
 
 function attachActiveRunIdToAssistantMessages(
@@ -1255,40 +1317,46 @@ function attachActiveRunIdToAssistantMessages(
   if (!runId) {
     return messages;
   }
+  return messages.map((message) =>
+    message.role === "assistant" && !message.runId
+      ? { ...message, runId }
+      : message,
+  );
+}
 
-  return messages.map((message) => {
-    if (message.role !== "assistant" || message.runId) {
-      return message;
-    }
-
-    return { ...message, runId };
-  });
+function replaceApproval(
+  approvals: InAppAgentPendingToolApproval[],
+  approval: InAppAgentPendingToolApproval,
+) {
+  const existingIndex = approvals.findIndex(({ id }) => id === approval.id);
+  if (existingIndex === -1) {
+    return approvals.concat(approval);
+  }
+  const nextApprovals = approvals.slice();
+  nextApprovals[existingIndex] = approval;
+  return nextApprovals;
 }
 
 function parseInAppAgentInterruptEvent(event: unknown) {
   if (!event || typeof event !== "object") {
     return null;
   }
-
   if (!("name" in event) || event.name !== "on_interrupt") {
     return null;
   }
-
   const value = "value" in event ? event.value : undefined;
   const parsedValue = typeof value === "string" ? parseJson(value) : value;
   const interrupt = MastraSuspendEventSchema.safeParse(parsedValue);
-
   if (!interrupt.success) {
     return null;
   }
-
   return {
     type: "tool_approval_request" as const,
     toolCallId: interrupt.data.toolCallId,
     toolName: interrupt.data.toolName,
     args: interrupt.data.args,
     runId: interrupt.data.runId,
-  } satisfies InAppAgentToolApprovalRequest;
+  };
 }
 
 function parseJson(value: string) {
@@ -1306,7 +1374,6 @@ function getInAppAgentUrl() {
 function getAgentErrorMessage(error: unknown): string {
   if (error && typeof error === "object") {
     const payload = "payload" in error ? error.payload : undefined;
-
     if (
       payload &&
       typeof payload === "object" &&
@@ -1315,31 +1382,22 @@ function getAgentErrorMessage(error: unknown): string {
     ) {
       return payload.error;
     }
-
     if ("message" in error && typeof error.message === "string") {
       return error.message;
     }
   }
-
   return "Assistant request failed. Please try again.";
 }
 
 export function useInAppAiAgent() {
-  const ctx = useContext(InAppAiAgentContext);
-  if (!ctx) {
-    return NOOP_CONTEXT;
-  }
-  return ctx;
+  return useContext(InAppAiAgentContext) ?? NOOP_CONTEXT;
 }
 
-/** Whether the current user/context may use the in-app assistant at all.
- * Shared gate for the launcher button and the window host. */
 export function useCanUseInAppAgent() {
   const { isAvailable } = useInAppAiAgent();
   const hasInAppAgentEntitlement = useHasEntitlement("in-app-agent");
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const { organization } = useQueryProjectOrOrganization();
-
   return (
     isAvailable &&
     hasInAppAgentEntitlement &&

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -6,8 +6,8 @@ import {
   useMemo,
   useRef,
   useState,
-  type Dispatch,
   type PropsWithChildren,
+  type Dispatch,
   type SetStateAction,
 } from "react";
 import { EventType, HttpAgent } from "@ag-ui/client";
@@ -18,47 +18,47 @@ import { useStore } from "zustand";
 
 import useSessionStorage from "@/src/components/useSessionStorage";
 import { env } from "@/src/env.mjs";
-import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "../constants";
 import {
   createInAppAgentConversationId,
   createInAppAgentMessageId,
   createInAppAgentRunId,
-} from "../ids";
+} from "@/src/ee/features/in-app-agent/ids";
+import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
 import {
   AgUiMessageSchema,
   type AgUiMessage,
   type InAppAgentMessageFeedback,
   type InAppAgentMessageFeedbackValue,
   type InAppAgentRuntimeState,
-} from "../schema";
+} from "@/src/ee/features/in-app-agent/schema";
+import type { InAppAgentError } from "@/src/ee/features/in-app-agent/components/utils/utils";
+import { useHasEntitlement } from "@/src/features/entitlements/hooks";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
+import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
+import { api } from "@/src/utils/api";
 import {
   createInAppAgentMessageEntryPointContext,
   createInAppAgentQuickActionAttributionContext,
   createInAppAgentScreenContext,
   createInAppAgentUserContext,
-} from "../context";
-import type { InAppAgentSubmitOptions } from "../quickActions";
+} from "@/src/ee/features/in-app-agent/context";
+import type { InAppAgentSubmitOptions } from "@/src/ee/features/in-app-agent/quickActions";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import {
   EMPTY_IN_APP_AGENT_CONVERSATION_STATE,
   NEW_CONVERSATION_DRAFT_KEY,
   createInAppAgentClientStore,
   type InAppAgentPendingToolApproval,
   type InAppAgentQueuedMessage,
-} from "./inAppAgentClientStore";
+} from "@/src/ee/features/in-app-agent/components/inAppAgentClientStore";
 import {
   getInAppAgentError,
   isInAppAgentRateLimited,
-  type InAppAgentError,
   type InAppAiAgentMessage,
-} from "./utils/utils";
-import { InAppAgentDisabledDialog } from "./InAppAgentDisabledDialog";
-import { useHasEntitlement } from "@/src/features/entitlements/hooks";
-import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
-import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { api } from "@/src/utils/api";
+} from "@/src/ee/features/in-app-agent/components/utils/utils";
 import { evaluateSetStateAction } from "@/src/utils/evaluate-set-state-action";
+import { InAppAgentDisabledDialog } from "@/src/ee/features/in-app-agent/components/InAppAgentDisabledDialog";
 
 const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -138,6 +138,7 @@ type InAppAiAgentContextType = {
   setDraft: (draft: string) => void;
   editQueuedMessage: (messageId: string, content: string) => void;
   deleteQueuedMessage: (messageId: string) => void;
+  reorderQueuedMessage: (messageId: string, targetMessageId: string) => void;
   submit: (
     content: string,
     options?: InAppAgentSubmitOptions,
@@ -180,6 +181,7 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
   setDraft: () => undefined,
   editQueuedMessage: () => undefined,
   deleteQueuedMessage: () => undefined,
+  reorderQueuedMessage: () => undefined,
   submit: async () => false,
   approveToolCall: async () => undefined,
   rejectToolCall: async () => undefined,
@@ -897,6 +899,32 @@ function InAppAiAgentProviderInner({
     },
     [selectedConversationId, updateConversation],
   );
+  const reorderQueuedMessage = useCallback(
+    (messageId: string, targetMessageId: string) => {
+      if (!selectedConversationId || messageId === targetMessageId) {
+        return;
+      }
+      updateConversation(selectedConversationId, (current) => {
+        const fromIndex = current.queuedMessages.findIndex(
+          ({ id }) => id === messageId,
+        );
+        const toIndex = current.queuedMessages.findIndex(
+          ({ id }) => id === targetMessageId,
+        );
+        if (fromIndex < 0 || toIndex < 0) {
+          return current;
+        }
+        const queuedMessages = current.queuedMessages.slice();
+        const [message] = queuedMessages.splice(fromIndex, 1);
+        if (!message) {
+          return current;
+        }
+        queuedMessages.splice(toIndex, 0, message);
+        return { ...current, queuedMessages };
+      });
+    },
+    [selectedConversationId, updateConversation],
+  );
 
   const submit = useCallback(
     async (content: string, options?: InAppAgentSubmitOptions) => {
@@ -1247,6 +1275,7 @@ function InAppAiAgentProviderInner({
       setDraft,
       editQueuedMessage,
       deleteQueuedMessage,
+      reorderQueuedMessage,
       submit,
       approveToolCall,
       rejectToolCall,
@@ -1269,6 +1298,7 @@ function InAppAiAgentProviderInner({
       open,
       openAssistant,
       rejectToolCall,
+      reorderQueuedMessage,
       selectConversation,
       selectedClientState,
       selectedConversationId,

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -106,7 +106,6 @@ export type InAppAiAgentConversation = {
     isRunning: boolean;
     requiresApproval: boolean;
     queuedCount: number;
-    unreadOutcome: "completed" | "failed" | null;
   };
 };
 
@@ -138,7 +137,6 @@ type InAppAiAgentContextType = {
   setDraft: (draft: string) => void;
   editQueuedMessage: (messageId: string, content: string) => void;
   deleteQueuedMessage: (messageId: string) => void;
-  reorderQueuedMessage: (messageId: string, targetMessageId: string) => void;
   submit: (
     content: string,
     options?: InAppAgentSubmitOptions,
@@ -181,7 +179,6 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
   setDraft: () => undefined,
   editQueuedMessage: () => undefined,
   deleteQueuedMessage: () => undefined,
-  reorderQueuedMessage: () => undefined,
   submit: async () => false,
   approveToolCall: async () => undefined,
   rejectToolCall: async () => undefined,
@@ -279,7 +276,6 @@ function InAppAiAgentProviderInner({
       {},
     );
   const runtimesRef = useRef(new Map<string, AgentRuntime>());
-  const selectedConversationIdRef = useRef<string | null>(null);
   const pumpConversationRef = useRef<(conversationId: string) => void>(
     () => undefined,
   );
@@ -343,7 +339,6 @@ function InAppAiAgentProviderInner({
   const selectedConversationId = isSelectedConversationNotFound
     ? null
     : _selectedConversationId;
-  selectedConversationIdRef.current = selectedConversationId;
 
   const conversations = useMemo<InAppAiAgentConversation[]>(() => {
     const remoteIds = new Set(remoteConversations.map(({ id }) => id));
@@ -361,7 +356,6 @@ function InAppAiAgentProviderInner({
               isRunning: state.isRunning || state.isSubmitting,
               requiresApproval: state.pendingToolApprovals.length > 0,
               queuedCount: state.queuedMessages.length,
-              unreadOutcome: state.unreadOutcome,
             }
           : undefined,
       };
@@ -663,7 +657,6 @@ function InAppAiAgentProviderInner({
       } finally {
         const activeRunId = runtime.activeRunId;
         runtime.activeRunId = null;
-        const failed = result === "failed";
         updateConversation(conversationId, (current) => ({
           ...current,
           isRunning: false,
@@ -673,14 +666,6 @@ function InAppAiAgentProviderInner({
             runtime.agent.messages.filter(isAgentConversationMessage),
             activeRunId,
           ),
-          unreadOutcome:
-            selectedConversationIdRef.current !== conversationId &&
-            current.pendingToolApprovals.length === 0 &&
-            result !== "rate_limited"
-              ? failed
-                ? "failed"
-                : "completed"
-              : current.unreadOutcome,
         }));
         Promise.all([
           utils.inAppAgent.listConversations.invalidate({ projectId }),
@@ -847,16 +832,9 @@ function InAppAiAgentProviderInner({
       if (conversationId === _selectedConversationId) {
         return;
       }
-      selectedConversationIdRef.current = conversationId;
       setSelectedConversationId(conversationId);
-      if (conversationId) {
-        updateConversation(conversationId, (current) => ({
-          ...current,
-          unreadOutcome: null,
-        }));
-      }
     },
-    [_selectedConversationId, setSelectedConversationId, updateConversation],
+    [_selectedConversationId, setSelectedConversationId],
   );
 
   const setDraft = useCallback(
@@ -899,33 +877,6 @@ function InAppAiAgentProviderInner({
     },
     [selectedConversationId, updateConversation],
   );
-  const reorderQueuedMessage = useCallback(
-    (messageId: string, targetMessageId: string) => {
-      if (!selectedConversationId || messageId === targetMessageId) {
-        return;
-      }
-      updateConversation(selectedConversationId, (current) => {
-        const fromIndex = current.queuedMessages.findIndex(
-          ({ id }) => id === messageId,
-        );
-        const toIndex = current.queuedMessages.findIndex(
-          ({ id }) => id === targetMessageId,
-        );
-        if (fromIndex < 0 || toIndex < 0) {
-          return current;
-        }
-        const queuedMessages = current.queuedMessages.slice();
-        const [message] = queuedMessages.splice(fromIndex, 1);
-        if (!message) {
-          return current;
-        }
-        queuedMessages.splice(toIndex, 0, message);
-        return { ...current, queuedMessages };
-      });
-    },
-    [selectedConversationId, updateConversation],
-  );
-
   const submit = useCallback(
     async (content: string, options?: InAppAgentSubmitOptions) => {
       const trimmedContent = content.trim();
@@ -977,7 +928,6 @@ function InAppAiAgentProviderInner({
             draft: "",
           }),
         );
-        selectedConversationIdRef.current = conversationId;
         setSelectedConversationId(conversationId);
       }
 
@@ -1275,7 +1225,6 @@ function InAppAiAgentProviderInner({
       setDraft,
       editQueuedMessage,
       deleteQueuedMessage,
-      reorderQueuedMessage,
       submit,
       approveToolCall,
       rejectToolCall,
@@ -1298,7 +1247,6 @@ function InAppAiAgentProviderInner({
       open,
       openAssistant,
       rejectToolCall,
-      reorderQueuedMessage,
       selectConversation,
       selectedClientState,
       selectedConversationId,

--- a/web/src/ee/features/in-app-agent/components/inAppAgentClientStore.ts
+++ b/web/src/ee/features/in-app-agent/components/inAppAgentClientStore.ts
@@ -1,0 +1,113 @@
+import { createStore, type StoreApi } from "zustand/vanilla";
+
+import type {
+  AgUiMessage,
+  AgUiRunAgentInput,
+  InAppAgentToolApprovalRequest,
+} from "../schema";
+import type { InAppAgentSubmitOptions } from "../quickActions";
+import type { InAppAgentError } from "./utils/utils";
+
+export type InAppAgentPendingToolApproval = {
+  id: string;
+  approvalRequest: InAppAgentToolApprovalRequest;
+  status: "pending" | "submitting";
+};
+
+export const NEW_CONVERSATION_DRAFT_KEY = "__new_conversation__";
+
+export type InAppAgentQueuedMessage = {
+  id: string;
+  content: string;
+  context: AgUiRunAgentInput["context"];
+  options?: InAppAgentSubmitOptions;
+};
+
+export type InAppAgentConversationClientState = {
+  messages: AgUiMessage[];
+  pendingToolApprovals: InAppAgentPendingToolApproval[];
+  isRunning: boolean;
+  isSubmitting: boolean;
+  loadingEventIds: ReadonlySet<string>;
+  error: InAppAgentError | null;
+  liveMessageVersion: number;
+  queuedMessages: InAppAgentQueuedMessage[];
+  draft: string;
+  unreadOutcome: "completed" | "failed" | null;
+};
+
+export const EMPTY_IN_APP_AGENT_CONVERSATION_STATE: InAppAgentConversationClientState =
+  {
+    messages: [],
+    pendingToolApprovals: [],
+    isRunning: false,
+    isSubmitting: false,
+    loadingEventIds: new Set(),
+    error: null,
+    liveMessageVersion: 0,
+    queuedMessages: [],
+    draft: "",
+    unreadOutcome: null,
+  };
+
+type InAppAgentClientStoreState = {
+  conversations: Record<string, InAppAgentConversationClientState>;
+  localConversations: Record<
+    string,
+    { id: string; title: string | null; updatedAt: Date; isWriteLocked: false }
+  >;
+  actions: {
+    updateConversation: (
+      conversationId: string,
+      update: (
+        current: InAppAgentConversationClientState,
+      ) => InAppAgentConversationClientState,
+    ) => void;
+    removeConversation: (conversationId: string) => void;
+    rememberLocalConversation: (conversationId: string, title: string) => void;
+  };
+};
+
+export type InAppAgentClientStore = StoreApi<InAppAgentClientStoreState>;
+
+export function createInAppAgentClientStore(): InAppAgentClientStore {
+  return createStore<InAppAgentClientStoreState>((set) => ({
+    conversations: {},
+    localConversations: {},
+    actions: {
+      updateConversation: (conversationId, update) => {
+        set((state) => ({
+          conversations: {
+            ...state.conversations,
+            [conversationId]: update(
+              state.conversations[conversationId] ??
+                EMPTY_IN_APP_AGENT_CONVERSATION_STATE,
+            ),
+          },
+        }));
+      },
+      removeConversation: (conversationId) => {
+        set((state) => {
+          const conversations = { ...state.conversations };
+          const localConversations = { ...state.localConversations };
+          delete conversations[conversationId];
+          delete localConversations[conversationId];
+          return { conversations, localConversations };
+        });
+      },
+      rememberLocalConversation: (conversationId, title) => {
+        set((state) => ({
+          localConversations: {
+            ...state.localConversations,
+            [conversationId]: {
+              id: conversationId,
+              title,
+              updatedAt: new Date(),
+              isWriteLocked: false,
+            },
+          },
+        }));
+      },
+    },
+  }));
+}

--- a/web/src/ee/features/in-app-agent/components/inAppAgentClientStore.ts
+++ b/web/src/ee/features/in-app-agent/components/inAppAgentClientStore.ts
@@ -33,7 +33,6 @@ export type InAppAgentConversationClientState = {
   liveMessageVersion: number;
   queuedMessages: InAppAgentQueuedMessage[];
   draft: string;
-  unreadOutcome: "completed" | "failed" | null;
 };
 
 export const EMPTY_IN_APP_AGENT_CONVERSATION_STATE: InAppAgentConversationClientState =
@@ -47,7 +46,6 @@ export const EMPTY_IN_APP_AGENT_CONVERSATION_STATE: InAppAgentConversationClient
     liveMessageVersion: 0,
     queuedMessages: [],
     draft: "",
-    unreadOutcome: null,
   };
 
 type InAppAgentClientStoreState = {

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -287,6 +287,7 @@ export const events = {
     "entry_point_click",
     "new_chat_started",
     "new_chat_turn",
+    "message_queued",
     "quick_action_started",
   ],
   cmd_k_menu: ["opened", "search_entered", "navigated"],

--- a/web/src/utils/sentryFilters.clienttest.ts
+++ b/web/src/utils/sentryFilters.clienttest.ts
@@ -3,6 +3,7 @@ import { type ErrorEvent } from "@sentry/nextjs";
 import {
   isDenylistedNoiseEvent,
   isNoisyHttpClientPollEvent,
+  isReactDevtoolsInternalEvent,
 } from "@/src/utils/sentryFilters";
 
 /**
@@ -531,6 +532,75 @@ describe("isDenylistedNoiseEvent", () => {
 
     it("keeps an event with an empty exception value", () => {
       expect(isDenylistedNoiseEvent(exceptionEvent(""))).toBe(false);
+    });
+  });
+});
+
+describe("isReactDevtoolsInternalEvent", () => {
+  describe("drops React DevTools internal probes", () => {
+    it("drops a message-event probe", () => {
+      expect(
+        isReactDevtoolsInternalEvent(
+          messageEvent(
+            "Cannot read properties of undefined (reading '__reactContextDevtoolDebugId')",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops an exception-value variant", () => {
+      expect(
+        isReactDevtoolsInternalEvent(
+          exceptionEvent(
+            "Cannot read properties of undefined (reading '__reactContextDevtoolDebugId')",
+            "TypeError",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops it when the text lives on event.logentry.message", () => {
+      expect(
+        isReactDevtoolsInternalEvent(
+          logentryEvent(
+            "Cannot read properties of null (reading '__reactContextDevtoolDebugId')",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops a mixed event: EMPTY exception value but text on message", () => {
+      // An empty-string exception value is not nullish, so a naive `??` chain
+      // would keep it and never look at `message`. `eventText` treats it as
+      // absent, so this still matches.
+      expect(
+        isReactDevtoolsInternalEvent({
+          exception: { values: [{ value: "" }] },
+          message:
+            "Cannot read properties of undefined (reading '__reactContextDevtoolDebugId')",
+        } as unknown as Parameters<typeof isReactDevtoolsInternalEvent>[0]),
+      ).toBe(true);
+    });
+  });
+
+  // The safety contract: a suppression predicate must not swallow real errors.
+  describe("KEEPS real errors (never masks a genuine app error)", () => {
+    it("keeps a real thrown TypeError unrelated to DevTools", () => {
+      expect(
+        isReactDevtoolsInternalEvent(
+          exceptionEvent("TypeError: cannot read x", "TypeError"),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps an unrelated message event", () => {
+      expect(
+        isReactDevtoolsInternalEvent(messageEvent("some unrelated message")),
+      ).toBe(false);
+    });
+
+    it("keeps an event with no exception/message/logentry text", () => {
+      expect(isReactDevtoolsInternalEvent({} as ErrorEvent)).toBe(false);
     });
   });
 });

--- a/web/src/utils/sentryFilters.ts
+++ b/web/src/utils/sentryFilters.ts
@@ -144,6 +144,40 @@ function coreMessage(value: string): string {
 }
 
 /**
+ * True for React DevTools' internal probes against React's private fiber
+ * properties (`__reactContextDevtoolDebugId` and similar). These are benign:
+ * DevTools reads properties React does not guarantee exist, and the resulting
+ * failure is DevTools' own instrumentation, not a Langfuse app bug — it fires
+ * only when the extension is attached and installs its own probes.
+ *
+ * Matched against ALL text fields (exception value, message-event text, and
+ * the `logentry` fallback) because these can arrive as either an exception or
+ * a message event depending on how DevTools triggers the failure.
+ */
+/**
+ * The event's first NON-EMPTY text field — the exception value, else the
+ * message-event text, else the `logentry` fallback. An empty-string exception
+ * value is treated as absent (not nullish, so `??` alone would keep it), so a
+ * "mixed" event — empty exception value but real text on `message` — still
+ * matches on the message rather than being silently skipped.
+ */
+function eventText(event: ErrorEvent): string {
+  const exceptionValue = event.exception?.values?.[0]?.value;
+  return (
+    (typeof exceptionValue === "string" && exceptionValue.length > 0
+      ? exceptionValue
+      : undefined) ??
+    event.message ??
+    event.logentry?.message ??
+    ""
+  );
+}
+
+export function isReactDevtoolsInternalEvent(event: ErrorEvent): boolean {
+  return eventText(event).includes("__reactContextDevtoolDebugId");
+}
+
+/**
  * True for known-benign CLIENT-side noise that cannot be a real Langfuse app
  * bug: browser-level network/transport failures, transient framework/vendor
  * poll logs, and expected browser-permission / cancellation artifacts. Returning
@@ -179,17 +213,13 @@ export function isDenylistedNoiseEvent(event: ErrorEvent): boolean {
   const exception = event.exception?.values?.[0];
   const exceptionType = exception?.type;
   const exceptionValue = exception?.value;
-  const hasExceptionValue =
-    typeof exceptionValue === "string" && exceptionValue.length > 0;
 
-  // The message-signature rules run against the exception value when present,
-  // otherwise the message-event text (console-origin noise has no exception).
-  const messageText =
-    (hasExceptionValue ? exceptionValue : undefined) ??
-    event.message ??
-    event.logentry?.message;
+  // Message-signature rules run against the first non-empty text field
+  // (exception value → message → logentry); `eventText` treats an empty
+  // exception value as absent so mixed events still match on the message.
+  const messageText = eventText(event);
 
-  if (typeof messageText === "string" && messageText.length > 0) {
+  if (messageText.length > 0) {
     const core = coreMessage(messageText);
 
     // --- A. Transport / connectivity (whole-message match after unwrapping) ---


### PR DESCRIPTION
## Summary

- allow one active assistant run per conversation so separate conversations can run concurrently
- keep running conversations alive while users switch, close the drawer, or start another conversation
- queue follow-up messages per conversation with edit, delete, and drag-to-reorder controls
- edit queued messages in the normal composer while preserving the conversation draft
- surface running, approval-required, queued, and unviewed completion states in conversation history
- keep New conversation, history, switching, and the composer available while a run is active
- add focused Storybook examples for the queue and composed running window

## Related Linear issues

- [LFE-14358 — Assistant: We shouldn't block input while the agent is in progress](https://linear.app/clickhouse/issue/LFE-14358/assistant-we-shouldnt-block-input-while-the-agent-is-in-progress)
- [LFE-10769 — Assistant: New chat button disabled when chat in progress](https://linear.app/clickhouse/issue/LFE-10769/assistant-new-chat-button-disabled-when-chat-in-progress-not-good)

## Impacted packages

- `web`

No backend API, schema, migration, or server-side queue changes.

## Verification

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- targeted client tests — `Tests 9 passed (9)`
- targeted Storybook tests — `Tests 16 passed (16)`
- changed-file type validation — `Changed files: 0 type errors`
- Storybook browser review in compact and expanded layouts, including edit, delete, drag reorder, draft preservation, and zero console errors

The full repository typecheck currently reaches `Tasks: 6 successful, 7 total` and fails on pre-existing unrelated web type errors outside the changed files.