### PR TITLE
fix(search-bar): placeholder no longer runs under Ask AI on narrow widths

### DIFF
--- a/web/src/features/search-bar/components/SearchComposer.tsx
+++ b/web/src/features/search-bar/components/SearchComposer.tsx
@@ -1294,8 +1294,17 @@ export function SearchComposer({
         {draft.length === 0 && (
           <div
             className={cn(
+              // Bound the right edge (not just pr-*) so `truncate` has a width
+              // to clip against — otherwise the placeholder grows to its full
+              // text width and runs under the top-right "Ask AI" button. The
+              // reserved gap matches the surface's pr-20/pr-8.
               "text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 truncate font-mono text-xs",
-              onActivateAi !== undefined ? "pr-20" : "pr-8",
+              // Mirror the surface's right reservation exactly: the "Ask AI"
+              // button (right-20) is hidden while diagnostics show, when the
+              // error icon takes over the top-right corner (right-8).
+              onActivateAi !== undefined && !showGlobalDiagnostics
+                ? "right-20"
+                : "right-8",
             )}
             title={COMPOSER_PLACEHOLDER}
           >


### PR DESCRIPTION
## TL;DR
On narrow / mobile widths the v4 search bar's empty-state placeholder text slid **behind the "Ask AI" button** instead of truncating. One-line cause, one-line fix.

## Why
The placeholder is an absolutely-positioned `left-3 truncate` element. It only had a *left* anchor plus a padding-based right gutter (`pr-20`). An absolutely-positioned element with no right bound is shrink-to-fit, so `truncate` (`overflow:hidden; text-overflow:ellipsis`) has **no width to clip against** — the placeholder grows to its full text width and, on a phone-width bar, runs straight under the top-right "Ask AI" control.

## What
Give the placeholder an explicit **right bound** (`right-20` when Ask AI shows, `right-8` otherwise) matching the surface's reserved gutter, so `truncate` clips before the control. The condition mirrors the surface exactly — Ask AI is hidden while global diagnostics show, when the error icon owns the top-right corner (`right-8`).

## Result
Placeholder ellipsizes cleanly before the control at every width; no behavior change where the bar is already wide. Verified locally at 360px that the bounded placeholder truncates (`Search — e.g. level:ERROR, …`) rather than overflowing.

<details>
<summary>Verification</summary>

- `pnpm --filter web run typecheck` — clean.
- Local browser at 360px viewport: placeholder measures `width: 298`, right edge `319` (inside the bar), text clipped — no overflow past the control gutter.
- Ask AI only renders on Langfuse Cloud; the shared mechanism (bounded width → truncate) is identical in both the `right-20` and `right-8` branches, and the `right-8` branch is exercised locally.
</details>

Part of the LFE-11067 mobile interface revamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes placeholder truncation in the v4 search bar at narrow widths.

- Adds an explicit right bound to the absolutely positioned placeholder.
- Reserves space for Ask AI or global diagnostics based on the visible control.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search-bar): keep placeholder from r..."](https://github.com/langfuse/langfuse/commit/e0ac05e19746e9964e9dc765cbb3460259546f13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46382318)</sub>

<!-- /greptile_comment -->