### PR TITLE
fix(v4): more comprehensive stats wiring

### DIFF
--- a/packages/shared/scripts/seeder/scenarios/scored-traces.ts
+++ b/packages/shared/scripts/seeder/scenarios/scored-traces.ts
@@ -71,6 +71,29 @@ const TRACE_NAMES = [
   "classify-intent",
 ] as const;
 
+const SDK_ATTRIBUTION_PROFILES = [
+  {
+    key: "python-legacy",
+    ingestion_sdk_name: "python",
+    ingestion_sdk_version: "4.6.9",
+  },
+  {
+    key: "python-current",
+    ingestion_sdk_name: "python",
+    ingestion_sdk_version: "4.7.1",
+  },
+  {
+    key: "javascript-legacy",
+    ingestion_sdk_name: "@langfuse/tracing",
+    ingestion_sdk_version: "5.3.9",
+  },
+  {
+    key: "javascript-current",
+    ingestion_sdk_name: "@langfuse/tracing",
+    ingestion_sdk_version: "5.4.1",
+  },
+] as const;
+
 const run = async (
   ctx: ScenarioContext,
   params: Record<string, string | number | boolean>,
@@ -130,6 +153,14 @@ const run = async (
   const events: EventRecordInsertType[] = [];
 
   for (let t = 0; t < traceCount; t++) {
+    const scoreStartIndex = scores.length;
+    const sdkAttribution =
+      SDK_ATTRIBUTION_PROFILES[t % SDK_ATTRIBUTION_PROFILES.length]!;
+    const ingestionAttribution = {
+      ingestion_api_key: `pk-lf-seed-${ctx.idPrefix}-${sdkAttribution.key}`,
+      ingestion_sdk_name: sdkAttribution.ingestion_sdk_name,
+      ingestion_sdk_version: sdkAttribution.ingestion_sdk_version,
+    };
     const traceId = `${ctx.idPrefix}-t${t}`;
     const timestamp =
       startMs + Math.floor(t * stepMs) + jitter(ctx.seed, t, 1000);
@@ -347,9 +378,15 @@ const run = async (
     );
 
     if (withV4) {
-      const traceEvent = traceToEvent(trace);
+      const traceEvent = {
+        ...traceToEvent(trace),
+        ...ingestionAttribution,
+      };
       events.push(traceEvent);
-      events.push(observationToEvent(observation, trace));
+      events.push({
+        ...observationToEvent(observation, trace),
+        ...ingestionAttribution,
+      });
 
       // Observation-level score attached to the v4 ROOT span (`t-<traceId>`):
       // the root's inline chips then MIX trace-level and observation-level
@@ -372,6 +409,10 @@ const run = async (
           timestamp,
         }),
       );
+    }
+
+    for (const score of scores.slice(scoreStartIndex)) {
+      Object.assign(score, ingestionAttribution);
     }
   }
 
