### PR TITLE
feat(trace): mobile detail-header ⋯ actions menu + collapsible metadata (LFE-11067)

### DIFF
--- a/web/src/components/trace/components/ObservationDetailView/ObservationDetailViewHeader.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationDetailViewHeader.tsx
@@ -52,14 +52,22 @@ import { useViewPreferences } from "@/src/components/trace/contexts/ViewPreferen
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { useTraceData } from "@/src/components/trace/contexts/TraceDataContext";
 import { Button } from "@/src/components/ui/button";
-import { LockIcon, SquarePen } from "lucide-react";
+import { LockIcon, MoreHorizontal, SquarePen } from "lucide-react";
 import {
   Drawer,
   DrawerContent,
   DrawerTrigger,
 } from "@/src/components/ui/drawer";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { DualAnnotationContent } from "@/src/features/scores/components/DualAnnotationContent";
+import { CollapsibleBadgeRow } from "@/src/components/trace/components/_shared/CollapsibleBadgeRow";
+import { useIsMobile } from "@/src/hooks/use-mobile";
+import { cn } from "@/src/utils/tailwind";
 
 export interface ObservationDetailViewHeaderProps {
   observation: ObservationReturnTypeWithMetadata;
@@ -102,6 +110,7 @@ export const ObservationDetailViewHeader = memo(
     treeNodeTotalCost,
   }: ObservationDetailViewHeaderProps) {
     const { isAnnotationMode } = useViewPreferences();
+    const isMobile = useIsMobile();
     const { isBetaEnabled: isV4Enabled } = useV4Beta();
     const { trace, serverScores } = useTraceData();
 
@@ -129,7 +138,12 @@ export const ObservationDetailViewHeader = memo(
         <div className="grid w-full grid-cols-1 items-start gap-2 @2xl:grid-cols-[auto_auto] @2xl:justify-between">
           <div className="flex w-full flex-row items-center gap-1">
             <ItemBadge type={observation.type as ObservationType} isSmall />
-            <span className="mb-0 line-clamp-2 min-w-0 font-bold break-all md:break-normal md:wrap-break-word">
+            <span
+              className={cn(
+                "mb-0 line-clamp-2 min-w-0 font-bold break-all md:break-normal md:wrap-break-word",
+                isMobile && "flex-1",
+              )}
+            >
               {observation.name || observation.id}
             </span>
             <DetailHeaderActionsMenu
@@ -146,98 +160,211 @@ export const ObservationDetailViewHeader = memo(
                 sessionId: observation.sessionId ?? null,
               }}
             />
-          </div>
-          {/* Action buttons */}
-          <div className="flex h-full flex-wrap content-start items-start justify-start gap-0.5 @2xl:mr-1 @2xl:justify-end">
-            {observationWithIO && (
-              <NewDatasetItemFromExistingObject
-                traceId={traceId}
-                observationId={observation.id}
-                projectId={projectId}
-                input={observationWithIO.input}
-                output={observationWithIO.output}
-                metadata={observationWithIO.metadata}
-                key={observation.id}
-                size="sm"
-              />
-            )}
-            {/* Hide annotation buttons in annotation mode (panel shown separately) */}
-            {!isAnnotationMode && (
-              <div className="flex items-start">
-                {isV4Enabled ? (
-                  <Drawer key={"annotation-drawer-" + observation.id}>
-                    <DrawerTrigger asChild>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        disabled={!hasAnnotationAccess}
-                        className="rounded-r-none"
-                      >
-                        {!hasAnnotationAccess ? (
-                          <LockIcon className="mr-1.5 h-3 w-3" />
-                        ) : (
-                          <SquarePen className="mr-1.5 h-3.5 w-3.5" />
-                        )}
-                        <span>Annotate</span>
-                      </Button>
-                    </DrawerTrigger>
-                    <DrawerContent className="p-3">
-                      <DualAnnotationContent
+            {/* Mobile: collapse the action-button cluster into a `⋯` overflow of
+                full-width labeled rows, next to the `⋮` utility menu. */}
+            {isMobile && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    aria-label="More actions"
+                    className="ml-auto shrink-0"
+                  >
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="end"
+                  className="flex w-auto min-w-44 flex-col gap-0.5 p-1"
+                >
+                  {observationWithIO && (
+                    <NewDatasetItemFromExistingObject
+                      traceId={traceId}
+                      observationId={observation.id}
+                      projectId={projectId}
+                      input={observationWithIO.input}
+                      output={observationWithIO.output}
+                      metadata={observationWithIO.metadata}
+                      layout="menu"
+                    />
+                  )}
+                  {!isAnnotationMode && (
+                    <>
+                      {isV4Enabled ? (
+                        <Drawer
+                          key={"annotation-drawer-menu-" + observation.id}
+                        >
+                          <DrawerTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={!hasAnnotationAccess}
+                              className="w-full justify-start gap-2 font-normal"
+                            >
+                              {!hasAnnotationAccess ? (
+                                <LockIcon className="h-3 w-3" />
+                              ) : (
+                                <SquarePen className="h-4 w-4" />
+                              )}
+                              <span className="text-sm">Annotate</span>
+                            </Button>
+                          </DrawerTrigger>
+                          <DrawerContent className="p-3">
+                            <DualAnnotationContent
+                              projectId={projectId}
+                              traceId={traceId}
+                              observationId={observation.id}
+                              traceEnvironment={trace.environment}
+                              observationEnvironment={observation.environment}
+                              observationScores={observationScores}
+                              traceScores={traceScores}
+                            />
+                          </DrawerContent>
+                        </Drawer>
+                      ) : (
+                        <AnnotateDrawer
+                          key={"annotation-drawer-menu-" + observation.id}
+                          projectId={projectId}
+                          scoreTarget={{
+                            type: "trace",
+                            traceId: traceId,
+                            observationId: observation.id,
+                          }}
+                          scores={observationScores}
+                          scoreMetadata={{
+                            projectId: projectId,
+                            environment: observation.environment,
+                          }}
+                          layout="menu"
+                        />
+                      )}
+                      <CreateNewAnnotationQueueItem
                         projectId={projectId}
-                        traceId={traceId}
-                        observationId={observation.id}
-                        traceEnvironment={trace.environment}
-                        observationEnvironment={observation.environment}
-                        observationScores={observationScores}
-                        traceScores={traceScores}
+                        objectId={observation.id}
+                        objectType={AnnotationQueueObjectType.OBSERVATION}
+                        layout="menu"
                       />
-                    </DrawerContent>
-                  </Drawer>
-                ) : (
-                  <AnnotateDrawer
-                    key={"annotation-drawer-" + observation.id}
+                    </>
+                  )}
+                  {observationWithIO &&
+                    isGenerationLike(observationWithIO.type) && (
+                      <JumpToPlaygroundButton
+                        source="generation"
+                        generation={observationWithIO}
+                        analyticsEventName="trace_detail:test_in_playground_button_click"
+                        layout="menu"
+                      />
+                    )}
+                  <CommentDrawerButton
                     projectId={projectId}
-                    scoreTarget={{
-                      type: "trace",
-                      traceId: traceId,
-                      observationId: observation.id,
-                    }}
-                    scores={observationScores}
-                    scoreMetadata={{
-                      projectId: projectId,
-                      environment: observation.environment,
-                    }}
+                    objectId={observation.id}
+                    objectType="OBSERVATION"
+                    count={commentCount}
+                    layout="menu"
+                    pendingSelection={pendingSelection}
+                    onSelectionUsed={onSelectionUsed}
+                    isOpen={isCommentDrawerOpen}
+                    onOpenChange={onCommentDrawerOpenChange}
+                  />
+                </PopoverContent>
+              </Popover>
+            )}
+          </div>
+          {/* Action buttons (desktop inline cluster) */}
+          {!isMobile && (
+            <div className="flex h-full flex-wrap content-start items-start justify-start gap-0.5 @2xl:mr-1 @2xl:justify-end">
+              {observationWithIO && (
+                <NewDatasetItemFromExistingObject
+                  traceId={traceId}
+                  observationId={observation.id}
+                  projectId={projectId}
+                  input={observationWithIO.input}
+                  output={observationWithIO.output}
+                  metadata={observationWithIO.metadata}
+                  key={observation.id}
+                  size="sm"
+                />
+              )}
+              {/* Hide annotation buttons in annotation mode (panel shown separately) */}
+              {!isAnnotationMode && (
+                <div className="flex items-start">
+                  {isV4Enabled ? (
+                    <Drawer key={"annotation-drawer-" + observation.id}>
+                      <DrawerTrigger asChild>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          disabled={!hasAnnotationAccess}
+                          className="rounded-r-none"
+                        >
+                          {!hasAnnotationAccess ? (
+                            <LockIcon className="mr-1.5 h-3 w-3" />
+                          ) : (
+                            <SquarePen className="mr-1.5 h-3.5 w-3.5" />
+                          )}
+                          <span>Annotate</span>
+                        </Button>
+                      </DrawerTrigger>
+                      <DrawerContent className="p-3">
+                        <DualAnnotationContent
+                          projectId={projectId}
+                          traceId={traceId}
+                          observationId={observation.id}
+                          traceEnvironment={trace.environment}
+                          observationEnvironment={observation.environment}
+                          observationScores={observationScores}
+                          traceScores={traceScores}
+                        />
+                      </DrawerContent>
+                    </Drawer>
+                  ) : (
+                    <AnnotateDrawer
+                      key={"annotation-drawer-" + observation.id}
+                      projectId={projectId}
+                      scoreTarget={{
+                        type: "trace",
+                        traceId: traceId,
+                        observationId: observation.id,
+                      }}
+                      scores={observationScores}
+                      scoreMetadata={{
+                        projectId: projectId,
+                        environment: observation.environment,
+                      }}
+                      size="sm"
+                    />
+                  )}
+                  <CreateNewAnnotationQueueItem
+                    projectId={projectId}
+                    objectId={observation.id}
+                    objectType={AnnotationQueueObjectType.OBSERVATION}
+                    size="sm"
+                  />
+                </div>
+              )}
+              {observationWithIO &&
+                isGenerationLike(observationWithIO.type) && (
+                  <JumpToPlaygroundButton
+                    source="generation"
+                    generation={observationWithIO}
+                    analyticsEventName="trace_detail:test_in_playground_button_click"
                     size="sm"
                   />
                 )}
-                <CreateNewAnnotationQueueItem
-                  projectId={projectId}
-                  objectId={observation.id}
-                  objectType={AnnotationQueueObjectType.OBSERVATION}
-                  size="sm"
-                />
-              </div>
-            )}
-            {observationWithIO && isGenerationLike(observationWithIO.type) && (
-              <JumpToPlaygroundButton
-                source="generation"
-                generation={observationWithIO}
-                analyticsEventName="trace_detail:test_in_playground_button_click"
+              <CommentDrawerButton
+                projectId={projectId}
+                objectId={observation.id}
+                objectType="OBSERVATION"
+                count={commentCount}
                 size="sm"
+                pendingSelection={pendingSelection}
+                onSelectionUsed={onSelectionUsed}
+                isOpen={isCommentDrawerOpen}
+                onOpenChange={onCommentDrawerOpenChange}
               />
-            )}
-            <CommentDrawerButton
-              projectId={projectId}
-              objectId={observation.id}
-              objectType="OBSERVATION"
-              count={commentCount}
-              size="sm"
-              pendingSelection={pendingSelection}
-              onSelectionUsed={onSelectionUsed}
-              isOpen={isCommentDrawerOpen}
-              onOpenChange={onCommentDrawerOpenChange}
-            />
-          </div>
+            </div>
+          )}
         </div>
 
         {/* Metadata badges */}
@@ -254,7 +381,7 @@ export const ObservationDetailViewHeader = memo(
 
           {/* Other badges */}
           {!isAnnotationMode && (
-            <div className="flex flex-wrap items-center gap-1">
+            <CollapsibleBadgeRow>
               <LatencyBadge latencySeconds={latencySeconds} />
               <TimeToFirstTokenBadge
                 timeToFirstToken={observation.timeToFirstToken}
@@ -317,7 +444,7 @@ export const ObservationDetailViewHeader = memo(
                   projectId={projectId}
                 />
               )}
-            </div>
+            </CollapsibleBadgeRow>
           )}
         </div>
       </div>

--- a/web/src/components/trace/components/ObservationDetailView/ObservationDetailViewHeader.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationDetailViewHeader.tsx
@@ -176,7 +176,13 @@ export const ObservationDetailViewHeader = memo(
                 </PopoverTrigger>
                 <PopoverContent
                   align="end"
-                  className="flex w-auto min-w-44 flex-col gap-0.5 p-1"
+                  // forceMount + hide-when-closed: CommentDrawerButton lives in
+                  // here, and its deep-link auto-open effect (?comments=open) and
+                  // controlled inline-selection flow only work while mounted. A
+                  // default Popover unmounts its content when closed (the default
+                  // state), silently breaking both. Keep it mounted, just hidden.
+                  forceMount
+                  className="flex w-auto min-w-44 flex-col gap-0.5 p-1 data-[state=closed]:hidden"
                 >
                   {observationWithIO && (
                     <NewDatasetItemFromExistingObject

--- a/web/src/components/trace/components/TraceDetailView/TraceDetailViewHeader.tsx
+++ b/web/src/components/trace/components/TraceDetailView/TraceDetailViewHeader.tsx
@@ -133,7 +133,13 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
               </PopoverTrigger>
               <PopoverContent
                 align="end"
-                className="flex w-auto min-w-44 flex-col gap-0.5 p-1"
+                // forceMount + hide-when-closed: CommentDrawerButton lives in
+                // here, and its deep-link auto-open effect (?comments=open) and
+                // controlled inline-selection flow only work while mounted. A
+                // default Popover unmounts its content when closed (the default
+                // state), silently breaking both. Keep it mounted, just hidden.
+                forceMount
+                className="flex w-auto min-w-44 flex-col gap-0.5 p-1 data-[state=closed]:hidden"
               >
                 <NewDatasetItemFromExistingObject
                   traceId={trace.id}

--- a/web/src/components/trace/components/TraceDetailView/TraceDetailViewHeader.tsx
+++ b/web/src/components/trace/components/TraceDetailView/TraceDetailViewHeader.tsx
@@ -42,6 +42,16 @@ import {
 import { aggregateTraceMetrics } from "@/src/components/trace/lib/trace-aggregation";
 import { resolveEvalExecutionMetadata } from "@/src/components/trace/lib/resolve-metadata";
 import { useViewPreferences } from "@/src/components/trace/contexts/ViewPreferencesContext";
+import { CollapsibleBadgeRow } from "@/src/components/trace/components/_shared/CollapsibleBadgeRow";
+import { useIsMobile } from "@/src/hooks/use-mobile";
+import { Button } from "@/src/components/ui/button";
+import { MoreHorizontal } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
+import { cn } from "@/src/utils/tailwind";
 
 export interface TraceDetailViewHeaderProps {
   trace: Omit<WithStringifiedMetadata<TraceDomain>, "input" | "output"> & {
@@ -74,6 +84,7 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
   onCommentDrawerOpenChange,
 }: TraceDetailViewHeaderProps) {
   const { isAnnotationMode } = useViewPreferences();
+  const isMobile = useIsMobile();
   const aggregatedMetrics = useMemo(
     () => aggregateTraceMetrics(observations),
     [observations],
@@ -90,7 +101,12 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
       <div className="grid w-full grid-cols-1 items-start gap-2 @2xl:grid-cols-[auto_auto] @2xl:justify-between">
         <div className="flex w-full flex-row items-center gap-1">
           <ItemBadge type="TRACE" isSmall />
-          <span className="line-clamp-2 min-w-0 font-bold break-all md:break-normal md:wrap-break-word">
+          <span
+            className={cn(
+              "line-clamp-2 min-w-0 font-bold break-all md:break-normal md:wrap-break-word",
+              isMobile && "flex-1",
+            )}
+          >
             {trace.name || trace.id}
           </span>
           <DetailHeaderActionsMenu
@@ -101,55 +117,120 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
               sessionId: trace.sessionId ?? null,
             }}
           />
-        </div>
-        {/* Action buttons */}
-        <div className="flex h-full flex-wrap content-start items-start justify-start gap-0.5 @2xl:mr-1 @2xl:justify-end">
-          <NewDatasetItemFromExistingObject
-            traceId={trace.id}
-            projectId={projectId}
-            input={trace.input}
-            output={trace.output}
-            metadata={trace.metadata}
-            key={trace.id}
-            size="sm"
-          />
-          {/* Hide annotation buttons in annotation mode (panel shown separately) */}
-          {!isAnnotationMode && (
-            <div className="flex items-start">
-              <AnnotateDrawer
-                key={"annotation-drawer-" + trace.id}
-                projectId={projectId}
-                scoreTarget={{
-                  type: "trace",
-                  traceId: trace.id,
-                }}
-                scores={traceScores}
-                scoreMetadata={{
-                  projectId: projectId,
-                  environment: trace.environment,
-                }}
-                size="sm"
-              />
-              <CreateNewAnnotationQueueItem
-                projectId={projectId}
-                objectId={trace.id}
-                objectType={AnnotationQueueObjectType.TRACE}
-                size="sm"
-              />
-            </div>
+          {/* Mobile: collapse the action-button cluster into a `⋯` overflow of
+              full-width labeled rows, next to the `⋮` utility menu. */}
+          {isMobile && (
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  aria-label="More actions"
+                  className="ml-auto shrink-0"
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="end"
+                className="flex w-auto min-w-44 flex-col gap-0.5 p-1"
+              >
+                <NewDatasetItemFromExistingObject
+                  traceId={trace.id}
+                  projectId={projectId}
+                  input={trace.input}
+                  output={trace.output}
+                  metadata={trace.metadata}
+                  layout="menu"
+                />
+                {!isAnnotationMode && (
+                  <>
+                    <AnnotateDrawer
+                      projectId={projectId}
+                      scoreTarget={{
+                        type: "trace",
+                        traceId: trace.id,
+                      }}
+                      scores={traceScores}
+                      scoreMetadata={{
+                        projectId: projectId,
+                        environment: trace.environment,
+                      }}
+                      layout="menu"
+                    />
+                    <CreateNewAnnotationQueueItem
+                      projectId={projectId}
+                      objectId={trace.id}
+                      objectType={AnnotationQueueObjectType.TRACE}
+                      layout="menu"
+                    />
+                  </>
+                )}
+                <CommentDrawerButton
+                  projectId={projectId}
+                  objectId={trace.id}
+                  objectType="TRACE"
+                  count={commentCount}
+                  layout="menu"
+                  pendingSelection={pendingSelection}
+                  onSelectionUsed={onSelectionUsed}
+                  isOpen={isCommentDrawerOpen}
+                  onOpenChange={onCommentDrawerOpenChange}
+                />
+              </PopoverContent>
+            </Popover>
           )}
-          <CommentDrawerButton
-            projectId={projectId}
-            objectId={trace.id}
-            objectType="TRACE"
-            count={commentCount}
-            size="sm"
-            pendingSelection={pendingSelection}
-            onSelectionUsed={onSelectionUsed}
-            isOpen={isCommentDrawerOpen}
-            onOpenChange={onCommentDrawerOpenChange}
-          />
         </div>
+        {/* Action buttons (desktop inline cluster) */}
+        {!isMobile && (
+          <div className="flex h-full flex-wrap content-start items-start justify-start gap-0.5 @2xl:mr-1 @2xl:justify-end">
+            <NewDatasetItemFromExistingObject
+              traceId={trace.id}
+              projectId={projectId}
+              input={trace.input}
+              output={trace.output}
+              metadata={trace.metadata}
+              key={trace.id}
+              size="sm"
+            />
+            {/* Hide annotation buttons in annotation mode (panel shown separately) */}
+            {!isAnnotationMode && (
+              <div className="flex items-start">
+                <AnnotateDrawer
+                  key={"annotation-drawer-" + trace.id}
+                  projectId={projectId}
+                  scoreTarget={{
+                    type: "trace",
+                    traceId: trace.id,
+                  }}
+                  scores={traceScores}
+                  scoreMetadata={{
+                    projectId: projectId,
+                    environment: trace.environment,
+                  }}
+                  size="sm"
+                />
+                <CreateNewAnnotationQueueItem
+                  projectId={projectId}
+                  objectId={trace.id}
+                  objectType={AnnotationQueueObjectType.TRACE}
+                  size="sm"
+                />
+              </div>
+            )}
+            <CommentDrawerButton
+              projectId={projectId}
+              objectId={trace.id}
+              objectType="TRACE"
+              count={commentCount}
+              size="sm"
+              pendingSelection={pendingSelection}
+              onSelectionUsed={onSelectionUsed}
+              isOpen={isCommentDrawerOpen}
+              onOpenChange={onCommentDrawerOpenChange}
+            />
+          </div>
+        )}
       </div>
 
       {/* Metadata badges */}
@@ -165,7 +246,7 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
 
         {/* Other badges */}
         {!isAnnotationMode && (
-          <div className="flex flex-wrap items-center gap-1">
+          <CollapsibleBadgeRow>
             <LatencyBadge latencySeconds={trace.latency ?? null} />
             <SessionBadge sessionId={trace.sessionId} projectId={projectId} />
             <UserIdBadge userId={trace.userId} projectId={projectId} />
@@ -190,7 +271,7 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
                   usageDetails={aggregatedMetrics.usageDetails}
                 />
               )}
-          </div>
+          </CollapsibleBadgeRow>
         )}
       </div>
     </div>

--- a/web/src/components/trace/components/_shared/CollapsibleBadgeRow.tsx
+++ b/web/src/components/trace/components/_shared/CollapsibleBadgeRow.tsx
@@ -39,7 +39,11 @@ export function CollapsibleBadgeRow({
       <div
         className={cn(
           "flex min-w-0 flex-1 items-center gap-1",
-          expanded ? "flex-wrap" : "flex-nowrap overflow-hidden",
+          // Collapsed: one clipped line. `[&>*]:shrink-0` stops flex from
+          // squeezing badges below their content width (which made long ones
+          // like "Time to first token" wrap vertically into a multi-line row);
+          // badges keep their natural width and overflow-hidden clips the rest.
+          expanded ? "flex-wrap" : "flex-nowrap overflow-hidden [&>*]:shrink-0",
         )}
       >
         {children}

--- a/web/src/components/trace/components/_shared/CollapsibleBadgeRow.tsx
+++ b/web/src/components/trace/components/_shared/CollapsibleBadgeRow.tsx
@@ -1,0 +1,64 @@
+/**
+ * CollapsibleBadgeRow - metadata-badge row wrapper shared by the trace and
+ * observation detail headers.
+ *
+ * Desktop: renders the full `flex flex-wrap` badge set exactly as before.
+ * Mobile: clips the badges to a single line and adds a chevron toggle that
+ * expands to the full wrapped set (and collapses back). Uses local state only;
+ * no effects.
+ */
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { Button } from "@/src/components/ui/button";
+import { cn } from "@/src/utils/tailwind";
+import { useIsMobile } from "@/src/hooks/use-mobile";
+
+export function CollapsibleBadgeRow({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const isMobile = useIsMobile();
+  const [expanded, setExpanded] = useState(false);
+
+  // Desktop: unchanged full wrapped badge row.
+  if (!isMobile) {
+    return (
+      <div className={cn("flex flex-wrap items-center gap-1", className)}>
+        {children}
+      </div>
+    );
+  }
+
+  // Mobile: default to a single clipped line with an expand/collapse chevron.
+  return (
+    <div className="flex items-start gap-1">
+      <div
+        className={cn(
+          "flex min-w-0 flex-1 items-center gap-1",
+          expanded ? "flex-wrap" : "flex-nowrap overflow-hidden",
+        )}
+      >
+        {children}
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label={expanded ? "Show fewer details" : "Show more details"}
+        aria-expanded={expanded}
+        className="mt-0.5 shrink-0"
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        {expanded ? (
+          <ChevronUp className="h-4 w-4" />
+        ) : (
+          <ChevronDown className="h-4 w-4" />
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -13,26 +13,37 @@ const PopoverTrigger = PopoverPrimitive.Trigger;
 const PopoverContent = React.forwardRef<
   React.ComponentRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => {
-  // Route into the `popover` overlay layer (above `modal`, so popovers opened
-  // inside a dialog render above it). null until mounted → falls back to
-  // <body>, SSR-parity. Layer order, not z-index, stacks it.
-  const container = useLayerContainer("popover");
-  return (
-    <PopoverPrimitive.Portal container={container}>
-      <PopoverPrimitive.Content
-        ref={ref}
-        align={align}
-        sideOffset={sideOffset}
-        className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-h-[calc(var(--radix-popover-content-available-height)-1rem)] max-w-[max(var(--radix-popover-trigger-width),fit-content)] min-w-72 overflow-y-auto rounded-md border p-3 shadow-md outline-hidden",
-          className,
-        )}
-        {...props}
-      />
-    </PopoverPrimitive.Portal>
-  );
-});
+>(
+  (
+    { className, align = "center", sideOffset = 4, forceMount, ...props },
+    ref,
+  ) => {
+    // Route into the `popover` overlay layer (above `modal`, so popovers opened
+    // inside a dialog render above it). null until mounted → falls back to
+    // <body>, SSR-parity. Layer order, not z-index, stacks it.
+    const container = useLayerContainer("popover");
+    // Forward `forceMount` to BOTH the Portal and the Content: Radix's Portal
+    // also gates on open state, so keeping the Content mounted while closed
+    // requires both. Callers pair this with `data-[state=closed]:hidden` when they
+    // need mounted-but-hidden content (e.g. a child whose effect must keep running
+    // while the popover is closed). Undefined for everyone else → default behavior.
+    return (
+      <PopoverPrimitive.Portal container={container} forceMount={forceMount}>
+        <PopoverPrimitive.Content
+          ref={ref}
+          align={align}
+          sideOffset={sideOffset}
+          forceMount={forceMount}
+          className={cn(
+            "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-h-[calc(var(--radix-popover-content-available-height)-1rem)] max-w-[max(var(--radix-popover-trigger-width),fit-content)] min-w-72 overflow-y-auto rounded-md border p-3 shadow-md outline-hidden",
+            className,
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Portal>
+    );
+  },
+);
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 const PopoverClose = PopoverPrimitive.Close;

--- a/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
@@ -46,7 +46,13 @@ export const NewDatasetItemFromExistingObject = (props: {
   isCopyItem?: boolean;
   buttonVariant?: ButtonProps["variant"];
   size?: ButtonProps["size"];
+  /**
+   * "toolbar" (default) is the inline button; "menu" renders the same trigger
+   * as a full-width labeled row for the mobile header overflow popover.
+   */
+  layout?: "toolbar" | "menu";
 }) => {
+  const isMenu = props.layout === "menu";
   const normalizePrefillValue = (
     value: Prisma.JsonValue | null,
   ): Prisma.JsonValue | null => {
@@ -109,12 +115,22 @@ export const NewDatasetItemFromExistingObject = (props: {
           <DropdownMenu open={hasAccess ? undefined : false}>
             <DropdownMenuTrigger asChild>
               <Button
-                variant="secondary"
-                size={buttonSize}
+                variant={isMenu ? "ghost" : "secondary"}
+                size={isMenu ? "sm" : buttonSize}
                 disabled={!hasAccess}
+                className={
+                  isMenu ? "w-full justify-start gap-2 font-normal" : undefined
+                }
               >
-                <span>{`In ${observationInDatasets.data.length} dataset(s)`}</span>
-                <ChevronDown className="ml-2 h-3 w-3" />
+                {isMenu ? (
+                  <PlusIcon className="h-4 w-4" aria-hidden="true" />
+                ) : null}
+                <span className={isMenu ? "text-sm" : undefined}>
+                  {`In ${observationInDatasets.data.length} dataset(s)`}
+                </span>
+                <ChevronDown
+                  className={isMenu ? "ml-auto h-3 w-3" : "ml-2 h-3 w-3"}
+                />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -154,22 +170,36 @@ export const NewDatasetItemFromExistingObject = (props: {
               object: props.observationId ? "observation" : "trace",
             });
           }}
-          variant={buttonVariant}
-          size={buttonSize}
+          variant={isMenu ? "ghost" : buttonVariant}
+          size={isMenu ? "sm" : buttonSize}
           disabled={!hasAccess}
+          className={
+            isMenu ? "w-full justify-start gap-2 font-normal" : undefined
+          }
         >
           {hasAccess ? (
             <PlusIcon
               className={cn(
-                "mr-1.5 -ml-0.5",
-                buttonSize === "sm" ? "h-3.5 w-3.5" : "h-4 w-4",
+                isMenu
+                  ? "h-4 w-4"
+                  : cn(
+                      "mr-1.5 -ml-0.5",
+                      buttonSize === "sm" ? "h-3.5 w-3.5" : "h-4 w-4",
+                    ),
               )}
               aria-hidden="true"
             />
           ) : null}
-          Add to datasets
+          {isMenu ? (
+            <span className="text-sm">Add to datasets</span>
+          ) : (
+            "Add to datasets"
+          )}
           {!hasAccess ? (
-            <LockIcon className="ml-1.5 h-3 w-3" aria-hidden="true" />
+            <LockIcon
+              className={isMenu ? "ml-auto h-3 w-3" : "ml-1.5 h-3 w-3"}
+              aria-hidden="true"
+            />
           ) : null}
         </Button>
       )}

--- a/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -68,6 +68,12 @@ type JumpToPlaygroundButtonProps = (
   variant?: ButtonProps["variant"];
   className?: string;
   size?: ButtonProps["size"];
+  /**
+   * "toolbar" (default) is the inline button; "menu" renders the same dropdown
+   * trigger as a full-width labeled row ("Test in playground") for the mobile
+   * header overflow popover.
+   */
+  layout?: "toolbar" | "menu";
 };
 
 export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
@@ -189,26 +195,42 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
     ? "Test in LLM playground"
     : "Test in LLM playground is not available since messages are not in valid ChatML format or tool calls have been used. If you think this is not correct, please open a GitHub issue.";
 
+  const isMenu = props.layout === "menu";
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
-          variant={props.variant ?? "secondary"}
-          size={props.size ?? "default"}
+          variant={isMenu ? "ghost" : (props.variant ?? "secondary")}
+          size={isMenu ? "sm" : (props.size ?? "default")}
           disabled={!isAvailable}
           title={tooltipMessage}
           className={cn(
-            "flex items-center gap-1",
+            isMenu
+              ? "w-full justify-start gap-2 font-normal"
+              : "flex items-center gap-1",
             !isAvailable ? "cursor-not-allowed opacity-50" : "cursor-pointer",
           )}
         >
           <Terminal
-            className={props.size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4"}
+            className={
+              isMenu
+                ? "h-4 w-4"
+                : props.size === "sm"
+                  ? "h-3.5 w-3.5"
+                  : "h-4 w-4"
+            }
           />
-          <span className={cn("hidden md:inline", props.className)}>
-            Playground
-          </span>
-          <ChevronDown className="h-3 w-3" />
+          {isMenu ? (
+            <span className="text-sm">Test in playground</span>
+          ) : (
+            <>
+              <span className={cn("hidden md:inline", props.className)}>
+                Playground
+              </span>
+              <ChevronDown className="h-3 w-3" />
+            </>
+          )}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">


### PR DESCRIPTION
## TL;DR
On mobile, the trace/observation **detail header** (the Info panel for a selected observation or the trace) was too tall — it stacked a full inline row of action buttons on top of a fully-wrapped set of metadata badges. This collapses both on mobile: the actions fold into a single `⋯` overflow menu of labeled rows, and the badges clip to one line with an expand chevron. **Desktop rendering is unchanged.**

Stacks on #15412 (session header ⋯ menu) → #15410. Part of the mobile-revamp epic (LFE-11067).

## Why
Both detail headers render an identical shape — a title row, an inline action-button cluster (Add to datasets / Annotate / Add to queue / Test in playground / Add comment), and wrapped metadata badges (latency, session, user, env, cost, usage, model, level, …). On a phone that cluster wraps to multiple rows and the badges wrap to several more, pushing the actual content far down the panel.

## What
Two mobile-only changes, applied to both `ObservationDetailViewHeader` and `TraceDetailViewHeader`, each gated on `useIsMobile()`:

1. **Action cluster → `⋯` overflow menu.** A single outline `⋯` button (next to the existing `⋮` utility menu) opens a Popover containing the same actions as full-width labeled rows. Reuses the `layout="menu"` mode already added to `CommentDrawerButton` / `AnnotateDrawer` / `CreateNewAnnotationQueueItem` on the base branch; adds the same opt-in prop to `NewDatasetItemFromExistingObject` and `JumpToPlaygroundButton`.
2. **Metadata badges → one clipped line + chevron.** A small shared `CollapsibleBadgeRow` helper renders the desktop wrapped set unchanged, and on mobile clips to a single line with a toggle that expands to the full set.

## Result
Mobile detail header is compact by default; every action and badge stays reachable. Desktop is byte-identical.

<details>
<summary>Implementation detail</summary>

- **Desktop safety:** new component props default to `"toolbar"` (current markup); the inline cluster and full wrapped badge row render exactly as before when `!useIsMobile()`. The name span only gains `flex-1` on mobile (so the `⋮`/`⋯` pair right-aligns and stays adjacent); on desktop `cn()` yields the identical class string.
- **New prop `layout?: "toolbar" | "menu"`** on `NewDatasetItemFromExistingObject` and `JumpToPlaygroundButton` — menu mode renders the trigger as a `w-full justify-start gap-2 font-normal` ghost row (icon + label), matching the pattern the three already-migrated components use. The v4 dual-annotation `Drawer` in the observation header gets an inline labeled menu-row trigger opening the same `DrawerContent`.
- **`CollapsibleBadgeRow`** (`web/src/components/trace/components/_shared/CollapsibleBadgeRow.tsx`): `useState` + event handler only, no `useEffect`; mobile branch is `flex-nowrap overflow-hidden` collapsed / `flex-wrap` expanded, with an `icon-xs` chevron toggle. Timestamp row stays outside it, visible in both states.
- **Preserved:** both `!isAnnotationMode` hidden branches (action cluster + badges) show under the same conditions as before; only the mobile surfacing changed.
- **Verification:** `pnpm --filter web run typecheck` → exit 0; `eslint` on all 5 changed files `--max-warnings 0` → exit 0; pre-commit `turbo run lint` → 7 successful, 7 total. Live/browser check deferred to the epic driver.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)