### PR TITLE
feat(otel): expose uploaded media bytes

### DIFF
--- a/packages/shared/src/server/otel/OtelMediaProcessor.test.ts
+++ b/packages/shared/src/server/otel/OtelMediaProcessor.test.ts
@@ -93,6 +93,14 @@ describe("processOtelMedia", () => {
       Buffer.byteLength(dataUri, "utf8"),
       { path: "data_uri" },
     );
+    expect(recordDistribution).toHaveBeenCalledWith(
+      "langfuse.ingestion.otel.media.byte_length",
+      PNG_BYTES.length,
+      {
+        outcome: "uploaded",
+        media_kind: "data_uri",
+      },
+    );
     expect(result).toMatchObject({
       candidates: 1,
       bytesProcessed: PNG_BYTES.length,
@@ -107,6 +115,22 @@ describe("processOtelMedia", () => {
         structured_payload: 0,
       },
     });
+  });
+
+  it("tags reused media byte length separately from uploaded media", async () => {
+    const dataUri = `data:image/png;base64,${PNG_BASE64}`;
+    const { event } = createEvent({ value: dataUri });
+
+    await processEvents([event], createUploadMock("reused"));
+
+    expect(recordDistribution).toHaveBeenCalledWith(
+      "langfuse.ingestion.otel.media.byte_length",
+      PNG_BYTES.length,
+      {
+        outcome: "reused",
+        media_kind: "data_uri",
+      },
+    );
   });
 
   it("processes every normalized media field and ignores unrelated fields", async () => {

--- a/packages/shared/src/server/otel/OtelMediaProcessor.ts
+++ b/packages/shared/src/server/otel/OtelMediaProcessor.ts
@@ -195,7 +195,10 @@ async function processCandidate(
     recordDistribution(
       "langfuse.ingestion.otel.media.byte_length",
       contentBytes.length,
-      { media_kind: candidate.kind },
+      {
+        outcome: uploadResult.outcome,
+        media_kind: candidate.kind,
+      },
     );
 
     return `@@@langfuseMedia:type=${candidate.contentType}|id=${uploadResult.mediaId}|source=${candidate.source}@@@`;


### PR DESCRIPTION
## What changed

- tag `langfuse.ingestion.otel.media.byte_length` distributions with the media upload outcome
- cover both newly uploaded and reused media in the focused OTEL media processor tests

## Why

The main ingestion dashboard needs to distinguish bytes newly uploaded to S3 from bytes belonging to deduplicated media that was reused. The processor already knows this low-cardinality `uploaded` or `reused` outcome, but the byte-length distribution previously exposed only `media_kind`.

After this change is deployed, `outcome:uploaded` measures bytes actually sent to S3 by the OTEL media extraction path. Historical samples are not backfilled, so exact uploaded-byte reporting starts after deployment.

Linear: [LFE-14445](https://linear.app/clickhouse/issue/LFE-14445/add-otel-media-extraction-metrics-to-the-main-datadog-dashboard)

## Validation

- `pnpm --filter @langfuse/shared run test OtelMediaProcessor.test.ts` — 16 tests passed
- `pnpm --filter @langfuse/shared run lint` — passed
- `pnpm --filter @langfuse/shared run typecheck` — passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds media upload outcomes to OTEL byte-length distribution metrics.
- Tags byte-length samples as `uploaded` or `reused`.
- Adds focused test coverage for both outcomes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new tag uses the existing successful upload outcomes, preserves current processing behavior, and is covered for both uploaded and reused media.

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(otel): tag media byte length by out..."](https://github.com/langfuse/langfuse/commit/db67b5ab6d648ce22fcf1ca3642d4661ba09fd04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46619679)</sub>

<!-- /greptile_comment -->