### PR TITLE
fix(models): match Vertex claude-haiku-4-5@20251001 and Claude Code [1m] model names

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2573,7 +2573,7 @@
   {
     "id": "c5qmrqolku82tra3vgdixmys",
     "modelName": "claude-sonnet-4-5-20250929",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)(\\[1m\\])?$",
     "createdAt": "2025-09-29T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3174,7 +3174,7 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "modelName": "claude-haiku-4-5-20251001",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001|claude-haiku-4-5@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
     "updatedAt": "2026-04-20T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3295,7 +3295,7 @@
   {
     "id": "90ec5ec3-1a48-4ff0-919c-70cdb8f632ed",
     "modelName": "claude-sonnet-4-6",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-6(-v1(:0)?)?|claude-sonnet-4-6)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-6(-v1(:0)?)?|claude-sonnet-4-6)(\\[1m\\])?$",
     "createdAt": "2026-02-18T00:00:00.000Z",
     "updatedAt": "2026-06-29T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3326,7 +3326,7 @@
   {
     "id": "13458bc0-1c20-44c2-8753-172f54b67647",
     "modelName": "claude-opus-4-6",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)(\\[1m\\])?$",
     "createdAt": "2026-02-09T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3357,7 +3357,7 @@
   {
     "id": "d506b291-cc9c-4833-9014-0f387a8e1cc8",
     "modelName": "claude-opus-4-7",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-7|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7-v1(:0)?|claude-opus-4-7)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-7|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7-v1(:0)?|claude-opus-4-7)(\\[1m\\])?$",
     "createdAt": "2026-04-16T00:00:00.000Z",
     "updatedAt": "2026-04-16T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3388,7 +3388,7 @@
   {
     "id": "80753fd5-342b-4ed3-bbb1-57d3d57b7e03",
     "modelName": "claude-opus-4-8",
-    "matchPattern": "(?i)^((anthropic\/)?claude-opus-4-8|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-8(-v1(:0)?)?)$",
+    "matchPattern": "(?i)^((anthropic\/)?claude-opus-4-8|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-8(-v1(:0)?)?)(\\[1m\\])?$",
     "createdAt": "2026-05-28T00:00:00.000Z",
     "updatedAt": "2026-05-28T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3419,7 +3419,7 @@
   {
     "id": "0b9a828d-9fdc-46d4-b5ec-f6574c42ad65",
     "modelName": "claude-fable-5",
-    "matchPattern": "(?i)^((anthropic\/)?claude-fable-5|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-fable-5(-v1(:0)?)?)$",
+    "matchPattern": "(?i)^((anthropic\/)?claude-fable-5|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-fable-5(-v1(:0)?)?)(\\[1m\\])?$",
     "createdAt": "2026-06-09T00:00:00.000Z",
     "updatedAt": "2026-06-09T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3481,7 +3481,7 @@
   {
     "id": "7c2e1f89-3a54-4b67-9d21-58e634b79a0c",
     "modelName": "claude-sonnet-5",
-    "matchPattern": "(?i)^((anthropic\\/)?claude-sonnet-5|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-5(-v1(:0)?)?)$",
+    "matchPattern": "(?i)^((anthropic\\/)?claude-sonnet-5|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-5(-v1(:0)?)?)(\\[1m\\])?$",
     "createdAt": "2026-07-01T00:00:00.000Z",
     "updatedAt": "2026-07-01T00:00:00.000Z",
     "tokenizerConfig": null,


### PR DESCRIPTION
## Problem

Two classes of Anthropic model names never match the built-in model definitions in `default-model-prices.json`, so cost tracking silently returns null for them on self-hosted (and presumably cloud) deployments:

1. **Vertex AI naming for Claude Haiku 4.5.** Vertex reports the model as `claude-haiku-4-5@20251001`, but the built-in pattern only matches the legacy reversed form `claude-4-5-haiku@20251001`. (Compare with the Sonnet 4.5 entry, which correctly matches `claude-sonnet-4-5@20250929`.)

2. **Claude Code 1M-context naming.** Claude Code appends `[1m]` to the model id when the 1M-token context beta is active, e.g. `claude-opus-4-8[1m]`, and these names flow into Langfuse via the usual integrations. On our deployment this is by far the largest unpriced model (~230k generations / 30 days).

## Change

- Add `claude-haiku-4-5@20251001` alongside the legacy Vertex alias in the Haiku 4.5 pattern.
- Add an optional `(\[1m\])?` suffix to the Anthropic models that support the 1M context window (Opus 4.6/4.7/4.8, Sonnet 4.5/4.6/5, Fable 5). Pricing is identical to the base entries — Anthropic charges no long-context premium on these models — so reusing the same definition is correct.

## Verification

Programmatically checked every modified pattern: all base names, provider-prefixed forms, and Bedrock/Vertex forms still match as before, and each new form (`claude-haiku-4-5@20251001`, `claude-opus-4-8[1m]`, `claude-sonnet-5[1m]`, `claude-sonnet-4-5-20250929[1m]`, `claude-fable-5[1m]`, …) resolves to exactly one definition.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two classes of Anthropic model-name mismatches in `default-model-prices.json` that were causing silent cost-tracking failures. All changes are confined to regex `matchPattern` fields in a single JSON file.

- **Vertex AI Haiku 4.5 alias**: Adds `claude-haiku-4-5@20251001` as an alternative alongside the pre-existing reversed form `claude-4-5-haiku@20251001`, bringing it in line with the Sonnet 4.5 Vertex convention (`claude-sonnet-4-5@20250929`).
- **Claude Code 1M-context suffix**: Appends `(\\[1m\\])?` to the `matchPattern` of seven models (Opus 4.6/4.7/4.8, Sonnet 4.5/4.6/5, Fable 5) so that `[1m]`-suffixed model IDs reported by Claude Code's 1M-context beta are matched correctly with no price change.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The changes are additive-only to regex match patterns in a JSON config file; existing model matching is unaffected and no logic paths change.

All modifications are isolated to matchPattern fields. The new (\[1m\])? suffix is correctly placed after the full outer group and before the $ anchor in every updated pattern, so existing names continue to match and the new suffixed forms are captured. The Vertex haiku-4-5 alias addition mirrors the established convention used by Sonnet 4.5. No code paths, pricing values, or tokenizer configs are changed.

No files require special attention. The only touched file is the model-prices JSON, and the regex changes are straightforward.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(models): match Vertex claude-haiku-4..."](https://github.com/langfuse/langfuse/commit/9ef76c95107257706d18f73904e7c5fd990ce93c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46424899)</sub>

<!-- /greptile_comment -->