### PR TITLE
fix: Preserve accurate retention backlog gauges after cleanup

### DIFF
--- a/worker/src/__tests__/batchDataRetentionCleaner.test.ts
+++ b/worker/src/__tests__/batchDataRetentionCleaner.test.ts
@@ -524,6 +524,22 @@ describe("BatchDataRetentionCleaner", () => {
       await commandClickhouse({ query: `DROP TABLE IF EXISTS ${tableName}` });
     });
 
+    it("resets gauges when it does not acquire the lock", async () => {
+      const cleaner = new BatchDataRetentionCleaner(table);
+      (
+        cleaner as unknown as {
+          lock: { acquire: () => Promise<"held_by_other"> };
+        }
+      ).lock.acquire = async () => "held_by_other";
+
+      await cleaner.processBatch();
+
+      expect(integrationHooks.gaugeCalls).toEqual([
+        ["langfuse.batch_data_retention_cleaner.pending_projects", 0],
+        ["langfuse.batch_data_retention_cleaner.seconds_past_cutoff", 0],
+      ]);
+    });
+
     it("prioritizes lag, breaks ties by total rows, and reports maximum lag", async () => {
       const [
         smallerTieProjectId,
@@ -577,7 +593,45 @@ describe("BatchDataRetentionCleaner", () => {
         getLastGaugeValue(
           "langfuse.batch_data_retention_cleaner.pending_projects",
         ),
-      ).toBe(3);
+      ).toBe(2);
+
+      const lagValue = getLastGaugeValue(
+        "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
+      );
+      expect(lagValue).toBeGreaterThan(2 * (dayMs / 1000));
+      expect(lagValue).toBeLessThan(4 * (dayMs / 1000));
+      expect(integrationHooks.gaugeCalls).toHaveLength(2);
+    });
+
+    it("reports the backlog remaining after a successful batch", async () => {
+      const [mostLateProjectId, nextLateProjectId] =
+        await createProjectsWithRetention(2);
+      const dayMs = 24 * 60 * 60 * 1000;
+      await insertRetentionTestRows(tableName, [
+        {
+          projectId: mostLateProjectId!,
+          startTime: Date.now() - 12 * dayMs,
+        },
+        {
+          projectId: nextLateProjectId!,
+          startTime: Date.now() - 10 * dayMs,
+        },
+      ]);
+      env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT = 1;
+
+      await new BatchDataRetentionCleaner(table).processBatch();
+
+      expect(
+        await getRetentionTestProjectCount(tableName, mostLateProjectId!),
+      ).toBe(0);
+      expect(
+        await getRetentionTestProjectCount(tableName, nextLateProjectId!),
+      ).toBe(1);
+      expect(
+        getLastGaugeValue(
+          "langfuse.batch_data_retention_cleaner.pending_projects",
+        ),
+      ).toBe(1);
 
       const lagValue = getLastGaugeValue(
         "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
@@ -613,6 +667,16 @@ describe("BatchDataRetentionCleaner", () => {
 
       expect(extendedDuringCandidateStream).toBe(true);
       expect(await getRetentionTestRowCount(tableName)).toBe(1);
+      expect(
+        getLastGaugeValue(
+          "langfuse.batch_data_retention_cleaner.pending_projects",
+        ),
+      ).toBe(1);
+      expect(
+        getLastGaugeValue(
+          "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
+        ),
+      ).toBeGreaterThan(2 * 24 * 60 * 60);
       expect(integrationHooks.incrementCalls).toContainEqual([
         "langfuse.batch_data_retention_cleaner.delete_failures",
         1,
@@ -637,10 +701,12 @@ describe("BatchDataRetentionCleaner", () => {
         1,
       ]);
       expect(
-        getLastGaugeValue(
-          "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
+        integrationHooks.gaugeCalls.some(
+          ([name]) =>
+            name ===
+            "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
         ),
-      ).toBe(0);
+      ).toBe(false);
     });
 
     it("continues other chunks after one enrichment exhausts its retry", async () => {
@@ -688,10 +754,12 @@ describe("BatchDataRetentionCleaner", () => {
         ),
       ).toHaveLength(1);
       expect(
-        getLastGaugeValue(
-          "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
+        integrationHooks.gaugeCalls.some(
+          ([name]) =>
+            name ===
+            "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
         ),
-      ).toBe(0);
+      ).toBe(false);
     });
 
     it("traces recovered enrichment without failing the runner outcome", async () => {
@@ -752,9 +820,14 @@ describe("BatchDataRetentionCleaner", () => {
       ).toBe(false);
       expect(
         getLastGaugeValue(
+          "langfuse.batch_data_retention_cleaner.pending_projects",
+        ),
+      ).toBe(0);
+      expect(
+        getLastGaugeValue(
           "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
         ),
-      ).toBeGreaterThan(2 * (dayMs / 1000));
+      ).toBe(0);
     });
   });
 });

--- a/worker/src/__tests__/batchDataRetentionCleaner.test.ts
+++ b/worker/src/__tests__/batchDataRetentionCleaner.test.ts
@@ -700,13 +700,7 @@ describe("BatchDataRetentionCleaner", () => {
         "langfuse.batch_data_retention_cleaner.candidate_query_failures",
         1,
       ]);
-      expect(
-        integrationHooks.gaugeCalls.some(
-          ([name]) =>
-            name ===
-            "langfuse.batch_data_retention_cleaner.seconds_past_cutoff",
-        ),
-      ).toBe(false);
+      expect(integrationHooks.gaugeCalls).toEqual([]);
     });
 
     it("continues other chunks after one enrichment exhausts its retry", async () => {
@@ -753,6 +747,11 @@ describe("BatchDataRetentionCleaner", () => {
             "langfuse.batch_data_retention_cleaner.enrichment_query_failures",
         ),
       ).toHaveLength(1);
+      expect(
+        getLastGaugeValue(
+          "langfuse.batch_data_retention_cleaner.pending_projects",
+        ),
+      ).toBe(0);
       expect(
         integrationHooks.gaugeCalls.some(
           ([name]) =>

--- a/worker/src/__tests__/periodicRunner.test.ts
+++ b/worker/src/__tests__/periodicRunner.test.ts
@@ -95,6 +95,7 @@ class TestExclusiveRunner extends PeriodicExclusiveRunner {
   public callCount = 0;
   public failNext = false;
   public lockAcquired = true;
+  public lockNotAcquiredCount = 0;
   public readonly operationError = new Error("Caught operation error");
 
   constructor(lockMode: "stub" | "unavailable" | "release_failure" = "stub") {
@@ -120,13 +121,19 @@ class TestExclusiveRunner extends PeriodicExclusiveRunner {
   }
 
   protected async execute(): Promise<void> {
-    await this.withLock(async () => {
-      this.callCount++;
-      if (this.failNext) {
-        this.failNext = false;
-        throw this.operationError;
-      }
-    });
+    await this.withLock(
+      async () => {
+        this.callCount++;
+        if (this.failNext) {
+          this.failNext = false;
+          throw this.operationError;
+        }
+      },
+      undefined,
+      () => {
+        this.lockNotAcquiredCount++;
+      },
+    );
   }
 }
 
@@ -277,6 +284,7 @@ describe("PeriodicRunner", () => {
     });
     expect(telemetry.traceException).not.toHaveBeenCalled();
     expect(telemetry.recordGauge).not.toHaveBeenCalled();
+    expect(runner.lockNotAcquiredCount).toBe(1);
     runner.stop();
   });
 

--- a/worker/src/features/batch-data-retention-cleaner/index.ts
+++ b/worker/src/features/batch-data-retention-cleaner/index.ts
@@ -59,6 +59,7 @@ interface ProjectWorkload extends ProjectRetention {
 interface ProjectWorkloadSelection {
   observedWorkloads: ProjectWorkload[];
   selectedWorkloads: ProjectWorkload[];
+  projectCountMeasurementComplete: boolean;
   lagMeasurementComplete: boolean;
 }
 
@@ -208,28 +209,39 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
   protected async execute(): Promise<void> {
     const timestampColumn = TIMESTAMP_COLUMN_MAP[this.tableName];
     let observedBacklog: ReturnType<typeof summarizeBacklog> | undefined;
-    const recordBacklog = ({
-      pendingProjects,
-      secondsPastCutoff,
-    }: ReturnType<typeof summarizeBacklog>) => {
+    let observedLagMeasurementComplete = false;
+    const recordBacklog = (
+      {
+        pendingProjects,
+        secondsPastCutoff,
+      }: ReturnType<typeof summarizeBacklog>,
+      includeLag = true,
+    ) => {
       recordGauge(`${METRIC_PREFIX}.pending_projects`, pendingProjects, {
         table: this.tableName,
       });
-      recordGauge(`${METRIC_PREFIX}.seconds_past_cutoff`, secondsPastCutoff, {
-        table: this.tableName,
-      });
+      if (includeLag) {
+        recordGauge(`${METRIC_PREFIX}.seconds_past_cutoff`, secondsPastCutoff, {
+          table: this.tableName,
+        });
+      }
     };
 
     await this.withLock(
       async () => {
         // Step 1: Get project workloads (streamed CH candidates + PG config)
-        const { observedWorkloads, selectedWorkloads, lagMeasurementComplete } =
-          await this.getProjectWorkloads();
+        const {
+          observedWorkloads,
+          selectedWorkloads,
+          projectCountMeasurementComplete,
+          lagMeasurementComplete,
+        } = await this.getProjectWorkloads();
 
         const currentBacklog = summarizeBacklog(observedWorkloads);
 
-        if (lagMeasurementComplete) {
+        if (projectCountMeasurementComplete) {
           observedBacklog = currentBacklog;
+          observedLagMeasurementComplete = lagMeasurementComplete;
         }
 
         // Step 2: Execute DELETE
@@ -258,10 +270,11 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
           );
         }
 
-        if (lagMeasurementComplete) {
+        if (projectCountMeasurementComplete) {
           // selectedWorkloads is the leading PROJECT_LIMIT slice.
           recordBacklog(
             summarizeBacklog(observedWorkloads.slice(selectedWorkloads.length)),
+            lagMeasurementComplete,
           );
         }
 
@@ -279,7 +292,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       },
       () => {
         if (observedBacklog) {
-          recordBacklog(observedBacklog);
+          recordBacklog(observedBacklog, observedLagMeasurementComplete);
         }
         recordIncrement(`${METRIC_PREFIX}.delete_failures`, 1, {
           table: this.tableName,
@@ -313,6 +326,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       return {
         observedWorkloads: [],
         selectedWorkloads: [],
+        projectCountMeasurementComplete: true,
         lagMeasurementComplete: true,
       };
     }
@@ -373,6 +387,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
             );
             return {
               workloads: enrichment.workloads,
+              discoveryComplete: discovery.complete,
               complete: discovery.complete && enrichment.complete,
             };
           } catch (error) {
@@ -430,6 +445,9 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
       selectedWorkloads: workloads.slice(
         0,
         env.LANGFUSE_BATCH_DATA_RETENTION_CLEANER_PROJECT_LIMIT,
+      ),
+      projectCountMeasurementComplete: chunkResults.every(
+        (result) => result.discoveryComplete,
       ),
       lagMeasurementComplete: chunkResults.every((result) => result.complete),
     };

--- a/worker/src/features/batch-data-retention-cleaner/index.ts
+++ b/worker/src/features/batch-data-retention-cleaner/index.ts
@@ -72,6 +72,19 @@ interface EnrichmentResult {
   complete: boolean;
 }
 
+function summarizeBacklog(workloads: ProjectWorkload[]) {
+  return {
+    pendingProjects: workloads.length,
+    secondsPastCutoff: workloads.reduce(
+      (maximum, workload) =>
+        workload.secondsPastCutoff === null
+          ? maximum
+          : Math.max(maximum, workload.secondsPastCutoff),
+      0,
+    ),
+  };
+}
+
 /**
  * Hash projectId to a short key for ClickHouse parameter names.
  */
@@ -194,15 +207,18 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
    */
   protected async execute(): Promise<void> {
     const timestampColumn = TIMESTAMP_COLUMN_MAP[this.tableName];
-
-    // Reset gauges before attempting lock - ensures they don't appear stuck
-    // if another worker holds the lock
-    recordGauge(`${METRIC_PREFIX}.pending_projects`, 0, {
-      table: this.tableName,
-    });
-    recordGauge(`${METRIC_PREFIX}.seconds_past_cutoff`, 0, {
-      table: this.tableName,
-    });
+    let observedBacklog: ReturnType<typeof summarizeBacklog> | undefined;
+    const recordBacklog = ({
+      pendingProjects,
+      secondsPastCutoff,
+    }: ReturnType<typeof summarizeBacklog>) => {
+      recordGauge(`${METRIC_PREFIX}.pending_projects`, pendingProjects, {
+        table: this.tableName,
+      });
+      recordGauge(`${METRIC_PREFIX}.seconds_past_cutoff`, secondsPastCutoff, {
+        table: this.tableName,
+      });
+    };
 
     await this.withLock(
       async () => {
@@ -210,33 +226,10 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
         const { observedWorkloads, selectedWorkloads, lagMeasurementComplete } =
           await this.getProjectWorkloads();
 
-        recordGauge(
-          `${METRIC_PREFIX}.pending_projects`,
-          observedWorkloads.length,
-          {
-            table: this.tableName,
-          },
-        );
-
-        // Retention cutoffs come from Postgres and are frozen once per run.
-        // Fold the per-project results here to preserve one maximum across all
-        // bounded ClickHouse queries.
-        const observedMaxSecondsPastCutoff = observedWorkloads.reduce(
-          (maximum, workload) =>
-            workload.secondsPastCutoff === null
-              ? maximum
-              : Math.max(maximum, workload.secondsPastCutoff),
-          0,
-        );
+        const currentBacklog = summarizeBacklog(observedWorkloads);
 
         if (lagMeasurementComplete) {
-          recordGauge(
-            `${METRIC_PREFIX}.seconds_past_cutoff`,
-            observedMaxSecondsPastCutoff,
-            {
-              table: this.tableName,
-            },
-          );
+          observedBacklog = currentBacklog;
         }
 
         // Step 2: Execute DELETE
@@ -248,7 +241,7 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
                 (workload) => workload.projectId,
               ),
               pendingProjectsSeen: observedWorkloads.length,
-              observedMaxSecondsPastCutoff,
+              observedMaxSecondsPastCutoff: currentBacklog.secondsPastCutoff,
               lagMeasurementComplete,
             },
           );
@@ -265,6 +258,13 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
           );
         }
 
+        if (lagMeasurementComplete) {
+          // selectedWorkloads is the leading PROJECT_LIMIT slice.
+          recordBacklog(
+            summarizeBacklog(observedWorkloads.slice(selectedWorkloads.length)),
+          );
+        }
+
         // Record successful deletion metrics
         recordIncrement(`${METRIC_PREFIX}.delete_successes`, 1, {
           table: this.tableName,
@@ -278,10 +278,14 @@ export class BatchDataRetentionCleaner extends PeriodicExclusiveRunner {
         );
       },
       () => {
+        if (observedBacklog) {
+          recordBacklog(observedBacklog);
+        }
         recordIncrement(`${METRIC_PREFIX}.delete_failures`, 1, {
           table: this.tableName,
         });
       },
+      () => recordBacklog({ pendingProjects: 0, secondsPastCutoff: 0 }),
     );
   }
 

--- a/worker/src/utils/PeriodicExclusiveRunner.ts
+++ b/worker/src/utils/PeriodicExclusiveRunner.ts
@@ -102,6 +102,7 @@ export abstract class PeriodicExclusiveRunner extends PeriodicRunner {
   protected async withLock<T>(
     operation: () => Promise<T>,
     onFailure?: (error: unknown) => T | Promise<T | void> | void,
+    onLockNotAcquired?: () => void,
   ): Promise<T | undefined> {
     const result = await this.lock.withLock(async () => {
       this.lastLockExtensionAt = 0;
@@ -122,6 +123,7 @@ export abstract class PeriodicExclusiveRunner extends PeriodicRunner {
 
     if (result === null) {
       this.markRunSkipped();
+      onLockNotAcquired?.();
       logger.debug(
         `${this.instanceName}: Lock not acquired, another worker is processing`,
       );


### PR DESCRIPTION
## Summary
- Track pending projects and lag for the backlog remaining after each successful cleanup batch
- Preserve observed backlog metrics when cleanup fails
- Reset gauges when the runner cannot acquire the lock
- Add coverage for backlog, failure, and lock-contention behavior

## Testing
- Added and updated worker unit and integration tests for retention cleanup and periodic lock handling