### PR TITLE
fix(version-update): delay the update refresh prompt (1 min post-load, 3 min after new version) (LFE-14537)

### DIFF
--- a/web/src/features/version-update/useAppSettled.clienttest.ts
+++ b/web/src/features/version-update/useAppSettled.clienttest.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createAppSettledGate } from "./useAppSettled";
+import { createAppSettledGate, APP_SETTLE_DELAY_MS } from "./useAppSettled";
+
+describe("APP_SETTLE_DELAY_MS", () => {
+  // Post-load grace: no reload prompt in the first minute of a session so a
+  // deploy that was in flight at page load can settle first (LFE-14537).
+  it("holds the banner back for one minute after load", () => {
+    expect(APP_SETTLE_DELAY_MS).toBe(60 * 1000);
+  });
+});
 
 describe("createAppSettledGate", () => {
   beforeEach(() => {

--- a/web/src/features/version-update/useAppSettled.ts
+++ b/web/src/features/version-update/useAppSettled.ts
@@ -2,14 +2,23 @@ import { useSyncExternalStore } from "react";
 
 /**
  * How long after the app first mounts before the version-update banner is
- * allowed to appear. During the initial mount/hydration window the layout
- * flickers and React StrictMode double-invokes mounts; because the banner
- * renders through an overlay portal, a mount landing in that churn is torn down
- * and recreated, replaying its entrance animation (a visible "jump"). Holding it
- * back until the app is quiet means it mounts exactly once, cleanly — and reads
- * better (no banner flashing in during startup).
+ * allowed to appear. This is a post-load grace serving two purposes:
+ *
+ *  1. **No mid-deploy prompt (LFE-14537).** A page can be loaded while the web
+ *     container is switching versions; offering a reload in that window pushes
+ *     the user to reload straight into a still-switching pod (a broken loading
+ *     state). Withholding the prompt for the first minute of a session lets a
+ *     deploy that was in flight at load time settle before we ever offer a
+ *     reload. Combined at the banner with the store's new-version debounce
+ *     ({@link VERSION_UPDATE_DEBOUNCE_MS}); both gates must pass.
+ *  2. **No startup flicker.** During the initial mount/hydration window the
+ *     layout flickers and React StrictMode double-invokes mounts; because the
+ *     banner renders through an overlay portal, a mount landing in that churn is
+ *     torn down and recreated, replaying its entrance animation (a visible
+ *     "jump"). A minute comfortably clears that window, so it mounts once,
+ *     cleanly.
  */
-export const APP_SETTLE_DELAY_MS = 5000;
+export const APP_SETTLE_DELAY_MS = 60 * 1000;
 
 /**
  * A one-shot "the app has settled after first render" gate as an external store.

--- a/web/src/features/version-update/versionUpdateStore.clienttest.ts
+++ b/web/src/features/version-update/versionUpdateStore.clienttest.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   createVersionUpdateStore,
   isVersionMismatch,
+  VERSION_UPDATE_DEBOUNCE_MS,
 } from "./versionUpdateStore";
 
 describe("isVersionMismatch", () => {
@@ -30,30 +31,30 @@ describe("isVersionMismatch", () => {
 
 describe("versionUpdateStore", () => {
   it("starts with no update available", () => {
-    const store = createVersionUpdateStore(() => "running");
+    const store = createVersionUpdateStore(() => "running", 0);
     expect(store.getSnapshot()).toBe(false);
   });
 
   it("stays silent when the observed build matches the running build", () => {
-    const store = createVersionUpdateStore(() => "running");
+    const store = createVersionUpdateStore(() => "running", 0);
     store.reportObservedBuildId("running");
     expect(store.getSnapshot()).toBe(false);
   });
 
   it("becomes available when a differing build id is observed", () => {
-    const store = createVersionUpdateStore(() => "running");
+    const store = createVersionUpdateStore(() => "running", 0);
     store.reportObservedBuildId("deployed");
     expect(store.getSnapshot()).toBe(true);
   });
 
   it("stays silent when the running build id is unknown", () => {
-    const store = createVersionUpdateStore(() => undefined);
+    const store = createVersionUpdateStore(() => undefined, 0);
     store.reportObservedBuildId("deployed");
     expect(store.getSnapshot()).toBe(false);
   });
 
   it("ignores empty/absent observed build ids", () => {
-    const store = createVersionUpdateStore(() => "running");
+    const store = createVersionUpdateStore(() => "running", 0);
     store.reportObservedBuildId(null);
     store.reportObservedBuildId(undefined);
     store.reportObservedBuildId("");
@@ -61,7 +62,7 @@ describe("versionUpdateStore", () => {
   });
 
   it("hides after dismiss and re-shows only when a not-yet-seen build arrives", () => {
-    const store = createVersionUpdateStore(() => "running");
+    const store = createVersionUpdateStore(() => "running", 0);
 
     store.reportObservedBuildId("deployed-1");
     expect(store.getSnapshot()).toBe(true);
@@ -83,7 +84,7 @@ describe("versionUpdateStore", () => {
   // three failure modes flagged in review.
   describe("rolling deploy robustness", () => {
     it("stays available once a differing build is seen — a later old-pod response cannot suppress it", () => {
-      const store = createVersionUpdateStore(() => "running");
+      const store = createVersionUpdateStore(() => "running", 0);
 
       store.reportObservedBuildId("deployed"); // new pod
       expect(store.getSnapshot()).toBe(true);
@@ -99,7 +100,7 @@ describe("versionUpdateStore", () => {
     });
 
     it("does not reopen a dismissed banner when an already-seen build re-appears (old pod)", () => {
-      const store = createVersionUpdateStore(() => "running");
+      const store = createVersionUpdateStore(() => "running", 0);
 
       store.reportObservedBuildId("deployed");
       store.dismiss();
@@ -113,7 +114,7 @@ describe("versionUpdateStore", () => {
     });
 
     it("re-observing an already-seen build never flaps the snapshot (no extra notifications)", () => {
-      const store = createVersionUpdateStore(() => "running");
+      const store = createVersionUpdateStore(() => "running", 0);
       const listener = vi.fn();
       store.subscribe(listener);
 
@@ -127,7 +128,7 @@ describe("versionUpdateStore", () => {
   });
 
   it("notifies subscribers when the snapshot changes and after unsubscribe stops", () => {
-    const store = createVersionUpdateStore(() => "running");
+    const store = createVersionUpdateStore(() => "running", 0);
     const listener = vi.fn();
     const unsubscribe = store.subscribe(listener);
 
@@ -147,7 +148,7 @@ describe("versionUpdateStore", () => {
   });
 
   it("has a server snapshot that is always false", () => {
-    const store = createVersionUpdateStore(() => "running");
+    const store = createVersionUpdateStore(() => "running", 0);
     store.reportObservedBuildId("deployed");
     expect(store.getServerSnapshot()).toBe(false);
   });
@@ -156,7 +157,7 @@ describe("versionUpdateStore", () => {
   // component state) so a banner remount cannot double-count one appearance.
   describe("markShownReported (banner_shown once-per-appearance guard)", () => {
     it("returns true once per appearance, then false", () => {
-      const store = createVersionUpdateStore(() => "running");
+      const store = createVersionUpdateStore(() => "running", 0);
       store.reportObservedBuildId("deployed");
 
       expect(store.markShownReported()).toBe(true);
@@ -167,7 +168,7 @@ describe("versionUpdateStore", () => {
     });
 
     it("resets for a genuinely new build id (a fresh appearance)", () => {
-      const store = createVersionUpdateStore(() => "running");
+      const store = createVersionUpdateStore(() => "running", 0);
 
       store.reportObservedBuildId("deployed-1");
       expect(store.markShownReported()).toBe(true);
@@ -180,7 +181,7 @@ describe("versionUpdateStore", () => {
     });
 
     it("does not reset when an already-seen build id is re-observed", () => {
-      const store = createVersionUpdateStore(() => "running");
+      const store = createVersionUpdateStore(() => "running", 0);
 
       store.reportObservedBuildId("deployed");
       expect(store.markShownReported()).toBe(true);
@@ -189,6 +190,93 @@ describe("versionUpdateStore", () => {
       store.reportObservedBuildId("deployed");
       store.reportObservedBuildId("running");
       expect(store.markShownReported()).toBe(false);
+    });
+  });
+
+  // A page loaded mid-deploy sees the new build id immediately; prompting a
+  // reload right then reloads into a still-switching pod (LFE-14537). The
+  // snapshot must stay false until the settling window elapses.
+  describe("new-version debounce (LFE-14537)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("stays hidden until the debounce elapses after the first new build id", () => {
+      const store = createVersionUpdateStore(() => "running", 180_000);
+
+      store.reportObservedBuildId("deployed");
+      // Available, but within the settling window → still not shown.
+      expect(store.getSnapshot()).toBe(false);
+
+      vi.advanceTimersByTime(179_999);
+      expect(store.getSnapshot()).toBe(false);
+
+      vi.advanceTimersByTime(1);
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("notifies subscribers exactly once, when the window elapses (not on detection)", () => {
+      const store = createVersionUpdateStore(() => "running", 180_000);
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.reportObservedBuildId("deployed");
+      expect(listener).not.toHaveBeenCalled(); // hidden → snapshot unchanged
+
+      vi.advanceTimersByTime(180_000);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("keys the window to the FIRST sighting — a second new build within it does not extend the wait", () => {
+      const store = createVersionUpdateStore(() => "running", 180_000);
+
+      store.reportObservedBuildId("deployed-1");
+      vi.advanceTimersByTime(100_000);
+      // A second genuinely-new build mid-window must not re-arm the timer.
+      store.reportObservedBuildId("deployed-2");
+      vi.advanceTimersByTime(79_999);
+      expect(store.getSnapshot()).toBe(false);
+
+      vi.advanceTimersByTime(1); // 180_000 total since the first sighting
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("re-prompts immediately for a new build once the window has already passed", () => {
+      const store = createVersionUpdateStore(() => "running", 180_000);
+
+      store.reportObservedBuildId("deployed-1");
+      vi.advanceTimersByTime(180_000);
+      expect(store.getSnapshot()).toBe(true);
+
+      store.dismiss();
+      expect(store.getSnapshot()).toBe(false);
+
+      // The settling window is already satisfied → a later new build shows at once.
+      store.reportObservedBuildId("deployed-2");
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("arms no timer when only the running build id is observed", () => {
+      const store = createVersionUpdateStore(() => "running", 180_000);
+
+      store.reportObservedBuildId("running"); // matches → no new-version signal
+      vi.advanceTimersByTime(180_000);
+      expect(store.getSnapshot()).toBe(false);
+    });
+
+    it("defaults the debounce window to three minutes", () => {
+      expect(VERSION_UPDATE_DEBOUNCE_MS).toBe(3 * 60 * 1000);
+
+      const store = createVersionUpdateStore(() => "running");
+      store.reportObservedBuildId("deployed");
+      vi.advanceTimersByTime(VERSION_UPDATE_DEBOUNCE_MS - 1);
+      expect(store.getSnapshot()).toBe(false);
+      vi.advanceTimersByTime(1);
+      expect(store.getSnapshot()).toBe(true);
     });
   });
 });

--- a/web/src/features/version-update/versionUpdateStore.ts
+++ b/web/src/features/version-update/versionUpdateStore.ts
@@ -12,6 +12,14 @@
  * which captures the `x-build-id` response header on every tRPC response. React
  * reads it via {@link useVersionUpdateAvailable} (a `useSyncExternalStore` hook)
  * — no polling, no effect-driven state sync.
+ *
+ * New-version debounce (LFE-14537): a page loaded while the web container is
+ * mid-deploy can see the new build id immediately, and prompting a reload right
+ * then reloads the tab into the still-switching pod (a broken loading state). So
+ * "update available" only flips the snapshot to `true` once at least
+ * {@link VERSION_UPDATE_DEBOUNCE_MS} has elapsed since the FIRST new build id was
+ * seen — a settling window for the deploy to finish. This gate is combined at the
+ * banner with a post-load grace (see `useAppSettled`); both must pass.
  */
 
 /**
@@ -29,10 +37,22 @@ export function isVersionMismatch(
   );
 }
 
+/**
+ * How long after the FIRST new build id is observed before the banner is allowed
+ * to appear — a debounce so a deploy that's still switching pods doesn't
+ * immediately prompt a reload into a half-deployed state (LFE-14537). Keyed on
+ * the first sighting, not re-armed per response, so it can't be starved by a
+ * rolling deploy re-serving build ids.
+ */
+export const VERSION_UPDATE_DEBOUNCE_MS = 3 * 60 * 1000;
+
 export type VersionUpdateStore = {
   /** Subscribe to snapshot changes (for `useSyncExternalStore`). */
   subscribe: (listener: () => void) => () => void;
-  /** Current snapshot: is an update available and not yet dismissed? */
+  /**
+   * Current snapshot: is an update available, not yet dismissed, AND has the
+   * new-version debounce ({@link VERSION_UPDATE_DEBOUNCE_MS}) elapsed?
+   */
   getSnapshot: () => boolean;
   /** SSR snapshot — always `false`; the mismatch only exists in a live tab. */
   getServerSnapshot: () => boolean;
@@ -79,9 +99,16 @@ export type VersionUpdateStore = {
  * Reloading always converges the tab to whatever build is currently served, so
  * "a build ≠ yours exists → offer reload" is the right action even though we
  * can't prove the other build is strictly newer.
+ *
+ * `debounceMs` is the new-version settling window (default
+ * {@link VERSION_UPDATE_DEBOUNCE_MS}); injected for deterministic testing. A
+ * value ≤ 0 disables the debounce (the update shows as soon as it is available)
+ * and stays synchronous — no timer — which keeps the detection/stickiness tests
+ * free of fake timers.
  */
 export function createVersionUpdateStore(
   getRunningBuildId: () => string | null | undefined,
+  debounceMs: number = VERSION_UPDATE_DEBOUNCE_MS,
 ): VersionUpdateStore {
   const listeners = new Set<() => void>();
   // Every build id observed that differs from the running one. Membership is
@@ -93,8 +120,16 @@ export function createVersionUpdateStore(
   // `banner_shown` analytics guard — true once the current appearance has been
   // reported. Reset when a genuinely new build id arrives (new appearance).
   let shownReported = false;
+  // New-version debounce (LFE-14537). `debounceStarted` guards the one-shot
+  // timer so it is armed exactly once — on the FIRST new build id, keyed to that
+  // sighting (never re-armed by later responses, so a rolling deploy can't
+  // starve it). `debounceElapsed` is sticky: once the window passes the update
+  // is eligible forever, and a later genuinely-new build re-prompts immediately.
+  let debounceStarted = false;
+  let debounceElapsed = false;
 
-  const compute = (): boolean => updateAvailable && !dismissed;
+  const compute = (): boolean =>
+    updateAvailable && !dismissed && debounceElapsed;
 
   // Cache the snapshot so `getSnapshot` returns a referentially stable value
   // between changes — `useSyncExternalStore` requires this to avoid re-render
@@ -106,6 +141,24 @@ export function createVersionUpdateStore(
     if (next === snapshot) return;
     snapshot = next;
     for (const listener of listeners) listener();
+  };
+
+  // Arm the new-version debounce once, on the first new build id. When it
+  // elapses the update becomes eligible; the timer emits so a tab that has been
+  // sitting on a settling deploy re-renders the banner in without any further
+  // response. A non-positive window elapses synchronously (no timer left
+  // running). One-shot and self-completing — nothing to clean up.
+  const startDebounce = () => {
+    if (debounceStarted) return;
+    debounceStarted = true;
+    if (debounceMs <= 0) {
+      debounceElapsed = true;
+      return;
+    }
+    setTimeout(() => {
+      debounceElapsed = true;
+      emitChange();
+    }, debounceMs);
   };
 
   return {
@@ -134,6 +187,9 @@ export function createVersionUpdateStore(
       // appearance for analytics.
       dismissed = false;
       shownReported = false;
+      // Arm the settling window on the first new build; a no-op on later ones
+      // (the debounce is keyed to the first sighting, not re-armed per build).
+      startDebounce();
       emitChange();
     },
     dismiss() {


### PR DESCRIPTION
## TL;DR

The "Langfuse got an update — reload" banner (shipped in #15279, LFE-10978) can appear the instant a page loads mid-deploy, nudging the user to reload straight into a still-switching web container — a broken loading state. This adds two grace periods so the prompt is only offered once things have settled: at least **1 minute after page load** and at least **3 minutes after a new version is first detected**. Both must pass. The banner's look and reload behavior are unchanged — only *when* it's allowed to appear.

## Why

A user hit a broken loading state: they loaded a page while the web container was switching versions, the tab immediately saw the new build id, and the banner immediately offered a reload — reloading during that window lands on a half-deployed pod. Prompting a refresh right in the middle of a version flip makes the problem worse rather than helping.

## What

Two gates, each kept in the store/hook that already owns the relevant timing (the banner component itself is untouched):

- **Post-load grace — 60s** (was 5s), in `useAppSettled`: no reload prompt in the first minute of a session, so a deploy that was in flight at page load can settle before we ever offer a reload.
- **New-version debounce — 3 min**, in `versionUpdateStore`: after the *first* new build id is seen, the store's snapshot only flips to "update available" once the settling window elapses.

The banner shows only when **both** gates pass (its visibility is still `updateAvailable && appSettled` — each gate now lives inside its respective store).

## Result

A page loaded mid-deploy no longer offers a reload into a switching pod. The refresh prompt appears only after the deploy has had time to settle. Verified with unit tests (fake timers).

<details>
<summary>Mechanism, edge cases & tests</summary>

**Mechanism**
- Both gates are module-level `useSyncExternalStore` singletons (matching the module's existing pattern), so the grace state survives banner remount (e.g. `AppLayout` switching between authenticated and minimal layouts) rather than restarting on each remount.
- The new-version debounce is a one-shot timer armed on the **first** differing build id and **keyed to that sighting** — not re-armed per response. A rolling deploy that re-serves build ids therefore can't starve it, and it never retracts an already-shown banner. `debounceElapsed` is sticky: once the window passes, a later genuinely-new build re-prompts immediately.
- `compute()` reads only booleans (no `Date.now()`), so the cached snapshot stays referentially stable for `useSyncExternalStore`; the timer callback drives the transition via `emitChange`.
- SSR-safe: both server snapshots stay `false`; no `window`/`document`/storage access.
- No persistence — both windows are in-memory, so every reload restarts them from scratch.
- No component-level timers introduced; the store timers are one-shot and self-completing (nothing to clean up on unmount, by design).

**Tests** (`*.clienttest.ts`, fake timers)
- Store: hidden until the 3-min window elapses; notifies subscribers exactly once, on elapse (not on detection); the window is keyed to the first sighting (a second new build mid-window doesn't extend it); re-prompts immediately for a new build once the window has passed; no timer armed for a matching build id; default window is 3 minutes. Existing detection/stickiness/dismiss/analytics tests preserved (run with a zero debounce for synchronous assertions).
- Post-load grace: `APP_SETTLE_DELAY_MS` locked at 60s; existing gate-mechanism tests intact.
- Connected banner: still hidden until both `updateAvailable` and `appSettled`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)