### PR TITLE
feat(assistant): queue follow-up messages while running

### DIFF
--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
 import { InAppAgentWindow } from "./InAppAgentWindow";
 import type { InAppAgentWindowConversation } from "./InAppAgentWindow";
@@ -41,6 +41,9 @@ export function ControlledInAppAgentWindow(
   const router = useRouter();
   const {
     conversations,
+    deleteQueuedMessage,
+    draft,
+    editQueuedMessage,
     error,
     hasMoreConversations,
     isLoadingMoreConversations,
@@ -52,11 +55,14 @@ export function ControlledInAppAgentWindow(
     liveMessageVersion,
     messages,
     pendingToolApprovals,
+    queuedMessages,
     approveToolCall,
     rejectToolCall,
     selectConversation,
     selectedConversationId,
     selectedConversationIsWriteLocked,
+    setDraft,
+    setTranscriptAnimating,
     submit,
     submitFeedback,
   } = useInAppAiAgent();
@@ -71,13 +77,25 @@ export function ControlledInAppAgentWindow(
     pendingToolApprovals,
     shouldFlush: error !== null,
   });
+  useEffect(() => {
+    setTranscriptAnimating(isAnimating);
+  }, [isAnimating, setTranscriptAnimating]);
+  useEffect(
+    () => () => {
+      setTranscriptAnimating(false);
+    },
+    [setTranscriptAnimating],
+  );
   const isInputDisabled =
+    selectedConversationIsWriteLocked || isSelectedConversationHydrating;
+  const isNavigationDisabled =
     isRunning ||
     isAnimating ||
     isSubmitting ||
     selectedConversationIsWriteLocked ||
     isSelectedConversationHydrating ||
-    pendingToolApprovals.length > 0;
+    pendingToolApprovals.length > 0 ||
+    queuedMessages.length > 0;
   const displayError = selectedConversationIsWriteLocked
     ? ({
         type: "generic",
@@ -129,8 +147,11 @@ export function ControlledInAppAgentWindow(
       isHeaderDragHandleEnabled={props.isHeaderDragHandleEnabled}
       isExpanded={props.isExpanded}
       isInputDisabled={isInputDisabled}
+      isNavigationDisabled={isNavigationDisabled}
       disablePendingToolApprovalActions={selectedConversationIsWriteLocked}
       messages={drawerMessages}
+      draft={draft}
+      queuedMessages={queuedMessages}
       quickActionContext={quickActionContext}
       focusedQuickActions={focusedQuickActions}
       quickActionResetKey={quickActionResetKey}
@@ -148,6 +169,9 @@ export function ControlledInAppAgentWindow(
       }}
       onExpandedChange={props.onExpandedChange}
       onSubmit={submit}
+      onDraftChange={setDraft}
+      onEditQueuedMessage={editQueuedMessage}
+      onDeleteQueuedMessage={deleteQueuedMessage}
       onApproveToolCall={approveToolCall}
       onRejectToolCall={rejectToolCall}
       onSubmitFeedback={submitFeedback}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.stories.tsx
@@ -1,0 +1,72 @@
+import { useState, type ComponentProps } from "react";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import preview from "../../../../../.storybook/preview";
+import {
+  InAppAgentQueuedMessages,
+  type InAppAgentQueuedMessageItem,
+} from "./InAppAgentQueuedMessages";
+
+const messages: InAppAgentQueuedMessageItem[] = [
+  { id: "queued-1", content: "Compare this against the previous week." },
+  {
+    id: "queued-2",
+    content:
+      "Then break the result down by model.\nCall out regressions larger than 10%.",
+  },
+];
+
+const meta = preview.meta({
+  component: InAppAgentQueuedMessages,
+  args: {
+    messages,
+    onEdit: fn(),
+    onDelete: fn(),
+  },
+});
+
+export const QueuedFollowUps = meta.story({
+  render: (args) => <QueueStory {...args} />,
+});
+
+export const Collapsed = meta.story({
+  args: { defaultExpanded: false },
+  render: (args) => <QueueStory {...args} />,
+});
+
+function QueueStory(args: ComponentProps<typeof InAppAgentQueuedMessages>) {
+  const [queuedMessages, setQueuedMessages] = useState(() =>
+    Array.from(args.messages),
+  );
+
+  return (
+    <InAppAgentQueuedMessages
+      {...args}
+      messages={queuedMessages}
+      onDelete={(messageId) => {
+        args.onDelete(messageId);
+        setQueuedMessages((current) =>
+          current.filter(({ id }) => id !== messageId),
+        );
+      }}
+    />
+  );
+}
+
+export const TestEditsAndDeletesFollowUps = meta.story({
+  name: "(Test) Edits And Deletes Follow-Ups",
+  render: (args) => <QueueStory {...args} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Edit queued message 1" }),
+    );
+    await expect(args.onEdit).toHaveBeenCalledWith("queued-1");
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Delete queued message 2" }),
+    );
+    await expect(args.onDelete).toHaveBeenCalledWith("queued-2");
+  },
+});

