### PR TITLE
fix(v4): show minimum SDK upgrade version

### DIFF
--- a/web/src/features/sdk-version/lib/sdkVersionCapabilities.ts
+++ b/web/src/features/sdk-version/lib/sdkVersionCapabilities.ts
@@ -85,6 +85,16 @@ export const getSdkVersionCapabilityStatus = (
   return "supported";
 };
 
+export const getSdkVersionCapabilityMinimum = (
+  sdkName: SdkVersionInfo["language"],
+  capability: SdkVersionCapability,
+): string | null => {
+  const normalizedSdkName = normalizeIngestionSdkName(sdkName);
+  return normalizedSdkName
+    ? SDK_VERSION_CAPABILITIES[capability][normalizedSdkName].join(".")
+    : null;
+};
+
 export const getSdkVersionCapability = (
   sdk: SdkVersionInfo | undefined,
   capability: SdkVersionCapability,

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -21,6 +21,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { cn } from "@/src/utils/tailwind";
 import {
+  formatSdkUpgradeRequirement,
   formatSdkVersion,
   type V4MigrationSdkState,
 } from "@/src/features/v4-migration/sdkVersionStatus";
@@ -247,7 +248,9 @@ function V4MigrationSdkSection({ sdk }: { sdk: V4MigrationSdkState }) {
                 </span>
                 {series.v4MigrationStatus === "upgrade_required" &&
                   !series.upgradeCompleted && (
-                    <span className="text-dark-yellow">· upgrade required</span>
+                    <span className="text-dark-yellow">
+                      · {formatSdkUpgradeRequirement(series.canonicalSdkName)}
+                    </span>
                   )}
                 {series.upgradeCompleted && <span>· upgrade completed</span>}
                 {series.v4MigrationStatus === "unknown" && (

--- a/web/src/features/v4-migration/sdkVersionStatus.clienttest.ts
+++ b/web/src/features/v4-migration/sdkVersionStatus.clienttest.ts
@@ -1,4 +1,5 @@
 import {
+  formatSdkUpgradeRequirement,
   formatSdkVersion,
   getV4MigrationSdkState,
   type V4MigrationSdkUsageSeries,
@@ -142,4 +143,15 @@ describe("v4 migration SDK status", () => {
     );
     expect(formatSdkVersion({ language: null, version: null })).toBeNull();
   });
+
+  it.each([
+    ["javascript", "upgrade required to >= 5.4.0"],
+    ["python", "upgrade required to >= 4.7.0"],
+    [null, "upgrade required"],
+  ] as const)(
+    "formats %s upgrade guidance with its minimum compatible version",
+    (sdkName, expected) => {
+      expect(formatSdkUpgradeRequirement(sdkName)).toBe(expected);
+    },
+  );
 });

--- a/web/src/features/v4-migration/sdkVersionStatus.ts
+++ b/web/src/features/v4-migration/sdkVersionStatus.ts
@@ -1,5 +1,8 @@
 import { type RouterOutputs } from "@/src/utils/api";
-import { type SdkVersionInfo } from "@/src/features/sdk-version/lib/sdkVersionCapabilities";
+import {
+  getSdkVersionCapabilityMinimum,
+  type SdkVersionInfo,
+} from "@/src/features/sdk-version/lib/sdkVersionCapabilities";
 
 export type V4MigrationSdkStatus =
   | "checking"
@@ -111,4 +114,17 @@ export const formatSdkVersion = (sdkVersion: SdkVersionInfo | undefined) => {
         ? "Python"
         : sdkVersion.language;
   return `${language} ${sdkVersion.version}`;
+};
+
+export const formatSdkUpgradeRequirement = (
+  sdkName: V4MigrationSdkUsageSeries["canonicalSdkName"],
+) => {
+  const minimumVersion = getSdkVersionCapabilityMinimum(
+    sdkName,
+    "appRootObservations",
+  );
+
+  return minimumVersion
+    ? `upgrade required to >= ${minimumVersion}`
+    : "upgrade required";
 };


### PR DESCRIPTION
## Summary
- show the exact minimum compatible SDK version in v4 migration upgrade callouts
- derive guidance from the existing app-root capability thresholds
- keep generic guidance for unrecognized SDKs

## Impacted package
- web

## Verification
- targeted client tests: 37 passed
- web typecheck
- targeted ESLint
- Prettier check