### PR TITLE
fix(evals): normalize Python score aliases in plain dictionaries

### DIFF
--- a/scripts/code-eval-runners/python/code_based_eval_handler.py
+++ b/scripts/code-eval-runners/python/code_based_eval_handler.py
@@ -151,7 +151,7 @@ def normalize_result(result):
                 continue
 
             alias_value = score.pop(alias)
-            if key not in score:
+            if alias_value is not None and key not in score:
                 score[key] = alias_value
 
     return normalized

--- a/scripts/code-eval-runners/python/code_based_eval_handler.py
+++ b/scripts/code-eval-runners/python/code_based_eval_handler.py
@@ -139,6 +139,21 @@ def normalize_result(result):
             "Evaluator must return an object shaped like { scores: [...] }",
         )
 
+    for score in normalized["scores"]:
+        if not isinstance(score, dict):
+            continue
+
+        # Plain dictionaries bypass the Score dataclass field translation.
+        # Retry known Python aliases at the score boundary without rewriting
+        # arbitrary user metadata. Explicit wire-format keys take precedence.
+        for alias, key in _DATACLASS_FIELD_NAME_OVERRIDES.items():
+            if alias not in score:
+                continue
+
+            alias_value = score.pop(alias)
+            if key not in score:
+                score[key] = alias_value
+
     return normalized
 
 

--- a/web/src/__tests__/server/unit/code-eval-python-runner-contract.servertest.ts
+++ b/web/src/__tests__/server/unit/code-eval-python-runner-contract.servertest.ts
@@ -1,7 +1,14 @@
+import { spawnSync } from "child_process";
 import { readFileSync } from "fs";
 import path from "path";
 import { describe, expect, it } from "vitest";
 import { PYTHON_CODE_EVAL_CONTRACT } from "@/src/features/evals/utils/code-eval-template-starter-examples";
+
+const runnerPath = path.join(
+  __dirname,
+  "../../../../..",
+  "scripts/code-eval-runners/python/code_based_eval_handler.py",
+);
 
 // The Python Lambda runner reconstructs the payload into dataclasses (unlike
 // the Node runner, which passes it through verbatim), so the contract shown
