### PR TITLE
build: run snyk on v3 branch (v3 backport of #15479)

### DIFF
--- a/.github/workflows/snyk-web.yml
+++ b/.github/workflows/snyk-web.yml
@@ -1,7 +1,7 @@
 name: Snyk Container - Web
 on:
   push:
-    branches: ["production", "main"]
+    branches: ["production", "main", "v3"]
 
 permissions:
   contents: read

--- a/.github/workflows/snyk-worker.yml
+++ b/.github/workflows/snyk-worker.yml
@@ -1,7 +1,7 @@
 name: Snyk Container - Worker
 on:
   push:
-    branches: ["production", "main"]
+    branches: ["production", "main", "v3"]
 
 permissions:
   contents: read


### PR DESCRIPTION
Backports #15479 (`22a2cb008`) from `main` to `v3`, adding `v3` to the `push` branch filters of `snyk-web.yml` and `snyk-worker.yml`.

Why this is needed on `v3` itself: the Snyk container scans are `push`-triggered, and GitHub evaluates push-triggered workflows from the workflow file at the pushed commit on that branch. With #15479 only on `main`, pushes to `v3` still see the old `["production", "main"]` filter and never fire. Once this merges, the merge push itself already carries the new filter, so both Snyk workflows run against `v3` immediately — and again on every subsequent merge (e.g. the pending v3 security backports #15473–#15477).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
