### PR TITLE
fix(agent): Resolve saved view filters

### DIFF
--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -8,7 +8,7 @@ import type {
 } from "@/src/ee/features/in-app-agent/schema";
 import { replaceRunEvents } from "@/src/ee/features/in-app-agent/server/persistence";
 import { env } from "@/src/env.mjs";
-import { prisma } from "@langfuse/shared/src/db";
+import { Prisma, prisma } from "@langfuse/shared/src/db";
 import {
   createAndAddApiKeysToDb,
   createBasicAuthHeader,
@@ -1033,6 +1033,207 @@ describe("in-app agent public API route auth", () => {
         { description: "current_timezone", value: "Europe/London" },
         { description: "browser_languages", value: "en-GB, en" },
       ]);
+    } finally {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+      (env as any).LANGFUSE_AWS_BEDROCK_MODEL = originalBedrockModel;
+      (env as any).LANGFUSE_AI_FEATURES_PUBLIC_KEY =
+        originalAiFeaturesPublicKey;
+      (env as any).LANGFUSE_AI_FEATURES_SECRET_KEY =
+        originalAiFeaturesSecretKey;
+    }
+  });
+
+  it("resolves saved view filters into screen context", async () => {
+    const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalBedrockModel = env.LANGFUSE_AWS_BEDROCK_MODEL;
+    const originalAiFeaturesPublicKey = env.LANGFUSE_AI_FEATURES_PUBLIC_KEY;
+    const originalAiFeaturesSecretKey = env.LANGFUSE_AI_FEATURES_SECRET_KEY;
+
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "DEV";
+    (env as any).LANGFUSE_AWS_BEDROCK_MODEL = "test-model";
+    (env as any).LANGFUSE_AI_FEATURES_PUBLIC_KEY = "pk-lf-test";
+    (env as any).LANGFUSE_AI_FEATURES_SECRET_KEY = "sk-lf-test";
+
+    const { org, project } = await createOrgProjectAndApiKey();
+    const filters = [
+      {
+        column: "name",
+        type: "stringOptions" as const,
+        operator: "any of" as const,
+        value: ["handle-chatbot-message"],
+      },
+    ];
+    const savedView = await prisma.tableViewPreset.create({
+      data: {
+        projectId: project.id,
+        name: "Chatbot messages",
+        tableName: "traces",
+        createdBy: null,
+        updatedBy: null,
+        filters,
+        columnOrder: [],
+        columnVisibility: {},
+        searchQuery: null,
+        orderBy: Prisma.JsonNull,
+      },
+    });
+
+    try {
+      await prisma.organization.update({
+        where: { id: org.id },
+        data: { aiFeaturesEnabled: true },
+      });
+      authMocks.getServerSession.mockResolvedValue(
+        await createPersistedInAppAgentSession({
+          orgId: org.id,
+          projectId: project.id,
+        }),
+      );
+
+      const { default: handler } =
+        await import("@/src/ee/features/in-app-agent/server/handler");
+      const response = await handler(
+        new Request("http://localhost/api/in-app-agent", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            threadId: "conversation-1",
+            runId: "client-run-1",
+            messages: [{ id: "message-1", role: "user", content: "hello" }],
+            tools: [],
+            context: [
+              {
+                description: "current_url",
+                value: `https://cloud.langfuse.com/project/${project.id}/traces?viewId=${savedView.id}&filter=name%3BstringOptions%3B%3Bany+of%3Bhandle-chatbot-message&orderBy=column-startTime_order-DESC`,
+              },
+            ],
+            state: {
+              type: "newConversation",
+              projectId: project.id,
+            },
+            forwardedProps: {},
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(agentMocks.createAgUiStream).toHaveBeenCalledOnce();
+      const streamInput = agentMocks.createAgUiStream.mock.calls[0][0].input;
+
+      expect(JSON.parse(streamInput.context[0].value)).toEqual({
+        pathname: `/project/${project.id}/traces`,
+        searchParams: [
+          { key: "viewId", value: savedView.id },
+          {
+            key: "filter",
+            value: "name;stringOptions;;any of;handle-chatbot-message",
+          },
+          { key: "orderBy", value: "column-startTime_order-DESC" },
+        ],
+        hash: "",
+        savedView: {
+          filters,
+        },
+      });
+    } finally {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+      (env as any).LANGFUSE_AWS_BEDROCK_MODEL = originalBedrockModel;
+      (env as any).LANGFUSE_AI_FEATURES_PUBLIC_KEY =
+        originalAiFeaturesPublicKey;
+      (env as any).LANGFUSE_AI_FEATURES_SECRET_KEY =
+        originalAiFeaturesSecretKey;
+    }
+  });
+
+  it("does not resolve saved views outside the current project", async () => {
+    const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalBedrockModel = env.LANGFUSE_AWS_BEDROCK_MODEL;
+    const originalAiFeaturesPublicKey = env.LANGFUSE_AI_FEATURES_PUBLIC_KEY;
+    const originalAiFeaturesSecretKey = env.LANGFUSE_AI_FEATURES_SECRET_KEY;
+
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "DEV";
+    (env as any).LANGFUSE_AWS_BEDROCK_MODEL = "test-model";
+    (env as any).LANGFUSE_AI_FEATURES_PUBLIC_KEY = "pk-lf-test";
+    (env as any).LANGFUSE_AI_FEATURES_SECRET_KEY = "sk-lf-test";
+
+    const { org, project } = await createOrgProjectAndApiKey();
+    const { project: otherProject } = await createOrgProjectAndApiKey();
+    const otherProjectView = await prisma.tableViewPreset.create({
+      data: {
+        projectId: otherProject.id,
+        name: "Private view",
+        tableName: "traces",
+        createdBy: null,
+        updatedBy: null,
+        filters: [
+          {
+            column: "name",
+            type: "stringOptions",
+            operator: "any of",
+            value: ["private-trace"],
+          },
+        ],
+        columnOrder: [],
+        columnVisibility: {},
+        searchQuery: null,
+        orderBy: Prisma.JsonNull,
+      },
+    });
+
+    try {
+      await prisma.organization.update({
+        where: { id: org.id },
+        data: { aiFeaturesEnabled: true },
+      });
+      authMocks.getServerSession.mockResolvedValue(
+        await createPersistedInAppAgentSession({
+          orgId: org.id,
+          projectId: project.id,
+        }),
+      );
+
+      const { default: handler } =
+        await import("@/src/ee/features/in-app-agent/server/handler");
+
+      for (const [index, viewId] of [
+        otherProjectView.id,
+        randomUUID(),
+      ].entries()) {
+        const response = await handler(
+          new Request("http://localhost/api/in-app-agent", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              threadId: `conversation-${index}`,
+              runId: `client-run-${index}`,
+              messages: [
+                { id: `message-${index}`, role: "user", content: "hello" },
+              ],
+              tools: [],
+              context: [
+                {
+                  description: "current_url",
+                  value: `https://cloud.langfuse.com/project/${project.id}/traces?viewId=${viewId}`,
+                },
+              ],
+              state: {
+                type: "newConversation",
+                projectId: project.id,
+              },
+              forwardedProps: {},
+            }),
+          }),
+        );
+
+        expect(response.status).toBe(200);
+        const streamInput =
+          agentMocks.createAgUiStream.mock.calls[index][0].input;
+        expect(JSON.parse(streamInput.context[0].value)).toEqual({
+          pathname: `/project/${project.id}/traces`,
+          searchParams: [{ key: "viewId", value: viewId }],
+          hash: "",
+        });
+      }
     } finally {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
       (env as any).LANGFUSE_AWS_BEDROCK_MODEL = originalBedrockModel;

--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -13,6 +13,7 @@ import {
   createAndAddApiKeysToDb,
   createBasicAuthHeader,
   createOrgProjectAndApiKey,
+  TableViewService,
 } from "@langfuse/shared/src/server";
 import type { Session } from "next-auth";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -1043,7 +1044,7 @@ describe("in-app agent public API route auth", () => {
     }
   });
 
-  it("resolves saved view filters into screen context", async () => {
+  it("resolves saved view filters only on a compatible table route", async () => {
     const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     const originalBedrockModel = env.LANGFUSE_AWS_BEDROCK_MODEL;
     const originalAiFeaturesPublicKey = env.LANGFUSE_AI_FEATURES_PUBLIC_KEY;
@@ -1135,6 +1136,39 @@ describe("in-app agent public API route auth", () => {
           filters,
         },
       });
+
+      const mismatchedResponse = await handler(
+        new Request("http://localhost/api/in-app-agent", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            threadId: "conversation-2",
+            runId: "client-run-2",
+            messages: [{ id: "message-2", role: "user", content: "hello" }],
+            tools: [],
+            context: [
+              {
+                description: "current_url",
+                value: `https://cloud.langfuse.com/project/${project.id}/sessions?viewId=${savedView.id}`,
+              },
+            ],
+            state: {
+              type: "newConversation",
+              projectId: project.id,
+            },
+            forwardedProps: {},
+          }),
+        }),
+      );
+
+      expect(mismatchedResponse.status).toBe(200);
+      const mismatchedStreamInput =
+        agentMocks.createAgUiStream.mock.calls[1][0].input;
+      expect(JSON.parse(mismatchedStreamInput.context[0].value)).toEqual({
+        pathname: `/project/${project.id}/sessions`,
+        searchParams: [{ key: "viewId", value: savedView.id }],
+        hash: "",
+      });
     } finally {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
       (env as any).LANGFUSE_AWS_BEDROCK_MODEL = originalBedrockModel;
@@ -1145,7 +1179,7 @@ describe("in-app agent public API route auth", () => {
     }
   });
 
