### PR TITLE
fix(prompts): reject invalid table columns as bad requests

### DIFF
--- a/packages/shared/src/server/filterToPrisma.ts
+++ b/packages/shared/src/server/filterToPrisma.ts
@@ -4,6 +4,7 @@ import { FilterState } from "../types";
 import { filterOperators, timeFilter } from "../interfaces/filters";
 import { z } from "zod";
 import { logger } from "./index";
+import { InvalidRequestError } from "../errors";
 
 const operatorReplacements = {
   "any of": "IN",
@@ -53,7 +54,7 @@ export function tableColumnsToSqlFilter(
     );
     if (!col) {
       logger.error("Invalid filter column", filter.column);
-      throw new Error("Invalid filter column: " + filter.column);
+      throw new InvalidRequestError("Invalid filter column: " + filter.column);
     }
     const colPrisma = Prisma.raw(col.internal);
     return {

--- a/packages/shared/src/server/orderByToPrisma.ts
+++ b/packages/shared/src/server/orderByToPrisma.ts
@@ -5,6 +5,7 @@ import { Prisma } from "@prisma/client";
 import type { ColumnDefinition } from "../tableDefinitions/types";
 import type { OrderByState } from "../interfaces/orderBy";
 import { logger } from "./logger";
+import { InvalidRequestError } from "../errors";
 
 /**
  * Convert orderBy to SQL ORDER BY clause
@@ -28,7 +29,7 @@ export function orderByToPrismaSql(
 
   if (!col) {
     logger.warn("Invalid filter column", orderBy.column);
-    throw new Error("Invalid filter column: " + orderBy.column);
+    throw new InvalidRequestError("Invalid filter column: " + orderBy.column);
   }
 
   // Assert that orderBy.order is either "asc" or "desc"

--- a/web/src/__tests__/server/orderByToPrisma.servertest.ts
+++ b/web/src/__tests__/server/orderByToPrisma.servertest.ts
@@ -16,7 +16,7 @@ import {
 
 // The test for the orderByToPrisma function
 describe("orderByToPrisma (Convert orderBy to Prisma.sql)", () => {
-  test("orderByToPrisma throws error for orderBy column not included in column defs", () => {
+  test("orderByToPrisma throws InvalidRequestError for orderBy column not included in column defs", () => {
     expect(() =>
       orderByToPrismaSql(
         {
@@ -25,7 +25,7 @@ describe("orderByToPrisma (Convert orderBy to Prisma.sql)", () => {
         },
         tracesTableCols,
       ),
-    ).toThrow(/Invalid filter column: InvalidCol/);
+    ).toThrow(InvalidRequestError);
   });
 
   test("orderByToPrisma throws error for orderBy order that is not valid", () => {

--- a/web/src/__tests__/server/prompts-trpc.servertest.ts
+++ b/web/src/__tests__/server/prompts-trpc.servertest.ts
@@ -7,9 +7,19 @@ import type { Session } from "next-auth";
 import { v4 } from "uuid";
 import waitForExpect from "wait-for-expect";
 
-async function prepare() {
-  const { project, org } = await createOrgProjectAndApiKey();
-
+function createCaller({
+  projectId,
+  orgId,
+  projectName = "Test project",
+  orgName = "Test organization",
+  admin = true,
+}: {
+  projectId: string;
+  orgId: string;
+  projectName?: string;
+  orgName?: string;
+  admin?: boolean;
+}) {
   const session: Session = {
     expires: "1",
     user: {
@@ -18,8 +28,8 @@ async function prepare() {
       name: "Demo User",
       organizations: [
         {
-          id: org.id,
-          name: org.name,
+          id: orgId,
+          name: orgName,
           role: "OWNER",
           plan: "cloud:hobby",
           cloudConfig: undefined,
@@ -28,12 +38,12 @@ async function prepare() {
           aiTelemetryEnabled: false,
           projects: [
             {
-              id: project.id,
+              id: projectId,
               role: "ADMIN",
               retentionDays: 30,
               deletedAt: null,
               hasTraces: false,
-              name: project.name,
+              name: projectName,
               metadata: {},
               createdAt: new Date().toISOString(),
             },
@@ -48,7 +58,7 @@ async function prepare() {
         observationEvals: false,
         experimentsV4Enabled: false,
       },
-      admin: true,
+      admin,
     },
     environment: {
       enableExperimentalFeatures: false,
@@ -59,6 +69,18 @@ async function prepare() {
   const ctx = createInnerTRPCContext({ session, headers: {} });
   const caller = appRouter.createCaller({ ...ctx, prisma });
 
+  return { session, ctx, caller };
+}
+
+async function prepare() {
+  const { project, org } = await createOrgProjectAndApiKey();
+  const { session, ctx, caller } = createCaller({
+    projectId: project.id,
+    orgId: org.id,
+    projectName: project.name,
+    orgName: org.name,
+  });
+
   return { project, org, session, ctx, caller };
 }
 
@@ -66,6 +88,50 @@ describe("prompts trpc", () => {
   afterAll(async () => {
     await disconnectQueues();
   });
+  describe("prompts.all input validation", () => {
+    it.each([
+      {
+        caseName: "filter",
+        filter: [
+          {
+            column: "bogus_xyz",
+            type: "string" as const,
+            operator: "=" as const,
+            value: "test",
+          },
+        ],
+        orderBy: { column: "createdAt", order: "DESC" as const },
+      },
+      {
+        caseName: "order by",
+        filter: [],
+        orderBy: { column: "bogus_xyz", order: "DESC" as const },
+      },
+    ])(
+      "rejects an invalid $caseName column as BAD_REQUEST",
+      async ({ filter, orderBy }) => {
+        const projectId = v4();
+        const { caller } = createCaller({
+          projectId,
+          orgId: v4(),
+          admin: false,
+        });
+
+        await expect(
+          caller.prompts.all({
+            projectId,
+            page: 0,
+            limit: 10,
+            filter,
+            orderBy,
+          }),
+        ).rejects.toMatchObject({
+          code: "BAD_REQUEST",
+        });
+      },
+    );
+  });
+
   describe("prompts.allVersions", () => {
     it("returns comment counts for the requested prompt version page only", async () => {
       const { project, caller } = await prepare();


### PR DESCRIPTION
## Summary

- map rejected PostgreSQL filter and order-by columns to `InvalidRequestError`
- return tRPC `BAD_REQUEST` instead of HTTP 500 for crafted `prompts.all` columns
- add database-free endpoint regressions for invalid filter and sort columns

Linear: [LFE-14500](https://linear.app/clickhouse/issue/LFE-14500/bug-promptsall-returns-500-for-rejected-filter-columns-in-prod-eu)

## Impacted packages

- `@langfuse/shared`
- `web`

## Verification

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter worker run typecheck` — exit 0
- `pnpm --filter @langfuse/shared run build` — exit 0
- `pnpm --filter web run test prompts-trpc.servertest.ts -t "prompts.all input validation"` — `Tests 2 passed | 18 skipped (20)`
- `pnpm --filter web run test orderByToPrisma.servertest.ts` — `Tests 6 passed (6)`
- `git diff --check` — exit 0

## Scope

This changes only error classification for unknown allowlisted columns. Accepted filters, sorting, SQL generation, and public API contracts are unchanged.