### PR TITLE
feat(table): mobile card-list rendering for data tables (LFE-11067)

### DIFF
--- a/web/src/components/table/data-table-mobile-card-list.stories.tsx
+++ b/web/src/components/table/data-table-mobile-card-list.stories.tsx
@@ -1,0 +1,298 @@
+import preview from "../../../.storybook/preview";
+import { useState } from "react";
+import { fn } from "storybook/test";
+import {
+  getCoreRowModel,
+  useReactTable,
+  type RowSelectionState,
+} from "@tanstack/react-table";
+import Decimal from "decimal.js";
+
+import { DataTableMobileCardList } from "@/src/components/table/data-table-mobile-card-list";
+import { type AsyncTableData } from "@/src/components/table/data-table";
+import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
+import { Badge } from "@/src/components/ui/badge";
+import { Checkbox } from "@/src/components/ui/checkbox";
+import { StarToggle } from "@/src/components/star-toggle";
+import TagList from "@/src/features/tag/components/TagList";
+import { formatIntervalSeconds } from "@/src/utils/dates";
+import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
+
+// =============================================================================
+// WHY THIS STORY RENDERS THE CARD LIST DIRECTLY
+// =============================================================================
+// `DataTableMobileCardList` is what `DataTable` swaps in on a mobile viewport
+// (`useIsMobile() && a column carries a `mobileCard` hint`). `useIsMobile`
+// resolves against the real viewport width via a `max-width` media query, so
+// there is no reliable way to "force mobile" from a story and let DataTable
+// pick the card branch. Instead we render the card list directly with a handful
+// of faked rows and a small columns array carrying `mobileCard` hints. A thin
+// wrapper builds a real TanStack table instance (the card list reads
+// `getRowModel()` / `getVisibleCells()` / `flexRender`) from those columns. The
+// decorator sizes the container like a phone so the vertical,
+// horizontal-scroll-free layout is visible in the Storybook browser.
+//
+// The list is virtualized: it measures its scroll container and renders the
+// cards that fit. The stories showcase the loaded / loading / empty states —
+// no play functions, since assertions on virtualized layout are brittle.
+
+// -----------------------------------------------------------------------------
+// Deterministic mock data (mirrors the load-bearing TracesTableRow fields)
+// -----------------------------------------------------------------------------
+
+function seeded(n: number) {
+  const x = Math.sin(n + 1) * 10000;
+  return x - Math.floor(x);
+}
+
+const TRACE_NAMES = [
+  "checkout-agent",
+  "retrieval-pipeline",
+  "summarizer-with-a-very-long-name-that-should-truncate",
+  "qa-bot",
+  "classification-job",
+  "embedding-batch",
+];
+const ENVIRONMENTS = ["production", "staging", "development"];
+const LEVELS = ["DEFAULT", "WARNING", "ERROR", "DEBUG"] as const;
+const TAG_POOL = [
+  ["production", "rag"],
+  ["staging"],
+  [],
+  ["experimental", "latency-sensitive", "reviewed"],
+];
+
+type CardRow = {
+  id: string;
+  bookmarked: boolean;
+  name: string;
+  timestamp: Date;
+  level: (typeof LEVELS)[number];
+  latency: number;
+  totalCost: Decimal;
+  totalTokens: number;
+  environment: string;
+  tags: string[];
+};
+
+function makeRow(index: number): CardRow {
+  const baseTime = Date.parse("2026-07-20T09:00:00.000Z");
+  return {
+    id: `trace-${(index + 1).toString().padStart(5, "0")}`,
+    bookmarked: index % 4 === 0,
+    name: TRACE_NAMES[index % TRACE_NAMES.length]!,
+    timestamp: new Date(baseTime - index * 137_000),
+    level: LEVELS[index % LEVELS.length]!,
+    latency: Number((0.2 + seeded(index) * 18).toFixed(3)),
+    totalCost: new Decimal(Number((seeded(index * 2) * 0.4).toFixed(6))),
+    totalTokens: Math.round(300 + seeded(index * 3) * 6000),
+    environment: ENVIRONMENTS[index % ENVIRONMENTS.length]!,
+    tags: TAG_POOL[index % TAG_POOL.length]!,
+  };
+}
+
+const ROWS: CardRow[] = Array.from({ length: 12 }, (_, i) => makeRow(i));
+
+function loadedData(count = 8): AsyncTableData<CardRow[]> {
+  return { isLoading: false, isError: false, data: ROWS.slice(0, count) };
+}
+
+const LEVEL_BADGE: Record<CardRow["level"], string> = {
+  DEFAULT: "bg-muted text-muted-foreground",
+  DEBUG: "bg-muted text-muted-foreground",
+  WARNING: "bg-yellow-100 text-yellow-800",
+  ERROR: "bg-red-100 text-red-800",
+};
+
+// A small, curated columns array — each carries a `mobileCard` slot hint, which
+// is the only signal the card list reads to place a cell.
+const columns: LangfuseColumnDef<CardRow>[] = [
+  {
+    accessorKey: "select",
+    id: "select",
+    header: "",
+    size: 30,
+    mobileCard: { slot: "select" },
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+  },
+  {
+    accessorKey: "level",
+    id: "level",
+    header: "Level",
+    mobileCard: { slot: "badge" },
+    cell: ({ row }) => (
+      <span
+        className={`rounded-sm px-1 py-0.5 text-xs ${LEVEL_BADGE[row.original.level]}`}
+      >
+        {row.original.level}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "name",
+    id: "name",
+    header: "Name",
+    mobileCard: { slot: "title" },
+    cell: ({ row }) => row.original.name ?? undefined,
+  },
+  {
+    accessorKey: "timestamp",
+    id: "timestamp",
+    header: "Timestamp",
+    mobileCard: { slot: "timestamp" },
+    cell: ({ row }) => <LocalIsoDate date={row.original.timestamp} />,
+  },
+  {
+    accessorKey: "bookmarked",
+    id: "bookmarked",
+    header: "",
+    mobileCard: { slot: "action" },
+    cell: ({ row }) => <BookmarkCell defaultValue={row.original.bookmarked} />,
+  },
+  {
+    accessorKey: "latency",
+    id: "latency",
+    header: "Latency",
+    mobileCard: { slot: "metric", order: 0 },
+    cell: ({ row }) => (
+      <span>{formatIntervalSeconds(row.original.latency)}</span>
+    ),
+  },
+  {
+    accessorKey: "totalCost",
+    id: "totalCost",
+    header: "Cost",
+    mobileCard: { slot: "metric", order: 1 },
+    cell: ({ row }) => (
+      <span>{usdFormatter(row.original.totalCost.toNumber())}</span>
+    ),
+  },
+  {
+    accessorKey: "totalTokens",
+    id: "totalTokens",
+    header: "Tokens",
+    mobileCard: { slot: "metric", order: 2 },
+    cell: ({ row }) => (
+      <span>{numberFormatter(row.original.totalTokens, 0)}</span>
+    ),
+  },
+  {
+    accessorKey: "tags",
+    id: "tags",
+    header: "Tags",
+    mobileCard: { slot: "context", order: 0 },
+    cell: ({ row }) =>
+      row.original.tags.length > 0 ? (
+        <div className="flex flex-wrap gap-x-2 gap-y-1">
+          <TagList
+            selectedTags={row.original.tags}
+            isLoading={false}
+            viewOnly
+          />
+        </div>
+      ) : null,
+  },
+  {
+    accessorKey: "environment",
+    id: "environment",
+    header: "Environment",
+    mobileCard: { slot: "context", order: 1 },
+    cell: ({ row }) => (
+      <Badge
+        variant="secondary"
+        className="max-w-fit truncate rounded-sm px-1 font-normal"
+      >
+        {row.original.environment}
+      </Badge>
+    ),
+  },
+];
+
+function BookmarkCell({ defaultValue }: { defaultValue: boolean }) {
+  const [value, setValue] = useState(defaultValue);
+  return (
+    <StarToggle
+      value={value}
+      size="icon-xs"
+      isLoading={false}
+      onClick={async (next) => setValue(next)}
+    />
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Thin wrapper: build a real TanStack table from the columns + data, then hand
+// it to the card list (which reads the row model + cell renderers).
+// -----------------------------------------------------------------------------
+
+type MobileCardListDemoProps = {
+  data: AsyncTableData<CardRow[]>;
+  onRowClick?: (row: CardRow) => void;
+  noResultsMessage?: React.ReactNode;
+};
+
+function MobileCardListDemo({
+  data,
+  onRowClick,
+  noResultsMessage,
+}: MobileCardListDemoProps) {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const table = useReactTable<CardRow>({
+    data: data.data ?? [],
+    columns,
+    state: { rowSelection },
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => row.id,
+  });
+  return (
+    <DataTableMobileCardList<CardRow>
+      table={table}
+      data={data}
+      onRowClick={onRowClick}
+      noResultsMessage={noResultsMessage}
+    />
+  );
+}
+
+const meta = preview.meta({
+  component: MobileCardListDemo,
+  parameters: { layout: "centered" },
+  args: {
+    data: loadedData(),
+    onRowClick: fn(),
+  },
+  decorators: [
+    // Size the frame like a phone so the vertical, no-horizontal-scroll layout
+    // is visible. The card list fills height and scrolls vertically only.
+    (Story) => (
+      <div className="bg-background flex h-[640px] w-[390px] flex-col overflow-hidden border">
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+export default meta;
+
+export const Default = meta.story({});
+
+export const Loading = meta.story({
+  args: {
+    data: { isLoading: true, isError: false },
+  },
+});
+
+export const Empty = meta.story({
+  args: {
+    data: { isLoading: false, isError: false, data: [] },
+    noResultsMessage: "No traces match the current filters.",
+  },
+});

--- a/web/src/components/table/data-table-mobile-card-list.tsx
+++ b/web/src/components/table/data-table-mobile-card-list.tsx
@@ -185,7 +185,9 @@ function MobileCard<TData>({
         onClick={
           isClickable
             ? (e) => {
-                if (shouldIgnoreRowClickTarget(e.target)) return;
+                // Exclude the card root (role="button") so only interactive
+                // CHILDREN (checkbox, star, links) swallow the tap.
+                if (shouldIgnoreRowClickTarget(e.target, e.currentTarget)) return;
                 onRowClick?.(row.original, e);
               }
             : undefined
@@ -194,7 +196,7 @@ function MobileCard<TData>({
           isClickable
             ? (e) => {
                 if (e.key !== "Enter") return;
-                if (shouldIgnoreRowClickTarget(e.target)) return;
+                if (shouldIgnoreRowClickTarget(e.target, e.currentTarget)) return;
                 onRowClick?.(row.original);
               }
             : undefined

--- a/web/src/components/table/data-table-mobile-card-list.tsx
+++ b/web/src/components/table/data-table-mobile-card-list.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import React, { useRef } from "react";
+import { useRouter } from "next/router";
+import { flexRender, type Cell, type Row } from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+import DocPopup from "@/src/components/layouts/doc-popup";
+import { Skeleton } from "@/src/components/ui/skeleton";
+import {
+  type AsyncTableData,
+  shouldIgnoreRowClickTarget,
+} from "@/src/components/table/data-table";
+import {
+  type LangfuseColumnDef,
+  type MobileCardSlot,
+} from "@/src/components/table/types";
+import {
+  type TableSelectionStoreLike,
+  useTableRowIsSelected,
+  useTableSelectAll,
+} from "@/src/components/table/table-selection-store";
+import { getPlainTextFromReactNode } from "@/src/utils/react-node-plain-text";
+import { cn } from "@/src/utils/tailwind";
+
+// -----------------------------------------------------------------------------
+// Mobile card list
+// -----------------------------------------------------------------------------
+// A vertical, virtualized alternative to the wide `table-fixed` body that the
+// desktop DataTable renders. Instead of ~13 fixed 150px columns forcing 2600px
+// of horizontal scroll on a phone, each row becomes a tappable card. Cards are
+// assembled ENTIRELY from the table's own cell renderers via `flexRender`, so
+// every formatter (dates, cost/latency/token, tags, level badge, IO preview,
+// selection checkbox, star) is reused verbatim — this component owns layout,
+// not presentation.
+//
+// Which cells appear, and where, is curated per table through the optional
+// `mobileCard` column hint (see types.ts). Un-annotated columns are omitted.
+
+interface DataTableMobileCardListProps<TData> {
+  table: {
+    getRowModel: () => { rows: Row<TData>[] };
+  };
+  data: AsyncTableData<TData[]>;
+  onRowClick?: (row: TData, event?: React.MouseEvent) => void;
+  selectionStore?: TableSelectionStoreLike;
+  noResultsMessage?: React.ReactNode;
+  help?: { description: string; href: string };
+  getRowClassName?: (row: TData) => string;
+}
+
+type SlotBuckets<TData> = Record<MobileCardSlot, Cell<TData, unknown>[]>;
+
+const EMPTY_BUCKETS: readonly MobileCardSlot[] = [
+  "select",
+  "badge",
+  "title",
+  "timestamp",
+  "action",
+  "metric",
+  "context",
+] as const;
+
+// Group a row's visible cells into slot buckets, ordered within each slot by
+// the column's `mobileCard.order` (ascending, default 0). Derived during
+// render from the row model — no state, no effect.
+function bucketCells<TData>(row: Row<TData>): SlotBuckets<TData> {
+  const buckets: SlotBuckets<TData> = {
+    select: [],
+    badge: [],
+    title: [],
+    timestamp: [],
+    action: [],
+    metric: [],
+    context: [],
+  };
+  for (const cell of row.getVisibleCells()) {
+    const hint = (cell.column.columnDef as LangfuseColumnDef<TData>).mobileCard;
+    if (hint) buckets[hint.slot].push(cell);
+  }
+  for (const slot of EMPTY_BUCKETS) {
+    buckets[slot].sort((a, b) => {
+      const ao =
+        (a.column.columnDef as LangfuseColumnDef<TData>).mobileCard?.order ?? 0;
+      const bo =
+        (b.column.columnDef as LangfuseColumnDef<TData>).mobileCard?.order ?? 0;
+      return ao - bo;
+    });
+  }
+  return buckets;
+}
+
+function renderCell<TData>(cell: Cell<TData, unknown>): React.ReactNode {
+  return flexRender(cell.column.columnDef.cell, cell.getContext());
+}
+
+// A short muted label for a metric, derived from the column header (falling
+// back to the column id). Function headers can't be flattened to text here, so
+// they fall back to the id.
+function columnLabel<TData>(cell: Cell<TData, unknown>): string {
+  const header = cell.column.columnDef.header;
+  if (typeof header === "string") return header;
+  return getPlainTextFromReactNode(header as React.ReactNode) ?? cell.column.id;
+}
+
+// A best-effort tooltip for the truncated title. Prefers the raw string value
+// (name accessors return a string) and falls back to the flattened cell node.
+function titleText<TData>(cell: Cell<TData, unknown>): string | undefined {
+  const value = cell.getValue();
+  if (typeof value === "string") return value;
+  return getPlainTextFromReactNode(renderCell(cell));
+}
+
+// Wrapper that collapses itself when its rendered value produces no DOM
+// content — this is how "skip a metric/context whose value is empty/nullish"
+// is honored without introspecting cell return values: a cell that renders
+// null leaves the value span (always the last child) `:empty`, and the
+// structural `:has` variant hides the whole slot. No whitespace inside the
+// value span, or `:empty` would not match. `break-words` keeps a long
+// unbroken token from forcing horizontal overflow (no `truncate`, which would
+// demand a static title on arbitrary rendered content).
+function ValueSlot({
+  label,
+  className,
+  children,
+}: {
+  label?: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex min-w-0 items-center gap-1",
+        "[&:has(>span:last-child:empty)]:hidden",
+        className,
+      )}
+    >
+      {label ? (
+        <span className="text-muted-foreground shrink-0">{label}</span>
+      ) : null}
+      <span className="min-w-0 break-words">{children}</span>
+    </span>
+  );
+}
+
+function MobileCard<TData>({
+  row,
+  onRowClick,
+  selectionStore,
+  getRowClassName,
+  measureRef,
+  index,
+}: {
+  row: Row<TData>;
+  onRowClick?: (row: TData, event?: React.MouseEvent) => void;
+  selectionStore?: TableSelectionStoreLike;
+  getRowClassName?: (row: TData) => string;
+  measureRef: (el: HTMLElement | null) => void;
+  index: number;
+}) {
+  const router = useRouter();
+  const peekRowId = router.query.peek as string | undefined;
+  const rowIsSelected = useTableRowIsSelected(
+    selectionStore,
+    row.id,
+    row.getIsSelected(),
+  );
+  const shouldHighlightAllRows = useTableSelectAll(selectionStore, false);
+  const isHighlighted =
+    rowIsSelected ||
+    shouldHighlightAllRows ||
+    (!!peekRowId && peekRowId === row.id);
+
+  const buckets = bucketCells(row);
+  const isClickable = !!onRowClick;
+
+  const title = buckets.title[0];
+
+  return (
+    <div ref={measureRef} data-index={index} className="px-2 pb-2">
+      <div
+        role={isClickable ? "button" : undefined}
+        tabIndex={isClickable ? 0 : undefined}
+        onClick={
+          isClickable
+            ? (e) => {
+                if (shouldIgnoreRowClickTarget(e.target)) return;
+                onRowClick?.(row.original, e);
+              }
+            : undefined
+        }
+        onKeyDown={
+          isClickable
+            ? (e) => {
+                if (e.key !== "Enter") return;
+                if (shouldIgnoreRowClickTarget(e.target)) return;
+                onRowClick?.(row.original);
+              }
+            : undefined
+        }
+        className={cn(
+          "bg-background flex w-full min-w-0 flex-col gap-2 overflow-hidden rounded-md border p-3",
+          isClickable && "hover:bg-accent cursor-pointer",
+          isHighlighted && "bg-muted/40 dark:bg-muted",
+          getRowClassName?.(row.original),
+        )}
+      >
+        {/* Header line: select · badge · title · timestamp · action */}
+        <div className="flex min-w-0 items-center gap-2">
+          {buckets.select.map((cell) => (
+            <span key={cell.id} className="shrink-0">
+              {renderCell(cell)}
+            </span>
+          ))}
+          {buckets.badge.map((cell) => (
+            <span
+              key={cell.id}
+              className="shrink-0 [&:empty]:hidden [&:has(>span:empty)]:hidden"
+            >
+              {renderCell(cell)}
+            </span>
+          ))}
+          {title ? (
+            <span
+              className="min-w-0 flex-1 truncate font-bold"
+              title={titleText(title)}
+            >
+              {renderCell(title)}
+            </span>
+          ) : (
+            <span className="min-w-0 flex-1" />
+          )}
+          {buckets.timestamp.map((cell) => (
+            <span
+              key={cell.id}
+              className="text-muted-foreground shrink-0 text-xs"
+            >
+              {renderCell(cell)}
+            </span>
+          ))}
+          {buckets.action.map((cell) => (
+            <span key={cell.id} className="shrink-0">
+              {renderCell(cell)}
+            </span>
+          ))}
+        </div>
+
+        {/* Metric strip: compact labelled values, wrapping, empties collapsed */}
+        {buckets.metric.length > 0 ? (
+          <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+            {buckets.metric.map((cell) => (
+              <ValueSlot key={cell.id} label={columnLabel(cell)}>
+                {renderCell(cell)}
+              </ValueSlot>
+            ))}
+          </div>
+        ) : null}
+
+        {/* Context line: tags, environment — wraps, never overflows */}
+        {buckets.context.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-1.5 text-xs">
+            {buckets.context.map((cell) => (
+              <ValueSlot key={cell.id}>{renderCell(cell)}</ValueSlot>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function DataTableMobileCardList<TData extends object>({
+  table,
+  data,
+  onRowClick,
+  selectionStore,
+  noResultsMessage,
+  help,
+  getRowClassName,
+}: DataTableMobileCardListProps<TData>) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const rows = table.getRowModel().rows;
+
+  // The virtualizer owns a real external system (the scroll container +
+  // ResizeObserver-based measurement), which is the sanctioned use of an
+  // effect — here it lives inside the library, not this component.
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 96,
+    // Key the measurement cache by row id (matching the React key) so that
+    // reordering/filtering rows never reuses a neighbour's measured height —
+    // cards have variable height (tags/metrics wrap over several lines).
+    getItemKey: (index) => rows[index]!.id,
+    overscan: 8,
+  });
+
+  const isLoading = data.isLoading || !data.data;
+
+  return (
+    <div
+      ref={parentRef}
+      className="relative min-h-0 w-full flex-1 overflow-x-hidden overflow-y-auto border-t py-2"
+    >
+      {isLoading ? (
+        <div aria-hidden="true">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={`mobile-card-skeleton-${i}`} className="px-2 pb-2">
+              <div className="bg-background flex w-full flex-col gap-2 rounded-md border p-3">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
+                  <Skeleton className="h-4 flex-1" />
+                  <Skeleton className="h-3 w-16 shrink-0" />
+                </div>
+                <div className="flex gap-3">
+                  <Skeleton className="h-3 w-12" />
+                  <Skeleton className="h-3 w-14" />
+                  <Skeleton className="h-3 w-10" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : rows.length ? (
+        <div
+          style={{
+            height: `${virtualizer.getTotalSize()}px`,
+            width: "100%",
+            position: "relative",
+          }}
+        >
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const row = rows[virtualRow.index]!;
+            return (
+              <div
+                key={row.id}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                <MobileCard
+                  row={row}
+                  index={virtualRow.index}
+                  onRowClick={onRowClick}
+                  selectionStore={selectionStore}
+                  getRowClassName={getRowClassName}
+                  measureRef={virtualizer.measureElement}
+                />
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="text-muted-foreground flex h-24 items-center justify-center px-4 text-center text-sm">
+          {noResultsMessage ?? (
+            <>
+              No results.{" "}
+              {help && (
+                <DocPopup description={help.description} href={help.href} />
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -56,6 +56,8 @@ import {
   useTableRowIsSelected,
   useTableSelectAll,
 } from "@/src/components/table/table-selection-store";
+import { DataTableMobileCardList } from "@/src/components/table/data-table-mobile-card-list";
+import { useIsMobile } from "@/src/hooks/use-mobile";
 
 interface DataTableProps<TData, TValue> {
   columns: LangfuseColumnDef<TData, TValue>[];
@@ -209,6 +211,22 @@ export function DataTable<TData extends object, TValue>({
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const rowheighttw = getRowHeightTailwindClass(rowHeight, customRowHeights);
   const capture = usePostHogClientCapture();
+
+  // Card rendering is opt-in per table: a table opts in by annotating any of
+  // its columns (including a grouped column's children) with a `mobileCard`
+  // hint. Tables without hints — and every desktop viewport — keep the exact
+  // table body below.
+  const isMobile = useIsMobile();
+  const hasMobileCardConfig = useMemo(
+    () =>
+      columns.some(
+        (c) =>
+          (c as LangfuseColumnDef<TData>).mobileCard ||
+          c.columns?.some((cc) => cc.mobileCard),
+      ),
+    [columns],
+  );
+  const useMobileCards = isMobile && hasMobileCardConfig;
   const flattedColumnsByGroup = useMemo(() => {
     const flatColumnsByGroup = new Map<string, string[]>();
 
@@ -392,190 +410,206 @@ export function DataTable<TData extends object, TValue>({
           className,
         )}
       >
-        <div
-          // pr-2 + scrollbar-gutter:stable reserve a small gutter on the right so the
-          // last column's resize handle is never flush against the scrollbar/edge and
-          // always has some cursor room. Partial mitigation for LFE-10460: a maximized
-          // browser still clamps the cursor at the screen edge, so this guarantees room
-          // to the right, not a complete fix.
-          className="relative min-h-full w-full overflow-auto border-t pr-2 [scrollbar-gutter:stable]"
-          style={{ ...columnSizeVars }}
-        >
-          <Table>
-            <TableHeader className="sticky top-0 z-20">
-              {tableHeaders.map((headerGroup) => (
-                <TableRow key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    const columnDef = header.column
-                      .columnDef as LangfuseColumnDef<ModelTableRow>;
-                    const sortingEnabled = columnDef.enableSorting;
-                    // if the header id does not translate to a valid css variable name, default to 150px as width
-                    // may only happen for dynamic columns, as column names are user defined
-                    const width = columnDef.isFlexWidth
-                      ? "auto"
-                      : isValidCssVariableName({
-                            name: header.id,
-                            includesHyphens: false,
-                          })
-                        ? `calc(var(--header-${header.id}-size) * 1px)`
-                        : 150;
+        {useMobileCards ? (
+          <DataTableMobileCardList
+            table={table}
+            data={data}
+            onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
+            selectionStore={selectionStore}
+            noResultsMessage={noResultsMessage}
+            help={help}
+            getRowClassName={getRowClassName}
+          />
+        ) : (
+          <div
+            // pr-2 + scrollbar-gutter:stable reserve a small gutter on the right so the
+            // last column's resize handle is never flush against the scrollbar/edge and
+            // always has some cursor room. Partial mitigation for LFE-10460: a maximized
+            // browser still clamps the cursor at the screen edge, so this guarantees room
+            // to the right, not a complete fix.
+            className="relative min-h-full w-full overflow-auto border-t pr-2 [scrollbar-gutter:stable]"
+            style={{ ...columnSizeVars }}
+          >
+            <Table>
+              <TableHeader className="sticky top-0 z-20">
+                {tableHeaders.map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => {
+                      const columnDef = header.column
+                        .columnDef as LangfuseColumnDef<ModelTableRow>;
+                      const sortingEnabled = columnDef.enableSorting;
+                      // if the header id does not translate to a valid css variable name, default to 150px as width
+                      // may only happen for dynamic columns, as column names are user defined
+                      const width = columnDef.isFlexWidth
+                        ? "auto"
+                        : isValidCssVariableName({
+                              name: header.id,
+                              includesHyphens: false,
+                            })
+                          ? `calc(var(--header-${header.id}-size) * 1px)`
+                          : 150;
 
-                    return header.column.getIsVisible() ? (
-                      <TableHead
-                        key={header.id}
-                        className={cn(
-                          "group p-1 first:pl-2",
-                          sortingEnabled && "cursor-pointer",
-                          getPinningClasses(header.column),
-                        )}
-                        style={{
-                          ...getCommonPinningStyles(header.column),
-                          width,
-                        }}
-                        onClick={(event) => {
-                          event.preventDefault();
+                      return header.column.getIsVisible() ? (
+                        <TableHead
+                          key={header.id}
+                          className={cn(
+                            "group p-1 first:pl-2",
+                            sortingEnabled && "cursor-pointer",
+                            getPinningClasses(header.column),
+                          )}
+                          style={{
+                            ...getCommonPinningStyles(header.column),
+                            width,
+                          }}
+                          onClick={(event) => {
+                            event.preventDefault();
 
-                          // Ignore the click synthesized when this column's own
-                          // resize drag is released over its header (other
-                          // headers stay clickable during that window).
-                          const lastResize = lastColumnResizeEndRef.current;
-                          if (
-                            lastResize.columnId === header.column.id &&
-                            Date.now() - lastResize.at < 250
-                          ) {
-                            return;
-                          }
+                            // Ignore the click synthesized when this column's own
+                            // resize drag is released over its header (other
+                            // headers stay clickable during that window).
+                            const lastResize = lastColumnResizeEndRef.current;
+                            if (
+                              lastResize.columnId === header.column.id &&
+                              Date.now() - lastResize.at < 250
+                            ) {
+                              return;
+                            }
 
-                          if (!setOrderBy || !columnDef.id || !sortingEnabled) {
-                            return;
-                          }
+                            if (
+                              !setOrderBy ||
+                              !columnDef.id ||
+                              !sortingEnabled
+                            ) {
+                              return;
+                            }
 
-                          if (orderBy?.column === columnDef.id) {
-                            if (orderBy.order === "DESC") {
-                              capture("table:column_sorting_header_click", {
-                                column: columnDef.id,
-                                order: "ASC",
-                              });
-                              setOrderBy({
-                                column: columnDef.id,
-                                order: "ASC",
-                              });
+                            if (orderBy?.column === columnDef.id) {
+                              if (orderBy.order === "DESC") {
+                                capture("table:column_sorting_header_click", {
+                                  column: columnDef.id,
+                                  order: "ASC",
+                                });
+                                setOrderBy({
+                                  column: columnDef.id,
+                                  order: "ASC",
+                                });
+                              } else {
+                                capture("table:column_sorting_header_click", {
+                                  column: columnDef.id,
+                                  order: "Disabled",
+                                });
+                                setOrderBy(null);
+                              }
                             } else {
                               capture("table:column_sorting_header_click", {
                                 column: columnDef.id,
-                                order: "Disabled",
+                                order: "DESC",
                               });
-                              setOrderBy(null);
+                              setOrderBy({
+                                column: columnDef.id,
+                                order: "DESC",
+                              });
                             }
-                          } else {
-                            capture("table:column_sorting_header_click", {
-                              column: columnDef.id,
-                              order: "DESC",
-                            });
-                            setOrderBy({
-                              column: columnDef.id,
-                              order: "DESC",
-                            });
-                          }
-                        }}
-                      >
-                        {header.isPlaceholder ? null : (
-                          <div className="flex items-center select-none">
-                            <span
-                              className="truncate leading-normal"
-                              title={getPlainTextFromReactNode(
-                                flexRender(
+                          }}
+                        >
+                          {header.isPlaceholder ? null : (
+                            <div className="flex items-center select-none">
+                              <span
+                                className="truncate leading-normal"
+                                title={getPlainTextFromReactNode(
+                                  flexRender(
+                                    header.column.columnDef.header,
+                                    header.getContext(),
+                                  ),
+                                )}
+                              >
+                                {flexRender(
                                   header.column.columnDef.header,
                                   header.getContext(),
-                                ),
+                                )}
+                              </span>
+                              {columnDef.headerTooltip && (
+                                <DocPopup
+                                  description={
+                                    columnDef.headerTooltip.description
+                                  }
+                                  href={columnDef.headerTooltip.href}
+                                />
                               )}
-                            >
-                              {flexRender(
-                                header.column.columnDef.header,
-                                header.getContext(),
-                              )}
-                            </span>
-                            {columnDef.headerTooltip && (
-                              <DocPopup
-                                description={
-                                  columnDef.headerTooltip.description
-                                }
-                                href={columnDef.headerTooltip.href}
-                              />
-                            )}
-                            {orderBy?.column === columnDef.id
-                              ? renderOrderingIndicator(orderBy)
-                              : null}
+                              {orderBy?.column === columnDef.id
+                                ? renderOrderingIndicator(orderBy)
+                                : null}
 
-                            <div
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                              }}
-                              onDoubleClick={() => header.column.resetSize()}
-                              onMouseDown={beginColumnResize(
-                                header.column.id,
-                                header.getResizeHandler(),
-                              )}
-                              onTouchStart={beginColumnResize(
-                                header.column.id,
-                                header.getResizeHandler(),
-                              )}
-                              className={cn(
-                                "bg-secondary absolute top-0 right-0 h-full w-1.5 cursor-col-resize touch-none opacity-0 select-none group-hover:opacity-100",
-                                header.column.getIsResizing() &&
-                                  "bg-primary-accent opacity-100",
-                              )}
-                            />
-                          </div>
-                        )}
-                      </TableHead>
-                    ) : null;
-                  })}
-                </TableRow>
-              ))}
-            </TableHeader>
-            {table.getState().columnSizingInfo.isResizingColumn ||
-            !!peekView ? (
-              <MemoizedTableBody
-                table={table}
-                rowheighttw={rowheighttw}
-                rowHeight={rowHeight}
-                columns={columns}
-                data={data}
-                help={help}
-                noResultsMessage={noResultsMessage}
-                onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
-                getRowClassName={getRowClassName}
-                highlightAllRows={highlightAllRows}
-                selectionStore={selectionStore}
-                topAlignCells={topAlignCells}
-                cellPadding={cellPadding}
-                tableSnapshot={{
-                  columnVisibility,
-                  columnOrder,
-                  rowSelection,
-                }}
-              />
-            ) : (
-              <TableBodyComponent
-                table={table}
-                rowheighttw={rowheighttw}
-                rowHeight={rowHeight}
-                columns={columns}
-                data={data}
-                help={help}
-                noResultsMessage={noResultsMessage}
-                onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
-                getRowClassName={getRowClassName}
-                highlightAllRows={highlightAllRows}
-                selectionStore={selectionStore}
-                topAlignCells={topAlignCells}
-                cellPadding={cellPadding}
-              />
-            )}
-          </Table>
-        </div>
+                              <div
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                }}
+                                onDoubleClick={() => header.column.resetSize()}
+                                onMouseDown={beginColumnResize(
+                                  header.column.id,
+                                  header.getResizeHandler(),
+                                )}
+                                onTouchStart={beginColumnResize(
+                                  header.column.id,
+                                  header.getResizeHandler(),
+                                )}
+                                className={cn(
+                                  "bg-secondary absolute top-0 right-0 h-full w-1.5 cursor-col-resize touch-none opacity-0 select-none group-hover:opacity-100",
+                                  header.column.getIsResizing() &&
+                                    "bg-primary-accent opacity-100",
+                                )}
+                              />
+                            </div>
+                          )}
+                        </TableHead>
+                      ) : null;
+                    })}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              {table.getState().columnSizingInfo.isResizingColumn ||
+              !!peekView ? (
+                <MemoizedTableBody
+                  table={table}
+                  rowheighttw={rowheighttw}
+                  rowHeight={rowHeight}
+                  columns={columns}
+                  data={data}
+                  help={help}
+                  noResultsMessage={noResultsMessage}
+                  onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
+                  getRowClassName={getRowClassName}
+                  highlightAllRows={highlightAllRows}
+                  selectionStore={selectionStore}
+                  topAlignCells={topAlignCells}
+                  cellPadding={cellPadding}
+                  tableSnapshot={{
+                    columnVisibility,
+                    columnOrder,
+                    rowSelection,
+                  }}
+                />
+              ) : (
+                <TableBodyComponent
+                  table={table}
+                  rowheighttw={rowheighttw}
+                  rowHeight={rowHeight}
+                  columns={columns}
+                  data={data}
+                  help={help}
+                  noResultsMessage={noResultsMessage}
+                  onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
+                  getRowClassName={getRowClassName}
+                  highlightAllRows={highlightAllRows}
+                  selectionStore={selectionStore}
+                  topAlignCells={topAlignCells}
+                  cellPadding={cellPadding}
+                />
+              )}
+            </Table>
+          </div>
+        )}
       </div>
       {!hidePagination && pagination !== undefined ? (
         <div className="bg-background sticky bottom-0 z-10 flex w-full justify-end border-t py-2 pr-2 font-bold">

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -133,10 +133,20 @@ function isValidCssVariableName({
 const INTERACTIVE_ROW_CLICK_SELECTOR =
   "a, button, input, select, textarea, summary, [role='button'], [role='link']";
 
-export const shouldIgnoreRowClickTarget = (target: EventTarget | null) => {
+export const shouldIgnoreRowClickTarget = (
+  target: EventTarget | null,
+  // Optional clickable container (e.g. a card that is itself role="button").
+  // Interactive CHILDREN of the row should swallow the click, but the container
+  // itself matching the selector must not — otherwise every click inside it is
+  // ignored and the row action never fires.
+  container?: Element | null,
+) => {
   if (!(target instanceof Element)) return false;
 
-  return Boolean(target.closest(INTERACTIVE_ROW_CLICK_SELECTOR));
+  const interactive = target.closest(INTERACTIVE_ROW_CLICK_SELECTOR);
+  if (!interactive) return false;
+  if (container && interactive === container) return false;
+  return true;
 };
 
 // These are the important styles to make sticky column pinning work!

--- a/web/src/components/table/types.ts
+++ b/web/src/components/table/types.ts
@@ -8,6 +8,29 @@ export type TableRowOptions = {
 
 export type DataTableCellPadding = "compact" | "comfortable" | "none";
 
+/**
+ * Slot a column occupies when a table is rendered as a mobile card list
+ * (see `data-table-mobile-card-list.tsx`). A column WITHOUT a `mobileCard`
+ * hint is not shown on the card — card content is curated per table by
+ * annotating a small subset of columns. The presence of any `mobileCard`
+ * hint on a table's columns is also what opts that table into card rendering
+ * on mobile; desktop and un-annotated tables are unaffected.
+ */
+export type MobileCardSlot =
+  | "title" // primary name — the card's headline
+  | "timestamp" // trailing time in the header line
+  | "metric" // compact labelled value in the metric strip (latency, cost, tokens)
+  | "badge" // small status badge/dot in the header line (e.g. level)
+  | "context" // wrapping chips below (tags, environment)
+  | "action" // trailing affordance in the header line (e.g. bookmark star)
+  | "select"; // leading selection checkbox
+
+export type MobileCardHint = {
+  slot: MobileCardSlot;
+  /** sort within a slot, ascending; default 0 */
+  order?: number;
+};
+
 declare module "@tanstack/react-table" {
   // extends tanstack ColumnDef to include additional properties
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -22,6 +45,8 @@ declare module "@tanstack/react-table" {
     isFlexWidth?: boolean; // if true, column absorbs leftover space (one per table)
     loadingCell?: React.ReactNode | (() => React.ReactNode);
     cellPadding?: DataTableCellPadding;
+    /** Opt a column into the mobile card list and place it in a slot. */
+    mobileCard?: MobileCardHint;
   }
 }
 

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -646,13 +646,16 @@ export default function TracesTable({
     ...(hideControls
       ? []
       : ([
-          selectActionColumn,
+          // Spread mobile-card hints onto the shared selection column locally
+          // so only this table opts into card rendering.
+          { ...selectActionColumn, mobileCard: { slot: "select" as const } },
           {
             accessorKey: "bookmarked",
             header: undefined,
             id: "bookmarked",
             size: 30,
             isFixedPosition: true,
+            mobileCard: { slot: "action" as const },
             loadingCell: <TableIconButtonLoadingCell />,
             cell: ({ row }) => {
               const bookmarked: TracesTableRow["bookmarked"] =
@@ -679,6 +682,7 @@ export default function TracesTable({
       size: 150,
       enableHiding: true,
       enableSorting,
+      mobileCard: { slot: "timestamp" },
       cell: ({ row }) => {
         const value: TracesTableRow["timestamp"] = row.getValue("timestamp");
         return value ? <LocalIsoDate date={value} /> : undefined;
@@ -691,6 +695,7 @@ export default function TracesTable({
       size: 150,
       enableHiding: true,
       enableSorting,
+      mobileCard: { slot: "title" },
       cell: ({ row }) => {
         const value: TracesTableRow["name"] = row.getValue("name");
         return value ?? undefined;
@@ -782,6 +787,7 @@ export default function TracesTable({
       id: "latency",
       header: "Latency",
       size: 100,
+      mobileCard: { slot: "metric", order: 0 },
       // add seconds to the end of the latency
       loadingCell: <TableTextLoadingCell />,
       cell: ({ row }) => {
@@ -800,6 +806,7 @@ export default function TracesTable({
       header: "Tokens",
       id: "tokens",
       size: 180,
+      mobileCard: { slot: "metric", order: 2 },
       loadingCell: <TableTextLoadingCell />,
       cell: ({ row }) => {
         const value: TracesTableRow["usage"] = row.getValue("usage");
@@ -830,6 +837,7 @@ export default function TracesTable({
       id: "totalCost",
       header: "Total Cost",
       size: 130,
+      mobileCard: { slot: "metric", order: 1 },
       loadingCell: <TableTextLoadingCell />,
       cell: ({ row }) => {
         const cost: TracesTableRow["totalCost"] = row.getValue("totalCost");
@@ -857,6 +865,7 @@ export default function TracesTable({
       size: 150,
       enableHiding: true,
       loadingCell: <TableBadgeLoadingCell />,
+      mobileCard: { slot: "context", order: 1 },
       cell: ({ row }) => {
         const value: TracesTableRow["environment"] =
           row.getValue("environment");
@@ -876,6 +885,7 @@ export default function TracesTable({
       id: "tags",
       header: "Tags",
       size: 150,
+      mobileCard: { slot: "context", order: 0 },
       headerTooltip: {
         description: (
           <>
@@ -1066,6 +1076,7 @@ export default function TracesTable({
       id: "level",
       header: "Level",
       size: 75,
+      mobileCard: { slot: "badge" },
       loadingCell: <TableTextLoadingCell />,
       cell: ({ row }) => {
         const value: TracesTableRow["level"] = row.getValue("level");

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1063,7 +1063,17 @@ export default function ObservationsEventsTable({
   const enableSorting = !hideControls;
 
   const columns: LangfuseColumnDef<EventsTableRow>[] = [
-    ...(hideControls ? [] : [selectActionColumn]),
+    // Spread a mobile-card hint onto the shared selection column locally so
+    // only this table opts into card rendering (the shared column stays
+    // un-annotated for other tables).
+    ...(hideControls
+      ? []
+      : [
+          {
+            ...selectActionColumn,
+            mobileCard: { slot: "select" as const },
+          },
+        ]),
     {
       accessorKey: "startTime",
       id: "startTime",
@@ -1071,6 +1081,7 @@ export default function ObservationsEventsTable({
       size: 150,
       enableHiding: true,
       enableSorting,
+      mobileCard: { slot: "timestamp" },
       cell: ({ row }) => {
         const value: Date = row.getValue("startTime");
         return <LocalIsoDate date={value} />;
@@ -1098,6 +1109,7 @@ export default function ObservationsEventsTable({
       header: getEventsColumnName("name"),
       size: 150,
       enableSorting,
+      mobileCard: { slot: "title" },
       cell: ({ row }) => {
         const value: EventsTableRow["name"] = row.getValue("name");
         return value ?? undefined;
@@ -1228,6 +1240,7 @@ export default function ObservationsEventsTable({
         href: "https://langfuse.com/docs/observability/features/log-levels",
       },
       enableHiding: true,
+      mobileCard: { slot: "badge" },
       cell: ({ row }) => {
         const value: ObservationLevelType | undefined = row.getValue("level");
         return value ? (
@@ -1272,6 +1285,7 @@ export default function ObservationsEventsTable({
       id: "latency",
       header: getEventsColumnName("latency"),
       size: 100,
+      mobileCard: { slot: "metric", order: 0 },
       cell: ({ row }) => {
         const latency: number | undefined = row.getValue("latency");
         return latency !== undefined ? (
@@ -1286,6 +1300,7 @@ export default function ObservationsEventsTable({
       header: getEventsColumnName("totalCost"),
       id: "totalCost",
       size: 120,
+      mobileCard: { slot: "metric", order: 1 },
       cell: ({ row }) => {
         const value: number | undefined = row.getValue("totalCost");
 
@@ -1489,6 +1504,7 @@ export default function ObservationsEventsTable({
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
+          mobileCard: { slot: "metric", order: 2 },
           cell: ({ row }) => {
             const value = row.getValue("usage") as {
               inputUsage: number;
@@ -1546,6 +1562,7 @@ export default function ObservationsEventsTable({
       size: 150,
       enableHiding: true,
       loadingCell: <TableBadgeLoadingCell />,
+      mobileCard: { slot: "context", order: 1 },
       cell: ({ row }) => {
         const value: EventsTableRow["environment"] =
           row.getValue("environment");
@@ -1567,6 +1584,7 @@ export default function ObservationsEventsTable({
       size: 250,
       enableHiding: true,
       loadingCell: <TableTextLoadingCell />,
+      mobileCard: { slot: "context", order: 0 },
       cell: ({ row }) => {
         const traceTags: string[] | undefined = row.getValue("traceTags");
         return (


### PR DESCRIPTION
## TL;DR
On mobile, list tables (traces v4 + legacy) now render as a real, app-like **vertical card list** instead of a ~2600px-wide table you can only scroll sideways. Fully **opt-in per table** and **byte-identical on desktop** — a table joins card mode only by tagging a few columns with a `mobileCard` slot hint.

## Why
No list table has a mobile layout. Both the v4 `ObservationsEventsTable` and the legacy `TracesTable` feed one generic `DataTable` that renders a `table-fixed` grid of ~13–15 fixed 150px columns. Measured at 390px the body is ~2663px wide, so the entire mobile experience is horizontal-scroll suffering. The row-tap → peek drawer is already mobile-native; the list itself was the gap.

## What
A new **virtualized vertical card list** that `DataTable` swaps in when the viewport is mobile **and** at least one column declares a `mobileCard` hint. It reuses the existing machinery rather than reimplementing it:

- Cards are assembled from the table's own cell renderers via `flexRender`, so every formatter (dates, cost/latency/tokens, tags, level badge, IO preview, selection checkbox, star) renders verbatim — the component owns layout, not presentation.
- A small `mobileCard` column hint (`types.ts`) places each cell in a slot: `title · timestamp · metric · badge · context · action · select` (with `order`). Un-annotated columns simply don't appear on the card.
- Selection store, row-tap → peek, and highlight styling are reused as-is.

The v4 events table and the legacy traces table are annotated with a curated subset; every other table (and all desktop viewports) is unchanged.

## Result
Real card list at ≤390px, no horizontal page scroll, vertical scroll only. Desktop rendering is untouched, and card mode is strictly opt-in via the presence of `mobileCard` hints.

<details>
<summary>Engineering detail & verification</summary>

**Seam**
- `types.ts` — optional `mobileCard?: { slot; order? }` added to the existing `ColumnDefBase` module augmentation (purely additive).
- `data-table-mobile-card-list.tsx` (new) — `useVirtualizer` over `table.getRowModel().rows`; measurement cache keyed by `row.id` (variable card heights from wrapping tags/metrics); buckets each row's *visible* cells by slot and sorts by `order`. Tap handling reuses `shouldIgnoreRowClickTarget`; highlight reuses `useTableRowIsSelected` / `useTableSelectAll` + the peek query param.
- `data-table.tsx` — `useMobileCards = useIsMobile() && hasMobileCardConfig` (the latter memoized, and it inspects grouped children too). Card list replaces the inner table block; outer wrapper and pagination footer are unchanged.

**Empty-cell collapse without value introspection** — a metric/context whose cell renders `null` leaves its value span `:empty`; a structural `[&:has(>span:last-child:empty)]:hidden` variant hides the whole slot. No per-accessor null-checking (which is unreliable when a cell reads a different key than its `accessorKey`).

**No new effects** — the only effect owner is the virtualizer's internal measurement (a legitimate external system); all slot bucketing is derived during render.

**`mobileCard` slot mapping applied**
- v4 `EventsTable`: `select`→select · `startTime`→timestamp · `name`→title · `level`→badge · `latency`→metric(0) · `totalCost`→metric(1) · `totalTokens`→metric(2) · `traceTags`→context(0) · `environment`→context(1).
- legacy `traces`: `select`→select · `bookmarked` star→action · `timestamp`→timestamp · `name`→title · `level`→badge · `latency`→metric(0) · `totalCost`→metric(1) · `tokens`→metric(2) · `tags`→context(0) · `environment`→context(1).

The shared selection column comes from `TableSelectionManager`; the hint is spread on locally per table so card mode stays opt-in and other tables that share that column are unaffected.

**Verification**
- `pnpm --filter web run typecheck` → 0 errors (clean full run).
- ESLint over the 6 touched files with `--max-warnings 0` → clean.
- `vitest run --project storybook data-table-mobile-card-list` → `Tests 3 passed (3)` (Default / Loading / Empty).

Live verification with seeded data is left to review.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in mobile card layout for shared data tables. The main changes are:

- A virtualized card-list renderer built from existing table cells.
- Mobile card slot metadata for column definitions.
- Card layouts for the traces and events tables.
- Storybook states for loaded, loading, and empty lists.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The mobile request-error path needs to be fixed before merging.

- Failed requests can remain on loading skeletons indefinitely.
- Focused cards do not implement Space-key button behavior.
- Desktop tables remain isolated from the new rendering branch.

web/src/components/table/data-table-mobile-card-list.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/table/data-table-mobile-card-list.tsx:299
**Request Errors Become Loading State**

When a mobile table request fails without `data`, this condition keeps rendering skeleton cards because it ignores `data.isError`. Unlike the replaced desktop body, the card list has no error branch, so users see an indefinite loading state instead of the request failure.

### Issue 2 of 2
web/src/components/table/data-table-mobile-card-list.tsx:195-199
**Space Key Skips Card Activation**

The card advertises native button semantics through `role="button"` and `tabIndex`, but the keyboard handler only accepts Enter. A keyboard user who presses Space on a focused card scrolls the list instead of opening that row.

```suggestion
            ? (e) => {
                if (e.key !== "Enter" && e.key !== " ") return;
                if (shouldIgnoreRowClickTarget(e.target)) return;
                e.preventDefault();
                onRowClick?.(row.original);
              }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(table): mobile card-list rendering ..."](https://github.com/langfuse/langfuse/commit/c41c73e6702a4007bb68460d30e1e941ec615741) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46405943)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->