### PR TITLE
fix(dashboards): keep existing widgets rendered when adding a widget (LFE-10986)

### DIFF
--- a/web/src/__tests__/sse-dashboard-query.clienttest.ts
+++ b/web/src/__tests__/sse-dashboard-query.clienttest.ts
@@ -232,6 +232,106 @@ describe("useSSEDashboardQuery", () => {
     expect(result.current.data).toEqual([{ count_count: 42 }]);
   });
 
+  it("keeps previously loaded rows during a same-input re-run", async () => {
+    const encoder = new TextEncoder();
+    let releaseSecondResponse: (() => void) | null = null;
+
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        body: {
+          getReader: () =>
+            createStreamReader([
+              encoder.encode(
+                'event: row\ndata: {"count_count":42}\n\n' +
+                  "event: done\ndata: {}\n\n",
+              ),
+            ]),
+        },
+      }))
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        body: {
+          getReader: () => {
+            let released = false;
+            let step = 0;
+            const waitForRelease = new Promise<void>((resolve) => {
+              releaseSecondResponse = () => {
+                released = true;
+                resolve();
+              };
+            });
+
+            return {
+              read: vi.fn().mockImplementation(async () => {
+                if (!released) {
+                  await waitForRelease;
+                }
+
+                if (step === 0) {
+                  step += 1;
+                  return {
+                    done: false,
+                    value: encoder.encode(
+                      'event: row\ndata: {"count_count":99}\n\n' +
+                        "event: done\ndata: {}\n\n",
+                    ),
+                  };
+                }
+
+                return { done: true, value: undefined };
+              }),
+            };
+          },
+        },
+      })) as typeof fetch;
+    global.TextDecoder = TextDecoder as typeof global.TextDecoder;
+
+    const input = createInput(
+      "2026-03-22T00:00:00.000Z",
+      "2026-03-23T00:00:00.000Z",
+    );
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useSSEDashboardQuery(input, {
+          enabled,
+          queryId: "widget-1",
+        }),
+      {
+        initialProps: { enabled: true },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([{ count_count: 42 }]);
+
+    // Scheduler re-promotion: the widget is disabled, then re-enabled with the
+    // exact same query input (a re-run it did not need).
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+
+    // The second stream is in flight. The chart must NOT blank: the previously
+    // loaded rows stay rendered until fresh rows arrive.
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+    expect(result.current.data).toEqual([{ count_count: 42 }]);
+
+    (releaseSecondResponse as (() => void) | null)?.();
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ count_count: 99 }]);
+    });
+    expect(result.current.isSuccess).toBe(true);
+  });
+
   it("treats a changed input as pending immediately and hides stale results", async () => {
     const encoder = new TextEncoder();
     let releaseSecondResponse: (() => void) | null = null;

--- a/web/src/__tests__/sse-dashboard-query.clienttest.ts
+++ b/web/src/__tests__/sse-dashboard-query.clienttest.ts
@@ -332,6 +332,104 @@ describe("useSSEDashboardQuery", () => {
     expect(result.current.isSuccess).toBe(true);
   });
 
+  it("clears stale rows when a same-input re-run errors", async () => {
+    const encoder = new TextEncoder();
+    let releaseSecondResponse: (() => void) | null = null;
+
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        body: {
+          getReader: () =>
+            createStreamReader([
+              encoder.encode(
+                'event: row\ndata: {"count_count":42}\n\n' +
+                  "event: done\ndata: {}\n\n",
+              ),
+            ]),
+        },
+      }))
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        body: {
+          getReader: () => {
+            let released = false;
+            let step = 0;
+            const waitForRelease = new Promise<void>((resolve) => {
+              releaseSecondResponse = () => {
+                released = true;
+                resolve();
+              };
+            });
+
+            return {
+              read: vi.fn().mockImplementation(async () => {
+                if (!released) {
+                  await waitForRelease;
+                }
+
+                if (step === 0) {
+                  step += 1;
+                  return {
+                    done: false,
+                    value: encoder.encode(
+                      'event: error\ndata: {"message":"boom"}\n\n',
+                    ),
+                  };
+                }
+
+                return { done: true, value: undefined };
+              }),
+            };
+          },
+        },
+      })) as typeof fetch;
+    global.TextDecoder = TextDecoder as typeof global.TextDecoder;
+
+    const input = createInput(
+      "2026-03-22T00:00:00.000Z",
+      "2026-03-23T00:00:00.000Z",
+    );
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useSSEDashboardQuery(input, {
+          enabled,
+          queryId: "widget-1",
+        }),
+      {
+        initialProps: { enabled: true },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([{ count_count: 42 }]);
+
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+
+    // While the re-run is in flight, previous rows are still shown.
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+    expect(result.current.data).toEqual([{ count_count: 42 }]);
+
+    // Once it errors, the stale success rows must not linger behind the error.
+    (releaseSecondResponse as (() => void) | null)?.();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBe("boom");
+  });
+
   it("treats a changed input as pending immediately and hides stale results", async () => {
     const encoder = new TextEncoder();
     let releaseSecondResponse: (() => void) | null = null;

--- a/web/src/hooks/useDashboardQueryScheduler.clienttest.ts
+++ b/web/src/hooks/useDashboardQueryScheduler.clienttest.ts
@@ -61,7 +61,12 @@ describe("getDashboardSchedulerResetKey", () => {
 });
 
 describe("useDashboardQueryScheduler", () => {
-  it("does not re-run already-done siblings when a new widget registers", () => {
+  // Characterizes `register`'s incremental behavior (a new id is inserted as
+  // `queued` and scheduled without iterating existing items). This is the
+  // property the reset-key fix relies on — not itself a guard for LFE-10986
+  // (register never touched siblings, pre- or post-fix). The regression guard
+  // for the bug is the getDashboardSchedulerResetKey composition test above.
+  it("schedules a newly registered widget without touching done siblings", () => {
     const { result } = renderHook(() =>
       useDashboardQueryScheduler({ maxConcurrent: 2, resetKey: "k1" }),
     );

--- a/web/src/hooks/useDashboardQueryScheduler.clienttest.ts
+++ b/web/src/hooks/useDashboardQueryScheduler.clienttest.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the dashboard query scheduler and its reset-key contract.
+ *
+ * The scheduler re-queues every in-flight / completed widget whenever its
+ * reset key changes (see `resetQueue`). The reset key must therefore depend
+ * only on genuinely query-affecting params (time range, filters, environment)
+ * and NOT on the set of widgets present — otherwise adding a widget re-runs
+ * every sibling, which on the SSE path blanks already-rendered charts
+ * (LFE-10986).
+ */
+import { act, renderHook } from "@testing-library/react";
+import {
+  getDashboardSchedulerResetKey,
+  useDashboardQueryScheduler,
+} from "@/src/hooks/useDashboardQueryScheduler";
+
+describe("getDashboardSchedulerResetKey", () => {
+  const base = {
+    projectId: "project-1",
+    dashboardId: "dashboard-1",
+    fromIso: "2026-01-01T00:00:00.000Z",
+    toIso: "2026-01-08T00:00:00.000Z",
+    filters: [] as unknown[],
+    environments: ["default"],
+  };
+
+  it("is composed of only query-affecting params (never the widget set)", () => {
+    // Pinning the exact composition guards against re-introducing the widget
+    // id list, which would re-queue every sibling on "Add Widget" (LFE-10986).
+    expect(getDashboardSchedulerResetKey(base)).toBe(
+      "project-1|dashboard-1|2026-01-01T00:00:00.000Z|2026-01-08T00:00:00.000Z|[]|default",
+    );
+  });
+
+  it("changes when the time range changes", () => {
+    expect(
+      getDashboardSchedulerResetKey({
+        ...base,
+        toIso: "2026-02-01T00:00:00.000Z",
+      }),
+    ).not.toBe(getDashboardSchedulerResetKey(base));
+  });
+
+  it("changes when the filters change", () => {
+    expect(
+      getDashboardSchedulerResetKey({
+        ...base,
+        filters: [{ column: "name", operator: "=", value: "x" }],
+      }),
+    ).not.toBe(getDashboardSchedulerResetKey(base));
+  });
+
+  it("changes when the environment selection changes", () => {
+    expect(
+      getDashboardSchedulerResetKey({
+        ...base,
+        environments: ["default", "prod"],
+      }),
+    ).not.toBe(getDashboardSchedulerResetKey(base));
+  });
+});
+
+describe("useDashboardQueryScheduler", () => {
+  it("does not re-run already-done siblings when a new widget registers", () => {
+    const { result } = renderHook(() =>
+      useDashboardQueryScheduler({ maxConcurrent: 2, resetKey: "k1" }),
+    );
+
+    act(() => {
+      result.current.register("w1", 1);
+      result.current.register("w2", 2);
+    });
+
+    // Both promoted (maxConcurrent = 2) then completed.
+    act(() => {
+      result.current.markDone("w1");
+      result.current.markDone("w2");
+    });
+
+    expect(result.current.canFetch("w1")).toBe(false);
+    expect(result.current.canFetch("w2")).toBe(false);
+
+    // "Add Widget": a brand-new placement registers and schedules on its own.
+    act(() => {
+      result.current.register("w3", 3);
+    });
+
+    expect(result.current.canFetch("w3")).toBe(true);
+    // The done siblings must stay done — never re-queued/re-run.
+    expect(result.current.canFetch("w1")).toBe(false);
+    expect(result.current.canFetch("w2")).toBe(false);
+  });
+
+  it("re-queues completed widgets when the reset key changes", () => {
+    const { result, rerender } = renderHook(
+      ({ resetKey }) =>
+        useDashboardQueryScheduler({ maxConcurrent: 5, resetKey }),
+      { initialProps: { resetKey: "k1" } },
+    );
+
+    act(() => {
+      result.current.register("w1", 1);
+    });
+    act(() => {
+      result.current.markDone("w1");
+    });
+
+    expect(result.current.canFetch("w1")).toBe(false);
+
+    // A genuine query-param change (new reset key) must refresh everything.
+    rerender({ resetKey: "k2" });
+
+    expect(result.current.canFetch("w1")).toBe(true);
+  });
+});

--- a/web/src/hooks/useDashboardQueryScheduler.tsx
+++ b/web/src/hooks/useDashboardQueryScheduler.tsx
@@ -62,7 +62,7 @@ export const getDashboardQuerySchedulerMaxConcurrent = (
 };
 
 /**
- * Reset key for the dashboard query scheduler.
+ * Reset key for the dashboard-detail query scheduler.
  *
  * When this key changes, the scheduler re-queues every in-flight and completed
  * widget (see `resetQueue`). It must therefore reflect ONLY parameters that
@@ -70,6 +70,11 @@ export const getDashboardQuerySchedulerMaxConcurrent = (
  * NOT the set of widgets present on the dashboard. Adding or removing a widget
  * registers/unregisters incrementally and must not disturb already-rendered
  * siblings (which, on the SSE path, would blank while they re-stream).
+ *
+ * Note: this is the reset key for the dashboard-detail page only. The Home page
+ * builds its own inline reset key (it additionally keys on metricsVersion and
+ * has never folded in the widget set), so this helper is not a single source of
+ * truth for every dashboard-like surface.
  */
 export const getDashboardSchedulerResetKey = (params: {
   projectId: string;

--- a/web/src/hooks/useDashboardQueryScheduler.tsx
+++ b/web/src/hooks/useDashboardQueryScheduler.tsx
@@ -61,6 +61,33 @@ export const getDashboardQuerySchedulerMaxConcurrent = (
   return 9;
 };
 
+/**
+ * Reset key for the dashboard query scheduler.
+ *
+ * When this key changes, the scheduler re-queues every in-flight and completed
+ * widget (see `resetQueue`). It must therefore reflect ONLY parameters that
+ * genuinely invalidate query results — time range, filters, environment — and
+ * NOT the set of widgets present on the dashboard. Adding or removing a widget
+ * registers/unregisters incrementally and must not disturb already-rendered
+ * siblings (which, on the SSE path, would blank while they re-stream).
+ */
+export const getDashboardSchedulerResetKey = (params: {
+  projectId: string;
+  dashboardId: string;
+  fromIso: string;
+  toIso: string;
+  filters: unknown;
+  environments: string[];
+}): string =>
+  [
+    params.projectId,
+    params.dashboardId,
+    params.fromIso,
+    params.toIso,
+    JSON.stringify(params.filters),
+    params.environments.join(","),
+  ].join("|");
+
 const parseIsoDateMs = (value: unknown): number | null => {
   if (typeof value !== "string") return null;
 

--- a/web/src/hooks/useSSEDashboardQuery.ts
+++ b/web/src/hooks/useSSEDashboardQuery.ts
@@ -89,6 +89,11 @@ export function useSSEDashboardQuery(
   const [error, setError] = useState<string | null>(null);
   const [stateInputKey, setStateInputKey] = useState<string | null>(null);
   const maxPercentRef = useRef(0);
+  // Input key of the last run that produced a successful result currently held
+  // in `data`. Used to keep-previous-data across a same-input re-run so an
+  // already-rendered widget never blanks on a re-run it did not need (e.g. the
+  // scheduler re-promoting an item). A genuine input change still clears.
+  const lastSuccessfulInputKeyRef = useRef<string | null>(null);
   const basePath = env.NEXT_PUBLIC_BASE_PATH ?? "";
 
   // Stable reference for the input to avoid re-triggering on every render
@@ -97,11 +102,18 @@ export function useSSEDashboardQuery(
 
   const runQuery = useCallback(
     async (runInputKey: string, signal: AbortSignal) => {
+      const isSameInputAsLastSuccess =
+        lastSuccessfulInputKeyRef.current === runInputKey;
       setStateInputKey(runInputKey);
       setStatus("loading");
       setProgress(null);
       setError(null);
-      setData(undefined);
+      // Keep the previously loaded rows when re-running the exact same query, so
+      // the chart stays rendered instead of flashing empty; only clear when the
+      // input actually changed (a genuinely new query).
+      if (!isSameInputAsLastSuccess) {
+        setData(undefined);
+      }
       maxPercentRef.current = 0;
 
       try {
@@ -170,6 +182,7 @@ export function useSSEDashboardQuery(
           } else if (event.type === "done") {
             setData(rows);
             setStatus("success");
+            lastSuccessfulInputKeyRef.current = runInputKey;
             terminated = true;
           } else if (event.type === "error") {
             try {
@@ -209,6 +222,7 @@ export function useSSEDashboardQuery(
           if (rows.length > 0) {
             setData(rows);
             setStatus("success");
+            lastSuccessfulInputKeyRef.current = runInputKey;
           } else {
             setError("Stream ended unexpectedly");
             setStatus("error");

--- a/web/src/hooks/useSSEDashboardQuery.ts
+++ b/web/src/hooks/useSSEDashboardQuery.ts
@@ -192,6 +192,10 @@ export function useSSEDashboardQuery(
               setError(event.data);
             }
             setStatus("error");
+            // An errored re-run must not keep stale success rows behind the
+            // error state (keep-previous-data applies to in-flight/success
+            // only). lastSuccessfulInputKeyRef is intentionally left untouched.
+            setData(undefined);
             terminated = true;
           }
         };
@@ -226,12 +230,14 @@ export function useSSEDashboardQuery(
           } else {
             setError("Stream ended unexpectedly");
             setStatus("error");
+            setData(undefined);
           }
         }
       } catch (err) {
         if (signal.aborted) return;
         setError(err instanceof Error ? err.message : "Unknown error");
         setStatus("error");
+        setData(undefined);
       }
     },
     [basePath],

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -59,6 +59,7 @@ import {
 import {
   DashboardQuerySchedulerProvider,
   getDashboardQuerySchedulerMaxConcurrent,
+  getDashboardSchedulerResetKey,
   useDashboardQueryScheduler,
 } from "@/src/hooks/useDashboardQueryScheduler";
 import {
@@ -1076,10 +1077,6 @@ export default function DashboardDetail() {
 
   const dashboardTimeRangePresets = DASHBOARD_AGGREGATION_OPTIONS;
   const widgetSchedulerPrefix = `dashboard:${projectId}:${dashboardId}:widget:`;
-  const widgetPlacements = useMemo(
-    () => localDashboardDefinition?.widgets ?? [],
-    [localDashboardDefinition?.widgets],
-  );
 
   const getWidgetSchedulerId = useCallback(
     (widgetPlacementId: string) =>
@@ -1087,25 +1084,30 @@ export default function DashboardDetail() {
     [widgetSchedulerPrefix],
   );
 
-  const schedulerResetKey = useMemo(() => {
-    return [
-      projectId,
+  // Reset key intentionally excludes the widget set: adding or removing a
+  // widget must not re-queue in-flight or already-rendered siblings (which,
+  // on the SSE path, blanks them while they re-stream — LFE-10986). A new
+  // widget registers with the scheduler incrementally; a removed one
+  // unregisters. Only genuinely query-affecting params belong here.
+  const schedulerResetKey = useMemo(
+    () =>
+      getDashboardSchedulerResetKey({
+        projectId,
+        dashboardId,
+        fromIso: absoluteTimeRange?.from?.toISOString() ?? "",
+        toIso: absoluteTimeRange?.to?.toISOString() ?? "",
+        filters: currentFilters,
+        environments: selectedEnvironments,
+      }),
+    [
+      absoluteTimeRange?.from,
+      absoluteTimeRange?.to,
+      currentFilters,
       dashboardId,
-      absoluteTimeRange?.from?.toISOString() ?? "",
-      absoluteTimeRange?.to?.toISOString() ?? "",
-      JSON.stringify(currentFilters),
-      selectedEnvironments.join(","),
-      widgetPlacements.map((widget) => widget.id).join(","),
-    ].join("|");
-  }, [
-    absoluteTimeRange?.from,
-    absoluteTimeRange?.to,
-    currentFilters,
-    dashboardId,
-    projectId,
-    selectedEnvironments,
-    widgetPlacements,
-  ]);
+      projectId,
+      selectedEnvironments,
+    ],
+  );
 
   const scheduler = useDashboardQueryScheduler({
     maxConcurrent: getDashboardQuerySchedulerMaxConcurrent(timeRange),


### PR DESCRIPTION
## TL;DR
On a dashboard, clicking **Add Widget** made already-rendered charts blank out and re-load until you refreshed the page. They now stay put. Verified live: adding a widget to a many-widget dashboard at a 90-day range leaves every existing chart rendered.

## Why
A user reported that adding a widget wiped their existing charts. The dashboard's query scheduler uses a "reset key" that, when it changes, re-runs every widget on the board — and that key incorrectly included **the list of widgets present**. So adding one widget changed the key and re-queued all the others. On the streaming (v4 events) data path a re-running widget clears its data first, so every sibling went blank and re-streamed. With many widgets on a long (90-day) range the concurrency cap is low (2 at a time), turning it into a slow, visible cascade. The classic (tRPC) path was immune because its cache survives the churn — which is why it only reproduced for some users.

## What
1. The reset key now depends only on things that actually change results (time range, filters, environment) — **not** which widgets are on the board. Adding/removing a widget now schedules just that widget and leaves the rest alone.
2. Safety net: a streaming widget keeps its last result on screen if it's ever asked to re-run the *exact same* query, instead of flashing empty.

## Result
Adding a widget no longer disturbs existing charts (verified live). Bonus: this also removes two pre-existing spurious full-resets — reordering or deleting a widget used to re-run everything too.

<details>
<summary>Mechanism &amp; verification</summary>

- Optimistic add appends a placement to the dashboard's widget list; `schedulerResetKey` folded in `widgetPlacements.map(w =&gt; w.id)`, so the key changed on every add → `resetQueue()` re-queued every `done`/`running` widget → re-promoted streaming widgets re-ran `runQuery`, whose first act was `setData(undefined)` → chart blanked under a loading overlay while re-streaming.
- Primary fix: a pure `getDashboardSchedulerResetKey({projectId, dashboardId, from, to, filters, environments})` helper that excludes the widget set. The scheduler's `register`/`unregister` already add/remove a single widget incrementally without touching siblings.
- Defense in depth: `useSSEDashboardQuery` retains the last successful rows across a same-input re-run (tracked via a `lastSuccessfulInputKeyRef`); genuine input changes still clear, and terminal errors clear so stale rows never sit behind an error state.
- Guarded by a reset-key composition test (fails if the widget set is refolded) and a streaming-hook test (fails if a same-input re-run blanks). `web` lint + typecheck green; live-verified on a 12-widget dashboard at 90 days.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
