### PR TITLE
feat(agent): Silent mode for tools

### DIFF
--- a/packages/shared/src/in-app-agent/constants.ts
+++ b/packages/shared/src/in-app-agent/constants.ts
@@ -3,6 +3,10 @@ export const IN_APP_AGENT_REDIRECT_TOOL_NAME = "langfuse_proposeRedirect";
 
 export const IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE = "tool_call_rejected";
 
+export const IN_APP_AGENT_SILENT_MCP_OUTPUT_TYPE = "silent-mcp-output";
+export const IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE =
+  "Output saved to /workspace/tool_calls";
+
 export const IN_APP_AGENT_MCP_USER_AGENT = "langfuse-in-app-agent";
 
 // Header used only by Langfuse's server-side in-app agent when it calls the

--- a/packages/shared/src/in-app-agent/server/agent.ts
+++ b/packages/shared/src/in-app-agent/server/agent.ts
@@ -23,7 +23,9 @@ import {
   createSandboxTools,
   createRedirectActionTool,
   filterInAppAgentAvailableLangfuseMcpTools,
+  getPublicInAppAgentMcpToolResultContent,
   type InAppAgentUserAccess,
+  withOptionalSilentMcpOutput,
   withInAppAgentToolApproval,
 } from "./tools";
 import { LANGFUSE_IN_APP_AGENT_SKILLS } from "./skills";
@@ -123,7 +125,7 @@ function formatSandboxContext(sandbox?: InAppAgentSandbox): string {
 <sandbox_filesystem>
 When working in the sandbox filesystem, assume this layout:
 - "/workspace" is the current working directory for normal file operations and shell commands.
-- "/workspace/tool_calls" contains all past tool calls and their outputs. Treat this directory as read-only. Any changes to it will be discarded before the next tool call.
+- "/workspace/tool_calls" contains all past tool calls and their outputs, including full results requested with the silent argument. Treat this directory as read-only; any changes to it will be discarded before the next tool call.
 </sandbox_filesystem>
 `;
 }
@@ -347,8 +349,19 @@ export async function createAgUiStream(params: {
               return;
             }
 
+            const publicEvent =
+              agUiEvent.type === EventType.TOOL_CALL_RESULT &&
+              typeof agUiEvent.content === "string"
+                ? {
+                    ...agUiEvent,
+                    content: getPublicInAppAgentMcpToolResultContent(
+                      agUiEvent.content,
+                    ),
+                  }
+                : agUiEvent;
+
             controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify(agUiEvent)}\n\n`),
