### PR TITLE
feat(nav): org/project switcher in the mobile nav drawer (LFE-11067)

### DIFF
--- a/web/src/components/layouts/breadcrumb.tsx
+++ b/web/src/components/layouts/breadcrumb.tsx
@@ -12,8 +12,10 @@ import {
 } from "@/src/components/ui/dropdown-menu";
 import { ChevronDownIcon, Slash } from "lucide-react";
 import { env } from "@/src/env.mjs";
-import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { useRouter } from "next/router";
+import {
+  useOrgProjectSwitchPaths,
+  useQueryProjectOrOrganization,
+} from "@/src/features/projects/hooks";
 import { useSession } from "next-auth/react";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { isCloudPlan, planLabels } from "@langfuse/shared";
@@ -29,9 +31,9 @@ const BreadcrumbComponent = ({
   items?: { name: string; href?: string }[];
   className?: string;
 }) => {
-  const router = useRouter();
   const session = useSession();
   const { organization, project } = useQueryProjectOrOrganization();
+  const { getProjectPath, getOrgPath } = useOrgProjectSwitchPaths();
 
   const organizations = session.data?.user?.organizations;
 
@@ -40,39 +42,6 @@ const BreadcrumbComponent = ({
     organizationId: organization?.id,
     scope: "projects:create",
   });
-
-  /**
-   * Truncate the path before the first dynamic segment that is not allowlisted.
-   * e.g. /project/[projectId]/traces/[traceId] -> /project/[projectId]/traces
-   */
-  const truncatePathBeforeDynamicSegments = (path: string) => {
-    const allowlistedIds = ["[projectId]", "[organizationId]", "[page]"];
-    const segments = router.route.split("/");
-    const idSegments = segments.filter(
-      (segment) => segment.startsWith("[") && segment.endsWith("]"),
-    );
-    const stopSegment = idSegments.filter((id) => !allowlistedIds.includes(id));
-    if (stopSegment.length === 0) return path;
-    const stopIndex = segments.indexOf(stopSegment[0]);
-    const truncatedPath = path.split("/").slice(0, stopIndex).join("/");
-    return truncatedPath;
-  };
-
-  const getProjectPath = (projectId: string) =>
-    router.query.projectId
-      ? truncatePathBeforeDynamicSegments(router.asPath).replace(
-          router.query.projectId as string,
-          projectId,
-        )
-      : `/project/${projectId}`;
-
-  const getOrgPath = (orgId: string) =>
-    router.query.organizationId
-      ? truncatePathBeforeDynamicSegments(router.asPath).replace(
-          router.query.organizationId as string,
-          orgId,
-        )
-      : `/organization/${orgId}`;
 
   return (
     <Breadcrumb className={className}>

--- a/web/src/components/nav/app-sidebar.tsx
+++ b/web/src/components/nav/app-sidebar.tsx
@@ -18,11 +18,13 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
+  useSidebar,
 } from "@/src/components/ui/sidebar";
 import { env } from "@/src/env.mjs";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import { LangfuseLogo } from "@/src/components/LangfuseLogo";
+import { MobileNavSwitcher } from "@/src/components/nav/mobile-nav-switcher";
 import { SidebarNotifications } from "@/src/components/nav/sidebar-notifications";
 import { type RouteGroup } from "@/src/components/layouts/routes";
 import { ExternalLink, Grid2X2 } from "lucide-react";
@@ -46,6 +48,8 @@ export function AppSidebar({
   userNavProps,
   ...props
 }: AppSidebarProps) {
+  const { isMobile } = useSidebar();
+
   return (
     <Sidebar collapsible="icon" variant="sidebar" {...props}>
       <SidebarHeader>
@@ -56,6 +60,7 @@ export function AppSidebar({
         <DemoBadge />
       </SidebarHeader>
       <SidebarContent>
+        {isMobile && <MobileNavSwitcher />}
         <NavMain items={navItems} />
         <div className="flex-1" />
         <div className="flex flex-col gap-2 p-2">

--- a/web/src/components/nav/mobile-nav-switcher.tsx
+++ b/web/src/components/nav/mobile-nav-switcher.tsx
@@ -1,0 +1,108 @@
+import { ChevronDownIcon } from "lucide-react";
+import { useSession } from "next-auth/react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/src/components/ui/sidebar";
+import { OrganizationDropdownMenu } from "@/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu";
+import { ProjectDropdownMenu } from "@/src/components/ProjectDropdownMenu/ProjectDropdownMenu";
+import {
+  useOrgProjectSwitchPaths,
+  useQueryProjectOrOrganization,
+} from "@/src/features/projects/hooks";
+import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
+
+/**
+ * Org + project switcher for the TOP of the mobile nav drawer.
+ *
+ * The mobile drawer (the `Sheet` branch of `Sidebar`, see ui/sidebar.tsx)
+ * otherwise only lists section links — the same switching affordance the
+ * desktop breadcrumb offers (`BreadcrumbComponent`) is easy to miss on
+ * mobile, since the breadcrumb sits in the page body. This reuses the exact
+ * dropdown menus and path builders the breadcrumb uses, so switching
+ * behavior is identical between both entry points; only rendered by
+ * `AppSidebar` when `useSidebar().isMobile` is true.
+ */
+export function MobileNavSwitcher() {
+  const session = useSession();
+  const { organization, project } = useQueryProjectOrOrganization();
+  const { getProjectPath, getOrgPath } = useOrgProjectSwitchPaths();
+
+  const organizations = session.data?.user?.organizations;
+  const canCreateOrganizations = session.data?.user?.canCreateOrganizations;
+  const canCreateProjects = useHasOrganizationAccess({
+    organizationId: organization?.id,
+    scope: "projects:create",
+  });
+
+  if (!organization) return null;
+
+  return (
+    <SidebarGroup className="border-b">
+      <SidebarGroupContent>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton>
+                  <span
+                    className="min-w-0 flex-1 truncate text-left"
+                    title={organization.name}
+                  >
+                    {organization.name}
+                  </span>
+                  <ChevronDownIcon className="ml-auto h-4 w-4 shrink-0" />
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <OrganizationDropdownMenu
+                {...(organizations
+                  ? { state: "loaded", organizations }
+                  : { state: "loading" })}
+                canCreateOrganizations={!!canCreateOrganizations}
+                getOrgPath={getOrgPath}
+              />
+            </DropdownMenu>
+          </SidebarMenuItem>
+          {project && (
+            <SidebarMenuItem>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <SidebarMenuButton>
+                    <span
+                      className="min-w-0 flex-1 truncate text-left"
+                      title={project.name}
+                    >
+                      {project.name}
+                    </span>
+                    <ChevronDownIcon className="ml-auto h-4 w-4 shrink-0" />
+                  </SidebarMenuButton>
+                </DropdownMenuTrigger>
+                <ProjectDropdownMenu
+                  organizationId={organization.id}
+                  {...(organizations
+                    ? {
+                        state: "loaded",
+                        projects:
+                          organizations.find(
+                            (org) => org.id === organization.id,
+                          )?.projects ?? [],
+                      }
+                    : { state: "loading" })}
+                  canCreateProjects={!!canCreateProjects}
+                  getProjectPath={getProjectPath}
+                />
+              </DropdownMenu>
+            </SidebarMenuItem>
+          )}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}

--- a/web/src/features/projects/hooks.ts
+++ b/web/src/features/projects/hooks.ts
@@ -67,3 +67,49 @@ export const useQueryProjectOrOrganization = () => {
 
   return p.project ? p : { organization: o, project: null };
 };
+
+/**
+ * Builds the target path for switching the current page to a different
+ * organization/project, preserving the page the user is on where possible
+ * (e.g. staying on `.../traces` when switching projects). Shared by every
+ * org/project switcher (breadcrumb, mobile nav drawer) so switching behavior
+ * stays identical across entry points.
+ */
+export const useOrgProjectSwitchPaths = () => {
+  const router = useRouter();
+
+  /**
+   * Truncate the path before the first dynamic segment that is not allowlisted.
+   * e.g. /project/[projectId]/traces/[traceId] -> /project/[projectId]/traces
+   */
+  const truncatePathBeforeDynamicSegments = (path: string) => {
+    const allowlistedIds = ["[projectId]", "[organizationId]", "[page]"];
+    const segments = router.route.split("/");
+    const idSegments = segments.filter(
+      (segment) => segment.startsWith("[") && segment.endsWith("]"),
+    );
+    const stopSegment = idSegments.filter((id) => !allowlistedIds.includes(id));
+    if (stopSegment.length === 0) return path;
+    const stopIndex = segments.indexOf(stopSegment[0]);
+    const truncatedPath = path.split("/").slice(0, stopIndex).join("/");
+    return truncatedPath;
+  };
+
+  const getProjectPath = (projectId: string) =>
+    router.query.projectId
+      ? truncatePathBeforeDynamicSegments(router.asPath).replace(
+          router.query.projectId as string,
+          projectId,
+        )
+      : `/project/${projectId}`;
+
+  const getOrgPath = (orgId: string) =>
+    router.query.organizationId
+      ? truncatePathBeforeDynamicSegments(router.asPath).replace(
+          router.query.organizationId as string,
+          orgId,
+        )
+      : `/organization/${orgId}`;
+
+  return { getProjectPath, getOrgPath };
+};


### PR DESCRIPTION
## TL;DR
On mobile, the hamburger drawer only had section links (Home/Tracing/…) — no way to switch org/project. Users reaching for the hamburger to switch context found nothing, since that switcher only existed in the page-body breadcrumb. This adds the same org/project switcher to the top of the mobile drawer.

## Why
Part of the mobile nav revamp (LFE-11067). A mobile audit found the drawer opened by the hamburger is missing the one control users instinctively look for there: switching organization or project. It's not that switching doesn't work on mobile — it's that the affordance is buried in a breadcrumb most mobile users never scroll to.

## What
- Added `MobileNavSwitcher`, rendered at the top of `AppSidebar`'s content, gated on `useSidebar().isMobile` so the desktop sidebar is untouched.
- Reuses the exact `OrganizationDropdownMenu` / `ProjectDropdownMenu` components and the same `useQueryProjectOrOrganization` context source the breadcrumb already uses — no new switching logic.
- Extracted the breadcrumb's path-truncation logic into a shared `useOrgProjectSwitchPaths` hook so both switchers navigate to identical target paths when switching.
- Breadcrumb switcher is unchanged/additive — this only adds the second entry point.

## Result
Mobile users can now switch org/project directly from the hamburger drawer, matching the touch-target style of the rest of the drawer (full-row tap targets, truncates long names instead of overflowing the 12rem drawer width).

<details>
<summary>Engineering detail</summary>

- `web/src/components/nav/mobile-nav-switcher.tsx` (new): the drawer switcher — an org row + (when a project is in scope) a project row, each a `SidebarMenuButton` wrapping a `DropdownMenuTrigger` that opens the same `OrganizationDropdownMenu`/`ProjectDropdownMenu` content used by the breadcrumb.
- `web/src/features/projects/hooks.ts`: extracted `useOrgProjectSwitchPaths()` (the `getOrgPath`/`getProjectPath` + dynamic-segment truncation previously inlined in `breadcrumb.tsx`) so both switchers build the same target path.
- `web/src/components/layouts/breadcrumb.tsx`: now consumes `useOrgProjectSwitchPaths()` instead of its own copy — no behavior change.
- `web/src/components/nav/app-sidebar.tsx`: renders `<MobileNavSwitcher />` above `NavMain` only when `useSidebar().isMobile`.
- Dropdown menus already portal into the `popover` overlay layer, which sits above the `panel` layer the `Sheet` drawer uses (`web/src/components/ui/layer.tsx`), so the switcher menu correctly renders above the drawer with no z-index changes needed.
- a11y: added `title` on the truncating name `span`s per the repo's `@repo/require-title-with-truncate` lint rule.
- Storybook: skipped — the switcher needs router/session/tRPC context to resolve org/project, which isn't practical to fake in isolation.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds organization and project switching to the mobile navigation drawer. The main changes are:

- A new mobile switcher using the existing dropdown menus.
- A shared hook for building organization and project switch paths.
- Conditional rendering inside the mobile sidebar.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The extracted path logic preserves the existing breadcrumb behavior.
- The new switcher uses the established sidebar context, dropdowns, and access checks.

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(nav): org/project switcher in the m..."](https://github.com/langfuse/langfuse/commit/cf4384d004221cfbfe5873a6d4fcb41f94d4e695) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46404857)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->