### PR TITLE
fix(mobile): header title crush on long labels + tighten spacing (LFE-11067)

### DIFF
--- a/web/src/components/layouts/mobile-page-title.tsx
+++ b/web/src/components/layouts/mobile-page-title.tsx
@@ -66,9 +66,21 @@ export const MobilePageTitle = ({
           so the header top block stays ~2 rows instead of the 4–5 it used to
           take (a big labelled type chip, a text-2xl title, then each action
           cluster wrapping onto its own row). */}
-      <div className="mt-1 flex min-w-0 items-center gap-2">
-        {itemType && <ItemBadge type={itemType} />}
-        <h1 className="text-primary text-base leading-tight font-bold wrap-break-word">
+      <div className="mt-2 flex min-w-0 items-center gap-2">
+        {/* Icon keeps its size — without shrink-0 a long title (e.g. a full
+            session id, the common case) squeezes it. */}
+        {itemType && (
+          <span className="flex shrink-0 items-center">
+            <ItemBadge type={itemType} />
+          </span>
+        )}
+        {/* min-w-0 + truncate: long titles ellipsize on one line instead of
+            pushing the ⋯ flush against the edge or crushing the icon. Full value
+            stays in the title attribute (and the ⋯ menu's Copy row). */}
+        <h1
+          title={title}
+          className="text-primary min-w-0 flex-1 truncate text-base leading-tight font-bold"
+        >
           {titleContent ? (
             titleContent
           ) : titleTooltip ? (
@@ -135,8 +147,12 @@ export const MobilePageTitle = ({
       {/* Hoisted page controls (time range, auto-refresh). The assistant
           launcher lives in the sticky MobileTopBar now (prominent + always
           reachable), not here where it wrapped onto its own line and shrank to
-          an easily-missed icon. */}
-      <div className="mt-2 flex flex-wrap items-center gap-2">
+          an easily-missed icon. The slot target is `display:contents`, so on
+          pages that hoist nothing (traces, session/trace detail) this wrapper is
+          empty — gate its top margin on actually having portaled controls
+          (`:has(>*>*)` = the contents target has children), so an empty slot
+          adds no phantom gap below the title. */}
+      <div className="flex flex-wrap items-center gap-2 [&:has(>*>*)]:mt-2">
         <PageHeaderControlsSlotTarget />
       </div>
 

--- a/web/src/components/layouts/mobile-page-title.tsx
+++ b/web/src/components/layouts/mobile-page-title.tsx
@@ -79,7 +79,7 @@ export const MobilePageTitle = ({
             stays in the title attribute (and the ⋯ menu's Copy row). */}
         <h1
           title={title}
-          className="text-primary min-w-0 flex-1 truncate text-base leading-tight font-bold"
+          className="text-primary min-w-0 truncate text-base leading-tight font-bold"
         >
           {titleContent ? (
             titleContent
@@ -97,19 +97,22 @@ export const MobilePageTitle = ({
           ) : (
             <span title={title}>{title}</span>
           )}
-          {help && (
-            <span className="align-middle whitespace-nowrap">
-              &nbsp;
-              <DocPopup
-                description={help.description}
-                href={help.href}
-                className={help.className}
-              />
-            </span>
-          )}
         </h1>
+        {/* Help lives OUTSIDE the truncating h1 (like titleBadges): kept inside,
+            a title long enough to fill the row clips the `?` past the overflow
+            boundary, making it invisible/untappable. As a shrink-0 sibling it
+            stays put. */}
+        {help && (
+          <span className="shrink-0 align-middle whitespace-nowrap">
+            <DocPopup
+              description={help.description}
+              href={help.href}
+              className={help.className}
+            />
+          </span>
+        )}
         {titleBadges && (
-          <div className="flex items-center gap-1">{titleBadges}</div>
+          <div className="flex shrink-0 items-center gap-1">{titleBadges}</div>
         )}
         {/* Actions collapse into a single right-aligned overflow popover of
             full-width labeled rows (icon + label) — the same pattern the table


### PR DESCRIPTION
## TL;DR
Two mobile page-header polish fixes on top of the compact header (#15410): long titles no longer crush the type icon or jam the `⋯`, and the header's vertical rhythm is evened out.

## Why
On a session detail page the title is a full session id (almost always long). In the compact header that shared its row with the `⋯`, the long id squeezed the type icon to nothing and shoved the `⋯` flush against the right edge. Separately, the title sat cramped directly under the breadcrumb while an empty (portal) controls slot reserved phantom space below it — an uneven rhythm.

## What
- **Icon** gets `shrink-0` so a long title can't squeeze it.
- **Title** is `min-w-0 truncate` (one line, ellipsis) with a `title` attribute; the full value stays available on hover and via the header's Copy row. The `⋯` keeps its right padding instead of being pushed flush.
- **Spacing**: breadcrumb→title gap `mt-1 → mt-2`, and the hoisted-controls slot only reserves its top margin when something is actually portaled into it (`:has(>*>*)` on the `display:contents` target), so pages that hoist no controls (traces, session/trace detail) get no phantom gap below the title.

## Result
Verified live at 390px: a UUID-length title keeps the icon at full size, truncates cleanly, and the `⋯` retains its 12px right padding; the traces header rhythm is even (8px above the title, no empty gap below) and the block is a touch shorter.

<details>
<summary>Verification</summary>

- Stress-tested a 56-char title in the session header: icon width stays 28px (not crushed), title truncates, `⋯` right gap = 12px, single-line row.
- Traces header measured: breadcrumb→title 8px, empty controls slot collapsed to 0, header 67px (was ~74px).
- `pnpm --filter web run typecheck` → exit 0; eslint on the changed file → exit 0 (incl. `@repo/require-title-with-truncate`, satisfied by the new `title` attribute).
- Shared component (`mobile-page-title.tsx`) — desktop `PageHeader` is a different component and is untouched.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)