### PR TITLE
feat: Add TraceView Audit event

### DIFF
--- a/web/src/__tests__/server/trace-view-audit-middleware.servertest.ts
+++ b/web/src/__tests__/server/trace-view-audit-middleware.servertest.ts
@@ -31,17 +31,29 @@ import {
 } from "@/src/server/api/trpc";
 import { getTraceById } from "@langfuse/shared/src/server";
 
-// Register under the real `traces.*` paths so the middleware sees the same
-// `opts.path` it does in production. Both procedures share enforceTraceAccess,
-// but only byIdWithObservationsAndScores is a genuine single-trace view; byId
-// backs the per-row traces-table IO/metadata cells, so it must NOT be audited.
+// Register under the real `traces.*` / `events.*` paths so the middleware sees
+// the same `opts.path` it gates on in production (AUDITED_TRACE_VIEW_PROCEDURES).
+// All share enforceTraceAccess, but only the content-detail views are audited:
+// `traces.byIdWithObservationsAndScores` (v3) and `events.byTraceId` (v4). The
+// per-row table-cell fetch `traces.byId` must NOT be audited. That the audited
+// paths still resolve to real prod procedures is guarded separately by
+// recordTraceViewAudit.drift.servertest.ts.
+const traceViewInput = z.object({
+  traceId: z.string(),
+  projectId: z.string(),
+});
 const middlewareTestRouter = createTRPCRouter({
   traces: createTRPCRouter({
     byId: protectedGetTraceProcedure
-      .input(z.object({ traceId: z.string(), projectId: z.string() }))
+      .input(traceViewInput)
       .query(() => ({ ok: true })),
     byIdWithObservationsAndScores: protectedGetTraceProcedure
-      .input(z.object({ traceId: z.string(), projectId: z.string() }))
+      .input(traceViewInput)
+      .query(() => ({ ok: true })),
+  }),
+  events: createTRPCRouter({
+    byTraceId: protectedGetTraceProcedure
+      .input(traceViewInput)
       .query(() => ({ ok: true })),
   }),
 });
@@ -172,6 +184,53 @@ describe("trace-view audit in tRPC trace-access middleware", () => {
       },
       resourceId: TRACE_ID,
     });
