### PR TITLE
fix(redis): keep sentinel connections alive when BullMQ's blocking watchdog fires mid-resolution

### DIFF
--- a/packages/shared/src/server/redis/redis.test.ts
+++ b/packages/shared/src/server/redis/redis.test.ts
@@ -1,15 +1,19 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { Redis } from "ioredis";
 
-vi.mock("../../env", () => ({
-  env: {
-    REDIS_CLUSTER_ENABLED: "false",
-    REDIS_ENABLE_AUTO_PIPELINING: "false",
-    REDIS_SENTINEL_ENABLED: "false",
-  },
+const mockEnv = vi.hoisted(() => ({
+  REDIS_CLUSTER_ENABLED: "false",
+  REDIS_ENABLE_AUTO_PIPELINING: "false",
+  REDIS_SENTINEL_ENABLED: "false",
+  REDIS_SENTINEL_MASTER_NAME: undefined as string | undefined,
+  REDIS_SENTINEL_NODES: undefined as string | undefined,
 }));
 
-import { scanKeys } from "./redis";
+vi.mock("../../env", () => ({
+  env: mockEnv,
+}));
+
+import { createNewRedisInstance, scanKeys } from "./redis";
 
 type ScanCall = [string, "MATCH", string, "COUNT", number];
 
@@ -78,5 +82,73 @@ describe("scanKeys", () => {
       "COUNT",
       1000,
     );
+  });
+});
+
+describe("sentinel connections vs BullMQ blocking-connection watchdog", () => {
+  beforeAll(() => {
+    mockEnv.REDIS_SENTINEL_ENABLED = "true";
+    mockEnv.REDIS_SENTINEL_MASTER_NAME = "mymaster";
+    // Closed port: master resolution can never complete, so the client stays
+    // in ioredis status "connecting" — the exact window in which BullMQ's
+    // watchdog disconnect parks unguarded sentinel connections in "end".
+    mockEnv.REDIS_SENTINEL_NODES = "127.0.0.1:1";
+  });
+
+  afterAll(() => {
+    mockEnv.REDIS_SENTINEL_ENABLED = "false";
+    mockEnv.REDIS_SENTINEL_MASTER_NAME = undefined;
+    mockEnv.REDIS_SENTINEL_NODES = undefined;
+  });
+
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  const createSentinelInstance = (): Redis => {
+    const instance = createNewRedisInstance();
+    expect(instance).not.toBeNull();
+    return instance as Redis;
+  };
+
+  const teardown = async (instance: Redis) => {
+    instance.disconnect();
+    await vi.waitFor(() => expect(instance.status).toBe("end"), {
+      timeout: 2_000,
+    });
+  };
+
+  it("survives disconnect(reconnect=true) during sentinel master resolution", async () => {
+    const instance = createSentinelInstance();
+    expect(instance.status).toBe("connecting");
+
+    // What bullmq's Worker.waitForJob watchdog fires when a blocking command
+    // gets no response in time: bclient.disconnect(!this.closing)
+    instance.disconnect(true);
+
+    // Give the in-flight sentinel resolution time to settle; unguarded, the
+    // pending connect() rejects and the client parks in terminal "end".
+    await sleep(500);
+    expect(instance.status).not.toBe("end");
+
+    await teardown(instance);
+  });
+
+  it("protects duplicated connections too (bullmq creates its blocking client via duplicate())", async () => {
+    const parent = createSentinelInstance();
+    const blocking = parent.duplicate();
+
+    expect(blocking.status).toBe("connecting");
+    blocking.disconnect(true);
+
+    await sleep(500);
+    expect(blocking.status).not.toBe("end");
+
+    await teardown(blocking);
+    await teardown(parent);
+  });
+
+  it("still tears down for real on disconnect() without reconnect intent", async () => {
+    const instance = createSentinelInstance();
+
+    await teardown(instance);
   });
 });

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -153,6 +153,38 @@ const createRedisClusterInstance = (
   return cluster;
 };
 
+/**
+ * BullMQ's Worker.waitForJob arms a watchdog that calls
+ * `bclient.disconnect(true)` when a blocking command gets no response in
+ * time. In sentinel mode the client spends whole seconds in status
+ * "connecting" with no live socket while it resolves the master through the
+ * sentinels (initial connect and every reconnect — e.g. during a failover).
+ * A disconnect landing in that window can never emit a socket "close" event,
+ * so retryStrategy is never consulted: the in-flight connect() rejects and
+ * ioredis parks the client in the terminal "end" state with all further
+ * errors silenced. Workers then stay detached from Redis until the process
+ * restarts (#13880). Suppressing exactly that call shape is safe: during
+ * master resolution no command is on the wire to unstick, and the pending
+ * resolution already retries on its own. BullMQ builds its blocking client
+ * via duplicate(), so duplicates must inherit the guard.
+ */
+const guardSentinelDisconnect = (instance: Redis): Redis => {
+  const originalDisconnect = instance.disconnect.bind(instance);
+  instance.disconnect = (reconnect = false): void => {
+    if (reconnect && instance.status === "connecting") {
+      logger.warn(
+        "Suppressed disconnect(reconnect=true) on a Redis sentinel connection during master resolution; it would park the connection in the unrecoverable 'end' state",
+      );
+      return;
+    }
+    originalDisconnect(reconnect);
+  };
+  const originalDuplicate = instance.duplicate.bind(instance);
+  instance.duplicate = (override?: Partial<RedisOptions>): Redis =>
+    guardSentinelDisconnect(originalDuplicate(override));
+  return instance;
+};
+
 const createRedisSentinelInstance = (
   additionalOptions: Partial<RedisOptions> = {},
 ): Redis | null => {
@@ -203,7 +235,7 @@ const createRedisSentinelInstance = (
     logger.error("Redis sentinel error", error);
   });
 
-  return instance;
+  return guardSentinelDisconnect(instance);
 };
 
 export const createNewRedisInstance = (


### PR DESCRIPTION
BullMQ's Worker.waitForJob arms a watchdog that calls bclient.disconnect(true) when a blocking command gets no response in time. In sentinel mode the client spends whole seconds in ioredis status "connecting" with no live socket while it resolves the master through the sentinels (initial connect and every reconnect, e.g. during a failover). A disconnect landing in that window can never emit a socket "close" event, so retryStrategy is never consulted: the in-flight connect() rejects and ioredis parks the client in the terminal "end" state with all further errors silenced. Worker pods then stay detached from Redis until restarted.

Reproduced with a local sentinel topology (master + replica + 3 sentinels, ioredis 5.10.1 + bullmq 5.76.3): a \~45s total outage reliably killed every worker blocking connection \~6s in, and they never recovered after Redis returned. With the guard, the same scenario recovers fully.

Suppress exactly that call shape - disconnect(reconnect=true) while the client is resolving the master - and propagate the guard through duplicate(), which is how BullMQ creates its blocking clients. During resolution no command is on the wire to unstick, and the pending resolution already retries on its own, so the suppressed call loses nothing. All other disconnect paths (shutdown, quit, BullMQ's own disconnect-then-reconnect flows) pass through unchanged.

Fixes langfuse/langfuse#13880