### PR TITLE
fix(chart-view): make Visualize panel responsive on mobile (LFE-11067)

### DIFF
--- a/web/src/features/chart-view/components/ChartViewPanel.stories.tsx
+++ b/web/src/features/chart-view/components/ChartViewPanel.stories.tsx
@@ -1,0 +1,62 @@
+import preview from "../../../../.storybook/preview";
+import { fn } from "storybook/test";
+import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props";
+import { ChartViewPanel } from "./ChartViewPanel";
+import { DEFAULT_CONFIG } from "../vocab";
+
+/**
+ * Deterministic fixture — count of events per hour, broken down by model.
+ * Small on purpose: `ChartViewPanel` just hands `data` to the shared
+ * `chart-library`, so a couple of buckets/series are enough to render a real
+ * line chart.
+ */
+const MODELS = [
+  { name: "gpt-4o", base: 12 },
+  { name: "claude-3-5-sonnet", base: 8 },
+];
+const HOURS = ["00:00", "01:00", "02:00", "03:00"];
+
+const DATA: DataPoint[] = HOURS.flatMap((hour, hourIndex) =>
+  MODELS.map(({ name, base }, seed) => ({
+    time_dimension: hour,
+    dimension: name,
+    metric: base + ((hourIndex + seed * 2) % 4) * 3,
+  })),
+);
+
+/**
+ * The "Take B" chart-view layout: a maximized canvas with the "Visualize"
+ * config docked in a collapsible panel (`EventsChartView`'s production UI).
+ * Presentational — `data`/`config` come in as props, so it renders without
+ * any query or context dependency.
+ *
+ * The panel's outer row is `flex-col md:flex-row` (LFE-11067): a config panel
+ * beside the chart at desktop widths, stacked below it under the `md`
+ * breakpoint. That's a real viewport-width media query, not a container
+ * query, so — unlike most other layout stories in this repo — a fixed-width
+ * wrapper `<div>` here would only clip the desktop layout rather than trigger
+ * the stack (this Storybook setup has no viewport-switching addon wired up).
+ * To see the mobile layout, narrow the actual browser window or the devtools
+ * device toolbar to ~390px while viewing this story — the preview iframe is
+ * fluid-width, so the same media query that fires on a phone fires there too.
+ */
+const meta = preview.meta({
+  component: ChartViewPanel,
+  args: {
+    config: DEFAULT_CONFIG,
+    data: DATA,
+    onConfigChange: fn(),
+  },
+  decorators: [
+    // `ChartViewPanel`'s root relies on a bounded-height flex ancestor
+    // (`flex-1`/`min-h-0`) — same as its production host (`EventsChartView`
+    // inside the events table) — so give it one here.
+    (Story) => (
+      <div className="flex h-[420px] flex-col">
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+export const Default = meta.story({});

--- a/web/src/features/chart-view/components/ChartViewPanel.tsx
+++ b/web/src/features/chart-view/components/ChartViewPanel.tsx
@@ -67,8 +67,10 @@ export const ChartViewPanel = React.memo(function ChartViewPanel({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col md:flex-row">
-      {/* Canvas */}
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-1 p-3">
+      {/* Canvas — floored on mobile so a tall stacked config panel can't shrink
+          the chart to 0 on short viewports (flex-basis:0 gets none of a negative
+          deficit); desktop keeps min-h-0 for the side-by-side row. */}
+      <div className="flex min-h-64 min-w-0 flex-1 flex-col gap-1 p-3 md:min-h-0">
         <div className="flex items-center justify-between gap-2">
           <div
             className="text-foreground min-w-0 truncate text-sm font-bold"
@@ -100,7 +102,7 @@ export const ChartViewPanel = React.memo(function ChartViewPanel({
 
       {/* Config panel */}
       {open ? (
-        <div className="flex w-full flex-col gap-3 overflow-y-auto border-b p-3 md:w-72 md:shrink-0 md:border-b-0 md:border-l">
+        <div className="flex w-full flex-col gap-3 overflow-y-auto border-t p-3 md:w-72 md:shrink-0 md:border-t-0 md:border-l">
           <div className="flex items-center justify-between">
             <span className="text-sm font-bold">Visualize</span>
             <Button

--- a/web/src/features/chart-view/components/ChartViewPanel.tsx
+++ b/web/src/features/chart-view/components/ChartViewPanel.tsx
@@ -66,11 +66,14 @@ export const ChartViewPanel = React.memo(function ChartViewPanel({
   );
 
   return (
-    <div className="flex min-h-0 flex-1">
+    <div className="flex min-h-0 flex-1 flex-col md:flex-row">
       {/* Canvas */}
       <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-1 p-3">
         <div className="flex items-center justify-between gap-2">
-          <div className="text-foreground text-sm font-bold">
+          <div
+            className="text-foreground min-w-0 truncate text-sm font-bold"
+            title={describeConfig(config)}
+          >
             {describeConfig(config)}
           </div>
           {chartActions}
@@ -97,7 +100,7 @@ export const ChartViewPanel = React.memo(function ChartViewPanel({
 
       {/* Config panel */}
       {open ? (
-        <div className="flex w-72 shrink-0 flex-col gap-3 overflow-y-auto border-l p-3">
+        <div className="flex w-full flex-col gap-3 overflow-y-auto border-b p-3 md:w-72 md:shrink-0 md:border-b-0 md:border-l">
           <div className="flex items-center justify-between">
             <span className="text-sm font-bold">Visualize</span>
             <Button
@@ -134,7 +137,7 @@ export const ChartViewPanel = React.memo(function ChartViewPanel({
           ) : null}
         </div>
       ) : (
-        <div className="flex shrink-0 flex-col items-center border-l p-1.5">
+        <div className="flex flex-col items-center border-t p-1.5 md:shrink-0 md:border-t-0 md:border-l">
           <Button
             variant="ghost"
             size="icon-xs"


### PR DESCRIPTION
## TL;DR
At ~390px, switching a table (traces/observations/events) to "Chart" view rendered broken: the "Visualize" config panel and the chart crammed side by side, and the chart title collapsed to one word per line. Fixed by making the panel's layout responsive.

## Why
`ChartViewPanel`'s outer row was an unconditional `flex` row with a fixed `w-72` config panel and no responsive variant, so on a phone the chart canvas got squeezed to ~70-90px wide, and the subtitle had no truncation guard.

## What
- Outer row stacks on mobile, row on `md:` and up (desktop unchanged).
- Config panel goes full-width until `md:`, and only refuses to shrink (`shrink-0`) at `md:` and up.
- The panel/rail divider flips from a bottom border on mobile to a left border at `md:` and up.
- The chart subtitle now truncates with an ellipsis (plus a `title` attribute for the full text) instead of wrapping one word per line.

## Result
The chart view now degrades gracefully on narrow viewports: canvas on top, config below, title always on one line. Desktop layout is unchanged.

<details>
<summary>Verification</summary>

- `pnpm --filter web run typecheck` — clean.
- `pnpm --filter web run lint` — clean (caught a real `require-title-with-truncate` violation, fixed by adding the `title` attribute).
- Added `ChartViewPanel.stories.tsx` (the component is presentational — data/config come in as props, no query or context dependency) and ran it through `pnpm run test-storybook`: all 27 story files / 170 tests pass, including the new one.
- Storybook here has no viewport-switching addon configured, and Tailwind's `md:` prefix is a real browser-viewport media query, not a container query — so a fixed-width wrapper `<div>` in a story can't faithfully trigger the mobile stack (it would just clip the desktop layout). Documented that in the story; real breakpoint verification needs an actual narrow browser viewport.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the chart configuration panel responsive on narrow screens. The main changes are:

- Stacks the chart and configuration panel below the `md` breakpoint.
- Uses responsive widths, borders, and shrinking behavior for the panel and collapsed rail.
- Truncates long chart subtitles while preserving the full text in a title.
- Adds a Storybook fixture for `ChartViewPanel`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The production change looks safe to merge, with non-blocking mobile coverage still missing.

- The responsive classes are consistent across the expanded panel, collapsed rail, and chart container.
- The new story renders the component but does not automatically enter the mobile viewport.

web/src/features/chart-view/components/ChartViewPanel.stories.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/chart-view/components/ChartViewPanel.stories.tsx:54-58
**Mobile Layout Remains Untested**

The decorator constrains only height, while the changed `md:` layout responds to the browser viewport. Automated Storybook runs therefore exercise the desktop row by default, so a regression that breaks the new mobile stack can still pass this story.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chart-view): make Visualize panel re..."](https://github.com/langfuse/langfuse/commit/c2ffe2bbe58d115568170e12a3ea0bd5e75bc1b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46395756)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->