### PR TITLE
fix(dashboards): return 404 instead of 500 when updating a missing dashboard

### DIFF
--- a/packages/shared/src/server/services/DashboardService/DashboardService.ts
+++ b/packages/shared/src/server/services/DashboardService/DashboardService.ts
@@ -103,6 +103,42 @@ export class DashboardService {
   }
 
   /**
+   * Updates a project-owned dashboard, translating Prisma's P2025 into a 404.
+   */
+  private static async updateDashboardRecord(
+    dashboardId: string,
+    projectId: string,
+    data: Prisma.DashboardUncheckedUpdateInput,
+  ): Promise<DashboardDomain> {
+    try {
+      const updatedDashboard = await prisma.dashboard.update({
+        where: {
+          id: dashboardId,
+          projectId,
+        },
+        data,
+      });
+
+      return DashboardDomainSchema.parse({
+        ...updatedDashboard,
+        owner: updatedDashboard.projectId ? "PROJECT" : "LANGFUSE",
+      });
+    } catch (e) {
+      // P2025 = row not found; also thrown for cross-project ids, so the 404
+      // does not leak whether the dashboard exists in another project.
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === "P2025"
+      ) {
+        throw new LangfuseNotFoundError(
+          `Dashboard ${dashboardId} not found in project ${projectId}`,
+        );
+      }
+      throw e;
+    }
+  }
+
+  /**
    * Updates a dashboard's definition.
    */
   public static async updateDashboardDefinition(
@@ -111,24 +147,13 @@ export class DashboardService {
     definition: z.infer<typeof DashboardDefinitionSchema>,
     userId?: string,
   ): Promise<DashboardDomain> {
-    const updatedDashboard = await prisma.dashboard.update({
-      where: {
-        id: dashboardId,
-        projectId,
+    return this.updateDashboardRecord(dashboardId, projectId, {
+      updatedBy: userId,
+      definition: {
+        // Already sanitized: the input is parsed against
+        // DashboardDefinitionSchema, which strips unknown keys.
+        widgets: definition.widgets,
       },
-      data: {
-        updatedBy: userId,
-        definition: {
-          // Already sanitized: the input is parsed against
-          // DashboardDefinitionSchema, which strips unknown keys.
-          widgets: definition.widgets,
-        },
-      },
-    });
-
-    return DashboardDomainSchema.parse({
-      ...updatedDashboard,
-      owner: updatedDashboard.projectId ? "PROJECT" : "LANGFUSE",
     });
   }
 
@@ -142,21 +167,10 @@ export class DashboardService {
     description: string,
     userId?: string,
   ): Promise<DashboardDomain> {
-    const updatedDashboard = await prisma.dashboard.update({
-      where: {
-        id: dashboardId,
-        projectId,
-      },
-      data: {
-        name,
-        description,
-        updatedBy: userId,
-      },
-    });
-
-    return DashboardDomainSchema.parse({
-      ...updatedDashboard,
-      owner: updatedDashboard.projectId ? "PROJECT" : "LANGFUSE",
+    return this.updateDashboardRecord(dashboardId, projectId, {
+      name,
+      description,
+      updatedBy: userId,
     });
   }
 
@@ -169,20 +183,9 @@ export class DashboardService {
     filters: z.infer<typeof singleFilter>[],
     userId?: string,
   ): Promise<DashboardDomain> {
-    const updatedDashboard = await prisma.dashboard.update({
-      where: {
-        id: dashboardId,
-        projectId,
-      },
-      data: {
-        updatedBy: userId,
-        filters,
-      },
-    });
-
-    return DashboardDomainSchema.parse({
-      ...updatedDashboard,
-      owner: updatedDashboard.projectId ? "PROJECT" : "LANGFUSE",
+    return this.updateDashboardRecord(dashboardId, projectId, {
+      updatedBy: userId,
+      filters,
     });
   }
 

--- a/web/src/__tests__/server/dashboard-service-update.servertest.ts
+++ b/web/src/__tests__/server/dashboard-service-update.servertest.ts
@@ -1,0 +1,27 @@
+import { v4 as uuidv4 } from "uuid";
+import {
+  createOrgProjectAndApiKey,
+  DashboardService,
+} from "@langfuse/shared/src/server";
+import { LangfuseNotFoundError } from "@langfuse/shared";
+
+describe("DashboardService update methods", () => {
+  it("throw LangfuseNotFoundError instead of P2025 for a missing dashboard", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const missingId = uuidv4();
+
+    await expect(
+      DashboardService.updateDashboardDefinition(missingId, projectId, {
+        widgets: [],
+      }),
+    ).rejects.toThrow(LangfuseNotFoundError);
+
+    await expect(
+      DashboardService.updateDashboard(missingId, projectId, "name", ""),
+    ).rejects.toThrow(LangfuseNotFoundError);
+
+    await expect(
+      DashboardService.updateDashboardFilters(missingId, projectId, []),
+    ).rejects.toThrow(LangfuseNotFoundError);
+  });
+});


### PR DESCRIPTION
## Problem

The tRPC mutations `dashboard.updateDashboardDefinition`, `updateDashboardMetadata`, and `updateDashboardFilters` call `prisma.dashboard.update()` directly. When the dashboard no longer exists (deleted in another tab / by another user) or the id belongs to a different project, Prisma throws P2025, which surfaced as an unhandled `TRPCError: Internal error` (HTTP 500) and error-level logs in Datadog.

Fixes [LFE-14502](https://linear.app/clickhouse/issue/LFE-14502).

## Fix

Add a private `DashboardService.updateDashboardRecord` helper that owns the update call and translates P2025 into `LangfuseNotFoundError`, mirroring the existing `deleteDashboard` handling. The three update methods delegate to it, so the handling lives in one place. The tRPC and REST middlewares already map `LangfuseNotFoundError` to 404 and log at info level — no router or frontend changes needed.

## Impacted packages

- `@langfuse/shared` — `DashboardService` update methods
- `web` — new server test only

## Verification

- `pnpm --filter web run test src/__tests__/server/dashboard-service-update.servertest.ts` — new test, confirmed failing with raw P2025 before the fix: `Tests  1 passed (1)`
- `pnpm --filter web run test src/__tests__/server/dashboard-widget-version.servertest.ts` — exercises `updateDashboardDefinition` via the router: `Tests  37 passed (37)`
- `pnpm --filter web run test src/__tests__/server/dashboard-service-delete.servertest.ts`: `Tests  3 passed (3)`
- `pnpm run lint`: `Tasks:    7 successful, 7 total`
- `pnpm --filter worker run typecheck`: clean

## Out of scope (pre-existing, never fired in prod)

- `dashboardWidget.update` has the same theoretical find-then-update race window
- `tx.dashboard.update` inside the widget-clone transaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)