### PR TITLE
ci(observability): register Sentry release + deploy marker on prod deploy (LFE-14421)

### DIFF
--- a/.github/workflows/_deploy_ecs_service.yml
+++ b/.github/workflows/_deploy_ecs_service.yml
@@ -100,3 +100,30 @@ jobs:
           service: ${{ inputs.environment }}-${{ inputs.service }}
           cluster: ${{ inputs.environment }}-cluster
           wait-for-service-stability: true
+      # Register a Sentry release for this build and record the deploy, so Sentry
+      # can attribute regressions to a release ("first seen in <release>"), show
+      # deploy markers, resolve-in-release, and reopen issues that recur later.
+      # This job runs once per environment, so the release lands in that region's
+      # Sentry org + project via the environment-scoped vars/secret below. The web
+      # client already tags events with this exact identifier
+      # (Sentry.init({ release: process.env.NEXT_PUBLIC_BUILD_ID }), baked to
+      # github.sha in the Docker build above), so the release now gains metadata.
+      # We deliberately do NOT upload source maps here: they are served publicly
+      # in production (PR #15277), so `sourcemaps` is omitted. Best-effort — never
+      # block a deploy on a Sentry hiccup or a missing/mis-scoped token (e.g. the
+      # separate EU org needs its own token).
+      - name: Register Sentry release
+        if: ${{ inputs.service == 'web' && vars.SENTRY_ORG != '' }}
+        continue-on-error: true
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+        with:
+          release: ${{ github.sha }}
+          environment: ${{ inputs.environment }}
+          # Suspect commits need the Sentry↔GitHub integration; keep deploys
+          # reliable and enable "auto" once that is confirmed.
+          set_commits: skip
+          finalize: true

--- a/.github/workflows/_deploy_ecs_service.yml
+++ b/.github/workflows/_deploy_ecs_service.yml
@@ -122,7 +122,15 @@ jobs:
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
           release: ${{ github.sha }}
-          environment: ${{ inputs.environment }}
+          # Match the environment tag on REAL browser events — the web client
+          # inits Sentry with `environment: NEXT_PUBLIC_SENTRY_ENVIRONMENT`
+          # (baked from this same var in the Docker build above), which may be a
+          # coarse value like "production" rather than the raw deploy-environment
+          # name (prod-eu/…). Using `inputs.environment` here would land the
+          # deploy marker under an environment with no matching events. Empty
+          # (unset) → action-release omits the deploy marker; the release is
+          # still created and finalized.
+          environment: ${{ vars.NEXT_PUBLIC_SENTRY_ENVIRONMENT }}
           # Suspect commits need the Sentry↔GitHub integration; keep deploys
           # reliable and enable "auto" once that is confirmed.
           set_commits: skip


### PR DESCRIPTION
## TL;DR
Register a **Sentry release + deploy marker** on every prod deploy, so we can finally ask Sentry *"what did this deploy introduce?"* — per region, in the right Sentry org/project automatically. No app-code change, best-effort (never blocks a deploy).

## Why
Sentry events already carry a `release` tag — `Sentry.init({ release: process.env.NEXT_PUBLIC_BUILD_ID })`, and the prod Docker build bakes `NEXT_PUBLIC_BUILD_ID = github.sha`. But **nothing creates the release _object_** in Sentry, so the Releases dashboard is empty and we get none of the payoff: the **Regressions** view ("first seen in `<release>`"), **deploy markers** on the timeline, **resolve-in-release**, and **auto-reopen** when a fixed issue recurs in a later release. Today, separating pre- vs post-deploy issues means eyeballing `firstSeen` timestamps — which is exactly the wall I hit triaging the v3.224.0 deploy.

This is a Sentry-noise-workstream lever (LFE-10974): sharper triage and regression detection = signal, not noise.

## What
A best-effort **`Register Sentry release`** step in the reusable prod-deploy workflow (`_deploy_ecs_service.yml`), using `getsentry/action-release` (SHA-pinned to v3.7.0). Release identifier = `github.sha` (matches `NEXT_PUBLIC_BUILD_ID` and the event `release` tag).

The deploy workflow already fans out **per environment** (`prod-eu`, `prod-us`, `prod-hipaa`, `prod-jp`) with per-environment `vars.SENTRY_ORG` / `vars.SENTRY_PROJECT` / `secrets.SENTRY_AUTH_TOKEN`, so the release lands in the **correct Sentry org + project per region automatically** — the US org's `langfuse` / `langfuse-us` projects, and the separate EU org — with zero hardcoding.

## Result
Once merged and deployed, each region's Sentry gets a finalized release + a production deploy marker per build, unlocking the Regressions/deploy views. No source maps are uploaded (they're served publicly, #15277). No application code changes.

## ⚠️ One config prerequisite
Each environment's `SENTRY_AUTH_TOKEN` must have access to **that environment's** Sentry org. **The EU org is separate**, so its environment needs an EU-org-scoped token if the current one is single-org. The step is `continue-on-error`, so a missing/mis-scoped token just **skips that region's release** rather than failing the deploy — safe to merge before the token is provisioned.

<details>
<summary>Mechanism, safety, and choices</summary>

- **Placement**: last step of the `ecs-deploy` job, after `wait-for-service-stability`, so the deploy marker reflects a stabilized rollout.
- **Gating**: `if: inputs.service == 'web' && vars.SENTRY_ORG != ''` — only the web client calls `Sentry.init` today, and the guard no-ops for any environment without Sentry configured.
- **Best-effort**: `continue-on-error: true` — a Sentry outage, rate limit, or token scope mismatch can never fail a prod deploy (the step runs *after* the deploy anyway).
- **No source maps**: `sourcemaps` is intentionally omitted — production serves them publicly (#15277), which was the deliberate "open-source, no upload magic" decision.
- **Suspect commits**: `set_commits: skip` for now (avoids failures when the previous release commit isn't resolvable); flip to `auto` once the Sentry↔GitHub integration is confirmed, to get blamed commits.
- **Pinning**: `getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528` (v3.7.0), matching the repo's SHA-pin convention.
- **Verification**: workflow YAML parses cleanly; the reusable workflow already declares and receives `SENTRY_AUTH_TOKEN` and exposes `vars.SENTRY_ORG` / `vars.SENTRY_PROJECT`, which this step reuses verbatim.

Follow-ups: enable `set_commits: auto`; worker/backend Sentry releases if server-side capture is added later.
</details>

Linear: LFE-14421 (sub-task of LFE-10974). Related: #15277 (serve source maps publicly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Sentry release metadata to the production web deployment workflow. The main changes are:

- Registers and finalizes a Sentry release after ECS reaches stability.
- Uses the deployed image SHA as the Sentry release identifier.
- Records regional deploy markers with environment-scoped Sentry settings.
- Keeps release registration best-effort and skips commit association.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The release identifier matches the SHA baked into the deployed web image.
- Registration runs only after ECS reports a stable deployment.
- Missing or invalid Sentry configuration remains an explicitly documented, non-blocking failure mode.
- No blocking issues were found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(observability): register Sentry relea..."](https://github.com/langfuse/langfuse/commit/5881813e85a58f3e0a57939b1daff01e1f70ac60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46365874)</sub>

<!-- /greptile_comment -->