--- a/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentQueuedMessages.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { ChevronDown, CornerDownRight, Pencil, Trash2 } from "lucide-react";
+
+import { Button } from "@/src/components/ui/button";
+import { cn } from "@/src/utils/tailwind";
+
+export type InAppAgentQueuedMessageItem = {
+  id: string;
+  content: string;
+};
+
+export function InAppAgentQueuedMessages({
+  messages,
+  defaultExpanded = true,
+  onEdit,
+  onDelete,
+}: {
+  messages: readonly InAppAgentQueuedMessageItem[];
+  defaultExpanded?: boolean;
+  onEdit: (messageId: string) => void;
+  onDelete: (messageId: string) => void;
+}) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  return (
+    <div className="border-border bg-card overflow-hidden rounded-md border">
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        className="hover:bg-muted/60 flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-xs font-bold"
+        onClick={() => {
+          setIsExpanded((current) => !current);
+        }}
+      >
+        <ChevronDown
+          aria-hidden="true"
+          className={cn(
+            "size-3.5 transition-transform",
+            !isExpanded && "-rotate-90",
+          )}
+        />
+        {messages.length} queued
+      </button>
+      {isExpanded ? (
+        <ol className="border-border divide-y border-t">
+          {messages.map((message, index) => (
+            <li key={message.id} className="bg-card flex gap-2 px-2 py-2">
+              <CornerDownRight className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+              <p className="min-w-0 flex-1 text-xs leading-5 wrap-break-word whitespace-pre-wrap">
+                {message.content}
+              </p>
+              <div className="flex shrink-0 items-start gap-0.5">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={`Edit queued message ${index + 1}`}
+                  onClick={() => {
+                    onEdit(message.id);
+                  }}
+                >
+                  <Pencil className="size-3" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="hover:text-destructive"
+                  aria-label={`Delete queued message ${index + 1}`}
+                  onClick={() => {
+                    onDelete(message.id);
+                  }}
+                >
+                  <Trash2 className="size-3" />
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -142,4 +142,72 @@ describe("InAppAgentWindow quick actions", () => {
       screen.getByRole("button", { name: /^Create a prompt/ }),
     ).toBeInTheDocument();
   });
+
+  it("keeps the busy composer enabled while navigation stays disabled and edits preserve the draft", () => {
+    const onEditQueuedMessage = vi.fn();
+
+    render(
+      windowElement({
+        conversations: [
+          {
+            id: "conversation-1",
+            title: "Running conversation",
+            updatedAt: new Date(),
+          },
+        ],
+        selectedConversationId: "conversation-1",
+        isAssistantTurnInProgress: true,
+        isInputDisabled: false,
+        isNavigationDisabled: true,
+        draft: "Unsent draft",
+        queuedMessages: [{ id: "queued-1", content: "Queued follow-up" }],
+        messages: [
+          {
+            id: "message-1",
+            role: "user",
+            content: { type: "text", text: "First" },
+          },
+        ],
+        onDraftChange: vi.fn(),
+        onEditQueuedMessage,
+        onDeleteQueuedMessage: vi.fn(),
+      }),
+    );
+
+    expect(screen.getByLabelText("Message the assistant")).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Start new conversation" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Conversation history" }),
+    ).toBeDisabled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit queued message 1" }),
+    );
+    const editor = screen.getByRole("textbox", { name: "Edit queued message" });
+    expect(editor).toHaveValue("Queued follow-up");
+    fireEvent.change(editor, { target: { value: "Discarded edit" } });
+    fireEvent.keyDown(editor, { key: "Escape" });
+    expect(onEditQueuedMessage).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Message the assistant")).toHaveValue(
+      "Unsent draft",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit queued message 1" }),
+    );
+    const savedEditor = screen.getByRole("textbox", {
+      name: "Edit queued message",
+    });
+    fireEvent.change(savedEditor, { target: { value: "Edited follow-up" } });
+    fireEvent.keyDown(savedEditor, { key: "Enter" });
+    expect(onEditQueuedMessage).toHaveBeenCalledWith(
+      "queued-1",
+      "Edited follow-up",
+    );
+    expect(screen.getByLabelText("Message the assistant")).toHaveValue(
+      "Unsent draft",
+    );
+  });
 });

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -654,6 +654,64 @@ export const ToolApprovalRequired = meta.story({
   },
 });
 
