### PR TITLE
fix(dashboards): show "No data" state for empty time-series widgets (LFE-14333)

### DIFF
--- a/web/src/features/monitors/components/MonitorChartPreview.tsx
+++ b/web/src/features/monitors/components/MonitorChartPreview.tsx
@@ -175,6 +175,10 @@ export const MonitorChartPreview = ({
             rowLimit={1000}
             thresholds={thresholds}
             metricFormatter={metricFormatter}
+            // Both queries feed `data`; while either is still pending it can
+            // be spuriously `[]`, which would otherwise flash "No data"
+            // before the real result (or the leading point) arrives.
+            isLoading={queryResult.isPending || scalarResult.isPending}
           />
           <ChartLoadingState
             isLoading={queryResult.isError}

--- a/web/src/features/widgets/chart-library/Chart.clienttest.tsx
+++ b/web/src/features/widgets/chart-library/Chart.clienttest.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Chart } from "@/src/features/widgets/chart-library/Chart";
+import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props";
+
+/**
+ * Dispatcher integration coverage for the LFE-14333 empty-state guard: a unit
+ * test on `isChartDataEmpty` alone can't catch a wiring mistake in `Chart`
+ * (wrong prop threaded through, guard applied to the wrong chart types, the
+ * `isLoading` gate dropped) — only rendering the real dispatcher can.
+ *
+ * jsdom has no `ResizeObserver`; recharts' `ResponsiveContainer` (via
+ * `useChartTickBudget`) needs one to mount without throwing. A minimal stub
+ * is enough — this suite never asserts on measured width.
+ */
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as typeof globalThis & { ResizeObserver: unknown }).ResizeObserver =
+  ResizeObserverStub;
+
+afterEach(cleanup);
+
+const point = (metric: DataPoint["metric"], dimension?: string): DataPoint => ({
+  time_dimension: "2026-01-01T00:00:00Z",
+  dimension,
+  metric,
+});
+
+describe("Chart dispatcher — empty-state guard (LFE-14333)", () => {
+  it("shows NoDataOrLoading for an empty data array", () => {
+    render(<Chart chartType="LINE_TIME_SERIES" data={[]} rowLimit={100} />);
+    expect(screen.getByText("No data")).toBeInTheDocument();
+  });
+
+  it("shows NoDataOrLoading when every point's metric is null", () => {
+    const data = [point(null), point(null, "series-a")];
+    render(<Chart chartType="LINE_TIME_SERIES" data={data} rowLimit={100} />);
+    expect(screen.getByText("No data")).toBeInTheDocument();
+  });
+
+  it("does NOT show NoDataOrLoading when every point's metric is a real 0", () => {
+    const data = [point(0), point(0, "series-a")];
+    const { container } = render(
+      <Chart chartType="LINE_TIME_SERIES" data={data} rowLimit={100} />,
+    );
+    expect(screen.queryByText("No data")).not.toBeInTheDocument();
+    // The real chart primitive mounted instead of the empty-state box —
+    // `ChartContainer` stamps a `data-chart` id on its wrapper unconditionally,
+    // independent of the (jsdom-only) 0x0 layout warning recharts logs when it
+    // can't measure a real box to size its <svg> surface.
+    expect(container.querySelector("[data-chart]")).toBeInTheDocument();
+  });
+
+  it("does NOT show NoDataOrLoading while isLoading, even with no data yet", () => {
+    render(
+      <Chart
+        chartType="LINE_TIME_SERIES"
+        data={[]}
+        rowLimit={100}
+        isLoading={true}
+      />,
+    );
+    expect(screen.queryByText("No data")).not.toBeInTheDocument();
+  });
+
+  it("applies the same guard to AREA_TIME_SERIES and BAR_TIME_SERIES", () => {
+    render(<Chart chartType="AREA_TIME_SERIES" data={[]} rowLimit={100} />);
+    expect(screen.getByText("No data")).toBeInTheDocument();
+    cleanup();
+    render(<Chart chartType="BAR_TIME_SERIES" data={[]} rowLimit={100} />);
+    expect(screen.getByText("No data")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/widgets/chart-library/Chart.tsx
+++ b/web/src/features/widgets/chart-library/Chart.tsx
@@ -10,6 +10,8 @@ import {
   type MissingBucketValue,
 } from "@/src/features/widgets/chart-library/chart-props";
 import { formatMetric } from "@/src/features/widgets/chart-library/utils";
+import { isChartDataEmpty } from "@/src/features/widgets/chart-library/isChartDataEmpty";
+import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import { CardContent } from "@/src/components/ui/card";
 import { LineChartTimeSeries } from "@/src/features/widgets/chart-library/LineChartTimeSeries";
 import { AreaChartTimeSeries } from "@/src/features/widgets/chart-library/AreaChartTimeSeries";
@@ -30,6 +32,18 @@ const DEFAULT_METRIC_THEME = {
   light: "hsl(var(--chart-1))",
   dark: "hsl(var(--chart-1))",
 } as const;
+
+/**
+ * Chart types whose recharts primitive draws nothing but empty axes/grid when
+ * every point is null/zero — a blank canvas rather than guidance (manifesto
+ * principle 8). Decided once here so no time-series component re-derives the
+ * emptiness check. (LFE-14333)
+ */
+const EMPTY_STATE_CHART_TYPES = new Set<DashboardWidgetChartType>([
+  "LINE_TIME_SERIES",
+  "AREA_TIME_SERIES",
+  "BAR_TIME_SERIES",
+]);
 
 const ChartComponent = ({
   chartType,
@@ -127,6 +141,19 @@ const ChartComponent = ({
   }, [config]);
 
   const renderChart = () => {
+    // A time-series query densifies an empty range into zero/null-filled
+    // bucket rows rather than an empty array, so recharts still gets data —
+    // it just draws blank axes with no series. Fail into guidance instead of
+    // that blank box; skip while loading so a first paint doesn't flash "No
+    // data" before the real result arrives. (LFE-14333, manifesto principle 8)
+    if (
+      EMPTY_STATE_CHART_TYPES.has(chartType) &&
+      !isLoading &&
+      isChartDataEmpty(data)
+    ) {
+      return <NoDataOrLoading isLoading={false} />;
+    }
+
     switch (chartType) {
       case "LINE_TIME_SERIES":
         return (

--- a/web/src/features/widgets/chart-library/Chart.tsx
+++ b/web/src/features/widgets/chart-library/Chart.tsx
@@ -141,11 +141,13 @@ const ChartComponent = ({
   }, [config]);
 
   const renderChart = () => {
-    // A time-series query densifies an empty range into zero/null-filled
-    // bucket rows rather than an empty array, so recharts still gets data —
-    // it just draws blank axes with no series. Fail into guidance instead of
-    // that blank box; skip while loading so a first paint doesn't flash "No
-    // data" before the real result arrives. (LFE-14333, manifesto principle 8)
+    // A time-series query can densify an empty range into null-filled bucket
+    // rows rather than an empty array, so recharts still gets data — it just
+    // draws blank axes with no series. Fail into guidance instead of that
+    // blank box. A real 0 is never treated as empty here (see
+    // isChartDataEmpty); skip while loading so a first paint doesn't flash
+    // "No data" before the real result arrives. (LFE-14333, manifesto
+    // principle 8)
     if (
       EMPTY_STATE_CHART_TYPES.has(chartType) &&
       !isLoading &&

--- a/web/src/features/widgets/chart-library/isChartDataEmpty.clienttest.ts
+++ b/web/src/features/widgets/chart-library/isChartDataEmpty.clienttest.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { isChartDataEmpty } from "@/src/features/widgets/chart-library/isChartDataEmpty";
+import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props";
+
+const point = (metric: DataPoint["metric"], dimension?: string): DataPoint => ({
+  time_dimension: "2026-01-01T00:00:00Z",
+  dimension,
+  metric,
+});
+
+describe("isChartDataEmpty", () => {
+  it("treats an empty array as empty", () => {
+    expect(isChartDataEmpty([])).toBe(true);
+  });
+
+  it("treats all-null metrics as empty (no honest value measured)", () => {
+    const data = [point(null), point(null, "series-a")];
+    expect(isChartDataEmpty(data)).toBe(true);
+  });
+
+  it("treats all-zero metrics as empty (mirrors legacy isEmptyTimeSeries)", () => {
+    const data = [point(0), point(0, "series-a"), point(0, "series-b")];
+    expect(isChartDataEmpty(data)).toBe(true);
+  });
+
+  it("treats a mix of null and zero as empty", () => {
+    const data = [point(null), point(0, "series-a"), point(null, "series-b")];
+    expect(isChartDataEmpty(data)).toBe(true);
+  });
+
+  it("is not empty when at least one point carries a real, non-zero value", () => {
+    const data = [point(null), point(5, "series-a"), point(0, "series-b")];
+    expect(isChartDataEmpty(data)).toBe(false);
+  });
+
+  it("is not empty when a real negative value is present", () => {
+    const data = [point(-3, "series-a")];
+    expect(isChartDataEmpty(data)).toBe(false);
+  });
+
+  it("treats an empty histogram (no bins) as empty", () => {
+    const data = [point([])];
+    expect(isChartDataEmpty(data)).toBe(true);
+  });
+
+  it("treats a histogram of only empty bin arrays as empty", () => {
+    const data = [point([[], []])];
+    expect(isChartDataEmpty(data)).toBe(true);
+  });
+
+  it("is not empty when a histogram has a populated bin", () => {
+    const data = [point([[0, 5, 10]])];
+    expect(isChartDataEmpty(data)).toBe(false);
+  });
+});

--- a/web/src/features/widgets/chart-library/isChartDataEmpty.clienttest.ts
+++ b/web/src/features/widgets/chart-library/isChartDataEmpty.clienttest.ts
@@ -18,18 +18,30 @@ describe("isChartDataEmpty", () => {
     expect(isChartDataEmpty(data)).toBe(true);
   });
 
-  it("treats all-zero metrics as empty (mirrors legacy isEmptyTimeSeries)", () => {
+  // A real 0 is a deliberate, honest value here (never coerced from a gap —
+  // manifesto V2 / DataPoint.metric's doc), so it must never be treated as
+  // "no data": additive count/sum series fill an empty bucket with a real 0
+  // (getWidgetMissingBucketValue), a genuine zero-average score chart still
+  // has something true to show (NumericScoreTimeSeriesChart's
+  // isNullValueAllowed:true opt-out of the legacy detector), and a monitor
+  // alert-preview whose measure is 0 across the window still needs its
+  // threshold bands drawn.
+  it("is NOT empty when every point is a real 0", () => {
     const data = [point(0), point(0, "series-a"), point(0, "series-b")];
-    expect(isChartDataEmpty(data)).toBe(true);
+    expect(isChartDataEmpty(data)).toBe(false);
   });
 
-  it("treats a mix of null and zero as empty", () => {
+  it("is NOT empty for a single real-0 point", () => {
+    expect(isChartDataEmpty([point(0)])).toBe(false);
+  });
+
+  it("is NOT empty for a mix of null and real-0 points (0 is real data)", () => {
     const data = [point(null), point(0, "series-a"), point(null, "series-b")];
-    expect(isChartDataEmpty(data)).toBe(true);
+    expect(isChartDataEmpty(data)).toBe(false);
   });
 
   it("is not empty when at least one point carries a real, non-zero value", () => {
-    const data = [point(null), point(5, "series-a"), point(0, "series-b")];
+    const data = [point(null), point(5, "series-a"), point(null, "series-b")];
     expect(isChartDataEmpty(data)).toBe(false);
   });
 

--- a/web/src/features/widgets/chart-library/isChartDataEmpty.ts
+++ b/web/src/features/widgets/chart-library/isChartDataEmpty.ts
@@ -5,13 +5,22 @@ import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props
  * honest to draw, so the dispatcher can fail into a "No data" state instead of
  * a blank canvas (manifesto principle 8).
  *
- * Mirrors the legacy `isEmptyTimeSeries` detector
- * (`dashboard/components/hooks.ts`): a metric of `null` (no honest value
- * measured — see {@link DataPoint}) or a real `0` both count as "nothing to
- * show", because the upstream query densifies an empty time range into
- * zero/null-filled bucket rows rather than an empty array. A histogram-shaped
- * metric (`number[][]`, see {@link DataPoint}) is empty when there are no bins
- * or every bin is itself an empty array.
+ * Empty means: no rows at all, or every point's metric is `null` — "measured
+ * nothing here" (see {@link DataPoint}'s doc). A histogram-shaped metric
+ * (`number[][]`, see {@link DataPoint}) is empty when there are no bins or
+ * every bin is itself an empty array.
+ *
+ * Deliberately NULL-ONLY, unlike the legacy `isEmptyTimeSeries` detector
+ * (`dashboard/components/hooks.ts`), which also collapses a real `0` into
+ * "empty" by default. A real `0` is an honest, deliberate value here — never
+ * coerced from a gap (manifesto V2 / principle 6; `DataPoint.metric`'s doc)
+ * — and callers already rely on it rendering: a genuine zero-average score
+ * chart (`NumericScoreTimeSeriesChart`, which opts out of the legacy
+ * detector's zero-collapsing via `isNullValueAllowed: true`), a monitor
+ * alert-preview whose measure is zero across the window (thresholds still
+ * need to draw), and any additive count/sum series whose honest value for an
+ * empty bucket is a real `0` (`getWidgetMissingBucketValue`). Treating that
+ * as "no data" would hide real, correct charts.
  *
  * Pure and side-effect free — see ARCHITECTURE.md.
  */
@@ -26,5 +35,5 @@ function isMetricEmpty(metric: DataPoint["metric"]): boolean {
   if (Array.isArray(metric)) {
     return metric.length === 0 || metric.every((bin) => bin.length === 0);
   }
-  return metric === 0;
+  return false; // a real number, including 0, is an honest value — never "empty".
 }

--- a/web/src/features/widgets/chart-library/isChartDataEmpty.ts
+++ b/web/src/features/widgets/chart-library/isChartDataEmpty.ts
@@ -1,0 +1,30 @@
+import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props";
+
+/**
+ * Preparer (data -> visualiser seam): decides whether a chart has nothing
+ * honest to draw, so the dispatcher can fail into a "No data" state instead of
+ * a blank canvas (manifesto principle 8).
+ *
+ * Mirrors the legacy `isEmptyTimeSeries` detector
+ * (`dashboard/components/hooks.ts`): a metric of `null` (no honest value
+ * measured — see {@link DataPoint}) or a real `0` both count as "nothing to
+ * show", because the upstream query densifies an empty time range into
+ * zero/null-filled bucket rows rather than an empty array. A histogram-shaped
+ * metric (`number[][]`, see {@link DataPoint}) is empty when there are no bins
+ * or every bin is itself an empty array.
+ *
+ * Pure and side-effect free — see ARCHITECTURE.md.
+ */
+export function isChartDataEmpty(data: DataPoint[]): boolean {
+  return (
+    data.length === 0 || data.every((point) => isMetricEmpty(point.metric))
+  );
+}
+
+function isMetricEmpty(metric: DataPoint["metric"]): boolean {
+  if (metric == null) return true;
+  if (Array.isArray(metric)) {
+    return metric.length === 0 || metric.every((bin) => bin.length === 0);
+  }
+  return metric === 0;
+}


### PR DESCRIPTION
## TL;DR
Time-series dashboard widgets with no data in the selected range rendered a blank chart — empty axes, no message, no hint. They now show the same "No data" state used elsewhere in the app. Verified live: an empty range shows "No data"; a range with data renders normally.

## Why
A time-series query over an empty range still returns bucket rows (values `null` — nothing measured), so the chart received data and drew empty axes with no series — indistinguishable from a broken chart. Deferred follow-up from #15262 (which fixed the env-filter override, not this).

## What
Added a small pure preparer, `isChartDataEmpty`, plus one guard in the `Chart` dispatcher that every widget/chart consumer already routes through. When a line/area/bar-over-time widget has nothing to draw, it renders the existing `NoDataOrLoading` "No data" state instead of a blank canvas.

"Empty" is deliberately **null-only**: no rows, or every point's value is `null`. A real `0` is an honest value in our charts ("missing is a gap, not a zero") and still renders as a flat line — so an all-zero count/cost series is **not** hidden. That also keeps the monitor alert-preview's threshold bands and genuine zero-average score charts intact.

## Result
Empty-range time-series widgets now show "No data"; charts with real values (including honest zeros) render unchanged.

<details>
<summary>Mechanism &amp; verification</summary>

- `isChartDataEmpty(data)`: true when the array is empty or every point's `metric` is `null` (histogram-shaped metric: no bins / all-empty bins). A real number, including `0`, is never "empty".
- The decision lives once in the `Chart` dispatcher (ahead of the `LINE_TIME_SERIES` / `AREA_TIME_SERIES` / `BAR_TIME_SERIES` cases), not duplicated per recharts component — consistent with the charts architecture's decide-once-in-the-preparer rule.
- Gated on `!isLoading` so a first paint doesn't flash "No data" before the query resolves; wired `isLoading` through the one consumer that was missing it (`MonitorChartPreview`).
- The null-only rule (vs. the legacy zero-collapsing detector) was chosen after review flagged that treating `0` as empty regressed numeric-score charts, the monitor alert-preview, and dataset-compare. Horizontal/vertical bar and pie (empty = no rows, different semantics) are a deliberate follow-up.
- Covered by unit tests for the empty rule and a dispatcher integration test (empty/all-null → "No data"; all-zero and `isLoading` → chart still renders). `web` lint + typecheck + build:check green; live-verified.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
