### PR TITLE
fix(llm): require fresh secrets for base URL changes

### DIFF
--- a/web/src/__tests__/server/llm-api-key.servertest.ts
+++ b/web/src/__tests__/server/llm-api-key.servertest.ts
@@ -597,6 +597,143 @@ describe("llmApiKey.all RPC", () => {
     expect(connection.extraHeaders).toBeUndefined();
   });
 
+  it("should reject updating the base URL without a new secret key", async () => {
+    const existingExtraHeaders = {
+      Authorization: "Bearer stored-token",
+    };
+
+    await caller.llmApiKey.create({
+      projectId,
+      provider: "openai",
+      adapter: LLMAdapter.OpenAI,
+      secretKey: "sk-original",
+      baseURL: "https://api.openai.com/v1",
+      extraHeaders: existingExtraHeaders,
+    });
+
+    const existingKey = await prisma.llmApiKeys.findFirstOrThrow({
+      where: {
+        projectId,
+        provider: "openai",
+      },
+    });
+
+    await expect(
+      caller.llmApiKey.update({
+        id: existingKey.id,
+        projectId,
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        baseURL: "https://example.net/v1",
+      }),
+    ).rejects.toThrow("Secret key is required when changing the base URL");
+
+    const unchangedKey = await prisma.llmApiKeys.findUniqueOrThrow({
+      where: {
+        id: existingKey.id,
+        projectId,
+      },
+    });
+
+    expect(unchangedKey.baseURL).toBe("https://api.openai.com/v1");
+    expect(decrypt(unchangedKey.secretKey)).toBe("sk-original");
+    expect(JSON.parse(decrypt(unchangedKey.extraHeaders as string))).toEqual(
+      existingExtraHeaders,
+    );
+  });
+
+  it("should not reuse stored extra headers when updating the base URL", async () => {
+    await caller.llmApiKey.create({
+      projectId,
+      provider: "openai",
+      adapter: LLMAdapter.OpenAI,
+      secretKey: "sk-original",
+      baseURL: "https://api.openai.com/v1",
+      extraHeaders: {
+        Authorization: "Bearer stored-token",
+        "X-Custom-Header": "stored-value",
+      },
+    });
+
+    const existingKey = await prisma.llmApiKeys.findFirstOrThrow({
+      where: {
+        projectId,
+        provider: "openai",
+      },
+    });
+
+    await caller.llmApiKey.update({
+      id: existingKey.id,
+      projectId,
+      provider: "openai",
+      adapter: LLMAdapter.OpenAI,
+      secretKey: "sk-rotated",
+      baseURL: "https://example.net/v1",
+      extraHeaders: {
+        Authorization: "",
+        "X-Custom-Header": "",
+      },
+    });
+
+    const updatedKey = await prisma.llmApiKeys.findUniqueOrThrow({
+      where: {
+        id: existingKey.id,
+        projectId,
+      },
+    });
+
+    expect(updatedKey.baseURL).toBe("https://example.net/v1");
+    expect(decrypt(updatedKey.secretKey)).toBe("sk-rotated");
+    expect(updatedKey.extraHeaders).toBeNull();
+    expect(updatedKey.extraHeaderKeys).toEqual([]);
+  });
+
+  it("should allow new extra headers when updating the base URL", async () => {
+    await caller.llmApiKey.create({
+      projectId,
+      provider: "openai",
+      adapter: LLMAdapter.OpenAI,
+      secretKey: "sk-original",
+      baseURL: "https://api.openai.com/v1",
+      extraHeaders: {
+        Authorization: "Bearer stored-token",
+        "X-Old-Header": "stored-value",
+      },
+    });
+
+    const existingKey = await prisma.llmApiKeys.findFirstOrThrow({
+      where: {
+        projectId,
+        provider: "openai",
+      },
+    });
+
+    await caller.llmApiKey.update({
+      id: existingKey.id,
+      projectId,
+      provider: "openai",
+      adapter: LLMAdapter.OpenAI,
+      secretKey: "sk-rotated",
+      baseURL: "https://example.net/v1",
+      extraHeaders: {
+        Authorization: "Bearer rotated-token",
+        "X-Old-Header": "",
+      },
+    });
+
+    const updatedKey = await prisma.llmApiKeys.findUniqueOrThrow({
+      where: {
+        id: existingKey.id,
+        projectId,
+      },
+    });
+
+    expect(JSON.parse(decrypt(updatedKey.extraHeaders as string))).toEqual({
+      Authorization: "Bearer rotated-token",
+    });
+    expect(updatedKey.extraHeaderKeys).toEqual(["Authorization"]);
+  });
+
   it("should create and update an llm api key", async () => {
     const secret = "test-secret";
     const provider = "openai";

--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -631,6 +631,13 @@ export const llmApiKeyRouter = createTRPCRouter({
             ? input.baseURL !== existingKey.baseURL
             : false;
 
+        if (isBaseURLChanged && !input.secretKey) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Secret key is required when changing the base URL",
+          });
+        }
+
         if (input.baseURL && isBaseURLChanged) {
           await validateBaseURLForWrite({
             baseURL: input.baseURL,
@@ -678,7 +685,9 @@ export const llmApiKeyRouter = createTRPCRouter({
         const decryptedHeaders = existingKey.extraHeaders
           ? decryptAndParseExtraHeaders(existingKey.extraHeaders)
           : null;
-        const existingHeaders: Record<string, string> = decryptedHeaders ?? {};
+        const existingHeaders: Record<string, string> = isBaseURLChanged
+          ? {}
+          : (decryptedHeaders ?? {});
 
         // Ensure we only update the extraHeaders where the value is not null
         let extraHeaders: Record<string, string> | undefined;
@@ -720,10 +729,14 @@ export const llmApiKeyRouter = createTRPCRouter({
             ...(input.secretKey ? { secretKey: encrypt(input.secretKey) } : {}),
             extraHeaders: extraHeaders
               ? encrypt(JSON.stringify(extraHeaders))
-              : undefined,
+              : isBaseURLChanged
+                ? null
+                : undefined,
             extraHeaderKeys: extraHeaders
               ? Object.keys(extraHeaders)
-              : undefined,
+              : isBaseURLChanged
+                ? []
+                : undefined,
             displaySecretKey: input.secretKey
               ? getDisplaySecretKey(input.secretKey)
               : undefined,


### PR DESCRIPTION
## What changed

- require a fresh LLM secret whenever an existing connection's base URL changes
- prevent stored extra-header credentials from being reused across destination changes
- allow explicitly supplied non-empty replacement headers while clearing masked or omitted stored values
- add direct tRPC regression coverage for rejection, credential clearing, and explicit replacement

## Why

An administrator could update an existing LLM connection's destination without providing the stored secret again. Prisma preserved the encrypted secret and masked header values, allowing a later completion to send those credentials to the new destination.

This moves the existing `testUpdate` invariant into the authoritative save mutation and binds stored credentials to their original destination.

Linear: [LFE-14464](https://linear.app/clickhouse/issue/LFE-14464/vulnerability-langfuse-stored-llm-secrets-can-be-sent-to-mutable)

## Impacted package

- `web`

## Verification

- `pnpm exec dotenv -e .env.dev.example -- pnpm --filter web run test llm-api-key.servertest.ts` — `Tests 30 passed (30)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`