+  });
+
+  it("records a read audit for the v4 events-backed detail view (events.byTraceId)", async () => {
+    // v4 beta fetches trace content via events.byTraceId, not
+    // traces.byIdWithObservationsAndScores. It hits the same middleware and
+    // must be audited too, or the audit guarantee silently fails for v4 users.
+    const { caller } = createTestCaller({ session: createMemberSession() });
+
+    await caller.events.byTraceId({
+      traceId: TRACE_ID,
+      projectId: PROJECT_ID,
+    });
+
+    expect(recordTraceViewAuditMock).toHaveBeenCalledTimes(1);
+    expect(recordTraceViewAuditMock).toHaveBeenCalledWith({
+      session: {
+        user: { id: "member-user-id" },
+        orgId: ORG_ID,
+        orgRole: "MEMBER",
+        projectId: PROJECT_ID,
+        projectRole: "MEMBER",
+      },
+      resourceId: TRACE_ID,
+    });
+  });
+
+  it("does NOT record an audit when a logged-in non-member views a public trace", async () => {
+    // Access is granted because the trace is public, but there is no
+    // member org to attribute and the user is not an admin, so there is no
+    // actor to audit — the view must pass through without an audit row.
+    mockGetTraceById.mockResolvedValue({
+      id: TRACE_ID,
+      input: "{}",
+      output: "{}",
+      public: true,
+      sessionId: null,
+    } as any);
+    const nonMemberSession = createAdminNonMemberSession();
+    nonMemberSession.user!.admin = false;
+    const { caller } = createTestCaller({ session: nonMemberSession });
+
+    await caller.traces.byIdWithObservationsAndScores({
+      traceId: TRACE_ID,
+      projectId: PROJECT_ID,
+    });
+
+    expect(recordTraceViewAuditMock).not.toHaveBeenCalled();
   });
 
   it("does NOT record an audit for traces.byId (table IO/metadata cell fetch)", async () => {

--- a/web/src/__tests__/server/trace-view-audit-middleware.servertest.ts
+++ b/web/src/__tests__/server/trace-view-audit-middleware.servertest.ts
@@ -1,0 +1,249 @@
+import type { Session } from "next-auth";
+import * as z from "zod";
+import { TRPCError } from "@trpc/server";
+
+// Session fixture sub-object types; casts keep the runtime fixtures unchanged
+// while satisfying newer required fields on the session user type.
+type SessionUser = NonNullable<Session["user"]>;
+type SessionProjects = SessionUser["organizations"][number]["projects"];
+type SessionFeatureFlags = SessionUser["featureFlags"];
+
+const { recordTraceViewAuditMock } = vi.hoisted(() => ({
+  recordTraceViewAuditMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/src/features/audit-logs/recordTraceViewAudit", () => ({
+  recordTraceViewAudit: recordTraceViewAuditMock,
+}));
+
+vi.mock("@langfuse/shared/src/server", async () => {
+  const originalModule = await vi.importActual("@langfuse/shared/src/server");
+  return {
+    ...originalModule,
+    getTraceById: vi.fn(),
+  };
+});
+
+import {
+  createTRPCRouter,
+  createInnerTRPCContext,
+  protectedGetTraceProcedure,
+} from "@/src/server/api/trpc";
+import { getTraceById } from "@langfuse/shared/src/server";
+
+// Register under the real `traces.*` paths so the middleware sees the same
+// `opts.path` it does in production. Both procedures share enforceTraceAccess,
+// but only byIdWithObservationsAndScores is a genuine single-trace view; byId
+// backs the per-row traces-table IO/metadata cells, so it must NOT be audited.
+const middlewareTestRouter = createTRPCRouter({
+  traces: createTRPCRouter({
+    byId: protectedGetTraceProcedure
+      .input(z.object({ traceId: z.string(), projectId: z.string() }))
+      .query(() => ({ ok: true })),
+    byIdWithObservationsAndScores: protectedGetTraceProcedure
+      .input(z.object({ traceId: z.string(), projectId: z.string() }))
+      .query(() => ({ ok: true })),
+  }),
+});
+
+const PROJECT_ID = "project-id";
+const ORG_ID = "org-id";
+const TRACE_ID = "trace-id";
+
+const createMemberSession = (): Session => ({
+  expires: "1",
+  user: {
+    id: "member-user-id",
+    email: "member@langfuse.com",
+    canCreateOrganizations: true,
+    name: "Member User",
+    organizations: [
+      {
+        id: ORG_ID,
+        name: "Member Organization",
+        role: "MEMBER",
+        plan: "cloud:hobby",
+        cloudConfig: undefined,
+        metadata: {},
+        projects: [
+          {
+            id: PROJECT_ID,
+            role: "MEMBER",
+            retentionDays: 30,
+            deletedAt: null,
+            name: "Project",
+          },
+        ] as SessionProjects,
+      } as SessionUser["organizations"][number],
+    ],
+    featureFlags: {
+      excludeClickhouseRead: false,
+      templateFlag: true,
+    } as SessionFeatureFlags,
+    admin: false,
+  },
+  environment: {} as any,
+});
+
+const createAdminNonMemberSession = (): Session => ({
+  expires: "1",
+  user: {
+    id: "admin-user-id",
+    email: "admin@langfuse.com",
+    canCreateOrganizations: true,
+    name: "Admin User",
+    organizations: [],
+    featureFlags: {
+      excludeClickhouseRead: false,
+      templateFlag: true,
+    } as SessionFeatureFlags,
+    admin: true,
+  },
+  environment: {} as any,
+});
+
+const createTestCaller = (params: {
+  session: Session;
+  dbProjectOrgId?: string | null;
+  traceSession?: { public: boolean } | null;
+}) => {
+  const mockPrisma = {
+    project: {
+      findFirst: vi
+        .fn()
+        .mockResolvedValue(
+          params.dbProjectOrgId === null
+            ? null
+            : { orgId: params.dbProjectOrgId ?? "db-org-id" },
+        ),
+    },
+    traceSession: {
+      findFirst: vi
+        .fn()
+        .mockResolvedValue(params.traceSession ?? { public: false }),
+    },
+  };
+
+  const context = createInnerTRPCContext({
+    session: params.session,
+    headers: {},
+  });
+
+  return {
+    caller: middlewareTestRouter.createCaller({
+      ...context,
+      prisma: mockPrisma as any,
+    }),
+    mockPrisma,
+  };
+};
+
+describe("trace-view audit in tRPC trace-access middleware", () => {
+  const mockGetTraceById = vi.mocked(getTraceById);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recordTraceViewAuditMock.mockResolvedValue(undefined);
+    mockGetTraceById.mockResolvedValue({
+      id: TRACE_ID,
+      input: "{}",
+      output: "{}",
+      public: false,
+      sessionId: null,
+    } as any);
+  });
+
+  it("records a read audit when a project member views a trace", async () => {
+    const { caller } = createTestCaller({ session: createMemberSession() });
+
+    await caller.traces.byIdWithObservationsAndScores({
+      traceId: TRACE_ID,
+      projectId: PROJECT_ID,
+    });
+
+    expect(recordTraceViewAuditMock).toHaveBeenCalledTimes(1);
+    expect(recordTraceViewAuditMock).toHaveBeenCalledWith({
+      session: {
+        user: { id: "member-user-id" },
+        orgId: ORG_ID,
+        orgRole: "MEMBER",
+        projectId: PROJECT_ID,
+        projectRole: "MEMBER",
+      },
+      resourceId: TRACE_ID,
+    });
+  });
+
+  it("does NOT record an audit for traces.byId (table IO/metadata cell fetch)", async () => {
+    // byId backs the per-row input/output/metadata cells in the traces table,
+    // fired for every visible row on list render — auditing it is a false
+    // positive. Only the full detail view counts as a view.
+    const { caller } = createTestCaller({ session: createMemberSession() });
+
+    await caller.traces.byId({ traceId: TRACE_ID, projectId: PROJECT_ID });
+
+    expect(recordTraceViewAuditMock).not.toHaveBeenCalled();
+  });
+
+  it("records a read audit for an admin non-member, resolving the org from the db", async () => {
+    const { caller, mockPrisma } = createTestCaller({
+      session: createAdminNonMemberSession(),
+      dbProjectOrgId: "db-org-id",
+    });
+
+    await caller.traces.byIdWithObservationsAndScores({
+      traceId: TRACE_ID,
+      projectId: PROJECT_ID,
+    });
+
+    // Admin org resolution happens off the request path, so wait for the
+    // fire-and-forget chain to settle before asserting.
+    await vi.waitFor(() =>
+      expect(recordTraceViewAuditMock).toHaveBeenCalledTimes(1),
+    );
+    expect(mockPrisma.project.findFirst).toHaveBeenCalledWith({
+      select: { orgId: true },
+      where: { id: PROJECT_ID, deletedAt: null },
+    });
+    expect(recordTraceViewAuditMock).toHaveBeenCalledWith({
+      session: {
+        user: { id: "admin-user-id" },
+        orgId: "db-org-id",
+        orgRole: "OWNER",
+        projectId: PROJECT_ID,
+        projectRole: "OWNER",
+      },
+      resourceId: TRACE_ID,
+    });
+  });
+
+  it("does not record an audit when access is denied (non-member, non-admin, private trace)", async () => {
+    // Non-admin, non-member session on a private trace → UNAUTHORIZED.
+    const deniedSession = createAdminNonMemberSession();
+    deniedSession.user!.admin = false;
+    const { caller } = createTestCaller({ session: deniedSession });
+
+    await expect(
+      caller.traces.byIdWithObservationsAndScores({
+        traceId: TRACE_ID,
+        projectId: PROJECT_ID,
+      }),
+    ).rejects.toThrow(TRPCError);
+
+    expect(recordTraceViewAuditMock).not.toHaveBeenCalled();
+  });
+
+  it("does not record an audit when the trace is not found", async () => {
+    mockGetTraceById.mockResolvedValue(null as any);
+    const { caller } = createTestCaller({ session: createMemberSession() });
+
+    await expect(
+      caller.traces.byIdWithObservationsAndScores({
+        traceId: TRACE_ID,
+        projectId: PROJECT_ID,
+      }),
+    ).rejects.toThrow(TRPCError);
+
+    expect(recordTraceViewAuditMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/server/traces-api.servertest.ts
+++ b/web/src/__tests__/server/traces-api.servertest.ts
@@ -29,6 +29,7 @@ import { randomUUID } from "crypto";
 import snakeCase from "lodash/snakeCase";
 import { env } from "@/src/env.mjs";
 import waitForExpect from "wait-for-expect";
+import { prisma, AuditLogRecordType } from "@langfuse/shared/src/db";
 
 // Helper type for creating observation/event data
 // Times are always in milliseconds, conversion handled internally
@@ -275,6 +276,40 @@ describe("/api/public/traces API Endpoint", () => {
         }),
       ]),
     );
+  });
+
+  it("records a read audit log attributed to the API key on GET single trace", async () => {
+    const traceId = randomUUID();
+    const createdTrace = createTrace({
+      id: traceId,
+      name: "audit-trace",
+      project_id: projectId,
+    });
+    await createTracesCh([createdTrace]);
+
+    await makeZodVerifiedAPICall(
+      GetTraceV1Response,
+      "GET",
+      "/api/public/traces/" + traceId,
+      undefined,
+      auth,
+    );
+
+    // The audit write is fire-and-forget, so poll for the row.
+    await waitForExpect(async () => {
+      const rows = await prisma.auditLog.findMany({
+        where: {
+          projectId,
+          resourceType: "trace",
+          resourceId: traceId,
+          action: "read",
+        },
+      });
+      expect(rows.length).toBe(1);
+      expect(rows[0]!.apiKeyId).not.toBeNull();
+      expect(rows[0]!.userId).toBeNull();
+      expect(rows[0]!.type).toBe(AuditLogRecordType.API_KEY);
+    });
   });
 
   it("should fetch a trace with core-only fields when fields=core", async () => {

--- a/web/src/__tests__/server/traces-api.servertest.ts
+++ b/web/src/__tests__/server/traces-api.servertest.ts
@@ -312,6 +312,43 @@ describe("/api/public/traces API Endpoint", () => {
     });
   });
 
