### PR TITLE
feat: add periodic runner telemetry

### DIFF
--- a/worker/src/__tests__/batchDataRetentionCleaner.test.ts
+++ b/worker/src/__tests__/batchDataRetentionCleaner.test.ts
@@ -16,12 +16,14 @@ import {
   createScoresCh,
   createTraceScore,
   queryClickhouse,
+  traceException,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { env } from "../env";
 
 const integrationHooks = vi.hoisted(() => ({
   failExactEnrichmentForProjectId: null as string | null,
+  failExactEnrichmentOnReadOnly: true,
   omitExactEnrichmentForProjectId: null as string | null,
   failCandidateStreamAfterFirstRow: false,
   activeCandidateStreams: 0,
@@ -61,7 +63,9 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
         Array.isArray(candidateProjectIds) &&
         candidateProjectIds.includes(
           integrationHooks.failExactEnrichmentForProjectId,
-        )
+        ) &&
+        (opts.preferredClickhouseService === undefined ||
+          integrationHooks.failExactEnrichmentOnReadOnly)
       ) {
         throw new Error("forced exact enrichment failure");
       }
@@ -107,6 +111,7 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
       integrationHooks.incrementCalls.push([args[0], args[1]]);
       return actual.recordIncrement(...args);
     },
+    traceException: vi.fn(actual.traceException),
   };
 });
 
