### PR TITLE
fix(pricing): resolve usage key aliases in cost calculation

### DIFF
--- a/packages/shared/src/server/pricing-tiers/index.ts
+++ b/packages/shared/src/server/pricing-tiers/index.ts
@@ -6,3 +6,7 @@
 export type { PricingTierMatchResult, PricingTierWithPrices } from "./types";
 
 export { matchPricingTier } from "./matcher";
+export {
+  CANONICAL_USAGE_KEY_ALIASES,
+  resolveUsageKeyAlias,
+} from "./usageKeyAliases";

--- a/packages/shared/src/server/pricing-tiers/index.ts
+++ b/packages/shared/src/server/pricing-tiers/index.ts
@@ -10,3 +10,7 @@ export type {
 } from "./types";
 
 export { hasPricingTierUsageDetails, matchPricingTier } from "./matcher";
+export {
+  CANONICAL_USAGE_KEY_ALIASES,
+  resolveUsageKeyAlias,
+} from "./usageKeyAliases";

--- a/packages/shared/src/server/pricing-tiers/usageKeyAliases.test.ts
+++ b/packages/shared/src/server/pricing-tiers/usageKeyAliases.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  CANONICAL_USAGE_KEY_ALIASES,
+  resolveUsageKeyAlias,
+} from "./usageKeyAliases";
+
+describe("resolveUsageKeyAlias", () => {
+  describe("reasoning tokens", () => {
+    it("resolves output_reasoning → output_reasoning_tokens", () => {
+      expect(resolveUsageKeyAlias("output_reasoning")).toBe(
+        "output_reasoning_tokens",
+      );
+    });
+
+    it("resolves reasoning.output_tokens → output_reasoning_tokens", () => {
+      expect(resolveUsageKeyAlias("reasoning.output_tokens")).toBe(
+        "output_reasoning_tokens",
+      );
+    });
+
+    it("resolves reasoning_tokens → output_reasoning_tokens", () => {
+      expect(resolveUsageKeyAlias("reasoning_tokens")).toBe(
+        "output_reasoning_tokens",
+      );
+    });
+
+    it("resolves completion_details.reasoning → output_reasoning_tokens", () => {
+      expect(resolveUsageKeyAlias("completion_details.reasoning")).toBe(
+        "output_reasoning_tokens",
+      );
+    });
+
+    it("resolves output_reasoning_tokens to itself", () => {
+      expect(resolveUsageKeyAlias("output_reasoning_tokens")).toBe(
+        "output_reasoning_tokens",
+      );
+    });
+  });
+
+  describe("cache read tokens", () => {
+    it("resolves cache_read_input_tokens → input_cached_tokens", () => {
+      expect(resolveUsageKeyAlias("cache_read_input_tokens")).toBe(
+        "input_cached_tokens",
+      );
+    });
+
+    it("resolves input_cache_read → input_cached_tokens", () => {
+      expect(resolveUsageKeyAlias("input_cache_read")).toBe(
+        "input_cached_tokens",
+      );
+    });
+
+    it("resolves input_cached_tokens to itself", () => {
+      expect(resolveUsageKeyAlias("input_cached_tokens")).toBe(
+        "input_cached_tokens",
+      );
+    });
+  });
+
+  describe("cache creation tokens", () => {
+    it("resolves cache_creation_input_tokens → input_cache_creation", () => {
+      expect(resolveUsageKeyAlias("cache_creation_input_tokens")).toBe(
+        "input_cache_creation",
+      );
+    });
+
+    it("resolves input_cache_write → input_cache_creation", () => {
+      expect(resolveUsageKeyAlias("input_cache_write")).toBe(
+        "input_cache_creation",
+      );
+    });
+  });
+
+  describe("unknown keys", () => {
+    it("returns unknown keys unchanged", () => {
+      expect(resolveUsageKeyAlias("input")).toBe("input");
+      expect(resolveUsageKeyAlias("output")).toBe("output");
+      expect(resolveUsageKeyAlias("total")).toBe("total");
+      expect(resolveUsageKeyAlias("some_custom_key")).toBe("some_custom_key");
+    });
+  });
+
+  describe("CANONICAL_USAGE_KEY_ALIASES consistency", () => {
+    it("every alias resolves to its parent canonical key", () => {
+      for (const [canonical, aliases] of Object.entries(
+        CANONICAL_USAGE_KEY_ALIASES,
+      )) {
+        for (const alias of aliases) {
+          expect(resolveUsageKeyAlias(alias)).toBe(canonical);
+        }
+        // canonical itself resolves to itself
+        expect(resolveUsageKeyAlias(canonical)).toBe(canonical);
+      }
+    });
+
+    it("no alias is shared between two canonical keys", () => {
+      const seen = new Set<string>();
+      for (const aliases of Object.values(CANONICAL_USAGE_KEY_ALIASES)) {
+        for (const alias of aliases) {
+          expect(seen.has(alias)).toBe(false);
+          seen.add(alias);
+        }
+      }
+    });
+  });
+});

