### PR TITLE
fix(events): keep Pulse touch tooltip on-screen at viewport edges (LFE-14451)

### DIFF
--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { cn } from "@/src/utils/tailwind";
 import { X } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
@@ -99,6 +99,19 @@ export function OutlierBarStrip({
   // Drag gesture bookkeeping lives in a ref: pointermove during a drag only
   // updates the SHARED selection via onSelectionChange, never local state.
   const dragRef = useRef<{ startX: number; dragging: boolean } | null>(null);
+  // The pinned preview centers on its anchor, so keeping it on-screen needs
+  // the rendered size. A callback ref measures in the commit phase (before
+  // paint — no mispositioned flash); the div is keyed per preview window so
+  // re-taps remount and re-measure.
+  const [previewSize, setPreviewSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+  const measurePreview = useCallback((el: HTMLDivElement | null) => {
+    setPreviewSize(
+      el ? { width: el.offsetWidth, height: el.offsetHeight } : null,
+    );
+  }, []);
 
   const metricSpec = OUTLIER_STRIP_METRICS[metric];
   const color = METRIC_COLOR[metric];
@@ -259,6 +272,11 @@ export function OutlierBarStrip({
   const previewHasData =
     previewStats !== null &&
     (previewStats.count > 0 || previewStats.value !== null);
+  // First render (pre-measure) treats the box as zero-width; the commit-phase
+  // measurement re-renders with the real clamp before the browser paints.
+  const previewHalfWidth = (previewSize?.width ?? 0) / 2;
+  const viewportWidth =
+    typeof window !== "undefined" ? window.innerWidth : Number.MAX_SAFE_INTEGER;
 
   return (
     <div className={cn("relative", className)} style={{ width: widthPx }}>
@@ -461,15 +479,23 @@ export function OutlierBarStrip({
       {activePreview && previewStats && (
         <Layer name="tooltip">
           <div
-            className="bg-popover text-popover-foreground fixed rounded border px-2 py-1.5 font-mono text-[11px] leading-tight whitespace-nowrap shadow-md"
+            key={`${activePreview.fromMs}:${activePreview.toMs}`}
+            ref={measurePreview}
+            className="bg-popover text-popover-foreground fixed max-w-[calc(100vw-16px)] rounded border px-2 py-1.5 font-mono text-[11px] leading-tight whitespace-nowrap shadow-md"
             style={{
+              // Clamp the center so the measured box stays fully on-screen —
+              // edge-of-viewport taps would otherwise clip half the tooltip.
               left: Math.min(
-                Math.max(activePreview.anchorX, 90),
-                typeof window !== "undefined"
-                  ? window.innerWidth - 90
-                  : activePreview.anchorX,
+                Math.max(activePreview.anchorX, 8 + previewHalfWidth),
+                Math.max(
+                  viewportWidth - 8 - previewHalfWidth,
+                  8 + previewHalfWidth,
+                ),
               ),
-              top: activePreview.anchorY - 6,
+              top: Math.max(
+                activePreview.anchorY - 6,
+                (previewSize?.height ?? 0) + 8,
+              ),
               transform: "translate(-50%, -100%)",
             }}
           >

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
@@ -101,16 +101,35 @@ export function OutlierBarStrip({
   const dragRef = useRef<{ startX: number; dragging: boolean } | null>(null);
   // The pinned preview centers on its anchor, so keeping it on-screen needs
   // the rendered size. A callback ref measures in the commit phase (before
-  // paint — no mispositioned flash); the div is keyed per preview window so
-  // re-taps remount and re-measure.
+  // paint — no mispositioned flash) and attaches a ResizeObserver so content
+  // changes while pinned (a live refetch growing the count, the Explore
+  // button toggling) re-clamp instead of drifting on a stale size.
   const [previewSize, setPreviewSize] = useState<{
     width: number;
     height: number;
   } | null>(null);
+  const previewResizeObserverRef = useRef<ResizeObserver | null>(null);
   const measurePreview = useCallback((el: HTMLDivElement | null) => {
-    setPreviewSize(
-      el ? { width: el.offsetWidth, height: el.offsetHeight } : null,
-    );
+    previewResizeObserverRef.current?.disconnect();
+    previewResizeObserverRef.current = null;
+    if (!el) {
+      setPreviewSize(null);
+      return;
+    }
+    const measure = () =>
+      setPreviewSize((prev) => {
+        const width = el.offsetWidth;
+        const height = el.offsetHeight;
+        return prev && prev.width === width && prev.height === height
+          ? prev
+          : { width, height };
+      });
+    measure();
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(measure);
+      observer.observe(el);
+      previewResizeObserverRef.current = observer;
+    }
   }, []);
 
   const metricSpec = OUTLIER_STRIP_METRICS[metric];


### PR DESCRIPTION
**TL;DR** On phones, tapping a bar near the screen edge clipped the pinned Pulse tooltip off-screen. It now measures itself and clamps fully into the viewport.

Follow-up to #15486 / #15521 (LFE-14451).

### Why
The touch preview tooltip centers on the tap anchor with a hardcoded 90px clamp — an implicit "tooltip is ≤180px wide" assumption. The real tooltip (time range + value + Explore button) is ~220px, so left-edge taps on a phone pushed half of it past the viewport edge.

### What
Measure the rendered tooltip box and clamp its center so both edges stay inside an 8px viewport margin (top edge too).

<details>
<summary>Mechanism + verification</summary>

- A callback ref measures the box in React's commit phase, so the clamped position renders before the browser paints — no mispositioned first frame. The div is keyed per preview window, so tapping a different bucket remounts and re-measures.
- `max-w-[calc(100vw-16px)]` as a belt-and-braces cap for viewports narrower than the tooltip.
- Verified on an iPhone-size viewport (390px, touch) via Playwright: far-left tap → tooltip left edge at 8px; far-right tap → right edge at 382px; center unchanged. All fully on-screen with the ✕ and Explore button reachable.
- Checks: web typecheck `Tasks: 4 successful, 4 total`; strip unit tests `Tests 13 passed (13)`; stories `Tests 8 passed (8)`; lint (pre-push) `Tasks: 7 successful, 7 total`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
