### PR TITLE
feat(session): mobile layout — reclaim viewport for session content (LFE-11067)

### DIFF
--- a/web/src/components/layouts/mobile-page-title.tsx
+++ b/web/src/components/layouts/mobile-page-title.tsx
@@ -93,14 +93,17 @@ export const MobilePageTitle = ({
         )}
       </div>
 
-      {actionButtonsRight && (
-        <div className="mt-2 flex flex-wrap items-center gap-1">
+      {/* Page actions live on ONE horizontally-scrollable row. Detail pages
+          (e.g. a session) hand us 6-9 buttons across both clusters; at phone
+          width, wrapping them stacks 200-300px of chrome above the content and
+          starves the actual page. `flex-nowrap` + `[&>*]:shrink-0` keeps each
+          action its natural size and lets the row scroll sideways within its
+          own `min-w-0`/`overflow-x-auto` box instead of wrapping or forcing
+          page-level horizontal overflow. Pages with a couple of actions never
+          need to scroll. */}
+      {(actionButtonsRight || actionButtonsLeft) && (
+        <div className="mt-2 flex min-w-0 flex-nowrap items-center gap-1 overflow-x-auto [&>*]:shrink-0">
           {actionButtonsRight}
-        </div>
-      )}
-
-      {actionButtonsLeft && (
-        <div className="mt-2 flex flex-wrap items-center gap-1">
           {actionButtonsLeft}
         </div>
       )}

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -21,6 +21,7 @@ import { useSession } from "next-auth/react";
 import {
   CheckIcon,
   ChevronDown,
+  ChevronUp,
   CopyIcon,
   Download,
   ExternalLinkIcon,
@@ -86,6 +87,7 @@ import { SessionVirtualizedRow } from "@/src/components/session/SessionVirtualiz
 import { createSessionDetailStore } from "@/src/components/session/sessionDetailStore";
 import { ModernSession } from "@/src/components/session/ModernSession";
 import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
+import { useIsMobile } from "@/src/hooks/use-mobile";
 import { useStore } from "zustand";
 import { useHistoryEntryRevisit } from "@/src/components/session/useHistoryEntryRevisit";
 import {
@@ -214,6 +216,60 @@ export function SessionUsers({
   );
 }
 
+/**
+ * SessionControlsBar — the session's sticky metadata/controls bar (LLM-call
+ * preset, Saved Views, "Filter observations", trace/cost/user/score stats).
+ *
+ * Desktop (>=768px): renders the always-visible bar exactly as before — the
+ * caller passes the original `desktopClassName`, so the DOM is byte-identical.
+ *
+ * Mobile: that bar wraps into a tall block which, stacked under the page title
+ * and action row, leaves the virtualized trace feed only a sliver of the
+ * viewport. Here it collapses into a default-closed accordion: a sticky summary
+ * header the user taps to reveal the full bar, mirroring the trace view's
+ * mobile NavigationPanel (plain `useState` + a click handler, no effects).
+ */
+const SessionControlsBar = ({
+  isMobile,
+  summary,
+  desktopClassName,
+  children,
+}: {
+  isMobile: boolean;
+  summary: React.ReactNode;
+  desktopClassName: string;
+  children: React.ReactNode;
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!isMobile) {
+    return <div className={desktopClassName}>{children}</div>;
+  }
+
+  return (
+    <div className="bg-background sticky top-0 z-40 flex shrink-0 flex-col border-b">
+      <Button
+        variant="ghost"
+        className="flex w-full justify-between gap-2 rounded-none px-4 py-3 text-left"
+        aria-expanded={isExpanded}
+        onClick={() => setIsExpanded((prev) => !prev)}
+      >
+        <span className="flex min-w-0 items-center gap-2">{summary}</span>
+        {isExpanded ? (
+          <ChevronUp className="h-4 w-4 shrink-0" />
+        ) : (
+          <ChevronDown className="h-4 w-4 shrink-0" />
+        )}
+      </Button>
+      {isExpanded && (
+        <div className="flex flex-wrap items-center gap-2 border-t p-4">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+};
+
 const SessionScores = ({
   scores,
 }: {
@@ -260,6 +316,7 @@ export const SessionPage: React.FC<{
   const userSession = useSession();
   const capture = usePostHogClientCapture();
   const utils = api.useUtils();
+  const isMobile = useIsMobile();
   const parentRef = useRef<HTMLDivElement>(null);
   const session = api.sessions.byIdWithScores.useQuery(
     {
@@ -499,7 +556,25 @@ export const SessionPage: React.FC<{
         }}
       >
         <div className="flex h-full flex-col overflow-auto">
-          <div className="bg-background sticky top-0 z-40 flex flex-wrap gap-2 border-b p-4">
+          <SessionControlsBar
+            isMobile={isMobile}
+            desktopClassName="bg-background sticky top-0 z-40 flex flex-wrap gap-2 border-b p-4"
+            summary={
+              <>
+                <span className="text-sm font-bold">Session controls</span>
+                <span
+                  className="text-muted-foreground truncate text-xs"
+                  title={`${session.data?.traces.length ?? 0} traces · ${usdFormatter(
+                    session.data?.totalCost ?? 0,
+                    2,
+                  )}`}
+                >
+                  {session.data?.traces.length ?? 0} traces ·{" "}
+                  {usdFormatter(session.data?.totalCost ?? 0, 2)}
+                </span>
+              </>
+            }
+          >
             {session.data?.users?.length ? (
               <SessionUsers projectId={projectId} users={session.data.users} />
             ) : null}
@@ -512,7 +587,7 @@ export const SessionPage: React.FC<{
               </Badge>
             )}
             <SessionScores scores={session.data?.scores ?? []} />
-          </div>
+          </SessionControlsBar>
           <div ref={parentRef} className="flex-1 overflow-auto p-4">
             <div
               style={{
@@ -660,6 +735,7 @@ const LoadedSessionEventsPage: React.FC<{
   const isModernSessionEnabled = useIsFeatureEnabled("modernSession", {
     enableForAdmins: false,
   });
+  const isMobile = useIsMobile();
   const parentRef = useRef<HTMLDivElement>(null);
   const defaultPresetAppliedRef = useRef(false);
 
@@ -1336,7 +1412,25 @@ const LoadedSessionEventsPage: React.FC<{
               : "flex h-full flex-col overflow-auto"
           }
         >
-          <div className="bg-background sticky top-0 z-40 flex flex-wrap items-center gap-2 border-b p-4">
+          <SessionControlsBar
+            isMobile={isMobile && !isModernSessionEnabled}
+            desktopClassName="bg-background sticky top-0 z-40 flex flex-wrap items-center gap-2 border-b p-4"
+            summary={
+              <>
+                <span className="text-sm font-bold">Session controls</span>
+                <span
+                  className="text-muted-foreground truncate text-xs"
+                  title={`${session.countTraces} traces · ${usdFormatter(
+                    session.totalCost ?? 0,
+                    2,
+                  )}`}
+                >
+                  {session.countTraces} traces ·{" "}
+                  {usdFormatter(session.totalCost ?? 0, 2)}
+                </span>
+              </>
+            }
+          >
             {isModernSessionEnabled ? (
               <Popover>
                 <PopoverTrigger asChild>
@@ -1444,7 +1538,7 @@ const LoadedSessionEventsPage: React.FC<{
 
             {/* Scores */}
             <SessionScores scores={session.scores} />
-          </div>
+          </SessionControlsBar>
           {!isModernSessionEnabled ? (
             <div ref={parentRef} className="flex-1 overflow-auto p-4">
               <div

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -573,7 +573,7 @@ export const SessionPage: React.FC<{
               <>
                 <span className="text-sm font-bold">Session controls</span>
                 <span
-                  className="text-muted-foreground truncate text-xs"
+                  className="text-muted-foreground min-w-0 truncate text-xs"
                   title={`${session.data?.traces.length ?? 0} traces · ${usdFormatter(
                     session.data?.totalCost ?? 0,
                     2,
@@ -1429,7 +1429,7 @@ const LoadedSessionEventsPage: React.FC<{
               <>
                 <span className="text-sm font-bold">Session controls</span>
                 <span
-                  className="text-muted-foreground truncate text-xs"
+                  className="text-muted-foreground min-w-0 truncate text-xs"
                   title={`${session.countTraces} traces · ${usdFormatter(
                     session.totalCost ?? 0,
                     2,

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/src/utils/tailwind";
 import { GroupedScoreBadges } from "@/src/components/grouped-score-badge";
 import { ErrorPage } from "@/src/components/error-page";
 import { PublishSessionSwitch } from "@/src/components/publish-object-switch";
@@ -261,11 +262,20 @@ const SessionControlsBar = ({
           <ChevronDown className="h-4 w-4 shrink-0" />
         )}
       </Button>
-      {isExpanded && (
-        <div className="flex flex-wrap items-center gap-2 border-t p-4">
-          {children}
-        </div>
-      )}
+      {/* Keep children MOUNTED when collapsed (hidden, not unmounted): the
+          TableViewPresetsDrawer trigger (#session-detail-view-trigger) lives in
+          here, and the per-trace "Switch the view" link clicks it by id — it
+          must be in the DOM before the accordion is ever expanded. `hidden`
+          (display:none) still takes no layout space, so the content keeps the
+          reclaimed viewport. */}
+      <div
+        className={cn(
+          "flex flex-wrap items-center gap-2 border-t p-4",
+          !isExpanded && "hidden",
+        )}
+      >
+        {children}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## TL;DR
On mobile the session detail page gave the actual session content only ~40% of the screen. This adds the missing mobile branch: page actions collapse to one scrollable row, and the session's metadata/controls bar becomes a default-collapsed accordion — so the virtualized trace feed reclaims the height. **Desktop is byte-identical.**

## Why
There was **no mobile layout** for the session view — the desktop layout was just shrunk to phone width. At ~390px, two non-collapsible headers stacked above the content:
1. `MobilePageTitle` rendered the session's 6–9 action buttons as **two** `flex-wrap` rows, wrapping into ~200–300px of chrome.
2. The session's own sticky metadata/controls bar (LLM-calls preset, Saved Views, "Filter observations", trace/cost/user/score stats) wrapped into another ~100–140px.

The `flex-1` virtualized trace feed got only the small remainder. The trace-detail view already solved this class of problem with a `useIsMobile()` branch + a collapsible accordion; this mirrors that.

## What
- **`MobilePageTitle`** (shared, all mobile detail pages): merge `actionButtonsRight` + `actionButtonsLeft` into **one horizontally-scrollable row** (`flex-nowrap` + `[&>*]:shrink-0` + `min-w-0 overflow-x-auto`). Actions keep their natural size and the row scrolls sideways within its own box instead of wrapping or causing page-level horizontal overflow. The title keeps its own line (does not regress the header-crush fix). Pages with few actions never need to scroll.
- **Session content** (`web/src/components/session/index.tsx`): a new in-file `SessionControlsBar` wrapper renders the sticky metadata/controls bar. On desktop it returns the original `<div>` with the caller-supplied className (byte-identical DOM). On mobile it collapses into a **default-collapsed accordion** — a sticky summary header (trace count · cost) + chevron toggle; the expanded body holds the full bar. Plain `useState` + a click handler, no effects. Applied to both the **v4 events default view** (`LoadedSessionEventsPage`) and the **legacy `SessionPage`**. The `parentRef` virtualized feed stays `flex-1` and takes the reclaimed height.

## Result
On mobile the session content region reclaims the height previously eaten by the two stacked headers. Desktop (≥768px) renders exactly as before.

<details>
<summary>Mechanism, scope, and verification</summary>

- **Desktop byte-identical:** `SessionControlsBar` with `isMobile=false` early-returns `<div className={desktopClassName}>{children}</div>` — same class string, same children, same DOM node. The `summary` prop is computed but unused on desktop.
- **ModernSession untouched:** the v4 call passes `isMobile={isMobile && !isModernSessionEnabled}`, so the admin-only Feature Preview always takes the desktop branch.
- **Preserved (load-bearing):** per-trace lazy virtualization (`LazySessionTraceEventsRow` + IntersectionObserver), the sticky per-card trace header, and the v4 data path (`sessions.*FromEvents`). None are touched.
- **No new effects:** accordion open state is `useState(false)` + an `onClick` toggle, matching the repo rule and the trace-view mobile pattern.
- **a11y:** the accordion toggle is a `Button` with `aria-expanded`; the summary count uses `truncate` + a `title`.
- **Checks:** `pnpm --filter web run typecheck` → exit 0, 0 TS errors. `pnpm --filter web run lint` → exit 0. Pre-commit hook: prettier `All matched files use Prettier code style!` and turbo lint `Tasks: 7 successful, 7 total`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)