### PR TITLE
refactor(shared): enforce column id for filter mapping

### DIFF
--- a/packages/shared/src/server/filterToPrisma.ts
+++ b/packages/shared/src/server/filterToPrisma.ts
@@ -48,8 +48,7 @@ export function tableColumnsToSqlFilter(
     // Get column definition to map column to internal name, e.g. "t.id"
     const col = tableColumns.find(
       (c) =>
-        // TODO: Only use id instead of name
-        c.name === filter.column || c.id === filter.column,
+        c.id === filter.column,
     );
     if (!col) {
       logger.error("Invalid filter column", filter.column);


### PR DESCRIPTION
## 💡 Executive Summary
This pull request refactors the Prisma filter state mapping to strictly use the column `id` instead of `name`. This ensures consistency across the API by removing the deprecated `name` fallback as requested in the existing `TODO` comment.

## 🔧 Technical Architecture & Approach
*   **Root Cause / Context:** The `tableColumnsToSqlFilter` function previously allowed `c.name === filter.column || c.id === filter.column`. Using `name` was deprecated and left behind a TODO to enforce `id` usage.
*   **Solution Design:** Removed the fallback to `c.name`, directly enforcing the use of `c.id === filter.column`. This prevents ambiguity in queries where column names might be duplicated or mapped differently across tables.
*   **Trade-offs Considered:** This enforces strictness on the API consumer to provide valid `id` values, ensuring better type safety and query accuracy at the potential cost of backward compatibility for undocumented/legacy endpoints that might still send `name`.

## 🧪 Verification & Test Coverage
*   [x] Verified that Prisma query generation continues to function as expected for valid IDs.
*   [x] Ensured no new dependencies or structural regressions were introduced.