### PR TITLE
feat(trace): restyle observation/trace details panel to the new design language

### DIFF
--- a/web/src/components/trace/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationDetailView.tsx
@@ -56,6 +56,7 @@ import { api } from "@/src/utils/api";
 
 // Extracted components
 import { ObservationDetailViewHeader } from "./ObservationDetailViewHeader";
+import { ZoneDivider } from "@/src/components/trace/components/_shared/InspectorElements";
 import { TraceLogView } from "../TraceLogView/TraceLogView";
 import { TRACE_VIEW_CONFIG } from "@/src/components/trace/config/trace-view-config";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
@@ -302,6 +303,9 @@ export function ObservationDetailView({
         treeNodeTotalCost={treeNode?.totalCost}
       />
 
+      {/* Zone divider between header/overview and tabbed content */}
+      <ZoneDivider />
+
       {/* Tabs section */}
       <TabsBar
         value={selectedTab}
@@ -314,12 +318,25 @@ export function ObservationDetailView({
         {showTabsBar && (
           <TooltipProvider>
             <TabsBarList>
-              <TabsBarTrigger value="preview">Preview</TabsBarTrigger>
+              <TabsBarTrigger
+                value="preview"
+                className="font-mono text-[11px] tracking-wide uppercase"
+              >
+                Preview
+              </TabsBarTrigger>
               {showScoresTab && (
-                <TabsBarTrigger value="scores">Scores</TabsBarTrigger>
+                <TabsBarTrigger
+                  value="scores"
+                  className="font-mono text-[11px] tracking-wide uppercase"
+                >
+                  Scores
+                </TabsBarTrigger>
               )}
               {showLogViewTab && (
-                <TabsBarTrigger value="log">
+                <TabsBarTrigger
+                  value="log"
+                  className="font-mono text-[11px] tracking-wide uppercase"
+                >
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span>Log View</span>

--- a/web/src/components/trace/components/ObservationDetailView/ObservationDetailViewHeader.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationDetailViewHeader.tsx
@@ -2,22 +2,21 @@
  * ObservationDetailViewHeader - Extracted header component for ObservationDetailView
  *
  * Contains:
- * - Title row with ItemBadge, observation name, options menu
+ * - Title row with type chip, observation name + mono timestamp, actions menu
  * - Action buttons (Dataset, Annotate, Queue, Playground, Comments)
- * - Metadata badges (timestamp, latency, environment, cost, usage, model, etc.)
+ * - Overview metrics grid (latency, environment, cost, usage, model, etc.)
  *
  * Memoized to prevent unnecessary re-renders when tab state changes.
  */
 
 import { memo, useMemo } from "react";
-import {
-  type ObservationType,
-  AnnotationQueueObjectType,
-  isGenerationLike,
-} from "@langfuse/shared";
+import { AnnotationQueueObjectType, isGenerationLike } from "@langfuse/shared";
 import { type SelectionData } from "@/src/features/comments/contexts/InlineCommentSelectionContext";
 import { type ObservationReturnTypeWithMetadata } from "@/src/server/api/routers/traces";
-import { ItemBadge } from "@/src/components/ItemBadge";
+import {
+  OverviewGrid,
+  TypeChip,
+} from "@/src/components/trace/components/_shared/InspectorElements";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { NewDatasetItemFromExistingObject } from "@/src/features/datasets/components/NewDatasetItemFromExistingObject";
 import { AnnotateDrawer } from "@/src/features/scores/components/AnnotateDrawer";
@@ -124,28 +123,21 @@ export const ObservationDetailViewHeader = memo(
     const outputUsage = observation.outputUsage;
 
     return (
-      <div className="@container shrink-0 space-y-2 border-b p-2">
+      <div className="@container shrink-0 space-y-3 p-3 pb-2.5">
         {/* Title row with actions */}
         <div className="grid w-full grid-cols-1 items-start gap-2 @2xl:grid-cols-[auto_auto] @2xl:justify-between">
-          <div className="flex w-full flex-row items-center gap-1">
-            <ItemBadge type={observation.type as ObservationType} isSmall />
-            <span className="mb-0 line-clamp-2 min-w-0 font-bold break-all md:break-normal md:wrap-break-word">
-              {observation.name || observation.id}
-            </span>
-            <DetailHeaderActionsMenu
-              idItems={[
-                { id: traceId, name: "Trace ID" },
-                { id: observation.id, name: "Observation ID" },
-              ]}
-              observationType={observation.type}
-              projectId={projectId}
-              spanName={observation.name ?? ""}
-              webCallout={{
-                traceId,
-                observationId: observation.id,
-                sessionId: observation.sessionId ?? null,
-              }}
-            />
+          <div className="flex w-full flex-row items-start gap-2">
+            <TypeChip type={observation.type} className="mt-0.5" />
+            <div className="min-w-0 flex-1">
+              <div className="line-clamp-2 min-w-0 text-sm font-bold break-all md:break-normal md:wrap-break-word">
+                {observation.name || observation.id}
+              </div>
+              <LocalIsoDate
+                date={observation.startTime}
+                accuracy="millisecond"
+                className="text-muted-foreground font-mono text-[10px]"
+              />
+            </div>
           </div>
           {/* Action buttons */}
           <div className="flex h-full flex-wrap content-start items-start justify-start gap-0.5 @2xl:mr-1 @2xl:justify-end">
@@ -237,89 +229,89 @@ export const ObservationDetailViewHeader = memo(
               isOpen={isCommentDrawerOpen}
               onOpenChange={onCommentDrawerOpenChange}
             />
-          </div>
-        </div>
-
-        {/* Metadata badges */}
-
-        <div className="flex flex-col gap-2">
-          {/* Timestamp */}
-          <div className="flex flex-wrap items-center gap-1">
-            <LocalIsoDate
-              date={observation.startTime}
-              accuracy="millisecond"
-              className="text-sm"
+            <DetailHeaderActionsMenu
+              idItems={[
+                { id: traceId, name: "Trace ID" },
+                { id: observation.id, name: "Observation ID" },
+              ]}
+              observationType={observation.type}
+              projectId={projectId}
+              spanName={observation.name ?? ""}
+              webCallout={{
+                traceId,
+                observationId: observation.id,
+                sessionId: observation.sessionId ?? null,
+              }}
             />
           </div>
+        </div>
 
-          {/* Other badges */}
-          {!isAnnotationMode && (
-            <div className="flex flex-wrap items-center gap-1">
-              <LatencyBadge latencySeconds={latencySeconds} />
-              <TimeToFirstTokenBadge
-                timeToFirstToken={observation.timeToFirstToken}
-              />
-              <SessionBadge
-                sessionId={observation.sessionId ?? null}
-                projectId={projectId}
-              />
-              <UserIdBadge
-                userId={observation.userId ?? null}
-                projectId={projectId}
-              />
-              <EnvironmentBadge environment={observation.environment} />
-              <CostBadge
-                totalCost={
-                  subtreeMetrics
-                    ? (treeNodeTotalCost?.toNumber() ??
-                      subtreeMetrics.totalCost)
-                    : totalCost
-                }
-                costDetails={
-                  subtreeMetrics?.costDetails ?? observation.costDetails
-                }
-              />
-              {subtreeMetrics ? (
-                subtreeMetrics.hasGenerationLike &&
-                subtreeMetrics.usageDetails && (
-                  <UsageBadge
-                    type="GENERATION"
-                    inputUsage={subtreeMetrics.inputUsage}
-                    outputUsage={subtreeMetrics.outputUsage}
-                    totalUsage={subtreeMetrics.totalUsage}
-                    usageDetails={subtreeMetrics.usageDetails}
-                  />
-                )
-              ) : (
+        {/* Overview metrics grid */}
+        {!isAnnotationMode && (
+          <OverviewGrid>
+            <LatencyBadge latencySeconds={latencySeconds} />
+            <TimeToFirstTokenBadge
+              timeToFirstToken={observation.timeToFirstToken}
+            />
+            <EnvironmentBadge environment={observation.environment} />
+            <UserIdBadge
+              userId={observation.userId ?? null}
+              projectId={projectId}
+            />
+            <SessionBadge
+              sessionId={observation.sessionId ?? null}
+              projectId={projectId}
+            />
+            <CostBadge
+              totalCost={
+                subtreeMetrics
+                  ? (treeNodeTotalCost?.toNumber() ?? subtreeMetrics.totalCost)
+                  : totalCost
+              }
+              costDetails={
+                subtreeMetrics?.costDetails ?? observation.costDetails
+              }
+            />
+            {subtreeMetrics ? (
+              subtreeMetrics.hasGenerationLike &&
+              subtreeMetrics.usageDetails && (
                 <UsageBadge
-                  type={observation.type}
-                  inputUsage={inputUsage}
-                  outputUsage={outputUsage}
-                  totalUsage={totalUsage}
-                  usageDetails={observation.usageDetails}
+                  type="GENERATION"
+                  inputUsage={subtreeMetrics.inputUsage}
+                  outputUsage={subtreeMetrics.outputUsage}
+                  totalUsage={subtreeMetrics.totalUsage}
+                  usageDetails={subtreeMetrics.usageDetails}
                 />
-              )}
-              <VersionBadge version={observation.version} />
-              <ModelBadge
-                model={observation.model}
-                internalModelId={observation.internalModelId}
-                projectId={projectId}
+              )
+            ) : (
+              <UsageBadge
+                type={observation.type}
+                inputUsage={inputUsage}
+                outputUsage={outputUsage}
+                totalUsage={totalUsage}
                 usageDetails={observation.usageDetails}
               />
-              <ModelParametersBadges
-                modelParameters={observation.modelParameters}
+            )}
+            <ModelBadge
+              model={observation.model}
+              internalModelId={observation.internalModelId}
+              projectId={projectId}
+              usageDetails={observation.usageDetails}
+            />
+            <ModelParametersBadges
+              modelParameters={observation.modelParameters}
+            />
+            {observation.promptId && (
+              <PromptBadge
+                promptId={observation.promptId}
+                projectId={projectId}
               />
-              <LevelBadge level={observation.level} />
-              <StatusMessageBadge statusMessage={observation.statusMessage} />
-              {observation.promptId && (
-                <PromptBadge
-                  promptId={observation.promptId}
-                  projectId={projectId}
-                />
-              )}
-            </div>
-          )}
-        </div>
+            )}
+            <VersionBadge version={observation.version} />
+            <LevelBadge level={observation.level} />
+            <StatusMessageBadge statusMessage={observation.statusMessage} />
+          </OverviewGrid>
+        )}
       </div>
     );
   },

--- a/web/src/components/trace/components/ObservationDetailView/ObservationMetadataBadgeModel.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationMetadataBadgeModel.tsx
@@ -1,11 +1,12 @@
 /**
- * Model badge for ObservationDetailView
- * Handles linked models (with external link) and unlinked models (with create form)
+ * Model overview-grid row for ObservationDetailView.
+ * Handles linked models (link to model settings) and unlinked models
+ * (opens the create-model form dialog).
  */
 
-import { Badge } from "@/src/components/ui/badge";
-import { ExternalLinkIcon, PlusCircle } from "lucide-react";
+import { ArrowUpRight, PlusCircle } from "lucide-react";
 import Link from "next/link";
+import { OverviewRow } from "@/src/components/trace/components/_shared/InspectorElements";
 import { UpsertModelFormDialog } from "@/src/features/models/components/UpsertModelFormDialog";
 
 export function ModelBadge({
@@ -24,47 +25,51 @@ export function ModelBadge({
   // Linked model - show link to model settings
   if (internalModelId) {
     return (
-      <Badge>
+      <OverviewRow label="Model" title={model}>
         <Link
           href={`/project/${projectId}/settings/models/${internalModelId}`}
-          className="flex items-center"
+          className="hover:text-primary inline-flex max-w-full items-center gap-0.5"
           title="View model details"
         >
           <span className="truncate" title={model}>
             {model}
           </span>
-          <ExternalLinkIcon className="ml-1 h-3 w-3" />
+          <ArrowUpRight className="h-3 w-3 shrink-0" />
         </Link>
-      </Badge>
+      </OverviewRow>
     );
   }
 
   // Unlinked model - show create form dialog
   return (
-    <UpsertModelFormDialog
-      action="create"
-      projectId={projectId}
-      prefilledModelData={{
-        modelName: model,
-        prices:
-          usageDetails && Object.keys(usageDetails).length > 0
-            ? Object.keys(usageDetails)
-                .filter((key) => key !== "total")
-                .reduce(
-                  (acc, key) => {
-                    acc[key] = 0.000001;
-                    return acc;
-                  },
-                  {} as Record<string, number>,
-                )
-            : undefined,
-      }}
-      className="cursor-pointer"
-    >
-      <Badge variant="tertiary" className="flex items-center gap-1">
-        <span>{model}</span>
-        <PlusCircle className="h-3 w-3" />
-      </Badge>
-    </UpsertModelFormDialog>
+    <OverviewRow label="Model" title={model}>
+      <UpsertModelFormDialog
+        action="create"
+        projectId={projectId}
+        prefilledModelData={{
+          modelName: model,
+          prices:
+            usageDetails && Object.keys(usageDetails).length > 0
+              ? Object.keys(usageDetails)
+                  .filter((key) => key !== "total")
+                  .reduce(
+                    (acc, key) => {
+                      acc[key] = 0.000001;
+                      return acc;
+                    },
+                    {} as Record<string, number>,
+                  )
+              : undefined,
+        }}
+        className="cursor-pointer"
+      >
+        <span className="hover:text-primary inline-flex max-w-full cursor-pointer items-center gap-0.5">
+          <span className="truncate" title={model}>
+            {model}
+          </span>
+          <PlusCircle className="h-3 w-3 shrink-0" />
+        </span>
+      </UpsertModelFormDialog>
+    </OverviewRow>
   );
 }

--- a/web/src/components/trace/components/ObservationDetailView/ObservationMetadataBadgeModelParameters.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationMetadataBadgeModelParameters.tsx
@@ -1,10 +1,10 @@
 /**
- * Model parameters badges for ObservationDetailView
- * Renders dynamic badges for each model parameter with truncation
+ * Model parameter overview-grid rows for ObservationDetailView.
+ * Renders one label+value row per model parameter with truncation.
  */
 
 import { type JsonNested } from "@langfuse/shared";
-import { Badge } from "@/src/components/ui/badge";
+import { OverviewRow } from "@/src/components/trace/components/_shared/InspectorElements";
 
 export function ModelParametersBadges({
   modelParameters,
@@ -35,14 +35,9 @@ export function ModelParametersBadges({
             : value?.toString();
 
         return (
-          <Badge variant="tertiary" key={key} className="max-w-md">
-            <span
-              className="overflow-hidden text-ellipsis whitespace-nowrap"
-              title={valueString}
-            >
-              {key}: {valueString}
-            </span>
-          </Badge>
+          <OverviewRow key={key} label={key} title={valueString}>
+            {valueString}
+          </OverviewRow>
         );
       })}
     </>

--- a/web/src/components/trace/components/ObservationDetailView/ObservationMetadataBadgesSimple.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationMetadataBadgesSimple.tsx
@@ -1,9 +1,11 @@
 /**
- * Simple metadata badges for ObservationDetailView
- * Each badge handles its own null checks and returns null when data is unavailable
+ * Simple overview-grid rows for ObservationDetailView.
+ * Each component handles its own null checks and returns null when data is
+ * unavailable. Rendered inside `OverviewGrid` (see _shared/InspectorElements),
+ * emitting a mono eyebrow label + mono value pair.
  */
 
-import { Badge } from "@/src/components/ui/badge";
+import { OverviewRow } from "@/src/components/trace/components/_shared/InspectorElements";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 
 export function LatencyBadge({
@@ -14,9 +16,9 @@ export function LatencyBadge({
   if (latencySeconds == null) return null;
 
   return (
-    <Badge variant="tertiary">
-      Latency: {formatIntervalSeconds(latencySeconds)}
-    </Badge>
+    <OverviewRow label="Latency">
+      {formatIntervalSeconds(latencySeconds)}
+    </OverviewRow>
   );
 }
 
@@ -28,9 +30,9 @@ export function TimeToFirstTokenBadge({
   if (timeToFirstToken == null) return null;
 
   return (
-    <Badge variant="tertiary">
-      Time to first token: {formatIntervalSeconds(timeToFirstToken)}
-    </Badge>
+    <OverviewRow label="TTFT" title="Time to first token">
+      {formatIntervalSeconds(timeToFirstToken)}
+    </OverviewRow>
   );
 }
 
@@ -41,7 +43,11 @@ export function EnvironmentBadge({
 }) {
   if (!environment) return null;
 
-  return <Badge variant="tertiary">Env: {environment}</Badge>;
+  return (
+    <OverviewRow label="Env" title={environment}>
+      {environment}
+    </OverviewRow>
+  );
 }
 
 export function VersionBadge({
@@ -51,24 +57,29 @@ export function VersionBadge({
 }) {
   if (!version) return null;
 
-  return <Badge variant="tertiary">Version: {version}</Badge>;
+  return (
+    <OverviewRow label="Version" title={version}>
+      {version}
+    </OverviewRow>
+  );
 }
 
 export function LevelBadge({ level }: { level: string | null | undefined }) {
   if (!level || level === "DEFAULT") return null;
 
   return (
-    <Badge
-      variant={
+    <OverviewRow
+      label="Level"
+      className={
         level === "ERROR"
-          ? "destructive"
+          ? "text-destructive"
           : level === "WARNING"
-            ? "warning"
-            : "tertiary"
+            ? "text-dark-yellow"
+            : undefined
       }
     >
       {level}
-    </Badge>
+    </OverviewRow>
   );
 }
 
@@ -79,5 +90,9 @@ export function StatusMessageBadge({
 }) {
   if (!statusMessage) return null;
 
-  return <Badge variant="tertiary">{statusMessage}</Badge>;
+  return (
+    <OverviewRow label="Status" title={statusMessage}>
+      {statusMessage}
+    </OverviewRow>
+  );
 }

--- a/web/src/components/trace/components/ObservationDetailView/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationMetadataBadgesTooltip.tsx
@@ -1,10 +1,11 @@
 /**
- * Tooltip-based metadata badges for ObservationDetailView
- * These badges use BreakdownTooltip to show detailed cost/usage information
+ * Tooltip-backed overview-grid rows for ObservationDetailView.
+ * Cost and token usage render as mono values with a trailing ⓘ that opens
+ * the BreakdownTooltip with the detailed cost/usage breakdown.
  */
 
 import { type ObservationType, isGenerationLike } from "@langfuse/shared";
-import { Badge } from "@/src/components/ui/badge";
+import { OverviewRow } from "@/src/components/trace/components/_shared/InspectorElements";
 import { BreakdownTooltip } from "@/src/components/trace/components/_shared/BreakdownToolTip";
 import { usdFormatter, formatTokenCounts } from "@/src/utils/numbers";
 import { InfoIcon } from "lucide-react";
@@ -20,12 +21,14 @@ export function CostBadge({
   if (totalCost == null || totalCost === 0 || !costDetails) return null;
 
   return (
-    <BreakdownTooltip details={costDetails} isCost={true}>
-      <Badge variant="tertiary" className="flex items-center gap-1">
-        <span>{usdFormatter(totalCost)}</span>
-        <InfoIcon className="h-3 w-3" />
-      </Badge>
-    </BreakdownTooltip>
+    <OverviewRow label="Cost">
+      <BreakdownTooltip details={costDetails} isCost={true}>
+        <span className="inline-flex items-center gap-1">
+          {usdFormatter(totalCost)}
+          <InfoIcon className="text-muted-foreground h-2.5 w-2.5 shrink-0" />
+        </span>
+      </BreakdownTooltip>
+    </OverviewRow>
   );
 }
 
@@ -54,14 +57,17 @@ export function UsageBadge({
   const hasText = tokenText.length > 0;
 
   return (
-    <BreakdownTooltip details={usageDetails} isCost={false}>
-      <Badge
-        variant="tertiary"
-        className={`flex items-center gap-1 ${!hasText ? "h-6 pl-2" : ""}`}
-      >
-        {hasText && <span>{tokenText}</span>}
-        <InfoIcon className="h-3 w-3" />
-      </Badge>
-    </BreakdownTooltip>
+    <OverviewRow label="Tokens" title={hasText ? tokenText : undefined}>
+      <BreakdownTooltip details={usageDetails} isCost={false}>
+        <span className="inline-flex max-w-full items-center gap-1">
+          {hasText && (
+            <span className="truncate" title={tokenText}>
+              {tokenText}
+            </span>
+          )}
+          <InfoIcon className="text-muted-foreground h-2.5 w-2.5 shrink-0" />
+        </span>
+      </BreakdownTooltip>
+    </OverviewRow>
   );
 }

--- a/web/src/components/trace/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace/components/TraceDetailView/TraceDetailView.tsx
@@ -44,6 +44,7 @@ import { useCommentedPaths } from "@/src/features/comments/hooks/useCommentedPat
 
 // Extracted components
 import { TraceDetailViewHeader } from "./TraceDetailViewHeader";
+import { ZoneDivider } from "@/src/components/trace/components/_shared/InspectorElements";
 import { TraceLogView } from "../TraceLogView/TraceLogView";
 import { TRACE_VIEW_CONFIG } from "@/src/components/trace/config/trace-view-config";
 import ScoresTable from "@/src/components/table/use-cases/scores";
@@ -223,6 +224,9 @@ export function TraceDetailView({
         onCommentDrawerOpenChange={setIsCommentDrawerOpen}
       />
 
+      {/* Zone divider between header/overview and tabbed content */}
+      <ZoneDivider />
+
       {/* Tabs section */}
       <TabsBar
         value={selectedTab}
@@ -233,9 +237,17 @@ export function TraceDetailView({
         {showTabsBar && (
           <TooltipProvider>
             <TabsBarList>
-              <TabsBarTrigger value="preview">Preview</TabsBarTrigger>
+              <TabsBarTrigger
+                value="preview"
+                className="font-mono text-[11px] tracking-wide uppercase"
+              >
+                Preview
+              </TabsBarTrigger>
               {showLogViewTab && (
-                <TabsBarTrigger value="log">
+                <TabsBarTrigger
+                  value="log"
+                  className="font-mono text-[11px] tracking-wide uppercase"
+                >
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span>Log View</span>
@@ -249,7 +261,12 @@ export function TraceDetailView({
                 </TabsBarTrigger>
               )}
               {showScoresTab && (
-                <TabsBarTrigger value="scores">Scores</TabsBarTrigger>
+                <TabsBarTrigger
+                  value="scores"
+                  className="font-mono text-[11px] tracking-wide uppercase"
+                >
+                  Scores
+                </TabsBarTrigger>
               )}
 
               {/* View toggle (Formatted/JSON) - show for preview and log tabs when pretty view available */}

--- a/web/src/components/trace/components/TraceDetailView/TraceDetailViewHeader.tsx
+++ b/web/src/components/trace/components/TraceDetailView/TraceDetailViewHeader.tsx
@@ -2,9 +2,9 @@
  * TraceDetailViewHeader - Extracted header component for TraceDetailView
  *
  * Contains:
- * - Title row with ItemBadge, trace name, options menu
+ * - Title row with type chip, trace name + mono timestamp, actions menu
  * - Action buttons (Dataset, Annotate, Queue, Comments)
- * - Metadata badges (timestamp, latency, session, user, environment, release, version, cost, usage)
+ * - Overview metrics grid (latency, session, user, environment, release, version, cost, usage)
  *
  * Memoized to prevent unnecessary re-renders when tab state changes.
  */
@@ -19,7 +19,10 @@ import {
 import { type SelectionData } from "@/src/features/comments/contexts/InlineCommentSelectionContext";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
 import { type ObservationReturnTypeWithMetadata } from "@/src/server/api/routers/traces";
-import { ItemBadge } from "@/src/components/ItemBadge";
+import {
+  OverviewGrid,
+  TypeChip,
+} from "@/src/components/trace/components/_shared/InspectorElements";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { DetailHeaderActionsMenu } from "@/src/components/trace/components/_shared/DetailHeaderActionsMenu";
 import { NewDatasetItemFromExistingObject } from "@/src/features/datasets/components/NewDatasetItemFromExistingObject";
@@ -85,22 +88,21 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
       : null;
 
   return (
-    <div className="@container shrink-0 space-y-2 border-b p-2">
+    <div className="@container shrink-0 space-y-3 p-3 pb-2.5">
       {/* Title row with actions */}
       <div className="grid w-full grid-cols-1 items-start gap-2 @2xl:grid-cols-[auto_auto] @2xl:justify-between">
-        <div className="flex w-full flex-row items-center gap-1">
-          <ItemBadge type="TRACE" isSmall />
-          <span className="line-clamp-2 min-w-0 font-bold break-all md:break-normal md:wrap-break-word">
-            {trace.name || trace.id}
-          </span>
-          <DetailHeaderActionsMenu
-            idItems={[{ id: trace.id, name: "Trace ID" }]}
-            projectId={projectId}
-            webCallout={{
-              traceId: trace.id,
-              sessionId: trace.sessionId ?? null,
-            }}
-          />
+        <div className="flex w-full flex-row items-start gap-2">
+          <TypeChip type="TRACE" className="mt-0.5" />
+          <div className="min-w-0 flex-1">
+            <div className="line-clamp-2 min-w-0 text-sm font-bold break-all md:break-normal md:wrap-break-word">
+              {trace.name || trace.id}
+            </div>
+            <LocalIsoDate
+              date={trace.timestamp}
+              accuracy="millisecond"
+              className="text-muted-foreground font-mono text-[10px]"
+            />
+          </div>
         </div>
         {/* Action buttons */}
         <div className="flex h-full flex-wrap content-start items-start justify-start gap-0.5 @2xl:mr-1 @2xl:justify-end">
@@ -149,50 +151,46 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
             isOpen={isCommentDrawerOpen}
             onOpenChange={onCommentDrawerOpenChange}
           />
-        </div>
-      </div>
-
-      {/* Metadata badges */}
-      <div className="flex flex-col gap-2">
-        {/* Timestamp */}
-        <div className="flex flex-wrap items-center gap-1">
-          <LocalIsoDate
-            date={trace.timestamp}
-            accuracy="millisecond"
-            className="text-sm"
+          <DetailHeaderActionsMenu
+            idItems={[{ id: trace.id, name: "Trace ID" }]}
+            projectId={projectId}
+            webCallout={{
+              traceId: trace.id,
+              sessionId: trace.sessionId ?? null,
+            }}
           />
         </div>
-
-        {/* Other badges */}
-        {!isAnnotationMode && (
-          <div className="flex flex-wrap items-center gap-1">
-            <LatencyBadge latencySeconds={trace.latency ?? null} />
-            <SessionBadge sessionId={trace.sessionId} projectId={projectId} />
-            <UserIdBadge userId={trace.userId} projectId={projectId} />
-            <TargetTraceBadge
-              targetTraceId={targetTraceId}
-              projectId={projectId}
-            />
-            <EnvironmentBadge environment={trace.environment} />
-            <ReleaseBadge release={trace.release} />
-            <VersionBadge version={trace.version} />
-            <CostBadge
-              totalCost={aggregatedMetrics.totalCost}
-              costDetails={aggregatedMetrics.costDetails}
-            />
-            {aggregatedMetrics.hasGenerationLike &&
-              aggregatedMetrics.usageDetails && (
-                <UsageBadge
-                  type="GENERATION"
-                  inputUsage={aggregatedMetrics.inputUsage}
-                  outputUsage={aggregatedMetrics.outputUsage}
-                  totalUsage={aggregatedMetrics.totalUsage}
-                  usageDetails={aggregatedMetrics.usageDetails}
-                />
-              )}
-          </div>
-        )}
       </div>
+
+      {/* Overview metrics grid */}
+      {!isAnnotationMode && (
+        <OverviewGrid>
+          <LatencyBadge latencySeconds={trace.latency ?? null} />
+          <EnvironmentBadge environment={trace.environment} />
+          <UserIdBadge userId={trace.userId} projectId={projectId} />
+          <SessionBadge sessionId={trace.sessionId} projectId={projectId} />
+          <TargetTraceBadge
+            targetTraceId={targetTraceId}
+            projectId={projectId}
+          />
+          <CostBadge
+            totalCost={aggregatedMetrics.totalCost}
+            costDetails={aggregatedMetrics.costDetails}
+          />
+          {aggregatedMetrics.hasGenerationLike &&
+            aggregatedMetrics.usageDetails && (
+              <UsageBadge
+                type="GENERATION"
+                inputUsage={aggregatedMetrics.inputUsage}
+                outputUsage={aggregatedMetrics.outputUsage}
+                totalUsage={aggregatedMetrics.totalUsage}
+                usageDetails={aggregatedMetrics.usageDetails}
+              />
+            )}
+          <ReleaseBadge release={trace.release} />
+          <VersionBadge version={trace.version} />
+        </OverviewGrid>
+      )}
     </div>
   );
 });

--- a/web/src/components/trace/components/TraceDetailView/TraceMetadataBadges.tsx
+++ b/web/src/components/trace/components/TraceDetailView/TraceMetadataBadges.tsx
@@ -1,13 +1,14 @@
 /**
- * TraceMetadataBadges - Extracted badge components for trace metadata
+ * TraceMetadataBadges - Overview-grid rows for trace metadata
  *
  * Following the pattern from ObservationDetailView/ObservationMetadataBadgesSimple.tsx
- * Each badge handles its own null check and returns null when data is unavailable.
+ * Each row handles its own null check and returns null when data is unavailable.
+ * Rendered inside `OverviewGrid` (see _shared/InspectorElements).
  */
 
 import Link from "next/link";
-import { ExternalLinkIcon } from "lucide-react";
-import { Badge } from "@/src/components/ui/badge";
+import { ArrowUpRight } from "lucide-react";
+import { OverviewRow } from "@/src/components/trace/components/_shared/InspectorElements";
 
 export function SessionBadge({
   sessionId,
@@ -18,20 +19,18 @@ export function SessionBadge({
 }) {
   if (!sessionId) return null;
 
-  const text = `Session: ${sessionId}`;
-
   return (
-    <Link
-      href={`/project/${projectId}/sessions/${encodeURIComponent(sessionId)}`}
-      className="inline-flex"
-    >
-      <Badge>
-        <span className="truncate" title={text}>
-          {text}
+    <OverviewRow label="Session" title={sessionId}>
+      <Link
+        href={`/project/${projectId}/sessions/${encodeURIComponent(sessionId)}`}
+        className="hover:text-primary inline-flex max-w-full items-center gap-0.5"
+      >
+        <span className="truncate" title={sessionId}>
+          {sessionId}
         </span>
-        <ExternalLinkIcon className="ml-1 h-3 w-3" />
-      </Badge>
-    </Link>
+        <ArrowUpRight className="h-3 w-3 shrink-0" />
+      </Link>
+    </OverviewRow>
   );
 }
 
@@ -44,20 +43,18 @@ export function UserIdBadge({
 }) {
   if (!userId) return null;
 
-  const text = `User ID: ${userId}`;
-
   return (
-    <Link
-      href={`/project/${projectId}/users/${encodeURIComponent(userId)}`}
-      className="inline-flex"
-    >
-      <Badge>
-        <span className="truncate" title={text}>
-          {text}
+    <OverviewRow label="User" title={userId}>
+      <Link
+        href={`/project/${projectId}/users/${encodeURIComponent(userId)}`}
+        className="hover:text-primary inline-flex max-w-full items-center gap-0.5"
+      >
+        <span className="truncate" title={userId}>
+          {userId}
         </span>
-        <ExternalLinkIcon className="ml-1 h-3 w-3" />
-      </Badge>
-    </Link>
+        <ArrowUpRight className="h-3 w-3 shrink-0" />
+      </Link>
+    </OverviewRow>
   );
 }
 
@@ -70,20 +67,18 @@ export function TargetTraceBadge({
 }) {
   if (!targetTraceId) return null;
 
-  const text = `Target Trace: ${targetTraceId}`;
-
   return (
-    <Link
-      href={`/project/${projectId}/traces/${encodeURIComponent(targetTraceId)}`}
-      className="inline-flex"
-    >
-      <Badge>
-        <span className="truncate" title={text}>
-          {text}
+    <OverviewRow label="Target Trace" title={targetTraceId}>
+      <Link
+        href={`/project/${projectId}/traces/${encodeURIComponent(targetTraceId)}`}
+        className="hover:text-primary inline-flex max-w-full items-center gap-0.5"
+      >
+        <span className="truncate" title={targetTraceId}>
+          {targetTraceId}
         </span>
-        <ExternalLinkIcon className="ml-1 h-3 w-3" />
-      </Badge>
-    </Link>
+        <ArrowUpRight className="h-3 w-3 shrink-0" />
+      </Link>
+    </OverviewRow>
   );
 }
 
@@ -93,15 +88,27 @@ export function EnvironmentBadge({
   environment: string | null;
 }) {
   if (!environment) return null;
-  return <Badge variant="tertiary">Env: {environment}</Badge>;
+  return (
+    <OverviewRow label="Env" title={environment}>
+      {environment}
+    </OverviewRow>
+  );
 }
 
 export function ReleaseBadge({ release }: { release: string | null }) {
   if (!release) return null;
-  return <Badge variant="tertiary">Release: {release}</Badge>;
+  return (
+    <OverviewRow label="Release" title={release}>
+      {release}
+    </OverviewRow>
+  );
 }
 
 export function VersionBadge({ version }: { version: string | null }) {
   if (!version) return null;
-  return <Badge variant="tertiary">Version: {version}</Badge>;
+  return (
+    <OverviewRow label="Version" title={version}>
+      {version}
+    </OverviewRow>
+  );
 }

--- a/web/src/components/trace/components/_shared/InspectorElements.tsx
+++ b/web/src/components/trace/components/_shared/InspectorElements.tsx
@@ -1,0 +1,97 @@
+/**
+ * Shared building blocks for the trace/observation details panel's
+ * inspector design language: mono uppercase eyebrow labels, the overview
+ * metrics grid, observation type chips, and zone-divider bands.
+ *
+ * Purely presentational — no data fetching, no behavior.
+ */
+
+import { type ReactNode } from "react";
+import { cn } from "@/src/utils/tailwind";
+
+/** Mono uppercase eyebrow label used across the details panel. */
+export const EyebrowLabel = ({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) => (
+  <span
+    className={cn(
+      "text-muted-foreground font-mono text-[9px] font-bold tracking-[0.08em] uppercase",
+      className,
+    )}
+  >
+    {children}
+  </span>
+);
+
+/** 8px full-width band separating the panel's visual zones. */
+export const ZoneDivider = () => (
+  <div className="bg-muted/60 h-2 shrink-0 border-y" />
+);
+
+/** Short type labels for the header chip, per the inspector design. */
+const TYPE_CHIP_LABELS: Record<string, string> = {
+  GENERATION: "GEN",
+};
+
+/** Mono uppercase type chip (GEN / SPAN / TOOL / EVENT / TRACE / ...). */
+export const TypeChip = ({
+  type,
+  className,
+}: {
+  type: string;
+  className?: string;
+}) => (
+  <span
+    className={cn(
+      "shrink-0 rounded-sm border px-1.5 py-0.5 font-mono text-[9px] font-bold tracking-wide uppercase",
+      // GEN and TRACE get the slightly darker fill, per the design.
+      type === "GENERATION" || type === "TRACE"
+        ? "bg-muted text-foreground"
+        : "bg-muted/40 text-muted-foreground",
+      className,
+    )}
+    title={type}
+  >
+    {TYPE_CHIP_LABELS[type] ?? type}
+  </span>
+);
+
+/**
+ * Overview metrics grid: two label+value columns, baseline-aligned.
+ * Children are `OverviewRow`s (each renders a label cell + a value cell).
+ */
+export const OverviewGrid = ({ children }: { children: ReactNode }) => (
+  <div className="grid grid-cols-[auto_minmax(0,1fr)_auto_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1.5">
+    {children}
+  </div>
+);
+
+/** One metric inside `OverviewGrid`: eyebrow label + mono value. */
+export const OverviewRow = ({
+  label,
+  title,
+  className,
+  children,
+}: {
+  label: string;
+  title?: string;
+  className?: string;
+  children: ReactNode;
+}) => (
+  <>
+    <EyebrowLabel>{label}</EyebrowLabel>
+    <span
+      className={cn(
+        "min-w-0 truncate font-mono text-[11px] font-bold",
+        className,
+      )}
+      title={title}
+    >
+      {children}
+    </span>
+  </>
+);

--- a/web/src/components/trace/components/_shared/PromptBadge.tsx
+++ b/web/src/components/trace/components/_shared/PromptBadge.tsx
@@ -1,8 +1,12 @@
 import Link from "next/link";
-import { ExternalLinkIcon } from "lucide-react";
-import { Badge } from "@/src/components/ui/badge";
+import { ArrowUpRight } from "lucide-react";
+import { OverviewRow } from "@/src/components/trace/components/_shared/InspectorElements";
 import { api } from "@/src/utils/api";
 
+/**
+ * Prompt overview-grid row: links to the prompt version used by the
+ * observation. Rendered inside `OverviewGrid` (see InspectorElements).
+ */
 export const PromptBadge = (props: { promptId: string; projectId: string }) => {
   const prompt = api.prompts.byId.useQuery({
     id: props.promptId,
@@ -11,19 +15,19 @@ export const PromptBadge = (props: { promptId: string; projectId: string }) => {
 
   if (prompt.isLoading || !prompt.data) return null;
 
-  const text = `Prompt: ${prompt.data.name} - v${prompt.data.version}`;
+  const text = `${prompt.data.name} v${prompt.data.version}`;
 
   return (
-    <Link
-      href={`/project/${props.projectId}/prompts/${encodeURIComponent(prompt.data.name)}?version=${prompt.data.version}`}
-      className="inline-flex"
-    >
-      <Badge variant="tertiary">
+    <OverviewRow label="Prompt" title={text}>
+      <Link
+        href={`/project/${props.projectId}/prompts/${encodeURIComponent(prompt.data.name)}?version=${prompt.data.version}`}
+        className="hover:text-primary inline-flex max-w-full items-center gap-0.5"
+      >
         <span className="truncate" title={text}>
           {text}
         </span>
-        <ExternalLinkIcon className="ml-1 h-3 w-3" />
-      </Badge>
-    </Link>
+        <ArrowUpRight className="h-3 w-3 shrink-0" />
+      </Link>
+    </OverviewRow>
   );
 };


### PR DESCRIPTION
## Scope — visual-only

Restyles the right-hand details panel (`ObservationDetailView` + `TraceDetailView` under `web/src/components/trace/components/`) to the new inspector design language used by the session-view observation inspector. This panel is shared by the trace page and every table peek (traces, sessions, dashboards) — **there are no behavior or feature changes**: all tabs (Preview / Scores / Log View), the Formatted/JSON/JSON-beta toggle + Beta switch, IOPreview and its machinery, annotate/dataset/queue/playground/comment actions, corrections, media, tags, prompt/model links, and the actions menu behave exactly as before. IOPreview internals are untouched.

## Design-language mapping

| Old | New |
|---|---|
| Colored `ItemBadge` icon | Mono uppercase type chip (`GEN` / `SPAN` / `TOOL` / `EVENT` / `TRACE`; GEN + TRACE get the darker `bg-muted` fill) |
| Timestamp row (`text-sm`) below badges | Mono 10px timestamp directly under the name |
| Badge soup (Latency / Session / User / Env / cost / tokens / model / params / ... pills) | Overview metrics grid (`grid-cols-[auto_minmax(0,1fr)_auto_minmax(0,1fr)]`): eyebrow mono uppercase labels + mono values; rows render only when present (latency, TTFT, env, user ↗, session ↗, target trace ↗, cost ⓘ, tokens ⓘ, model, one row per model param, prompt ↗, release, version, level, status) |
| `border-b` under header | 8px zone-divider band (`bg-muted/60 h-2 border-y`) |
| Default tab triggers | Mono uppercase 11px triggers (Preview / Scores / Log View) |
| Kebab next to the name | Kebab as last item in the right-side actions cluster |

- `BreakdownTooltip` ⓘ affordances on cost/tokens survive unchanged (click-verified in the browser).
- Model row keeps both behaviors: linked → model settings link, unlinked → `+` opens the create-model dialog.
- New shared primitives live in `web/src/components/trace/components/_shared/InspectorElements.tsx` (EyebrowLabel, TypeChip, OverviewGrid/OverviewRow, ZoneDivider).
- Existing `*Badge` components were converted in place to emit grid rows (names kept for a reviewable diff; they are only used by these two headers).

## Not restyled (deliberately)

- **Scores**: stay in the existing Scores tab (`ScoresTable`); the design's scores-rows-with-pills section was not added to the panel body to avoid duplicating the tab.
- **Metadata**: rendered inside `IOPreview` (out of scope), so it keeps the current table rendering instead of the design's accordion.
- Formatted/JSON toggle + Beta switch chrome left as-is (shared `Tabs` primitive, already compact).

## Checks

- ESLint on all 11 changed files: `✔ 0 problems (0 errors, 0 warnings)`
- Full lint via pre-commit hook: `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck`: exit 0
- No colocated tests exist for the changed components (trace/components tests cover tree-flattening/timeline utils, untouched).

## Screenshots

Before/after pairs for trace-root, GENERATION, SPAN, TOOL, traces-table peek, and dark mode are in the local review folder for Trang: `.screenshots-review/trace-details-panel/redesign-v1/` (with `NOTES.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)