### PR TITLE
fix: keep bare string dataset item inputs as strings

### DIFF
--- a/packages/shared/src/server/repositories/dataset-items.ts
+++ b/packages/shared/src/server/repositories/dataset-items.ts
@@ -35,7 +35,23 @@ import {
 import { postgresSearchCondition } from "../queries";
 import { TracingSearchType } from "../../interfaces/search";
 
-const emptyNormalizeOpts: { sanitizeControlChars?: boolean } = {};
+/**
+ * Normalization options for dataset item payloads.
+ *
+ * `parseJsonStrings` must only be set by callers whose values are still
+ * JSON-encoded strings: tRPC (the web form submits strings) and the worker
+ * batch action (ClickHouse returns input/output as String columns). Callers
+ * holding already-parsed values — the Public API and MCP, where the HTTP body
+ * parser has already decoded the payload — must leave it unset, so a bare
+ * string such as "123456" is stored verbatim instead of being decoded a second
+ * time into the number 123456 (#15342).
+ */
+export type DatasetItemNormalizeOpts = {
+  sanitizeControlChars?: boolean;
+  parseJsonStrings?: boolean;
+};
+
+const emptyNormalizeOpts: DatasetItemNormalizeOpts = {};
 const emptyValidateOpts: { normalizeUndefinedToNull?: boolean } = {};
 
 /**
@@ -231,9 +247,7 @@ export async function createDatasetItem(props: {
   metadata?: string | unknown | null;
   sourceTraceId?: string;
   sourceObservationId?: string;
-  normalizeOpts?: {
-    sanitizeControlChars?: boolean;
-  };
+  normalizeOpts?: DatasetItemNormalizeOpts;
   validateOpts?: {
     normalizeUndefinedToNull?: boolean;
   };
@@ -292,7 +306,7 @@ export async function upsertDatasetItem(
     sourceTraceId?: string;
     sourceObservationId?: string;
     status?: DatasetStatus;
-    normalizeOpts?: { sanitizeControlChars?: boolean };
+    normalizeOpts?: DatasetItemNormalizeOpts;
     validateOpts: { normalizeUndefinedToNull?: boolean };
   } & IdOrName,
 ): Promise<DatasetItemDomain & { datasetName: string }> {
@@ -604,7 +618,7 @@ export async function deleteDatasetItem(props: {
 export async function createManyDatasetItems(props: {
   projectId: string;
   items: CreateManyItemsPayload;
-  normalizeOpts?: { sanitizeControlChars?: boolean };
+  normalizeOpts?: DatasetItemNormalizeOpts;
   validateOpts?: { normalizeUndefinedToNull?: boolean };
   allowPartialSuccess?: boolean;
 }): Promise<

--- a/packages/shared/src/server/repositories/dataset-items.ts
+++ b/packages/shared/src/server/repositories/dataset-items.ts
@@ -197,27 +197,22 @@ function toDomainType<
   return withDatasetName as any;
 }
 
+/**
+ * Merge the non-IO fields (source ids, status) of an update with the existing
+ * item, keeping the existing value for anything the caller omitted. IO fields
+ * (input/expectedOutput/metadata) are merged inside
+ * DatasetItemValidator.validateAndNormalize, so a carried-over already-decoded
+ * value is never re-parsed (#15342).
+ */
 function mergeItemData(
   existingItem: DatasetItemDomain,
   newData: {
-    input?: string | unknown | null;
-    expectedOutput?: string | unknown | null;
-    metadata?: string | unknown | null;
     sourceTraceId?: string;
     sourceObservationId?: string;
     status?: DatasetStatus;
   },
 ) {
   return {
-    input: newData.input !== undefined ? newData.input : existingItem?.input,
-    expectedOutput:
-      newData.expectedOutput !== undefined
-        ? newData.expectedOutput
-        : existingItem?.expectedOutput,
-    metadata:
-      newData.metadata !== undefined
-        ? newData.metadata
-        : existingItem?.metadata,
     sourceTraceId:
       newData.sourceTraceId === undefined
         ? existingItem?.sourceTraceId
@@ -342,8 +337,10 @@ export async function upsertDatasetItem(
     "langfuse.dataset_item.upsert.existing_item_count": existingItem ? 1 : 0,
   });
 
-  // 3. Merge incoming data with existing data
-  // For fields where props value is undefined, use existing value
+  // 3. Merge non-IO fields (source ids, status) with existing data.
+  // For fields where props value is undefined, use existing value.
+  // IO fields are merged inside validateAndNormalize instead, so a
+  // carried-over already-decoded value is never re-parsed (#15342).
   const mergedItemData = existingItem
     ? mergeItemData(existingItem, props)
     : props;
@@ -358,9 +355,17 @@ export async function upsertDatasetItem(
   });
 
   const itemPayload = validator.validateAndNormalize({
-    input: mergedItemData.input,
-    expectedOutput: mergedItemData.expectedOutput,
-    metadata: mergedItemData.metadata,
+    input: props.input,
+    expectedOutput: props.expectedOutput,
+    metadata: props.metadata,
+    existingItem: existingItem
+      ? {
+          input: existingItem.input as Prisma.InputJsonValue | null,
+          expectedOutput:
+            existingItem.expectedOutput as Prisma.InputJsonValue | null,
+          metadata: existingItem.metadata as Prisma.InputJsonValue | null,
+        }
+      : undefined,
     normalizeOpts: props.normalizeOpts,
     validateOpts: props.validateOpts,
   });

--- a/packages/shared/src/server/services/DatasetService/DatasetItemValidator.test.ts
+++ b/packages/shared/src/server/services/DatasetService/DatasetItemValidator.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { Prisma } from "../../../db";
+import { DatasetItemValidator } from "./DatasetItemValidator";
+
+const noSchemas = { inputSchema: null, expectedOutputSchema: null };
+
+const normalizeViaApi = (value: unknown) => {
+  const validator = new DatasetItemValidator(noSchemas);
+  const result = validator.validateAndNormalize({
+    input: value,
+    expectedOutput: undefined,
+    metadata: undefined,
+    normalizeOpts: { sanitizeControlChars: true },
+    validateOpts: { normalizeUndefinedToNull: true },
+  });
+  if (!result.success) throw new Error(result.message);
+  return result.input;
+};
+
+const normalizeViaTrpc = (value: string) => {
+  const validator = new DatasetItemValidator(noSchemas);
+  const result = validator.validateAndNormalize({
+    input: value,
+    expectedOutput: undefined,
+    metadata: undefined,
+    normalizeOpts: { sanitizeControlChars: true, parseJsonStrings: true },
+    validateOpts: { normalizeUndefinedToNull: true },
+  });
+  if (!result.success) throw new Error(result.message);
+  return result.input;
+};
+
+describe("DatasetItemValidator", () => {
+  // Public API / SDK path: values arrive already parsed by the HTTP body
+  // parser, so a string must stay a string (issue #15342).
+  describe("already-parsed values (Public API)", () => {
+    it("preserves a numeric string instead of coercing it to a number", () => {
+      expect(normalizeViaApi("123456")).toBe("123456");
+    });
+
+    it.each([
+      ["digits", "0042"],
+      ["float-like", "1.5"],
+      ["negative", "-7"],
+      ["boolean-like", "true"],
+      ["null-like", "null"],
+      ["object-like", '{"key":"value"}'],
+      ["array-like", "[1,2,3]"],
+      ["scientific notation", "1e5"],
+      ["big integer", "12345678901234567890"],
+    ])("preserves a %s string verbatim", (_label, value) => {
+      expect(normalizeViaApi(value)).toBe(value);
+    });
+
+    it("still passes through non-string values untouched", () => {
+      expect(normalizeViaApi({ key: "value" })).toEqual({ key: "value" });
+      expect(normalizeViaApi([1, 2, 3])).toEqual([1, 2, 3]);
+      expect(normalizeViaApi(123456)).toBe(123456);
+      expect(normalizeViaApi(true)).toBe(true);
+    });
+
+    it("still sanitizes control characters in preserved strings", () => {
+      expect(normalizeViaApi("12\u00003456")).toBe("123456");
+    });
+
+    it("still treats an empty string as a DB null", () => {
+      expect(normalizeViaApi("")).toBe(Prisma.DbNull);
+    });
+  });
+
+  // Opted-in paths: the tRPC form and the worker batch action both hand over
+  // JSON-encoded strings that still need decoding.
+  describe("JSON-encoded strings (parseJsonStrings)", () => {
+    it("parses an object literal", () => {
+      expect(normalizeViaTrpc('{"key":"value"}')).toEqual({ key: "value" });
+    });
+
+    it("parses a bare number literal", () => {
+      expect(normalizeViaTrpc("123456")).toBe(123456);
+    });
+
+    it("parses a quoted string back to a string", () => {
+      expect(normalizeViaTrpc('"123456"')).toBe("123456");
+    });
+
+    it("leaves unparsable text as a string", () => {
+      expect(normalizeViaTrpc("Hello World")).toBe("Hello World");
+    });
+  });
+});

--- a/packages/shared/src/server/services/DatasetService/DatasetItemValidator.test.ts
+++ b/packages/shared/src/server/services/DatasetService/DatasetItemValidator.test.ts
@@ -87,4 +87,59 @@ describe("DatasetItemValidator", () => {
       expect(normalizeViaTrpc("Hello World")).toBe("Hello World");
     });
   });
