### PR TITLE
fix(traces): include observation IO in legacy trace JSON download

### DIFF
--- a/web/src/__tests__/server/mapTraceDetailObservations.servertest.ts
+++ b/web/src/__tests__/server/mapTraceDetailObservations.servertest.ts
@@ -1,0 +1,68 @@
+/** @vitest-environment node */
+import {
+  createObservation,
+  createObservationsCh,
+  getObservationsForTrace,
+} from "@langfuse/shared/src/server";
+import { v4 } from "uuid";
+import { describe, expect, it } from "vitest";
+import { mapTraceDetailObservations } from "@/src/features/traces/server/mapTraceDetailObservations";
+
+const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+describe("legacy trace download observation IO", () => {
+  it("maps ClickHouse observations with IO for export", async () => {
+    const observationId = v4();
+    const traceId = v4();
+    const metadata = { export_marker: "present" };
+
+    const observation = createObservation({
+      id: observationId,
+      trace_id: traceId,
+      project_id: projectId,
+      type: "SPAN",
+      metadata,
+      provided_usage_details: { input: 10, output: 20, total: 30 },
+      provided_cost_details: { input: 1, output: 2, total: 3 },
+      usage_details: { input: 10, output: 20, total: 30 },
+      cost_details: { input: 1, output: 2, total: 3 },
+      is_deleted: 0,
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      start_time: Date.now(),
+      event_ts: Date.now(),
+      name: "download-io-span",
+      level: "DEFAULT",
+      status_message: null,
+      version: "1.0",
+      input: JSON.stringify({ prompt: "hello" }),
+      output: JSON.stringify({ completion: "world" }),
+      provided_model_name: "sample_model",
+      internal_model_id: "sample_internal_model_id",
+      model_parameters: "{}",
+      total_cost: 3,
+      prompt_id: null,
+      prompt_name: null,
+      prompt_version: null,
+      end_time: Date.now(),
+      completion_start_time: null,
+    });
+
+    await createObservationsCh([observation]);
+
+    const observations = await getObservationsForTrace({
+      traceId,
+      projectId,
+      includeIO: true,
+    });
+
+    const [mappedWithoutIO] = mapTraceDetailObservations(observations, false);
+    expect(mappedWithoutIO.input).toBeUndefined();
+    expect(mappedWithoutIO.output).toBeUndefined();
+
+    const [mappedWithIO] = mapTraceDetailObservations(observations, true);
+    expect(mappedWithIO.input).toBe('{"prompt":"hello"}');
+    expect(mappedWithIO.output).toBe('{"completion":"world"}');
+    expect(mappedWithIO.metadata).toBe('{"export_marker":"present"}');
+  });
+});

