### PR TITLE
fix(search-bar): preset preview clips instead of resizing the search bar (LFE-11067)

### DIFF
--- a/web/src/features/search-bar/components/ComposerWithPreview.tsx
+++ b/web/src/features/search-bar/components/ComposerWithPreview.tsx
@@ -8,10 +8,14 @@
 // projection, undo history, selection mirroring), and a preview never needs any
 // of that. Stacking keeps the editor MOUNTED — unmounting would wipe its
 // undo/selection/autocomplete refs — and never reprojects its DOM, so a preview
-// cannot interact with editing state by construction. The grid cell sizes to
-// max(editor, preview), so a wrapping preview grows the band instead of
-// clipping. Both surfaces share their chrome via composer-chrome.ts so the
-// overlay renders pixel-identical.
+// cannot interact with editing state by construction. The EDITOR owns the band
+// height (kept mounted + visibility:invisible under an active preview); the
+// preview overlays it ABSOLUTELY and clips (overflow-hidden) to that height, so
+// hovering a long preset preview never resizes the field. Growing the band on
+// hover otherwise fed a layout-thrash loop at narrow widths: the taller field
+// shifted the anchored presets dropdown out from under the cursor, changing the
+// hovered row → the preview → the height, oscillating (LFE-11067). Both surfaces
+// share their chrome via composer-chrome.ts so the overlay renders pixel-identical.
 
 import * as React from "react";
 
@@ -40,12 +44,13 @@ export function ComposerWithPreview(
   );
 
   return (
-    <div className="grid">
+    <div className="relative grid">
       <div
         className={cn(
           "col-start-1 row-start-1 min-w-0",
           // visibility (not display) keeps the editor's height contributing
-          // to the cell, so the band never collapses under a shorter preview.
+          // to the band, so it stays the single source of the band height —
+          // the preview (absolute, below) neither grows nor collapses it.
           previewActive && "invisible",
         )}
       >
@@ -56,7 +61,10 @@ export function ComposerWithPreview(
           data-testid="search-bar-preview"
           data-composer-preview-text={previewText}
           className={cn(
-            "col-start-1 row-start-1 min-w-0",
+            // Overlay the editor's box and clip to its height (rather than a
+            // grid cell sized to max(editor, preview)); a wrapping preview then
+            // clips instead of growing the band — see the header note.
+            "absolute inset-0 min-w-0 overflow-hidden",
             "animate-in fade-in-0 duration-150",
           )}
         >


### PR DESCRIPTION
## TL;DR
Hovering a quick-preset row previewed its query into the search bar; a preview long enough to wrap grew the bar's height. On a narrow screen that fed a **layout-thrash oscillation**. Now the preview **clips** to the bar's height and never resizes it.

## Why
The preview surface shared a single CSS grid cell with the editor, so the cell sized to `max(editor, preview)` — a two-line preview grew the band. The growth then shifted the anchored presets dropdown out from under the cursor → a different row got hovered → a different-length preview → a different height → repeat. (Mouse-only — there's no hover on touch, so it doesn't affect real mobile; surfaced while testing the filter overlay on a narrow desktop window.)

## What
Keep the **editor as the single source of the band height** (it already stays mounted and `visibility:invisible` under an active preview) and overlay the preview **absolutely** with `overflow-hidden`, so it clips to the editor's height instead of contributing to it. The preview can no longer change the field size — this is the "cut itself, don't resize" approach (chosen over pinning the dropdown position, which is fragile where reflow is actually wanted).

## Result
`ComposerWithPreview` change only. Typecheck + lint clean. The fix is a CSS-structural guarantee (an `absolute inset-0 overflow-hidden` overlay can't grow its parent and clips its content), verified structurally + baseline band height unchanged.

<details>
<summary>Verification note</summary>

The live oscillation needs a project with **real backing presets** to reproduce (the local seed's Quality/Slow/Cost presets are inert — hovering them previews nothing), so I verified the mechanism structurally rather than by driving the loop. On a project with presets: hover a preset that previews a long filter in a narrow window — the bar should hold its height and clip the preview, with no dropdown jitter.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes preset-hover layout oscillation in the search bar.
- Makes the editor the sole source of the composer band height.
- Positions preset previews as absolute overlays and clips overflowing preview content.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The editor remains mounted and determines the wrapper height, while the absolutely positioned preview no longer contributes to layout and intentionally clips overflowing content.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search-bar): preview clips instead o..."](https://github.com/langfuse/langfuse/commit/90aceb57bc8c30a1b2cc5b524722373cca0ca3c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46701345)</sub>

<!-- /greptile_comment -->