### PR TITLE
fix(evals): support Sonnet 5 on Bedrock

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -94,7 +94,7 @@
     "seed": "dotenv -e ../../.env -- tsx scripts/seeder/seed-postgres.ts"
   },
   "dependencies": {
-    "@ai-sdk/amazon-bedrock": "^5.0.8",
+    "@ai-sdk/amazon-bedrock": "^5.0.24",
     "@ai-sdk/anthropic": "^4.0.5",
     "@ai-sdk/azure": "^4.0.5",
     "@ai-sdk/google": "^4.0.6",

--- a/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
@@ -54,17 +54,22 @@ type CapturedRequest = {
  * provider response, so the assertion target is the exact wire format the AI
  * SDK provider constructs (URL, auth header, JSON body).
  */
-function createCaptureFetch(response: unknown) {
+function createCaptureFetch(
+  response: unknown | ((request: CapturedRequest) => unknown),
+) {
   const calls: CapturedRequest[] = [];
   const fetchImpl: typeof fetch = async (input, init) => {
     const request = new Request(input, init);
-    calls.push({
+    const capturedRequest = {
       url: request.url,
       method: request.method,
       headers: request.headers,
       body: JSON.parse(await request.text()) as Record<string, unknown>,
-    });
-    return new Response(JSON.stringify(response), {
+    };
+    calls.push(capturedRequest);
+    const responseBody =
+      typeof response === "function" ? response(capturedRequest) : response;
+    return new Response(JSON.stringify(responseBody), {
       status: 200,
       headers: { "content-type": "application/json" },
     });
@@ -536,17 +541,23 @@ describe("AI SDK request shapes", () => {
 
   // The Bedrock builder deliberately uses no custom fetch (VPC endpoints),
   // so capture at the global fetch the AI SDK falls back to.
-  async function runBedrockCompletion() {
+  async function runBedrockCompletion(params?: {
+    model?: string;
+    output?: ReturnType<typeof createLLMOutput>;
+    response?: unknown | ((request: CapturedRequest) => unknown);
+  }) {
     const modelParams: ModelParams = {
       provider: "bedrock",
       adapter: LLMAdapter.Bedrock,
-      model: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+      model: params?.model ?? "anthropic.claude-3-5-sonnet-20241022-v2:0",
       max_tokens: 64,
       providerOptions: { top_k: 10 },
     };
     const llmConnectionConfig = { region: "us-east-1" };
 
-    const { calls, fetch } = createCaptureFetch(BEDROCK_RESPONSE);
+    const { calls, fetch } = createCaptureFetch(
+      params?.response ?? BEDROCK_RESPONSE,
+    );
     vi.stubGlobal("fetch", fetch);
 
     const result = await generateLLMText({
@@ -564,15 +575,18 @@ describe("AI SDK request shapes", () => {
         },
       }),
       timeout: 10_000,
+      output: params?.output,
     });
 
-    expect(result.text).toBe("ok");
+    if (!params?.output) {
+      expect(result.text).toBe("ok");
+    }
     expect(calls).toHaveLength(1);
-    return calls[0];
+    return { result, request: calls[0] };
   }
 
   it("Bedrock: converse URL from validated region, SigV4 auth, verbatim additional fields", async () => {
-    const request = await runBedrockCompletion();
+    const { request } = await runBedrockCompletion();
 
     expect(decodeURIComponent(request.url)).toBe(
       "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse",
@@ -580,6 +594,64 @@ describe("AI SDK request shapes", () => {
     expect(request.headers.get("authorization")).toMatch(/^AWS4-HMAC-SHA256/);
     expect(request.body.additionalModelRequestFields).toEqual({ top_k: 10 });
     expect(request.body.inferenceConfig).toMatchObject({ maxTokens: 64 });
+  });
+
+  it("Bedrock: Sonnet 5 structured output falls back to the JSON tool", async () => {
+    const schema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+      required: ["answer"],
+      additionalProperties: false,
+    } as const;
+    const { result, request } = await runBedrockCompletion({
+      model: "us.anthropic.claude-sonnet-5",
+      output: createLLMOutput(schema),
+      response: (capturedRequest: CapturedRequest) =>
+        capturedRequest.body.toolConfig
+          ? {
+              output: {
+                message: {
+                  role: "assistant",
+                  content: [
+                    {
+                      toolUse: {
+                        toolUseId: "tool-1",
+                        name: "json",
+                        input: { answer: "ok" },
+                      },
+                    },
+                  ],
+                },
+              },
+              stopReason: "tool_use",
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              metrics: { latencyMs: 1 },
+            }
+          : {
+              ...BEDROCK_RESPONSE,
+              output: {
+                message: {
+                  role: "assistant",
+                  content: [{ text: '{"answer":"ok"}' }],
+                },
+              },
+            },
+    });
+
+    expect(result.output).toEqual({ answer: "ok" });
+    expect(request.body.additionalModelRequestFields).toEqual({ top_k: 10 });
+    expect(request.body.toolConfig).toEqual({
+      tools: [
+        {
+          toolSpec: {
+            name: "json",
+            description: "Respond with a JSON object.",
+            inputSchema: { json: schema },
+          },
+        },
+      ],
+      toolChoice: { any: {} },
+    });
   });
 
   it("Bedrock: tenant credentials suppress server-level env auth fallbacks", async () => {
@@ -590,7 +662,7 @@ describe("AI SDK request shapes", () => {
     vi.stubEnv("AWS_BEARER_TOKEN_BEDROCK", "server-bearer-token");
     vi.stubEnv("AWS_SESSION_TOKEN", "server-session-token");
 
-    const request = await runBedrockCompletion();
+    const { request } = await runBedrockCompletion();
 
     // SigV4 with the tenant keys — not `Bearer server-bearer-token`.
     expect(request.headers.get("authorization")).toMatch(/^AWS4-HMAC-SHA256/);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,8 +203,8 @@ importers:
   packages/shared:
     dependencies:
       '@ai-sdk/amazon-bedrock':
-        specifier: ^5.0.8
-        version: 5.0.8(zod@4.3.6)
+        specifier: ^5.0.24
+        version: 5.0.24(zod@4.3.6)
       '@ai-sdk/anthropic':
         specifier: ^4.0.5
         version: 4.0.5(zod@4.3.6)
@@ -1199,8 +1199,8 @@ packages:
     peerDependencies:
       zod: 4.3.6
 
-  '@ai-sdk/amazon-bedrock@5.0.8':
-    resolution: {integrity: sha512-E4TozODmCKGS5VlCBnCR1Iffd0e0hkcbjpjzlqvxQPTJlw0hm9sJ3vltAIRU3wTKVTn0BfZiKzYylu2CAEyP6g==}
+  '@ai-sdk/amazon-bedrock@5.0.24':
+    resolution: {integrity: sha512-DqepS/e0mZfpfFjbCKIG7LzsvrQYeKJT0aoQDC6WyXvR81Vi1VIJVk6IL2q6dq2zwuBNnXIQkUPFF0NTXRXGRQ==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: 4.3.6
@@ -1214,6 +1214,12 @@ packages:
   '@ai-sdk/anthropic@3.0.62':
     resolution: {integrity: sha512-CkShXR8tmNO7QQnvpKbSMe2Vr1zUUcpqlp69iR+DYrbHm+tDJO9u6zZsjEHjcoRU9/e9z++p0W6NiuLC3aZ4Bg==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: 4.3.6
+
+  '@ai-sdk/anthropic@4.0.16':
+    resolution: {integrity: sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: 4.3.6
 
@@ -1283,6 +1289,12 @@ packages:
     peerDependencies:
       zod: 4.3.6
 
+  '@ai-sdk/openai@4.0.16':
+    resolution: {integrity: sha512-Yh+PsXaf9NbN7oA3oKwOuyjTiHMPD75phf3SqGbDNNKQ3Yj3oTntp/WhO3nCHIPA6gr5/1lyridQokmOpPf9oQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: 4.3.6
+
   '@ai-sdk/openai@4.0.5':
     resolution: {integrity: sha512-a9cYQNAKAbkMTt6bHAvDuLv3klwtJT9m0A6x7s8EZlf1ebcxadg/1CONaYh1GA80ZRA9UQHJUS2wHoOphkQQkg==}
     engines: {node: '>=22'}
@@ -1298,6 +1310,12 @@ packages:
   '@ai-sdk/provider-utils@4.0.27':
     resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@5.0.11':
+    resolution: {integrity: sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: 4.3.6
 
@@ -1335,6 +1353,10 @@ packages:
 
   '@ai-sdk/provider@4.0.1':
     resolution: {integrity: sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
     engines: {node: '>=22'}
 
   '@ai-sdk/ui-utils@1.2.11':
@@ -4918,8 +4940,16 @@ packages:
     resolution: {integrity: sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.29.5':
+    resolution: {integrity: sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.8':
     resolution: {integrity: sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.4.10':
+    resolution: {integrity: sha512-yG1n59zLQMa979xvXlTQ9+FpNmm4RRPR+2rYZo57wk28E27zmKZN4ST9wc2pKkyspLpDal2/84ST72KLJhbP1w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.4.5':
@@ -5085,6 +5115,10 @@ packages:
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.4.10':
+    resolution: {integrity: sha512-4pWFv2sxrykZqaTixXhkgAsG6+k/VxgAiyZ6M0iLEmsOqcJaR0eidlTCmuKKtMJMIEw8lYwDTvEyR4NyC+V0cw==}
+    engines: {node: '>=18.0.0'}
 
   '@smithy/util-utf8@4.4.5':
     resolution: {integrity: sha512-ZS7Y5X8mU9qRSsqwOeGKw86WWtPsRxa396kX2HyhYwADRqFHJ0cb3p2uFk6QnFF3BluUUBHTZJpPA9QuEl0tlg==}
@@ -7684,6 +7718,10 @@ packages:
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -11768,14 +11806,14 @@ snapshots:
       aws4fetch: 1.0.20
       zod: 4.3.6
 
-  '@ai-sdk/amazon-bedrock@5.0.8(zod@4.3.6)':
+  '@ai-sdk/amazon-bedrock@5.0.24(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/anthropic': 4.0.5(zod@4.3.6)
-      '@ai-sdk/openai': 4.0.5(zod@4.3.6)
-      '@ai-sdk/provider': 4.0.1
-      '@ai-sdk/provider-utils': 5.0.3(zod@4.3.6)
-      '@smithy/eventstream-codec': 4.4.5
-      '@smithy/util-utf8': 4.4.5
+      '@ai-sdk/anthropic': 4.0.16(zod@4.3.6)
+      '@ai-sdk/openai': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@4.3.6)
+      '@smithy/eventstream-codec': 4.4.10
+      '@smithy/util-utf8': 4.4.10
       aws4fetch: 1.0.20
       zod: 4.3.6
 
@@ -11789,6 +11827,12 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/anthropic@4.0.16(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/anthropic@4.0.5(zod@4.3.6)':
@@ -11868,6 +11912,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/openai@4.0.16(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/openai@4.0.5(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 4.0.1
@@ -11886,6 +11936,14 @@ snapshots:
       '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@5.0.11(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@5.0.2(zod@4.3.6)':
@@ -11925,6 +11983,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@4.0.1':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -16012,10 +16074,20 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/core@3.29.5':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.8':
     dependencies:
       '@smithy/core': 3.29.3
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.4.10':
+    dependencies:
+      '@smithy/core': 3.29.5
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.4.5':
@@ -16255,6 +16327,11 @@ snapshots:
   '@smithy/util-utf8@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.4.10':
+    dependencies:
+      '@smithy/core': 3.29.5
       tslib: 2.8.1
 
   '@smithy/util-utf8@4.4.5':
@@ -19157,6 +19234,8 @@ snapshots:
   events@3.3.0: {}
 
   eventsource-parser@3.0.8: {}
+
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:


### PR DESCRIPTION
## What does this PR do?

Fixes Amazon Bedrock Claude Sonnet 5 evaluator calls that fail because the provider sends unsupported `output_config.format` fields.

- upgrades the shared `@ai-sdk/amazon-bedrock` provider to `5.0.24`, whose Sonnet 5 capability guard falls back to a synthetic JSON tool
- adds a wire-shape regression proving `us.anthropic.claude-sonnet-5` structured output uses `toolConfig` while preserving existing provider options
- leaves the separate web Bedrock v4 dependency unchanged

Linear: [LFE-14350](https://linear.app/clickhouse/issue/LFE-14350/sonnet-5-evaluator-setup-fails-with-extra-inputs-in-output)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Validation

- `pnpm --filter @langfuse/shared run test requestShape.test.ts` — 16 passed
- `pnpm --filter web run test src/__tests__/server/unit/evaluator-preflight.servertest.ts` — 6 passed
- `pnpm --filter worker run test src/features/evaluation/executeLLMAsJudgeEvaluation.test.ts` — 37 passed
- `pnpm run lint` — 7 successful, 7 total

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upgrades the shared Amazon Bedrock AI SDK provider and adds a Sonnet 5 structured-output request-shape regression.
- Updates `@ai-sdk/amazon-bedrock` from 5.0.8 to 5.0.24 and refreshes its transitive lockfile entries.
- Extends the capture-fetch helper to produce request-dependent mock responses.
- Verifies Sonnet 5 structured output uses a synthetic JSON tool while preserving Bedrock provider options.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking gap in the regression test’s assertion of the original failure condition.

The dependency and lockfile changes are consistent, and the new test exercises the intended JSON-tool fallback, but its request-dependent mock can accept a request that still includes the unsupported structured-output field.

packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/llm/ai-sdk/requestShape.test.ts:643
**Unsupported field remains unasserted**

The request-dependent mock returns a successful tool response whenever `toolConfig` is present, but the assertions never verify that the unsupported `output_config.format` field is absent. The regression can therefore pass without protecting against the original Bedrock validation failure.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): support Sonnet 5 on Bedrock"](https://github.com/langfuse/langfuse/commit/b02e584e138c463311e14e03db72483890ad041d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46700768)</sub>

**Context used:**

- Knowledge Base — [Prompt Management and Playground](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->