+  it("dedups repeated reads within the window: two GETs of the same trace write one audit row", async () => {
+    // The whole point of the feature is one row per (actor, trace) per window;
+    // this exercises the real Redis SET NX dedup end-to-end (the unit test only
+    // mocks Redis, and the single-GET test above never re-reads).
+    const traceId = randomUUID();
+    const createdTrace = createTrace({
+      id: traceId,
+      name: "audit-trace-dedup",
+      project_id: projectId,
+    });
+    await createTracesCh([createdTrace]);
+
+    for (let i = 0; i < 2; i++) {
+      await makeZodVerifiedAPICall(
+        GetTraceV1Response,
+        "GET",
+        "/api/public/traces/" + traceId,
+        undefined,
+        auth,
+      );
+    }
+
+    // Wait for the first fire-and-forget write to land, then assert the second
+    // read did not add a row.
+    await waitForExpect(async () => {
+      const rows = await prisma.auditLog.findMany({
+        where: {
+          projectId,
+          resourceType: "trace",
+          resourceId: traceId,
+          action: "read",
+        },
+      });
+      expect(rows.length).toBe(1);
+    });
+  });
+
   it("should fetch a trace with core-only fields when fields=core", async () => {
     const traceId = randomUUID();
     const createdTrace = createTrace({

--- a/web/src/__tests__/server/unit/recordTraceViewAudit.drift.servertest.ts
+++ b/web/src/__tests__/server/unit/recordTraceViewAudit.drift.servertest.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { AUDITED_TRACE_VIEW_PROCEDURES } from "@/src/server/api/trpc";
+import { traceRouter } from "@/src/server/api/routers/traces";
+import { eventsRouter } from "@/src/features/events/server/eventsRouter";
+
+/**
+ * Drift guard for the trace-view read-audit gate. The middleware audits a view
+ * when `AUDITED_TRACE_VIEW_PROCEDURES.has(opts.path)`; that set is a hand-kept
+ * list of dotted paths. This test binds the list to the ACTUAL routers so it
+ * cannot drift from prod: renaming/moving an audited procedure makes its path
+ * disappear from `realPaths` and fails the first assertion — exactly the
+ * silent-audit-goes-dark case a hardcoded string (or a fake test router) can't
+ * catch.
+ */
+function pathsFor(
+  prefix: string,
+  // Router `_def.procedures` is a flat record keyed by the procedure name.
+  router: { _def: { procedures: Record<string, unknown> } },
+): string[] {
+  return Object.keys(router._def.procedures).map((name) => `${prefix}.${name}`);
+}
+
+describe("audited trace-view procedure drift guard", () => {
+  const realPaths = new Set([
+    ...pathsFor("traces", traceRouter),
+    ...pathsFor("events", eventsRouter),
+  ]);
+
+  it("every audited path resolves to a real procedure", () => {
+    for (const path of AUDITED_TRACE_VIEW_PROCEDURES) {
+      expect(realPaths.has(path)).toBe(true);
+    }
+  });
+
+  it("audits exactly the two single-trace content detail paths", () => {
+    expect([...AUDITED_TRACE_VIEW_PROCEDURES].sort()).toEqual([
+      "events.byTraceId",
+      "traces.byIdWithObservationsAndScores",
+    ]);
+  });
+
+  it("does NOT audit high-frequency or non-content trace procedures", () => {
+    // These share enforceTraceAccess but must stay out of the audited set:
+    // byId/batchIO back per-row table cells; getAgentGraphData and
+    // scoresForTrace are not content views.
+    for (const path of [
+      "traces.byId",
+      "traces.getAgentGraphData",
+      "events.batchIO",
+      "events.scoresForTrace",
+      "events.getAgentGraphData",
+    ]) {
+      // Sanity: it is a real procedure (so a rename here would also surface) ...
+      expect(realPaths.has(path)).toBe(true);
+      // ... and it is deliberately excluded from auditing.
+      expect(AUDITED_TRACE_VIEW_PROCEDURES.has(path)).toBe(false);
+    }
+  });
+});

--- a/web/src/__tests__/server/unit/recordTraceViewAudit.servertest.ts
+++ b/web/src/__tests__/server/unit/recordTraceViewAudit.servertest.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type Role } from "@langfuse/shared/src/db";
+
+const { auditLogMock, redisSetMock, loggerMock } = vi.hoisted(() => ({
+  auditLogMock: vi.fn(),
+  redisSetMock: vi.fn(),
+  loggerMock: { warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/src/features/audit-logs/auditLog", () => ({
+  auditLog: (...args: unknown[]) => auditLogMock(...args),
+}));
+
+// Fully replace the heavy server module: the `server-unit` project resolver
+// cannot `importActual` this aliased package, so we stub only what this test
+// (redis.set, logger) and the global teardown (redis.status/disconnect,
+// logger.debug, ClickHouseClientManager) touch.
+vi.mock("@langfuse/shared/src/server", () => ({
+  logger: loggerMock,
+  redis: {
+    set: (...args: unknown[]) => redisSetMock(...args),
+    status: "end",
+    disconnect: vi.fn(),
+  },
+  ClickHouseClientManager: {
+    getInstance: () => ({
+      closeAllConnections: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+import { recordTraceViewAudit } from "@/src/features/audit-logs/recordTraceViewAudit";
+
+describe("recordTraceViewAudit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: dedup key did not exist yet → first view → write.
+    redisSetMock.mockResolvedValue("OK");
+  });
+
+  it("builds session-variant auditLog args for UI views", async () => {
+    await recordTraceViewAudit({
+      session: {
+        user: { id: "u1" },
+        orgId: "o1",
+        orgRole: "OWNER" as Role,
+        projectId: "p1",
+        projectRole: "MEMBER" as Role,
+      },
+      resourceId: "t1",
+    });
+
+    expect(auditLogMock).toHaveBeenCalledWith({
+      session: {
+        user: { id: "u1" },
+        orgId: "o1",
+        orgRole: "OWNER",
+        projectId: "p1",
+        projectRole: "MEMBER",
+      },
+      resourceId: "t1",
+      resourceType: "trace",
+      action: "read",
+    });
+  });
+
+  it("builds apiKeyId-variant auditLog args for SDK reads", async () => {
+    await recordTraceViewAudit({
+      apiKeyId: "k1",
+      orgId: "o1",
+      projectId: "p1",
+      resourceId: "t1",
+    });
+
+    expect(auditLogMock).toHaveBeenCalledWith({
+      apiKeyId: "k1",
+      orgId: "o1",
+      projectId: "p1",
+      resourceId: "t1",
+      resourceType: "trace",
+      action: "read",
+    });
+  });
+
+  it("dedups on a per-user key with NX + 15 min TTL for UI views", async () => {
+    await recordTraceViewAudit({
+      session: { user: { id: "u1" }, orgId: "o1" },
+      resourceId: "t1",
+    });
+
+    expect(redisSetMock).toHaveBeenCalledWith(
+      "auditview:user:u1:t1",
+      "1",
+      "EX",
+      900,
+      "NX",
+    );
+  });
+
+  it("dedups on a per-api-key key for SDK reads", async () => {
+    await recordTraceViewAudit({
+      apiKeyId: "k1",
+      orgId: "o1",
+      projectId: "p1",
+      resourceId: "t1",
+    });
+
+    expect(redisSetMock).toHaveBeenCalledWith(
+      "auditview:api:k1:t1",
+      "1",
+      "EX",
+      900,
+      "NX",
+    );
+  });
+
+  it("skips the write when the dedup key already exists in the window", async () => {
+    redisSetMock.mockResolvedValue(null); // NX failed → already audited
+
+    await recordTraceViewAudit({
+      apiKeyId: "k1",
+      orgId: "o1",
+      projectId: "p1",
+      resourceId: "t1",
+    });
+
+    expect(auditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("fails open: still writes when the dedup check throws", async () => {
+    redisSetMock.mockRejectedValue(new Error("redis unavailable"));
+
+    await recordTraceViewAudit({
+      apiKeyId: "k1",
+      orgId: "o1",
+      projectId: "p1",
+      resourceId: "t1",
+    });
+
+    expect(auditLogMock).toHaveBeenCalledTimes(1);
+    expect(loggerMock.warn).toHaveBeenCalled();
+  });
+
+  it("never propagates a write failure to the caller", async () => {
+    auditLogMock.mockRejectedValue(new Error("postgres unavailable"));
+
+    await expect(
+      recordTraceViewAudit({
+        apiKeyId: "k1",
+        orgId: "o1",
+        projectId: "p1",
+        resourceId: "t1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(loggerMock.error).toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/server/unit/recordTraceViewAudit.servertest.ts
+++ b/web/src/__tests__/server/unit/recordTraceViewAudit.servertest.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type Role } from "@langfuse/shared/src/db";
 
-const { auditLogMock, redisSetMock, loggerMock } = vi.hoisted(() => ({
-  auditLogMock: vi.fn(),
-  redisSetMock: vi.fn(),
-  loggerMock: { warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-}));
+const { auditLogMock, redisSetMock, redisDelMock, loggerMock } = vi.hoisted(
+  () => ({
+    auditLogMock: vi.fn(),
+    redisSetMock: vi.fn(),
+    redisDelMock: vi.fn(),
+    loggerMock: { warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  }),
+);
 
 vi.mock("@/src/features/audit-logs/auditLog", () => ({
   auditLog: (...args: unknown[]) => auditLogMock(...args),
@@ -19,6 +22,7 @@ vi.mock("@langfuse/shared/src/server", () => ({
   logger: loggerMock,
   redis: {
     set: (...args: unknown[]) => redisSetMock(...args),
+    del: (...args: unknown[]) => redisDelMock(...args),
     status: "end",
     disconnect: vi.fn(),
   },
@@ -34,8 +38,12 @@ import { recordTraceViewAudit } from "@/src/features/audit-logs/recordTraceViewA
 describe("recordTraceViewAudit", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: dedup key did not exist yet → first view → write.
+    // Default: dedup key did not exist yet → first view → write succeeds.
+    // (clearAllMocks resets call history but not implementations, so reset the
+    // resolved/rejected value each test explicitly.)
     redisSetMock.mockResolvedValue("OK");
+    redisDelMock.mockResolvedValue(1);
+    auditLogMock.mockResolvedValue(undefined);
   });
 
   it("builds session-variant auditLog args for UI views", async () => {
@@ -82,14 +90,16 @@ describe("recordTraceViewAudit", () => {
     });
   });
 
-  it("dedups on a per-user key with NX + 15 min TTL for UI views", async () => {
+  it("dedups on a per-user, per-project key with NX + 15 min TTL for UI views", async () => {
     await recordTraceViewAudit({
-      session: { user: { id: "u1" }, orgId: "o1" },
+      session: { user: { id: "u1" }, orgId: "o1", projectId: "p1" },
       resourceId: "t1",
     });
 
+    // projectId is part of the key: trace ids are unique per project, so the
+    // same id viewed in a second project must not collapse into this window.
     expect(redisSetMock).toHaveBeenCalledWith(
-      "auditview:user:u1:t1",
+      "auditview:user:u1:p1:t1",
       "1",
       "EX",
       900,
@@ -154,5 +164,29 @@ describe("recordTraceViewAudit", () => {
     ).resolves.toBeUndefined();
 
     expect(loggerMock.error).toHaveBeenCalled();
+  });
+
+  it("clears the dedup key when the write fails so the next view can retry", async () => {
+    auditLogMock.mockRejectedValue(new Error("postgres unavailable"));
+
+    await recordTraceViewAudit({
+      session: { user: { id: "u1" }, orgId: "o1", projectId: "p1" },
+      resourceId: "t1",
+    });
+
+    // Durability outranks dedup: a dropped write must not leave a key that
+    // blocks re-auditing for the full window.
+    expect(redisDelMock).toHaveBeenCalledWith("auditview:user:u1:p1:t1");
+    expect(loggerMock.error).toHaveBeenCalled();
+  });
+
+  it("does not clear the dedup key when the write succeeds", async () => {
+    await recordTraceViewAudit({
+      session: { user: { id: "u1" }, orgId: "o1", projectId: "p1" },
+      resourceId: "t1",
+    });
+
+    expect(auditLogMock).toHaveBeenCalledTimes(1);
+    expect(redisDelMock).not.toHaveBeenCalled();
   });
 });

--- a/web/src/features/audit-logs/recordTraceViewAudit.ts
+++ b/web/src/features/audit-logs/recordTraceViewAudit.ts
@@ -1,0 +1,71 @@
+import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { type Role } from "@langfuse/shared/src/db";
+import { logger, redis } from "@langfuse/shared/src/server";
+
+/**
+ * Durable read-audit of single-trace views (UI + SDK) for compliance/security.
+ * Emits a `read` event into the Postgres `audit_logs` table.
+ *
+ * Fire-and-forget: callers invoke with `void` and it never throws. A dropped
+ * write defeats the audit, so write failures log at `error` level.
+ */
+
+// One row per (actor, trace) per 15 min — collapses double-fire and poll noise.
+const DEDUP_TTL_SECONDS = 15 * 60;
+
+type RecordTraceViewAuditArgs = { resourceId: string } & (
+  | {
+      session: {
+        user: { id: string };
+        orgId: string;
+        orgRole?: Role;
+        projectId?: string;
+        projectRole?: Role;
+      };
+    }
+  | { apiKeyId: string; orgId: string; projectId: string }
+);
+
+function dedupKey(args: RecordTraceViewAuditArgs): string {
+  return "session" in args
+    ? `auditview:user:${args.session.user.id}:${args.resourceId}`
+    : `auditview:api:${args.apiKeyId}:${args.resourceId}`;
+}
+
+export async function recordTraceViewAudit(
+  args: RecordTraceViewAuditArgs,
+): Promise<void> {
+  // Dedup check and write are separate try/catch on purpose: a Redis error
+  // (or a null client when the connection failed) must fail OPEN — still write
+  // the row, since audit durability outranks dedup.
+  try {
+    if (redis) {
+      const isFirstView = await redis.set(
+        dedupKey(args),
+        "1",
+        "EX",
+        DEDUP_TTL_SECONDS,
+        "NX",
+      );
+      if (isFirstView === null) {
+        // Key already existed within the window → already audited, skip.
+        return;
+      }
+    }
+  } catch (e) {
+    logger.warn(
+      "trace-view audit dedup check failed, failing open (writing audit anyway)",
+      e,
+    );
+  }
+
+  try {
+    await auditLog({
+      ...args,
+      resourceType: "trace",
+      action: "read",
+    });
+  } catch (e) {
+    logger.error("Failed to write trace-view audit log", e);
+  }
+}

--- a/web/src/features/audit-logs/recordTraceViewAudit.ts
+++ b/web/src/features/audit-logs/recordTraceViewAudit.ts
@@ -6,8 +6,10 @@ import { logger, redis } from "@langfuse/shared/src/server";
  * Durable read-audit of single-trace views (UI + SDK) for compliance/security.
  * Emits a `read` event into the Postgres `audit_logs` table.
  *
- * Fire-and-forget: callers invoke with `void` and it never throws. A dropped
- * write defeats the audit, so write failures log at `error` level.
+ * Fire-and-forget: callers invoke without `await` and it never throws. Audit
+ * durability outranks dedup, so a dropped write logs at `error` level AND
+ * clears the dedup key it set, letting the next view re-audit instead of
+ * silently swallowing the row for the full window.
  */
 
 // One row per (actor, trace) per 15 min — collapses double-fire and poll noise.
@@ -19,7 +21,9 @@ type RecordTraceViewAuditArgs = { resourceId: string } & (
         user: { id: string };
         orgId: string;
         orgRole?: Role;
-        projectId?: string;
+        // Required: trace ids are unique per project, so projectId must scope
+        // the dedup key or a same-named trace in another project is dropped.
+        projectId: string;
         projectRole?: Role;
       };
     }
@@ -27,21 +31,31 @@ type RecordTraceViewAuditArgs = { resourceId: string } & (
 );
 
 function dedupKey(args: RecordTraceViewAuditArgs): string {
+  // Trace ids are user-suppliable and unique per project, not globally, so the
+  // key is scoped by project. The SDK path is already project-scoped through
+  // apiKeyId (one key belongs to one project).
   return "session" in args
-    ? `auditview:user:${args.session.user.id}:${args.resourceId}`
+    ? `auditview:user:${args.session.user.id}:${args.session.projectId}:${args.resourceId}`
     : `auditview:api:${args.apiKeyId}:${args.resourceId}`;
 }
 
 export async function recordTraceViewAudit(
   args: RecordTraceViewAuditArgs,
 ): Promise<void> {
+  const key = dedupKey(args);
+
   // Dedup check and write are separate try/catch on purpose: a Redis error
   // (or a null client when the connection failed) must fail OPEN — still write
   // the row, since audit durability outranks dedup.
+  //
+  // The NX key is set BEFORE the write so concurrent double-fires still collapse
+  // to one row; if the write then fails, we clear the key (below) so durability
+  // is preserved despite the up-front set.
+  let dedupKeySet = false;
   try {
     if (redis) {
       const isFirstView = await redis.set(
-        dedupKey(args),
+        key,
         "1",
         "EX",
         DEDUP_TTL_SECONDS,
@@ -51,6 +65,7 @@ export async function recordTraceViewAudit(
         // Key already existed within the window → already audited, skip.
         return;
       }
+      dedupKeySet = true;
     }
   } catch (e) {
     logger.warn(
@@ -67,5 +82,18 @@ export async function recordTraceViewAudit(
     });
   } catch (e) {
     logger.error("Failed to write trace-view audit log", e);
+    // Write failed: clear the dedup key we set so the next view re-audits
+    // rather than being suppressed for the full window. Best-effort — a stale
+    // key at worst costs one skipped audit.
+    if (dedupKeySet && redis) {
+      try {
+        await redis.del(key);
+      } catch (delErr) {
+        logger.warn(
+          "Failed to clear trace-view audit dedup key after write failure",
+          delErr,
+        );
+      }
+    }
   }
 }

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -27,6 +27,7 @@ import {
 } from "@langfuse/shared/src/server";
 import Decimal from "decimal.js";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { recordTraceViewAudit } from "@/src/features/audit-logs/recordTraceViewAudit";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
 
 export default withMiddlewares(
@@ -73,6 +74,16 @@ export default withMiddlewares(
             `Trace ${traceId} not found within authorized project`,
           );
         }
+
+        // Durable read-audit of SDK single-trace reads. Emitted after the
+        // trace resolves so we never audit a 404. No human user on this path —
+        // attribute to the API key. Fire-and-forget: never throws.
+        recordTraceViewAudit({
+          apiKeyId: auth.scope.apiKeyId,
+          orgId: auth.scope.orgId,
+          projectId: auth.scope.projectId,
+          resourceId: traceId,
+        });
 
         const [observations, scores] = await Promise.all([
           includeObservations || includeMetrics

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -491,6 +491,25 @@ const inputTraceSchema = z.object({
   verbosity: z.enum(["compact", "truncated", "full"]).default("full"),
 });
 
+/**
+ * tRPC procedure paths (`opts.path`) that count as a genuine single-trace
+ * *content* view and are opted into durable read-audit logging in
+ * `enforceTraceAccess`. This is the single source of truth: the middleware
+ * gates on it and a drift-guard test (recordTraceViewAudit.drift.servertest.ts)
+ * asserts every entry still resolves to a real procedure, so a rename/move
+ * can't silently turn auditing off.
+ *
+ * Includes both detail-view paths: `traces.byIdWithObservationsAndScores`
+ * (v3/traces-table backing) and `events.byTraceId` (v4/events-table backing —
+ * fired first by the events detail hook, gating the rest). Deliberately EXCLUDES
+ * high-frequency table-cell fetches (`traces.byId`, `events.batchIO`) and
+ * non-content paths (`*.getAgentGraphData`, `events.scoresForTrace`).
+ */
+export const AUDITED_TRACE_VIEW_PROCEDURES: ReadonlySet<string> = new Set([
+  "traces.byIdWithObservationsAndScores",
+  "events.byTraceId",
+]);
+
 const enforceTraceAccess = t.middleware(async (opts) => {
   const { ctx, next } = opts;
   const actualInput = await opts.getRawInput();
@@ -610,13 +629,14 @@ const enforceTraceAccess = t.middleware(async (opts) => {
   // access. Anonymous public-share views have no actor/org to attribute, so
   // they are skipped.
   //
-  // Only `traces.byIdWithObservationsAndScores` is a genuine single-trace view
-  // (full detail page and table peek both fetch through it). The same
-  // middleware also serves `traces.byId` (backs the per-row table
-  // input/output/metadata cells) and `traces.getAgentGraphData`; auditing
-  // those would be a false positive. Gate on the procedure path.
-  const isSingleTraceView =
-    opts.path === "traces.byIdWithObservationsAndScores";
+  // The audited set (AUDITED_TRACE_VIEW_PROCEDURES) is the single source of
+  // truth for which procedures count as a genuine single-trace content view:
+  // `traces.byIdWithObservationsAndScores` (v3 detail) and `events.byTraceId`
+  // (v4 events-backed detail). This middleware also serves high-frequency
+  // table-cell fetches (`traces.byId`, `events.batchIO`) and non-content paths
+  // (`*.getAgentGraphData`, `events.scoresForTrace`), which are excluded to
+  // avoid false positives.
+  const isSingleTraceView = AUDITED_TRACE_VIEW_PROCEDURES.has(opts.path);
   if (isSingleTraceView && traceId && ctx.session?.user?.id) {
     const userId = ctx.session.user.id;
     const memberOrg = ctx.session.user.organizations.find((org) =>

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -93,6 +93,7 @@ import {
 } from "@langfuse/shared/src/server";
 
 import { AdminApiAuthService } from "@/src/ee/features/admin-api/server/adminApiAuth";
+import { recordTraceViewAudit } from "@/src/features/audit-logs/recordTraceViewAudit";
 import { env } from "@/src/env.mjs";
 import { isBaseError, parseIO } from "@langfuse/shared";
 import { type Flag } from "@/src/features/feature-flags/types";
@@ -602,6 +603,64 @@ const enforceTraceAccess = t.middleware(async (opts) => {
       email: ctx.session.user.email,
       projectId,
     });
+  }
+
+  // Durable read-audit of authenticated single-trace views. We reach here only
+  // after auth passed and the trace exists, so we never audit denied/404
+  // access. Anonymous public-share views have no actor/org to attribute, so
+  // they are skipped.
+  //
+  // Only `traces.byIdWithObservationsAndScores` is a genuine single-trace view
+  // (full detail page and table peek both fetch through it). The same
+  // middleware also serves `traces.byId` (backs the per-row table
+  // input/output/metadata cells) and `traces.getAgentGraphData`; auditing
+  // those would be a false positive. Gate on the procedure path.
+  const isSingleTraceView =
+    opts.path === "traces.byIdWithObservationsAndScores";
+  if (isSingleTraceView && traceId && ctx.session?.user?.id) {
+    const userId = ctx.session.user.id;
+    const memberOrg = ctx.session.user.organizations.find((org) =>
+      org.projects.some((project) => project.id === projectId),
+    );
+    if (memberOrg) {
+      // Fire-and-forget: recordTraceViewAudit never throws and we do not await
+      // it, so the audit write cannot add latency to or fail the trace view.
+      recordTraceViewAudit({
+        session: {
+          user: { id: userId },
+          orgId: memberOrg.id,
+          orgRole: memberOrg.role,
+          projectId,
+          projectRole: sessionProject?.role,
+        },
+        resourceId: traceId,
+      });
+    } else if (ctx.session.user.admin === true) {
+      // Admins bypass membership but their org is not in the session — resolve
+      // it off the request path so the lookup adds no latency to the view.
+      ctx.prisma.project
+        .findFirst({
+          select: { orgId: true },
+          where: { id: projectId, deletedAt: null },
+        })
+        .then((project: { orgId: string } | null) => {
+          if (project) {
+            return recordTraceViewAudit({
+              session: {
+                user: { id: userId },
+                orgId: project.orgId,
+                orgRole: Role.OWNER,
+                projectId,
+                projectRole: Role.OWNER,
+              },
+              resourceId: traceId,
+            });
+          }
+        })
+        .catch((e: unknown) =>
+          logger.error("Failed to record admin trace-view audit", e),
+        );
+    }
   }
 
   return next({


### PR DESCRIPTION
## What does this PR do?

This PR a new Audit event for viewing traces, this is needed for compliance purposes as LLM traces often contains PII information, for a human actor, the record contains the user_id, and resource_id is the trace_id, for apikeys they use type api_key
the audit event is de-duped as to not overload the db, (in case de-dup with redis fails we do store the audit event.)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #12527 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->