### PR TITLE
docs: link self-hosting update newsletter from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Run Langfuse on your own infrastructure:
 
 See [self-hosting documentation](https://langfuse.com/self-hosting) to learn more about architecture and configuration options.
 
+> [!TIP]
+> **Self-hosting Langfuse?** Subscribe to the [self-hosting update list](https://langfuse.com/self-hosting#subscribe) to get an email about important features and new releases for open source Langfuse — self-hosting updates only, no marketing.
+
 ## 🔌 Integrations
 
 <img width="2400" alt="integrations" src="https://github.com/user-attachments/assets/b85c9a45-68f0-4f76-b545-0e8632abef9f" />


### PR DESCRIPTION
## Summary

Adds a short tip to the **Self-Host** section of the README pointing self-hosters to a new open source update mailing list — self-hosting feature updates and releases only, no marketing.

The link deep-links to the `#subscribe` anchor on the self-hosting docs overview, where the signup box lives.

## Related

- Companion PR in `langfuse/langfuse-docs` (#3369) adds the signup box, the dedicated Loops list wiring, and the `#subscribe` anchor this link targets.

Note: the repo's Prettier `format:check` only covers `js/jsx/ts/tsx/css`, so this Markdown-only change is not reformatted by CI. The change is a single `> [!TIP]` block with no unrelated edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a README tip directing self-hosters to the open-source update mailing list.
- Links directly to the subscription section of the self-hosting documentation.
- Clarifies that the list covers self-hosting features and releases without marketing.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The new tip uses an admonition format already established in the README, and its external deep link intentionally targets the subscription anchor supplied by the companion documentation change.

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: link self-hosting update newslette..."](https://github.com/langfuse/langfuse/commit/5ec639f87846173b7f830a6ed7a9cb8a700c3f98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46723359)</sub>

<!-- /greptile_comment -->