### PR TITLE
fix(posthog): raise SDK maxQueueSize to stop silent event drops (LFE-14456)

### DIFF
--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -41,12 +41,8 @@ type PostHogExecutionConfig = {
 
 const postHogSettings = {
   flushAt: 1000,
-  // The SDK evicts the oldest queued event (with only an info log, no error)
-  // once the queue reaches maxQueueSize, which defaults to max(flushAt, 1000).
-  // The capture loops below enqueue from the ClickHouse stream faster than
-  // background flushes drain and only await flush() every 10k events, so at
-  // high volume most events were silently dropped (LFE-14456). Matching the
-  // manual flush cadence keeps the queue below the cap at all times.
+  // Must be >= the capture loops' manual flush cadence (every 10k events);
+  // past this cap the SDK silently drops the oldest queued event.
   maxQueueSize: 10000,
 };
 

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -41,6 +41,13 @@ type PostHogExecutionConfig = {
 
 const postHogSettings = {
   flushAt: 1000,
+  // The SDK evicts the oldest queued event (with only an info log, no error)
+  // once the queue reaches maxQueueSize, which defaults to max(flushAt, 1000).
+  // The capture loops below enqueue from the ClickHouse stream faster than
+  // background flushes drain and only await flush() every 10k events, so at
+  // high volume most events were silently dropped (LFE-14456). Matching the
+  // manual flush cadence keeps the queue below the cap at all times.
+  maxQueueSize: 10000,
 };
 
 type PostHogClientOptions = NonNullable<


### PR DESCRIPTION
**Automated first pass from ticket [LFE-14456](https://linear.app/clickhouse/issue/LFE-14456)** — PostHog integration throughput cap causing data loss. Please verify before review.

## Findings

- Customer reports only ~17-18% of observations/traces arrive in PostHog above ~8k events/hour; loss tracks volume.
- Root cause: `postHogSettings` in `worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts` sets `flushAt: 1000` but not `maxQueueSize`. `@posthog/core` (posthog-node 5.38.4) caps its in-memory queue at `max(flushAt, 1000) = 1000` and on each enqueue past the cap does `queue.shift()` — silently dropping the oldest event with only an info-level log. No `error` event is emitted, so the handler's error guard never fires and `lastSyncAt` still advances.
- The capture loops enqueue from the ClickHouse stream faster than background HTTP flushes drain and only `await posthog.flush()` every 10k events, so up to ~9k of every 10k could be evicted. The ClickHouse queries have no LIMIT — loss is purely client-side queue eviction.

## Fix

Set `maxQueueSize: 10000` to match the manual flush cadence: the queue starts empty after each awaited flush and at most 9,999 events are queued before the next one, so the eviction cap is never reached.

## Notes for reviewer

- Related: LFE-13521 (export bursts overwhelm the target PostHog instance). This change preserves burst rate; throttling is a separate concern not addressed here.
- No test run in this pass (time-boxed automation); `worker/src/__tests__/posthogIntegrationProjectJob.test.ts` is the relevant suite. A regression test could stub a slow fetch and assert all captured events are delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Raises the PostHog SDK queue capacity from its default to 10,000 events so bulk-export capture loops can reach their awaited flush boundary without silently evicting queued events.
- Applies the queue setting to each PostHog client used for trace, generation, score, and event exports.
- Documents the SDK eviction behavior and its relationship to the existing 10,000-event manual flush cadence.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the enlarged queue addressing silent PostHog event eviction without changing export selection or synchronization behavior.

Each export stream uses its own PostHog client, captures an event before awaiting a flush every 10,000 records, and receives the new queue-capacity setting through the shared client configuration.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(posthog): raise SDK maxQueueSize to ..."](https://github.com/langfuse/langfuse/commit/913ee29f606221966a30aa25f9b8d33ed9219e5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46711602)</sub>

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->