### PR TITLE
feat(public-api): add DELETE /api/public/comments/{commentId}

### DIFF
--- a/fern/apis/server/definition/comments.yml
+++ b/fern/apis/server/definition/comments.yml
@@ -44,6 +44,15 @@ service:
           type: string
           docs: The unique langfuse identifier of a comment
       response: commons.Comment
+    delete:
+      docs: Delete a comment by id
+      method: DELETE
+      path: /comments/{commentId}
+      path-parameters:
+        commentId:
+          type: string
+          docs: The unique langfuse identifier of the comment to delete
+      response: DeleteCommentResponse
 types:
   CreateCommentRequest:
     properties:
@@ -71,3 +80,6 @@ types:
     properties:
       data: list<commons.Comment>
       meta: pagination.MetaResponse
+  DeleteCommentResponse:
+    properties:
+      message: string

--- a/packages/shared/src/interfaces/rate-limits.ts
+++ b/packages/shared/src/interfaces/rate-limits.ts
@@ -14,6 +14,7 @@ export const RateLimitResource = z.enum([
   "datasets",
   "trace-delete",
   "score-delete",
+  "comment-delete",
   "in-app-agent-run",
   "feedback",
 ]);

--- a/web/src/__tests__/server/comments-api.servertest.ts
+++ b/web/src/__tests__/server/comments-api.servertest.ts
@@ -1,5 +1,6 @@
 import { makeZodVerifiedAPICall } from "@/src/__tests__/test-utils";
 import {
+  DeleteCommentV1Response,
   GetCommentsV1Response,
   GetCommentV1Response,
   PostCommentsV1Response,
@@ -383,5 +384,104 @@ describe("Public API does NOT process mentions", () => {
     expect(response.body.content).toBe(
       "Hey @[FakeAdmin](user:user-1) and @[InvalidUser](user:invalid-id), check this!",
     );
+  });
+});
+
+describe("DELETE /api/public/comments/:commentId", () => {
+  beforeAll(async () => {
+    // Seed a trace so we can attach comments to it for the delete cases.
+    const traces = [
+      createTrace({
+        name: "delete-comment-trace",
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        id: "delete-comment-trace",
+      }),
+    ];
+    await createTracesCh(traces);
+
+    await prisma.comment.deleteMany({
+      where: { projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a" },
+    });
+  });
+
+  it("deletes an existing comment and returns the success message", async () => {
+    const { body: created } = await makeZodVerifiedAPICall(
+      PostCommentsV1Response,
+      "POST",
+      "/api/public/comments",
+      {
+        content: "to be deleted",
+        objectId: "delete-comment-trace",
+        objectType: "TRACE",
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        authorUserId: "user-1",
+      },
+    );
+
+    const { id: commentId } = created;
+
+    const deleteResponse = await makeZodVerifiedAPICall(
+      DeleteCommentV1Response,
+      "DELETE",
+      `/api/public/comments/${commentId}`,
+    );
+
+    expect(deleteResponse.status).toBe(200);
+    expect(deleteResponse.body).toEqual({
+      message: "Comment deleted successfully",
+    });
+
+    // The row is gone from Postgres.
+    const row = await prisma.comment.findUnique({ where: { id: commentId } });
+    expect(row).toBeNull();
+
+    // A follow-up GET returns 404 (the comment no longer exists).
+    await expect(
+      makeZodVerifiedAPICall(
+        GetCommentV1Response,
+        "GET",
+        `/api/public/comments/${commentId}`,
+      ),
+    ).rejects.toThrow(/returned status 404/);
+  });
+
+  it("returns 404 when the comment id does not exist", async () => {
+    await expect(
+      makeZodVerifiedAPICall(
+        DeleteCommentV1Response,
+        "DELETE",
+        "/api/public/comments/does-not-exist",
+      ),
+    ).rejects.toThrow(/returned status 404/);
+  });
+
+  it("returns 404 when the comment belongs to a different project", async () => {
+    // Seed a comment in a different project directly via Prisma. The public
+    // API key in the test harness is scoped to the default test project, so
+    // getCommentRecordOrThrow's { id, projectId } filter will miss and the
+    // handler must return 404.
+    const otherProjectId = "01234567-89ab-cdef-0123-456789abcdef";
+    const otherComment = await prisma.comment.create({
+      data: {
+        projectId: otherProjectId,
+        content: "in a different project",
+        objectId: "delete-comment-trace",
+        objectType: "TRACE",
+        authorUserId: "user-1",
+      },
+    });
+
+    try {
+      await expect(
+        makeZodVerifiedAPICall(
+          DeleteCommentV1Response,
+          "DELETE",
+          `/api/public/comments/${otherComment.id}`,
+        ),
+      ).rejects.toThrow(/returned status 404/);
+    } finally {
+      // Cleanup the foreign-project row so the suite stays isolated.
+      await prisma.comment.delete({ where: { id: otherComment.id } });
+    }
   });
 });

--- a/web/src/features/comments/server/publicCommentService.ts
+++ b/web/src/features/comments/server/publicCommentService.ts
@@ -154,3 +154,40 @@ export const getCommentForApi = async ({
   const comment = await getCommentRecordOrThrow({ projectId, commentId });
   return toPublicComment(comment);
 };
+
+type DeleteCommentInput = {
+  projectId: string;
+  orgId: string;
+  apiKeyId: string;
+  commentId: string;
+};
+
+export const deleteCommentForApi = async ({
+  projectId,
+  orgId,
+  apiKeyId,
+  commentId,
+}: DeleteCommentInput) => {
+  // Project-scope check via the shared helper: 404 if the comment is missing
+  // or belongs to a different project. This is the same authorization model
+  // as the GET handler.
+  const comment = await getCommentRecordOrThrow({ projectId, commentId });
+
+  await prisma.comment.delete({
+    where: {
+      id: comment.id,
+    },
+  });
+
+  await auditLog({
+    action: "delete",
+    resourceType: "comment",
+    resourceId: comment.id,
+    projectId,
+    orgId,
+    apiKeyId,
+    before: comment,
+  });
+
+  return { message: "Comment deleted successfully" };
+};

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -331,6 +331,12 @@ const getPlanBasedRateLimitConfig = (
             points: 50,
             durationInSec: 86400, // 50 requests per day
           };
+        case "comment-delete":
+          return {
+            resource: "comment-delete",
+            points: 50,
+            durationInSec: 86400, // 50 requests per day
+          };
         case "in-app-agent-run":
           return {
             resource: "in-app-agent-run",
@@ -429,6 +435,12 @@ const getPlanBasedRateLimitConfig = (
             points: 200,
             durationInSec: 86400, // 200 requests per day
           };
+        case "comment-delete":
+          return {
+            resource: "comment-delete",
+            points: 200,
+            durationInSec: 86400, // 200 requests per day
+          };
         case "in-app-agent-run":
           return {
             resource: "in-app-agent-run",
@@ -518,6 +530,12 @@ const getPlanBasedRateLimitConfig = (
         case "score-delete":
           return {
             resource: "score-delete",
+            points: 1000,
+            durationInSec: 86400, // 1000 requests per day
+          };
+        case "comment-delete":
+          return {
+            resource: "comment-delete",
             points: 1000,
             durationInSec: 86400, // 1000 requests per day
           };

--- a/web/src/features/public-api/types/comments.ts
+++ b/web/src/features/public-api/types/comments.ts
@@ -74,3 +74,15 @@ export const GetCommentV1Query = z
   })
   .strict();
 export const GetCommentV1Response = APIComment;
+
+// DELETE /comments/:id
+export const DeleteCommentV1Query = z
+  .object({
+    commentId: z.string(),
+  })
+  .strict();
+export const DeleteCommentV1Response = z
+  .object({
+    message: z.string(),
+  })
+  .strict();

--- a/web/src/pages/api/public/comments/[commentId].ts
+++ b/web/src/pages/api/public/comments/[commentId].ts
@@ -1,9 +1,14 @@
-import { getCommentForApi } from "@/src/features/comments/server/publicCommentService";
+import {
+  deleteCommentForApi,
+  getCommentForApi,
+} from "@/src/features/comments/server/publicCommentService";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import {
   GetCommentV1Query,
   GetCommentV1Response,
+  DeleteCommentV1Query,
+  DeleteCommentV1Response,
 } from "@/src/features/public-api/types/comments";
 
 export default withMiddlewares({
@@ -15,6 +20,19 @@ export default withMiddlewares({
       await getCommentForApi({
         commentId: query.commentId,
         projectId: auth.scope.projectId,
+      }),
+  }),
+  DELETE: createAuthedProjectAPIRoute({
+    name: "Delete Comment",
+    querySchema: DeleteCommentV1Query,
+    responseSchema: DeleteCommentV1Response,
+    rateLimitResource: "comment-delete",
+    fn: async ({ query, auth }) =>
+      await deleteCommentForApi({
+        commentId: query.commentId,
+        projectId: auth.scope.projectId,
+        orgId: auth.scope.orgId,
+        apiKeyId: auth.scope.apiKeyId,
       }),
   }),
 });


### PR DESCRIPTION
## What does this PR do?

Add `DELETE /api/public/comments/{commentId}` to the public REST API. Today the public API has `POST` and `GET` for comments but no delete path; the corresponding tRPC mutation (`comments.delete`) and the underlying Prisma delete are already in place. This PR wires the new endpoint up, adds a per-plan `comment-delete` rate-limit bucket, and covers the new surface with three servertests.

`POST` and the new `DELETE` now sit at full parity with `traces` and `scores`, which already have public delete endpoints.

Fixes #15443

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] New servertest coverage in `web/src/__tests__/server/comments-api.servertest.ts`
- [x] Fern definition updated in `fern/apis/server/definition/comments.yml` (the generated `openapi.yml` is regenerated by CI)

## Implementation notes

1. New `comment-delete` rate-limit resource in `@langfuse/shared` with per-plan tiers (hobby 50/day, core 200/day, pro/team/enterprise 1000/day). The exhaustive `switch` in `RateLimitService.ts` will fail to compile if a future plan is added without a case for it, which acts as a compile-time safety net.
2. New `DeleteCommentV1Query` / `DeleteCommentV1Response` zod schemas in the public API types module.
3. New `deleteCommentForApi` service function in `web/src/features/comments/server/publicCommentService.ts`. Reuses `getCommentRecordOrThrow` for the 404 + project-scope check, runs the Prisma delete, and emits the audit log entry. No author-only check — the public API key is project-scoped, matching `trace-delete` and `score-delete`. The tRPC mutation keeps its author-only check unchanged.
4. DELETE handler wired in `web/src/pages/api/public/comments/[commentId].ts` under the new `comment-delete` rate-limit bucket. No `allowInAppAgentKey` (matches trace-delete / score-delete), no `rejectInEventsOnlyMode` (comments live in Postgres, not ClickHouse).
5. Servertest cases added:
   - Happy path: create + delete + verify 404 on follow-up GET + verify the row is gone from Postgres.
   - Missing id returns 404.
   - Cross-project: a comment seeded in a different project returns 404 via the default-project API key (proves the `getCommentRecordOrThrow` `{ id, projectId }` filter).

## Local verification

- `pnpm --filter web exec prettier --check` on every changed file → `All matched files use Prettier code style!`
- `pnpm --filter web exec eslint` on every changed file → no output (clean)
- `pnpm --filter web exec tsc --noEmit -p tsconfig.json` → no new errors in the touched files (`comments-api.servertest.ts`, `[commentId].ts`, `publicCommentService.ts`, `types/comments.ts`, `RateLimitService.ts`, `rate-limits.ts`). Pre-existing failures in `helpers.ts` (boolean score widget, PR #15255), `sessions.ts` / `traces.ts` / `extractTools.ts` (missing exports), and missing optional dev deps are present on upstream `main` and unrelated to this PR.
- Servertests require a full Postgres + Redis + ClickHouse stack via `docker-compose.dev.yml`, same as the rest of the `comments-api.servertest.ts` suite. They were not executed locally in this environment.

## Risks

Minimal. Purely additive: a new endpoint, a new rate-limit resource, a new Fern operation, and three new test cases. The exhaustive `switch` in `RateLimitService.ts` makes a forgotten per-plan case a compile-time failure.
