### PR TITLE
chore: clean up legacy queue metrics after migration

### DIFF
--- a/.agents/skills/datadog-query-recipes/references/queue-consumers.md
+++ b/.agents/skills/datadog-query-recipes/references/queue-consumers.md
@@ -15,10 +15,9 @@ spans.
 - Worker consumer env vars:
   `worker/src/env.ts` (`QUEUE_CONSUMER_*_IS_ENABLED` plus feature-specific
   gates).
-- Worker registration, request/error counters, wait/processing time, and
-  sampled old-style depth metrics:
+- Worker registration, request/error/stalled rates, and wait/processing time:
   `worker/src/queues/workerManager.ts`.
-- Queue depth background reporter:
+- Queue depth and DLQ oldest-age background reporter:
   `worker/src/features/queue-metrics-runner/index.ts`.
 - Metric name conversion:
   `packages/shared/src/server/instrumentation/index.ts`
@@ -185,7 +184,7 @@ Examples:
 | `trace-upsert` | `langfuse.queue.trace_upsert` |
 | `batch-export-queue` | `langfuse.queue.batch_export` |
 
-Prefer the newer tagged metrics:
+Use the tagged queue metrics:
 
 ```text
 <metric_base>.depth{env:<env>,type:waiting}
@@ -194,36 +193,39 @@ Prefer the newer tagged metrics:
 <metric_base>.rate{env:<env>,type:request}
 <metric_base>.rate{env:<env>,type:failed}
 <metric_base>.rate{env:<env>,type:error}
+<metric_base>.rate{env:<env>,type:stalled}
 <metric_base>.time_distribution{env:<env>,type:wait}
 <metric_base>.time_distribution{env:<env>,type:processing}
+<metric_base>.dlq_oldest_age{env:<env>}
 ```
 
-For sharded queues, use the `shard` tag when present. `shard:all` is emitted by
-the depth runner for aggregate depth across shards.
+Metric emission and shard handling differ by source:
 
-Backward-compatible metrics may still appear:
+- `WorkerManager` emits `.rate` and `.time_distribution`. A non-sharded queue
+  has no `shard` tag. A sharded worker uses the base queue's metric name and
+  sets `shard` to the full physical queue name. It does not emit `shard:all`.
+- `QueueMetricsRunner` emits `.depth` and `.dlq_oldest_age` only for queue
+  instances with a worker registered in the current process. It does not add a
+  `shard` tag for a non-sharded queue. For a sharded queue, it emits one series
+  per registered physical shard plus `shard:all`.
 
-```text
-<metric_base>.length
-<metric_base>.dlq_length
-<metric_base>.active
-<metric_base>.request
-<metric_base>.failed
-<metric_base>.error
-<metric_base>.wait_time
-<metric_base>.processing_time
-```
+For `.depth`, `shard:all` is the sum across registered shards when every poll
+succeeds. If only some shard polls succeed, the runner estimates the total by
+scaling the successful sum by `registered shard count / successful poll count`.
+For `.dlq_oldest_age`, `shard:all` is the maximum age returned by the successful
+shard polls; failed polls are omitted and are not extrapolated.
 
-For non-BullMQ internal write buffering, `ClickhouseWriter` emits
-`langfuse.queue.clickhouse_writer.*` metrics, but it is not a `QueueName`
-consumer.
+Exclude `langfuse.queue.clickhouse_writer.*` from BullMQ consumer checks.
+Despite the metric prefix, those metrics come from
+`worker/src/services/ClickhouseWriter/index.ts` and describe its in-memory
+buffers and ClickHouse flushes, not a BullMQ queue.
 
 ## Consumer Running Checklist
 
 To establish whether a consumer is running in production:
 
 1. Check queue depth metrics for waiting, failed, and active counts.
-2. Check `rate{type:request}` or old `.request` metrics for recent processing.
+2. Check `rate{type:request}` for recent processing.
 3. Search BullMQ processor spans on `worker` and `worker-cpu`.
 4. Search worker logs for the queue name or processor-specific log prefix.
 5. If all signals are empty, verify the relevant `QUEUE_CONSUMER_*_IS_ENABLED`

