### PR TITLE
fix(api): stop logging public API request payloads (v3 backport of #15399)

### DIFF
--- a/web/src/__tests__/server/unit/create-authed-project-api-route-auth-errors.servertest.ts
+++ b/web/src/__tests__/server/unit/create-authed-project-api-route-auth-errors.servertest.ts
@@ -7,6 +7,7 @@ const {
   mockIsPrismaException,
   mockRateLimitRequest,
   mockTraceException,
+  mockLoggerDebug,
   mockCreateUnstablePublicApiAuthError,
   mockSendUnstablePublicApiErrorResponse,
 } = vi.hoisted(() => ({
@@ -14,6 +15,7 @@ const {
   mockIsPrismaException: vi.fn(),
   mockRateLimitRequest: vi.fn(),
   mockTraceException: vi.fn(),
+  mockLoggerDebug: vi.fn(),
   mockCreateUnstablePublicApiAuthError: vi.fn((value) => value),
   mockSendUnstablePublicApiErrorResponse: vi.fn(),
 }));
@@ -31,7 +33,7 @@ vi.mock("@langfuse/shared/src/db", () => ({
 vi.mock("@langfuse/shared/src/server", () => ({
   redis: null,
   logger: {
-    debug: vi.fn(),
+    debug: mockLoggerDebug,
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
@@ -243,6 +245,43 @@ describe("createAuthedProjectAPIRoute auth error handling", () => {
       errorContract: undefined,
       upgradePath,
     });
+  });
+
+  it("does not include request query or body data in debug logs", async () => {
+    mockVerifyAuthHeaderAndReturnScope.mockResolvedValueOnce(validAuth);
+
+    const handler = createAuthedProjectAPIRoute({
+      name: "Sensitive Route",
+      querySchema: z.object({ token: z.string() }),
+      bodySchema: z.object({
+        secretKey: z.string(),
+        extraHeaders: z.record(z.string(), z.string()),
+      }),
+      responseSchema: z.object({ ok: z.literal(true) }),
+      fn: async () => ({ ok: true as const }),
+    });
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "PUT",
+      headers: {
+        authorization: "Basic test",
+      },
+      query: {
+        token: "SENTINEL_QUERY_TOKEN",
+      },
+      body: {
+        secretKey: "SENTINEL_SECRET_KEY",
+        extraHeaders: {
+          Authorization: "Bearer SENTINEL_HEADER_TOKEN",
+        },
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockLoggerDebug).toHaveBeenCalledExactlyOnceWith(
+      "Request to route Sensitive Route projectId project-1",
+    );
   });
 
   it("throws a 422 payload error when response serialization exceeds V8 string limits", async () => {

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -380,10 +380,6 @@ export const createAuthedProjectAPIRoute = <
 
     logger.debug(
       `Request to route ${routeConfig.name} projectId ${auth.scope.projectId}`,
-      {
-        query: req.query,
-        body: req.body,
-      },
     );
 
     let query: z.infer<TQuery>;


### PR DESCRIPTION
Backports #15399 (`cc1a5607`) from `main` to `v3`. Part of the v3 security backport previously bundled in #15468, split into per-fix PRs so squash merging keeps one commit per fix.

Removes request `query` and `body` payloads from the `createAuthedProjectAPIRoute` debug log line, so user-authored content and secrets in public API requests no longer reach logs.

Two conflict resolutions vs main:
- `web/src/pages/api/public/feedback.ts` does not exist on `v3` (the feedback route is main-only), so that part of the fix was dropped.
- `createAuthedProjectAPIRoute.ts`: main's hunk context includes the `redactLogBody`/`deprecation` options that `v3` never had; resolved to simply remove `query`/`body` from the debug log call.

**Verification:** `web/src/__tests__/server/unit/create-authed-project-api-route-auth-errors.servertest.ts` — `Tests  7 passed (7)` locally against `v3` (includes the new sentinel-leak regression test); the identical change also passed the full CI suite on #15468.

> ⚠️ Security-relevant logging change — please review before merging; do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
