### PR TITLE
fix(filters): use legacy environments in dual mode

### DIFF
--- a/packages/shared/src/server/repositories/environments.test.ts
+++ b/packages/shared/src/server/repositories/environments.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { env } from "../../env";
+import { getEnvironmentsForProject } from "./environments";
+import { queryClickhouse } from "./clickhouse";
+
+vi.mock("./clickhouse", () => ({
+  queryClickhouse: vi.fn(),
+}));
+
+const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+
+afterEach(() => {
+  vi.mocked(queryClickhouse).mockReset();
+  (
+    env as { LANGFUSE_MIGRATION_V4_WRITE_MODE: string }
+  ).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+});
+
+describe("getEnvironmentsForProject", () => {
+  it("returns legacy environments for legacy table filters in dual mode", async () => {
+    (
+      env as { LANGFUSE_MIGRATION_V4_WRITE_MODE: string }
+    ).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+
+    vi.mocked(queryClickhouse).mockImplementation(({ query }) => {
+      if (query.includes("FROM traces")) {
+        return Promise.resolve([{ environment: "prod" }]);
+      }
+      if (query.includes("FROM events_core")) {
+        return Promise.resolve([{ environment: "PROD" }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await expect(
+      getEnvironmentsForProject({ projectId: "project-id" }),
+    ).resolves.toEqual([{ environment: "prod" }, { environment: "default" }]);
+  });
+
+  it("returns events environments in events-only mode", async () => {
+    (
+      env as { LANGFUSE_MIGRATION_V4_WRITE_MODE: string }
+    ).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
+
+    vi.mocked(queryClickhouse).mockImplementation(({ query }) => {
+      if (query.includes("FROM events_core")) {
+        return Promise.resolve([{ environment: "PROD" }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await expect(
+      getEnvironmentsForProject({ projectId: "project-id" }),
+    ).resolves.toEqual([{ environment: "PROD" }, { environment: "default" }]);
+  });
+});

--- a/packages/shared/src/server/repositories/environments.ts
+++ b/packages/shared/src/server/repositories/environments.ts
@@ -12,14 +12,14 @@ export const getEnvironmentsForProject = async (
 ): Promise<{ environment: string }[]> => {
   const { projectId, fromTimestamp } = props;
 
-  // In dual and events_only write modes all tracing data lands in the events
-  // tables: a single events_core scan covers traces and observations and is
-  // the only populated source under events_only. Scores keep their own table
-  // in every write mode. The events read may be routed to a dedicated
-  // ClickHouse service (CLICKHOUSE_EVENTS_READ_ONLY_URL), so it cannot share
-  // a query with the scores read.
+  // This lookup feeds legacy-table filters, so dual mode must use the matching
+  // legacy traces/observations values. In events_only mode those tables are no
+  // longer populated, and a single events_core scan covers tracing data.
+  // Scores keep their own table in every write mode. The events read may be
+  // routed to a dedicated ClickHouse service
+  // (CLICKHOUSE_EVENTS_READ_ONLY_URL), so it cannot share a query with scores.
   const tracingEnvironmentsPromise =
-    env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "legacy"
+    env.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "events_only"
       ? queryClickhouse<{ environment: string }>({
           query: `
             (


### PR DESCRIPTION
## Summary

- make dual-write deployments source environment options from the legacy tracing tables used by the v3 filters
- keep events-only deployments sourced from `events_core`
- add focused coverage for both routing modes

## Root cause

The shared environment-options lookup switched dual mode to `events_core` in #14959. The v3 traces/observations facets still consume that lookup while filtering the legacy tables with case-sensitive values, so an events value such as `PROD` could not match the corresponding legacy `prod` rows.

## Impacted package

- `@langfuse/shared`

## Verification

- `pnpm exec dotenv -e .env.dev.example -e .env.test.example -- pnpm --filter @langfuse/shared run test environments.test.ts` — 2 passed
- `pnpm run lint` — Tasks: 7 successful, 7 total
- `pnpm exec dotenv -e .env.dev.example -e .env.test.example -- pnpm --filter @langfuse/shared run typecheck` — passed
- `pnpm exec dotenv -e .env.dev.example -e .env.test.example -- pnpm --filter web run typecheck` — passed
- `pnpm exec dotenv -e .env.dev.example -e .env.test.example -- pnpm --filter worker run typecheck` — passed

Linear: [LFE-14403](https://linear.app/clickhouse/issue/LFE-14403/environment-filter-shows-prod-instead-of-prod)