### PR TITLE
fix(clickhouse): disable filter push down on ClickHouse 26.5+ to fix scores UI NOT_FOUND_COLUMN_IN_BLOCK

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -224,3 +224,4 @@ CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE="true"
 # `auto` detects affected ClickHouse versions on startup. Set `true` to force
 # the workaround or `false` to force-disable it.
 CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION=auto
+CLICKHOUSE_DISABLE_FILTER_PUSH_DOWN=auto

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -142,6 +142,9 @@ const EnvSchema = z.object({
   CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: z
     .enum(["auto", "true", "false"])
     .default("auto"),
+  CLICKHOUSE_DISABLE_FILTER_PUSH_DOWN: z
+    .enum(["auto", "true", "false"])
+    .default("auto"),
   CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY: z.coerce
     .number()
     .default(32_000_000_000), // ~32GB

--- a/packages/shared/src/server/clickhouse/compatibility.test.ts
+++ b/packages/shared/src/server/clickhouse/compatibility.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 const envMock = vi.hoisted(() => ({
   env: {
     CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "auto",
+    CLICKHOUSE_DISABLE_FILTER_PUSH_DOWN: "auto",
   },
 }));
 
@@ -62,6 +63,7 @@ describe("resolveClickHouseCompatibility", () => {
 
     expect(resolved.settings).toEqual({
       query_plan_optimize_lazy_materialization: 0,
+      query_plan_filter_push_down: 0,
     });
     expect(resolved.parsedVersion).toMatchObject({
       major: 26,
@@ -73,6 +75,14 @@ describe("resolveClickHouseCompatibility", () => {
       expect.objectContaining({
         id: "disable-lazy-materialization",
         setting: "query_plan_optimize_lazy_materialization",
+        value: 0,
+        override: "auto",
+        matchesVersionBand: true,
+        applied: true,
+      }),
+      expect.objectContaining({
+        id: "disable-filter-push-down",
+        setting: "query_plan_filter_push_down",
         value: 0,
         override: "auto",
         matchesVersionBand: true,
@@ -95,6 +105,12 @@ describe("resolveClickHouseCompatibility", () => {
         matchesVersionBand: false,
         applied: false,
       }),
+      expect.objectContaining({
+        id: "disable-filter-push-down",
+        override: "auto",
+        matchesVersionBand: false,
+        applied: false,
+      }),
     ]);
   });
 
@@ -111,8 +127,59 @@ describe("resolveClickHouseCompatibility", () => {
     expect(
       resolveClickHouseCompatibility({
         version: "26.5.1.882",
-        overrides: { CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "false" },
+        overrides: {
+          CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "false",
+          CLICKHOUSE_DISABLE_FILTER_PUSH_DOWN: "false",
+        },
       }).settings,
     ).toEqual({});
+  });
+
+  it("applies filter push down workaround in auto mode for 26.5+", () => {
+    const resolved = resolveClickHouseCompatibility({
+      version: "26.6.1.1193",
+      overrides: { CLICKHOUSE_DISABLE_FILTER_PUSH_DOWN: "auto" },
+    });
+
+    expect(resolved.settings).toMatchObject({
+      query_plan_filter_push_down: 0,
+    });
+    expect(resolved.flags).toContainEqual(
+      expect.objectContaining({
+        id: "disable-filter-push-down",
+        setting: "query_plan_filter_push_down",
+        value: 0,
+        override: "auto",
+        matchesVersionBand: true,
+        applied: true,
+      }),
+    );
+  });
+
+  it("does not apply filter push down workaround in auto mode before 26.5", () => {
+    expect(
+      resolveClickHouseCompatibility({
+        version: "26.4.5.143",
+        overrides: { CLICKHOUSE_DISABLE_FILTER_PUSH_DOWN: "auto" },
+      }).settings,
+    ).not.toHaveProperty("query_plan_filter_push_down");
+  });
+
+  it("allows forcing filter push down workaround on", () => {
+    expect(
+      resolveClickHouseCompatibility({
+        version: null,
+        overrides: { CLICKHOUSE_DISABLE_FILTER_PUSH_DOWN: "true" },
+      }).settings,
+    ).toMatchObject({ query_plan_filter_push_down: 0 });
+  });
+
+  it("allows forcing filter push down workaround off", () => {
+    expect(
+      resolveClickHouseCompatibility({
+        version: "26.6.1.1193",
+        overrides: { CLICKHOUSE_DISABLE_FILTER_PUSH_DOWN: "false" },
+      }).settings,
+    ).not.toHaveProperty("query_plan_filter_push_down");
   });
 });

--- a/packages/shared/src/server/clickhouse/compatibility.ts
+++ b/packages/shared/src/server/clickhouse/compatibility.ts
@@ -18,7 +18,9 @@ export type ClickHouseVersionBand = {
   maxExclusive?: string;
 };
 
-type ClickHouseCompatibilityEnvKey = "CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION";
+type ClickHouseCompatibilityEnvKey =
+  | "CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION"
+  | "CLICKHOUSE_DISABLE_FILTER_PUSH_DOWN";
 
 type ClickHouseCompatibilityEnvValue = "auto" | "true" | "false";
 
@@ -65,6 +67,17 @@ const CLICKHOUSE_COMPATIBILITY_RULES: ClickHouseCompatibilityRule[] = [
       "Work around ClickHouse analyzer failures that can surface as `Not found column and(...)` on compound predicates.",
     versionBands: [{ minInclusive: "25.4.0" }],
     overrideEnvKey: "CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION",
+  },
+  {
+    id: "disable-filter-push-down",
+    setting: "query_plan_filter_push_down",
+    value: 0,
+    reason:
+      "Work around a ClickHouse 26.5+ analyzer regression where FINAL on the left table of a JOIN " +
+      "fails with `Not found column and(...)` (NOT_FOUND_COLUMN_IN_BLOCK) once the WHERE clause " +
+      "prunes every part, e.g. the scores UI query filtered to a project with no matching rows.",
+    versionBands: [{ minInclusive: "26.5.0" }],
+    overrideEnvKey: "CLICKHOUSE_DISABLE_FILTER_PUSH_DOWN",
   },
 ];
 


### PR DESCRIPTION
## What does this PR do?

Fixes #15125

On ClickHouse 26.5+ (the untagged `clickhouse-server` image in `docker-compose.yml` currently resolves to 26.6.1), the `scores.all` query (`FROM scores s FINAL LEFT JOIN traces`) fails at planning time with `NOT_FOUND_COLUMN_IN_BLOCK` once the WHERE clause prunes every part, so the Scores table 500s for self-hosters who pulled `latest`.

Reproduced against the real Langfuse ClickHouse schema (all unclustered migrations applied, 1000 rows inserted so parts exist on disk):

| ClickHouse | Result |
| --- | --- |
| 25.12 | ok |
| 26.1.12.23 | ok |
| 26.4.5.143 | ok |
| 26.5.5.8 | NOT_FOUND_COLUMN_IN_BLOCK |
| 26.6.1.1193 | NOT_FOUND_COLUMN_IN_BLOCK |

Setting bisect on 26.6.1: `query_plan_filter_push_down = 0` fixes it; `query_plan_optimize_lazy_materialization = 0`, `optimize_move_to_prewhere = 0`, `query_plan_optimize_prewhere = 0`, `query_plan_merge_filters = 0`, and `optimize_read_in_order = 0` do not. `enable_analyzer = 0` also fixes it, as noted in the issue, but that is a much bigger hammer.

This adds a second rule to the existing ClickHouse compatibility framework: `query_plan_filter_push_down = 0` for versions >= 26.5.0, with a `CLICKHOUSE_DISABLE_FILTER_PUSH_DOWN` env override (`auto`/`true`/`false`) mirroring `CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION`. Once a fixed ClickHouse release exists, the band can get a `maxExclusive`.

Two things deliberately left out, happy to follow up on either: pinning the `docker-compose.yml` ClickHouse image to a tagged version (it currently pulls `latest`, which is how self-hosters end up on 26.x while `docker-compose.dev.yml` pins 25.12), and an upstream report to ClickHouse.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project (`pnpm run format`)
- I have checked that my changes generate no new warnings (`pnpm run lint`)
- I have added tests that prove my fix is effective (`compatibility.test.ts`: band + override coverage, 12 passing)
- New and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a ClickHouse compatibility workaround for the filter push-down regression. The main changes are:

- Disables `query_plan_filter_push_down` automatically on ClickHouse 26.5 and newer.
- Adds an `auto`/`true`/`false` environment override.
- Adds version-band and override tests for the new rule.
- Documents the new environment variable in the development example.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(clickhouse): disable filter push dow..."](https://github.com/langfuse/langfuse/commit/af2f9bf0e05b4dc57ba113458c70c8bfd0e5e3d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46402642)</sub>

<!-- /greptile_comment -->