### PR TITLE
fix(auth): resolve API key scope publicKey from the verified key (v3 backport of #15456)

### DIFF
--- a/web/src/__tests__/server/api-auth.servertest.ts
+++ b/web/src/__tests__/server/api-auth.servertest.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import {
   OrgEnrichedApiKey,
   createAndAddApiKeysToDb,
@@ -7,6 +8,7 @@ import {
   generateKeySet,
   getDisplaySecretKey,
   hashSecretKey,
+  logger,
 } from "@langfuse/shared/src/server";
 import { Prisma, type PrismaClient, prisma } from "@langfuse/shared/src/db";
 import { env } from "@/src/env.mjs";
@@ -328,6 +330,64 @@ describe("Authenticate API calls", () => {
       if (auth.validKey) {
         expect(auth.scope.isInAppAgentKey).toBe(true);
       }
+    });
+
+    it("returns the API key's actual public key in scope and warns when the submitted public key does not match", async () => {
+      // first use sets fastHashedSecretKey so the secret-hash lookup path is taken
+      await new ApiAuthService(prisma, null).verifyAuthHeaderAndReturnScope(
+        getValidAuthHeader(),
+      );
+
+      const warnSpy = vi.spyOn(logger, "warn");
+      const submittedPublicKey = `pk-lf-mismatch-${v4()}`;
+
+      const auth = await new ApiAuthService(
+        prisma,
+        null,
+      ).verifyAuthHeaderAndReturnScope(
+        createBasicAuthHeader(submittedPublicKey, testApiKey.secretKey),
+      );
+
+      expect(auth.validKey).toBe(true);
+      if (auth.validKey) {
+        expect(auth.scope.publicKey).toBe(testApiKey.publicKey);
+        expect(auth.scope.projectId).toBe(testApiKey.projectId);
+      }
+
+      const mismatchWarning = warnSpy.mock.calls
+        .map((call) => String(call[0]))
+        .find((message) => message.includes("Public key mismatch"));
+      expect(mismatchWarning).toBeDefined();
+      expect(mismatchWarning).toContain(submittedPublicKey);
+      expect(mismatchWarning).toContain(testApiKey.publicKey);
+      expect(mismatchWarning).toContain(testApiKey.projectId);
+
+      warnSpy.mockRestore();
+    });
+
+    it("does not warn when the submitted public key matches", async () => {
+      await new ApiAuthService(prisma, null).verifyAuthHeaderAndReturnScope(
+        getValidAuthHeader(),
+      );
+
+      const warnSpy = vi.spyOn(logger, "warn");
+
+      const auth = await new ApiAuthService(
+        prisma,
+        null,
+      ).verifyAuthHeaderAndReturnScope(getValidAuthHeader());
+
+      expect(auth.validKey).toBe(true);
+      if (auth.validKey) {
+        expect(auth.scope.publicKey).toBe(testApiKey.publicKey);
+      }
+      expect(
+        warnSpy.mock.calls.filter((call) =>
+          String(call[0]).includes("Public key mismatch"),
+        ),
+      ).toHaveLength(0);
+
+      warnSpy.mockRestore();
     });
   });
 

--- a/web/src/features/public-api/server/apiAuth.ts
+++ b/web/src/features/public-api/server/apiAuth.ts
@@ -178,6 +178,15 @@ export class ApiAuthService {
                 ? ("organization" as const)
                 : ("project" as const);
 
+            // The API key is resolved via the hash of the secret key, so the
+            // submitted public key may not belong to it, e.g. after a partial
+            // credential rotation on the client.
+            if (publicKey !== finalApiKey.publicKey) {
+              logger.warn(
+                `Public key mismatch on basic auth: submitted public key ${publicKey} does not match public key ${finalApiKey.publicKey} of the API key resolved via the secret key (apiKeyId ${finalApiKey.id}, projectId ${finalApiKey.projectId}, orgId ${finalApiKey.orgId})`,
+              );
+            }
+
             const result = {
               validKey: true as const,
               scope: {
@@ -188,7 +197,7 @@ export class ApiAuthService {
                 rateLimitOverrides: finalApiKey.rateLimitOverrides ?? [],
                 apiKeyId: finalApiKey.id,
                 scope: finalApiKey.scope,
-                publicKey,
+                publicKey: finalApiKey.publicKey,
                 isIngestionSuspended: finalApiKey.isIngestionSuspended,
                 isInAppAgentKey: finalApiKey.isInAppAgentKey,
               },


### PR DESCRIPTION
Backports #15456 (`77909f75`) from `main` to `v3`. Part of the v3 security backport previously bundled in #15468, split into per-fix PRs so squash merging keeps one commit per fix.

The Basic auth handler now resolves the API key scope's `publicKey` from the verified key record instead of the client-submitted `pk`, so the scope can no longer carry a claimed-but-unverified public key.

The commit applied onto `v3` without conflicts.

**Verification:** `web/src/__tests__/server/api-auth.servertest.ts` — `Tests  24 passed (24)` locally against `v3`; the identical change also passed the full CI suite on #15468.

> ⚠️ Touches API key auth — please review before merging; do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
