### PR TITLE
feat(api): promote score creation from legacy

### DIFF
--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -75,8 +75,9 @@ jobs:
           # (could not find the right option to prevent this in generation step)
           rm -rf langfuse/api/tests
 
-          # Install dependencies and format
+          # Install dependencies, preserve backwards-compatible score creation aliases, and format
           uv sync --all-extras --frozen
+          uv run python scripts/patch_generated_score_compat.py
           uv run ruff format langfuse/api
 
           # Check for changes and show diff for debugging
@@ -121,6 +122,9 @@ jobs:
 
           # Copy generated TypeScript SDK files
           cp -r ../langfuse/generated/typescript/* packages/core/src/api/
+
+          # Preserve backwards-compatible score creation aliases
+          node scripts/patch-generated-score-create-alias.mjs
 
           # Patch compilation error inducing output
           # Without this patch, the JS SDK will not build due to

--- a/fern/apis/server/definition/legacy/score-v1.yml
+++ b/fern/apis/server/definition/legacy/score-v1.yml
@@ -1,17 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
-imports:
-  pagination: ../utils/pagination.yml
-  commons: ../commons.yml
 service:
   auth: true
   base-path: /api/public
   endpoints:
-    create:
-      docs: Create a score (supports both trace and session scores)
-      method: POST
-      path: /scores
-      request: CreateScoreRequest
-      response: CreateScoreResponse
     delete:
       docs: Delete a score (supports both trace and session scores)
       method: DELETE
@@ -20,97 +11,3 @@ service:
         scoreId:
           type: string
           docs: The unique langfuse identifier of a score
-types:
-  CreateScoreRequest:
-    properties:
-      id: optional<string>
-      traceId: optional<string>
-      sessionId: optional<string>
-      observationId: optional<string>
-      datasetRunId: optional<string>
-      name: string
-      value:
-        type: commons.CreateScoreValue
-        docs: The value of the score. Must be passed as string for categorical and text scores, and numeric for boolean and numeric scores. Boolean score values must equal either 1 or 0 (true or false). Text score values must be between 1 and 500 characters.
-      comment: optional<string>
-      metadata: optional<map<string, unknown>>
-      environment:
-        type: optional<string>
-        docs: The environment of the score. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'.
-      queueId:
-        type: optional<string>
-        docs: The annotation queue referenced by the score. Indicates if score was initially created while processing annotation queue.
-      dataType:
-        type: optional<commons.ScoreDataType>
-        docs: The data type of the score. When passing a configId this field is inferred. Otherwise, this field must be passed or will default to numeric.
-      configId:
-        type: optional<string>
-        docs: Reference a score config on a score. The unique langfuse identifier of a score config. When passing this field, the dataType and stringValue fields are automatically populated.
-      source:
-        type: optional<CreateScoreSource>
-        docs: The source of the score. Defaults to API. Set to ANNOTATION to prefill scores (e.g. from an LLM) for a human reviewer to verify in an annotation queue. When source is ANNOTATION, a configId is required unless dataType is CORRECTION. EVAL is reserved for internal evaluator outputs and is not accepted on this endpoint.
-    examples:
-      - value:
-          name: "novelty"
-          value: 0.9
-          traceId: "cdef-1234-5678-90ab"
-      - value:
-          name: "consistency"
-          value: 1.2
-          dataType: "NUMERIC"
-          traceId: "cdef-1234-5678-90ab"
-      - value:
-          name: "accuracy"
-          value: 0.9
-          dataType: "NUMERIC"
-          configId: "9203-4567-89ab-cdef"
-          traceId: "cdef-1234-5678-90ab"
-          environment: "test"
-      - value:
-          name: "toxicity"
-          value: "not toxic"
-          traceId: "cdef-1234-5678-90ab"
-          environment: "production"
-      - value:
-          name: "correctness"
-          value: "partially correct"
-          dataType: "CATEGORICAL"
-          configId: "1234-5678-90ab-cdef"
-          traceId: "cdef-1234-5678-90ab"
-      - value:
-          name: "hallucination"
-          value: 0
-          dataType: "BOOLEAN"
-          traceId: "cdef-1234-5678-90ab"
-      - value:
-          name: "helpfulness"
-          value: 1
-          dataType: "BOOLEAN"
-          configId: "1234-5678-90ab-cdef"
-          traceId: "cdef-1234-5678-90ab"
-      - value:
-          name: "feedback"
-          value: "Great explanation of the concept"
-          dataType: "TEXT"
-          traceId: "cdef-1234-5678-90ab"
-      - value:
-          name: "accuracy"
-          value: 0.9
-          dataType: "NUMERIC"
-          configId: "9203-4567-89ab-cdef"
-          traceId: "cdef-1234-5678-90ab"
-          source: "ANNOTATION"
-          queueId: "aq-1234-5678-90ab-cdef"
-  CreateScoreSource:
-    docs: |
-      Source values accepted when creating a score via the public REST API.
-      EVAL is reserved for internal evaluator outputs and is intentionally not
-      exposed here — use commons.ScoreSource when reading scores.
-    enum:
-      - API
-      - ANNOTATION
-  CreateScoreResponse:
-    properties:
-      id:
-        type: string
-        docs: The id of the created object in Langfuse

--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -4,8 +4,14 @@ imports:
   commons: ./commons.yml
 service:
   auth: true
-  base-path: /api/public/v2
+  base-path: /api/public
   endpoints:
+    create:
+      docs: Create a score (supports trace, observation, session, and dataset run scores)
+      method: POST
+      path: /scores
+      request: CreateScoreRequest
+      response: CreateScoreResponse
     get-many:
       availability:
         status: deprecated
@@ -16,7 +22,7 @@ service:
 
         Get a list of scores (supports both trace and session scores)
       method: GET
-      path: /scores
+      path: /v2/scores
       request:
         name: GetScoresRequest
         query-parameters:
@@ -101,7 +107,7 @@ service:
 
         Get a score (supports both trace and session scores)
       method: GET
-      path: /scores/{scoreId}
+      path: /v2/scores/{scoreId}
       path-parameters:
         scoreId:
           type: string
@@ -109,6 +115,100 @@ service:
       response: commons.Score
 
 types:
+  CreateScoreRequest:
+    properties:
+      id: optional<string>
+      traceId: optional<string>
+      sessionId: optional<string>
+      observationId: optional<string>
+      datasetRunId: optional<string>
+      name: string
+      value:
+        type: commons.CreateScoreValue
+        docs: The value of the score. Must be passed as string for categorical and text scores, and numeric for boolean and numeric scores. Boolean score values must equal either 1 or 0 (true or false). Text score values must be between 1 and 500 characters.
+      comment: optional<string>
+      metadata: optional<map<string, unknown>>
+      environment:
+        type: optional<string>
+        docs: The environment of the score. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'.
+      queueId:
+        type: optional<string>
+        docs: The annotation queue referenced by the score. Indicates if score was initially created while processing annotation queue.
+      dataType:
+        type: optional<commons.ScoreDataType>
+        docs: The data type of the score. When passing a configId this field is inferred. Otherwise, this field must be passed or will default to numeric.
+      configId:
+        type: optional<string>
+        docs: Reference a score config on a score. The unique langfuse identifier of a score config. When passing this field, the dataType and stringValue fields are automatically populated.
+      source:
+        type: optional<CreateScoreSource>
+        docs: The source of the score. Defaults to API. Set to ANNOTATION to prefill scores (e.g. from an LLM) for a human reviewer to verify in an annotation queue. When source is ANNOTATION, a configId is required unless dataType is CORRECTION. EVAL is reserved for internal evaluator outputs and is not accepted on this endpoint.
+    examples:
+      - value:
+          name: "novelty"
+          value: 0.9
+          traceId: "cdef-1234-5678-90ab"
+      - value:
+          name: "consistency"
+          value: 1.2
+          dataType: "NUMERIC"
+          traceId: "cdef-1234-5678-90ab"
+      - value:
+          name: "accuracy"
+          value: 0.9
+          dataType: "NUMERIC"
+          configId: "9203-4567-89ab-cdef"
+          traceId: "cdef-1234-5678-90ab"
+          environment: "test"
+      - value:
+          name: "toxicity"
+          value: "not toxic"
+          traceId: "cdef-1234-5678-90ab"
+          environment: "production"
+      - value:
+          name: "correctness"
+          value: "partially correct"
+          dataType: "CATEGORICAL"
+          configId: "1234-5678-90ab-cdef"
+          traceId: "cdef-1234-5678-90ab"
+      - value:
+          name: "hallucination"
+          value: 0
+          dataType: "BOOLEAN"
+          traceId: "cdef-1234-5678-90ab"
+      - value:
+          name: "helpfulness"
+          value: 1
+          dataType: "BOOLEAN"
+          configId: "1234-5678-90ab-cdef"
+          traceId: "cdef-1234-5678-90ab"
+      - value:
+          name: "feedback"
+          value: "Great explanation of the concept"
+          dataType: "TEXT"
+          traceId: "cdef-1234-5678-90ab"
+      - value:
+          name: "accuracy"
+          value: 0.9
+          dataType: "NUMERIC"
+          configId: "9203-4567-89ab-cdef"
+          traceId: "cdef-1234-5678-90ab"
+          source: "ANNOTATION"
+          queueId: "aq-1234-5678-90ab-cdef"
+  CreateScoreSource:
+    docs: |
+      Source values accepted when creating a score via the public REST API.
+      EVAL is reserved for internal evaluator outputs and is intentionally not
+      exposed here — use commons.ScoreSource when reading scores.
+    enum:
+      - API
+      - ANNOTATION
+  CreateScoreResponse:
+    properties:
+      id:
+        type: string
+        docs: The id of the created object in Langfuse
+
   GetScoresResponseTraceData:
     properties:
       userId:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2422,52 +2422,6 @@ paths:
             application/json:
               schema: {}
       security: *ref_0
-  /api/public/scores:
-    post:
-      description: Create a score (supports both trace and session scores)
-      operationId: legacy_scoreV1_create
-      tags:
-        - LegacyScoreV1
-      parameters: []
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/legacyCreateScoreResponse'
-        '400':
-          description: ''
-          content:
-            application/json:
-              schema: {}
-        '401':
-          description: ''
-          content:
-            application/json:
-              schema: {}
-        '403':
-          description: ''
-          content:
-            application/json:
-              schema: {}
-        '404':
-          description: ''
-          content:
-            application/json:
-              schema: {}
-        '405':
-          description: ''
-          content:
-            application/json:
-              schema: {}
-      security: *ref_0
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/legacyCreateScoreRequest'
   /api/public/scores/{scoreId}:
     delete:
       description: Delete a score (supports both trace and session scores)
@@ -5686,6 +5640,54 @@ paths:
             application/json:
               schema: {}
       security: *ref_0
+  /api/public/scores:
+    post:
+      description: >-
+        Create a score (supports trace, observation, session, and dataset run
+        scores)
+      operationId: scores_create
+      tags:
+        - Scores
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateScoreResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security: *ref_0
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateScoreRequest'
   /api/public/v2/scores:
     get:
       description: |-
@@ -11950,99 +11952,6 @@ components:
       required:
         - data
         - meta
-    legacyCreateScoreRequest:
-      title: legacyCreateScoreRequest
-      type: object
-      properties:
-        id:
-          type: string
-          nullable: true
-        traceId:
-          type: string
-          nullable: true
-        sessionId:
-          type: string
-          nullable: true
-        observationId:
-          type: string
-          nullable: true
-        datasetRunId:
-          type: string
-          nullable: true
-        name:
-          type: string
-        value:
-          $ref: '#/components/schemas/CreateScoreValue'
-          description: >-
-            The value of the score. Must be passed as string for categorical and
-            text scores, and numeric for boolean and numeric scores. Boolean
-            score values must equal either 1 or 0 (true or false). Text score
-            values must be between 1 and 500 characters.
-        comment:
-          type: string
-          nullable: true
-        metadata:
-          type: object
-          additionalProperties: true
-          nullable: true
-        environment:
-          type: string
-          nullable: true
-          description: >-
-            The environment of the score. Can be any lowercase alphanumeric
-            string with hyphens and underscores that does not start with
-            'langfuse'.
-        queueId:
-          type: string
-          nullable: true
-          description: >-
-            The annotation queue referenced by the score. Indicates if score was
-            initially created while processing annotation queue.
-        dataType:
-          $ref: '#/components/schemas/ScoreDataType'
-          nullable: true
-          description: >-
-            The data type of the score. When passing a configId this field is
-            inferred. Otherwise, this field must be passed or will default to
-            numeric.
-        configId:
-          type: string
-          nullable: true
-          description: >-
-            Reference a score config on a score. The unique langfuse identifier
-            of a score config. When passing this field, the dataType and
-            stringValue fields are automatically populated.
-        source:
-          $ref: '#/components/schemas/legacyCreateScoreSource'
-          nullable: true
-          description: >-
-            The source of the score. Defaults to API. Set to ANNOTATION to
-            prefill scores (e.g. from an LLM) for a human reviewer to verify in
-            an annotation queue. When source is ANNOTATION, a configId is
-            required unless dataType is CORRECTION. EVAL is reserved for
-            internal evaluator outputs and is not accepted on this endpoint.
-      required:
-        - name
-        - value
-    legacyCreateScoreSource:
-      title: legacyCreateScoreSource
-      type: string
-      enum:
-        - API
-        - ANNOTATION
-      description: |-
-        Source values accepted when creating a score via the public REST API.
-        EVAL is reserved for internal evaluator outputs and is intentionally not
-        exposed here — use commons.ScoreSource when reading scores.
-    legacyCreateScoreResponse:
-      title: legacyCreateScoreResponse
-      type: object
-      properties:
-        id:
-          type: string
-          description: The id of the created object in Langfuse
-      required:
-        - id
     LlmConnection:
       title: LlmConnection
       type: object
@@ -13905,6 +13814,99 @@ components:
       required:
         - data
         - meta
+    CreateScoreRequest:
+      title: CreateScoreRequest
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        traceId:
+          type: string
+          nullable: true
+        sessionId:
+          type: string
+          nullable: true
+        observationId:
+          type: string
+          nullable: true
+        datasetRunId:
+          type: string
+          nullable: true
+        name:
+          type: string
+        value:
+          $ref: '#/components/schemas/CreateScoreValue'
+          description: >-
+            The value of the score. Must be passed as string for categorical and
+            text scores, and numeric for boolean and numeric scores. Boolean
+            score values must equal either 1 or 0 (true or false). Text score
+            values must be between 1 and 500 characters.
+        comment:
+          type: string
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties: true
+          nullable: true
+        environment:
+          type: string
+          nullable: true
+          description: >-
+            The environment of the score. Can be any lowercase alphanumeric
+            string with hyphens and underscores that does not start with
+            'langfuse'.
+        queueId:
+          type: string
+          nullable: true
+          description: >-
+            The annotation queue referenced by the score. Indicates if score was
+            initially created while processing annotation queue.
+        dataType:
+          $ref: '#/components/schemas/ScoreDataType'
+          nullable: true
+          description: >-
+            The data type of the score. When passing a configId this field is
+            inferred. Otherwise, this field must be passed or will default to
+            numeric.
+        configId:
+          type: string
+          nullable: true
+          description: >-
+            Reference a score config on a score. The unique langfuse identifier
+            of a score config. When passing this field, the dataType and
+            stringValue fields are automatically populated.
+        source:
+          $ref: '#/components/schemas/CreateScoreSource'
+          nullable: true
+          description: >-
+            The source of the score. Defaults to API. Set to ANNOTATION to
+            prefill scores (e.g. from an LLM) for a human reviewer to verify in
+            an annotation queue. When source is ANNOTATION, a configId is
+            required unless dataType is CORRECTION. EVAL is reserved for
+            internal evaluator outputs and is not accepted on this endpoint.
+      required:
+        - name
+        - value
+    CreateScoreSource:
+      title: CreateScoreSource
+      type: string
+      enum:
+        - API
+        - ANNOTATION
+      description: |-
+        Source values accepted when creating a score via the public REST API.
+        EVAL is reserved for internal evaluator outputs and is intentionally not
+        exposed here — use commons.ScoreSource when reading scores.
+    CreateScoreResponse:
+      title: CreateScoreResponse
+      type: object
+      properties:
+        id:
+          type: string
+          description: The id of the created object in Langfuse
+      required:
+        - id
     GetScoresResponseTraceData:
       title: GetScoresResponseTraceData
       type: object


### PR DESCRIPTION
## What

- Promote `POST /api/public/scores` from `legacy.scoreV1.create` to `scores.create` in the Fern definition.
- Keep the existing HTTP route unchanged and preserve the existing v2 score-read routes.
- Run SDK-owned compatibility postprocessors during generation so existing Python and TypeScript `legacy.scoreV1.create` calls remain available.
- Update the generated OpenAPI artifact so the endpoint appears under Scores without a deprecated/legacy operation.

## Compatibility and rollout

This is intentionally one HTTP endpoint and one canonical Fern operation. The SDK repositories add generated-source postprocessors that expose the old legacy method and types as delegating aliases:

- Python: https://github.com/langfuse/langfuse-python/pull/1786
- TypeScript: https://github.com/langfuse/langfuse-js/pull/888

The SDK compatibility PRs must merge before this PR so the generation workflow can invoke their scripts from each repository's default branch.

Linear: https://linear.app/langfuse/issue/LFE-10397

## Validation

- `npx --yes --cache /tmp/lfe-10397-npm-cache fern-api@3.88.0 check --api server` — `All checks passed`
- Fern TypeScript and Python generation — both `Finished`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter @langfuse/shared run db:generate` — Prisma client generated successfully
- `pnpm --filter @langfuse/shared run build` — `tsc` completed successfully
- Generated TypeScript and Python clients expose `scores.create` at `/api/public/scores`
- SDK postprocessors were validated against the generated output; canonical and legacy calls use the same route

The targeted server integration suite could not complete locally because Postgres, Redis, and the web server were not running; its requests failed on local infrastructure connectivity rather than endpoint assertions.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR promotes score creation into the canonical Scores Fern service while preserving its HTTP path and existing v2 read routes.
- Moves `POST /api/public/scores` and its request/response types from `legacy.scoreV1` to `scores`.
- Retains `GET /api/public/v2/scores` and `GET /api/public/v2/scores/{scoreId}` under the Scores service.
- Adds Python and TypeScript SDK compatibility postprocessing to the generation workflow.
- Regenerates OpenAPI with the canonical `scores_create` operation and schema names.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The SDK generation workflow needs a repository-controlled availability guarantee for both compatibility scripts before this PR is safe to merge.

The Fern and OpenAPI route migration preserves the HTTP contracts, but the generation job unconditionally executes scripts from unpinned external default branches and fails without producing SDK updates when either script is absent.

**Files Needing Attention:** .github/workflows/sdk-api-spec.yml
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Fern[Scores Fern service] --> Canonical[scores.create]
  Canonical --> Route[POST /api/public/scores]
  Route --> OpenAPI[scores_create]
  OpenAPI --> Python[Generated Python SDK]
  OpenAPI --> TypeScript[Generated TypeScript SDK]
  Python --> PythonCompat[legacy.scoreV1.create alias]
  TypeScript --> TypeScriptCompat[legacy.scoreV1.create alias]
  Fern --> Reads[Existing v2 score reads]
  Reads --> V2Route[GET /api/public/v2/scores]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/sdk-api-spec.yml:80
**Unpinned compatibility scripts break generation**

When this workflow runs while either compatibility script is absent from its SDK repository's default branch, the unconditional Python or TypeScript invocation exits nonzero, causing the generation job to fail before either SDK update PR is produced. Pin the clones to refs containing the scripts or guard the rollout within the workflow rather than relying solely on cross-repository merge ordering.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api): promote score creation from l..."](https://github.com/langfuse/langfuse/commit/53a91b9e2416a6ccec8af2d253774265e9625878) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48297083)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->