@@ -499,6 +504,7 @@ describe("BatchDataRetentionCleaner", () => {
         env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT;
       timestampColumns[tableName] = "start_time";
       integrationHooks.failExactEnrichmentForProjectId = null;
+      integrationHooks.failExactEnrichmentOnReadOnly = true;
       integrationHooks.omitExactEnrichmentForProjectId = null;
       integrationHooks.failCandidateStreamAfterFirstRow = false;
       integrationHooks.activeCandidateStreams = 0;
@@ -506,6 +512,7 @@ describe("BatchDataRetentionCleaner", () => {
       integrationHooks.exactEnrichmentRequests = [];
       integrationHooks.gaugeCalls = [];
       integrationHooks.incrementCalls = [];
+      vi.mocked(traceException).mockClear();
       await createRetentionTestTable(tableName);
     });
 
@@ -685,6 +692,37 @@ describe("BatchDataRetentionCleaner", () => {
           "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
         ),
       ).toBe(0);
+    });
+
+    it("traces recovered enrichment without failing the runner outcome", async () => {
+      const [projectId] = await createProjectsWithRetention(1);
+      await insertRetentionTestRows(tableName, [
+        {
+          projectId: projectId!,
+          startTime: Date.now() - 10 * 24 * 60 * 60 * 1000,
+        },
+      ]);
+      integrationHooks.failExactEnrichmentForProjectId = projectId!;
+      integrationHooks.failExactEnrichmentOnReadOnly = false;
+
+      const cleaner = new BatchDataRetentionCleaner(table);
+      const markRunFailed = vi.spyOn(
+        cleaner as unknown as {
+          markRunFailed(error: unknown): void;
+        },
+        "markRunFailed",
+      );
+
+      await cleaner.processBatch();
+
+      expect(
+        integrationHooks.exactEnrichmentRequests.map(
+          (request) => request.preferredClickhouseService,
+        ),
+      ).toEqual([undefined, "ReadOnly"]);
+      expect(await getRetentionTestRowCount(tableName)).toBe(0);
+      expect(traceException).toHaveBeenCalledTimes(1);
+      expect(markRunFailed).not.toHaveBeenCalled();
     });
 
     it("keeps sibling enrichment when a candidate disappears", async () => {

--- a/worker/src/__tests__/periodicRunner.test.ts
+++ b/worker/src/__tests__/periodicRunner.test.ts
@@ -1,5 +1,36 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const telemetry = vi.hoisted(() => ({
+  recordDistribution: vi.fn(),
+  recordGauge: vi.fn(),
+  recordIncrement: vi.fn(),
+  span: { setAttribute: vi.fn() },
+  traceException: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  getCurrentSpan: vi.fn(() => telemetry.span),
+  instrumentAsync: vi.fn(
+    (
+      _options: unknown,
+      callback: (span: typeof telemetry.span) => Promise<unknown>,
+    ) => callback(telemetry.span),
+  ),
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  recordDistribution: telemetry.recordDistribution,
+  recordGauge: telemetry.recordGauge,
+  recordIncrement: telemetry.recordIncrement,
+  redis: null,
+  traceException: telemetry.traceException,
+}));
+
 import { PeriodicRunner } from "../utils/PeriodicRunner";
+import { PeriodicExclusiveRunner } from "../utils/PeriodicExclusiveRunner";
 
 /**
  * Helper to flush microtasks without advancing timers
@@ -22,11 +53,25 @@ import { PeriodicRunner } from "../utils/PeriodicRunner";
  */
 const flushMicrotasks = () => new Promise((r) => queueMicrotask(r));
 
+const expectCompleted = (
+  outcome: "success" | "failed" | "skipped",
+  tags: Record<string, string>,
+) =>
+  expect(telemetry.recordIncrement).toHaveBeenCalledWith(
+    "langfuse.periodic_runner.completed",
+    1,
+    { outcome, ...tags },
+  );
+
 // Test subclass that tracks execution
 class TestRunner extends PeriodicRunner {
   public callCount = 0;
   public shouldThrow = false;
   public returnInterval: number | undefined = undefined;
+
+  constructor() {
+    super("test_runner");
+  }
 
   protected get name(): string {
     return "test-runner";
@@ -46,22 +91,83 @@ class TestRunner extends PeriodicRunner {
   }
 }
 
+class TestExclusiveRunner extends PeriodicExclusiveRunner {
+  public callCount = 0;
+  public failNext = false;
+  public lockAcquired = true;
+  public readonly operationError = new Error("Caught operation error");
+
+  constructor(lockMode: "stub" | "unavailable" | "release_failure" = "stub") {
+    super({
+      name: "test-exclusive-runner",
+      metricName: "test_exclusive_runner",
+      metricScope: "test_scope",
+      lockKey: "test-exclusive-runner-lock",
+      lockTtlSeconds: 60,
+      onUnavailable: "fail",
+    });
+    if (lockMode !== "unavailable") {
+      this.lock.acquire = async () =>
+        this.lockAcquired ? "acquired" : "held_by_other";
+    }
+    if (lockMode !== "release_failure") {
+      this.lock.release = async () => true;
+    }
+  }
+
+  protected get defaultIntervalMs(): number {
+    return 1000;
+  }
+
+  protected async execute(): Promise<void> {
+    await this.withLock(async () => {
+      this.callCount++;
+      if (this.failNext) {
+        this.failNext = false;
+        throw this.operationError;
+      }
+    });
+  }
+}
+
 describe("PeriodicRunner", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-23T08:00:00.000Z"));
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("should call execute on start", async () => {
+  it("should call execute on start and record canonical metrics", async () => {
     const runner = new TestRunner();
 
     runner.start();
     await flushMicrotasks();
 
     expect(runner.callCount).toBe(1);
+    expect(telemetry.recordIncrement).toHaveBeenCalledWith(
+      "langfuse.periodic_runner.started",
+      1,
+      { runner: "test_runner" },
+    );
+    expectCompleted("success", { runner: "test_runner" });
+    expect(telemetry.recordDistribution).toHaveBeenCalledWith(
+      "langfuse.periodic_runner.duration_ms",
+      0,
+      {
+        outcome: "success",
+        runner: "test_runner",
+        unit: "milliseconds",
+      },
+    );
+    expect(telemetry.recordGauge).toHaveBeenCalledWith(
+      "langfuse.periodic_runner.last_healthy_timestamp_seconds",
+      Date.now() / 1000,
+      { runner: "test_runner", unit: "seconds" },
+    );
     runner.stop();
   });
 
@@ -136,4 +242,59 @@ describe("PeriodicRunner", () => {
     expect(runner.callCount).toBe(1);
     runner.stop();
   });
+
+  it("marks a caught error failed and keeps the loop running", async () => {
+    const runner = new TestExclusiveRunner();
+    runner.failNext = true;
+
+    runner.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(telemetry.traceException).toHaveBeenCalledWith(
+      runner.operationError,
+    );
+    expectCompleted("failed", {
+      runner: "test_exclusive_runner",
+      scope: "test_scope",
+    });
+    expect(telemetry.recordGauge).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(runner.callCount).toBe(2);
+    runner.stop();
+  });
+
+  it("records a lock miss as skipped", async () => {
+    const runner = new TestExclusiveRunner();
+    runner.lockAcquired = false;
+
+    runner.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expectCompleted("skipped", {
+      runner: "test_exclusive_runner",
+      scope: "test_scope",
+    });
+    expect(telemetry.traceException).not.toHaveBeenCalled();
+    expect(telemetry.recordGauge).not.toHaveBeenCalled();
+    runner.stop();
+  });
+
+  it.each(["unavailable", "release_failure"] as const)(
+    "records a %s lock as failed",
+    async (lockMode) => {
+      const runner = new TestExclusiveRunner(lockMode);
+
+      runner.start();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(telemetry.traceException).toHaveBeenCalledWith(expect.any(Error));
+      expectCompleted("failed", {
+        runner: "test_exclusive_runner",
+        scope: "test_scope",
+      });
+      expect(telemetry.recordGauge).not.toHaveBeenCalled();
+      runner.stop();
+    },
+  );
 });

--- a/worker/src/features/batch-data-retention-cleaner/index.ts
+++ b/worker/src/features/batch-data-retention-cleaner/index.ts
@@ -11,6 +11,7 @@ import {
   queryClickhouseStream,
   recordGauge,
   recordIncrement,
+  traceException,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { getRetentionCutoffDate } from "../utils";
@@ -660,7 +661,8 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       if (error instanceof BatchDataRetentionCleanerLeaseLostError) {
         throw error;
       }
-      this.markRunFailed(error);
+      // Preserve the APM error, but let a successful retry keep the runner outcome healthy.
+      traceException(error);
       logger.warn(
         `${this.instanceName}: Candidate enrichment failed; retrying on read-only`,
         {
@@ -686,6 +688,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
           throw retryError;
         }
 
+        this.markRunFailed(retryError);
         recordIncrement(`${METRIC_PREFIX}.enrichment_query_failures`, 1, {
           table: this.tableName,
         });

--- a/worker/src/features/batch-data-retention-cleaner/index.ts
+++ b/worker/src/features/batch-data-retention-cleaner/index.ts
@@ -165,6 +165,8 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
 
     super({
       name: `BatchDataRetentionCleaner(${tableName})`,
+      metricName: "batch_data_retention_cleaner",
+      metricScope: tableName,
       lockKey: `${BATCH_DATA_RETENTION_CLEANER_LOCK_PREFIX}:${tableName}`,
       lockTtlSeconds,
       onUnavailable: "fail",
@@ -538,6 +540,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       recordIncrement(`${METRIC_PREFIX}.candidate_query_failures`, 1, {
         table: this.tableName,
       });
+      this.markRunFailed(error);
       logger.warn(`${this.instanceName}: Candidate query did not complete`, {
         error,
         candidatesFound: candidatesById.size,
@@ -657,6 +660,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       if (error instanceof BatchDataRetentionCleanerLeaseLostError) {
         throw error;
       }
+      this.markRunFailed(error);
       logger.warn(
         `${this.instanceName}: Candidate enrichment failed; retrying on read-only`,
         {

--- a/worker/src/features/batch-project-blob-cleaner/index.ts
+++ b/worker/src/features/batch-project-blob-cleaner/index.ts
@@ -4,7 +4,6 @@ import {
   queryClickhouse,
   recordIncrement,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
-  traceException,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { PeriodicExclusiveRunner } from "../../utils/PeriodicExclusiveRunner";
@@ -35,6 +34,7 @@ export class BatchProjectBlobCleaner extends PeriodicExclusiveRunner {
 
     super({
       name: "BatchProjectBlobCleaner",
+      metricName: "batch_project_blob_cleaner",
       lockKey: "langfuse:batch-project-blob-cleaner",
       lockTtlSeconds,
     });
@@ -70,7 +70,7 @@ export class BatchProjectBlobCleaner extends PeriodicExclusiveRunner {
       logger.error(`${this.instanceName}: Failed to query deleted projects`, {
         error,
       });
-      traceException(error);
+      this.markRunFailed(error);
       return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
     }
 
@@ -87,7 +87,7 @@ export class BatchProjectBlobCleaner extends PeriodicExclusiveRunner {
         `${this.instanceName}: Failed to query ClickHouse blob counts`,
         { error },
       );
-      traceException(error);
+      this.markRunFailed(error);
       return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
     }
 

--- a/worker/src/features/batch-project-cleaner/index.ts
+++ b/worker/src/features/batch-project-cleaner/index.ts
@@ -3,7 +3,6 @@ import {
   logger,
   queryClickhouse,
   commandClickhouse,
-  traceException,
   recordIncrement,
 } from "@langfuse/shared/src/server";
 
@@ -57,6 +56,8 @@ export class BatchProjectCleaner extends PeriodicExclusiveRunner {
 
     super({
       name: `BatchProjectCleaner(${tableName})`,
+      metricName: "batch_project_cleaner",
+      metricScope: tableName,
       lockKey: `${BATCH_PROJECT_CLEANER_LOCK_PREFIX}:${tableName}`,
       lockTtlSeconds,
     });
@@ -97,7 +98,7 @@ export class BatchProjectCleaner extends PeriodicExclusiveRunner {
       logger.error(`${this.instanceName}: Failed to query deleted projects`, {
         error,
       });
-      traceException(error);
+      this.markRunFailed(error);
       return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
     }
 
@@ -112,7 +113,7 @@ export class BatchProjectCleaner extends PeriodicExclusiveRunner {
         `${this.instanceName}: Failed to query ClickHouse counts`,
         error,
       );
-      traceException(error);
+      this.markRunFailed(error);
       return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
     }
 

--- a/worker/src/features/batch-project-media-cleaner/index.ts
+++ b/worker/src/features/batch-project-media-cleaner/index.ts
@@ -7,7 +7,6 @@ import {
   logger,
   recordGauge,
   recordIncrement,
-  traceException,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { PeriodicExclusiveRunner } from "../../utils/PeriodicExclusiveRunner";
@@ -35,6 +34,7 @@ export class BatchProjectMediaCleaner extends PeriodicExclusiveRunner {
 
     super({
       name: "BatchProjectMediaCleaner",
+      metricName: "batch_project_media_cleaner",
       lockKey: "langfuse:batch-project-media-cleaner",
       lockTtlSeconds,
     });
@@ -64,7 +64,7 @@ export class BatchProjectMediaCleaner extends PeriodicExclusiveRunner {
               `${this.instanceName}: Failed to query target project`,
               { error },
             );
-            traceException(error);
+            this.markRunFailed(error);
             return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
           }
 

--- a/worker/src/features/batch-trace-deletion-cleaner/index.ts
+++ b/worker/src/features/batch-trace-deletion-cleaner/index.ts
@@ -1,9 +1,5 @@
 import { prisma } from "@langfuse/shared/src/db";
-import {
-  logger,
-  recordIncrement,
-  traceException,
-} from "@langfuse/shared/src/server";
+import { logger, recordIncrement } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { PeriodicExclusiveRunner } from "../../utils/PeriodicExclusiveRunner";
 import { processClickhouseTraceDelete } from "../traces/processClickhouseTraceDelete";
@@ -46,6 +42,7 @@ export class BatchTraceDeletionCleaner extends PeriodicExclusiveRunner {
   constructor() {
     super({
       name: "BatchTraceDeletionCleaner",
+      metricName: "batch_trace_deletion_cleaner",
       lockKey: BATCH_TRACE_DELETION_CLEANER_LOCK_KEY,
       lockTtlSeconds:
         env.LANGFUSE_BATCH_TRACE_DELETION_CLEANER_LOCK_TTL_SECONDS,
@@ -78,7 +75,6 @@ export class BatchTraceDeletionCleaner extends PeriodicExclusiveRunner {
           logger.error(`${this.name}: Failed to query project workload`, {
             error,
           });
-          traceException(error);
           recordIncrement(`${METRIC_PREFIX}.query_failures`, 1);
           throw error;
         }
@@ -172,7 +168,7 @@ export class BatchTraceDeletionCleaner extends PeriodicExclusiveRunner {
       { backend: "clickhouse" as const, result: clickhouseDeletion },
     ].flatMap(({ backend, result }) => {
       if (result.status === "rejected") {
-        traceException(result.reason);
+        this.markRunFailed(result.reason);
         return [
           {
             backend,

--- a/worker/src/features/deleted-mask-cleaner/index.ts
+++ b/worker/src/features/deleted-mask-cleaner/index.ts
@@ -52,6 +52,7 @@ export class DeletedMaskCleaner extends PeriodicExclusiveRunner {
 
     super({
       name: "DeletedMaskCleaner",
+      metricName: "deleted_mask_cleaner",
       lockKey: DELETED_MASK_CLEANER_LOCK_KEY,
       lockTtlSeconds,
       onUnavailable: "fail",

--- a/worker/src/features/media-retention-cleaner/index.ts
+++ b/worker/src/features/media-retention-cleaner/index.ts
@@ -7,7 +7,6 @@ import {
   recordGauge,
   recordIncrement,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
-  traceException,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { getRetentionCutoffDate } from "../utils";
@@ -44,6 +43,7 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
 
     super({
       name: "MediaRetentionCleaner",
+      metricName: "media_retention_cleaner",
       lockKey: MEDIA_RETENTION_CLEANER_LOCK_KEY,
       lockTtlSeconds,
       onUnavailable: "fail",
@@ -80,7 +80,6 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
           logger.error(`${this.name}: Failed to query project workload`, {
             error,
           });
-          traceException(error);
           recordIncrement(`${METRIC_PREFIX}.query_failures`, 1);
           throw error;
         }

--- a/worker/src/features/monitor-runner/index.ts
+++ b/worker/src/features/monitor-runner/index.ts
@@ -21,6 +21,8 @@ export class MonitorRunner extends PeriodicExclusiveRunner {
   constructor(schedulerId: number, totalSchedulers: number) {
     super({
       name: `MonitorRunner(${schedulerId + 1}/${totalSchedulers})`,
+      metricName: "monitor_runner",
+      metricScope: String(schedulerId + 1),
       lockKey: `langfuse:monitor:${schedulerId}`,
       lockTtlSeconds,
     });

--- a/worker/src/features/queue-metrics-runner/index.ts
+++ b/worker/src/features/queue-metrics-runner/index.ts
@@ -51,6 +51,10 @@ function emitDepth(
 }
 
 export class QueueMetricsRunner extends PeriodicRunner {
+  constructor() {
+    super("queue_metrics_runner");
+  }
+
   protected get name(): string {
     return "queue-metrics-runner";
   }
@@ -71,6 +75,7 @@ export class QueueMetricsRunner extends PeriodicRunner {
       updateActiveIngestFailureProjectsMetric()
         .then(() => undefined)
         .catch((err) => {
+          this.markRunFailed(err);
           logger.error(
             "Queue metrics: failed to record active ingestion failure projects",
             err,
@@ -99,6 +104,7 @@ export class QueueMetricsRunner extends PeriodicRunner {
             );
           })
           .catch((err) => {
+            this.markRunFailed(err);
             logger.error(
               `Queue metrics: failed to collect dlq oldest age for ${queueName}`,
               err,
@@ -127,6 +133,7 @@ export class QueueMetricsRunner extends PeriodicRunner {
             }
           })
           .catch((err) => {
+            this.markRunFailed(err);
             logger.error(
               `Queue metrics: failed to collect depth for ${queueName}`,
               err,
@@ -159,6 +166,7 @@ export class QueueMetricsRunner extends PeriodicRunner {
             return age;
           })
           .catch((err) => {
+            this.markRunFailed(err);
             logger.error(
               `Queue metrics: failed to collect dlq oldest age for ${shardName}`,
               err,
@@ -200,6 +208,7 @@ export class QueueMetricsRunner extends PeriodicRunner {
             return depths;
           })
           .catch((err) => {
+            this.markRunFailed(err);
             logger.error(
               `Queue metrics: failed to collect depth for ${shardName}`,
               err,

--- a/worker/src/features/trace-delete-batch-action-runner/index.ts
+++ b/worker/src/features/trace-delete-batch-action-runner/index.ts
@@ -9,7 +9,6 @@ import {
   logger,
   recordGauge,
   recordIncrement,
-  traceException,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { PeriodicExclusiveRunner } from "../../utils/PeriodicExclusiveRunner";
@@ -70,6 +69,7 @@ export class TraceDeleteBatchActionRunner extends PeriodicExclusiveRunner {
 
     super({
       name: "TraceDeleteBatchActionRunner",
+      metricName: "trace_delete_batch_action_runner",
       lockKey: TRACE_DELETE_BATCH_ACTION_RUNNER_LOCK_KEY,
       lockTtlSeconds,
       onUnavailable: "fail",
@@ -109,7 +109,6 @@ export class TraceDeleteBatchActionRunner extends PeriodicExclusiveRunner {
           logger.error(`${this.instanceName}: Failed to query active actions`, {
             error,
           });
-          traceException(error);
           recordIncrement(`${METRIC_PREFIX}.query_failures`, 1);
           throw error;
         }

--- a/worker/src/utils/PeriodicExclusiveRunner.ts
+++ b/worker/src/utils/PeriodicExclusiveRunner.ts
@@ -17,16 +17,19 @@ export abstract class PeriodicExclusiveRunner extends PeriodicRunner {
 
   constructor(params: {
     name: string;
+    metricName: string;
+    metricScope?: string;
     lockKey: string;
     lockTtlSeconds: number;
     onUnavailable?: OnUnavailableBehavior;
   }) {
-    super();
+    super(params.metricName, params.metricScope);
     this.instanceName = params.name;
     this.lock = new RedisLock(params.lockKey, {
       ttlSeconds: params.lockTtlSeconds,
       name: params.name,
       onUnavailable: params.onUnavailable || "proceed",
+      onError: (error) => this.markRunFailed(error),
     });
   }
 
@@ -59,7 +62,8 @@ export abstract class PeriodicExclusiveRunner extends PeriodicRunner {
         return await operation();
       } catch (error) {
         logger.error(`${this.instanceName}: Operation failed`, { error });
-        // Error will be traced by parent instrumentAsync in PeriodicRunner
+        // This error is intentionally handled below, so instrumentAsync will not see it.
+        this.markRunFailed(error);
         return await onFailure?.(error);
       }
     });
@@ -70,6 +74,7 @@ export abstract class PeriodicExclusiveRunner extends PeriodicRunner {
     span?.setAttribute("lock.key", this.lock.key);
 
     if (result === null) {
+      this.markRunSkipped();
       logger.debug(
         `${this.instanceName}: Lock not acquired, another worker is processing`,
       );

--- a/worker/src/utils/PeriodicRunner.ts
+++ b/worker/src/utils/PeriodicRunner.ts
@@ -1,5 +1,15 @@
-import { logger, instrumentAsync } from "@langfuse/shared/src/server";
+import {
+  instrumentAsync,
+  logger,
+  recordDistribution,
+  recordGauge,
+  recordIncrement,
+  traceException,
+} from "@langfuse/shared/src/server";
 import { SpanKind } from "@opentelemetry/api";
+
+const METRIC_PREFIX = "langfuse.periodic_runner";
+type RunOutcome = "success" | "failed" | "skipped";
 
 /**
  * Abstract base class for periodic task execution.
@@ -10,17 +20,25 @@ import { SpanKind } from "@opentelemetry/api";
 export abstract class PeriodicRunner {
   private timeoutId: NodeJS.Timeout | null = null;
   private isRunning = false;
+  private activeRun: { outcome: RunOutcome } | null = null;
 
   protected abstract get name(): string;
   protected abstract get defaultIntervalMs(): number;
   protected abstract execute(): Promise<number | void>;
+
+  protected constructor(
+    private readonly metricName: string,
+    private readonly metricScope?: string,
+  ) {}
 
   public start(): void {
     if (this.isRunning) {
       return;
     }
     this.isRunning = true;
-    this.runAndScheduleNext();
+    if (!this.activeRun) {
+      this.runAndScheduleNext();
+    }
   }
 
   public stop(): void {
@@ -31,8 +49,32 @@ export abstract class PeriodicRunner {
     }
   }
 
+  protected markRunFailed(error: unknown): void {
+    if (this.activeRun) {
+      this.activeRun.outcome = "failed";
+    }
+    traceException(error);
+  }
+
+  protected markRunSkipped(): void {
+    if (this.activeRun?.outcome === "success") {
+      this.activeRun.outcome = "skipped";
+    }
+  }
+
   private async runAndScheduleNext(): Promise<void> {
+    const run: { outcome: RunOutcome } = { outcome: "success" };
+    this.activeRun = run;
     let nextDelayMs = this.defaultIntervalMs;
+    const startedAt = Date.now();
+    const metricTags = {
+      runner: this.metricName,
+      ...(this.metricScope ? { scope: this.metricScope } : {}),
+    };
+
+    this.emitTelemetry(() => {
+      recordIncrement(`${METRIC_PREFIX}.started`, 1, metricTags);
+    });
 
     try {
       await instrumentAsync(
@@ -53,10 +95,44 @@ export abstract class PeriodicRunner {
         },
       );
     } catch (error) {
-      // instrumentAsync already calls traceException, just log here
+      run.outcome = "failed";
+      // Errors that escape execute() are already traced by instrumentAsync.
+      // Errors handled inside execute() must call markRunFailed().
       logger.error(`Unexpected error in ${this.name}`, error);
     } finally {
+      const completedAt = Date.now();
+      this.emitTelemetry(() => {
+        const outcomeTags = { ...metricTags, outcome: run.outcome };
+        recordIncrement(`${METRIC_PREFIX}.completed`, 1, outcomeTags);
+        recordDistribution(
+          `${METRIC_PREFIX}.duration_ms`,
+          completedAt - startedAt,
+          {
+            ...outcomeTags,
+            unit: "milliseconds",
+          },
+        );
+        if (run.outcome === "success") {
+          recordGauge(
+            `${METRIC_PREFIX}.last_healthy_timestamp_seconds`,
+            Math.floor(completedAt / 1000),
+            {
+              ...metricTags,
+              unit: "seconds",
+            },
+          );
+        }
+      });
+      this.activeRun = null;
       this.scheduleNext(nextDelayMs);
+    }
+  }
+
+  private emitTelemetry(emit: () => void): void {
+    try {
+      emit();
+    } catch (error) {
+      logger.error(`${this.name}: Failed to emit metrics`, error);
     }
   }
 

--- a/worker/src/utils/RedisLock.ts
+++ b/worker/src/utils/RedisLock.ts
@@ -49,6 +49,7 @@ export class RedisLock {
   private readonly ttlSeconds: number;
   private readonly name: string;
   private readonly onUnavailable: OnUnavailableBehavior;
+  private readonly onError?: (error: unknown) => void;
 
   // Lua script for atomic check-and-delete (only delete if we own the lock)
   private static readonly RELEASE_LOCK_SCRIPT = `
@@ -123,6 +124,7 @@ export class RedisLock {
       name?: string;
       /** Behavior when Redis is unavailable. Default: "proceed" */
       onUnavailable?: OnUnavailableBehavior;
+      onError?: (error: unknown) => void;
     },
   ) {
     this.lockKey = lockKey;
@@ -130,6 +132,7 @@ export class RedisLock {
     this.ttlSeconds = options.ttlSeconds;
     this.name = options.name ?? lockKey;
     this.onUnavailable = options.onUnavailable ?? "proceed";
+    this.onError = options.onError;
   }
 
   /**
@@ -169,6 +172,9 @@ export class RedisLock {
   public async acquire(): Promise<LockAcquireResult> {
     if (!redis) {
       logger.warn(`[${this.name}] Redis unavailable, allowing processing`);
+      if (this.onUnavailable === "fail") {
+        this.onError?.(new Error(`[${this.name}] Redis unavailable`));
+      }
       return "skipped";
     }
 
@@ -198,6 +204,7 @@ export class RedisLock {
         `[${this.name}] Failed to acquire lock due to an error`,
         error,
       );
+      this.onError?.(error);
       // On error, allow processing but don't claim to hold the lock
       return "skipped";
     }
@@ -210,6 +217,9 @@ export class RedisLock {
    */
   public async release(): Promise<boolean> {
     if (!redis) {
+      this.onError?.(
+        new Error(`[${this.name}] Redis unavailable during lock release`),
+      );
       return false;
     }
 
@@ -225,13 +235,16 @@ export class RedisLock {
         return true;
       }
 
-      logger.warn(
+      const error = new Error(
         `[${this.name}] Lock was not released (not owned or already expired)`,
       );
+      logger.warn(error.message);
+      this.onError?.(error);
       return false;
     } catch (error) {
       // Log but don't throw - lock will expire via TTL anyway
       logger.error(`[${this.name}] Failed to release lock`, error);
+      this.onError?.(error);
       return false;
     }
   }


### PR DESCRIPTION
## Summary

- Add canonical started, completed, duration, and last-healthy metrics for periodic runners.
- Track successful, failed, and skipped runs, including Redis lock failures and misses.
- Instrument cleaner and queue runner errors through shared run outcome telemetry.
- Add coverage for runner metrics and exclusive-lock outcomes.

## Testing

- Added and updated Vitest coverage for periodic runner telemetry, failures, skips, and lock errors.
- PR validation CI checks not run (not requested).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds canonical execution telemetry to periodic worker runners.
- Records started, completed, duration, outcome, and last-healthy metrics.
- Propagates caught runner and Redis-lock errors into shared outcome telemetry.
- Adds stable runner and scope tags across cleaner, monitor, and queue-metrics runners.
- Expands tests for successful, failed, skipped, and lock-error outcomes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The recoverable enrichment path should be corrected before merging because a successful fallback is currently reported as a failed periodic run.

The primary enrichment catch permanently marks the active run failed even when the read-only retry succeeds and the cleaner completes its work, producing an incorrect completion outcome and stale health gauge.

worker/src/features/batch-data-retention-cleaner/index.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Tick[Periodic runner tick] --> Start[Record started metric]
  Start --> Execute[Execute runner]
  Execute --> Success[Success]
  Execute --> Handled[Handled error or lock error]
  Execute --> Skip[Lock held elsewhere]
  Success --> CompleteSuccess[Record completed: success]
  CompleteSuccess --> Healthy[Refresh last-healthy timestamp]
  Handled --> CompleteFailed[Record completed: failed]
  Skip --> CompleteSkipped[Record completed: skipped]
  CompleteSuccess --> Schedule[Schedule next run]
  CompleteFailed --> Schedule
  CompleteSkipped --> Schedule
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/features/batch-data-retention-cleaner/index.ts:663
**Recovered enrichment stays failed**

When the primary ClickHouse enrichment query fails but the read-only retry succeeds, this call leaves the run marked as failed, causing the completed metric to report `outcome="failed"` and preventing the last-healthy timestamp from being refreshed despite the cleaner completing successfully.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add telemetry outcomes to periodic runne..."](https://github.com/langfuse/langfuse/commit/7f512681b3e043b7a68d558c62325a17feda919f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46634083)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Worker Queues](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/worker-queues.md)
- Knowledge Base — [Batch Actions and Data Exports](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md)

<!-- /greptile_comment -->