### PR TITLE
fix(filter-sidebar): always show Clear when a filter is active (LFE-14402)

### DIFF
--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -973,7 +973,7 @@ const FilterAccordionTrigger = ({
   // top-0: the panel header row sits outside the scroll container
   // (ScrollArea wraps only the facet list), so triggers stick to its top.
   // The expand chevron leads the row (> closed, v open); the clear button
-  // overlays on hover without reserving layout space.
+  // sits at the row's right edge and stays visible whenever a value is set.
   <AccordionPrimitive.Header className="bg-background sticky top-0 z-[1] flex px-2 py-0.5">
     <AccordionPrimitive.Trigger
       className={cn(
@@ -1133,9 +1133,12 @@ export function FilterAccordionItem({
           <Tooltip delayDuration={80}>
             <TooltipTrigger asChild>
               {/* div[role=button], not <Button>: the accordion trigger is
-                  already a <button> and buttons cannot nest. Rendered as a
-                  hover/focus-revealed OVERLAY (absolute, own background) so
-                  it never shifts the header layout. */}
+                  already a <button> and buttons cannot nest. Always visible
+                  while the facet has a selection (no hover gating) — the clear
+                  affordance used to reveal only on header hover, which hid the
+                  one obvious way to drop a filter. shrink-0 keeps it in flow at
+                  the row's right edge so the label/chip truncate before reaching
+                  it; self-start pins it to the top line on two-line headers. */}
               <div
                 role="button"
                 tabIndex={0}
@@ -1150,15 +1153,11 @@ export function FilterAccordionItem({
                     onReset();
                   }
                 }}
-                // top-1 anchors the button to the label line — a 20px
-                // button in the 28px single-line header reads centered, and
-                // on two-line headers it stays top-right. bg-accent matches
-                // the hovered header band (the button is only visible while
-                // the band shows its hover color).
-                className="bg-accent text-muted-foreground hover:text-foreground absolute top-0.5 right-1 flex h-5 w-5 cursor-pointer items-center justify-center rounded-sm opacity-0 transition-opacity group-hover/facet:opacity-100 focus-visible:opacity-100"
+                className="text-muted-foreground hover:text-foreground flex shrink-0 cursor-pointer items-center gap-0.5 self-start rounded-sm px-1 py-0.5 text-[11px] leading-4 font-normal transition-colors hover:underline focus-visible:underline focus-visible:outline-none"
                 aria-label={`Clear ${label} filter`}
               >
-                <IconX className="h-3 w-3" />
+                <IconX className="h-3 w-3 shrink-0" />
+                Clear
               </div>
             </TooltipTrigger>
             <TooltipContent side="right" className="text-xs">


### PR DESCRIPTION
## TL;DR
In the table filter sidebar, when a facet has an active selection its **Clear** control is now **always visible** (with a "Clear" text label), instead of appearing only when you hover the section header.

## Why
The clear affordance was hover-gated (`opacity-0 group-hover/facet:opacity-100`). Once a filter was selected, there was no obvious way to clear it — you had to discover that hovering the section header (e.g. **Environment**) revealed a bare `×` icon. Reported internally as a paper-cut (LFE-14402).

## What
In `FilterAccordionItem` (the shared facet header used by every sidebar facet), the clear control now:
- renders in normal flow at the header's right edge and stays visible whenever the facet has a selection (`isActive`), with no hover gating;
- shows an **icon + "Clear" text** label instead of an icon alone;
- is unchanged when there is no selection — those facets show nothing, so the collapsed state stays uncluttered.

## Result
Selecting a filter immediately shows a persistent, labelled **Clear** control; clicking it clears that facet. Facets with no selection are unaffected.

<details>
<summary>Mechanism, a11y &amp; verification</summary>

**Mechanism**
- The control was already gated behind `{isActive && onReset && …}`, so it only ever renders for a facet with a live selection. The change drops the `absolute … opacity-0 transition-opacity group-hover/facet:opacity-100 focus-visible:opacity-100` overlay styling and makes it an in-flow, `shrink-0` element (`self-start` pins it to the top line on two-line headers; the label/summary chip truncate before reaching it).
- The `group/facet` marker on the trigger is retained — it is still used by the collapsed-summary chip's `group-data-[state=open]/facet:hidden` rule. Only this button's hover-opacity utility was removed, so no other hover interaction changes.
- Other, unrelated hover affordances (per-chip text-filter remove, the "Only/All" label hint) are intentionally left as-is.

**Accessibility**
- Still a `div[role="button"]` (the accordion trigger is itself a `<button>`, which cannot nest a real button) with `tabIndex={0}`, Enter/Space handlers, and `aria-label="Clear <facet> filter"`. Keyboard focus now shows an underline, and the affordance is no longer icon-only.

**Verification (local, Chrome via Playwright)**
- Signed in, opened a traces page, selected a boolean facet: the **× Clear** control was visible at full opacity with the pointer far from the sidebar (no hover), and facets without a selection showed no clear control.
- Clicking **Clear** removed the filter (URL `?filter=…` reset to clean) and the control disappeared.
- Checked the collapsed-but-active state: **× Clear** stays pinned top-right without colliding with the selection summary chip.
- `tsc --noEmit` and `eslint` on the changed file both clean; pre-commit prettier + full `turbo run lint` passed.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the clear control for active table filters persistent and easier to identify. The main changes are:

- Replaces the hover-only clear icon with an always-visible icon and text label.
- Keeps the control in the facet header’s flex layout.
- Preserves mouse and keyboard reset handling.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The control remains limited to active facets with a reset callback.
- Click and keyboard events still avoid toggling the surrounding accordion.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(filter-sidebar): always show Clear w..."](https://github.com/langfuse/langfuse/commit/ef7c97c7ddaa0eff5f9e184c3f097a45be49fee9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46338938)</sub>

<!-- /greptile_comment -->