+
+  // Update merge: fields the caller omits fall back to the existing DB value,
+  // which is already decoded and must not be parsed again even when the caller
+  // opted into parseJsonStrings (the tRPC updateDatasetItem path — #15342).
+  describe("update merge (existingItem)", () => {
+    const updateWith = (params: {
+      input?: unknown;
+      existing: {
+        input: unknown;
+        expectedOutput: unknown;
+        metadata: unknown;
+      };
+    }) => {
+      const validator = new DatasetItemValidator(noSchemas);
+      const result = validator.validateAndNormalize({
+        input: params.input,
+        expectedOutput: undefined,
+        metadata: undefined,
+        existingItem: params.existing as never,
+        normalizeOpts: { parseJsonStrings: true },
+        validateOpts: { normalizeUndefinedToNull: false },
+      });
+      if (!result.success) throw new Error(result.message);
+      return result;
+    };
+
+    it("carries over a stored numeric string without re-parsing it", () => {
+      const result = updateWith({
+        input: undefined,
+        existing: {
+          input: "123456",
+          expectedOutput: "true",
+          metadata: null,
+        },
+      });
+      expect(result.input).toBe("123456");
+      expect(result.expectedOutput).toBe("true");
+    });
+
+    it("still parses a freshly supplied JSON string on update", () => {
+      const result = updateWith({
+        input: '{"key":"value"}',
+        existing: { input: "123456", expectedOutput: null, metadata: null },
+      });
+      expect(result.input).toEqual({ key: "value" });
+    });
+
+    it("carries over a stored null as a DB null", () => {
+      const result = updateWith({
+        input: undefined,
+        existing: { input: null, expectedOutput: null, metadata: null },
+      });
+      expect(result.input).toBe(Prisma.DbNull);
+    });
+  });
 });