+              encoder.encode(`data: ${JSON.stringify(publicEvent)}\n\n`),
             );
           })
           .catch((error: unknown) => {
@@ -777,12 +790,21 @@ async function createMastraAdapter(params: {
     const tools = withInAppAgentToolApproval({
       ...prefixToolsetTools(
         "langfuse",
-        filterInAppAgentAvailableLangfuseMcpTools({
-          tools: toolsets.langfuse,
-          userAccess: params.options.langfuseMcp.userAccess,
+        withOptionalSilentMcpOutput({
+          tools: filterInAppAgentAvailableLangfuseMcpTools({
+            tools: toolsets.langfuse,
+            userAccess: params.options.langfuseMcp.userAccess,
+          }),
+          sandbox: params.options.sandbox,
         }),
       ),
-      ...prefixToolsetTools("langfuseDocs", toolsets.langfuseDocs),
+      ...prefixToolsetTools(
+        "langfuseDocs",
+        withOptionalSilentMcpOutput({
+          tools: toolsets.langfuseDocs,
+          sandbox: params.options.sandbox,
+        }),
+      ),
       [IN_APP_AGENT_REDIRECT_TOOL_NAME]: createRedirectActionTool({
         projectId: params.options.redirectAction.projectId,
         isV4Enabled: params.options.redirectAction.isV4Enabled,
@@ -859,7 +881,10 @@ async function createMastraAdapter(params: {
           },
         });
 
-        return tool.toModelOutput ? tool.toModelOutput(result) : result;
+        return {
+          result,
+          modelResult: tool.toModelOutput ? tool.toModelOutput(result) : result,
+        };
       },
       interrupt: () => agent.abortRunStream(params.input.runId),
       cleanup: () => mcpClient.disconnect(),

--- a/packages/shared/src/in-app-agent/server/agent.ts
+++ b/packages/shared/src/in-app-agent/server/agent.ts
@@ -708,7 +708,7 @@ export async function createAgUiStream(params: {
 
 type ExecutableInAppAgentTool = {
   execute?: (inputData: unknown, context: unknown) => Promise<unknown>;
-  toModelOutput?: (output: unknown) => unknown;
+  toModelOutput?: (output: unknown) => unknown | PromiseLike<unknown>;
 };
 
 async function createMastraAdapter(params: {
@@ -874,7 +874,9 @@ async function createMastraAdapter(params: {
 
         return {
           result,
-          modelResult: tool.toModelOutput ? tool.toModelOutput(result) : result,
+          modelResult: tool.toModelOutput
+            ? await tool.toModelOutput(result)
+            : result,
         };
       },
       interrupt: () => agent.abortRunStream(params.input.runId),

--- a/packages/shared/src/in-app-agent/server/agent.ts
+++ b/packages/shared/src/in-app-agent/server/agent.ts
@@ -23,6 +23,7 @@ import {
   createSandboxTools,
   createRedirectActionTool,
   filterInAppAgentAvailableLangfuseMcpTools,
+  type CompletedInAppAgentMcpToolCall,
   type InAppAgentUserAccess,
   withOptionalSilentMcpOutput,
   withInAppAgentToolApproval,
@@ -155,6 +156,7 @@ export function getBedrockReasoningProviderOptions(modelId: string) {
 
 type CreateAgUiStreamOptions = {
   onEvent?: (event: AgUiEvent) => void | Promise<void>;
+  onMcpToolCallCompleted?: (toolCall: CompletedInAppAgentMcpToolCall) => void;
   onApprovedToolCallExecuted?: () => void | Promise<void>;
   onComplete?: () => void | Promise<void>;
   onAbort?: () => void | Promise<void>;
@@ -779,23 +781,22 @@ async function createMastraAdapter(params: {
     // discovery, then prefix tool names for constructor-based tools so the
     // model sees the same names that later appear in AG-UI tool-call events.
     const tools = withInAppAgentToolApproval({
-      ...prefixToolsetTools(
-        "langfuse",
-        withOptionalSilentMcpOutput({
-          tools: filterInAppAgentAvailableLangfuseMcpTools({
+      ...withOptionalSilentMcpOutput({
+        tools: prefixToolsetTools(
+          "langfuse",
+          filterInAppAgentAvailableLangfuseMcpTools({
             tools: toolsets.langfuse,
             userAccess: params.options.langfuseMcp.userAccess,
           }),
-          sandbox: params.options.sandbox,
-        }),
-      ),
-      ...prefixToolsetTools(
-        "langfuseDocs",
-        withOptionalSilentMcpOutput({
-          tools: toolsets.langfuseDocs,
-          sandbox: params.options.sandbox,
-        }),
-      ),
+        ),
+        sandbox: params.options.sandbox,
+        onToolCallCompleted: params.options.onMcpToolCallCompleted,
+      }),
+      ...withOptionalSilentMcpOutput({
+        tools: prefixToolsetTools("langfuseDocs", toolsets.langfuseDocs),
+        sandbox: params.options.sandbox,
+        onToolCallCompleted: params.options.onMcpToolCallCompleted,
+      }),
       [IN_APP_AGENT_REDIRECT_TOOL_NAME]: createRedirectActionTool({
         projectId: params.options.redirectAction.projectId,
         isV4Enabled: params.options.redirectAction.isV4Enabled,

--- a/packages/shared/src/in-app-agent/server/agent.ts
+++ b/packages/shared/src/in-app-agent/server/agent.ts
@@ -23,11 +23,11 @@ import {
   createSandboxTools,
   createRedirectActionTool,
   filterInAppAgentAvailableLangfuseMcpTools,
-  getPublicInAppAgentMcpToolResultContent,
   type InAppAgentUserAccess,
   withOptionalSilentMcpOutput,
   withInAppAgentToolApproval,
 } from "./tools";
+import { toPublicEvent } from "./watch";
 import { LANGFUSE_IN_APP_AGENT_SKILLS } from "./skills";
 import type { InAppAgentSandbox } from "./sandbox";
 import { DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS } from "../../features/filters/internalEnvironments";
@@ -349,19 +349,10 @@ export async function createAgUiStream(params: {
               return;
             }
 
-            const publicEvent =
-              agUiEvent.type === EventType.TOOL_CALL_RESULT &&
-              typeof agUiEvent.content === "string"
-                ? {
-                    ...agUiEvent,
-                    content: getPublicInAppAgentMcpToolResultContent(
-                      agUiEvent.content,
-                    ),
-                  }
-                : agUiEvent;
-
             controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify(publicEvent)}\n\n`),
+              encoder.encode(
+                `data: ${JSON.stringify(toPublicEvent(agUiEvent))}\n\n`,
+              ),
             );
           })
           .catch((error: unknown) => {

--- a/packages/shared/src/in-app-agent/server/human-in-the-loop.ts
+++ b/packages/shared/src/in-app-agent/server/human-in-the-loop.ts
@@ -176,7 +176,7 @@ export async function createManualToolApprovalRunInput(params: {
   input: AgUiRunAgentInput;
   executeToolCall: (
     approvalRequest: InAppAgentToolApprovalRequest,
-  ) => Promise<unknown>;
+  ) => Promise<{ result: unknown; modelResult: unknown }>;
   onApprovedToolCallExecuted?: () => void | Promise<void>;
 }): Promise<ManualToolApprovalRunInput> {
   const forwardedProps = getResumeForwardedProps(params.input);
@@ -220,18 +220,20 @@ export async function createManualToolApprovalRunInput(params: {
     };
   }
 
-  const { toolResult, toolError } = await executeApprovedToolCall({
-    approvalRequest,
-    executeToolCall: params.executeToolCall,
-  });
+  const { toolResult, modelToolResult, toolError } =
+    await executeApprovedToolCall({
+      approvalRequest,
+      executeToolCall: params.executeToolCall,
+    });
   await params.onApprovedToolCallExecuted?.();
   const toolResultContent = serializeToolResultContent(toolResult);
   const assistantMessage =
     createManualToolCallAssistantMessage(approvalRequest);
+  const modelToolResultContent = serializeToolResultContent(modelToolResult);
   const toolMessage: AgUiMessage = {
     id: createManualToolResultMessageId(approvalRequest),
     role: "tool",
-    content: toolResultContent,
+    content: modelToolResultContent,
     toolCallId: approvalRequest.toolCallId,
     ...(toolError ? { error: toolError } : {}),
   };
@@ -286,14 +288,22 @@ async function executeApprovedToolCall(params: {
   approvalRequest: InAppAgentToolApprovalRequest;
   executeToolCall: (
     approvalRequest: InAppAgentToolApprovalRequest,
-  ) => Promise<unknown>;
-}): Promise<{ toolResult: unknown; toolError?: string }> {
+  ) => Promise<{ result: unknown; modelResult: unknown }>;
+}): Promise<{
+  toolResult: unknown;
+  modelToolResult: unknown;
+  toolError?: string;
+}> {
   try {
-    return { toolResult: await params.executeToolCall(params.approvalRequest) };
+    const { result, modelResult } = await params.executeToolCall(
+      params.approvalRequest,
+    );
+
+    return { toolResult: result, modelToolResult: modelResult };
   } catch (error) {
     const toolError = formatToolExecutionError(error);
 
-    return { toolResult: toolError, toolError };
+    return { toolResult: toolError, modelToolResult: toolError, toolError };
   }
 }
 

--- a/packages/shared/src/in-app-agent/server/persistence.test.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 
 import type { PrismaClient } from "../../db";
 import { IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE } from "../constants";
-import { getConversationMessages } from "./persistence";
+import {
+  createSandboxToolCallFileAccumulator,
+  getConversationMessages,
+} from "./persistence";
 
 describe("getConversationMessages", () => {
   it("redacts silent MCP tool outputs", async () => {
@@ -41,6 +44,65 @@ describe("getConversationMessages", () => {
         role: "tool",
         toolCallId: "tool-call-1",
         content: IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE,
+      },
+    ]);
+  });
+});
+
+describe("createSandboxToolCallFileAccumulator", () => {
+  it("incrementally builds files from tool-call events", () => {
+    const accumulator = createSandboxToolCallFileAccumulator([]);
+    const createdAt = new Date("2026-08-05T00:00:00.000Z");
+
+    accumulator.processEvent({
+      createdAt,
+      runId: "run-1",
+      event: {
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tool-call-1",
+        toolCallName: "langfuse_getHealth",
+      },
+    });
+    accumulator.processEvent({
+      createdAt,
+      runId: "run-1",
+      event: {
+        type: EventType.TEXT_MESSAGE_CHUNK,
+        messageId: "message-1",
+        delta: "ignored token",
+      },
+    });
+    accumulator.processEvent({
+      createdAt,
+      runId: "run-1",
+      event: {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: "tool-call-1",
+        delta: '{"projectId":"project-1"}',
+      },
+    });
+    accumulator.processEvent({
+      createdAt,
+      runId: "run-1",
+      event: {
+        type: EventType.TOOL_CALL_RESULT,
+        toolCallId: "tool-call-1",
+        content: '{"status":"ok"}',
+      },
+    });
+
+    expect(accumulator.getFiles()).toEqual([
+      {
+        path: "tool_calls/2026-08-05T00-00-00.000Z_langfuse_getHealth_tool-call-1.json",
+        content: JSON.stringify(
+          {
+            request: { projectId: "project-1" },
+            response: { status: "ok" },
+            error: null,
+          },
+          null,
+          2,
+        ),
       },
     ]);
   });

--- a/packages/shared/src/in-app-agent/server/persistence.test.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.test.ts
@@ -1,0 +1,47 @@
+import { EventType } from "@ag-ui/core";
+import { describe, expect, it } from "vitest";
+
+import type { PrismaClient } from "../../db";
+import { IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE } from "../constants";
+import { getConversationMessages } from "./persistence";
+
+describe("getConversationMessages", () => {
+  it("redacts silent MCP tool outputs", async () => {
+    const content = JSON.stringify({
+      type: "silent-mcp-output",
+      output: { data: [{ id: "observation-1" }] },
+    });
+    const prisma = {
+      inAppAgentEvent: {
+        findMany: async () => [
+          {
+            event: {
+              type: EventType.TOOL_CALL_RESULT,
+              messageId: "tool-result-1",
+              toolCallId: "tool-call-1",
+              content,
+            },
+            runId: "run-1",
+            createdAt: new Date("2026-08-05T00:00:00.000Z"),
+            sequenceNumber: 0,
+          },
+        ],
+      },
+    } as unknown as PrismaClient;
+
+    await expect(
+      getConversationMessages({
+        prisma,
+        projectId: "project-1",
+        conversationId: "conversation-1",
+      }),
+    ).resolves.toEqual([
+      {
+        id: "tool-result-1",
+        role: "tool",
+        toolCallId: "tool-call-1",
+        content: IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE,
+      },
+    ]);
+  });
+});

--- a/packages/shared/src/in-app-agent/server/persistence.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.ts
@@ -765,7 +765,7 @@ function sanitizeConversationMessagesForReplay(
   );
 }
 
-function redactSilentToolMessages(messages: readonly AgUiMessage[]) {
+export function redactSilentToolMessages(messages: readonly AgUiMessage[]) {
   let changed = false;
   const sanitizedMessages = messages.map((message): AgUiMessage => {
     if (message.role !== "tool") {

--- a/packages/shared/src/in-app-agent/server/persistence.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.ts
@@ -38,7 +38,10 @@ import { assertConversationAccess } from "./access";
 import { compactPersistedEventDeltas } from "./eventCompaction";
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "../constants";
 import { safeJsonParse } from "../../utils/json";
-import { IN_APP_AGENT_SANDBOX_TOOL_NAMES } from "./tools";
+import {
+  getPublicInAppAgentMcpToolResultContent,
+  IN_APP_AGENT_SANDBOX_TOOL_NAMES,
+} from "./tools";
 
 // Keep this close to the route maxDuration (120s) so a killed foreground stream
 // does not block the conversation long after the route can no longer respond.
@@ -498,6 +501,24 @@ export async function getConversationMessages(params: {
   conversationId: string;
 }) {
   return getMessagesFromPersistedEvents(await getConversationEvents(params));
+}
+
+export async function getConversationMessagesForDisplay(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  conversationId: string;
+}) {
+  const messages = await getConversationMessages(params);
+  return dropEmptyAssistantMessages(
+    dropUnpairedAssistantToolCalls(messages),
+  ).map((message) =>
+    message.role === "tool"
+      ? {
+          ...message,
+          content: getPublicInAppAgentMcpToolResultContent(message.content),
+        }
+      : message,
+  );
 }
 
 export async function getConversationMessagesForReplay(params: {

--- a/packages/shared/src/in-app-agent/server/persistence.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.ts
@@ -39,6 +39,7 @@ import { compactPersistedEventDeltas } from "./eventCompaction";
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "../constants";
 import { safeJsonParse } from "../../utils/json";
 import {
+  type CompletedInAppAgentMcpToolCall,
   getPublicInAppAgentMcpToolResultContent,
   getSandboxInAppAgentMcpToolResultContent,
   IN_APP_AGENT_SANDBOX_TOOL_NAMES,
@@ -421,10 +422,7 @@ export async function getConversationEvents(params: {
   }));
 }
 
-/**
- * Returns `tool_calls` file payloads reconstructed from prior non-sandbox tool
- * calls so each sandbox session can mount the same context.
- */
+/** Builds sandbox `tool_calls` files from persisted and live MCP calls. */
 export function createSandboxToolCallFileAccumulator(
   events: readonly Omit<PersistedConversationEvent, "sequenceNumber">[],
 ) {
@@ -437,6 +435,31 @@ export function createSandboxToolCallFileAccumulator(
     }
   >();
   const files: Array<{ path: string; content: string }> = [];
+  const completedToolCallIds = new Set<string>();
+
+  const processToolCall = (toolCall: CompletedInAppAgentMcpToolCall) => {
+    if (completedToolCallIds.has(toolCall.toolCallId)) {
+      return;
+    }
+
+    const draft = drafts.get(toolCall.toolCallId);
+    drafts.delete(toolCall.toolCallId);
+    completedToolCallIds.add(toolCall.toolCallId);
+    files.push({
+      path: `tool_calls/${formatSandboxToolCallTimestamp(draft?.createdAt ?? toolCall.createdAt)}_${draft?.toolName ?? toolCall.toolName}_${toolCall.toolCallId}.json`,
+      content: JSON.stringify(
+        {
+          request: draft
+            ? parseSandboxToolCallValue(draft.request)
+            : toolCall.request,
+          response: toolCall.response,
+          error: toolCall.error,
+        },
+        null,
+        2,
+      ),
+    });
+  };
 
   const processEvent = ({
     event,
@@ -448,6 +471,7 @@ export function createSandboxToolCallFileAccumulator(
 
       if (
         toolCallId &&
+        !completedToolCallIds.has(toolCallId) &&
         toolName &&
         !IN_APP_AGENT_SANDBOX_TOOL_NAMES.has(toolName)
       ) {
@@ -477,11 +501,12 @@ export function createSandboxToolCallFileAccumulator(
     const toolCallId = getString(event, "toolCallId");
     const draft = toolCallId ? drafts.get(toolCallId) : undefined;
 
-    if (!toolCallId || !draft) {
+    if (!toolCallId || completedToolCallIds.has(toolCallId) || !draft) {
       return;
     }
 
     drafts.delete(toolCallId);
+    completedToolCallIds.add(toolCallId);
     files.push({
       path: `tool_calls/${formatSandboxToolCallTimestamp(draft.createdAt)}_${draft.toolName}_${toolCallId}.json`,
       content: JSON.stringify(
@@ -505,6 +530,7 @@ export function createSandboxToolCallFileAccumulator(
 
   return {
     processEvent,
+    processToolCall,
     getFiles: () => files,
   };
 }

--- a/packages/shared/src/in-app-agent/server/persistence.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.ts
@@ -512,16 +512,17 @@ export async function getConversationMessagesForDisplay(params: {
   projectId: string;
   conversationId: string;
 }) {
-  const messages = await getConversationMessages(params);
-  return dropEmptyAssistantMessages(
-    dropUnpairedAssistantToolCalls(messages),
-  ).map((message) =>
-    message.role === "tool"
-      ? {
-          ...message,
-          content: getPublicInAppAgentMcpToolResultContent(message.content),
-        }
-      : message,
+  return getConversationMessagesForDisplayFromEvents(
+    await getConversationEvents(params),
+  );
+}
+
+export function getConversationMessagesForDisplayFromEvents(
+  events: readonly PersistedConversationEvent[],
+) {
+  const messages = getMessagesFromPersistedEvents(events);
+  return redactSilentToolMessages(
+    dropEmptyAssistantMessages(dropUnpairedAssistantToolCalls(messages)),
   );
 }
 
@@ -702,7 +703,7 @@ function getMessagesFromPersistedEvents(
     accumulator.processEvent(event, runId);
   }
 
-  return accumulator.getMessages();
+  return redactSilentToolMessages(accumulator.getMessages());
 }
 
 function sanitizeConversationMessagesForReplay(
@@ -717,11 +718,8 @@ function sanitizeConversationMessagesForReplay(
   const messagesWithoutOrphanToolCalls = dropUnpairedAssistantToolCalls(
     messagesWithoutRedirectActions,
   );
-  const messagesWithoutSilentToolOutput = redactSilentToolMessages(
-    messagesWithoutOrphanToolCalls,
-  );
   return stripAssistantRunIds(
-    dropEmptyAssistantMessages(messagesWithoutSilentToolOutput),
+    dropEmptyAssistantMessages(messagesWithoutOrphanToolCalls),
   );
 }
 

--- a/packages/shared/src/in-app-agent/server/persistence.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.ts
@@ -425,7 +425,7 @@ export async function getConversationEvents(params: {
  * Returns `tool_calls` file payloads reconstructed from prior non-sandbox tool
  * calls so each sandbox session can mount the same context.
  */
-export function getSandboxToolCallFiles(
+export function createSandboxToolCallFileAccumulator(
   events: readonly Omit<PersistedConversationEvent, "sequenceNumber">[],
 ) {
   const drafts = new Map<
@@ -438,7 +438,10 @@ export function getSandboxToolCallFiles(
   >();
   const files: Array<{ path: string; content: string }> = [];
 
-  for (const { event, createdAt } of events) {
+  const processEvent = ({
+    event,
+    createdAt,
+  }: Omit<PersistedConversationEvent, "sequenceNumber">) => {
     if (event.type === EventType.TOOL_CALL_START) {
       const toolCallId = getString(event, "toolCallId");
       const toolName = getString(event, "toolCallName");
@@ -454,7 +457,7 @@ export function getSandboxToolCallFiles(
           request: "",
         });
       }
-      continue;
+      return;
     }
 
     if (event.type === EventType.TOOL_CALL_ARGS) {
@@ -464,18 +467,18 @@ export function getSandboxToolCallFiles(
       if (draft) {
         draft.request += getString(event, "delta") ?? "";
       }
-      continue;
+      return;
     }
 
     if (event.type !== EventType.TOOL_CALL_RESULT) {
-      continue;
+      return;
     }
 
     const toolCallId = getString(event, "toolCallId");
     const draft = toolCallId ? drafts.get(toolCallId) : undefined;
 
     if (!toolCallId || !draft) {
-      continue;
+      return;
     }
 
     drafts.delete(toolCallId);
@@ -494,9 +497,22 @@ export function getSandboxToolCallFiles(
         2,
       ),
     });
+  };
+
+  for (const event of events) {
+    processEvent(event);
   }
 
-  return files;
+  return {
+    processEvent,
+    getFiles: () => files,
+  };
+}
+
+export function getSandboxToolCallFiles(
+  events: readonly Omit<PersistedConversationEvent, "sequenceNumber">[],
+) {
+  return createSandboxToolCallFileAccumulator(events).getFiles();
 }
 
 export async function getConversationMessages(params: {

--- a/packages/shared/src/in-app-agent/server/persistence.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.ts
@@ -40,6 +40,7 @@ import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "../constants";
 import { safeJsonParse } from "../../utils/json";
 import {
   getPublicInAppAgentMcpToolResultContent,
+  getSandboxInAppAgentMcpToolResultContent,
   IN_APP_AGENT_SANDBOX_TOOL_NAMES,
 } from "./tools";
 
@@ -483,7 +484,10 @@ export function getSandboxToolCallFiles(
       content: JSON.stringify(
         {
           request: parseSandboxToolCallValue(draft.request),
-          response: parseSandboxToolCallValue(getString(event, "content")),
+          response: parseSandboxToolCallValue(
+            getString(event, "content"),
+            getSandboxInAppAgentMcpToolResultContent,
+          ),
           error: getString(event, "error") ?? null,
         },
         null,
@@ -713,9 +717,31 @@ function sanitizeConversationMessagesForReplay(
   const messagesWithoutOrphanToolCalls = dropUnpairedAssistantToolCalls(
     messagesWithoutRedirectActions,
   );
-  return stripAssistantRunIds(
-    dropEmptyAssistantMessages(messagesWithoutOrphanToolCalls),
+  const messagesWithoutSilentToolOutput = redactSilentToolMessages(
+    messagesWithoutOrphanToolCalls,
   );
+  return stripAssistantRunIds(
+    dropEmptyAssistantMessages(messagesWithoutSilentToolOutput),
+  );
+}
+
+function redactSilentToolMessages(messages: readonly AgUiMessage[]) {
+  let changed = false;
+  const sanitizedMessages = messages.map((message): AgUiMessage => {
+    if (message.role !== "tool") {
+      return message;
+    }
+
+    const content = getPublicInAppAgentMcpToolResultContent(message.content);
+    if (content === message.content) {
+      return message;
+    }
+
+    changed = true;
+    return { ...message, content };
+  });
+
+  return changed ? sanitizedMessages : messages;
 }
 
 export function shouldFlushPersistedEvent(event: AgUiEvent) {
@@ -1538,9 +1564,20 @@ function compactObject<T extends Record<string, unknown>>(value: T): T {
   ) as T;
 }
 
-function parseSandboxToolCallValue(value: string | undefined) {
+function parseSandboxToolCallValue(
+  value: string | undefined,
+  transform?: (value: string) => unknown,
+) {
   if (!value) {
     return null;
+  }
+
+  if (transform) {
+    try {
+      return transform(value);
+    } catch {
+      return value;
+    }
   }
 
   const parsed = safeJsonParse(value);

--- a/packages/shared/src/in-app-agent/server/tools.ts
+++ b/packages/shared/src/in-app-agent/server/tools.ts
@@ -622,6 +622,12 @@ export function getPublicInAppAgentMcpToolResultContent(content: string) {
   }
 }
 
+export function getSandboxInAppAgentMcpToolResultContent(content: string) {
+  const parsed = JSON.parse(content) as unknown;
+
+  return isSilentMcpToolOutput(parsed) ? parsed.output : parsed;
+}
+
 function isSilentMcpToolOutput(value: unknown): value is SilentMcpToolOutput {
   return (
     typeof value === "object" &&

--- a/packages/shared/src/in-app-agent/server/tools.ts
+++ b/packages/shared/src/in-app-agent/server/tools.ts
@@ -540,9 +540,19 @@ type SilentMcpToolOutput = {
   output: unknown;
 };
 
+export type CompletedInAppAgentMcpToolCall = {
+  toolCallId: string;
+  toolName: string;
+  request: unknown;
+  response: unknown;
+  error: string | null;
+  createdAt: Date;
+};
+
 export function withOptionalSilentMcpOutput(params: {
   tools: Record<string, unknown> | undefined;
   sandbox?: InAppAgentSandbox;
+  onToolCallCompleted?: (toolCall: CompletedInAppAgentMcpToolCall) => void;
 }): Record<string, Tool> {
   return Object.fromEntries(
     Object.entries(params.tools ?? {}).map(([toolName, tool]) => {
@@ -586,8 +596,37 @@ export function withOptionalSilentMcpOutput(params: {
 
       tool.execute = async (input, context) => {
         const { silent, ...toolInput } = SilentMcpToolInputSchema.parse(input);
+        const toolCallId = getToolCallId(context);
+        const createdAt = new Date();
+        let result: unknown;
 
-        const result: unknown = await execute(toolInput, context);
+        try {
+          result = await execute(toolInput, context);
+        } catch (error) {
+          if (toolCallId) {
+            params.onToolCallCompleted?.({
+              toolCallId,
+              toolName,
+              request: input,
+              response: null,
+              error: error instanceof Error ? error.message : String(error),
+              createdAt,
+            });
+          }
+
+          throw error;
+        }
+
+        if (toolCallId) {
+          params.onToolCallCompleted?.({
+            toolCallId,
+            toolName,
+            request: input,
+            response: result,
+            error: null,
+            createdAt,
+          });
+        }
 
         if (!silent) {
           return result;
@@ -610,6 +649,22 @@ export function withOptionalSilentMcpOutput(params: {
       return [toolName, tool];
     }),
   ) as Record<string, Tool>;
+}
+
+function getToolCallId(context: unknown) {
+  if (
+    typeof context !== "object" ||
+    context === null ||
+    !("agent" in context) ||
+    typeof context.agent !== "object" ||
+    context.agent === null ||
+    !("toolCallId" in context.agent) ||
+    typeof context.agent.toolCallId !== "string"
+  ) {
+    return undefined;
+  }
+
+  return context.agent.toolCallId;
 }
 
 export function getPublicInAppAgentMcpToolResultContent(content: string) {

--- a/packages/shared/src/in-app-agent/server/tools.ts
+++ b/packages/shared/src/in-app-agent/server/tools.ts
@@ -1,4 +1,8 @@
-import { createTool } from "@mastra/core/tools";
+import {
+  standardSchemaToJSONSchema,
+  toStandardSchema,
+} from "@mastra/core/schema";
+import { createTool, Tool } from "@mastra/core/tools";
 import type { InAppAgentSandbox } from "./sandbox";
 import {
   hasProjectAccessByRole,
@@ -27,7 +31,11 @@ import z from "zod";
 import { TABLE_AGGREGATION_OPTIONS } from "../../utils/dateRanges";
 import { ObservationLevelDomain, TracingSearchType } from "../../index";
 import { Role } from "../../db";
-import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "../constants";
+import {
+  IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE,
+  IN_APP_AGENT_SILENT_MCP_OUTPUT_TYPE,
+} from "../constants";
 
 type InAppAgentMcpToolApproval = "auto" | "approval";
 
@@ -515,6 +523,113 @@ export function createSandboxTools(sandbox: InAppAgentSandbox) {
         sandbox.bash({ command, timeoutMs }),
     }),
   };
+}
+
+const SILENT_MCP_TOOL_PARAMETER_DESCRIPTION =
+  "Suppress the tool output from the conversation and save the full result to /workspace/tool_calls.";
+
+const SilentMcpToolInputSchema = z.looseObject({
+  silent: z
+    .boolean()
+    .optional()
+    .describe(SILENT_MCP_TOOL_PARAMETER_DESCRIPTION),
+});
+
+type SilentMcpToolOutput = {
+  type: typeof IN_APP_AGENT_SILENT_MCP_OUTPUT_TYPE;
+  output: unknown;
+};
+
+export function withOptionalSilentMcpOutput(params: {
+  tools: Record<string, unknown> | undefined;
+  sandbox?: InAppAgentSandbox;
+}): Record<string, Tool> {
+  return Object.fromEntries(
+    Object.entries(params.tools ?? {}).map(([toolName, tool]) => {
+      if (!params.sandbox) {
+        return [toolName, tool];
+      }
+
+      if (!(tool instanceof Tool)) {
+        return [toolName, tool];
+      }
+
+      const { execute, inputSchema, toModelOutput } = tool;
+      if (!execute || !inputSchema) {
+        return [toolName, tool];
+      }
+
+      if (inputSchema instanceof z.ZodObject) {
+        tool.inputSchema = inputSchema.extend({
+          silent: z
+            .boolean()
+            .optional()
+            .describe(SILENT_MCP_TOOL_PARAMETER_DESCRIPTION),
+        });
+      } else {
+        const jsonInputSchema = standardSchemaToJSONSchema(inputSchema);
+        if (jsonInputSchema.type !== "object") {
+          return [toolName, tool];
+        }
+
+        tool.inputSchema = toStandardSchema({
+          ...jsonInputSchema,
+          properties: {
+            ...jsonInputSchema.properties,
+            silent: {
+              type: "boolean",
+              description: SILENT_MCP_TOOL_PARAMETER_DESCRIPTION,
+            },
+          },
+        });
+      }
+
+      tool.execute = async (input, context) => {
+        const { silent, ...toolInput } = SilentMcpToolInputSchema.parse(input);
+
+        const result: unknown = await execute(toolInput, context);
+
+        if (!silent) {
+          return result;
+        }
+
+        // Preserve the raw result for the existing tool_calls persistence flow.
+        return {
+          type: IN_APP_AGENT_SILENT_MCP_OUTPUT_TYPE,
+          output: result,
+        } satisfies SilentMcpToolOutput;
+      };
+      tool.toModelOutput = (output) => {
+        if (isSilentMcpToolOutput(output)) {
+          return IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE;
+        }
+
+        return toModelOutput ? toModelOutput(output) : output;
+      };
+
+      return [toolName, tool];
+    }),
+  ) as Record<string, Tool>;
+}
+
+export function getPublicInAppAgentMcpToolResultContent(content: string) {
+  try {
+    return isSilentMcpToolOutput(JSON.parse(content) as unknown)
+      ? IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE
+      : content;
+  } catch {
+    return content;
+  }
+}
+
+function isSilentMcpToolOutput(value: unknown): value is SilentMcpToolOutput {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === IN_APP_AGENT_SILENT_MCP_OUTPUT_TYPE &&
+    "output" in value
+  );
 }
 
 const InAppAgentRedirectDestinationSchema = z.enum([

--- a/packages/shared/src/in-app-agent/server/watch.test.ts
+++ b/packages/shared/src/in-app-agent/server/watch.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { InAppAgentRunStatus } from "../../index";
 import type { PrismaClient } from "../../db";
+import { IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE } from "../constants";
 import type { InAppAgentWatchFrame } from "../backgroundWatch";
 import { watchConversationFrames } from "./watch";
 
@@ -288,6 +289,44 @@ describe("watchConversationFrames", () => {
     expect(relayedRunStarted?.event).toMatchObject({
       type: EventType.RUN_STARTED,
       runId: "run-1",
+    });
+  });
+
+  it("redacts silent MCP tool outputs from relayed tool result events", async () => {
+    const frames = await collect(
+      fakePrisma([
+        {
+          events: [
+            runStarted("run-1", 0),
+            {
+              sequenceNumber: 1,
+              runId: "run-1",
+              event: {
+                type: EventType.TOOL_CALL_RESULT,
+                messageId: "tool-result-1",
+                toolCallId: "tool-call-1",
+                role: "tool",
+                content: JSON.stringify({
+                  type: "silent-mcp-output",
+                  output: { data: [{ id: "observation-1" }] },
+                }),
+              },
+            },
+            runFinished("run-1", 2),
+          ],
+          run: succeeded,
+        },
+      ]),
+      -1,
+    );
+
+    const relayedToolResult = eventFrames(frames).find(
+      (frame) => frame.event.type === EventType.TOOL_CALL_RESULT,
+    );
+
+    expect(relayedToolResult?.event).toMatchObject({
+      type: EventType.TOOL_CALL_RESULT,
+      content: IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE,
     });
   });
 

--- a/packages/shared/src/in-app-agent/server/watch.ts
+++ b/packages/shared/src/in-app-agent/server/watch.ts
@@ -8,6 +8,7 @@ import {
 } from "../backgroundWatch";
 import type { AgUiEvent } from "../schema";
 import { reconcileConversationRuns } from "./runLifecycle";
+import { getPublicInAppAgentMcpToolResultContent } from "./tools";
 import {
   IN_APP_AGENT_HEARTBEAT_STALE_MS,
   IN_APP_AGENT_WATCH_KEEPALIVE_MS,
@@ -227,16 +228,27 @@ function isStaleClaimedRun(
   return now - lastSign.getTime() > IN_APP_AGENT_HEARTBEAT_STALE_MS;
 }
 
-/** Match foreground streaming by withholding persisted replay input. */
+/** Match foreground streaming by withholding private persisted event payloads. */
 function toPublicEvent(event: AgUiEvent): AgUiEvent {
-  if (event.type !== EventType.RUN_STARTED || event.input === undefined) {
-    return event;
+  if (event.type === EventType.RUN_STARTED && event.input !== undefined) {
+    const publicEvent = { ...event };
+    delete publicEvent.input;
+
+    return publicEvent;
   }
 
-  const publicEvent = { ...event };
-  delete publicEvent.input;
+  if (event.type === EventType.TOOL_CALL_RESULT) {
+    if (typeof event.content !== "string") {
+      return event;
+    }
 
-  return publicEvent;
+    return {
+      ...event,
+      content: getPublicInAppAgentMcpToolResultContent(event.content),
+    };
+  }
+
+  return event;
 }
 
 function syntheticFrame(

--- a/packages/shared/src/in-app-agent/server/watch.ts
+++ b/packages/shared/src/in-app-agent/server/watch.ts
@@ -229,7 +229,7 @@ function isStaleClaimedRun(
 }
 
 /** Match foreground streaming by withholding private persisted event payloads. */
-function toPublicEvent(event: AgUiEvent): AgUiEvent {
+export function toPublicEvent(event: AgUiEvent): AgUiEvent {
   if (event.type === EventType.RUN_STARTED && event.input !== undefined) {
     const publicEvent = { ...event };
     delete publicEvent.input;

--- a/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
@@ -41,6 +41,7 @@ import { inAppAgentRouter } from "@/src/features/in-app-agent/server/router";
 import {
   createRun,
   ensureOwnedConversation,
+  getConversationEvents,
   finishRun,
   getConversationMessagesForReplay,
   maybeInferAndPersistConversationTitle,
@@ -1459,6 +1460,84 @@ describe("in-app agent persistence", () => {
         toolCallId: "paired-tool-call",
       },
     ]);
+  });
+
+  it("redacts silent MCP output from replayed conversation history", async () => {
+    const { projectId, userId } = await createCaller();
+    const conversation = await createConversation({ projectId, userId });
+    const run = await createConversationRun({
+      projectId,
+      conversationId: conversation.id,
+      userId,
+    });
+    const events = await startCompactRun({
+      projectId,
+      conversationId: conversation.id,
+      runId: run.id,
+      messageId: "user-1",
+      content: "search observations silently",
+    });
+    const process = (event: AgUiEvent) =>
+      processAndPersistEvent({
+        projectId,
+        conversationId: conversation.id,
+        runId: run.id,
+        events,
+        event,
+      });
+
+    await process({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tool-call-1",
+      toolCallName: "langfuse_listObservations",
+      parentMessageId: "assistant-1",
+    });
+    await process({
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: "tool-call-1",
+      delta: JSON.stringify({ silent: true, traceId: "trace-1" }),
+    });
+    await process({
+      type: EventType.TOOL_CALL_END,
+      toolCallId: "tool-call-1",
+    });
+    await process({
+      type: EventType.TOOL_CALL_RESULT,
+      messageId: "tool-result-1",
+      toolCallId: "tool-call-1",
+      content: JSON.stringify({
+        type: "silent-mcp-output",
+        output: { data: [{ id: "observation-1" }] },
+      }),
+      role: "tool",
+    });
+
+    await expect(
+      getConversationMessagesForReplay({
+        prisma,
+        projectId,
+        conversationId: conversation.id,
+      }),
+    ).resolves.toContainEqual({
+      id: "tool-result-1",
+      role: "tool",
+      content: "Output saved to /workspace/tool_calls",
+      toolCallId: "tool-call-1",
+    });
+
+    const persistedEvents = await getConversationEvents({
+      prisma,
+      projectId,
+      conversationId: conversation.id,
+    });
+    expect(persistedEvents).toContainEqual(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: EventType.TOOL_CALL_ARGS,
+          delta: JSON.stringify({ silent: true, traceId: "trace-1" }),
+        }),
+      }),
+    );
   });
 
   it("drops assistant tool calls without results from loaded conversation history", async () => {

--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -58,6 +58,18 @@ const adapterEvents = vi.hoisted(() => ({
     name: "readiness",
     dataType: "NUMERIC",
   }),
+  createScoreConfigToModelOutput: vi.fn((output: unknown) => {
+    if (
+      typeof output === "object" &&
+      output !== null &&
+      "type" in output &&
+      output.type === "silent-mcp-output"
+    ) {
+      return "Output saved to /workspace/tool_calls";
+    }
+
+    return output;
+  }),
 }));
 
 const instrumentationMocks = vi.hoisted(() => {
@@ -210,18 +222,7 @@ vi.mock("@mastra/mcp", () => ({
             createScoreConfig: {
               server: "langfuse",
               execute: adapterEvents.createScoreConfigExecute,
-              toModelOutput: (output: unknown) => {
-                if (
-                  typeof output === "object" &&
-                  output !== null &&
-                  "type" in output &&
-                  output.type === "silent-mcp-output"
-                ) {
-                  return "Output saved to /workspace/tool_calls";
-                }
-
-                return output;
-              },
+              toModelOutput: adapterEvents.createScoreConfigToModelOutput,
             },
           },
           langfuseDocs: {
@@ -1105,6 +1106,9 @@ describe("createAgUiStream", () => {
         secret: "full-tool-output",
       },
     });
+    adapterEvents.createScoreConfigToModelOutput.mockImplementationOnce(
+      async () => "Output saved to /workspace/tool_calls",
+    );
     adapterEvents.inputs = [];
     adapterEvents.items = [
       {

--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -210,6 +210,18 @@ vi.mock("@mastra/mcp", () => ({
             createScoreConfig: {
               server: "langfuse",
               execute: adapterEvents.createScoreConfigExecute,
+              toModelOutput: (output: unknown) => {
+                if (
+                  typeof output === "object" &&
+                  output !== null &&
+                  "type" in output &&
+                  output.type === "silent-mcp-output"
+                ) {
+                  return "Output saved to /workspace/tool_calls";
+                }
+
+                return output;
+              },
             },
           },
           langfuseDocs: {
@@ -534,6 +546,16 @@ describe("createAgUiStream", () => {
         messageId: "assistant-message-1",
       },
       {
+        type: EventType.TOOL_CALL_RESULT,
+        messageId: "tool-result-1",
+        toolCallId: "tool-call-1",
+        content: JSON.stringify({
+          type: "silent-mcp-output",
+          output: { data: [{ id: "observation-1" }] },
+        }),
+        role: "tool",
+      },
+      {
         type: EventType.RUN_FINISHED,
         threadId: input.threadId,
         runId: input.runId,
@@ -576,6 +598,14 @@ describe("createAgUiStream", () => {
 
     expect(streamedText).toContain(EventType.MESSAGES_SNAPSHOT);
     expect(streamedText).toContain(EventType.REASONING_MESSAGE_CONTENT);
+    expect(streamedText).toContain("Output saved to /workspace/tool_calls");
+    expect(streamedText).not.toContain("observation-1");
+    expect(persistedEvents).toContainEqual(
+      expect.objectContaining({
+        type: EventType.TOOL_CALL_RESULT,
+        content: expect.stringContaining("observation-1"),
+      }),
+    );
     expect(adapterEvents.inputs).toEqual([input]);
     const { Agent } = await import("@mastra/core/agent");
     expect(Agent).toHaveBeenCalledWith(
@@ -724,6 +754,7 @@ describe("createAgUiStream", () => {
       EventType.TEXT_MESSAGE_START,
       EventType.TEXT_MESSAGE_CONTENT,
       EventType.TEXT_MESSAGE_END,
+      EventType.TOOL_CALL_RESULT,
       EventType.RUN_FINISHED,
     ]);
     expect(persistedEvents[0]).toMatchObject({
@@ -747,6 +778,8 @@ describe("createAgUiStream", () => {
       `stream:${EventType.TEXT_MESSAGE_CONTENT}`,
       `persist:${EventType.TEXT_MESSAGE_END}`,
       `stream:${EventType.TEXT_MESSAGE_END}`,
+      `persist:${EventType.TOOL_CALL_RESULT}`,
+      `stream:${EventType.TOOL_CALL_RESULT}`,
       `persist:${EventType.RUN_FINISHED}`,
       `stream:${EventType.RUN_FINISHED}`,
     ]);
@@ -787,6 +820,7 @@ describe("createAgUiStream", () => {
       EventType.TEXT_MESSAGE_START,
       EventType.TEXT_MESSAGE_CONTENT,
       EventType.TEXT_MESSAGE_END,
+      EventType.TOOL_CALL_RESULT,
       EventType.RUN_FINISHED,
     ]);
     expect(instrumentationMocks.instrumentation.end).toHaveBeenCalledWith({});
@@ -1054,6 +1088,85 @@ describe("createAgUiStream", () => {
         agent: expect.objectContaining({
           toolCallId: "tool-call-1",
           threadId: "conversation-1",
+        }),
+      }),
+    );
+  });
+
+  it("persists raw silent output for approved tools while resuming with redacted content", async () => {
+    const { createAgUiStream } =
+      await import("@langfuse/shared/in-app-agent/server/agent");
+    const input = createToolApprovalResumeInput(true, { silent: true });
+    adapterEvents.createScoreConfigExecute.mockResolvedValueOnce({
+      type: "silent-mcp-output",
+      output: {
+        id: "score-config-1",
+        name: "readiness",
+        secret: "full-tool-output",
+      },
+    });
+    adapterEvents.inputs = [];
+    adapterEvents.items = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+    ];
+    const persistedEvents: AgUiEvent[] = [];
+    const langfuseClient = {
+      getPrompt: promptMocks.getPrompt,
+    } as unknown as Langfuse;
+
+    const stream = await createAgUiStream({
+      input,
+      signal: new AbortController().signal,
+      options: {
+        onEvent: (event) => {
+          persistedEvents.push(event);
+        },
+        awsBedrock: { modelId: "test-model" },
+        langfuseMcp: {
+          url: "https://example.com/api/public/mcp",
+          publicKey: "pk",
+          secretKey: "sk",
+          userAccess: defaultInAppAgentUserAccess,
+          runOverride: "run-override",
+        },
+        redirectAction: {
+          projectId: "project-1",
+          isV4Enabled: false,
+        },
+        langfuseClient,
+        sandbox: (await createTestSandbox()).sandbox,
+        useLocalPrompt: false,
+      },
+    });
+    const streamedText = await readStream(stream);
+
+    const resumedInput = adapterEvents.inputs[0] as {
+      messages?: { id: string; role: string; content?: unknown }[];
+    };
+    const resumedToolMessage = resumedInput.messages?.find(
+      (message) => message.id === "tool-call-1-approval-tool-result",
+    );
+
+    expect(resumedToolMessage).toMatchObject({
+      role: "tool",
+      content: "Output saved to /workspace/tool_calls",
+    });
+    expect(streamedText).toContain("Output saved to /workspace/tool_calls");
+    expect(streamedText).not.toContain("full-tool-output");
+    expect(persistedEvents).toContainEqual(
+      expect.objectContaining({
+        type: EventType.TOOL_CALL_RESULT,
+        content: JSON.stringify({
+          type: "silent-mcp-output",
+          output: {
+            id: "score-config-1",
+            name: "readiness",
+            secret: "full-tool-output",
+          },
         }),
       }),
     );
@@ -1699,7 +1812,10 @@ async function readStream(
   }
 }
 
-function createToolApprovalResumeInput(approved: boolean) {
+function createToolApprovalResumeInput(
+  approved: boolean,
+  args?: Record<string, unknown>,
+) {
   return {
     threadId: "conversation-1",
     runId: "run-2",
@@ -1730,6 +1846,7 @@ function createToolApprovalResumeInput(approved: boolean) {
               dataType: "NUMERIC",
               numericMinValue: 0,
               numericMaxValue: 1,
+              ...args,
             },
             runId: "interrupted-run-1",
           },

--- a/web/src/__tests__/server/unit/in-app-agent-background-snapshot.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-background-snapshot.servertest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { InAppAgentRunStatus } from "@langfuse/shared";
 import { Prisma, type PrismaClient } from "@langfuse/shared/src/db";
+import { IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE } from "@langfuse/shared/in-app-agent";
 
 vi.mock("@langfuse/shared/src/server", () => ({
   ClickHouseClientManager: {
@@ -15,8 +16,37 @@ vi.mock("@langfuse/shared/src/server", () => ({
 }));
 
 import { getBackgroundConversationSnapshot } from "@/src/features/in-app-agent/server/backgroundRunService";
+import { getConversationSnapshotFromEvents } from "@/src/features/in-app-agent/server/conversationSnapshot";
 
 describe("getBackgroundConversationSnapshot", () => {
+  it("redacts silent MCP output from hydrated messages", () => {
+    const snapshot = getConversationSnapshotFromEvents([
+      {
+        sequenceNumber: 0,
+        runId: "run-1",
+        createdAt: new Date("2026-08-05T00:00:00.000Z"),
+        event: {
+          type: EventType.TOOL_CALL_RESULT,
+          messageId: "tool-result-1",
+          toolCallId: "tool-call-1",
+          content: JSON.stringify({
+            type: "silent-mcp-output",
+            output: { secret: "full-tool-output" },
+          }),
+        },
+      },
+    ]);
+
+    expect(snapshot.messages).toEqual([
+      {
+        id: "tool-result-1",
+        role: "tool",
+        toolCallId: "tool-call-1",
+        content: IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE,
+      },
+    ]);
+  });
+
   it("does not combine a terminal run with an event cursor from before that commit", async () => {
     const projectId = "project-1";
     const conversationId = "conversation-1";

--- a/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  createSandboxToolCallFileAccumulator,
   getConversationMessagesForDisplay,
   getSandboxToolCallFiles,
 } from "@langfuse/shared/in-app-agent/server/persistence";
@@ -110,7 +111,7 @@ describe("in-app agent sandbox", () => {
 
   it("syncs same-turn silent tool output into sandbox tool-call files", async () => {
     const files = new Map<string, string>();
-    let readonlyFiles = getSandboxToolCallFiles([]);
+    const toolCallFiles = createSandboxToolCallFileAccumulator([]);
     const sandbox = await createInAppAgentSandbox({
       conversationId: "conversation-1",
       projectId: "project-1",
@@ -146,45 +147,33 @@ describe("in-app agent sandbox", () => {
           };
         },
       },
-      getToolCallFiles: async () => readonlyFiles,
+      getToolCallFiles: async () => toolCallFiles.getFiles(),
       saveState: async () => undefined,
     });
+    const tools = withOptionalSilentMcpOutput({
+      tools: {
+        listObservations: new Tool({
+          id: "listObservations",
+          description: "List observations",
+          inputSchema: z.object({}),
+          execute: async () => ({ data: [{ id: "observation-1" }] }),
+        }),
+      },
+      sandbox: sandbox.sandbox,
+      onToolCallCompleted: toolCallFiles.processToolCall,
+    });
 
-    readonlyFiles = getSandboxToolCallFiles([
-      {
-        createdAt: new Date("2026-07-02T12:00:00.000Z"),
-        runId: "run-1",
-        event: {
-          type: EventType.TOOL_CALL_START,
-          toolCallId: "tool-call-1",
-          toolCallName: "langfuse_listObservations",
-        },
-      },
-      {
-        createdAt: new Date("2026-07-02T12:00:00.100Z"),
-        runId: "run-1",
-        event: {
-          type: EventType.TOOL_CALL_ARGS,
-          toolCallId: "tool-call-1",
-          delta: '{"silent":true}',
-        },
-      },
-      {
-        createdAt: new Date("2026-07-02T12:00:00.200Z"),
-        runId: "run-1",
-        event: {
-          type: EventType.TOOL_CALL_RESULT,
-          toolCallId: "tool-call-1",
-          content: JSON.stringify({
-            type: "silent-mcp-output",
-            output: { data: [{ id: "observation-1" }] },
-          }),
-        },
-      },
-    ]);
+    await tools.listObservations.execute?.({ silent: true }, {
+      agent: { toolCallId: "tool-call-1" },
+    } as never);
+
+    const path = toolCallFiles.getFiles()[0]?.path;
+    if (!path) {
+      throw new Error("Expected completed tool call file");
+    }
 
     const result = await sandbox.sandbox.read({
-      path: "tool_calls/2026-07-02T12-00-00.000Z_langfuse_listObservations_tool-call-1.json",
+      path,
     });
 
     expect(JSON.parse((result as { content: string }).content)).toEqual({

--- a/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
@@ -108,6 +108,90 @@ describe("in-app agent sandbox", () => {
     });
   });
 
+  it("syncs same-turn silent tool output into sandbox tool-call files", async () => {
+    const files = new Map<string, string>();
+    let readonlyFiles = getSandboxToolCallFiles([]);
+    const sandbox = await createInAppAgentSandbox({
+      conversationId: "conversation-1",
+      projectId: "project-1",
+      provider: {
+        async ensureSession() {
+          return {
+            sessionId: "session-1",
+            sandbox: {
+              async syncReadonlyFiles({ files: nextFiles }) {
+                for (const key of Array.from(files.keys())) {
+                  if (key.startsWith("tool_calls/")) {
+                    files.delete(key);
+                  }
+                }
+
+                for (const file of nextFiles) {
+                  files.set(file.path, file.content);
+                }
+              },
+              async read({ path }) {
+                return { path, content: files.get(path) ?? null };
+              },
+              async write() {
+                return { path: "notes.txt", bytesWritten: 0 };
+              },
+              async edit() {
+                return { path: "notes.txt", replaced: false };
+              },
+              async bash() {
+                return { stdout: "", stderr: "", exitCode: 0 };
+              },
+            },
+          };
+        },
+      },
+      getToolCallFiles: async () => readonlyFiles,
+      saveState: async () => undefined,
+    });
+
+    readonlyFiles = getSandboxToolCallFiles([
+      {
+        createdAt: new Date("2026-07-02T12:00:00.000Z"),
+        runId: "run-1",
+        event: {
+          type: EventType.TOOL_CALL_START,
+          toolCallId: "tool-call-1",
+          toolCallName: "langfuse_listObservations",
+        },
+      },
+      {
+        createdAt: new Date("2026-07-02T12:00:00.100Z"),
+        runId: "run-1",
+        event: {
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: "tool-call-1",
+          delta: '{"silent":true}',
+        },
+      },
+      {
+        createdAt: new Date("2026-07-02T12:00:00.200Z"),
+        runId: "run-1",
+        event: {
+          type: EventType.TOOL_CALL_RESULT,
+          toolCallId: "tool-call-1",
+          content: JSON.stringify({
+            type: "silent-mcp-output",
+            output: { data: [{ id: "observation-1" }] },
+          }),
+        },
+      },
+    ]);
+
+    const result = await sandbox.sandbox.read({
+      path: "tool_calls/2026-07-02T12-00-00.000Z_langfuse_listObservations_tool-call-1.json",
+    });
+
+    expect((result as { content: string | null }).content).toContain(
+      "observation-1",
+    );
+  });
+
   it("exports prior non-sandbox tool calls into tool_calls files", () => {
     const files = getSandboxToolCallFiles([
       {

--- a/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
@@ -187,9 +187,11 @@ describe("in-app agent sandbox", () => {
       path: "tool_calls/2026-07-02T12-00-00.000Z_langfuse_listObservations_tool-call-1.json",
     });
 
-    expect((result as { content: string | null }).content).toContain(
-      "observation-1",
-    );
+    expect(JSON.parse((result as { content: string }).content)).toEqual({
+      request: { silent: true },
+      response: { data: [{ id: "observation-1" }] },
+      error: null,
+    });
   });
 
   it("exports prior non-sandbox tool calls into tool_calls files", () => {

--- a/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
@@ -1,10 +1,70 @@
 import { EventType } from "@ag-ui/core";
+import { standardSchemaToJSONSchema } from "@mastra/core/schema";
+import { Tool } from "@mastra/core/tools";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
-import { getSandboxToolCallFiles } from "@langfuse/shared/in-app-agent/server/persistence";
+import {
+  getConversationMessagesForDisplay,
+  getSandboxToolCallFiles,
+} from "@langfuse/shared/in-app-agent/server/persistence";
 import { createInAppAgentSandbox } from "@langfuse/shared/in-app-agent/server/sandbox";
+import { withOptionalSilentMcpOutput } from "@langfuse/shared/in-app-agent/server/tools";
 
 describe("in-app agent sandbox", () => {
+  it("redacts silent MCP output from persisted conversation display", async () => {
+    const silentResult = JSON.stringify({
+      type: "silent-mcp-output",
+      output: { data: [{ id: "observation-1" }] },
+    });
+    const events = [
+      {
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tool-call-1",
+        toolCallName: "listObservations",
+        parentMessageId: "assistant-1",
+      },
+      {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: "tool-call-1",
+        delta: "{}",
+      },
+      {
+        type: EventType.TOOL_CALL_END,
+        toolCallId: "tool-call-1",
+      },
+      {
+        type: EventType.TOOL_CALL_RESULT,
+        messageId: "result-1",
+        toolCallId: "tool-call-1",
+        content: silentResult,
+        role: "tool",
+      },
+    ];
+    const messages = await getConversationMessagesForDisplay({
+      prisma: {
+        inAppAgentEvent: {
+          findMany: async () =>
+            events.map((event) => ({
+              event,
+              runId: "run-1",
+              createdAt: new Date("2026-07-27T10:00:00.000Z"),
+            })),
+        },
+      } as never,
+      projectId: "project-1",
+      conversationId: "conversation-1",
+    });
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        role: "tool",
+        content: "Output saved to /workspace/tool_calls",
+      }),
+    );
+    expect(events[3]?.content).toBe(silentResult);
+  });
+
   it("persists sandbox session state when a turn ends", async () => {
     const sandboxSession = {
       async syncReadonlyFiles() {},
@@ -167,5 +227,143 @@ describe("in-app agent sandbox", () => {
       "tool_calls/2026-07-02T12-00-00.000Z_langfuse_getHealth_tool-call-1.json",
       "tool_calls/2026-07-02T12-00-00.000Z_langfuse_getHealth_tool-call-2.json",
     ]);
+  });
+
+  it("returns the sandbox tool-call directory for silent MCP output", async () => {
+    const execute = async (input: { query: string }) => ({
+      result: input.query,
+    });
+    const tools = withOptionalSilentMcpOutput({
+      tools: {
+        search: new Tool({
+          id: "search",
+          description: "Search",
+          inputSchema: z.object({ query: z.string() }),
+          execute,
+        }),
+      },
+      sandbox: {
+        async read() {
+          return null;
+        },
+        async write() {
+          return null;
+        },
+        async edit() {
+          return null;
+        },
+        async bash() {
+          return null;
+        },
+      },
+    });
+    const tool = tools.search;
+
+    if (!(tool.inputSchema instanceof z.ZodObject)) {
+      throw new Error("Expected a Zod object input schema");
+    }
+
+    expect(
+      tool.inputSchema.safeParse({ query: "test", silent: true }).success,
+    ).toBe(true);
+
+    const output = await tool.execute?.(
+      { query: "test", silent: true },
+      {} as never,
+    );
+
+    expect(output).toEqual({
+      type: "silent-mcp-output",
+      output: { result: "test" },
+    });
+    expect(tool.toModelOutput?.(output)).toBe(
+      "Output saved to /workspace/tool_calls",
+    );
+  });
+
+  it("advertises silent MCP output for JSON Schema tools", () => {
+    const tools = withOptionalSilentMcpOutput({
+      tools: {
+        search: new Tool({
+          id: "search",
+          description: "Search",
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+            },
+            required: ["query"],
+            additionalProperties: false,
+          },
+          execute: async (input: { query: string }) => ({
+            result: input.query,
+          }),
+        }),
+      },
+      sandbox: {
+        async read() {
+          return null;
+        },
+        async write() {
+          return null;
+        },
+        async edit() {
+          return null;
+        },
+        async bash() {
+          return null;
+        },
+      },
+    });
+
+    if (!tools.search.inputSchema) {
+      throw new Error("Expected an input schema");
+    }
+
+    expect(standardSchemaToJSONSchema(tools.search.inputSchema)).toMatchObject({
+      properties: {
+        silent: {
+          type: "boolean",
+          description:
+            "Suppress the tool output from the conversation and save the full result to /workspace/tool_calls.",
+        },
+      },
+    });
+  });
+
+  it("returns normal MCP output when silent is omitted", async () => {
+    const tools = withOptionalSilentMcpOutput({
+      tools: {
+        search: new Tool({
+          id: "search",
+          description: "Search",
+          inputSchema: z.object({ query: z.string() }),
+          execute: async (input) => ({ result: input.query }),
+        }),
+      },
+    });
+
+    const output = await tools.search.execute?.({ query: "test" }, {} as never);
+
+    expect(output).toEqual({ result: "test" });
+  });
+
+  it("does not advertise silent MCP output without a sandbox", () => {
+    const tools = withOptionalSilentMcpOutput({
+      tools: {
+        search: new Tool({
+          id: "search",
+          description: "Search",
+          inputSchema: z.object({ query: z.string() }),
+          execute: async (input) => ({ result: input.query }),
+        }),
+      },
+    });
+
+    if (!(tools.search.inputSchema instanceof z.ZodObject)) {
+      throw new Error("Expected a Zod object input schema");
+    }
+
+    expect("silent" in tools.search.inputSchema.shape).toBe(false);
   });
 });

--- a/web/src/features/in-app-agent/server/conversationSnapshot.ts
+++ b/web/src/features/in-app-agent/server/conversationSnapshot.ts
@@ -1,6 +1,9 @@
 import { EventType } from "@ag-ui/core";
 
-import { createConversationMessageAccumulator } from "@langfuse/shared/in-app-agent/server/persistence";
+import {
+  createConversationMessageAccumulator,
+  redactSilentToolMessages,
+} from "@langfuse/shared/in-app-agent/server/persistence";
 import type { PersistedConversationEvent } from "@langfuse/shared/in-app-agent/server/persistence";
 
 import {
@@ -68,7 +71,10 @@ export function getConversationSnapshotFromEvents(
     }
   }
 
-  return { messages: accumulator.getMessages(), displayState };
+  return {
+    messages: redactSilentToolMessages(accumulator.getMessages()),
+    displayState,
+  };
 }
 
 function getEventString(event: unknown, key: string): string | undefined {

--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -52,6 +52,7 @@ import {
   flushPendingRunEvents,
   shouldFlushPersistedEvent,
   toPersistableAgentEvent,
+  type PersistedConversationEvent,
 } from "@langfuse/shared/in-app-agent/server/persistence";
 import { createInAppAgentSandbox } from "@langfuse/shared/in-app-agent/server/sandbox";
 import {
@@ -291,6 +292,9 @@ export default async function handler(request: Request) {
     const resumeApprovalRequest = isResumeAgentInput(sanitizedInput)
       ? sanitizedInput.forwardedProps.command.resume.approvalRequest
       : undefined;
+    const currentRunSandboxToolCallEvents: Array<
+      Omit<PersistedConversationEvent, "sequenceNumber">
+    > = [];
     const sandboxProviderType = getDefaultInAppAgentSandboxProviderType();
     const sandboxProvider =
       await getInAppAgentSandboxProvider(sandboxProviderType);
@@ -301,7 +305,10 @@ export default async function handler(request: Request) {
           providerSessionId: conversation.providerSessionId,
           provider: sandboxProvider,
           getToolCallFiles: async () =>
-            getSandboxToolCallFiles(conversationEvents),
+            getSandboxToolCallFiles([
+              ...conversationEvents,
+              ...currentRunSandboxToolCallEvents,
+            ]),
           saveState: async (state) => {
             await prisma.inAppAgentConversation.update({
               where: {
@@ -444,6 +451,11 @@ export default async function handler(request: Request) {
                 }
 
                 pendingPersistedEvents.push(persistedEvent);
+                currentRunSandboxToolCallEvents.push({
+                  event: persistedEvent,
+                  runId: sanitizedInput.runId,
+                  createdAt: new Date(),
+                });
 
                 if (!shouldFlushPersistedEvent(persistedEvent)) {
                   return;

--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -457,6 +457,7 @@ export default async function handler(request: Request) {
 
                 return flushPersistedRunEvents();
               },
+              onMcpToolCallCompleted: sandboxToolCallFiles.processToolCall,
               onApprovedToolCallExecuted: () => {
                 approvedToolResultPersisted = true;
               },

--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -41,6 +41,7 @@ import {
 } from "@langfuse/shared/in-app-agent/server/tools";
 import type { McpToolName } from "@/src/features/mcp/server/bootstrap";
 import {
+  createSandboxToolCallFileAccumulator,
   createRun,
   ensureOwnedConversation,
   finishRun,
@@ -48,11 +49,9 @@ import {
   getConversationMessagesForReplay,
   isInAppAgentConversationWriteLocked,
   maybeInferAndPersistConversationTitle,
-  getSandboxToolCallFiles,
   flushPendingRunEvents,
   shouldFlushPersistedEvent,
   toPersistableAgentEvent,
-  type PersistedConversationEvent,
 } from "@langfuse/shared/in-app-agent/server/persistence";
 import { createInAppAgentSandbox } from "@langfuse/shared/in-app-agent/server/sandbox";
 import {
@@ -292,9 +291,8 @@ export default async function handler(request: Request) {
     const resumeApprovalRequest = isResumeAgentInput(sanitizedInput)
       ? sanitizedInput.forwardedProps.command.resume.approvalRequest
       : undefined;
-    const currentRunSandboxToolCallEvents: Array<
-      Omit<PersistedConversationEvent, "sequenceNumber">
-    > = [];
+    const sandboxToolCallFiles =
+      createSandboxToolCallFileAccumulator(conversationEvents);
     const sandboxProviderType = getDefaultInAppAgentSandboxProviderType();
     const sandboxProvider =
       await getInAppAgentSandboxProvider(sandboxProviderType);
@@ -304,11 +302,7 @@ export default async function handler(request: Request) {
           projectId,
           providerSessionId: conversation.providerSessionId,
           provider: sandboxProvider,
-          getToolCallFiles: async () =>
-            getSandboxToolCallFiles([
-              ...conversationEvents,
-              ...currentRunSandboxToolCallEvents,
-            ]),
+          getToolCallFiles: async () => sandboxToolCallFiles.getFiles(),
           saveState: async (state) => {
             await prisma.inAppAgentConversation.update({
               where: {
@@ -451,7 +445,7 @@ export default async function handler(request: Request) {
                 }
 
                 pendingPersistedEvents.push(persistedEvent);
-                currentRunSandboxToolCallEvents.push({
+                sandboxToolCallFiles.processEvent({
                   event: persistedEvent,
                   runId: sanitizedInput.runId,
                   createdAt: new Date(),

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.ts
@@ -28,12 +28,12 @@ import {
   createAgUiStream,
   createInAppAgentMcpRunOverride,
   createInAppAgentSandbox,
+  createSandboxToolCallFileAccumulator,
   finishClaimedRun,
   flushPendingRunEvents,
   getConversationEvents,
   getConversationMessagesForReplay,
   getInAppAgentPromptClient,
-  getSandboxToolCallFiles,
   heartbeatClaimedRun,
   IN_APP_AGENT_HEARTBEAT_INTERVAL_MS,
   isInAppAgentConversationWriteLocked,
@@ -298,20 +298,15 @@ export async function executeInAppAgentRun(params: {
       );
     }
 
-    const currentRunSandboxToolCallEvents: Array<
-      Omit<PersistedConversationEvent, "sequenceNumber">
-    > = [];
+    const sandboxToolCallFiles =
+      createSandboxToolCallFileAccumulator(conversationEvents);
     const sandboxState = sandboxProvider
       ? await createInAppAgentSandbox({
           conversationId: conversation.id,
           projectId,
           providerSessionId: conversation.providerSessionId,
           provider: sandboxProvider,
-          getToolCallFiles: async () =>
-            getSandboxToolCallFiles([
-              ...conversationEvents,
-              ...currentRunSandboxToolCallEvents,
-            ]),
+          getToolCallFiles: async () => sandboxToolCallFiles.getFiles(),
           saveState: async (state) => {
             await prisma.inAppAgentConversation.update({
               where: { id_projectId: { id: conversation.id, projectId } },
@@ -423,7 +418,7 @@ export async function executeInAppAgentRun(params: {
           }
 
           pendingPersistedEvents.push(persistedEvent);
-          currentRunSandboxToolCallEvents.push({
+          sandboxToolCallFiles.processEvent({
             event: persistedEvent,
             runId,
             createdAt: new Date(),

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.ts
@@ -430,6 +430,7 @@ export async function executeInAppAgentRun(params: {
 
           return flushPersistedRunEvents();
         },
+        onMcpToolCallCompleted: sandboxToolCallFiles.processToolCall,
         onComplete: async () => {
           await flushPersistedRunEvents(
             interruptRequest

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.ts
@@ -298,6 +298,9 @@ export async function executeInAppAgentRun(params: {
       );
     }
 
+    const currentRunSandboxToolCallEvents: Array<
+      Omit<PersistedConversationEvent, "sequenceNumber">
+    > = [];
     const sandboxState = sandboxProvider
       ? await createInAppAgentSandbox({
           conversationId: conversation.id,
@@ -305,7 +308,10 @@ export async function executeInAppAgentRun(params: {
           providerSessionId: conversation.providerSessionId,
           provider: sandboxProvider,
           getToolCallFiles: async () =>
-            getSandboxToolCallFiles(conversationEvents),
+            getSandboxToolCallFiles([
+              ...conversationEvents,
+              ...currentRunSandboxToolCallEvents,
+            ]),
           saveState: async (state) => {
             await prisma.inAppAgentConversation.update({
               where: { id_projectId: { id: conversation.id, projectId } },
@@ -417,6 +423,11 @@ export async function executeInAppAgentRun(params: {
           }
 
           pendingPersistedEvents.push(persistedEvent);
+          currentRunSandboxToolCallEvents.push({
+            event: persistedEvent,
+            runId,
+            createdAt: new Date(),
+          });
 
           if (!shouldFlushPersistedEvent(persistedEvent)) {
             return;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15487.preview.langfuse.com](https://pr-15487.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds optional silent execution for in-app-agent MCP tools.
- Extends eligible MCP tool schemas with a `silent` argument when a sandbox is available.
- Preserves full silent results in persisted events and sandbox tool-call files while redacting streamed, displayed, replayed, and model-visible output.
- Makes current-run tool-call results available to subsequent sandbox operations in both web and worker execution paths.
- Updates manual tool approval handling to distinguish persisted results from model-facing results and adds coverage for streaming, replay, persistence, and sandbox behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with silent results consistently preserved for sandbox use and redacted from public and model-facing output.

The web and worker paths both track current-run tool events, persistence retains the raw result, and stream, display, replay, and approval paths consistently substitute the intended public message.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Model
  participant Agent
  participant MCP
  participant Events as Event persistence
  participant Sandbox
  participant Client
  Model->>Agent: "Call MCP tool with silent=true"
  Agent->>MCP: Execute without synthetic silent argument
  MCP-->>Agent: Full result
  Agent->>Events: Persist wrapped full result
  Agent-->>Model: Output saved to /workspace/tool_calls
  Events-->>Client: Redacted tool result
  Sandbox->>Events: Refresh current and prior tool calls
  Events-->>Sandbox: File containing full unwrapped result
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/langfuse/langfuse/commit/99fc45dda2209241988a1fff2ce9f32fd02e0094) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48672222)</sub>

<!-- /greptile_comment -->