### PR TITLE
fix(nav): close the mobile nav drawer when navigation starts (LFE-11067)

### DIFF
--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useRouter } from "next/router";
 import { Slot } from "@radix-ui/react-slot";
 import { type VariantProps, cva } from "class-variance-authority";
 import { Menu, PanelLeft } from "lucide-react";
@@ -67,6 +68,7 @@ const SidebarProvider = React.forwardRef<
     ref,
   ) => {
     const isMobile = useIsMobile();
+    const router = useRouter();
     const [openMobile, setOpenMobile] = React.useState(false);
 
     // Use local storage to persist sidebar state
@@ -113,6 +115,18 @@ const SidebarProvider = React.forwardRef<
       window.addEventListener("keydown", handleKeyDown);
       return () => window.removeEventListener("keydown", handleKeyDown);
     }, [toggleSidebar]);
+
+    // Close the mobile drawer as soon as a navigation starts. The drawer is a
+    // full-screen overlay Sheet on mobile; without this it stays open on top of
+    // the destination after tapping a nav link or switching project/org (the
+    // Next.js router does shallow client transitions, so the component never
+    // unmounts to reset `openMobile`). Subscribing to router events is a genuine
+    // external-system effect. No-op on desktop, where `openMobile` is unused.
+    React.useEffect(() => {
+      const closeDrawer = () => setOpenMobile(false);
+      router.events.on("routeChangeStart", closeDrawer);
+      return () => router.events.off("routeChangeStart", closeDrawer);
+    }, [router.events]);
 
     // We add a state so that we can do data-state="expanded" or "collapsed".
     // This makes it easier to style the sidebar with Tailwind classes.


### PR DESCRIPTION
## TL;DR
On mobile, tapping a section in the hamburger drawer navigated but left the drawer + scrim covering the destination. Now the drawer closes the moment navigation starts.

## Why
The mobile sidebar is a full-screen overlay `Sheet`. Its open state (`openMobile`) lived only in `SidebarProvider`, which never unmounts across the router's shallow client transitions — and the nav links are plain `<Link>`s that don't close it. So after tapping "Tracing" you'd land on Traces with the 192px drawer + dark scrim still on top, needing a manual dismiss. It was the most jarring, least app-like moment in the whole mobile flow (flagged as the #1 shell issue in the mobile audit).

## What
Subscribe `SidebarProvider` to the Next.js router's `routeChangeStart` event and close the mobile drawer as soon as any navigation begins — covering nav links, the breadcrumb project/org switcher, and programmatic pushes alike. Genuine external-system effect with matching cleanup; no-op on desktop where `openMobile` is unused.

## Result
Verified locally at 390px: open drawer → tap "Tracing" → lands on `/traces` with the drawer and scrim already gone (`drawerStillOpen: false`).

Part of the LFE-11067 mobile interface revamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes the mobile sidebar when client-side navigation starts. The main changes are:

- Adds the Pages Router hook to `SidebarProvider`.
- Subscribes to `routeChangeStart` and resets the mobile drawer state.
- Removes the route listener when the provider unmounts.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Production uses the Pages Router context required by `useRouter`.
- Current navigation paths emit `routeChangeStart`.
- The listener uses matching setup and cleanup callbacks.
- No blocking issues found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(nav): close the mobile nav drawer wh..."](https://github.com/langfuse/langfuse/commit/6741a9fe8eaa7a98fb71df0b4f3d2a9d78e097fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46396339)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->