-  it("does not resolve saved views outside the current project", async () => {
+  it("continues without resolved filters when saved view lookup fails", async () => {
     const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     const originalBedrockModel = env.LANGFUSE_AWS_BEDROCK_MODEL;
     const originalAiFeaturesPublicKey = env.LANGFUSE_AI_FEATURES_PUBLIC_KEY;
@@ -1179,6 +1213,7 @@ describe("in-app agent public API route auth", () => {
         orderBy: Prisma.JsonNull,
       },
     });
+    const lookupSpy = vi.spyOn(TableViewService, "getTableViewPresetsById");
 
     try {
       await prisma.organization.update({
@@ -1195,10 +1230,17 @@ describe("in-app agent public API route auth", () => {
       const { default: handler } =
         await import("@/src/ee/features/in-app-agent/server/handler");
 
-      for (const [index, viewId] of [
-        otherProjectView.id,
-        randomUUID(),
-      ].entries()) {
+      const lookupScenarios = [
+        { viewId: otherProjectView.id },
+        { viewId: randomUUID() },
+        { viewId: randomUUID(), error: new Error("database unavailable") },
+      ];
+
+      for (const [index, { viewId, error }] of lookupScenarios.entries()) {
+        if (error) {
+          lookupSpy.mockRejectedValueOnce(error);
+        }
+
         const response = await handler(
           new Request("http://localhost/api/in-app-agent", {
             method: "POST",
@@ -1235,6 +1277,7 @@ describe("in-app agent public API route auth", () => {
         });
       }
     } finally {
+      lookupSpy.mockRestore();
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
       (env as any).LANGFUSE_AWS_BEDROCK_MODEL = originalBedrockModel;
       (env as any).LANGFUSE_AI_FEATURES_PUBLIC_KEY =

--- a/web/src/ee/features/in-app-agent/context.ts
+++ b/web/src/ee/features/in-app-agent/context.ts
@@ -4,6 +4,7 @@ import {
   type InAppAgentQuickActionAttribution,
 } from "@/src/ee/features/in-app-agent/quickActions";
 import { getInAppAgentProjectRoute } from "@/src/ee/features/in-app-agent/routeContext";
+import type { FilterState } from "@langfuse/shared";
 
 type InAppAgentContext = AgUiRunAgentInput["context"];
 
@@ -167,6 +168,7 @@ export function createInAppAgentScreenContext(params: {
 export function sanitizeInAppAgentContext(
   context: InAppAgentContext,
   projectId: string,
+  viewFilters?: FilterState,
 ): InAppAgentContext {
   const sanitizedContext: InAppAgentContext = [];
   const currentUrlContext = context.find(
@@ -181,14 +183,26 @@ export function sanitizeInAppAgentContext(
     const serializedCurrentUrl = currentUrl
       ? JSON.stringify(currentUrl)
       : undefined;
+    const serializedResolvedCurrentUrl =
+      currentUrl && viewFilters
+        ? JSON.stringify({
+            ...currentUrl,
+            savedView: { filters: viewFilters },
+          })
+        : undefined;
+    const boundedCurrentUrl =
+      serializedResolvedCurrentUrl &&
+      serializedResolvedCurrentUrl.length <= MAX_SCREEN_CONTEXT_JSON_LENGTH
+        ? serializedResolvedCurrentUrl
+        : serializedCurrentUrl;
 
     if (
-      serializedCurrentUrl &&
-      serializedCurrentUrl.length <= MAX_SCREEN_CONTEXT_JSON_LENGTH
+      boundedCurrentUrl &&
+      boundedCurrentUrl.length <= MAX_SCREEN_CONTEXT_JSON_LENGTH
     ) {
       sanitizedContext.push({
         description: CURRENT_URL_CONTEXT_DESCRIPTION,
-        value: serializedCurrentUrl,
+        value: boundedCurrentUrl,
       });
     }
   }

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -13,7 +13,6 @@ import {
   sanitizeInAppAgentContext,
 } from "@/src/ee/features/in-app-agent/context";
 import { getInAppAgentInstrumentationTraceId } from "@/src/ee/features/in-app-agent/constants";
-import { getInAppAgentProjectRoute } from "@/src/ee/features/in-app-agent/routeContext";
 import {
   AgUiRunAgentInputSchema,
   type AgUiRunAgentInput,
@@ -65,6 +64,7 @@ import {
 import { getLangfuseAITraceSinkParams } from "@/src/features/ai-features/server/bedrockCompletion";
 import { isProjectMemberOrAdmin } from "@/src/server/utils/checkProjectMembershipOrAdmin";
 import { getProductBaseUrl } from "@/src/utils/base-url";
+import { parseSavedViewFromURL } from "@/src/utils/product-url";
 import { assertUnreachable } from "@/src/utils/types";
 import {
   BaseError,
@@ -73,6 +73,7 @@ import {
   InvalidRequestError,
   LangfuseNotFoundError,
   type RateLimitResult,
+  TableViewPresetTableName,
   UnauthorizedError,
   CloudConfigSchema,
 } from "@langfuse/shared";
@@ -201,7 +202,11 @@ export default async function handler(request: Request) {
       );
     }
 
-    const sanitizedInput = await prepareAgentInput(input, projectId);
+    const sanitizedInput = await prepareAgentInput(
+      input,
+      projectId,
+      user.v4BetaEnabled ?? false,
+    );
     const awsProfile = env.LANGFUSE_IN_APP_AGENT_AWS_PROFILE;
     const bedrockModelId = env.LANGFUSE_AWS_BEDROCK_MODEL;
     const langfuseAiFeaturesPublicKey = env.LANGFUSE_AI_FEATURES_PUBLIC_KEY;
@@ -863,6 +868,7 @@ function isResumeAgentInput(
 async function prepareAgentInput(
   input: AgUiRunAgentInput,
   projectId: string,
+  isV4Enabled: boolean,
 ): Promise<SanitizedAgentInput> {
   const forwardedProps: unknown = input.forwardedProps;
 
@@ -878,21 +884,35 @@ async function prepareAgentInput(
   const currentUrlContext = input.context.find(
     (item) => item.description === "current_url",
   );
-  const currentProjectRoute = currentUrlContext
-    ? getInAppAgentProjectRoute(currentUrlContext.value)
+  const selectedSavedView = currentUrlContext
+    ? parseSavedViewFromURL(currentUrlContext.value, isV4Enabled)
     : undefined;
-  const savedViewId = currentProjectRoute?.parsedUrl.searchParams.get("viewId");
   let viewFilters: FilterState | undefined;
 
-  if (savedViewId) {
+  if (selectedSavedView) {
     try {
-      viewFilters = (
-        await TableViewService.getTableViewPresetsById(savedViewId, projectId)
-      ).filters;
+      const { filters, tableName } =
+        await TableViewService.getTableViewPresetsById(
+          selectedSavedView.viewId,
+          projectId,
+        );
+
+      if (
+        tableName === selectedSavedView.tableName ||
+        (selectedSavedView.tableName ===
+          TableViewPresetTableName.ObservationsEvents &&
+          tableName === TableViewPresetTableName.Observations)
+      ) {
+        viewFilters = filters;
+      }
     } catch (error) {
       // Saved views can be deleted while their URLs remain open or shared.
       if (!(error instanceof LangfuseNotFoundError)) {
-        throw error;
+        logger.warn("Failed to resolve saved view for in-app agent context", {
+          error,
+          projectId,
+          savedViewId: selectedSavedView.viewId,
+        });
       }
     }
   }

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -13,6 +13,7 @@ import {
   sanitizeInAppAgentContext,
 } from "@/src/ee/features/in-app-agent/context";
 import { getInAppAgentInstrumentationTraceId } from "@/src/ee/features/in-app-agent/constants";
+import { getInAppAgentProjectRoute } from "@/src/ee/features/in-app-agent/routeContext";
 import {
   AgUiRunAgentInputSchema,
   type AgUiRunAgentInput,
@@ -68,7 +69,9 @@ import { assertUnreachable } from "@/src/utils/types";
 import {
   BaseError,
   ForbiddenError,
+  type FilterState,
   InvalidRequestError,
+  LangfuseNotFoundError,
   type RateLimitResult,
   UnauthorizedError,
   CloudConfigSchema,
@@ -77,6 +80,7 @@ import { prisma } from "@langfuse/shared/src/db";
 import {
   logger,
   redis,
+  TableViewService,
   type ApiAccessScope,
 } from "@langfuse/shared/src/server";
 import {
@@ -197,7 +201,7 @@ export default async function handler(request: Request) {
       );
     }
 
-    const sanitizedInput = sanitizeAgentInput(input, projectId);
+    const sanitizedInput = await prepareAgentInput(input, projectId);
     const awsProfile = env.LANGFUSE_IN_APP_AGENT_AWS_PROFILE;
     const bedrockModelId = env.LANGFUSE_AWS_BEDROCK_MODEL;
     const langfuseAiFeaturesPublicKey = env.LANGFUSE_AI_FEATURES_PUBLIC_KEY;
@@ -856,10 +860,10 @@ function isResumeAgentInput(
   return "command" in input.forwardedProps;
 }
 
-function sanitizeAgentInput(
+async function prepareAgentInput(
   input: AgUiRunAgentInput,
   projectId: string,
-): SanitizedAgentInput {
+): Promise<SanitizedAgentInput> {
   const forwardedProps: unknown = input.forwardedProps;
 
   if (
@@ -870,6 +874,34 @@ function sanitizeAgentInput(
   ) {
     throw new InvalidRequestError("Invalid forwarded props");
   }
+
+  const currentUrlContext = input.context.find(
+    (item) => item.description === "current_url",
+  );
+  const currentProjectRoute = currentUrlContext
+    ? getInAppAgentProjectRoute(currentUrlContext.value)
+    : undefined;
+  const savedViewId = currentProjectRoute?.parsedUrl.searchParams.get("viewId");
+  let viewFilters: FilterState | undefined;
+
+  if (savedViewId) {
+    try {
+      viewFilters = (
+        await TableViewService.getTableViewPresetsById(savedViewId, projectId)
+      ).filters;
+    } catch (error) {
+      // Saved views can be deleted while their URLs remain open or shared.
+      if (!(error instanceof LangfuseNotFoundError)) {
+        throw error;
+      }
+    }
+  }
+
+  const context = sanitizeInAppAgentContext(
+    input.context,
+    projectId,
+    viewFilters,
+  );
 
   if (forwardedProps && "command" in forwardedProps) {
     const resumeForwardedProps =
@@ -886,7 +918,7 @@ function sanitizeAgentInput(
       state: null,
       messages: [],
       tools: [],
-      context: sanitizeInAppAgentContext(input.context, projectId),
+      context,
       forwardedProps: resumeForwardedProps.data,
     };
   }
@@ -904,7 +936,7 @@ function sanitizeAgentInput(
     state: null,
     messages: [{ ...lastUserMessage, id: createInAppAgentMessageId() }],
     tools: [],
-    context: sanitizeInAppAgentContext(input.context, projectId),
+    context,
     forwardedProps: {},
   };
 }

--- a/web/src/utils/product-url.ts
+++ b/web/src/utils/product-url.ts
@@ -1,4 +1,8 @@
-import type { APIScoreV3, FilterState } from "@langfuse/shared";
+import {
+  TableViewPresetTableName,
+  type APIScoreV3,
+  type FilterState,
+} from "@langfuse/shared";
 import { encodeFiltersGeneric } from "@/src/features/filters/lib/filter-query-encoding";
 import { getProductBaseUrl } from "@/src/utils/base-url";
 import {
@@ -7,6 +11,74 @@ import {
 } from "@/src/utils/date-range-utils";
 
 type ProductPathQuery = Record<string, string | string[] | null | undefined>;
+
+export function parseSavedViewFromURL(
+  currentUrl: string,
+  isV4Enabled: boolean,
+) {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(currentUrl, "https://langfuse.local");
+  } catch {
+    return undefined;
+  }
+
+  const pathSegments = parsedUrl.pathname.split("/").filter(Boolean);
+  const projectSegmentIndex = pathSegments.indexOf("project");
+  const section = pathSegments[projectSegmentIndex + 2];
+  const detailId = pathSegments[projectSegmentIndex + 3];
+  const viewId = parsedUrl.searchParams.get("viewId");
+
+  if (projectSegmentIndex === -1 || !section || !viewId) {
+    return undefined;
+  }
+
+  if (section === "traces" && !detailId) {
+    return {
+      viewId,
+      tableName: isV4Enabled
+        ? TableViewPresetTableName.ObservationsEvents
+        : TableViewPresetTableName.Traces,
+    };
+  }
+
+  if (section === "observations" && !detailId) {
+    return {
+      viewId,
+      tableName: isV4Enabled
+        ? TableViewPresetTableName.ObservationsEvents
+        : TableViewPresetTableName.Observations,
+    };
+  }
+
+  if (section === "sessions") {
+    return {
+      viewId,
+      tableName: detailId
+        ? TableViewPresetTableName.SessionDetail
+        : TableViewPresetTableName.Sessions,
+    };
+  }
+
+  if (section === "datasets" && !detailId) {
+    return { viewId, tableName: TableViewPresetTableName.Datasets };
+  }
+
+  if (section === "scores" && !detailId) {
+    return { viewId, tableName: TableViewPresetTableName.Scores };
+  }
+
+  if (section === "experiments" && detailId === "results") {
+    return { viewId, tableName: TableViewPresetTableName.ExperimentItems };
+  }
+
+  if (section === "experiments" && !detailId) {
+    return { viewId, tableName: TableViewPresetTableName.Experiments };
+  }
+
+  return undefined;
+}
 
 type TracesPathTimeRange =
   | { preset: (typeof TABLE_AGGREGATION_OPTIONS)[number] }


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds saved-view filters to the in-app agent's screen context. The main changes are:

- Resolve saved-view filters from the current product URL.
- Check that saved views match the current table route.
- Continue agent requests when optional saved-view lookup fails.
- Keep enriched screen context within the existing size limit.
- Add server tests for successful, mismatched, missing, and failed lookups.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The latest fixes look safe to merge.

- Saved-view lookup failures no longer block agent requests.
- Presets from unrelated tables are excluded from the agent context.
- No additional distinct blocking issue qualifies for this follow-up.

</details>

<sub>Reviews (2): Last reviewed commit: ["Address PR feedback"](https://github.com/langfuse/langfuse/commit/bf99f07205b128d8aabc77136e4c5cdf288711b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46308840)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->