@@ -462,7 +503,7 @@ const run = async (
 export const scoredTracesScenario: ScenarioDefinition = {
   name: "scored-traces",
   description:
-    'Standalone traces each carrying numeric + categorical scores whose names contain SPACES (e.g. "Rouge Score") at observation and trace level, plus DUAL-LEVEL names ("confidence", "verdict") that exist at BOTH levels on the same trace — observation confidence < 0.5 <= trace confidence, verdict "pass" trace-only — for the level-agnostic scores filter + ScoreTag edge case (LFE-10596).',
+    'Standalone traces with mixed current/legacy Python and JavaScript SDK attribution, each carrying numeric + categorical scores whose names contain SPACES (e.g. "Rouge Score") at observation and trace level, plus DUAL-LEVEL names ("confidence", "verdict") that exist at BOTH levels on the same trace — observation confidence < 0.5 <= trace confidence, verdict "pass" trace-only — for the level-agnostic scores filter + ScoreTag edge case (LFE-10596).',
   supportsV4: true,
   flags: [
     {

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -1289,7 +1289,7 @@ describe("v4TransitionRouter", () => {
     expect(rows).toEqual([
       {
         projectId,
-        outdatedSdkUsageSeriesCount: 1,
+        outdatedSdkUsageSeriesCount: 2,
         sdkUsageSeries: [
           {
             sdkName: "python",
@@ -1319,7 +1319,7 @@ describe("v4TransitionRouter", () => {
       },
       {
         projectId: secondProjectId,
-        outdatedSdkUsageSeriesCount: 0,
+        outdatedSdkUsageSeriesCount: 1,
         sdkUsageSeries: [
           {
             sdkName: "@langfuse/tracing",

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -1247,21 +1247,28 @@ describe("v4TransitionRouter", () => {
         sdkName: "python",
         sdkVersion: "3.9.0",
         publicKey: "pk-lf-old-python",
-        count: "8",
+        lastSeen: "2026-06-24T12:00:00Z",
       },
       {
         projectId,
         sdkName: "python",
-        sdkVersion: "4.0.0",
+        sdkVersion: "4.6.9",
+        publicKey: "pk-lf-pre-v4-python",
+        lastSeen: "2026-06-24T13:00:00Z",
+      },
+      {
+        projectId,
+        sdkName: "python",
+        sdkVersion: "4.7.0",
         publicKey: "pk-lf-current-python",
-        count: "13",
+        lastSeen: "2026-06-24T14:00:00Z",
       },
       {
         projectId: secondProjectId,
         sdkName: "@langfuse/tracing",
-        sdkVersion: "4.2.0",
-        publicKey: "pk-lf-old-js",
-        count: "5",
+        sdkVersion: "5.3.9",
+        publicKey: "pk-lf-pre-v4-js",
+        lastSeen: "2026-06-24T15:00:00Z",
       },
     ]);
     const mockPrisma = {
@@ -1283,10 +1290,46 @@ describe("v4TransitionRouter", () => {
       {
         projectId,
         outdatedSdkUsageSeriesCount: 1,
+        sdkUsageSeries: [
+          {
+            sdkName: "python",
+            sdkVersion: "3.9.0",
+            canonicalSdkName: "python",
+            publicKey: "pk-lf-old-python",
+            lastSeen: "2026-06-24T12:00:00Z",
+            v4MigrationStatus: "upgrade_required",
+          },
+          {
+            sdkName: "python",
+            sdkVersion: "4.6.9",
+            canonicalSdkName: "python",
+            publicKey: "pk-lf-pre-v4-python",
+            lastSeen: "2026-06-24T13:00:00Z",
+            v4MigrationStatus: "upgrade_required",
+          },
+          {
+            sdkName: "python",
+            sdkVersion: "4.7.0",
+            canonicalSdkName: "python",
+            publicKey: "pk-lf-current-python",
+            lastSeen: "2026-06-24T14:00:00Z",
+            v4MigrationStatus: "compatible",
+          },
+        ],
       },
       {
         projectId: secondProjectId,
-        outdatedSdkUsageSeriesCount: 1,
+        outdatedSdkUsageSeriesCount: 0,
+        sdkUsageSeries: [
+          {
+            sdkName: "@langfuse/tracing",
+            sdkVersion: "5.3.9",
+            canonicalSdkName: "javascript",
+            publicKey: "pk-lf-pre-v4-js",
+            lastSeen: "2026-06-24T15:00:00Z",
+            v4MigrationStatus: "upgrade_required",
+          },
+        ],
       },
     ]);
 
@@ -1312,6 +1355,7 @@ describe("v4TransitionRouter", () => {
     expect(usageQuery?.query).toContain(
       "GROUP BY project_id, sdk_name, sdk_version, public_key",
     );
+    expect(usageQuery?.query).toContain("max(event_time)");
     expect(usageQuery?.params).toMatchObject({
       projectIds: [projectId, secondProjectId],
       fromTimestamp: "2026-06-24 00:00:00.000",

--- a/web/src/features/events/hooks/useAppRootDefault.ts
+++ b/web/src/features/events/hooks/useAppRootDefault.ts
@@ -80,7 +80,6 @@ export function useAppRootDefault(params: {
   const sdkVersionState = useProjectSdkVersionInfo({
     projectId,
     enabled: enabled && router.isReady && !dismissed,
-    refreshMode: "if-stale",
   });
 
   const defaultViewQuery = api.TableViewPresets.getDefault.useQuery(
@@ -104,7 +103,6 @@ export function useAppRootDefault(params: {
     routerReady: router.isReady,
     appRootSupported,
     sdkCheckedAt: sdkVersionState.checkedAt,
-    sdkCheckSettled: sdkVersionState.querySettled,
     preference,
     defaultViewSettled: !defaultViewQuery.isLoading,
     savedViewOwnsState,

--- a/web/src/features/events/lib/appRootDefault.clienttest.ts
+++ b/web/src/features/events/lib/appRootDefault.clienttest.ts
@@ -42,7 +42,10 @@ describe("app-root default policy", () => {
     ["typescript", "5.10.0", "supported"],
     ["python", "4.7.0", "supported"],
     ["python", "4.6.9", "unsupported"],
-    ["python", "4.7.0rc1", "unknown"],
+    ["python", "4.7.0rc1", "supported"],
+    ["python", "4.6.9rc1", "unsupported"],
+    ["javascript", "5.4.0-beta.1", "supported"],
+    ["javascript", "5.3.9-beta.1", "unsupported"],
     ["custom", "1.0.0", "unknown"],
   ] as const)(
     "reports the %s %s capability status as %s",

--- a/web/src/features/events/lib/appRootDefault.clienttest.ts
+++ b/web/src/features/events/lib/appRootDefault.clienttest.ts
@@ -12,6 +12,7 @@ import {
 } from "./appRootDefaultFilterPolicy";
 import {
   getSdkVersionCapability,
+  getSdkVersionCapabilityStatus,
   toSdkVersionInfo,
 } from "@/src/features/sdk-version/lib/sdkVersionCapabilities";
 
@@ -27,7 +28,6 @@ const basePolicy = {
   routerReady: true,
   appRootSupported: true,
   sdkCheckedAt: "2026-07-14T12:00:00.000Z",
-  sdkCheckSettled: false,
   preference: null,
   defaultViewSettled: true,
   savedViewOwnsState: false,
@@ -37,21 +37,25 @@ const basePolicy = {
 
 describe("app-root default policy", () => {
   it.each([
-    ["javascript", "5.4.0", true],
-    ["javascript", "5.3.9", false],
-    ["typescript", "5.10.0", true],
-    ["python", "4.7.0", true],
-    ["python", "4.6.9", false],
-    ["python", "4.7.0rc1", false],
-    ["unknown", "99.0.0", false],
-  ])("classifies %s %s", (name, version, expected) => {
-    expect(
-      getSdkVersionCapability(
-        toSdkVersionInfo({ isOtel: true, name, version }),
-        "appRootObservations",
-      ),
-    ).toBe(expected);
-  });
+    ["javascript", "5.4.0", "supported"],
+    ["javascript", "5.3.9", "unsupported"],
+    ["typescript", "5.10.0", "supported"],
+    ["python", "4.7.0", "supported"],
+    ["python", "4.6.9", "unsupported"],
+    ["python", "4.7.0rc1", "unknown"],
+    ["custom", "1.0.0", "unknown"],
+  ] as const)(
+    "reports the %s %s capability status as %s",
+    (name, version, expected) => {
+      const sdkVersion = toSdkVersionInfo({ isOtel: true, name, version });
+      expect(
+        getSdkVersionCapabilityStatus(sdkVersion, "appRootObservations"),
+      ).toBe(expected);
+      expect(getSdkVersionCapability(sdkVersion, "appRootObservations")).toBe(
+        expected === "supported",
+      );
+    },
+  );
 
   it.each([
     [{}, true],

--- a/web/src/features/events/lib/appRootDefaultFilterPolicy.ts
+++ b/web/src/features/events/lib/appRootDefaultFilterPolicy.ts
@@ -34,7 +34,6 @@ export const getAppRootDefaultPolicy = (params: {
   routerReady: boolean;
   appRootSupported: boolean;
   sdkCheckedAt: string | null;
-  sdkCheckSettled: boolean;
   preference: string | null;
   defaultViewSettled: boolean;
   savedViewOwnsState: boolean;
@@ -42,8 +41,7 @@ export const getAppRootDefaultPolicy = (params: {
   now: number;
 }) => {
   const sdkCheckCached = Number.isFinite(Date.parse(params.sdkCheckedAt ?? ""));
-  const capabilitySupported =
-    params.appRootSupported && (sdkCheckCached || params.sdkCheckSettled);
+  const capabilitySupported = params.appRootSupported && sdkCheckCached;
   const shouldApplyFilter =
     params.enabled &&
     params.routerReady &&

--- a/web/src/features/sdk-version/hooks/useProjectSdkVersionInfo.clienttest.ts
+++ b/web/src/features/sdk-version/hooks/useProjectSdkVersionInfo.clienttest.ts
@@ -1,29 +1,24 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 
-import {
-  useProjectSdkVersionInfo,
-  useProjectsSdkVersionInfo,
-} from "@/src/features/sdk-version/hooks/useProjectSdkVersionInfo";
+import { useProjectSdkVersionInfo } from "@/src/features/sdk-version/hooks/useProjectSdkVersionInfo";
 import { persistProjectSdkVersionInfo } from "@/src/features/sdk-version/lib/sdkVersionStorage";
 import { sdkVersionStorageKeys } from "@/src/features/sdk-version/lib/sdkVersionCapabilities";
 
 const apiMocks = vi.hoisted(() => ({
   getSdkVersionInfo: vi.fn(),
-  queryResults: [] as unknown[],
+  queryResult: null as unknown,
 }));
 
 vi.mock("@/src/utils/api", () => ({
   api: {
-    useQueries: (
-      buildQueries: (router: {
-        events: { getSdkVersionInfo: typeof apiMocks.getSdkVersionInfo };
-      }) => unknown,
-    ) => {
-      buildQueries({
-        events: { getSdkVersionInfo: apiMocks.getSdkVersionInfo },
-      });
-      return apiMocks.queryResults;
+    events: {
+      getSdkVersionInfo: {
+        useQuery: (...args: unknown[]) => {
+          apiMocks.getSdkVersionInfo(...args);
+          return apiMocks.queryResult;
+        },
+      },
     },
   },
 }));
@@ -63,59 +58,29 @@ describe("project SDK version hook", () => {
   beforeEach(() => {
     window.localStorage.clear();
     apiMocks.getSdkVersionInfo.mockReset();
-    apiMocks.queryResults = [];
+    apiMocks.queryResult = pendingQuery;
   });
 
   it("returns cached data immediately while refreshing in the background", () => {
     persistProjectSdkVersionInfo(
       "project-1",
       { language: "javascript", version: "5.4.0" },
-      "2026-07-23T10:00:00.000Z",
+      new Date(Date.now() - 31 * 86_400_000).toISOString(),
     );
-    apiMocks.queryResults = [pendingQuery];
+    apiMocks.queryResult = pendingQuery;
 
     const { result } = renderHook(() =>
       useProjectSdkVersionInfo({
         projectId: "project-1",
         enabled: true,
-        refreshMode: "always",
       }),
     );
 
     expect(result.current).toMatchObject({
       sdkVersion: { language: "javascript", version: "5.4.0" },
-      isRefreshing: true,
     });
     expect(apiMocks.getSdkVersionInfo).toHaveBeenCalledWith(
       { projectId: "project-1" },
-      expect.objectContaining({ enabled: true }),
-    );
-  });
-
-  it("creates one non-blocking query per project", () => {
-    apiMocks.queryResults = [pendingQuery, pendingQuery];
-
-    renderHook(() =>
-      useProjectsSdkVersionInfo({
-        projectIds: ["project-1", "project-2"],
-        enabled: true,
-        refreshMode: "always",
-      }),
-    );
-
-    expect(apiMocks.getSdkVersionInfo).toHaveBeenCalledTimes(2);
-    expect(apiMocks.getSdkVersionInfo).toHaveBeenNthCalledWith(
-      1,
-      { projectId: "project-1" },
-      expect.objectContaining({
-        enabled: true,
-        refetchOnWindowFocus: false,
-        retry: false,
-      }),
-    );
-    expect(apiMocks.getSdkVersionInfo).toHaveBeenNthCalledWith(
-      2,
-      { projectId: "project-2" },
       expect.objectContaining({ enabled: true }),
     );
   });
@@ -131,15 +96,14 @@ describe("project SDK version hook", () => {
         { language: "python", version: "4.7.0" },
         checkedAt,
       );
-      apiMocks.queryResults = [
-        enabled ? pendingQuery : { ...pendingQuery, isFetching: false },
-      ];
+      apiMocks.queryResult = enabled
+        ? pendingQuery
+        : { ...pendingQuery, isFetching: false };
 
       renderHook(() =>
         useProjectSdkVersionInfo({
           projectId: "project-1",
           enabled: true,
-          refreshMode: "if-stale",
         }),
       );
 
@@ -152,28 +116,24 @@ describe("project SDK version hook", () => {
 
   it("persists a settled query in the shared app-root cache", async () => {
     const checkedAt = new Date("2026-07-23T10:00:00.000Z").getTime();
-    apiMocks.queryResults = [
-      {
-        data: { isOtel: true, name: "python", version: "4.7.1" },
-        dataUpdatedAt: checkedAt,
-        isFetching: false,
-        isSuccess: true,
-        isError: false,
-      },
-    ];
+    apiMocks.queryResult = {
+      data: { isOtel: true, name: "python", version: "4.7.1" },
+      dataUpdatedAt: checkedAt,
+      isFetching: false,
+      isSuccess: true,
+      isError: false,
+    };
 
     const { result } = renderHook(() =>
       useProjectSdkVersionInfo({
         projectId: "project-1",
         enabled: true,
-        refreshMode: "always",
       }),
     );
 
     expect(result.current).toMatchObject({
       sdkVersion: { language: "python", version: "4.7.1" },
       checkedAt: new Date(checkedAt).toISOString(),
-      querySettled: true,
     });
 
     const keys = sdkVersionStorageKeys("project-1");

--- a/web/src/features/sdk-version/hooks/useProjectSdkVersionInfo.ts
+++ b/web/src/features/sdk-version/hooks/useProjectSdkVersionInfo.ts
@@ -5,25 +5,10 @@ import {
   sdkVersionNeedsRefresh,
   sdkVersionStorageKeys,
   toSdkVersionInfo,
-  type SdkVersionInfo,
 } from "@/src/features/sdk-version/lib/sdkVersionCapabilities";
 import { persistProjectSdkVersionInfo } from "@/src/features/sdk-version/lib/sdkVersionStorage";
 
-type ProjectSdkVersionRefreshMode = "if-stale" | "always";
-
-export type ProjectSdkVersionState = {
-  sdkVersion: SdkVersionInfo | undefined;
-  checkedAt: string | null;
-  isRefreshing: boolean;
-  querySettled: boolean;
-  isError: boolean;
-};
-
-const MIGRATION_QUERY_STALE_TIME_MS = 5 * 60 * 1000;
-
-const readCachedSdkVersion = (
-  projectId: string,
-): Pick<ProjectSdkVersionState, "sdkVersion" | "checkedAt"> => {
+const readCachedSdkVersion = (projectId: string) => {
   if (typeof window === "undefined") {
     return { sdkVersion: undefined, checkedAt: null };
   }
@@ -45,97 +30,50 @@ const readCachedSdkVersion = (
   }
 };
 
-export function useProjectsSdkVersionInfo(params: {
-  projectIds: readonly string[];
-  enabled: boolean;
-  refreshMode: ProjectSdkVersionRefreshMode;
-}): Map<string, ProjectSdkVersionState> {
-  const { projectIds, enabled, refreshMode } = params;
-  const cachedSdkVersions = projectIds.map(readCachedSdkVersion);
-  const now = Date.now();
-  const shouldQuery = cachedSdkVersions.map(({ checkedAt }) => {
-    return (
-      enabled &&
-      (refreshMode === "always" || sdkVersionNeedsRefresh(checkedAt, now))
-    );
-  });
-
-  const queries = api.useQueries((t) =>
-    projectIds.map((projectId, index) =>
-      t.events.getSdkVersionInfo(
-        { projectId },
-        {
-          enabled: shouldQuery[index],
-          refetchOnWindowFocus: false,
-          retry: false,
-          staleTime:
-            refreshMode === "always"
-              ? MIGRATION_QUERY_STALE_TIME_MS
-              : undefined,
-        },
-      ),
-    ),
-  );
-
-  useEffect(() => {
-    queries.forEach((query, index) => {
-      if (!query.isSuccess || query.isFetching || !query.data) return;
-
-      const sdkVersion = toSdkVersionInfo(query.data);
-      if (!sdkVersion) return;
-
-      persistProjectSdkVersionInfo(
-        projectIds[index]!,
-        sdkVersion,
-        new Date(query.dataUpdatedAt).toISOString(),
-      );
-    });
-  }, [projectIds, queries]);
-
-  return new Map(
-    projectIds.map((projectId, index) => {
-      const query = queries[index];
-      const cachedSdkVersion = cachedSdkVersions[index]!;
-      const querySettled = Boolean(
-        query?.isSuccess && !query.isFetching && query.data,
-      );
-      const queryCheckedAt = querySettled
-        ? new Date(query!.dataUpdatedAt).toISOString()
-        : null;
-
-      return [
-        projectId,
-        {
-          sdkVersion:
-            toSdkVersionInfo(query?.data) ?? cachedSdkVersion.sdkVersion,
-          checkedAt: queryCheckedAt ?? cachedSdkVersion.checkedAt,
-          isRefreshing: Boolean(shouldQuery[index] && query?.isFetching),
-          querySettled,
-          isError: Boolean(query?.isError && !cachedSdkVersion.sdkVersion),
-        },
-      ];
-    }),
-  );
-}
-
 export function useProjectSdkVersionInfo(params: {
   projectId: string;
   enabled: boolean;
-  refreshMode: ProjectSdkVersionRefreshMode;
-}): ProjectSdkVersionState {
-  const sdkVersions = useProjectsSdkVersionInfo({
-    projectIds: [params.projectId],
-    enabled: params.enabled,
-    refreshMode: params.refreshMode,
-  });
-
-  return (
-    sdkVersions.get(params.projectId) ?? {
-      sdkVersion: undefined,
-      checkedAt: null,
-      isRefreshing: false,
-      querySettled: false,
-      isError: false,
-    }
+}) {
+  const { projectId, enabled } = params;
+  const cachedSdkVersion = readCachedSdkVersion(projectId);
+  const now = Date.now();
+  const shouldQuery =
+    enabled && sdkVersionNeedsRefresh(cachedSdkVersion.checkedAt, now);
+  const query = api.events.getSdkVersionInfo.useQuery(
+    { projectId },
+    {
+      enabled: shouldQuery,
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
   );
+
+  useEffect(() => {
+    if (!query.isSuccess || query.isFetching || !query.data) return;
+
+    const sdkVersion = toSdkVersionInfo(query.data);
+    if (!sdkVersion) return;
+
+    persistProjectSdkVersionInfo(
+      projectId,
+      sdkVersion,
+      new Date(query.dataUpdatedAt).toISOString(),
+    );
+  }, [
+    projectId,
+    query.data,
+    query.dataUpdatedAt,
+    query.isFetching,
+    query.isSuccess,
+  ]);
+
+  const queryCheckedAt =
+    query.isSuccess && !query.isFetching && query.data
+      ? new Date(query.dataUpdatedAt).toISOString()
+      : null;
+
+  return {
+    sdkVersion: toSdkVersionInfo(query.data) ?? cachedSdkVersion.sdkVersion,
+    checkedAt: queryCheckedAt ?? cachedSdkVersion.checkedAt,
+  };
 }

--- a/web/src/features/sdk-version/lib/sdkVersionCapabilities.ts
+++ b/web/src/features/sdk-version/lib/sdkVersionCapabilities.ts
@@ -27,6 +27,10 @@ const SDK_VERSION_CAPABILITIES = {
 } as const;
 
 type SdkVersionCapability = keyof typeof SDK_VERSION_CAPABILITIES;
+export type SdkVersionCapabilityStatus =
+  | "supported"
+  | "unsupported"
+  | "unknown";
 
 export const toSdkVersionInfo = (
   sdk: SdkMetadata | undefined,
@@ -58,22 +62,27 @@ const parseStableVersion = (version?: string | null) => {
   return parsed.every(Number.isSafeInteger) ? parsed : null;
 };
 
-export const getSdkVersionCapability = (
+export const getSdkVersionCapabilityStatus = (
   sdk: SdkVersionInfo | undefined,
   capability: SdkVersionCapability,
-): boolean => {
-  if (!sdk) return false;
+): SdkVersionCapabilityStatus => {
+  if (!sdk) return "unknown";
 
   const sdkName = normalizeIngestionSdkName(sdk.language);
   const version = parseStableVersion(sdk.version);
-  if (!sdkName || !version) return false;
+  if (!sdkName || !version) return "unknown";
 
   const minimum = SDK_VERSION_CAPABILITIES[capability][sdkName];
   for (let index = 0; index < version.length; index++) {
     if (version[index] !== minimum[index]) {
-      return version[index]! > minimum[index]!;
+      return version[index]! > minimum[index]! ? "supported" : "unsupported";
     }
   }
 
-  return true;
+  return "supported";
 };
+
+export const getSdkVersionCapability = (
+  sdk: SdkVersionInfo | undefined,
+  capability: SdkVersionCapability,
+): boolean => getSdkVersionCapabilityStatus(sdk, capability) === "supported";

--- a/web/src/features/sdk-version/lib/sdkVersionCapabilities.ts
+++ b/web/src/features/sdk-version/lib/sdkVersionCapabilities.ts
@@ -52,10 +52,10 @@ export const sdkVersionNeedsRefresh = (
   );
 };
 
-const parseStableVersion = (version?: string | null) => {
+const parseVersionCore = (version?: string | null) => {
   const match = version
     ?.trim()
-    .match(/^v?(\d+)\.(\d+)\.(\d+)(?:\+[0-9A-Za-z.-]+)?$/);
+    .match(/^v?(\d+)\.(\d+)\.(\d+)(?:[-+.]?[0-9A-Za-z][0-9A-Za-z.-]*)?$/);
   if (!match) return null;
 
   const parsed = match.slice(1, 4).map(Number);
@@ -69,7 +69,7 @@ export const getSdkVersionCapabilityStatus = (
   if (!sdk) return "unknown";
 
   const sdkName = normalizeIngestionSdkName(sdk.language);
-  const version = parseStableVersion(sdk.version);
+  const version = parseVersionCore(sdk.version);
   if (!sdkName || !version) return "unknown";
 
   const minimum = SDK_VERSION_CAPABILITIES[capability][sdkName];

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -20,10 +20,9 @@ import {
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { cn } from "@/src/utils/tailwind";
-import { type ProjectSdkVersionState } from "@/src/features/sdk-version/hooks/useProjectSdkVersionInfo";
 import {
   formatSdkVersion,
-  type V4MigrationSdkStatus,
+  type V4MigrationSdkState,
 } from "@/src/features/v4-migration/sdkVersionStatus";
 import { useProjectV4MigrationData } from "@/src/features/v4-migration/hooks/useV4MigrationData";
 import {
@@ -31,6 +30,8 @@ import {
   type MigrationCountState,
 } from "@/src/features/v4-migration/migrationData";
 import { numberFormatter } from "@/src/utils/numbers";
+import { formatCompactRelativeTime } from "@/src/utils/dates";
+import { useProject } from "@/src/features/projects/hooks";
 
 // Single source of truth for the v4-migration copy and content. Both surfaces
 // (side panel and modal) render these components — edit copy here only.
@@ -152,53 +153,92 @@ function MigrationCountChip({
   );
 }
 
-function V4MigrationSdkSection({
-  sdkVersionState,
-  status,
-}: {
-  sdkVersionState: ProjectSdkVersionState;
-  status: V4MigrationSdkStatus;
-}) {
-  const detectedSdk = formatSdkVersion(sdkVersionState.sdkVersion);
-
+function V4MigrationSdkSection({ sdk }: { sdk: V4MigrationSdkState }) {
+  const detectedSdkSeries = sdk.sdkUsageSeries.filter(
+    (series) => series.canonicalSdkName !== null,
+  );
   const chip =
-    status === "latest" ? (
+    sdk.status === "latest" ? (
       <Chip variant="success">Up to date</Chip>
-    ) : status === "checking" ? (
+    ) : sdk.status === "checking" ? (
       <Chip variant="warning">Checking</Chip>
-    ) : status === "unknown" ? (
-      <Chip variant="warning">Not detected</Chip>
-    ) : status === "error" ? (
+    ) : sdk.status === "unknown" ? (
+      <Chip variant="warning">
+        {detectedSdkSeries.length > 0 ? "Needs review" : "Not detected"}
+      </Chip>
+    ) : sdk.status === "error" ? (
       <Chip variant="warning">Check failed</Chip>
     ) : (
-      <Chip variant="warning">Legacy</Chip>
+      <Chip variant="warning">{sdk.upgradeRequiredCount} outdated</Chip>
     );
 
   return (
     <Section title="Tracing Instrumentation" chip={chip}>
       <p className="text-muted-foreground text-sm leading-relaxed">
-        {status === "checking" ? (
+        {sdk.status === "checking" ? (
           "Checking the latest traces for this project…"
-        ) : status === "unknown" ? (
-          <>
-            We could not detect an attributed Langfuse SDK in traces from the
-            last 7 days. If this project uses one, verify that it is up to date.
-          </>
-        ) : status === "error" ? (
+        ) : sdk.status === "unknown" ? (
+          detectedSdkSeries.length > 0 ? (
+            "We could not recognize every detected SDK version. Verify that these SDKs are up to date."
+          ) : (
+            <>
+              We could not detect an attributed Langfuse SDK in traces from the
+              last 7 days. If this project uses one, verify that it is up to
+              date.
+            </>
+          )
+        ) : sdk.status === "error" ? (
           "We could not check the latest traces for this project. Try again later."
-        ) : status === "latest" ? (
-          <>
-            This project uses <MonoValue>{detectedSdk}</MonoValue>. Nothing to
-            do.
-          </>
+        ) : sdk.status === "latest" ? (
+          "All detected Langfuse SDK versions are up to date."
         ) : (
           <>
-            This project uses <MonoValue>{detectedSdk}</MonoValue>.{" "}
+            {sdk.upgradeRequiredCount} detected SDK{" "}
+            {sdk.upgradeRequiredCount === 1
+              ? "configuration needs"
+              : "configurations need"}{" "}
+            an update.{" "}
             <ExternalLink href={SDK_UPGRADE_URL}>Upgrade the SDK</ExternalLink>{" "}
             for real-time data and the latest tracing experience.
           </>
         )}
       </p>
+      {detectedSdkSeries.length > 0 && (
+        <ul className="mt-2 flex flex-col gap-1.5">
+          {detectedSdkSeries.map((series) => {
+            const sdkLabel = formatSdkVersion({
+              language: series.canonicalSdkName ?? series.sdkName,
+              version: series.sdkVersion,
+            });
+            const publicKey =
+              series.publicKey.length > 18
+                ? `${series.publicKey.slice(0, 9)}…${series.publicKey.slice(-6)}`
+                : series.publicKey || "No API key";
+
+            return (
+              <li
+                key={`${series.sdkName}:${series.sdkVersion}:${series.publicKey}`}
+                className="text-muted-foreground flex flex-wrap items-baseline gap-x-1.5 text-xs"
+              >
+                <MonoValue>{sdkLabel}</MonoValue>
+                <span title={series.publicKey || undefined}>{publicKey}</span>
+                <span>
+                  · last seen{" "}
+                  {formatCompactRelativeTime(new Date(series.lastSeen))}
+                </span>
+                {series.v4MigrationStatus === "upgrade_required" && (
+                  <span className="text-dark-yellow">· upgrade required</span>
+                )}
+                {series.v4MigrationStatus === "unknown" && (
+                  <span className="text-dark-yellow">
+                    · version not recognized
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </Section>
   );
 }
@@ -258,8 +298,10 @@ export function V4MigrationDetailsContent({
   const projectId =
     projectIdProp ??
     (typeof routeProjectId === "string" ? routeProjectId : undefined);
+  const { organization } = useProject(projectId ?? null);
   const migrationData = useProjectV4MigrationData({
     projectId,
+    orgId: organization?.id,
     enabled: Boolean(projectId),
   });
 
@@ -311,10 +353,7 @@ export function V4MigrationDetailsContent({
           <span className="text-dark-yellow">Oct 1</span>.
         </p>
         <div>
-          <V4MigrationSdkSection
-            sdkVersionState={migrationData.sdkVersionState}
-            status={migrationData.sdkStatus}
-          />
+          <V4MigrationSdkSection sdk={migrationData.sdk} />
 
           <Section
             title="Evals"

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
@@ -2,23 +2,21 @@ import { ChevronRight } from "lucide-react";
 import { useV4UpgradeUiEnabled } from "@/src/features/v4-migration/useV4UpgradeUiEnabled";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useQueryProject } from "@/src/features/projects/hooks";
-import { useProjectSdkVersionInfo } from "@/src/features/sdk-version/hooks/useProjectSdkVersionInfo";
-import { getV4MigrationSdkStatus } from "@/src/features/v4-migration/sdkVersionStatus";
 import { useOpenV4MigrationPanel } from "@/src/features/v4-migration/hooks/useOpenV4MigrationPanel";
+import { useProjectV4SdkData } from "@/src/features/v4-migration/hooks/useV4MigrationData";
 
 export function V4MigrationDelayBadge() {
   const v4UpgradeUiEnabled = useV4UpgradeUiEnabled();
   const openMigrationPanel = useOpenV4MigrationPanel();
-  const { project } = useQueryProject();
+  const { project, organization } = useQueryProject();
   const capture = usePostHogClientCapture();
-  const sdkVersionState = useProjectSdkVersionInfo({
-    projectId: project?.id ?? "",
+  const sdk = useProjectV4SdkData({
+    projectId: project?.id,
+    orgId: organization?.id,
     enabled: v4UpgradeUiEnabled && Boolean(project),
-    refreshMode: "always",
   });
-  const sdkStatus = getV4MigrationSdkStatus(sdkVersionState);
 
-  if (!v4UpgradeUiEnabled || !project || sdkStatus !== "legacy") {
+  if (!v4UpgradeUiEnabled || !project || sdk.status !== "legacy") {
     return null;
   }
 

--- a/web/src/features/v4-migration/V4MigrationNavItem.tsx
+++ b/web/src/features/v4-migration/V4MigrationNavItem.tsx
@@ -11,10 +11,11 @@ export function V4MigrationNavItem() {
   const v4UpgradeUiEnabled = useV4UpgradeUiEnabled();
   const openMigrationPanel = useOpenV4MigrationPanel();
   const { isMobile, setOpenMobile: setOpenMobileSidebar } = useSidebar();
-  const { project } = useQueryProject();
+  const { project, organization } = useQueryProject();
   const capture = usePostHogClientCapture();
   const migrationData = useProjectV4MigrationData({
     projectId: project?.id,
+    orgId: organization?.id,
     enabled: v4UpgradeUiEnabled && Boolean(project),
   });
 
@@ -22,7 +23,7 @@ export function V4MigrationNavItem() {
     return null;
   }
   const readiness = getProjectMigrationReadiness({
-    sdk: migrationData.sdkStatus,
+    sdk: migrationData.sdk,
     evals: migrationData.evals,
     apis: migrationData.apis,
     exports: migrationData.exports,

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -3,6 +3,14 @@ import { describe, expect, it, vi } from "vitest";
 
 import V4MigrationStatusPage from "./V4MigrationStatusPage";
 
+const mocks = vi.hoisted(() => ({
+  sdk: {
+    status: "latest" as "latest" | "legacy",
+    sdkUsageSeries: [],
+    upgradeRequiredCount: 0,
+  },
+}));
+
 vi.mock("next-auth/react", () => ({
   useSession: () => ({
     status: "authenticated",
@@ -66,7 +74,7 @@ vi.mock("@/src/features/v4-migration/hooks/useV4MigrationData", () => ({
       [
         "project-1",
         {
-          sdk: "latest",
+          sdk: mocks.sdk,
           evals: { status: "loaded", count: 0 },
           apis: { status: "loaded", count: 0 },
           exports: { status: "loaded", count: 0 },
@@ -86,6 +94,14 @@ vi.mock("@/src/utils/api", () => ({
 }));
 
 describe("V4MigrationStatusPage", () => {
+  beforeEach(() => {
+    mocks.sdk = {
+      status: "latest",
+      sdkUsageSeries: [],
+      upgradeRequiredCount: 0,
+    };
+  });
+
   it("keeps the project table readable through horizontal scrolling", () => {
     render(<V4MigrationStatusPage />);
 
@@ -99,5 +115,17 @@ describe("V4MigrationStatusPage", () => {
 
     expect(screen.getByText("Ready")).toBeInTheDocument();
     expect(screen.getByText("of 1 projects migrated")).toBeInTheDocument();
+  });
+
+  it("shows the exact number of outdated SDK configurations", () => {
+    mocks.sdk = {
+      status: "legacy",
+      sdkUsageSeries: [],
+      upgradeRequiredCount: 2,
+    };
+
+    render(<V4MigrationStatusPage />);
+
+    expect(screen.getByText("2 outdated")).toBeInTheDocument();
   });
 });

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -201,13 +201,13 @@ function OrgStatusSection({
             }[getProjectMigrationReadiness(row.status)]
           : 0;
       case "sdk":
-        return row.status?.sdk === "latest"
+        return row.status?.sdk.status === "latest"
           ? 4
-          : row.status?.sdk === "legacy"
+          : row.status?.sdk.status === "legacy"
             ? 3
-            : row.status?.sdk === "unknown"
+            : row.status?.sdk.status === "unknown"
               ? 2
-              : row.status?.sdk === "checking"
+              : row.status?.sdk.status === "checking"
                 ? 1
                 : 0;
       case "evals":
@@ -317,22 +317,24 @@ function OrgStatusSection({
                       <StatusPill readiness={readiness} />
                     </TableCell>
                     <TableCell density="comfortable">
-                      {row.status.sdk === "latest" ? (
+                      {row.status.sdk.status === "latest" ? (
                         <span className="text-foreground-tertiary">Latest</span>
-                      ) : row.status.sdk === "checking" ? (
+                      ) : row.status.sdk.status === "checking" ? (
                         <span className="text-foreground-tertiary">
                           Checking…
                         </span>
-                      ) : row.status.sdk === "unknown" ? (
+                      ) : row.status.sdk.status === "unknown" ? (
                         <span className="text-foreground-tertiary">
                           Unknown
                         </span>
-                      ) : row.status.sdk === "error" ? (
+                      ) : row.status.sdk.status === "error" ? (
                         <span className="text-foreground-tertiary">
                           Unavailable
                         </span>
                       ) : (
-                        <span>Legacy</span>
+                        <span>
+                          {row.status.sdk.upgradeRequiredCount} outdated
+                        </span>
                       )}
                     </TableCell>
                     <TableCell density="comfortable">

--- a/web/src/features/v4-migration/hooks/useV4MigrationData.clienttest.ts
+++ b/web/src/features/v4-migration/hooks/useV4MigrationData.clienttest.ts
@@ -7,8 +7,8 @@ const mocks = vi.hoisted(() => ({
   summaryByProject: vi.fn(),
   traceLevelEvalSummaryByProject: vi.fn(),
   legacyApiUsageSummaryByProject: vi.fn(),
+  sdkUsageSummaryByProject: vi.fn(),
   queryResultSets: [] as unknown[][],
-  sdkVersions: new Map(),
 }));
 
 vi.mock("@/src/utils/api", () => ({
@@ -19,6 +19,7 @@ vi.mock("@/src/utils/api", () => ({
           summaryByProject: typeof mocks.summaryByProject;
           traceLevelEvalSummaryByProject: typeof mocks.traceLevelEvalSummaryByProject;
           legacyApiUsageSummaryByProject: typeof mocks.legacyApiUsageSummaryByProject;
+          sdkUsageSummaryByProject: typeof mocks.sdkUsageSummaryByProject;
         };
       }) => unknown,
     ) => {
@@ -27,6 +28,7 @@ vi.mock("@/src/utils/api", () => ({
           summaryByProject: mocks.summaryByProject,
           traceLevelEvalSummaryByProject: mocks.traceLevelEvalSummaryByProject,
           legacyApiUsageSummaryByProject: mocks.legacyApiUsageSummaryByProject,
+          sdkUsageSummaryByProject: mocks.sdkUsageSummaryByProject,
         },
       });
       return mocks.queryResultSets.shift() ?? [];
@@ -34,33 +36,26 @@ vi.mock("@/src/utils/api", () => ({
   },
 }));
 
-vi.mock("@/src/features/sdk-version/hooks/useProjectSdkVersionInfo", () => ({
-  useProjectsSdkVersionInfo: () => mocks.sdkVersions,
-  useProjectSdkVersionInfo: vi.fn(),
-}));
-
 const loadedQuery = <T>(data: T) => ({
   data,
   isError: false,
 });
+
+const currentSdkSeries = {
+  sdkName: "python",
+  sdkVersion: "4.7.0",
+  canonicalSdkName: "python" as const,
+  publicKey: "pk-lf-python",
+  lastSeen: "2026-07-23T10:00:00Z",
+  v4MigrationStatus: "compatible" as const,
+};
 
 describe("account v4 migration data", () => {
   beforeEach(() => {
     mocks.summaryByProject.mockReset();
     mocks.traceLevelEvalSummaryByProject.mockReset();
     mocks.legacyApiUsageSummaryByProject.mockReset();
-    mocks.sdkVersions = new Map([
-      [
-        "project-1",
-        {
-          sdkVersion: { language: "python", version: "4.7.0" },
-          checkedAt: "2026-07-23T10:00:00.000Z",
-          isRefreshing: false,
-          querySettled: true,
-          isError: false,
-        },
-      ],
-    ]);
+    mocks.sdkUsageSummaryByProject.mockReset();
     mocks.queryResultSets = [
       [
         loadedQuery({
@@ -83,6 +78,15 @@ describe("account v4 migration data", () => {
           {
             projectId: "project-1",
             traceLevelEvalCount: 2,
+          },
+        ]),
+      ],
+      [
+        loadedQuery([
+          {
+            projectId: "project-1",
+            outdatedSdkUsageSeriesCount: 0,
+            sdkUsageSeries: [currentSdkSeries],
           },
         ]),
       ],
@@ -118,7 +122,11 @@ describe("account v4 migration data", () => {
     );
 
     expect(result.current.get("project-1")).toEqual({
-      sdk: "latest",
+      sdk: {
+        status: "latest",
+        sdkUsageSeries: [currentSdkSeries],
+        upgradeRequiredCount: 0,
+      },
       evals: { status: "loaded", count: 2 },
       apis: { status: "loaded", count: 2 },
       exports: { status: "loaded", count: 1 },
@@ -128,6 +136,10 @@ describe("account v4 migration data", () => {
       expect.objectContaining({ enabled: true }),
     );
     expect(mocks.legacyApiUsageSummaryByProject).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: "org-1" }),
+      expect.objectContaining({ enabled: true }),
+    );
+    expect(mocks.sdkUsageSummaryByProject).toHaveBeenCalledWith(
       expect.objectContaining({ orgId: "org-1" }),
       expect.objectContaining({ enabled: true }),
     );

--- a/web/src/features/v4-migration/hooks/useV4MigrationData.ts
+++ b/web/src/features/v4-migration/hooks/useV4MigrationData.ts
@@ -3,17 +3,13 @@ import { useState } from "react";
 import { api } from "@/src/utils/api";
 import { countLegacyApiEntrypoints } from "@/src/features/v4/utils";
 import {
-  useProjectSdkVersionInfo,
-  useProjectsSdkVersionInfo,
-} from "@/src/features/sdk-version/hooks/useProjectSdkVersionInfo";
-import {
   aggregateLegacyApiUsage,
   createV4MigrationDetectionRange,
   getLegacyIntegrationLabels,
   getMigrationCountState,
   type ProjectMigrationStatus,
 } from "@/src/features/v4-migration/migrationData";
-import { getV4MigrationSdkStatus } from "@/src/features/v4-migration/sdkVersionStatus";
+import { getV4MigrationSdkState } from "@/src/features/v4-migration/sdkVersionStatus";
 
 const QUERY_STALE_TIME_MS = 5 * 60 * 1000;
 
@@ -34,14 +30,6 @@ export function useAccountV4MigrationData(params: {
 }): Map<string, ProjectMigrationStatus> {
   const { organizations, enabled } = params;
   const [detectionRange] = useState(createV4MigrationDetectionRange);
-  const projectIds = organizations.flatMap((organization) =>
-    organization.projects.map((project) => project.id),
-  );
-  const sdkVersionByProjectId = useProjectsSdkVersionInfo({
-    projectIds,
-    enabled,
-    refreshMode: "always",
-  });
 
   const integrationQueries = api.useQueries((t) =>
     organizations.map((organization) =>
@@ -58,6 +46,21 @@ export function useAccountV4MigrationData(params: {
     organizations.map((organization) =>
       t.v4Transition.traceLevelEvalSummaryByProject(
         { orgId: organization.id },
+        {
+          ...queryOptions,
+          enabled,
+          trpc: { context: { skipBatch: true } },
+        },
+      ),
+    ),
+  );
+  const sdkQueries = api.useQueries((t) =>
+    organizations.map((organization) =>
+      t.v4Transition.sdkUsageSummaryByProject(
+        {
+          orgId: organization.id,
+          ...detectionRange,
+        },
         {
           ...queryOptions,
           enabled,
@@ -87,14 +90,19 @@ export function useAccountV4MigrationData(params: {
   organizations.forEach((organization, organizationIndex) => {
     const integrationQuery = integrationQueries[organizationIndex] ?? null;
     const evalQuery = evalQueries[organizationIndex] ?? null;
+    const sdkQuery = sdkQueries[organizationIndex] ?? null;
     const apiQuery = apiQueries[organizationIndex] ?? null;
 
     organization.projects.forEach((project) => {
-      const sdkVersionState = sdkVersionByProjectId.get(project.id);
+      const sdkSummary = sdkQuery?.data?.find(
+        (row) => row.projectId === project.id,
+      );
       statusByProjectId.set(project.id, {
-        sdk: sdkVersionState
-          ? getV4MigrationSdkStatus(sdkVersionState)
-          : "checking",
+        sdk: getV4MigrationSdkState({
+          summary: sdkSummary,
+          isLoading: sdkQuery?.data === undefined && !sdkQuery?.isError,
+          isError: sdkQuery?.isError ?? false,
+        }),
         evals: getMigrationCountState(evalQuery, (rows) => {
           return (
             rows.find((row) => row.projectId === project.id)
@@ -119,17 +127,46 @@ export function useAccountV4MigrationData(params: {
   return statusByProjectId;
 }
 
-export function useProjectV4MigrationData(params: {
+export function useProjectV4SdkData(params: {
   projectId: string | undefined;
+  orgId: string | undefined;
   enabled: boolean;
 }) {
-  const { projectId, enabled } = params;
+  const { projectId, orgId, enabled } = params;
+  const [detectionRange] = useState(createV4MigrationDetectionRange);
+  const queryEnabled = enabled && Boolean(projectId) && Boolean(orgId);
+  const sdkQuery = api.v4Transition.sdkUsageSummaryByProject.useQuery(
+    {
+      orgId: orgId ?? "",
+      ...detectionRange,
+    },
+    {
+      ...queryOptions,
+      enabled: queryEnabled,
+      trpc: { context: { skipBatch: true } },
+    },
+  );
+  const summary = sdkQuery.data?.find((row) => row.projectId === projectId);
+
+  return getV4MigrationSdkState({
+    summary,
+    isLoading: sdkQuery.data === undefined && !sdkQuery.isError,
+    isError: sdkQuery.isError,
+  });
+}
+
+export function useProjectV4MigrationData(params: {
+  projectId: string | undefined;
+  orgId: string | undefined;
+  enabled: boolean;
+}) {
+  const { projectId, orgId, enabled } = params;
   const queryEnabled = enabled && Boolean(projectId);
   const [detectionRange] = useState(createV4MigrationDetectionRange);
-  const sdkVersionState = useProjectSdkVersionInfo({
-    projectId: projectId ?? "",
-    enabled: queryEnabled,
-    refreshMode: "always",
+  const sdk = useProjectV4SdkData({
+    projectId,
+    orgId,
+    enabled,
   });
   const evalQuery = api.v4Transition.traceLevelEvalSummary.useQuery(
     { projectId: projectId ?? "" },
@@ -158,8 +195,7 @@ export function useProjectV4MigrationData(params: {
   );
 
   return {
-    sdkVersionState,
-    sdkStatus: getV4MigrationSdkStatus(sdkVersionState),
+    sdk,
     evals: getMigrationCountState(
       evalQuery,
       (data) => data.traceLevelEvalCount,

--- a/web/src/features/v4-migration/migrationData.clienttest.ts
+++ b/web/src/features/v4-migration/migrationData.clienttest.ts
@@ -4,9 +4,23 @@ import {
   getLegacyIntegrationLabels,
   getMigrationCountState,
   getProjectMigrationReadiness,
+  type ProjectMigrationStatus,
 } from "@/src/features/v4-migration/migrationData";
 
 const loaded = (count: number) => ({ status: "loaded" as const, count });
+const migrationStatus = (
+  overrides: Partial<ProjectMigrationStatus> = {},
+): ProjectMigrationStatus => ({
+  sdk: {
+    status: "latest",
+    sdkUsageSeries: [],
+    upgradeRequiredCount: 0,
+  },
+  evals: loaded(0),
+  apis: loaded(0),
+  exports: loaded(0),
+  ...overrides,
+});
 
 describe("v4 migration data", () => {
   it("uses a stable seven-day range aligned to the hour", () => {
@@ -36,37 +50,25 @@ describe("v4 migration data", () => {
   });
 
   it("only marks a fully loaded project without affected items as ready", () => {
+    expect(getProjectMigrationReadiness(migrationStatus())).toBe("ready");
     expect(
-      getProjectMigrationReadiness({
-        sdk: "latest",
-        evals: loaded(0),
-        apis: loaded(0),
-        exports: loaded(0),
-      }),
-    ).toBe("ready");
-    expect(
-      getProjectMigrationReadiness({
-        sdk: "latest",
-        evals: loaded(1),
-        apis: loaded(0),
-        exports: loaded(0),
-      }),
+      getProjectMigrationReadiness(migrationStatus({ evals: loaded(1) })),
     ).toBe("action-needed");
     expect(
-      getProjectMigrationReadiness({
-        sdk: "latest",
-        evals: { status: "loading", count: 0 },
-        apis: loaded(0),
-        exports: loaded(0),
-      }),
+      getProjectMigrationReadiness(
+        migrationStatus({ evals: { status: "loading", count: 0 } }),
+      ),
     ).toBe("checking");
     expect(
-      getProjectMigrationReadiness({
-        sdk: "error",
-        evals: loaded(0),
-        apis: loaded(0),
-        exports: loaded(0),
-      }),
+      getProjectMigrationReadiness(
+        migrationStatus({
+          sdk: {
+            status: "error",
+            sdkUsageSeries: [],
+            upgradeRequiredCount: 0,
+          },
+        }),
+      ),
     ).toBe("unavailable");
   });
 

--- a/web/src/features/v4-migration/migrationData.ts
+++ b/web/src/features/v4-migration/migrationData.ts
@@ -1,6 +1,6 @@
 import { type RouterOutputs } from "@/src/utils/api";
 import { normalizeLegacyApiEntrypoint } from "@/src/features/v4/utils";
-import { type V4MigrationSdkStatus } from "@/src/features/v4-migration/sdkVersionStatus";
+import { type V4MigrationSdkState } from "@/src/features/v4-migration/sdkVersionStatus";
 
 export const V4_MIGRATION_LOOKBACK_DAYS = 7;
 
@@ -52,7 +52,7 @@ export const getMigrationCountState = <T>(
 };
 
 export type ProjectMigrationStatus = {
-  sdk: V4MigrationSdkStatus;
+  sdk: V4MigrationSdkState;
   evals: MigrationCountState;
   apis: MigrationCountState;
   exports: MigrationCountState;
@@ -70,18 +70,21 @@ export const getProjectMigrationReadiness = (
   const counts = [status.evals, status.apis, status.exports];
 
   if (
-    status.sdk === "error" ||
+    status.sdk.status === "error" ||
     counts.some((count) => count.status === "error")
   ) {
     return "unavailable";
   }
   if (
-    status.sdk === "checking" ||
+    status.sdk.status === "checking" ||
     counts.some((count) => count.status === "loading")
   ) {
     return "checking";
   }
-  if (status.sdk === "latest" && counts.every((count) => count.count === 0)) {
+  if (
+    status.sdk.status === "latest" &&
+    counts.every((count) => count.count === 0)
+  ) {
     return "ready";
   }
   return "action-needed";

--- a/web/src/features/v4-migration/sdkVersionStatus.clienttest.ts
+++ b/web/src/features/v4-migration/sdkVersionStatus.clienttest.ts
@@ -1,59 +1,91 @@
 import {
   formatSdkVersion,
-  getV4MigrationSdkStatus,
+  getV4MigrationSdkState,
+  type V4MigrationSdkUsageSeries,
 } from "@/src/features/v4-migration/sdkVersionStatus";
 
-const baseState = {
-  checkedAt: "2026-07-23T10:00:00.000Z",
-  isRefreshing: false,
-  querySettled: false,
-  isError: false,
-};
+const sdkSeries = (
+  overrides: Partial<V4MigrationSdkUsageSeries> = {},
+): V4MigrationSdkUsageSeries => ({
+  sdkName: "python",
+  sdkVersion: "4.7.0",
+  canonicalSdkName: "python" as const,
+  publicKey: "pk-lf-python",
+  lastSeen: "2026-07-23T10:00:00Z",
+  v4MigrationStatus: "compatible" as const,
+  ...overrides,
+});
+
+const getLoadedSdkState = (...sdkUsageSeries: ReturnType<typeof sdkSeries>[]) =>
+  getV4MigrationSdkState({
+    summary: {
+      projectId: "project-1",
+      outdatedSdkUsageSeriesCount: 0,
+      sdkUsageSeries,
+    },
+    isError: false,
+    isLoading: false,
+  });
 
 describe("v4 migration SDK status", () => {
-  it.each([
-    ["javascript", "5.4.0", "latest"],
-    ["javascript", "5.3.9", "legacy"],
-    ["python", "4.7.0", "latest"],
-    ["python", "4.6.9", "legacy"],
-  ] as const)("classifies %s %s as %s", (language, version, expected) => {
+  it("requires an upgrade when any detected SDK series is incompatible", () => {
     expect(
-      getV4MigrationSdkStatus({
-        ...baseState,
-        sdkVersion: { language, version },
-      }),
-    ).toBe(expected);
+      getLoadedSdkState(
+        sdkSeries(),
+        sdkSeries({
+          sdkVersion: "4.6.9",
+          publicKey: "pk-lf-old-python",
+          v4MigrationStatus: "upgrade_required",
+        }),
+      ),
+    ).toMatchObject({
+      status: "legacy",
+      upgradeRequiredCount: 1,
+    });
   });
 
-  it("distinguishes an in-flight first check from an unknown result", () => {
+  it("does not let unattributed usage override a compatible SDK", () => {
     expect(
-      getV4MigrationSdkStatus({
-        sdkVersion: undefined,
-        checkedAt: null,
-        isRefreshing: true,
-        querySettled: false,
+      getLoadedSdkState(
+        sdkSeries(),
+        sdkSeries({
+          sdkName: "unknown",
+          sdkVersion: "unknown",
+          canonicalSdkName: null,
+          publicKey: "",
+          v4MigrationStatus: "unknown",
+        }),
+      ),
+    ).toMatchObject({ status: "latest", upgradeRequiredCount: 0 });
+  });
+
+  it("keeps a recognized SDK with an invalid version unknown", () => {
+    expect(
+      getLoadedSdkState(
+        sdkSeries({
+          sdkVersion: "invalid",
+          v4MigrationStatus: "unknown",
+        }),
+      ),
+    ).toMatchObject({ status: "unknown" });
+  });
+
+  it("distinguishes loading, errors, and a loaded empty result", () => {
+    expect(
+      getV4MigrationSdkState({
+        summary: undefined,
+        isLoading: true,
         isError: false,
-      }),
+      }).status,
     ).toBe("checking");
     expect(
-      getV4MigrationSdkStatus({
-        ...baseState,
-        sdkVersion: { language: null, version: null },
-        querySettled: true,
-      }),
-    ).toBe("unknown");
-  });
-
-  it("distinguishes a failed first check from an unknown SDK", () => {
-    expect(
-      getV4MigrationSdkStatus({
-        sdkVersion: undefined,
-        checkedAt: null,
-        isRefreshing: false,
-        querySettled: false,
+      getV4MigrationSdkState({
+        summary: undefined,
+        isLoading: false,
         isError: true,
-      }),
+      }).status,
     ).toBe("error");
+    expect(getLoadedSdkState().status).toBe("unknown");
   });
 
   it("formats detected SDK versions for migration copy", () => {

--- a/web/src/features/v4-migration/sdkVersionStatus.ts
+++ b/web/src/features/v4-migration/sdkVersionStatus.ts
@@ -1,7 +1,5 @@
-import {
-  getSdkVersionCapability,
-  type SdkVersionInfo,
-} from "@/src/features/sdk-version/lib/sdkVersionCapabilities";
+import { type RouterOutputs } from "@/src/utils/api";
+import { type SdkVersionInfo } from "@/src/features/sdk-version/lib/sdkVersionCapabilities";
 
 export type V4MigrationSdkStatus =
   | "checking"
@@ -10,27 +8,78 @@ export type V4MigrationSdkStatus =
   | "legacy"
   | "latest";
 
-export const getV4MigrationSdkStatus = (params: {
-  sdkVersion: SdkVersionInfo | undefined;
-  checkedAt: string | null;
-  isRefreshing: boolean;
-  querySettled: boolean;
+type SdkUsageSummary =
+  RouterOutputs["v4Transition"]["sdkUsageSummaryByProject"][number];
+
+export type V4MigrationSdkUsageSeries =
+  SdkUsageSummary["sdkUsageSeries"][number];
+
+export type V4MigrationSdkState = {
+  status: V4MigrationSdkStatus;
+  sdkUsageSeries: V4MigrationSdkUsageSeries[];
+  upgradeRequiredCount: number;
+};
+
+const statusOrder: Record<
+  V4MigrationSdkUsageSeries["v4MigrationStatus"],
+  number
+> = {
+  upgrade_required: 0,
+  unknown: 1,
+  compatible: 2,
+};
+
+const sortSdkUsageSeries = (
+  rows: V4MigrationSdkUsageSeries[],
+): V4MigrationSdkUsageSeries[] =>
+  [...rows].sort(
+    (left, right) =>
+      statusOrder[left.v4MigrationStatus] -
+      statusOrder[right.v4MigrationStatus],
+  );
+
+export const getV4MigrationSdkState = (params: {
+  summary: SdkUsageSummary | undefined;
+  isLoading: boolean;
   isError: boolean;
-}): V4MigrationSdkStatus => {
-  const { sdkVersion } = params;
-  if (sdkVersion?.language && sdkVersion.version) {
-    // The migration UX and automatic app-root filter share the same boundary:
-    // SDKs new enough to emit the current root-observation metadata.
-    return getSdkVersionCapability(sdkVersion, "appRootObservations")
-      ? "latest"
-      : "legacy";
+}): V4MigrationSdkState => {
+  if (!params.summary) {
+    return {
+      status: params.isError
+        ? "error"
+        : params.isLoading
+          ? "checking"
+          : "unknown",
+      sdkUsageSeries: [],
+      upgradeRequiredCount: 0,
+    };
   }
 
-  if (params.isError) return "error";
+  const sdkUsageSeries = sortSdkUsageSeries(params.summary.sdkUsageSeries);
+  const upgradeRequiredCount = sdkUsageSeries.filter(
+    (series) => series.v4MigrationStatus === "upgrade_required",
+  ).length;
+  const hasUnknownRecognizedSdk = sdkUsageSeries.some(
+    (series) =>
+      series.canonicalSdkName !== null &&
+      series.v4MigrationStatus === "unknown",
+  );
+  const hasCompatibleSdk = sdkUsageSeries.some(
+    (series) => series.v4MigrationStatus === "compatible",
+  );
 
-  return params.isRefreshing && !params.checkedAt && !params.querySettled
-    ? "checking"
-    : "unknown";
+  return {
+    status:
+      upgradeRequiredCount > 0
+        ? "legacy"
+        : hasUnknownRecognizedSdk
+          ? "unknown"
+          : hasCompatibleSdk
+            ? "latest"
+            : "unknown",
+    sdkUsageSeries,
+    upgradeRequiredCount,
+  };
 };
 
 export const formatSdkVersion = (sdkVersion: SdkVersionInfo | undefined) => {

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -16,6 +16,7 @@ import {
   systemTableRef,
   type IngestionSdkUpgradeStatus,
 } from "@langfuse/shared/src/server";
+import { getSdkVersionCapabilityStatus } from "@/src/features/sdk-version/lib/sdkVersionCapabilities";
 import {
   addTimelineBucket,
   floorTimelineBucket,
@@ -145,12 +146,22 @@ type SdkUsageSummaryByProjectRow = {
   sdkName: string;
   sdkVersion: string;
   publicKey: string;
-  count: string | number;
+  lastSeen: string;
+};
+
+type SdkUsageSummaryByProjectSeries = {
+  sdkName: string;
+  sdkVersion: string;
+  canonicalSdkName: "python" | "javascript" | null;
+  publicKey: string;
+  lastSeen: string;
+  v4MigrationStatus: "compatible" | "upgrade_required" | "unknown";
 };
 
 type SdkUsageSummaryByProjectResultRow = {
   projectId: string;
   outdatedSdkUsageSeriesCount: number;
+  sdkUsageSeries: SdkUsageSummaryByProjectSeries[];
 };
 
 const getEmptyTimelineBuckets = (
@@ -681,6 +692,7 @@ ORDER BY ${bucketTimeSql} ASC, sdk_name ASC, sdk_version ASC, public_key ASC
 
   SELECT
     project_id,
+    timestamp AS event_time,
     if(ingestion_sdk_name = '', 'unknown', ingestion_sdk_name) AS sdk_name,
     if(ingestion_sdk_version = '', 'unknown', ingestion_sdk_version) AS sdk_version,
     ingestion_api_key AS public_key
@@ -698,6 +710,7 @@ ORDER BY ${bucketTimeSql} ASC, sdk_name ASC, sdk_version ASC, public_key ASC
 WITH selected AS (
   SELECT
     project_id,
+    start_time AS event_time,
     if(ingestion_sdk_name = '', 'unknown', ingestion_sdk_name) AS sdk_name,
     if(ingestion_sdk_version = '', 'unknown', ingestion_sdk_version) AS sdk_version,
     ingestion_api_key AS public_key
@@ -717,7 +730,7 @@ SELECT
   sdk_name AS sdkName,
   sdk_version AS sdkVersion,
   public_key AS publicKey,
-  count() AS count
+  formatDateTime(max(event_time), '%Y-%m-%dT%H:%i:%SZ', 'UTC') AS lastSeen
 FROM selected
 GROUP BY project_id, sdk_name, sdk_version, public_key
 ORDER BY project_id ASC, sdk_name ASC, sdk_version ASC, public_key ASC
@@ -734,6 +747,10 @@ ORDER BY project_id ASC, sdk_name ASC, sdk_version ASC, public_key ASC
       });
 
       const outdatedCountsByProjectId = new Map<string, number>();
+      const sdkUsageSeriesByProjectId = new Map<
+        string,
+        SdkUsageSummaryByProjectSeries[]
+      >();
 
       for (const row of rows) {
         const classification = classifyIngestionSdkVersion({
@@ -741,15 +758,33 @@ ORDER BY project_id ASC, sdk_name ASC, sdk_version ASC, public_key ASC
           sdkVersion: row.sdkVersion,
         });
 
-        if (
-          classification.status === "outdated_major" &&
-          Number(row.count) > 0
-        ) {
+        if (classification.status === "outdated_major") {
           outdatedCountsByProjectId.set(
             row.projectId,
             (outdatedCountsByProjectId.get(row.projectId) ?? 0) + 1,
           );
         }
+
+        const capabilityStatus = getSdkVersionCapabilityStatus(
+          { language: row.sdkName, version: row.sdkVersion },
+          "appRootObservations",
+        );
+        const projectSeries =
+          sdkUsageSeriesByProjectId.get(row.projectId) ?? [];
+        projectSeries.push({
+          sdkName: row.sdkName,
+          sdkVersion: row.sdkVersion,
+          canonicalSdkName: classification.canonicalSdkName,
+          publicKey: row.publicKey,
+          lastSeen: row.lastSeen,
+          v4MigrationStatus:
+            capabilityStatus === "supported"
+              ? "compatible"
+              : capabilityStatus === "unsupported"
+                ? "upgrade_required"
+                : "unknown",
+        });
+        sdkUsageSeriesByProjectId.set(row.projectId, projectSeries);
       }
 
       return projectIds.map(
@@ -757,6 +792,7 @@ ORDER BY project_id ASC, sdk_name ASC, sdk_version ASC, public_key ASC
           projectId,
           outdatedSdkUsageSeriesCount:
             outdatedCountsByProjectId.get(projectId) ?? 0,
+          sdkUsageSeries: sdkUsageSeriesByProjectId.get(projectId) ?? [],
         }),
       );
     }),

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -757,18 +757,17 @@ ORDER BY project_id ASC, sdk_name ASC, sdk_version ASC, public_key ASC
           sdkName: row.sdkName,
           sdkVersion: row.sdkVersion,
         });
-
-        if (classification.status === "outdated_major") {
+        const capabilityStatus = getSdkVersionCapabilityStatus(
+          { language: row.sdkName, version: row.sdkVersion },
+          "appRootObservations",
+        );
+        if (capabilityStatus === "unsupported") {
           outdatedCountsByProjectId.set(
             row.projectId,
             (outdatedCountsByProjectId.get(row.projectId) ?? 0) + 1,
           );
         }
 
-        const capabilityStatus = getSdkVersionCapabilityStatus(
-          { language: row.sdkName, version: row.sdkVersion },
-          "appRootObservations",
-        );
         const projectSeries =
           sdkUsageSeriesByProjectId.get(row.projectId) ?? [];
         projectSeries.push({


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands v4 migration statistics and SDK compatibility reporting.
- Aggregates SDK usage across events and scores by project, SDK version, and API key.
- Shows detailed SDK series, compatibility state, and last-seen timestamps in migration surfaces.
- Reworks SDK-version caching and app-root capability detection.
- Adds seeded SDK attribution and updates migration/router tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking scalability concern in the new organization-wide SDK summary.

The functional wiring consistently propagates the richer SDK status model, but the new summary query and response grow with every distinct project, SDK, version, and API-key tuple.

web/src/features/v4/server/v4TransitionRouter.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  CH[ClickHouse events_core and scores] --> Router[sdkUsageSummaryByProject]
  Router --> Classification[SDK capability classification]
  Classification --> Account[Account migration status]
  Classification --> Project[Project migration panel and badge]
  Account --> Readiness[Migration readiness]
  Project --> Readiness
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/v4/server/v4TransitionRouter.ts:736
**Unbounded SDK usage series**

This organization-wide query groups every accessible project by SDK name, version, and public key without a limit or aggregation cap. Organizations with many projects, rotated keys, or SDK versions produce increasingly large ClickHouse results and client payloads, increasing migration-status page latency and resource usage.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): more comprehensive stats wiring"](https://github.com/langfuse/langfuse/commit/c0b9675b2e981f952c5875c1b68e12d6f127e33b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46808075)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->