### PR TITLE
feat(admin-api): list user organizations by email

### DIFF
--- a/fern/apis/organizations/definition/organizations.yml
+++ b/fern/apis/organizations/definition/organizations.yml
@@ -122,6 +122,18 @@ service:
         - commons.UnauthorizedError
         - commons.MethodNotAllowedError
 
+    getOrganizationsByUserEmail:
+      docs: Get all organizations for a user by email address
+      method: GET
+      path: /users/{email}/organizations
+      path-parameters:
+        email: string
+      response: UserOrganizations
+      errors:
+        - commons.Error
+        - commons.UnauthorizedError
+        - commons.MethodNotAllowedError
+
 types:
   Organizations:
     docs: List of organizations
@@ -180,3 +192,20 @@ types:
       secretKey: string
       displaySecretKey: string
       note: optional<string>
+
+  UserOrganizations:
+    docs: Organizations a user belongs to
+    properties:
+      email: string
+      organizations: list<UserOrganization>
+
+  UserOrganization:
+    docs: Organization membership for a user
+    properties:
+      id: string
+      name: string
+      role: string
+      createdAt: datetime
+      metadata:
+        type: map<string, unknown>
+        docs: Metadata for the organization

--- a/web/public/generated/organizations-api/openapi.yml
+++ b/web/public/generated/organizations-api/openapi.yml
@@ -423,6 +423,50 @@ paths:
               schema:
                 type: string
       security: *ref_0
+  /api/admin/users/{email}/organizations:
+    get:
+      description: Get all organizations for a user by email address
+      operationId: organizations_getOrganizationsByUserEmail
+      tags:
+        - Organizations
+      parameters:
+        - name: email
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserOrganizations'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: string
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: string
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: string
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: string
+      security: *ref_0
 components:
   schemas:
     Organizations:
@@ -562,6 +606,44 @@ components:
         - publicKey
         - secretKey
         - displaySecretKey
+    UserOrganizations:
+      title: UserOrganizations
+      type: object
+      description: Organizations a user belongs to
+      properties:
+        email:
+          type: string
+        organizations:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserOrganization'
+      required:
+        - email
+        - organizations
+    UserOrganization:
+      title: UserOrganization
+      type: object
+      description: Organization membership for a user
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        role:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Metadata for the organization
+      required:
+        - id
+        - name
+        - role
+        - createdAt
+        - metadata
   securitySchemes:
     BearerAuth:
       type: http

--- a/web/src/__tests__/server/organizations-api.servertest.ts
+++ b/web/src/__tests__/server/organizations-api.servertest.ts
@@ -2,7 +2,7 @@ import {
   makeZodVerifiedAPICall,
   makeAPICall,
 } from "@/src/__tests__/test-utils";
-import { prisma, type Prisma } from "@langfuse/shared/src/db";
+import { prisma, type Prisma, Role } from "@langfuse/shared/src/db";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import {
@@ -59,6 +59,19 @@ const ApiKeyListSchema = z.object({
       note: z.string().nullable(),
       publicKey: z.string(),
       displaySecretKey: z.string(),
+    }),
+  ),
+});
+
+const UserOrganizationsSchema = z.object({
+  email: z.string(),
+  organizations: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      role: z.string(),
+      createdAt: z.iso.datetime(),
+      metadata: z.record(z.string(), z.unknown()),
     }),
   ),
 });
@@ -813,6 +826,58 @@ describe("Admin Organizations API", () => {
     );
     expect(result.status).toBe(405);
     expect(result.body.error).toContain("Method Not Allowed");
+  });
+
+  describe("GET /api/admin/users/[email]/organizations", () => {
+    const seededUserEmail = "demo@langfuse.com";
+
+    it("should return organizations for a user by email", async () => {
+      const response = await makeZodVerifiedAPICall(
+        UserOrganizationsSchema,
+        "GET",
+        `/api/admin/users/${encodeURIComponent(seededUserEmail)}/organizations`,
+        undefined,
+        `Bearer ${ADMIN_API_KEY}`,
+        200,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.email).toBe(seededUserEmail);
+      expect(response.body.organizations.length).toBeGreaterThan(0);
+      expect(response.body.organizations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+            name: expect.any(String),
+            role: expect.any(String),
+            createdAt: expect.any(String),
+            metadata: expect.any(Object),
+          }),
+        ]),
+      );
+    });
+
+    it("should return 404 when the user does not exist", async () => {
+      const response = await makeAPICall<{ error: string }>(
+        "GET",
+        `/api/admin/users/${encodeURIComponent(`missing-${randomUUID()}@example.com`)}/organizations`,
+        undefined,
+        `Bearer ${ADMIN_API_KEY}`,
+      );
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toBe("User not found");
+    });
+
+    it("should return 401 when no authorization header is provided", async () => {
+      const response = await makeAPICall<{ error: string }>(
+        "GET",
+        `/api/admin/users/${encodeURIComponent(seededUserEmail)}/organizations`,
+      );
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toContain("Unauthorized");
+    });
   });
 });
 

