### PR TITLE
feat(nav): promote the Assistant launcher to the mobile top bar (LFE-11067)

### DIFF
--- a/web/src/components/layouts/mobile-page-title.tsx
+++ b/web/src/components/layouts/mobile-page-title.tsx
@@ -2,7 +2,6 @@ import { ItemBadge } from "@/src/components/ItemBadge";
 import BreadcrumbComponent from "@/src/components/layouts/breadcrumb";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { PageHeaderControlsSlotTarget } from "@/src/components/layouts/page-header-controls-slot";
-import { InAppAiAgentButton } from "@/src/components/nav/in-app-ai-agent-button";
 import { PageTabs } from "@/src/components/layouts/page-tabs";
 import { type PageHeaderProps } from "@/src/components/layouts/page-header";
 import {
@@ -106,11 +105,12 @@ export const MobilePageTitle = ({
         </div>
       )}
 
-      {/* Hoisted page controls (time range, auto-refresh) + agent launcher.
-          Temporary home until the expandable bottom bar owns them. */}
+      {/* Hoisted page controls (time range, auto-refresh). The assistant
+          launcher lives in the sticky MobileTopBar now (prominent + always
+          reachable), not here where it wrapped onto its own line and shrank to
+          an easily-missed icon. */}
       <div className="mt-2 flex flex-wrap items-center gap-2">
         <PageHeaderControlsSlotTarget />
-        <InAppAiAgentButton />
       </div>
 
       {tabsProps && <PageTabs {...tabsProps} scrollable className="mt-2" />}

--- a/web/src/components/layouts/mobile-top-bar.tsx
+++ b/web/src/components/layouts/mobile-top-bar.tsx
@@ -5,6 +5,7 @@ import { useSidebar } from "@/src/components/ui/sidebar";
 import { TopbarBrand } from "@/src/components/nav/topbar-brand";
 import { useHasAppSidebar } from "@/src/components/nav/sidebar-presence";
 import { TopbarAccount } from "@/src/components/nav/topbar-account";
+import { InAppAiAgentButton } from "@/src/components/nav/in-app-ai-agent-button";
 import { EnvLabel } from "@/src/components/EnvLabel";
 
 /**
@@ -53,8 +54,11 @@ export const MobileTopBar = ({
       {/* Center: the Langfuse wordmark. */}
       <TopbarBrand variant="wordmark" />
 
