### PR TITLE
fix(agent): Instrument user info on in-app agent requests

### DIFF
--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -39,6 +39,10 @@ const agentMocks = vi.hoisted(() => ({
   createAgUiStream: vi.fn(),
 }));
 
+const instrumentationMocks = vi.hoisted(() => ({
+  addUserToSpan: vi.fn(),
+}));
+
 const SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE =
   "Sandbox-enabled conversations become read-only after 8 hours. Start a new conversation to continue.";
 
@@ -78,6 +82,11 @@ vi.mock("@/src/ee/features/in-app-agent/server/agent", () => ({
 
 vi.mock("@/src/features/natural-language-filters/server/utils", () => ({
   getLangfuseClient: langfuseClientMocks.getLangfuseClient,
+}));
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  addUserToSpan: instrumentationMocks.addUserToSpan,
 }));
 
 describe("in-app agent public API route auth", () => {
@@ -182,6 +191,21 @@ describe("in-app agent public API route auth", () => {
         },
       }),
     ).toEqual(tools);
+  });
+
+  it("adds the authenticated user to the request span", async () => {
+    authMocks.getServerSession.mockResolvedValue(
+      createInAppAgentSession({ orgId: "org-1", projectId: "project-1" }),
+    );
+
+    const { default: handler } =
+      await import("@/src/ee/features/in-app-agent/server/handler");
+    await handler(new Request("http://localhost/api/in-app-agent"));
+
+    expect(instrumentationMocks.addUserToSpan).toHaveBeenCalledWith({
+      userId: "user-1",
+      email: "test@example.com",
+    });
   });
 
   it("passes validated resume forwarded props without requiring a user message", async () => {
@@ -791,6 +815,10 @@ describe("in-app agent public API route auth", () => {
         orgId: org.id,
         projectId: project.id,
       });
+      const sessionUser = session.user;
+      if (!sessionUser) {
+        throw new Error("Expected an authenticated session user");
+      }
       authMocks.getServerSession.mockResolvedValue(session);
       rateLimitMocks.rateLimitRequest.mockResolvedValue({
         isRateLimited: () => true,
@@ -850,6 +878,13 @@ describe("in-app agent public API route auth", () => {
         }),
         "in-app-agent-run",
       );
+      expect(instrumentationMocks.addUserToSpan).toHaveBeenLastCalledWith({
+        userId: sessionUser.id,
+        email: sessionUser.email,
+        projectId: project.id,
+        orgId: org.id,
+        plan: "cloud:team",
+      });
     } finally {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
       (env as any).LANGFUSE_AWS_BEDROCK_MODEL = originalBedrockModel;

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -79,6 +79,7 @@ import {
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
+  addUserToSpan,
   logger,
   redis,
   TableViewService,
@@ -105,6 +106,11 @@ export default async function handler(request: Request) {
 
     const user = session.user;
     const userId = user.id;
+
+    addUserToSpan({
+      userId,
+      email: user.email ?? undefined,
+    });
 
     if (!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
       throw new BaseError(
@@ -243,13 +249,21 @@ export default async function handler(request: Request) {
       false,
     );
 
-    // TODO: Add an additional user-level cap once the rate-limit service supports non-org keys.
-    const rateLimitScope = getInAppAgentRateLimitScope(
+    const rateLimitScope = getInAppAgentApiAccessScope(
       user,
       projectId,
       project.organization,
     );
 
+    addUserToSpan({
+      userId,
+      email: user.email ?? undefined,
+      projectId: rateLimitScope.projectId ?? undefined,
+      orgId: rateLimitScope.orgId,
+      plan: rateLimitScope.plan,
+    });
+
+    // TODO: Add an additional user-level cap once the rate-limit service supports non-org keys.
     const rateLimitResponse = await rateLimitInAppAgentRequest(
       rateLimitScope,
       "in-app-agent-run",
@@ -661,7 +675,7 @@ function getInAppAgentUserAccess(
   };
 }
 
-function getInAppAgentRateLimitScope(
+function getInAppAgentApiAccessScope(
   user: SessionUser,
   projectId: string,
   projectOrganization: {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds user and access-scope details to in-app agent request spans. The main changes are:

- Records the authenticated user on the request span.
- Enriches the span with project, organization, plan, and access-key fields.
- Adds server tests for both instrumentation stages.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after clarifying the synthetic API-key attribution.

- Request-local user and project metadata is added after the relevant authentication and access checks.
- The synthetic API-key values can make per-key telemetry misleading, but do not change request authorization or rate limiting.

web/src/ee/features/in-app-agent/server/handler.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/ee/features/in-app-agent/server/handler.ts:261-262
**Synthetic Key Collapses Attribution**

Every in-app agent request records `in-app-agent-session` as both its API key ID and public key. Any tracing, usage, or billing analysis that groups these standard attributes by credential will combine requests from all users, projects, and organizations under one apparent key, producing incorrect per-key attribution.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Instrument user info on in-a..."](https://github.com/langfuse/langfuse/commit/333764a48ac1033384c70b1fecba196e8b14a07f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46350026)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->