### PR TITLE
feat(events): PostHog instrumentation for the Pulse outlier strip (LFE-14451)

### DIFF
--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1,5 +1,6 @@
 import { DataTable } from "@/src/components/table/data-table";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import {
   DataTableControlsProvider,
   DataTableControls,
@@ -489,6 +490,7 @@ export default function ObservationsEventsTable({
     "events-outlier-strip-closed",
     null,
   );
+  const capture = usePostHogClientCapture();
   // Drill-in writes the clicked bucket as an absolute range. URL-only
   // (pushIn → browser Back restores the outer window) and deliberately NOT
   // persisted as the project's default range — a transient zoom must not
@@ -1095,13 +1097,17 @@ export default function ObservationsEventsTable({
   const pulseClosed = pulseClosedStored ?? isMobile;
   // One reopen affordance for both surfaces: the desktop toolbar slot (left of
   // Columns) and the mobile header band — mobile defaults to closed, so
-  // without this the strip would be unreachable there.
-  const pulseReopenButton =
+  // without this the strip would be unreachable there. `surface` feeds
+  // analytics only.
+  const pulseReopenButton = (surface: "toolbar" | "mobile_header") =>
     outlierStripEnabled && chartViewMode !== "chart" && pulseClosed ? (
       <Button
         variant="outline"
         size="sm"
-        onClick={() => setPulseClosed(false)}
+        onClick={() => {
+          capture("pulse:reopened", { surface, isV4: true });
+          setPulseClosed(false);
+        }}
         className="h-8 gap-1.5 text-xs"
       >
         <ChartNoAxesColumn className="h-3.5 w-3.5" />
@@ -2011,7 +2017,7 @@ export default function ObservationsEventsTable({
                 onModeChange={setChartViewMode}
               />
             )}
-            {pulseReopenButton}
+            {pulseReopenButton("mobile_header")}
           </div>
         )}
         {!hideControls && !isMobile && (
@@ -2094,7 +2100,7 @@ export default function ObservationsEventsTable({
               setRowHeight={setRowHeight}
               timeRange={showControlsInPageHeader ? undefined : timeRange}
               setTimeRange={showControlsInPageHeader ? undefined : setTimeRange}
-              preColumnsSlot={pulseReopenButton ?? undefined}
+              preColumnsSlot={pulseReopenButton("toolbar") ?? undefined}
               viewModeToggle={
                 chartEnabled ? (
                   <ViewModeToggle

--- a/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
@@ -361,13 +361,19 @@ export function EventsOutlierStrip({
   };
 
   const handleModeChange = (next: StripMode) => {
-    if (next === mode) return;
-    capture("pulse:mode_switch", {
-      mode: next,
-      previousMode: mode,
-      isV4: true,
-    });
-    update({ mode: next });
+    // Event only when the DISPLAYED mode changes; persistence whenever the
+    // STORED preference differs. The two diverge while a stored Split is
+    // width-degraded to Cost: an explicit Cost pick there displays nothing
+    // new (no event) but must stick — otherwise the strip silently snaps
+    // back to Split once the window widens again.
+    if (next !== mode) {
+      capture("pulse:mode_switch", {
+        mode: next,
+        previousMode: mode,
+        isV4: true,
+      });
+    }
+    if (next !== settings.mode) update({ mode: next });
   };
 
   const setAggregation = (

--- a/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
@@ -15,7 +15,11 @@ import {
   chartFilterExclusionReason,
   toChartFilters,
 } from "@/src/features/chart-view/lib/chartFilterCompatibility";
-import { OutlierBarStrip } from "./OutlierBarStrip";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import {
+  OutlierBarStrip,
+  type OutlierStripDrillTrigger,
+} from "./OutlierBarStrip";
 import {
   OUTLIER_STRIP_METRICS,
   outlierStripQueryMetrics,
@@ -205,6 +209,7 @@ export function EventsOutlierStrip({
   onSelectRange: (range: { from: Date; to: Date }) => void;
   onClose: () => void;
 }) {
+  const capture = usePostHogClientCapture();
   const [wrapperRef, size] = useElementSize<HTMLDivElement>();
   // Transient drag selection, shared across the sibling charts so a drag on
   // one strip highlights the same time span on all (LFE-14532, Grafana-style).
@@ -330,14 +335,52 @@ export function EventsOutlierStrip({
     ],
   );
 
-  const handleSelectBucket = (range: { fromMs: number; toMs: number }) => {
+  // Analytics props are metadata only (enums, counts, the granularity step) —
+  // never bucket values or range contents. `isV4` per the filters:* taxonomy
+  // convention: the strip only exists on the v4 events table (LFE-10781).
+  const handleSelectBucket = (
+    range: { fromMs: number; toMs: number },
+    meta: { trigger: OutlierStripDrillTrigger },
+    metric: OutlierStripMetricKey,
+  ) => {
+    capture("pulse:drill_in", {
+      trigger: meta.trigger,
+      metric,
+      aggregation: aggregationFor(metric),
+      mode,
+      stepSeconds: granularity.stepSeconds,
+      spanBuckets: Math.max(
+        1,
+        Math.round(
+          (range.toMs - range.fromMs) / (granularity.stepSeconds * 1000),
+        ),
+      ),
+      isV4: true,
+    });
     onSelectRange({ from: new Date(range.fromMs), to: new Date(range.toMs) });
+  };
+
+  const handleModeChange = (next: StripMode) => {
+    if (next === mode) return;
+    capture("pulse:mode_switch", {
+      mode: next,
+      previousMode: mode,
+      isV4: true,
+    });
+    update({ mode: next });
   };
 
   const setAggregation = (
     metric: OutlierStripMetricKey,
     agg: OutlierStripAggKey,
   ) => {
+    if (agg === aggregationFor(metric)) return;
+    capture("pulse:aggregation_switch", {
+      metric,
+      aggregation: agg,
+      previousAggregation: aggregationFor(metric),
+      isV4: true,
+    });
     if (metric === "latency") {
       update({ latencyAgg: agg as OutlierStripSettings["latencyAgg"] });
     } else if (metric === "cost") {
@@ -380,7 +423,10 @@ export function EventsOutlierStrip({
             variant="ghost"
             size="icon"
             aria-label="Close Pulse chart"
-            onClick={onClose}
+            onClick={() => {
+              capture("pulse:closed", { mode, isV4: true });
+              onClose();
+            }}
             className="text-muted-foreground absolute top-0.5 right-1 z-[1] h-6 w-6"
           >
             <X className="h-3.5 w-3.5" />
@@ -414,7 +460,7 @@ export function EventsOutlierStrip({
                           <ModeDropdown
                             value={mode}
                             options={modeOptions}
-                            onChange={(next) => update({ mode: next })}
+                            onChange={handleModeChange}
                           />
                           {mode === "split" && (
                             <span className="text-muted-foreground font-mono text-[11px] leading-none">
@@ -462,7 +508,16 @@ export function EventsOutlierStrip({
                       stepMs={stepMs}
                       metric={metric}
                       widthPx={chartWidth}
-                      onSelectBucket={handleSelectBucket}
+                      onSelectBucket={(range, meta) =>
+                        handleSelectBucket(range, meta, metric)
+                      }
+                      onPreviewPinned={(trigger) =>
+                        capture("pulse:preview_pinned", {
+                          trigger,
+                          metric,
+                          isV4: true,
+                        })
+                      }
                       selection={activeSelection}
                       onSelectionChange={handleSelectionChange}
                     />

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
@@ -32,6 +32,12 @@ const METRIC_COLOR: Record<OutlierStripMetricKey, string> = {
 /** Pointer travel before a press becomes a range-drag instead of a click. */
 const DRAG_THRESHOLD_PX = 5;
 
+/** Which gesture drove a drill-in — carried to the caller for analytics. */
+export type OutlierStripDrillTrigger =
+  | "bucket_click"
+  | "drag_span"
+  | "touch_explore";
+
 export type OutlierBarStripProps = {
   dense: OutlierStripDenseBin[];
   /** Max metric value across buckets (0 = no data anywhere). */
@@ -54,7 +60,13 @@ export type OutlierBarStripProps = {
   showActivityTicks?: boolean;
   /** Sparse time labels under the gridline ticks. */
   showTimeLabels?: boolean;
-  onSelectBucket?: (range: { fromMs: number; toMs: number }) => void;
+  onSelectBucket?: (
+    range: { fromMs: number; toMs: number },
+    meta: { trigger: OutlierStripDrillTrigger },
+  ) => void;
+  /** Touch preview pinned (tap or drag release) — the analytics seam for the
+   *  preview → explore funnel; never fired for mouse interactions. */
+  onPreviewPinned?: (trigger: "tap" | "drag") => void;
   /** Transient drag selection (ms range), shared across sibling charts so a
    *  drag on one strip highlights on all (LF-34, Grafana-style). */
   selection?: { fromMs: number; toMs: number } | null;
@@ -76,6 +88,7 @@ export function OutlierBarStrip({
   showActivityTicks = true,
   showTimeLabels = true,
   onSelectBucket,
+  onPreviewPinned,
   selection = null,
   onSelectionChange,
   className,
@@ -327,12 +340,13 @@ export function OutlierBarStrip({
                 anchorY: rect.top,
                 windowKey,
               });
+              onPreviewPinned?.("drag");
               return;
             }
             // Mouse, Grafana-style: apply the dragged span to the range.
             onSelectionChange?.(null);
             setTouchPreview(null);
-            onSelectBucket?.(range);
+            onSelectBucket?.(range, { trigger: "drag_span" });
             return;
           }
           const index = Math.floor(x / slotPx);
@@ -353,16 +367,20 @@ export function OutlierBarStrip({
             });
             setHoverIndex(index);
             setMouse(null);
+            onPreviewPinned?.("tap");
             return;
           }
           // Mouse click without movement drills into the bucket. Mirror the
           // tooltip's guard — a truly empty bucket would just drill the table
           // into a zero-row window.
           if ((bin.count > 0 || bin.value !== null) && onSelectBucket) {
-            onSelectBucket({
-              fromMs: bin.bucketStartMs,
-              toMs: bin.bucketStartMs + stepMs,
-            });
+            onSelectBucket(
+              {
+                fromMs: bin.bucketStartMs,
+                toMs: bin.bucketStartMs + stepMs,
+              },
+              { trigger: "bucket_click" },
+            );
           }
         }}
         onPointerCancel={() => {
@@ -517,7 +535,7 @@ export function OutlierBarStrip({
                   setTouchPreview(null);
                   setHoverIndex(null);
                   onSelectionChange?.(null);
-                  onSelectBucket?.(range);
+                  onSelectBucket?.(range, { trigger: "touch_explore" });
                 }}
               >
                 Explore this window

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -56,6 +56,17 @@ export const events = {
   // `routePattern` (the Next.js route pattern, never a concrete URL) so opens
   // can be sliced by surface without leaking ids.
   peek: ["opened", "closed", "expand_toggle", "resized", "open_in_new_tab"],
+  // Pulse outlier strip above the v4 events table (LFE-14451). Props are
+  // metadata only — mode/metric/aggregation enums, gesture trigger, bucket
+  // counts — never bucket values or time-range contents.
+  pulse: [
+    "drill_in",
+    "preview_pinned",
+    "mode_switch",
+    "aggregation_switch",
+    "closed",
+    "reopened",
+  ],
   generations: ["export"],
   // Lazy JSON viewer perf telemetry (LFE-14419): learn whether the size gate
   // and main-thread assumptions hold on real payloads. Metadata only —


### PR DESCRIPTION
**TL;DR** The Pulse strip (#15486) shipped without analytics. This adds a small `pulse:*` PostHog taxonomy — six events at the strip's intent seams — live-verified for exactly-once firing, populated dimensions, and privacy.

Follow-up to #15486 (LFE-14451), per the `posthog-instrumentation` skill.

### Tracking plan

| Question | Event | Props |
|---|---|---|
| Do people drill into outliers, and how? | `pulse:drill_in` | `trigger` (`bucket_click` \| `drag_span` \| `touch_explore`), `metric`, `aggregation`, `mode`, `stepSeconds`, `spanBuckets` |
| Does the touch preview→explore funnel convert? | `pulse:preview_pinned` | `trigger` (`tap` \| `drag`), `metric` |
| Which metric/layout do people watch? | `pulse:mode_switch` | `mode`, `previousMode` |
| Which aggregates matter (max vs sum, max vs p95)? | `pulse:aggregation_switch` | `metric`, `aggregation`, `previousAggregation` |
| Do people reject / come back to the strip? | `pulse:closed` / `pulse:reopened` | `mode` / `surface` (`toolbar` \| `mobile_header`) |

All events carry `isV4: true` (the strip only exists on the v4 events table). **Metadata only — no raw values:** props are enums, bucket counts, and the granularity step; never bucket values, time-range contents, filter values, or search text.

<details>
<summary>Mechanism + live verification</summary>

- Captures live at the intent seams (mode/agg handlers, close/reopen buttons, the gesture handlers), never in shared setters; mode/agg handlers guard same-value re-selection so a no-op pick emits nothing.
- The visualiser stays analytics-free: it reports the gesture (`trigger`) through `onSelectBucket` meta and a new `onPreviewPinned` callback; the container translates to `capture()` with the metric/mode context per chart slot.
- The shared reopen button became a per-surface render so `surface` is honest (toolbar vs mobile header band) instead of a defaulted dimension.
- Live-verified via Playwright against a stubbed same-origin PostHog host with `posthog.debug()` console spying: every event fires exactly once per action; re-selecting the current mode/agg fires nothing; `trigger`/`metric`/`mode`/`surface`/`spanBuckets` all populated (desktop mouse + iPhone touch flows); a payload scan of every captured event found no properties beyond the planned metadata and PostHog `$` internals. (Two Playwright gotchas: posthog-js silently drops `capture()` for bot UAs and `navigator.webdriver === true` — spoof both or you validate nothing.)
- Checks: web typecheck `Tasks: 4 successful, 4 total`; strip tests `Tests 13 passed (13)`; stories `Tests 8 passed (8)`; lint (pre-push) `Tasks: 7 successful, 7 total`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