--- a/web/src/ee/features/admin-api/server/users/organizationsByEmail.ts
+++ b/web/src/ee/features/admin-api/server/users/organizationsByEmail.ts
@@ -1,0 +1,61 @@
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { prisma } from "@langfuse/shared/src/db";
+import { z } from "zod";
+
+const emailSchema = z.email();
+
+export async function handleGetUserOrganizationsByEmail(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const emailParam = req.query.email;
+  if (typeof emailParam !== "string" || emailParam.length === 0) {
+    return res.status(400).json({ error: "Invalid email parameter" });
+  }
+
+  const normalizedEmail = decodeURIComponent(emailParam).trim().toLowerCase();
+  const parsedEmail = emailSchema.safeParse(normalizedEmail);
+  if (!parsedEmail.success) {
+    return res.status(400).json({ error: "Invalid email address" });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: parsedEmail.data },
+    select: {
+      email: true,
+      organizationMemberships: {
+        select: {
+          role: true,
+          organization: {
+            select: {
+              id: true,
+              name: true,
+              createdAt: true,
+              metadata: true,
+            },
+          },
+        },
+        orderBy: {
+          organization: {
+            name: "asc",
+          },
+        },
+      },
+    },
+  });
+
+  if (!user) {
+    return res.status(404).json({ error: "User not found" });
+  }
+
+  return res.status(200).json({
+    email: user.email,
+    organizations: user.organizationMemberships.map((membership) => ({
+      id: membership.organization.id,
+      name: membership.organization.name,
+      role: membership.role,
+      createdAt: membership.organization.createdAt,
+      metadata: membership.organization.metadata ?? {},
+    })),
+  });
+}

--- a/web/src/pages/api/admin/users/[email]/organizations.ts
+++ b/web/src/pages/api/admin/users/[email]/organizations.ts
@@ -1,0 +1,38 @@
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { logger } from "@langfuse/shared/src/server";
+import { AdminApiAuthService } from "@/src/ee/features/admin-api/server/adminApiAuth";
+import { handleGetUserOrganizationsByEmail } from "@/src/ee/features/admin-api/server/users/organizationsByEmail";
+import { hasEntitlementBasedOnPlan } from "@/src/features/entitlements/server/hasEntitlement";
+import { getSelfHostedInstancePlanServerSide } from "@/src/features/entitlements/server/getPlan";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    if (req.method !== "GET") {
+      res.status(405).json({ error: "Method Not Allowed" });
+      return;
+    }
+
+    if (!AdminApiAuthService.handleAdminAuth(req, res)) {
+      return;
+    }
+
+    if (
+      !hasEntitlementBasedOnPlan({
+        plan: getSelfHostedInstancePlanServerSide(),
+        entitlement: "admin-api",
+      })
+    ) {
+      return res.status(403).json({
+        error: "This feature is not available on your current plan.",
+      });
+    }
+
+    return await handleGetUserOrganizationsByEmail(req, res);
+  } catch (error) {
+    logger.error("Failed to process user organizations request", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds a new admin API endpoint to list all organizations a user belongs to, looked up by email address.

**Endpoint:** `GET /api/admin/users/{email}/organizations`

**Response includes:**
- User email
- Organizations with id, name, role, createdAt, and metadata

This avoids the current workaround of fetching all organizations and checking membership individually.

Fixes #15445

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

### Local test results

```
✓ |server| src/__tests__/server/organizations-api.servertest.ts (3 tests)
  ✓ should return organizations for a user by email
  ✓ should return 404 when the user does not exist
  ✓ should return 401 when no authorization header is provided
```

Manual verification:
```bash
curl -H "Authorization: Bearer $ADMIN_API_KEY" \
  "http://localhost:3000/api/admin/users/demo%40langfuse.com/organizations"
```