--- a/packages/shared/src/server/services/DatasetService/DatasetItemValidator.ts
+++ b/packages/shared/src/server/services/DatasetService/DatasetItemValidator.ts
@@ -112,25 +112,27 @@ export class DatasetItemValidator {
 
   private normalize(
     data: string | unknown | null | undefined,
-    opts?: { sanitizeControlChars?: boolean },
+    opts?: { sanitizeControlChars?: boolean; parseJsonStrings?: boolean },
   ): Prisma.InputJsonValue | null | undefined {
     if (data === "") return null;
     if (data === undefined) return undefined;
     if (data === null) return null;
 
     try {
-      // Handle both string (tRPC) and already-parsed values (Public API)
       // InputJsonValue accepts objects, arrays, strings, numbers, booleans, null
       let parsed: Prisma.InputJsonValue;
 
-      if (typeof data === "string") {
-        // Try to parse as JSON first (for tRPC which sends JSON strings like '{"key":"value"}')
+      if (opts?.parseJsonStrings && typeof data === "string") {
+        // Opted-in callers still hold JSON-encoded strings like
+        // '{"key":"value"}' (tRPC forms, ClickHouse String columns).
         const parsedJson = parseJsonPrioritised(data);
         parsed = (
           parsedJson === undefined ? data : parsedJson
         ) as Prisma.InputJsonValue;
       } else {
-        // Public API sends already-parsed values - use directly
+        // Already-parsed value (Public API, MCP): a string here is a real
+        // string, so re-parsing it would silently coerce JSON-literal-looking
+        // values such as "123456" to the number 123456 (#15342).
         parsed = data as Prisma.InputJsonValue;
       }
 
@@ -186,7 +188,9 @@ export class DatasetItemValidator {
    * Combines JSON parsing, control character sanitization, and schema validation.
    *
    * **Flexible input:** Accepts both JSON strings (from tRPC) and already-parsed
-   * objects (from Public API). Handles both seamlessly.
+   * objects (from Public API). Callers holding JSON-encoded strings must set
+   * `normalizeOpts.parseJsonStrings`; everyone else gets their values stored
+   * verbatim.
    *
    * @param params.input - JSON string, parsed object, or null
    * @param params.expectedOutput - JSON string, parsed object, or null
@@ -197,7 +201,10 @@ export class DatasetItemValidator {
     input: string | unknown | null | undefined;
     expectedOutput: string | unknown | null | undefined;
     metadata: string | unknown | null | undefined;
-    normalizeOpts?: { sanitizeControlChars?: boolean };
+    normalizeOpts?: {
+      sanitizeControlChars?: boolean;
+      parseJsonStrings?: boolean;
+    };
     validateOpts: { normalizeUndefinedToNull?: boolean };
   }): ValidateAndNormalizeResult {
     // If we have a create operation, input cannot be undefined / null

--- a/packages/shared/src/server/services/DatasetService/DatasetItemValidator.ts
+++ b/packages/shared/src/server/services/DatasetService/DatasetItemValidator.ts
@@ -110,6 +110,26 @@ export class DatasetItemValidator {
     return value === null ? Prisma.DbNull : value;
   }
 
+  /**
+   * Normalize one IO field for an upsert.
+   *
+   * A value the caller actually supplied is normalized, and JSON-parsed when
+   * the caller opted in. A field the caller omitted (`undefined`) on an update
+   * falls back to the existing, already-decoded DB value, which is passed
+   * through untouched — re-parsing a carried-over bare string like "123456"
+   * would coerce it back to the number 123456, reintroducing #15342 on a
+   * routine status toggle.
+   */
+  private normalizeUpsertField(
+    value: string | unknown | null | undefined,
+    existing: { present: boolean; value: Prisma.InputJsonValue | null },
+    opts?: { sanitizeControlChars?: boolean; parseJsonStrings?: boolean },
+  ): Prisma.InputJsonValue | null | undefined {
+    if (value !== undefined) return this.normalize(value, opts);
+    if (existing.present) return existing.value;
+    return undefined;
+  }
+
   private normalize(
     data: string | unknown | null | undefined,
     opts?: { sanitizeControlChars?: boolean; parseJsonStrings?: boolean },
@@ -201,6 +221,17 @@ export class DatasetItemValidator {
     input: string | unknown | null | undefined;
     expectedOutput: string | unknown | null | undefined;
     metadata: string | unknown | null | undefined;
+    /**
+     * Already-decoded values of the item being updated. When a field is
+     * omitted from `params`, its value here is carried over verbatim instead
+     * of being re-normalized, so a stored string is never parsed a second
+     * time. Omit entirely for create operations.
+     */
+    existingItem?: {
+      input: Prisma.InputJsonValue | null;
+      expectedOutput: Prisma.InputJsonValue | null;
+      metadata: Prisma.InputJsonValue | null;
+    };
     normalizeOpts?: {
       sanitizeControlChars?: boolean;
       parseJsonStrings?: boolean;
@@ -227,14 +258,25 @@ export class DatasetItemValidator {
       };
     }
 
-    // 1. Normalize IO
-    const normalizedInput = this.normalize(params.input, params.normalizeOpts);
-    const normalizedExpectedOutput = this.normalize(
-      params.expectedOutput,
+    // 1. Normalize IO. On an update, fields omitted by the caller fall back to
+    // the existing already-decoded value rather than being parsed again.
+    const existing = params.existingItem;
+    const normalizedInput = this.normalizeUpsertField(
+      params.input,
+      { present: existing !== undefined, value: existing?.input ?? null },
       params.normalizeOpts,
     );
-    const normalizedMetadata = this.normalize(
+    const normalizedExpectedOutput = this.normalizeUpsertField(
+      params.expectedOutput,
+      {
+        present: existing !== undefined,
+        value: existing?.expectedOutput ?? null,
+      },
+      params.normalizeOpts,
+    );
+    const normalizedMetadata = this.normalizeUpsertField(
       params.metadata,
+      { present: existing !== undefined, value: existing?.metadata ?? null },
       params.normalizeOpts,
     );
 

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -837,6 +837,48 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     expect(getDatasetItem.body).toMatchObject(singleItem);
   });
 
+  // Regression: bare string payloads used to be re-parsed as JSON server-side,
+  // so "123456" round-tripped back as the number 123456 (issue #15342).
+  it.each([
+    ["a numeric string", "123456"],
+    ["a float-like string", "1.5"],
+    ["a boolean-like string", "true"],
+    ["a null-like string", "null"],
+  ])("should preserve %s on round-trip", async (_label, value) => {
+    await makeZodVerifiedAPICall(
+      PostDatasetsV1Response,
+      "POST",
+      "/api/public/datasets",
+      { name: "dataset-string-roundtrip" },
+      auth,
+    );
+
+    const created = await makeZodVerifiedAPICall(
+      PostDatasetItemsV1Response,
+      "POST",
+      "/api/public/dataset-items",
+      {
+        datasetName: "dataset-string-roundtrip",
+        input: value,
+        expectedOutput: value,
+        metadata: value,
+      },
+      auth,
+    );
+    expect(created.body.input).toBe(value);
+
+    const fetched = await makeZodVerifiedAPICall(
+      GetDatasetItemV1Response,
+      "GET",
+      `/api/public/dataset-items/${created.body.id}`,
+      undefined,
+      auth,
+    );
+    expect(fetched.body.input).toBe(value);
+    expect(fetched.body.expectedOutput).toBe(value);
+    expect(fetched.body.metadata).toBe(value);
+  });
+
   it("should upsert a dataset item", async () => {
     await makeZodVerifiedAPICall(
       PostDatasetsV1Response,

--- a/web/src/__tests__/server/datasets-schema-validation.servertest.ts
+++ b/web/src/__tests__/server/datasets-schema-validation.servertest.ts
@@ -352,6 +352,7 @@ describe("Unit Tests - DatasetItemValidator", () => {
       input: '{"input_number":107505301260286111,"safe_number":42}',
       expectedOutput: '{"output_number":107505301260286111}',
       metadata: '{"metadata_number":107505301260286111}',
+      normalizeOpts: { parseJsonStrings: true },
       validateOpts: { normalizeUndefinedToNull: true },
     });
 
@@ -380,6 +381,7 @@ describe("Unit Tests - DatasetItemValidator", () => {
       input: "null",
       expectedOutput: "null",
       metadata: "null",
+      normalizeOpts: { parseJsonStrings: true },
       validateOpts: { normalizeUndefinedToNull: true },
     });
 

--- a/web/src/__tests__/server/repositories/dataset-items-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/dataset-items-repository.servertest.ts
@@ -852,6 +852,41 @@ describe("Dataset Items Repository - Versioning Tests", () => {
       expect(item.input).toEqual({ key: "value" });
     });
 
+    it("does not re-coerce a carried-over string field on a status-only update (#15342)", async () => {
+      const datasetId = v4();
+      const itemId = v4();
+      await prisma.dataset.create({
+        data: { id: datasetId, name: v4(), projectId },
+      });
+
+      // Public API semantics: the value is already decoded, so the bare
+      // string "123456" is stored as a string rather than the number 123456.
+      const created = await upsertDatasetItem({
+        projectId,
+        datasetId,
+        datasetItemId: itemId,
+        input: "123456",
+        normalizeOpts: {},
+        validateOpts: { normalizeUndefinedToNull: true },
+      });
+      expect(created.input).toBe("123456");
+
+      // Archive toggle from the UI hits updateDatasetItem, which supplies only
+      // status and always sets parseJsonStrings. The omitted input is filled
+      // from the existing, already-decoded value and must not be parsed again.
+      const updated = await upsertDatasetItem({
+        projectId,
+        datasetId,
+        datasetItemId: itemId,
+        status: "ARCHIVED",
+        normalizeOpts: { parseJsonStrings: true },
+        validateOpts: { normalizeUndefinedToNull: false },
+      });
+
+      expect(updated.status).toBe("ARCHIVED");
+      expect(updated.input).toBe("123456");
+    });
+
     it("should create new version on update with same ID", async () => {
       const datasetId = v4();
       const itemId = v4();

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1138,6 +1138,7 @@ export const datasetRouter = createTRPCRouter({
         sourceTraceId: input.sourceTraceId,
         sourceObservationId: input.sourceObservationId,
         status: input.status,
+        normalizeOpts: { parseJsonStrings: true },
         validateOpts: { normalizeUndefinedToNull: false }, // For UPDATE, undefined means "don't update"
       });
 
@@ -1644,7 +1645,7 @@ export const datasetRouter = createTRPCRouter({
         metadata: input.metadata,
         sourceTraceId: input.sourceTraceId,
         sourceObservationId: input.sourceObservationId,
-        normalizeOpts: { sanitizeControlChars: true },
+        normalizeOpts: { sanitizeControlChars: true, parseJsonStrings: true },
         validateOpts: {
           normalizeUndefinedToNull: true, // For CREATE, undefined becomes null in DB
         },
@@ -1708,7 +1709,7 @@ export const datasetRouter = createTRPCRouter({
         const result = await createManyDatasetItems({
           projectId: input.projectId,
           items: input.items,
-          normalizeOpts: { sanitizeControlChars: true },
+          normalizeOpts: { sanitizeControlChars: true, parseJsonStrings: true },
           validateOpts: { normalizeUndefinedToNull: true },
         });
 

--- a/worker/src/features/batchAction/processAddObservationsToDataset.ts
+++ b/worker/src/features/batchAction/processAddObservationsToDataset.ts
@@ -88,7 +88,9 @@ async function processChunk(params: {
     const result = await createManyDatasetItems({
       projectId,
       items,
-      normalizeOpts: { sanitizeControlChars: true },
+      // Observation input/output arrive as JSON strings from ClickHouse
+      // (Nullable(String) columns), so they still need decoding here.
+      normalizeOpts: { sanitizeControlChars: true, parseJsonStrings: true },
       validateOpts: { normalizeUndefinedToNull: true },
       allowPartialSuccess: true, // Allow partial success for bulk operations
     });

--- a/worker/src/features/batchAction/processAddObservationsToDataset.ts
+++ b/worker/src/features/batchAction/processAddObservationsToDataset.ts
@@ -88,8 +88,12 @@ async function processChunk(params: {
     const result = await createManyDatasetItems({
       projectId,
       items,
-      // Observation input/output arrive as JSON strings from ClickHouse
-      // (Nullable(String) columns), so they still need decoding here.
+      // Full-mode mappings pass the raw ClickHouse input/output through
+      // verbatim (Nullable(String) columns), so those JSON strings still need
+      // decoding here. Custom JSONPath mappings already decode in
+      // applyFieldMapping, so an extracted bare scalar string gets re-parsed a
+      // second time — a pre-existing #15342-class coercion tracked separately,
+      // not addressed here to avoid changing documented batch-action behaviour.
       normalizeOpts: { sanitizeControlChars: true, parseJsonStrings: true },
       validateOpts: { normalizeUndefinedToNull: true },
       allowPartialSuccess: true, // Allow partial success for bulk operations

--- a/worker/src/features/batchAction/processAddObservationsToDataset.ts
+++ b/worker/src/features/batchAction/processAddObservationsToDataset.ts
@@ -88,12 +88,15 @@ async function processChunk(params: {
     const result = await createManyDatasetItems({
       projectId,
       items,
-      // Full-mode mappings pass the raw ClickHouse input/output through
-      // verbatim (Nullable(String) columns), so those JSON strings still need
-      // decoding here. Custom JSONPath mappings already decode in
-      // applyFieldMapping, so an extracted bare scalar string gets re-parsed a
-      // second time — a pre-existing #15342-class coercion tracked separately,
-      // not addressed here to avoid changing documented batch-action behaviour.
+      // parseJsonStrings is only strictly correct for the events-table stream
+      // (getEventsStreamForDataset), which yields raw ClickHouse input/output.
+      // The default observations-table stream (getObservationStream) already
+      // decodes them upstream via convertObservation/applyInputOutputRendering
+      // (shouldJsonParse), so re-parsing here double-decodes a bare scalar
+      // string on that path — a pre-existing #15342-class coercion, not a
+      // regression (the validator parsed unconditionally before this change).
+      // Left as a follow-up: a real fix (decode in the events stream and drop
+      // this flag) would change documented batch-action output.
       normalizeOpts: { sanitizeControlChars: true, parseJsonStrings: true },
       validateOpts: { normalizeUndefinedToNull: true },
       allowPartialSuccess: true, // Allow partial success for bulk operations


### PR DESCRIPTION
## What does this PR do?

Creating a dataset item through the public API with a bare string input like `"123456"` stored it as the number `123456`, so reading the dataset back through the SDK returned an `int` instead of the `str` that went in. The UI still rendered it as a string, which made it look like a retrieval bug, but the value was already a number in Postgres.

Fixes langfuse/langfuse#15342

### Cause

`DatasetItemValidator.normalize()` ran every string through `parseJsonPrioritised()`:

```ts
if (typeof data === "string") {
  const parsedJson = parseJsonPrioritised(data);
  parsed = (parsedJson === undefined ? data : parsedJson) as Prisma.InputJsonValue;
}
```

That is correct for tRPC, where the dataset item form submits JSON-encoded strings like `'{"key":"value"}'`. It is wrong for the public API, where the HTTP body parser has already decoded the payload, so a string is a real string. Any value that happens to look like a JSON literal got parsed a second time, turning `"123456"`, `"1.5"`, `"true"` and `"null"` into a number, a boolean and null.

One function was serving two callers with opposite needs and had no way to tell them apart.

### Fix

Parsing is now opt-in through `normalizeOpts.parseJsonStrings`, so the decision is made by the caller that knows whether its values are still encoded:

<!-- linear:table-colwidths:266,266,266 -->
| Caller | Parses | Why |
| -- | -- | -- |
| tRPC `createDatasetItem`, `createManyDatasetItems`, `updateDatasetItem` | yes | the item form submits JSON-encoded strings |
| worker `processAddObservationsToDataset` | yes | reads `input`/`output` from ClickHouse `Nullable(String)` columns |
| Public API (`createDatasetItemForApi`) and MCP | no | the HTTP body parser has already decoded the payload |

Two call sites are worth flagging for review. `updateDatasetItem` previously passed no `normalizeOpts` at all and was relying on the old implicit default, so it needed the opt-in to keep working. The worker batch action genuinely depends on the parse, since ClickHouse returns those columns as strings — I confirmed the column types rather than assuming.

Behaviour is unchanged everywhere except the public API and MCP, which is the path in the issue.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Tests

Failing tests were written first, and confirmed to fail before the fix:

* `packages/shared/src/server/services/DatasetService/DatasetItemValidator.test.ts` (new) covers both paths: already-parsed values are stored verbatim, opted-in JSON strings are still decoded. 8 of the 17 assertions failed before the fix.
* `web/src/__tests__/server/datasets-api.servertest.ts` adds a public API round-trip for `"123456"`, `"1.5"`, `"true"` and `"null"`. To check these actually catch the regression rather than passing vacuously, I reverted the fix and confirmed all four flip to failing, then restored it.
* The two existing `datasets-schema-validation` unit tests that feed JSON strings directly to the validator now pass `parseJsonStrings: true`, since they model the tRPC path.

Local runs: `typecheck` and `lint` both `7 successful, 7 total`; `DatasetItemValidator` 17/17; `datasets-api` 27/27; `datasets-schema-validation` 48/48; `dataset-items-repository` 46/46; `dataset-service` 35/35; worker `batchAction.test.ts` 15/15.

Also verified end to end against a local instance: an item posted via the public API with input `"123456"` is stored as a JSON `string` and reads back as `str`, while items created and edited through the UI form are still stored as parsed objects.

<details><summary>Greptile Summary</summary>

This PR makes dataset-item JSON-string parsing caller-controlled.

* Adds `parseJsonStrings` normalization configuration and preserves literal strings by default.
* Opts the tRPC and observation batch-action paths into parsing while leaving public API and MCP values decoded.
* Adds validator and public API regression coverage for JSON-literal-looking strings.

</details>

<details><summary>Confidence Score: 4/5</summary>

The PR appears safe to merge, with the non-blocking source-file encoding issue corrected to keep the new test reviewable as text.

Caller-specific parsing preserves the existing tRPC and worker behavior while fixing public API string coercion; the only accepted concern is that an actual NUL byte makes the new test binary to Git.

packages/shared/src/server/services/DatasetService/DatasetItemValidator.test.ts

</details>

<details><summary>Prompt To Fix All With AI</summary>

```markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/services/DatasetService/DatasetItemValidator.test.ts:68
**Keep the test source text-diffable**

This string literal contains an actual NUL byte, so Git classifies the TypeScript file as binary and hides the entire test from normal diffs. Using the `\u0000` source escape exercises the same runtime character while keeping reviews and future merges text-based.
```

</details>

Reviews (1): Last reviewed commit: ["fix: keep bare string dataset item input..."](<https://github.com/langfuse/langfuse/commit/f8cb0577578276782d5207129d8b979150b8e3ea>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=46834796>)

**Context used:**

* Knowledge Base — [Datasets, Dataset Runs, and Experiments](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-experiments.md>)
* Knowledge Base — [Batch Actions and Data Exports](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md>)