### PR TITLE
fix(otel): preserve structured {role, parts} gen_ai.system_instructions

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.systemInstructions.test.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.systemInstructions.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Regression tests for gen_ai.system_instructions handling in the OTel
+ * ingestion processor. See issue #15336.
+ *
+ * Two emitter shapes are supported:
+ * - "parts" shape (pydantic-ai, etc.): array of text-part objects
+ *   like {type: "text", content: "..."}. Joined into a single system
+ *   message — pre-fix behavior, kept for backward compatibility.
+ * - "structured message" shape (LiteLLM, etc.): array of complete
+ *   messages like {role: "system", parts: [...]}. Each is preserved
+ *   as its own system message so non-text parts survive ingestion.
+ *
+ * The pre-fix bug: structured messages fell through to `String(p)`,
+ * producing the literal string "[object Object]" and silently
+ * destroying the captured system instructions.
+ *
+ * processToIngestionEvents awaits redis.set (seen-traces tracking);
+ * CI's tests-shared job sets REDIS_HOST without a running Redis
+ * server, so we stub the client the same way the metadata_dropped
+ * test does.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../redis/redis", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../redis/redis")>()),
+  redis: { set: vi.fn().mockResolvedValue("OK") },
+}));
+
+import {
+  OtelIngestionProcessor,
+  type ResourceSpan,
+} from "./OtelIngestionProcessor";
+
+const PROJECT_ID = "test-project-lfe-15336";
+
+const createProcessor = () =>
+  new OtelIngestionProcessor({
+    projectId: PROJECT_ID,
+    publicKey: "pk-test",
+    sdkName: "python",
+    sdkVersion: "3.8.1",
+  });
+
+// Build a single-span OTel batch with the given span attributes. Uses
+// pydantic-ai scope so the OpenTelemetry messages path is exercised
+// (the path that calls prependSystemInstructions for the system
+// instructions attribute).
+const buildPydanticAiBatch = (
+  systemInstructionsJson: string,
+  allMessagesJson: string,
+): ResourceSpan[] => [
+  {
+    resource: {
+      attributes: [
+        { key: "service.name", value: { stringValue: "test-svc" } },
+      ],
+    },
+    scopeSpans: [
+      {
+        scope: {
+          name: "pydantic-ai",
+          version: "1.66.0",
+          attributes: [],
+        },
+        spans: [
+          {
+            traceId: Buffer.from("0123456789abcdef0123456789abcdef", "hex"),
+            spanId: Buffer.from("0123456789abcdef", "hex"),
+            name: "agent-run",
+            kind: 1,
+            startTimeUnixNano: "1752384000000000000",
+            endTimeUnixNano: "1752384001000000000",
+            attributes: [
+              {
+                key: "langfuse.observation.type",
+                value: { stringValue: "span" },
+              },
+              {
+                key: "pydantic_ai.all_messages",
+                value: { stringValue: allMessagesJson },
+              },
+              {
+                key: "gen_ai.system_instructions",
+                value: { stringValue: systemInstructionsJson },
+              },
+            ],
+            status: {},
+          },
+        ],
+      },
+    ],
+  },
+];
+
+// Same as above but exercises the generic OpenTelemetry path
+// (gen_ai.input.messages + gen_ai.system_instructions, no pydantic-ai
+// scope). Used to confirm both call sites behave the same.
+const buildGenericOtelBatch = (
+  systemInstructionsJson: string,
+  inputMessagesJson: string,
+): ResourceSpan[] => [
+  {
+    resource: {
+      attributes: [
+        { key: "service.name", value: { stringValue: "test-svc" } },
+      ],
+    },
+    scopeSpans: [
+      {
+        scope: {
+          name: "openinference-instrumentation-openai",
+          version: "0.1.0",
+          attributes: [],
+        },
+        spans: [
+          {
+            traceId: Buffer.from("0123456789abcdef0123456789abcdef", "hex"),
+            spanId: Buffer.from("0123456789abcdef", "hex"),
+            name: "chat",
+            kind: 1,
+            startTimeUnixNano: "1752384000000000000",
+            endTimeUnixNano: "1752384001000000000",
+            attributes: [
+              {
+                key: "langfuse.observation.type",
+                value: { stringValue: "generation" },
+              },
+              {
+                key: "gen_ai.input.messages",
+                value: { stringValue: inputMessagesJson },
+              },
+              {
+                key: "gen_ai.system_instructions",
+                value: { stringValue: systemInstructionsJson },
+              },
+            ],
+            status: {},
+          },
+        ],
+      },
+    ],
+  },
+];
+
+// LiteLLM's actual emission shape per
+// https://github.com/BerriAI/litellm/blob/301a02b7/tests/test_litellm/integrations/test_opentelemetry.py#L4059
+const LITELLM_SYSTEM_INSTRUCTIONS = JSON.stringify([
+  {
+    role: "system",
+    parts: [
+      {
+        type: "text",
+        content: "You are a helpful assistant.",
+      },
+    ],
+  },
+]);
+
+// Pydantic-AI emission shape, mirrors the pre-fix otelMapping.servertest
+// fixture so the existing behavior is regression-tested.
+const PYDANTIC_AI_SYSTEM_INSTRUCTIONS = JSON.stringify([
+  {
+    type: "text",
+    content: "You are a helpful assistant.",
+  },
+]);
+
+const ALL_MESSAGES = JSON.stringify([
+  {
+    role: "user",
+    parts: [{ type: "text", content: "Hello" }],
+  },
+]);
+
+const findSpanEvent = (events: ReadonlyArray<unknown>) =>
+  events.find(
+    (e): e is { type: string; body: { input?: unknown } } =>
+      typeof e === "object" &&
+      e !== null &&
+      "type" in e &&
+      (e as { type: unknown }).type === "span-create" &&
+      "body" in e &&
+      typeof (e as { body: unknown }).body === "object" &&
+      (e as { body: unknown }).body !== null,
+  );
+
+describe("OtelIngestionProcessor: gen_ai.system_instructions (#15336)", () => {
+  describe("structured message shape (LiteLLM) — {role, parts}", () => {
+    it("preserves a single structured system message and does NOT coerce to '[object Object]'", async () => {
+      const events = await createProcessor().processToIngestionEvents(
+        buildPydanticAiBatch(LITELLM_SYSTEM_INSTRUCTIONS, ALL_MESSAGES),
+      );
+
+      const spanEvent = findSpanEvent(events);
+      const input = JSON.parse((spanEvent?.body.input ?? "[]") as string);
+      expect(input).toHaveLength(2);
+
+      // The first message is the preserved structured system message,
+      // not a string-coerced "[object Object]".
+      const system = input[0];
+      expect(system.role).toBe("system");
+      expect(system.parts).toEqual([
+        { type: "text", content: "You are a helpful assistant." },
+      ]);
+      expect(system.content).toBeUndefined();
+
+      // The original user message is unchanged.
+      expect(input[1]).toEqual({
+        role: "user",
+        parts: [{ type: "text", content: "Hello" }],
+      });
+    });
+
+    it("preserves multiple structured system messages as separate system messages", async () => {
+      const instructions = JSON.stringify([
+        {
+          role: "system",
+          parts: [{ type: "text", content: "You are concise." }],
+        },
+        {
+          role: "system",
+          parts: [{ type: "text", content: "You are precise." }],
+        },
+      ]);
+      const events = await createProcessor().processToIngestionEvents(
+        buildPydanticAiBatch(instructions, ALL_MESSAGES),
+      );
+
+      const input = JSON.parse(
+        (findSpanEvent(events)?.body.input ?? "[]") as string,
+      );
+      expect(input).toHaveLength(3);
+      expect(input[0]).toEqual({
+        role: "system",
+        parts: [{ type: "text", content: "You are concise." }],
+      });
+      expect(input[1]).toEqual({
+        role: "system",
+        parts: [{ type: "text", content: "You are precise." }],
+      });
+      expect(input[2].role).toBe("user");
+    });
+
+    it("preserves non-text parts (e.g. tool/function parts) without string coercion", async () => {
+      const instructions = JSON.stringify([
+        {
+          role: "system",
+          parts: [
+            { type: "text", content: "Use the calculator." },
+            {
+              type: "function",
+              name: "calculator",
+              input: { expression: "2+2" },
+            },
+          ],
+        },
+      ]);
+      const events = await createProcessor().processToIngestionEvents(
+        buildPydanticAiBatch(instructions, ALL_MESSAGES),
+      );
+
+      const input = JSON.parse(
+        (findSpanEvent(events)?.body.input ?? "[]") as string,
+      );
+      expect(input[0].parts).toEqual([
+        { type: "text", content: "Use the calculator." },
+        { type: "function", name: "calculator", input: { expression: "2+2" } },
+      ]);
+      expect(input[0].content).toBeUndefined();
+    });
+
+    it("fills a missing role with 'system'", async () => {
+      const instructions = JSON.stringify([
+        { parts: [{ type: "text", content: "no role here" }] },
+      ]);
+      const events = await createProcessor().processToIngestionEvents(
+        buildPydanticAiBatch(instructions, ALL_MESSAGES),
+      );
+
+      const input = JSON.parse(
+        (findSpanEvent(events)?.body.input ?? "[]") as string,
+      );
+      expect(input[0].role).toBe("system");
+      expect(input[0].parts).toEqual([
+        { type: "text", content: "no role here" },
+      ]);
+    });
+  });
+
+  describe("parts shape (pydantic-ai) — {type, content} — backward compatibility", () => {
+    it("joins text content into a single {role: 'system', content} message", async () => {
+      // Mirrors the pre-fix otelMapping.servertest.ts fixture at line 2413.
+      const events = await createProcessor().processToIngestionEvents(
+        buildPydanticAiBatch(PYDANTIC_AI_SYSTEM_INSTRUCTIONS, ALL_MESSAGES),
+      );
+
+      const input = JSON.parse(
+        (findSpanEvent(events)?.body.input ?? "[]") as string,
+      );
+      expect(input).toHaveLength(2);
+      expect(input[0]).toEqual({
+        role: "system",
+        content: "You are a helpful assistant.",
+      });
+      expect(input[1].role).toBe("user");
+    });
+
+    it("joins multiple text parts with newlines", async () => {
+      const instructions = JSON.stringify([
+        { type: "text", content: "Be concise." },
+        { type: "text", content: "Be accurate." },
+      ]);
+      const events = await createProcessor().processToIngestionEvents(
+        buildPydanticAiBatch(instructions, ALL_MESSAGES),
+      );
+
+      const input = JSON.parse(
+        (findSpanEvent(events)?.body.input ?? "[]") as string,
+      );
+      expect(input[0]).toEqual({
+        role: "system",
+        content: "Be concise.\nBe accurate.",
+      });
+    });
+  });
+
+  describe("plain string instructions", () => {
+    it("wraps a plain string in {role: 'system', content}", async () => {
+      const events = await createProcessor().processToIngestionEvents(
+        buildPydanticAiBatch(JSON.stringify("Be helpful."), ALL_MESSAGES),
+      );
+
+      const input = JSON.parse(
+        (findSpanEvent(events)?.body.input ?? "[]") as string,
+      );
+      expect(input[0]).toEqual({ role: "system", content: "Be helpful." });
+    });
+  });
+
+  describe("safety: empty / malformed / unsafe input", () => {
+    it("does not prepend anything when system instructions is an empty array", async () => {
+      const events = await createProcessor().processToIngestionEvents(
+        buildPydanticAiBatch("[]", ALL_MESSAGES),
+      );
+
+      const input = JSON.parse(
+        (findSpanEvent(events)?.body.input ?? "[]") as string,
+      );
+      expect(input).toHaveLength(1);
+      expect(input[0].role).toBe("user");
+    });
+
+    it("does not prepend when system instructions is an array of only unsafe values", async () => {
+      // Numbers, booleans, null — none can become useful content and
+      // the pre-fix code would have stringified them, which the
+      // post-fix code refuses to do silently.
+      const instructions = JSON.stringify([42, true, null]);
+      const events = await createProcessor().processToIngestionEvents(
+        buildPydanticAiBatch(instructions, ALL_MESSAGES),
+      );
+
+      const input = JSON.parse(
+        (findSpanEvent(events)?.body.input ?? "[]") as string,
+      );
+      // Only the original user message remains.
+      expect(input).toHaveLength(1);
+      expect(input[0].role).toBe("user");
+    });
+
+    it("falls back to a single system message when system instructions is invalid JSON", async () => {
+      // The whole point of the try/catch in parseSystemInstructions: a
+      // bad JSON string should not crash ingestion. It should be
+      // wrapped as {role: 'system', content: <raw>}.
+      const events = await createProcessor().processToIngestionEvents(
+        buildPydanticAiBatch("not valid json", ALL_MESSAGES),
+      );
+
+      const input = JSON.parse(
+        (findSpanEvent(events)?.body.input ?? "[]") as string,
+      );
+      expect(input[0]).toEqual({
+        role: "system",
+        content: "not valid json",
+      });
+    });
+
+    it("does not duplicate the system message when input already contains one", async () => {
+      const userMessages = JSON.stringify([
+        { role: "system", parts: [{ type: "text", content: "Pre-existing." }] },
+        { role: "user", parts: [{ type: "text", content: "Hello" }] },
+      ]);
+      const events = await createProcessor().processToIngestionEvents(
+        buildPydanticAiBatch(LITELLM_SYSTEM_INSTRUCTIONS, userMessages),
+      );
+
+      const input = JSON.parse(
+        (findSpanEvent(events)?.body.input ?? "[]") as string,
+      );
+      // No prepending happened — the pre-existing system message is the
+      // first entry, and the new LiteLLM system message was dropped.
+      expect(input).toHaveLength(2);
+      expect(input[0]).toEqual({
+        role: "system",
+        parts: [{ type: "text", content: "Pre-existing." }],
+      });
+      expect(input[1].role).toBe("user");
+    });
+  });
+
+  describe("generic OpenTelemetry path (gen_ai.input.messages)", () => {
+    // The two call sites of prependSystemInstructions are the pydantic-ai
+    // path (tested above) and the generic OpenTelemetry path. The
+    // structured-message fix should apply to both.
+
+    const genericInputMessages = JSON.stringify([
+      { role: "user", content: "What is 2+2?" },
+    ]);
+
+    it("preserves structured system messages via the generic OTEL path", async () => {
+      const events = await createProcessor().processToIngestionEvents(
+        buildGenericOtelBatch(LITELLM_SYSTEM_INSTRUCTIONS, genericInputMessages),
+      );
+
+      const spanEvent = events.find((e) => e.type === "generation-create");
+      const input = JSON.parse((spanEvent?.body.input ?? "[]") as string);
+      expect(input).toHaveLength(2);
+      expect(input[0]).toEqual({
+        role: "system",
+        parts: [{ type: "text", content: "You are a helpful assistant." }],
+      });
+      expect(input[1]).toEqual({
+        role: "user",
+        content: "What is 2+2?",
+      });
+    });
+  });
+});

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.systemInstructions.test.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.systemInstructions.test.ts
@@ -156,6 +156,23 @@ const LITELLM_SYSTEM_INSTRUCTIONS = JSON.stringify([
   },
 ]);
 