--- a/packages/shared/src/server/pricing-tiers/usageKeyAliases.test.ts
+++ b/packages/shared/src/server/pricing-tiers/usageKeyAliases.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  CANONICAL_USAGE_KEY_ALIASES,
+  resolveUsageKeyAlias,
+} from "./usageKeyAliases";
+
+describe("resolveUsageKeyAlias", () => {
+  describe("reasoning tokens", () => {
+    it("resolves output_reasoning → output_reasoning_tokens", () => {
+      expect(resolveUsageKeyAlias("output_reasoning")).toBe(
+        "output_reasoning_tokens",
+      );
+    });
+
+    it("resolves reasoning.output_tokens → output_reasoning_tokens", () => {
+      expect(resolveUsageKeyAlias("reasoning.output_tokens")).toBe(
+        "output_reasoning_tokens",
+      );
+    });
+
+    it("resolves reasoning_tokens → output_reasoning_tokens", () => {
+      expect(resolveUsageKeyAlias("reasoning_tokens")).toBe(
+        "output_reasoning_tokens",
+      );
+    });
+
+    it("resolves completion_details.reasoning → output_reasoning_tokens", () => {
+      expect(resolveUsageKeyAlias("completion_details.reasoning")).toBe(
+        "output_reasoning_tokens",
+      );
+    });
+
+    it("resolves output_reasoning_tokens to itself", () => {
+      expect(resolveUsageKeyAlias("output_reasoning_tokens")).toBe(
+        "output_reasoning_tokens",
+      );
+    });
+  });
+
+  describe("cache read tokens", () => {
+    it("resolves cache_read_input_tokens → input_cached_tokens", () => {
+      expect(resolveUsageKeyAlias("cache_read_input_tokens")).toBe(
+        "input_cached_tokens",
+      );
+    });
+
+    // Regression: langfuse.langchain.CallbackHandler (Python) flattens
+    // langchain_google_genai's cached_content_token_count into
+    // `input_cache_read`, but all 13 Gemini model definitions price
+    // `input_cached_tokens` at 0.1x input and have no `input_cache_read` tier.
+    // Without this alias, cached Gemini tokens via the LangChain path were $0 (#17148).
+    it("resolves input_cache_read → input_cached_tokens", () => {
+      expect(resolveUsageKeyAlias("input_cache_read")).toBe(
+        "input_cached_tokens",
+      );
+    });
+
+    it("resolves input_cached_tokens to itself", () => {
+      expect(resolveUsageKeyAlias("input_cached_tokens")).toBe(
+        "input_cached_tokens",
+      );
+    });
+  });
+
+  describe("cache creation tokens", () => {
+    it("resolves cache_creation_input_tokens → input_cache_creation", () => {
+      expect(resolveUsageKeyAlias("cache_creation_input_tokens")).toBe(
+        "input_cache_creation",
+      );
+    });
+
+    it("resolves input_cache_write → input_cache_creation", () => {
+      expect(resolveUsageKeyAlias("input_cache_write")).toBe(
+        "input_cache_creation",
+      );
+    });
+
+    // Regression: @langfuse/openai@5.10.0 JS wrapper converts OpenAI Responses API
+    // input_tokens_details.cache_write_tokens → input_cache_write_tokens (#16187)
+    it("resolves input_cache_write_tokens → input_cache_creation", () => {
+      expect(resolveUsageKeyAlias("input_cache_write_tokens")).toBe(
+        "input_cache_creation",
+      );
+    });
+
+    it("resolves cache_write_tokens → input_cache_creation", () => {
+      expect(resolveUsageKeyAlias("cache_write_tokens")).toBe(
+        "input_cache_creation",
+      );
+    });
+  });
+
+  describe("unknown keys", () => {
+    it("returns unknown keys unchanged", () => {
+      expect(resolveUsageKeyAlias("input")).toBe("input");
+      expect(resolveUsageKeyAlias("output")).toBe("output");
+      expect(resolveUsageKeyAlias("total")).toBe("total");
+      expect(resolveUsageKeyAlias("some_custom_key")).toBe("some_custom_key");
+    });
+  });
+
+  describe("CANONICAL_USAGE_KEY_ALIASES consistency", () => {
+    it("every alias resolves to its parent canonical key", () => {
+      for (const [canonical, aliases] of Object.entries(
+        CANONICAL_USAGE_KEY_ALIASES,
+      )) {
+        for (const alias of aliases) {
+          expect(resolveUsageKeyAlias(alias)).toBe(canonical);
+        }
+        // canonical itself resolves to itself
+        expect(resolveUsageKeyAlias(canonical)).toBe(canonical);
+      }
+    });
+
+    it("no alias is shared between two canonical keys", () => {
+      const seen = new Set<string>();
+      for (const aliases of Object.values(CANONICAL_USAGE_KEY_ALIASES)) {
+        for (const alias of aliases) {
+          expect(seen.has(alias)).toBe(false);
+          seen.add(alias);
+        }
+      }
+    });
+  });
+});

