### PR TITLE
feat(mobile): hide keyboard-shortcut hints on touch viewports (LFE-11067)

### DIFF
--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -74,7 +74,7 @@ export const InAppAiAgentButton = () => {
       <BotMessageSquare className="h-4 w-4" />
       <span className="hidden sm:inline">Assistant</span>
       <KeyboardShortcut
-        className="hidden bg-transparent shadow-none md:inline-flex"
+        className="bg-transparent shadow-none"
         keys={[
           typeof navigator !== "undefined" &&
           navigator.userAgent.includes("Mac")

--- a/web/src/components/ui/KeyboardShortcut.stories.tsx
+++ b/web/src/components/ui/KeyboardShortcut.stories.tsx
@@ -1,0 +1,27 @@
+import preview from "../../../.storybook/preview";
+import { KeyboardShortcut } from "./keyboard-shortcut";
+
+const meta = preview.meta({
+  component: KeyboardShortcut,
+});
+
+// Hidden below the `md` breakpoint (768px, the same cutoff `useIsMobile`
+// uses) by default: a keyboard-shortcut hint is noise on a touch device with
+// no physical keyboard (LFE-11067). The underlying shortcut still fires there
+// — only this visual chip is gated. Resize the Storybook canvas below 768px
+// to see it disappear (CSS-only; jsdom-based story tests don't apply media
+// queries, so this is only visible when the canvas renders in a real browser).
+export const Default = meta.story({
+  args: {
+    children: "K",
+  },
+});
+
+// Multiple glyphs (e.g. a modifier + a letter) render as separate chips
+// inside the same kbd, joined by a small gap — the "⌘K" / "⌘ Enter" shape
+// used for command-menu and submit hints.
+export const MultipleKeys = meta.story({
+  args: {
+    keys: ["⌘", "Enter"],
+  },
+});

--- a/web/src/components/ui/keyboard-shortcut.tsx
+++ b/web/src/components/ui/keyboard-shortcut.tsx
@@ -17,7 +17,13 @@ const KeyboardShortcut = React.forwardRef<HTMLElement, KeyboardShortcutProps>(
     <kbd
       ref={ref}
       className={cn(
-        "bg-muted text-muted-foreground pointer-events-none inline-flex h-5 min-w-5 items-center justify-center gap-1 rounded-md border px-1.5 font-mono text-[10px] leading-none font-bold shadow-xs select-none",
+        // Hidden below `md` (768px, matches useIsMobile) by default: a
+        // keyboard-shortcut hint is noise on a touch device with no physical
+        // keyboard. This only hides the visual chip — the shortcut's own
+        // keydown handler is untouched, so a Bluetooth keyboard still works.
+        // CSS-only (no useIsMobile()) so SSR'd hints don't hydration-mismatch
+        // or flash on first paint (LFE-11067).
+        "bg-muted text-muted-foreground pointer-events-none hidden h-5 min-w-5 items-center justify-center gap-1 rounded-md border px-1.5 font-mono text-[10px] leading-none font-bold shadow-xs select-none md:inline-flex",
         className,
       )}
       {...props}

--- a/web/src/features/comments/CommentList.tsx
+++ b/web/src/features/comments/CommentList.tsx
@@ -538,7 +538,7 @@ export function CommentList({
                 )}
                 {!searchQuery && (
                   <KeyboardShortcut
-                    className="absolute top-1/2 right-1 hidden -translate-y-1/2 opacity-50 sm:inline-flex"
+                    className="absolute top-1/2 right-1 -translate-y-1/2 opacity-50"
                     keys={
                       typeof navigator !== "undefined" &&
                       navigator.userAgent.includes("Macintosh")

--- a/web/src/features/evals/components/code-eval-template-form-body.tsx
+++ b/web/src/features/evals/components/code-eval-template-form-body.tsx
@@ -282,7 +282,7 @@ export function CodeEvalTemplateFormBody({
             )}
             Format
             <KeyboardShortcut
-              className="ml-2 hidden h-4 sm:inline-flex"
+              className="ml-2 h-4"
               keys={
                 typeof navigator !== "undefined" &&
                 navigator.userAgent.includes("Macintosh")

--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -1154,7 +1154,7 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
                                                   ) ?? -1) + 1;
                                                 return digit >= 1 &&
                                                   digit <= 9 ? (
-                                                  <KeyboardShortcut className="ml-0.5 hidden h-3.5 min-w-3.5 px-1 text-[9px] group-focus-within:inline-flex">
+                                                  <KeyboardShortcut className="ml-0.5 h-3.5 min-w-3.5 px-1 text-[9px] md:group-focus-within:inline-flex">
                                                     {digit}
                                                   </KeyboardShortcut>
                                                 ) : null;
@@ -1231,7 +1231,11 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
             />
           </div>
           {rowCount > 0 && (
-            <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 px-0.5 text-[11px]">
+            // This legend only exists to advertise keyboard shortcuts, so hide
+            // the whole strip on touch viewports rather than just the kbd
+            // chips inside it (LFE-11067) — the shortcuts themselves still
+            // work if a physical keyboard is attached.
+            <div className="text-muted-foreground hidden flex-wrap items-center gap-x-2 gap-y-1 px-0.5 text-[11px] md:flex">
               {rowCount > 1 && (
                 <span className="flex items-center gap-1">
                   <KeyboardShortcut className="h-4 min-w-4 px-1 text-[9px]">

--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -1154,7 +1154,7 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
                                                   ) ?? -1) + 1;
                                                 return digit >= 1 &&
                                                   digit <= 9 ? (
-                                                  <KeyboardShortcut className="ml-0.5 h-3.5 min-w-3.5 px-1 text-[9px] md:group-focus-within:inline-flex">
+                                                  <KeyboardShortcut className="ml-0.5 h-3.5 min-w-3.5 px-1 text-[9px] md:hidden md:group-focus-within:inline-flex">
                                                     {digit}
                                                   </KeyboardShortcut>
                                                 ) : null;


### PR DESCRIPTION
## TL;DR
Keyboard-shortcut hint chips ("Esc", "⌘I", "⌘K", etc.) now hide below 768px — they're dead weight on a touch screen with no keyboard. The shortcuts themselves are untouched, so a Bluetooth keyboard still works everywhere.

## Why
Part of the mobile interface revamp (LFE-11067). Chips like the Assistant's "⌘I" or the search bar's "Esc" only make sense to someone with a physical keyboard; on a phone or tablet they're just visual noise crowding an already tight layout.

## What
Centralized the fix in the shared `KeyboardShortcut` component: it now defaults to `hidden md:inline-flex` (768px cutoff, matching `useIsMobile`), so every call site — `CommandShortcut`, `InputCommandShortcut`, and direct usages across search bar, comments, evals, playground, nav, and annotation UI — inherits the hide automatically. This is CSS-only, not `useIsMobile()`, so there's no hydration mismatch or first-paint flash for server-rendered hints.

A few call sites needed individual attention beyond the shared default — see details below.

## Result
Keyboard-shortcut chips disappear on phones/tablets; all shortcut handlers keep working unchanged (including via an attached Bluetooth keyboard).

<details>
<summary>Implementation detail</summary>

- `web/src/components/ui/keyboard-shortcut.tsx` — the primary lever: base classes now include `hidden md:inline-flex` instead of a plain `inline-flex`.
- `web/src/components/nav/in-app-ai-agent-button.tsx` — dropped the now-redundant per-site `hidden ... md:inline-flex` override on the Assistant's "⌘I" hint.
- `web/src/features/comments/CommentList.tsx` and `web/src/features/evals/components/code-eval-template-form-body.tsx` — these previously used a `640px` (`sm:`) cutoff for their own hint; removed the override so they align with the shared `768px` cutoff.
- `web/src/features/scores/components/AnnotationForm.tsx` — two spots needed more than the shared default:
  - the per-option digit hint reveals via `group-focus-within` on the whole score row (real keyboard-driven row focus), independent of screen width — scoped it to `md:group-focus-within:inline-flex` so it can't leak through on a touch-focused row below 768px;
  - the "↑↓ move between fields / 1…9 select option / ↵ edit field" legend footer exists only to advertise shortcuts, so the whole strip is now hidden below `768px` rather than just the kbd chips inside it.
- Added `web/src/components/ui/KeyboardShortcut.stories.tsx` (no story previously existed) with a comment documenting the responsive-hide behavior for anyone poking at the component later.
- Verified: `pnpm --filter web run typecheck` and `pnpm --filter web run lint` both pass; also ran the new story through the Storybook vitest project (`2 passed`).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hides keyboard-shortcut hints on viewports below the `md` breakpoint. The main changes are:

- Adds responsive hiding to the shared `KeyboardShortcut` component.
- Removes redundant responsive classes from individual call sites.
- Hides AnnotationForm shortcut hints and its shortcut legend on narrow screens.
- Adds Storybook examples for single and multiple key hints.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(mobile): hide keyboard-shortcut hin..."](https://github.com/langfuse/langfuse/commit/0fe3fce7fd3f3c8e7a1fe0a7659959cfc033ddfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46397698)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->