+// Mixed-shape emission (structured + text-content entries in the same
+// array). The pre-fix structured path silently dropped the text-only
+// entry; the new behavior should fall through to the text path and
+// preserve the content.
+const MIXED_SHAPE_SYSTEM_INSTRUCTIONS = JSON.stringify([
+  { type: "text", content: "preamble" },
+  {
+    role: "system",
+    parts: [
+      {
+        type: "text",
+        content: "You are a helpful assistant.",
+      },
+    ],
+  },
+]);
+
 // Pydantic-AI emission shape, mirrors the pre-fix otelMapping.servertest
 // fixture so the existing behavior is regression-tested.
 const PYDANTIC_AI_SYSTEM_INSTRUCTIONS = JSON.stringify([
@@ -427,6 +444,30 @@ describe("OtelIngestionProcessor: gen_ai.system_instructions (#15336)", () => {
       expect(input[0]).toEqual({
         role: "system",
         parts: [{ type: "text", content: "You are a helpful assistant." }],
+      });
+      expect(input[1]).toEqual({
+        role: "user",
+        content: "What is 2+2?",
+      });
+    });
+
+    it("falls back to the text path when a mixed-shape array is emitted", async () => {
+      // The structured path would have silently dropped the text-only
+      // "preamble" entry. After the fix, a mixed array routes through
+      // the text path so the content is preserved.
+      const events = await createProcessor().processToIngestionEvents(
+        buildGenericOtelBatch(
+          MIXED_SHAPE_SYSTEM_INSTRUCTIONS,
+          genericInputMessages,
+        ),
+      );
+
+      const spanEvent = events.find((e) => e.type === "generation-create");
+      const input = JSON.parse((spanEvent?.body.input ?? "[]") as string);
+      expect(input).toHaveLength(2);
+      expect(input[0]).toEqual({
+        role: "system",
+        content: "preamble\nYou are a helpful assistant.",
       });
       expect(input[1]).toEqual({
         role: "user",

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2050,8 +2050,20 @@ export class OtelIngestionProcessor {
   }
 
   /**
-   * Prepends gen_ai.system_instructions as a {role: "system", content} message,
-   * consistent with how gen_ai.system.message events are mapped.
+   * Prepends gen_ai.system_instructions as one or more {role: "system", ...}
+   * messages, consistent with how gen_ai.system.message events are mapped.
+   *
+   * Two emitter shapes are supported without coercion:
+   * - "parts" shape (pydantic-ai, etc.): the array contains text-part objects
+   *   like {type: "text", content: "..."}. Their text content is joined with
+   *   newlines into a single system message (preserves pre-fix behavior).
+   * - "structured message" shape (LiteLLM, etc.): the array contains complete
+   *   messages like {role: "system", parts: [...]}. Each is preserved as its
+   *   own system message so non-text parts survive ingestion.
+   *
+   * Elements that are neither recognized shape nor have any text/parts content
+   * are dropped silently rather than coerced to "[object Object]".
+   *
    * No-ops if messages already contain a system message.
    */
   private prependSystemInstructions(
@@ -2067,33 +2079,77 @@ export class OtelIngestionProcessor {
       );
       if (hasSystemMessage) return input;
 
-      let content: string;
-      try {
-        const parsed =
-          typeof systemInstructions === "string"
-            ? JSON.parse(systemInstructions)
-            : systemInstructions;
-        if (Array.isArray(parsed)) {
-          content = parsed
-            .map((p: Record<string, unknown>) =>
-              typeof p === "object" && p?.content
-                ? String(p.content)
-                : String(p),
-            )
-            .join("\n");
-        } else {
-          content = String(parsed);
-        }
-      } catch {
-        content = String(systemInstructions);
-      }
+      const systemMessages = this.parseSystemInstructions(systemInstructions);
+      if (systemMessages.length === 0) return input;
 
-      const systemMessage = { role: "system", content };
-      const merged = [systemMessage, ...messages];
+      const merged = [...systemMessages, ...messages];
       return typeof input === "string" ? JSON.stringify(merged) : merged;
     } catch {
       return input;
     }
+  }
+
+  /**
+   * Normalize a gen_ai.system_instructions value into an array of complete
+   * system messages. See {@link prependSystemInstructions} for shape details.
+   *
+   * Returns [] for empty/unsafe input. Never throws.
+   */
+  private parseSystemInstructions(
+    systemInstructions: unknown,
+  ): Array<Record<string, unknown>> {
+    let parsed: unknown = systemInstructions;
+    if (typeof parsed === "string") {
+      try {
+        parsed = JSON.parse(parsed);
+      } catch {
+        parsed = systemInstructions;
+      }
+    }
+
+    if (typeof parsed === "string") {
+      return parsed.length > 0 ? [{ role: "system", content: parsed }] : [];
+    }
+
+    if (!Array.isArray(parsed)) return [];
+
+    const isStructuredMessage = (entry: unknown): boolean =>
+      entry !== null &&
+      typeof entry === "object" &&
+      !Array.isArray(entry) &&
+      Array.isArray((entry as Record<string, unknown>).parts);
+
+    const hasStructured = parsed.some(isStructuredMessage);
+
+    if (hasStructured) {
+      const messages: Array<Record<string, unknown>> = [];
+      for (const entry of parsed) {
+        if (!isStructuredMessage(entry)) continue;
+        const msg: Record<string, unknown> = { ...(entry as Record<string, unknown>) };
+        if (typeof msg.role !== "string" || msg.role.length === 0) {
+          msg.role = "system";
+        }
+        messages.push(msg);
+      }
+      return messages;
+    }
+
+    const textParts: string[] = [];
+    for (const entry of parsed) {
+      if (typeof entry === "string") {
+        if (entry.length > 0) textParts.push(entry);
+        continue;
+      }
+      if (entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
+        const content = (entry as Record<string, unknown>).content;
+        if (typeof content === "string" && content.length > 0) {
+          textParts.push(content);
+        }
+      }
+    }
+
+    if (textParts.length === 0) return [];
+    return [{ role: "system", content: textParts.join("\n") }];
   }
 
   private extractEnvironment(

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2122,6 +2122,21 @@ export class OtelIngestionProcessor {
     const hasStructured = parsed.some(isStructuredMessage);
 
     if (hasStructured) {
+      // The spec only defines one of the two shapes per array; mixing
+      // {role, parts} and {type, content} in the same system_instructions
+      // payload is undefined. If we see a mix, fall through to the text
+      // path below so text-only entries are not silently dropped.
+      const hasTextContent = parsed.some(
+        (entry) =>
+          entry !== null &&
+          typeof entry === "object" &&
+          !Array.isArray(entry) &&
+          typeof (entry as Record<string, unknown>).content === "string",
+      );
+      if (hasTextContent) {
+        return this.parseSystemInstructionsAsText(parsed);
+      }
+
       const messages: Array<Record<string, unknown>> = [];
       for (const entry of parsed) {
         if (!isStructuredMessage(entry)) continue;
@@ -2134,6 +2149,12 @@ export class OtelIngestionProcessor {
       return messages;
     }
 
+    return this.parseSystemInstructionsAsText(parsed);
+  }
+
+  private parseSystemInstructionsAsText(
+    parsed: unknown[],
+  ): Array<Record<string, unknown>> {
     const textParts: string[] = [];
     for (const entry of parsed) {
       if (typeof entry === "string") {
@@ -2144,6 +2165,23 @@ export class OtelIngestionProcessor {
         const content = (entry as Record<string, unknown>).content;
         if (typeof content === "string" && content.length > 0) {
           textParts.push(content);
+          continue;
+        }
+        // Mixed-shape fallback: structured entries that lack a top-level
+        // content string may still carry text inside parts[].content.
+        const parts = (entry as Record<string, unknown>).parts;
+        if (Array.isArray(parts)) {
+          for (const part of parts) {
+            if (
+              part !== null &&
+              typeof part === "object" &&
+              !Array.isArray(part) &&
+              typeof (part as Record<string, unknown>).content === "string" &&
+              ((part as Record<string, unknown>).content as string).length > 0
+            ) {
+              textParts.push((part as Record<string, unknown>).content as string);
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
### Problem

LiteLLM emits `gen_ai.system_instructions` as a JSON-encoded array of complete system messages:

```json
[{ "role": "system", "parts": [{ "type": "text", "content": "You are a helpful assistant." }] }]
```

The pre-fix `prependSystemInstructions` at `OtelIngestionProcessor.ts` called `String(p)` on any array element without a top-level `content` property. A structured `{role, parts}` element has no `content`, so it was coerced to the literal string `"[object Object]"` and silently destroyed — losing the captured system instructions and producing misleading trace input.

### Fix

`OtelIngestionProcessor.prependSystemInstructions` now distinguishes two shapes:

- **"parts" shape** (pydantic-ai, etc.) — `[{type: "text", content: "..."}]`: text content is still joined with newlines into a single `{role: "system", content}` message. Unchanged behavior.
- **"structured message" shape** (LiteLLM, etc.) — `[{role: "system", parts: [...]}]`: each entry is preserved as a complete system message so non-text parts (function calls, image parts, etc.) survive ingestion. Missing `role` defaults to `"system"` for safety.

Elements with neither `parts` nor a string `content` (e.g. primitives, malformed objects) are dropped silently rather than stringified.

### Testing

- New file `OtelIngestionProcessor.systemInstructions.test.ts` with 12 regression tests:
  - LiteLLM single + multiple + non-text + missing-role structured messages
  - pydantic-ai single + multi-part joined text content (regression)
  - Plain string instructions
  - Empty / unsafe / malformed input
  - Idempotency when input already has a system message
  - Both call sites: `pydantic_ai.all_messages` and the generic `gen_ai.input.messages` path
- `pnpm --filter @langfuse/shared run test OtelIngestionProcessor.systemInstructions` → 12/12 passed
- `pnpm --filter @langfuse/shared run test OtelIngestionProcessor.metadataDropped` → 22/22 passed (no regression)
- `pnpm --filter @langfuse/shared run lint` → clean
- `pnpm --filter @langfuse/shared run typecheck` → only pre-existing errors in `src/features/monitors/service/helpers.ts` (confirmed on `upstream/main` HEAD, unrelated to this change)

### Why this matters

LiteLLM is one of the most-used LLM gateways, and its OpenTelemetry integration ships a system-prompt shape that Langfuse was actively destroying on ingestion. The fix:

- Preserves observability data that was being silently lost
- Keeps the `pydantic-ai` and other text-content emitters behaving exactly as before
- Costs less than the old code path (one `Array.isArray` check replaces the `String(p)` fallback)

Fixes #15336

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a data-loss bug in `OtelIngestionProcessor.prependSystemInstructions` where LiteLLM's structured `{role, parts}` system-instruction entries were silently coerced to the string `"[object Object]"` via `String(p)`. The old code only handled objects with a top-level `content` string; structured messages with no `content` fell through the coercion fallback.

- The core logic is extracted into a new `parseSystemInstructions` private method that discriminates between the "parts" shape (`{type, content}` — pydantic-ai, backward-compatible) and the "structured message" shape (`{role, parts}` — LiteLLM), preserving each structured entry as a first-class system message instead of stringifying it.
- Invalid JSON, empty arrays, and unsafe primitives are all handled defensively, and the no-op path when a system message already exists is preserved.
- A new test file adds 12 regression tests covering both shapes, both call sites, and the edge/malformed-input cases.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The change is self-contained to one private method in the OTel ingestion processor, the old coercion bug is clearly fixed, and backward-compatible behavior for pydantic-ai emitters is preserved and regression-tested.

The fix is narrowly scoped and well-tested across both emitter shapes and edge cases. The one open question is how a hypothetical mixed-shape array (structured entries alongside text-part entries) would behave — the `hasStructured` flag causes the text-part entries to be silently dropped in that scenario, with no comment or test acknowledging it. This is unlikely to occur in practice but is a behavioral blind spot worth noting before merge.

The `parseSystemInstructions` method in `OtelIngestionProcessor.ts` around the `hasStructured` branching logic deserves a second look for the mixed-array case.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["prependSystemInstructions(input, systemInstructions)"] --> B{messages already\ncontain system msg?}
    B -- yes --> C[return input unchanged]
    B -- no --> D["parseSystemInstructions(systemInstructions)"]

    D --> E{typeof === 'string'?}
    E -- yes --> F[JSON.parse attempt]
    F -- parse fails --> G[treat as raw string]
    F -- parse succeeds --> H{result type?}
    G --> I["return [{role:'system', content: rawString}]"]

    H -- string --> I
    H -- not array --> J[return empty array]
    H -- array --> K{any entry has\n'parts' array?}

    K -- yes\nstructured shape\nLiteLLM --> L[loop: keep entries\nwith parts array,\ndefault role='system']
    K -- no\nparts shape\npydantic-ai --> M[loop: collect\nstring content values]

    L --> N["return array of\n{role, parts, ...} messages"]
    M --> O{any text collected?}
    O -- no --> J
    O -- yes --> P["return [{role:'system',\ncontent: joined text}]"]

    N --> Q[prepend systemMessages\nto input messages]
    P --> Q
    I --> Q
    Q --> R[return merged array\nor JSON string]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/otel/OtelIngestionProcessor.ts:2122-2134
**Silent data loss on mixed-shape arrays**

The `hasStructured` flag is computed once with `.some()` and then controls the entire branch. Any array that contains at least one `{role, parts}` entry will enter the structured path, which skips every entry that lacks a `parts` array — including otherwise-valid `{type: "text", content: "..."}` text-part entries. In a hypothetical mixed emission like `[{type:"text",content:"preamble"},{role:"system",parts:[...]}]`, the `"preamble"` text part would be silently dropped. There's no test for this case, and the current design offers no fallback. If mixed arrays are not expected by the spec, a brief comment here clarifying that assumption (or an early-reject guard) would prevent future confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(otel): cover structured and parts s..."](https://github.com/langfuse/langfuse/commit/d75b18c273ecd299a27810edf066a0732685da84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46552809)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->