### PR TITLE
feat(filters): refine event facet counts from the row query's filter state (LFE-14489)

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -1019,7 +1019,7 @@ const LoadedSessionEventsPage: React.FC<{
 
   const { filterOptions, isFilterOptionsPending } = useEventsFilterOptions({
     projectId,
-    oldFilterState: timeFiltersForOptions,
+    startTimeFilter: timeFiltersForOptions,
   });
   const typedFilterOptions = filterOptions as EventFilterOptions;
 

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -486,10 +486,8 @@ export default function ObservationsEventsTable({
     projectId,
   });
 
-  // Route-state half of the sidebar filters. Runs BEFORE the facet-options
-  // query so its effectiveFilterState — the same state that scopes the row
-  // query — can refine the facet counts (LFE-14489). The option-aware UI half
-  // (useSidebarFilterPresentation) runs after the options arrive.
+  // Route-state half of the sidebar filters, ahead of the facet-options query
+  // so the same state that scopes the rows can refine the counts (LFE-14489).
   const filterStateOptions: UseSidebarFilterStateOptions = useMemo(() => {
     const baseOptions = {
       implicitDefaultConfig: DEFAULT_SIDEBAR_IMPLICIT_ENVIRONMENT_CONFIG,
@@ -578,10 +576,8 @@ export default function ObservationsEventsTable({
     [userId, sessionId, promptName, promptVersion],
   );
 
-  // Facet counts refine against exactly what scopes the rows (LFE-14489): the
-  // sidebar's effective filter state (or the caller's external filter) plus the
-  // embed scoping. The time window travels separately as startTimeFilter, on
-  // the tick-decoupled range so the auto refresh leaves the facets alone.
+  // The time window travels separately, on the tick-decoupled range so the
+  // auto refresh leaves the facets alone.
   const facetRefiningFilter = useMemo(
     () =>
       externalFilterState ??
@@ -734,9 +730,8 @@ export default function ObservationsEventsTable({
   //     : [];
 
   // The sidebar's effective filter state is the single source of truth in both
-  // modes — the search bar syncs into it rather than replacing it. The same
-  // state + embed scoping feed the facet-count refinement above, so the counts
-  // can never diverge from the rows (LFE-14489).
+  // modes — the search bar syncs into it, and the facet counts above refine
+  // from the same state + embed scoping (LFE-14489).
   const combinedFilterState = queryFilter.effectiveFilterState
     .concat(dateRangeFilter)
     .concat(embedScopeFilterState);

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -508,9 +508,12 @@ export default function ObservationsEventsTable({
 
   const dateRangeFilter: FilterState = toStartTimeFilterState(dateRange);
 
-  // Facet options are scoped only by the time window (the facet hook reads just
-  // the start-time filters); use the tick-decoupled range so the auto refresh
-  // leaves them alone.
+  // Facet options are refined by the active filter set so counts stay
+  // consistent with it (LFE-14489): the hook feeds every applied filter except
+  // the time window through as a refining filter, and reads the start-time
+  // filters for its bounded scope. The time window uses the tick-decoupled
+  // range so the auto refresh leaves the facets alone; a user filter edit is
+  // what re-queries them.
   const oldFilterState = (isolateTableState ? [] : inputFilterState).concat(
     toStartTimeFilterState(filterOptionsDateRange),
   );

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -6,11 +6,11 @@ import {
 } from "@/src/components/table/data-table-controls";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
-import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
 import {
   type UseSidebarFilterStateOptions,
-  useSidebarFilterState,
+  useSidebarFilterPresentation,
+  useSidebarFilterStateCore,
 } from "@/src/features/filters/hooks/useSidebarFilterState";
 import {
   getEventsColumnName,
@@ -35,6 +35,7 @@ import {
   BatchActionType,
   ActionId,
   RESOURCE_LIMIT_ERROR_MESSAGE,
+  type TimeFilter,
   type TracingSearchType,
 } from "@langfuse/shared";
 import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
@@ -78,7 +79,6 @@ import {
   useDetailPageLists,
 } from "@/src/features/navigate-detail-pages/context";
 import { useTableViewManager } from "@/src/components/table/table-view-presets/hooks/useTableViewManager";
-import { useRouter } from "next/router";
 import { useFullTextSearch } from "@/src/components/table/use-cases/useFullTextSearch";
 import { TableSelectionManager } from "@/src/features/table/components/TableSelectionManager";
 import { useSelectAll } from "@/src/features/table/hooks/useSelectAll";
@@ -240,10 +240,10 @@ export type EventsTableProps = {
   isolateTableState?: boolean;
 };
 
-// Build the start-time `FilterState` for an absolute date range (lower bound
+// Build the start-time filters for an absolute date range (lower bound
 // always, upper bound when present). Shared by the live table-rows range and the
 // tick-decoupled facet-options range.
-const toStartTimeFilterState = (range?: TableDateRange): FilterState =>
+const toStartTimeFilterState = (range?: TableDateRange): TimeFilter[] =>
   range
     ? [
         {
@@ -281,8 +281,6 @@ export default function ObservationsEventsTable({
   isolateTableState = false,
 }: EventsTableProps) {
   const peekContext = usePeekTableState();
-  const router = useRouter();
-  const { viewId } = router.query;
   const eventsFilterConfig = useMemo(
     () => getObservationEventsFilterConfig(omittedFilter),
     [omittedFilter],
@@ -325,31 +323,6 @@ export default function ObservationsEventsTable({
   const [rowHeight, setRowHeight] = useRowHeightLocalStorage(
     "observations",
     "s",
-  );
-
-  const [inputFilterState] = useQueryFilterState(
-    // Default type filter - exclude SPAN and EVENT types
-    !viewId
-      ? [
-          {
-            column: "type",
-            type: "stringOptions",
-            operator: "any of",
-            value: [
-              "GENERATION",
-              "AGENT",
-              "TOOL",
-              "CHAIN",
-              "RETRIEVER",
-              "EVALUATOR",
-              "EMBEDDING",
-              "GUARDRAIL",
-            ],
-          },
-        ]
-      : [],
-    "generations", // Use "generations" table name for compatibility
-    projectId,
   );
 
   const [orderByState, setOrderByState] = useOrderByState({
@@ -508,43 +481,18 @@ export default function ObservationsEventsTable({
 
   const dateRangeFilter: FilterState = toStartTimeFilterState(dateRange);
 
-  // Facet options are refined by the active filter set so counts stay
-  // consistent with it (LFE-14489): the hook feeds every applied filter except
-  // the time window through as a refining filter, and reads the start-time
-  // filters for its bounded scope. The time window uses the tick-decoupled
-  // range so the auto refresh leaves the facets alone; a user filter edit is
-  // what re-queries them.
-  const oldFilterState = (isolateTableState ? [] : inputFilterState).concat(
-    toStartTimeFilterState(filterOptionsDateRange),
-  );
-
-  // Fetch filter options. Lazy: start with the eagerly-visible facets and load
-  // the rest (high-cardinality userId/sessionId, model/prompt/score facets) only
-  // when a sidebar section is opened or a field is typed into the search bar.
-  const {
-    filterOptions,
-    isFilterOptionsPending,
-    erroredColumns,
-    loadingColumns,
-    requestColumns,
-  } = useEventsFilterOptions({
-    projectId,
-    oldFilterState,
-    lazy: true,
-  });
-
   const appRootDefault = useAppRootDefault({
     enabled: enableAppRootDefault,
     projectId,
   });
 
-  const queryFilterOptions: UseSidebarFilterStateOptions = useMemo(() => {
+  // Route-state half of the sidebar filters. Runs BEFORE the facet-options
+  // query so its effectiveFilterState — the same state that scopes the row
+  // query — can refine the facet counts (LFE-14489). The option-aware UI half
+  // (useSidebarFilterPresentation) runs after the options arrive.
+  const filterStateOptions: UseSidebarFilterStateOptions = useMemo(() => {
     const baseOptions = {
-      loading: isFilterOptionsPending,
-      loadingColumns,
       implicitDefaultConfig: DEFAULT_SIDEBAR_IMPLICIT_ENVIRONMENT_CONFIG,
-      // v4 fast-mode surface — drives `isV4` on filters:* analytics (LFE-10781).
-      isV4: true,
       defaultExplicitFilterState: appRootDefault.defaultExplicitFilterState,
       onExplicitFilterStateChange: appRootDefault.onExplicitFilterStateChange,
     };
@@ -571,18 +519,106 @@ export default function ObservationsEventsTable({
     };
   }, [
     tableStatePolicy.filterStateLocation,
-    isFilterOptionsPending,
-    loadingColumns,
     peekContext,
     projectId,
     appRootDefault.defaultExplicitFilterState,
     appRootDefault.onExplicitFilterStateChange,
   ]);
 
-  const queryFilter = useSidebarFilterState(
+  const filterCore = useSidebarFilterStateCore(
+    eventsFilterConfig,
+    filterStateOptions,
+  );
+
+  // Embed scoping (user/session detail tabs, prompt linked generations): these
+  // conditions bound the row query, so they refine the facet counts too.
+  const embedScopeFilterState: FilterState = useMemo(
+    () => [
+      ...(userId
+        ? [
+            {
+              column: "User ID",
+              type: "string" as const,
+              operator: "=" as const,
+              value: userId,
+            },
+          ]
+        : []),
+      ...(sessionId
+        ? [
+            {
+              column: "Session ID",
+              type: "string" as const,
+              operator: "=" as const,
+              value: sessionId,
+            },
+          ]
+        : []),
+      ...(promptName
+        ? [
+            {
+              column: "promptName",
+              type: "string" as const,
+              operator: "=" as const,
+              value: promptName,
+            },
+          ]
+        : []),
+      ...(promptVersion
+        ? [
+            {
+              column: "promptVersion",
+              type: "number" as const,
+              operator: "=" as const,
+              value: promptVersion,
+            },
+          ]
+        : []),
+    ],
+    [userId, sessionId, promptName, promptVersion],
+  );
+
+  // Facet counts refine against exactly what scopes the rows (LFE-14489): the
+  // sidebar's effective filter state (or the caller's external filter) plus the
+  // embed scoping. The time window travels separately as startTimeFilter, on
+  // the tick-decoupled range so the auto refresh leaves the facets alone.
+  const facetRefiningFilter = useMemo(
+    () =>
+      externalFilterState ??
+      filterCore.filterState.concat(embedScopeFilterState),
+    [externalFilterState, filterCore.filterState, embedScopeFilterState],
+  );
+  const facetStartTimeFilter = useMemo(
+    () => toStartTimeFilterState(filterOptionsDateRange),
+    [filterOptionsDateRange],
+  );
+
+  // Fetch filter options. Lazy: start with the eagerly-visible facets and load
+  // the rest (high-cardinality userId/sessionId, model/prompt/score facets) only
+  // when a sidebar section is opened or a field is typed into the search bar.
+  const {
+    filterOptions,
+    isFilterOptionsPending,
+    erroredColumns,
+    loadingColumns,
+    requestColumns,
+  } = useEventsFilterOptions({
+    projectId,
+    startTimeFilter: facetStartTimeFilter,
+    refiningFilter: facetRefiningFilter,
+    lazy: true,
+  });
+
+  const queryFilter = useSidebarFilterPresentation(
+    filterCore,
     eventsFilterConfig,
     filterOptions,
-    queryFilterOptions,
+    {
+      loading: isFilterOptionsPending,
+      loadingColumns,
+      // v4 fast-mode surface — drives `isV4` on filters:* analytics (LFE-10781).
+      isV4: true,
+    },
   );
 
   // Lazy filter-options: load a facet's values when its sidebar section is
@@ -697,59 +733,13 @@ export default function ObservationsEventsTable({
   //       ]
   //     : [];
 
-  // Create user ID filter if userId is provided
-  const userIdFilter: FilterState = userId
-    ? [
-        {
-          column: "User ID",
-          type: "string",
-          operator: "=",
-          value: userId,
-        },
-      ]
-    : [];
-
-  const sessionIdFilter: FilterState = sessionId
-    ? [
-        {
-          column: "Session ID",
-          type: "string",
-          operator: "=",
-          value: sessionId,
-        },
-      ]
-    : [];
-
-  const promptNameFilter: FilterState = promptName
-    ? [
-        {
-          column: "promptName",
-          type: "string",
-          operator: "=",
-          value: promptName,
-        },
-      ]
-    : [];
-
-  const promptVersionFilter: FilterState = promptVersion
-    ? [
-        {
-          column: "promptVersion",
-          type: "number",
-          operator: "=",
-          value: promptVersion,
-        },
-      ]
-    : [];
-
   // The sidebar's effective filter state is the single source of truth in both
-  // modes — the search bar syncs into it rather than replacing it.
+  // modes — the search bar syncs into it rather than replacing it. The same
+  // state + embed scoping feed the facet-count refinement above, so the counts
+  // can never diverge from the rows (LFE-14489).
   const combinedFilterState = queryFilter.effectiveFilterState
     .concat(dateRangeFilter)
-    .concat(userIdFilter)
-    .concat(sessionIdFilter)
-    .concat(promptNameFilter)
-    .concat(promptVersionFilter);
+    .concat(embedScopeFilterState);
 
   // Use external filter state if provided, otherwise use combined filter
   // state. Even with an external filter, still apply the date-range bound so

--- a/web/src/features/events/hooks/useEventsFilterOptions.clienttest.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.clienttest.ts
@@ -1,7 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { FilterState } from "@langfuse/shared";
+import type { FilterState, TimeFilter } from "@langfuse/shared";
 
 const mocks = vi.hoisted(() => ({
   bulkInputs: [] as any[],
@@ -9,8 +9,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 // Capture the exact tRPC inputs the hook builds for the bulk `useQuery` and each
-// per-column `useQueries` entry, so we can assert the filtered-facet-count
-// contract (LFE-14489) without a live server.
+// per-column `useQueries` entry, so we can assert the query plan is wired
+// through to the server contract (LFE-14489) without a live server. The plan
+// SEMANTICS (self-exclusion, score catalog, id/label canonicalization) are
+// covered by the pure planner tests in lib/facet-query-plan.clienttest.ts.
 vi.mock("@/src/utils/api", () => ({
   api: {
     events: {
@@ -50,7 +52,7 @@ vi.mock("@/src/utils/api", () => ({
 
 import { useEventsFilterOptions } from "@/src/features/events/hooks/useEventsFilterOptions";
 
-const START_TIME: FilterState[number] = {
+const START_TIME: TimeFilter = {
   column: "startTime",
   type: "datetime",
   operator: ">=",
@@ -68,25 +70,15 @@ const ENV_PROD: FilterState[number] = {
   operator: "any of",
   value: ["production"],
 };
-const SCORE_QUALITY: FilterState[number] = {
-  column: "scores_avg",
-  type: "numberObject",
-  key: "quality",
-  operator: ">",
-  value: 0.5,
-};
-// Same environment facet, but keyed by its DISPLAY NAME (as the search bar
-// lowers it) instead of its id — self-exclusion must still recognize it.
-const ENV_PROD_BY_LABEL: FilterState[number] = {
-  column: "Environment",
-  type: "stringOptions",
-  operator: "any of",
-  value: ["production"],
-};
 
-function run(oldFilterState: FilterState) {
+function run(refiningFilter: FilterState) {
   renderHook(() =>
-    useEventsFilterOptions({ projectId: "p", oldFilterState, lazy: true }),
+    useEventsFilterOptions({
+      projectId: "p",
+      startTimeFilter: [START_TIME],
+      refiningFilter,
+      lazy: true,
+    }),
   );
   return {
     bulk: mocks.bulkInputs.at(-1),
@@ -101,7 +93,7 @@ describe("useEventsFilterOptions filtered facet counts (LFE-14489)", () => {
   });
 
   it("sends only the start-time scope and no refining filter when idle", () => {
-    const { bulk, perColumn } = run([START_TIME]);
+    const { bulk, perColumn } = run([]);
     expect(bulk.startTimeFilter).toEqual([START_TIME]);
     expect(bulk.filter).toBeUndefined();
     expect(bulk.columns).toContain("name");
@@ -109,59 +101,21 @@ describe("useEventsFilterOptions filtered facet counts (LFE-14489)", () => {
     expect(perColumn).toHaveLength(0);
   });
 
-  it("refines the bulk value facets by the active filter and pulls the filtered facet out to self-exclude it", () => {
-    const { bulk, perColumn } = run([START_TIME, LEVEL_ERROR]);
+  it("executes the query plan: refined bulk + self-excluded per-column queries", () => {
+    const { bulk, perColumn } = run([ENV_PROD, LEVEL_ERROR]);
 
-    // `level` self-collapses under its own filter, so it leaves the bulk...
+    // The self-filtered facets leave the bulk; the rest refine by everything.
+    expect(bulk.columns).not.toContain("environment");
     expect(bulk.columns).not.toContain("level");
     expect(bulk.columns).toContain("name");
-    // ...but every remaining value facet is refined by level=ERROR.
-    expect(bulk.filter).toEqual([LEVEL_ERROR]);
-    // start-time never travels as a refining filter.
-    expect(bulk.filter).not.toContainEqual(START_TIME);
-
-    // `level` gets its own query, refined by everything EXCEPT its own filter
-    // (here: nothing), so its option list stays complete.
-    const levelQuery = perColumn.find((q) => q.columns?.[0] === "level");
-    expect(levelQuery).toBeDefined();
-    expect(levelQuery.filter).toBeUndefined();
-  });
-
-  it("self-excludes each facet's own column while cross-refining the others", () => {
-    const { bulk, perColumn } = run([START_TIME, ENV_PROD, LEVEL_ERROR]);
-
-    expect(bulk.columns).not.toContain("environment");
-    expect(bulk.columns).not.toContain("level");
     expect(bulk.filter).toEqual([ENV_PROD, LEVEL_ERROR]);
 
+    // Each pulled-out facet gets its own query carrying the OTHER conditions,
+    // and the shared start-time scope.
     const envQuery = perColumn.find((q) => q.columns?.[0] === "environment");
     const levelQuery = perColumn.find((q) => q.columns?.[0] === "level");
-    // environment counts reflect level=ERROR but NOT environment itself.
     expect(envQuery.filter).toEqual([LEVEL_ERROR]);
-    // level counts reflect environment=production but NOT level itself.
     expect(levelQuery.filter).toEqual([ENV_PROD]);
-  });
-
-  it("self-excludes a facet whose filter is keyed by display name, not id", () => {
-    const { bulk, perColumn } = run([START_TIME, ENV_PROD_BY_LABEL]);
-
-    // The "Environment" label must resolve to the "environment" facet id so the
-    // facet is pulled out of the bulk instead of self-collapsing there.
-    expect(bulk.columns).not.toContain("environment");
-    const envQuery = perColumn.find((q) => q.columns?.[0] === "environment");
-    expect(envQuery).toBeDefined();
-    // environment refined by nothing but itself → its own filter is dropped.
-    expect(envQuery.filter).toBeUndefined();
-  });
-
-  it("keeps the score catalog in the bulk and never self-excludes it", () => {
-    const { bulk, perColumn } = run([START_TIME, SCORE_QUALITY]);
-
-    // Score-catalog columns are project metadata the server never refines, so
-    // they ride the bulk even while a score filter is active...
-    expect(bulk.columns).toContain("scores_avg");
-    // ...and the score filter still refines the value facets in the bulk.
-    expect(bulk.filter).toEqual([SCORE_QUALITY]);
-    expect(perColumn).toHaveLength(0);
+    expect(envQuery.startTimeFilter).toEqual([START_TIME]);
   });
 });

--- a/web/src/features/events/hooks/useEventsFilterOptions.clienttest.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.clienttest.ts
@@ -75,6 +75,14 @@ const SCORE_QUALITY: FilterState[number] = {
   operator: ">",
   value: 0.5,
 };
+// Same environment facet, but keyed by its DISPLAY NAME (as the search bar
+// lowers it) instead of its id — self-exclusion must still recognize it.
+const ENV_PROD_BY_LABEL: FilterState[number] = {
+  column: "Environment",
+  type: "stringOptions",
+  operator: "any of",
+  value: ["production"],
+};
 
 function run(oldFilterState: FilterState) {
   renderHook(() =>
@@ -132,6 +140,18 @@ describe("useEventsFilterOptions filtered facet counts (LFE-14489)", () => {
     expect(envQuery.filter).toEqual([LEVEL_ERROR]);
     // level counts reflect environment=production but NOT level itself.
     expect(levelQuery.filter).toEqual([ENV_PROD]);
+  });
+
+  it("self-excludes a facet whose filter is keyed by display name, not id", () => {
+    const { bulk, perColumn } = run([START_TIME, ENV_PROD_BY_LABEL]);
+
+    // The "Environment" label must resolve to the "environment" facet id so the
+    // facet is pulled out of the bulk instead of self-collapsing there.
+    expect(bulk.columns).not.toContain("environment");
+    const envQuery = perColumn.find((q) => q.columns?.[0] === "environment");
+    expect(envQuery).toBeDefined();
+    // environment refined by nothing but itself → its own filter is dropped.
+    expect(envQuery.filter).toBeUndefined();
   });
 
   it("keeps the score catalog in the bulk and never self-excludes it", () => {

--- a/web/src/features/events/hooks/useEventsFilterOptions.clienttest.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.clienttest.ts
@@ -1,0 +1,147 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FilterState } from "@langfuse/shared";
+
+const mocks = vi.hoisted(() => ({
+  bulkInputs: [] as any[],
+  perColumnInputs: [] as any[],
+}));
+
+// Capture the exact tRPC inputs the hook builds for the bulk `useQuery` and each
+// per-column `useQueries` entry, so we can assert the filtered-facet-count
+// contract (LFE-14489) without a live server.
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    events: {
+      filterOptions: {
+        useQuery: (input: any) => {
+          mocks.bulkInputs.push(input);
+          return {
+            data: {},
+            isFetching: false,
+            isError: false,
+            isPending: false,
+          };
+        },
+      },
+    },
+    useQueries: (
+      build: (t: any) => unknown[],
+      opts: { combine: (results: any[]) => unknown },
+    ) => {
+      const descriptors = build({
+        events: {
+          filterOptions: (input: any) => {
+            mocks.perColumnInputs.push(input);
+            return { input };
+          },
+        },
+      });
+      const results = descriptors.map(() => ({
+        data: {},
+        isFetching: false,
+        isError: false,
+      }));
+      return opts.combine(results);
+    },
+  },
+}));
+
+import { useEventsFilterOptions } from "@/src/features/events/hooks/useEventsFilterOptions";
+
+const START_TIME: FilterState[number] = {
+  column: "startTime",
+  type: "datetime",
+  operator: ">=",
+  value: new Date("2026-01-01T00:00:00.000Z"),
+};
+const LEVEL_ERROR: FilterState[number] = {
+  column: "level",
+  type: "stringOptions",
+  operator: "any of",
+  value: ["ERROR"],
+};
+const ENV_PROD: FilterState[number] = {
+  column: "environment",
+  type: "stringOptions",
+  operator: "any of",
+  value: ["production"],
+};
+const SCORE_QUALITY: FilterState[number] = {
+  column: "scores_avg",
+  type: "numberObject",
+  key: "quality",
+  operator: ">",
+  value: 0.5,
+};
+
+function run(oldFilterState: FilterState) {
+  renderHook(() =>
+    useEventsFilterOptions({ projectId: "p", oldFilterState, lazy: true }),
+  );
+  return {
+    bulk: mocks.bulkInputs.at(-1),
+    perColumn: mocks.perColumnInputs,
+  };
+}
+
+describe("useEventsFilterOptions filtered facet counts (LFE-14489)", () => {
+  beforeEach(() => {
+    mocks.bulkInputs = [];
+    mocks.perColumnInputs = [];
+  });
+
+  it("sends only the start-time scope and no refining filter when idle", () => {
+    const { bulk, perColumn } = run([START_TIME]);
+    expect(bulk.startTimeFilter).toEqual([START_TIME]);
+    expect(bulk.filter).toBeUndefined();
+    expect(bulk.columns).toContain("name");
+    expect(bulk.columns).toContain("scores_avg");
+    expect(perColumn).toHaveLength(0);
+  });
+
+  it("refines the bulk value facets by the active filter and pulls the filtered facet out to self-exclude it", () => {
+    const { bulk, perColumn } = run([START_TIME, LEVEL_ERROR]);
+
+    // `level` self-collapses under its own filter, so it leaves the bulk...
+    expect(bulk.columns).not.toContain("level");
+    expect(bulk.columns).toContain("name");
+    // ...but every remaining value facet is refined by level=ERROR.
+    expect(bulk.filter).toEqual([LEVEL_ERROR]);
+    // start-time never travels as a refining filter.
+    expect(bulk.filter).not.toContainEqual(START_TIME);
+
+    // `level` gets its own query, refined by everything EXCEPT its own filter
+    // (here: nothing), so its option list stays complete.
+    const levelQuery = perColumn.find((q) => q.columns?.[0] === "level");
+    expect(levelQuery).toBeDefined();
+    expect(levelQuery.filter).toBeUndefined();
+  });
+
+  it("self-excludes each facet's own column while cross-refining the others", () => {
+    const { bulk, perColumn } = run([START_TIME, ENV_PROD, LEVEL_ERROR]);
+
+    expect(bulk.columns).not.toContain("environment");
+    expect(bulk.columns).not.toContain("level");
+    expect(bulk.filter).toEqual([ENV_PROD, LEVEL_ERROR]);
+
+    const envQuery = perColumn.find((q) => q.columns?.[0] === "environment");
+    const levelQuery = perColumn.find((q) => q.columns?.[0] === "level");
+    // environment counts reflect level=ERROR but NOT environment itself.
+    expect(envQuery.filter).toEqual([LEVEL_ERROR]);
+    // level counts reflect environment=production but NOT level itself.
+    expect(levelQuery.filter).toEqual([ENV_PROD]);
+  });
+
+  it("keeps the score catalog in the bulk and never self-excludes it", () => {
+    const { bulk, perColumn } = run([START_TIME, SCORE_QUALITY]);
+
+    // Score-catalog columns are project metadata the server never refines, so
+    // they ride the bulk even while a score filter is active...
+    expect(bulk.columns).toContain("scores_avg");
+    // ...and the score filter still refines the value facets in the bulk.
+    expect(bulk.filter).toEqual([SCORE_QUALITY]);
+    expect(perColumn).toHaveLength(0);
+  });
+});

--- a/web/src/features/events/hooks/useEventsFilterOptions.clienttest.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.clienttest.ts
@@ -8,11 +8,8 @@ const mocks = vi.hoisted(() => ({
   perColumnInputs: [] as any[],
 }));
 
-// Capture the exact tRPC inputs the hook builds for the bulk `useQuery` and each
-// per-column `useQueries` entry, so we can assert the query plan is wired
-// through to the server contract (LFE-14489) without a live server. The plan
-// SEMANTICS (self-exclusion, score catalog, id/label canonicalization) are
-// covered by the pure planner tests in lib/facet-query-plan.clienttest.ts.
+// Capture the tRPC inputs the hook builds, to assert the plan is wired through
+// to the server contract. Plan SEMANTICS live in the planner's own tests.
 vi.mock("@/src/utils/api", () => ({
   api: {
     events: {

--- a/web/src/features/events/hooks/useEventsFilterOptions.clienttest.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.clienttest.ts
@@ -98,6 +98,20 @@ describe("useEventsFilterOptions filtered facet counts (LFE-14489)", () => {
     expect(perColumn).toHaveLength(0);
   });
 
+  it("re-routes user-authored start-time conditions into startTimeFilter", () => {
+    // A search-bar `startTime:>…` narrows the rows; the server ignores it in
+    // `filter`, so it must reach the queries via the authoritative channel.
+    const userStartTime: FilterState[number] = {
+      column: "startTime",
+      type: "datetime",
+      operator: ">",
+      value: new Date("2026-02-01T00:00:00.000Z"),
+    };
+    const { bulk } = run([userStartTime, LEVEL_ERROR]);
+    expect(bulk.startTimeFilter).toEqual([START_TIME, userStartTime]);
+    expect(bulk.filter).toEqual([LEVEL_ERROR]);
+  });
+
   it("executes the query plan: refined bulk + self-excluded per-column queries", () => {
     const { bulk, perColumn } = run([ENV_PROD, LEVEL_ERROR]);
 

--- a/web/src/features/events/hooks/useEventsFilterOptions.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.ts
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import { type FilterState, type TimeFilter } from "@langfuse/shared";
 import {
   planEventFacetQueries,
-  toRefiningFilter,
+  splitFacetFilter,
 } from "@/src/features/events/lib/facet-query-plan";
 
 type EventFilterOptionColumnsInput =
@@ -114,7 +114,7 @@ type UseEventsFilterOptionsParams = {
   startTimeFilter?: TimeFilter[];
   /** Active filters the counts refine against (LFE-14489). Pass the SAME state
    *  that scopes the row query; each facet self-excludes its own column via the
-   *  query plan. Start-time conditions are stripped. */
+   *  query plan. Start-time conditions are re-routed into `startTimeFilter`. */
   refiningFilter?: FilterState;
   isRootObservation?: boolean;
   /** Explicit column subset (non-lazy; ignored when `lazy`). Omit to request
@@ -139,17 +139,30 @@ export function useEventsFilterOptions({
   columns,
   lazy = false,
 }: UseEventsFilterOptionsParams) {
-  const baseInput = useMemo(
-    () => ({
-      projectId,
-      startTimeFilter:
-        startTimeFilter && startTimeFilter.length > 0
-          ? startTimeFilter
-          : undefined,
-      isRootObservation,
-    }),
-    [projectId, startTimeFilter, isRootObservation],
+  // User-authored start-time conditions (search-bar `startTime:>…`) merge into
+  // the authoritative startTimeFilter channel — the server ignores them in
+  // `filter`, so counts would otherwise silently ignore that narrowing.
+  const splitFilter = useMemo(
+    () => splitFacetFilter(refiningFilter),
+    [refiningFilter],
   );
+
+  const baseInput = useMemo(() => {
+    const mergedStartTime = [
+      ...(startTimeFilter ?? []),
+      ...splitFilter.startTimeFilter,
+    ];
+    return {
+      projectId,
+      startTimeFilter: mergedStartTime.length > 0 ? mergedStartTime : undefined,
+      isRootObservation,
+    };
+  }, [
+    projectId,
+    startTimeFilter,
+    splitFilter.startTimeFilter,
+    isRootObservation,
+  ]);
 
   // Lazy mode owns a monotonically-growing set of on-demand columns (everything
   // beyond the eager set). It only grows — re-collapsing a facet does not narrow
@@ -191,11 +204,11 @@ export function useEventsFilterOptions({
   const plan = useMemo(
     () =>
       planEventFacetQueries<EventFilterOptionColumn>({
-        refiningFilter: toRefiningFilter(refiningFilter),
+        refiningFilter: splitFilter.refiningFilter,
         eagerColumns: lazy ? EAGER_EVENT_FILTER_OPTION_COLUMNS : columns,
         lazyColumns,
       }),
-    [refiningFilter, lazy, columns, lazyColumns],
+    [splitFilter.refiningFilter, lazy, columns, lazyColumns],
   );
 
   // Eager bulk query: one ClickHouse scan for the plan's shared columns.

--- a/web/src/features/events/hooks/useEventsFilterOptions.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.ts
@@ -194,14 +194,24 @@ export function useEventsFilterOptions({
   // these self-collapse under the shared bulk query, so only these are pulled
   // out for self-exclusion. Score-catalog columns are excluded — the server
   // never refines them, so they stay in the bulk regardless of a score filter.
+  //
+  // Keyed on a stable sorted string (column ids are comma-free) so this Set —
+  // and every partition derived from it below — keeps a stable identity across
+  // re-renders when the filter set is unchanged. The call site rebuilds
+  // `oldFilterState` on every render, so without this the combine + merged
+  // `filterOptions` would churn identity each render (they must not).
+  const filteredColumnsKey = Array.from(
+    new Set(
+      refinementFilter
+        .map((f) => toFacetColumnId(f.column))
+        .filter((c) => !UNREFINED_SCORE_CATALOG_COLUMNS.has(c)),
+    ),
+  )
+    .sort()
+    .join(",");
   const filteredColumns = useMemo(
-    () =>
-      new Set(
-        refinementFilter
-          .map((f) => toFacetColumnId(f.column))
-          .filter((c) => !UNREFINED_SCORE_CATALOG_COLUMNS.has(c)),
-      ),
-    [refinementFilter],
+    () => new Set(filteredColumnsKey ? filteredColumnsKey.split(",") : []),
+    [filteredColumnsKey],
   );
 
   // A facet never filters itself: its options/counts must reflect every OTHER
@@ -274,6 +284,11 @@ export function useEventsFilterOptions({
   // columns that remain are either clean value facets or score-catalog columns,
   // so the bulk gets the FULL refining set: clean value facets are refined by
   // every active filter, and the server leaves the score catalog untouched.
+  //
+  // Non-lazy "request all" (columns undefined) can't enumerate a dirty column to
+  // pull out; that path is only used with a start-time-only filter (the session
+  // view), where nothing is dirty. A future non-lazy caller passing a refining
+  // filter would need an explicit column list to keep self-exclusion working.
   const eagerCandidates = lazy ? EAGER_EVENT_FILTER_OPTION_COLUMNS : columns;
   const bulkColumns = useMemo(
     () => eagerCandidates?.filter((c) => !filteredColumns.has(c)),

--- a/web/src/features/events/hooks/useEventsFilterOptions.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.ts
@@ -79,6 +79,23 @@ const VALID_FILTER_OPTION_COLUMNS: ReadonlySet<string> = new Set(
   ALL_EVENT_FILTER_OPTION_COLUMNS,
 );
 
+// Score-catalog columns list score NAMES/categories/buckets, not per-value
+// counts. The server discovers them from the trace-score scope (time-bounded
+// only) and NEVER applies the refining filter to them, so they never refine and
+// never self-collapse. Keeping the full catalog also protects the search-bar
+// grammar: its score-type routing and its AI score-name validation read this
+// list, so a name filtered out of the active set must still be recognized as a
+// real score (LFE-10596). They therefore stay in the shared bulk query and are
+// excluded from the per-facet self-exclusion below.
+const UNREFINED_SCORE_CATALOG_COLUMNS: ReadonlySet<string> = new Set([
+  "scores_avg",
+  "score_categories",
+  "score_booleans",
+  "trace_scores_avg",
+  "trace_score_categories",
+  "trace_score_booleans",
+]);
+
 const isEventFilterOptionColumn = (
   column: string,
 ): column is EventFilterOptionColumn => VALID_FILTER_OPTION_COLUMNS.has(column);
@@ -137,6 +154,54 @@ export function useEventsFilterOptions({
     ) as TimeFilter[];
   }, [oldFilterState]);
 
+  // Active filters that refine the facet counts (LFE-14489). Start-time stays in
+  // the dedicated startTimeFilter (authoritative for the bounded scan + score
+  // lookback); every OTHER active filter narrows the counts so a facet value can
+  // no longer promise rows the current filter set excludes. The server drops the
+  // non-participating columns (input/output/comment*, positionInTrace) and omits
+  // counts while one of them is active — we forward the set verbatim.
+  const refinementFilter = useMemo(
+    () =>
+      oldFilterState.filter(
+        (f) =>
+          !(
+            f.type === "datetime" &&
+            (f.column === "startTime" || f.column === "Start Time")
+          ),
+      ),
+    [oldFilterState],
+  );
+
+  // Value columns (name/level/type/…) that carry their OWN active filter. Only
+  // these self-collapse under the shared bulk query, so only these are pulled
+  // out for self-exclusion. Score-catalog columns are excluded — the server
+  // never refines them, so they stay in the bulk regardless of a score filter.
+  const filteredColumns = useMemo(
+    () =>
+      new Set(
+        refinementFilter
+          .map((f) => f.column)
+          .filter((c) => !UNREFINED_SCORE_CATALOG_COLUMNS.has(c)),
+      ),
+    [refinementFilter],
+  );
+
+  // A facet never filters itself: its options/counts must reflect every OTHER
+  // active filter, so selecting `level=ERROR` still lists WARNING/DEFAULT (with
+  // refined counts) and the `none of` complement stays computable. Drop the
+  // queried column's own conditions from its refining set. Returns `undefined`
+  // when nothing refines it, preserving the pre-filter react-query cache key.
+  const refiningFilterFor = useCallback(
+    (cols: readonly string[] | undefined): FilterState | undefined => {
+      if (refinementFilter.length === 0) return undefined;
+      if (!cols) return refinementFilter;
+      const own = new Set(cols);
+      const refined = refinementFilter.filter((f) => !own.has(f.column));
+      return refined.length > 0 ? refined : undefined;
+    },
+    [refinementFilter],
+  );
+
   const baseInput = useMemo(
     () => ({
       projectId,
@@ -183,14 +248,44 @@ export function useEventsFilterOptions({
   );
 
   // Eager bulk query: one ClickHouse scan for the always-visible columns (lazy
-  // mode) — or the explicit/all columns in non-lazy mode (unchanged behavior).
-  const eagerColumns = lazy ? [...EAGER_EVENT_FILTER_OPTION_COLUMNS] : columns;
+  // mode) — or the explicit/all columns in non-lazy mode. Value facets carrying
+  // their OWN active filter are pulled out (they would self-collapse under the
+  // shared filter) and re-issued as self-excluded per-column queries below. The
+  // columns that remain are either clean value facets or score-catalog columns,
+  // so the bulk gets the FULL refining set: clean value facets are refined by
+  // every active filter, and the server leaves the score catalog untouched.
+  const eagerCandidates = lazy ? EAGER_EVENT_FILTER_OPTION_COLUMNS : columns;
+  const bulkColumns = useMemo(
+    () => eagerCandidates?.filter((c) => !filteredColumns.has(c)),
+    [eagerCandidates, filteredColumns],
+  );
+  const dirtyBulkColumns = useMemo(
+    () => eagerCandidates?.filter((c) => filteredColumns.has(c)) ?? [],
+    [eagerCandidates, filteredColumns],
+  );
+  const bulkFilter = refiningFilterFor(undefined);
   const eagerQuery = api.events.filterOptions.useQuery(
-    { ...baseInput, columns: eagerColumns },
+    {
+      ...baseInput,
+      filter: bulkFilter,
+      columns: bulkColumns,
+    },
     {
       trpc: { context: { skipBatch: true } },
       ...FILTER_OPTION_QUERY_OPTIONS,
     },
+  );
+
+  // Per-column queries: the lazily-requested on-demand facets PLUS any eager
+  // facet pulled out of the bulk for self-exclusion. Each is its own cached
+  // query keyed by its (self-excluded) refining filter. The two inputs are
+  // disjoint (lazy columns are never eager), but a Set guards against overlap.
+  const perColumnColumns = useMemo(
+    () =>
+      Array.from(
+        new Set<EventFilterOptionColumn>([...lazyColumns, ...dirtyBulkColumns]),
+      ).sort(),
+    [lazyColumns, dirtyBulkColumns],
   );
 
   // One independently-cached query per on-demand column. `combine` merges them
@@ -202,7 +297,7 @@ export function useEventsFilterOptions({
       const pendingColumns: string[] = [];
       const erroredColumns: string[] = [];
       results.forEach((r, i) => {
-        const column = lazyColumns[i];
+        const column = perColumnColumns[i];
         if (column === undefined) return;
         // Publish data first: a post-success refetch error keeps placeholderData,
         // so an already-loaded facet retains its values instead of blanking out —
@@ -222,14 +317,18 @@ export function useEventsFilterOptions({
       });
       return { data, pendingColumns, erroredColumns };
     },
-    [lazyColumns],
+    [perColumnColumns],
   );
 
   const lazyResult = api.useQueries(
     (t) =>
-      lazyColumns.map((column) =>
+      perColumnColumns.map((column) =>
         t.events.filterOptions(
-          { ...baseInput, columns: [column] },
+          {
+            ...baseInput,
+            filter: refiningFilterFor([column]),
+            columns: [column],
+          },
           FILTER_OPTION_QUERY_OPTIONS,
         ),
       ),
@@ -323,12 +422,14 @@ export function useEventsFilterOptions({
     const pending = new Set<string>(lazyResult.pendingColumns);
     if (isEagerFetching) {
       const data = rawData as Record<string, unknown>;
-      for (const column of EAGER_EVENT_FILTER_OPTION_COLUMNS) {
+      // Only the columns actually in the bulk query — the dirty ones pulled out
+      // for self-exclusion report through lazyResult.pendingColumns instead.
+      for (const column of bulkColumns ?? []) {
         if (data[column] === undefined) pending.add(column);
       }
     }
     return pending;
-  }, [lazy, lazyResult.pendingColumns, isEagerFetching, rawData]);
+  }, [lazy, lazyResult.pendingColumns, isEagerFetching, rawData, bulkColumns]);
 
   // Columns whose fetch terminally errored, per column. Consumers settle these to
   // the empty state (no skeleton, no perpetual loading row — there is no
@@ -340,11 +441,11 @@ export function useEventsFilterOptions({
   const erroredColumns = useMemo<ReadonlySet<string>>(() => {
     const errored = new Set<string>(lazyErroredColumns);
     if (isEagerError) {
-      for (const column of EAGER_EVENT_FILTER_OPTION_COLUMNS)
+      for (const column of bulkColumns ?? EAGER_EVENT_FILTER_OPTION_COLUMNS)
         errored.add(column);
     }
     return errored;
-  }, [lazyErroredColumns, isEagerError]);
+  }, [lazyErroredColumns, isEagerError, bulkColumns]);
 
   return {
     filterOptions: newFilterOptions,

--- a/web/src/features/events/hooks/useEventsFilterOptions.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.ts
@@ -1,6 +1,10 @@
 import { api, type RouterInputs, type RouterOutputs } from "@/src/utils/api";
 import { useCallback, useMemo, useState } from "react";
-import { type FilterState, type TimeFilter } from "@langfuse/shared";
+import {
+  eventsTableCols,
+  type FilterState,
+  type TimeFilter,
+} from "@langfuse/shared";
 
 type EventFilterOptionColumnsInput =
   RouterInputs["events"]["filterOptions"]["columns"];
@@ -96,6 +100,20 @@ const UNREFINED_SCORE_CATALOG_COLUMNS: ReadonlySet<string> = new Set([
   "trace_score_booleans",
 ]);
 
+// Filter conditions arrive keyed by either the column id ("environment") or its
+// display name ("Environment"), depending on the source (URL, sidebar, or the
+// search bar's lowering). Facet/option columns are always ids, so normalize a
+// filter's column to its id before matching it to a facet — otherwise a
+// label-keyed filter slips past self-exclusion and its facet self-collapses.
+const FACET_COLUMN_ID_BY_NAME_OR_ID: ReadonlyMap<string, string> = new Map(
+  eventsTableCols.flatMap((c) => [
+    [c.id, c.id],
+    [c.name, c.id],
+  ]),
+);
+const toFacetColumnId = (column: string): string =>
+  FACET_COLUMN_ID_BY_NAME_OR_ID.get(column) ?? column;
+
 const isEventFilterOptionColumn = (
   column: string,
 ): column is EventFilterOptionColumn => VALID_FILTER_OPTION_COLUMNS.has(column);
@@ -180,7 +198,7 @@ export function useEventsFilterOptions({
     () =>
       new Set(
         refinementFilter
-          .map((f) => f.column)
+          .map((f) => toFacetColumnId(f.column))
           .filter((c) => !UNREFINED_SCORE_CATALOG_COLUMNS.has(c)),
       ),
     [refinementFilter],
@@ -196,7 +214,9 @@ export function useEventsFilterOptions({
       if (refinementFilter.length === 0) return undefined;
       if (!cols) return refinementFilter;
       const own = new Set(cols);
-      const refined = refinementFilter.filter((f) => !own.has(f.column));
+      const refined = refinementFilter.filter(
+        (f) => !own.has(toFacetColumnId(f.column)),
+      );
       return refined.length > 0 ? refined : undefined;
     },
     [refinementFilter],

--- a/web/src/features/events/hooks/useEventsFilterOptions.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.ts
@@ -1,10 +1,10 @@
 import { api, type RouterInputs, type RouterOutputs } from "@/src/utils/api";
 import { useCallback, useMemo, useState } from "react";
+import { type FilterState, type TimeFilter } from "@langfuse/shared";
 import {
-  eventsTableCols,
-  type FilterState,
-  type TimeFilter,
-} from "@langfuse/shared";
+  planEventFacetQueries,
+  toRefiningFilter,
+} from "@/src/features/events/lib/facet-query-plan";
 
 type EventFilterOptionColumnsInput =
   RouterInputs["events"]["filterOptions"]["columns"];
@@ -83,45 +83,14 @@ const VALID_FILTER_OPTION_COLUMNS: ReadonlySet<string> = new Set(
   ALL_EVENT_FILTER_OPTION_COLUMNS,
 );
 
-// Score-catalog columns list score NAMES/categories/buckets, not per-value
-// counts. The server discovers them from the trace-score scope (time-bounded
-// only) and NEVER applies the refining filter to them, so they never refine and
-// never self-collapse. Keeping the full catalog also protects the search-bar
-// grammar: its score-type routing and its AI score-name validation read this
-// list, so a name filtered out of the active set must still be recognized as a
-// real score (LFE-10596). They therefore stay in the shared bulk query and are
-// excluded from the per-facet self-exclusion below.
-const UNREFINED_SCORE_CATALOG_COLUMNS: ReadonlySet<string> = new Set([
-  "scores_avg",
-  "score_categories",
-  "score_booleans",
-  "trace_scores_avg",
-  "trace_score_categories",
-  "trace_score_booleans",
-]);
-
-// Filter conditions arrive keyed by either the column id ("environment") or its
-// display name ("Environment"), depending on the source (URL, sidebar, or the
-// search bar's lowering). Facet/option columns are always ids, so normalize a
-// filter's column to its id before matching it to a facet — otherwise a
-// label-keyed filter slips past self-exclusion and its facet self-collapses.
-const FACET_COLUMN_ID_BY_NAME_OR_ID: ReadonlyMap<string, string> = new Map(
-  eventsTableCols.flatMap((c) => [
-    [c.id, c.id],
-    [c.name, c.id],
-  ]),
-);
-const toFacetColumnId = (column: string): string =>
-  FACET_COLUMN_ID_BY_NAME_OR_ID.get(column) ?? column;
-
 const isEventFilterOptionColumn = (
   column: string,
 ): column is EventFilterOptionColumn => VALID_FILTER_OPTION_COLUMNS.has(column);
 
 // Shared react-query options: filter options change slowly and are never live —
 // fetch once and keep (no refetch on mount/focus/reconnect, infinite stale time),
-// and keep prior values on screen while a key changes (time-range move) so the
-// sidebar/bar never flicker.
+// and keep prior values on screen while a key changes (time-range move or filter
+// edit) so the sidebar/bar never flicker.
 const FILTER_OPTION_QUERY_OPTIONS = {
   refetchOnMount: false,
   refetchOnWindowFocus: false,
@@ -136,13 +105,30 @@ type LazyFilterOptionResult = {
   isError: boolean;
 };
 
+const EMPTY_FILTER_STATE: FilterState = [];
+
 type UseEventsFilterOptionsParams = {
   projectId: string;
-  oldFilterState: FilterState;
+  /**
+   * Authoritative time scope for the bounded facet scan and its score lookback.
+   * Kept separate from `refiningFilter` — a time-window move re-keys every
+   * facet query, while a filter edit re-keys only the refined ones.
+   */
+  startTimeFilter?: TimeFilter[];
+  /**
+   * The active filter set the facet counts refine against (LFE-14489). Pass the
+   * SAME filters that scope the row query so a facet value can never promise
+   * rows the current filters exclude. Facets self-exclude their own column via
+   * the query plan; the server drops non-participating columns (input/output/
+   * comment*, positionInTrace) and omits counts while one is active. Start-time
+   * conditions are stripped here (see `startTimeFilter`).
+   */
+  refiningFilter?: FilterState;
   isRootObservation?: boolean;
   /**
    * Explicit column subset to request (non-lazy). Ignored when `lazy` is set.
-   * Omit to request every column (the default bulk behavior).
+   * Omit to request every column — request-all cannot self-exclude, so it is
+   * only valid together with an empty `refiningFilter`.
    */
   columns?: EventFilterOptionColumnsInput;
   /**
@@ -158,88 +144,22 @@ type UseEventsFilterOptionsParams = {
 
 export function useEventsFilterOptions({
   projectId,
-  oldFilterState,
+  startTimeFilter,
+  refiningFilter = EMPTY_FILTER_STATE,
   isRootObservation,
   columns,
   lazy = false,
 }: UseEventsFilterOptionsParams) {
-  // Extract start time filters for filter options query
-  const startTimeFilters = useMemo(() => {
-    return oldFilterState.filter(
-      (f) =>
-        (f.column === "Start Time" || f.column === "startTime") &&
-        f.type === "datetime",
-    ) as TimeFilter[];
-  }, [oldFilterState]);
-
-  // Active filters that refine the facet counts (LFE-14489). Start-time stays in
-  // the dedicated startTimeFilter (authoritative for the bounded scan + score
-  // lookback); every OTHER active filter narrows the counts so a facet value can
-  // no longer promise rows the current filter set excludes. The server drops the
-  // non-participating columns (input/output/comment*, positionInTrace) and omits
-  // counts while one of them is active — we forward the set verbatim.
-  const refinementFilter = useMemo(
-    () =>
-      oldFilterState.filter(
-        (f) =>
-          !(
-            f.type === "datetime" &&
-            (f.column === "startTime" || f.column === "Start Time")
-          ),
-      ),
-    [oldFilterState],
-  );
-
-  // Value columns (name/level/type/…) that carry their OWN active filter. Only
-  // these self-collapse under the shared bulk query, so only these are pulled
-  // out for self-exclusion. Score-catalog columns are excluded — the server
-  // never refines them, so they stay in the bulk regardless of a score filter.
-  //
-  // Keyed on a stable sorted string (column ids are comma-free) so this Set —
-  // and every partition derived from it below — keeps a stable identity across
-  // re-renders when the filter set is unchanged. The call site rebuilds
-  // `oldFilterState` on every render, so without this the combine + merged
-  // `filterOptions` would churn identity each render (they must not).
-  const filteredColumnsKey = Array.from(
-    new Set(
-      refinementFilter
-        .map((f) => toFacetColumnId(f.column))
-        .filter((c) => !UNREFINED_SCORE_CATALOG_COLUMNS.has(c)),
-    ),
-  )
-    .sort()
-    .join(",");
-  const filteredColumns = useMemo(
-    () => new Set(filteredColumnsKey ? filteredColumnsKey.split(",") : []),
-    [filteredColumnsKey],
-  );
-
-  // A facet never filters itself: its options/counts must reflect every OTHER
-  // active filter, so selecting `level=ERROR` still lists WARNING/DEFAULT (with
-  // refined counts) and the `none of` complement stays computable. Drop the
-  // queried column's own conditions from its refining set. Returns `undefined`
-  // when nothing refines it, preserving the pre-filter react-query cache key.
-  const refiningFilterFor = useCallback(
-    (cols: readonly string[] | undefined): FilterState | undefined => {
-      if (refinementFilter.length === 0) return undefined;
-      if (!cols) return refinementFilter;
-      const own = new Set(cols);
-      const refined = refinementFilter.filter(
-        (f) => !own.has(toFacetColumnId(f.column)),
-      );
-      return refined.length > 0 ? refined : undefined;
-    },
-    [refinementFilter],
-  );
-
   const baseInput = useMemo(
     () => ({
       projectId,
       startTimeFilter:
-        startTimeFilters.length > 0 ? startTimeFilters : undefined,
+        startTimeFilter && startTimeFilter.length > 0
+          ? startTimeFilter
+          : undefined,
       isRootObservation,
     }),
-    [projectId, startTimeFilters, isRootObservation],
+    [projectId, startTimeFilter, isRootObservation],
   );
 
   // Lazy mode owns a monotonically-growing set of on-demand columns (everything
@@ -277,33 +197,26 @@ export function useEventsFilterOptions({
     [lazyColumnSet],
   );
 
-  // Eager bulk query: one ClickHouse scan for the always-visible columns (lazy
-  // mode) — or the explicit/all columns in non-lazy mode. Value facets carrying
-  // their OWN active filter are pulled out (they would self-collapse under the
-  // shared filter) and re-issued as self-excluded per-column queries below. The
-  // columns that remain are either clean value facets or score-catalog columns,
-  // so the bulk gets the FULL refining set: clean value facets are refined by
-  // every active filter, and the server leaves the score catalog untouched.
-  //
-  // Non-lazy "request all" (columns undefined) can't enumerate a dirty column to
-  // pull out; that path is only used with a start-time-only filter (the session
-  // view), where nothing is dirty. A future non-lazy caller passing a refining
-  // filter would need an explicit column list to keep self-exclusion working.
-  const eagerCandidates = lazy ? EAGER_EVENT_FILTER_OPTION_COLUMNS : columns;
-  const bulkColumns = useMemo(
-    () => eagerCandidates?.filter((c) => !filteredColumns.has(c)),
-    [eagerCandidates, filteredColumns],
+  // The pure query plan: which columns share the bulk query, which get their
+  // own self-excluded per-column query, and each query's refining filter. All
+  // refinement semantics (self-exclusion, score-catalog handling, id/label
+  // canonicalization) live in the plan module.
+  const plan = useMemo(
+    () =>
+      planEventFacetQueries<EventFilterOptionColumn>({
+        refiningFilter: toRefiningFilter(refiningFilter),
+        eagerColumns: lazy ? EAGER_EVENT_FILTER_OPTION_COLUMNS : columns,
+        lazyColumns,
+      }),
+    [refiningFilter, lazy, columns, lazyColumns],
   );
-  const dirtyBulkColumns = useMemo(
-    () => eagerCandidates?.filter((c) => filteredColumns.has(c)) ?? [],
-    [eagerCandidates, filteredColumns],
-  );
-  const bulkFilter = refiningFilterFor(undefined);
+
+  // Eager bulk query: one ClickHouse scan for the plan's shared columns.
   const eagerQuery = api.events.filterOptions.useQuery(
     {
       ...baseInput,
-      filter: bulkFilter,
-      columns: bulkColumns,
+      filter: plan.bulk.filter,
+      columns: plan.bulk.columns,
     },
     {
       trpc: { context: { skipBatch: true } },
@@ -311,28 +224,18 @@ export function useEventsFilterOptions({
     },
   );
 
-  // Per-column queries: the lazily-requested on-demand facets PLUS any eager
-  // facet pulled out of the bulk for self-exclusion. Each is its own cached
-  // query keyed by its (self-excluded) refining filter. The two inputs are
-  // disjoint (lazy columns are never eager), but a Set guards against overlap.
-  const perColumnColumns = useMemo(
-    () =>
-      Array.from(
-        new Set<EventFilterOptionColumn>([...lazyColumns, ...dirtyBulkColumns]),
-      ).sort(),
-    [lazyColumns, dirtyBulkColumns],
-  );
-
-  // One independently-cached query per on-demand column. `combine` merges them
-  // into a single payload + derives which columns are still loading / errored,
-  // and react-query memoizes the result so identity is stable between changes.
+  // One independently-cached query per plan.perColumn entry. `combine` merges
+  // them into a single payload + derives which columns are still loading /
+  // errored, and react-query memoizes the result so identity is stable between
+  // changes.
+  const perColumnPlan = plan.perColumn;
   const combineLazy = useCallback(
     (results: readonly LazyFilterOptionResult[]) => {
       const data: FilterOptionsData = {};
       const pendingColumns: string[] = [];
       const erroredColumns: string[] = [];
       results.forEach((r, i) => {
-        const column = perColumnColumns[i];
+        const column = perColumnPlan[i]?.column;
         if (column === undefined) return;
         // Publish data first: a post-success refetch error keeps placeholderData,
         // so an already-loaded facet retains its values instead of blanking out —
@@ -352,18 +255,14 @@ export function useEventsFilterOptions({
       });
       return { data, pendingColumns, erroredColumns };
     },
-    [perColumnColumns],
+    [perColumnPlan],
   );
 
   const lazyResult = api.useQueries(
     (t) =>
-      perColumnColumns.map((column) =>
+      perColumnPlan.map(({ column, filter }) =>
         t.events.filterOptions(
-          {
-            ...baseInput,
-            filter: refiningFilterFor([column]),
-            columns: [column],
-          },
+          { ...baseInput, filter, columns: [column] },
           FILTER_OPTION_QUERY_OPTIONS,
         ),
       ),
@@ -452,13 +351,14 @@ export function useEventsFilterOptions({
   // "no data". On a terminal error the column is dropped (no auto-retry, so the
   // facet renders its empty state instead of skeletoning forever).
   const isEagerFetching = eagerQuery.isFetching;
+  const bulkColumns = plan.bulk.columns;
   const loadingColumns = useMemo<ReadonlySet<string> | undefined>(() => {
     if (!lazy) return undefined;
     const pending = new Set<string>(lazyResult.pendingColumns);
     if (isEagerFetching) {
       const data = rawData as Record<string, unknown>;
-      // Only the columns actually in the bulk query — the dirty ones pulled out
-      // for self-exclusion report through lazyResult.pendingColumns instead.
+      // Only the columns actually in the bulk query — the self-excluded ones
+      // report through lazyResult.pendingColumns instead.
       for (const column of bulkColumns ?? []) {
         if (data[column] === undefined) pending.add(column);
       }

--- a/web/src/features/events/hooks/useEventsFilterOptions.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.ts
@@ -109,27 +109,16 @@ const EMPTY_FILTER_STATE: FilterState = [];
 
 type UseEventsFilterOptionsParams = {
   projectId: string;
-  /**
-   * Authoritative time scope for the bounded facet scan and its score lookback.
-   * Kept separate from `refiningFilter` — a time-window move re-keys every
-   * facet query, while a filter edit re-keys only the refined ones.
-   */
+  /** Time scope for the bounded facet scan. Separate from `refiningFilter`, so
+   *  a window move re-keys every query but a filter edit only the refined ones. */
   startTimeFilter?: TimeFilter[];
-  /**
-   * The active filter set the facet counts refine against (LFE-14489). Pass the
-   * SAME filters that scope the row query so a facet value can never promise
-   * rows the current filters exclude. Facets self-exclude their own column via
-   * the query plan; the server drops non-participating columns (input/output/
-   * comment*, positionInTrace) and omits counts while one is active. Start-time
-   * conditions are stripped here (see `startTimeFilter`).
-   */
+  /** Active filters the counts refine against (LFE-14489). Pass the SAME state
+   *  that scopes the row query; each facet self-excludes its own column via the
+   *  query plan. Start-time conditions are stripped. */
   refiningFilter?: FilterState;
   isRootObservation?: boolean;
-  /**
-   * Explicit column subset to request (non-lazy). Ignored when `lazy` is set.
-   * Omit to request every column — request-all cannot self-exclude, so it is
-   * only valid together with an empty `refiningFilter`.
-   */
+  /** Explicit column subset (non-lazy; ignored when `lazy`). Omit to request
+   *  all — request-all cannot self-exclude, so only valid unfiltered. */
   columns?: EventFilterOptionColumnsInput;
   /**
    * Lazy mode (v4 events table): request only the eagerly-visible columns up
@@ -197,10 +186,8 @@ export function useEventsFilterOptions({
     [lazyColumnSet],
   );
 
-  // The pure query plan: which columns share the bulk query, which get their
-  // own self-excluded per-column query, and each query's refining filter. All
-  // refinement semantics (self-exclusion, score-catalog handling, id/label
-  // canonicalization) live in the plan module.
+  // All refinement semantics (self-exclusion, score catalog, id/label
+  // canonicalization) live in the pure plan module.
   const plan = useMemo(
     () =>
       planEventFacetQueries<EventFilterOptionColumn>({

--- a/web/src/features/events/lib/facet-query-plan.clienttest.ts
+++ b/web/src/features/events/lib/facet-query-plan.clienttest.ts
@@ -5,7 +5,7 @@ import type { FilterState } from "@langfuse/shared";
 import {
   planEventFacetQueries,
   resolveEventFacetColumnId,
-  toRefiningFilter,
+  splitFacetFilter,
 } from "@/src/features/events/lib/facet-query-plan";
 
 const START_TIME: FilterState[number] = {
@@ -50,15 +50,15 @@ const USER_SCOPE_BY_LABEL: FilterState[number] = {
 
 const EAGER = ["environment", "level", "name", "scores_avg"] as const;
 
-describe("toRefiningFilter", () => {
-  it("strips start-time conditions (id and display name) and keeps the rest", () => {
+describe("splitFacetFilter", () => {
+  it("routes start-time conditions (id and display name) into startTimeFilter", () => {
+    const startTimeByLabel = { ...START_TIME, column: "Start Time" };
     expect(
-      toRefiningFilter([
-        START_TIME,
-        { ...START_TIME, column: "Start Time" },
-        LEVEL_ERROR,
-      ]),
-    ).toEqual([LEVEL_ERROR]);
+      splitFacetFilter([START_TIME, startTimeByLabel, LEVEL_ERROR]),
+    ).toEqual({
+      startTimeFilter: [START_TIME, startTimeByLabel],
+      refiningFilter: [LEVEL_ERROR],
+    });
   });
 });
 

--- a/web/src/features/events/lib/facet-query-plan.clienttest.ts
+++ b/web/src/features/events/lib/facet-query-plan.clienttest.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import type { FilterState } from "@langfuse/shared";
+
+import {
+  planEventFacetQueries,
+  resolveEventFacetColumnId,
+  toRefiningFilter,
+} from "@/src/features/events/lib/facet-query-plan";
+
+const START_TIME: FilterState[number] = {
+  column: "startTime",
+  type: "datetime",
+  operator: ">=",
+  value: new Date("2026-01-01T00:00:00.000Z"),
+};
+const LEVEL_ERROR: FilterState[number] = {
+  column: "level",
+  type: "stringOptions",
+  operator: "any of",
+  value: ["ERROR"],
+};
+const ENV_PROD: FilterState[number] = {
+  column: "environment",
+  type: "stringOptions",
+  operator: "any of",
+  value: ["production"],
+};
+const SCORE_QUALITY: FilterState[number] = {
+  column: "scores_avg",
+  type: "numberObject",
+  key: "quality",
+  operator: ">",
+  value: 0.5,
+};
+// Display-name keyed conditions: the search bar's lowering and the embed-scope
+// filters (user/session detail pages) produce these instead of column ids.
+const ENV_PROD_BY_LABEL: FilterState[number] = {
+  column: "Environment",
+  type: "stringOptions",
+  operator: "any of",
+  value: ["production"],
+};
+const USER_SCOPE_BY_LABEL: FilterState[number] = {
+  column: "User ID",
+  type: "string",
+  operator: "=",
+  value: "user-1",
+};
+
+const EAGER = ["environment", "level", "name", "scores_avg"] as const;
+
+describe("toRefiningFilter", () => {
+  it("strips start-time conditions (id and display name) and keeps the rest", () => {
+    expect(
+      toRefiningFilter([
+        START_TIME,
+        { ...START_TIME, column: "Start Time" },
+        LEVEL_ERROR,
+      ]),
+    ).toEqual([LEVEL_ERROR]);
+  });
+});
+
+describe("resolveEventFacetColumnId", () => {
+  it("maps display names to column ids and passes ids/unknowns through", () => {
+    expect(resolveEventFacetColumnId("Environment")).toBe("environment");
+    expect(resolveEventFacetColumnId("User ID")).toBe("userId");
+    expect(resolveEventFacetColumnId("environment")).toBe("environment");
+    expect(resolveEventFacetColumnId("not-a-column")).toBe("not-a-column");
+  });
+});
+
+describe("planEventFacetQueries", () => {
+  it("keeps everything in one unrefined bulk when no filter is active", () => {
+    const plan = planEventFacetQueries({
+      refiningFilter: [],
+      eagerColumns: EAGER,
+      lazyColumns: [],
+    });
+    expect(plan.bulk.columns).toEqual([...EAGER]);
+    expect(plan.bulk.filter).toBeUndefined();
+    expect(plan.perColumn).toEqual([]);
+  });
+
+  it("pulls a self-filtered facet out of the bulk and self-excludes it", () => {
+    const plan = planEventFacetQueries({
+      refiningFilter: [LEVEL_ERROR],
+      eagerColumns: EAGER,
+      lazyColumns: [],
+    });
+    // `level` would self-collapse under its own condition → own query...
+    expect(plan.bulk.columns).not.toContain("level");
+    expect(plan.bulk.columns).toContain("name");
+    // ...while the remaining bulk facets are refined by it.
+    expect(plan.bulk.filter).toEqual([LEVEL_ERROR]);
+    expect(plan.perColumn).toEqual([{ column: "level", filter: undefined }]);
+  });
+
+  it("cross-refines self-excluded facets against each other", () => {
+    const plan = planEventFacetQueries({
+      refiningFilter: [ENV_PROD, LEVEL_ERROR],
+      eagerColumns: EAGER,
+      lazyColumns: [],
+    });
+    expect(plan.bulk.columns).toEqual(["name", "scores_avg"]);
+    expect(plan.bulk.filter).toEqual([ENV_PROD, LEVEL_ERROR]);
+    // environment sees level's condition but not its own — and vice versa.
+    expect(plan.perColumn).toEqual([
+      { column: "environment", filter: [LEVEL_ERROR] },
+      { column: "level", filter: [ENV_PROD] },
+    ]);
+  });
+
+  it("never evicts the score catalog from the bulk", () => {
+    const plan = planEventFacetQueries({
+      refiningFilter: [SCORE_QUALITY],
+      eagerColumns: EAGER,
+      lazyColumns: [],
+    });
+    // The server ignores the filter for the catalog; the score condition still
+    // refines the value facets sharing the bulk.
+    expect(plan.bulk.columns).toEqual([...EAGER]);
+    expect(plan.bulk.filter).toEqual([SCORE_QUALITY]);
+    expect(plan.perColumn).toEqual([]);
+  });
+
+  it("matches display-name keyed conditions to their facet ids", () => {
+    const plan = planEventFacetQueries({
+      refiningFilter: [ENV_PROD_BY_LABEL],
+      eagerColumns: EAGER,
+      lazyColumns: [],
+    });
+    expect(plan.bulk.columns).not.toContain("environment");
+    expect(plan.perColumn).toEqual([
+      { column: "environment", filter: undefined },
+    ]);
+  });
+
+  it("refines every facet by an embed-scope condition without evicting the unrequested column", () => {
+    // The user page scopes by `User ID` but omits the userId facet; the
+    // condition refines all requested facets and evicts none of them.
+    const plan = planEventFacetQueries({
+      refiningFilter: [USER_SCOPE_BY_LABEL],
+      eagerColumns: EAGER,
+      lazyColumns: [],
+    });
+    expect(plan.bulk.columns).toEqual([...EAGER]);
+    expect(plan.bulk.filter).toEqual([USER_SCOPE_BY_LABEL]);
+    expect(plan.perColumn).toEqual([]);
+  });
+
+  it("gives lazy columns their own self-excluded queries alongside dirty eager facets", () => {
+    const plan = planEventFacetQueries({
+      refiningFilter: [ENV_PROD],
+      eagerColumns: EAGER,
+      lazyColumns: ["userId", "environment"],
+    });
+    // Deduped + sorted: the dirty eager facet and both lazy columns.
+    expect(plan.perColumn).toEqual([
+      { column: "environment", filter: undefined },
+      { column: "userId", filter: [ENV_PROD] },
+    ]);
+  });
+
+  it("supports request-all mode (columns undefined) for unfiltered callers", () => {
+    const plan = planEventFacetQueries({
+      refiningFilter: [],
+      eagerColumns: undefined,
+      lazyColumns: [],
+    });
+    expect(plan.bulk.columns).toBeUndefined();
+    expect(plan.bulk.filter).toBeUndefined();
+    expect(plan.perColumn).toEqual([]);
+  });
+});

--- a/web/src/features/events/lib/facet-query-plan.ts
+++ b/web/src/features/events/lib/facet-query-plan.ts
@@ -1,0 +1,130 @@
+import { eventsTableCols, type FilterState } from "@langfuse/shared";
+
+// Pure planning for the events filter-options queries (LFE-14489): given the
+// active filter set, decide which facet columns can share one bulk query and
+// which need their own self-excluded query, and what refining filter each
+// query carries. Keeping this a pure module (no hooks, no react-query) makes
+// the refinement semantics directly testable; useEventsFilterOptions merely
+// executes the returned plan.
+
+// Score-catalog columns list score NAMES/categories/buckets, not per-value
+// counts. The server discovers them from the trace-score scope (time-bounded
+// only) and NEVER applies the refining filter to them, so they never refine and
+// never self-collapse. Keeping the full catalog also protects the search-bar
+// grammar: its score-type routing and its AI score-name validation read this
+// list, so a name filtered out of the active set must still be recognized as a
+// real score (LFE-10596). They therefore always stay in the shared bulk query
+// and are never treated as self-filtered.
+const UNREFINED_SCORE_CATALOG_COLUMNS: ReadonlySet<string> = new Set([
+  "scores_avg",
+  "score_categories",
+  "score_booleans",
+  "trace_scores_avg",
+  "trace_score_categories",
+  "trace_score_booleans",
+]);
+
+// Filter conditions can be keyed by the column id ("environment") or its
+// display name ("Environment") — URL state is normalized to ids by
+// decodeAndNormalizeFilters, but embed-scope filters (e.g. the user page's
+// `User ID` condition) and legacy callers still use display names. Facet and
+// option columns are always ids, so normalize before matching a filter to a
+// facet — a label-keyed filter that slips past self-exclusion self-collapses
+// its facet.
+const FACET_COLUMN_ID_BY_NAME_OR_ID: ReadonlyMap<string, string> = new Map(
+  eventsTableCols.flatMap((c) => [
+    [c.id, c.id],
+    [c.name, c.id],
+  ]),
+);
+
+export const resolveEventFacetColumnId = (column: string): string =>
+  FACET_COLUMN_ID_BY_NAME_OR_ID.get(column) ?? column;
+
+/**
+ * Drop start-time conditions from a refining filter. The dedicated
+ * `startTimeFilter` input stays authoritative for the bounded facet scan and
+ * its score lookback; everything else refines the counts. The server drops the
+ * non-participating columns (input/output/comment*, positionInTrace) and omits
+ * counts while one of them is active — those are forwarded verbatim.
+ */
+export const toRefiningFilter = (filter: FilterState): FilterState =>
+  filter.filter(
+    (f) =>
+      !(
+        f.type === "datetime" &&
+        (f.column === "startTime" || f.column === "Start Time")
+      ),
+  );
+
+export type FacetQueryPlan<Column extends string = string> = {
+  /**
+   * The shared bulk query: clean value facets + the score catalog, refined by
+   * the FULL filter (the server ignores it for the catalog). `columns` is
+   * undefined for the "request all" mode (no self-exclusion possible there —
+   * only valid with an empty refining filter).
+   */
+  bulk: {
+    columns: Column[] | undefined;
+    filter: FilterState | undefined;
+  };
+  /**
+   * One query per facet that must not see part of the filter: every requested
+   * value facet with its own active condition (self-exclusion — a facet's
+   * options/counts must reflect every OTHER filter so its full option list
+   * stays visible and the `none of` complement stays computable), plus any
+   * lazily-requested on-demand column. `filter` is undefined when nothing
+   * refines that column.
+   */
+  perColumn: { column: Column; filter: FilterState | undefined }[];
+};
+
+/**
+ * Partition the requested facet columns into the shared bulk query and
+ * self-excluded per-column queries, attaching each query's refining filter.
+ *
+ * `refiningFilter` must already be start-time-free (see `toRefiningFilter`).
+ * `lazyColumns` are always per-column (they load on demand and each keeps its
+ * own react-query cache entry); they self-exclude like any other facet.
+ */
+export function planEventFacetQueries<Column extends string>(params: {
+  refiningFilter: FilterState;
+  eagerColumns: readonly Column[] | undefined;
+  lazyColumns: readonly Column[];
+}): FacetQueryPlan<Column> {
+  const { refiningFilter, eagerColumns, lazyColumns } = params;
+
+  const filterFor = (column: Column): FilterState | undefined => {
+    const refined = refiningFilter.filter(
+      (f) => resolveEventFacetColumnId(f.column) !== column,
+    );
+    return refined.length > 0 ? refined : undefined;
+  };
+
+  // Value columns carrying their OWN active condition. Only these would
+  // self-collapse under the shared bulk filter; the score catalog never
+  // refines, so a score condition does not evict its column from the bulk.
+  const selfFilteredColumns = new Set(
+    refiningFilter
+      .map((f) => resolveEventFacetColumnId(f.column))
+      .filter((c) => !UNREFINED_SCORE_CATALOG_COLUMNS.has(c)),
+  );
+
+  const bulkColumns = eagerColumns?.filter((c) => !selfFilteredColumns.has(c));
+  const dirtyEagerColumns =
+    eagerColumns?.filter((c) => selfFilteredColumns.has(c)) ?? [];
+
+  const perColumn = Array.from(
+    new Set<Column>([...lazyColumns, ...dirtyEagerColumns]),
+  )
+    .sort()
+    .map((column) => ({ column, filter: filterFor(column) }));
+
+  return {
+    bulk: {
+      columns: bulkColumns,
+      filter: refiningFilter.length > 0 ? refiningFilter : undefined,
+    },
+    perColumn,
+  };
+}

--- a/web/src/features/events/lib/facet-query-plan.ts
+++ b/web/src/features/events/lib/facet-query-plan.ts
@@ -1,20 +1,12 @@
 import { eventsTableCols, type FilterState } from "@langfuse/shared";
 
-// Pure planning for the events filter-options queries (LFE-14489): given the
-// active filter set, decide which facet columns can share one bulk query and
-// which need their own self-excluded query, and what refining filter each
-// query carries. Keeping this a pure module (no hooks, no react-query) makes
-// the refinement semantics directly testable; useEventsFilterOptions merely
-// executes the returned plan.
+// Pure query planning for the events filter options (LFE-14489): which facet
+// columns share one bulk query, which need a self-excluded per-column query,
+// and the refining filter each carries. useEventsFilterOptions executes the plan.
 
-// Score-catalog columns list score NAMES/categories/buckets, not per-value
-// counts. The server discovers them from the trace-score scope (time-bounded
-// only) and NEVER applies the refining filter to them, so they never refine and
-// never self-collapse. Keeping the full catalog also protects the search-bar
-// grammar: its score-type routing and its AI score-name validation read this
-// list, so a name filtered out of the active set must still be recognized as a
-// real score (LFE-10596). They therefore always stay in the shared bulk query
-// and are never treated as self-filtered.
+// Score-catalog columns (score names, not per-value counts) always stay in the
+// bulk: the server never refines them, and the search-bar grammar's score-type
+// routing + AI score-name validation must see the full catalog (LFE-10596).
 const UNREFINED_SCORE_CATALOG_COLUMNS: ReadonlySet<string> = new Set([
   "scores_avg",
   "score_categories",
@@ -24,13 +16,9 @@ const UNREFINED_SCORE_CATALOG_COLUMNS: ReadonlySet<string> = new Set([
   "trace_score_booleans",
 ]);
 
-// Filter conditions can be keyed by the column id ("environment") or its
-// display name ("Environment") — URL state is normalized to ids by
-// decodeAndNormalizeFilters, but embed-scope filters (e.g. the user page's
-// `User ID` condition) and legacy callers still use display names. Facet and
-// option columns are always ids, so normalize before matching a filter to a
-// facet — a label-keyed filter that slips past self-exclusion self-collapses
-// its facet.
+// Filters can be keyed by column id ("environment") or display name ("User ID",
+// as the embed-scope filters are). Facet columns are always ids — a label that
+// slipped past self-exclusion would self-collapse its facet.
 const FACET_COLUMN_ID_BY_NAME_OR_ID: ReadonlyMap<string, string> = new Map(
   eventsTableCols.flatMap((c) => [
     [c.id, c.id],
@@ -42,11 +30,9 @@ export const resolveEventFacetColumnId = (column: string): string =>
   FACET_COLUMN_ID_BY_NAME_OR_ID.get(column) ?? column;
 
 /**
- * Drop start-time conditions from a refining filter. The dedicated
- * `startTimeFilter` input stays authoritative for the bounded facet scan and
- * its score lookback; everything else refines the counts. The server drops the
- * non-participating columns (input/output/comment*, positionInTrace) and omits
- * counts while one of them is active — those are forwarded verbatim.
+ * Drop start-time conditions — the dedicated `startTimeFilter` input owns the
+ * time scope. Non-participating columns (input/output/comment*, positionInTrace)
+ * pass through verbatim; the server omits all counts while one is active.
  */
 export const toRefiningFilter = (filter: FilterState): FilterState =>
   filter.filter(
@@ -58,34 +44,22 @@ export const toRefiningFilter = (filter: FilterState): FilterState =>
   );
 
 export type FacetQueryPlan<Column extends string = string> = {
-  /**
-   * The shared bulk query: clean value facets + the score catalog, refined by
-   * the FULL filter (the server ignores it for the catalog). `columns` is
-   * undefined for the "request all" mode (no self-exclusion possible there —
-   * only valid with an empty refining filter).
-   */
+  /** Shared bulk query: clean facets + score catalog, refined by the full
+   *  filter. `columns` undefined = request-all (only valid unfiltered). */
   bulk: {
     columns: Column[] | undefined;
     filter: FilterState | undefined;
   };
-  /**
-   * One query per facet that must not see part of the filter: every requested
-   * value facet with its own active condition (self-exclusion — a facet's
-   * options/counts must reflect every OTHER filter so its full option list
-   * stays visible and the `none of` complement stays computable), plus any
-   * lazily-requested on-demand column. `filter` is undefined when nothing
-   * refines that column.
-   */
+  /** One query per self-excluded facet — its own condition removed, so its full
+   *  option list survives and the `none of` complement stays computable — plus
+   *  each lazily-requested column. */
   perColumn: { column: Column; filter: FilterState | undefined }[];
 };
 
 /**
- * Partition the requested facet columns into the shared bulk query and
- * self-excluded per-column queries, attaching each query's refining filter.
- *
- * `refiningFilter` must already be start-time-free (see `toRefiningFilter`).
- * `lazyColumns` are always per-column (they load on demand and each keeps its
- * own react-query cache entry); they self-exclude like any other facet.
+ * Partition the requested columns into the bulk and per-column queries, with
+ * each query's refining filter. `refiningFilter` must be start-time-free (see
+ * `toRefiningFilter`); lazy columns are always per-column (own cache entry each).
  */
 export function planEventFacetQueries<Column extends string>(params: {
   refiningFilter: FilterState;
@@ -101,9 +75,8 @@ export function planEventFacetQueries<Column extends string>(params: {
     return refined.length > 0 ? refined : undefined;
   };
 
-  // Value columns carrying their OWN active condition. Only these would
-  // self-collapse under the shared bulk filter; the score catalog never
-  // refines, so a score condition does not evict its column from the bulk.
+  // Only facets carrying their own condition would self-collapse in the bulk;
+  // a score condition never evicts its (unrefined) catalog column.
   const selfFilteredColumns = new Set(
     refiningFilter
       .map((f) => resolveEventFacetColumnId(f.column))

--- a/web/src/features/events/lib/facet-query-plan.ts
+++ b/web/src/features/events/lib/facet-query-plan.ts
@@ -1,4 +1,8 @@
-import { eventsTableCols, type FilterState } from "@langfuse/shared";
+import {
+  eventsTableCols,
+  type FilterState,
+  type TimeFilter,
+} from "@langfuse/shared";
 
 // Pure query planning for the events filter options (LFE-14489): which facet
 // columns share one bulk query, which need a self-excluded per-column query,
@@ -29,19 +33,24 @@ const FACET_COLUMN_ID_BY_NAME_OR_ID: ReadonlyMap<string, string> = new Map(
 export const resolveEventFacetColumnId = (column: string): string =>
   FACET_COLUMN_ID_BY_NAME_OR_ID.get(column) ?? column;
 
+const isStartTimeCondition = (f: FilterState[number]): f is TimeFilter =>
+  f.type === "datetime" &&
+  (f.column === "startTime" || f.column === "Start Time");
+
 /**
- * Drop start-time conditions — the dedicated `startTimeFilter` input owns the
- * time scope. Non-participating columns (input/output/comment*, positionInTrace)
- * pass through verbatim; the server omits all counts while one is active.
+ * Split user-authored start-time conditions (e.g. a search-bar `startTime:>…`)
+ * from the refining rest. They must travel via the authoritative
+ * `startTimeFilter` channel — the server drops start-time entries from the
+ * participating filter, so leaving them here would silently un-scope the counts.
+ * Non-participating columns (input/output/comment*, positionInTrace) pass
+ * through verbatim; the server omits all counts while one is active.
  */
-export const toRefiningFilter = (filter: FilterState): FilterState =>
-  filter.filter(
-    (f) =>
-      !(
-        f.type === "datetime" &&
-        (f.column === "startTime" || f.column === "Start Time")
-      ),
-  );
+export const splitFacetFilter = (
+  filter: FilterState,
+): { startTimeFilter: TimeFilter[]; refiningFilter: FilterState } => ({
+  startTimeFilter: filter.filter(isStartTimeCondition),
+  refiningFilter: filter.filter((f) => !isStartTimeCondition(f)),
+});
 
 export type FacetQueryPlan<Column extends string = string> = {
   /** Shared bulk query: clean facets + score catalog, refined by the full
@@ -59,7 +68,7 @@ export type FacetQueryPlan<Column extends string = string> = {
 /**
  * Partition the requested columns into the bulk and per-column queries, with
  * each query's refining filter. `refiningFilter` must be start-time-free (see
- * `toRefiningFilter`); lazy columns are always per-column (own cache entry each).
+ * `splitFacetFilter`); lazy columns are always per-column (own cache entry each).
  */
 export function planEventFacetQueries<Column extends string>(params: {
   refiningFilter: FilterState;

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -473,14 +473,10 @@ const toUrlFilterQuery = (encoded: string): string =>
   encoded.length > MAX_URL_FILTER_QUERY_LENGTH ? "" : encoded;
 
 /**
- * State half of the sidebar filter hook: decodes and owns the applied
- * FilterState (URL / session-storage / memory / peek), layers the explicit
- * defaults and the managed-environment policy into the EFFECTIVE state, and
- * exposes the writer. Deliberately independent of the filter-OPTIONS payload,
- * so a view can derive its applied filters BEFORE fetching options — the
- * events table feeds `effectiveFilterState` into the facet-count query
- * (LFE-14489) and only then builds the option-aware UI via
- * `useSidebarFilterPresentation`.
+ * State half of the sidebar filters: owns the applied FilterState
+ * (URL/session/memory/peek decode + defaults + managed-env policy) and its
+ * writer. Independent of the filter-OPTIONS payload, so a view can read its
+ * applied filters BEFORE fetching options (events facet counts, LFE-14489).
  */
 export function useSidebarFilterStateCore(
   config: FilterConfig,
@@ -919,10 +915,8 @@ export type SidebarFilterPresentationOptions = Pick<
 >;
 
 /**
- * Presentation half: option-aware facet actions, analytics, and the UIFilter
- * list, layered over a `useSidebarFilterStateCore` instance. Split from the
- * core so the applied filter state exists before the filter-options payload —
- * which this half consumes — has been fetched.
+ * Presentation half over a core instance: option-aware facet actions,
+ * analytics, and the UIFilter list.
  */
 export function useSidebarFilterPresentation(
   core: SidebarFilterStateCore,
@@ -1915,10 +1909,8 @@ export function useSidebarFilterPresentation(
 }
 
 /**
- * Combined sidebar filter hook: state core + option-aware presentation in one
- * call. Views that need the applied filter state BEFORE fetching options (to
- * refine facet counts, LFE-14489) call `useSidebarFilterStateCore` and
- * `useSidebarFilterPresentation` separately instead.
+ * Core + presentation in one call. Views that need the applied filter state
+ * before fetching options compose the two hooks directly (see EventsTable).
  */
 export function useSidebarFilterState(
   config: FilterConfig,

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -472,22 +472,21 @@ const DEFAULT_HOOK_OPTIONS: UseSidebarFilterStateOptions = {
 const toUrlFilterQuery = (encoded: string): string =>
   encoded.length > MAX_URL_FILTER_QUERY_LENGTH ? "" : encoded;
 
-export function useSidebarFilterState(
+/**
+ * State half of the sidebar filter hook: decodes and owns the applied
+ * FilterState (URL / session-storage / memory / peek), layers the explicit
+ * defaults and the managed-environment policy into the EFFECTIVE state, and
+ * exposes the writer. Deliberately independent of the filter-OPTIONS payload,
+ * so a view can derive its applied filters BEFORE fetching options — the
+ * events table feeds `effectiveFilterState` into the facet-count query
+ * (LFE-14489) and only then builds the option-aware UI via
+ * `useSidebarFilterPresentation`.
+ */
+export function useSidebarFilterStateCore(
   config: FilterConfig,
-  options: Record<
-    string,
-    (string | SingleValueOption)[] | Record<string, string[]> | undefined
-  >,
   hookOptions: UseSidebarFilterStateOptions = DEFAULT_HOOK_OPTIONS,
 ) {
-  const {
-    loading,
-    loadingColumns,
-    implicitDefaultConfig,
-    onExplicitFilterStateChange,
-  } = hookOptions;
-  const isV4Surface = hookOptions.isV4 ?? false;
-  const capture = usePostHogClientCapture();
+  const { implicitDefaultConfig, onExplicitFilterStateChange } = hookOptions;
   const stateLocationType = hookOptions.stateLocation;
   const peekContext =
     stateLocationType === "peekContext" ? hookOptions.context : undefined;
@@ -705,29 +704,6 @@ export function useSidebarFilterState(
   const managedEnvironmentColumn =
     managedEnvironmentPolicyConfig.managedEnvironmentColumn;
 
-  // Context the pure facet-action functions (lib/sidebar-filter-actions)
-  // read: facet/column metadata, the option lists, and — only while the
-  // managed-environment policy is active — the managed column, which gates
-  // its explicit enable-all-environments override.
-  const actionContext: SidebarFilterActionContext = useMemo(
-    () => ({
-      facets: config.facets,
-      columnDefinitions: config.columnDefinitions,
-      options,
-      managedEnvironmentColumn:
-        managedEnvironmentPolicyConfig.hiddenEnvironments.length > 0
-          ? managedEnvironmentColumn
-          : undefined,
-    }),
-    [
-      config.facets,
-      config.columnDefinitions,
-      options,
-      managedEnvironmentColumn,
-      managedEnvironmentPolicyConfig.hiddenEnvironments,
-    ],
-  );
-
   const effectiveEnvironmentFilterState: FilterState = useMemo(
     () =>
       buildEffectiveEnvironmentFilter({
@@ -920,6 +896,78 @@ export function useSidebarFilterState(
     storedFiltersQuery,
     setStoredFiltersQuery,
   ]);
+
+  return {
+    /** Effective applied filters: explicit + defaults + managed-env policy. */
+    filterState,
+    explicitFilterState,
+    setFilterState,
+    expandedState,
+    onExpandedChange,
+    managedEnvironmentColumn,
+    managedEnvironmentPolicyConfig,
+  };
+}
+
+export type SidebarFilterStateCore = ReturnType<
+  typeof useSidebarFilterStateCore
+>;
+
+export type SidebarFilterPresentationOptions = Pick<
+  BaseUseSidebarFilterStateOptions,
+  "loading" | "loadingColumns" | "isV4"
+>;
+
+/**
+ * Presentation half: option-aware facet actions, analytics, and the UIFilter
+ * list, layered over a `useSidebarFilterStateCore` instance. Split from the
+ * core so the applied filter state exists before the filter-options payload —
+ * which this half consumes — has been fetched.
+ */
+export function useSidebarFilterPresentation(
+  core: SidebarFilterStateCore,
+  config: FilterConfig,
+  options: Record<
+    string,
+    (string | SingleValueOption)[] | Record<string, string[]> | undefined
+  >,
+  presentationOptions: SidebarFilterPresentationOptions = {},
+) {
+  const { loading, loadingColumns } = presentationOptions;
+  const isV4Surface = presentationOptions.isV4 ?? false;
+  const capture = usePostHogClientCapture();
+  const {
+    filterState,
+    explicitFilterState,
+    setFilterState,
+    expandedState,
+    onExpandedChange,
+    managedEnvironmentColumn,
+    managedEnvironmentPolicyConfig,
+  } = core;
+
+  // Context the pure facet-action functions (lib/sidebar-filter-actions)
+  // read: facet/column metadata, the option lists, and — only while the
+  // managed-environment policy is active — the managed column, which gates
+  // its explicit enable-all-environments override.
+  const actionContext: SidebarFilterActionContext = useMemo(
+    () => ({
+      facets: config.facets,
+      columnDefinitions: config.columnDefinitions,
+      options,
+      managedEnvironmentColumn:
+        managedEnvironmentPolicyConfig.hiddenEnvironments.length > 0
+          ? managedEnvironmentColumn
+          : undefined,
+    }),
+    [
+      config.facets,
+      config.columnDefinitions,
+      options,
+      managedEnvironmentColumn,
+      managedEnvironmentPolicyConfig.hiddenEnvironments,
+    ],
+  );
 
   // When true, the applied-filter capture inside `updateFilter` is suppressed —
   // set by `updateOperator`, which funnels through `updateFilter` but must emit
@@ -1864,4 +1912,22 @@ export function useSidebarFilterState(
     // v3-vs-v4 dimension as the hook's own events.
     isV4: isV4Surface,
   };
+}
+
+/**
+ * Combined sidebar filter hook: state core + option-aware presentation in one
+ * call. Views that need the applied filter state BEFORE fetching options (to
+ * refine facet counts, LFE-14489) call `useSidebarFilterStateCore` and
+ * `useSidebarFilterPresentation` separately instead.
+ */
+export function useSidebarFilterState(
+  config: FilterConfig,
+  options: Record<
+    string,
+    (string | SingleValueOption)[] | Record<string, string[]> | undefined
+  >,
+  hookOptions: UseSidebarFilterStateOptions = DEFAULT_HOOK_OPTIONS,
+) {
+  const core = useSidebarFilterStateCore(config, hookOptions);
+  return useSidebarFilterPresentation(core, config, options, hookOptions);
 }


### PR DESCRIPTION
## TL;DR

The events-table filter facets now recompute their **counts against the currently-applied filter set**, not just the time window — you can no longer pick a facet value that then returns "No results". Frontend wiring for the already-merged backend (#15424). The core design decision: facet counts and table rows **share one filter source**, so they structurally cannot disagree.

Closes **LFE-14489**.

## Why

Facet counts were scoped only by the time range. With `environment = development` active, the Status facet still advertised project-wide counts (e.g. `ERROR 334`) — click it and the table comes back near-empty. That "the number lied" confusion is the friction tracked in LFE-10644.

## Key decisions

1. **One filter source — the counts refine from the exact `FilterState` that scopes the rows.** The events table previously kept a second, vestigial decoder of the `?filter=` URL param for the facet query (wrong table's column config → filters on events-only columns silently dropped; no embed scoping; a hardcoded type default the rows never applied). That decoder is deleted; the facet query now consumes the sidebar's `effectiveFilterState` — including the app-root default, the implicit environment policy, and the user/session/prompt embed scoping — verbatim.

2. **Sidebar filter hook split into core + presentation; no store.** `useSidebarFilterState` conflated route state (URL/session/memory decode, defaults, policy, writer) with option-aware presentation (facet actions, UIFilter list). The apparent cycle — "the sidebar hook needs the options; the options query needs the filter state" — was false: the state half never reads the options payload. It's now `useSidebarFilterStateCore` + `useSidebarFilterPresentation`, composed as before for every other table (public API unchanged), and composed *around* the facet-options query by the events table. Filter state stays URL-owned route state — a client store would fight the URL as source of truth.

3. **A facet never filters itself (pure query planner).** Refining a facet by its own condition would collapse it to the selected values and break the `none of` complement math. `lib/facet-query-plan.ts` plans the fetch: facets carrying their own active filter are pulled out of the shared bulk query and re-issued self-excluded; everything else is cross-refined in one scan. Column id/label canonicalization lives here too (embed-scope filters are label-keyed, e.g. `User ID`).

4. **The score catalog is never refined.** The score-name columns are time-bounded project metadata the backend deliberately doesn't narrow — and the search bar's score-type routing plus its AI score-name validation must keep seeing every score name, or a filtered-out score would be treated as unknown and its filter dropped.

5. **Explicit `startTimeFilter` vs `refiningFilter` hook inputs.** Previously one mixed filter array; splitting them means a time-window move re-keys every facet query while a filter edit re-keys only the refined ones — and it removed the render-identity workarounds the mixed array required.

## Result

Verified live in the browser (seeded project, 90-day window):
- Applying `environment = development` (286 events) recomputes the Status facet `DEFAULT 8K / ERROR 334 / WARNING 181 → 275 / 10 / 1` (sum = 286), while the Environment facet still lists **all four** environments.
- On a fresh landing, the facet query's filter is **byte-identical** to the row query's filter.
- On a user detail page, facet counts are scoped to that user's events — Status showed `22 / 2 / 1`, exactly the 25 rows in the table.

<details>
<summary>Architecture, mechanism & verification</summary>

**One-way flow** (per `frontend-large-feature-architecture`): route state → pure query plan → server options → presentation.

```
useSidebarFilterStateCore ──► planEventFacetQueries ──► events.filterOptions ──► useSidebarFilterPresentation
(decode once, events config)     (pure, tested)            (react-query)          (UIFilters with counts)
        │
        └── same effectiveFilterState ──► row query
```

**Planner contract** — `planEventFacetQueries({refiningFilter, eagerColumns, lazyColumns})` → `{bulk: {columns, filter}, perColumn: [{column, filter}]}`. Lazily-requested facets are per-column queries with their own react-query cache entries and self-exclude like any other facet. `useEventsFilterOptions` just executes the plan.

**Known, by-design behaviors** (not regressions): a non-participating filter (input/output/comment fields, position-in-trace) drops counts from all facets per the backend contract; a facet value with no rows under the *other* active filters drops out of that facet's list; a facet briefly skeletons when it first gains/loses its own filter (it moves between the bulk and its own query key).

**Checks** — `pnpm --filter web run typecheck` (0 errors), `pnpm --filter web run lint` (7/7 packages), clienttests across events/filters/search-bar/table `Tests 564 passed (564)` (incl. 10 planner tests + hook wiring tests), plus the live browser passes above.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