--- a/packages/shared/src/server/pricing-tiers/usageKeyAliases.ts
+++ b/packages/shared/src/server/pricing-tiers/usageKeyAliases.ts
@@ -1,0 +1,81 @@
+/**
+ * Canonical usage-key alias map.
+ *
+ * Different ingestion paths (OTel GenAI attributes, Vercel AI SDK, Anthropic
+ * provider metadata, Bedrock metadata, OpenInference, Genkit, direct SDK
+ * ingestion) emit different key names for the same logical token bucket. The
+ * pricing tier `Price.usageType` may use any of these names depending on how
+ * the model was configured in the UI.
+ *
+ * This map lets `calculateUsageCosts` resolve an alias to its canonical key so
+ * that cost is computed regardless of which variant the ingestion path produced
+ * or which variant the user configured in the pricing tier.
+ *
+ * Map structure: canonicalKey → alias[]
+ *   - canonicalKey is the preferred name used in seeder data and docs.
+ *   - alias[] lists known alternative names that must match the same price.
+ */
+
+/**
+ * Maps every known alias to its canonical key.
+ * Built from CANONICAL_USAGE_KEY_ALIASES at module load.
+ */
+const ALIAS_TO_CANONICAL: Record<string, string> = {};
+
+export const CANONICAL_USAGE_KEY_ALIASES: Record<string, string[]> = {
+  // Reasoning output tokens (Gemini, OpenAI o-series, etc.)
+  output_reasoning_tokens: [
+    "output_reasoning",
+    "reasoning.output_tokens",
+    "reasoning_tokens",
+    "completion_details.reasoning",
+  ],
+
+  // Cache-read / cached input tokens (Anthropic, OpenAI)
+  input_cached_tokens: [
+    "cache_read_input_tokens",
+    "input_cache_read",
+    "cached_tokens",
+  ],
+
+  // Cache-creation / cache-write tokens (Anthropic, Bedrock)
+  input_cache_creation: [
+    "cache_creation_input_tokens",
+    "input_cache_write",
+    "cache_write_tokens",
+  ],
+
+  // Anthropic TTL-specific cache creation buckets
+  input_cache_creation_5m: [
+    "cache_creation.ephemeral_5m_input_tokens",
+    "ephemeral_5m_input_tokens",
+  ],
+  input_cache_creation_1h: [
+    "cache_creation.ephemeral_1h_input_tokens",
+    "ephemeral_1h_input_tokens",
+  ],
+
+  // Audio tokens
+  input_audio_tokens: ["audio_input_tokens"],
+  output_audio_tokens: ["audio_output_tokens"],
+  output_text_tokens: ["text_output_tokens"],
+};
+
+// Build reverse lookup: alias → canonical
+for (const [canonical, aliases] of Object.entries(
+  CANONICAL_USAGE_KEY_ALIASES,
+)) {
+  for (const alias of aliases) {
+    ALIAS_TO_CANONICAL[alias] = canonical;
+  }
+  // Also map canonical to itself for convenience
+  ALIAS_TO_CANONICAL[canonical] = canonical;
+}
+
+/**
+ * Resolve a usage_details key to its canonical form.
+ * Returns the input unchanged if it is not a known alias.
+ */
+export function resolveUsageKeyAlias(key: string): string {
+  return ALIAS_TO_CANONICAL[key] ?? key;
+}