--- a/worker/src/__tests__/bullmqVersionCheckOptions.test.ts
+++ b/worker/src/__tests__/bullmqVersionCheckOptions.test.ts
@@ -194,20 +194,12 @@ describe("BullMQ Redis version check options", () => {
         error: vi.fn(),
         info: vi.fn(),
       },
-      recordGauge: vi.fn(),
-      recordHistogram: vi.fn(),
+      recordDistribution: vi.fn(),
       recordIncrement: vi.fn(),
       traceException: vi.fn(),
     }));
 
-    vi.doMock("../env", () => ({
-      env: {
-        LANGFUSE_QUEUE_METRICS_SAMPLE_RATE: 0,
-      },
-    }));
-
     vi.doMock("../queues/shardedQueueRegistry", () => ({
-      resolveQueueInstance: vi.fn(),
       SHARDED_QUEUE_BASE_NAMES: [],
     }));
 

--- a/worker/src/__tests__/workerManagerMetrics.test.ts
+++ b/worker/src/__tests__/workerManagerMetrics.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => void>(),
+  processor: undefined as
+    | ((job: { data: unknown; timestamp: number }) => Promise<unknown>)
+    | undefined,
+  legacyRecordGauge: vi.fn(),
+  legacyRecordHistogram: vi.fn(),
+  recordDistribution: vi.fn(),
+  recordIncrement: vi.fn(),
+}));
+
+vi.mock("bullmq", () => ({
+  Job: class {},
+  Worker: class {
+    constructor(
+      _queueName: string,
+      processor: (job: {
+        data: unknown;
+        timestamp: number;
+      }) => Promise<unknown>,
+    ) {
+      mocks.processor = processor;
+    }
+
+    close = vi.fn(async () => undefined);
+    isRunning = vi.fn(() => true);
+    on = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      mocks.handlers.set(event, handler);
+    });
+  },
+}));
+
+vi.mock("@opentelemetry/api", () => ({
+  context: {
+    with: (_context: unknown, callback: () => unknown) => callback(),
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  QueueName: {
+    TraceDelete: "trace-delete",
+  },
+  contextWithLangfuseProps: vi.fn(() => ({})),
+  convertQueueNameToMetricName: (queueName: string) =>
+    `langfuse.queue.${queueName.replace(/-/g, "_").replace(/_queue$/, "")}`,
+  createBullMQWorkerOptionsWithRedis: vi.fn(() => ({ connection: {} })),
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  recordGauge: mocks.legacyRecordGauge,
+  recordHistogram: mocks.legacyRecordHistogram,
+  recordDistribution: mocks.recordDistribution,
+  recordIncrement: mocks.recordIncrement,
+  traceException: vi.fn(),
+}));
+
+vi.mock("../queues/shardedQueueRegistry", () => ({
+  resolveQueueInstance: vi.fn(() => ({
+    getActiveCount: vi.fn(async () => 0),
+    getFailed: vi.fn(async () => []),
+    getFailedCount: vi.fn(async () => 0),
+    getWaitingCount: vi.fn(async () => 0),
+  })),
+  SHARDED_QUEUE_BASE_NAMES: new Set(),
+}));
+
+vi.mock("../utils/hostId", () => ({
+  WORKER_HOST_ID: "test-host",
+}));
+
+import { WorkerManager } from "../queues/workerManager";
+
+describe("WorkerManager queue metrics", () => {
+  beforeEach(() => {
+    mocks.handlers.clear();
+    mocks.processor = undefined;
+    vi.clearAllMocks();
+  });
+
+  it("emits only tagged rate and time metrics", async () => {
+    WorkerManager.register("trace-delete" as never, async () => "processed");
+
+    expect(mocks.processor).toBeDefined();
+    await expect(
+      mocks.processor!({
+        data: { payload: { projectId: "project-id" } },
+        timestamp: Date.now() - 50,
+      }),
+    ).resolves.toBe("processed");
+    await Promise.resolve();
+
+    expect(mocks.recordIncrement.mock.calls).toEqual([
+      ["langfuse.queue.trace_delete.rate", 1, { type: "request" }],
+    ]);
+    expect(
+      mocks.recordDistribution.mock.calls.map(([metric, _value, tags]) => [
+        metric,
+        tags,
+      ]),
+    ).toEqual([
+      [
+        "langfuse.queue.trace_delete.time_distribution",
+        { type: "wait", unit: "milliseconds" },
+      ],
+      [
+        "langfuse.queue.trace_delete.time_distribution",
+        { type: "processing", unit: "milliseconds" },
+      ],
+    ]);
+    expect(mocks.legacyRecordGauge).not.toHaveBeenCalled();
+    expect(mocks.legacyRecordHistogram).not.toHaveBeenCalled();
+
+    mocks.recordIncrement.mockClear();
+    mocks.handlers.get("failed")?.(
+      { id: "job-id", name: "job" },
+      new Error("failed"),
+    );
+    mocks.handlers.get("error")?.(new Error("errored"));
+    mocks.handlers.get("stalled")?.("job-id");
+
+    expect(mocks.recordIncrement.mock.calls).toEqual([
+      ["langfuse.queue.trace_delete.rate", 1, { type: "failed" }],
+      ["langfuse.queue.trace_delete.rate", 1, { type: "error" }],
+      ["langfuse.queue.trace_delete.rate", 1, { type: "stalled" }],
+    ]);
+  });
+});

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -571,11 +571,6 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(2),
-  LANGFUSE_QUEUE_METRICS_SAMPLE_RATE: z.coerce
-    .number()
-    .min(0)
-    .max(1)
-    .default(0.3), // Probability for recording sharded queue depth metrics
   LANGFUSE_QUEUE_METRICS_INTERVAL_MS: z.coerce.number().min(100).default(1000),
   LANGFUSE_QUEUE_METRICS_ENABLED: z.enum(["true", "false"]).default("true"),
 });

