### PR TITLE
feat(feature-previews): redesigned feature preview modal

### DIFF
--- a/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
@@ -2,6 +2,8 @@ import { useSession } from "next-auth/react";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
+import { useInAppAiAgent } from "@/src/ee/features/in-app-agent/components/InAppAiAgentProvider";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { api } from "@/src/utils/api";
 
@@ -28,6 +30,8 @@ export function ControlledFeaturePreviewModal({
   const authSession = useSession();
   const { isBetaEnabled } = useV4Beta();
   const capture = usePostHogClientCapture();
+  const { setOpen: setSupportDrawerOpen } = useSupportDrawer();
+  const { setOpen: setAiAgentOpen } = useInAppAiAgent();
   const setFeaturePreviewEnabled =
     api.userAccount.setFeaturePreviewEnabled.useMutation({
       onSuccess: async (_data, variables) => {
@@ -61,9 +65,7 @@ export function ControlledFeaturePreviewModal({
         authSession.data?.environment.enableExperimentalFeatures === true,
       warningReason: !isBetaEnabled
         ? "Compact Session View is only available on the events-backed session view. Turn on Fast (Preview) to enable it."
-        : authSession.data?.environment.enableExperimentalFeatures === true
-          ? "This preview is enabled by LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES, so a per-user opt-out does not disable it."
-          : undefined,
+        : undefined,
       onToggle: onToggle("modernSession"),
       isToggling: setFeaturePreviewEnabled.isPending,
     },
@@ -82,6 +84,13 @@ export function ControlledFeaturePreviewModal({
       open={open}
       onOpenChange={onOpenChange}
       state={state}
+      onContactSupport={() => {
+        // Same interaction as the sidebar Support button; close this dialog
+        // first so it does not cover the drawer (panel layer < modal layer).
+        onOpenChange(false);
+        setAiAgentOpen(false);
+        setSupportDrawerOpen(true);
+      }}
     />
   );
 }

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.stories.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.stories.tsx
@@ -64,6 +64,23 @@ const meta = preview.meta({
 
 export const Default = meta.story({});
 
+export const Enabled = meta.story({
+  args: {
+    state: {
+      modernSession: { enabled: true, onToggle: fn(), isToggling: false },
+    },
+  },
+});
+
+export const MultipleFeatures = meta.story({
+  args: {
+    state: {
+      modernSession: { enabled: true, onToggle: fn(), isToggling: false },
+      searchBar: { enabled: false, onToggle: fn(), isToggling: false },
+    },
+  },
+});
+
 export const Warning = meta.story({
   args: {
     state: {

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.stories.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.stories.tsx
@@ -55,6 +55,7 @@ const meta = preview.meta({
   args: {
     open: true,
     onOpenChange: fn(),
+    onContactSupport: fn(),
     state: {
       modernSession: { enabled: false, onToggle: fn(), isToggling: false },
     },
@@ -86,8 +87,9 @@ export const Warning = meta.story({
     state: {
       modernSession: {
         enabled: false,
+        disabled: true,
         warningReason:
-          "This preview is enabled globally, so a per-user opt-out does not disable it.",
+          "Compact Session View is only available on the events-backed session view. Turn on Fast (Preview) to enable it.",
         onToggle: fn(),
       },
     },

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
@@ -5,11 +5,11 @@ import {
   Dialog,
   DialogBody,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/src/components/ui/dialog";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
+import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
 
@@ -31,6 +31,14 @@ type PreviewIllustration = {
   alt: string;
 };
 
+/** Static provenance shown as a small mono metadata line in the detail pane.
+ *  Dates come from the git history of the registry entry — update `updated`
+ *  when a preview materially changes. Optional; omit rather than guess. */
+type PreviewDates = {
+  added: string;
+  updated?: string;
+};
+
 type PreviewRegistryItem = {
   flag: PreviewFlag;
   title: string;
@@ -39,6 +47,7 @@ type PreviewRegistryItem = {
   details: string;
   feedbackUrl: string;
   illustration: PreviewIllustration;
+  dates?: PreviewDates;
 };
 
 /** Per-preview dynamic state, supplied by ControlledFeaturePreviewModal (which
@@ -68,6 +77,7 @@ const PREVIEW_REGISTRY: PreviewRegistryItem[] = [
       dark: modernSessionDarkIllustration,
       alt: "Compact Session View showing a trace minimap beside a continuous session conversation feed.",
     },
+    dates: { added: "Jul 20, 2026" },
   },
   // TODO(remove ~2026-06-19): dead registry entry — "searchBar" is GA on the v4
   // events tables and no longer surfaced in the dialog (no state entry in
@@ -87,12 +97,11 @@ const PREVIEW_REGISTRY: PreviewRegistryItem[] = [
       dark: filterSearchBarDarkIllustration,
       alt: "The filter search bar turns typed queries like level:ERROR -env:dev into Observations and Traces table filters with inline suggestions.",
     },
+    dates: { added: "Jun 17, 2026", updated: "Jun 18, 2026" },
   },
 ];
 
 const FEATURE_PREVIEW_MODAL_TITLE = "Feature Preview";
-const FEATURE_PREVIEW_MODAL_SUBTITLE =
-  "Try upcoming and experimental product experiences before they become generally available.";
 
 export type FeaturePreviewModalProps = {
   open: boolean;
@@ -116,102 +125,105 @@ export function FeaturePreviewModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        size="lg"
-        closeOnInteractionOutside
-        overlayMode="blocking"
-        className="border-border bg-background text-foreground max-h-[88vh] p-0 shadow-2xl sm:rounded-2xl"
-      >
+      <DialogContent size="lg" closeOnInteractionOutside overlayMode="blocking">
         <DialogHeader>
-          <DialogTitle className="text-foreground text-lg font-bold">
+          <DialogTitle className="text-lg font-bold">
             {FEATURE_PREVIEW_MODAL_TITLE}
           </DialogTitle>
-          <DialogDescription className="mt-0">
-            {FEATURE_PREVIEW_MODAL_SUBTITLE}
-          </DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="grid min-h-0 gap-0 overflow-hidden p-0 md:grid-cols-[220px_1fr]">
-          <aside className="border-border bg-muted/20 border-b p-3 md:border-r md:border-b-0">
-            <div className="flex gap-2 overflow-x-auto md:flex-col md:overflow-x-visible">
-              {items.map((item) => {
-                const isSelected = item.flag === selected?.flag;
-                return (
+        <DialogBody className="grid min-h-0 gap-0 overflow-hidden p-0 md:grid-cols-[240px_1fr]">
+          <aside className="border-border flex flex-col gap-1 border-b p-2 md:border-r md:border-b-0">
+            {items.map((item) => {
+              const itemState = state[item.flag];
+              const isSelected = item.flag === selected?.flag;
+              return (
+                <div
+                  key={item.flag}
+                  className={cn(
+                    "flex items-center gap-3 rounded-md px-3 py-2 transition-colors",
+                    isSelected ? "bg-muted" : "hover:bg-muted/50",
+                  )}
+                >
                   <button
-                    key={item.flag}
                     type="button"
                     onClick={() => setSelectedFlag(item.flag)}
                     aria-pressed={isSelected}
+                    title={item.sidebarLabel}
                     className={cn(
-                      "flex min-w-48 items-start rounded-md border px-3 py-3 text-left transition-colors md:min-w-0",
-                      isSelected
-                        ? "bg-muted text-foreground border-transparent"
-                        : "text-muted-foreground hover:bg-muted/50 border-transparent",
+                      "min-w-0 flex-1 truncate text-left text-sm font-bold",
+                      isSelected ? "text-foreground" : "text-muted-foreground",
                     )}
                   >
-                    <span className="min-w-0">
-                      <span className="block text-sm font-bold">
-                        {item.sidebarLabel}
-                      </span>
-                      <span className="text-muted-foreground mt-1 line-clamp-2 block text-xs">
-                        {state[item.flag]?.disabled
-                          ? "Unavailable"
-                          : state[item.flag]?.enabled
-                            ? "Enabled"
-                            : "Available"}
-                      </span>
-                    </span>
+                    {item.sidebarLabel}
                   </button>
-                );
-              })}
-            </div>
+                  <Switch
+                    checked={itemState?.enabled === true}
+                    disabled={
+                      itemState?.disabled === true ||
+                      itemState?.isToggling === true
+                    }
+                    onCheckedChange={(enabled) => {
+                      setSelectedFlag(item.flag);
+                      itemState?.onToggle(enabled);
+                    }}
+                    aria-label={`Toggle ${item.title}`}
+                  />
+                </div>
+              );
+            })}
           </aside>
 
-          <section className="bg-background min-h-0 overflow-y-auto p-6">
+          <section className="min-h-0 overflow-y-auto p-6">
             {selected && selectedState ? (
               <>
                 {selectedState.warningReason ? (
-                  <div className="mb-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-800 dark:text-yellow-200">
+                  <div className="mb-4 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-800 dark:text-yellow-200">
                     {selectedState.warningReason}
                   </div>
                 ) : null}
 
-                <div className="flex items-start justify-between gap-6">
-                  <div>
-                    <h2 className="text-foreground text-xl font-bold">
-                      {selected.title}
-                    </h2>
-                    <p className="text-muted-foreground mt-2 max-w-2xl text-sm leading-5">
-                      {selected.description}
-                    </p>
-                    <Button asChild className="mt-4">
-                      <a
-                        href={selected.feedbackUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        Give feedback
-                      </a>
-                    </Button>
-                  </div>
-                  <div className="flex shrink-0 flex-col items-end gap-2">
-                    <Switch
-                      checked={selectedState.enabled}
-                      disabled={
-                        selectedState.disabled === true ||
-                        selectedState.isToggling === true
-                      }
-                      onCheckedChange={selectedState.onToggle}
-                      aria-label={`Toggle ${selected.title}`}
-                    />
-                  </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <h2 className="text-foreground text-xl font-bold">
+                    {selected.title}
+                  </h2>
+                  <Badge
+                    variant={selectedState.enabled ? "success" : "secondary"}
+                  >
+                    {selectedState.enabled ? "Enabled" : "Disabled"}
+                  </Badge>
                 </div>
+
+                <p className="text-muted-foreground mt-2 max-w-2xl text-sm leading-5">
+                  {selected.description}
+                </p>
+
+                {selected.dates ? (
+                  <p className="text-muted-foreground mt-2 font-mono text-xs">
+                    added {selected.dates.added}
+                    {selected.dates.updated
+                      ? ` · updated ${selected.dates.updated}`
+                      : null}
+                  </p>
+                ) : null}
 
                 <PreviewMockupPanel illustration={selected.illustration} />
 
                 <p className="text-muted-foreground mt-5 text-sm leading-5">
                   {selected.details}
                 </p>
+
+                <div className="border-border mt-6 border-t border-dashed" />
+
+                <Button asChild className="mt-4">
+                  <a
+                    href={selected.feedbackUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Give feedback
+                  </a>
+                </Button>
               </>
             ) : null}
           </section>
@@ -227,7 +239,7 @@ function PreviewMockupPanel({
   illustration: PreviewIllustration;
 }) {
   return (
-    <div className="border-border bg-muted/30 mt-6 overflow-hidden rounded-2xl border shadow-inner">
+    <div className="border-border bg-muted/30 mt-6 overflow-hidden rounded-md border">
       <Image
         src={illustration.light}
         alt={illustration.alt}

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
@@ -31,14 +31,6 @@ type PreviewIllustration = {
   alt: string;
 };
 
-/** Static provenance shown as a small mono metadata line in the detail pane.
- *  Dates come from the git history of the registry entry — update `updated`
- *  when a preview materially changes. Optional; omit rather than guess. */
-type PreviewDates = {
-  added: string;
-  updated?: string;
-};
-
 type PreviewRegistryItem = {
   flag: PreviewFlag;
   title: string;
@@ -47,7 +39,6 @@ type PreviewRegistryItem = {
   details: string;
   feedbackUrl: string;
   illustration: PreviewIllustration;
-  dates?: PreviewDates;
 };
 
 /** Per-preview dynamic state, supplied by ControlledFeaturePreviewModal (which
@@ -77,7 +68,6 @@ const PREVIEW_REGISTRY: PreviewRegistryItem[] = [
       dark: modernSessionDarkIllustration,
       alt: "Compact Session View showing a trace minimap beside a continuous session conversation feed.",
     },
-    dates: { added: "Jul 20, 2026" },
   },
   // TODO(remove ~2026-06-19): dead registry entry — "searchBar" is GA on the v4
   // events tables and no longer surfaced in the dialog (no state entry in
@@ -97,7 +87,6 @@ const PREVIEW_REGISTRY: PreviewRegistryItem[] = [
       dark: filterSearchBarDarkIllustration,
       alt: "The filter search bar turns typed queries like level:ERROR -env:dev into Observations and Traces table filters with inline suggestions.",
     },
-    dates: { added: "Jun 17, 2026", updated: "Jun 18, 2026" },
   },
 ];
 
@@ -108,12 +97,15 @@ export type FeaturePreviewModalProps = {
   onOpenChange: (open: boolean) => void;
   /** Dynamic state per preview flag. Only previews with an entry here render. */
   state: Partial<Record<PreviewFlag, PreviewState>>;
+  /** Same interaction as the sidebar Support button (opens the support drawer). */
+  onContactSupport: () => void;
 };
 
 export function FeaturePreviewModal({
   open,
   onOpenChange,
   state,
+  onContactSupport,
 }: FeaturePreviewModalProps) {
   const items = PREVIEW_REGISTRY.filter((item) => state[item.flag]);
   const [selectedFlag, setSelectedFlag] = useState<PreviewFlag | null>(
@@ -192,38 +184,35 @@ export function FeaturePreviewModal({
                   >
                     {selectedState.enabled ? "Enabled" : "Disabled"}
                   </Badge>
+                  <div className="ml-auto flex items-center gap-2">
+                    <Button asChild size="sm">
+                      <a
+                        href={selected.feedbackUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Give feedback
+                      </a>
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={onContactSupport}
+                    >
+                      Contact support
+                    </Button>
+                  </div>
                 </div>
 
                 <p className="text-muted-foreground mt-2 max-w-2xl text-sm leading-5">
                   {selected.description}
                 </p>
 
-                {selected.dates ? (
-                  <p className="text-muted-foreground mt-2 font-mono text-xs">
-                    added {selected.dates.added}
-                    {selected.dates.updated
-                      ? ` · updated ${selected.dates.updated}`
-                      : null}
-                  </p>
-                ) : null}
-
                 <PreviewMockupPanel illustration={selected.illustration} />
 
                 <p className="text-muted-foreground mt-5 text-sm leading-5">
                   {selected.details}
                 </p>
-
-                <div className="border-border mt-6 border-t border-dashed" />
-
-                <Button asChild className="mt-4">
-                  <a
-                    href={selected.feedbackUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Give feedback
-                  </a>
-                </Button>
               </>
             ) : null}
           </section>


### PR DESCRIPTION
## Summary

Restyles the Feature Preview dialog (`web/src/features/feature-previews/components/FeaturePreviewModal.tsx`) into a cleaner two-pane layout based on a design mock:

- **Header**: standard `DialogHeader`/`DialogTitle` — just "Feature Preview" top-left and the close button top-right (subtitle sentence dropped).
- **Left sidebar**: one row per available preview — feature name + its toggle `Switch` on the right; the selected row has a subtle `bg-muted` fill. Toggling a row's switch also selects it.
- **Right detail pane**: large title with an `Enabled`/`Disabled` status badge, one-line description, a small mono metadata line ("added <date> · updated <date>"), the existing illustration + details copy, a subtle dashed divider, then the existing "Give feedback" action.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/langfuse/langfuse/e1f076c0e5168f4b12881c400821c63c8d416289/01-before-light-disabled.png" alt="Before: light mode, feature disabled" /> | <img src="https://raw.githubusercontent.com/langfuse/langfuse/e1f076c0e5168f4b12881c400821c63c8d416289/01-after-light-disabled.png" alt="After: light mode, feature disabled" /> |
| <img src="https://raw.githubusercontent.com/langfuse/langfuse/e1f076c0e5168f4b12881c400821c63c8d416289/02-before-dark-disabled.png" alt="Before: dark mode" /> | <img src="https://raw.githubusercontent.com/langfuse/langfuse/e1f076c0e5168f4b12881c400821c63c8d416289/02-after-dark-enabled.png" alt="After: dark mode" /> |
| <img src="https://raw.githubusercontent.com/langfuse/langfuse/e1f076c0e5168f4b12881c400821c63c8d416289/03-before-light-enabled-fullpage.png" alt="Before: light mode enabled, page context" /> | <img src="https://raw.githubusercontent.com/langfuse/langfuse/e1f076c0e5168f4b12881c400821c63c8d416289/03-after-light-enabled.png" alt="After: light mode, feature enabled (green badge)" /> |

Row 1: light mode, Compact Session View off. Row 2: dark mode — the toggle state differs between before/after because flipping it exercises the real mutation; the flag ended ON (the demo user's original state). Row 3: before is a full-page viewport shot for page context; after shows the enabled state with the green badge.

New states (no "before" equivalent), from the new `MultipleFeatures` and existing `Warning` Storybook stories:

| Multiple features (sidebar selection) | Second feature selected (full metadata line) | Warning banner (unchanged, new layout) |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/langfuse/langfuse/e1f076c0e5168f4b12881c400821c63c8d416289/04-after-light-multiple-features-storybook.png" alt="Storybook: two sidebar rows with switches" /> | <img src="https://raw.githubusercontent.com/langfuse/langfuse/e1f076c0e5168f4b12881c400821c63c8d416289/05-after-light-second-feature-selected-storybook.png" alt="Storybook: second (disabled) feature selected showing added/updated metadata" /> | <img src="https://raw.githubusercontent.com/langfuse/langfuse/e1f076c0e5168f4b12881c400821c63c8d416289/06-after-light-warning-storybook.png" alt="Storybook: warning banner in the new layout" /> |

(Images are hosted on the asset-only branch `screenshots/pr-15348`, pinned to its commit SHA; the branch can be deleted after merge without breaking them.)

## Consistency mapping (mock → codebase)

- Switch: existing design-system `Switch` (`@/src/components/design-system/Switch/Switch`), now in the sidebar rows.
- Status badge: existing `Badge` variants `success` / `secondary`, sentence case (not the mock's ALL CAPS), matching app-wide badge usage.
- Radii/borders: dropped the bespoke `sm:rounded-2xl` / `shadow-2xl` dialog overrides for the stock `bg-modal` dialog; illustration panel `rounded-2xl shadow-inner` → `rounded-md border`.
- Text: `text-sm font-bold` sidebar labels (repo lint rule `@repo/no-raw-font-weight` forbids `font-medium`), `text-muted-foreground` secondary copy, `font-mono text-xs` metadata.
- Metadata dates are real, from the git history of each registry entry (Compact Session View added 2026-07-20 in #15190; retired searchBar entry Jun 17/18 from #14237/#14340), stored as optional static `dates` fields on the preview registry — omitted when absent, never fabricated.

## Not changed (behavior)

- Which flags are listed (`state`-gated registry filter), the toggle mutation wiring, gating/disabled logic and warning banner, the feedback link, and all of `ControlledFeaturePreviewModal.tsx` (no shared markup — untouched).
- Kept the illustration panel and details paragraph even though the mock omits them — removing product content felt out of scope for a restyle; easy to delete if preferred.

## Stories

`FeaturePreviewModal.stories.tsx` gains `Enabled` and `MultipleFeatures` (two sidebar rows, enabled + disabled, exercising selection) alongside the existing `Default`, `Warning`, `Loading`.

## Test evidence

- `pnpm --filter web exec eslint <changed files>` → clean (0 problems)
- `pnpm --filter web run typecheck` → 453 pre-existing errors, identical count on a stashed baseline run → **0 new errors** (none in `feature-previews/**`)
- Pre-commit `turbo run lint` → `Tasks: 7 successful, 7 total`
- Browser-verified on a local dev server (demo user): open modal, toggle a preview from the sidebar switch (mutation + toast path fires, state persists across reopen), select different features (via Storybook `MultipleFeatures`), light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
