### PR TITLE
fix(share trace): create correct shareable trace link

### DIFF
--- a/web/src/components/publish-object-switch.tsx
+++ b/web/src/components/publish-object-switch.tsx
@@ -13,6 +13,7 @@ import {
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { env } from "@/src/env.mjs";
 import { api } from "@/src/utils/api";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { cn } from "@/src/utils/tailwind";
@@ -174,6 +175,18 @@ export const PublishSessionSwitch = (props: {
   );
 };
 
+const getShareUrlWithBasePath = (shareUrl: string) => {
+  const basePath = (env.NEXT_PUBLIC_BASE_PATH ?? "").replace(/\/$/, "");
+  const shouldPrependBasePath =
+    Boolean(basePath) &&
+    shareUrl.startsWith("/") &&
+    !shareUrl.startsWith("//") &&
+    shareUrl !== basePath &&
+    !shareUrl.startsWith(`${basePath}/`);
+
+  return shouldPrependBasePath ? `${basePath}${shareUrl}` : shareUrl;
+};
+
 const Base = (props: {
   itemName: string;
   onChange: (value: boolean) => Promise<unknown>;
@@ -192,7 +205,10 @@ const Base = (props: {
     setIsCopied(true);
     copyTextToClipboard(
       props.shareUrl
-        ? new URL(props.shareUrl, window.location.origin).toString()
+        ? new URL(
+            getShareUrlWithBasePath(props.shareUrl),
+            window.location.origin,
+          ).toString()
         : window.location.href,
     );
     setTimeout(() => setIsCopied(false), 2500);

--- a/web/src/components/publish-object-switch.tsx
+++ b/web/src/components/publish-object-switch.tsx
@@ -26,6 +26,7 @@ export const PublishTraceSwitch = (props: {
   projectId: string;
   timestamp?: Date;
   isPublic: boolean;
+  shareUrl?: string;
   size?: "icon" | "icon-xs";
   /** When set, render as a full-width labeled menu item instead of an icon. */
   label?: string;
@@ -112,6 +113,7 @@ export const PublishTraceSwitch = (props: {
     <Base
       itemName="trace"
       isPublic={props.isPublic}
+      shareUrl={props.shareUrl}
       size={props.size}
       label={props.label}
       tooltip={props.tooltip}
@@ -177,6 +179,7 @@ const Base = (props: {
   onChange: (value: boolean) => Promise<unknown>;
   isLoading: boolean;
   isPublic: boolean;
+  shareUrl?: string;
   disabled?: boolean;
   size?: "icon" | "icon-xs";
   label?: string;
@@ -187,7 +190,11 @@ const Base = (props: {
 
   const copyUrl = () => {
     setIsCopied(true);
-    copyTextToClipboard(window.location.href);
+    copyTextToClipboard(
+      props.shareUrl
+        ? new URL(props.shareUrl, window.location.origin).toString()
+        : window.location.href,
+    );
     setTimeout(() => setIsCopied(false), 2500);
   };
 

--- a/web/src/components/table/peek/peek-observation-detail.tsx
+++ b/web/src/components/table/peek/peek-observation-detail.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/src/components/trace/TraceDetailBody";
 import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
 import { resolvePeekTraceParams } from "@/src/components/table/peek/resolvePeekTraceParams";
+import { buildTraceDetailPath } from "@/src/utils/navigation";
 import { useRouter } from "next/router";
 import { useRef } from "react";
 
@@ -49,6 +50,16 @@ export const TablePeekViewObservationDetail = (
         projectId: trace.data.projectId,
         bookmarked: trace.data.bookmarked,
         isPublic: trace.data.public,
+        shareUrl: buildTraceDetailPath({
+          projectId: trace.data.projectId,
+          traceId: trace.data.id,
+          observationId:
+            typeof router.query.traceId === "string"
+              ? peekObservationId
+              : undefined,
+          timestamp:
+            typeof router.query.traceId === "string" ? undefined : timestamp,
+        }),
         name: trace.data.name,
         timestamp,
         onAfterDelete: (deletedTraceId: string) => {

--- a/web/src/components/table/peek/peek-trace-detail.tsx
+++ b/web/src/components/table/peek/peek-trace-detail.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/src/components/table/peek";
 import { TraceDetailActions } from "@/src/components/trace/TraceDetailActions";
 import { resolvePeekTraceParams } from "@/src/components/table/peek/resolvePeekTraceParams";
+import { buildTraceDetailPath } from "@/src/utils/navigation";
 
 export const TablePeekViewTraceDetail = (
   props: Omit<
@@ -48,6 +49,11 @@ export const TablePeekViewTraceDetail = (
         projectId: trace.data.projectId,
         bookmarked: trace.data.bookmarked,
         isPublic: trace.data.public,
+        shareUrl: buildTraceDetailPath({
+          projectId: trace.data.projectId,
+          traceId: trace.data.id,
+          timestamp,
+        }),
         name: trace.data.name,
         timestamp,
         onAfterDelete: (deletedTraceId: string) => {

--- a/web/src/components/trace/TraceDetailActions.tsx
+++ b/web/src/components/trace/TraceDetailActions.tsx
@@ -29,6 +29,7 @@ export function TraceDetailActions({
   projectId,
   bookmarked,
   isPublic,
+  shareUrl,
   name,
   timestamp,
   deleteRedirectUrl,
@@ -40,6 +41,7 @@ export function TraceDetailActions({
   projectId: string;
   bookmarked: boolean;
   isPublic: boolean;
+  shareUrl?: string;
   name?: string | null;
   timestamp?: Date;
   deleteRedirectUrl?: string;
@@ -74,6 +76,7 @@ export function TraceDetailActions({
           traceId={traceId}
           timestamp={timestamp}
           isPublic={isPublic}
+          shareUrl={shareUrl}
           label="Share"
         />
         <DeleteTraceButton
@@ -107,6 +110,7 @@ export function TraceDetailActions({
         traceId={traceId}
         timestamp={timestamp}
         isPublic={isPublic}
+        shareUrl={shareUrl}
         size={size}
         tooltip={isPublic ? "Shared (public)" : "Share"}
       />


### PR DESCRIPTION
## Summary
- Copy a canonical trace detail URL from the share popover instead of the current table/peek URL when available.
- Pass standalone trace URLs from trace and observation peek detail actions, preserving observation selection for v4 observation peeks.



## Issue with public shareable trace links

https://github.com/user-attachments/assets/6af9dc3a-6a16-443e-a4a6-caaafca5ea21


## Fixed version


https://github.com/user-attachments/assets/9f4f8ca7-20d8-4268-943a-e120e60bc9e6




## Impacted packages
- web

## Verification
- `CI=true pnpm run lint` — `Tasks:    7 successful, 7 total`
- `CI=true pnpm --filter web run typecheck` — exited 0
- commit hook: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli` — `All matched files use Prettier code style!`
- commit hook: `turbo run lint` — `Tasks:    7 successful, 7 total`