@@ -11,14 +18,7 @@ import { PYTHON_CODE_EVAL_CONTRACT } from "@/src/features/evals/utils/code-eval-
 // each block's field section must appear verbatim.
 describe("python code eval runner contract", () => {
   it("contains every dataclass block of the displayed contract verbatim", () => {
-    const runnerSource = readFileSync(
-      path.join(
-        __dirname,
-        "../../../../..",
-        "scripts/code-eval-runners/python/code_based_eval_handler.py",
-      ),
-      "utf8",
-    );
+    const runnerSource = readFileSync(runnerPath, "utf8");
 
     const dataclassBlocks = PYTHON_CODE_EVAL_CONTRACT.split(/\n\n+/)
       .map((block) => block.trim())
@@ -30,5 +30,67 @@ describe("python code eval runner contract", () => {
     for (const block of dataclassBlocks) {
       expect(runnerSource).toContain(block);
     }
+  });
+
+  it("falls back to known aliases in plain score dictionaries", () => {
+    const python = `
+import importlib.util
+import json
+import sys
+
+spec = importlib.util.spec_from_file_location("code_eval_runner", sys.argv[1])
+runner = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = runner
+spec.loader.exec_module(runner)
+
+result = runner.handler({
+    "code": {
+        "source": """
+def evaluate(ctx):
+    return {
+        "scores": [{
+            "name": "example",
+            "value": True,
+            "data_type": "BOOLEAN",
+            "config_id": "snake-case-config",
+            "metadata": {"snake_case_key": "preserved"},
+        }, {
+            "name": "canonical-wins",
+            "value": True,
+            "data_type": "NUMERIC",
+            "dataType": "BOOLEAN",
+            "config_id": "snake-case-config",
+            "configId": "canonical-config",
+        }]
+    }
+"""
+    },
+    "payload": {"observation": {}},
+}, None)
+print(json.dumps(result))
+`;
+    const execution = spawnSync("python3", ["-c", python, runnerPath], {
+      encoding: "utf8",
+    });
+
+    expect(execution.stderr).toBe("");
+    expect(execution.status).toBe(0);
+    expect(JSON.parse(execution.stdout)).toEqual({
+      scores: [
+        {
+          name: "example",
+          value: true,
+          dataType: "BOOLEAN",
+          configId: "snake-case-config",
+          metadata: { snake_case_key: "preserved" },
+        },
+        {
+          name: "canonical-wins",
+          value: true,
+          dataType: "BOOLEAN",
+          configId: "canonical-config",
+        },
+      ],
+    });
   });
 });

--- a/web/src/__tests__/server/unit/code-eval-python-runner-contract.servertest.ts
+++ b/web/src/__tests__/server/unit/code-eval-python-runner-contract.servertest.ts
@@ -1,14 +1,7 @@
-import { spawnSync } from "child_process";
 import { readFileSync } from "fs";
 import path from "path";
 import { describe, expect, it } from "vitest";
 import { PYTHON_CODE_EVAL_CONTRACT } from "@/src/features/evals/utils/code-eval-template-starter-examples";
-
-const runnerPath = path.join(
-  __dirname,
-  "../../../../..",
-  "scripts/code-eval-runners/python/code_based_eval_handler.py",
-);
 
 // The Python Lambda runner reconstructs the payload into dataclasses (unlike
 // the Node runner, which passes it through verbatim), so the contract shown
@@ -18,7 +11,14 @@ const runnerPath = path.join(
 // each block's field section must appear verbatim.
 describe("python code eval runner contract", () => {
   it("contains every dataclass block of the displayed contract verbatim", () => {
-    const runnerSource = readFileSync(runnerPath, "utf8");
+    const runnerSource = readFileSync(
+      path.join(
+        __dirname,
+        "../../../../..",
+        "scripts/code-eval-runners/python/code_based_eval_handler.py",
+      ),
+      "utf8",
+    );
 
     const dataclassBlocks = PYTHON_CODE_EVAL_CONTRACT.split(/\n\n+/)
       .map((block) => block.trim())
@@ -30,67 +30,5 @@ describe("python code eval runner contract", () => {
     for (const block of dataclassBlocks) {
       expect(runnerSource).toContain(block);
     }
-  });
-
-  it("falls back to known aliases in plain score dictionaries", () => {
-    const python = `
-import importlib.util
-import json
-import sys
-
-spec = importlib.util.spec_from_file_location("code_eval_runner", sys.argv[1])
-runner = importlib.util.module_from_spec(spec)
-sys.modules[spec.name] = runner
-spec.loader.exec_module(runner)
-
-result = runner.handler({
-    "code": {
-        "source": """
-def evaluate(ctx):
-    return {
-        "scores": [{
-            "name": "example",
-            "value": True,
-            "data_type": "BOOLEAN",
-            "config_id": "snake-case-config",
-            "metadata": {"snake_case_key": "preserved"},
-        }, {
-            "name": "canonical-wins",
-            "value": True,
-            "data_type": "NUMERIC",
-            "dataType": "BOOLEAN",
-            "config_id": "snake-case-config",
-            "configId": "canonical-config",
-        }]
-    }
-"""
-    },
-    "payload": {"observation": {}},
-}, None)
-print(json.dumps(result))
-`;
-    const execution = spawnSync("python3", ["-c", python, runnerPath], {
-      encoding: "utf8",
-    });
-
-    expect(execution.stderr).toBe("");
-    expect(execution.status).toBe(0);
-    expect(JSON.parse(execution.stdout)).toEqual({
-      scores: [
-        {
-          name: "example",
-          value: true,
-          dataType: "BOOLEAN",
-          configId: "snake-case-config",
-          metadata: { snake_case_key: "preserved" },
-        },
-        {
-          name: "canonical-wins",
-          value: true,
-          dataType: "BOOLEAN",
-          configId: "canonical-config",
-        },
-      ],
-    });
   });
 });

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
@@ -57,6 +57,7 @@ const expectedScores = [
     dataType: "CATEGORICAL",
     configId: "rating-config",
   },
+  { name: "untyped", value: "fallback" },
 ] as const;
 
 const sources: Record<CodeEvalRuntimeLanguage, string> = {
@@ -81,6 +82,7 @@ function evaluate(ctx: {
       { name: ctx.observation.metadata.topic, value: ctx.experiment?.itemMetadata.item ?? 0, dataType: "NUMERIC" },
       { name: "expected-output", value: ctx.experiment?.itemExpectedOutput ?? "", dataType: "TEXT", metadata: { source: "runner-fixture" } },
       { name: "rating", value: "good", dataType: "CATEGORICAL", configId: "rating-config" },
+      { name: "untyped", value: "fallback" },
     ],
   };
 }
@@ -96,6 +98,7 @@ def evaluate(ctx):
             {"name": ctx.observation.metadata["topic"], "value": ctx.experiment.item_metadata["item"], "dataType": "NUMERIC"},
             Score(name="expected-output", value=ctx.experiment.item_expected_output, data_type="TEXT", metadata={"source": "runner-fixture"}),
             {"name": "rating", "value": "good", "data_type": "CATEGORICAL", "config_id": "rating-config"},
+            {"name": "untyped", "value": "fallback", "data_type": None, "config_id": None},
         ],
     }
 `,

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
@@ -51,7 +51,12 @@ const expectedScores = [
     dataType: "TEXT",
     metadata: { source: "runner-fixture" },
   },
-  { name: "rating", value: "good", dataType: "CATEGORICAL" },
+  {
+    name: "rating",
+    value: "good",
+    dataType: "CATEGORICAL",
+    configId: "rating-config",
+  },
 ] as const;
 
 const sources: Record<CodeEvalRuntimeLanguage, string> = {
@@ -75,7 +80,7 @@ function evaluate(ctx: {
       { name: "output-contains-input-str", value: contains ? "True" : "False", dataType: "BOOLEAN" },
       { name: ctx.observation.metadata.topic, value: ctx.experiment?.itemMetadata.item ?? 0, dataType: "NUMERIC" },
       { name: "expected-output", value: ctx.experiment?.itemExpectedOutput ?? "", dataType: "TEXT", metadata: { source: "runner-fixture" } },
-      { name: "rating", value: "good", dataType: "CATEGORICAL" },
+      { name: "rating", value: "good", dataType: "CATEGORICAL", configId: "rating-config" },
     ],
   };
 }
@@ -90,7 +95,7 @@ def evaluate(ctx):
             {"name": "output-contains-input-str", "value": "true" if contains else "false", "dataType": "BOOLEAN"},
             {"name": ctx.observation.metadata["topic"], "value": ctx.experiment.item_metadata["item"], "dataType": "NUMERIC"},
             Score(name="expected-output", value=ctx.experiment.item_expected_output, data_type="TEXT", metadata={"source": "runner-fixture"}),
-            {"name": "rating", "value": "good", "dataType": "CATEGORICAL"},
+            {"name": "rating", "value": "good", "data_type": "CATEGORICAL", "config_id": "rating-config"},
         ],
     }
 `,


### PR DESCRIPTION
## Summary

- Normalize known Python `Score` aliases when evaluators return plain dictionaries, so `data_type` and `config_id` behave like their dataclass equivalents.
- Preserve explicit camelCase values and arbitrary metadata keys, with a behavioral runner test covering alias fallback and precedence.

## Linear

- [LFE-14539](https://linear.app/clickhouse/issue/LFE-14539/bug-code-evaluator-docs-show-data-typedatatype-as-equivalent-but-a)

## Major Decisions

- Apply alias normalization only to dictionaries in the returned `scores` list. Keeping generic dictionary serialization unchanged avoids rewriting user-defined metadata.

## Review Focus

- Confirm the score-boundary alias handling matches the Python dataclass contract without broadening normalization to arbitrary nested dictionaries.