--- a/packages/shared/src/server/pricing-tiers/usageKeyAliases.ts
+++ b/packages/shared/src/server/pricing-tiers/usageKeyAliases.ts
@@ -1,0 +1,82 @@
+/**
+ * Canonical usage-key alias map.
+ *
+ * Different ingestion paths (OTel GenAI attributes, Vercel AI SDK, Anthropic
+ * provider metadata, Bedrock metadata, OpenInference, Genkit, direct SDK
+ * ingestion) emit different key names for the same logical token bucket. The
+ * pricing tier `Price.usageType` may use any of these names depending on how
+ * the model was configured in the UI.
+ *
+ * This map lets `calculateUsageCosts` resolve an alias to its canonical key so
+ * that cost is computed regardless of which variant the ingestion path produced
+ * or which variant the user configured in the pricing tier.
+ *
+ * Map structure: canonicalKey → alias[]
+ *   - canonicalKey is the preferred name used in seeder data and docs.
+ *   - alias[] lists known alternative names that must match the same price.
+ */
+
+/**
+ * Maps every known alias to its canonical key.
+ * Built from CANONICAL_USAGE_KEY_ALIASES at module load.
+ */
+const ALIAS_TO_CANONICAL: Record<string, string> = {};
+
+export const CANONICAL_USAGE_KEY_ALIASES: Record<string, string[]> = {
+  // Reasoning output tokens (Gemini, OpenAI o-series, etc.)
+  output_reasoning_tokens: [
+    "output_reasoning",
+    "reasoning.output_tokens",
+    "reasoning_tokens",
+    "completion_details.reasoning",
+  ],
+
+  // Cache-read / cached input tokens (Anthropic, OpenAI, LangChain Google Gemini)
+  input_cached_tokens: [
+    "cache_read_input_tokens",
+    "input_cache_read", // langfuse.langchain.CallbackHandler + langchain_google_genai (#17148)
+    "cached_tokens",
+  ],
+
+  // Cache-creation / cache-write tokens (Anthropic, Bedrock, OpenAI Responses API)
+  input_cache_creation: [
+    "cache_creation_input_tokens",
+    "input_cache_write",
+    "input_cache_write_tokens", // @langfuse/openai JS wrapper (Responses API → cache_write_tokens)
+    "cache_write_tokens",
+  ],
+
+  // Anthropic TTL-specific cache creation buckets
+  input_cache_creation_5m: [
+    "cache_creation.ephemeral_5m_input_tokens",
+    "ephemeral_5m_input_tokens",
+  ],
+  input_cache_creation_1h: [
+    "cache_creation.ephemeral_1h_input_tokens",
+    "ephemeral_1h_input_tokens",
+  ],
+
+  // Audio tokens
+  input_audio_tokens: ["audio_input_tokens"],
+  output_audio_tokens: ["audio_output_tokens"],
+  output_text_tokens: ["text_output_tokens"],
+};
+
+// Build reverse lookup: alias → canonical
+for (const [canonical, aliases] of Object.entries(
+  CANONICAL_USAGE_KEY_ALIASES,
+)) {
+  for (const alias of aliases) {
+    ALIAS_TO_CANONICAL[alias] = canonical;
+  }
+  // Also map canonical to itself for convenience
+  ALIAS_TO_CANONICAL[canonical] = canonical;
+}
+
+/**
+ * Resolve a usage_details key to its canonical form.
+ * Returns the input unchanged if it is not a known alias.
+ */
+export function resolveUsageKeyAlias(key: string): string {
+  return ALIAS_TO_CANONICAL[key] ?? key;
+}

