### PR TITLE
revert(deploy): remove ECS task_arn DD_TAGS tagging (LFE-11028)

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -124,24 +124,5 @@ if [ $status -ne 0 ]; then
     exit $status
 fi
 
-# On ECS, resolve the task ARN from the container metadata endpoint and append
-# it to DD_TAGS so dd-trace stamps tracer telemetry (runtime metrics, spans)
-# with task_arn.  The full ARN exact-match joins with EventBridge's taskArn
-# field and Datadog's ECS task_arn tag convention.  Reuses the separator
-# DD_TAGS already uses (comma or space).  Best-effort, bounded to ~2s total:
-# on any failure DD_TAGS is left untouched and startup proceeds — this block
-# never fails boot.
-if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
-    _task_arn=$(timeout 2 wget -T 2 -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-    if [ -n "$_task_arn" ]; then
-        case "$DD_TAGS" in
-            *,*) _sep="," ;;
-            *" "*) _sep=" " ;;
-            *) _sep="," ;;
-        esac
-        export DD_TAGS="${DD_TAGS:+${DD_TAGS}${_sep}}task_arn:${_task_arn}"
-    fi
-fi
-
 # Run the command passed to the docker image on start
 exec "$@"

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -19,21 +19,5 @@ if [ -z "$DATABASE_URL" ]; then
     fi
 fi
 
-# On ECS, append task_arn:<full TaskARN> from the container metadata endpoint
-# to DD_TAGS, reusing its existing separator (bounded ~2s total; never fails
-# boot).  Full ARN exact-match joins with EventBridge taskArn / Datadog's ECS
-# task_arn tag convention.
-if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
-    _task_arn=$(timeout 2 wget -T 2 -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" | sed -n 's/.*"TaskARN"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-    if [ -n "$_task_arn" ]; then
-        case "$DD_TAGS" in
-            *,*) _sep="," ;;
-            *" "*) _sep=" " ;;
-            *) _sep="," ;;
-        esac
-        export DD_TAGS="${DD_TAGS:+${DD_TAGS}${_sep}}task_arn:${_task_arn}"
-    fi
-fi
-
 # Run the command passed to the docker image on start
 exec "$@"


### PR DESCRIPTION
## What does this PR do?

Reverts #15286 (LFE-11028), which appended `task_arn:<ecs task arn>` to `DD_TAGS` in the web/worker entrypoints.

The intent was to tag only tracer telemetry (spans + `runtime.node.*` metrics). However, our `langfuse.*` custom metrics are emitted through dd-trace's built-in DogStatsD client (`recordIncrement`/`recordGauge`/… in `packages/shared/src/server/instrumentation/index.ts`), and dd-trace stamps its global tags — parsed from `DD_TAGS` — onto every DogStatsD call as well. As a result, every `langfuse.*` custom metric picked up a per-task `task_arn` tag in all prod environments after rollout, multiplying billed custom-metric cardinality: the EU org's `datadog.estimated_usage.metrics.custom` rose from a ~6.5–8k baseline to ~57–70k (~8–9×) starting the rollout hour; the US org shows the same tag leak.

Reverting stops the billed-cardinality accrual. Both entrypoints return byte-identical to their pre-#15286 state. The `task_arn` tagging will be re-landed once custom metrics no longer inherit tracer global tags (follow-up documented on LFE-11028).

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reverts the ECS task ARN injection into `DD_TAGS` that was previously added to both `web/entrypoint.sh` and `worker/entrypoint.sh`. The removed block fetched the task ARN from the ECS container metadata endpoint at startup and appended it as a `task_arn` tag to Datadog.

- Removes the `wget`-based ECS metadata fetch and `DD_TAGS` manipulation from both entrypoint scripts, leaving the `exec "$@"` call as the final step in both.
- Both entrypoints are otherwise unchanged; all database and ClickHouse migration logic in `web/entrypoint.sh` remains intact.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Clean removal of a best-effort observability block that explicitly never prevented startup; no functional code is affected.

Both entrypoint scripts have only the ECS/Datadog tagging block removed. The remaining logic — database URL construction, migrations, and the final exec — is identical to what existed before that feature was added. The removed block was explicitly designed to be no-op on failure and had no side effects on the application itself.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["revert(deploy): remove ECS task\_arn DD\_T..."](https://github.com/langfuse/langfuse/commit/ddd11a74780ae09a038a546c997e7982a7c6bbae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46431146)</sub>

<!-- /greptile_comment -->