### PR TITLE
fix(filters): allow filtering for traces without a name

### DIFF
--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -1003,6 +1003,7 @@ function FilterBuilderForm({
                             column?.type === filter.type &&
                             columnsWithCustomSelect.includes(column.id)
                           }
+                          allowEmptyOption={filter.type === "stringOptions"}
                         />
                       ) : filter.type === "categoryOptions" &&
                         column?.type === "categoryOptions" ? (

--- a/web/src/features/filters/components/multi-select.clienttest.tsx
+++ b/web/src/features/filters/components/multi-select.clienttest.tsx
@@ -1,0 +1,311 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { FilterOption } from "@langfuse/shared";
+import { MultiSelect } from "./multi-select";
+
+// Radix Popover + cmdk rely on browser APIs jsdom does not implement.
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn(() => false);
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+});
+
+/**
+ * Renders the dropdown and returns the open popover listbox.
+ *
+ * Traces without a name are stored as an empty string in ClickHouse, so the
+ * filter-options endpoint legitimately returns `{ value: "", count: n }`.
+ */
+const openDropdown = (options: FilterOption[], values: string[] = []) => {
+  const onValueChange = vi.fn();
+  render(
+    <MultiSelect
+      title="Value"
+      values={values}
+      onValueChange={onValueChange}
+      options={options}
+      allowEmptyOption
+    />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: /select/i }));
+  return { onValueChange };
+};
+
+const TRACE_NAME_OPTIONS: FilterOption[] = [
+  { value: "chat-completion", count: 12 },
+  { value: "", count: 3 },
+];
+
+describe("MultiSelect empty-string option (langfuse#1198)", () => {
+  it("offers the empty-string option as '(empty)' so nameless traces are filterable", () => {
+    openDropdown(TRACE_NAME_OPTIONS);
+
+    expect(screen.getByText("(empty)")).toBeInTheDocument();
+  });
+
+  it("emits the empty string as the filter value when '(empty)' is selected", () => {
+    const { onValueChange } = openDropdown(TRACE_NAME_OPTIONS);
+
+    fireEvent.click(screen.getByText("(empty)"));
+
+    expect(onValueChange).toHaveBeenCalledWith([""]);
+  });
+
+  it("shows the option's trace count alongside '(empty)'", () => {
+    openDropdown(TRACE_NAME_OPTIONS);
+
+    const emptyOption = screen.getByText("(empty)").closest("[cmdk-item]");
+    expect(emptyOption).not.toBeNull();
+    expect(
+      within(emptyOption as HTMLElement).getByText("3"),
+    ).toBeInTheDocument();
+  });
+
+  it("includes the empty option in 'Select All'", () => {
+    const { onValueChange } = openDropdown(TRACE_NAME_OPTIONS);
+
+    fireEvent.click(screen.getByText("Select All"));
+
+    expect(onValueChange).toHaveBeenCalledWith(
+      expect.arrayContaining(["chat-completion", ""]),
+    );
+  });
+
+  it("deselects the empty option when it is already selected", () => {
+    const { onValueChange } = openDropdown(TRACE_NAME_OPTIONS, [""]);
+
+    // "(empty)" also renders as the trigger badge, so scope to the list item.
+    const emptyOption = screen
+      .getAllByText("(empty)")
+      .map((el) => el.closest("[cmdk-item]"))
+      .find((el): el is HTMLElement => el !== null);
+    expect(emptyOption).toBeDefined();
+    fireEvent.click(emptyOption as HTMLElement);
+
+    expect(onValueChange).toHaveBeenCalledWith([]);
+  });
+
+  it("labels the selected empty value as '(empty)' on the trigger badge", () => {
+    openDropdown(TRACE_NAME_OPTIONS, [""]);
+
+    const badge = screen
+      .getAllByText("(empty)")
+      .find((el) => el.closest("[cmdk-item]") === null);
+    expect(badge).toBeDefined();
+  });
+
+  it("treats an already-selected empty value as fully selected for 'Select All'", () => {
+    const { onValueChange } = openDropdown(TRACE_NAME_OPTIONS, [
+      "chat-completion",
+      "",
+    ]);
+
+    // Everything is selected, so the control must offer the inverse action.
+    fireEvent.click(screen.getByText("Deselect All"));
+
+    expect(onValueChange).toHaveBeenCalledWith([]);
+  });
+
+  it("keeps a selected '(empty)' when a custom value is added alongside it", () => {
+    // traceName enables custom select, so the free-text row is rendered.
+    const onValueChange = vi.fn();
+    render(
+      <MultiSelect
+        title="Value"
+        values={[""]}
+        onValueChange={onValueChange}
+        options={TRACE_NAME_OPTIONS}
+        isCustomSelectEnabled
+        allowEmptyOption
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+
+    const freeTextBox = screen.getByPlaceholderText("Enter custom value");
+    fireEvent.change(freeTextBox, { target: { value: "my-custom-name" } });
+    fireEvent.click(freeTextBox.closest("[cmdk-item]") as HTMLElement);
+
+    expect(onValueChange).toHaveBeenCalledWith(
+      expect.arrayContaining(["", "my-custom-name"]),
+    );
+  });
+
+  it("clears the filter when the custom box is emptied, even though '' is an option", () => {
+    // Regression: "" is a valid option here, so the old empty-stripping guard
+    // no longer fired and clearing the box silently became an "is empty" filter.
+    vi.useFakeTimers();
+    try {
+      const onValueChange = vi.fn();
+      render(
+        <MultiSelect
+          title="Value"
+          values={["typed-value"]}
+          onValueChange={onValueChange}
+          options={TRACE_NAME_OPTIONS}
+          isCustomSelectEnabled
+          allowEmptyOption
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /select/i }));
+
+      const freeTextBox = screen.getByPlaceholderText("Enter custom value");
+      fireEvent.change(freeTextBox, { target: { value: "" } });
+      vi.advanceTimersByTime(600);
+
+      expect(onValueChange).toHaveBeenCalledWith([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not add '' when the free-text row is activated with an empty box", () => {
+    // Regression: the else-branch added freeText ("") as a filter value and a
+    // second activation re-added it instead of toggling it off.
+    const onValueChange = vi.fn();
+    render(
+      <MultiSelect
+        title="Value"
+        values={[]}
+        onValueChange={onValueChange}
+        options={TRACE_NAME_OPTIONS}
+        isCustomSelectEnabled
+        allowEmptyOption
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+
+    fireEvent.click(
+      screen
+        .getByPlaceholderText("Enter custom value")
+        .closest("[cmdk-item]") as HTMLElement,
+    );
+
+    expect(onValueChange).toHaveBeenCalledWith([]);
+  });
+
+  it("still discards the empty free-text value when '' is not a real option", () => {
+    const onValueChange = vi.fn();
+    render(
+      <MultiSelect
+        title="Value"
+        values={[]}
+        onValueChange={onValueChange}
+        options={[{ value: "chat-completion", count: 12 }]}
+        isCustomSelectEnabled
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+
+    // Selecting the free-text row with an empty box must not add "".
+    const freeTextRow = screen
+      .getByPlaceholderText("Enter custom value")
+      .closest("[cmdk-item]") as HTMLElement;
+    fireEvent.click(freeTextRow);
+
+    expect(onValueChange).toHaveBeenCalledWith([]);
+  });
+
+  it("does not mark the free-text row as active when only '(empty)' is selected", () => {
+    // The empty option is not a typed custom value, so the free-text row must
+    // not render as checked above an empty input.
+    render(
+      <MultiSelect
+        title="Value"
+        values={[""]}
+        onValueChange={vi.fn()}
+        options={TRACE_NAME_OPTIONS}
+        isCustomSelectEnabled
+        allowEmptyOption
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+
+    const freeTextRow = screen
+      .getByPlaceholderText("Enter custom value")
+      .closest("[cmdk-item]") as HTMLElement;
+    const checkbox = freeTextRow.querySelector("div");
+    expect(checkbox?.className).toContain("invisible");
+  });
+
+  it("keeps '(empty)' selected when options have not loaded yet", () => {
+    // While the filter-options query is in flight `options` is empty, so a
+    // selected "" must not be mistaken for a custom free-text value.
+    const onValueChange = vi.fn();
+    render(
+      <MultiSelect
+        title="Value"
+        values={[""]}
+        onValueChange={onValueChange}
+        options={[]}
+        isCustomSelectEnabled
+        allowEmptyOption
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+
+    fireEvent.click(
+      screen
+        .getByPlaceholderText("Enter custom value")
+        .closest("[cmdk-item]") as HTMLElement,
+    );
+
+    // Nothing was typed, so the selection must be left untouched.
+    expect(onValueChange).not.toHaveBeenCalledWith([]);
+  });
+
+  it("still renders ordinary options unchanged", () => {
+    const { onValueChange } = openDropdown(TRACE_NAME_OPTIONS);
+
+    fireEvent.click(screen.getByText("chat-completion"));
+
+    expect(onValueChange).toHaveBeenCalledWith(["chat-completion"]);
+  });
+
+  it("does not invent an '(empty)' entry when no empty option exists", () => {
+    openDropdown([{ value: "chat-completion", count: 12 }]);
+
+    expect(screen.queryByText("(empty)")).not.toBeInTheDocument();
+  });
+
+  describe("without allowEmptyOption (arrayOptions/categoryOptions selectors)", () => {
+    // "" is not a meaningful member of a tag array — an arrayOptions filter
+    // containing "" resolves to hasAll(tags, [""]) and matches nothing — so
+    // these selectors must keep hiding it, including from "Select All".
+    const renderDefault = (values: string[] = []) => {
+      const onValueChange = vi.fn();
+      render(
+        <MultiSelect
+          title="Value"
+          values={values}
+          onValueChange={onValueChange}
+          options={[
+            { value: "production", count: 4 },
+            { value: "", count: 2 },
+          ]}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /select/i }));
+      return { onValueChange };
+    };
+
+    it("hides the empty option by default", () => {
+      renderDefault();
+
+      expect(screen.queryByText("(empty)")).not.toBeInTheDocument();
+    });
+
+    it("does not sweep the empty value into 'Select All'", () => {
+      const { onValueChange } = renderDefault();
+
+      fireEvent.click(screen.getByText("Select All"));
+
+      expect(onValueChange).toHaveBeenCalledWith(["production"]);
+    });
+  });
+});

--- a/web/src/features/filters/components/multi-select.tsx
+++ b/web/src/features/filters/components/multi-select.tsx
@@ -30,7 +30,14 @@ const getFreeTextInput = (
   optionValues: Set<string>,
 ): string | undefined =>
   isCustomSelectEnabled
-    ? Array.from(values.values()).find((value) => !optionValues.has(value))
+    ? Array.from(values.values()).find(
+        // "" is never a typed custom value: it is only ever picked from the
+        // option list, where it means "records without a value". Without this
+        // guard a selected "" looks like a custom value whenever it is missing
+        // from `options` (e.g. while the filter-options query is still loading)
+        // and the free-text handlers would overwrite the user's selection.
+        (value) => value !== "" && !optionValues.has(value),
+      )
     : undefined;
 
 export function MultiSelect({
@@ -43,6 +50,7 @@ export function MultiSelect({
   disabled,
   isCustomSelectEnabled = false,
   labelTruncateCutOff = 2,
+  allowEmptyOption = false,
 }: {
   title?: string;
   label?: string;
@@ -53,6 +61,14 @@ export function MultiSelect({
   disabled?: boolean;
   isCustomSelectEnabled?: boolean;
   labelTruncateCutOff?: number;
+  /**
+   * Offer "" as a selectable "(empty)" option, meaning "records without a
+   * value" (e.g. traces ingested without a name). Only meaningful for
+   * `stringOptions`, whose schema rejects empty arrays so "" is unambiguous.
+   * `arrayOptions`/`categoryOptions` accept empty arrays and have no use for an
+   * empty member, so they keep hiding it.
+   */
+  allowEmptyOption?: boolean;
 }) {
   const selectedValues = useMemo(() => new Set(values), [values]);
   const optionValues = new Set(options.map((option) => option.value));
@@ -68,39 +84,29 @@ export function MultiSelect({
   const mergedOptions = useMemo(() => {
     const optionSet = new Set(options.map((o) => o.value));
     const missingSelectedOptions: FilterOption[] = values
-      .filter((v) => !optionSet.has(v) && v.length > 0)
+      .filter((v) => !optionSet.has(v))
       .map((v) => ({ value: v }));
-    return [...options, ...missingSelectedOptions];
-  }, [options, values]);
-
-  const selectableOptions = useMemo(
-    () => mergedOptions.filter((option) => option.value.length > 0),
-    [mergedOptions],
-  );
+    const merged = [...options, ...missingSelectedOptions];
+    return allowEmptyOption
+      ? merged
+      : merged.filter((option) => option.value.length > 0);
+  }, [options, values, allowEmptyOption]);
 
   const allSelectedState = useMemo(() => {
-    if (selectableOptions.length === 0) return false;
-    return selectableOptions.every((option) =>
-      selectedValues.has(option.value),
-    );
-  }, [selectableOptions, selectedValues]);
+    if (mergedOptions.length === 0) return false;
+    return mergedOptions.every((option) => selectedValues.has(option.value));
+  }, [mergedOptions, selectedValues]);
 
   const handleSelectAll = useCallback(() => {
     const newSelectedValues = new Set(selectedValues);
     if (allSelectedState) {
-      // Deselect all selectable options
-      selectableOptions.forEach((option) =>
-        newSelectedValues.delete(option.value),
-      );
+      mergedOptions.forEach((option) => newSelectedValues.delete(option.value));
     } else {
-      // Select all selectable options
-      selectableOptions.forEach((option) =>
-        newSelectedValues.add(option.value),
-      );
+      mergedOptions.forEach((option) => newSelectedValues.add(option.value));
     }
     const filterValues = Array.from(newSelectedValues);
     onValueChange(filterValues.length ? filterValues : []);
-  }, [allSelectedState, selectableOptions, selectedValues, onValueChange]);
+  }, [allSelectedState, mergedOptions, selectedValues, onValueChange]);
 
   const debounceTimeout = useRef<NodeJS.Timeout | null>(null);
   const handleDebouncedChange = (value: string) => {
@@ -110,10 +116,13 @@ export function MultiSelect({
       optionValues,
     );
 
-    if (!!freeTextInput) {
+    // Compare against undefined: "" is a real selection (a record with no
+    // value), so truthiness would misread it as "there is no custom value".
+    if (freeTextInput !== undefined) {
       selectedValues.delete(freeTextInput);
-      selectedValues.add(value);
-      selectedValues.delete("");
+      // An empty box contributes nothing. "" as a filter value means "no value"
+      // and is only ever chosen from the option list, never typed here.
+      if (value) selectedValues.add(value);
       const filterValues = Array.from(selectedValues);
       onValueChange(filterValues.length ? filterValues : []);
     }
@@ -201,7 +210,7 @@ export function MultiSelect({
               <InputCommandEmpty>No results found.</InputCommandEmpty>
             )}
             <InputCommandGroup>
-              {selectableOptions.length > 0 && (
+              {mergedOptions.length > 0 && (
                 <>
                   <InputCommandItem key="select-all" onSelect={handleSelectAll}>
                     <div
@@ -222,7 +231,6 @@ export function MultiSelect({
                 </>
               )}
               {mergedOptions.map((option) => {
-                if (option.value.length === 0) return;
                 const isSelected = selectedValues.has(option.value);
                 const displayValue =
                   option.displayValue ??
@@ -296,12 +304,11 @@ export function MultiSelect({
                       optionValues,
                     );
 
-                    if (!!freeTextInput) {
+                    if (freeTextInput !== undefined) {
                       selectedValues.delete(freeTextInput);
-                    } else {
+                    } else if (freeText) {
                       selectedValues.add(freeText);
                     }
-                    selectedValues.delete("");
                     const filterValues = Array.from(selectedValues);
                     onValueChange(filterValues.length ? filterValues : []);
                   }}
@@ -313,8 +320,9 @@ export function MultiSelect({
                         isCustomSelectEnabled,
                         values,
                         optionValues,
-                      ) ||
-                        (optionValues.has(freeText) &&
+                      ) !== undefined ||
+                        (!!freeText &&
+                          optionValues.has(freeText) &&
                           selectedValues.has(freeText))
                         ? "bg-control-fill border-control-fill text-primary-foreground"
                         : "opacity-50 [&_svg]:invisible",

--- a/web/src/features/filters/hooks/useFilterState.clienttest.ts
+++ b/web/src/features/filters/hooks/useFilterState.clienttest.ts
@@ -1,0 +1,84 @@
+import type { FilterState } from "@langfuse/shared";
+import { getCommaArrayParam } from "./useFilterState";
+
+const param = getCommaArrayParam("traces");
+
+const roundTrip = (filters: FilterState) =>
+  param.decode(param.encode(filters) ?? null);
+
+/**
+ * Traces ingested without a name are stored as an empty string, so `[""]` is a
+ * legitimate stringOptions selection meaning "no trace name". The legacy query
+ * encoder used by the dashboard page must preserve it, matching the behaviour
+ * of decodeFiltersGeneric used by the newer sidebar filters.
+ */
+describe("useFilterState legacy query encoding (langfuse#1198)", () => {
+  it("preserves an empty-string stringOptions filter through a URL round-trip", () => {
+    const filters: FilterState = [
+      {
+        column: "Name",
+        type: "stringOptions",
+        operator: "any of",
+        value: [""],
+      },
+    ];
+
+    expect(roundTrip(filters)).toEqual(filters);
+  });
+
+  it("preserves an empty string alongside real values", () => {
+    const filters: FilterState = [
+      {
+        column: "Name",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["", "chat-completion"],
+      },
+    ];
+
+    expect(roundTrip(filters)).toEqual(filters);
+  });
+
+  it("still round-trips ordinary stringOptions filters", () => {
+    const filters: FilterState = [
+      {
+        column: "Name",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["chat-completion", "summarize"],
+      },
+    ];
+
+    expect(roundTrip(filters)).toEqual(filters);
+  });
+
+  // Only stringOptions may treat a blank segment as [""]: it is the one options
+  // type whose schema rejects [], so a blank segment there is unambiguous. The
+  // types below permit [], so a blank segment means "nothing selected" and must
+  // not silently become a filter for the empty string. Column ids must be real
+  // ids for the table under test, otherwise the filter is dropped during column
+  // resolution and the assertion would pass without exercising this logic.
+  it.each([
+    ["arrayOptions", param, "traceTags;arrayOptions;;all of;"],
+    [
+      "categoryOptions",
+      getCommaArrayParam("dataset_runs"),
+      "agg_score_categories;categoryOptions;quality;any of;",
+    ],
+  ] as const)(
+    "does not turn an empty %s selection into an empty-string value",
+    (_type, codec, encoded) => {
+      const decoded = codec.decode(encoded);
+
+      expect(
+        decoded?.some((f) => JSON.stringify(f.value) === '[""]'),
+      ).toBeFalsy();
+    },
+  );
+
+  it("still drops a blank string filter instead of applying an empty match", () => {
+    // `contains ""` would match nothing while the input looks blank. "userId"
+    // is a real `string` column on traces, so this reaches the value logic.
+    expect(param.decode("userId;string;;contains;")).toEqual([]);
+  });
+});

--- a/web/src/features/filters/hooks/useFilterState.ts
+++ b/web/src/features/filters/hooks/useFilterState.ts
@@ -36,7 +36,7 @@ const DEBUG_QUERY_STATE = false;
 // encode/decode filter state
 // The decode has to return null or undefined so that withDefault will use the default value.
 // An empty array will be interpreted as existing state and hence the default value will not be used.
-const getCommaArrayParam = (table: TableName) => ({
+export const getCommaArrayParam = (table: TableName) => ({
   encode: (filterState: FilterState) =>
     encodeDelimitedArray(
       filterState
@@ -85,12 +85,21 @@ const getCommaArrayParam = (table: TableName) => ({
         if (DEBUG_QUERY_STATE)
           console.log("values", [column, type, key, operator, value]);
         const decodedValue = value ? decodeURIComponent(value) : undefined;
+        // A blank value segment is ambiguous: for most types it means "absent",
+        // but `stringOptions` rejects empty arrays (see stringOptionsFilter),
+        // so a blank segment there can only be the single value "" — i.e. a
+        // deliberate filter for records without a value, such as an unnamed
+        // trace. Other types keep the previous "drop the filter" behaviour:
+        // `categoryOptions`/`arrayOptions` do allow [], so for them a blank
+        // segment really is an empty selection rather than an empty string.
+        const isEmptyStringOptions = type === "stringOptions" && value === "";
         const normalizedKey =
           type === "positionInTrace"
             ? normalizeLegacySessionPositionInTraceKey(key)
             : key;
-        const parsedValue =
-          decodedValue === undefined || type === undefined
+        const parsedValue = isEmptyStringOptions
+          ? [""]
+          : decodedValue === undefined || type === undefined
             ? undefined
             : type === "datetime"
               ? new Date(decodedValue)


### PR DESCRIPTION
## What does this PR do?

Fixes #1198

Traces that come in without a name get stored as an empty string. The dashboard shows them as "Unknown", but you can't actually filter for them, because the empty option never appears in the Trace Name dropdown.

Turns out most of this was already fixed. #11189 added the "(empty)" label, the styling and the URL handling, but there's an older guard from #6039 sitting a couple of lines above it in the render loop that returns early on empty values, so none of that code ever ran. The backend side was fine all along.

In this PR:

- shows the empty option again, but only for stringOptions filters. Tags and score categories don't need it, and an empty tag filter would match nothing anyway
- includes it in Select All / Deselect All
- stops the custom value box from adding "" as a filter value by accident, which was wiping out the selection on columns like traceName
- fixes the legacy query param encoding so the filter survives a reload. Before this it would apply and then quietly disappear on the next navigation

Added tests for all of it.

One thing that might come up in review: tracesTable.ts says nullable: true and some old migrations have Nullable(String), but those belong to the traces_null / amt tables that 0029 dropped. The live traces.name column is a plain String, so unnamed traces really are stored as '' and the IS NOT NULL check in getTracesGroupedByName doesn't do anything.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

Removed the items that don't apply. Format, lint and tests pass locally, and I don't think this needs any doc changes.
