### PR TITLE
fix: reduce batch cleaner query concurrency and stagger worker startup

### DIFF
--- a/worker/src/__tests__/batchProjectCleaner.test.ts
+++ b/worker/src/__tests__/batchProjectCleaner.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it, afterEach } from "vitest";
+import { expect, describe, it, afterEach, vi } from "vitest";
 import { randomUUID } from "crypto";
 import {
   BatchProjectCleaner,
@@ -16,6 +16,12 @@ import {
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { env } from "../env";
+import type { RedisLock } from "../utils/RedisLock";
+
+type TestableBatchProjectCleaner = {
+  lock: RedisLock;
+  getProjectCounts: (projectIds: string[]) => Promise<Map<string, number>>;
+};
 
 async function getClickhouseCount(
   table: string,
@@ -77,7 +83,7 @@ describe("BatchProjectCleaner", () => {
         env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS,
       );
 
-      // Verify lock was not taken
+      // Verify lock was released
       const lockValue = await redis?.get(TEST_LOCK_KEY);
       expect(lockValue).toBeNull();
     });
@@ -102,11 +108,16 @@ describe("BatchProjectCleaner", () => {
 
       // Run processBatch
       const cleaner = new BatchProjectCleaner(TEST_TABLE);
+      const extendLockSpy = vi.spyOn(
+        (cleaner as unknown as TestableBatchProjectCleaner).lock,
+        "extend",
+      );
       const nextDelayMs = await cleaner.processBatch();
 
       // Verify traces were deleted
       const countAfter = await getClickhouseCount(TEST_TABLE, projectId);
       expect(countAfter).toBe(0);
+      expect(extendLockSpy).toHaveBeenCalledOnce();
 
       // Verify returned check interval (work was done)
       expect(nextDelayMs).toBe(
@@ -198,7 +209,13 @@ describe("BatchProjectCleaner", () => {
 
       // Run processBatch - should skip because lock is held
       const cleaner = new BatchProjectCleaner(TEST_TABLE);
+      const getProjectCountsSpy = vi.spyOn(
+        cleaner as unknown as TestableBatchProjectCleaner,
+        "getProjectCounts",
+      );
       const nextDelayMs = await cleaner.processBatch();
+
+      expect(getProjectCountsSpy).not.toHaveBeenCalled();
 
       // Verify traces were NOT deleted (lock blocked processing)
       expect(await getClickhouseCount(TEST_TABLE, projectId)).toBe(1);

--- a/worker/src/__tests__/periodicRunner.test.ts
+++ b/worker/src/__tests__/periodicRunner.test.ts
@@ -68,6 +68,7 @@ class TestRunner extends PeriodicRunner {
   public callCount = 0;
   public shouldThrow = false;
   public returnInterval: number | undefined = undefined;
+  public initialDelayMsForTest = 0;
 
   constructor() {
     super("test_runner");
@@ -79,6 +80,10 @@ class TestRunner extends PeriodicRunner {
 
   protected get defaultIntervalMs(): number {
     return 1000;
+  }
+
+  protected get initialDelayMs(): number {
+    return this.initialDelayMsForTest;
   }
 
   protected async execute(): Promise<number | void> {
@@ -168,6 +173,19 @@ describe("PeriodicRunner", () => {
       Date.now() / 1000,
       { runner: "test_runner", unit: "seconds" },
     );
+    runner.stop();
+  });
+
+  it("should delay the initial execution when configured", async () => {
+    const runner = new TestRunner();
+    runner.initialDelayMsForTest = 250;
+
+    runner.start();
+    await vi.advanceTimersByTimeAsync(249);
+    expect(runner.callCount).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runner.callCount).toBe(1);
     runner.stop();
   });
 

--- a/worker/src/features/batch-project-cleaner/index.ts
+++ b/worker/src/features/batch-project-cleaner/index.ts
@@ -36,16 +36,20 @@ interface ProjectCount {
  *
  * Flow:
  * 1. Query PG for projects with deleted_at set (no lock needed)
- * 2. Query ClickHouse for counts per project (no lock needed)
- * 3. Acquire Redis lock for DELETE only
- * 4. Execute DELETE
- * 5. On failure: re-run count query to determine partial success
+ * 2. Acquire the per-table Redis lock
+ * 3. Query ClickHouse for counts per project
+ * 4. Renew the lock and execute DELETE
+ * 5. On failure: re-run count query before releasing the lock
  */
 export class BatchProjectCleaner extends PeriodicExclusiveRunner {
   private readonly tableName: BatchDeletionTable;
 
   protected get defaultIntervalMs(): number {
     return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
+  }
+
+  protected get initialDelayMs(): number {
+    return BATCH_DELETION_TABLES.indexOf(this.tableName) * 10_000;
   }
 
   constructor(tableName: BatchDeletionTable) {
@@ -60,6 +64,7 @@ export class BatchProjectCleaner extends PeriodicExclusiveRunner {
       metricScope: tableName,
       lockKey: `${BATCH_PROJECT_CLEANER_LOCK_PREFIX}:${tableName}`,
       lockTtlSeconds,
+      onUnavailable: "fail",
     });
     this.tableName = tableName;
   }
@@ -102,37 +107,44 @@ export class BatchProjectCleaner extends PeriodicExclusiveRunner {
       return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
     }
 
-    // Step 2: Query ClickHouse for counts per project (no lock needed)
-    let initialCounts: Map<string, number>;
-    try {
-      initialCounts = await this.getProjectCounts(
-        deletedProjects.map((p) => p.id),
-      );
-    } catch (error) {
-      logger.error(
-        `${this.instanceName}: Failed to query ClickHouse counts`,
-        error,
-      );
-      this.markRunFailed(error);
+    if (deletedProjects.length === 0) {
+      logger.info(`${this.instanceName}: No deleted projects found`);
       return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
     }
 
-    // Filter to only projects that have data
-    const projectIdsWithData = Array.from(initialCounts.entries())
-      .filter(([, count]) => count > 0)
-      .map(([projectId]) => projectId);
+    let deleteAttemptProjectIds: string[] | undefined;
 
-    if (projectIdsWithData.length === 0) {
-      logger.info(
-        `${this.instanceName}: No data found for deleted projects in ${this.tableName}`,
-      );
-      return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
-    }
-
-    // Step 3 & 4: Execute DELETE under distributed lock
+    // Steps 2-5: Keep the entire ClickHouse count/delete cycle under the lock.
     return (
       (await this.withLock(
         async () => {
+          let initialCounts: Map<string, number>;
+          try {
+            initialCounts = await this.getProjectCounts(
+              deletedProjects.map((p) => p.id),
+            );
+          } catch (error) {
+            logger.error(
+              `${this.instanceName}: Failed to query ClickHouse counts`,
+              error,
+            );
+            this.markRunFailed(error);
+            return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
+          }
+
+          const projectIdsWithData = Array.from(initialCounts.entries())
+            .filter(([, count]) => count > 0)
+            .map(([projectId]) => projectId);
+
+          if (projectIdsWithData.length === 0) {
+            logger.info(
+              `${this.instanceName}: No data found for deleted projects in ${this.tableName}`,
+            );
+            return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
+          }
+
+          await this.extendLockOnProgress(true);
+          deleteAttemptProjectIds = projectIdsWithData;
           await this.executeDelete(projectIdsWithData);
 
           const totalRows = Array.from(initialCounts.values()).reduce(
@@ -148,29 +160,34 @@ export class BatchProjectCleaner extends PeriodicExclusiveRunner {
           return env.LANGFUSE_BATCH_PROJECT_CLEANER_CHECK_INTERVAL_MS;
         },
         async (error) => {
-          // Step 5: On failure, re-run count query to determine partial success
+          if (!deleteAttemptProjectIds) {
+            return env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS;
+          }
+
           recordIncrement("langfuse.batch_project_cleaner.delete_failures", 1, {
             table: this.tableName,
           });
 
           let finalCounts: Map<string, number> | undefined;
           try {
-            finalCounts = await this.getProjectCounts(projectIdsWithData);
+            await this.extendLockOnProgress(true);
+            finalCounts =
+              await this.getProjectCounts(deleteAttemptProjectIds);
           } catch (countError) {
             // Can't determine partial success
             logger.error(
-              `${this.instanceName}: Failed to re-query counts after DELETE failure`,
+              `${this.instanceName}: Failed to renew lock or re-query counts after DELETE failure`,
               countError,
             );
           }
 
           // Calculate projects that couldn't be fully cleaned
           const incompleteProjects = finalCounts
-            ? projectIdsWithData.filter((projectId) => {
+            ? deleteAttemptProjectIds.filter((projectId) => {
                 const finalCount = finalCounts.get(projectId) ?? 0;
                 return finalCount > 0;
               })
-            : projectIdsWithData;
+            : deleteAttemptProjectIds;
 
           if (incompleteProjects.length > 0) {
             recordIncrement(

--- a/worker/src/features/batch-project-cleaner/index.ts
+++ b/worker/src/features/batch-project-cleaner/index.ts
@@ -171,8 +171,7 @@ export class BatchProjectCleaner extends PeriodicExclusiveRunner {
           let finalCounts: Map<string, number> | undefined;
           try {
             await this.extendLockOnProgress(true);
-            finalCounts =
-              await this.getProjectCounts(deleteAttemptProjectIds);
+            finalCounts = await this.getProjectCounts(deleteAttemptProjectIds);
           } catch (countError) {
             // Can't determine partial success
             logger.error(

--- a/worker/src/utils/PeriodicRunner.ts
+++ b/worker/src/utils/PeriodicRunner.ts
@@ -24,6 +24,9 @@ export abstract class PeriodicRunner {
 
   protected abstract get name(): string;
   protected abstract get defaultIntervalMs(): number;
+  protected get initialDelayMs(): number {
+    return 0;
+  }
   protected abstract execute(): Promise<number | void>;
 
   protected constructor(
@@ -37,7 +40,11 @@ export abstract class PeriodicRunner {
     }
     this.isRunning = true;
     if (!this.activeRun) {
-      this.runAndScheduleNext();
+      if (this.initialDelayMs > 0) {
+        this.scheduleNext(this.initialDelayMs);
+      } else {
+        this.runAndScheduleNext();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Upon worker containers restart multiple instances may put unnecessary heavy load on CH 
- Hold the per-table Redis lock across ClickHouse counting, deletion, and failure recovery.
- Renew the lock before deletion and during recovery, and fail fast when it is unavailable.
- Stagger batch cleaner startup to reduce simultaneous load.