--- a/web/src/components/trace/components/_layout/TracePanelNavigationHeader.tsx
+++ b/web/src/components/trace/components/_layout/TracePanelNavigationHeader.tsx
@@ -36,6 +36,7 @@ import {
 import { StringParam, useQueryParam } from "use-query-params";
 import { cn } from "@/src/utils/tailwind";
 import { useCallback } from "react";
+import { api } from "@/src/utils/api";
 import {
   TraceSettingsDropdown,
   TraceViewOptionsMenuItems,
@@ -95,6 +96,7 @@ function TracePanelNavigationHeaderExpanded({
   const { roots, trace, observations } = useTraceData();
   const { isGraphViewAvailable } = useTraceGraphData();
   const { isBetaEnabled } = useV4Beta();
+  const utils = api.useUtils();
   const [viewMode, setViewMode] = useQueryParam("view", StringParam);
   const capture = usePostHogClientCapture();
   const analyticsDimensions = useTraceAnalyticsDimensions();
@@ -150,9 +152,19 @@ function TracePanelNavigationHeaderExpanded({
       capture("trace_detail:download_button_click", analyticsDimensions);
       try {
         if (!isBetaEnabled) {
+          const traceForDownload =
+            await utils.traces.byIdWithObservationsAndScores.fetch({
+              traceId: trace.id,
+              projectId: trace.projectId,
+              includeObservationIO: true,
+            });
+
           downloadLegacyTraceAsJson({
-            trace,
-            observations,
+            trace: {
+              ...traceForDownload,
+              observations: traceForDownload.observations,
+            },
+            observations: traceForDownload.observations,
           });
           return;
         }
@@ -174,7 +186,14 @@ function TracePanelNavigationHeaderExpanded({
             : "Failed to download trace JSON",
         );
       }
-    }, [isBetaEnabled, observations, trace, capture, analyticsDimensions]);
+    }, [
+      isBetaEnabled,
+      observations,
+      trace,
+      capture,
+      analyticsDimensions,
+      utils.traces.byIdWithObservationsAndScores,
+    ]);
 
   const isTimelineView = viewMode === "timeline";
 

--- a/web/src/features/traces/server/mapTraceDetailObservations.ts
+++ b/web/src/features/traces/server/mapTraceDetailObservations.ts
@@ -1,0 +1,25 @@
+import { type Observation } from "@langfuse/shared";
+import { type ObservationReturnTypeWithMetadata } from "@/src/server/api/routers/traces";
+import { toDomainWithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
+
+export function mapTraceDetailObservations(
+  observations: Observation[],
+  includeObservationIO: boolean,
+): ObservationReturnTypeWithMetadata[] {
+  return observations.map((o) => {
+    const observation = toDomainWithStringifiedMetadata(o);
+    if (!includeObservationIO) {
+      return {
+        ...observation,
+        output: undefined,
+        input: undefined,
+      };
+    }
+
+    return {
+      ...observation,
+      input: o.input != null ? JSON.stringify(o.input) : null,
+      output: o.output != null ? JSON.stringify(o.output) : null,
+    };
+  }) as ObservationReturnTypeWithMetadata[];
+}

--- a/web/src/features/traces/server/mapTraceDetailObservations.unit.test.ts
+++ b/web/src/features/traces/server/mapTraceDetailObservations.unit.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment node */
-import { ObservationLevel, ObservationType } from "@langfuse/shared";
+import { ObservationLevel, ObservationType, type Observation } from "@langfuse/shared";
 import { describe, expect, it } from "vitest";
 import { mapTraceDetailObservations } from "./mapTraceDetailObservations";
 
@@ -7,6 +7,7 @@ const baseObservation = {
   id: "obs-1",
   traceId: "trace-1",
   projectId: "project-1",
+  environment: "default",
   type: ObservationType.SPAN,
   startTime: new Date("2026-01-01T00:00:00.000Z"),
   endTime: new Date("2026-01-01T00:00:01.000Z"),
@@ -14,12 +15,37 @@ const baseObservation = {
   level: ObservationLevel.DEFAULT,
   statusMessage: null,
   version: null,
+  parentObservationId: null,
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
   input: { prompt: "hello" },
   output: { completion: "" },
   metadata: { export_marker: "present" },
-} as const;
+  model: null,
+  internalModelId: null,
+  modelParameters: null,
+  completionStartTime: null,
+  promptId: null,
+  promptName: null,
+  promptVersion: null,
+  latency: null,
+  timeToFirstToken: null,
+  providedUsageDetails: {},
+  usageDetails: {},
+  costDetails: {},
+  providedCostDetails: {},
+  inputCost: null,
+  outputCost: null,
+  totalCost: null,
+  inputUsage: 0,
+  outputUsage: 0,
+  totalUsage: 0,
+  usagePricingTierId: null,
+  usagePricingTierName: null,
+  toolDefinitions: null,
+  toolCalls: null,
+  toolCallNames: null,
+} satisfies Observation;
 
 describe("mapTraceDetailObservations", () => {
   it("strips observation IO by default for lightweight trace detail loads", () => {

--- a/web/src/features/traces/server/mapTraceDetailObservations.unit.test.ts
+++ b/web/src/features/traces/server/mapTraceDetailObservations.unit.test.ts
@@ -1,0 +1,40 @@
+/** @vitest-environment node */
+import { ObservationLevel, ObservationType } from "@langfuse/shared";
+import { describe, expect, it } from "vitest";
+import { mapTraceDetailObservations } from "./mapTraceDetailObservations";
+
+const baseObservation = {
+  id: "obs-1",
+  traceId: "trace-1",
+  projectId: "project-1",
+  type: ObservationType.SPAN,
+  startTime: new Date("2026-01-01T00:00:00.000Z"),
+  endTime: new Date("2026-01-01T00:00:01.000Z"),
+  name: "test-span",
+  level: ObservationLevel.DEFAULT,
+  statusMessage: null,
+  version: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  input: { prompt: "hello" },
+  output: { completion: "" },
+  metadata: { export_marker: "present" },
+} as const;
+
+describe("mapTraceDetailObservations", () => {
+  it("strips observation IO by default for lightweight trace detail loads", () => {
+    const [mapped] = mapTraceDetailObservations([baseObservation], false);
+
+    expect(mapped.input).toBeUndefined();
+    expect(mapped.output).toBeUndefined();
+    expect(mapped.metadata).toBe('{"export_marker":"present"}');
+  });
+
+  it("includes observation IO when requested for legacy trace download", () => {
+    const [mapped] = mapTraceDetailObservations([baseObservation], true);
+
+    expect(mapped.input).toBe('{"prompt":"hello"}');
+    expect(mapped.output).toBe('{"completion":""}');
+    expect(mapped.metadata).toBe('{"export_marker":"present"}');
+  });
+});

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -97,6 +97,9 @@ export type ObservationReturnTypeWithMetadata = Omit<
   metadata: string | null;
   traceName?: string | null;
   traceTags?: string[];
+  // Populated only when includeObservationIO is true on the trace detail query.
+  input?: string | null;
+  output?: string | null;
   // optional, because in v4 an observation can have those properties
   userId?: string | null;
   sessionId?: string | null;

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -68,6 +68,7 @@ import {
   toDomainWithStringifiedMetadata,
   toDomainArrayWithStringifiedMetadata,
 } from "@/src/utils/clientSideDomainTypes";
+import { mapTraceDetailObservations } from "@/src/features/traces/server/mapTraceDetailObservations";
 import { scoreFilters } from "@/src/features/scores/lib/scoreColumns";
 import partition from "lodash/partition";
 
@@ -389,6 +390,10 @@ export const traceRouter = createTRPCRouter({
         timestamp: z.date().nullish(), // timestamp of the trace. Used to query CH more efficiently
         fromTimestamp: z.date().nullish(), // min timestamp of the trace. Used to query CH more efficiently
         projectId: z.string(), // used for security check
+        // When true, observation input/output are loaded for export (e.g. legacy
+        // trace JSON download). Defaults to false to keep the trace detail view
+        // payload lightweight.
+        includeObservationIO: z.boolean().optional().default(false),
       }),
     )
     .query(async ({ input, ctx }) => {
@@ -399,12 +404,14 @@ export const traceRouter = createTRPCRouter({
         });
       }
 
+      const includeObservationIO = input.includeObservationIO;
+
       const [observations, traceScores] = await Promise.all([
         getObservationsForTrace({
           traceId: input.traceId,
           projectId: input.projectId,
           timestamp: input.timestamp ?? input.fromTimestamp ?? undefined,
-          includeIO: false,
+          includeIO: includeObservationIO,
         }),
         getScoresAndCorrectionsForTraces({
           projectId: input.projectId,
@@ -452,11 +459,10 @@ export const traceRouter = createTRPCRouter({
         scores: scoresDomain,
         corrections,
         latency: latencyMs !== undefined ? latencyMs / 1000 : undefined,
-        observations: observations.map((o) => ({
-          ...toDomainWithStringifiedMetadata(o),
-          output: undefined,
-          input: undefined, // this is not queried above.
-        })) as ObservationReturnTypeWithMetadata[],
+        observations: mapTraceDetailObservations(
+          observations,
+          includeObservationIO,
+        ),
       };
     }),
   deleteMany: protectedProjectProcedure


### PR DESCRIPTION
## What does this PR do?

Fixes #15337

Legacy trace JSON downloads serialized observations from `traces.byIdWithObservationsAndScores`, which intentionally loads observations with `includeIO: false` and strips `input`/`output` for the lightweight trace detail view. The download button reused that payload client-side, so exported observations had `input: null`, `output: null`, and empty metadata even though the observation detail panel showed the full data.

### Root cause

- `byIdWithObservationsAndScores` queries ClickHouse with `includeIO: false`
- The router then explicitly clears `input` and `output` on each observation before returning
- Legacy download (`!v4Beta`) called `downloadLegacyTraceAsJson({ trace, observations })` with that in-memory payload
- V4 download already uses `/api/traces/[traceId]/download`, which loads full observation IO server-side

### Proposed changes

- **`web/src/server/api/routers/traces.ts`**: add optional `includeObservationIO` input; when true, query observations with `includeIO: true` and stringify IO for export
- **`web/src/components/trace/components/_layout/TracePanelNavigationHeader.tsx`**: legacy download now fetches trace data with `includeObservationIO: true` before serializing JSON
- **`web/src/features/traces/server/mapTraceDetailObservations.ts`**: extract observation mapping helper used by the trace router
- **`web/src/__tests__/server/mapTraceDetailObservations.servertest.ts`**: ClickHouse integration coverage for the export path
- **`web/src/features/traces/server/mapTraceDetailObservations.unit.test.ts`**: unit coverage for stripped vs exported observation IO

### Impacted packages

- `web`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked if my PR needs changes to the documentation
- [x] I have checked that my changes generate no new warnings (`npm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

## Testing

Verified on the local VM against running Docker infra (`postgres`, `clickhouse`, `redis`, `minio`):

```bash
cd /root/langfuse
source ~/.nvm/nvm.sh && nvm use 24
docker compose -f docker-compose.dev.yml up -d --wait

pnpm --filter web exec vitest run \
  src/features/traces/server/mapTraceDetailObservations.unit.test.ts \
  src/__tests__/server/mapTraceDetailObservations.servertest.ts
```

Results:

- `mapTraceDetailObservations.unit.test.ts`: 2 passed
- `mapTraceDetailObservations.servertest.ts`: 1 passed (writes to ClickHouse, verifies exported `input`, `output`, and `metadata`)

Manual verification still recommended in the UI:

1. Open a trace with legacy mode enabled (v4 beta off)
2. Click **Download trace as JSON**
3. Confirm exported observations include the same `input`, `output`, and `metadata` shown in the observation detail panel