### PR TITLE
chore(web): tag sdk_name onto http.server spans (LFE-10210)

### DIFF
--- a/web/src/__tests__/server/unit/sdkName.servertest.ts
+++ b/web/src/__tests__/server/unit/sdkName.servertest.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SDK_NAME_HEADER,
+  extractSdkName,
+} from "@/src/server/observability/sdkName";
+
+describe("extractSdkName", () => {
+  it("canonicalizes first-party SDK names to the ingestion closed set", () => {
+    expect(extractSdkName({ [SDK_NAME_HEADER]: "python" })).toBe("python");
+    expect(extractSdkName({ [SDK_NAME_HEADER]: "langfuse-python" })).toBe(
+      "python",
+    );
+    expect(extractSdkName({ [SDK_NAME_HEADER]: "JavaScript" })).toBe(
+      "javascript",
+    );
+    expect(extractSdkName({ [SDK_NAME_HEADER]: "ts" })).toBe("javascript");
+  });
+
+  it("returns undefined for absent or blank headers", () => {
+    expect(extractSdkName({})).toBeUndefined();
+    expect(extractSdkName({ [SDK_NAME_HEADER]: "   " })).toBeUndefined();
+  });
+
+  it("drops unknown, caller-controlled values to cap cardinality", () => {
+    expect(extractSdkName({ [SDK_NAME_HEADER]: "b3d1c0de" })).toBeUndefined();
+    // Node comma-joins duplicate headers; the joined value fails the allowlist.
+    expect(
+      extractSdkName({ [SDK_NAME_HEADER]: "python, javascript" }),
+    ).toBeUndefined();
+  });
+});

--- a/web/src/observability.config.ts
+++ b/web/src/observability.config.ts
@@ -20,6 +20,10 @@ import { WinstonInstrumentation } from "@opentelemetry/instrumentation-winston";
 import { AwsInstrumentation } from "@opentelemetry/instrumentation-aws-sdk";
 import { BullMQInstrumentation } from "@appsignal/opentelemetry-instrumentation-bullmq";
 import { ioredisRequestHook } from "@langfuse/shared/src/server";
+import {
+  SDK_NAME_ATTRIBUTE,
+  extractSdkName,
+} from "@/src/server/observability/sdkName";
 import { envDetector, resourceFromAttributes } from "@opentelemetry/resources";
 import { awsEcsDetector } from "@opentelemetry/resource-detector-aws";
 import { containerDetector } from "@opentelemetry/resource-detector-container";
@@ -134,6 +138,13 @@ const sdk = new NodeSDK({
         }
         span.updateName(`${req?.method} ${path}`);
         span.setAttribute("http.route", path);
+
+        // Incoming requests (IncomingMessage) carry headers; outgoing
+        // ClientRequests expose `path` instead.
+        if (!("path" in req) && req?.headers) {
+          const sdkName = extractSdkName(req.headers);
+          if (sdkName) span.setAttribute(SDK_NAME_ATTRIBUTE, sdkName);
+        }
       },
     }),
     new PrismaInstrumentation({

--- a/web/src/server/observability/sdkName.ts
+++ b/web/src/server/observability/sdkName.ts
@@ -1,0 +1,21 @@
+import { type IncomingHttpHeaders } from "http";
+import {
+  getLangfuseHeaderValue,
+  normalizeIngestionSdkName,
+} from "@langfuse/shared/src/server";
+
+export const SDK_NAME_HEADER = "x-langfuse-sdk-name";
+export const SDK_NAME_ATTRIBUTE = "sdk_name";
+
+// Canonicalize to the same closed set as the ingestion path
+// (python | javascript) so the span tag stays low-cardinality;
+// unknown / non-SDK callers resolve to undefined.
+export function extractSdkName(
+  headers: IncomingHttpHeaders,
+): string | undefined {
+  return (
+    normalizeIngestionSdkName(
+      getLangfuseHeaderValue(headers, SDK_NAME_HEADER),
+    ) ?? undefined
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Tags a low-cardinality `sdk_name` attribute onto the web service's OpenTelemetry `http.server` spans, read from the `x-langfuse-sdk-name` header that first-party Langfuse SDKs already send (`python`, `javascript`, `java`, ...). This lets us break down public API traffic by caller in Datadog — e.g. what fraction of `POST /api/public/scores` is first-party SDK vs. third-party/custom clients. Non-SDK callers omit the header, so the attribute is simply unset for them.

The ticket originally proposed doing this purely via the `DD_TRACE_HEADER_TAGS=x-langfuse-sdk-name:sdk_name` env var. That is a **no-op** in this service: `observability.config.ts` runs dd-trace with `dd.init({ plugins: false })` (and infra additionally sets `DD_TRACE_DISABLED_PLUGINS=...,http,...,next,...`), so dd-trace's HTTP plugin — the only thing that reads that env var — is disabled. The request spans are produced by OpenTelemetry's `HttpInstrumentation`, so the header is captured on the OTel `http.server` span via its existing `requestHook` instead.

Datadog-side follow-up (not code): add `sdk_name` as an APM **primary tag** so the breakdown is computed on the unsampled `trace.*.server.hits` metric.

Fixes LFE-10210

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] Added a unit test covering the header extraction (`sdkName.servertest.ts`).
- [x] Lint + typecheck pass (`turbo run lint typecheck --filter=web`: 5 successful).