+export const RunningWithQueuedFollowUps = meta.story({
+  render: function Render(args) {
+    const [draft, setDraft] = useState(
+      "A third follow-up can still be composed",
+    );
+    const [queuedMessages, setQueuedMessages] = useState([
+      { id: "queued-1", content: "Compare this with last week." },
+      {
+        id: "queued-2",
+        content:
+          "Break down the result by model.\nHighlight regressions above 10%.",
+      },
+    ]);
+
+    return (
+      <StatefulInAppAgentWindow
+        {...args}
+        draft={draft}
+        queuedMessages={queuedMessages}
+        onDraftChange={setDraft}
+        onEditQueuedMessage={(messageId, content) => {
+          setQueuedMessages((current) =>
+            current.map((message) =>
+              message.id === messageId ? { ...message, content } : message,
+            ),
+          );
+        }}
+        onDeleteQueuedMessage={(messageId) => {
+          setQueuedMessages((current) =>
+            current.filter((message) => message.id !== messageId),
+          );
+        }}
+      />
+    );
+  },
+  args: {
+    isAssistantTurnInProgress: true,
+    isInputDisabled: false,
+    isNavigationDisabled: true,
+    selectedConversationId: "conversation-1",
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        content: { type: "text", text: "Investigate recent latency spikes." },
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: {
+          type: "text",
+          text: "I’m comparing slow traces and model usage now.",
+        },
+      },
+    ],
+  },
+});
+
 export const Empty = meta.story({
   args: {
     messages: [],
@@ -950,11 +1008,11 @@ export const LoadingAfterToolCall = meta.story({
 });
 
 export const FeedbackControlsWaitForTurnEnd = meta.story({
-  name: "(Test) Feedback Controls Wait For Turn End",
+  name: "(Test) Feedback Controls Stay During Queued Handoff",
   args: {
     selectedConversationId: "conversation-1",
-    isInputDisabled: true,
-    isAssistantTurnInProgress: true,
+    isInputDisabled: false,
+    isAssistantTurnInProgress: false,
     onSubmitFeedback: fn(),
     messages: [
       {
@@ -967,11 +1025,18 @@ export const FeedbackControlsWaitForTurnEnd = meta.story({
       },
       {
         id: "assistant-1",
-        runId: "run-1",
         role: "assistant",
         content: {
           type: "text",
           text: "I found a cluster of ingestion errors around malformed JSON payloads",
+        },
+      },
+      {
+        id: "user-2",
+        role: "user",
+        content: {
+          type: "text",
+          text: "Which payloads were affected?",
         },
       },
     ],
@@ -983,14 +1048,12 @@ export const FeedbackControlsWaitForTurnEnd = meta.story({
       "I found a cluster of ingestion errors around malformed JSON payloads",
     );
 
-    await waitFor(() => {
-      expect(
-        canvas.queryByRole("button", { name: "Good response" }),
-      ).not.toBeInTheDocument();
-      expect(
-        canvas.queryByRole("button", { name: "Bad response" }),
-      ).not.toBeInTheDocument();
-    });
+    await expect(
+      canvas.findByRole("button", { name: "Good response" }),
+    ).resolves.toBeDisabled();
+    await expect(
+      canvas.findByRole("button", { name: "Bad response" }),
+    ).resolves.toBeDisabled();
   },
 });
 

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -61,6 +61,7 @@ import {
 } from "@/src/ee/features/in-app-agent/quickActions";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
+import { InAppAgentQueuedMessages } from "./InAppAgentQueuedMessages";
 
 const AUTO_SCROLL_THRESHOLD_PX = 50;
 const SCROLL_DIRECTION_TOLERANCE_PX = 1;
@@ -262,8 +263,11 @@ export type InAppAgentWindowProps = {
   isHeaderDragHandleEnabled?: boolean;
   isExpanded: boolean;
   isInputDisabled: boolean;
+  isNavigationDisabled?: boolean;
   isLoadingMoreConversations: boolean;
   messages: InAppAgentWindowMessage[];
+  draft?: string;
+  queuedMessages?: readonly { id: string; content: string }[];
   onExpandedChange: (isExpanded: boolean) => void;
   onDeleteConversation: (conversation: InAppAgentWindowConversation) => void;
   onLoadMoreConversations: () => void;
@@ -282,6 +286,9 @@ export type InAppAgentWindowProps = {
     value: InAppAgentMessageFeedbackValue | null;
     comment?: string | null;
   }) => Promise<void>;
+  onDraftChange?: (draft: string) => void;
+  onEditQueuedMessage?: (messageId: string, content: string) => void;
+  onDeleteQueuedMessage?: (messageId: string) => void;
   screenContextDescription: InAppAgentScreenContextDescription;
   quickActionContext: InAppAgentQuickActionContext;
   focusedQuickActions?: readonly InAppAgentQuickAction[];
@@ -363,8 +370,11 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     isHeaderDragHandleEnabled = false,
     isExpanded,
     isInputDisabled: baseIsInputDisabled,
+    isNavigationDisabled = baseIsInputDisabled,
     isLoadingMoreConversations,
     messages,
+    draft,
+    queuedMessages = [],
     onDeleteConversation,
     onExpandedChange,
     onLoadMoreConversations,
@@ -375,6 +385,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     onSelectConversation,
     onSubmit,
     onSubmitFeedback,
+    onDraftChange,
+    onEditQueuedMessage,
+    onDeleteQueuedMessage,
     focusedQuickActions,
     quickActionContext,
     quickActionResetKey,
@@ -392,7 +405,19 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const previousScrollTopRef = useRef(0);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const previousIsInputDisabledRef = useRef(isInputDisabled);
-  const [input, setInput] = useState("");
+  const [localInput, setLocalInput] = useState("");
+  const input = draft ?? localInput;
+  const setInput = onDraftChange ?? setLocalInput;
+  const [queuedMessageEdit, setQueuedMessageEdit] = useState<{
+    messageId: string;
+    content: string;
+  } | null>(null);
+  const activeQueuedMessageEdit =
+    queuedMessageEdit !== null &&
+    queuedMessages.some(({ id }) => id === queuedMessageEdit.messageId)
+      ? queuedMessageEdit
+      : null;
+  const composerInput = activeQueuedMessageEdit?.content ?? input;
   const [isConversationHistoryOpen, setIsConversationHistoryOpen] =
     useState(false);
   const hasUserMessage = messages.some((message) => message.role === "user");
@@ -432,14 +457,21 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
       return;
     }
 
+    if (activeQueuedMessageEdit && onEditQueuedMessage) {
+      onEditQueuedMessage(activeQueuedMessageEdit.messageId, trimmedContent);
+      setQueuedMessageEdit(null);
+      inputRef.current?.focus();
+      return;
+    }
+
     Promise.resolve(onSubmit(trimmedContent, options))
       .then((submitted) => {
         if (submitted) {
           isAutoScrollAttachedRef.current = true;
 
-          setInput((currentInput) =>
-            currentInput.trim() === trimmedContent ? "" : currentInput,
-          );
+          if (inputRef.current?.value.trim() === trimmedContent) {
+            setInput("");
+          }
 
           window.requestAnimationFrame(() => {
             scrollViewportToBottom(viewportRef.current);
@@ -492,7 +524,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
 
     input.style.height = "auto";
     input.style.height = `${Math.min(input.scrollHeight, 160)}px`;
-  }, [input]);
+  }, [composerInput]);
 
   return (
     <section
@@ -528,7 +560,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 size="icon"
                 className="size-6 shrink-0"
                 onClick={onNewConversation}
-                disabled={baseIsInputDisabled}
+                disabled={isNavigationDisabled}
                 aria-label="Start new conversation"
               >
                 <Plus className="size-3" />
@@ -554,7 +586,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                     variant="ghost"
                     size="icon"
                     className="size-6 shrink-0"
-                    disabled={baseIsInputDisabled}
+                    disabled={isNavigationDisabled}
                     aria-label="Conversation history"
                   >
                     <History className="size-3" />
@@ -601,7 +633,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                         variant="ghost"
                         size="icon-xs"
                         className="text-muted-foreground hover:text-destructive -mr-1.5 shrink-0"
-                        disabled={baseIsInputDisabled}
+                        disabled={isNavigationDisabled}
                         aria-label="Delete conversation"
                         onClick={(event) => {
                           event.preventDefault();
@@ -749,13 +781,13 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 const isLastMessageOfTurn = visibleMessages
                   .slice(index + 1, nextTurnStartIndex)
                   .every((nextMessage) => nextMessage.role !== "assistant");
-                const feedbackRunId =
+                const shouldShowFeedback =
                   message.role === "assistant" &&
                   message.content.type === "text" &&
-                  !isCurrentTurnInProgress &&
-                  isLastMessageOfTurn
-                    ? message.runId
-                    : undefined;
+                  isLastMessageOfTurn;
+                const feedbackRunId = shouldShowFeedback
+                  ? message.runId
+                  : undefined;
 
                 return (
                   <li
@@ -770,15 +802,21 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                       role={message.role}
                       content={message.content}
                       isCompact={!isExpanded}
-                      isFeedbackDisabled={baseIsInputDisabled}
+                      isFeedbackDisabled={
+                        baseIsInputDisabled ||
+                        isCurrentTurnInProgress ||
+                        !feedbackRunId
+                      }
                       onSubmitFeedback={
-                        feedbackRunId
+                        shouldShowFeedback
                           ? (params) =>
-                              onSubmitFeedback({
-                                messageId: message.id,
-                                runId: feedbackRunId,
-                                ...params,
-                              })
+                              feedbackRunId
+                                ? onSubmitFeedback({
+                                    messageId: message.id,
+                                    runId: feedbackRunId,
+                                    ...params,
+                                  })
+                                : Promise.resolve()
                           : undefined
                       }
                     />
@@ -888,6 +926,39 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
             </div>
           </div>
         ) : null}
+        {queuedMessages.length > 0 &&
+        onEditQueuedMessage &&
+        onDeleteQueuedMessage ? (
+          <div
+            className={cn(
+              "shrink-0 px-1.5 pt-1.5",
+              isExpanded && "mx-auto w-full max-w-3xl",
+            )}
+          >
+            <InAppAgentQueuedMessages
+              messages={queuedMessages}
+              onEdit={(messageId) => {
+                const message = queuedMessages.find(
+                  ({ id }) => id === messageId,
+                );
+                if (!message) {
+                  return;
+                }
+                setQueuedMessageEdit({
+                  messageId,
+                  content: message.content,
+                });
+                window.requestAnimationFrame(() => inputRef.current?.focus());
+              }}
+              onDelete={(messageId) => {
+                if (activeQueuedMessageEdit?.messageId === messageId) {
+                  setQueuedMessageEdit(null);
+                }
+                onDeleteQueuedMessage(messageId);
+              }}
+            />
+          </div>
+        ) : null}
         <div
           className={cn(
             "p-1.5",
@@ -897,9 +968,10 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
         >
           <form
             className={cn(
-              "relative flex w-full items-end gap-2 rounded-md",
-              isExpanded &&
-                "mx-auto max-w-3xl cursor-text flex-col border focus-within:ring focus-within:ring-blue-500 focus-within:ring-offset-0",
+              "relative flex w-full flex-col rounded-md",
+              (isExpanded || activeQueuedMessageEdit) &&
+                "cursor-text border focus-within:ring focus-within:ring-blue-500 focus-within:ring-offset-0",
+              isExpanded && "mx-auto max-w-3xl",
             )}
             onClick={() => {
               if (isExpanded) {
@@ -908,62 +980,109 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
             }}
             onSubmit={(event) => {
               event.preventDefault();
-              submitInput(input);
+              submitInput(composerInput);
             }}
           >
-            <textarea
-              autoFocus={!isExpanded}
-              ref={setInputRef}
-              value={input}
-              onChange={(event) => {
-                setInput(event.target.value);
-              }}
-              onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
-                if (
-                  event.key === "Enter" &&
-                  !event.shiftKey &&
-                  !event.nativeEvent.isComposing
-                ) {
-                  event.preventDefault();
-                  event.currentTarget.form?.requestSubmit();
+            {activeQueuedMessageEdit ? (
+              <div className="border-border flex w-full items-center justify-between border-b px-3 py-2 text-xs font-bold">
+                <span>Editing queued message</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-1.5 text-xs"
+                  onClick={() => {
+                    setQueuedMessageEdit(null);
+                    inputRef.current?.focus();
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            ) : null}
+            <div className="flex w-full items-end gap-2">
+              <textarea
+                autoFocus={!isExpanded}
+                ref={setInputRef}
+                value={composerInput}
+                onChange={(event) => {
+                  if (activeQueuedMessageEdit) {
+                    setQueuedMessageEdit({
+                      ...activeQueuedMessageEdit,
+                      content: event.target.value,
+                    });
+                  } else {
+                    setInput(event.target.value);
+                  }
+                }}
+                onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
+                  if (event.key === "Escape" && activeQueuedMessageEdit) {
+                    event.preventDefault();
+                    setQueuedMessageEdit(null);
+                    return;
+                  }
+                  if (
+                    event.key === "Enter" &&
+                    !event.shiftKey &&
+                    !event.nativeEvent.isComposing
+                  ) {
+                    event.preventDefault();
+                    event.currentTarget.form?.requestSubmit();
+                  }
+                }}
+                disabled={isInputDisabled}
+                aria-label={
+                  activeQueuedMessageEdit
+                    ? "Edit queued message"
+                    : "Message the assistant"
                 }
-              }}
-              disabled={isInputDisabled}
-              aria-label="Message the assistant"
-              placeholder="Let me know what I can do for you..."
-              rows={1}
-              className={cn(
-                "bg-background placeholder:text-foreground-tertiary w-full flex-1 resize-none overflow-y-auto rounded-md text-sm leading-5 disabled:cursor-not-allowed disabled:opacity-60",
-                isExpanded
-                  ? "max-h-40 min-h-14 border-none ring-0"
-                  : "border-input max-h-40 min-h-8 px-3 py-1",
-              )}
-            />
-            {!isExpanded && (
-              <Button
-                type="submit"
-                size="icon"
-                className="h-8 w-8 rounded-md border"
-                aria-label="Send message"
-                variant="outline"
-                disabled={isInputDisabled || !input.trim()}
-              >
-                <SendHorizontal className="h-4 w-4" />
-              </Button>
-            )}
+                placeholder="Let me know what I can do for you..."
+                rows={1}
+                className={cn(
+                  "bg-background placeholder:text-foreground-tertiary w-full flex-1 resize-none overflow-y-auto rounded-md text-sm leading-5 disabled:cursor-not-allowed disabled:opacity-60",
+                  isExpanded || activeQueuedMessageEdit
+                    ? "max-h-40 min-h-14 border-none px-3 py-2 ring-0"
+                    : "border-input max-h-40 min-h-8 px-3 py-1",
+                )}
+              />
+              {!isExpanded ? (
+                <Button
+                  type="submit"
+                  size="icon"
+                  className={cn(
+                    "h-8 w-8 shrink-0 rounded-md border",
+                    activeQueuedMessageEdit && "m-1",
+                  )}
+                  aria-label={
+                    activeQueuedMessageEdit
+                      ? "Save queued message"
+                      : "Send message"
+                  }
+                  variant="outline"
+                  disabled={isInputDisabled || !composerInput.trim()}
+                >
+                  <SendHorizontal className="h-4 w-4" />
+                </Button>
+              ) : null}
+            </div>
 
             {isExpanded && (
               <div className="flex w-full justify-end p-1">
                 <Button
                   type="submit"
                   className="h-8 w-fit rounded-md px-3"
-                  aria-label="Send message"
-                  disabled={isInputDisabled || !input.trim()}
+                  aria-label={
+                    activeQueuedMessageEdit
+                      ? "Save queued message"
+                      : "Send message"
+                  }
+                  disabled={isInputDisabled || !composerInput.trim()}
                   onClick={(e) => {
                     e.stopPropagation();
                   }}
                 >
-                  Send <SendHorizontal className="ml-2 h-4 w-4" />
+                  {activeQueuedMessageEdit ? "Save" : "Send"}{" "}
+                  <SendHorizontal className="ml-2 h-4 w-4" />
                 </Button>
               </div>
             )}

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.clienttest.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.clienttest.tsx
@@ -1,0 +1,354 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type * as AgUiClient from "@ag-ui/client";
+
+import { InAppAiAgentProvider, useInAppAiAgent } from "./InAppAiAgentProvider";
+
+const mocks = vi.hoisted(() => {
+  type Subscriber = {
+    onCustomEvent?: (payload: { event: unknown }) => void;
+    onMessagesChanged?: (payload: { messages: unknown[] }) => void;
+  };
+
+  class MockHttpAgent {
+    readonly threadId: string;
+    messages: unknown[];
+    isRunning = false;
+    readonly abortRun = vi.fn();
+    readonly runAgent = vi.fn();
+    private subscriber: Subscriber | undefined;
+    private pendingRuns: Array<{
+      resolve: () => void;
+      reject: (error: unknown) => void;
+    }> = [];
+
+    constructor(options: { threadId: string; initialMessages?: unknown[] }) {
+      this.threadId = options.threadId;
+      this.messages = [...(options.initialMessages ?? [])];
+      this.runAgent.mockImplementation(() => {
+        this.isRunning = true;
+        return new Promise<void>((resolve, reject) => {
+          this.pendingRuns.push({
+            resolve: () => {
+              this.isRunning = false;
+              resolve();
+            },
+            reject: (error) => {
+              this.isRunning = false;
+              reject(error);
+            },
+          });
+        });
+      });
+      agents.push(this);
+    }
+
+    addMessage(message: unknown) {
+      this.messages.push(message);
+      this.subscriber?.onMessagesChanged?.({ messages: this.messages });
+    }
+
+    subscribe(subscriber: Subscriber) {
+      this.subscriber = subscriber;
+      return { unsubscribe: vi.fn() };
+    }
+
+    finishNextRun() {
+      const run = this.pendingRuns.shift();
+      if (!run) {
+        throw new Error("No run to finish");
+      }
+      run.resolve();
+    }
+
+    failNextRun(error: unknown) {
+      const run = this.pendingRuns.shift();
+      if (!run) {
+        throw new Error("No run to fail");
+      }
+      run.reject(error);
+    }
+
+    requestApproval() {
+      this.subscriber?.onCustomEvent?.({
+        event: {
+          name: "on_interrupt",
+          value: {
+            type: "mastra_suspend",
+            toolCallId: "approval-1",
+            toolName: "createDashboardWidget",
+            runId: "run-1",
+          },
+        },
+      });
+    }
+
+    get userMessages() {
+      return this.messages
+        .filter(
+          (message): message is { role: string; content: string } =>
+            typeof message === "object" &&
+            message !== null &&
+            "role" in message &&
+            message.role === "user" &&
+            "content" in message &&
+            typeof message.content === "string",
+        )
+        .map((message) => message.content);
+    }
+  }
+
+  const agents: MockHttpAgent[] = [];
+  return { agents, capture: vi.fn(), MockHttpAgent };
+});
+
+vi.mock("@ag-ui/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof AgUiClient>();
+  return { ...actual, HttpAgent: mocks.MockHttpAgent };
+});
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    asPath: "/project/project-1/traces",
+    query: { projectId: "project-1" },
+  }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { name: "Ada" } } }),
+}));
+
+vi.mock("@/src/features/entitlements/hooks", () => ({
+  useHasEntitlement: () => true,
+}));
+
+vi.mock("@/src/features/organizations/hooks", () => ({
+  useLangfuseCloudRegion: () => ({ isLangfuseCloud: true }),
+}));
+
+vi.mock("@/src/features/projects/hooks", () => ({
+  useQueryProjectOrOrganization: () => ({
+    organization: { id: "org-1", aiFeaturesEnabled: true },
+  }),
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => mocks.capture,
+}));
+
+vi.mock("./InAppAgentDisabledDialog", () => ({
+  InAppAgentDisabledDialog: () => null,
+}));
+
+vi.mock("@/src/utils/api", () => {
+  const invalidate = vi.fn().mockResolvedValue(undefined);
+  return {
+    api: {
+      useUtils: () => ({
+        inAppAgent: {
+          getConversation: { invalidate },
+          listConversations: { invalidate },
+        },
+      }),
+      inAppAgent: {
+        listConversations: {
+          useInfiniteQuery: () => ({
+            data: { pages: [{ conversations: [] }] },
+            error: null,
+            fetchNextPage: vi.fn(),
+            hasNextPage: false,
+            isFetchingNextPage: false,
+          }),
+        },
+        getConversation: {
+          useQuery: () => ({ data: undefined, error: null, isLoading: false }),
+        },
+        deleteConversation: {
+          useMutation: () => ({ mutateAsync: vi.fn() }),
+        },
+        submitFeedback: {
+          useMutation: () => ({ mutateAsync: vi.fn() }),
+        },
+      },
+    },
+  };
+});
+
+function Harness() {
+  const agent = useInAppAiAgent();
+
+  return (
+    <>
+      {["first", "second", "third", "fourth"].map((content) => (
+        <button key={content} onClick={() => agent.submit(content)}>
+          Submit {content}
+        </button>
+      ))}
+      <button
+        onClick={() => {
+          agent.setTranscriptAnimating(true);
+        }}
+      >
+        Start animation
+      </button>
+      <button
+        onClick={() => {
+          agent.setTranscriptAnimating(false);
+        }}
+      >
+        Finish animation
+      </button>
+      <button onClick={() => agent.approveToolCall("approval-1")}>
+        Approve
+      </button>
+      {agent.queuedMessages.map((message) => (
+        <div key={message.id}>
+          <span>{message.content}</span>
+          <button
+            aria-label={`Edit ${message.content}`}
+            onClick={() => {
+              agent.editQueuedMessage(message.id, "edited");
+            }}
+          >
+            Edit
+          </button>
+          <button
+            aria-label={`Delete ${message.content}`}
+            onClick={() => {
+              agent.deleteQueuedMessage(message.id);
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <InAppAiAgentProvider defaultOpen>
+      <Harness />
+    </InAppAiAgentProvider>,
+  );
+}
+
+describe("InAppAiAgentProvider follow-up queue", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    mocks.agents.length = 0;
+    mocks.capture.mockClear();
+  });
+
+  it("waits for transcript settlement and approval continuation before dispatching FIFO", async () => {
+    renderProvider();
+
+    fireEvent.click(screen.getByText("Submit first"));
+    await waitFor(() => {
+      expect(mocks.agents).toHaveLength(1);
+    });
+    const agent = mocks.agents[0];
+    if (!agent) {
+      throw new Error("Expected an agent");
+    }
+
+    fireEvent.click(screen.getByText("Start animation"));
+    fireEvent.click(screen.getByText("Submit second"));
+    fireEvent.click(screen.getByText("Submit third"));
+    act(() => {
+      agent.requestApproval();
+    });
+    await act(async () => {
+      agent.finishNextRun();
+    });
+
+    fireEvent.click(screen.getByText("Finish animation"));
+    expect(agent.runAgent).toHaveBeenCalledOnce();
+    expect(agent.userMessages).toEqual(["first"]);
+
+    fireEvent.click(screen.getByText("Approve"));
+    await waitFor(() => {
+      expect(agent.runAgent).toHaveBeenCalledTimes(2);
+    });
+    fireEvent.click(screen.getByText("Start animation"));
+    await act(async () => {
+      agent.finishNextRun();
+    });
+    fireEvent.click(screen.getByText("Finish animation"));
+
+    await waitFor(() => {
+      expect(agent.userMessages).toEqual(["first", "second"]);
+    });
+    expect(agent.runAgent).toHaveBeenCalledTimes(3);
+
+    fireEvent.click(screen.getByText("Start animation"));
+    await act(async () => {
+      agent.finishNextRun();
+    });
+    fireEvent.click(screen.getByText("Finish animation"));
+
+    await waitFor(() => {
+      expect(agent.userMessages).toEqual(["first", "second", "third"]);
+    });
+    expect(mocks.capture).toHaveBeenCalledWith("in_app_agent:message_queued", {
+      queueDepth: 1,
+    });
+  });
+
+  it("edits and deletes pending messages and retries a rate-limited dispatch without duplication", async () => {
+    renderProvider();
+
+    fireEvent.click(screen.getByText("Submit first"));
+    await waitFor(() => {
+      expect(mocks.agents).toHaveLength(1);
+    });
+    const agent = mocks.agents[0];
+    if (!agent) {
+      throw new Error("Expected an agent");
+    }
+
+    fireEvent.click(screen.getByText("Submit second"));
+    fireEvent.click(screen.getByText("Submit third"));
+    fireEvent.click(screen.getByText("Submit fourth"));
+    fireEvent.click(screen.getByRole("button", { name: "Edit third" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete second" }));
+
+    await act(async () => {
+      agent.finishNextRun();
+    });
+    await waitFor(() => {
+      expect(agent.userMessages).toEqual(["first", "edited"]);
+    });
+
+    await act(async () => {
+      agent.failNextRun({
+        payload: {
+          code: "rate_limited",
+          details: { retryAfterSeconds: 1 },
+        },
+      });
+    });
+    await waitFor(
+      () => {
+        expect(agent.runAgent).toHaveBeenCalledTimes(3);
+      },
+      {
+        timeout: 2_000,
+      },
+    );
+    expect(agent.userMessages).toEqual(["first", "edited"]);
+
+    await act(async () => {
+      agent.finishNextRun();
+    });
+    await waitFor(() => {
+      expect(agent.userMessages).toEqual(["first", "edited", "fourth"]);
+    });
+  });
+});

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -26,6 +26,7 @@ import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/
 import {
   AgUiMessageSchema,
   type AgUiMessage,
+  type AgUiRunAgentInput,
   type InAppAgentMessageFeedback,
   type InAppAgentMessageFeedbackValue,
   type InAppAgentRuntimeState,
@@ -97,6 +98,8 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
   isRunning: false,
   isSubmitting: false,
   pendingToolApprovals: [],
+  queuedMessages: [],
+  draft: "",
   isSelectedConversationHydrating: false,
   error: null,
   messages: [],
@@ -111,6 +114,10 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
   selectConversation: () => undefined,
   deleteConversation: async () => undefined,
   submit: async () => false,
+  setDraft: () => undefined,
+  editQueuedMessage: () => undefined,
+  deleteQueuedMessage: () => undefined,
+  setTranscriptAnimating: () => undefined,
   approveToolCall: async () => undefined,
   rejectToolCall: async () => undefined,
   submitFeedback: async () => undefined,
@@ -125,6 +132,13 @@ export type InAppAgentPendingToolApproval = {
   id: string;
   approvalRequest: InAppAgentToolApprovalRequest;
   status: "pending" | "submitting";
+};
+
+export type InAppAgentQueuedMessage = {
+  id: string;
+  content: string;
+  context: AgUiRunAgentInput["context"];
+  options?: InAppAgentSubmitOptions;
 };
 
 export type InAppAiAgentConversation = {
@@ -147,6 +161,8 @@ type InAppAiAgentContextType = {
   isRunning: boolean;
   isSubmitting: boolean;
   pendingToolApprovals: InAppAgentPendingToolApproval[];
+  queuedMessages: InAppAgentQueuedMessage[];
+  draft: string;
   isSelectedConversationHydrating: boolean;
   error: InAppAgentError | null;
   messages: InAppAiAgentMessage[];
@@ -164,6 +180,10 @@ type InAppAiAgentContextType = {
     content: string,
     options?: InAppAgentSubmitOptions,
   ) => Promise<boolean>;
+  setDraft: (draft: string) => void;
+  editQueuedMessage: (messageId: string, content: string) => void;
+  deleteQueuedMessage: (messageId: string) => void;
+  setTranscriptAnimating: (isAnimating: boolean) => void;
   approveToolCall: (approvalId: string) => Promise<void>;
   rejectToolCall: (approvalId: string) => Promise<void>;
   submitFeedback: (params: {
@@ -264,6 +284,11 @@ function InAppAiAgentProviderInner({
     InAppAgentPendingToolApproval[]
   >([]);
   const pendingToolApprovalsRef = useRef<InAppAgentPendingToolApproval[]>([]);
+  const [queuedMessages, setQueuedMessages] = useState<
+    InAppAgentQueuedMessage[]
+  >([]);
+  const queuedMessagesRef = useRef<InAppAgentQueuedMessage[]>([]);
+  const [draft, setDraft] = useState("");
   const [isRunning, setIsRunning] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -276,6 +301,10 @@ function InAppAiAgentProviderInner({
   const intentionalAbortRef = useRef(false);
   const submitInFlightRef = useRef(false);
   const runInFlightRef = useRef(false);
+  const transcriptAnimatingRef = useRef(false);
+  const queuedRateLimitRetryRef = useRef(false);
+  const queuedRateLimitTimeoutRef = useRef<number | null>(null);
+  const pumpQueueRef = useRef<() => void>(() => undefined);
   const subscriptionRef = useRef<ReturnType<HttpAgent["subscribe"]> | null>(
     null,
   );
@@ -427,6 +456,45 @@ function InAppAiAgentProviderInner({
     },
     [],
   );
+  const updateQueuedMessages = useCallback(
+    (
+      updater: (
+        currentMessages: InAppAgentQueuedMessage[],
+      ) => InAppAgentQueuedMessage[],
+    ) => {
+      const nextMessages = updater(queuedMessagesRef.current);
+      queuedMessagesRef.current = nextMessages;
+      setQueuedMessages(nextMessages);
+    },
+    [],
+  );
+  const buildRunContext = useCallback(
+    (
+      quickActionAttribution?: InAppAgentQuickActionAttribution,
+      messageEntryPoint?: InAppAgentMessageEntryPoint,
+    ) =>
+      createInAppAgentScreenContext({
+        currentUrl: window.location.href,
+      }).concat(
+        createInAppAgentUserContext({
+          userName: session.data?.user?.name,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          languages:
+            navigator.languages.length > 0
+              ? Array.from(navigator.languages)
+              : [navigator.language],
+        }),
+        quickActionAttribution
+          ? createInAppAgentQuickActionAttributionContext(
+              quickActionAttribution,
+            )
+          : [],
+        messageEntryPoint
+          ? createInAppAgentMessageEntryPointContext(messageEntryPoint)
+          : [],
+      ),
+    [session.data?.user?.name],
+  );
   const updateLoadingEvent = useCallback(
     (eventId: string, isLoading: boolean) => {
       setLoadingEventIds((currentIds) => {
@@ -467,6 +535,11 @@ function InAppAiAgentProviderInner({
     activeRunIdRef.current = null;
     pendingToolApprovalsRef.current = [];
     setPendingToolApprovals([]);
+    if (queuedRateLimitTimeoutRef.current !== null) {
+      window.clearTimeout(queuedRateLimitTimeoutRef.current);
+      queuedRateLimitTimeoutRef.current = null;
+      queuedRateLimitRetryRef.current = false;
+    }
     clearLoadingEvents();
   }, [clearLoadingEvents]);
 
@@ -668,6 +741,8 @@ function InAppAiAgentProviderInner({
       runParameters?: Parameters<HttpAgent["runAgent"]>[0],
       quickActionAttribution?: InAppAgentQuickActionAttribution,
       messageEntryPoint?: InAppAgentMessageEntryPoint,
+      capturedContext?: AgUiRunAgentInput["context"],
+      retryOnRateLimit = false,
     ) => {
       if (runInFlightRef.current) {
         return Promise.resolve(false);
@@ -680,26 +755,9 @@ function InAppAiAgentProviderInner({
         try {
           await agent.runAgent({
             ...runParameters,
-            context: createInAppAgentScreenContext({
-              currentUrl: window.location.href,
-            }).concat(
-              createInAppAgentUserContext({
-                userName: session.data?.user?.name,
-                timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                languages:
-                  navigator.languages.length > 0
-                    ? Array.from(navigator.languages)
-                    : [navigator.language],
-              }),
-              quickActionAttribution
-                ? createInAppAgentQuickActionAttributionContext(
-                    quickActionAttribution,
-                  )
-                : [],
-              messageEntryPoint
-                ? createInAppAgentMessageEntryPointContext(messageEntryPoint)
-                : [],
-            ),
+            context:
+              capturedContext ??
+              buildRunContext(quickActionAttribution, messageEntryPoint),
           });
           return true;
         } catch (error) {
@@ -711,8 +769,30 @@ function InAppAiAgentProviderInner({
             throw error;
           }
 
-          setError(getInAppAgentError(error));
+          const agentError = getInAppAgentError(error);
+          setError(agentError);
           console.error("In-app agent drawer error", error);
+
+          if (agentError.type === "rate_limit" && retryOnRateLimit) {
+            queuedRateLimitRetryRef.current = true;
+            queuedRateLimitTimeoutRef.current = window.setTimeout(
+              () => {
+                queuedRateLimitTimeoutRef.current = null;
+                queuedRateLimitRetryRef.current = false;
+                setError(null);
+                runAgent(
+                  agent,
+                  conversationId,
+                  runParameters,
+                  quickActionAttribution,
+                  messageEntryPoint,
+                  capturedContext,
+                  true,
+                ).catch(() => undefined);
+              },
+              Math.max(0, agentError.retryAt - Date.now()),
+            );
+          }
           return false;
         } finally {
           const runId = activeRunIdRef.current;
@@ -733,23 +813,117 @@ function InAppAiAgentProviderInner({
           activeRunIdRef.current = null;
           intentionalAbortRef.current = false;
           runInFlightRef.current = false;
+          pumpQueueRef.current();
         }
       })();
     },
     [
+      buildRunContext,
       projectId,
       clearLoadingEvents,
       publishLiveMessages,
       releaseSubmitLock,
-      session.data?.user?.name,
       utils.inAppAgent.getConversation,
       utils.inAppAgent.listConversations,
     ],
   );
 
+  const dispatchNextQueuedMessage = useCallback(() => {
+    const queuedMessage = queuedMessagesRef.current[0];
+    const conversationId = selectedConversationId;
+    const agent = agentRef.current;
+    if (
+      !queuedMessage ||
+      !conversationId ||
+      !agent ||
+      agent.threadId !== conversationId
+    ) {
+      return;
+    }
+
+    updateQueuedMessages((currentMessages) => currentMessages.slice(1));
+    submitInFlightRef.current = true;
+    setIsSubmitting(true);
+    setError(null);
+
+    agent.addMessage({
+      id: queuedMessage.id,
+      role: "user",
+      content: queuedMessage.content,
+    } satisfies AgUiMessage);
+    setMessages(agent.messages.filter(isAgentConversationMessage));
+    const entryPoint = queuedMessage.options?.entryPoint ?? "chat";
+    capture("in_app_agent:new_chat_turn", { entryPoint });
+    runAgent(
+      agent,
+      conversationId,
+      undefined,
+      queuedMessage.options?.quickAction,
+      entryPoint,
+      queuedMessage.context,
+      true,
+    ).catch(() => undefined);
+  }, [capture, runAgent, selectedConversationId, updateQueuedMessages]);
+
+  const pumpQueue = useCallback(() => {
+    if (
+      transcriptAnimatingRef.current ||
+      queuedRateLimitRetryRef.current ||
+      runInFlightRef.current ||
+      submitInFlightRef.current ||
+      pendingToolApprovalsRef.current.length > 0 ||
+      agentRef.current?.isRunning ||
+      isInAppAgentRateLimited(error)
+    ) {
+      return;
+    }
+
+    dispatchNextQueuedMessage();
+  }, [dispatchNextQueuedMessage, error]);
+  pumpQueueRef.current = pumpQueue;
+
+  const setTranscriptAnimating = useCallback((isAnimating: boolean) => {
+    transcriptAnimatingRef.current = isAnimating;
+    if (!isAnimating) {
+      pumpQueueRef.current();
+    }
+  }, []);
+
+  const editQueuedMessage = useCallback(
+    (messageId: string, content: string) => {
+      const trimmedContent = content.trim();
+      if (!trimmedContent) {
+        return;
+      }
+      updateQueuedMessages((currentMessages) =>
+        currentMessages.map((message) =>
+          message.id === messageId
+            ? { ...message, content: trimmedContent }
+            : message,
+        ),
+      );
+    },
+    [updateQueuedMessages],
+  );
+
+  const deleteQueuedMessage = useCallback(
+    (messageId: string) => {
+      updateQueuedMessages((currentMessages) =>
+        currentMessages.filter((message) => message.id !== messageId),
+      );
+    },
+    [updateQueuedMessages],
+  );
+
   const selectConversation = useCallback(
     (conversationId: string | null) => {
-      if (isRunning || conversationId === _selectedConversationId) {
+      if (
+        isRunning ||
+        isSubmitting ||
+        pendingToolApprovalsRef.current.length > 0 ||
+        queuedMessagesRef.current.length > 0 ||
+        conversationId === _selectedConversationId
+      ) {
         return;
       }
 
@@ -758,14 +932,26 @@ function InAppAiAgentProviderInner({
       );
       resetAgent();
       setMessages([]);
+      setDraft("");
       setSelectedConversationId(conversationId);
     },
-    [_selectedConversationId, isRunning, resetAgent, setSelectedConversationId],
+    [
+      _selectedConversationId,
+      isRunning,
+      isSubmitting,
+      resetAgent,
+      setSelectedConversationId,
+    ],
   );
 
   const deleteConversation = useCallback(
     async (conversationId: string) => {
-      if (isRunning) {
+      if (
+        isRunning ||
+        isSubmitting ||
+        pendingToolApprovalsRef.current.length > 0 ||
+        queuedMessagesRef.current.length > 0
+      ) {
         return;
       }
 
@@ -808,6 +994,7 @@ function InAppAiAgentProviderInner({
     [
       deleteConversationMutation,
       isRunning,
+      isSubmitting,
       projectId,
       resetAgent,
       selectedConversationId,
@@ -820,16 +1007,48 @@ function InAppAiAgentProviderInner({
 
   const submit = useCallback(
     async (content: string, options?: InAppAgentSubmitOptions) => {
+      const trimmedContent = content.trim();
       if (
-        !content ||
-        isRunning ||
+        !trimmedContent ||
         isInAppAgentRateLimited(error) ||
-        (options?.newConversation !== true &&
-          isSelectedConversationHydrating) ||
-        submitInFlightRef.current ||
-        runInFlightRef.current
+        (options?.newConversation !== true && isSelectedConversationHydrating)
       ) {
         return false;
+      }
+
+      const isBusy =
+        isRunning ||
+        isSubmitting ||
+        submitInFlightRef.current ||
+        runInFlightRef.current ||
+        agentRef.current?.isRunning === true ||
+        pendingToolApprovalsRef.current.length > 0 ||
+        transcriptAnimatingRef.current;
+      if (isBusy) {
+        if (
+          options?.newConversation === true ||
+          !selectedConversationId ||
+          selectedConversationIsWriteLocked
+        ) {
+          return false;
+        }
+
+        const queuedMessage: InAppAgentQueuedMessage = {
+          id: createInAppAgentMessageId(),
+          content: trimmedContent,
+          context: buildRunContext(
+            options?.quickAction,
+            options?.entryPoint ?? "chat",
+          ),
+          options,
+        };
+        const queueDepth = queuedMessagesRef.current.length + 1;
+        updateQueuedMessages((currentMessages) =>
+          currentMessages.concat(queuedMessage),
+        );
+        setDraft("");
+        capture("in_app_agent:message_queued", { queueDepth });
+        return true;
       }
 
       submitInFlightRef.current = true;
@@ -885,7 +1104,7 @@ function InAppAiAgentProviderInner({
         const userMessage = {
           id: createInAppAgentMessageId(),
           role: "user",
-          content,
+          content: trimmedContent,
         } satisfies AgUiMessage;
 
         agent.addMessage(userMessage);
@@ -895,6 +1114,7 @@ function InAppAiAgentProviderInner({
           capture("in_app_agent:new_chat_started", { entryPoint });
         }
         capture("in_app_agent:new_chat_turn", { entryPoint });
+        setDraft("");
         startedRun = true;
         runAgent(
           agent,
@@ -915,6 +1135,7 @@ function InAppAiAgentProviderInner({
       }
     },
     [
+      buildRunContext,
       conversationQuery.data,
       capture,
       ensureSubscription,
@@ -922,12 +1143,14 @@ function InAppAiAgentProviderInner({
       getOrCreateAgent,
       isSelectedConversationHydrating,
       isRunning,
+      isSubmitting,
       messages,
       releaseSubmitLock,
       runAgent,
       selectedConversationId,
       selectedConversationIsWriteLocked,
       setSelectedConversationId,
+      updateQueuedMessages,
     ],
   );
 
@@ -1088,6 +1311,7 @@ function InAppAiAgentProviderInner({
             (currentApproval) => currentApproval.id !== approvalId,
           ),
         );
+        pumpQueueRef.current();
       } catch (error) {
         const errorMessage = getAgentErrorMessage(error);
         if (errorMessage === "Invalid forwarded props") {
@@ -1101,6 +1325,7 @@ function InAppAiAgentProviderInner({
             message: "This tool approval is no longer valid. Please try again.",
           });
           console.error("Failed to resume in-app agent tool call", error);
+          pumpQueueRef.current();
           return;
         }
 
@@ -1150,6 +1375,8 @@ function InAppAiAgentProviderInner({
       pendingToolApprovals: isSelectedConversationNotFound
         ? []
         : pendingToolApprovals,
+      queuedMessages,
+      draft,
       isSelectedConversationHydrating,
       error,
       messages: messagesWithUiState,
@@ -1164,6 +1391,10 @@ function InAppAiAgentProviderInner({
       selectConversation,
       deleteConversation,
       submit,
+      setDraft,
+      editQueuedMessage,
+      deleteQueuedMessage,
+      setTranscriptAnimating,
       approveToolCall,
       rejectToolCall,
       submitFeedback,
@@ -1181,14 +1412,19 @@ function InAppAiAgentProviderInner({
       isSubmitting,
       isSelectedConversationNotFound,
       deleteConversation,
+      deleteQueuedMessage,
+      draft,
+      editQueuedMessage,
       loadMoreConversations,
       liveMessageVersion,
       messagesWithUiState,
       open,
       openAssistant,
       pendingToolApprovals,
+      queuedMessages,
       rejectToolCall,
       setAgentOpen,
+      setTranscriptAnimating,
       invalidateConversations,
       selectConversation,
       selectedConversationId,

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -285,6 +285,7 @@ export const events = {
   ], // also used on landing page for consistency
   in_app_agent: [
     "entry_point_click",
+    "message_queued",
     "new_chat_started",
     "new_chat_turn",
     "quick_action_started",


### PR DESCRIPTION
## What does this PR do?

Adds a client-side FIFO follow-up queue for the in-app assistant while the selected conversation is busy.

- keeps the composer enabled during runs, approvals, submission, and transcript animation
- queues follow-ups with captured screen and attribution context
- drains only after both the backend run and transcript animation settle
- supports editing through the normal composer and immediate deletion
- preserves the existing singleton agent and current busy-state navigation behavior
- reserves the final assistant feedback row during queued handoff to avoid layout shift
- tracks queue adoption with metadata-only in_app_agent:message_queued events

Linear: https://linear.app/clickhouse/issue/LFE-14358/assistant-we-shouldnt-block-input-while-the-agent-is-in-progress

Impacted package: web

No backend, persistence, concurrent-conversation, cancellation, reordering, Steer, or Submit-now behavior is included.

Sentry decision: expected rate limits and transport failures remain user-facing states; this PR adds no new client-side error capture.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- pnpm run lint — Tasks: 7 successful, 7 total
- targeted client tests — Tests 5 passed (5)
- targeted Storybook tests — Tests 16 passed (16)
- compact and expanded Storybook browser review, including edit/save/cancel and feedback handoff
- pnpm run typecheck currently stops in unchanged main code because @langfuse/shared barrel exports are missing for existing web imports; none of the changed assistant files appear in its errors

Storybook: http://langfuse-wt4.localhost:6010/?path=/story/playground-inappagentwindow--running-with-queued-follow-ups
