### PR TITLE
fix(events): resolve permanent loading state for traces with zero observations

### DIFF
--- a/web/src/features/events/hooks/useEventsTraceData.ts
+++ b/web/src/features/events/hooks/useEventsTraceData.ts
@@ -132,7 +132,34 @@ export function useEventsTraceData(
 
   // Step 5: Transform and merge data
   const transformed = useMemo(() => {
-    if (!observations?.length) return null;
+    if (!observations) return null; // query still in-flight
+    if (observations.length === 0) {
+      // Query completed but the trace has no observations. Return a minimal shell
+      // so callers don't confuse "no data" with "still loading".
+      const now = new Date();
+      return {
+        id: traceId,
+        name: null,
+        timestamp: now,
+        environment: "",
+        tags: [],
+        bookmarked: false,
+        public: false,
+        release: null,
+        version: null,
+        metadata: null,
+        createdAt: now,
+        updatedAt: now,
+        sessionId: null,
+        userId: null,
+        projectId,
+        input: null,
+        output: null,
+        observations: [] as AdaptedTraceData["observations"],
+        scores: [] as WithStringifiedMetadata<ScoreDomain>[],
+        corrections: [] as ScoreDomain[],
+      };
+    }
 
     // Validate and partition scores
     const validatedScores = filterAndValidateDbScoreList({


### PR DESCRIPTION
When a trace in v4 beta/events mode has no observations, `eventsQuery` completes and returns `observations = []`. The `transformed` memo guarded with `!observations?.length` returned `null` for both the in-flight case (`observations === undefined`) and the zero-observations case (`observations.length === 0`).

The caller checks `!data` to show the loading spinner, so a completed query with zero observations caused an indefinite "Loading…" screen — the user could never annotate the item.

Split the guard into two distinct cases:
- `!observations` → query still in-flight, return `null` as before
- `observations.length === 0` → query finished with no results, return a minimal synthetic trace shell so the annotation UI can render

The shell has empty `observations`, `scores`, and `corrections` arrays with the `traceId` and `projectId` filled in, which is enough for the annotation queue to display the item without hanging.

Fixes #15007