### PR TITLE
fix(v4): update deprecated migration labels and links

### DIFF
--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1,0 +1,120 @@
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { V4MigrationDetailsContent } from "./V4MigrationContent";
+
+const mocks = vi.hoisted(() => ({
+  migrationData: {
+    sdk: {
+      status: "latest" as const,
+      sdkUsageSeries: [],
+      upgradeRequiredCount: 0,
+    },
+    evals: { status: "loaded" as const, count: 0 },
+    apis: { status: "loaded" as const, count: 1 },
+    exports: { status: "loaded" as const, count: 3 },
+    apiUsage: [{ endpoint: "GET /api/public/traces", count: 42 }],
+    legacyIntegrations: ["PostHog", "Mixpanel", "Blob Storage"],
+  },
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ query: { projectId: "project-1" } }),
+}));
+
+vi.mock("@/src/features/support-chat/SupportDrawerProvider", () => ({
+  useSupportDrawer: () => ({ openWithMode: vi.fn() }),
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+vi.mock("@/src/features/projects/hooks", () => ({
+  useProject: () => ({ organization: { id: "org-1" } }),
+}));
+
+vi.mock("@/src/features/v4-migration/hooks/useV4MigrationData", () => ({
+  useProjectV4MigrationData: () => mocks.migrationData,
+}));
+
+vi.mock("@/src/components/ui/collapsible", () => ({
+  Collapsible: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+describe("V4MigrationDetailsContent", () => {
+  beforeEach(() => {
+    mocks.migrationData.apis = { status: "loaded", count: 1 };
+    mocks.migrationData.exports = { status: "loaded", count: 3 };
+    mocks.migrationData.apiUsage = [
+      { endpoint: "GET /api/public/traces", count: 42 },
+    ];
+    mocks.migrationData.legacyIntegrations = [
+      "PostHog",
+      "Mixpanel",
+      "Blob Storage",
+    ];
+  });
+
+  it("uses deprecated terminology and links to the migration guides", () => {
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    expect(screen.getByText("Deprecated APIs")).toBeInTheDocument();
+    expect(screen.getByText("Deprecated Integrations")).toBeInTheDocument();
+    expect(screen.queryByText("Legacy APIs")).not.toBeInTheDocument();
+    expect(screen.queryByText("Legacy Integrations")).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", { name: "GET /api/public/traces" }),
+    ).toHaveAttribute(
+      "href",
+      "https://langfuse.com/faq/all/deprecated-api-migration",
+    );
+
+    const expectedIntegrationGuides = {
+      PostHog:
+        "https://langfuse.com/integrations/analytics/posthog#migrate-export-source",
+      Mixpanel:
+        "https://langfuse.com/integrations/analytics/mixpanel#migrate-export-source",
+      "Blob Storage":
+        "https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage#upgrade-path",
+    };
+
+    for (const [name, href] of Object.entries(expectedIntegrationGuides)) {
+      const settingsLink = screen.getByRole("link", { name });
+      expect(settingsLink).toHaveAttribute(
+        "href",
+        "/project/project-1/settings/integrations",
+      );
+      expect(
+        within(settingsLink.parentElement!).getByRole("link", {
+          name: "Migration guide",
+        }),
+      ).toHaveAttribute("href", href);
+    }
+  });
+
+  it("uses deprecated terminology in the empty states", () => {
+    mocks.migrationData.apis = { status: "loaded", count: 0 };
+    mocks.migrationData.exports = { status: "loaded", count: 0 };
+    mocks.migrationData.apiUsage = [];
+    mocks.migrationData.legacyIntegrations = [];
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    expect(
+      screen.getByText(/No deprecated public API usage detected/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("No deprecated integration exports detected."),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -41,6 +41,16 @@ const SDK_UPGRADE_URL =
   "https://langfuse.com/docs/observability/sdk/upgrade-path";
 const OTEL_V4_MIGRATION_URL =
   "https://langfuse.com/integrations/native/opentelemetry/migration-to-v4";
+const DEPRECATED_API_MIGRATION_URL =
+  "https://langfuse.com/faq/all/deprecated-api-migration";
+const DEPRECATED_INTEGRATION_MIGRATION_URLS: Record<string, string> = {
+  PostHog:
+    "https://langfuse.com/integrations/analytics/posthog#migrate-export-source",
+  Mixpanel:
+    "https://langfuse.com/integrations/analytics/mixpanel#migrate-export-source",
+  "Blob Storage":
+    "https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage#upgrade-path",
+};
 
 const CODING_AGENT_PROMPT = `Migrate this project's Langfuse setup to v4:
 1. Upgrade the Langfuse SDK to the latest major version. Upgrade guide: ${SDK_UPGRADE_URL}
@@ -423,7 +433,7 @@ export function V4MigrationDetailsContent({
           </Section>
 
           <Section
-            title="Legacy APIs"
+            title="Deprecated APIs"
             chip={
               <MigrationCountChip
                 state={migrationData.apis}
@@ -445,10 +455,10 @@ export function V4MigrationDetailsContent({
                   You&apos;ve called these deprecated endpoints in the last{" "}
                   {V4_MIGRATION_LOOKBACK_DAYS} days. They stop working{" "}
                   <span className="text-dark-yellow">Oct 1</span>; the{" "}
-                  <ExternalLink href="https://api.reference.langfuse.com">
-                    new APIs
+                  <ExternalLink href={DEPRECATED_API_MIGRATION_URL}>
+                    migration guide
                   </ExternalLink>{" "}
-                  cover the same data.
+                  maps each endpoint to its replacement.
                 </p>
                 <div className="flex flex-col">
                   {migrationData.apiUsage.map((usage) => (
@@ -457,7 +467,7 @@ export function V4MigrationDetailsContent({
                       className="flex items-center justify-between gap-2 py-0.5"
                     >
                       <ExternalLink
-                        href="https://api.reference.langfuse.com"
+                        href={DEPRECATED_API_MIGRATION_URL}
                         className="text-sm"
                       >
                         {usage.endpoint}
@@ -471,14 +481,14 @@ export function V4MigrationDetailsContent({
               </>
             ) : (
               <p className="text-muted-foreground text-sm">
-                No legacy public API usage detected in the last{" "}
+                No deprecated public API usage detected in the last{" "}
                 {V4_MIGRATION_LOOKBACK_DAYS} days.
               </p>
             )}
           </Section>
 
           <Section
-            title="Legacy Integrations"
+            title="Deprecated Integrations"
             chip={
               <MigrationCountChip
                 state={migrationData.exports}
@@ -503,7 +513,10 @@ export function V4MigrationDetailsContent({
                 </p>
                 <div className="flex flex-col">
                   {migrationData.legacyIntegrations.map((name) => (
-                    <div key={name} className="flex items-center py-0.5">
+                    <div
+                      key={name}
+                      className="flex items-baseline gap-1.5 py-0.5"
+                    >
                       {integrationsUrl ? (
                         <Link
                           href={integrationsUrl}
@@ -515,13 +528,23 @@ export function V4MigrationDetailsContent({
                       ) : (
                         <span className="text-sm">{name}</span>
                       )}
+                      <span className="text-muted-foreground text-xs">·</span>
+                      <ExternalLink
+                        href={
+                          DEPRECATED_INTEGRATION_MIGRATION_URLS[name] ??
+                          V4_DOCS_URL
+                        }
+                        className="text-xs"
+                      >
+                        Migration guide
+                      </ExternalLink>
                     </div>
                   ))}
                 </div>
               </>
             ) : (
               <p className="text-muted-foreground text-sm">
-                No legacy integration exports detected.
+                No deprecated integration exports detected.
               </p>
             )}
           </Section>


### PR DESCRIPTION
## Summary

- rename the v4 migration sections from “Legacy APIs/Integrations” to “Deprecated APIs/Integrations”, including their empty states
- replace the generic API-reference links with the canonical deprecated-API migration guide
- add migration-specific links for PostHog, Mixpanel, and Blob Storage while preserving the in-app integration settings links
- add client coverage for the terminology, empty states, and documentation targets

## Why

The v4 migration UI should use the current deprecation terminology and send affected users to the migration guides added and refined in `langfuse/langfuse-docs` over the last week. The shared component powers both the side panel and modal.

## Impacted package

- `web`

## Validation

- `pnpm --filter web run test-client src/features/v4-migration/V4MigrationContent.clienttest.tsx` — 2 tests passed
- `pnpm run lint` — 7 tasks successful
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter web run typecheck`
- `git diff --check`

Browser review was attempted, but the local Docker daemon was unavailable, so the seeded app flow could not be started.