### PR TITLE
fix: getBlobStorageByProjectIdBeforeDate is a streaming query that shouldn't be killed by aggressive max_execution_time

### DIFF
--- a/packages/shared/src/server/repositories/blobStorageLog.ts
+++ b/packages/shared/src/server/repositories/blobStorageLog.ts
@@ -65,6 +65,11 @@ export const getBlobStorageByProjectIdBeforeDate = (
       projectId,
       beforeDate: convertDateToClickhouseDateTime(beforeDate),
     },
+    clickhouseConfigs: {
+      clickhouse_settings: {
+        max_execution_time: 0,
+      },
+    },
     tags: { projectId },
   });
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables ClickHouse’s server-side execution timeout for the date-bounded blob-storage streaming query so long-running retention cleanup streams can complete.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The timeout override is scoped to a distinctly configured ClickHouse client for this streaming query, and existing client configuration merging allows the explicit setting to override the derived execution limit.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: getBlobStorageByProjectIdBeforeDate..."](https://github.com/langfuse/langfuse/commit/fd72a54bfb56327990e7146b96bb714880c095a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46779001)</sub>

<!-- /greptile_comment -->