### PR TITLE
fix(ingestion): extract tool calls from OTel GenAI output message parts

### DIFF
--- a/packages/shared/src/server/ingestion/extractToolsBackend.ts
+++ b/packages/shared/src/server/ingestion/extractToolsBackend.ts
@@ -256,6 +256,29 @@ function addToolArgumentFromContentPart(
 }
 
 /**
+ * Helper to add tool calls from OTel GenAI semconv `parts` arrays
+ * (gen_ai.output.messages): {type: "tool_call", id, name, arguments}.
+ * Emitted by Pydantic AI, Google ADK, and other OTel GenAI semconv sources.
+ * `tool_call_response` parts (tool results, not calls) are skipped.
+ */
+function addToolArgumentsFromOtelParts(
+  args: ClickhouseToolArgument[],
+  parts: unknown,
+): void {
+  if (!Array.isArray(parts)) return;
+
+  for (const part of parts) {
+    if (
+      part &&
+      typeof part === "object" &&
+      (part as Record<string, unknown>).type === "tool_call"
+    ) {
+      addToolArgument(args, part);
+    }
+  }
+}
+
+/**
  * Extract tool definitions from raw input data (top-level tools array).
  */
 function extractToolsFromRawInput(
@@ -366,6 +389,9 @@ function extractToolCallsFromRawOutput(
     }
   }
 
+  // Tool calls in OTel GenAI semconv `parts` arrays (gen_ai.output.messages)
+  addToolArgumentsFromOtelParts(args, obj.parts);
+
   // LangChain additional_kwargs: {additional_kwargs: {tool_calls: [...]}}
   const additionalKwargs = obj.additional_kwargs as
     | Record<string, unknown>
@@ -399,6 +425,9 @@ function extractToolCallsFromMessage(
       }
     }
   }
+
+  // Tool calls in OTel GenAI semconv `parts` arrays (gen_ai.output.messages)
+  addToolArgumentsFromOtelParts(args, msg.parts);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/worker/src/__tests__/extractToolsBackend.test.ts
+++ b/worker/src/__tests__/extractToolsBackend.test.ts
@@ -547,6 +547,108 @@ describe("extractToolsFromObservation", () => {
       });
     });
 
+    it("extracts OTel GenAI tool_call parts from output messages", () => {
+      // gen_ai.output.messages format (Pydantic AI, Google ADK, etc.)
+      const output = [
+        {
+          role: "assistant",
+          parts: [
+            { type: "text", content: "Let me check the weather." },
+            {
+              type: "tool_call",
+              id: "call_ZuzwalMMtvv9BC6xlVe3fiBP",
+              name: "get_weather",
+              arguments: { location: "Boston" },
+            },
+          ],
+          finish_reason: "tool_call",
+        },
+      ];
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toHaveLength(1);
+      expect(toolArguments[0]).toEqual({
+        id: "call_ZuzwalMMtvv9BC6xlVe3fiBP",
+        name: "get_weather",
+        arguments: JSON.stringify({ location: "Boston" }),
+        type: "tool_call",
+      });
+    });
+
+    it("extracts OTel GenAI tool_call parts from a single message object", () => {
+      const output = {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool_call",
+            id: "call_1",
+            name: "final_result",
+            arguments: { quality: "good" },
+          },
+        ],
+        finish_reason: "tool_call",
+      };
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toHaveLength(1);
+      expect(toolArguments[0]).toEqual({
+        id: "call_1",
+        name: "final_result",
+        arguments: JSON.stringify({ quality: "good" }),
+        type: "tool_call",
+      });
+    });
+
+    it("extracts OTel GenAI tool_call parts when output is a JSON string", () => {
+      // gen_ai.output.messages is ingested as a JSON string attribute
+      const output = JSON.stringify([
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "tool_call",
+              id: "call_2",
+              name: "search",
+              arguments: { query: "test" },
+            },
+          ],
+          finish_reason: "tool_call",
+        },
+      ]);
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toHaveLength(1);
+      expect(toolArguments[0]).toMatchObject({
+        id: "call_2",
+        name: "search",
+        arguments: JSON.stringify({ query: "test" }),
+        type: "tool_call",
+      });
+    });
+
+    it("does not treat OTel GenAI tool_call_response parts as tool calls", () => {
+      const output = [
+        {
+          role: "tool",
+          parts: [
+            {
+              type: "tool_call_response",
+              id: "call_1",
+              name: "get_weather",
+              response: { temperature: 20 },
+            },
+          ],
+        },
+      ];
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toHaveLength(0);
+    });
+
     it("extracts LangChain additional_kwargs tool_calls", () => {
       const output = {
         additional_kwargs: {


### PR DESCRIPTION
## What does this PR do?

Ingestion-time tool call extraction (`extractToolsBackend.ts`) walks `message.tool_calls` and `message.content[]` (Anthropic `tool_use`, AI SDK `tool-call`), but never `message.parts[]` — which is where the [OTel GenAI semconv](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) puts tool calls in `gen_ai.output.messages`:

```json
[{"role": "assistant", "parts": [{"type": "tool_call", "id": "call_...", "name": "get_weather", "arguments": {...}}], "finish_reason": "tool_call"}]
```

As a result, generations from **Pydantic AI** (instrumentation version >= 2, the default since pydantic-ai v1), **Google ADK**, and other OTel GenAI semconv sources ingest with empty `tool_calls` / `tool_call_names` columns. The **Tool Calls** eval variable mapping always renders `[]`, and the **Called Tool Names** / **Tool Call Count** observation filters never match — even though the calls are visibly rendered in the trace UI (which reads the ChatML mapping, not these columns). The seeded `pydantic-ai-tools-2025-12-04.json` framework trace reproduces this.

Tool **definitions** from these sources are already handled (`gen_ai.tool.definitions`, `model_request_parameters.function_tools`, indexed `llm.tools.*`); this closes the same gap for tool **calls**:

- New `addToolArgumentsFromOtelParts` helper picks `{type: "tool_call"}` entries out of `parts` arrays; `tool_call_response` parts (results, not calls) are excluded.
- Wired into both `extractToolCallsFromMessage` (messages inside output arrays) and the top-level object path of `extractToolCallsFromRawOutput` (single-message outputs).
- `flattenToolCall` already understands the flat `{id, name, arguments}` shape, so extraction, argument stringification, and dedup behave identically to the existing formats.

Tests: 4 new cases in `worker/src/__tests__/extractToolsBackend.test.ts` (message array, single message object, JSON-string output as ingested from the OTel attribute, and a negative case for `tool_call_response`). All 58 tests in the file pass.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project (`pnpm run format` — no diff)
- I have added tests that prove my fix is effective
- New and existing unit tests pass locally with my changes (`vitest run src/__tests__/extractToolsBackend.test.ts`: 58 passed)