--- a/worker/src/features/queue-metrics-runner/index.test.ts
+++ b/worker/src/features/queue-metrics-runner/index.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getFailed: vi.fn(),
+  getJobCounts: vi.fn(),
+  recordGauge: vi.fn(),
+  updateActiveIngestFailureProjectsMetric: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  QueueName: {
+    TraceDelete: "trace-delete",
+  },
+  convertQueueNameToMetricName: (queueName: string) =>
+    `langfuse.queue.${queueName.replace(/-/g, "_").replace(/_queue$/, "")}`,
+  instrumentAsync: vi.fn(),
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  recordDistribution: vi.fn(),
+  recordGauge: mocks.recordGauge,
+  recordIncrement: vi.fn(),
+  traceException: vi.fn(),
+  updateActiveIngestFailureProjectsMetric:
+    mocks.updateActiveIngestFailureProjectsMetric,
+}));
+
+vi.mock("../../env", () => ({
+  env: {
+    LANGFUSE_QUEUE_METRICS_INTERVAL_MS: 1_000,
+  },
+}));
+
+vi.mock("../../queues/workerManager", () => ({
+  WorkerManager: {
+    computeDlqOldestAgeMs: vi.fn(() => 0),
+    getRegisteredQueueNames: vi.fn(() => ["trace-delete"]),
+  },
+}));
+
+vi.mock("../../queues/shardedQueueRegistry", () => ({
+  SHARDED_QUEUES: [],
+  SHARDED_QUEUE_BASE_NAMES: new Set(),
+  resolveQueueInstance: vi.fn(() => ({
+    getFailed: mocks.getFailed,
+    getJobCounts: mocks.getJobCounts,
+  })),
+}));
+
+import { QueueMetricsRunner } from ".";
+
+class TestQueueMetricsRunner extends QueueMetricsRunner {
+  public executeOnce(): Promise<void> {
+    return this.execute();
+  }
+}
+
+describe("QueueMetricsRunner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getFailed.mockResolvedValue([]);
+    mocks.getJobCounts.mockResolvedValue({
+      active: 2,
+      failed: 3,
+      paused: 5,
+      waiting: 7,
+    });
+    mocks.updateActiveIngestFailureProjectsMetric.mockResolvedValue(undefined);
+  });
+
+  it("emits only the canonical gauges for a non-sharded queue", async () => {
+    await new TestQueueMetricsRunner().executeOnce();
+
+    expect(mocks.getJobCounts).toHaveBeenCalledWith(
+      "waiting",
+      "paused",
+      "failed",
+      "active",
+    );
+    expect(mocks.recordGauge).toHaveBeenCalledTimes(4);
+    expect(mocks.recordGauge).toHaveBeenCalledWith(
+      "langfuse.queue.trace_delete.dlq_oldest_age",
+      0,
+      { unit: "milliseconds" },
+    );
+    expect(mocks.recordGauge).toHaveBeenCalledWith(
+      "langfuse.queue.trace_delete.depth",
+      12,
+      { type: "waiting", unit: "records" },
+    );
+    expect(mocks.recordGauge).toHaveBeenCalledWith(
+      "langfuse.queue.trace_delete.depth",
+      3,
+      { type: "failed", unit: "records" },
+    );
+    expect(mocks.recordGauge).toHaveBeenCalledWith(
+      "langfuse.queue.trace_delete.depth",
+      2,
+      { type: "active", unit: "records" },
+    );
+    const legacyMetricNames = new Set([
+      "langfuse.queue.trace_delete.length",
+      "langfuse.queue.trace_delete.dlq_length",
+      "langfuse.queue.trace_delete.active",
+    ]);
+    expect(
+      mocks.recordGauge.mock.calls
+        .map(([metricName]) => metricName)
+        .filter((metricName) => legacyMetricNames.has(metricName)),
+    ).toEqual([]);
+  });
+});

