### PR TITLE
build: remove pg 12 from CI and pin CH to 25.12 in docker-compose

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -468,7 +468,7 @@ jobs:
     strategy:
       matrix:
         node-version: [24]
-        postgres-version: [12, 15]
+        postgres-version: [15]
         deploy-mode: ["", "-azure", "-redis-cluster"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -630,7 +630,7 @@ jobs:
     strategy:
       matrix:
         node-version: [24]
-        postgres-version: [12, 15]
+        postgres-version: [15]
         deploy-mode: ["", "-azure", "-redis-cluster"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-}
 
   clickhouse:
-    image: docker.io/clickhouse/clickhouse-server
+    image: docker.io/clickhouse/clickhouse-server:25.12
     restart: always
     user: "101:101"
     environment:


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR narrows the PostgreSQL CI matrix and pins the default Docker Compose ClickHouse service.
- Changes the web-test PostgreSQL matrix from versions 12 and 15 to version 15 only.
- Pins the ClickHouse server image in `docker-compose.yml` to version 25.12.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until the PostgreSQL matrix retains version 12 and removes version 15 as intended.

The changed matrix leaves PostgreSQL 15 as the sole effective web-test version and eliminates PostgreSQL 12 coverage even though the repository still maintains PostgreSQL 12 compatibility behavior.

.github/workflows/pipeline.yml
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/pipeline.yml:471
**PostgreSQL 12 coverage is removed**

When the web-test matrix runs, this leaves PostgreSQL 15 as its only database version instead of removing 15 as intended, causing PostgreSQL 12 compatibility regressions to pass CI undetected.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["build: remove pg 15 from CI and pin CH t..."](https://github.com/langfuse/langfuse/commit/2555e1b47010192f2f3eaf4694f80a06d8ed7bf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46697123)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->