### PR TITLE
feat(events): unified mobile filters sheet (LFE-11067)

### DIFF
--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -51,8 +51,13 @@ import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import {
   toAbsoluteTimeRange,
   type TableDateRange,
+  TABLE_AGGREGATION_OPTIONS,
 } from "@/src/utils/date-range-utils";
 import { TableHeaderControls } from "@/src/components/table/table-header-controls";
+import { TimeRangePicker } from "@/src/components/date-picker";
+import { DataTableRefreshButton } from "@/src/components/table/data-table-refresh-button";
+import { MobileFiltersSheet } from "@/src/features/events/components/MobileFiltersSheet";
+import { useIsMobile } from "@/src/hooks/use-mobile";
 import { type ScoreAggregate } from "@langfuse/shared";
 import TagList from "@/src/features/tag/components/TagList";
 import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTableStateContext";
@@ -1837,17 +1842,133 @@ export default function ObservationsEventsTable({
     setInterval: setRefreshInterval,
   };
 
+  // Mobile collapses the whole toolbar into one Filters bottom sheet. Desktop
+  // (≥768px) is byte-identical to before — everything below is gated on this.
+  const isMobile = useIsMobile();
+  // Count shown on the mobile Filters trigger. Same source as the desktop
+  // rail's active-facet count — distinct filtered COLUMNS (a facet can emit
+  // several FilterState entries) — plus free-text search, which now also lives
+  // in the sheet.
+  const mobileActiveFilterCount =
+    new Set(
+      (queryFilter.explicitFilterState ?? []).map((filter) => filter.column),
+    ).size + (searchQuery && searchQuery.trim().length > 0 ? 1 : 0);
+
   return (
     <DataTableControlsProvider tableName={eventsFilterConfig.tableName}>
       <div className="flex h-full w-full flex-col">
-        {showControlsInPageHeader && !hideControls && (
+        {showControlsInPageHeader && !hideControls && !isMobile && (
           <TableHeaderControls
             timeRange={timeRange}
             setTimeRange={setTimeRange}
             refresh={refreshConfig}
           />
         )}
-        {!hideControls && (
+        {/* Mobile: a single toolbar row — Filters(N) sheet trigger + view-mode
+            toggle. Search, time range, preset chips, saved views and the facet
+            sidebar all move INTO the sheet (same controllers, hosted there).
+            Columns / row-height / export are omitted on the card list. */}
+        {!hideControls && isMobile && (
+          <div className="my-2 flex items-center gap-2 px-2">
+            <MobileFiltersSheet
+              activeCount={mobileActiveFilterCount}
+              resultCount={totalCount}
+              onClearAll={() => {
+                queryFilter.clearAll();
+                setSearchQuery("");
+              }}
+              search={
+                searchBarMode ? (
+                  <EventsSearchBarRow
+                    projectId={projectId}
+                    tableName={eventsFilterConfig.tableName}
+                    store={searchBarStore}
+                    commit={searchBarCommit}
+                    observed={observedOptions}
+                    erroredColumns={erroredColumns}
+                    fieldReason={
+                      chartActive ? chartSearchFieldReason : undefined
+                    }
+                    freeTextReason={
+                      chartFreeTextIgnored
+                        ? CHART_SEARCH_QUERY_REASON
+                        : undefined
+                    }
+                    onApplyFilters={searchBarApplyFilters}
+                    onRequestColumns={requestColumns}
+                    aiDataContext={aiDataContext}
+                    aiScoreNames={aiScoreNames}
+                  />
+                ) : undefined
+              }
+              timeRange={
+                <div className="flex flex-wrap items-center gap-2">
+                  <TimeRangePicker
+                    timeRange={timeRange}
+                    onTimeRangeChange={setTimeRange}
+                    timeRangePresets={TABLE_AGGREGATION_OPTIONS}
+                    className="my-0 max-w-full overflow-x-auto"
+                  />
+                  <DataTableRefreshButton
+                    onRefresh={refreshConfig.onRefresh}
+                    isRefreshing={refreshConfig.isRefreshing}
+                    interval={refreshConfig.interval}
+                    setInterval={refreshConfig.setInterval}
+                  />
+                </div>
+              }
+              presets={
+                tableStatePolicy.disableSavedViews ? undefined : (
+                  <CategoryPresetChips
+                    projectId={projectId}
+                    activeViewId={
+                      viewControllers.appliedViewId ??
+                      viewControllers.selectedViewId
+                    }
+                    onApplyView={viewControllers.handleSetViewId}
+                    applyViewState={viewControllers.applyViewState}
+                    onPreviewView={previewViewInSearchBar}
+                  />
+                )
+              }
+              savedViews={
+                tableStatePolicy.disableSavedViews ? undefined : (
+                  <TableViewPresetsDrawer
+                    viewConfig={{
+                      tableName: TableViewPresetTableName.ObservationsEvents,
+                      projectId,
+                      controllers: viewControllers,
+                    }}
+                    currentState={{
+                      orderBy: orderByState ?? null,
+                      filters: queryFilter.explicitFilterState ?? [],
+                      columnOrder,
+                      columnVisibility,
+                      searchQuery: searchQuery ?? "",
+                    }}
+                  />
+                )
+              }
+              facets={
+                <DataTableControls
+                  key={viewControllers.selectedViewId ?? "no-view"}
+                  queryFilter={queryFilter}
+                  filterWithAI={!searchBarMode}
+                  blockedColumnReason={
+                    chartActive ? chartFilterExclusionReason : undefined
+                  }
+                />
+              }
+            />
+            {chartEnabled && (
+              <ViewModeToggle
+                mode={chartViewMode}
+                onModeChange={setChartViewMode}
+              />
+            )}
+          </div>
+        )}
+        {!hideControls && !isMobile && (
           <div
             className={cn(
               // This is a table-internal sticky band below PageHeader. Using
@@ -2037,7 +2158,10 @@ export default function ObservationsEventsTable({
         {/* Content area with sidebar and table. The facet sidebar stays in
             search-bar mode and syncs bidirectionally with the bar. */}
         <ResizableFilterLayout>
-          {!hideControls && (
+          {/* On mobile the facet sidebar moves into the Filters sheet above,
+              so it is not rendered inline here (leaving only the table content
+              in the layout). */}
+          {!hideControls && !isMobile && (
             <DataTableControls
               // Remount the sidebar when the saved view changes so the new view's filters replace any stale draft UI state.
               key={viewControllers.selectedViewId ?? "no-view"}

--- a/web/src/features/events/components/MobileFiltersSheet.stories.tsx
+++ b/web/src/features/events/components/MobileFiltersSheet.stories.tsx
@@ -1,0 +1,119 @@
+import preview from "../../../../.storybook/preview";
+import { useState, type ComponentProps } from "react";
+import { fn } from "storybook/test";
+
+import { MobileFiltersSheet } from "@/src/features/events/components/MobileFiltersSheet";
+import { ControlsContext } from "@/src/components/table/data-table-controls";
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
+import { Input } from "@/src/components/ui/input";
+
+// =============================================================================
+// WHY THIS STORY FAKES THE CONTROL NODES
+// =============================================================================
+// `MobileFiltersSheet` is a pure LAYOUT surface: EventsTable builds the real
+// controllers (grammar search bar, time-range picker, preset chips, saved-views
+// drawer, facet sidebar) and passes them in as nodes. Those controllers depend
+// on tRPC, routing and several providers, so the story substitutes structural
+// placeholders that stand in for each section. This exercises the sheet's own
+// concerns — labeled sections, sticky footer, active-count badge, the bounded
+// facet region — without dragging the whole page into Storybook.
+//
+// Open state is read from `ControlsContext` (the DataTableControls provider).
+// The demo wrapper supplies that context with `open: true` so the sheet renders
+// open; the trigger button and the footer's close still toggle it live.
+
+const fakeSearch = <Input placeholder="Search traces…" className="h-9" />;
+
+const fakeTimeRange = (
+  <Button variant="outline" size="sm" className="h-8">
+    Past 24 hours
+  </Button>
+);
+
+const fakePresets = (
+  <div className="flex flex-wrap gap-2">
+    {["Quality", "Slow", "Cost"].map((chip) => (
+      <Badge key={chip} variant="outline" className="cursor-pointer">
+        {chip}
+      </Badge>
+    ))}
+  </div>
+);
+
+const fakeSavedViews = (
+  <Button variant="outline" size="sm" className="h-8">
+    My Views
+  </Button>
+);
+
+// Stand-in for DataTableControls: its own "Filters" header + a scrollable facet
+// list, so the bounded flex region reads correctly in the sheet.
+const fakeFacets = (
+  <div className="bg-background flex min-h-0 flex-1 flex-col border-t">
+    <div className="flex h-10 shrink-0 items-center gap-1.5 border-b px-3">
+      <span className="text-sm font-bold">Filters</span>
+    </div>
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      {[
+        "Name",
+        "Environment",
+        "Level",
+        "Tags",
+        "Model",
+        "User",
+        "Session",
+        "Latency",
+        "Cost",
+        "Metadata",
+      ].map((facet) => (
+        <div
+          key={facet}
+          className="text-muted-foreground border-b px-3 py-2 text-sm"
+        >
+          {facet}
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+function MobileFiltersSheetDemo(
+  props: ComponentProps<typeof MobileFiltersSheet>,
+) {
+  const [open, setOpen] = useState(true);
+  return (
+    <ControlsContext.Provider value={{ open, setOpen, tableName: "storybook" }}>
+      <MobileFiltersSheet {...props} />
+    </ControlsContext.Provider>
+  );
+}
+
+const meta = preview.meta({
+  component: MobileFiltersSheetDemo,
+  parameters: { layout: "fullscreen" },
+  args: {
+    activeCount: 0,
+    resultCount: null,
+    onClearAll: fn(),
+    search: fakeSearch,
+    timeRange: fakeTimeRange,
+    presets: fakePresets,
+    savedViews: fakeSavedViews,
+    facets: fakeFacets,
+  },
+});
+
+export default meta;
+
+// Open sheet, no active filters — trigger badge hidden, footer reads
+// "Show results" (count unknown, as on the lazily-counted events table).
+export const Default = meta.story({});
+
+// Active filters set the trigger badge and a known result count in the footer.
+export const WithActiveFilters = meta.story({
+  args: {
+    activeCount: 3,
+    resultCount: 1284,
+  },
+});

--- a/web/src/features/events/components/MobileFiltersSheet.tsx
+++ b/web/src/features/events/components/MobileFiltersSheet.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { SlidersHorizontal, X } from "lucide-react";
+
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@/src/components/ui/sheet";
+import { useDataTableControls } from "@/src/components/table/data-table-controls";
+import { numberFormatter } from "@/src/utils/numbers";
+
+interface MobileFiltersSheetProps {
+  /** Count shown on the trigger badge — active facet columns (+ free-text
+   *  search, which also lives in this sheet now). Derived by the caller from
+   *  the same sidebar filter state the desktop rail counts. */
+  activeCount: number;
+  /** Total matching results for the "Show N results" footer button. Null when
+   *  the count is unknown (the events table counts lazily), which renders a
+   *  plain "Show results" label instead. */
+  resultCount: number | null;
+  /** Clears filter state + search. Results update live, so this does not close
+   *  the sheet. */
+  onClearAll: () => void;
+  /** Grammar search bar row (search-bar mode only). */
+  search?: ReactNode;
+  /** Time-range picker (+ optional refresh). */
+  timeRange?: ReactNode;
+  /** Category preset chips. */
+  presets?: ReactNode;
+  /** Saved-views drawer trigger ("My Views"). */
+  savedViews?: ReactNode;
+  /** Facet sidebar (DataTableControls). Owns its own "Filters" header + count
+   *  badge and internal scroll, so it gets a bounded flex region rather than a
+   *  labeled section of its own. */
+  facets?: ReactNode;
+}
+
+function Section({ label, children }: { label: string; children: ReactNode }) {
+  if (!children) return null;
+  return (
+    <section className="flex flex-col gap-2">
+      <h3 className="text-muted-foreground text-xs font-bold tracking-wide uppercase">
+        {label}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * Mobile-only bottom sheet that collapses the traces toolbar's scattered
+ * filter controls into ONE surface: search · time range · quick presets ·
+ * saved views · facets. It hosts the SAME controllers EventsTable already
+ * builds for desktop (passed in as nodes) — a presentation reshuffle, not a
+ * state migration.
+ *
+ * Open state is the shared DataTableControls context (`mobileOpen`), so the
+ * facet list expands (its rail-vs-expanded toggle keys off the provider's
+ * `data-expanded`) and its in-sheet "Hide filters" button closes the sheet.
+ */
+export function MobileFiltersSheet({
+  activeCount,
+  resultCount,
+  onClearAll,
+  search,
+  timeRange,
+  presets,
+  savedViews,
+  facets,
+}: MobileFiltersSheetProps) {
+  const { open, setOpen } = useDataTableControls();
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button variant="outline" size="sm" className="h-8 shrink-0 gap-2">
+          <SlidersHorizontal className="h-4 w-4" />
+          <span>Filters</span>
+          {activeCount > 0 && (
+            <Badge variant="secondary" className="ml-0.5 h-5 px-1.5 text-xs">
+              {activeCount}
+            </Badge>
+          )}
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side="bottom"
+        // No description; tell Radix it is intentional so it doesn't warn.
+        aria-describedby={undefined}
+        // Hide the wrapper's default close X (our header provides one) and
+        // drop the default padding/gap so header/body/footer own their spacing.
+        className="flex max-h-[85svh] flex-col gap-0 p-0 [&>button]:hidden"
+      >
+        {/* Accessible name for the dialog; the visible heading is below. */}
+        <SheetTitle className="sr-only">Filters</SheetTitle>
+        <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">
+          <span className="text-foreground text-lg font-bold">Filters</span>
+          <SheetClose asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Close filters"
+              className="h-8 w-8"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </SheetClose>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col">
+          {/* Short top controls. Capped + scrollable so a tall stack (wrapping
+              preset chips on a short screen) never starves the facet list. */}
+          {(search || timeRange || presets || savedViews) && (
+            <div className="flex max-h-[45svh] shrink-0 flex-col gap-5 overflow-y-auto border-b px-4 py-4">
+              <Section label="Search">{search}</Section>
+              <Section label="Time range">{timeRange}</Section>
+              <Section label="Quick presets">{presets}</Section>
+              <Section label="My views">{savedViews}</Section>
+            </div>
+          )}
+          {/* Facets fill the remaining height; DataTableControls scrolls its
+              own list within this bounded region. */}
+          {facets && (
+            <div className="flex min-h-0 flex-1 flex-col">{facets}</div>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2 border-t px-4 py-3">
+          <Button variant="outline" className="flex-1" onClick={onClearAll}>
+            Clear all
+          </Button>
+          <SheetClose asChild>
+            <Button className="flex-1">
+              {resultCount != null
+                ? `Show ${numberFormatter(resultCount, 0)} results`
+                : "Show results"}
+            </Button>
+          </SheetClose>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## TL;DR
On mobile, the traces view's six-row filter toolbar collapses into **one** Filters bottom sheet. The mobile toolbar row becomes just **`Filters (N)` + Table/Chart toggle**. Tapping Filters opens a bottom sheet holding, top→bottom: search · time range · quick presets · saved views · facets. Desktop (≥768px) is byte-identical to today.

> **Stacked PR — base is `feature/lfe-11067-mobile-card-list` (#15331), not `main`.** Merge **after** #15331 so the diff stays filters-only.

## Why
On a phone the toolbar is a 6-row stack — search bar, preset chips, "My Views", "Show filters", Table/Chart toggle, Columns/row-height/export — plus the time-range picker in the page header. It wraps into an unusable cramped band beside the new mobile card list. Product decision (locked): on mobile everything filter-related collapses into a single sheet.

## What
A filter-state audit confirmed all six controls already read/write the **same** state (4 URL params + the sidebar's `UIFilter[]`); none keep a private copy. So this is a **presentation reshuffle, not a state migration**. `EventsTable` already constructs every controller for desktop — this PR hosts those *same* controller nodes in a bottom sheet on mobile.

- New `MobileFiltersSheet.tsx` — a bottom `Sheet` (portalled through the `panel` layer via the ui/sheet wrapper) with labeled sections and a sticky footer (**Clear all** + **Show results**). No second apply path — results update live as controls change.
- `EventsTable` gates everything on `useIsMobile()`: mobile renders the compact row + routes the existing controller nodes into the sheet; desktop is unchanged.
- Reuses the shared `DataTableControls` open state (`mobileOpen`) to drive the sheet, superseding the inline `ResizableFilterLayout` mobile branch + `FilterToggleButton` for this table.

## Result
One mobile row (`Filters (N)` + view toggle); search / time / presets / views / facets all live in the sheet, sharing the exact controllers desktop uses. Verified: web typecheck (exit 0), eslint (exit 0), Storybook test (`Tests 2 passed (2)`). Desktop diff is additive-only (conditions gained `!isMobile`).

<details>
<summary>Mechanism, reuse & verification detail</summary>

**How each control is reused (not duplicated):**
- **Search** — the same `<EventsSearchBarRow>` node (`searchBarStore`/`commit`/`applyFilters`, `observedOptions`, chart `fieldReason`/`freeTextReason`), gated by `searchBarMode`.
- **Quick presets** — the same `<CategoryPresetChips>` wired to `viewControllers` + `previewViewInSearchBar`.
- **My views** — the same `<TableViewPresetsDrawer>` with the identical `viewConfig`/`currentState`.
- **Facets** — the same `<DataTableControls queryFilter=… blockedColumnReason=…>`. Its rail-vs-expanded toggle keys off the provider's `data-expanded`; portalled out of the provider's group div it renders expanded, and its own "Hide filters" button closes the sheet.
- **Time range** — `TimeRangePicker` (+ refresh) built from the same `useTableDateRange`/`refreshConfig`; on mobile it moves out of the page-header portal into the sheet.
- **View-mode toggle** — the same `<ViewModeToggle>` stays in the toolbar row.
- **Active count** — derived exactly as the desktop rail: distinct filtered columns in `explicitFilterState`, plus free-text search (now in the sheet).

**Chart mode:** blocked-filter reasons (`chartFilterExclusionReason` / `chartSearchFieldReason` / `CHART_SEARCH_QUERY_REASON`) are passed through, so greyed controls read the same inside the sheet.

**a11y / layout:** sr-only `SheetTitle` "Filters" + custom header/close (default X hidden via `[&>button]:hidden`), `aria-describedby={undefined}`, `max-h-[85svh]`; top controls capped + scrollable, facets fill a bounded `flex-1 min-h-0` region so their own list scrolls; no horizontal overflow at 360px.

**Known scope note:** the multi-select select-all banner + batch-action menu live inside the shared `DataTableToolbar` (which the mobile row replaces), so they are desktop-only in this pass. The card-list PR added mobile selection checkboxes; a dedicated mobile action surface is a follow-up for that feature, not this filters reshuffle.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates the events filters into a mobile bottom sheet. The main changes are:

- Moves search, time range, presets, saved views, and facets into one mobile sheet.
- Adds a compact mobile row with the filter count and view-mode toggle.
- Keeps the existing desktop controls behind the desktop breakpoint.
- Adds Storybook coverage for default and active-filter states.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The mobile clear action and selected-event workflow need fixes before merging.

- Clear all can leave revealed facets visible.
- Replacing the mobile toolbar removes the action surface for selected cards.
- The remaining sheet wiring follows the existing shared controller state.

web/src/features/events/components/EventsTable.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/events/components/EventsTable.tsx:1876-1879
**Clear All Leaves Revealed Facets**

When a user reveals a facet without assigning a value, this new action clears the applied filters and search but not `revealedColumns`. The facet therefore remains in the mobile sheet after **Clear all**, unlike the existing controls action that resets both states.

### Issue 2 of 2
web/src/features/events/components/EventsTable.tsx:1971
**Mobile Selection Loses Action Surface**

The mobile card list exposes selection checkboxes, but this condition removes the `DataTableToolbar` that contains the select-all banner and batch-action menu. Mobile users can select events but cannot run or manage the corresponding batch actions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(events): unified mobile filters she..."](https://github.com/langfuse/langfuse/commit/e24a84ebcb92c7ab9ea4cc713ca1a8f74c4ef7c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46415725)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->