### PR TITLE
chore: align metadata values index names with prod

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0043_add_events_metadata_ngram_index.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0043_add_events_metadata_ngram_index.down.sql
@@ -1,2 +1,2 @@
-ALTER TABLE events_full ON CLUSTER default DROP INDEX IF EXISTS idx_fts_metadata_values_ngram SETTINGS enable_full_text_index = 1, alter_sync = 2;
-ALTER TABLE events_core ON CLUSTER default DROP INDEX IF EXISTS idx_fts_metadata_values_ngram SETTINGS enable_full_text_index = 1, alter_sync = 2;
+ALTER TABLE events_full ON CLUSTER default DROP INDEX IF EXISTS idx_ngram_metadata_values SETTINGS enable_full_text_index = 1, alter_sync = 2;
+ALTER TABLE events_core ON CLUSTER default DROP INDEX IF EXISTS idx_ngram_metadata_values SETTINGS enable_full_text_index = 1, alter_sync = 2;

--- a/packages/shared/clickhouse/migrations/clustered/0043_add_events_metadata_ngram_index.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0043_add_events_metadata_ngram_index.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE events_full ON CLUSTER default ADD INDEX IF NOT EXISTS idx_fts_metadata_values_ngram arrayStringConcat(metadata_values) TYPE ngrambf_v1(4, 32000, 3, 0) GRANULARITY 2 SETTINGS enable_full_text_index = 1, alter_sync = 2;
-ALTER TABLE events_core ON CLUSTER default ADD INDEX IF NOT EXISTS idx_fts_metadata_values_ngram arrayStringConcat(metadata_values) TYPE ngrambf_v1(4, 32000, 3, 0) GRANULARITY 2 SETTINGS enable_full_text_index = 1, alter_sync = 2;
+ALTER TABLE events_full ON CLUSTER default ADD INDEX IF NOT EXISTS idx_ngram_metadata_values arrayStringConcat(metadata_values) TYPE ngrambf_v1(4, 32000, 3, 0) GRANULARITY 2 SETTINGS enable_full_text_index = 1, alter_sync = 2;
+ALTER TABLE events_core ON CLUSTER default ADD INDEX IF NOT EXISTS idx_ngram_metadata_values arrayStringConcat(metadata_values) TYPE ngrambf_v1(4, 32000, 3, 0) GRANULARITY 2 SETTINGS enable_full_text_index = 1, alter_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0043_add_events_metadata_ngram_index.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0043_add_events_metadata_ngram_index.down.sql
@@ -1,2 +1,2 @@
-ALTER TABLE events_full DROP INDEX IF EXISTS idx_fts_metadata_values_ngram SETTINGS enable_full_text_index = 1;
-ALTER TABLE events_core DROP INDEX IF EXISTS idx_fts_metadata_values_ngram SETTINGS enable_full_text_index = 1;
+ALTER TABLE events_full DROP INDEX IF EXISTS idx_ngram_metadata_values SETTINGS enable_full_text_index = 1;
+ALTER TABLE events_core DROP INDEX IF EXISTS idx_ngram_metadata_values SETTINGS enable_full_text_index = 1;

--- a/packages/shared/clickhouse/migrations/unclustered/0043_add_events_metadata_ngram_index.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0043_add_events_metadata_ngram_index.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE events_full ADD INDEX IF NOT EXISTS idx_fts_metadata_values_ngram arrayStringConcat(metadata_values) TYPE ngrambf_v1(4, 32000, 3, 0) GRANULARITY 2 SETTINGS enable_full_text_index = 1;
-ALTER TABLE events_core ADD INDEX IF NOT EXISTS idx_fts_metadata_values_ngram arrayStringConcat(metadata_values) TYPE ngrambf_v1(4, 32000, 3, 0) GRANULARITY 2 SETTINGS enable_full_text_index = 1;
+ALTER TABLE events_full ADD INDEX IF NOT EXISTS idx_ngram_metadata_values arrayStringConcat(metadata_values) TYPE ngrambf_v1(4, 32000, 3, 0) GRANULARITY 2 SETTINGS enable_full_text_index = 1;
+ALTER TABLE events_core ADD INDEX IF NOT EXISTS idx_ngram_metadata_values arrayStringConcat(metadata_values) TYPE ngrambf_v1(4, 32000, 3, 0) GRANULARITY 2 SETTINGS enable_full_text_index = 1;


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Aligns the metadata-value ngram index name with production.
- Renames the index to `idx_ngram_metadata_values` for clustered `events_full` and `events_core` tables.
- Applies the same rename to the unclustered migrations.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The rollback mismatch should be fixed before merging because migration 0043 can report a successful rollback while retaining the renamed indexes.

Both up migrations now create indexes under a new name, while their unchanged down migrations use `IF EXISTS` to silently target the old name and therefore do not reverse fresh applications.

packages/shared/clickhouse/migrations/clustered/0043_add_events_metadata_ngram_index.up.sql and packages/shared/clickhouse/migrations/unclustered/0043_add_events_metadata_ngram_index.up.sql
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/clickhouse/migrations/clustered/0043_add_events_metadata_ngram_index.up.sql:1-2
**Rollback targets the old index**

When migration 0043 is rolled back after a fresh installation, the unchanged down migration drops only `idx_fts_metadata_values_ngram`, while these statements created `idx_ngram_metadata_values`. Because the drop uses `IF EXISTS`, rollback succeeds silently but leaves the renamed indexes on `events_full` and `events_core`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: align metadata values index names..."](https://github.com/langfuse/langfuse/commit/72d13cfb7505df5706e9deeebb949016167dbbd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46662118)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->