### PR TITLE
fix(api): stop logging public API request payloads

### DIFF
--- a/web/src/__tests__/server/unit/create-authed-project-api-route-auth-errors.servertest.ts
+++ b/web/src/__tests__/server/unit/create-authed-project-api-route-auth-errors.servertest.ts
@@ -7,6 +7,7 @@ const {
   mockIsPrismaException,
   mockRateLimitRequest,
   mockTraceException,
+  mockLoggerDebug,
   mockCreateUnstablePublicApiAuthError,
   mockSendUnstablePublicApiErrorResponse,
 } = vi.hoisted(() => ({
@@ -14,6 +15,7 @@ const {
   mockIsPrismaException: vi.fn(),
   mockRateLimitRequest: vi.fn(),
   mockTraceException: vi.fn(),
+  mockLoggerDebug: vi.fn(),
   mockCreateUnstablePublicApiAuthError: vi.fn((value) => value),
   mockSendUnstablePublicApiErrorResponse: vi.fn(),
 }));
@@ -31,7 +33,7 @@ vi.mock("@langfuse/shared/src/db", () => ({
 vi.mock("@langfuse/shared/src/server", () => ({
   redis: null,
   logger: {
-    debug: vi.fn(),
+    debug: mockLoggerDebug,
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
@@ -243,6 +245,43 @@ describe("createAuthedProjectAPIRoute auth error handling", () => {
       errorContract: undefined,
       upgradePath,
     });
+  });
+
+  it("does not include request query or body data in debug logs", async () => {
+    mockVerifyAuthHeaderAndReturnScope.mockResolvedValueOnce(validAuth);
+
+    const handler = createAuthedProjectAPIRoute({
+      name: "Sensitive Route",
+      querySchema: z.object({ token: z.string() }),
+      bodySchema: z.object({
+        secretKey: z.string(),
+        extraHeaders: z.record(z.string(), z.string()),
+      }),
+      responseSchema: z.object({ ok: z.literal(true) }),
+      fn: async () => ({ ok: true as const }),
+    });
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "PUT",
+      headers: {
+        authorization: "Basic test",
+      },
+      query: {
+        token: "SENTINEL_QUERY_TOKEN",
+      },
+      body: {
+        secretKey: "SENTINEL_SECRET_KEY",
+        extraHeaders: {
+          Authorization: "Bearer SENTINEL_HEADER_TOKEN",
+        },
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockLoggerDebug).toHaveBeenCalledExactlyOnceWith(
+      "Request to route Sensitive Route projectId project-1",
+    );
   });
 
   it("throws a 422 payload error when response serialization exceeds V8 string limits", async () => {

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -86,11 +86,6 @@ export type AuthedProjectAPIRouteConfig<
    * events_only mode and would silently return stale or empty data.
    */
   rejectInEventsOnlyMode?: boolean;
-  /**
-   * Redact or summarize the request body before logging. Use this for routes
-   * accepting user-authored content, secrets, or other sensitive payloads.
-   */
-  redactLogBody?: (body: unknown) => unknown;
   /** Stamps a top-level `_deprecation` object onto responses (LFE-10895). */
   deprecation?: ApiDeprecationInfo;
   fn: (params: {
@@ -405,12 +400,6 @@ export const createAuthedProjectAPIRoute = <
 
     logger.debug(
       `Request to route ${routeConfig.name} projectId ${auth.scope.projectId}`,
-      {
-        query: req.query,
-        body: routeConfig.redactLogBody
-          ? routeConfig.redactLogBody(req.body)
-          : req.body,
-      },
     );
 
     let query: z.infer<TQuery>;

--- a/web/src/pages/api/public/feedback.ts
+++ b/web/src/pages/api/public/feedback.ts
@@ -12,17 +12,6 @@ export default withMiddlewares({
     bodySchema: PostFeedbackBody,
     responseSchema: PostFeedbackResponse,
     successStatusCode: 201,
-    redactLogBody: (body) => {
-      const candidate =
-        typeof body === "object" && body !== null
-          ? (body as {
-              targetType?: unknown;
-            })
-          : {};
-      return {
-        targetType: candidate.targetType,
-      };
-    },
     fn: async ({ body, auth }) =>
       await submitFeedback({
         input: body,


### PR DESCRIPTION
## Summary

- remove public API request query and body data from shared debug logs
- retain route name and project ID for request diagnostics
- remove the obsolete feedback-specific redaction hook now that payload logging is disabled globally
- add regression coverage with sentinel credentials in query, `secretKey`, and `extraHeaders`

## Security impact

Prevents authenticated public API request payloads, including LLM provider credentials and arbitrary authorization headers, from being serialized into JSON debug logs before validation or encryption.

## Impacted package

- `web`

## Verification

- `pnpm exec dotenv -e .env.dev.example -e .env.test.example -- pnpm --filter web run test 'src/__tests__/server/unit/create-authed-project-api-route-auth-errors.servertest.ts'` — `Tests 7 passed (7)`
- `pnpm exec dotenv -e .env.dev.example -e .env.test.example -- pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm exec dotenv -e .env.dev.example -e .env.test.example -- pnpm --filter web exec tsgo -p tsconfig.json --noEmit --skipLibCheck --incremental --tsBuildInfoFile .tsbuildinfo` — passed with no diagnostics

## Tracking

- [LFE-14465](https://linear.app/clickhouse/issue/LFE-14465/vulnerability-langfuse-llm-provider-credentials-can-be-written-to)