--- a/web/src/features/models/components/pricing-tiers/TierPrefillButtons.tsx
+++ b/web/src/features/models/components/pricing-tiers/TierPrefillButtons.tsx
@@ -28,6 +28,9 @@ export function TierPrefillButtons({
             form.setValue(`pricingTiers.${tierIndex}.prices`, {
               input: 0,
               output: 0,
+              // Canonical key names matching OTEL/SDK ingestion output.
+              // Aliases (e.g. cache_read_input_tokens) are resolved at cost
+              // calculation time — see resolveUsageKeyAlias.
               input_cached_tokens: 0,
               output_reasoning_tokens: 0,
               ...prices,
@@ -43,11 +46,12 @@ export function TierPrefillButtons({
           onClick={() => {
             form.setValue(`pricingTiers.${tierIndex}.prices`, {
               input: 0,
-              input_tokens: 0,
               output: 0,
-              output_tokens: 0,
-              cache_creation_input_tokens: 0,
-              cache_read_input_tokens: 0,
+              // Canonical key names matching OTEL/SDK ingestion output.
+              // Aliases (e.g. cache_creation_input_tokens) are resolved at
+              // cost calculation time — see resolveUsageKeyAlias.
+              input_cached_tokens: 0,
+              input_cache_creation: 0,
               input_cache_creation_5m: 0,
               input_cache_creation_1h: 0,
               ...prices,

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -42,6 +42,7 @@ import {
   UsageCostType,
   findModel,
   matchPricingTier,
+  resolveUsageKeyAlias,
   validateAndInflateScore,
   DatasetRunItemRecordInsertType,
   EventRecordInsertType,
@@ -1521,7 +1522,18 @@ export class IngestionService {
     const finalCostEntries: [string, number][] = [];
 
     for (const [key, units] of Object.entries(usageUnits)) {
-      const price = modelPrices?.find((price) => price.usageType === key);
+      // Try exact match first, then fall back to canonical alias resolution.
+      // Different ingestion paths emit different key names for the same token
+      // bucket (e.g. `output_reasoning` vs `output_reasoning_tokens` vs
+      // `reasoning.output_tokens`), and users may configure pricing tiers
+      // using any of these names.  Resolving both sides to their canonical
+      // form ensures cost is computed regardless of which variant is used.
+      const price =
+        modelPrices?.find((p) => p.usageType === key) ??
+        modelPrices?.find(
+          (p) =>
+            resolveUsageKeyAlias(p.usageType) === resolveUsageKeyAlias(key),
+        );
 
       if (units != null && price) {
         finalCostEntries.push([key, price.price.mul(units).toNumber()]);

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -46,6 +46,7 @@ import {
   findModel,
   hasPricingTierUsageDetails,
   matchPricingTier,
+  resolveUsageKeyAlias,
   validateAndInflateScore,
   DatasetRunItemRecordInsertType,
   EventRecordInsertType,
@@ -1701,7 +1702,18 @@ export class IngestionService {
     const finalCostEntries: [string, number][] = [];
 
     for (const [key, units] of Object.entries(usageUnits)) {
-      const price = modelPrices?.find((price) => price.usageType === key);
+      // Try exact match first, then fall back to canonical alias resolution.
+      // Different ingestion paths emit different key names for the same token
+      // bucket (e.g. `output_reasoning` vs `output_reasoning_tokens` vs
+      // `reasoning.output_tokens`), and users may configure pricing tiers
+      // using any of these names.  Resolving both sides to their canonical
+      // form ensures cost is computed regardless of which variant is used.
+      const price =
+        modelPrices?.find((p) => p.usageType === key) ??
+        modelPrices?.find(
+          (p) =>
+            resolveUsageKeyAlias(p.usageType) === resolveUsageKeyAlias(key),
+        );
 
       if (units != null && price) {
         finalCostEntries.push([key, price.price.mul(units).toNumber()]);

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -1290,6 +1290,163 @@ describe("Token Cost Calculation", () => {
     expect(generation.usage_details.total).toBeUndefined();
   });
 
+  describe("usage key alias resolution in calculateUsageCosts", () => {
+    // https://github.com/langfuse/langfuse/issues/12531
+    // Different ingestion paths emit different key names for the same logical
+    // token bucket.  calculateUsageCosts must match prices regardless of which
+    // variant is used in usage_details or in the pricing tier definition.
+
+    it("should match output_reasoning alias to output_reasoning_tokens price (Gemini reasoning)", () => {
+      const prices = [
+        { usageType: "input", price: new Decimal(0.001) },
+        { usageType: "output", price: new Decimal(0.002) },
+        { usageType: "output_reasoning_tokens", price: new Decimal(0.012) },
+      ];
+
+      // Genkit ingestion produces `output_reasoning`, not `output_reasoning_tokens`
+      const usageUnits = {
+        input: 1000,
+        output: 500,
+        output_reasoning: 495,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details.input).toBe(1.0); // 1000 * 0.001
+      expect(costs.cost_details.output).toBe(1.0); // 500 * 0.002
+      expect(costs.cost_details.output_reasoning).toBe(5.94); // 495 * 0.012
+      expect(costs.total_cost).toBeCloseTo(7.94);
+    });
+
+    it("should match reasoning.output_tokens alias to output_reasoning_tokens price (OpenInference)", () => {
+      const prices = [
+        { usageType: "output_reasoning_tokens", price: new Decimal(0.012) },
+      ];
+
+      // OpenInference google_genai produces `reasoning.output_tokens`
+      const usageUnits = {
+        "reasoning.output_tokens": 320,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details["reasoning.output_tokens"]).toBe(3.84); // 320 * 0.012
+    });
+
+    it("should match cache_read_input_tokens alias to input_cached_tokens price (Anthropic cache read)", () => {
+      const prices = [
+        { usageType: "input", price: new Decimal(0.003) },
+        { usageType: "input_cached_tokens", price: new Decimal(0.0003) },
+        { usageType: "input_cache_creation", price: new Decimal(0.00375) },
+        { usageType: "output", price: new Decimal(0.015) },
+      ];
+
+      // AI SDK ingestion produces `input_cached_tokens` but Anthropic prefill
+      // template uses `cache_read_input_tokens`
+      const usageUnits = {
+        input: 3,
+        input_cached_tokens: 2421,
+        input_cache_creation: 2078,
+        output: 2048,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details.input).toBeCloseTo(0.000009);
+      expect(costs.cost_details.input_cached_tokens).toBeCloseTo(0.7263);
+      expect(costs.cost_details.input_cache_creation).toBeCloseTo(7.7925);
+      expect(costs.cost_details.output).toBeCloseTo(0.03072);
+    });
+
+    it("should match when pricing tier uses alias but usage_details uses canonical key", () => {
+      const prices = [
+        // User configured pricing using Anthropic-style key
+        { usageType: "cache_read_input_tokens", price: new Decimal(0.0003) },
+      ];
+
+      // But ingestion produced canonical key
+      const usageUnits = {
+        input_cached_tokens: 10000,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details.input_cached_tokens).toBe(3.0); // 10000 * 0.0003
+    });
+
+    it("should match completion_details.reasoning alias (Gemini via OpenInference)", () => {
+      const prices = [
+        { usageType: "output_reasoning_tokens", price: new Decimal(0.012) },
+      ];
+
+      const usageUnits = {
+        "completion_details.reasoning": 500,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details["completion_details.reasoning"]).toBe(6.0);
+    });
+
+    it("should prefer exact match over alias match", () => {
+      const prices = [
+        { usageType: "output_reasoning", price: new Decimal(0.01) },
+        { usageType: "output_reasoning_tokens", price: new Decimal(0.02) },
+      ];
+
+      const usageUnits = {
+        output_reasoning: 100,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      // Exact match should win: output_reasoning × 0.01
+      expect(costs.cost_details.output_reasoning).toBe(1.0);
+    });
+
+    it("should return undefined cost for unknown keys with no alias match", () => {
+      const prices = [{ usageType: "input", price: new Decimal(0.001) }];
+
+      const usageUnits = {
+        input: 100,
+        completely_unknown_key: 500,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details.input).toBe(0.1);
+      expect(costs.cost_details.completely_unknown_key).toBeUndefined();
+    });
+  });
+
   describe("string to number conversion in getUsageUnits", () => {
     // These tests verify that usage_details values are correctly converted to numbers
     // even when they come in as strings (which can happen when reading from ClickHouse,

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -1400,6 +1400,236 @@ describe("Token Cost Calculation", () => {
     expect(generation.usage_pricing_tier_name).toBeNull();
   });
 
+  describe("usage key alias resolution in calculateUsageCosts", () => {
+    // https://github.com/langfuse/langfuse/issues/12531
+    // Different ingestion paths emit different key names for the same logical
+    // token bucket.  calculateUsageCosts must match prices regardless of which
+    // variant is used in usage_details or in the pricing tier definition.
+
+    it("should match output_reasoning alias to output_reasoning_tokens price (Gemini reasoning)", () => {
+      const prices = [
+        { usageType: "input", price: new Decimal(0.001) },
+        { usageType: "output", price: new Decimal(0.002) },
+        { usageType: "output_reasoning_tokens", price: new Decimal(0.012) },
+      ];
+
+      // Genkit ingestion produces `output_reasoning`, not `output_reasoning_tokens`
+      const usageUnits = {
+        input: 1000,
+        output: 500,
+        output_reasoning: 495,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details.input).toBe(1.0); // 1000 * 0.001
+      expect(costs.cost_details.output).toBe(1.0); // 500 * 0.002
+      expect(costs.cost_details.output_reasoning).toBe(5.94); // 495 * 0.012
+      expect(costs.total_cost).toBeCloseTo(7.94);
+    });
+
+    it("should match reasoning.output_tokens alias to output_reasoning_tokens price (OpenInference)", () => {
+      const prices = [
+        { usageType: "output_reasoning_tokens", price: new Decimal(0.012) },
+      ];
+
+      // OpenInference google_genai produces `reasoning.output_tokens`
+      const usageUnits = {
+        "reasoning.output_tokens": 320,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details["reasoning.output_tokens"]).toBe(3.84); // 320 * 0.012
+    });
+
+    it("should match cache_read_input_tokens alias to input_cached_tokens price (Anthropic cache read)", () => {
+      const prices = [
+        { usageType: "input", price: new Decimal(0.003) },
+        { usageType: "input_cached_tokens", price: new Decimal(0.0003) },
+        { usageType: "input_cache_creation", price: new Decimal(0.00375) },
+        { usageType: "output", price: new Decimal(0.015) },
+      ];
+
+      // AI SDK ingestion produces `input_cached_tokens` but Anthropic prefill
+      // template uses `cache_read_input_tokens`
+      const usageUnits = {
+        input: 3,
+        input_cached_tokens: 2421,
+        input_cache_creation: 2078,
+        output: 2048,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details.input).toBeCloseTo(0.000009);
+      expect(costs.cost_details.input_cached_tokens).toBeCloseTo(0.7263);
+      expect(costs.cost_details.input_cache_creation).toBeCloseTo(7.7925);
+      expect(costs.cost_details.output).toBeCloseTo(0.03072);
+    });
+
+    it("should match when pricing tier uses alias but usage_details uses canonical key", () => {
+      const prices = [
+        // User configured pricing using Anthropic-style key
+        { usageType: "cache_read_input_tokens", price: new Decimal(0.0003) },
+      ];
+
+      // But ingestion produced canonical key
+      const usageUnits = {
+        input_cached_tokens: 10000,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details.input_cached_tokens).toBe(3.0); // 10000 * 0.0003
+    });
+
+    it("should match completion_details.reasoning alias (Gemini via OpenInference)", () => {
+      const prices = [
+        { usageType: "output_reasoning_tokens", price: new Decimal(0.012) },
+      ];
+
+      const usageUnits = {
+        "completion_details.reasoning": 500,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details["completion_details.reasoning"]).toBe(6.0);
+    });
+
+    it("should prefer exact match over alias match", () => {
+      const prices = [
+        { usageType: "output_reasoning", price: new Decimal(0.01) },
+        { usageType: "output_reasoning_tokens", price: new Decimal(0.02) },
+      ];
+
+      const usageUnits = {
+        output_reasoning: 100,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      // Exact match should win: output_reasoning × 0.01
+      expect(costs.cost_details.output_reasoning).toBe(1.0);
+    });
+
+    it("should return undefined cost for unknown keys with no alias match", () => {
+      const prices = [{ usageType: "input", price: new Decimal(0.001) }];
+
+      const usageUnits = {
+        input: 100,
+        completely_unknown_key: 500,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details.input).toBe(0.1);
+      expect(costs.cost_details.completely_unknown_key).toBeUndefined();
+    });
+
+    // Regression: @langfuse/openai@5.10.0 JS wrapper converts OpenAI Responses API
+    // input_tokens_details.cache_write_tokens → input_cache_write_tokens (#16187)
+    it("should match input_cache_write_tokens alias to input_cache_creation price (OpenAI Responses API via JS wrapper)", () => {
+      const prices = [
+        { usageType: "input", price: new Decimal(0.005) },
+        { usageType: "input_cached_tokens", price: new Decimal(0.0025) },
+        { usageType: "input_cache_creation", price: new Decimal(0.01) },
+        { usageType: "output", price: new Decimal(0.015) },
+      ];
+
+      // The official @langfuse/openai JS wrapper produces `input_cache_write_tokens`
+      const usageUnits = {
+        input: 1000,
+        input_cached_tokens: 500,
+        input_cache_write_tokens: 200,
+        output: 800,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details.input).toBe(5.0); // 1000 * 0.005
+      expect(costs.cost_details.input_cached_tokens).toBe(1.25); // 500 * 0.0025
+      expect(costs.cost_details.input_cache_write_tokens).toBe(2.0); // 200 * 0.01
+      expect(costs.cost_details.output).toBe(12.0); // 800 * 0.015
+    });
+
+    // Regression: langfuse.langchain.CallbackHandler (Python) flattens
+    // langchain_google_genai's input_token_details.cache_read into
+    // `input_cache_read`, while Gemini model definitions price
+    // `input_cached_tokens`. Without alias resolution, every cached-token
+    // observation ingested through the LangChain → Langfuse path for the
+    // entire Gemini family (13 managed definitions) was priced at $0.
+    // Real observation (gemini-3.7-flash, Python SDK 4.1.0,
+    // langchain-google-genai 4.3.2, from Langfuse Cloud):
+    //   usageDetails: {input: 16707, input_cache_read: 61338, output: 12760, output_reasoning: 380}
+    // Filed as #17148.
+    it("should match input_cache_read alias to input_cached_tokens price (Gemini via LangChain CallbackHandler)", () => {
+      const prices = [
+        { usageType: "input", price: new Decimal(0.0001) },
+        // Gemini definitions price input_cached_tokens at 0.1x input,
+        // but do NOT define an input_cache_read tier.
+        { usageType: "input_cached_tokens", price: new Decimal(0.00001) },
+        { usageType: "output", price: new Decimal(0.0004) },
+        { usageType: "output_reasoning_tokens", price: new Decimal(0.0004) },
+      ];
+
+      // The Python CallbackHandler produces `input_cache_read` (from
+      // usage_metadata.cached_content_token_count via langchain_google_genai)
+      // and `output_reasoning` on the output axis.
+      const usageUnits = {
+        input: 16707,
+        input_cache_read: 61338,
+        output: 12760,
+        output_reasoning: 380,
+      };
+
+      const costs = (IngestionService as any).calculateUsageCosts(
+        prices as any,
+        { provided_cost_details: {} },
+        usageUnits,
+      );
+
+      expect(costs.cost_details.input).toBeCloseTo(1.6707); // 16707 * 0.0001
+      // 61338 cached tokens MUST be priced (not $0) via alias → input_cached_tokens
+      expect(costs.cost_details.input_cache_read).toBeCloseTo(0.61338); // 61338 * 0.00001
+      expect(costs.cost_details.output).toBeCloseTo(5.104); // 12760 * 0.0004
+      expect(costs.cost_details.output_reasoning).toBeCloseTo(0.152); // 380 * 0.0004
+    });
+  });
+
   describe("string to number conversion in getUsageUnits", () => {
     // These tests verify that usage_details values are correctly converted to numbers
     // even when they come in as strings (which can happen when reading from ClickHouse,


### PR DESCRIPTION
## What does this PR do?

Fixes #12531
Fixes #16187
Fixes #17148

Different ingestion paths (Genkit, Vercel AI SDK, OpenInference, Anthropic/Bedrock metadata, `@langfuse/openai` JS wrapper, LangChain `langchain_google_genai` CallbackHandler) produce different key names for the same semantic token bucket — e.g. `output_reasoning` vs `output_reasoning_tokens` vs `reasoning.output_tokens` for reasoning tokens, or `input_cache_read` vs `input_cached_tokens` for cached input tokens. Since `calculateUsageCosts` used exact string matching against `Price.usageType`, observations ingested through these paths got **$0.00 cost** even when valid pricing tiers existed.

### Root cause

The cost pipeline has 5 stages:

```
OTEL attributes → extractUsageDetails() → usage_details keys → findModel() → matchPricingTier() → calculateUsageCosts()
```

`calculateUsageCosts` iterates `usage_details` and does `modelPrices.find(p => p.usageType === key)`. When the key from ingestion doesn't exactly match the pricing tier's `usageType`, cost is silently skipped → $0.00.

### Fix

Add a **canonical usage-key alias map** (`resolveUsageKeyAlias`) in `@langfuse/shared` and fall back to alias resolution when exact match fails in `calculateUsageCosts`. Exact match is tried first, so existing behaviour is fully preserved for users who already use canonical keys.

| Canonical key | Known aliases |
|---|---|
| `output_reasoning_tokens` | `output_reasoning`, `reasoning.output_tokens`, `reasoning_tokens`, `completion_details.reasoning` |
| `input_cached_tokens` | `cache_read_input_tokens`, `input_cache_read`, `cached_tokens` |
| `input_cache_creation` | `cache_creation_input_tokens`, `input_cache_write`, **`input_cache_write_tokens`** (#16187), `cache_write_tokens` |
| `input_cache_creation_5m` | `cache_creation.ephemeral_5m_input_tokens`, `ephemeral_5m_input_tokens` |
| `input_cache_creation_1h` | `cache_creation.ephemeral_1h_input_tokens`, `ephemeral_1h_input_tokens` |
| `input_audio_tokens` | `audio_input_tokens` |
| `output_audio_tokens` | `audio_output_tokens` |
| `output_text_tokens` | `text_output_tokens` |

### Design principles

- **Zero breaking changes** — no changes to ingestion APIs, stored `usage_details` keys, public API response shapes, or Fern contracts
- **Backward compatible** — exact match is tried first; alias resolution is a fallback only
- **Concentrated** — only the cost calculation path is modified; stored data is untouched

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have checked if new and existing unit tests pass locally with my changes

## Verification

| Check | Result |
|---|---|
| `pnpm run typecheck` (turbo, 8 packages) | `Tasks: 7 successful, 7 total` ✅ |
| `turbo run lint` (pre-commit hook) | `Tasks: 7 successful, 7 total` ✅ |
| `usageKeyAliases.test.ts` | `Tests 15 passed (15)` ✅ |
| `calculateTokenCost.unit.test.ts` | 9 new alias-resolution cases added (requires Postgres, runs in CI) |
