### PR TITLE
chore(storybook): fix two story-guide violations (layout decorator + variant name)

### DIFF
--- a/web/src/components/ScoreTag.mdx
+++ b/web/src/components/ScoreTag.mdx
@@ -24,7 +24,7 @@ The coding is **global**: one hue per level, identical on every surface
 hues are theme tokens in `globals.css` (light + dark) and live only in
 `score-tag.tsx` — never restate them at a call site.
 
-<Canvas of={ScoreTagStories.AllLevels} />
+<Canvas of={ScoreTagStories.VariantMatrix} />
 
 ## Full vs compact
 

--- a/web/src/components/ScoreTag.stories.tsx
+++ b/web/src/components/ScoreTag.stories.tsx
@@ -24,7 +24,7 @@ const ALL_LEVELS = Object.keys(SCORE_LEVEL_LABELS) as ScoreLevel[];
 
 // The global score-level color coding at a glance: all four levels, full pill
 // and compact dot. Flip the toolbar theme to check the dark-mode tokens.
-export const AllLevels = meta.story({
+export const VariantMatrix = meta.story({
   args: {
     level: "trace",
   },

--- a/web/src/features/chart-view/components/ChartViewPanel.stories.tsx
+++ b/web/src/features/chart-view/components/ChartViewPanel.stories.tsx
@@ -46,17 +46,12 @@ const meta = preview.meta({
     config: DEFAULT_CONFIG,
     data: DATA,
     onConfigChange: fn(),
+    // In production the panel fills a bounded-height flex ancestor (`flex-1`
+    // inside `EventsChartView`); standalone it needs an explicit height. Give it
+    // one through the component's own `className` prop rather than a layout
+    // decorator (Storybook guide: render the component as it is).
+    className: "h-[420px]",
   },
-  decorators: [
-    // `ChartViewPanel`'s root relies on a bounded-height flex ancestor
-    // (`flex-1`/`min-h-0`) — same as its production host (`EventsChartView`
-    // inside the events table) — so give it one here.
-    (Story) => (
-      <div className="flex h-[420px] flex-col">
-        <Story />
-      </div>
-    ),
-  ],
 });
 
 export const Default = meta.story({});

--- a/web/src/features/chart-view/components/ChartViewPanel.tsx
+++ b/web/src/features/chart-view/components/ChartViewPanel.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 import { type DashboardWidgetChartType } from "@langfuse/shared/src/db";
 import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props";
 import { Button } from "@/src/components/ui/button";
+import { cn } from "@/src/utils/tailwind";
 import {
   type AggregationFn,
   type ChartViewConfig,
@@ -35,6 +36,7 @@ export const ChartViewPanel = React.memo(function ChartViewPanel({
   emptyMessage,
   granularitySlot,
   chartActions,
+  className,
 }: {
   config: ChartViewConfig;
   onConfigChange: (patch: Partial<ChartViewConfig>) => void;
@@ -45,6 +47,10 @@ export const ChartViewPanel = React.memo(function ChartViewPanel({
   granularitySlot?: React.ReactNode;
   /** Right-aligned actions next to the chart subtitle (e.g. "Add to dashboard"). */
   chartActions?: React.ReactNode;
+  /** Root class passthrough. The panel fills a bounded-height flex ancestor via
+   *  `flex-1`; a standalone caller (e.g. a story) can give it an explicit height
+   *  here instead of relying on a host. */
+  className?: string;
 }) {
   const [open, setOpen] = useState(true);
 
@@ -66,7 +72,7 @@ export const ChartViewPanel = React.memo(function ChartViewPanel({
   );
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+    <div className={cn("flex min-h-0 flex-1 flex-col md:flex-row", className)}>
       {/* Canvas — floored on mobile so a tall stacked config panel can't shrink
           the chart to 0 on short viewports (flex-basis:0 gets none of a negative
           deficit); desktop keeps min-h-0 for the side-by-side row. */}


### PR DESCRIPTION
## TL;DR

Two Storybook-guide violations found by auditing recently-merged stories against `WritingGoodStories.mdx`. Both were in main; neither breaks CI, both are quick.

## What

- **`ChartViewPanel.stories.tsx`** used a `decorators` wrapper to give the panel a bounded-height flex host — the guide says *"never use decorators to add styling or layout; render the component as it is."* The panel's root is `flex-1` (fills a host in production), so standalone it needs a height. Fix: add a `className` passthrough to `ChartViewPanel` and set the story height via that **prop** (`className: "h-[420px]"`) instead of a decorator. Production callers pass no `className`, so they're unaffected.
- **`ScoreTag.stories.tsx`** named its variant-grid story `AllLevels`; the guide requires `VariantMatrix` (and explicitly calls out avoiding generic names like `AllVariants`). Renamed the export and updated the `ScoreTag.mdx` `<Canvas>` reference.

## Verify

- `pnpm --filter web run test-storybook ChartViewPanel ScoreTag` → 5 stories render (incl. `Default` with the new className height, and the renamed `VariantMatrix`).
- Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates Storybook stories to follow repository conventions.
- Renames the ScoreTag variant-grid story to `VariantMatrix` and updates its MDX reference.
- Adds an optional root `className` to `ChartViewPanel`.
- Sets the standalone ChartViewPanel story height through the component prop instead of a layout decorator.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The renamed story reference is updated consistently, and applying a fixed height to the panel root preserves the bounded height required by its internal flex layout without changing production callers.

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(storybook): fix two story-guide vi..."](https://github.com/langfuse/langfuse/commit/dc6af413f4ded5c2025d3a03d4b0949be8a4dcc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46709913)</sub>

<!-- /greptile_comment -->