### PR TITLE
fix(prisma): restore applied migration checksum

### DIFF
--- a/packages/shared/prisma/migrations/20260722070000_add_in_app_agent_run_lifecycle_fields/migration.sql
+++ b/packages/shared/prisma/migrations/20260722070000_add_in_app_agent_run_lifecycle_fields/migration.sql
@@ -11,7 +11,7 @@ ALTER TABLE "in_app_agent_runs"
   ADD COLUMN "cancel_requested_at" TIMESTAMP(3);
 
 -- Close only runs the app itself would already consider stale (>150s,
--- ACTIVE_RUN_STALE_AFTER_MS in web/src/features/in-app-agent/server/persistence.ts).
+-- ACTIVE_RUN_STALE_AFTER_MS in web/src/ee/features/in-app-agent/server/persistence.ts).
 -- Younger unfinished rows are genuinely running foreground streams and must
 -- stay open, or their event flushes and finish would silently no-op.
 UPDATE "in_app_agent_runs"


### PR DESCRIPTION
## Summary

- Restore the original path in an already-applied Prisma migration comment.
- Keep the migration checksum aligned with the version already applied in environments.

## Verification

- `git diff --check` passed.
- Prettier passed in the commit hook.
- Repository-wide lint was started by the commit hook but stopped after hanging without output; no standalone tests or typechecks were run.