--- a/worker/src/features/queue-metrics-runner/index.ts
+++ b/worker/src/features/queue-metrics-runner/index.ts
@@ -117,19 +117,6 @@ export class QueueMetricsRunner extends PeriodicRunner {
           .then((depths) => {
             if (depths) {
               emitDepth(metricBase, depths);
-              // Old-style metrics for backward compatibility.
-              // These duplicate what workerManager.metricWrapper emits on job
-              // completion. Both sources coexist during migration — once dashboards
-              // switch to the new .depth metrics, remove all but .depth
-              recordGauge(metricBase + ".length", depths.waiting, {
-                unit: "records",
-              });
-              recordGauge(metricBase + ".dlq_length", depths.failed, {
-                unit: "records",
-              });
-              recordGauge(metricBase + ".active", depths.active, {
-                unit: "records",
-              });
             }
           })
           .catch((err) => {

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -7,17 +7,11 @@ import {
   logger,
   QueueName,
   recordDistribution,
-  recordGauge,
-  recordHistogram,
   recordIncrement,
   traceException,
 } from "@langfuse/shared/src/server";
-import { env } from "../env";
 import { WORKER_HOST_ID } from "../utils/hostId";
-import {
-  resolveQueueInstance,
-  SHARDED_QUEUE_BASE_NAMES,
-} from "./shardedQueueRegistry";
+import { SHARDED_QUEUE_BASE_NAMES } from "./shardedQueueRegistry";
 
 export class WorkerManager {
   private static workers: { [key: string]: Worker } = {};
@@ -72,22 +66,17 @@ export class WorkerManager {
     processor: Processor,
     queueName: QueueName,
   ): Processor {
-    const oldMetric = convertQueueNameToMetricName(queueName);
     const { baseMetric, shardTag } = WorkerManager.resolveMetricInfo(queueName);
 
     return async (job: Job) => {
       const startTime = Date.now();
       const waitTime = Date.now() - job.timestamp;
 
-      recordIncrement(oldMetric + ".request");
       recordIncrement(baseMetric + ".rate", 1, {
         type: "request",
         ...shardTag,
       });
 
-      recordHistogram(oldMetric + ".wait_time", waitTime, {
-        unit: "milliseconds",
-      });
       recordDistribution(baseMetric + ".time_distribution", waitTime, {
         type: "wait",
         unit: "milliseconds",
@@ -105,48 +94,7 @@ export class WorkerManager {
         processor(job),
       );
 
-      const queue = resolveQueueInstance(queueName);
-      // Sample queue depth gauges for sharded queues to reduce metric volume.
-      const shouldSample =
-        !shardTag || Math.random() < env.LANGFUSE_QUEUE_METRICS_SAMPLE_RATE;
-
-      if (shouldSample) {
-        Promise.allSettled([
-          // Here we only consider waiting jobs instead of the default ("waiting" or "delayed"
-          // or "prioritized" or "waiting-children") that count provides
-          queue?.getWaitingCount().then((count) => {
-            recordGauge(oldMetric + ".length", count, {
-              unit: "records",
-            });
-          }),
-          queue?.getFailedCount().then((count) => {
-            recordGauge(oldMetric + ".dlq_length", count, {
-              unit: "records",
-            });
-          }),
-          // getFailed returns newest-first (ZREVRANGE on failure time), so
-          // index -1 is the oldest job.
-          queue?.getFailed(-1, -1).then((jobs) => {
-            recordGauge(
-              oldMetric + ".dlq_oldest_age",
-              WorkerManager.computeDlqOldestAgeMs(jobs, Date.now()),
-              { unit: "milliseconds" },
-            );
-          }),
-          queue?.getActiveCount().then((count) => {
-            recordGauge(oldMetric + ".active", count, {
-              unit: "records",
-            });
-          }),
-        ]).catch((err) => {
-          logger.error("Failed to record queue length", err);
-        });
-      }
-
       const processingTime = Date.now() - startTime;
-      recordHistogram(oldMetric + ".processing_time", processingTime, {
-        unit: "milliseconds",
-      });
       recordDistribution(baseMetric + ".time_distribution", processingTime, {
         type: "processing",
         unit: "milliseconds",
@@ -201,7 +149,6 @@ export class WorkerManager {
     WorkerManager.workers[queueName] = worker;
     logger.info(`${queueName} executor started: ${worker.isRunning()}`);
 
-    const oldMetric = convertQueueNameToMetricName(queueName);
     const { baseMetric, shardTag } = WorkerManager.resolveMetricInfo(queueName);
 
     // Add error handling
@@ -211,7 +158,6 @@ export class WorkerManager {
         err,
       );
       traceException(err);
-      recordIncrement(oldMetric + ".failed");
       recordIncrement(baseMetric + ".rate", 1, {
         type: "failed",
         ...shardTag,
@@ -223,7 +169,6 @@ export class WorkerManager {
         failedReason,
       );
       traceException(failedReason);
-      recordIncrement(oldMetric + ".error");
       recordIncrement(baseMetric + ".rate", 1, {
         type: "error",
         ...shardTag,
@@ -237,7 +182,6 @@ export class WorkerManager {
       logger.warn(
         `Queue job ${jobId} in ${queueName} stalled (lock expired, re-enqueued) detectedOnHost=${WORKER_HOST_ID}`,
       );
-      recordIncrement(oldMetric + ".stalled");
       recordIncrement(baseMetric + ".rate", 1, {
         type: "stalled",
         ...shardTag,


### PR DESCRIPTION
## Summary

- Remove legacy BullMQ queue metrics and the unused sampling configuration.
- Keep canonical tagged rate, distribution, depth, and DLQ age metrics.
- Clarify queue metric emission, shard handling, and ClickHouse writer exclusions in Datadog guidance.
- Add coverage for worker and queue metrics behavior.

