### PR TITLE
[DO NOT MERGE] Mobile revamp — integration preview (LFE-11067)

### DIFF
--- a/web/src/components/layouts/breadcrumb.tsx
+++ b/web/src/components/layouts/breadcrumb.tsx
@@ -12,8 +12,10 @@ import {
 } from "@/src/components/ui/dropdown-menu";
 import { ChevronDownIcon, Slash } from "lucide-react";
 import { env } from "@/src/env.mjs";
-import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { useRouter } from "next/router";
+import {
+  useOrgProjectSwitchPaths,
+  useQueryProjectOrOrganization,
+} from "@/src/features/projects/hooks";
 import { useSession } from "next-auth/react";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { isCloudPlan, planLabels } from "@langfuse/shared";
@@ -29,9 +31,9 @@ const BreadcrumbComponent = ({
   items?: { name: string; href?: string }[];
   className?: string;
 }) => {
-  const router = useRouter();
   const session = useSession();
   const { organization, project } = useQueryProjectOrOrganization();
+  const { getProjectPath, getOrgPath } = useOrgProjectSwitchPaths();
 
   const organizations = session.data?.user?.organizations;
 
@@ -40,39 +42,6 @@ const BreadcrumbComponent = ({
     organizationId: organization?.id,
     scope: "projects:create",
   });
-
-  /**
-   * Truncate the path before the first dynamic segment that is not allowlisted.
-   * e.g. /project/[projectId]/traces/[traceId] -> /project/[projectId]/traces
-   */
-  const truncatePathBeforeDynamicSegments = (path: string) => {
-    const allowlistedIds = ["[projectId]", "[organizationId]", "[page]"];
-    const segments = router.route.split("/");
-    const idSegments = segments.filter(
-      (segment) => segment.startsWith("[") && segment.endsWith("]"),
-    );
-    const stopSegment = idSegments.filter((id) => !allowlistedIds.includes(id));
-    if (stopSegment.length === 0) return path;
-    const stopIndex = segments.indexOf(stopSegment[0]);
-    const truncatedPath = path.split("/").slice(0, stopIndex).join("/");
-    return truncatedPath;
-  };
-
-  const getProjectPath = (projectId: string) =>
-    router.query.projectId
-      ? truncatePathBeforeDynamicSegments(router.asPath).replace(
-          router.query.projectId as string,
-          projectId,
-        )
-      : `/project/${projectId}`;
-
-  const getOrgPath = (orgId: string) =>
-    router.query.organizationId
-      ? truncatePathBeforeDynamicSegments(router.asPath).replace(
-          router.query.organizationId as string,
-          orgId,
-        )
-      : `/organization/${orgId}`;
 
   return (
     <Breadcrumb className={className}>

--- a/web/src/components/layouts/mobile-page-title.tsx
+++ b/web/src/components/layouts/mobile-page-title.tsx
@@ -52,47 +52,53 @@ export const MobilePageTitle = ({
         {breadcrumbBadges}
       </div>
 
-      <div className="mt-1.5 flex items-start justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-2">
-          {itemType && <ItemBadge type={itemType} showLabel />}
-          <h1 className="text-primary text-2xl leading-tight font-bold wrap-break-word">
-            {titleContent ? (
-              titleContent
-            ) : titleTooltip ? (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="cursor-help">{title}</span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" className="max-w-xs">
-                    {titleTooltip}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            ) : (
-              <span title={title}>{title}</span>
-            )}
-            {help && (
-              <span className="align-middle whitespace-nowrap">
-                &nbsp;
-                <DocPopup
-                  description={help.description}
-                  href={help.href}
-                  className={help.className}
-                />
-              </span>
-            )}
-          </h1>
-          {titleBadges && (
-            <div className="flex items-center gap-1">{titleBadges}</div>
+      {/* Title on its own full-width line. On desktop the PageHeader packs the
+          title and its action clusters onto one justified row, but at phone
+          width there is no room: a `shrink-0` action cluster sharing the row
+          crushes the `min-w-0` title (a fixed-width search input, or a
+          dashboard selector + edit + setup, would overlap the heading). So the
+          mobile title owns its line and every action cluster wraps onto its
+          own row below — matching how the controls/agent row already behaves. */}
+      <div className="mt-1.5 flex min-w-0 items-center gap-2">
+        {itemType && <ItemBadge type={itemType} showLabel />}
+        <h1 className="text-primary text-2xl leading-tight font-bold wrap-break-word">
+          {titleContent ? (
+            titleContent
+          ) : titleTooltip ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="cursor-help">{title}</span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs">
+                  {titleTooltip}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            <span title={title}>{title}</span>
           )}
-        </div>
-        {actionButtonsRight && (
-          <div className="flex shrink-0 items-center gap-1">
-            {actionButtonsRight}
-          </div>
+          {help && (
+            <span className="align-middle whitespace-nowrap">
+              &nbsp;
+              <DocPopup
+                description={help.description}
+                href={help.href}
+                className={help.className}
+              />
+            </span>
+          )}
+        </h1>
+        {titleBadges && (
+          <div className="flex items-center gap-1">{titleBadges}</div>
         )}
       </div>
+
+      {actionButtonsRight && (
+        <div className="mt-2 flex flex-wrap items-center gap-1">
+          {actionButtonsRight}
+        </div>
+      )}
 
       {actionButtonsLeft && (
         <div className="mt-2 flex flex-wrap items-center gap-1">

--- a/web/src/components/nav/app-sidebar.tsx
+++ b/web/src/components/nav/app-sidebar.tsx
@@ -18,11 +18,13 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
+  useSidebar,
 } from "@/src/components/ui/sidebar";
 import { env } from "@/src/env.mjs";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import { LangfuseLogo } from "@/src/components/LangfuseLogo";
+import { MobileNavSwitcher } from "@/src/components/nav/mobile-nav-switcher";
 import { SidebarNotifications } from "@/src/components/nav/sidebar-notifications";
 import { type RouteGroup } from "@/src/components/layouts/routes";
 import { ExternalLink, Grid2X2 } from "lucide-react";
@@ -46,6 +48,8 @@ export function AppSidebar({
   userNavProps,
   ...props
 }: AppSidebarProps) {
+  const { isMobile } = useSidebar();
+
   return (
     <Sidebar collapsible="icon" variant="sidebar" {...props}>
       <SidebarHeader>
@@ -56,6 +60,7 @@ export function AppSidebar({
         <DemoBadge />
       </SidebarHeader>
       <SidebarContent>
+        {isMobile && <MobileNavSwitcher />}
         <NavMain items={navItems} />
         <div className="flex-1" />
         <div className="flex flex-col gap-2 p-2">

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -74,7 +74,7 @@ export const InAppAiAgentButton = () => {
       <BotMessageSquare className="h-4 w-4" />
       <span className="hidden sm:inline">Assistant</span>
       <KeyboardShortcut
-        className="hidden bg-transparent shadow-none md:inline-flex"
+        className="bg-transparent shadow-none"
         keys={[
           typeof navigator !== "undefined" &&
           navigator.userAgent.includes("Mac")

--- a/web/src/components/nav/mobile-nav-switcher.tsx
+++ b/web/src/components/nav/mobile-nav-switcher.tsx
@@ -1,0 +1,108 @@
+import { ChevronDownIcon } from "lucide-react";
+import { useSession } from "next-auth/react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/src/components/ui/sidebar";
+import { OrganizationDropdownMenu } from "@/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu";
+import { ProjectDropdownMenu } from "@/src/components/ProjectDropdownMenu/ProjectDropdownMenu";
+import {
+  useOrgProjectSwitchPaths,
+  useQueryProjectOrOrganization,
+} from "@/src/features/projects/hooks";
+import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
+
+/**
+ * Org + project switcher for the TOP of the mobile nav drawer.
+ *
+ * The mobile drawer (the `Sheet` branch of `Sidebar`, see ui/sidebar.tsx)
+ * otherwise only lists section links — the same switching affordance the
+ * desktop breadcrumb offers (`BreadcrumbComponent`) is easy to miss on
+ * mobile, since the breadcrumb sits in the page body. This reuses the exact
+ * dropdown menus and path builders the breadcrumb uses, so switching
+ * behavior is identical between both entry points; only rendered by
+ * `AppSidebar` when `useSidebar().isMobile` is true.
+ */
+export function MobileNavSwitcher() {
+  const session = useSession();
+  const { organization, project } = useQueryProjectOrOrganization();
+  const { getProjectPath, getOrgPath } = useOrgProjectSwitchPaths();
+
+  const organizations = session.data?.user?.organizations;
+  const canCreateOrganizations = session.data?.user?.canCreateOrganizations;
+  const canCreateProjects = useHasOrganizationAccess({
+    organizationId: organization?.id,
+    scope: "projects:create",
+  });
+
+  if (!organization) return null;
+
+  return (
+    <SidebarGroup className="border-b">
+      <SidebarGroupContent>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton>
+                  <span
+                    className="min-w-0 flex-1 truncate text-left"
+                    title={organization.name}
+                  >
+                    {organization.name}
+                  </span>
+                  <ChevronDownIcon className="ml-auto h-4 w-4 shrink-0" />
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <OrganizationDropdownMenu
+                {...(organizations
+                  ? { state: "loaded", organizations }
+                  : { state: "loading" })}
+                canCreateOrganizations={!!canCreateOrganizations}
+                getOrgPath={getOrgPath}
+              />
+            </DropdownMenu>
+          </SidebarMenuItem>
+          {project && (
+            <SidebarMenuItem>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <SidebarMenuButton>
+                    <span
+                      className="min-w-0 flex-1 truncate text-left"
+                      title={project.name}
+                    >
+                      {project.name}
+                    </span>
+                    <ChevronDownIcon className="ml-auto h-4 w-4 shrink-0" />
+                  </SidebarMenuButton>
+                </DropdownMenuTrigger>
+                <ProjectDropdownMenu
+                  organizationId={organization.id}
+                  {...(organizations
+                    ? {
+                        state: "loaded",
+                        projects:
+                          organizations.find(
+                            (org) => org.id === organization.id,
+                          )?.projects ?? [],
+                      }
+                    : { state: "loading" })}
+                  canCreateProjects={!!canCreateProjects}
+                  getProjectPath={getProjectPath}
+                />
+              </DropdownMenu>
+            </SidebarMenuItem>
+          )}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}

--- a/web/src/components/table/data-table-mobile-card-list.stories.tsx
+++ b/web/src/components/table/data-table-mobile-card-list.stories.tsx
@@ -1,0 +1,298 @@
+import preview from "../../../.storybook/preview";
+import { useState } from "react";
+import { fn } from "storybook/test";
+import {
+  getCoreRowModel,
+  useReactTable,
+  type RowSelectionState,
+} from "@tanstack/react-table";
+import Decimal from "decimal.js";
+
+import { DataTableMobileCardList } from "@/src/components/table/data-table-mobile-card-list";
+import { type AsyncTableData } from "@/src/components/table/data-table";
+import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
+import { Badge } from "@/src/components/ui/badge";
+import { Checkbox } from "@/src/components/ui/checkbox";
+import { StarToggle } from "@/src/components/star-toggle";
+import TagList from "@/src/features/tag/components/TagList";
+import { formatIntervalSeconds } from "@/src/utils/dates";
+import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
+
+// =============================================================================
+// WHY THIS STORY RENDERS THE CARD LIST DIRECTLY
+// =============================================================================
+// `DataTableMobileCardList` is what `DataTable` swaps in on a mobile viewport
+// (`useIsMobile() && a column carries a `mobileCard` hint`). `useIsMobile`
+// resolves against the real viewport width via a `max-width` media query, so
+// there is no reliable way to "force mobile" from a story and let DataTable
+// pick the card branch. Instead we render the card list directly with a handful
+// of faked rows and a small columns array carrying `mobileCard` hints. A thin
+// wrapper builds a real TanStack table instance (the card list reads
+// `getRowModel()` / `getVisibleCells()` / `flexRender`) from those columns. The
+// decorator sizes the container like a phone so the vertical,
+// horizontal-scroll-free layout is visible in the Storybook browser.
+//
+// The list is virtualized: it measures its scroll container and renders the
+// cards that fit. The stories showcase the loaded / loading / empty states —
+// no play functions, since assertions on virtualized layout are brittle.
+
+// -----------------------------------------------------------------------------
+// Deterministic mock data (mirrors the load-bearing TracesTableRow fields)
+// -----------------------------------------------------------------------------
+
+function seeded(n: number) {
+  const x = Math.sin(n + 1) * 10000;
+  return x - Math.floor(x);
+}
+
+const TRACE_NAMES = [
+  "checkout-agent",
+  "retrieval-pipeline",
+  "summarizer-with-a-very-long-name-that-should-truncate",
+  "qa-bot",
+  "classification-job",
+  "embedding-batch",
+];
+const ENVIRONMENTS = ["production", "staging", "development"];
+const LEVELS = ["DEFAULT", "WARNING", "ERROR", "DEBUG"] as const;
+const TAG_POOL = [
+  ["production", "rag"],
+  ["staging"],
+  [],
+  ["experimental", "latency-sensitive", "reviewed"],
+];
+
+type CardRow = {
+  id: string;
+  bookmarked: boolean;
+  name: string;
+  timestamp: Date;
+  level: (typeof LEVELS)[number];
+  latency: number;
+  totalCost: Decimal;
+  totalTokens: number;
+  environment: string;
+  tags: string[];
+};
+
+function makeRow(index: number): CardRow {
+  const baseTime = Date.parse("2026-07-20T09:00:00.000Z");
+  return {
+    id: `trace-${(index + 1).toString().padStart(5, "0")}`,
+    bookmarked: index % 4 === 0,
+    name: TRACE_NAMES[index % TRACE_NAMES.length]!,
+    timestamp: new Date(baseTime - index * 137_000),
+    level: LEVELS[index % LEVELS.length]!,
+    latency: Number((0.2 + seeded(index) * 18).toFixed(3)),
+    totalCost: new Decimal(Number((seeded(index * 2) * 0.4).toFixed(6))),
+    totalTokens: Math.round(300 + seeded(index * 3) * 6000),
+    environment: ENVIRONMENTS[index % ENVIRONMENTS.length]!,
+    tags: TAG_POOL[index % TAG_POOL.length]!,
+  };
+}
+
+const ROWS: CardRow[] = Array.from({ length: 12 }, (_, i) => makeRow(i));
+
+function loadedData(count = 8): AsyncTableData<CardRow[]> {
+  return { isLoading: false, isError: false, data: ROWS.slice(0, count) };
+}
+
+const LEVEL_BADGE: Record<CardRow["level"], string> = {
+  DEFAULT: "bg-muted text-muted-foreground",
+  DEBUG: "bg-muted text-muted-foreground",
+  WARNING: "bg-yellow-100 text-yellow-800",
+  ERROR: "bg-red-100 text-red-800",
+};
+
+// A small, curated columns array — each carries a `mobileCard` slot hint, which
+// is the only signal the card list reads to place a cell.
+const columns: LangfuseColumnDef<CardRow>[] = [
+  {
+    accessorKey: "select",
+    id: "select",
+    header: "",
+    size: 30,
+    mobileCard: { slot: "select" },
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+  },
+  {
+    accessorKey: "level",
+    id: "level",
+    header: "Level",
+    mobileCard: { slot: "badge" },
+    cell: ({ row }) => (
+      <span
+        className={`rounded-sm px-1 py-0.5 text-xs ${LEVEL_BADGE[row.original.level]}`}
+      >
+        {row.original.level}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "name",
+    id: "name",
+    header: "Name",
+    mobileCard: { slot: "title" },
+    cell: ({ row }) => row.original.name ?? undefined,
+  },
+  {
+    accessorKey: "timestamp",
+    id: "timestamp",
+    header: "Timestamp",
+    mobileCard: { slot: "timestamp" },
+    cell: ({ row }) => <LocalIsoDate date={row.original.timestamp} />,
+  },
+  {
+    accessorKey: "bookmarked",
+    id: "bookmarked",
+    header: "",
+    mobileCard: { slot: "action" },
+    cell: ({ row }) => <BookmarkCell defaultValue={row.original.bookmarked} />,
+  },
+  {
+    accessorKey: "latency",
+    id: "latency",
+    header: "Latency",
+    mobileCard: { slot: "metric", order: 0 },
+    cell: ({ row }) => (
+      <span>{formatIntervalSeconds(row.original.latency)}</span>
+    ),
+  },
+  {
+    accessorKey: "totalCost",
+    id: "totalCost",
+    header: "Cost",
+    mobileCard: { slot: "metric", order: 1 },
+    cell: ({ row }) => (
+      <span>{usdFormatter(row.original.totalCost.toNumber())}</span>
+    ),
+  },
+  {
+    accessorKey: "totalTokens",
+    id: "totalTokens",
+    header: "Tokens",
+    mobileCard: { slot: "metric", order: 2 },
+    cell: ({ row }) => (
+      <span>{numberFormatter(row.original.totalTokens, 0)}</span>
+    ),
+  },
+  {
+    accessorKey: "tags",
+    id: "tags",
+    header: "Tags",
+    mobileCard: { slot: "context", order: 0 },
+    cell: ({ row }) =>
+      row.original.tags.length > 0 ? (
+        <div className="flex flex-wrap gap-x-2 gap-y-1">
+          <TagList
+            selectedTags={row.original.tags}
+            isLoading={false}
+            viewOnly
+          />
+        </div>
+      ) : null,
+  },
+  {
+    accessorKey: "environment",
+    id: "environment",
+    header: "Environment",
+    mobileCard: { slot: "context", order: 1 },
+    cell: ({ row }) => (
+      <Badge
+        variant="secondary"
+        className="max-w-fit truncate rounded-sm px-1 font-normal"
+      >
+        {row.original.environment}
+      </Badge>
+    ),
+  },
+];
+
+function BookmarkCell({ defaultValue }: { defaultValue: boolean }) {
+  const [value, setValue] = useState(defaultValue);
+  return (
+    <StarToggle
+      value={value}
+      size="icon-xs"
+      isLoading={false}
+      onClick={async (next) => setValue(next)}
+    />
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Thin wrapper: build a real TanStack table from the columns + data, then hand
+// it to the card list (which reads the row model + cell renderers).
+// -----------------------------------------------------------------------------
+
+type MobileCardListDemoProps = {
+  data: AsyncTableData<CardRow[]>;
+  onRowClick?: (row: CardRow) => void;
+  noResultsMessage?: React.ReactNode;
+};
+
+function MobileCardListDemo({
+  data,
+  onRowClick,
+  noResultsMessage,
+}: MobileCardListDemoProps) {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const table = useReactTable<CardRow>({
+    data: data.data ?? [],
+    columns,
+    state: { rowSelection },
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => row.id,
+  });
+  return (
+    <DataTableMobileCardList<CardRow>
+      table={table}
+      data={data}
+      onRowClick={onRowClick}
+      noResultsMessage={noResultsMessage}
+    />
+  );
+}
+
+const meta = preview.meta({
+  component: MobileCardListDemo,
+  parameters: { layout: "centered" },
+  args: {
+    data: loadedData(),
+    onRowClick: fn(),
+  },
+  decorators: [
+    // Size the frame like a phone so the vertical, no-horizontal-scroll layout
+    // is visible. The card list fills height and scrolls vertically only.
+    (Story) => (
+      <div className="bg-background flex h-[640px] w-[390px] flex-col overflow-hidden border">
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+export default meta;
+
+export const Default = meta.story({});
+
+export const Loading = meta.story({
+  args: {
+    data: { isLoading: true, isError: false },
+  },
+});
+
+export const Empty = meta.story({
+  args: {
+    data: { isLoading: false, isError: false, data: [] },
+    noResultsMessage: "No traces match the current filters.",
+  },
+});

--- a/web/src/components/table/data-table-mobile-card-list.tsx
+++ b/web/src/components/table/data-table-mobile-card-list.tsx
@@ -185,7 +185,9 @@ function MobileCard<TData>({
         onClick={
           isClickable
             ? (e) => {
-                if (shouldIgnoreRowClickTarget(e.target)) return;
+                // Exclude the card root (role="button") so only interactive
+                // CHILDREN (checkbox, star, links) swallow the tap.
+                if (shouldIgnoreRowClickTarget(e.target, e.currentTarget)) return;
                 onRowClick?.(row.original, e);
               }
             : undefined
@@ -194,7 +196,7 @@ function MobileCard<TData>({
           isClickable
             ? (e) => {
                 if (e.key !== "Enter") return;
-                if (shouldIgnoreRowClickTarget(e.target)) return;
+                if (shouldIgnoreRowClickTarget(e.target, e.currentTarget)) return;
                 onRowClick?.(row.original);
               }
             : undefined

--- a/web/src/components/table/data-table-mobile-card-list.tsx
+++ b/web/src/components/table/data-table-mobile-card-list.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import React, { useRef } from "react";
+import { useRouter } from "next/router";
+import { flexRender, type Cell, type Row } from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+import DocPopup from "@/src/components/layouts/doc-popup";
+import { Skeleton } from "@/src/components/ui/skeleton";
+import {
+  type AsyncTableData,
+  shouldIgnoreRowClickTarget,
+} from "@/src/components/table/data-table";
+import {
+  type LangfuseColumnDef,
+  type MobileCardSlot,
+} from "@/src/components/table/types";
+import {
+  type TableSelectionStoreLike,
+  useTableRowIsSelected,
+  useTableSelectAll,
+} from "@/src/components/table/table-selection-store";
+import { getPlainTextFromReactNode } from "@/src/utils/react-node-plain-text";
+import { cn } from "@/src/utils/tailwind";
+
+// -----------------------------------------------------------------------------
+// Mobile card list
+// -----------------------------------------------------------------------------
+// A vertical, virtualized alternative to the wide `table-fixed` body that the
+// desktop DataTable renders. Instead of ~13 fixed 150px columns forcing 2600px
+// of horizontal scroll on a phone, each row becomes a tappable card. Cards are
+// assembled ENTIRELY from the table's own cell renderers via `flexRender`, so
+// every formatter (dates, cost/latency/token, tags, level badge, IO preview,
+// selection checkbox, star) is reused verbatim — this component owns layout,
+// not presentation.
+//
+// Which cells appear, and where, is curated per table through the optional
+// `mobileCard` column hint (see types.ts). Un-annotated columns are omitted.
+
+interface DataTableMobileCardListProps<TData> {
+  table: {
+    getRowModel: () => { rows: Row<TData>[] };
+  };
+  data: AsyncTableData<TData[]>;
+  onRowClick?: (row: TData, event?: React.MouseEvent) => void;
+  selectionStore?: TableSelectionStoreLike;
+  noResultsMessage?: React.ReactNode;
+  help?: { description: string; href: string };
+  getRowClassName?: (row: TData) => string;
+}
+
+type SlotBuckets<TData> = Record<MobileCardSlot, Cell<TData, unknown>[]>;
+
+const EMPTY_BUCKETS: readonly MobileCardSlot[] = [
+  "select",
+  "badge",
+  "title",
+  "timestamp",
+  "action",
+  "metric",
+  "context",
+] as const;
+
+// Group a row's visible cells into slot buckets, ordered within each slot by
+// the column's `mobileCard.order` (ascending, default 0). Derived during
+// render from the row model — no state, no effect.
+function bucketCells<TData>(row: Row<TData>): SlotBuckets<TData> {
+  const buckets: SlotBuckets<TData> = {
+    select: [],
+    badge: [],
+    title: [],
+    timestamp: [],
+    action: [],
+    metric: [],
+    context: [],
+  };
+  for (const cell of row.getVisibleCells()) {
+    const hint = (cell.column.columnDef as LangfuseColumnDef<TData>).mobileCard;
+    if (hint) buckets[hint.slot].push(cell);
+  }
+  for (const slot of EMPTY_BUCKETS) {
+    buckets[slot].sort((a, b) => {
+      const ao =
+        (a.column.columnDef as LangfuseColumnDef<TData>).mobileCard?.order ?? 0;
+      const bo =
+        (b.column.columnDef as LangfuseColumnDef<TData>).mobileCard?.order ?? 0;
+      return ao - bo;
+    });
+  }
+  return buckets;
+}
+
+function renderCell<TData>(cell: Cell<TData, unknown>): React.ReactNode {
+  return flexRender(cell.column.columnDef.cell, cell.getContext());
+}
+
+// A short muted label for a metric, derived from the column header (falling
+// back to the column id). Function headers can't be flattened to text here, so
+// they fall back to the id.
+function columnLabel<TData>(cell: Cell<TData, unknown>): string {
+  const header = cell.column.columnDef.header;
+  if (typeof header === "string") return header;
+  return getPlainTextFromReactNode(header as React.ReactNode) ?? cell.column.id;
+}
+
+// A best-effort tooltip for the truncated title. Prefers the raw string value
+// (name accessors return a string) and falls back to the flattened cell node.
+function titleText<TData>(cell: Cell<TData, unknown>): string | undefined {
+  const value = cell.getValue();
+  if (typeof value === "string") return value;
+  return getPlainTextFromReactNode(renderCell(cell));
+}
+
+// Wrapper that collapses itself when its rendered value produces no DOM
+// content — this is how "skip a metric/context whose value is empty/nullish"
+// is honored without introspecting cell return values: a cell that renders
+// null leaves the value span (always the last child) `:empty`, and the
+// structural `:has` variant hides the whole slot. No whitespace inside the
+// value span, or `:empty` would not match. `break-words` keeps a long
+// unbroken token from forcing horizontal overflow (no `truncate`, which would
+// demand a static title on arbitrary rendered content).
+function ValueSlot({
+  label,
+  className,
+  children,
+}: {
+  label?: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex min-w-0 items-center gap-1",
+        "[&:has(>span:last-child:empty)]:hidden",
+        className,
+      )}
+    >
+      {label ? (
+        <span className="text-muted-foreground shrink-0">{label}</span>
+      ) : null}
+      <span className="min-w-0 break-words">{children}</span>
+    </span>
+  );
+}
+
+function MobileCard<TData>({
+  row,
+  onRowClick,
+  selectionStore,
+  getRowClassName,
+  measureRef,
+  index,
+}: {
+  row: Row<TData>;
+  onRowClick?: (row: TData, event?: React.MouseEvent) => void;
+  selectionStore?: TableSelectionStoreLike;
+  getRowClassName?: (row: TData) => string;
+  measureRef: (el: HTMLElement | null) => void;
+  index: number;
+}) {
+  const router = useRouter();
+  const peekRowId = router.query.peek as string | undefined;
+  const rowIsSelected = useTableRowIsSelected(
+    selectionStore,
+    row.id,
+    row.getIsSelected(),
+  );
+  const shouldHighlightAllRows = useTableSelectAll(selectionStore, false);
+  const isHighlighted =
+    rowIsSelected ||
+    shouldHighlightAllRows ||
+    (!!peekRowId && peekRowId === row.id);
+
+  const buckets = bucketCells(row);
+  const isClickable = !!onRowClick;
+
+  const title = buckets.title[0];
+
+  return (
+    <div ref={measureRef} data-index={index} className="px-2 pb-2">
+      <div
+        role={isClickable ? "button" : undefined}
+        tabIndex={isClickable ? 0 : undefined}
+        onClick={
+          isClickable
+            ? (e) => {
+                if (shouldIgnoreRowClickTarget(e.target)) return;
+                onRowClick?.(row.original, e);
+              }
+            : undefined
+        }
+        onKeyDown={
+          isClickable
+            ? (e) => {
+                if (e.key !== "Enter") return;
+                if (shouldIgnoreRowClickTarget(e.target)) return;
+                onRowClick?.(row.original);
+              }
+            : undefined
+        }
+        className={cn(
+          "bg-background flex w-full min-w-0 flex-col gap-2 overflow-hidden rounded-md border p-3",
+          isClickable && "hover:bg-accent cursor-pointer",
+          isHighlighted && "bg-muted/40 dark:bg-muted",
+          getRowClassName?.(row.original),
+        )}
+      >
+        {/* Header line: select · badge · title · timestamp · action */}
+        <div className="flex min-w-0 items-center gap-2">
+          {buckets.select.map((cell) => (
+            <span key={cell.id} className="shrink-0">
+              {renderCell(cell)}
+            </span>
+          ))}
+          {buckets.badge.map((cell) => (
+            <span
+              key={cell.id}
+              className="shrink-0 [&:empty]:hidden [&:has(>span:empty)]:hidden"
+            >
+              {renderCell(cell)}
+            </span>
+          ))}
+          {title ? (
+            <span
+              className="min-w-0 flex-1 truncate font-bold"
+              title={titleText(title)}
+            >
+              {renderCell(title)}
+            </span>
+          ) : (
+            <span className="min-w-0 flex-1" />
+          )}
+          {buckets.timestamp.map((cell) => (
+            <span
+              key={cell.id}
+              className="text-muted-foreground shrink-0 text-xs"
+            >
+              {renderCell(cell)}
+            </span>
+          ))}
+          {buckets.action.map((cell) => (
+            <span key={cell.id} className="shrink-0">
+              {renderCell(cell)}
+            </span>
+          ))}
+        </div>
+
+        {/* Metric strip: compact labelled values, wrapping, empties collapsed */}
+        {buckets.metric.length > 0 ? (
+          <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+            {buckets.metric.map((cell) => (
+              <ValueSlot key={cell.id} label={columnLabel(cell)}>
+                {renderCell(cell)}
+              </ValueSlot>
+            ))}
+          </div>
+        ) : null}
+
+        {/* Context line: tags, environment — wraps, never overflows */}
+        {buckets.context.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-1.5 text-xs">
+            {buckets.context.map((cell) => (
+              <ValueSlot key={cell.id}>{renderCell(cell)}</ValueSlot>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function DataTableMobileCardList<TData extends object>({
+  table,
+  data,
+  onRowClick,
+  selectionStore,
+  noResultsMessage,
+  help,
+  getRowClassName,
+}: DataTableMobileCardListProps<TData>) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const rows = table.getRowModel().rows;
+
+  // The virtualizer owns a real external system (the scroll container +
+  // ResizeObserver-based measurement), which is the sanctioned use of an
+  // effect — here it lives inside the library, not this component.
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 96,
+    // Key the measurement cache by row id (matching the React key) so that
+    // reordering/filtering rows never reuses a neighbour's measured height —
+    // cards have variable height (tags/metrics wrap over several lines).
+    getItemKey: (index) => rows[index]!.id,
+    overscan: 8,
+  });
+
+  const isLoading = data.isLoading || !data.data;
+
+  return (
+    <div
+      ref={parentRef}
+      className="relative min-h-0 w-full flex-1 overflow-x-hidden overflow-y-auto border-t py-2"
+    >
+      {isLoading ? (
+        <div aria-hidden="true">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={`mobile-card-skeleton-${i}`} className="px-2 pb-2">
+              <div className="bg-background flex w-full flex-col gap-2 rounded-md border p-3">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
+                  <Skeleton className="h-4 flex-1" />
+                  <Skeleton className="h-3 w-16 shrink-0" />
+                </div>
+                <div className="flex gap-3">
+                  <Skeleton className="h-3 w-12" />
+                  <Skeleton className="h-3 w-14" />
+                  <Skeleton className="h-3 w-10" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : rows.length ? (
+        <div
+          style={{
+            height: `${virtualizer.getTotalSize()}px`,
+            width: "100%",
+            position: "relative",
+          }}
+        >
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const row = rows[virtualRow.index]!;
+            return (
+              <div
+                key={row.id}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                <MobileCard
+                  row={row}
+                  index={virtualRow.index}
+                  onRowClick={onRowClick}
+                  selectionStore={selectionStore}
+                  getRowClassName={getRowClassName}
+                  measureRef={virtualizer.measureElement}
+                />
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="text-muted-foreground flex h-24 items-center justify-center px-4 text-center text-sm">
+          {noResultsMessage ?? (
+            <>
+              No results.{" "}
+              {help && (
+                <DocPopup description={help.description} href={help.href} />
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -56,6 +56,8 @@ import {
   useTableRowIsSelected,
   useTableSelectAll,
 } from "@/src/components/table/table-selection-store";
+import { DataTableMobileCardList } from "@/src/components/table/data-table-mobile-card-list";
+import { useIsMobile } from "@/src/hooks/use-mobile";
 
 interface DataTableProps<TData, TValue> {
   columns: LangfuseColumnDef<TData, TValue>[];
@@ -209,6 +211,22 @@ export function DataTable<TData extends object, TValue>({
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const rowheighttw = getRowHeightTailwindClass(rowHeight, customRowHeights);
   const capture = usePostHogClientCapture();
+
+  // Card rendering is opt-in per table: a table opts in by annotating any of
+  // its columns (including a grouped column's children) with a `mobileCard`
+  // hint. Tables without hints — and every desktop viewport — keep the exact
+  // table body below.
+  const isMobile = useIsMobile();
+  const hasMobileCardConfig = useMemo(
+    () =>
+      columns.some(
+        (c) =>
+          (c as LangfuseColumnDef<TData>).mobileCard ||
+          c.columns?.some((cc) => cc.mobileCard),
+      ),
+    [columns],
+  );
+  const useMobileCards = isMobile && hasMobileCardConfig;
   const flattedColumnsByGroup = useMemo(() => {
     const flatColumnsByGroup = new Map<string, string[]>();
 
@@ -392,190 +410,206 @@ export function DataTable<TData extends object, TValue>({
           className,
         )}
       >
-        <div
-          // pr-2 + scrollbar-gutter:stable reserve a small gutter on the right so the
-          // last column's resize handle is never flush against the scrollbar/edge and
-          // always has some cursor room. Partial mitigation for LFE-10460: a maximized
-          // browser still clamps the cursor at the screen edge, so this guarantees room
-          // to the right, not a complete fix.
-          className="relative min-h-full w-full overflow-auto border-t pr-2 [scrollbar-gutter:stable]"
-          style={{ ...columnSizeVars }}
-        >
-          <Table>
-            <TableHeader className="sticky top-0 z-20">
-              {tableHeaders.map((headerGroup) => (
-                <TableRow key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    const columnDef = header.column
-                      .columnDef as LangfuseColumnDef<ModelTableRow>;
-                    const sortingEnabled = columnDef.enableSorting;
-                    // if the header id does not translate to a valid css variable name, default to 150px as width
-                    // may only happen for dynamic columns, as column names are user defined
-                    const width = columnDef.isFlexWidth
-                      ? "auto"
-                      : isValidCssVariableName({
-                            name: header.id,
-                            includesHyphens: false,
-                          })
-                        ? `calc(var(--header-${header.id}-size) * 1px)`
-                        : 150;
+        {useMobileCards ? (
+          <DataTableMobileCardList
+            table={table}
+            data={data}
+            onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
+            selectionStore={selectionStore}
+            noResultsMessage={noResultsMessage}
+            help={help}
+            getRowClassName={getRowClassName}
+          />
+        ) : (
+          <div
+            // pr-2 + scrollbar-gutter:stable reserve a small gutter on the right so the
+            // last column's resize handle is never flush against the scrollbar/edge and
+            // always has some cursor room. Partial mitigation for LFE-10460: a maximized
+            // browser still clamps the cursor at the screen edge, so this guarantees room
+            // to the right, not a complete fix.
+            className="relative min-h-full w-full overflow-auto border-t pr-2 [scrollbar-gutter:stable]"
+            style={{ ...columnSizeVars }}
+          >
+            <Table>
+              <TableHeader className="sticky top-0 z-20">
+                {tableHeaders.map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => {
+                      const columnDef = header.column
+                        .columnDef as LangfuseColumnDef<ModelTableRow>;
+                      const sortingEnabled = columnDef.enableSorting;
+                      // if the header id does not translate to a valid css variable name, default to 150px as width
+                      // may only happen for dynamic columns, as column names are user defined
+                      const width = columnDef.isFlexWidth
+                        ? "auto"
+                        : isValidCssVariableName({
+                              name: header.id,
+                              includesHyphens: false,
+                            })
+                          ? `calc(var(--header-${header.id}-size) * 1px)`
+                          : 150;
 
-                    return header.column.getIsVisible() ? (
-                      <TableHead
-                        key={header.id}
-                        className={cn(
-                          "group p-1 first:pl-2",
-                          sortingEnabled && "cursor-pointer",
-                          getPinningClasses(header.column),
-                        )}
-                        style={{
-                          ...getCommonPinningStyles(header.column),
-                          width,
-                        }}
-                        onClick={(event) => {
-                          event.preventDefault();
+                      return header.column.getIsVisible() ? (
+                        <TableHead
+                          key={header.id}
+                          className={cn(
+                            "group p-1 first:pl-2",
+                            sortingEnabled && "cursor-pointer",
+                            getPinningClasses(header.column),
+                          )}
+                          style={{
+                            ...getCommonPinningStyles(header.column),
+                            width,
+                          }}
+                          onClick={(event) => {
+                            event.preventDefault();
 
-                          // Ignore the click synthesized when this column's own
-                          // resize drag is released over its header (other
-                          // headers stay clickable during that window).
-                          const lastResize = lastColumnResizeEndRef.current;
-                          if (
-                            lastResize.columnId === header.column.id &&
-                            Date.now() - lastResize.at < 250
-                          ) {
-                            return;
-                          }
+                            // Ignore the click synthesized when this column's own
+                            // resize drag is released over its header (other
+                            // headers stay clickable during that window).
+                            const lastResize = lastColumnResizeEndRef.current;
+                            if (
+                              lastResize.columnId === header.column.id &&
+                              Date.now() - lastResize.at < 250
+                            ) {
+                              return;
+                            }
 
-                          if (!setOrderBy || !columnDef.id || !sortingEnabled) {
-                            return;
-                          }
+                            if (
+                              !setOrderBy ||
+                              !columnDef.id ||
+                              !sortingEnabled
+                            ) {
+                              return;
+                            }
 
-                          if (orderBy?.column === columnDef.id) {
-                            if (orderBy.order === "DESC") {
-                              capture("table:column_sorting_header_click", {
-                                column: columnDef.id,
-                                order: "ASC",
-                              });
-                              setOrderBy({
-                                column: columnDef.id,
-                                order: "ASC",
-                              });
+                            if (orderBy?.column === columnDef.id) {
+                              if (orderBy.order === "DESC") {
+                                capture("table:column_sorting_header_click", {
+                                  column: columnDef.id,
+                                  order: "ASC",
+                                });
+                                setOrderBy({
+                                  column: columnDef.id,
+                                  order: "ASC",
+                                });
+                              } else {
+                                capture("table:column_sorting_header_click", {
+                                  column: columnDef.id,
+                                  order: "Disabled",
+                                });
+                                setOrderBy(null);
+                              }
                             } else {
                               capture("table:column_sorting_header_click", {
                                 column: columnDef.id,
-                                order: "Disabled",
+                                order: "DESC",
                               });
-                              setOrderBy(null);
+                              setOrderBy({
+                                column: columnDef.id,
+                                order: "DESC",
+                              });
                             }
-                          } else {
-                            capture("table:column_sorting_header_click", {
-                              column: columnDef.id,
-                              order: "DESC",
-                            });
-                            setOrderBy({
-                              column: columnDef.id,
-                              order: "DESC",
-                            });
-                          }
-                        }}
-                      >
-                        {header.isPlaceholder ? null : (
-                          <div className="flex items-center select-none">
-                            <span
-                              className="truncate leading-normal"
-                              title={getPlainTextFromReactNode(
-                                flexRender(
+                          }}
+                        >
+                          {header.isPlaceholder ? null : (
+                            <div className="flex items-center select-none">
+                              <span
+                                className="truncate leading-normal"
+                                title={getPlainTextFromReactNode(
+                                  flexRender(
+                                    header.column.columnDef.header,
+                                    header.getContext(),
+                                  ),
+                                )}
+                              >
+                                {flexRender(
                                   header.column.columnDef.header,
                                   header.getContext(),
-                                ),
+                                )}
+                              </span>
+                              {columnDef.headerTooltip && (
+                                <DocPopup
+                                  description={
+                                    columnDef.headerTooltip.description
+                                  }
+                                  href={columnDef.headerTooltip.href}
+                                />
                               )}
-                            >
-                              {flexRender(
-                                header.column.columnDef.header,
-                                header.getContext(),
-                              )}
-                            </span>
-                            {columnDef.headerTooltip && (
-                              <DocPopup
-                                description={
-                                  columnDef.headerTooltip.description
-                                }
-                                href={columnDef.headerTooltip.href}
-                              />
-                            )}
-                            {orderBy?.column === columnDef.id
-                              ? renderOrderingIndicator(orderBy)
-                              : null}
+                              {orderBy?.column === columnDef.id
+                                ? renderOrderingIndicator(orderBy)
+                                : null}
 
-                            <div
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                              }}
-                              onDoubleClick={() => header.column.resetSize()}
-                              onMouseDown={beginColumnResize(
-                                header.column.id,
-                                header.getResizeHandler(),
-                              )}
-                              onTouchStart={beginColumnResize(
-                                header.column.id,
-                                header.getResizeHandler(),
-                              )}
-                              className={cn(
-                                "bg-secondary absolute top-0 right-0 h-full w-1.5 cursor-col-resize touch-none opacity-0 select-none group-hover:opacity-100",
-                                header.column.getIsResizing() &&
-                                  "bg-primary-accent opacity-100",
-                              )}
-                            />
-                          </div>
-                        )}
-                      </TableHead>
-                    ) : null;
-                  })}
-                </TableRow>
-              ))}
-            </TableHeader>
-            {table.getState().columnSizingInfo.isResizingColumn ||
-            !!peekView ? (
-              <MemoizedTableBody
-                table={table}
-                rowheighttw={rowheighttw}
-                rowHeight={rowHeight}
-                columns={columns}
-                data={data}
-                help={help}
-                noResultsMessage={noResultsMessage}
-                onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
-                getRowClassName={getRowClassName}
-                highlightAllRows={highlightAllRows}
-                selectionStore={selectionStore}
-                topAlignCells={topAlignCells}
-                cellPadding={cellPadding}
-                tableSnapshot={{
-                  columnVisibility,
-                  columnOrder,
-                  rowSelection,
-                }}
-              />
-            ) : (
-              <TableBodyComponent
-                table={table}
-                rowheighttw={rowheighttw}
-                rowHeight={rowHeight}
-                columns={columns}
-                data={data}
-                help={help}
-                noResultsMessage={noResultsMessage}
-                onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
-                getRowClassName={getRowClassName}
-                highlightAllRows={highlightAllRows}
-                selectionStore={selectionStore}
-                topAlignCells={topAlignCells}
-                cellPadding={cellPadding}
-              />
-            )}
-          </Table>
-        </div>
+                              <div
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                }}
+                                onDoubleClick={() => header.column.resetSize()}
+                                onMouseDown={beginColumnResize(
+                                  header.column.id,
+                                  header.getResizeHandler(),
+                                )}
+                                onTouchStart={beginColumnResize(
+                                  header.column.id,
+                                  header.getResizeHandler(),
+                                )}
+                                className={cn(
+                                  "bg-secondary absolute top-0 right-0 h-full w-1.5 cursor-col-resize touch-none opacity-0 select-none group-hover:opacity-100",
+                                  header.column.getIsResizing() &&
+                                    "bg-primary-accent opacity-100",
+                                )}
+                              />
+                            </div>
+                          )}
+                        </TableHead>
+                      ) : null;
+                    })}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              {table.getState().columnSizingInfo.isResizingColumn ||
+              !!peekView ? (
+                <MemoizedTableBody
+                  table={table}
+                  rowheighttw={rowheighttw}
+                  rowHeight={rowHeight}
+                  columns={columns}
+                  data={data}
+                  help={help}
+                  noResultsMessage={noResultsMessage}
+                  onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
+                  getRowClassName={getRowClassName}
+                  highlightAllRows={highlightAllRows}
+                  selectionStore={selectionStore}
+                  topAlignCells={topAlignCells}
+                  cellPadding={cellPadding}
+                  tableSnapshot={{
+                    columnVisibility,
+                    columnOrder,
+                    rowSelection,
+                  }}
+                />
+              ) : (
+                <TableBodyComponent
+                  table={table}
+                  rowheighttw={rowheighttw}
+                  rowHeight={rowHeight}
+                  columns={columns}
+                  data={data}
+                  help={help}
+                  noResultsMessage={noResultsMessage}
+                  onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
+                  getRowClassName={getRowClassName}
+                  highlightAllRows={highlightAllRows}
+                  selectionStore={selectionStore}
+                  topAlignCells={topAlignCells}
+                  cellPadding={cellPadding}
+                />
+              )}
+            </Table>
+          </div>
+        )}
       </div>
       {!hidePagination && pagination !== undefined ? (
         <div className="bg-background sticky bottom-0 z-10 flex w-full justify-end border-t py-2 pr-2 font-bold">

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -133,10 +133,20 @@ function isValidCssVariableName({
 const INTERACTIVE_ROW_CLICK_SELECTOR =
   "a, button, input, select, textarea, summary, [role='button'], [role='link']";
 
-export const shouldIgnoreRowClickTarget = (target: EventTarget | null) => {
+export const shouldIgnoreRowClickTarget = (
+  target: EventTarget | null,
+  // Optional clickable container (e.g. a card that is itself role="button").
+  // Interactive CHILDREN of the row should swallow the click, but the container
+  // itself matching the selector must not — otherwise every click inside it is
+  // ignored and the row action never fires.
+  container?: Element | null,
+) => {
   if (!(target instanceof Element)) return false;
 
-  return Boolean(target.closest(INTERACTIVE_ROW_CLICK_SELECTOR));
+  const interactive = target.closest(INTERACTIVE_ROW_CLICK_SELECTOR);
+  if (!interactive) return false;
+  if (container && interactive === container) return false;
+  return true;
 };
 
 // These are the important styles to make sticky column pinning work!

--- a/web/src/components/table/types.ts
+++ b/web/src/components/table/types.ts
@@ -8,6 +8,29 @@ export type TableRowOptions = {
 
 export type DataTableCellPadding = "compact" | "comfortable" | "none";
 
+/**
+ * Slot a column occupies when a table is rendered as a mobile card list
+ * (see `data-table-mobile-card-list.tsx`). A column WITHOUT a `mobileCard`
+ * hint is not shown on the card — card content is curated per table by
+ * annotating a small subset of columns. The presence of any `mobileCard`
+ * hint on a table's columns is also what opts that table into card rendering
+ * on mobile; desktop and un-annotated tables are unaffected.
+ */
+export type MobileCardSlot =
+  | "title" // primary name — the card's headline
+  | "timestamp" // trailing time in the header line
+  | "metric" // compact labelled value in the metric strip (latency, cost, tokens)
+  | "badge" // small status badge/dot in the header line (e.g. level)
+  | "context" // wrapping chips below (tags, environment)
+  | "action" // trailing affordance in the header line (e.g. bookmark star)
+  | "select"; // leading selection checkbox
+
+export type MobileCardHint = {
+  slot: MobileCardSlot;
+  /** sort within a slot, ascending; default 0 */
+  order?: number;
+};
+
 declare module "@tanstack/react-table" {
   // extends tanstack ColumnDef to include additional properties
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -22,6 +45,8 @@ declare module "@tanstack/react-table" {
     isFlexWidth?: boolean; // if true, column absorbs leftover space (one per table)
     loadingCell?: React.ReactNode | (() => React.ReactNode);
     cellPadding?: DataTableCellPadding;
+    /** Opt a column into the mobile card list and place it in a slot. */
+    mobileCard?: MobileCardHint;
   }
 }
 

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -646,13 +646,16 @@ export default function TracesTable({
     ...(hideControls
       ? []
       : ([
-          selectActionColumn,
+          // Spread mobile-card hints onto the shared selection column locally
+          // so only this table opts into card rendering.
+          { ...selectActionColumn, mobileCard: { slot: "select" as const } },
           {
             accessorKey: "bookmarked",
             header: undefined,
             id: "bookmarked",
             size: 30,
             isFixedPosition: true,
+            mobileCard: { slot: "action" as const },
             loadingCell: <TableIconButtonLoadingCell />,
             cell: ({ row }) => {
               const bookmarked: TracesTableRow["bookmarked"] =
@@ -679,6 +682,7 @@ export default function TracesTable({
       size: 150,
       enableHiding: true,
       enableSorting,
+      mobileCard: { slot: "timestamp" },
       cell: ({ row }) => {
         const value: TracesTableRow["timestamp"] = row.getValue("timestamp");
         return value ? <LocalIsoDate date={value} /> : undefined;
@@ -691,6 +695,7 @@ export default function TracesTable({
       size: 150,
       enableHiding: true,
       enableSorting,
+      mobileCard: { slot: "title" },
       cell: ({ row }) => {
         const value: TracesTableRow["name"] = row.getValue("name");
         return value ?? undefined;
@@ -782,6 +787,7 @@ export default function TracesTable({
       id: "latency",
       header: "Latency",
       size: 100,
+      mobileCard: { slot: "metric", order: 0 },
       // add seconds to the end of the latency
       loadingCell: <TableTextLoadingCell />,
       cell: ({ row }) => {
@@ -800,6 +806,7 @@ export default function TracesTable({
       header: "Tokens",
       id: "tokens",
       size: 180,
+      mobileCard: { slot: "metric", order: 2 },
       loadingCell: <TableTextLoadingCell />,
       cell: ({ row }) => {
         const value: TracesTableRow["usage"] = row.getValue("usage");
@@ -830,6 +837,7 @@ export default function TracesTable({
       id: "totalCost",
       header: "Total Cost",
       size: 130,
+      mobileCard: { slot: "metric", order: 1 },
       loadingCell: <TableTextLoadingCell />,
       cell: ({ row }) => {
         const cost: TracesTableRow["totalCost"] = row.getValue("totalCost");
@@ -857,6 +865,7 @@ export default function TracesTable({
       size: 150,
       enableHiding: true,
       loadingCell: <TableBadgeLoadingCell />,
+      mobileCard: { slot: "context", order: 1 },
       cell: ({ row }) => {
         const value: TracesTableRow["environment"] =
           row.getValue("environment");
@@ -876,6 +885,7 @@ export default function TracesTable({
       id: "tags",
       header: "Tags",
       size: 150,
+      mobileCard: { slot: "context", order: 0 },
       headerTooltip: {
         description: (
           <>
@@ -1066,6 +1076,7 @@ export default function TracesTable({
       id: "level",
       header: "Level",
       size: 75,
+      mobileCard: { slot: "badge" },
       loadingCell: <TableTextLoadingCell />,
       cell: ({ row }) => {
         const value: TracesTableRow["level"] = row.getValue("level");

--- a/web/src/components/ui/KeyboardShortcut.stories.tsx
+++ b/web/src/components/ui/KeyboardShortcut.stories.tsx
@@ -1,0 +1,27 @@
+import preview from "../../../.storybook/preview";
+import { KeyboardShortcut } from "./keyboard-shortcut";
+
+const meta = preview.meta({
+  component: KeyboardShortcut,
+});
+
+// Hidden below the `md` breakpoint (768px, the same cutoff `useIsMobile`
+// uses) by default: a keyboard-shortcut hint is noise on a touch device with
+// no physical keyboard (LFE-11067). The underlying shortcut still fires there
+// — only this visual chip is gated. Resize the Storybook canvas below 768px
+// to see it disappear (CSS-only; jsdom-based story tests don't apply media
+// queries, so this is only visible when the canvas renders in a real browser).
+export const Default = meta.story({
+  args: {
+    children: "K",
+  },
+});
+
+// Multiple glyphs (e.g. a modifier + a letter) render as separate chips
+// inside the same kbd, joined by a small gap — the "⌘K" / "⌘ Enter" shape
+// used for command-menu and submit hints.
+export const MultipleKeys = meta.story({
+  args: {
+    keys: ["⌘", "Enter"],
+  },
+});

--- a/web/src/components/ui/keyboard-shortcut.tsx
+++ b/web/src/components/ui/keyboard-shortcut.tsx
@@ -17,7 +17,13 @@ const KeyboardShortcut = React.forwardRef<HTMLElement, KeyboardShortcutProps>(
     <kbd
       ref={ref}
       className={cn(
-        "bg-muted text-muted-foreground pointer-events-none inline-flex h-5 min-w-5 items-center justify-center gap-1 rounded-md border px-1.5 font-mono text-[10px] leading-none font-bold shadow-xs select-none",
+        // Hidden below `md` (768px, matches useIsMobile) by default: a
+        // keyboard-shortcut hint is noise on a touch device with no physical
+        // keyboard. This only hides the visual chip — the shortcut's own
+        // keydown handler is untouched, so a Bluetooth keyboard still works.
+        // CSS-only (no useIsMobile()) so SSR'd hints don't hydration-mismatch
+        // or flash on first paint (LFE-11067).
+        "bg-muted text-muted-foreground pointer-events-none hidden h-5 min-w-5 items-center justify-center gap-1 rounded-md border px-1.5 font-mono text-[10px] leading-none font-bold shadow-xs select-none md:inline-flex",
         className,
       )}
       {...props}

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useRouter } from "next/router";
 import { Slot } from "@radix-ui/react-slot";
 import { type VariantProps, cva } from "class-variance-authority";
 import { Menu, PanelLeft } from "lucide-react";
@@ -67,6 +68,7 @@ const SidebarProvider = React.forwardRef<
     ref,
   ) => {
     const isMobile = useIsMobile();
+    const router = useRouter();
     const [openMobile, setOpenMobile] = React.useState(false);
 
     // Use local storage to persist sidebar state
@@ -113,6 +115,18 @@ const SidebarProvider = React.forwardRef<
       window.addEventListener("keydown", handleKeyDown);
       return () => window.removeEventListener("keydown", handleKeyDown);
     }, [toggleSidebar]);
+
+    // Close the mobile drawer as soon as a navigation starts. The drawer is a
+    // full-screen overlay Sheet on mobile; without this it stays open on top of
+    // the destination after tapping a nav link or switching project/org (the
+    // Next.js router does shallow client transitions, so the component never
+    // unmounts to reset `openMobile`). Subscribing to router events is a genuine
+    // external-system effect. No-op on desktop, where `openMobile` is unused.
+    React.useEffect(() => {
+      const closeDrawer = () => setOpenMobile(false);
+      router.events.on("routeChangeStart", closeDrawer);
+      return () => router.events.off("routeChangeStart", closeDrawer);
+    }, [router.events]);
 
     // We add a state so that we can do data-state="expanded" or "collapsed".
     // This makes it easier to style the sidebar with Tailwind classes.

--- a/web/src/features/chart-view/components/ChartViewPanel.stories.tsx
+++ b/web/src/features/chart-view/components/ChartViewPanel.stories.tsx
@@ -1,0 +1,62 @@
+import preview from "../../../../.storybook/preview";
+import { fn } from "storybook/test";
+import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props";
+import { ChartViewPanel } from "./ChartViewPanel";
+import { DEFAULT_CONFIG } from "../vocab";
+
+/**
+ * Deterministic fixture — count of events per hour, broken down by model.
+ * Small on purpose: `ChartViewPanel` just hands `data` to the shared
+ * `chart-library`, so a couple of buckets/series are enough to render a real
+ * line chart.
+ */
+const MODELS = [
+  { name: "gpt-4o", base: 12 },
+  { name: "claude-3-5-sonnet", base: 8 },
+];
+const HOURS = ["00:00", "01:00", "02:00", "03:00"];
+
+const DATA: DataPoint[] = HOURS.flatMap((hour, hourIndex) =>
+  MODELS.map(({ name, base }, seed) => ({
+    time_dimension: hour,
+    dimension: name,
+    metric: base + ((hourIndex + seed * 2) % 4) * 3,
+  })),
+);
+
+/**
+ * The "Take B" chart-view layout: a maximized canvas with the "Visualize"
+ * config docked in a collapsible panel (`EventsChartView`'s production UI).
+ * Presentational — `data`/`config` come in as props, so it renders without
+ * any query or context dependency.
+ *
+ * The panel's outer row is `flex-col md:flex-row` (LFE-11067): a config panel
+ * beside the chart at desktop widths, stacked below it under the `md`
+ * breakpoint. That's a real viewport-width media query, not a container
+ * query, so — unlike most other layout stories in this repo — a fixed-width
+ * wrapper `<div>` here would only clip the desktop layout rather than trigger
+ * the stack (this Storybook setup has no viewport-switching addon wired up).
+ * To see the mobile layout, narrow the actual browser window or the devtools
+ * device toolbar to ~390px while viewing this story — the preview iframe is
+ * fluid-width, so the same media query that fires on a phone fires there too.
+ */
+const meta = preview.meta({
+  component: ChartViewPanel,
+  args: {
+    config: DEFAULT_CONFIG,
+    data: DATA,
+    onConfigChange: fn(),
+  },
+  decorators: [
+    // `ChartViewPanel`'s root relies on a bounded-height flex ancestor
+    // (`flex-1`/`min-h-0`) — same as its production host (`EventsChartView`
+    // inside the events table) — so give it one here.
+    (Story) => (
+      <div className="flex h-[420px] flex-col">
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+export const Default = meta.story({});

--- a/web/src/features/chart-view/components/ChartViewPanel.tsx
+++ b/web/src/features/chart-view/components/ChartViewPanel.tsx
@@ -66,11 +66,14 @@ export const ChartViewPanel = React.memo(function ChartViewPanel({
   );
 
   return (
-    <div className="flex min-h-0 flex-1">
+    <div className="flex min-h-0 flex-1 flex-col md:flex-row">
       {/* Canvas */}
       <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-1 p-3">
         <div className="flex items-center justify-between gap-2">
-          <div className="text-foreground text-sm font-bold">
+          <div
+            className="text-foreground min-w-0 truncate text-sm font-bold"
+            title={describeConfig(config)}
+          >
             {describeConfig(config)}
           </div>
           {chartActions}
@@ -97,7 +100,7 @@ export const ChartViewPanel = React.memo(function ChartViewPanel({
 
       {/* Config panel */}
       {open ? (
-        <div className="flex w-72 shrink-0 flex-col gap-3 overflow-y-auto border-l p-3">
+        <div className="flex w-full flex-col gap-3 overflow-y-auto border-b p-3 md:w-72 md:shrink-0 md:border-b-0 md:border-l">
           <div className="flex items-center justify-between">
             <span className="text-sm font-bold">Visualize</span>
             <Button
@@ -134,7 +137,7 @@ export const ChartViewPanel = React.memo(function ChartViewPanel({
           ) : null}
         </div>
       ) : (
-        <div className="flex shrink-0 flex-col items-center border-l p-1.5">
+        <div className="flex flex-col items-center border-t p-1.5 md:shrink-0 md:border-t-0 md:border-l">
           <Button
             variant="ghost"
             size="icon-xs"

--- a/web/src/features/comments/CommentList.tsx
+++ b/web/src/features/comments/CommentList.tsx
@@ -538,7 +538,7 @@ export function CommentList({
                 )}
                 {!searchQuery && (
                   <KeyboardShortcut
-                    className="absolute top-1/2 right-1 hidden -translate-y-1/2 opacity-50 sm:inline-flex"
+                    className="absolute top-1/2 right-1 -translate-y-1/2 opacity-50"
                     keys={
                       typeof navigator !== "undefined" &&
                       navigator.userAgent.includes("Macintosh")

--- a/web/src/features/evals/components/code-eval-template-form-body.tsx
+++ b/web/src/features/evals/components/code-eval-template-form-body.tsx
@@ -282,7 +282,7 @@ export function CodeEvalTemplateFormBody({
             )}
             Format
             <KeyboardShortcut
-              className="ml-2 hidden h-4 sm:inline-flex"
+              className="ml-2 h-4"
               keys={
                 typeof navigator !== "undefined" &&
                 navigator.userAgent.includes("Macintosh")

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1063,7 +1063,17 @@ export default function ObservationsEventsTable({
   const enableSorting = !hideControls;
 
   const columns: LangfuseColumnDef<EventsTableRow>[] = [
-    ...(hideControls ? [] : [selectActionColumn]),
+    // Spread a mobile-card hint onto the shared selection column locally so
+    // only this table opts into card rendering (the shared column stays
+    // un-annotated for other tables).
+    ...(hideControls
+      ? []
+      : [
+          {
+            ...selectActionColumn,
+            mobileCard: { slot: "select" as const },
+          },
+        ]),
     {
       accessorKey: "startTime",
       id: "startTime",
@@ -1071,6 +1081,7 @@ export default function ObservationsEventsTable({
       size: 150,
       enableHiding: true,
       enableSorting,
+      mobileCard: { slot: "timestamp" },
       cell: ({ row }) => {
         const value: Date = row.getValue("startTime");
         return <LocalIsoDate date={value} />;
@@ -1098,6 +1109,7 @@ export default function ObservationsEventsTable({
       header: getEventsColumnName("name"),
       size: 150,
       enableSorting,
+      mobileCard: { slot: "title" },
       cell: ({ row }) => {
         const value: EventsTableRow["name"] = row.getValue("name");
         return value ?? undefined;
@@ -1228,6 +1240,7 @@ export default function ObservationsEventsTable({
         href: "https://langfuse.com/docs/observability/features/log-levels",
       },
       enableHiding: true,
+      mobileCard: { slot: "badge" },
       cell: ({ row }) => {
         const value: ObservationLevelType | undefined = row.getValue("level");
         return value ? (
@@ -1272,6 +1285,7 @@ export default function ObservationsEventsTable({
       id: "latency",
       header: getEventsColumnName("latency"),
       size: 100,
+      mobileCard: { slot: "metric", order: 0 },
       cell: ({ row }) => {
         const latency: number | undefined = row.getValue("latency");
         return latency !== undefined ? (
@@ -1286,6 +1300,7 @@ export default function ObservationsEventsTable({
       header: getEventsColumnName("totalCost"),
       id: "totalCost",
       size: 120,
+      mobileCard: { slot: "metric", order: 1 },
       cell: ({ row }) => {
         const value: number | undefined = row.getValue("totalCost");
 
@@ -1489,6 +1504,7 @@ export default function ObservationsEventsTable({
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
+          mobileCard: { slot: "metric", order: 2 },
           cell: ({ row }) => {
             const value = row.getValue("usage") as {
               inputUsage: number;
@@ -1546,6 +1562,7 @@ export default function ObservationsEventsTable({
       size: 150,
       enableHiding: true,
       loadingCell: <TableBadgeLoadingCell />,
+      mobileCard: { slot: "context", order: 1 },
       cell: ({ row }) => {
         const value: EventsTableRow["environment"] =
           row.getValue("environment");
@@ -1567,6 +1584,7 @@ export default function ObservationsEventsTable({
       size: 250,
       enableHiding: true,
       loadingCell: <TableTextLoadingCell />,
+      mobileCard: { slot: "context", order: 0 },
       cell: ({ row }) => {
         const traceTags: string[] | undefined = row.getValue("traceTags");
         return (

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -51,8 +51,13 @@ import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import {
   toAbsoluteTimeRange,
   type TableDateRange,
+  TABLE_AGGREGATION_OPTIONS,
 } from "@/src/utils/date-range-utils";
 import { TableHeaderControls } from "@/src/components/table/table-header-controls";
+import { TimeRangePicker } from "@/src/components/date-picker";
+import { DataTableRefreshButton } from "@/src/components/table/data-table-refresh-button";
+import { MobileFiltersSheet } from "@/src/features/events/components/MobileFiltersSheet";
+import { useIsMobile } from "@/src/hooks/use-mobile";
 import { type ScoreAggregate } from "@langfuse/shared";
 import TagList from "@/src/features/tag/components/TagList";
 import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTableStateContext";
@@ -1837,17 +1842,133 @@ export default function ObservationsEventsTable({
     setInterval: setRefreshInterval,
   };
 
+  // Mobile collapses the whole toolbar into one Filters bottom sheet. Desktop
+  // (≥768px) is byte-identical to before — everything below is gated on this.
+  const isMobile = useIsMobile();
+  // Count shown on the mobile Filters trigger. Same source as the desktop
+  // rail's active-facet count — distinct filtered COLUMNS (a facet can emit
+  // several FilterState entries) — plus free-text search, which now also lives
+  // in the sheet.
+  const mobileActiveFilterCount =
+    new Set(
+      (queryFilter.explicitFilterState ?? []).map((filter) => filter.column),
+    ).size + (searchQuery && searchQuery.trim().length > 0 ? 1 : 0);
+
   return (
     <DataTableControlsProvider tableName={eventsFilterConfig.tableName}>
       <div className="flex h-full w-full flex-col">
-        {showControlsInPageHeader && !hideControls && (
+        {showControlsInPageHeader && !hideControls && !isMobile && (
           <TableHeaderControls
             timeRange={timeRange}
             setTimeRange={setTimeRange}
             refresh={refreshConfig}
           />
         )}
-        {!hideControls && (
+        {/* Mobile: a single toolbar row — Filters(N) sheet trigger + view-mode
+            toggle. Search, time range, preset chips, saved views and the facet
+            sidebar all move INTO the sheet (same controllers, hosted there).
+            Columns / row-height / export are omitted on the card list. */}
+        {!hideControls && isMobile && (
+          <div className="my-2 flex items-center gap-2 px-2">
+            <MobileFiltersSheet
+              activeCount={mobileActiveFilterCount}
+              resultCount={totalCount}
+              onClearAll={() => {
+                queryFilter.clearAll();
+                setSearchQuery("");
+              }}
+              search={
+                searchBarMode ? (
+                  <EventsSearchBarRow
+                    projectId={projectId}
+                    tableName={eventsFilterConfig.tableName}
+                    store={searchBarStore}
+                    commit={searchBarCommit}
+                    observed={observedOptions}
+                    erroredColumns={erroredColumns}
+                    fieldReason={
+                      chartActive ? chartSearchFieldReason : undefined
+                    }
+                    freeTextReason={
+                      chartFreeTextIgnored
+                        ? CHART_SEARCH_QUERY_REASON
+                        : undefined
+                    }
+                    onApplyFilters={searchBarApplyFilters}
+                    onRequestColumns={requestColumns}
+                    aiDataContext={aiDataContext}
+                    aiScoreNames={aiScoreNames}
+                  />
+                ) : undefined
+              }
+              timeRange={
+                <div className="flex flex-wrap items-center gap-2">
+                  <TimeRangePicker
+                    timeRange={timeRange}
+                    onTimeRangeChange={setTimeRange}
+                    timeRangePresets={TABLE_AGGREGATION_OPTIONS}
+                    className="my-0 max-w-full overflow-x-auto"
+                  />
+                  <DataTableRefreshButton
+                    onRefresh={refreshConfig.onRefresh}
+                    isRefreshing={refreshConfig.isRefreshing}
+                    interval={refreshConfig.interval}
+                    setInterval={refreshConfig.setInterval}
+                  />
+                </div>
+              }
+              presets={
+                tableStatePolicy.disableSavedViews ? undefined : (
+                  <CategoryPresetChips
+                    projectId={projectId}
+                    activeViewId={
+                      viewControllers.appliedViewId ??
+                      viewControllers.selectedViewId
+                    }
+                    onApplyView={viewControllers.handleSetViewId}
+                    applyViewState={viewControllers.applyViewState}
+                    onPreviewView={previewViewInSearchBar}
+                  />
+                )
+              }
+              savedViews={
+                tableStatePolicy.disableSavedViews ? undefined : (
+                  <TableViewPresetsDrawer
+                    viewConfig={{
+                      tableName: TableViewPresetTableName.ObservationsEvents,
+                      projectId,
+                      controllers: viewControllers,
+                    }}
+                    currentState={{
+                      orderBy: orderByState ?? null,
+                      filters: queryFilter.explicitFilterState ?? [],
+                      columnOrder,
+                      columnVisibility,
+                      searchQuery: searchQuery ?? "",
+                    }}
+                  />
+                )
+              }
+              facets={
+                <DataTableControls
+                  key={viewControllers.selectedViewId ?? "no-view"}
+                  queryFilter={queryFilter}
+                  filterWithAI={!searchBarMode}
+                  blockedColumnReason={
+                    chartActive ? chartFilterExclusionReason : undefined
+                  }
+                />
+              }
+            />
+            {chartEnabled && (
+              <ViewModeToggle
+                mode={chartViewMode}
+                onModeChange={setChartViewMode}
+              />
+            )}
+          </div>
+        )}
+        {!hideControls && !isMobile && (
           <div
             className={cn(
               // This is a table-internal sticky band below PageHeader. Using
@@ -2037,7 +2158,10 @@ export default function ObservationsEventsTable({
         {/* Content area with sidebar and table. The facet sidebar stays in
             search-bar mode and syncs bidirectionally with the bar. */}
         <ResizableFilterLayout>
-          {!hideControls && (
+          {/* On mobile the facet sidebar moves into the Filters sheet above,
+              so it is not rendered inline here (leaving only the table content
+              in the layout). */}
+          {!hideControls && !isMobile && (
             <DataTableControls
               // Remount the sidebar when the saved view changes so the new view's filters replace any stale draft UI state.
               key={viewControllers.selectedViewId ?? "no-view"}

--- a/web/src/features/events/components/MobileFiltersSheet.stories.tsx
+++ b/web/src/features/events/components/MobileFiltersSheet.stories.tsx
@@ -1,0 +1,119 @@
+import preview from "../../../../.storybook/preview";
+import { useState, type ComponentProps } from "react";
+import { fn } from "storybook/test";
+
+import { MobileFiltersSheet } from "@/src/features/events/components/MobileFiltersSheet";
+import { ControlsContext } from "@/src/components/table/data-table-controls";
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
+import { Input } from "@/src/components/ui/input";
+
+// =============================================================================
+// WHY THIS STORY FAKES THE CONTROL NODES
+// =============================================================================
+// `MobileFiltersSheet` is a pure LAYOUT surface: EventsTable builds the real
+// controllers (grammar search bar, time-range picker, preset chips, saved-views
+// drawer, facet sidebar) and passes them in as nodes. Those controllers depend
+// on tRPC, routing and several providers, so the story substitutes structural
+// placeholders that stand in for each section. This exercises the sheet's own
+// concerns — labeled sections, sticky footer, active-count badge, the bounded
+// facet region — without dragging the whole page into Storybook.
+//
+// Open state is read from `ControlsContext` (the DataTableControls provider).
+// The demo wrapper supplies that context with `open: true` so the sheet renders
+// open; the trigger button and the footer's close still toggle it live.
+
+const fakeSearch = <Input placeholder="Search traces…" className="h-9" />;
+
+const fakeTimeRange = (
+  <Button variant="outline" size="sm" className="h-8">
+    Past 24 hours
+  </Button>
+);
+
+const fakePresets = (
+  <div className="flex flex-wrap gap-2">
+    {["Quality", "Slow", "Cost"].map((chip) => (
+      <Badge key={chip} variant="outline" className="cursor-pointer">
+        {chip}
+      </Badge>
+    ))}
+  </div>
+);
+
+const fakeSavedViews = (
+  <Button variant="outline" size="sm" className="h-8">
+    My Views
+  </Button>
+);
+
+// Stand-in for DataTableControls: its own "Filters" header + a scrollable facet
+// list, so the bounded flex region reads correctly in the sheet.
+const fakeFacets = (
+  <div className="bg-background flex min-h-0 flex-1 flex-col border-t">
+    <div className="flex h-10 shrink-0 items-center gap-1.5 border-b px-3">
+      <span className="text-sm font-bold">Filters</span>
+    </div>
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      {[
+        "Name",
+        "Environment",
+        "Level",
+        "Tags",
+        "Model",
+        "User",
+        "Session",
+        "Latency",
+        "Cost",
+        "Metadata",
+      ].map((facet) => (
+        <div
+          key={facet}
+          className="text-muted-foreground border-b px-3 py-2 text-sm"
+        >
+          {facet}
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+function MobileFiltersSheetDemo(
+  props: ComponentProps<typeof MobileFiltersSheet>,
+) {
+  const [open, setOpen] = useState(true);
+  return (
+    <ControlsContext.Provider value={{ open, setOpen, tableName: "storybook" }}>
+      <MobileFiltersSheet {...props} />
+    </ControlsContext.Provider>
+  );
+}
+
+const meta = preview.meta({
+  component: MobileFiltersSheetDemo,
+  parameters: { layout: "fullscreen" },
+  args: {
+    activeCount: 0,
+    resultCount: null,
+    onClearAll: fn(),
+    search: fakeSearch,
+    timeRange: fakeTimeRange,
+    presets: fakePresets,
+    savedViews: fakeSavedViews,
+    facets: fakeFacets,
+  },
+});
+
+export default meta;
+
+// Open sheet, no active filters — trigger badge hidden, footer reads
+// "Show results" (count unknown, as on the lazily-counted events table).
+export const Default = meta.story({});
+
+// Active filters set the trigger badge and a known result count in the footer.
+export const WithActiveFilters = meta.story({
+  args: {
+    activeCount: 3,
+    resultCount: 1284,
+  },
+});

--- a/web/src/features/events/components/MobileFiltersSheet.tsx
+++ b/web/src/features/events/components/MobileFiltersSheet.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { SlidersHorizontal, X } from "lucide-react";
+
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@/src/components/ui/sheet";
+import { useDataTableControls } from "@/src/components/table/data-table-controls";
+import { numberFormatter } from "@/src/utils/numbers";
+
+interface MobileFiltersSheetProps {
+  /** Count shown on the trigger badge — active facet columns (+ free-text
+   *  search, which also lives in this sheet now). Derived by the caller from
+   *  the same sidebar filter state the desktop rail counts. */
+  activeCount: number;
+  /** Total matching results for the "Show N results" footer button. Null when
+   *  the count is unknown (the events table counts lazily), which renders a
+   *  plain "Show results" label instead. */
+  resultCount: number | null;
+  /** Clears filter state + search. Results update live, so this does not close
+   *  the sheet. */
+  onClearAll: () => void;
+  /** Grammar search bar row (search-bar mode only). */
+  search?: ReactNode;
+  /** Time-range picker (+ optional refresh). */
+  timeRange?: ReactNode;
+  /** Category preset chips. */
+  presets?: ReactNode;
+  /** Saved-views drawer trigger ("My Views"). */
+  savedViews?: ReactNode;
+  /** Facet sidebar (DataTableControls). Owns its own "Filters" header + count
+   *  badge and internal scroll, so it gets a bounded flex region rather than a
+   *  labeled section of its own. */
+  facets?: ReactNode;
+}
+
+function Section({ label, children }: { label: string; children: ReactNode }) {
+  if (!children) return null;
+  return (
+    <section className="flex flex-col gap-2">
+      <h3 className="text-muted-foreground text-xs font-bold tracking-wide uppercase">
+        {label}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * Mobile-only bottom sheet that collapses the traces toolbar's scattered
+ * filter controls into ONE surface: search · time range · quick presets ·
+ * saved views · facets. It hosts the SAME controllers EventsTable already
+ * builds for desktop (passed in as nodes) — a presentation reshuffle, not a
+ * state migration.
+ *
+ * Open state is the shared DataTableControls context (`mobileOpen`), so the
+ * facet list expands (its rail-vs-expanded toggle keys off the provider's
+ * `data-expanded`) and its in-sheet "Hide filters" button closes the sheet.
+ */
+export function MobileFiltersSheet({
+  activeCount,
+  resultCount,
+  onClearAll,
+  search,
+  timeRange,
+  presets,
+  savedViews,
+  facets,
+}: MobileFiltersSheetProps) {
+  const { open, setOpen } = useDataTableControls();
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button variant="outline" size="sm" className="h-8 shrink-0 gap-2">
+          <SlidersHorizontal className="h-4 w-4" />
+          <span>Filters</span>
+          {activeCount > 0 && (
+            <Badge variant="secondary" className="ml-0.5 h-5 px-1.5 text-xs">
+              {activeCount}
+            </Badge>
+          )}
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side="bottom"
+        // No description; tell Radix it is intentional so it doesn't warn.
+        aria-describedby={undefined}
+        // Hide the wrapper's default close X (our header provides one) and
+        // drop the default padding/gap so header/body/footer own their spacing.
+        className="flex max-h-[85svh] flex-col gap-0 p-0 [&>button]:hidden"
+      >
+        {/* Accessible name for the dialog; the visible heading is below. */}
+        <SheetTitle className="sr-only">Filters</SheetTitle>
+        <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">
+          <span className="text-foreground text-lg font-bold">Filters</span>
+          <SheetClose asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Close filters"
+              className="h-8 w-8"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </SheetClose>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col">
+          {/* Short top controls. Capped + scrollable so a tall stack (wrapping
+              preset chips on a short screen) never starves the facet list. */}
+          {(search || timeRange || presets || savedViews) && (
+            <div className="flex max-h-[45svh] shrink-0 flex-col gap-5 overflow-y-auto border-b px-4 py-4">
+              <Section label="Search">{search}</Section>
+              <Section label="Time range">{timeRange}</Section>
+              <Section label="Quick presets">{presets}</Section>
+              <Section label="My views">{savedViews}</Section>
+            </div>
+          )}
+          {/* Facets fill the remaining height; DataTableControls scrolls its
+              own list within this bounded region. */}
+          {facets && (
+            <div className="flex min-h-0 flex-1 flex-col">{facets}</div>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2 border-t px-4 py-3">
+          <Button variant="outline" className="flex-1" onClick={onClearAll}>
+            Clear all
+          </Button>
+          <SheetClose asChild>
+            <Button className="flex-1">
+              {resultCount != null
+                ? `Show ${numberFormatter(resultCount, 0)} results`
+                : "Show results"}
+            </Button>
+          </SheetClose>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/web/src/features/projects/hooks.ts
+++ b/web/src/features/projects/hooks.ts
@@ -67,3 +67,49 @@ export const useQueryProjectOrOrganization = () => {
 
   return p.project ? p : { organization: o, project: null };
 };
+
+/**
+ * Builds the target path for switching the current page to a different
+ * organization/project, preserving the page the user is on where possible
+ * (e.g. staying on `.../traces` when switching projects). Shared by every
+ * org/project switcher (breadcrumb, mobile nav drawer) so switching behavior
+ * stays identical across entry points.
+ */
+export const useOrgProjectSwitchPaths = () => {
+  const router = useRouter();
+
+  /**
+   * Truncate the path before the first dynamic segment that is not allowlisted.
+   * e.g. /project/[projectId]/traces/[traceId] -> /project/[projectId]/traces
+   */
+  const truncatePathBeforeDynamicSegments = (path: string) => {
+    const allowlistedIds = ["[projectId]", "[organizationId]", "[page]"];
+    const segments = router.route.split("/");
+    const idSegments = segments.filter(
+      (segment) => segment.startsWith("[") && segment.endsWith("]"),
+    );
+    const stopSegment = idSegments.filter((id) => !allowlistedIds.includes(id));
+    if (stopSegment.length === 0) return path;
+    const stopIndex = segments.indexOf(stopSegment[0]);
+    const truncatedPath = path.split("/").slice(0, stopIndex).join("/");
+    return truncatedPath;
+  };
+
+  const getProjectPath = (projectId: string) =>
+    router.query.projectId
+      ? truncatePathBeforeDynamicSegments(router.asPath).replace(
+          router.query.projectId as string,
+          projectId,
+        )
+      : `/project/${projectId}`;
+
+  const getOrgPath = (orgId: string) =>
+    router.query.organizationId
+      ? truncatePathBeforeDynamicSegments(router.asPath).replace(
+          router.query.organizationId as string,
+          orgId,
+        )
+      : `/organization/${orgId}`;
+
+  return { getProjectPath, getOrgPath };
+};

--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -1154,7 +1154,7 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
                                                   ) ?? -1) + 1;
                                                 return digit >= 1 &&
                                                   digit <= 9 ? (
-                                                  <KeyboardShortcut className="ml-0.5 hidden h-3.5 min-w-3.5 px-1 text-[9px] group-focus-within:inline-flex">
+                                                  <KeyboardShortcut className="ml-0.5 h-3.5 min-w-3.5 px-1 text-[9px] md:group-focus-within:inline-flex">
                                                     {digit}
                                                   </KeyboardShortcut>
                                                 ) : null;
@@ -1231,7 +1231,11 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
             />
           </div>
           {rowCount > 0 && (
-            <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 px-0.5 text-[11px]">
+            // This legend only exists to advertise keyboard shortcuts, so hide
+            // the whole strip on touch viewports rather than just the kbd
+            // chips inside it (LFE-11067) — the shortcuts themselves still
+            // work if a physical keyboard is attached.
+            <div className="text-muted-foreground hidden flex-wrap items-center gap-x-2 gap-y-1 px-0.5 text-[11px] md:flex">
               {rowCount > 1 && (
                 <span className="flex items-center gap-1">
                   <KeyboardShortcut className="h-4 min-w-4 px-1 text-[9px]">

--- a/web/src/features/search-bar/components/SearchComposer.tsx
+++ b/web/src/features/search-bar/components/SearchComposer.tsx
@@ -1294,8 +1294,17 @@ export function SearchComposer({
         {draft.length === 0 && (
           <div
             className={cn(
+              // Bound the right edge (not just pr-*) so `truncate` has a width
+              // to clip against — otherwise the placeholder grows to its full
+              // text width and runs under the top-right "Ask AI" button. The
+              // reserved gap matches the surface's pr-20/pr-8.
               "text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 truncate font-mono text-xs",
-              onActivateAi !== undefined ? "pr-20" : "pr-8",
+              // Mirror the surface's right reservation exactly: the "Ask AI"
+              // button (right-20) is hidden while diagnostics show, when the
+              // error icon takes over the top-right corner (right-8).
+              onActivateAi !== undefined && !showGlobalDiagnostics
+                ? "right-20"
+                : "right-8",
             )}
             title={COMPOSER_PLACEHOLDER}
           >


### PR DESCRIPTION
## ⚠️ Preview only — DO NOT MERGE

This branch just **merges the individual mobile-revamp PRs together** so the whole mobile traces experience can be tested at one preview URL (`pr-<N>.preview.langfuse.com`). Merge the individual PRs below, not this.

### What it combines
| PR | Piece |
|----|-------|
| #15325 | mobile page header no longer crushes the title |
| #15327 | nav drawer closes on navigation |
| #15330 | org/project switcher in the mobile drawer |
| #15326 | chart-view stacks on mobile |
| #15328 | keyboard-shortcut hints hidden on touch |
| #15323 | search placeholder no longer under Ask AI |
| #15331 | **mobile card-list** (replaces the wide table) |
| #15332 | **unified mobile Filters sheet** (stacked on #15331) |

### Verified on this integration @390px
Project list → tap project → Home → hamburger (org/project switcher) → tap Tracing (drawer auto-closes) → **card list** (no horizontal scroll) → tap card → trace peek drawer → open **Filters** (search · time · presets · views · facets in one sheet) → apply a facet (list re-queries, badge shows count) → flip **Table/Chart** (config panel stacks, no overflow). Zero horizontal overflow at every step.

Merge order: #15331 before #15332 (stacked). The rest are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)