-      {/* Right: account. Balances the left slot so the brand stays centered. */}
-      <div className="flex min-w-0 flex-1 items-center justify-end">
+      {/* Right: the assistant launcher (prominent, gradient-bordered so it
+          reads as a real entry point here) + account. Balances the left slot
+          so the brand stays centered. */}
+      <div className="flex min-w-0 flex-1 items-center justify-end gap-1">
+        <InAppAiAgentButton prominent />
         <TopbarAccount />
       </div>
     </div>

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -12,8 +12,17 @@ import { cn } from "@/src/utils/tailwind";
 
 /** Launcher only — the assistant window itself is rendered by
  * InAppAgentWindowHost from the persistent authenticated layout, so it
- * survives the per-page remount of this button on navigation. */
-export const InAppAiAgentButton = () => {
+ * survives the per-page remount of this button on navigation.
+ *
+ * `prominent` is the compact, icon-only launcher for the mobile top bar: a
+ * gradient border in the agent's own palette (the colors of its window's
+ * conic-gradient) so the entry point stands out, instead of the easily-missed
+ * ghost icon it became when buried in the wrapping page controls row. */
+export const InAppAiAgentButton = ({
+  prominent = false,
+}: {
+  prominent?: boolean;
+} = {}) => {
   const { open, setOpen, openAssistant } = useInAppAiAgent();
   const canUseAssistant = useCanUseInAppAgent();
 
@@ -65,13 +74,31 @@ export const InAppAiAgentButton = () => {
       aria-pressed={open}
       data-ignore-outside-interaction
       onClick={() => toggleAssistant("top_nav")}
+      // Gradient border in the agent palette (its window's conic-gradient
+      // colors). Inline style rather than Tailwind arbitrary values: a
+      // two-layer background with per-layer clip is fiddly to quote, and this
+      // also overrides the outline variant's own border/bg cleanly.
+      style={
+        prominent
+          ? {
+              border: "1.5px solid transparent",
+              background:
+                "linear-gradient(hsl(var(--background)), hsl(var(--background))) padding-box, linear-gradient(130deg, var(--color-2), var(--color-3)) border-box",
+            }
+          : undefined
+      }
       className={cn(
         "gap-2",
-        open &&
+        // Compact icon-only launcher for the top bar.
+        prominent && "size-9 shrink-0 px-0",
+        !prominent &&
+          open &&
           "border-primary-accent bg-primary-accent/10 hover:bg-primary-accent/15",
       )}
     >
-      <BotMessageSquare className="h-4 w-4" />
+      <BotMessageSquare
+        className={cn("h-4 w-4", prominent && open && "text-primary-accent")}
+      />
       <span className="hidden sm:inline">Assistant</span>
       <KeyboardShortcut
         className="bg-transparent shadow-none"

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -99,17 +99,24 @@ export const InAppAiAgentButton = ({
       <BotMessageSquare
         className={cn("h-4 w-4", prominent && open && "text-primary-accent")}
       />
-      <span className="hidden sm:inline">Assistant</span>
-      <KeyboardShortcut
-        className="bg-transparent shadow-none"
-        keys={[
-          typeof navigator !== "undefined" &&
-          navigator.userAgent.includes("Mac")
-            ? "⌘"
-            : "Ctrl",
-          "I",
-        ]}
-      />
+      {/* The prominent launcher is a fixed 36px square (top bar, below md), so
+          it stays strictly icon-only — the `sm:inline` label would otherwise
+          reveal in the 640–767px band and overflow the box. */}
+      {!prominent && (
+        <>
+          <span className="hidden sm:inline">Assistant</span>
+          <KeyboardShortcut
+            className="bg-transparent shadow-none"
+            keys={[
+              typeof navigator !== "undefined" &&
+              navigator.userAgent.includes("Mac")
+                ? "⌘"
+                : "Ctrl",
+              "I",
+            ]}
+          />
+        </>
+      )}
     </Button>
   );
 };


### PR DESCRIPTION
## TL;DR
On mobile the Assistant was a ghost icon tucked at the end of the page's controls row — it wrapped onto its own line and shrank so much it was easy to miss. It's now a **prominent, gradient-bordered launcher in the sticky top bar**, consistent on every page.

## Why
The launcher sat in `MobilePageTitle`'s hoisted controls row (next to the time-range), in a `flex-wrap` container: at narrow widths it wrapped to a second line, and with the label/`⌘I` hidden on mobile it collapsed to a bare icon with no emphasis. Low visibility for a primary feature.

## What
- New `prominent` variant on `InAppAiAgentButton`: a compact, icon-only launcher with a **gradient border in the agent's own palette** (`--color-2`/`--color-3` — the colors of the agent window's conic-gradient), so the entry point reads as distinct. (Inline style for the two-layer gradient border — cleaner than fighting the outline variant + Tailwind arbitrary-value quoting.)
- Placed it in `MobileTopBar`'s right slot, before the account avatar.
- Removed it from `MobilePageTitle`'s controls row.
- Desktop (`PageHeader`) is unchanged — it keeps the full labeled `Assistant ⌘I` button.

## Result
Verified at 390px: single launcher in the top bar (top-right), gradient border, no wrap, no horizontal overflow; the controls row below is now just the time-range. Because it's in the shared `MobileTopBar`, it appears identically on all mobile pages (and stays gated by `useCanUseInAppAgent`, so it's absent on public-share/MinimalLayout).

<details>
<summary>Tuning note</summary>

The gradient border is static and subtle (1.5px). Easy to make it bolder / add a hover or on-open emphasis if you want more pop — say the word.
</details>

Part of the LFE-11067 mobile interface revamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves the mobile Assistant launcher into the shared sticky top bar.
- Adds a compact gradient-bordered `prominent` launcher variant.
- Removes the launcher from the mobile page controls row.
- Places the new launcher before the account avatar while leaving the desktop launcher unchanged.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The responsive label overflow in the new mobile launcher should be fixed before merging.

At 640–767px, the mobile top bar remains active while the Assistant label becomes visible inside a fixed 36px launcher, causing its contents to overflow and crowd neighboring controls.

web/src/components/nav/in-app-ai-agent-button.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/nav/in-app-ai-agent-button.tsx:93
**Responsive label overflows launcher**

When the viewport is 640–767px wide, the mobile top bar still renders while `hidden sm:inline` reveals the Assistant label inside this fixed 36px square, causing the text to overflow the launcher and crowd the adjacent account control.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(nav): promote the Assistant launche..."](https://github.com/langfuse/langfuse/commit/a22aa4def1d21fe57180e01c76e369d5b3c4c329) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46709487)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->