### PR TITLE
fix(events): Pulse tap clears a leftover drag-selection band (LFE-14451)

### DIFF
--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
@@ -340,7 +340,10 @@ export function OutlierBarStrip({
           if (!bin) return;
           if (event.pointerType !== "mouse") {
             // Touch tap = PREVIEW: pin the tooltip over the bucket; the
-            // tooltip's Explore action performs the navigation.
+            // tooltip's Explore action performs the navigation. A leftover
+            // drag band from a previous span preview clears — one preview,
+            // one highlight.
+            onSelectionChange?.(null);
             setTouchPreview({
               fromMs: bin.bucketStartMs,
               toMs: bin.bucketStartMs + stepMs,


### PR DESCRIPTION
## TL;DR
Tiny follow-up to #15486 (the Pulse outlier strip): on touch, tapping a bucket after a drag-span preview replaced the tooltip but left the previous drag's highlight band painted. A tap now clears any leftover band — one preview, one highlight.

## Why
The touch model is preview-first (tap previews a bucket, drag previews a span). The two gestures share the strip's highlight surfaces, and the tap path forgot to reset the drag's shared selection band. Found in a self-review of the final pre-merge commits; the branch was already locked in the merge queue, hence the follow-up.

## What
One line in the tap handler (`onSelectionChange?.(null)`) plus its comment.

Checks: web typecheck PASS, strip stories `Tests  8 passed (8)`, binning clienttests `Tests  13 passed (13)`, lint PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)