### PR TITLE
feat(nav): prod-style sidenav restyle

### DIFF
--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -275,7 +275,10 @@ function CommandMenuTrigger() {
         });
         setOpen(true);
       }}
-      className="whitespace-nowrap"
+      tooltip="Go to... (⌘K)"
+      // Sessions-handoff "Go to…" row: inset, closed by a dashed hairline,
+      // no fill on hover (the icon rail keeps the square hover fill).
+      className="border-sidebar-border group-data-[collapsible=icon]:hover:bg-sidebar-accent mx-2 w-[calc(100%-1rem)] rounded-none border-b border-dashed whitespace-nowrap group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:rounded-sm group-data-[collapsible=icon]:border-0 hover:bg-transparent"
     >
       <Search className="h-4 w-4" />
       Go to...

--- a/web/src/components/nav/app-sidebar.tsx
+++ b/web/src/components/nav/app-sidebar.tsx
@@ -54,12 +54,11 @@ export function AppSidebar({
 
   return (
     <Sidebar collapsible="icon" variant="sidebar" {...props}>
-      <SidebarHeader className="gap-0 pt-0">
-        {/* Logo band (sessions handoff): fixed-height row closed by a
-            full-bleed hairline, logo + mono version inside. */}
-        <div className="border-sidebar-border flex h-10 shrink-0 items-center gap-2 border-b pt-2 pr-0 pl-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2">
+      <SidebarHeader>
+        <div className="flex min-h-9 items-center gap-2 py-2 pr-0 pl-2 group-data-[collapsible=icon]:p-3">
           <LangfuseLogo version />
         </div>
+        <div className="h-1 flex-1 border-b" />
         <DemoBadge />
       </SidebarHeader>
       <SidebarContent>

--- a/web/src/components/nav/app-sidebar.tsx
+++ b/web/src/components/nav/app-sidebar.tsx
@@ -54,11 +54,12 @@ export function AppSidebar({
 
   return (
     <Sidebar collapsible="icon" variant="sidebar" {...props}>
-      <SidebarHeader>
-        <div className="flex min-h-9 items-center gap-2 py-2 pr-0 pl-2 group-data-[collapsible=icon]:p-3">
+      <SidebarHeader className="gap-0 pt-0">
+        {/* Logo band (sessions handoff): fixed-height row closed by a
+            full-bleed hairline, logo + mono version inside. */}
+        <div className="border-sidebar-border flex h-10 shrink-0 items-center gap-2 border-b pt-2 pr-0 pl-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2">
           <LangfuseLogo version />
         </div>
-        <div className="h-1 flex-1 border-b" />
         <DemoBadge />
       </SidebarHeader>
       <SidebarContent>

--- a/web/src/components/nav/nav-main.tsx
+++ b/web/src/components/nav/nav-main.tsx
@@ -83,7 +83,10 @@ export function NavMain({
       {items.grouped &&
         Object.entries(items.grouped).map(([group, items]) => (
           <SidebarGroup key={group}>
-            <SidebarGroupLabel>{group}</SidebarGroupLabel>
+            {/* Mono section eyebrow per the sessions-view handoff. */}
+            <SidebarGroupLabel className="h-auto px-2 pt-3 pb-0.5 font-mono text-[10px] font-normal tracking-[0.05em] uppercase">
+              {group}
+            </SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
                 {items.map((item) => (

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -23,7 +23,8 @@ import {
 const SIDEBAR_STORAGE_KEY = "sidebar:state";
 const SIDEBAR_WIDTH = "11.5rem";
 const SIDEBAR_WIDTH_MOBILE = "12rem";
-const SIDEBAR_WIDTH_ICON = "3rem";
+// 56px icon rail per the sessions-view handoff (was 3rem).
+const SIDEBAR_WIDTH_ICON = "3.5rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 
 type SidebarContext = {


### PR DESCRIPTION
Extracts the **sidenav restyle** from the session detail redesign (#15346) into its own reviewable PR. Cherry-picked from `session-redesign` (88d0fc154 restyle + d8a8843d9 logo restoration) — the current logo/wordmark band is kept as on `main`.

## What's in here

- **"Go to…" row**: inset with a dashed hairline underneath, no hover fill in the expanded state (the collapsed icon rail keeps the square hover fill), tooltip added (`web/src/components/layouts/routes.tsx`).
- **Section eyebrows**: mono 10px uppercase tracked labels for the nav groups (`web/src/components/nav/nav-main.tsx`).
- **Collapsed icon rail** widened 48px → 56px via `SIDEBAR_WIDTH_ICON` (`web/src/components/ui/sidebar.tsx`).

All existing layout primitives are reused (`SidebarMenuButton`, `SidebarGroupLabel`); no structural changes, and the header/logo band is untouched relative to `main`.

## Dependency

**Base: `app-theme-v5` (#15418).** The eyebrows use `font-mono` (Geist Mono) and the row styling leans on the retuned `--sidebar-*` tokens, so this stacks on the theme PR for a clean diff (3 files, +10/−3). Merge #15418 first; this PR then retargets to `main` automatically.

## Screenshots

Light/dark captures (expanded + collapsed rail) are in the local review folder `.screenshots-review/session-redesign/pr-split-theme-v1/` (prefix `pr-b-`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
