### PR TITLE
fix(otel): preserve structured system instructions from LiteLLM instead of coercing to object Object

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2050,9 +2050,9 @@ export class OtelIngestionProcessor {
   }
 
   /**
-   * Prepends gen_ai.system_instructions as a {role: "system", content} message,
-   * consistent with how gen_ai.system.message events are mapped.
-   * No-ops if messages already contain a system message.
+   * Prepends gen_ai.system_instructions as system message content or parts.
+   * No-ops if instructions cannot be represented safely or input already
+   * contains a system message.
    */
   private prependSystemInstructions(
     input: unknown,
@@ -2067,29 +2067,76 @@ export class OtelIngestionProcessor {
       );
       if (hasSystemMessage) return input;
 
-      let content: string;
-      try {
-        const parsed =
-          typeof systemInstructions === "string"
-            ? JSON.parse(systemInstructions)
-            : systemInstructions;
-        if (Array.isArray(parsed)) {
-          content = parsed
-            .map((p: Record<string, unknown>) =>
-              typeof p === "object" && p?.content
-                ? String(p.content)
-                : String(p),
-            )
-            .join("\n");
-        } else {
-          content = String(parsed);
+      let parsed = systemInstructions;
+      if (typeof systemInstructions === "string") {
+        try {
+          parsed = JSON.parse(systemInstructions);
+        } catch {
+          parsed = systemInstructions;
         }
-      } catch {
-        content = String(systemInstructions);
       }
 
-      const systemMessage = { role: "system", content };
-      const merged = [systemMessage, ...messages];
+      let systemMessages: unknown[];
+      if (Array.isArray(parsed)) {
+        if (parsed.length === 0) return input;
+
+        const isSystemMessage = (
+          value: unknown,
+        ): value is Record<string, unknown> =>
+          OtelIngestionProcessor.isPlainObject(value) &&
+          value.role === "system" &&
+          (Array.isArray(value.parts) || typeof value.content === "string");
+        const isInstructionPart = (
+          value: unknown,
+        ): value is Record<string, unknown> =>
+          OtelIngestionProcessor.isPlainObject(value) &&
+          typeof value.type === "string" &&
+          (value.type !== "text" || typeof value.content === "string");
+        const isTextInstructionPart = (
+          value: unknown,
+        ): value is Record<"type" | "content", string> =>
+          OtelIngestionProcessor.isPlainObject(value) &&
+          value.type === "text" &&
+          typeof value.content === "string";
+
+        // Some instrumentations, including LiteLLM, emit complete system
+        // messages instead of instruction parts. Preserve those messages
+        // rather than nesting them as parts.
+        if (parsed.every(isSystemMessage)) {
+          systemMessages = parsed.filter(
+            (message) =>
+              (typeof message.content === "string" &&
+                message.content.trim().length > 0) ||
+              (Array.isArray(message.parts) && message.parts.length > 0),
+          );
+          if (systemMessages.length === 0) return input;
+        } else if (parsed.every((part) => typeof part === "string")) {
+          const content = parsed
+            .filter((part) => part.trim().length > 0)
+            .join("\n");
+          if (!content) return input;
+          systemMessages = [{ role: "system", content }];
+        } else {
+          if (!parsed.every(isInstructionPart)) return input;
+
+          if (parsed.every(isTextInstructionPart)) {
+            const content = parsed
+              .map((part) => part.content)
+              .filter((part) => part.trim().length > 0)
+              .join("\n");
+            if (!content) return input;
+            systemMessages = [{ role: "system", content }];
+          } else {
+            systemMessages = [{ role: "system", parts: parsed }];
+          }
+        }
+      } else if (typeof parsed === "string" && parsed.trim().length > 0) {
+        systemMessages = [{ role: "system", content: parsed }];
+      } else {
+        return input;
+      }
+
+      const merged = systemMessages.concat(messages);
       return typeof input === "string" ? JSON.stringify(merged) : merged;
     } catch {
       return input;

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2071,6 +2071,15 @@ export class OtelIngestionProcessor {
       if (typeof systemInstructions === "string") {
         try {
           parsed = JSON.parse(systemInstructions);
+          // OTLP string attributes cannot distinguish raw primitive-looking
+          // text from a JSON-encoded primitive, so preserve the original text.
+          if (
+            parsed === null ||
+            typeof parsed === "boolean" ||
+            typeof parsed === "number"
+          ) {
+            parsed = systemInstructions;
+          }
         } catch {
           parsed = systemInstructions;
         }
@@ -2098,6 +2107,11 @@ export class OtelIngestionProcessor {
           OtelIngestionProcessor.isPlainObject(value) &&
           value.type === "text" &&
           typeof value.content === "string";
+        const isMeaningfulInstructionPart = (value: unknown): boolean =>
+          isInstructionPart(value) &&
+          (value.type !== "text" ||
+            (typeof value.content === "string" &&
+              value.content.trim().length > 0));
 
         // Some instrumentations, including LiteLLM, emit complete system
         // messages instead of instruction parts. Preserve those messages
@@ -2107,7 +2121,8 @@ export class OtelIngestionProcessor {
             (message) =>
               (typeof message.content === "string" &&
                 message.content.trim().length > 0) ||
-              (Array.isArray(message.parts) && message.parts.length > 0),
+              (Array.isArray(message.parts) &&
+                message.parts.some(isMeaningfulInstructionPart)),
           );
           if (systemMessages.length === 0) return input;
         } else if (parsed.every((part) => typeof part === "string")) {

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -3928,6 +3928,129 @@ describe("OTel Resource Span Mapping", () => {
       },
     );
 
+    describe("gen_ai.system_instructions", () => {
+      const inputMessages = [
+        { role: "user", parts: [{ type: "text", content: "Hello" }] },
+      ];
+
+      const convertWithSystemInstructions = async (
+        systemInstructions: unknown,
+      ) => {
+        const resourceSpan = {
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  ...defaultSpanProps,
+                  attributes: [
+                    {
+                      key: "gen_ai.operation.name",
+                      value: { stringValue: "chat" },
+                    },
+                    {
+                      key: "gen_ai.input.messages",
+                      value: { stringValue: JSON.stringify(inputMessages) },
+                    },
+                    {
+                      key: "gen_ai.system_instructions",
+                      value: {
+                        stringValue: JSON.stringify(systemInstructions),
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        const events = await convertOtelSpanToIngestionEvent(
+          resourceSpan,
+          new Set(),
+        );
+
+        return events.find((event) => event.type === "generation-create")?.body
+          .input;
+      };
+
+      it("should preserve complete system messages instead of coercing them to strings", async () => {
+        const systemMessages = [
+          {
+            role: "system",
+            parts: [{ type: "text", content: "Be concise." }],
+          },
+          {
+            role: "system",
+            parts: [{ type: "text", content: "Use plain language." }],
+          },
+        ];
+
+        expect(await convertWithSystemInstructions(systemMessages)).toBe(
+          JSON.stringify([...systemMessages, ...inputMessages]),
+        );
+      });
+
+      it("should preserve non-text OpenTelemetry system instruction parts", async () => {
+        const systemInstructionParts = [
+          { type: "provider_defined", policy_id: "policy-1" },
+        ];
+
+        expect(
+          await convertWithSystemInstructions(systemInstructionParts),
+        ).toBe(
+          JSON.stringify([
+            { role: "system", parts: systemInstructionParts },
+            ...inputMessages,
+          ]),
+        );
+      });
+
+      it("should join string system instruction parts", async () => {
+        expect(
+          await convertWithSystemInstructions([
+            "Be concise.",
+            "Use plain language.",
+          ]),
+        ).toBe(
+          JSON.stringify([
+            {
+              role: "system",
+              content: "Be concise.\nUse plain language.",
+            },
+            ...inputMessages,
+          ]),
+        );
+      });
+
+      it.each([
+        ["an empty array", []],
+        ["an empty complete system message", [{ role: "system", parts: [] }]],
+        ["empty objects", [{}, {}]],
+        [
+          "object-valued text content",
+          [
+            { type: "text", content: {} },
+            { type: "text", content: {} },
+          ],
+        ],
+        ["null", null],
+        [
+          "mixed-role complete messages",
+          [
+            { role: "system", content: "Policy" },
+            { role: "user", content: "Do not reinterpret me" },
+          ],
+        ],
+      ])(
+        "should not prepend a synthetic system message for %s",
+        async (_name, systemInstructions) => {
+          expect(await convertWithSystemInstructions(systemInstructions)).toBe(
+            JSON.stringify(inputMessages),
+          );
+        },
+      );
+    });
+
     describe("prompt linking gated to GENERATION observations", () => {
       const buildResourceSpan = (attributes: Record<string, any>[]) =>
         ({

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -3935,6 +3935,7 @@ describe("OTel Resource Span Mapping", () => {
 
       const convertWithSystemInstructions = async (
         systemInstructions: unknown,
+        options?: { serialize?: boolean },
       ) => {
         const resourceSpan = {
           scopeSpans: [
@@ -3954,7 +3955,10 @@ describe("OTel Resource Span Mapping", () => {
                     {
                       key: "gen_ai.system_instructions",
                       value: {
-                        stringValue: JSON.stringify(systemInstructions),
+                        stringValue:
+                          options?.serialize === false
+                            ? String(systemInstructions)
+                            : JSON.stringify(systemInstructions),
                       },
                     },
                   ],
@@ -4022,9 +4026,34 @@ describe("OTel Resource Span Mapping", () => {
         );
       });
 
+      it.each(["null", "true", "123"])(
+        "should preserve raw text that is valid JSON primitive syntax: %s",
+        async (systemInstructions) => {
+          expect(
+            await convertWithSystemInstructions(systemInstructions, {
+              serialize: false,
+            }),
+          ).toBe(
+            JSON.stringify([
+              { role: "system", content: systemInstructions },
+              ...inputMessages,
+            ]),
+          );
+        },
+      );
+
       it.each([
         ["an empty array", []],
         ["an empty complete system message", [{ role: "system", parts: [] }]],
+        [
+          "a complete system message with only blank text parts",
+          [
+            {
+              role: "system",
+              parts: [{ type: "text", content: "   " }],
+            },
+          ],
+        ],
         ["empty objects", [{}, {}]],
         [
           "object-valued text content",
@@ -4033,7 +4062,6 @@ describe("OTel Resource Span Mapping", () => {
             { type: "text", content: {} },
           ],
         ],
-        ["null", null],
         [
           "mixed-role complete messages",
           [


### PR DESCRIPTION
## PR description

Closes #15336 

### What does this PR do?

This PR prevents structured `gen_ai.system_instructions` from being converted to JavaScript’s `"[object Object]"` representation during OTEL ingestion.

It updates `OtelIngestionProcessor.prependSystemInstructions()` to distinguish between:

- Complete system messages such as `{ role: "system", parts: [...] }`.
- Plain string instructions.
- Arrays of strings.
- Canonical text instruction parts.
- Structured non-text instruction parts.
- Empty or unsupported values.

Complete system messages are preserved and prepended directly. Text instruction parts retain the existing system-content representation. Other valid structured parts are preserved under `parts`. Empty, mixed-role, or otherwise unsafe values leave the original input unchanged.

The existing behavior of not prepending instructions when the input already contains a system message is unchanged.

### Why make this change?

Support for mapping `gen_ai.system_instructions` was introduced by [PR #12442](https://github.com/langfuse/langfuse/pull/12442). The implementation converts instruction arrays into a synthetic system message, but its fallback applies `String()` to objects that do not have a top-level `content` property.

For payloads such as:

```json
[
  {
    "role": "system",
    "parts": [{ "type": "text", "content": "Be concise." }]
  },
  {
    "role": "system",
    "parts": [{ "type": "text", "content": "Use plain language." }]
  }
]
```

that produces:

```text
[object Object]
[object Object]
```

This is silent data corruption: the instructions are present in the span, but their structured contents are discarded.

The affected shape is part of LiteLLM’s emitted OTEL behavior:

- Its [OpenTelemetry documentation](https://docs.litellm.ai/docs/observability/opentelemetry_integration#attributes-reference) describes the GenAI message attributes as JSON-encoded arrays of `{role, parts: [...]}` objects.
- Its [upstream OpenTelemetry test](https://github.com/BerriAI/litellm/blob/301a02b7bede045053352555f1c57f3fd25dd387/tests/test_litellm/integrations/test_opentelemetry.py#L4059-L4075) passes a complete system message and verifies that its serialized representation retains `role: "system"` and `parts`.
- LiteLLM also supports [plain string instructions](https://github.com/BerriAI/litellm/blob/301a02b7bede045053352555f1c57f3fd25dd387/tests/test_litellm/integrations/test_opentelemetry.py#L4033-L4057), which remain supported by this change.

This is therefore a defensive compatibility fix in Langfuse ingestion, rather than a change requiring callers to reshape LiteLLM’s output.

### Implementation

The mapping now:

- Parses JSON-encoded instructions while retaining raw strings.
- Preserves arrays of complete system messages.
- Joins arrays of non-empty strings.
- Joins canonical text instruction parts into system content.
- Preserves valid non-text parts structurally.
- Rejects mixed-role complete-message arrays rather than relabeling them as system content.
- No-ops for empty arrays, empty messages, `null`, and object-valued text content.
- Never uses generic `String(object)` coercion for structured instruction values.

The helper is shared by the Pydantic AI and generic OpenTelemetry GenAI input paths.

### Red-green TDD evidence

#### Red

The regression test was added before changing the implementation. It sends a real OTLP resource span through the ingestion processor with:

- `gen_ai.input.messages`
- Two complete `{ role: "system", parts: [...] }` entries in `gen_ai.system_instructions`

Before the fix, it failed with:

```text
Expected:
[
  {"role":"system","parts":[...]},
  {"role":"system","parts":[...]},
  {"role":"user","parts":[...]}
]

Received:
[
  {
    "role":"system",
    "content":"[object Object]\n[object Object]"
  },
  {"role":"user","parts":[...]}
]
```

This reproduces the reported corruption directly in the server-side ingestion path.

#### Green

After the implementation:

- `pnpm --filter web run test otelMapping.servertest.ts`
  - `Tests 230 passed | 1 skipped (231)`
- `pnpm --filter worker run test otelFlueMapping.test.ts`
  - `Tests 6 passed (6)`
- `pnpm run lint`
  - `Tasks: 7 successful, 7 total`
- Commit-hook formatting:
  - All matched files use Prettier formatting
- `git diff --check`
  - Clean

The new tests cover:

- Complete LiteLLM-style system messages.
- Canonical text parts.
- Structured non-text parts.
- String instruction arrays.
- Empty arrays and empty complete messages.
- Empty objects.
- Object-valued text content.
- `null`.
- Mixed-role complete-message arrays.
- Existing system-message deduplication through the pre-existing suite.

### Scope and risk

Impacted areas:

- `packages/shared`: OTEL ingestion mapping.
- `web`: server-side OTEL mapping regression tests.

The change is limited to spans where system instructions are being combined with an existing message input. It does not change storage schemas, public APIs, authentication, or unrelated OTEL attributes.

Unsupported values now leave the original input unchanged instead of producing synthetic corrupted content. Existing Pydantic AI and generic OTEL mapping tests continue to pass.

### E2E testing

This was not tested against the currently deployed Langfuse Cloud ingestion service because the server-side fix is not deployed there yet.

The regression test exercises the real `OtelIngestionProcessor` with a complete OTLP resource-span fixture rather than mocking the helper. A synthetic replay against the PR preview can be added after the preview is available.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent data-corruption bug where LiteLLM-style `gen_ai.system_instructions` containing complete `{ role: "system", parts: [...] }` objects were coerced to the string `"[object Object]"` via `String()` during OTEL ingestion. The fix replaces the single-branch coercion in `prependSystemInstructions` with a typed, branched parser that handles complete system messages, text/non-text instruction parts, string arrays, and plain strings, returning input unchanged for empty, null, mixed-role, or unrecognised shapes.

- **`OtelIngestionProcessor.ts`**: Rewrites `prependSystemInstructions` to classify instruction arrays using three local type-guard predicates and preserve complete system messages directly rather than extracting a `content` string from them.
- **`otelMapping.servertest.ts`**: Adds a comprehensive `gen_ai.system_instructions` describe block with positive tests for all new branches and a parameterised negative suite covering every documented no-op input shape.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is scoped to a single private helper and all failure modes fall back to returning the original input unchanged.

The implementation is carefully defensive — every unrecognised or ambiguous input shape returns the original input rather than producing synthetic content. The new tests route real OTLP fixtures through the full ingestion processor and cover every documented branch. The only nit is that the three type-guard closures are re-created on each call and could be static methods, but this has no correctness impact.

No files require special attention; both changed files are narrow and well-tested.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[prependSystemInstructions called] --> B{input has system message?}
    B -- Yes --> Z[return input unchanged]
    B -- No --> C{typeof systemInstructions === 'string'?}
    C -- Yes --> D[Try JSON.parse]
    D -- Success --> E[parsed = result]
    D -- Fail --> F[parsed = original string]
    C -- No --> G[parsed = systemInstructions]
    E --> H{Array.isArray parsed?}
    F --> H
    G --> H
    H -- Yes, empty --> Z
    H -- Yes --> I{every item is isSystemMessage?}
    I -- Yes --> J[Filter out empty messages]
    J --> K{systemMessages empty?}
    K -- Yes --> Z
    K -- No --> R[prepend systemMessages]
    I -- No --> L{every item is string?}
    L -- Yes --> M[join non-empty strings as content]
    M --> R
    L -- No --> N{every item passes isInstructionPart?}
    N -- No --> Z
    N -- Yes --> O{every item passes isTextInstructionPart?}
    O -- Yes --> P[join text content strings]
    P --> R
    O -- No --> Q[wrap as parts array]
    Q --> R
    H -- No --> S{typeof parsed === 'string' and non-empty?}
    S -- Yes --> T[create content message]
    T --> R
    S -- No --> Z
    R --> U[return merged array or JSON string]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/otel/OtelIngestionProcessor.ts:2083-2100
**Helper predicates defined inside method body**

`isSystemMessage`, `isInstructionPart`, and `isTextInstructionPart` are re-created as closures on every call to `prependSystemInstructions`. These are pure, stateless type guards with no dependency on instance or local state; lifting them to `private static` methods would avoid the per-call allocation, make them independently unit-testable, and improve readability alongside `isPlainObject`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): preserve structured system in..."](https://github.com/langfuse/langfuse/commit/bbfcd3310d5b7b44a18deb95c762fc14d14b2eaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46525326)</sub>

<!-- /greptile_comment -->