### PR TITLE
feat(trace): perf telemetry for the lazy JSON viewer (LFE-14419)

### DIFF
--- a/web/src/components/ui/AdvancedJsonViewer/lazy/react/LazyJsonViewer.tsx
+++ b/web/src/components/ui/AdvancedJsonViewer/lazy/react/LazyJsonViewer.tsx
@@ -19,9 +19,68 @@ import { useStore } from "zustand";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
 import { cn } from "@/src/utils/tailwind";
 import { LazyJsonList } from "./LazyJsonList";
-import { createRowModelStore } from "./rowModelStore";
+import { createRowModelStore, type LazyViewerMetric } from "./rowModelStore";
 import { TreeRowModel } from "../treeRowModel";
 import { sourceFromSerialized } from "../asyncJsonSource";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { reportError } from "@/src/utils/reportError";
+
+// Provisional main-thread budgets (LFE-14419) — the telemetry exists to LEARN
+// the right thresholds from prod, so treat these as starting guesses. An index
+// or expand slower than these means our size gate let through more than the main
+// thread handles comfortably.
+const MAIN_THREAD_INDEX_BUDGET_MS = 1000;
+const SLOW_EXPAND_BUDGET_MS = 500;
+
+// A main-thread build blowing its budget means the size gate is miscalibrated —
+// an actionable, our-code signal. This is the sentry skill's one allowed bend of
+// "expected states are not events": it fires only when our heuristic was wrong,
+// and is rate-limited to once per session (module scope) so it never floods.
+let miscalibrationReported = false;
+
+/** Turn the store's raw perf signals into analytics + a miscalibration alarm.
+ *  Metadata only — sizes/durations/counts, never payload content. */
+function handleMetric(
+  capture: ReturnType<typeof usePostHogClientCapture>,
+  sizeChars: number | undefined,
+  metric: LazyViewerMetric,
+): void {
+  if (metric.kind === "indexed") {
+    capture("json_viewer:indexed", {
+      buildMs: Math.round(metric.buildMs),
+      rowCount: metric.rowCount,
+      sizeChars,
+      tier: "main",
+    });
+    if (
+      metric.buildMs > MAIN_THREAD_INDEX_BUDGET_MS &&
+      !miscalibrationReported
+    ) {
+      miscalibrationReported = true;
+      reportError(
+        new Error("lazy JSON viewer: main-thread index exceeded budget"),
+        {
+          area: "json-viewer",
+          extra: {
+            buildMs: Math.round(metric.buildMs),
+            sizeChars,
+            rowCount: metric.rowCount,
+            budgetMs: MAIN_THREAD_INDEX_BUDGET_MS,
+          },
+        },
+      );
+    }
+    return;
+  }
+  // expand — capture only slow ones (budget-gated → naturally rare, not noise).
+  if (metric.ms > SLOW_EXPAND_BUDGET_MS) {
+    capture("json_viewer:slow_expand", {
+      expandMs: Math.round(metric.ms),
+      sizeChars,
+      tier: "main",
+    });
+  }
+}
 
 export interface LazyJsonViewerProps {
   /**
@@ -51,16 +110,25 @@ export function LazyJsonViewer({
   // document passed to init is that string (see below). `useState` reads props
   // once on mount, which is fine: a given mount is one mode.
   const usesSerialized = serialized !== undefined;
-  const [store] = useState(() =>
-    createRowModelStore(
-      usesSerialized
+  // `capture` is a stable useCallback, so capturing it once in the store's lazy
+  // initializer is safe (no stale-closure risk).
+  const capture = usePostHogClientCapture();
+  const [store] = useState(() => {
+    const sizeChars = usesSerialized
+      ? (serialized as string).length
+      : undefined;
+    const onMetric = (metric: LazyViewerMetric) =>
+      handleMetric(capture, sizeChars, metric);
+    return createRowModelStore({
+      ...(usesSerialized
         ? {
-            buildModel: (doc) =>
+            buildModel: (doc: unknown) =>
               TreeRowModel.create(sourceFromSerialized(doc as string)),
           }
-        : undefined,
-    ),
-  );
+        : {}),
+      onMetric,
+    });
+  });
 
   // The document identity re-init keys on: the serialized string, or the value.
   const doc = usesSerialized ? serialized : value;

--- a/web/src/components/ui/AdvancedJsonViewer/lazy/react/rowModelStore.clienttest.ts
+++ b/web/src/components/ui/AdvancedJsonViewer/lazy/react/rowModelStore.clienttest.ts
@@ -9,7 +9,7 @@
 // stub it so the error-capture tests can assert without touching Sentry.
 vi.mock("@/src/utils/reportError", () => ({ reportError: vi.fn() }));
 
-import { createRowModelStore } from "./rowModelStore";
+import { createRowModelStore, type LazyViewerMetric } from "./rowModelStore";
 import { PAGE_SIZE } from "../treeRowModel";
 import type { JsonRow, RowModel, RowWindow } from "../rowModel";
 import { reportError } from "@/src/utils/reportError";
@@ -69,6 +69,36 @@ describe("rowModelStore", () => {
 
     await store.getState().toggle(b.nodeId, true); // collapse
     expect(store.getState().totalVisible).toBe(3);
+  });
+
+  it("emits an `indexed` perf metric once the first window is ready (LFE-14419)", async () => {
+    const metrics: LazyViewerMetric[] = [];
+    const store = createRowModelStore({ onMetric: (m) => metrics.push(m) });
+    await store.getState().init({ a: 1, b: [10, 20, 30] });
+
+    const indexed = metrics.filter((m) => m.kind === "indexed");
+    expect(indexed).toHaveLength(1);
+    expect(indexed[0]).toMatchObject({ kind: "indexed", rowCount: 3 });
+    // buildMs is a real, non-negative duration (time-to-first-row).
+    expect((indexed[0] as { buildMs: number }).buildMs).toBeGreaterThanOrEqual(
+      0,
+    );
+  });
+
+  it("emits an `expand` metric on expand but not on collapse (LFE-14419)", async () => {
+    const metrics: LazyViewerMetric[] = [];
+    const store = createRowModelStore({ onMetric: (m) => metrics.push(m) });
+    await store.getState().init({ a: 1, b: [10, 20, 30] });
+
+    const b = findRow(store, "b")!;
+    await store.getState().toggle(b.nodeId, false); // expand
+    await store.getState().toggle(b.nodeId, true); // collapse
+
+    // Expand pays the deferred per-container scan and is measured; collapse has
+    // no scan and emits nothing.
+    const expands = metrics.filter((m) => m.kind === "expand");
+    expect(expands).toHaveLength(1);
+    expect((expands[0] as { ms: number }).ms).toBeGreaterThanOrEqual(0);
   });
 
   it("load-more reveals the next page and drops the load-more row when drained", async () => {

--- a/web/src/components/ui/AdvancedJsonViewer/lazy/react/rowModelStore.ts
+++ b/web/src/components/ui/AdvancedJsonViewer/lazy/react/rowModelStore.ts
@@ -67,6 +67,20 @@ export interface RowModelState {
 
 export type RowModelStore = StoreApi<RowModelState>;
 
+/**
+ * Perf signals the store measures and hands to the view boundary (LFE-14419).
+ * The store only MEASURES; what to do with the numbers (PostHog capture, a
+ * miscalibration alarm) is a telemetry policy that lives in the React boundary.
+ * - `indexed`: emitted once when the first window is ready — `buildMs` is
+ *   effectively time-to-first-row (build + first page) on whatever tier ran.
+ * - `expand`: emitted per container expand — `ms` covers the byte engine's
+ *   deferred per-container scan, i.e. the cost a wide container pays on first
+ *   open. The boundary decides which are "slow" enough to report.
+ */
+export type LazyViewerMetric =
+  | { kind: "indexed"; buildMs: number; rowCount: number }
+  | { kind: "expand"; ms: number };
+
 export interface RowModelStoreOptions {
   /**
    * How to build the model for a value. Defaults to the in-memory path
@@ -76,6 +90,11 @@ export interface RowModelStoreOptions {
    * responses the in-process source cannot express.
    */
   buildModel?: (value: unknown) => Promise<RowModel>;
+  /**
+   * Perf-signal sink (LFE-14419). Called with timing facts; the boundary turns
+   * them into analytics/alarms. No-op by default.
+   */
+  onMetric?: (metric: LazyViewerMetric) => void;
 }
 
 export function createRowModelStore(
@@ -84,6 +103,7 @@ export function createRowModelStore(
   const buildModel =
     options.buildModel ??
     ((value: unknown) => TreeRowModel.create(sourceFromValue(value)));
+  const emitMetric = options.onMetric ?? (() => {});
   // Non-reactive internals live in the factory closure, not in store state:
   // they must not trigger renders and must survive across actions.
   let model: RowModel | null = null;
@@ -159,6 +179,7 @@ export function createRowModelStore(
       init: async (value) => {
         const myGen = ++gen;
         model = null;
+        const startedAt = performance.now();
         set({
           status: "loading",
           error: null,
@@ -180,6 +201,13 @@ export function createRowModelStore(
           await get().ensureRange(0, INITIAL_ROW_COUNT);
           if (gen !== myGen) return;
           set({ status: "ready" });
+          // Build + first window = time-to-first-row; the boundary retunes the
+          // size gate from this and alarms if it blew the main-thread budget.
+          emitMetric({
+            kind: "indexed",
+            buildMs: performance.now() - startedAt,
+            rowCount: get().totalVisible,
+          });
         } catch (e) {
           if (gen !== myGen) return;
           captureAndSetError(e);
@@ -247,6 +275,7 @@ export function createRowModelStore(
         return serialize(async () => {
           if (!model || gen !== callGen) return;
           setPending(nodeId, true);
+          const startedAt = performance.now();
           try {
             if (currentlyExpanded) {
               await model.collapse(nodeId);
@@ -255,6 +284,12 @@ export function createRowModelStore(
             }
             if (gen !== callGen) return;
             await refreshAfterMutation();
+            // Expand pays the byte engine's deferred per-container scan (a wide
+            // container's O(N) cost lands here); measure it so the boundary can
+            // flag slow expands. Collapse has no scan — don't bother.
+            if (!currentlyExpanded) {
+              emitMetric({ kind: "expand", ms: performance.now() - startedAt });
+            }
           } catch (e) {
             // Deferred per-container scan threw on expand — don't let serialize's
             // rejection handler swallow it silently.

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -57,6 +57,10 @@ export const events = {
   // can be sliced by surface without leaking ids.
   peek: ["opened", "closed", "expand_toggle", "resized", "open_in_new_tab"],
   generations: ["export"],
+  // Lazy JSON viewer perf telemetry (LFE-14419): learn whether the size gate
+  // and main-thread assumptions hold on real payloads. Metadata only —
+  // durations, char counts, tier; never payload content.
+  json_viewer: ["indexed", "slow_expand"],
   saved_views: [
     "create",
     "update",


### PR DESCRIPTION
**TL;DR** — Instrument the lazy JSON viewer so we learn, from real payloads, whether our hand-picked size gate (3,333 rows) and main-thread assumptions actually hold — and whether the still-unbuilt Worker tier is even needed. PostHog perf events + a rate-limited Sentry miscalibration alarm. Metadata only.

**Why** — The lazy viewer (LFE-10847) shipped with a size gate and M1-calibrated main-thread assumptions we picked by hand, with zero prod data. Without telemetry we're guessing whether the gate is right and whether we ever need to move indexing off the main thread.

**What**
- `rowModelStore` measures raw timings — build / time-to-first-row and per-expand scan duration — and emits them via an injected `onMetric`. The store only *measures*; the telemetry policy lives at the React boundary.
- `LazyJsonViewer` fires `json_viewer:indexed` once per mount, and `json_viewer:slow_expand` only when an expand blows a budget.
- On a main-thread build over budget, a **once-per-session** Sentry `reportError` — the size gate is miscalibrated.

**Result** — We can retune the gate from the `buildMs`-vs-`sizeChars` distribution, and the alarm tells us when a payload slipped the gate. This is the data that decides whether LFE-14418 (Worker tier) / LFE-14461 (resumable scan) are worth building — measure before optimizing.

<details>
<summary>Tracking plan, privacy, Sentry decision, verification</summary>

**Tracking plan** (metadata only)

| Question | Event | Props |
|---|---|---|
| Is the size gate right? How long does main-thread index take vs payload size? | `json_viewer:indexed` (once/mount) | `buildMs`, `sizeChars`, `rowCount`, `tier` |
| Do wide containers jank on expand (LFE-14461 in the wild)? | `json_viewer:slow_expand` (budget-gated) | `expandMs`, `sizeChars`, `tier` |

Props are durations / char counts / an enum tier — **never keys, values, or any payload content** (PostHog skill Rule 1). `v4BetaEnabled` rides via the super property.

**Sentry decision** (sentry skill) — one new capture: `reportError` when a *main-thread build exceeds its budget*. Classification: our heuristic was wrong → capture. It's the skill's one sanctioned bend of "expected states are not events" (a deliberate miscalibration alarm), so it's **rate-limited to once per session** and carries only numbers in `extra`. Gate hits and "went to Worker" are expected and NOT captured.

**Provisional budgets** — `MAIN_THREAD_INDEX_BUDGET_MS = 1000`, `SLOW_EXPAND_BUDGET_MS = 500`; retuning them from this data is the point. `tier` is `"main"` until the Worker source lands (LFE-14418).

**Verification** — store contract covered by unit tests (`indexed` emitted once with a real `buildMs`; `expand` on expand, not collapse). Per the PostHog skill, a live capture check (spy on `window.posthog.capture` on a seeded large trace → fires once, metadata-only) is recommended at signoff.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
