### PR TITLE
chore(deps): bump Snyk-flagged path-to-regexp and @ai-sdk/provider-utils

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,11 @@ overrides:
   glob: ^10.5.0
   qs: 6.15.2
   path-to-regexp@0.1.12: 0.1.13
+  path-to-regexp@8.3.0: 8.4.0
   ip-address@10.1.0: 10.2.0
-  '@ai-sdk/provider-utils@<=4.0.26': 4.0.27
-  '@ai-sdk/provider-utils-v5': npm:@ai-sdk/provider-utils@4.0.27
+  '@ai-sdk/provider-utils@<=4.0.32': 4.0.33
+  '@ai-sdk/provider-utils-v5': npm:@ai-sdk/provider-utils@4.0.33
+  '@ai-sdk/provider-utils-v6': npm:@ai-sdk/provider-utils@4.0.33
   '@ai-sdk/ui-utils>@ai-sdk/provider-utils': 2.2.8
   '@anthropic-ai/vertex-sdk>@anthropic-ai/sdk': 0.104.1
   next-auth>nodemailer: ^9.0.3
@@ -1386,8 +1388,8 @@ packages:
     peerDependencies:
       zod: 4.3.6
 
-  '@ai-sdk/provider-utils@4.0.27':
-    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+  '@ai-sdk/provider-utils@4.0.33':
+    resolution: {integrity: sha512-nJ0bAfegMAIJtrzMJtbzer1cS3nb7c7DsyU1S4nrPm7ZU0Mn6SBBZv5IGZZGTbpWTJwqKTSPeZJTXalbAxt1BA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 4.3.6
@@ -1426,6 +1428,10 @@ packages:
 
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.12':
+    resolution: {integrity: sha512-sj9DWTJ2Ze0WR9qsiOPqoqzNx3OxL6iMxHImbhvoe9qOspekbzxNDMiJ4TIGfYHYh9w4OmBjz3prvqhzTi96+Q==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.14':
@@ -9878,8 +9884,8 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -11953,7 +11959,7 @@ snapshots:
     dependencies:
       '@ai-sdk/anthropic': 3.0.62(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       '@smithy/eventstream-codec': 4.4.10
       '@smithy/util-utf8': 4.4.10
       aws4fetch: 1.0.20
@@ -11973,13 +11979,13 @@ snapshots:
   '@ai-sdk/anthropic@2.0.87(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/anthropic@3.0.62(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/anthropic@4.0.16(zod@4.3.6)':
@@ -12028,7 +12034,7 @@ snapshots:
       '@ai-sdk/google': 2.0.82(zod@4.3.6)
       '@ai-sdk/openai-compatible': 1.0.46(zod@4.3.6)
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       google-auth-library: 10.6.2
       zod: 4.3.6
     transitivePeerDependencies:
@@ -12049,7 +12055,7 @@ snapshots:
   '@ai-sdk/google@2.0.82(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/google@3.0.95(zod@4.3.6)':
@@ -12074,7 +12080,7 @@ snapshots:
   '@ai-sdk/openai-compatible@1.0.46(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/openai-compatible@3.0.3(zod@4.3.6)':
@@ -12108,9 +12114,9 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 4.3.6
 
-  '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider': 3.0.12
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 4.3.6
@@ -12155,6 +12161,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.12':
     dependencies:
       json-schema: 0.4.0
 
@@ -14233,8 +14243,8 @@ snapshots:
   '@mastra/core@1.37.1(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(effect@3.21.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(ai@6.0.230(zod@4.3.6))(express@5.2.1)(openapi-types@12.1.3)(rxjs@7.8.1)(zod@4.3.6)':
     dependencies:
       '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.4)(express@5.2.1)
-      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
-      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
       '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
       '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.10'
       '@ai-sdk/ui-utils-v5': '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)'
@@ -14283,8 +14293,8 @@ snapshots:
   '@mastra/core@1.37.1(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(effect@3.21.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(ai@7.0.8(zod@4.3.6))(express@5.2.1)(openapi-types@12.1.3)(rxjs@7.8.1)(zod@4.3.6)':
     dependencies:
       '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.4)(express@5.2.1)
-      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
-      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
       '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
       '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.10'
       '@ai-sdk/ui-utils-v5': '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)'
@@ -14333,8 +14343,8 @@ snapshots:
   '@mastra/core@1.46.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@6.0.230(zod@4.3.6))(express@5.2.1)(rxjs@7.8.1)(zod@4.3.6)':
     dependencies:
       '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.4)(express@5.2.1)
-      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
-      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
       '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
       '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.10'
       '@isaacs/ttlcache': 2.1.5
@@ -14376,8 +14386,8 @@ snapshots:
   '@mastra/core@1.46.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.8(zod@4.3.6))(express@5.2.1)(rxjs@7.8.1)(zod@4.3.6)':
     dependencies:
       '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.4)(express@5.2.1)
-      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
-      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
       '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
       '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.10'
       '@isaacs/ttlcache': 2.1.5
@@ -22106,7 +22116,7 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.0: {}
 
   pathe@2.0.3: {}
 
@@ -22827,7 +22837,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,12 +71,18 @@ overrides:
   glob: ^10.5.0
   qs: 6.15.2
   path-to-regexp@0.1.12: 0.1.13
+  # ReDoS only affects the 8.x line (CVE-2026-4926/-4923, >=8.0.0 <8.4.0).
+  path-to-regexp@8.3.0: 8.4.0
   ip-address@10.1.0: 10.2.0
-  "@ai-sdk/provider-utils@<=4.0.26": 4.0.27
-  "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@4.0.27"
+  # SSRF + throttling fixes land in 4.0.29/4.0.33. @mastra/core pins its
+  # provider-utils-v6 alias to exactly 4.0.27, which the range key can't
+  # catch — aliased deps need alias-name overrides (same reason -v5 exists).
+  "@ai-sdk/provider-utils@<=4.0.32": 4.0.33
+  "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@4.0.33"
+  "@ai-sdk/provider-utils-v6": "npm:@ai-sdk/provider-utils@4.0.33"
   # @ag-ui/mastra imports parsePartialJson from @ai-sdk/ui-utils, whose module
   # evaluation needs exports (validatorSymbol) that only exist in its own
-  # provider-utils 2.x line — exempt it from the blanket 4.0.27 lift above.
+  # provider-utils 2.x line — exempt it from the blanket 4.0.33 lift above.
   "@ai-sdk/ui-utils>@ai-sdk/provider-utils": 2.2.8
   # Keep Anthropic's Vertex client on an SDK version that emits Vertex rawPredict URLs.
   # Remove once @langchain/anthropic allows the same SDK range.


### PR DESCRIPTION
## Context

#15421 moved the in-app-agent runtime into `packages/shared`, whose fresh Snyk baseline flagged 7 security findings that web has carried since #14018 (the Mastra introduction). This bumps the two families whose fixes are outside the `minimumReleaseAge` window, via `pnpm-workspace.yaml` overrides (same pattern as #13845, #14318). Lockfile resolutions are workspace-wide, so this clears the same open issues on the web project too. `minimumReleaseAge` settings are deliberately untouched.

## Changes

- **path-to-regexp 8.3.0 → 8.4.0** (SNYK-JS-PATHTOREGEXP-15789763 / -15789765, ReDoS, CVSS 8.7/8.2): new version-scoped override. Per the GitHub advisories only `>=8.0.0 <8.4.0` is affected, so the existing 0.1.x pin and the 6.3.0 resolution are untouched.
- **@ai-sdk/provider-utils 4.0.27 → 4.0.33** (SSRF + throttling): bumped the blanket override and widened its key to `<=4.0.32`; added a `provider-utils-v6` alias override because `@mastra/core` pins that alias to exactly 4.0.27, which the range key cannot catch (aliased deps need alias-name overrides — same reason the `-v5` override exists).

**Deferred until they pass the 5-day `minimumReleaseAge` window** (rather than adding `minimumReleaseAgeExclude` entries):
- `@hono/node-server` 1.19.14 → 1.19.17 (SNYK-JS-HONONODESERVER-18170326, directory traversal) — fix published 2026-07-27, eligible ~Aug 1. Dedupe-only once eligible (MCP SDK's `^1.19.9` range covers it).
- `ip-address` 10.2.0 → 10.2.1 (CVE-2026-54272, SSRF) — fix published 2026-07-25, eligible ~Jul 30. One-line bump of the existing override.

**Intentionally not fixed** (Snyk dashboard ignores instead):
- `@ai-sdk/ui-utils → @ai-sdk/provider-utils@2.2.8` — no fixed 2.x release exists; blocked on upstream `@ag-ui/mastra` dropping `ui-utils`.
- `js-yaml@3.15.0` via `gray-matter@4.0.3` — gray-matter binds `yaml.safeLoad`, removed in js-yaml 4.x; an override would crash at module load.
- The 12 MPL-2.0 license findings (lightningcss platform binaries) are unmodified, optional native binaries of vite/tailwind build tooling entering via the `vitest` devDependency, never distributed — addressed via org license policy, not versions.

## Impacted packages

Workspace-wide resolved-version changes (web, worker, packages/shared): only path-to-regexp 8.x and @ai-sdk/provider-utils 4.0.x move; `pnpm dedupe` produced no further churn.

## Verification

- `pnpm run lint` — Tasks: 7 successful, 7 total
- `pnpm tc` — Tasks: 7 successful, 7 total
- `pnpm --filter web run test in-app-agent-stream.servertest.ts` — Tests 14 passed (14) (imports the full mastra/AG-UI/MCP graph in-process, covering the module-eval risk behind the ui-utils exemption)
- `pnpm --filter worker run test aisdk.test.ts` — Tests 19 passed (19)
- Runtime smoke: in-app assistant drawer conversation with reasoning + 2 MCP tool calls on the bumped graph, answered correctly
- `pnpm why -r` confirms the resolved graph: path-to-regexp 0.1.13/6.3.0/8.4.0, provider-utils 4.0.33/4.0.40/5.x (+ the documented 2.2.8 exemption); @hono/node-server and ip-address unchanged from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)